### PR TITLE
deps: bump dompurify from 3.4.0 to 3.4.10 in /platform

### DIFF
--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -114,7 +114,7 @@
     "cheerio": "^1.2.0",
     "confluence.js": "^2.1.0",
     "croner": "^10.0.1",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.10",
     "dotenv": "^17.3.1",
     "drizzle-kit": "^0.31.9",
     "drizzle-orm": "^0.45.2",

--- a/platform/frontend/package.json
+++ b/platform/frontend/package.json
@@ -71,7 +71,7 @@
     "croner": "^10.0.1",
     "cronstrue": "^3.13.0",
     "date-fns": "^4.1.0",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.10",
     "elkjs": "^0.11.1",
     "embla-carousel-react": "^8.6.0",
     "handlebars": "^4.7.9",

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -44,7 +44,7 @@ overrides:
   form-data@<4: 3.0.5
   '@hono/node-server': 1.19.14
   body-parser: 2.2.1
-  dompurify: 3.4.0
+  dompurify: 3.4.10
   glob: 11.1.0
   esbuild: '>=0.28.1'
   mdast-util-to-hast: 13.2.1
@@ -356,8 +356,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
       dompurify:
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 3.4.10
+        version: 3.4.10
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -684,8 +684,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       dompurify:
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 3.4.10
+        version: 3.4.10
       elkjs:
         specifier: ^0.11.1
         version: 0.11.1
@@ -7142,8 +7142,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -17624,7 +17624,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.0:
+  dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -19223,7 +19223,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.19
-      dompurify: 3.4.0
+      dompurify: 3.4.10
       es-toolkit: 1.45.1
       katex: 0.16.28
       khroma: 2.1.0
@@ -19470,7 +19470,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.0
+      dompurify: 3.4.10
       marked: 14.0.0
 
   ms@2.1.3: {}
@@ -20013,7 +20013,7 @@ snapshots:
       '@posthog/core': 1.23.4
       '@posthog/types': 1.360.2
       core-js: 3.48.0
-      dompurify: 3.4.0
+      dompurify: 3.4.10
       fflate: 0.4.8
       preact: 10.28.3
       query-selector-shadow-dom: 1.0.1

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -38,7 +38,7 @@ overrides:
   form-data@<4: 3.0.5
   '@hono/node-server': 1.19.14
   body-parser: 2.2.1
-  dompurify: 3.4.0
+  dompurify: 3.4.10
   glob: 11.1.0
   # GHSA-gv7w-rqvm-qjhr (esbuild "Untrusted Search Path", HIGH) fixed in 0.28.1.
   esbuild: '>=0.28.1'


### PR DESCRIPTION
Supersedes #5662.

dompurify is pinned to `3.4.0` by a workspace `override` in `platform/pnpm-workspace.yaml`, which fixes the resolved version irrespective of the `package.json` range. Dependabot #5662 bumped only the ranges, so its lockfile kept dompurify at 3.4.0 (the upgrade never reached the tree) while re-resolving unrelated transitive deps into `baseline-browser-mapping@2.10.38` and `nanoid@3.3.13` — both inside the 7-day `minimumReleaseAge` cooldown — which is what turned its CI red.

This moves the override and both `package.json` ranges to 3.4.10 together, so the upgrade actually applies, and touches nothing else in the lockfile.

Target is 3.4.10, not the latest 3.4.11: 3.4.11 was published 2026-06-17 and is still inside the 7-day cooldown (clears 2026-06-24), so resolving to it would fail the supply-chain gate today. 3.4.10 (published 2026-06-12) is already past the window and carries the 3.4.5–3.4.10 sanitizer hardening (IN_PLACE / shadow-DOM clobbering, Trusted Types, hook-pollution fixes).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>