### PR TITLE
fix(cost-stats): correct 90d bucketing, UTC alignment, and savings math

### DIFF
--- a/platform/backend/src/models/statistics.test.ts
+++ b/platform/backend/src/models/statistics.test.ts
@@ -900,5 +900,131 @@ describe("StatisticsModel", () => {
       expect(result).toHaveLength(1);
       expect(result[0].cost).toBeCloseTo(0.15);
     });
+
+    test("buckets 90d data into 3-day windows without projecting timestamps into the future", () => {
+      // Regression guard: the old day-bucketing treated "days since the epoch"
+      // as "day of year" and added it to Jan 1 of the row's year, projecting
+      // 90d buckets ~56 years into the future (e.g. 2024 -> 2080).
+      const data = [
+        {
+          timeBucket: "2024-02-02T00:00:00.000Z",
+          model: "gpt-4",
+          requests: 1,
+          inputTokens: 10,
+          outputTokens: 5,
+          cost: 0.01,
+        },
+        {
+          timeBucket: "2024-02-03T00:00:00.000Z",
+          model: "gpt-4",
+          requests: 2,
+          inputTokens: 20,
+          outputTokens: 10,
+          cost: 0.02,
+        },
+        {
+          timeBucket: "2024-02-10T00:00:00.000Z",
+          model: "gpt-4",
+          requests: 4,
+          inputTokens: 40,
+          outputTokens: 20,
+          cost: 0.04,
+        },
+      ];
+
+      const result = StatisticsModel.groupTimeSeries(data, "90d", "model");
+
+      // Every bucket timestamp must stay in the input's year, not decades later.
+      for (const row of result) {
+        expect(new Date(row.timeBucket).getUTCFullYear()).toBe(2024);
+      }
+      // Feb 2 and Feb 3 share the 3-day window starting Feb 2 (UTC, epoch-aligned);
+      // Feb 10 falls in a later window.
+      expect(result).toHaveLength(2);
+      const [first, second] = result;
+      expect(first.timeBucket).toBe("2024-02-02T00:00:00.000Z");
+      expect(first.requests).toBe(3);
+      expect(first.cost).toBeCloseTo(0.03);
+      expect(second.timeBucket).toBe("2024-02-08T00:00:00.000Z");
+      expect(second.requests).toBe(4);
+      // No cost is lost during re-bucketing.
+      const totalCost = result.reduce((sum, row) => sum + row.cost, 0);
+      expect(totalCost).toBeCloseTo(0.07);
+    });
+
+    test("aligns 7d buckets to UTC 6-hour boundaries", () => {
+      const data = [
+        {
+          timeBucket: "2024-01-15T14:00:00.000Z",
+          model: "gpt-4",
+          requests: 1,
+          inputTokens: 10,
+          outputTokens: 5,
+          cost: 0.01,
+        },
+        {
+          timeBucket: "2024-01-15T17:00:00.000Z",
+          model: "gpt-4",
+          requests: 1,
+          inputTokens: 10,
+          outputTokens: 5,
+          cost: 0.01,
+        },
+      ];
+
+      const result = StatisticsModel.groupTimeSeries(data, "7d", "model");
+
+      // 14:00 and 17:00 both fall in the 12:00-18:00 UTC window.
+      expect(result).toHaveLength(1);
+      expect(result[0].timeBucket).toBe("2024-01-15T12:00:00.000Z");
+      expect(result[0].requests).toBe(2);
+    });
+  });
+
+  describe("getCostSavingsStatistics", () => {
+    test("reports real spend as actual cost and reconciles the savings breakdown", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+      makeInteraction,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+
+      // Real spend 1.00; the same usage would have cost 1.50 on the original
+      // model (0.50 optimization savings); TOON saved 0.20; cache saved 0.30.
+      await makeInteraction(agent.id, {
+        cost: "1.00",
+        baselineCost: "1.50",
+        toonCostSavings: "0.20",
+        cacheSavings: "0.30",
+      });
+
+      const result = await StatisticsModel.getCostSavingsStatistics(
+        "24h",
+        user.id,
+        true,
+      );
+
+      // Actual cost is the real spend — NOT real spend minus toon savings (the
+      // savings are already baked into `cost`, so subtracting them double-counts).
+      expect(result.totalActualCost).toBeCloseTo(1.0);
+      expect(result.totalOptimizationSavings).toBeCloseTo(0.5);
+      expect(result.totalToonSavings).toBeCloseTo(0.2);
+      expect(result.totalCacheSavings).toBeCloseTo(0.3);
+      // Non-optimized cost sits above actual by the sum of all three savings.
+      expect(result.totalBaselineCost).toBeCloseTo(1.0 + 0.5 + 0.2 + 0.3);
+      expect(result.totalSavings).toBeCloseTo(0.5 + 0.2 + 0.3);
+
+      // The per-point gap between the non-optimized and actual lines must equal
+      // the stacked savings breakdown, so the two charts reconcile.
+      expect(result.timeSeries).toHaveLength(1);
+      const point = result.timeSeries[0];
+      expect(point.actualCost).toBeCloseTo(1.0);
+      expect(point.baselineCost - point.actualCost).toBeCloseTo(
+        point.optimizationSavings + point.toonSavings + point.cacheSavings,
+      );
+    });
   });
 });

