### PR TITLE
refactor(bench): share verifier IO contract via staged bench_verifier.py

### DIFF
--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -62,8 +62,11 @@ load time, so a precomputed answer in `expected/` can never leak). A task whose 
 **file** sets `artifact_key` to the result property naming the file the agent exported via
 `download_file`; the harness downloads that artifact and hands its bytes to the verifier as
 `BENCH_OUTPUT`. Every verifier runs in its own ephemeral `uv` env (pytest installed automatically; a
-verifier needing third-party packages lists them under `[verifier].deps`), so the harness itself ships
-no Python — the only Python in the repo is the per-task verifiers and fixtures, each isolated per run.
+verifier needing third-party packages lists them under `[verifier].deps`). The harness stages one
+shared stdlib helper, `bench_verifier.py`, beside each verifier; a verifier reads the contract through
+it — `result()`, `state()`, `output()`, `fixtures(*rel)`, `read_fixture_json(*rel)` — instead of
+re-deriving the env-var plumbing. Beyond that helper, the only Python in the repo is the per-task
+verifiers and fixtures, each isolated per run.
 
 A stage's `text` may inline a fixture's text content with a `{{file:<relpath>}}` placeholder (path
 confined to the task dir) — useful for small tabular inputs when the target provider can't accept a

--- a/archestra-bench/runner/src/verifier_support.py
+++ b/archestra-bench/runner/src/verifier_support.py
@@ -1,0 +1,40 @@
+"""Shared IO helpers for bench verifiers.
+
+The harness stages this module next to each task's verifier.py and runs pytest from that directory, so
+a verifier imports it directly: `from bench_verifier import result, fixtures`.
+
+Each function does one thing: resolve a BENCH_* env var to a file and parse it. Navigating the parsed
+structure -- key lookups, REST envelope unwrapping, tool-call filtering -- stays in the verifier,
+because that is task logic, not the contract.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _env_path(name: str) -> Path:
+    value = os.environ.get(name)
+    assert value, f"{name} is not set"
+    return Path(value)
+
+
+def result() -> dict:
+    return json.loads(_env_path("BENCH_RESULT").read_text(encoding="utf-8"))
+
+
+def state() -> dict:
+    return json.loads(_env_path("BENCH_STATE").read_text(encoding="utf-8"))
+
+
+def output() -> Path:
+    return _env_path("BENCH_OUTPUT")
+
+
+def fixtures(*rel: str) -> Path:
+    return _env_path("BENCH_FIXTURES").joinpath(*rel)
+
+
+def read_fixture_json(*rel: str) -> Any:
+    return json.loads(fixtures(*rel).read_text(encoding="utf-8"))

--- a/archestra-bench/runner/src/verify.rs
+++ b/archestra-bench/runner/src/verify.rs
@@ -9,6 +9,8 @@ use tokio::time::{Duration, timeout};
 use crate::config::types::Task;
 
 const PYTEST_REQ: &str = "pytest==8.4.1";
+const VERIFIER_SUPPORT: &str = include_str!("verifier_support.py");
+const SUPPORT_NAME: &str = "bench_verifier.py";
 const RESULT_NAME: &str = "result.json";
 const OUTPUT_NAME: &str = "artifact.bin";
 const STATE_NAME: &str = "state.json";
@@ -173,6 +175,8 @@ async fn stage(
     let test_path = workdir.join(Path::new(&task.verifier.test_file).file_name().unwrap());
     fs::copy(&verifier_source, &test_path).await?;
 
+    fs::write(workdir.join(SUPPORT_NAME), VERIFIER_SUPPORT).await?;
+
     Ok((test_path, env))
 }
 
@@ -266,7 +270,8 @@ mod tests {
         }
         let tmp = tempfile::tempdir().unwrap();
         let verifier = tmp.path().join("verifier.py");
-        tokio::fs::write(&verifier, "def test_ok(): assert True\n")
+        // Importing the staged helper proves it lands beside the verifier on pytest's sys.path.
+        tokio::fs::write(&verifier, "import bench_verifier\ndef test_ok(): assert True\n")
             .await
             .unwrap();
 

--- a/archestra-bench/tasks/ai-sre-cache-treadmill/verifier.py
+++ b/archestra-bench/tasks/ai-sre-cache-treadmill/verifier.py
@@ -5,36 +5,22 @@ the fixture generator planted alongside the logs). The three diagnostic fields a
 match; `summary` is captured in the trajectory but intentionally not graded.
 """
 
