### PR TITLE
fix(bench): gate submit instruction to the final stage of multi-stage tasks

### DIFF
--- a/archestra-bench/runner/src/config/envs.rs
+++ b/archestra-bench/runner/src/config/envs.rs
@@ -7,8 +7,8 @@ use super::toml_util::{self, TomlTable};
 use super::types::{EnvConfig, Mcp, PlatformConfig, SkillRef, ToolExposureMode};
 
 // Empty by default: lanes mimic a regular Archestra user who sets no custom system prompt, so the
-// agent runs on Archestra's stock chat instructions. Submission guidance is appended to the user
-// message instead (see SUBMIT_INSTRUCTION in run.rs).
+// agent runs on Archestra's stock chat instructions. Submission guidance is appended to the
+// final-stage user message instead (see SUBMIT_INSTRUCTION in run.rs).
 const DEFAULT_SYSTEM_PROMPT: &str = "";
 
 #[derive(Debug, thiserror::Error)]

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -35,13 +35,20 @@ use crate::verify::{VerifyOutcome, run_verifier};
 // lane only ever discovers its own server); isolated lanes own their backend and use the bare name.
 const BENCH_MCP_NAME: &str = "final_answer";
 const SUBMIT_TOOL_SUFFIX: &str = "__submit_result";
-// Appended to every user message. Kept short and tool-agnostic: it nudges submission without naming
-// the search/run meta-tools (Archestra's stock prompt already explains discovery), so a model that
-// solves the task still closes the loop by finding and calling its submit tool instead of replying in
-// prose.
+// Appended to a stage's user message only when submission is open (the final stage; submit_result is
+// server-gated until then). Kept short and tool-agnostic: it nudges submission without naming the
+// search/run meta-tools (Archestra's stock prompt already explains discovery), so a model that solves
+// the task still closes the loop by finding and calling its submit tool instead of replying in prose.
 const SUBMIT_INSTRUCTION: &str = "When you are done, find a tool to submit your final result -- replying in chat does not submit it.";
-// One-shot follow-up sent when a lane ends its turn without submitting. drive_stage still appends
-// SUBMIT_INSTRUCTION, so this only has to call out the omission.
+// Appended instead of SUBMIT_INSTRUCTION on a non-final stage, where submit_result is still gated.
+// Deliberately says nothing about submitting: a real user does not mention the hand-in protocol until
+// the final ask, so the model learns submission is required only on the final stage. Steers the model
+// to do the step's work and end its turn (a chat reply, which advances the runner to the next stage)
+// rather than hunting for a submit tool and looping on the "more steps" rejection.
+const CONTINUE_INSTRUCTION: &str = "When you've finished this step, tell me where things stand and wait for my next message.";
+// One-shot follow-up sent when a lane ends its turn without submitting. The nudge runs on the final
+// stage (submission open), so drive_stage still appends SUBMIT_INSTRUCTION; this only calls out the
+// omission.
 const SUBMIT_NUDGE: &str = "You ended your turn without submitting a result. The task is not complete until you submit it.";
 const STATE_NAME: &str = "state.json";
 const MAX_WORKERS_CAP: usize = 4;
@@ -1310,8 +1317,8 @@ async fn grade_rollout(
     ]);
 
     // Capture once: the agent's configured system prompt plus the expanded stage-0 task text
-    // (pre-SUBMIT_INSTRUCTION, i.e. the human-authored prompt). drive_stage appends
-    // SUBMIT_INSTRUCTION when it actually sends each stage.
+    // (the human-authored prompt, before any trailing instruction). drive_stage appends the trailer
+    // when it sends each stage: SUBMIT_INSTRUCTION on the final stage, CONTINUE_INSTRUCTION otherwise.
     let initial_user_message = task
         .stages
         .first()
