### PR TITLE
fix(bench): decode-cipher verifier rejects correct `cd && perl` runs

### DIFF
--- a/archestra-bench/tasks/decode-cipher/verifier.py
+++ b/archestra-bench/tasks/decode-cipher/verifier.py
@@ -1,19 +1,15 @@
-"""Verify the agent decoded the cipher by running the bundled skill script.
+"""Verify the agent decoded the cipher by recovering the bespoke plaintext.
 
-The plaintext is bespoke-cipher output, recoverable only via the seeded `cipher-decoder` skill, so an
-exact match against the never-staged ground truth (BENCH_FIXTURES/expected/plaintext.txt) is the real
-gate. We additionally require, from BENCH_STATE, that the skill was seeded from the repo and that a
-run_command actually invoked the mounted decode.pl on the ciphertext -- a bare `cat`/`echo` of the
-path, or the path without the ciphertext argument, does not count.
+The plaintext is bespoke-cipher output, recoverable only by running the ciphertext through the
+seeded `cipher-decoder` skill, so an exact match against the never-staged ground truth
+(BENCH_FIXTURES/expected/plaintext.txt) is the real gate. We additionally require, from
+BENCH_STATE, that the skill was loaded and seeded from the repo -- robust signals that the agent
+engaged the skill and that the bench provisioned it correctly.
 """
 
 import json
 import os
-import shlex
 from pathlib import Path
-
-MOUNT = "/skills/cipher-decoder"
-SCRIPT = "decode.pl"
 
 
 def _load_json(env_var: str) -> dict:
@@ -26,26 +22,6 @@ def _fixture_text(relpath: str) -> str:
     base = os.environ.get("BENCH_FIXTURES")
     assert base, "BENCH_FIXTURES is not set"
     return Path(base, relpath).read_text(encoding="utf-8")
-
-
-def _ran_decoder_on_ciphertext(call: dict, ciphertext: str) -> bool:
-    if call.get("name") != "archestra__run_command":
-        return False
-    inp = call.get("input") or {}
-    try:
-        argv = shlex.split(str(inp.get("command") or ""))
-    except ValueError:
-        return False
-    if not argv or os.path.basename(argv[0]) != "perl":
-        return False
-    scripts = [a for a in argv[1:] if os.path.basename(a) == SCRIPT]
-    if not scripts:
-        return False
-    script = scripts[0]
-    cwd = str(inp.get("cwd") or "")
-    mounted = script.startswith(MOUNT) or (not script.startswith("/") and MOUNT in cwd)
-    # the ciphertext must be a real argv token (passed to the script), not merely echoed in the text
-    return mounted and ciphertext in argv
 
 
 def test_plaintext_matches() -> None:
@@ -61,16 +37,6 @@ def test_skill_loaded() -> None:
         if c.get("name") == "archestra__load_skill" and "cipher-decoder" in json.dumps(c.get("input") or {})
     ]
     assert loaded, "no load_skill call for cipher-decoder; the skill was not loaded"
-
-
-def test_decoder_script_ran_on_ciphertext() -> None:
-    state = _load_json("BENCH_STATE")
-    ciphertext = _fixture_text("inputs/cipher.txt").strip()
-    ran = [c for c in state.get("tool_calls", []) if _ran_decoder_on_ciphertext(c, ciphertext)]
-    assert ran, (
-        f"no run_command invoked `perl {MOUNT}/.../{SCRIPT} <ciphertext>` with the ciphertext as an "
-        "argument; the bundled decoder was not executed on the blob"
-    )
 
 
 def test_skill_seeded_from_repo() -> None:


### PR DESCRIPTION
## Problem

`decode-cipher`'s `test_decoder_script_ran_on_ciphertext` statically parsed the agent's `run_command` shell string to assert *how* `decode.pl` was invoked (`argv[0] == "perl"`, ciphertext as a bare token). It false-rejected correct solutions whose submitted plaintext exactly matched the never-staged ground truth — e.g. the common idioms:

- `cd /skills/cipher-decoder && perl scripts/decode.pl --mult 73 --add 41 <hex>` (`argv[0] == "cd"`; recorded `cwd` is `null`)
- `HEX="<hex>" && perl scripts/decode.pl … "$HEX"` (ciphertext bound to a shell var)

## Why deletion, not a better parser

A first attempt to parse the command into shell segments (tracking `cd`/`VAR=` state) was reviewed adversarially twice. Each round surfaced more idioms it mishandled in **both** directions — `bash -c`, `export`, stdin redirects, dead `&&`/`||` branches, subshell `cd` leaks, `../` path escapes, substring blobs, command substitution. Statically proving dynamic shell execution is unwinnable short of embedding a shell.

The exact match against the bespoke, never-staged plaintext is the real gate: it is only recoverable by running the ciphertext through this exact cipher. `test_skill_loaded` and `test_skill_seeded_from_repo` remain as robust, parse-free engagement/provisioning signals.

## Change

Delete `test_decoder_script_ran_on_ciphertext` and its `shlex`-based machinery (helpers, imports, constants). Net −40/+6.

## Validation

Replayed the verifier against recorded `state.json` from real runs:
- both previously false-rejected `glm` runs now pass (3/3)
- absolute-path runs still pass
- wrong plaintext, missing `load_skill`, and `sourceType != github` still fail

https://claude.ai/code/session_019ns1u3cmgwH1u1d4S8Fogk

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>