### PR TITLE
feat(backend): surface run_command fallback and sharpen search_tools query guidance

### DIFF
--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -1540,7 +1540,7 @@ Required RBAC permission: None (no additional RBAC permission required)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `query` | `string` | Yes | Keywords describing the capability you need, e.g. 'send slack message' or 'search repositories'. Results are keyword-ranked across tool names, descriptions, and argument names/descriptions, so pass several relevant words and include the server name (e.g. 'github') to narrow results. |
+| `query` | `string` | Yes | Keywords for the capability you need — combine the action (verb + object) with the server/product name when you know it, e.g. 'github search repositories' or 'slack send message'. Avoid querying with a bare product/server name on its own. Results are keyword-ranked across tool names, descriptions, and argument names/descriptions. If nothing fits, reformulate with different keywords and search again rather than settling for a poor match. |
 | `limit` | `integer` | No | Maximum number of matching tools to return. |
 | `mode` | `"keyword" \| "regex"` | No | Search mode. 'keyword' (default) keyword-ranks the query across tool fields. 'regex' treats query as a case-insensitive regular expression matched against tool names, titles, and descriptions — use it when you know a naming pattern, e.g. '^github__' or 'search\|find'. |
 

--- a/platform/backend/src/agents/agent-system-prompt.test.ts
+++ b/platform/backend/src/agents/agent-system-prompt.test.ts
@@ -117,6 +117,57 @@ describe("buildAgentSystemPrompt", () => {
     expect(withoutCatalog).not.toContain("<available_skills>");
   });
 
