### PR TITLE
feat(bench): per-stage new_conversation flag + persistent-file task

### DIFF
--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -107,6 +107,10 @@ read-only against backend state), and a set of sandbox tasks including —
   count grows without bound, so there is no fixed offline fixture).
 - `lena-png-size` — report the size in KiB (floored) of scikit-image's pinned `lena.png`; the verifier
   checks against recorded ground truth.
+- `purchase-ledger` — clean a transaction CSV into a saved file in one chat, then in a fresh
+  conversation (a `new_conversation` stage) rediscover it from persistent storage via `search_files`
+  and report the completed-purchase total; exercises cross-conversation persistent "My Files". The
+  verifier recomputes the total from the fixture.
 - `ai-sre-fk-drain` — triage a zip of unsorted incident logs (a reconstructed real incident) and
   name the root cause of a crash-looping backend: a foreign-key violation when a conversation is
   deleted mid-drain; the verifier exact-matches a closed-set component/failure-class plus the `runId`

--- a/archestra-bench/envs/basic.toml
+++ b/archestra-bench/envs/basic.toml
@@ -1,10 +1,11 @@
 id = "basic"
 name = "Basic"
-tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "github-stars", "lena-png-size", "sqlite-orders", "cv-shortlist", "invoice-approval", "ai-sre-fk-drain", "ai-sre-cache-treadmill", "decode-cipher", "xlsx-live-formulas"]
+tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "github-stars", "lena-png-size", "sqlite-orders", "cv-shortlist", "invoice-approval", "ai-sre-fk-drain", "ai-sre-cache-treadmill", "decode-cipher", "xlsx-live-formulas", "purchase-ledger"]
 
-# These tasks are read-only against backend state (they run sandbox code + download artifacts, never
-# mutating the skill/tool catalog), and the skill surface is large + web-pinned -- so seed one backend
-# once and let concurrent lanes share it. Sandbox workspaces are per-conversation, so lanes don't clash.
+# These tasks don't mutate shared backend state (the skill/tool catalog), and the skill surface is
+# large + web-pinned -- so seed one backend once and let concurrent lanes share it. Sandbox workspaces
+# are per-conversation and persistent files are per-lane project-scoped, so lanes don't clash even
+# though purchase-ledger writes and re-reads a persistent file across conversations.
 share_backend = true
 
 # Platform feature flags applied when creating this env's agents. Optional; defaults shown.

--- a/archestra-bench/envs/file-storage.toml
+++ b/archestra-bench/envs/file-storage.toml
@@ -1,0 +1,9 @@
+id = "file-storage"
+name = "File storage"
+tasks = ["purchase-ledger"]
+
+# A persistence task: the agent exports a file in one chat and must rediscover it from persistent
+# storage in a follow-up chat (a `new_conversation` stage). `search_files` is the discovery tool and is
+# not part of the base sandbox set, so grant it here. The env is isolated by default (no share_backend)
+# -- each lane gets a fresh backend, so the only persistent files present are the ones this task makes.
+tools = ["search_files"]

--- a/archestra-bench/envs/file-storage.toml
+++ b/archestra-bench/envs/file-storage.toml
@@ -1,9 +1,0 @@
-id = "file-storage"
-name = "File storage"
-tasks = ["purchase-ledger"]
-
-# A persistence task: the agent exports a file in one chat and must rediscover it from persistent
-# storage in a follow-up chat (a `new_conversation` stage). `search_files` is the discovery tool and is
-# not part of the base sandbox set, so grant it here. The env is isolated by default (no share_backend)
-# -- each lane gets a fresh backend, so the only persistent files present are the ones this task makes.
-tools = ["search_files"]

