### PR TITLE
fix(chat): respect prompt draft and selected agent in chat flows

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -1,6 +1,7 @@
 import { E2eTestId } from "@archestra/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NEW_CHAT_DRAFT_STORAGE_KEY } from "@/lib/chat/chat-utils";
 
 const {
   mockUseOrganization,
@@ -665,7 +666,9 @@ describe("ArchestraPromptInput", () => {
     it("flag on: Send anyway with a throwing consumer keeps the draft and does not hang", () => {
       mockFeatureState.chatSecretScanEnabled = true;
       const agentId = "agent-1";
-      const draftKey = `archestra_chat_draft_new_${agentId}`;
+      // The new-chat draft key is agent-independent (so a typed prompt survives
+      // an agent switch); the agentId prop below no longer affects the key.
+      const draftKey = NEW_CHAT_DRAFT_STORAGE_KEY;
       const text = `please rotate ${fakeGithubToken}`;
       localStorage.setItem(draftKey, text);
       mockControllerState.value = text;
@@ -704,7 +707,9 @@ describe("ArchestraPromptInput", () => {
     it("flag on: Send anyway with an async-rejecting consumer keeps the draft and does not hang", async () => {
       mockFeatureState.chatSecretScanEnabled = true;
       const agentId = "agent-1";
-      const draftKey = `archestra_chat_draft_new_${agentId}`;
+      // The new-chat draft key is agent-independent (so a typed prompt survives
+      // an agent switch); the agentId prop below no longer affects the key.
+      const draftKey = NEW_CHAT_DRAFT_STORAGE_KEY;
       const text = `please rotate ${fakeGithubToken}`;
       localStorage.setItem(draftKey, text);
       mockControllerState.value = text;
@@ -803,7 +808,9 @@ describe("ArchestraPromptInput", () => {
 
   describe("draft retention on submit", () => {
     const agentId = "agent-1";
-    const draftKey = `archestra_chat_draft_new_${agentId}`;
+    // The new-chat draft key is agent-independent (so a typed prompt survives
+    // an agent switch); the agentId prop below no longer affects the key.
+    const draftKey = NEW_CHAT_DRAFT_STORAGE_KEY;
 
     it("keeps the saved draft when the consumer rejects the submit", () => {
       const text = "draft text the user typed";

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -34,7 +34,10 @@ import { SensitiveDataConfirmDialog } from "@/components/chat/sensitive-data-con
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useConversation, useToggleHooksDebug } from "@/lib/chat/chat.query";
 import { useChatPlaceholder } from "@/lib/chat/chat-placeholder.hook";
-import { conversationStorageKeys } from "@/lib/chat/chat-utils";
+import {
+  chatDraftStorageKey,
+  migrateLegacyNewChatDraft,
+} from "@/lib/chat/chat-utils";
 import { useFeature } from "@/lib/config/config.query";
 import { useOrganization } from "@/lib/organization.query";
 import { scanText } from "@/lib/sensitive-data";
@@ -209,11 +212,19 @@ const PromptInputContent = ({
     skillCommands,
   ]);
 
-  const storageKey = conversationId
-    ? conversationStorageKeys(conversationId).draft
-    : `archestra_chat_draft_new_${agentId}`;
+  // Keyed by conversation only — NOT by agentId. Keying the new-chat draft by
+  // agent made the restore effect below re-run on every agent switch and clear
+  // the input, dropping the user's in-progress prompt.
+  const storageKey = chatDraftStorageKey(conversationId);
 
   const isRestored = useRef(false);
+
+  // One-time migration of pre-upgrade per-agent new-chat drafts to the shared
+  // key, so an unsent draft written before this change is not dropped. Runs
+  // before the restore effect below so the restore reads the migrated value.
+  useEffect(() => {
+    migrateLegacyNewChatDraft(localStorage);
+  }, []);
 
   // Restore draft on mount or conversation change
   useEffect(() => {

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -49,6 +49,7 @@ import {
   type VisibilityOption,
   VisibilitySelector,
 } from "@/components/visibility-selector";
+import { buildProjectChatHandoffUrl } from "@/lib/projects/project-chat-handoff";
 import {
   useDeleteProject,
   useProject,
@@ -200,9 +201,9 @@ function ProjectChatInput({ projectId }: { projectId: string }) {
 
   return (
     <NewChatComposer
-      onSubmitPrompt={(text) =>
+      onSubmitPrompt={(text, agentId) =>
         router.push(
-          `/chat?project=${projectId}&user_prompt=${encodeURIComponent(text)}`,
+          buildProjectChatHandoffUrl({ projectId, prompt: text, agentId }),
         )
       }
     />

--- a/platform/frontend/src/components/chat/new-chat-composer.tsx
+++ b/platform/frontend/src/components/chat/new-chat-composer.tsx
@@ -19,13 +19,15 @@ import { useOrganization } from "@/lib/organization.query";
  * creating a conversation in place.
  *
  * Used by surfaces that start a chat elsewhere (e.g. a project page handing
- * off to /chat). Selections made here persist through the same stores the
- * /chat page reads, so the handed-off chat is created with what was picked.
+ * off to /chat). The selected agent is handed to `onSubmitPrompt` so the
+ * caller can forward it explicitly (the saved-agent store alone is not
+ * authoritative — the /chat resolution chain ranks the org default and the
+ * permission-gated saved pick, so the choice must travel with the handoff).
  */
 export function NewChatComposer({
   onSubmitPrompt,
 }: {
-  onSubmitPrompt: (text: string) => void;
+  onSubmitPrompt: (text: string, agentId: string) => void;
 }) {
   const { data: internalAgents = [] } = useInternalAgents();
   const { data: defaultAgentId } = useDefaultAgentId();
@@ -83,7 +85,7 @@ export function NewChatComposer({
             // Reject the submit so the typed prompt (and its saved draft) survive.
             throw new Error("attachments-not-supported");
           }
-          onSubmitPrompt(text);
+          onSubmitPrompt(text, agentId);
         }}
         status="ready"
         selectedModel={modelId}

--- a/platform/frontend/src/lib/chat/chat-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.test.ts
@@ -2,13 +2,36 @@ import type { UIMessage } from "@ai-sdk/react";
 import { describe, expect, it } from "vitest";
 import {
   applyTextEditToMessages,
+  chatDraftStorageKey,
+  conversationStorageKeys,
   getChatExternalAgentId,
   getConversationDisplayTitle,
   getManualCompactionSkippedMessage,
   mergePersistedMessageMetadata,
+  migrateLegacyNewChatDraft,
+  NEW_CHAT_DRAFT_STORAGE_KEY,
   PERSISTED_MESSAGE_ID_METADATA_KEY,
   resolveCanonicalMessageId,
 } from "./chat-utils";
+
+/** Minimal in-memory localStorage stand-in for the draft migration tests. */
+function makeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return map.size;
+    },
+    key: (index: number) => Array.from(map.keys())[index] ?? null,
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      map.set(key, value);
+    },
+    removeItem: (key: string) => {
+      map.delete(key);
+    },
+    snapshot: () => Object.fromEntries(map),
+  };
+}
 
 const DEFAULT_SESSION_NAME = "New Chat Session";
 
@@ -613,5 +636,83 @@ describe("applyTextEditToMessages", () => {
     });
 
     expect(updated[0]?.parts[0]).toBe(messages[0]?.parts[0]);
+  });
+});
+
+describe("chatDraftStorageKey", () => {
+  it("returns the conversation-scoped draft key for an existing conversation", () => {
+    expect(chatDraftStorageKey("conv-123")).toBe(
+      conversationStorageKeys("conv-123").draft,
+    );
+  });
+
+  it("returns the shared new-chat key when there is no conversation", () => {
+    expect(chatDraftStorageKey(undefined)).toBe(NEW_CHAT_DRAFT_STORAGE_KEY);
+    expect(chatDraftStorageKey(null)).toBe(NEW_CHAT_DRAFT_STORAGE_KEY);
+  });
+
+  it("does not vary the new-chat key by agent so a typed prompt survives an agent switch", () => {
+    // Regression guard: the draft key must be agent-independent. Previously it
+    // embedded the agentId, so switching agents re-keyed the draft and the
+    // restore effect cleared the user's in-progress prompt.
+    const keyForAgentA = chatDraftStorageKey(undefined);
+    const keyForAgentB = chatDraftStorageKey(undefined);
+    expect(keyForAgentA).toBe(keyForAgentB);
+  });
+});
+
+describe("migrateLegacyNewChatDraft", () => {
+  it("adopts a pre-upgrade per-agent draft into the shared key, then clears legacy keys", () => {
+    const storage = makeStorage({
+      [`${NEW_CHAT_DRAFT_STORAGE_KEY}_agent-1`]: "draft I was typing",
+    });
+
+    migrateLegacyNewChatDraft(storage);
+
+    expect(storage.snapshot()).toEqual({
+      [NEW_CHAT_DRAFT_STORAGE_KEY]: "draft I was typing",
+    });
+  });
+
+  it("does not overwrite an existing shared draft, but still cleans up legacy keys", () => {
+    const storage = makeStorage({
+      [NEW_CHAT_DRAFT_STORAGE_KEY]: "current draft",
+      [`${NEW_CHAT_DRAFT_STORAGE_KEY}_agent-1`]: "stale legacy draft",
+    });
+
+    migrateLegacyNewChatDraft(storage);
+
+    expect(storage.snapshot()).toEqual({
+      [NEW_CHAT_DRAFT_STORAGE_KEY]: "current draft",
+    });
+  });
+
+  it("leaves unrelated keys untouched and is a no-op without legacy keys", () => {
+    const storage = makeStorage({
+      [conversationStorageKeys("conv-1").draft]: "a saved conversation draft",
+      "some-other-key": "value",
+    });
+
+    migrateLegacyNewChatDraft(storage);
+
+    expect(storage.snapshot()).toEqual({
+      [conversationStorageKeys("conv-1").draft]: "a saved conversation draft",
+      "some-other-key": "value",
+    });
+  });
+
+  it("is idempotent: a second run finds nothing left to migrate", () => {
+    const storage = makeStorage({
+      [`${NEW_CHAT_DRAFT_STORAGE_KEY}_agent-1`]: "draft",
+    });
+
+    migrateLegacyNewChatDraft(storage);
+    const afterFirst = storage.snapshot();
+    migrateLegacyNewChatDraft(storage);
+
+    expect(storage.snapshot()).toEqual(afterFirst);
+    expect(storage.snapshot()).toEqual({
+      [NEW_CHAT_DRAFT_STORAGE_KEY]: "draft",
+    });
   });
 });

--- a/platform/frontend/src/lib/chat/chat-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.ts
@@ -39,6 +39,71 @@ export function conversationStorageKeys(conversationId: string) {
 }
 
 /**
+ * localStorage key for the new-chat composer's prompt draft. Deliberately a
+ * single, agent-independent key: the draft is the message the user is
+ * composing, so switching the selected agent must NOT swap (and thereby drop)
+ * what they have typed.
+ */
+export const NEW_CHAT_DRAFT_STORAGE_KEY = "archestra_chat_draft_new";
+
+/**
+ * Resolves the prompt-draft localStorage key for the prompt input: a
+ * conversation-scoped key when editing an existing conversation, otherwise the
+ * shared new-chat key. Keeping this in one place ensures the draft survives an
+ * agent change on a new chat (the key does not depend on the agent).
+ */
+export function chatDraftStorageKey(
+  conversationId: string | null | undefined,
+): string {
+  return conversationId
+    ? conversationStorageKeys(conversationId).draft
+    : NEW_CHAT_DRAFT_STORAGE_KEY;
+}
+
+/** The Storage surface the draft migration needs (a subset of `localStorage`). */
+type DraftStorage = Pick<
+  Storage,
+  "length" | "key" | "getItem" | "setItem" | "removeItem"
+>;
+
+/**
+ * One-time migration of pre-upgrade new-chat drafts. Earlier builds keyed the
+ * new-chat draft by agent (`archestra_chat_draft_new_<agentId>`); this build
+ * uses a single agent-independent key. Without migrating, an unsent draft
+ * written before the upgrade would be ignored — and then cleared — on the next
+ * new chat. Adopt one legacy draft into the shared key when it is empty, then
+ * remove every legacy key so the migration effectively runs once. Idempotent.
+ */
+export function migrateLegacyNewChatDraft(storage: DraftStorage): void {
+  const legacyPrefix = `${NEW_CHAT_DRAFT_STORAGE_KEY}_`;
+  const legacyKeys: string[] = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key?.startsWith(legacyPrefix)) {
+      legacyKeys.push(key);
+    }
+  }
+  if (legacyKeys.length === 0) {
+    return;
+  }
+
+  // Only adopt a legacy draft when the user has not started a new shared draft.
+  if (!storage.getItem(NEW_CHAT_DRAFT_STORAGE_KEY)) {
+    for (const key of legacyKeys) {
+      const value = storage.getItem(key);
+      if (value) {
+        storage.setItem(NEW_CHAT_DRAFT_STORAGE_KEY, value);
+        break;
+      }
+    }
+  }
+
+  for (const key of legacyKeys) {
+    storage.removeItem(key);
+  }
+}
+
+/**
  * Extracts a display title for a conversation.
  * Priority: explicit title > first user message > default session name
  */

--- a/platform/frontend/src/lib/projects/project-chat-handoff.test.ts
+++ b/platform/frontend/src/lib/projects/project-chat-handoff.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildProjectChatHandoffUrl } from "./project-chat-handoff";
+
+describe("buildProjectChatHandoffUrl", () => {
+  it("forwards the selected agent so the project chat respects it", () => {
+    // Regression guard: the project handoff previously omitted agentId, so the
+    // /chat resolution chain fell back to the org default / saved pick instead
+    // of the agent chosen in the project composer.
+    const url = buildProjectChatHandoffUrl({
+      projectId: "proj-1",
+      prompt: "hello",
+      agentId: "agent-42",
+    });
+
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("agentId")).toBe("agent-42");
+    expect(params.get("project")).toBe("proj-1");
+  });
+
+  it("round-trips a prompt with special characters", () => {
+    const prompt = "summarize: a & b? c=d #1";
+    const url = buildProjectChatHandoffUrl({
+      projectId: "proj-1",
+      prompt,
+      agentId: "agent-42",
+    });
+
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("user_prompt")).toBe(prompt);
+  });
+
+  it("targets the /chat route", () => {
+    const url = buildProjectChatHandoffUrl({
+      projectId: "proj-1",
+      prompt: "hi",
+      agentId: "agent-42",
+    });
+
+    expect(url.startsWith("/chat?")).toBe(true);
+  });
+});

--- a/platform/frontend/src/lib/projects/project-chat-handoff.ts
+++ b/platform/frontend/src/lib/projects/project-chat-handoff.ts
@@ -1,0 +1,21 @@
+/**
+ * Builds the `/chat` handoff URL used when a chat is started from a project.
+ *
+ * The selected agent is forwarded as `agentId` so `/chat` opens with exactly
+ * the agent picked in the project composer. The URL param is the highest
+ * priority in the chat agent-resolution chain, ahead of the org default agent
+ * and the permission-gated saved pick that would otherwise override it — so
+ * relying on the saved-agent store alone did not reliably respect the choice.
+ */
+export function buildProjectChatHandoffUrl(params: {
+  projectId: string;
+  prompt: string;
+  agentId: string;
+}): string {
+  const search = new URLSearchParams({
+    project: params.projectId,
+    user_prompt: params.prompt,
+    agentId: params.agentId,
+  });
+  return `/chat?${search.toString()}`;
+}


### PR DESCRIPTION
## Summary

Fixes two chat agent-selection bugs, one commit each.

### 1. Prompt draft dropped when changing agent (`fix(chat)`)
The new-chat composer keyed its localStorage draft by agent (`archestra_chat_draft_new_<agentId>`). The restore effect depends on that key, so changing the selected agent re-ran it, found no draft under the new agent's key, and called `setInput("")` — silently wiping whatever the user had typed.

- Key the new-chat draft by conversation only, via a single agent-independent `chatDraftStorageKey`, so switching agents no longer re-keys or clears the draft.
- Migrate any pre-upgrade per-agent draft into the shared key on mount (`migrateLegacyNewChatDraft`) so an unsent draft written before this change isn't lost on rollout.

### 2. Starting a chat from a project ignored the selected agent (`fix(projects)`)
The project chat composer lets the user pick an agent, but the handoff to `/chat` only carried `project` and `user_prompt` — not the agent. `/chat` then re-resolved the agent from its own chain (URL param > org default > saved pick > member default > first). With no `agentId` in the URL, an org default agent or the permission-gated saved pick won, so the chosen agent was ignored.

- Forward the selected `agentId` in the handoff URL (the highest-priority signal in the resolution chain) via a small `buildProjectChatHandoffUrl` helper.
- Surface the agent through `NewChatComposer`'s `onSubmitPrompt` so the project page can pass it along.

## Testing
- New unit tests: `chatDraftStorageKey` / `migrateLegacyNewChatDraft` (agent-independence + idempotent migration) and `buildProjectChatHandoffUrl` (agent is forwarded, prompt round-trips).
- Updated existing `prompt-input.test.tsx` draft-retention tests to the new agent-independent key.
- `pnpm type-check`, `pnpm lint`, `pnpm knip` clean; 572 tests pass across the chat/projects areas.
- Each commit's diff was reviewed with Codex (`/codex:review`); the one flagged item (rollout draft loss) is handled by the migration above.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>