### PR TITLE
fix: scope optimization rules

### DIFF
--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -2,7 +2,7 @@
 title: Costs & Limits
 category: LLM Proxy
 order: 4
-lastUpdated: 2026-06-09
+lastUpdated: 2026-06-22
 ---
 
 Archestra tracks LLM usage costs, enforces usage limits, and records savings from model optimization and tool-result compression. These controls work together: pricing defines cost, logs and statistics show what happened, limits stop or shape usage, and optimization reduces spend before a request reaches a model.
@@ -64,15 +64,15 @@ If you use custom or self-hosted models, add pricing explicitly so cost reportin
 
 ## Optimization Rules
 
-Optimization rules reduce cost before a request is sent to an LLM. They evaluate request context and can switch the request to a lower-cost model when the rule conditions match.
+Optimization rules reduce cost before a request is sent to an LLM. They evaluate request context and can switch the request to a lower-cost model when the rule conditions match. Rules can target the organization, a team, or a specific agent.
 
 Typical uses:
 
 - route short prompts to a cheaper model
 - use a less expensive model when tool use is not required
-- apply time-based policies for predictable traffic patterns
+- make a specific agent or team use a cheaper fallback model
 
-Rules are applied by priority order. This makes them useful for layered policies, where a specific exception should win over a general fallback.
+Rules are applied by specificity first: agent rules, then team rules, then organization rules. Within the same scope, older rules are evaluated first.
 
 ## TOON Compression
 

--- a/platform/backend/src/models/optimization-rule.test.ts
+++ b/platform/backend/src/models/optimization-rule.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "@/test";
-import type { InsertOptimizationRule, OptimizationRule } from "@/types";
+import type { OptimizationRule } from "@/types";
 import AgentModel from "./agent";
 import OptimizationRuleModel from "./optimization-rule";
 
@@ -151,35 +151,146 @@ describe("OptimizationRuleModel.matchByRules", () => {
   });
 });
 
