### PR TITLE
fix(backend): degrade transient verifyToken errors to 401, not 500

### DIFF
--- a/platform/backend/src/auth/fastify-plugin/middleware.ts
+++ b/platform/backend/src/auth/fastify-plugin/middleware.ts
@@ -247,12 +247,19 @@ export class Authnz {
         );
       }
 
-      const serviceAccountResult =
-        await ServiceAccountModel.verifyToken(authHeader);
-      if (serviceAccountResult) {
-        request.serviceAccountAuthResult = serviceAccountResult;
-        logger.trace("[Authnz] Service account token verification succeeded");
-        return true;
+      try {
+        const serviceAccountResult =
+          await ServiceAccountModel.verifyToken(authHeader);
+        if (serviceAccountResult) {
+          request.serviceAccountAuthResult = serviceAccountResult;
+          logger.trace("[Authnz] Service account token verification succeeded");
+          return true;
+        }
+      } catch (error) {
+        logger.warn(
+          { error: error instanceof Error ? error.message : "unknown" },
+          "[Authnz] Service account token verification errored, treating as unauthenticated",
+        );
       }
     }
 


### PR DESCRIPTION
## What

In `isAuthenticated`, wrap the `ServiceAccountModel.verifyToken` call in a try/catch that logs a warning and falls through (→ 401) on a thrown error, matching the sibling `getSession` / `verifyApiKey` checks which already swallow-and-fall-through.

## Why

`verifyToken` ran a Drizzle join (`service_account_tokens` ⋈ `service_accounts`) bare. During a transient Postgres recovery window (SQLSTATE `57P03`), the pool-level retries (`database/retry.ts`, `MAX_RETRIES=3`) exhausted and the query threw; the uncaught throw escaped the auth middleware as an HTTP **500** on `POST /api/chat/conversations`, killing the request, instead of degrading to **401** like the other two auth methods.

Fails closed: a thrown `verifyToken` can never authenticate (auth state is set only on the non-null success path), and the `warn` log preserves observability of the transient event.

https://claude.ai/code/session_0172eYVvVhZjsNPbxhMGrnc9

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>