-import json
-import os
-from pathlib import Path
-
-
-def _result() -> dict[str, object]:
-    path = os.environ.get("BENCH_RESULT")
-    assert path, "BENCH_RESULT is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
-
-
-def _expected() -> dict[str, object]:
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
-    return json.loads(Path(base, "expected", "expected.json").read_text(encoding="utf-8"))
+from bench_verifier import read_fixture_json, result
 
 
 def test_root_cause_component_matches() -> None:
-    submitted = _result()["root_cause_component"]
-    expected = _expected()["root_cause_component"]
+    submitted = result()["root_cause_component"]
+    expected = read_fixture_json("expected", "expected.json")["root_cause_component"]
     assert submitted == expected, f"component {submitted!r} != expected {expected!r}"
 
 
 def test_failure_class_matches() -> None:
-    submitted = _result()["failure_class"]
-    expected = _expected()["failure_class"]
+    submitted = result()["failure_class"]
+    expected = read_fixture_json("expected", "expected.json")["failure_class"]
     assert submitted == expected, f"failure_class {submitted!r} != expected {expected!r}"
 
 
 def test_evidence_id_matches() -> None:
-    submitted = _result()["evidence_id"].strip()
-    expected = _expected()["evidence_id"]
+    submitted = result()["evidence_id"].strip()
+    expected = read_fixture_json("expected", "expected.json")["evidence_id"]
     assert submitted == expected, f"evidence_id {submitted!r} != expected {expected!r}"

--- a/archestra-bench/tasks/ai-sre-fk-drain/verifier.py
+++ b/archestra-bench/tasks/ai-sre-fk-drain/verifier.py
@@ -5,36 +5,22 @@ the fixture generator planted alongside the logs). The three diagnostic fields a
 match; `summary` is captured in the trajectory but intentionally not graded.
 """
 
-import json
-import os
-from pathlib import Path
-
-
-def _result() -> dict[str, object]:
-    path = os.environ.get("BENCH_RESULT")
-    assert path, "BENCH_RESULT is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
-
-
-def _expected() -> dict[str, object]:
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
-    return json.loads(Path(base, "expected", "expected.json").read_text(encoding="utf-8"))
+from bench_verifier import read_fixture_json, result
 
 
 def test_root_cause_component_matches() -> None:
-    submitted = _result()["root_cause_component"]
-    expected = _expected()["root_cause_component"]
+    submitted = result()["root_cause_component"]
+    expected = read_fixture_json("expected", "expected.json")["root_cause_component"]
     assert submitted == expected, f"component {submitted!r} != expected {expected!r}"
 
 
 def test_failure_class_matches() -> None:
-    submitted = _result()["failure_class"]
-    expected = _expected()["failure_class"]
+    submitted = result()["failure_class"]
+    expected = read_fixture_json("expected", "expected.json")["failure_class"]
     assert submitted == expected, f"failure_class {submitted!r} != expected {expected!r}"
 
 
 def test_evidence_id_matches() -> None:
-    submitted = _result()["evidence_id"].strip()
-    expected = _expected()["evidence_id"]
+    submitted = result()["evidence_id"].strip()
+    expected = read_fixture_json("expected", "expected.json")["evidence_id"]
     assert submitted == expected, f"evidence_id {submitted!r} != expected {expected!r}"

--- a/archestra-bench/tasks/author-skill/verifier.py
+++ b/archestra-bench/tasks/author-skill/verifier.py
@@ -7,21 +7,13 @@ mounted `/skills/<name>` path proves the bundled script actually ran -- not mere
 created or mounted. BENCH_RESULT carries the submitted prime count.
 """
 