-describe("OptimizationRuleModel.getFirstOrganizationId", () => {
-  test("returns organization ID when rules exist", async ({
+describe("OptimizationRuleModel.findEnabledApplicableToAgent", () => {
+  test("returns only enabled provider rules applicable to the agent, ordered by specificity", async ({
+    makeAgent,
     makeOrganization,
+    makeTeam,
+    makeUser,
   }) => {
     const org = await makeOrganization();
+    const otherOrg = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const otherTeam = await makeTeam(org.id, user.id);
+    const agent = await makeAgent({
+      organizationId: org.id,
+      scope: "team",
+      teams: [team.id],
+    });
+    const otherAgent = await makeAgent({ organizationId: org.id });
 
-    // Create an organization-level optimization rule
-    const ruleData: InsertOptimizationRule = {
+    const organizationRule = await OptimizationRuleModel.create({
       entityType: "organization",
       entityId: org.id,
       conditions: [{ maxLength: 1000 }],
       provider: "openai",
-      targetModel: "gpt-4o-mini",
+      targetModel: "org-model",
       enabled: true,
-    };
-    await OptimizationRuleModel.create(ruleData);
+    });
+    const teamRule = await OptimizationRuleModel.create({
+      entityType: "team",
+      entityId: team.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "team-model",
+      enabled: true,
+    });
+    const agentRule = await OptimizationRuleModel.create({
+      entityType: "agent",
+      entityId: agent.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "agent-model",
+      enabled: true,
+    });
 
-    const result = await OptimizationRuleModel.getFirstOrganizationId();
+    await OptimizationRuleModel.create({
+      entityType: "team",
+      entityId: otherTeam.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "other-team-model",
+      enabled: true,
+    });
+    await OptimizationRuleModel.create({
+      entityType: "agent",
+      entityId: otherAgent.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "other-agent-model",
+      enabled: true,
+    });
+    await OptimizationRuleModel.create({
+      entityType: "organization",
+      entityId: otherOrg.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "other-org-model",
+      enabled: true,
+    });
+    await OptimizationRuleModel.create({
+      entityType: "organization",
+      entityId: org.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "anthropic",
+      targetModel: "wrong-provider-model",
+      enabled: true,
+    });
+    await OptimizationRuleModel.create({
+      entityType: "organization",
+      entityId: org.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "disabled-model",
+      enabled: false,
+    });
 
-    expect(result).toBe(org.id);
+    const rules = await OptimizationRuleModel.findEnabledApplicableToAgent({
+      organizationId: org.id,
+      agentId: agent.id,
+      teamIds: [team.id],
+      provider: "openai",
+    });
+
+    expect(rules.map((rule) => rule.id)).toEqual([
+      agentRule.id,
+      teamRule.id,
+      organizationRule.id,
+    ]);
   });
 
-  test("returns null when no organization rules exist", async () => {
-    // Since we're in a test with a fresh database, there should be no rules
-    // Note: This test might be flaky if other tests create rules and don't clean up
-    const result = await OptimizationRuleModel.getFirstOrganizationId();
+  test("ignores team rules for cross-organization agent-team assignments", async ({
+    makeAgent,
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    const agentOrg = await makeOrganization();
+    const foreignOrg = await makeOrganization();
+    const user = await makeUser();
+    const foreignTeam = await makeTeam(foreignOrg.id, user.id);
+    const agent = await makeAgent({
+      organizationId: agentOrg.id,
+      scope: "team",
+      teams: [foreignTeam.id],
+    });
+    const organizationRule = await OptimizationRuleModel.create({
+      entityType: "organization",
+      entityId: agentOrg.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "agent-org-model",
+      enabled: true,
+    });
 
-    // Result could be null or an org ID depending on test isolation
-    expect(result === null || typeof result === "string").toBe(true);
+    await OptimizationRuleModel.create({
+      entityType: "team",
+      entityId: foreignTeam.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "foreign-team-model",
+      enabled: true,
+    });
+
+    const rules = await OptimizationRuleModel.findEnabledApplicableToAgent({
+      organizationId: agentOrg.id,
+      agentId: agent.id,
+      teamIds: [foreignTeam.id],
+      provider: "openai",
+    });
+
+    expect(rules.map((rule) => rule.id)).toEqual([organizationRule.id]);
   });
 });
 

--- a/platform/backend/src/models/optimization-rule.ts
+++ b/platform/backend/src/models/optimization-rule.ts
@@ -1,5 +1,5 @@
 import type { SupportedProvider } from "@archestra/shared";
-import { and, asc, eq, getTableColumns, or, sql } from "drizzle-orm";
+import { and, asc, eq, getTableColumns, inArray, or, sql } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { notDeleted } from "@/database/schemas/soft-deletable-table";
 import logger from "@/logging";
@@ -180,56 +180,75 @@ class OptimizationRuleModel {
   }
 
   /**
-   * Find enabled rules for an organization and provider
+   * Find enabled optimization rules that apply to one agent at runtime.
    */
-  static async findEnabledByOrganizationAndProvider(
-    organizationId: string,
-    provider: SupportedProvider,
-  ): Promise<OptimizationRule[]> {
+  static async findEnabledApplicableToAgent(params: {
+    organizationId: string;
+    agentId: string;
+    teamIds: string[];
+    provider: SupportedProvider;
+  }): Promise<OptimizationRule[]> {
+    const { organizationId, agentId, teamIds, provider } = params;
     logger.debug(
-      { organizationId, provider },
-      "OptimizationRuleModel.findEnabledByOrganizationAndProvider: fetching rules",
+      { organizationId, agentId, teamIds, provider },
+      "OptimizationRuleModel.findEnabledApplicableToAgent: fetching rules",
     );
+
+    const applicableScopes = [
+      and(
+        eq(schema.optimizationRulesTable.entityType, "agent"),
+        eq(schema.optimizationRulesTable.entityId, agentId),
+        sql`EXISTS (
+          SELECT 1 FROM ${schema.agentsTable}
+          WHERE ${schema.agentsTable.id}::text = ${schema.optimizationRulesTable.entityId}
+            AND ${schema.agentsTable.organizationId} = ${organizationId}
+            AND ${schema.agentsTable.deletedAt} IS NULL
+        )`,
+      ),
+      and(
+        eq(schema.optimizationRulesTable.entityType, "organization"),
+        eq(schema.optimizationRulesTable.entityId, organizationId),
+      ),
+    ];
+
+    if (teamIds.length > 0) {
+      applicableScopes.push(
+        and(
+          eq(schema.optimizationRulesTable.entityType, "team"),
+          inArray(schema.optimizationRulesTable.entityId, teamIds),
+          sql`EXISTS (
+            SELECT 1 FROM ${schema.teamsTable}
+            WHERE ${schema.teamsTable.id} = ${schema.optimizationRulesTable.entityId}
+              AND ${schema.teamsTable.organizationId} = ${organizationId}
+          )`,
+        ),
+      );
+    }
+
     const rules = await db
       .select()
       .from(schema.optimizationRulesTable)
       .where(
         and(
-          eq(schema.optimizationRulesTable.entityType, "organization"),
-          eq(schema.optimizationRulesTable.entityId, organizationId),
           eq(schema.optimizationRulesTable.provider, provider),
           eq(schema.optimizationRulesTable.enabled, true),
+          or(...applicableScopes),
         ),
       )
-      .orderBy(asc(schema.optimizationRulesTable.createdAt));
+      .orderBy(
+        sql<number>`CASE
+          WHEN ${schema.optimizationRulesTable.entityType} = 'agent' THEN 0
+          WHEN ${schema.optimizationRulesTable.entityType} = 'team' THEN 1
+          ELSE 2
+        END`,
+        asc(schema.optimizationRulesTable.createdAt),
+      );
 
     logger.debug(
-      { organizationId, provider, count: rules.length },
-      "OptimizationRuleModel.findEnabledByOrganizationAndProvider: completed",
+      { organizationId, agentId, provider, count: rules.length },
+      "OptimizationRuleModel.findEnabledApplicableToAgent: completed",
     );
     return rules;
-  }
-
-  /**
-   * Get the first organization ID that has optimization rules
-   * Used as fallback when an agent has no teams
-   */
-  static async getFirstOrganizationId(): Promise<string | null> {
-    logger.debug(
-      "OptimizationRuleModel.getFirstOrganizationId: fetching first organization with rules",
-    );
-    const [result] = await db
-      .select({ entityId: schema.optimizationRulesTable.entityId })
-      .from(schema.optimizationRulesTable)
-      .where(sql`${schema.optimizationRulesTable.entityType} = 'organization'`)
-      .limit(1);
-
-    const organizationId = result?.entityId || null;
-    logger.debug(
-      { organizationId },
-      "OptimizationRuleModel.getFirstOrganizationId: completed",
-    );
-    return organizationId;
   }
 
   /**

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
@@ -1,4 +1,4 @@
-import { ModelModel } from "@/models";
+import { ModelModel, OptimizationRuleModel } from "@/models";
 import { describe, expect, test } from "@/test";
 import { TiktokenTokenizer } from "@/tokenizers";
 import type { CommonMcpToolDefinition } from "@/types";
@@ -6,6 +6,7 @@ import {
   calculateCacheCost,
   calculateCost,
   estimateToolTokens,
+  getOptimizedModel,
 } from "./cost-optimization";
 
 describe("calculateCost", () => {
@@ -332,5 +333,105 @@ describe("estimateToolTokens", () => {
 
     const tokens = estimateToolTokens(tools, tokenizer);
     expect(tokens).toBeGreaterThan(0);
+  });
+});
+
+describe("getOptimizedModel", () => {
+  const messages = [{ role: "user" as const, content: "Short prompt" }];
+
+  test("applies a team-scoped optimization rule to an agent in that team", async ({
+    makeAgent,
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const agent = await makeAgent({
+      organizationId: org.id,
+      scope: "team",
+      teams: [team.id],
+    });
+
+    await OptimizationRuleModel.create({
+      entityType: "team",
+      entityId: team.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "team-model",
+      enabled: true,
+    });
+
+    await expect(
+      getOptimizedModel(agent, messages, "openai", false),
+    ).resolves.toBe("team-model");
+  });
+
+  test("uses agent rules before broader matching rules", async ({
+    makeAgent,
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const agent = await makeAgent({
+      organizationId: org.id,
+      scope: "team",
+      teams: [team.id],
+    });
+
+    await OptimizationRuleModel.create({
+      entityType: "organization",
+      entityId: org.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "org-model",
+      enabled: true,
+    });
+    await OptimizationRuleModel.create({
+      entityType: "team",
+      entityId: team.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "team-model",
+      enabled: true,
+    });
+    await OptimizationRuleModel.create({
+      entityType: "agent",
+      entityId: agent.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "agent-model",
+      enabled: true,
+    });
+
+    await expect(
+      getOptimizedModel(agent, messages, "openai", false),
+    ).resolves.toBe("agent-model");
+  });
+
+  test("does not apply another organization's rule to a teamless agent", async ({
+    makeAgent,
+    makeOrganization,
+  }) => {
+    const otherOrg = await makeOrganization();
+    const agentOrg = await makeOrganization();
+    const agent = await makeAgent({ organizationId: agentOrg.id, teams: [] });
+
+    await OptimizationRuleModel.create({
+      entityType: "organization",
+      entityId: otherOrg.id,
+      conditions: [{ maxLength: 1000 }],
+      provider: "openai",
+      targetModel: "other-org-model",
+      enabled: true,
+    });
+
+    await expect(
+      getOptimizedModel(agent, messages, "openai", false),
+    ).resolves.toBeNull();
   });
 });

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.ts
@@ -1,11 +1,6 @@
 import type { SupportedProvider } from "@archestra/shared";
 import logger from "@/logging";
-import {
-  AgentTeamModel,
-  ModelModel,
-  OptimizationRuleModel,
-  TeamModel,
-} from "@/models";
+import { AgentTeamModel, ModelModel, OptimizationRuleModel } from "@/models";
 import {
   getTokenizer,
   type ProviderMessage,
@@ -87,48 +82,16 @@ export async function getOptimizedModel<
   tools: CommonMcpToolDefinition[] = [],
 ): Promise<string | null> {
   const agentId = agent.id;
-
-  // Get organizationId the same way limits do: from agent's teams OR fallback
-  let organizationId: string | null = null;
+  const organizationId = agent.organizationId;
   const agentTeamIds = await AgentTeamModel.getTeamsForAgent(agentId);
 
-  if (agentTeamIds.length > 0) {
-    // Get organizationId from agent's first team
-    const teams = await TeamModel.findByIds(agentTeamIds);
-    if (teams.length > 0 && teams[0].organizationId) {
-      organizationId = teams[0].organizationId;
-      logger.info(
-        { agentId, organizationId },
-        "[CostOptimization] resolved organizationId from team",
-      );
-    }
-  } else {
-    // If agent has no teams, check if there are any organization optimization rules to apply (fallback)
-    // TODO: this fallback doesn't work if there are multiple organizations.
-    organizationId = await OptimizationRuleModel.getFirstOrganizationId();
-
-    if (organizationId) {
-      logger.info(
-        { agentId, organizationId },
-        "[CostOptimization] agent has no teams - using fallback organization",
-      );
-    }
-  }
-
-  if (!organizationId) {
-    logger.warn(
-      { agentId },
-      "[CostOptimization] could not resolve organizationId",
-    );
-    return null;
-  }
-
   // Fetch enabled optimization rules for this organization, agent, and provider
-  const rules =
-    await OptimizationRuleModel.findEnabledByOrganizationAndProvider(
-      organizationId,
-      provider,
-    );
+  const rules = await OptimizationRuleModel.findEnabledApplicableToAgent({
+    organizationId,
+    agentId,
+    teamIds: agentTeamIds,
+    provider,
+  });
 
   if (rules.length === 0) {
     logger.info(

--- a/platform/frontend/src/app/llm/(costs)/optimization-rules/_parts/rule.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/optimization-rules/_parts/rule.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { OptimizationRuleForm } from "./rule";
+
+vi.mock("@/components/llm-model-picker", () => ({
+  LlmModelPicker: () => <div>Model picker</div>,
+}));
+
+describe("OptimizationRuleForm", () => {
+  it("shows the selected agent for agent-scoped rules", () => {
+    render(
+      <OptimizationRuleForm
+        enabled
+        entityType="agent"
+        entityId="agent-1"
+        conditions={[{ maxLength: 1000 }]}
+        provider="openai"
+        targetModel="gpt-4o-mini"
+        tokenPrices={[]}
+        teams={[]}
+        agents={[
+          {
+            id: "agent-1",
+            name: "Research Agent",
+            description: null,
+          },
+        ]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Research Agent")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/app/llm/(costs)/optimization-rules/_parts/rule.tsx
+++ b/platform/frontend/src/app/llm/(costs)/optimization-rules/_parts/rule.tsx
@@ -17,6 +17,7 @@ import { WithPermissions } from "@/components/roles/with-permissions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { SearchableSelect } from "@/components/ui/searchable-select";
 import {
   Select,
   SelectContent,
@@ -31,15 +32,25 @@ import { cn } from "@/lib/utils";
 
 type EntityType = OptimizationRule["entityType"];
 type Conditions = OptimizationRule["conditions"];
+type RuleAgent = {
+  id: string;
+  name: string;
+  description?: string | null;
+};
 
 // Helper to get entity display name
 function getEntityName(
   entityType: EntityType,
   entityId: string,
   teams: Team[],
+  agents: RuleAgent[],
 ): string {
   if (entityType === "organization") {
     return "whole organization";
+  }
+  if (entityType === "agent") {
+    const agent = agents.find((candidate) => candidate.id === entityId);
+    return agent?.name || "unknown agent";
   }
   const team = teams.find((t) => t.id === entityId);
   return team?.name || "unknown team";
@@ -86,17 +97,19 @@ function EntitySelect({
   entityType,
   entityId,
   teams,
+  agents,
   onChange,
   editable,
 }: {
   entityType: EntityType;
   entityId: string;
   teams: Team[];
+  agents: RuleAgent[];
   onChange: (entityType: EntityType, entityId?: string) => void;
   editable?: boolean;
 }) {
   if (!editable) {
-    const entityName = getEntityName(entityType, entityId, teams);
+    const entityName = getEntityName(entityType, entityId, teams, agents);
     return (
       <Badge variant="outline" className="text-sm">
         {entityName}
@@ -109,7 +122,11 @@ function EntitySelect({
       <Select
         value={entityType}
         onValueChange={(value) => {
-          if (value === "organization" || value === "team") {
+          if (
+            value === "organization" ||
+            value === "team" ||
+            value === "agent"
+          ) {
             onChange(value, undefined);
           }
         }}
@@ -120,6 +137,7 @@ function EntitySelect({
         <SelectContent>
           <SelectItem value="organization">Organization</SelectItem>
           <SelectItem value="team">Team</SelectItem>
+          <SelectItem value="agent">Agent</SelectItem>
         </SelectContent>
       </Select>
       {entityType === "team" && (
@@ -139,6 +157,21 @@ function EntitySelect({
           </SelectContent>
         </Select>
       )}
+      {entityType === "agent" && (
+        <SearchableSelect
+          value={entityId}
+          onValueChange={(value) => onChange(entityType, value)}
+          placeholder="Select agent"
+          searchPlaceholder="Search agents"
+          emptyMessage="No agents found."
+          items={agents.map((agent) => ({
+            value: agent.id,
+            label: agent.name,
+            description: agent.description ?? undefined,
+          }))}
+          className="w-full sm:flex-1"
+        />
+      )}
     </div>
   );
 }
@@ -146,6 +179,7 @@ function EntitySelect({
 type RuleProps = Omit<OptimizationRule, "createdAt" | "updatedAt"> & {
   tokenPrices: ModelPricing;
   teams?: Team[];
+  agents?: RuleAgent[];
   editable?: boolean;
   onChange?: (
     data: Omit<OptimizationRule, "id" | "createdAt" | "updatedAt">,
@@ -166,6 +200,7 @@ type OptimizationRuleFormProps = Pick<
 > & {
   tokenPrices: ModelPricing;
   teams?: Team[];
+  agents?: RuleAgent[];
   onChange?: (
     data: Omit<OptimizationRule, "id" | "createdAt" | "updatedAt">,
   ) => void;
@@ -181,6 +216,7 @@ export function OptimizationRuleForm({
   targetModel,
   tokenPrices,
   teams = [],
+  agents = [],
   onChange,
   onToggle,
 }: OptimizationRuleFormProps) {
@@ -249,6 +285,7 @@ export function OptimizationRuleForm({
             entityType={formData.entityType}
             entityId={formData.entityId}
             teams={teams}
+            agents={agents}
             onChange={(nextEntityType, nextEntityId) =>
               updateFormData({
                 entityType: nextEntityType,
@@ -336,6 +373,7 @@ export function Rule({
   targetModel,
   tokenPrices,
   teams = [],
+  agents = [],
   editable,
   onChange,
   onToggle,
@@ -445,6 +483,7 @@ export function Rule({
         entityType={formData.entityType}
         entityId={formData.entityId}
         teams={teams}
+        agents={agents}
         onChange={onEntityChange}
         editable={editable}
       />

--- a/platform/frontend/src/app/llm/(costs)/optimization-rules/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/optimization-rules/page.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import OptimizationRulesPage from "./page";
+
+const mockSetCostsAction = vi.fn();
+const mockUseOptimizationRules = vi.fn();
+
+vi.mock("@/app/llm/(costs)/layout", () => ({
+  useSetCostsAction: () => mockSetCostsAction,
+}));
+
+vi.mock("@/lib/optimization-rule.query", () => ({
+  useOptimizationRules: () => mockUseOptimizationRules(),
+  useCreateOptimizationRule: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateOptimizationRule: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteOptimizationRule: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/lib/teams/team.query", () => ({
+  useTeams: () => ({ data: [{ id: "team-1", name: "Finance" }] }),
+}));
+
+vi.mock("@/lib/agent.query", () => ({
+  useProfiles: () => ({
+    data: [
+      {
+        id: "agent-1",
+        name: "Research Agent",
+        agentType: "agent",
+        description: null,
+      },
+    ],
+  }),
+}));
+
+vi.mock("@/lib/organization.query", () => ({
+  useOrganization: () => ({ data: { id: "org-1" } }),
+}));
+
+vi.mock("@/lib/llm-models.query", () => ({
+  useModelsWithApiKeys: () => ({
+    data: [
+      {
+        modelId: "gpt-4o-mini",
+        provider: "openai",
+        pricePerMillionInput: "0.15",
+        pricePerMillionOutput: "0.60",
+      },
+    ],
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-data-table-query-params", () => ({
+  useDataTableQueryParams: () => ({
+    searchParams: new URLSearchParams(),
+    updateQueryParams: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/loading", () => ({
+  LoadingSpinner: () => <div>Loading</div>,
+  LoadingWrapper: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/components/ui/data-table", () => ({
+  DataTable: ({
+    data,
+    columns,
+  }: {
+    data: Array<Record<string, unknown>>;
+    columns: Array<{
+      accessorKey?: string;
+      cell?: (info: {
+        row: { original: Record<string, unknown> };
+      }) => React.ReactNode;
+    }>;
+  }) => (
+    <div>
+      {data.map((row) => (
+        <div key={String(row.id)} data-testid={`rule-row-${String(row.id)}`}>
+          {columns.map((column, index) => (
+            <span key={column.accessorKey ?? index}>
+              {column.cell
+                ? column.cell({ row: { original: row } })
+                : column.accessorKey
+                  ? String(row[column.accessorKey])
+                  : null}
+            </span>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/permission-button", () => ({
+  PermissionButton: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/llm-model-select", () => ({
+  LlmModelSearchableSelect: () => <div>Model filter</div>,
+}));
+
+vi.mock("@/components/llm-provider-select-items", () => ({
+  LlmProviderOptionLabel: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+vi.mock("@/components/form-dialog", () => ({
+  FormDialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div>{children}</div> : null),
+}));
+
+vi.mock("@/components/delete-confirm-dialog", () => ({
+  DeleteConfirmDialog: () => null,
+}));
+
+vi.mock("@/components/table-row-actions", () => ({
+  TableRowActions: () => null,
+}));
+
+describe("OptimizationRulesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseOptimizationRules.mockReturnValue({
+      data: [],
+      isPending: false,
+    });
+  });
+
+  it("shows agent as an applied-to filter option", () => {
+    render(<OptimizationRulesPage />);
+
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+  });
+
+  it("shows agent name in table for agent-scoped rules", () => {
+    mockUseOptimizationRules.mockReturnValue({
+      data: [
+        {
+          id: "rule-agent",
+          entityType: "agent",
+          entityId: "agent-1",
+          conditions: [{ maxLength: 1000 }],
+          provider: "openai",
+          targetModel: "gpt-4o-mini",
+          enabled: true,
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+        },
+      ],
+      isPending: false,
+    });
+
+    render(<OptimizationRulesPage />);
+
+    const row = screen.getByTestId("rule-row-rule-agent");
+    expect(row).toHaveTextContent("Research Agent");
+    expect(row).not.toHaveTextContent("Unknown team");
+  });
+});

--- a/platform/frontend/src/app/llm/(costs)/optimization-rules/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/optimization-rules/page.tsx
@@ -28,6 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useProfiles } from "@/lib/agent.query";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useModelsWithApiKeys } from "@/lib/llm-models.query";
 import type { OptimizationRule } from "@/lib/optimization-rule.query";
@@ -81,6 +82,9 @@ export default function OptimizationRulesPage() {
   const { data: rules = [], isPending } = useOptimizationRules();
   const { data: modelsWithApiKeys = [] } = useModelsWithApiKeys();
   const { data: teams = [] } = useTeams();
+  const { data: agents = [] } = useProfiles({
+    filters: { agentTypes: ["agent"] },
+  });
   const { data: organization } = useOrganization();
   const createRule = useCreateOptimizationRule();
   const updateRule = useUpdateOptimizationRule();
@@ -157,6 +161,12 @@ export default function OptimizationRulesPage() {
         cell: ({ row }) => {
           if (row.original.entityType === "organization") {
             return "Organization";
+          }
+          if (row.original.entityType === "agent") {
+            const agent = agents.find(
+              (candidate) => candidate.id === row.original.entityId,
+            );
+            return agent?.name ?? "Unknown agent";
           }
           const team = teams.find(
             (candidate) => candidate.id === row.original.entityId,
@@ -242,11 +252,14 @@ export default function OptimizationRulesPage() {
         ),
       },
     ],
-    [teams, updateRule],
+    [agents, teams, updateRule],
   );
 
   async function handleSubmit() {
     if (draft.entityType === "organization" && !organization?.id) {
+      return;
+    }
+    if (draft.entityType !== "organization" && !draft.entityId) {
       return;
     }
 
@@ -316,6 +329,7 @@ export default function OptimizationRulesPage() {
             <SelectItem value="all">All applied to</SelectItem>
             <SelectItem value="organization">Organization</SelectItem>
             <SelectItem value="team">Team</SelectItem>
+            <SelectItem value="agent">Agent</SelectItem>
           </SelectContent>
         </Select>
 
@@ -392,6 +406,7 @@ export default function OptimizationRulesPage() {
               {...draft}
               tokenPrices={tokenPrices}
               teams={teams}
+              agents={agents}
               onChange={setDraft}
               onToggle={(enabled) =>
                 setDraft((current) => ({ ...current, enabled }))
@@ -410,6 +425,7 @@ export default function OptimizationRulesPage() {
               type="submit"
               disabled={
                 !draft.targetModel ||
+                (draft.entityType !== "organization" && !draft.entityId) ||
                 createRule.isPending ||
                 updateRule.isPending
               }


### PR DESCRIPTION
- Scope optimization rule lookup to the agent organization and applicable teams.
- Apply agent, team, then organization precedence at runtime.
- Add regression coverage for cross-org team assignments and agent-rule UI display.
- Update costs docs for scoped optimization rule behavior.