### PR TITLE
feat(projects): require an LLM provider key + drop chat count on project cards

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { UIMessage } from "@ai-sdk/react";
-import { type ChatSkillMetadata, E2eTestId } from "@archestra/shared";
+import type { ChatSkillMetadata } from "@archestra/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
@@ -56,12 +56,11 @@ import {
 } from "@/components/chat/right-side-panel";
 import { ShareConversationDialog } from "@/components/chat/share-conversation-dialog";
 import { StreamTimeoutWarning } from "@/components/chat/stream-timeout-warning";
-import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
-import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-key-form";
 import { LoadingSpinner } from "@/components/loading";
 import MessageThread, {
   type PartialUIMessage,
 } from "@/components/message-thread";
+import { NoApiKeySetup } from "@/components/no-api-key-setup";
 import { StandardDialog } from "@/components/standard-dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -1800,7 +1799,9 @@ export function ChatPageContent({
 
   // If API key is not configured, show setup prompt with inline creation dialog
   if (!hasAnyApiKey) {
-    return <NoApiKeySetup />;
+    // Reset to a clean /chat URL after a key is added so no stale conversation
+    // param lingers; the keys query refetch then reveals the composer.
+    return <NoApiKeySetup onKeyAdded={() => router.push("/chat")} />;
   }
 
   // If no agents exist and we're not viewing a conversation with a deleted agent, show empty state
@@ -2504,49 +2505,4 @@ type ChatMessagePart =
 // so the message is well-formed and the backend can inject the skill
 function ensureNonEmptyParts(parts: ChatMessagePart[]): ChatMessagePart[] {
   return parts.length === 0 ? [{ type: "text", text: "" }] : parts;
-}
-
-// =========================================================================
-// No API Key Setup — shown when user has no API keys configured
-// =========================================================================
-
-const DEFAULT_FORM_VALUES: Partial<LlmProviderApiKeyFormValues> = {
-  isPrimary: true,
-};
-
-function NoApiKeySetup() {
-  const router = useRouter();
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-
-  return (
-    <div className="flex h-full w-full items-center justify-center p-8">
-      <div className="text-center space-y-4">
-        <div className="space-y-2">
-          <h2 className="text-xl font-semibold">Add an LLM Provider Key</h2>
-          <p className="text-sm text-muted-foreground">
-            Connect an LLM provider to start chatting
-          </p>
-        </div>
-        <Button
-          data-testid={E2eTestId.QuickstartAddApiKeyButton}
-          onClick={() => setIsDialogOpen(true)}
-        >
-          <Plus className="h-4 w-4" />
-          Add API Key
-        </Button>
-      </div>
-      <CreateLlmProviderApiKeyDialog
-        open={isDialogOpen}
-        onOpenChange={setIsDialogOpen}
-        title="Add API Key"
-        description="Add an LLM provider API key to start chatting"
-        defaultValues={DEFAULT_FORM_VALUES}
-        showConsoleLink
-        onSuccess={() => {
-          // Navigate to clean /chat URL so there's no stale conversation param
-          router.push("/chat");
-        }}
-      />
-    </div>
-  );
 }

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -8,12 +8,14 @@ import { useForm } from "react-hook-form";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { AgentIcon } from "@/components/agent-icon";
 import { AgentIconPicker } from "@/components/agent-icon-picker";
+import { NoApiKeySetup } from "@/components/no-api-key-setup";
 import { PageLayout } from "@/components/page-layout";
 import { StandardFormDialog } from "@/components/standard-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { useHasAnyApiKey } from "@/lib/llm-provider-api-keys.query";
 import { useCreateProject, useProjects } from "@/lib/projects/projects.query";
 
 export default function ProjectsPageClient() {
@@ -24,20 +26,36 @@ export default function ProjectsPageClient() {
   );
 }
 
