### PR TITLE
fix(e2e): update merge-queue specs for renamed app/dialog labels

### DIFF
--- a/platform/e2e-tests/tests/apps.spec.ts
+++ b/platform/e2e-tests/tests/apps.spec.ts
@@ -1,12 +1,12 @@
 import { goToPage } from "../fixtures";
 import { expect, test } from "./api-fixtures";
 
-// Seed an app from the `form` template (resolved server-side from templateId),
-// open /apps/:id/run, and assert through the nested sandbox frames
-// (host page → sandbox proxy iframe → inner app iframe) that the form reaches
-// "Ready." — which the template only shows after the injected runtime bridge
-// connected the guest SDK and completed a data-store read round-trip. This is
-// the end-to-end proof of the serve-time bridge injection in a real browser.
+// Seed an app from the default template, open /apps/:id/run, and assert through
+// the nested sandbox frames (host page → sandbox proxy iframe → inner app
+// iframe) that the app reaches "Ready." — which the template only shows after
+// the injected runtime bridge connected the guest SDK and completed a
+// data-store read round-trip. This is the end-to-end proof of the serve-time
+// bridge injection in a real browser.
 test("create an app from a template and run it standalone", async ({
   page,
   request,
@@ -34,7 +34,7 @@ test("create an app from a template and run it standalone", async ({
     request,
     method: "post",
     urlSuffix: "/api/apps",
-    data: { name, scope: "personal", templateId: "form" },
+    data: { name, scope: "personal" },
   });
   const app = (await createRes.json()) as { id: string };
 
@@ -47,10 +47,10 @@ test("create an app from a template and run it standalone", async ({
     await expect(appFrame.getByText("Ready.")).toBeVisible({
       timeout: 20_000,
     });
-    // auto-auth: the SDK bootstrap carries the viewer identity and the form
-    // template personalizes its title from archestra.user.name
+    // auto-auth: the SDK bootstrap carries the viewer identity and the default
+    // template personalizes its heading from archestra.user.name
     await expect(
-      appFrame.getByRole("heading", { name: /'s notes$/ }),
+      appFrame.getByRole("heading", { name: /^Hello, / }),
     ).toBeVisible();
 
     const diagnostics = await page.evaluate(

--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -169,7 +169,7 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
         .getByRole("dialog")
         .filter({ visible: true })
         .last()
-        .getByRole("button", { name: /^Credentials\b/ });
+        .getByRole("button", { name: /^Connections\b/ });
       await expect(connectionsButton).toBeVisible();
       await closeOpenDialogs(page);
 
@@ -332,7 +332,7 @@ test("Verify Manage Credentials dialog shows correct other users credentials", a
     await install(page, canCreateTeamCredential);
   }
 
-  // Check Credentials counter
+  // Check Connections counter
   const checkCredentialsCount = async (page: Page) => {
     await goToPage(page, "/mcp/registry");
     await openManageCredentialsDialog(page, catalogItemName);
@@ -340,7 +340,7 @@ test("Verify Manage Credentials dialog shows correct other users credentials", a
       .getByRole("dialog")
       .filter({ visible: true })
       .last()
-      .getByRole("button", { name: /^Credentials\b/ });
+      .getByRole("button", { name: /^Connections\b/ });
     await expect(connectionsButton).toBeVisible();
     await closeOpenDialogs(page);
   };

--- a/platform/e2e-tests/utils/mcp-gateway.ts
+++ b/platform/e2e-tests/utils/mcp-gateway.ts
@@ -529,7 +529,7 @@ export async function openManageCredentialsDialog(
     E2eTestId.McpServerSettingsConnectionsNavButton,
   );
   const connectionsHeading = settingsDialog.getByRole("heading", {
-    name: "Credentials",
+    name: "Connections",
     exact: true,
   });
   if (await settingsDialog.isVisible().catch(() => false)) {
@@ -602,7 +602,7 @@ export async function getVisibleCredentials(page: Page): Promise<string[]> {
     .filter({ visible: true })
     .last();
   const connectionsNavButton = visibleDialog.getByRole("button", {
-    name: /^Credentials\b/,
+    name: /^Connections\b/,
   });
   const badgeText =
     (await connectionsNavButton.textContent().catch(() => "")) ?? "";


### PR DESCRIPTION
Two e2e specs asserted UI labels the product renamed/removed, so they failed on every `merge_group` run and ejected every PR from the merge queue.

- `apps.spec.ts`: the `form` app template was removed; the server now seeds the single default template, whose heading renders `Hello, <name>`. Drop the now-ignored `templateId: "form"` and assert `/^Hello, /` instead of the gone `/'s notes$/`.
- MCP-server settings dialog renamed its **Credentials** page to **Connections**. Update the harness (`utils/mcp-gateway.ts`) and `static-credentials-management.spec.ts` matchers to the new label.

Test-only; no product change. Label sources verified in `app-templates/default.ts` and `mcp-server-settings-dialog.tsx`. Local biome / type-check / knip pass.

https://claude.ai/code/session_018soq5AckfCrdQg4xLQNHEh

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>