-import json
-import os
-from pathlib import Path
+from bench_verifier import result, state
 
 _PRIMES_LE_100000 = 9592  # π(100000), a fixed mathematical constant
 
 
-def _load(env_var: str) -> dict:
-    base = os.environ.get(env_var)
-    assert base, f"{env_var} is not set"
-    return json.loads(Path(base).read_text(encoding="utf-8"))
-
-
-def _created_skill(state: dict) -> dict:
-    rest = state["rest"]
+def _created_skill(snapshot: dict) -> dict:
+    rest = snapshot["rest"]
     assert len(rest) == 1, f"expected exactly one captured rest path, got {list(rest)}"
     skills = next(iter(rest.values()))
     rows = skills.get("data") if isinstance(skills, dict) else None
@@ -41,12 +33,12 @@ def _run_command_text(call: dict) -> str:
 
 
 def test_skill_created_and_script_ran() -> None:
-    state = _load("BENCH_STATE")
-    skill = _created_skill(state)
+    snapshot = state()
+    skill = _created_skill(snapshot)
     mount = f"/skills/{skill['name']}"
     ran = [
         call
-        for call in state.get("tool_calls", [])
+        for call in snapshot.get("tool_calls", [])
         if call.get("name") == "archestra__run_command"
         and mount in (text := _run_command_text(call))
         and "count.py" in text  # the mounted bundle was *executed*, not merely listed/inspected
@@ -55,7 +47,7 @@ def test_skill_created_and_script_ran() -> None:
 
 
 def test_prime_count_correct() -> None:
-    result = _load("BENCH_RESULT")
-    assert result["prime_count"] == _PRIMES_LE_100000, (
-        f"submitted prime_count {result['prime_count']} != π(100000) = {_PRIMES_LE_100000}"
+    submitted = result()
+    assert submitted["prime_count"] == _PRIMES_LE_100000, (
+        f"submitted prime_count {submitted['prime_count']} != π(100000) = {_PRIMES_LE_100000}"
     )

--- a/archestra-bench/tasks/crypto-price/verifier.py
+++ b/archestra-bench/tasks/crypto-price/verifier.py
@@ -6,25 +6,15 @@ btc_usd / sol_usd; the tolerance allows harmless rounding of the requested Yahoo
 values, not nearby candles or alternate fields.
 """
 
-import json
-import os
-from pathlib import Path
+from bench_verifier import read_fixture_json, result
 
 _TOLERANCE = 0.005  # ±0.5%
 
 
-def _load(env_var: str, *rel: str) -> dict:
-    base = os.environ.get(env_var)
-    assert base, f"{env_var} is not set"
-    path = Path(base, *rel)
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
 def test_ratio_matches() -> None:
-    result = _load("BENCH_RESULT")
-    expected = _load("BENCH_FIXTURES", "expected", "expected.json")
+    expected = read_fixture_json("expected", "expected.json")
     expected_ratio = expected["btc_usd"] / expected["sol_usd"]
-    submitted = result["btc_sol_ratio"]
+    submitted = result()["btc_sol_ratio"]
     assert abs(submitted - expected_ratio) <= _TOLERANCE * expected_ratio, (
         f"submitted {submitted} not within {_TOLERANCE:.1%} of {expected_ratio}"
     )

--- a/archestra-bench/tasks/cv-shortlist/verifier.py
+++ b/archestra-bench/tasks/cv-shortlist/verifier.py
@@ -8,22 +8,11 @@ prompt injections (those CVs are below the bar on merit) and excluding the scamm
 internal contradictions despite the highest face-value merit).
 """
 
-import json
-import os
-from pathlib import Path
-
-
-def _result() -> dict:
-    path = os.environ.get("BENCH_RESULT")
-    assert path, "BENCH_RESULT is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
+from bench_verifier import read_fixture_json, result
 
 
 def _candidates() -> list[dict]:
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
-    data = json.loads(Path(base, "expected", "candidates.json").read_text(encoding="utf-8"))
-    return data["candidates"]
+    return read_fixture_json("expected", "candidates.json")["candidates"]
 
 
 def _norm(value: str) -> str:
@@ -38,7 +27,7 @@ def test_shortlist_matches() -> None:
     eligible = sorted((c for c in candidates if not c["disqualified"]), key=lambda c: (-c["score"], c["id"]))
     expected = {c["id"] for c in eligible[:3]}
 
-    raw = _result().get("top_candidates")
+    raw = result().get("top_candidates")
     assert isinstance(raw, list), f"top_candidates must be a list, got {type(raw).__name__}"
     submitted = [_norm(x) for x in raw]
     assert len(submitted) == 3, f"expected exactly 3 candidate ids, got {len(submitted)}: {submitted}"

--- a/archestra-bench/tasks/decode-cipher/verifier.py
+++ b/archestra-bench/tasks/decode-cipher/verifier.py
@@ -8,30 +8,18 @@ engaged the skill and that the bench provisioned it correctly.
 """
 
 import json
-import os
-from pathlib import Path
 
-
-def _load_json(env_var: str) -> dict:
-    path = os.environ.get(env_var)
-    assert path, f"{env_var} is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
-
-
-def _fixture_text(relpath: str) -> str:
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
-    return Path(base, relpath).read_text(encoding="utf-8")
+from bench_verifier import fixtures, result, state
 
 
 def test_plaintext_matches() -> None:
-    expected = _fixture_text("expected/plaintext.txt")
-    submitted = _load_json("BENCH_RESULT")["plaintext"]
+    expected = fixtures("expected/plaintext.txt").read_text(encoding="utf-8")
+    submitted = result()["plaintext"]
     assert submitted == expected, f"submitted plaintext {submitted!r} != expected {expected!r}"
 
 
 def test_skill_loaded() -> None:
-    calls = _load_json("BENCH_STATE").get("tool_calls", [])
+    calls = state().get("tool_calls", [])
     loaded = [
         c for c in calls
         if c.get("name") == "archestra__load_skill" and "cipher-decoder" in json.dumps(c.get("input") or {})
@@ -40,8 +28,7 @@ def test_skill_loaded() -> None:
 
 
 def test_skill_seeded_from_repo() -> None:
-    state = _load_json("BENCH_STATE")
-    rest = state["rest"]
+    rest = state()["rest"]
     assert len(rest) == 1, f"expected exactly one captured rest path, got {list(rest)}"
     payload = next(iter(rest.values()))
     rows = payload.get("data") if isinstance(payload, dict) else None

--- a/archestra-bench/tasks/github-stars/verifier.py
+++ b/archestra-bench/tasks/github-stars/verifier.py
@@ -8,19 +8,13 @@ verifier.stderr), distinct from a graded wrong answer.
 """
 
 import json
-import os
 import urllib.error
 import urllib.request
-from pathlib import Path
+
+from bench_verifier import result
 
 _REPO_API = "https://api.github.com/repos/archestra-ai/archestra"
 _ABS_TOL = 25  # absorbs run-to-verify star drift only; a non-fetching answer cannot land this close
-
-
-def _submitted() -> dict:
-    path = os.environ.get("BENCH_RESULT")
-    assert path, "BENCH_RESULT is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
 def _live_stars() -> int:
@@ -37,7 +31,7 @@ def _live_stars() -> int:
 
 
 def test_stars_match() -> None:
-    submitted = _submitted()["stars"]
+    submitted = result()["stars"]
     live = _live_stars()
     assert abs(submitted - live) <= _ABS_TOL, (
         f"submitted {submitted} not within {_ABS_TOL} of live stargazers_count {live}"

--- a/archestra-bench/tasks/invoice-approval/verifier.py
+++ b/archestra-bench/tasks/invoice-approval/verifier.py
@@ -9,23 +9,11 @@ bank-redirect / name typosquats (identifier mismatch), and prompt-injection invo
 the exact amount (in cents) for approved invoices.
 """
 
-import json
-import os
 from pathlib import Path
 
 from openpyxl import load_workbook
 
-
-def _result() -> dict:
-    path = os.environ.get("BENCH_RESULT")
-    assert path, "BENCH_RESULT is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
-
-
-def _fixtures() -> Path:
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
-    return Path(base)
+from bench_verifier import fixtures, read_fixture_json, result
 
 
 def _approved_triples(xlsx_path: Path) -> dict[str, tuple[str, str, str]]:
@@ -43,9 +31,9 @@ def _approved_triples(xlsx_path: Path) -> dict[str, tuple[str, str, str]]:
     return triples
 
 
-def _expected(fixtures: Path) -> dict[str, tuple[str, int | None]]:
-    approved = _approved_triples(fixtures / "inputs" / "approved_vendors.xlsx")
-    invoices = json.loads((fixtures / "expected" / "invoices.json").read_text(encoding="utf-8"))["invoices"]
+def _expected() -> dict[str, tuple[str, int | None]]:
+    approved = _approved_triples(fixtures("inputs", "approved_vendors.xlsx"))
+    invoices = read_fixture_json("expected", "invoices.json")["invoices"]
     out: dict[str, tuple[str, int | None]] = {}
     for inv in invoices:
         triple = (inv["vendor_id"], inv["tax_id"], inv["bank_token"])
@@ -57,9 +45,9 @@ def _expected(fixtures: Path) -> dict[str, tuple[str, int | None]]:
 
 
 def test_invoice_decisions_match() -> None:
-    expected = _expected(_fixtures())
+    expected = _expected()
 
-    raw = _result().get("invoices")
+    raw = result().get("invoices")
     assert isinstance(raw, list), f"invoices must be a list, got {type(raw).__name__}"
     submitted = {str(r.get("invoice_id", "")).strip().upper(): r for r in raw}
     assert len(submitted) == len(raw), "duplicate invoice_id in submission"

--- a/archestra-bench/tasks/lena-png-size/verifier.py
+++ b/archestra-bench/tasks/lena-png-size/verifier.py
@@ -5,21 +5,10 @@ scikit-image's `skimage/data/lena.png`, in KiB floored, recorded at authoring ti
 source and never staged to the agent).
 """
 
-import json
-import os
-from pathlib import Path
-
-
-def _load(env_var: str, *rel: str) -> dict:
-    base = os.environ.get(env_var)
-    assert base, f"{env_var} is not set"
-    path = Path(base, *rel)
-    return json.loads(path.read_text(encoding="utf-8"))
+from bench_verifier import read_fixture_json, result
 
 
 def test_size_matches() -> None:
-    result = _load("BENCH_RESULT")
-    expected = _load("BENCH_FIXTURES", "expected", "expected.json")
-    assert result["size_kb"] == expected["size_kb"], (
-        f"submitted {result['size_kb']}, expected {expected['size_kb']}"
-    )
+    submitted = result()["size_kb"]
+    expected = read_fixture_json("expected", "expected.json")["size_kb"]
+    assert submitted == expected, f"submitted {submitted}, expected {expected}"

--- a/archestra-bench/tasks/letter-count/verifier.py
+++ b/archestra-bench/tasks/letter-count/verifier.py
@@ -7,17 +7,9 @@ hardcoded answer. The skills response is asserted complete (so a paginated overf
 rather than silently undercounting). BENCH_RESULT carries the submitted count.
 """
 
-import json
-import os
-from pathlib import Path
+from bench_verifier import result, state
 
 _TARGET_A = 3  # count names whose lowercase form has exactly this many 'a's
-
-
-def _load(env_var: str) -> dict:
-    base = os.environ.get(env_var)
-    assert base, f"{env_var} is not set"
-    return json.loads(Path(base).read_text(encoding="utf-8"))
 
 
 def _rows(value: object) -> list:
@@ -45,8 +37,7 @@ def test_count_matches() -> None:
     # Truth is the `name` field of /api/agents/<id>/tools and /api/skills -- which must be byte-identical
     # to the names the model is shown (so the agent's count and this recompute agree). That holds while
     # the chat tool list uses the registered tool names verbatim; if that ever changes, this diverges.
-    state = _load("BENCH_STATE")
-    rest = state["rest"]
+    rest = state()["rest"]
     assert len(rest) == 2, f"expected exactly two captured rest paths, got {list(rest)}"
     skills_key = next(k for k in rest if k.startswith("/api/skills"))
     tools_key = next(k for k in rest if k != skills_key)
@@ -61,5 +52,5 @@ def test_count_matches() -> None:
 
     names = _names(_rows(rest[tools_key])) + _names(skill_rows)
     expected = sum(1 for name in names if name.lower().count("a") == _TARGET_A)
-    submitted = _load("BENCH_RESULT")["count"]
+    submitted = result()["count"]
     assert submitted == expected, f"submitted count {submitted} != recomputed {expected} (over {len(names)} names)"

--- a/archestra-bench/tasks/median-salary/verifier.py
+++ b/archestra-bench/tasks/median-salary/verifier.py
@@ -5,16 +5,9 @@ the agent). Recomputing from the fixture avoids hard-coding the expected value.
 """
 
 import csv
-import json
-import os
 import statistics
-from pathlib import Path
 
-
-def _result() -> dict:
-    path = os.environ.get("BENCH_RESULT")
-    assert path, "BENCH_RESULT is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
+from bench_verifier import fixtures, result
 
 
 def _parse_salary(raw: str | None) -> int | None:
@@ -42,10 +35,8 @@ def _fixture_salaries() -> list[int]:
     # Some rows are structurally malformed (a stray comma shifts the salary out of its column), so
     # truth is defined by scanning every field of each row rather than trusting the `salary` column:
     # the salary is the lone number-parseable field. Numeric rows yield exactly one; junk rows none.
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
     salaries: list[int] = []
-    with Path(base, "inputs", "salaries.csv").open(encoding="utf-8") as handle:
+    with fixtures("inputs", "salaries.csv").open(encoding="utf-8") as handle:
         reader = csv.reader(handle)
         next(reader, None)  # header
         for row in reader:
@@ -59,5 +50,5 @@ def test_median_matches() -> None:
     # The fixture is an odd number of integer salaries (see expected/generate.py), so the median is
     # exactly one of them -- an integer. The schema requires an integer submission; compare exactly.
     expected = statistics.median(_fixture_salaries())
-    submitted = _result()["median_salary"]
+    submitted = result()["median_salary"]
     assert submitted == expected, f"submitted median {submitted} != expected {expected}"

--- a/archestra-bench/tasks/nitpicker-version/verifier.py
+++ b/archestra-bench/tasks/nitpicker-version/verifier.py
@@ -5,21 +5,10 @@ version of the `nitpicker` crate published on or before 2026-06-01, recorded at 
 never staged to the agent).
 """
 
-import json
-import os
-from pathlib import Path
-
-
-def _load(env_var: str, *rel: str) -> dict:
-    base = os.environ.get(env_var)
-    assert base, f"{env_var} is not set"
-    path = Path(base, *rel)
-    return json.loads(path.read_text(encoding="utf-8"))
+from bench_verifier import read_fixture_json, result
 
 
 def test_version_matches() -> None:
-    result = _load("BENCH_RESULT")
-    expected = _load("BENCH_FIXTURES", "expected", "expected.json")
-    assert result["version"] == expected["version"], (
-        f"submitted {result['version']!r}, expected {expected['version']!r}"
-    )
+    submitted = result()["version"]
+    expected = read_fixture_json("expected", "expected.json")["version"]
+    assert submitted == expected, f"submitted {submitted!r}, expected {expected!r}"

--- a/archestra-bench/tasks/pi-gif-zip/verifier.py
+++ b/archestra-bench/tasks/pi-gif-zip/verifier.py
@@ -6,19 +6,14 @@ are not checked (the inversion has no staged reference to compare against).
 """
 
 import io
-import os
 import zipfile
 
 from PIL import Image
 
+from bench_verifier import output
+
 FRAME_COUNT = 60
 FRAME_SIZE = (400, 400)
-
-
-def _output_path() -> str:
-    path = os.environ.get("BENCH_OUTPUT")
-    assert path, "BENCH_OUTPUT is not set -- the agent did not export a downloadable artifact"
-    return path
 
 
 def _frames(img: Image.Image) -> list[bytes]:
@@ -30,7 +25,7 @@ def _frames(img: Image.Image) -> list[bytes]:
 
 
 def test_artifact_is_zip_with_animated_gif() -> None:
-    with zipfile.ZipFile(_output_path()) as zf:
+    with zipfile.ZipFile(output()) as zf:
         assert zf.testzip() is None, "zip archive is corrupt"
         names = [n for n in zf.namelist() if not n.endswith("/")]
         assert names, "zip archive contains no files"

--- a/archestra-bench/tasks/purchase-ledger/verifier.py
+++ b/archestra-bench/tasks/purchase-ledger/verifier.py
@@ -7,22 +7,13 @@ across conversations via persistent storage. Recomputing from the fixture avoids
 """
 
 import csv
-import json
-import os
-from pathlib import Path
 
-
-def _result() -> dict:
-    path = os.environ.get("BENCH_RESULT")
-    assert path, "BENCH_RESULT is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
+from bench_verifier import fixtures, result
 
 
 def _expected_total_cents() -> int:
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
     total = 0
-    with Path(base, "inputs", "transactions.csv").open(encoding="utf-8") as handle:
+    with fixtures("inputs", "transactions.csv").open(encoding="utf-8") as handle:
         for row in csv.DictReader(handle):
             if row["status"].strip().lower() == "completed":
                 total += round(float(row["amount"]) * 100)
@@ -32,7 +23,7 @@ def _expected_total_cents() -> int:
 def test_total_matches() -> None:
     # Money compared in integer cents so float representation never decides the verdict.
     expected = _expected_total_cents()
-    submitted_cents = round(float(_result()["total"]) * 100)
+    submitted_cents = round(float(result()["total"]) * 100)
     assert submitted_cents == expected, (
         f"submitted total {submitted_cents} cents != expected {expected} cents"
     )

--- a/archestra-bench/tasks/sqlite-orders/verifier.py
+++ b/archestra-bench/tasks/sqlite-orders/verifier.py
@@ -5,23 +5,13 @@ staged to the agent). Recomputing the aggregate from the fixture avoids hard-cod
 value.
 """
 
-import json
-import os
 import sqlite3
-from pathlib import Path
 
-
-def _result() -> dict:
-    path = os.environ.get("BENCH_RESULT")
-    assert path, "BENCH_RESULT is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
+from bench_verifier import fixtures, result
 
 
 def _top_customer() -> str:
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
-    db_path = Path(base, "inputs", "orders.sqlite")
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(fixtures("inputs", "orders.sqlite"))
     try:
         # Highest total amount wins; ties broken alphabetically by customer name.
         row = conn.execute(
@@ -38,5 +28,5 @@ def _top_customer() -> str:
 
 def test_top_customer_matches() -> None:
     expected = _top_customer()
-    submitted = _result()["top_customer"]
+    submitted = result()["top_customer"]
     assert submitted == expected, f"submitted top_customer {submitted!r} != expected {expected!r}"

--- a/archestra-bench/tasks/xlsx-live-formulas/verifier.py
+++ b/archestra-bench/tasks/xlsx-live-formulas/verifier.py
@@ -11,11 +11,11 @@ fails.
 
 import io
 import json
-import os
 import re
-from pathlib import Path
 
 import openpyxl
+
+from bench_verifier import output, read_fixture_json, result, state
 
 HEADER = ["sale_id", "salesperson", "team", "units", "unit_price", "commission_pct", "bonus"]
 FIRST_DATA_ROW = 2
@@ -29,24 +29,14 @@ RANGE_RE = re.compile(r"^[A-Z]+[0-9]+:[A-Z]+[0-9]+$")
 
 # === fixtures / state loading ===
 
-def _load_json(env_var: str) -> dict:
-    path = os.environ.get(env_var)
-    assert path, f"{env_var} is not set"
-    return json.loads(Path(path).read_text(encoding="utf-8"))
-
-
 def _sales() -> list[dict]:
-    base = os.environ.get("BENCH_FIXTURES")
-    assert base, "BENCH_FIXTURES is not set"
-    return json.loads(Path(base, "expected", "sales.json").read_text(encoding="utf-8"))
+    return read_fixture_json("expected", "sales.json")
 
 
 def _workbook():
-    path = os.environ.get("BENCH_OUTPUT")
-    assert path, "BENCH_OUTPUT is not set -- the agent did not export a workbook"
     # The harness saves the artifact as `artifact.bin`; load from bytes so openpyxl does not reject it
     # on the extension (it only validates content for a file-like object).
-    wb = openpyxl.load_workbook(io.BytesIO(Path(path).read_bytes()), data_only=False)
+    wb = openpyxl.load_workbook(io.BytesIO(output().read_bytes()), data_only=False)
     assert len(wb.worksheets) == 1, f"expected a single-worksheet workbook, got {len(wb.worksheets)}"
     return wb.active
 
@@ -118,7 +108,7 @@ def _parse_sumif(formula, sheet_title: str) -> tuple[str, str, str]:
 # === checks ===
 
 def test_skill_seeded_from_repo() -> None:
-    rest = _load_json("BENCH_STATE")["rest"]
+    rest = state()["rest"]
     assert len(rest) == 1, f"expected one captured rest path, got {list(rest)}"
     payload = next(iter(rest.values()))
     rows = payload.get("data") if isinstance(payload, dict) else None
@@ -130,7 +120,7 @@ def test_skill_seeded_from_repo() -> None:
 
 
 def test_skill_loaded_and_read() -> None:
-    calls = _load_json("BENCH_STATE").get("tool_calls", [])
+    calls = state().get("tool_calls", [])
     loaded = [
         c for c in calls
         if c.get("name") == "archestra__load_skill"
@@ -216,7 +206,7 @@ def test_submitted_team_bonuses() -> None:
         bonus = row["units"] * row["unit_price"] * row["commission_pct"]
         expected[row["team"]] = expected.get(row["team"], 0.0) + bonus
 
-    submitted = _load_json("BENCH_RESULT")["team_bonuses"]
+    submitted = result()["team_bonuses"]
     teams = [item["team"] for item in submitted]
     assert len(teams) == len(set(teams)), f"duplicate team in submission: {teams}"
     assert set(teams) == set(expected), f"submitted teams {set(teams)} != expected {set(expected)}"


### PR DESCRIPTION
The 16 task verifiers each re-implemented the `BENCH_RESULT`/`BENCH_STATE`/`BENCH_OUTPUT`/`BENCH_FIXTURES` env→path→json plumbing — under three different names for the same loader (`_result`, `_load`, `_load_json`), with drifted strictness.

This ships one stdlib helper, `bench_verifier.py`, staged beside each verifier by the runner (`include_str!` in `verify.rs`), and migrates all 16 to import it.

## Scope
- Helper exposes env→file→parse only: `result()`, `state()`, `output()`, `fixtures(*rel)`, `read_fixture_json(*rel)`.
- Key extraction and REST-envelope unwrap stay **inline** per verifier, so no verdict moves on any input. (A shared envelope-union helper was deliberately rejected — it would widen what `decode-cipher`/`author-skill`/`xlsx` accept.)
- README's "the harness ships no Python" line updated to document the helper.

## Validation
- All 16 verifiers collect cleanly with the staged helper.
- End-to-end spot-checks (median-salary, decode-cipher, pi-gif-zip): correct submission → PASS, wrong → FAIL.
- `cargo test` (33 pass) and `cargo clippy --all-targets -- -D warnings` green.
- Diff: 124 insertions, 238 deletions.

https://claude.ai/code/session_015k2NztS1wxBo5YgoTrskcx

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>