+const PROJECTS_DESCRIPTION =
+  "Collections of chats with shared files. Share a project to let teammates follow along and start their own chats.";
+
 function ProjectsList() {
   const { data, isPending } = useProjects();
+  const { hasAnyApiKey, isLoading: isApiKeyLoading } = useHasAnyApiKey();
   const [createOpen, setCreateOpen] = useState(false);
   const projects = data ?? [];
+
+  // Mirror the new-chat screen: with no usable LLM key there's nothing to run a
+  // project on, so prompt to add one instead of offering project creation.
+  if (!isApiKeyLoading && !hasAnyApiKey) {
+    return (
+      <PageLayout title="Projects" description={PROJECTS_DESCRIPTION}>
+        <NoApiKeySetup />
+      </PageLayout>
+    );
+  }
 
   return (
     <PageLayout
       title="Projects"
-      description="Collections of chats with shared files. Share a project to let teammates follow along and start their own chats."
+      description={PROJECTS_DESCRIPTION}
       actionButton={
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          New project
-        </Button>
+        hasAnyApiKey ? (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            New project
+          </Button>
+        ) : undefined
       }
     >
       <CreateProjectDialog open={createOpen} onOpenChange={setCreateOpen} />

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -98,10 +98,6 @@ function ProjectsList() {
                   {project.description}
                 </p>
               )}
-              <p className="mt-2 text-xs text-muted-foreground">
-                {project.conversationCount}{" "}
-                {project.conversationCount === 1 ? "chat" : "chats"}
-              </p>
             </Link>
           ))}
         </div>

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -40,7 +40,7 @@ function ProjectsList() {
   if (!isApiKeyLoading && !hasAnyApiKey) {
     return (
       <PageLayout title="Projects" description={PROJECTS_DESCRIPTION}>
-        <NoApiKeySetup />
+        <NoApiKeySetup description="Connect an LLM provider to start a project" />
       </PageLayout>
     );
   }

--- a/platform/frontend/src/components/no-api-key-setup.tsx
+++ b/platform/frontend/src/components/no-api-key-setup.tsx
@@ -17,10 +17,18 @@ const DEFAULT_FORM_VALUES: Partial<LlmProviderApiKeyFormValues> = {
  * mutation invalidates the keys query, so the calling screen reactively shows
  * its real content once a key exists.
  *
+ * @param description subtitle under the heading; defaults to the chat copy so
+ * each surface can phrase the "why" for its own context.
  * @param onKeyAdded extra work after a key is created (e.g. the chat screen
  * resets its URL). Optional — most callers just rely on the query refetch.
  */
-export function NoApiKeySetup({ onKeyAdded }: { onKeyAdded?: () => void }) {
+export function NoApiKeySetup({
+  description = "Connect an LLM provider to start chatting",
+  onKeyAdded,
+}: {
+  description?: string;
+  onKeyAdded?: () => void;
+}) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
@@ -28,9 +36,7 @@ export function NoApiKeySetup({ onKeyAdded }: { onKeyAdded?: () => void }) {
       <div className="text-center space-y-4">
         <div className="space-y-2">
           <h2 className="text-xl font-semibold">Add an LLM Provider Key</h2>
-          <p className="text-sm text-muted-foreground">
-            Connect an LLM provider to start chatting
-          </p>
+          <p className="text-sm text-muted-foreground">{description}</p>
         </div>
         <Button
           data-testid={E2eTestId.QuickstartAddApiKeyButton}

--- a/platform/frontend/src/components/no-api-key-setup.tsx
+++ b/platform/frontend/src/components/no-api-key-setup.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { E2eTestId } from "@archestra/shared";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
+import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-key-form";
+import { Button } from "@/components/ui/button";
+
+const DEFAULT_FORM_VALUES: Partial<LlmProviderApiKeyFormValues> = {
+  isPrimary: true,
+};
+
+/**
+ * Empty state shown when the user has no usable LLM provider key — on the new
+ * chat screen and the projects page. Lets them add a key inline; the create
+ * mutation invalidates the keys query, so the calling screen reactively shows
+ * its real content once a key exists.
+ *
+ * @param onKeyAdded extra work after a key is created (e.g. the chat screen
+ * resets its URL). Optional — most callers just rely on the query refetch.
+ */
+export function NoApiKeySetup({ onKeyAdded }: { onKeyAdded?: () => void }) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <div className="text-center space-y-4">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Add an LLM Provider Key</h2>
+          <p className="text-sm text-muted-foreground">
+            Connect an LLM provider to start chatting
+          </p>
+        </div>
+        <Button
+          data-testid={E2eTestId.QuickstartAddApiKeyButton}
+          onClick={() => setIsDialogOpen(true)}
+        >
+          <Plus className="h-4 w-4" />
+          Add API Key
+        </Button>
+      </div>
+      <CreateLlmProviderApiKeyDialog
+        open={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        title="Add API Key"
+        description="Add an LLM provider API key to start chatting"
+        defaultValues={DEFAULT_FORM_VALUES}
+        showConsoleLink
+        onSuccess={onKeyAdded}
+      />
+    </div>
+  );
+}

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.ts
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.ts
@@ -6,6 +6,7 @@ import {
 } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { handleApiError, toApiError } from "@/lib/utils";
 
 export type { SupportedProvider };
@@ -57,6 +58,31 @@ export function useLlmProviderApiKeys(params?: LlmProviderApiKeysQueryParams) {
     },
     enabled: params?.enabled,
   });
+}
+
+/**
+ * Whether the user has any usable LLM provider key — the same check the new
+ * chat screen uses to choose between the composer and the "Add an LLM Provider
+ * Key" prompt. System keys for keyless providers (Vertex AI Gemini, vLLM,
+ * Ollama) count, since they surface as keys here. Gated on the read permissions
+ * the underlying query needs, so a user lacking them doesn't trigger a 403.
+ */
+export function useHasAnyApiKey(): {
+  hasAnyApiKey: boolean;
+  isLoading: boolean;
+} {
+  const { data: canReadKeys } = useHasPermissions({
+    llmProviderApiKey: ["read"],
+  });
+  const { data: canReadModels } = useHasPermissions({ llmModel: ["read"] });
+  const enabled = canReadKeys === true && canReadModels === true;
+  const { data: keys = [], isLoading } = useLlmProviderApiKeys({ enabled });
+  const permissionsResolving =
+    canReadKeys === undefined || canReadModels === undefined;
+  return {
+    hasAnyApiKey: keys.length > 0,
+    isLoading: permissionsResolving || (enabled && isLoading),
+  };
 }
 
 export function useAvailableLlmProviderApiKeys(


### PR DESCRIPTION
Two small projects-page changes.

## 1. Require an LLM provider key before creating a project

A project only makes sense once you can chat in it, so the projects page now mirrors the **new-chat** screen: with no usable LLM provider key it shows the same "Add an LLM Provider Key" prompt instead of the project list and "New project" button. Adding a key invalidates the keys query, so the page reveals its real content without a reload.

- Extracts the new-chat `NoApiKeySetup` empty state into a shared `src/components/no-api-key-setup.tsx` (with an optional `onKeyAdded` callback so chat keeps its `/chat` redirect, and a `description` prop so each surface phrases the "why" for its own context — chat keeps "…to start chatting", projects says "…to start a project").
- Adds `useHasAnyApiKey()` to `lib/llm-provider-api-keys.query.ts` — the same permission-gated keys check the chat screen uses.
- `app/projects/page.client.tsx` renders `NoApiKeySetup` when there's no key and hides "New project" until a key exists.

## 2. Drop the chat count from project cards

Removed the per-project "N chats" line — noise without much signal. `conversationCount` stays in the API response for other consumers.

## Validation (live, local stack)
- Project cards no longer show a chat count.
- With a key configured, the projects page renders normally and "New project" works.
- The chat screen still renders the composer after the `NoApiKeySetup` extraction.
- The no-key empty state wasn't exercised live (this stack has a key configured), but it reuses the same component + `hasAnyApiKey` check as the already-proven chat no-key flow.

`pnpm type-check`, `pnpm knip`, `biome ci` — all clean.

## Commits
1. `feat(projects): require an LLM provider key before creating a project`
2. `feat(projects): drop the chat count from project cards`
3. `fix(projects): phrase the no-key empty state for projects, not chat`

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>