### PR TITLE
feat(backend): terminate runs stuck repeating identical tool calls

### DIFF
--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -7,9 +7,15 @@
 
 import { ChatErrorCode } from "@archestra/shared";
 import type { ModelMessage } from "ai";
-import { simulateReadableStream } from "ai";
+import { simulateReadableStream, tool } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+import {
+  REPEAT_CALL_TERMINATION_CEILING,
+  REPEAT_CALL_TERMINATION_NOTICE,
+  type ToolCallRepeatTracker,
+} from "@/clients/tool-call-repeat-tracker";
 import { ProviderError } from "@/routes/chat/errors";
 import { executeA2AMessage } from "./a2a-executor";
 
@@ -249,5 +255,66 @@ describe("executeA2AMessage real stream boundary", () => {
       model.doStreamCalls[0].prompt.length,
     );
     expect(result.text).toBe("Recovered after trim");
+  });
+
+  test("stops via the repeat-call ceiling and surfaces a termination notice as text", async () => {
+    // The model repeats the same tool call every step (unique call ids, identical
+    // name+args), so the run's tracker streak climbs to the ceiling.
+    let step = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "stream-start", warnings: [] },
+            {
+              type: "tool-call",
+              toolCallId: `tc-${step++}`,
+              toolName: "stuck_tool",
+              input: "{}",
+            },
+            {
+              type: "finish",
+              finishReason: { unified: "tool-calls", raw: "tool-calls" },
+              usage,
+            },
+          ],
+        }),
+      }),
+    });
+    primeAgent(model);
+
+    // Stand in for the real breaker (which lives in the mocked getChatMcpTools):
+    // record into the run's tracker and skip execution. The run hands its own
+    // tracker to getChatMcpTools and reads the same instance in its stopWhen.
+    let captured: ToolCallRepeatTracker | undefined;
+    mockGetChatMcpTools.mockImplementation(
+      ({ repeatTracker }: { repeatTracker: ToolCallRepeatTracker }) => {
+        captured = repeatTracker;
+        return Promise.resolve({
+          stuck_tool: tool({
+            description: "always repeated",
+            inputSchema: z.object({}),
+            execute: async () => {
+              repeatTracker.record("stuck_tool", {});
+              return "skipped: repeated call";
+            },
+          }),
+        });
+      },
+    );
+
+    const result = await executeA2AMessage({
+      agentId: "agent-child",
+      message: "Handle this",
+      organizationId: "org-1",
+      userId: "user-1",
+      conversationId: "conv-1",
+    });
+
+    // The loop stopped once the streak hit the ceiling, before MAX_AGENT_STEPS.
+    expect(captured?.hasReachedTerminationCeiling()).toBe(true);
+    expect(model.doStreamCalls).toHaveLength(REPEAT_CALL_TERMINATION_CEILING);
+    // No assistant text was produced, so the caller-visible notice stands in.
+    expect(result.text).toBe(REPEAT_CALL_TERMINATION_NOTICE);
   });
 });

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -17,6 +17,11 @@ import { subagentExecutionTracker } from "@/agents/subagent-execution-tracker";
 import { closeChatMcpClient, getChatMcpTools } from "@/clients/chat-mcp-client";
 import { createLLMModelForAgent } from "@/clients/llm-client";
 import mcpClient from "@/clients/mcp-client";