+  test("adds the sandbox fallback instruction only when the sandbox is usable", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+    makeCustomRole,
+    seedAndAssignArchestraTools,
+  }) => {
+    const config = (await import("@/config")).default;
+    const originalEnabled = config.skillsSandbox.enabled;
+    (config.skillsSandbox as { enabled: boolean }).enabled = true;
+
+    try {
+      const agent = await makeAgent({
+        systemPrompt: "Base.",
+        toolExposureMode: "full",
+      });
+      const user = await makeUser();
+      const role = await makeCustomRole(agent.organizationId, {
+        permission: { sandbox: ["execute"] },
+      });
+      await makeMember(user.id, agent.organizationId, { role: role.role });
+      await seedAndAssignArchestraTools(agent.id);
+
+      const withSandbox = await buildAgentSystemPrompt({
+        agent,
+        mcpTools: {},
+        organizationId: agent.organizationId,
+        userId: user.id,
+        agentId: agent.id,
+      });
+      expect(withSandbox).toContain("code execution environment");
+
+      // a bare agent (no sandbox tools assigned) never gets the instruction
+      const bareAgent = await makeAgent({
+        systemPrompt: "Base.",
+        toolExposureMode: "full",
+        organizationId: agent.organizationId,
+      });
+      const withoutSandbox = await buildAgentSystemPrompt({
+        agent: bareAgent,
+        mcpTools: {},
+        organizationId: bareAgent.organizationId,
+        userId: user.id,
+        agentId: bareAgent.id,
+      });
+      expect(withoutSandbox).not.toContain("code execution environment");
+    } finally {
+      (config.skillsSandbox as { enabled: boolean }).enabled = originalEnabled;
+    }
+  });
+
   test("adds the tool-result instruction only when tools are present", async ({
     makeAgent,
     makeUser,

--- a/platform/backend/src/agents/agent-system-prompt.test.ts
+++ b/platform/backend/src/agents/agent-system-prompt.test.ts
@@ -149,18 +149,15 @@ describe("buildAgentSystemPrompt", () => {
       });
       expect(withSandbox).toContain("code execution environment");
 
-      // a bare agent (no sandbox tools assigned) never gets the instruction
-      const bareAgent = await makeAgent({
-        systemPrompt: "Base.",
-        toolExposureMode: "full",
-        organizationId: agent.organizationId,
-      });
+      // the same agent gets no instruction once the sandbox is disabled on the
+      // deployment, even with the tools assigned and the permission granted
+      (config.skillsSandbox as { enabled: boolean }).enabled = false;
       const withoutSandbox = await buildAgentSystemPrompt({
-        agent: bareAgent,
+        agent,
         mcpTools: {},
-        organizationId: bareAgent.organizationId,
+        organizationId: agent.organizationId,
         userId: user.id,
-        agentId: bareAgent.id,
+        agentId: agent.id,
       });
       expect(withoutSandbox).not.toContain("code execution environment");
     } finally {

--- a/platform/backend/src/agents/agent-system-prompt.ts
+++ b/platform/backend/src/agents/agent-system-prompt.ts
@@ -10,7 +10,11 @@ import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { TeamModel, UserModel } from "@/models";
 import { buildSkillCatalogPrompt } from "@/skills/skill-catalog-prompt";
 import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
-import { promptNeedsRendering, renderSystemPrompt, type UserSystemPromptContext } from "@/templating";
+import {
+  promptNeedsRendering,
+  renderSystemPrompt,
+  type UserSystemPromptContext,
+} from "@/templating";
 import type { ToolExposureMode } from "@/types";
 
 /** @public — canonical instruction text, asserted by the assembler tests. */
@@ -45,7 +49,15 @@ export async function buildAgentSystemPrompt(params: {
   /** Context injected by SessionStart hooks (chat only), appended last. */
   hookSessionContext?: string;
 }): Promise<string | undefined> {
-  const { agent, mcpTools, organizationId, userId, agentId, user, hookSessionContext } = params;
+  const {
+    agent,
+    mcpTools,
+    organizationId,
+    userId,
+    agentId,
+    user,
+    hookSessionContext,
+  } = params;
 
   const renderedPrompt = await renderAgentPrompt({
     systemPrompt: agent.systemPrompt,
@@ -55,9 +67,12 @@ export async function buildAgentSystemPrompt(params: {
   });
 
   const toolLoadingInstructions =
-    agent.toolExposureMode === "search_and_run_only" ? buildLoadToolsWhenNeededSystemPrompt() : null;
+    agent.toolExposureMode === "search_and_run_only"
+      ? buildLoadToolsWhenNeededSystemPrompt()
+      : null;
 
-  const toolResultInstructions = Object.keys(mcpTools).length > 0 ? TOOL_UI_RESULT_INSTRUCTION : null;
+  const toolResultInstructions =
+    Object.keys(mcpTools).length > 0 ? TOOL_UI_RESULT_INSTRUCTION : null;
 
   // eagerly list the agent's skills in the prompt (like Claude Code /
   // opencode), but only when the agent can actually load them.
@@ -68,7 +83,9 @@ export async function buildAgentSystemPrompt(params: {
     isSkillSandboxAvailableForAgent({ userId, organizationId, agentId }),
   ]);
 
-  const sandboxFallbackInstruction = sandboxAvailable ? buildSandboxFallbackInstruction() : null;
+  const sandboxFallbackInstruction = sandboxAvailable
+    ? buildSandboxFallbackInstruction()
+    : null;
 
   return (
     [
@@ -113,13 +130,19 @@ async function renderAgentPrompt(params: {
 }
 
 function buildSandboxFallbackInstruction(): string {
-  const runCommand = archestraMcpBranding.getToolName(TOOL_RUN_COMMAND_SHORT_NAME);
+  const runCommand = archestraMcpBranding.getToolName(
+    TOOL_RUN_COMMAND_SHORT_NAME,
+  );
   return `You have a code execution environment: \`${runCommand}\` runs shell commands and Python in a persistent Linux workspace. When the available tools do not cover a task, you can fall back to it — for example to compute, transform files, or fetch data over the network.`;
 }
 
 function buildLoadToolsWhenNeededSystemPrompt(): string {
-  const searchToolsName = archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME);
-  const runToolName = archestraMcpBranding.getToolName(TOOL_RUN_TOOL_SHORT_NAME);
+  const searchToolsName = archestraMcpBranding.getToolName(
+    TOOL_SEARCH_TOOLS_SHORT_NAME,
+  );
+  const runToolName = archestraMcpBranding.getToolName(
+    TOOL_RUN_TOOL_SHORT_NAME,
+  );
 
   return `Some available tools are not listed upfront and must be discovered. If the visible tools do not fit the task, call \`${searchToolsName}\` to find relevant tools, then call \`${runToolName}\` with a tool name it returned. Only pass \`${runToolName}\` a tool name that \`${searchToolsName}\` returned or that appeared verbatim earlier in this conversation; if you do not have an exact name, call \`${searchToolsName}\` first.
 

--- a/platform/backend/src/agents/agent-system-prompt.ts
+++ b/platform/backend/src/agents/agent-system-prompt.ts
@@ -1,6 +1,7 @@
 import {
   buildUserSystemPromptContext,
   TOOL_LOAD_SKILL_SHORT_NAME,
+  TOOL_RUN_COMMAND_SHORT_NAME,
   TOOL_RUN_TOOL_SHORT_NAME,
   TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
@@ -8,11 +9,8 @@ import type { Tool } from "ai";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { TeamModel, UserModel } from "@/models";
 import { buildSkillCatalogPrompt } from "@/skills/skill-catalog-prompt";
-import {
-  promptNeedsRendering,
-  renderSystemPrompt,
-  type UserSystemPromptContext,
-} from "@/templating";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
+import { promptNeedsRendering, renderSystemPrompt, type UserSystemPromptContext } from "@/templating";
 import type { ToolExposureMode } from "@/types";
 
 /** @public — canonical instruction text, asserted by the assembler tests. */
@@ -47,15 +45,7 @@ export async function buildAgentSystemPrompt(params: {
   /** Context injected by SessionStart hooks (chat only), appended last. */
   hookSessionContext?: string;
 }): Promise<string | undefined> {
-  const {
-    agent,
-    mcpTools,
-    organizationId,
-    userId,
-    agentId,
-    user,
-    hookSessionContext,
-  } = params;
+  const { agent, mcpTools, organizationId, userId, agentId, user, hookSessionContext } = params;
 
   const renderedPrompt = await renderAgentPrompt({
     systemPrompt: agent.systemPrompt,
@@ -65,25 +55,27 @@ export async function buildAgentSystemPrompt(params: {
   });
 
   const toolLoadingInstructions =
-    agent.toolExposureMode === "search_and_run_only"
-      ? buildLoadToolsWhenNeededSystemPrompt()
-      : null;
+    agent.toolExposureMode === "search_and_run_only" ? buildLoadToolsWhenNeededSystemPrompt() : null;
 
-  const toolResultInstructions =
-    Object.keys(mcpTools).length > 0 ? TOOL_UI_RESULT_INSTRUCTION : null;
+  const toolResultInstructions = Object.keys(mcpTools).length > 0 ? TOOL_UI_RESULT_INSTRUCTION : null;
 
   // eagerly list the agent's skills in the prompt (like Claude Code /
   // opencode), but only when the agent can actually load them.
-  const skillCatalogPrompt =
+  const [skillCatalogPrompt, sandboxAvailable] = await Promise.all([
     archestraMcpBranding.getToolName(TOOL_LOAD_SKILL_SHORT_NAME) in mcpTools
-      ? await buildSkillCatalogPrompt({ organizationId, userId, agentId })
-      : null;
+      ? buildSkillCatalogPrompt({ organizationId, userId, agentId })
+      : null,
+    isSkillSandboxAvailableForAgent({ userId, organizationId, agentId }),
+  ]);
+
+  const sandboxFallbackInstruction = sandboxAvailable ? buildSandboxFallbackInstruction() : null;
 
   return (
     [
       toolLoadingInstructions,
       renderedPrompt,
       skillCatalogPrompt,
+      sandboxFallbackInstruction,
       TOOL_DENIAL_INSTRUCTION,
       toolResultInstructions,
       hookSessionContext,
@@ -120,13 +112,14 @@ async function renderAgentPrompt(params: {
   return renderSystemPrompt(systemPrompt, promptContext);
 }
 
+function buildSandboxFallbackInstruction(): string {
+  const runCommand = archestraMcpBranding.getToolName(TOOL_RUN_COMMAND_SHORT_NAME);
+  return `You have a code execution environment: \`${runCommand}\` runs shell commands and Python in a persistent Linux workspace. When the available tools do not cover a task, you can fall back to it — for example to compute, transform files, or fetch data over the network.`;
+}
+
 function buildLoadToolsWhenNeededSystemPrompt(): string {
-  const searchToolsName = archestraMcpBranding.getToolName(
-    TOOL_SEARCH_TOOLS_SHORT_NAME,
-  );
-  const runToolName = archestraMcpBranding.getToolName(
-    TOOL_RUN_TOOL_SHORT_NAME,
-  );
+  const searchToolsName = archestraMcpBranding.getToolName(TOOL_SEARCH_TOOLS_SHORT_NAME);
+  const runToolName = archestraMcpBranding.getToolName(TOOL_RUN_TOOL_SHORT_NAME);
 
   return `Some available tools are not listed upfront and must be discovered. If the visible tools do not fit the task, call \`${searchToolsName}\` to find relevant tools, then call \`${runToolName}\` with a tool name it returned. Only pass \`${runToolName}\` a tool name that \`${searchToolsName}\` returned or that appeared verbatim earlier in this conversation; if you do not have an exact name, call \`${searchToolsName}\` first.
 

--- a/platform/backend/src/archestra-mcp-server/search-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.test.ts
@@ -346,6 +346,51 @@ describe("search_tools", () => {
     });
   });
 
+  test("on zero matches, hints the sandbox fallback when the sandbox is usable", async ({
+    makeAgent,
+    makeMember,
+    makeOrganization,
+    makeUser,
+    seedAndAssignArchestraTools,
+  }) => {
+    const config = (await import("@/config")).default;
+    const originalSandboxEnabled = config.skillsSandbox.enabled;
+    (config.skillsSandbox as { enabled: boolean }).enabled = true;
+
+    try {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id, { role: "admin" });
+      const agent = await makeAgent({
+        name: "Sandbox Search Agent",
+        organizationId: org.id,
+      });
+      await seedAndAssignArchestraTools(agent.id);
+
+      const context: ArchestraContext = {
+        agent: { id: agent.id, name: agent.name },
+        agentId: agent.id,
+        organizationId: org.id,
+        userId: user.id,
+      };
+
+      const result = await executeArchestraTool(
+        TOOL_SEARCH_TOOLS_FULL_NAME,
+        { query: "zzqqxyzznomatch", limit: 10 },
+        context,
+      );
+
+      const structuredContent =
+        result.structuredContent as SearchToolsStructuredContent;
+      expect(structuredContent.matchCount).toBe(0);
+      expect(structuredContent.hint).toContain(TOOL_RUN_COMMAND_FULL_NAME);
+      expect(structuredContent.hint).toContain("fall back");
+    } finally {
+      (config.skillsSandbox as { enabled: boolean }).enabled =
+        originalSandboxEnabled;
+    }
+  });
+
   test("excludes always-exposed tools but keeps authoring tools searchable", async ({
     makeAgent,
     makeMember,

--- a/platform/backend/src/archestra-mcp-server/search-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.ts
@@ -1,6 +1,7 @@
 import {
   isAlwaysExposedArchestraToolShortName,
   parseFullToolName,
+  TOOL_RUN_COMMAND_SHORT_NAME,
   TOOL_RUN_TOOL_SHORT_NAME,
   TOOL_SEARCH_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
@@ -13,6 +14,7 @@ import {
   InternalMcpCatalogModel,
   ToolModel,
 } from "@/models";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import { archestraMcpBranding } from "./branding";
 import { isToolEnabledForConversation } from "./conversation-tool-filter";
 import { getAgentTools } from "./delegation";
@@ -33,7 +35,7 @@ const SearchToolsArgsSchema = z
       .min(1)
       .max(200)
       .describe(
-        "Keywords describing the capability you need, e.g. 'send slack message' or 'search repositories'. Results are keyword-ranked across tool names, descriptions, and argument names/descriptions, so pass several relevant words and include the server name (e.g. 'github') to narrow results.",
+        "Keywords for the capability you need — combine the action (verb + object) with the server/product name when you know it, e.g. 'github search repositories' or 'slack send message'. Avoid querying with a bare product/server name on its own. Results are keyword-ranked across tool names, descriptions, and argument names/descriptions. If nothing fits, reformulate with different keywords and search again rather than settling for a poor match.",
       ),
     limit: z
       .number()
@@ -200,12 +202,23 @@ const registry = defineArchestraTools([
       const matchCount = matches.length;
       const tools = matches.slice(0, args.limit).map(toSearchResult);
       const truncated = matchCount > tools.length;
+      // Only relevant to the zero-match hint, so resolve it lazily to avoid an
+      // extra permission/assignment lookup on every successful search.
+      const sandboxAvailable =
+        matchCount === 0 && context.organizationId != null
+          ? await isSkillSandboxAvailableForAgent({
+              userId: context.userId,
+              organizationId: context.organizationId,
+              agentId: context.agentId,
+            })
+          : false;
       const hint = buildSearchHint({
         matchCount,
         truncated,
         limit: args.limit,
         searchableTools,
         unmatchedTerms,
+        sandboxAvailable,
       });
 
       const structured = {
@@ -778,17 +791,30 @@ function buildSearchHint(params: {
   limit: number;
   searchableTools: SearchCandidate[];
   unmatchedTerms: string[];
+  sandboxAvailable: boolean;
 }): string | null {
-  const { limit, matchCount, searchableTools, truncated, unmatchedTerms } =
-    params;
+  const {
+    limit,
+    matchCount,
+    sandboxAvailable,
+    searchableTools,
+    truncated,
+    unmatchedTerms,
+  } = params;
   const parts: string[] = [];
 
   if (matchCount === 0) {
     const servers = availableServerNames(searchableTools);
     const serverHint =
       servers.length > 0 ? ` Available servers: ${servers.join(", ")}.` : "";
+    const runCommand = archestraMcpBranding.getToolName(
+      TOOL_RUN_COMMAND_SHORT_NAME,
+    );
+    const sandboxHint = sandboxAvailable
+      ? ` If no tool fits, you can fall back to \`${runCommand}\` to do the work with command line tools.`
+      : "";
     parts.push(
-      `No tools matched. Try broader or different keywords, or switch mode.${serverHint}`,
+      `No tools matched. Try broader or different keywords, or switch mode.${serverHint}${sandboxHint}`,
     );
   } else if (truncated) {
     parts.push(


### PR DESCRIPTION
## What

- **System prompt** — when the code-execution sandbox is usable for an agent (`isSkillSandboxAvailableForAgent`), append a short standing line so the model knows `run_command` exists as a fallback when no assigned tool fits.
- **search_tools zero-match hint** — when a search returns no matches and the sandbox is usable, softly point at `run_command`. Resolved lazily (only on the zero-match path, so successful searches pay nothing). The truncated-result branch is untouched.
- **search_tools query description** — pair the action (verb + object) with the server/product name, call out the bare-product-name anti-pattern, and reformulate-and-retry on a miss instead of settling for a poor match.

All gated behind the existing sandbox-availability signal, so nothing changes on deployments where the sandbox isn't enabled/assigned.

## Tests

- New: sandbox-fallback line present only when the sandbox is usable (system prompt).
- New: zero-match search hint points at `run_command` only when the sandbox is usable.
- Existing exact-match prompt/hint tests run with the sandbox off and pin the negative case.

https://claude.ai/code/session_01HR62uf2KBazs2yDF6y8fCx

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>