### PR TITLE
fix(backend): keep built-in tools when a conversation enables zero tools

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -1006,6 +1006,87 @@ describe("chat-mcp-client tool caching", () => {
     chatClient.clearChatMcpClient(agent.id);
     await chatClient.__test.clearToolCache(cacheKey);
   });
+
+  test("empty conversation selection keeps built-in search/run tools and drops user tools", async ({
+    makeAgent,
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const agent = await makeAgent({ teams: [team.id] });
+    await makeTeamMember(team.id, user.id);
+    await TeamTokenModel.createTeamToken(team.id, team.name);
+
+    const cacheKey = chatClient.__test.getCacheKey(agent.id, user.id);
+    chatClient.clearChatMcpClient(agent.id);
+    await chatClient.__test.clearToolCache(cacheKey);
+
+    archestraMcpBranding.syncFromOrganization(null);
+    const searchToolsName = getArchestraToolFullName("search_tools");
+    const runToolName = getArchestraToolFullName("run_tool");
+
+    const mockClient = {
+      ping: vi.fn().mockResolvedValue({}),
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: searchToolsName,
+            description: "Search tools",
+            inputSchema: {
+              type: "object",
+              properties: { query: { type: "string" } },
+            },
+          },
+          {
+            name: runToolName,
+            description: "Run tool",
+            inputSchema: {
+              type: "object",
+              properties: {
+                tool_name: { type: "string" },
+                tool_args: { type: "object" },
+              },
+              required: ["tool_name"],
+            },
+          },
+          {
+            name: "workspace__find_projects",
+            description: "Find projects",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      }),
+      callTool: vi.fn(),
+      close: vi.fn(),
+    };
+
+    chatClient.__test.setCachedClient(
+      cacheKey,
+      mockClient as unknown as Client,
+    );
+
+    // A search_and_run_only conversation with zero user-selectable tools enabled
+    // resolves to an empty enabledToolIds; the built-in meta tools must survive.
+    const tools = await chatClient.getChatMcpTools({
+      agentName: agent.name,
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
+      enabledToolIds: [],
+    });
+
+    expect(Object.keys(tools).sort()).toEqual(
+      [runToolName, searchToolsName].sort(),
+    );
+    expect(tools).not.toHaveProperty("workspace__find_projects");
+
+    chatClient.clearChatMcpClient(agent.id);
+    await chatClient.__test.clearToolCache(cacheKey);
+  });
 });
 
 describe("filterToolsByEnabledIds", () => {
@@ -1099,6 +1180,62 @@ describe("filterToolsByEnabledIds", () => {
 
     expect(Object.keys(result)).toContain("github__list_repos");
     expect(Object.keys(result)).not.toContain("slack__send_message");
+  });
+
+  test("empty array returns nothing when there are no built-in tools", async () => {
+    archestraMcpBranding.syncFromOrganization(null);
+    const tools = {
+      github__list_repos: makeMockTool(),
+      slack__send_message: makeMockTool(),
+    };
+
+    // No archestra built-ins to bypass the selection, so disabling every
+    // user-selectable tool genuinely yields an empty set.
+    const result = await filterToolsByEnabledIds(tools, []);
+
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  test("empty array retains white-labeled built-in tools", async () => {
+    archestraMcpBranding.syncFromOrganization({
+      appName: "Acme Copilot",
+      iconLogo: null,
+    });
+    const brandedWhoami = getArchestraToolFullName(TOOL_WHOAMI_SHORT_NAME, {
+      appName: "Acme Copilot",
+      fullWhiteLabeling: true,
+    });
+
+    const tools = {
+      github__list_repos: makeMockTool(),
+      [brandedWhoami]: makeMockTool("Who am I"),
+    };
+
+    // The bypass must recognize the white-labeled built-in name under an empty
+    // selection too, or white-label deployments lose search/run.
+    const result = await filterToolsByEnabledIds(tools, []);
+
+    expect(Object.keys(result)).toEqual([brandedWhoami]);
+  });
+
+  test("empty array drops names that carry the archestra prefix but are not real built-ins", async () => {
+    archestraMcpBranding.syncFromOrganization(null);
+    const searchToolsName = getArchestraToolFullName("search_tools");
+    const prefixedNonTool = searchToolsName.replace(
+      "search_tools",
+      "bogus_not_a_tool",
+    );
+
+    const tools = {
+      [prefixedNonTool]: makeMockTool("Looks built-in but is not"),
+      [searchToolsName]: makeMockTool("Search tools"),
+    };
+
+    // isToolName validates the short name against the known set, so a name that
+    // merely carries the prefix is treated as user-selectable and filtered out.
+    const result = await filterToolsByEnabledIds(tools, []);
+
+    expect(Object.keys(result)).toEqual([searchToolsName]);
   });
 });
 

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -1031,13 +1031,21 @@ describe("filterToolsByEnabledIds", () => {
     expect(Object.keys(result)).toHaveLength(2);
   });
 
-  test("returns empty when enabledToolIds is empty array", async () => {
+  test("empty array retains archestra built-in tools and drops the rest", async () => {
+    archestraMcpBranding.syncFromOrganization(null);
+    const searchToolsName = getArchestraToolFullName("search_tools");
+
     const tools = {
       github__list_repos: makeMockTool(),
+      [searchToolsName]: makeMockTool("Search tools"),
     };
 
+    // Empty custom selection = zero user-selectable tools enabled. Built-ins
+    // (search_tools/run_tool) must still survive so search_and_run_only agents
+    // can call tools; only the user-selectable tool is dropped.
     const result = await filterToolsByEnabledIds(tools, []);
-    expect(Object.keys(result)).toHaveLength(0);
+
+    expect(Object.keys(result)).toEqual([searchToolsName]);
   });
 
   test("white-labeled built-in tools bypass custom selection filtering", async ({

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -1057,7 +1057,8 @@ export async function fetchToolUiResource({
 /**
  * Filter tools by enabled tool IDs
  * If enabledToolIds is undefined, returns all tools (no custom selection = all enabled)
- * If enabledToolIds is empty array, returns no tools (explicit selection of zero tools)
+ * If enabledToolIds is empty array, returns only archestra built-in tools (a custom
+ *   selection of zero user-selectable tools; built-ins always bypass the selection)
  * If enabledToolIds has items, fetches tool names by IDs and filters to only include those
  *
  * @param tools - All available tools (keyed by tool name)
@@ -1080,25 +1081,15 @@ async function filterToolsByEnabledIds(
     return tools;
   }
 
-  // Empty array = explicit selection of zero tools
-  if (enabledToolIds.length === 0) {
-    logger.info(
-      {
-        totalTools: Object.keys(tools).length,
-        enabledToolIds: 0,
-        reason: "empty array - all tools explicitly disabled",
-      },
-      "All tools filtered out - user disabled all tools",
-    );
-    return {};
-  }
-
-  // Fetch tool names for the enabled IDs
+  // Fetch tool names for the enabled IDs (empty array -> empty set, leaving only
+  // the built-in bypass below to populate the result)
   const enabledToolNames = await ToolModel.getNamesByIds(enabledToolIds);
 
-  // Filter tools to only include enabled ones
+  // Filter tools to only include enabled ones.
   // Archestra built-in tools always bypass custom selection (they are auto-injected
-  // and hidden from the UI, so users cannot select them)
+  // and hidden from the UI, so users cannot select or deselect them). This is what
+  // keeps search_tools/run_tool available to search_and_run_only agents even when a
+  // conversation's custom selection enables zero user-selectable tools.
   const filteredTools: Record<string, Tool> = {};
   const excludedTools: string[] = [];
   for (const [name, tool] of Object.entries(tools)) {

--- a/platform/backend/src/routes/chat/build-chat-context.test.ts
+++ b/platform/backend/src/routes/chat/build-chat-context.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, vi } from "vitest";
+import { ConversationEnabledToolModel } from "@/models";
+import { describe, expect, test } from "@/test";
+
+const mockGetChatMcpTools = vi.hoisted(() => vi.fn());
+const mockGetChatMcpToolUiResourceUris = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients/chat-mcp-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/clients/chat-mcp-client")>();
+  return {
+    ...actual,
+    getChatMcpTools: mockGetChatMcpTools,
+    getChatMcpToolUiResourceUris: mockGetChatMcpToolUiResourceUris,
+  };
+});
+
+const { buildChatContext } = await import("./build-chat-context");
+
+describe("buildChatContext enabled-tool selection", () => {
+  beforeEach(() => {
+    mockGetChatMcpTools.mockReset().mockResolvedValue({});
+    mockGetChatMcpToolUiResourceUris.mockReset().mockResolvedValue({});
+  });
+
+  const run = (params: {
+    conversationId: string;
+    agentId: string;
+    agentName: string;
+    organizationId: string;
+    user: { id: string; email: string; name: string };
+  }) =>
+    buildChatContext({
+      conversationId: params.conversationId,
+      agentId: params.agentId,
+      agent: {
+        name: params.agentName,
+        systemPrompt: null,
+        toolExposureMode: "full",
+      },
+      user: params.user,
+      organizationId: params.organizationId,
+      hookSessionContext: undefined,
+      hookRunCollector: [],
+      elicitation: {} as never,
+      abortSignal: new AbortController().signal,
+    });
+
+  test("no custom selection fetches tools with enabledToolIds undefined", async ({
+    makeAgent,
+    makeConversation,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeAgent({ organizationId: org.id });
+    const conversation = await makeConversation(agent.id, {
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    const result = await run({
+      conversationId: conversation.id,
+      agentId: agent.id,
+      agentName: agent.name,
+      organizationId: org.id,
+      user: { id: user.id, email: user.email, name: user.name },
+    });
+
+    // A new conversation has no custom selection, so it must NOT be filtered:
+    // passing undefined (not []) is what keeps all assigned tools enabled.
+    expect(mockGetChatMcpTools).toHaveBeenCalledTimes(1);
+    expect(
+      mockGetChatMcpTools.mock.calls[0]?.[0].enabledToolIds,
+    ).toBeUndefined();
+    expect(result.toolSelection).toEqual({
+      hasCustomSelection: false,
+      enabledToolCount: 0,
+    });
+  });
+
+  test("empty custom selection fetches tools with an empty enabledToolIds array", async ({
+    makeAgent,
+    makeConversation,
+    makeOrganization,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeAgent({ organizationId: org.id });
+    const conversation = await makeConversation(agent.id, {
+      organizationId: org.id,
+      userId: user.id,
+    });
+    await ConversationEnabledToolModel.setEnabledTools(conversation.id, []);
+
+    const result = await run({
+      conversationId: conversation.id,
+      agentId: agent.id,
+      agentName: agent.name,
+      organizationId: org.id,
+      user: { id: user.id, email: user.email, name: user.name },
+    });
+
+    // An explicit empty selection passes [] (not undefined), and the surfaced
+    // log fields report a custom selection of zero tools.
+    expect(mockGetChatMcpTools.mock.calls[0]?.[0].enabledToolIds).toEqual([]);
+    expect(result.toolSelection).toEqual({
+      hasCustomSelection: true,
+      enabledToolCount: 0,
+    });
+  });
+});

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -754,6 +754,55 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(systemPrompt).toContain("the error describes the expected input");
   });
 
+  test("passes the search/run tools it tells the model to call to streamText", async () => {
+    const { AgentModel } = await import("@/models");
+    await AgentModel.update(agentId, {
+      toolExposureMode: "search_and_run_only",
+      systemPrompt: "You are a careful analyst.",
+    });
+    const searchToolsName = archestraMcpBranding.getToolName(
+      TOOL_SEARCH_TOOLS_SHORT_NAME,
+    );
+    const runToolName = archestraMcpBranding.getToolName(
+      TOOL_RUN_TOOL_SHORT_NAME,
+    );
+    mockStreamText.mockClear();
+    mockGetChatMcpTools.mockResolvedValueOnce({
+      [searchToolsName]: { description: "Search tools" },
+      [runToolName]: { description: "Run tool" },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+    const call = mockStreamText.mock.calls[0]?.[0];
+    // The system prompt instructs the model to call these tools; they must also
+    // be present in the request, or the model is told to call tools it cannot
+    // invoke (the search_and_run_only zero-tools failure).
+    expect(call.system).toContain(
+      `call \`${searchToolsName}\` to find relevant tools`,
+    );
+    expect(Object.keys(call.tools ?? {})).toEqual(
+      expect.arrayContaining([searchToolsName, runToolName]),
+    );
+  });
+
   test("adds load-tools guidance when the agent has no authored prompt", async () => {
     const { AgentModel } = await import("@/models");
     await AgentModel.update(agentId, {


### PR DESCRIPTION
## Summary

In `search_and_run_only` mode, agents with an empty per-conversation tool selection sent **zero callable tools** to the model. The model was told (via the mode-gated system prompt) that `search_tools`/`run_tool` exist, but had nothing to call — so it emitted tool calls as plain text and never executed a tool. Observed on staging with GPT-5.5: the chat request carried `toolCount: 0` despite the MCP Gateway returning the built-in tools normally.

The cause is in `filterToolsByEnabledIds` (`platform/backend/src/clients/chat-mcp-client.ts`). A conversation with `hasCustomToolSelection = true` and no enabled rows resolves to `enabledToolIds: []`. The empty-array branch short-circuited and returned `{}`, skipping the archestra-built-in bypass that the non-empty branch always applies. Built-ins (including `search_tools`/`run_tool`, and the skill/sandbox/app tools the gateway keeps available in both exposure modes) were dropped.

Removing the short-circuit lets the empty case fall through to the single filter loop, where built-ins bypass the selection and only user-selectable tools are dropped. This makes the empty-selection case consistent with the non-empty branch and with the gateway's per-mode exposure contract (`filterExposedTools`): an empty custom selection now means "no user-selectable tools," not "no tools at all."

Built-ins are auto-injected and hidden from the tool-selection UI, so users cannot select or deselect them — surfacing them on an empty selection matches how every other selection state already behaves.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>