### PR TITLE
fix(projects): stop 404 storm and error toasts on project delete

### DIFF
--- a/platform/frontend/src/lib/projects/projects.query.ts
+++ b/platform/frontend/src/lib/projects/projects.query.ts
@@ -1,7 +1,17 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { getApiErrorType, handleApiError } from "@/lib/utils";
+
+/**
+ * A project the user is viewing can vanish — deleted in this tab, or by someone
+ * else who shared it. The detail page already renders that gracefully ("Project
+ * not found."), so a not-found is an expected empty state, not an error worth a
+ * toast + Sentry capture. Other failures still surface normally.
+ */
+function isProjectNotFound(error: unknown): boolean {
+  return getApiErrorType(error) === "api_not_found_error";
+}
 
 const {
   createProject,
@@ -37,7 +47,7 @@ export function useProject(id: string | undefined) {
         path: { id: id as string },
       });
       if (error) {
-        handleApiError(error);
+        if (!isProjectNotFound(error)) handleApiError(error);
         return null;
       }
       return data;
@@ -54,7 +64,7 @@ export function useProjectConversations(id: string | undefined) {
         path: { id: id as string },
       });
       if (error) {
-        handleApiError(error);
+        if (!isProjectNotFound(error)) handleApiError(error);
         return null;
       }
       return data;
@@ -73,7 +83,7 @@ export function useProjectFiles(id: string | undefined) {
         path: { id: id as string },
       });
       if (error) {
-        handleApiError(error);
+        if (!isProjectNotFound(error)) handleApiError(error);
         return null;
       }
       return data;
@@ -171,7 +181,11 @@ export function useDeleteProject() {
       toast.success(
         "Project deleted — its chats were kept as ordinary conversations.",
       );
-      queryClient.invalidateQueries({ queryKey: ["projects"] });
+      // Refresh only the project LIST. `exact` keeps this from prefix-matching
+      // — and thus refetching — the deleted project's own detail/conversations/
+      // files queries, which are still mounted for the instant before we
+      // navigate away and would 404 on the now-gone id.
+      queryClient.invalidateQueries({ queryKey: ["projects"], exact: true });
     },
   });
 }

--- a/platform/frontend/src/lib/utils/api.ts
+++ b/platform/frontend/src/lib/utils/api.ts
@@ -52,6 +52,24 @@ export function getApiErrorMessage(error: unknown): string {
 }
 
 /**
+ * The machine-readable `type` of an API error (e.g. `"api_not_found_error"`),
+ * if present. Lets a caller branch on the kind of failure — e.g. treat a
+ * not-found as an expected empty state instead of toasting it as an error.
+ */
+export function getApiErrorType(error: unknown): string | undefined {
+  const unwrapped = unwrapApiError(error);
+  if (
+    typeof unwrapped === "object" &&
+    unwrapped !== null &&
+    "type" in unwrapped &&
+    typeof (unwrapped as { type?: unknown }).type === "string"
+  ) {
+    return (unwrapped as { type: string }).type;
+  }
+  return undefined;
+}
+
+/**
  * Convert an API SDK error object into a proper Error instance.
  * Use this instead of `throw error` to avoid Sentry's
  * "Object captured as exception with keys: error" warning.

--- a/platform/frontend/src/lib/utils/index.ts
+++ b/platform/frontend/src/lib/utils/index.ts
@@ -1,4 +1,9 @@
-export { getApiErrorMessage, handleApiError, toApiError } from "./api";
+export {
+  getApiErrorMessage,
+  getApiErrorType,
+  handleApiError,
+  toApiError,
+} from "./api";
 export {
   formatDate,
   formatRelativeTime,


### PR DESCRIPTION
## Problem

Deleting a project fired **three 404s right after the successful `DELETE`** — `GET` on the project, its conversations, and its files — each surfaced as a 12-second red error toast plus a Sentry capture. From a captured session:

```
DELETE /api/projects/{id}              200
GET    /api/projects/{id}              404   ← "Project not found"
GET    /api/projects/{id}/conversations 404
GET    /api/projects/{id}/files         404
GET    /api/projects                   200
```

The backend response is actually informative (`{"error":{"message":"Project not found","type":"api_not_found_error"}}`); the noise is entirely frontend-side.

## Root cause

`useDeleteProject.onSuccess` invalidated `["projects"]`. TanStack Query invalidation is **prefix-matching**, so `["projects"]` also matched the deleted project's still-mounted `["projects", id]`, `["projects", id, "conversations"]` and `["projects", id, "files"]` queries and refetched them against the now-gone id — three guaranteed 404s, fired the same instant as the navigation away.

## Fix

1. **`exact: true`** on the delete's list invalidation — refreshes only the project list, never the deleted project's sub-resource queries. *(the load-bearing fix)*
2. **Not-found = expected empty state**, scoped to `useProject` / `useProjectConversations` / `useProjectFiles`: on `api_not_found_error` they skip `handleApiError` and return `null`; the page already renders "Project not found." gracefully. Defense-in-depth for the 5s files poll race, back-navigation, and a **shared project deleted by its owner** while a teammate is viewing it.
3. Adds `getApiErrorType(error)` to `lib/utils/api.ts` (+ barrel) to read the error's machine `type` for that check.

## Validation (live, against local stack)

Repro'd the exact flow — create project → open it (chats list + Files panel mounted) → delete:

| | Before | After |
|---|---|---|
| `DELETE /api/projects/{id}` | 200 | 200 |
| three `GET …/{id}[/conversations|/files]` | **404 ×3** | not fired |
| `GET /api/projects` (list) | 200 | 200 |
| error toasts / Sentry | 3 | **none** |
| console | 3 errors | clean |

Static checks: `pnpm type-check`, `pnpm knip`, `biome ci` all clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>