--- a/archestra-bench/runner/src/config/tasks.rs
+++ b/archestra-bench/runner/src/config/tasks.rs
@@ -44,7 +44,14 @@ pub fn load_task(task_dir: &Path) -> Result<Task, TaskConfigError> {
     let mut stages = Vec::with_capacity(stage_rows.len());
     for (i, row) in stage_rows.iter().enumerate() {
         let row_ctx = format!("{ctx} [[stages]][{i}]");
-        stages.push(load_stage(row, &row_ctx, task_dir)?);
+        let stage = load_stage(row, &row_ctx, task_dir)?;
+        if i == 0 && stage.new_conversation {
+            return Err(TaskConfigError(format!(
+                "{row_ctx}: the first stage cannot set new_conversation; the initial conversation is \
+                 created automatically"
+            )));
+        }
+        stages.push(stage);
     }
 
     let schema = toml_util::table(&data, "result_schema", &ctx)?;
@@ -84,7 +91,12 @@ fn load_stage(row: &TomlTable, ctx: &str, task_dir: &Path) -> Result<Stage, Task
     let text = toml_util::req_str(row, "text", ctx)?;
     let text = expand_files(&text, task_dir, ctx)?;
     let files = load_staged_files(row, ctx, &task_dir.join("inputs"))?;
-    Ok(Stage { text, files })
+    let new_conversation = toml_util::opt_bool(row, "new_conversation", ctx, false)?;
+    Ok(Stage {
+        text,
+        files,
+        new_conversation,
+    })
 }
 
 fn expand_files(text: &str, task_dir: &Path, ctx: &str) -> Result<String, TaskConfigError> {
@@ -275,5 +287,61 @@ mod tests {
         assert!(validate_state_path("/other", "ctx").is_err());
         assert!(validate_state_path("http://host/api/x", "ctx").is_err());
         assert!(validate_state_path("//host/api/x", "ctx").is_err());
+    }
+
+    /// Write a minimal slug-named task dir (verifier + result_schema) with the given `[[stages]]`
+    /// TOML, returning the temp dir whose `sample-task` child is the loadable task dir.
+    fn write_task(stages_toml: &str) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sample-task");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("verifier.py"), "def test_ok(): assert True\n").unwrap();
+        std::fs::write(
+            dir.join("task.toml"),
+            format!("{stages_toml}\n[result_schema]\ntype = \"object\"\n"),
+        )
+        .unwrap();
+        tmp
+    }
+
+    #[test]
+    fn stage_new_conversation_defaults_false() {
+        let tmp = write_task("[[stages]]\ntext = \"go\"\n");
+        let task = load_task(&tmp.path().join("sample-task")).unwrap();
+        assert_eq!(task.stages.len(), 1);
+        assert!(!task.stages[0].new_conversation);
+    }
+
+    #[test]
+    fn stage_new_conversation_parsed_on_later_stage() {
+        let tmp = write_task(
+            "[[stages]]\ntext = \"a\"\n\n[[stages]]\ntext = \"b\"\nnew_conversation = true\n",
+        );
+        let task = load_task(&tmp.path().join("sample-task")).unwrap();
+        assert!(!task.stages[0].new_conversation);
+        assert!(task.stages[1].new_conversation);
+    }
+
+    #[test]
+    fn stage_new_conversation_rejected_on_first_stage() {
+        let tmp = write_task("[[stages]]\ntext = \"a\"\nnew_conversation = true\n");
+        let err = load_task(&tmp.path().join("sample-task")).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("first stage cannot set new_conversation"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn stage_new_conversation_rejects_non_bool() {
+        let tmp = write_task(
+            "[[stages]]\ntext = \"a\"\n\n[[stages]]\ntext = \"b\"\nnew_conversation = \"yes\"\n",
+        );
+        let err = load_task(&tmp.path().join("sample-task")).unwrap_err();
+        assert!(
+            err.to_string().contains("new_conversation"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/archestra-bench/runner/src/config/types.rs
+++ b/archestra-bench/runner/src/config/types.rs
@@ -90,6 +90,10 @@ pub struct StagedFile {
 pub struct Stage {
     pub text: String,
     pub files: Vec<StagedFile>,
+    /// Drive this stage (and the ones after it) in a fresh conversation rather than continuing the
+    /// task's current one. Lets a task verify that files persist across conversations: a stage exports
+    /// a file, then a later `new_conversation` stage rediscovers it from persistent storage.
+    pub new_conversation: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -1268,12 +1268,23 @@ async fn capture_effective_prompts(
     turn_count: usize,
     artifacts: &RunArtifacts,
 ) {
+    // Every emitted event carries `conversation_id` so a multi-conversation rollout's captured prompts
+    // can be attributed to the conversation they came from.
+    let emit_error = async |message: &str| {
+        artifacts
+            .append(
+                "effective_prompt_error",
+                serde_json::json!({"conversation_id": conversation_id, "error": message}),
+            )
+            .await;
+    };
+
     let interactions = match client.fetch_session_interactions(conversation_id).await {
         Ok(rows) => rows,
         Err(e) => {
             let msg = format!("failed to fetch interactions: {e}");
             warn!("{msg}");
-            artifacts.append_error("effective_prompt_error", &msg).await;
+            emit_error(&msg).await;
             return;
         }
     };
@@ -1281,27 +1292,31 @@ async fn capture_effective_prompts(
     if turn_count > 0 && interactions.is_empty() {
         let msg = "no interactions found despite the conversation taking turns".to_string();
         warn!("{msg}");
-        artifacts.append_error("effective_prompt_error", &msg).await;
+        emit_error(&msg).await;
         return;
     }
 
     let outcome = extract_effective_prompts(&interactions);
     for prompt in &outcome.prompts {
         match serde_json::to_value(prompt) {
-            Ok(value) => artifacts.append("effective_prompt", value).await,
+            Ok(mut value) => {
+                if let serde_json::Value::Object(map) = &mut value {
+                    map.insert(
+                        "conversation_id".to_string(),
+                        serde_json::Value::String(conversation_id.to_string()),
+                    );
+                }
+                artifacts.append("effective_prompt", value).await
+            }
             Err(e) => {
                 warn!("failed to serialize effective prompt: {e}");
-                artifacts
-                    .append_error("effective_prompt_error", &e.to_string())
-                    .await;
+                emit_error(&e.to_string()).await;
             }
         }
     }
     for error in &outcome.errors {
         warn!("effective-prompt anomaly: {error}");
-        artifacts
-            .append_error("effective_prompt_error", error)
-            .await;
+        emit_error(error).await;
     }
 }
 

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -49,7 +49,8 @@ const SUBMIT_INSTRUCTION: &str = "When you are done, find a tool to submit your 
 // the final ask, so the model learns submission is required only on the final stage. Steers the model
 // to do the step's work and end its turn (a chat reply, which advances the runner to the next stage)
 // rather than hunting for a submit tool and looping on the "more steps" rejection.
-const CONTINUE_INSTRUCTION: &str = "When you've finished this step, tell me where things stand and wait for my next message.";
+const CONTINUE_INSTRUCTION: &str =
+    "When you've finished this step, tell me where things stand and wait for my next message.";
 // One-shot follow-up sent when a lane ends its turn without submitting. The nudge runs on the final
 // stage (submission open), so drive_stage still appends SUBMIT_INSTRUCTION; this only calls out the
 // omission.
@@ -1303,6 +1304,41 @@ async fn capture_effective_prompts(
     }
 }
 
+/// Create a conversation for the running task and record it. Used both for the task's initial
+/// conversation and for each `new_conversation` stage, which opens a fresh one (same agent, project,
+/// model, and key) so the agent starts from an empty sandbox and chat history.
+async fn open_conversation(
+    client: &EvalClient,
+    agent_id: &str,
+    title: &str,
+    resolved: &ResolvedModel,
+    project_id: Option<&str>,
+    artifacts: &RunArtifacts,
+) -> Result<String, RunError> {
+    let conversation = client
+        .create_conversation(
+            agent_id,
+            Some(title),
+            Some(&resolved.model_id),
+            Some(&resolved.api_key_id),
+            project_id,
+        )
+        .await?;
+    let conversation_id = conversation
+        .get("id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| RunError::Config("create_conversation returned no `id`".to_string()))?
+        .to_string();
+    artifacts
+        .append(
+            "conversation_created",
+            serde_json::json!({"conversation_id": conversation_id}),
+        )
+        .await;
+    Ok(conversation_id)
+}
+
 async fn grade_rollout(
     client: EvalClient,
     bench_mcp: BenchmarkMcp,
@@ -1323,28 +1359,20 @@ async fn grade_rollout(
         .await
         .map_err(|e| RunError::Mcp(e.to_string()))?;
 
-    let conversation = client
-        .create_conversation(
-            agent_id,
-            Some(rollout_key),
-            Some(&resolved.model_id),
-            Some(&resolved.api_key_id),
-            project_id,
-        )
-        .await?;
-    let conversation_id = conversation
-        .get("id")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| RunError::Config("create_conversation returned no `id`".to_string()))?
-        .to_string();
+    let mut conversation_id = open_conversation(
+        &client,
+        agent_id,
+        rollout_key,
+        resolved,
+        project_id,
+        artifacts,
+    )
+    .await?;
+    // Every conversation this rollout drives, in order. `new_conversation` stages append to it;
+    // `metadata["conversation_id"]` tracks the current one so run.json points at the conversation that
+    // produced the result, and effective-prompt capture runs over all of them after the loop.
+    let mut conversation_ids = vec![conversation_id.clone()];
     metadata["conversation_id"] = serde_json::Value::String(conversation_id.clone());
-    artifacts
-        .append(
-            "conversation_created",
-            serde_json::json!({"conversation_id": conversation_id}),
-        )
-        .await;
     artifacts.write_run(metadata).await;
 
     let runtime: HashMap<String, String> = HashMap::from([
@@ -1374,6 +1402,23 @@ async fn grade_rollout(
     let mut stage_error: Option<String> = None;
     let final_stage = task.stages.len().saturating_sub(1);
     for (index, stage) in task.stages.iter().enumerate() {
+        // A `new_conversation` stage starts a fresh conversation (empty sandbox + chat history) and
+        // becomes the current one for this and later stages -- so a task can export a file in one chat
+        // and rediscover it from persistent storage in the next. Rejected on the first stage at load
+        // time, since the initial conversation is already created above.
+        if stage.new_conversation {
+            conversation_id = open_conversation(
+                &client,
+                agent_id,
+                rollout_key,
+                resolved,
+                project_id,
+                artifacts,
+            )
+            .await?;
+            conversation_ids.push(conversation_id.clone());
+            metadata["conversation_id"] = serde_json::Value::String(conversation_id.clone());
+        }
         // Single source of truth: the final stage both opens the server-side submission gate and gets
         // the SUBMIT_INSTRUCTION trailer (earlier stages get CONTINUE_INSTRUCTION). Binding it once
         // keeps the gate and the prompt trailer from drifting apart.
@@ -1381,6 +1426,9 @@ async fn grade_rollout(
         if submission_open {
             bench_mcp.allow_submission(rollout_key).await;
         }
+        // Carry prior chat history only when continuing the same conversation; a freshly opened one
+        // (first stage, or a `new_conversation` stage) starts empty.
+        let expect_prior_history = index > 0 && !stage.new_conversation;
         stage_error = drive_stage_with_retry(
             &client,
             &conversation_id,
@@ -1389,7 +1437,7 @@ async fn grade_rollout(
             &mut run,
             artifacts,
             &runtime,
-            index > 0,
+            expect_prior_history,
             submission_open,
         )
         .await?;
@@ -1418,6 +1466,7 @@ async fn grade_rollout(
         let nudge = Stage {
             text: SUBMIT_NUDGE.to_string(),
             files: Vec::new(),
+            new_conversation: false,
         };
         stage_error = drive_stage_with_retry(
             &client,
@@ -1433,7 +1482,11 @@ async fn grade_rollout(
         .await?;
     }
 
-    capture_effective_prompts(&client, &conversation_id, run.turn_count, artifacts).await;
+    // Capture every conversation the rollout drove, not just the last -- a `new_conversation` task
+    // splits its turns across several, and each one's effective prompts are worth recording.
+    for cid in &conversation_ids {
+        capture_effective_prompts(&client, cid, run.turn_count, artifacts).await;
+    }
 
     metadata["finish_reason"] =
         serde_json::to_value(&run.finish_reason).unwrap_or(serde_json::Value::Null);

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -70,6 +70,7 @@ const REQUIRED_TOOL_SHORT_NAMES: &[&str] = &[
     "download_file",
     "list_skills",
     "load_skill",
+    "search_files",
 ];
 const MUTATING_SKILL_TOOL_SHORT_NAMES: &[&str] = &["create_skill", "update_skill"];
 

--- a/archestra-bench/runner/src/verify.rs
+++ b/archestra-bench/runner/src/verify.rs
@@ -245,6 +245,7 @@ mod tests {
             stages: vec![Stage {
                 text: "go".to_string(),
                 files: vec![],
+                new_conversation: false,
             }],
             result_schema: serde_json::json!({"type": "object"}),
             verifier: Verifier {

--- a/archestra-bench/tasks/purchase-ledger/inputs/transactions.csv
+++ b/archestra-bench/tasks/purchase-ledger/inputs/transactions.csv
@@ -1,0 +1,14 @@
+date,description,status,amount
+2024-01-03,Acme widgets order,completed,128.50
+2024-01-05,Returned item refund,refund,-42.00
+2024-01-07,Globex subscription,completed,59.99
+2024-01-09,Office supplies,completed,23.45
+2024-01-11,Initrode order awaiting stock,pending,75.00
+2024-01-12,Initech license,completed,410.00
+2024-01-15,Duplicate charge refund,refund,-59.99
+2024-01-18,Umbrella Corp catering,completed,212.75
+2024-01-20,Hooli cloud credits,completed,89.00
+2024-01-22,Cancelled Vandelay order,pending,33.20
+2024-01-25,Wayne Enterprises consulting,completed,1500.00
+2024-01-28,Stark Industries parts,completed,640.30
+2024-01-30,Overpayment refund,refund,-128.50

--- a/archestra-bench/tasks/purchase-ledger/task.toml
+++ b/archestra-bench/tasks/purchase-ledger/task.toml
@@ -1,0 +1,22 @@
+[[stages]]
+text = """Here's our transaction export for January -- it's got some refunds and a couple of orders that never went through mixed in with the real sales. Could you pull out just the completed purchases into a clean file and keep it saved for me? I'll want to come back to it later, so make sure it won't get lost. No need to total anything yet.
+
+```csv
+{{file:inputs/transactions.csv}}
+```"""
+
+[[stages]]
+new_conversation = true
+text = """Earlier I had you put together a clean file of just our completed January purchases and save it for me. Can you pull that back up and tell me the grand total dollar amount across all of them? Send the number over with result = {"total": <dollars>}."""
+
+[result_schema]
+type = "object"
+required = ["total"]
+additionalProperties = false
+
+  [result_schema.properties.total]
+  type = "number"
+  minimum = 0
+
+[verifier]
+deps = []

--- a/archestra-bench/tasks/purchase-ledger/verifier.py
+++ b/archestra-bench/tasks/purchase-ledger/verifier.py
@@ -1,0 +1,38 @@
+"""Verify the submitted total against a recompute from the same transactions fixture.
+
+Reads BENCH_RESULT (submitted JSON) and BENCH_FIXTURES/inputs/transactions.csv (the same export shown
+to the agent). The agent receives the export in one chat and is asked, in a *separate* chat, for the
+grand total of just the completed purchases -- so a correct answer requires it to have carried the file
+across conversations via persistent storage. Recomputing from the fixture avoids hard-coding the value.
+"""
+
+import csv
+import json
+import os
+from pathlib import Path
+
+
+def _result() -> dict:
+    path = os.environ.get("BENCH_RESULT")
+    assert path, "BENCH_RESULT is not set"
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _expected_total_cents() -> int:
+    base = os.environ.get("BENCH_FIXTURES")
+    assert base, "BENCH_FIXTURES is not set"
+    total = 0
+    with Path(base, "inputs", "transactions.csv").open(encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            if row["status"].strip().lower() == "completed":
+                total += round(float(row["amount"]) * 100)
+    return total
+
+
+def test_total_matches() -> None:
+    # Money compared in integer cents so float representation never decides the verdict.
+    expected = _expected_total_cents()
+    submitted_cents = round(float(_result()["total"]) * 100)
+    assert submitted_cents == expected, (
+        f"submitted total {submitted_cents} cents != expected {expected} cents"
+    )


### PR DESCRIPTION
## What

Adds a per-stage `new_conversation = true` knob to archestra-bench tasks. When a stage sets it, the runner opens a **fresh Archestra conversation** (same agent / project / model / key) for that stage and the ones after it, so the agent starts from an empty per-conversation sandbox and chat history.

This makes Archestra's cross-conversation **persistent file storage** ("My Files") testable: a task can export a file in one chat and rediscover it from persistent storage in the next.

## Why this works

- Ephemeral `/home/sandbox` is scoped per-conversation, so a new conversation starts empty.
- Files exported via `download_file` land in persistent "My Files", which `search_files` reads back — **project-scoped**, and the bench creates one project per lane, so the second chat (same lane) sees the first chat's file while lanes stay isolated.

## Changes

- **Runner** (`runner/src/`): `Stage.new_conversation`; parsed via the existing `opt_bool`; rejected on the first stage at load time (the initial conversation already exists). In `grade_rollout`, `conversation_id` is now mutable and re-opened on a `new_conversation` stage via a new `open_conversation` helper; `expect_prior_history = index > 0 && !new_conversation`. `metadata["conversation_id"]` tracks the current conversation and effective-prompt capture runs over every conversation the rollout drove.
- **Sample task** `tasks/purchase-ledger/` in a new isolated env `envs/file-storage.toml` (grants `search_files`, which is not in the base sandbox tool set): chat 1 cleans a transaction CSV and saves it; chat 2 (a `new_conversation` stage) re-finds it and reports the completed-purchase total. The raw data is staged only in chat 1 and never inlined in chat 2, so a correct answer is unrecoverable without retrieving the persisted file. Verifier recomputes the total from the fixture.

## Tests / validation

- 4 new `config::tasks` unit tests (default false / parsed-true / first-stage rejection / non-bool rejection).
- `test_load_real_envs` loads the new env + task; `cargo fmt --check` (my files), `clippy --workspace -D warnings`, `cargo test --workspace` pass.
- Verifier smoke-tested offline (accepts the correct total, rejects a wrong one). Full end-to-end **grading** of `purchase-ledger` needs a live dev stack (Dagger + bench Postgres + provider key) and is not run in CI.

## Review notes (adversarial gates run)

- A mid-task conversation-open failure intentionally propagates as an `infra:` agent_error (correct classification, consistent with the initial-create path) rather than a model error.
- No unit test drives the live split (it would require mocking `create_conversation`, a backend boundary); the sample task covers that end-to-end on a live stack.

https://claude.ai/code/session_01LSJ5Jwpe4aPrLTmxuPf3US

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>