+import {
+  REPEAT_CALL_TERMINATION_NOTICE,
+  repeatCeilingStopCondition,
+  ToolCallRepeatTracker,
+} from "@/clients/tool-call-repeat-tracker";
 import logger from "@/logging";
 import { AgentModel, McpServerModel } from "@/models";
 import {
@@ -195,6 +200,10 @@ export async function executeA2AMessage(
   }
 
   try {
+    // One tracker per run, shared between the breaker (records each call) and the
+    // stop condition below (terminates the run once repeats hit the ceiling).
+    const repeatTracker = new ToolCallRepeatTracker();
+
     // Fetch MCP tools for the agent (including delegation tools)
     // Pass sessionId, delegationChain, and isolationKey for browser tab isolation
     const mcpTools = await getChatMcpTools({
@@ -211,6 +220,7 @@ export async function executeA2AMessage(
       abortSignal,
       blockOnApprovalRequired: params.blockOnApprovalRequired ?? true,
       scheduleTriggerRunId,
+      repeatTracker,
     });
 
     const systemPrompt = await buildAgentSystemPrompt({
@@ -271,7 +281,10 @@ export async function executeA2AMessage(
       model,
       system: systemPrompt,
       tools: mcpTools,
-      stopWhen: stepCountIs(MAX_AGENT_STEPS),
+      stopWhen: [
+        stepCountIs(MAX_AGENT_STEPS),
+        repeatCeilingStopCondition(repeatTracker),
+      ],
       abortSignal,
     };
     const config: Parameters<typeof streamText>[0] =
@@ -351,6 +364,16 @@ export async function executeA2AMessage(
         throw new Error(
           "A2A execution failed: no response UIMessage generated",
         );
+      }
+
+      // The repeat-call ceiling stops the loop on a tool-call step, so the model
+      // never took a turn to produce assistant text and `finalText` is empty.
+      // Headless callers read only `text`, so surface why the run ended.
+      if (
+        finalText.trim() === "" &&
+        repeatTracker.hasReachedTerminationCeiling()
+      ) {
+        finalText = REPEAT_CALL_TERMINATION_NOTICE;
       }
     } catch (streamError) {
       const capturedStreamError = getCapturedStreamError();

--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -20,7 +20,11 @@ import { resolveSessionExternalIdpToken } from "@/services/identity-providers/se
 import { beforeEach, describe, expect, test } from "@/test";
 import * as chatClient from "./chat-mcp-client";
 import mcpClient from "./mcp-client";
-import { MAX_IDENTICAL_TOOL_CALLS } from "./tool-call-repeat-tracker";
+import {
+  MAX_IDENTICAL_TOOL_CALLS,
+  REPEAT_CALL_TERMINATION_CEILING,
+  ToolCallRepeatTracker,
+} from "./tool-call-repeat-tracker";
 
 const mockExecuteA2AMessage = vi.fn();
 
@@ -670,6 +674,44 @@ describe("getChatMcpTools repeated-call circuit breaker", () => {
     // A fresh run executes the same call rather than carrying over the nudge.
     expect(toolResultContent(fresh)).toContain("ok");
     expect(mcpClient.executeToolCallForOwner).toHaveBeenCalledTimes(1);
+  });
+
+  test("at the termination ceiling the breaker emits a terminal message and the caller's tracker reports termination", async () => {
+    const { baseParams } = await setupChatToolEnv({
+      gatewayTools: [externalTool("extsrv__fetch_data")],
+    });
+
+    vi.spyOn(hookDispatcherService, "fire").mockResolvedValue({
+      decision: "proceed",
+      runs: [],
+    });
+    vi.mocked(mcpClient.executeToolCallForOwner).mockResolvedValue({
+      content: [{ type: "text", text: "external result" }],
+      isError: false,
+    } as never);
+
+    // The run owns the tracker so the breaker records into the same instance the
+    // run's stop condition reads.
+    const repeatTracker = new ToolCallRepeatTracker();
+    const tools = await chatClient.getChatMcpTools({
+      ...baseParams,
+      repeatTracker,
+    });
+
+    for (let i = 1; i < REPEAT_CALL_TERMINATION_CEILING; i++) {
+      await tools.extsrv__fetch_data.execute?.(
+        { query: "stuck" },
+        execOptions(`call-${i}`),
+      );
+      expect(repeatTracker.hasReachedTerminationCeiling()).toBe(false);
+    }
+
+    const terminal = await tools.extsrv__fetch_data.execute?.(
+      { query: "stuck" },
+      execOptions("call-ceiling"),
+    );
+    expect(toolResultContent(terminal)).toContain("run is being stopped");
+    expect(repeatTracker.hasReachedTerminationCeiling()).toBe(true);
   });
 
   test("breaks repeated identical delegation calls without spawning more child agents", async () => {

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -689,6 +689,7 @@ export async function getChatMcpTools({
   blockOnApprovalRequired,
   scheduleTriggerRunId,
   hookRunCollector,
+  repeatTracker,
 }: {
   agentName: string;
   agentId: string;
@@ -727,6 +728,14 @@ export async function getChatMcpTools({
   scheduleTriggerRunId?: string;
   /** Per-turn sink for inline `data-hook-run` entries (chat path only). */
   hookRunCollector?: CollectedHookRun[];
+  /**
+   * Per-run repeated-tool-call tracker. Run entrypoints that own a `stopWhen`
+   * pass their own instance so the breaker records into the same tracker the
+   * run's `repeatCeilingStopCondition` reads (single source of truth). Callers
+   * with no stream (e.g. the tool-listing endpoint) and tests omit it and get a
+   * fresh internal tracker.
+   */
+  repeatTracker?: ToolCallRepeatTracker;
 }): Promise<Record<string, Tool>> {
   const scopeKey = isolationKey ?? conversationId;
   const toolCacheKey = getToolCacheKey(agentId, userId, scopeKey);
@@ -742,8 +751,10 @@ export async function getChatMcpTools({
     // once per run, and every wrapper reads the tracker through this context.
     // Best-effort under concurrency: two overlapping no-abortSignal runs on the
     // same scope share this context, so a reset can clear the other's in-flight
-    // streak — fail-open (the breaker under-fires, never falsely fires).
-    cached.context.repeatTracker = new ToolCallRepeatTracker();
+    // streak — fail-open (the breaker under-fires, never falsely fires). When the
+    // caller owns the tracker, bind that instance so its stop condition reads the
+    // same streak the breaker records into.
+    cached.context.repeatTracker = repeatTracker ?? new ToolCallRepeatTracker();
     logger.info(
       {
         agentId,
@@ -863,9 +874,10 @@ export async function getChatMcpTools({
       considerContextUntrusted,
       teams,
       userTeams,
-      // One tracker per run. On a cache hit the cached context's tracker is
-      // reset (see above) so repeat counts never carry across runs.
-      repeatTracker: new ToolCallRepeatTracker(),
+      // One tracker per run: the caller's instance when it owns a stop policy,
+      // otherwise a fresh one. On a cache hit it is rebound (see above) so
+      // repeat counts never carry across runs.
+      repeatTracker: repeatTracker ?? new ToolCallRepeatTracker(),
     };
     const aiTools: Record<string, Tool> = {};
 

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -29,7 +29,10 @@ import {
 } from "@/archestra-mcp-server";
 import type { ChatMcpElicitationBridge } from "@/clients/chat-mcp-elicitation";
 import mcpClient, { type TokenAuthContext } from "@/clients/mcp-client";
-import type { ToolCallRepeatTracker } from "@/clients/tool-call-repeat-tracker";
+import type {
+  RepeatSeverity,
+  ToolCallRepeatTracker,
+} from "@/clients/tool-call-repeat-tracker";
 import { hookDispatcherService } from "@/hooks/hook-dispatcher-service";
 import { type CollectedHookRun, toCollectedRuns } from "@/hooks/hook-run-parts";
 import logger from "@/logging";
@@ -1255,9 +1258,18 @@ function buildPreToolUseBlockedResult(reason: string | null): string {
 /**
  * Tool-result text returned in place of executing a tool call that has repeated
  * with identical arguments past the threshold (see ToolCallRepeatTracker). The
- * call is not executed; this message replaces its result.
+ * call is not executed; this message replaces its result. At the termination
+ * tier the run is also stopped (see repeatCeilingStopCondition), so this text is
+ * the last recorded content and states why the run ended.
  */
-function buildRepeatedCallNudge(toolName: string, count: number): string {
+function buildRepeatedCallNudge(
+  toolName: string,
+  count: number,
+  severity: RepeatSeverity,
+): string {
+  if (severity === "terminate") {
+    return `You have called \`${toolName}\` with identical arguments ${count} times in a row despite earlier nudges, so the run is being stopped — repeating it cannot produce a different result.`;
+  }
   return `You have called \`${toolName}\` with identical arguments ${count} times in a row, so it was not executed again — repeating it will not produce a different result. Change the arguments, use a different tool, or give your best final answer with what you already know.`;
 }
 
@@ -1289,8 +1301,11 @@ function applyRepeatedCallBreaker(params: {
       sessionId: ctx.sessionId ?? null,
       toolName,
       count: repeat.count,
+      severity: repeat.severity,
     },
-    "Skipping repeated identical tool call; nudging the model",
+    repeat.severity === "terminate"
+      ? "Repeated identical tool call hit the ceiling; stopping the run"
+      : "Skipping repeated identical tool call; nudging the model",
   );
   span.setAttribute(ATTR_MCP_IS_ERROR_RESULT, false);
   reportToolMetrics({
@@ -1300,7 +1315,7 @@ function applyRepeatedCallBreaker(params: {
     startTime,
     isError: false,
   });
-  return buildRepeatedCallNudge(toolName, repeat.count);
+  return buildRepeatedCallNudge(toolName, repeat.count, repeat.severity);
 }
 
 /** Max chars of tool output passed to a PostToolUse hook payload. */

--- a/platform/backend/src/clients/tool-call-repeat-tracker.test.ts
+++ b/platform/backend/src/clients/tool-call-repeat-tracker.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   MAX_IDENTICAL_TOOL_CALLS,
+  REPEAT_CALL_TERMINATION_CEILING,
+  repeatCeilingStopCondition,
   ToolCallRepeatTracker,
 } from "./tool-call-repeat-tracker";
 
@@ -11,30 +13,63 @@ describe("ToolCallRepeatTracker", () => {
 
     for (let i = 1; i <= MAX_IDENTICAL_TOOL_CALLS; i++) {
       const record = tracker.record("read_file", args);
-      expect(record).toEqual({ count: i, shouldNudge: false });
+      expect(record).toEqual({
+        count: i,
+        shouldNudge: false,
+        severity: "none",
+      });
     }
 
     const overThreshold = tracker.record("read_file", args);
     expect(overThreshold).toEqual({
       count: MAX_IDENTICAL_TOOL_CALLS + 1,
       shouldNudge: true,
+      severity: "nudge",
     });
   });
 
-  it("resets the counter when a different call interleaves", () => {
+  it("escalates to terminate at the ceiling", () => {
     const tracker = new ToolCallRepeatTracker();
     const args = { q: "stuck" };
 
-    for (let i = 0; i < MAX_IDENTICAL_TOOL_CALLS + 2; i++) {
+    // Below the ceiling the breaker only nudges.
+    for (let i = 1; i < REPEAT_CALL_TERMINATION_CEILING; i++) {
+      const record = tracker.record("search", args);
+      expect(record.severity).toBe(
+        i > MAX_IDENTICAL_TOOL_CALLS ? "nudge" : "none",
+      );
+      expect(tracker.hasReachedTerminationCeiling()).toBe(false);
+    }
+
+    const atCeiling = tracker.record("search", args);
+    expect(atCeiling).toEqual({
+      count: REPEAT_CALL_TERMINATION_CEILING,
+      shouldNudge: true,
+      severity: "terminate",
+    });
+    expect(tracker.hasReachedTerminationCeiling()).toBe(true);
+  });
+
+  it("resets the counter (and termination) when a different call interleaves", () => {
+    const tracker = new ToolCallRepeatTracker();
+    const args = { q: "stuck" };
+
+    for (let i = 0; i < REPEAT_CALL_TERMINATION_CEILING; i++) {
       tracker.record("search", args);
     }
-    expect(tracker.record("search", args).shouldNudge).toBe(true);
+    expect(tracker.hasReachedTerminationCeiling()).toBe(true);
 
     // A different tool resets, so the next "search" starts a fresh streak.
-    expect(tracker.record("other_tool", {}).shouldNudge).toBe(false);
+    expect(tracker.record("other_tool", {})).toEqual({
+      count: 1,
+      shouldNudge: false,
+      severity: "none",
+    });
+    expect(tracker.hasReachedTerminationCeiling()).toBe(false);
     expect(tracker.record("search", args)).toEqual({
       count: 1,
       shouldNudge: false,
+      severity: "none",
     });
   });
 
@@ -46,6 +81,7 @@ describe("ToolCallRepeatTracker", () => {
     expect(tracker.record("read_file", { path: "/b" })).toEqual({
       count: 1,
       shouldNudge: false,
+      severity: "none",
     });
   });
 
@@ -62,7 +98,23 @@ describe("ToolCallRepeatTracker", () => {
     expect(tracker.record("noop", undefined)).toEqual({
       count: 1,
       shouldNudge: false,
+      severity: "none",
     });
     expect(tracker.record("noop", undefined).count).toBe(2);
+  });
+});
+
+describe("repeatCeilingStopCondition", () => {
+  it("fires only once the bound tracker reaches the ceiling", () => {
+    const tracker = new ToolCallRepeatTracker();
+    const stop = repeatCeilingStopCondition(tracker);
+    const noSteps = { steps: [] } as unknown as Parameters<typeof stop>[0];
+
+    for (let i = 1; i < REPEAT_CALL_TERMINATION_CEILING; i++) {
+      tracker.record("run_tool", {});
+      expect(stop(noSteps)).toBe(false);
+    }
+    tracker.record("run_tool", {});
+    expect(stop(noSteps)).toBe(true);
   });
 });

--- a/platform/backend/src/clients/tool-call-repeat-tracker.ts
+++ b/platform/backend/src/clients/tool-call-repeat-tracker.ts
@@ -1,8 +1,12 @@
 // Per-run guard against a model re-issuing the identical tool call forever.
-// The agent loop only stops at MAX_AGENT_STEPS (agents/agent-run-stream.ts),
-// so a model stuck repeating one call burns hundreds of steps silently. This
-// tracker detects consecutive identical (toolName + arguments) calls within a
-// single run so the tool layer can nudge the model instead of re-executing.
+// Without a ceiling the agent loop only stops at MAX_AGENT_STEPS
+// (agents/agent-run-stream.ts), so a model stuck repeating one call burns
+// hundreds of steps silently. This tracker counts consecutive identical
+// (toolName + arguments) calls within a single run so the tool layer can nudge
+// the model, and — once the repeats cross a ceiling — so the run's stop policy
+// can terminate the loop instead of nudging into the void.
+
+import type { StopCondition, ToolSet } from "ai";
 
 /**
  * Consecutive identical tool calls that execute normally before the tracker
@@ -12,11 +16,38 @@
  */
 export const MAX_IDENTICAL_TOOL_CALLS = 3;
 
+/**
+ * Consecutive identical calls at which the breaker stops nudging and the run is
+ * terminated (via {@link repeatCeilingStopCondition}). A model still repeating
+ * after several nudges will not recover, so stopping here caps wasted compute
+ * instead of letting it run to MAX_AGENT_STEPS. Named constant, not config.
+ * @public exported for tests and the stop-condition wiring.
+ */
+export const REPEAT_CALL_TERMINATION_CEILING = 6;
+
+/**
+ * Caller-facing result text for a headless run that the ceiling stopped on a
+ * tool-call step. The model never got a turn to produce assistant text, so
+ * `stream.text` is empty; surfaces a reason in its place. Interactive chat does
+ * not need this — it renders the breaker's terminal tool-result part directly.
+ */
+export const REPEAT_CALL_TERMINATION_NOTICE =
+  "The run was stopped because the agent repeatedly issued the same tool call with identical arguments without making progress.";
+
+/**
+ * How the breaker should respond to a recorded call:
+ * `none` — under threshold, execute normally; `nudge` — skip and nudge;
+ * `terminate` — skip, emit a terminal message, and stop the run.
+ */
+export type RepeatSeverity = "none" | "nudge" | "terminate";
+
 interface RepeatRecord {
   /** How many times this exact call has occurred consecutively (>= 1). */
   count: number;
   /** True once the consecutive count exceeds MAX_IDENTICAL_TOOL_CALLS. */
   shouldNudge: boolean;
+  /** Escalation tier for this call, derived from the consecutive count. */
+  severity: RepeatSeverity;
 }
 
 /**
@@ -43,11 +74,40 @@ export class ToolCallRepeatTracker {
       this.lastFingerprint = fingerprint;
       this.consecutiveCount = 1;
     }
+    const severity = severityFor(this.consecutiveCount);
     return {
       count: this.consecutiveCount,
-      shouldNudge: this.consecutiveCount > MAX_IDENTICAL_TOOL_CALLS,
+      shouldNudge: severity !== "none",
+      severity,
     };
   }
+
+  /**
+   * Whether the current consecutive streak has reached the termination ceiling.
+   * Read by {@link repeatCeilingStopCondition} at each step boundary; the SDK
+   * evaluates stop conditions after the step's tool call has been recorded, so
+   * the streak this reads already includes the call that hit the ceiling.
+   */
+  hasReachedTerminationCeiling(): boolean {
+    return this.consecutiveCount >= REPEAT_CALL_TERMINATION_CEILING;
+  }
+}
+
+/**
+ * Stop condition bound to one run's tracker: terminates the agent loop once the
+ * run's repeated-call streak reaches the ceiling. Added to a caller's `stopWhen`
+ * array alongside `stepCountIs(MAX_AGENT_STEPS)`, the same termination channel.
+ */
+export function repeatCeilingStopCondition(
+  tracker: ToolCallRepeatTracker,
+): StopCondition<ToolSet> {
+  return () => tracker.hasReachedTerminationCeiling();
+}
+
+function severityFor(count: number): RepeatSeverity {
+  if (count >= REPEAT_CALL_TERMINATION_CEILING) return "terminate";
+  if (count > MAX_IDENTICAL_TOOL_CALLS) return "nudge";
+  return "none";
 }
 
 /**

--- a/platform/backend/src/routes/chat/build-chat-context.ts
+++ b/platform/backend/src/routes/chat/build-chat-context.ts
@@ -5,6 +5,7 @@ import {
   getChatMcpToolUiResourceUris,
 } from "@/clients/chat-mcp-client";
 import type { ChatMcpElicitationBridge } from "@/clients/chat-mcp-elicitation";
+import { ToolCallRepeatTracker } from "@/clients/tool-call-repeat-tracker";
 import type { CollectedHookRun } from "@/hooks/hook-run-parts";
 import { ConversationEnabledToolModel } from "@/models";
 import type { ToolExposureMode } from "@/types";
@@ -35,6 +36,8 @@ export async function buildChatContext(params: {
   systemPrompt: string | undefined;
   /** How the tool set was filtered — surfaced for the stream-start log line. */
   toolSelection: { hasCustomSelection: boolean; enabledToolCount: number };
+  /** Per-run tracker shared with the stream's repeated-call stop condition. */
+  repeatTracker: ToolCallRepeatTracker;
 }> {
   const {
     conversationId,
@@ -52,6 +55,9 @@ export async function buildChatContext(params: {
     ConversationEnabledToolModel.findByConversation(conversationId),
     ConversationEnabledToolModel.hasCustomSelection(conversationId),
   ]);
+
+  // One tracker per run, shared with the stream's repeated-call stop condition.
+  const repeatTracker = new ToolCallRepeatTracker();
 
   // Fetch MCP tools with enabled tool filtering
   // Pass undefined if no custom selection (use all tools)
@@ -72,6 +78,7 @@ export async function buildChatContext(params: {
       elicitation,
       user,
       hookRunCollector,
+      repeatTracker,
     }),
     getChatMcpToolUiResourceUris(agentId),
   ]);
@@ -94,5 +101,6 @@ export async function buildChatContext(params: {
       hasCustomSelection,
       enabledToolCount: enabledToolIds.length,
     },
+    repeatTracker,
   };
 }

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/clients/llm-client", async (importOriginal) => {
 
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { createLLMModel } from "@/clients/llm-client";
+import { ToolCallRepeatTracker } from "@/clients/tool-call-repeat-tracker";
 import ConversationModel from "@/models/conversation";
 import MessageModel from "@/models/message";
 import { test } from "@/test";
@@ -1115,10 +1116,10 @@ describe("buildChatStopConditions", () => {
       iconLogo: null,
     });
 
-    const stopConditions = buildChatStopConditions();
+    const stopConditions = buildChatStopConditions(new ToolCallRepeatTracker());
     const toolNames = getChatStopToolNames();
 
-    expect(stopConditions).toHaveLength(3);
+    expect(stopConditions).toHaveLength(4);
     expect(toolNames.swapAgentToolName).toBe("acme_control_plane__swap_agent");
     expect(toolNames.swapToDefaultAgentToolName).toBe(
       "acme_control_plane__swap_to_default_agent",

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -45,6 +45,10 @@ import {
   createLLMModelForAgent,
   isApiKeyRequired,
 } from "@/clients/llm-client";
+import {
+  repeatCeilingStopCondition,
+  type ToolCallRepeatTracker,
+} from "@/clients/tool-call-repeat-tracker";
 import config from "@/config";
 import { withDbTransaction } from "@/database";
 import { browserStreamFeature } from "@/features/browser-stream/services/browser-stream.feature";
@@ -456,7 +460,13 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
         // Tools + system prompt, alongside the org settings the stream needs.
         const [
-          { mcpTools, toolUiResourceUris, systemPrompt, toolSelection },
+          {
+            mcpTools,
+            toolUiResourceUris,
+            systemPrompt,
+            toolSelection,
+            repeatTracker,
+          },
           slimChatErrorUi,
           organization,
         ] = await Promise.all([
@@ -795,7 +805,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   model,
                   messages: modelMessages,
                   ...(supportsToolCalling && { tools: mcpTools }),
-                  stopWhen: buildChatStopConditions(),
+                  stopWhen: buildChatStopConditions(repeatTracker),
                   abortSignal: chatAbortController.signal,
                   // Repair tool names that carry a leaked harmony sentinel token
                   // (e.g. `archestra__run_command<|channel|>commentary`) before
@@ -2660,11 +2670,12 @@ export function extractFirstMessages(messages: unknown[]): ExtractedMessages {
   return { firstUserMessage, firstAssistantMessage };
 }
 
-export function buildChatStopConditions() {
+export function buildChatStopConditions(repeatTracker: ToolCallRepeatTracker) {
   return [
     stepCountIs(MAX_AGENT_STEPS),
     hasToolCall(getChatStopToolNames().swapAgentToolName),
     hasToolCall(getChatStopToolNames().swapToDefaultAgentToolName),
+    repeatCeilingStopCondition(repeatTracker),
   ];
 }
 


### PR DESCRIPTION
## Problem
The repeated-identical-tool-call breaker returns one static nudge forever once a `(toolName, args)` call repeats past the threshold. The only loop bound is `MAX_AGENT_STEPS=500`, so a stuck model (observed: 236× `run_tool {}`) burns the whole step budget.

## Change
- **`ToolCallRepeatTracker`**: `record()` returns a `severity` (`none` → `nudge` → `terminate`); nudge at counts 4–5, terminate at `REPEAT_CALL_TERMINATION_CEILING=6`. Adds `hasReachedTerminationCeiling()` and `repeatCeilingStopCondition(tracker)` — an AI-SDK `StopCondition` that halts the loop via the same `stopWhen` channel as `stepCountIs(MAX_AGENT_STEPS)`.
- **Tracker ownership**: `getChatMcpTools` takes an optional caller-owned `repeatTracker` (default `new` keeps back-compat), so the breaker records into the same instance the run's stop condition reads.
- **Wiring**: both run entrypoints add the stop condition — A2A (`a2a-executor.ts`) and chat (`build-chat-context.ts` → `routes.ts buildChatStopConditions`).
- **Terminal message**: reworded to terminal framing (no unactionable instruction).
- **Headless observability**: A2A surfaces `REPEAT_CALL_TERMINATION_NOTICE` in `text` when the ceiling stops a tool-call step (headless callers read only `.text`; chat renders the tool-result nudge directly).

Effect: a stuck model gets two nudges, then the run stops at ~6 steps instead of ~500.

## Tests
- `tool-call-repeat-tracker.test.ts`: severity tiers, ceiling, reset, stop-condition factory.
- `chat-mcp-client.tools.test.ts`: terminal-tier message + shared-tracker termination via the real breaker.
- `a2a-executor.stream.test.ts`: real-boundary test — the loop stops at the ceiling (`doStream` called exactly 6×) and returns the notice.

Type-check, biome, and knip (dev+production) clean.

https://claude.ai/code/session_018soq5AckfCrdQg4xLQNHEh

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>