--- a/platform/backend/src/models/statistics.ts
+++ b/platform/backend/src/models/statistics.ts
@@ -167,41 +167,24 @@ class StatisticsModel {
   }
 
   /**
-   * Round timestamp to bucket interval
+   * Round a timestamp down to the start of its bucket.
+   *
+   * Buckets are aligned to whole multiples of the interval measured from the
+   * Unix epoch (1970-01-01T00:00:00Z) and computed entirely in UTC, so the
+   * result stays consistent with the UTC `.toISOString()` returned here and
+   * with the SQL `DATE_TRUNC` that produced the input. Working purely in epoch
+   * milliseconds also avoids the previous local-time `getFullYear()`/`setDate()`
+   * arithmetic, which mistook "days since the epoch" for "day of year" and
+   * projected multi-day buckets (e.g. the 90d view) decades into the future.
    */
   private static roundToBucket(
     timestamp: string,
     intervalMinutes: number,
   ): string {
-    const date = new Date(timestamp);
-
-    if (intervalMinutes >= 1440) {
-      // 1 day or more
-      const days = Math.floor(intervalMinutes / 1440);
-      const dayOfYear = Math.floor(date.getTime() / (1000 * 60 * 60 * 24));
-      const roundedDay = Math.floor(dayOfYear / days) * days;
-
-      const startOfYear = new Date(date.getFullYear(), 0, 1);
-      startOfYear.setDate(startOfYear.getDate() + roundedDay);
-      startOfYear.setHours(0, 0, 0, 0);
-      return startOfYear.toISOString();
-    } else if (intervalMinutes >= 60) {
-      // 1 hour or more
-      const hours = Math.floor(intervalMinutes / 60);
-      const hourOfDay = date.getHours();
-      const roundedHour = Math.floor(hourOfDay / hours) * hours;
-
-      date.setHours(roundedHour, 0, 0, 0);
-      return date.toISOString();
-    } else {
-      // Less than 1 hour
-      const minutes = date.getMinutes();
-      const roundedMinutes =
-        Math.floor(minutes / intervalMinutes) * intervalMinutes;
-
-      date.setMinutes(roundedMinutes, 0, 0);
-      return date.toISOString();
-    }
+    const intervalMs = intervalMinutes * 60 * 1000;
+    const ms = new Date(timestamp).getTime();
+    const rounded = Math.floor(ms / intervalMs) * intervalMs;
+    return new Date(rounded).toISOString();
   }
 
   /**
@@ -380,18 +363,11 @@ class StatisticsModel {
 
     const rawTimeSeriesData = await query;
 
-    // Debug logging for 1h timeframe only
-    if (timeframe === "1h") {
-    }
-
     const timeSeriesData = StatisticsModel.groupTimeSeries(
       rawTimeSeriesData,
       timeframe,
       "teamId",
     );
-
-    if (timeframe === "1h") {
-    }
 
     // Get team member counts
     const teamMemberCounts = await db
@@ -557,18 +533,11 @@ class StatisticsModel {
 
     const rawTimeSeriesData = await query;
 
-    // Debug logging for 1h timeframe only
-    if (timeframe === "1h") {
-    }
-
     const timeSeriesData = StatisticsModel.groupTimeSeries(
       rawTimeSeriesData,
       timeframe,
       "agentId",
     );
-
-    if (timeframe === "1h") {
-    }
 
     // Aggregate data by agent
     const agentMap = new Map<string, AgentStatistics>();
@@ -799,20 +768,6 @@ class StatisticsModel {
   }
 
   /**
-   * Calculate actual cost: cost - toon_savings
-   * This represents the final cost after all optimizations
-   * - cost = cost after model optimization
-   * - toonSavings = savings from TOON compression
-   * - actual cost = cost after both model optimization and TOON
-   */
-  private static calculateActualCost(
-    cost: number,
-    toonSavings: number,
-  ): number {
-    return cost - toonSavings;
-  }
-
-  /**
    * Get cost savings statistics
    */
   static async getCostSavingsStatistics(
@@ -951,13 +906,31 @@ class StatisticsModel {
     let totalCacheSavings = 0;
 
     const timeSeries = timeSeriesData.map((row) => {
-      const baselineCost = Number(row.baselineCost);
-      const cost = Number(row.actualCost);
+      // `row.actualCost` is SUM(interactions.cost): the real spend. It already
+      // reflects every applied optimization — the cheaper model, TOON's reduced
+      // billed token count, and the prompt-cache discount — so it is the true
+      // "Actual Cost". (The previous code subtracted toonSavings from it, which
+      // double-counted savings already baked into `cost` and reported an actual
+      // cost below what was really spent.)
+      const actualCost = Number(row.actualCost);
+      // `row.baselineCost` is SUM(interactions.baseline_cost): the same usage
+      // priced at the original (pre-optimization) model.
+      const baselineModelCost = Number(row.baselineCost);
       const toonSavings = Number(row.toonSavings);
       const cacheSavings = Number(row.cacheSavings);
 
-      const actualCost = StatisticsModel.calculateActualCost(cost, toonSavings);
-      const optimizationSavings = baselineCost - cost;
+      // Savings from optimization rules alone: identical token usage, original
+      // model vs. the model actually used.
+      const optimizationSavings = baselineModelCost - actualCost;
+
+      // "Non-optimized" cost: what the request would have cost with none of the
+      // optimizations applied (original model, uncompressed tokens, no cache).
+      // Adding each realized saving back onto the real spend keeps this line
+      // exactly `optimizationSavings + toonSavings + cacheSavings` above the
+      // actual-cost line, so the savings-breakdown chart reconciles with the
+      // gap shown in the non-optimized-vs-actual chart.
+      const baselineCost =
+        actualCost + optimizationSavings + toonSavings + cacheSavings;
 
       totalBaselineCost += baselineCost;
       totalActualCost += actualCost;

--- a/platform/backend/src/test/fixtures.ts
+++ b/platform/backend/src/test/fixtures.ts
@@ -812,7 +812,16 @@ async function makeInteraction(
   overrides: Partial<
     Pick<
       InsertInteraction,
-      "request" | "response" | "type" | "model" | "inputTokens" | "outputTokens"
+      | "request"
+      | "response"
+      | "type"
+      | "model"
+      | "inputTokens"
+      | "outputTokens"
+      | "cost"
+      | "baselineCost"
+      | "toonCostSavings"
+      | "cacheSavings"
     >
   > = {},
 ) {


### PR DESCRIPTION
## Summary

Fixes three bugs in the aggregation that powers the `/llm/cost/statistics` graphs (`StatisticsModel`), found during an audit. Per-interaction cost math (`calculateCost`) was correct — all three are in the statistics aggregation layer.

### 1. 90d charts plotted buckets ~56 years in the future (critical)
`roundToBucket`'s day-branch treated *days since the Unix epoch* as *day of year* and added it to Jan 1 of the row's year, so e.g. Feb 2024 rendered as 2080. The `90d` timeframe is the only path that reached this branch. Rewrote `roundToBucket` to align to whole interval multiples from the epoch using pure epoch-millisecond arithmetic.

### 2. Bucket boundaries were timezone-dependent
The old code mixed local-time getters/setters (`getHours`/`getMinutes`/`getFullYear`) with a UTC `.toISOString()` result and UTC SQL `DATE_TRUNC` input. On non-UTC servers the `7d` (6h) and minute buckets drifted off their boundaries. The epoch-ms rewrite computes everything in UTC, so it matches `DATE_TRUNC` and the emitted timestamps.

### 3. Cost-savings "Actual Cost" understated real spend
`actualCost` was computed as `cost - toonSavings`, but `interactions.cost` already reflects the TOON-compressed (lower) billed token count, so this double-counted savings. Actual cost is now the stored `cost` (real spend), and the non-optimized baseline is built up as `actualCost + optimizationSavings + toonSavings + cacheSavings`. This makes the gap in the non-optimized-vs-actual chart equal the stacked savings-breakdown chart (which previously omitted cache savings entirely).

Also removed dead empty `if (timeframe === "1h") {}` debug blocks.

## Tests
- `groupTimeSeries` regression tests: 90d (no future timestamps) and 7d (UTC 6h alignment).
- `getCostSavingsStatistics` test: asserts actual cost = real spend and that the savings breakdown reconciles with the non-optimized-vs-actual gap.
- Extended the `makeInteraction` fixture to accept `cost`/`baselineCost`/`toonCostSavings`/`cacheSavings`.
- Response schema is unchanged. `pnpm type-check` and Biome pass; all 32 tests in `statistics.test.ts` pass.