@@ -1331,7 +1338,11 @@ async fn grade_rollout(
     let mut stage_error: Option<String> = None;
     let final_stage = task.stages.len().saturating_sub(1);
     for (index, stage) in task.stages.iter().enumerate() {
-        if index == final_stage {
+        // Single source of truth: the final stage both opens the server-side submission gate and gets
+        // the SUBMIT_INSTRUCTION trailer (earlier stages get CONTINUE_INSTRUCTION). Binding it once
+        // keeps the gate and the prompt trailer from drifting apart.
+        let submission_open = index == final_stage;
+        if submission_open {
             bench_mcp.allow_submission(rollout_key).await;
         }
         stage_error = drive_stage_with_retry(
@@ -1343,6 +1354,7 @@ async fn grade_rollout(
             artifacts,
             &runtime,
             index > 0,
+            submission_open,
         )
         .await?;
         if stage_error.is_some() {
@@ -1379,6 +1391,7 @@ async fn grade_rollout(
             &mut run,
             artifacts,
             &runtime,
+            true,
             true,
         )
         .await?;
@@ -1573,6 +1586,7 @@ async fn drive_stage_with_retry(
     artifacts: &RunArtifacts,
     runtime: &HashMap<String, String>,
     expect_prior_history: bool,
+    submission_open: bool,
 ) -> Result<Option<String>, RunError> {
     // Resend prior turns so the agent keeps task context across stages and submit-nudges; the
     // platform builds LLM context from the request body only. The first turn has no history yet;
@@ -1604,6 +1618,7 @@ async fn drive_stage_with_retry(
         runtime,
         &prior_messages,
         &turn_id,
+        submission_open,
     )
     .await?;
     let Some(error) = first else {
@@ -1626,6 +1641,7 @@ async fn drive_stage_with_retry(
         runtime,
         &prior_messages,
         &turn_id,
+        submission_open,
     )
     .await
 }
@@ -1641,6 +1657,18 @@ fn stage_error_is_retryable(error: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Assemble a stage's user message: the (runtime-expanded) stage text plus the trailing instruction.
+/// On the final stage submission is open, so SUBMIT_INSTRUCTION is appended; on earlier stages it is
+/// gated, so CONTINUE_INSTRUCTION is appended instead (which reveals nothing about submission).
+fn stage_message(stage_text: &str, submission_open: bool) -> String {
+    let trailer = if submission_open {
+        SUBMIT_INSTRUCTION
+    } else {
+        CONTINUE_INSTRUCTION
+    };
+    format!("{stage_text}\n\n{trailer}")
+}
+
 async fn drive_stage(
     client: &EvalClient,
     conversation_id: &str,
@@ -1651,6 +1679,7 @@ async fn drive_stage(
     runtime: &HashMap<String, String>,
     prior_messages: &[serde_json::Value],
     turn_id: &str,
+    submission_open: bool,
 ) -> Result<Option<String>, RunError> {
     let files: Vec<FilePart> = stage
         .files
@@ -1665,10 +1694,7 @@ async fn drive_stage(
             data: std::fs::read(task.inputs_dir().join(&f.src)).unwrap_or_default(),
         })
         .collect();
-    let text = format!(
-        "{}\n\n{SUBMIT_INSTRUCTION}",
-        expand_runtime(&stage.text, runtime)
-    );
+    let text = stage_message(&expand_runtime(&stage.text, runtime), submission_open);
     let mut stream_parse_error: Option<String> = None;
     let mut coalescer = StreamCoalescer::new(artifacts);
     run.stage_tokens = None;
@@ -2450,6 +2476,24 @@ mod tests {
     fn test_rollout_token() {
         let token = rollout_token("basic/t1/openai/gpt-4", "gpt-4-turbo");
         assert!(token.starts_with("gpt-4-turbo-"));
+    }
+
+    #[test]
+    fn test_stage_message_final_appends_submit() {
+        // Final stage: submission is open, so the hand-in instruction is appended (unchanged behavior).
+        let msg = stage_message("do the thing", true);
+        assert_eq!(msg, format!("do the thing\n\n{SUBMIT_INSTRUCTION}"));
+        assert!(msg.ends_with(SUBMIT_INSTRUCTION));
+    }
+
+    #[test]
+    fn test_stage_message_nonfinal_appends_continue() {
+        // Non-final stage: submission is gated, so the continuation line is appended and the message
+        // reveals nothing about submitting.
+        let msg = stage_message("do the thing", false);
+        assert_eq!(msg, format!("do the thing\n\n{CONTINUE_INSTRUCTION}"));
+        assert!(!msg.contains(SUBMIT_INSTRUCTION));
+        assert!(!msg.to_lowercase().contains("submit"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In a multi-stage task, `drive_stage` appended `SUBMIT_INSTRUCTION` ("find a tool to submit your final result") to **every** stage's user message. But `submit_result` is server-gated until the final stage — `allow_submission` is called only at `index == final_stage` (`runner/src/run.rs`), and before that the bench MCP server rejects with *"This task has more steps to complete"* (`runner/src/mcp_server.rs`).

So on non-final stages the harness instructed the model to do exactly the action the server rejects. In run `20260621_184407` this produced a thrash loop on the only multi-stage task (`pi-gif-zip`) across all four lanes — `pi-gif-zip__minimax-3` spent ~10 steps scaffolding an irrelevant app before giving up and ending its turn.

## Fix

Thread a `submission_open` flag (`= index == final_stage`) through `drive_stage_with_retry` → `drive_stage` and gate the trailer:

- **Final stage** (and the post-loop submit-nudge): `SUBMIT_INSTRUCTION`, unchanged.
- **Non-final stages**: a new `CONTINUE_INSTRUCTION` that steers the model to do the step and end its turn (which advances the runner) and **deliberately reveals nothing about submission** — a real multi-turn user only names the deliverable at the end, so the model learns a submission is required only on the final stage.

The predicate is bound once per loop iteration so the server gate and the prompt trailer cannot drift apart.

## Scope

- Single-stage tasks (14/15) are byte-identical: `final_stage == 0`, so their only stage is the final stage and still gets `SUBMIT_INSTRUCTION`.
- Out of scope (optional follow-ups): rewording the `mcp_server.rs` gate message; an upfront "this task has N steps" announcement.

## Validation

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p archestra_bench` — 85 unit + 3 integration pass, incl. 2 new `stage_message` tests

Reviewed adversarially by two independent gates (external codex + internal subagent); both returned SHIP. Their shared minor finding (gate/trailer predicate could desync) is addressed structurally by the single-binding refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>