### PR TITLE
refactor(archestra-bench): de-clue tool names + emphasis, add task feature table

### DIFF
--- a/archestra-bench/CLAUDE.md
+++ b/archestra-bench/CLAUDE.md
@@ -6,9 +6,13 @@ file layout, lifecycle) live in `../README.md` -- this file is the discipline, n
 ## The prompt is a real user's ask
 
 - Read like a coworker's request, not a spec sheet. No mention of the sandbox, `run_command`,
-  `search_tools`, `/home/sandbox` paths, or "the verifier". The only tool a prompt names is
-  `submit_result` (the protocol requires it).
-- Don't spoon-feed the approach or name the skill/tool that solves it -- discovering it is the task.
+  `search_tools`, `/home/sandbox` paths, or "the verifier".
+- Don't spoon-feed the approach or name the skill/tool that solves it -- finding the right tool is
+  itself a key capability under test, so naming it hands the model the answer. A prompt names only the
+  **delivery-protocol** tools the harness grades through -- `submit_result` (always) and `download_file`
+  (file-output tasks) -- never a task-solving tool (`create_skill`, `load_skill`, `list_skills`, a
+  skill, a sandbox command). State the goal ("author a skill that…", "use that skill to…"); let the
+  agent discover how.
 - Never reveal the agent is inside a benchmark/eval/harness. No "benchmark", "eval", "test", "graded",
   or "fixture" language on any agent-facing surface -- the prompt **and** the skills/files it loads. A
   real user would never say "the benchmark blobs"; they have a blob and want it decoded.

--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -85,18 +85,18 @@ Which Archestra capability each task is built to exercise. A task usually leans 
 |------|-----|:-------:|:-------:|:--------:|:------:|:--------:|:-----------:|:-------------:|
 | `pi-gif-zip` | basic | ✓ | | ✓ | | | | |
 | `crypto-price` | basic | ✓ | | | | ✓ | | |
-| `median-salary` | basic | | | | | | trap | |
+| `median-salary` | basic | | | | | | messy-data | |
 | `nitpicker-version` | basic | | | | | ✓ | | |
 | `github-stars` | basic | ✓ | | | | ✓ | | |
 | `lena-png-size` | basic | ✓ | | | | ✓ | | |
 | `sqlite-orders` | basic | ✓ | ✓ | | | | | |
-| `cv-shortlist` | basic | ✓ | ✓ | | | | inj | |
-| `invoice-approval` | basic | ✓ | ✓ | | | | inj | |
-| `ai-sre-fk-drain` | basic | ✓ | ✓ | | | | trap | |
-| `ai-sre-cache-treadmill` | basic | ✓ | ✓ | | | | trap | |
+| `cv-shortlist` | basic | ✓ | ✓ | | | | injection | |
+| `invoice-approval` | basic | ✓ | ✓ | | | | injection | |
+| `ai-sre-fk-drain` | basic | ✓ | ✓ | | | | red-herring | |
+| `ai-sre-cache-treadmill` | basic | ✓ | ✓ | | | | red-herring | |
 | `decode-cipher` | basic | ✓ | | | use | | | |
 | `xlsx-live-formulas` | basic | ✓ | | ✓ | use | | | |
-| `purchase-ledger` | basic | ✓ | | | | | trap | persist |
+| `purchase-ledger` | basic | ✓ | | | | | messy-data | persist |
 | `author-skill` | archestra-api | ✓ | | | author | | | state |
 | `letter-count` | archestra-api | | | | | | | state |
 
@@ -107,9 +107,10 @@ Which Archestra capability each task is built to exercise. A task usually leans 
 - **Skills** — `use`: a pinned skill gates the task (`decode-cipher` → cipher-decoder, `xlsx-live-formulas`
   → sales-ledger); `author`: the task authors a skill.
 - **Web/live** — requires fetching live data off the box (a web page / public API).
-- **Adversarial** — the inputs contain a trap. `inj`: real embedded prompt-injection payloads the agent
-  must resist; `trap`: non-injection distractors (red-herring log lines, malformed/mixed rows) it must
-  not be fooled by.
+- **Adversarial** — the inputs contain something engineered to fool a naive solver: `injection` (real
+  embedded prompt-injection payloads the agent must resist), `red-herring` (misleading distractor
+  evidence pointing at the wrong root cause), or `messy-data` (heterogeneous/malformed/mixed records
+  that defeat naive parsing or filtering).
 - **State/persist** — `state`: graded via the `[state].rest` backend snapshot (what the agent *did* to
   Archestra); `persist`: a file carried across a `new_conversation` boundary via persistent storage.
 

--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -86,7 +86,7 @@ Which Archestra capability each task is built to exercise. A task usually leans 
 | `pi-gif-zip` | basic | ✓ | | ✓ | | | | |
 | `crypto-price` | basic | ✓ | | | | ✓ | | |
 | `median-salary` | basic | | | | | | messy-data | |
-| `nitpicker-version` | basic | | | | | ✓ | | |
+| `nitpicker-version` | basic | ✓ | | | | ✓ | | |
 | `github-stars` | basic | ✓ | | | | ✓ | | |
 | `lena-png-size` | basic | ✓ | | | | ✓ | | |
 | `sqlite-orders` | basic | ✓ | ✓ | | | | | |
@@ -105,14 +105,20 @@ Which Archestra capability each task is built to exercise. A task usually leans 
   exercises reading non-text formats.
 - **File out** — the deliverable is a file the agent exports via `download_file` (graded as `BENCH_OUTPUT`).
 - **Skills** — `use`: a pinned skill gates the task (`decode-cipher` → cipher-decoder, `xlsx-live-formulas`
-  → sales-ledger); `author`: the task authors a skill.
-- **Web/live** — requires fetching live data off the box (a web page / public API).
+  → sales-ledger); `author`: the task authors a skill. For both `use` tasks the verifier *enforces* that
+  the skill was actually loaded (and, for xlsx, its asset read) via a `[state].rest` + tool-call snapshot,
+  so a hand-rolled answer that skips the skill fails even when the value is right.
+- **Web/live** — requires fetching live data off the box (a web page / public API). There's no direct
+  fetch tool, so this goes through `curl` in the sandbox — every `Web/live` task also marks Sandbox.
 - **Adversarial** — the inputs contain something engineered to fool a naive solver: `injection` (real
   embedded prompt-injection payloads the agent must resist), `red-herring` (misleading distractor
   evidence pointing at the wrong root cause), or `messy-data` (heterogeneous/malformed/mixed records
   that defeat naive parsing or filtering).
-- **State/persist** — `state`: graded via the `[state].rest` backend snapshot (what the agent *did* to
-  Archestra); `persist`: a file carried across a `new_conversation` boundary via persistent storage.
+- **State/persist** — marked only where introspecting/mutating Archestra's own state is the task's
+  *headline* point. `state`: the answer itself comes from what the agent *did* to Archestra, graded via
+  the `[state].rest` backend snapshot (`author-skill`, `letter-count`); `persist`: a file carried across
+  a `new_conversation` boundary via persistent storage. (`decode-cipher`/`xlsx-live-formulas` also
+  snapshot `[state].rest`, but only to enforce skill use — counted under Skills, not here.)
 
 The three seeded remote MCP servers (DeepWiki, Microsoft Learn, Context7) are surface **distractors** —
 no task requires them, so MCP tool-use is not a graded capability here.

--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -76,6 +76,46 @@ the run's ordered tool calls (`{name, input}`), so the isolated verifier can ass
 runtime placeholders `{{cell}}` (a per-cell unique slug, so mutating tasks don't collide across a
 multi-model matrix on one backend) and `{{agent_id}}`, substituted at run time.
 
+### Feature coverage
+
+Which Archestra capability each task is built to exercise. A task usually leans on one or two as its
+*point*; the table marks those, not every tool it might incidentally touch.
+
+| Task | Env | Sandbox | File in | File out | Skills | Web/live | Adversarial | State/persist |
+|------|-----|:-------:|:-------:|:--------:|:------:|:--------:|:-----------:|:-------------:|
+| `pi-gif-zip` | basic | ✓ | | ✓ | | | | |
+| `crypto-price` | basic | ✓ | | | | ✓ | | |
+| `median-salary` | basic | | | | | | trap | |
+| `nitpicker-version` | basic | | | | | ✓ | | |
+| `github-stars` | basic | ✓ | | | | ✓ | | |
+| `lena-png-size` | basic | ✓ | | | | ✓ | | |
+| `sqlite-orders` | basic | ✓ | ✓ | | | | | |
+| `cv-shortlist` | basic | ✓ | ✓ | | | | inj | |
+| `invoice-approval` | basic | ✓ | ✓ | | | | inj | |
+| `ai-sre-fk-drain` | basic | ✓ | ✓ | | | | trap | |
+| `ai-sre-cache-treadmill` | basic | ✓ | ✓ | | | | trap | |
+| `decode-cipher` | basic | ✓ | | | use | | | |
+| `xlsx-live-formulas` | basic | ✓ | | ✓ | use | | | |
+| `purchase-ledger` | basic | ✓ | | | | | trap | persist |
+| `author-skill` | archestra-api | ✓ | | | author | | | state |
+| `letter-count` | archestra-api | | | | | | | state |
+
+- **Sandbox** — needs code execution in the per-conversation sandbox.
+- **File in** — a file is staged into the sandbox as an attachment (PDF/DOCX/XLSX/SQLite/zip); the task
+  exercises reading non-text formats.
+- **File out** — the deliverable is a file the agent exports via `download_file` (graded as `BENCH_OUTPUT`).
+- **Skills** — `use`: a pinned skill gates the task (`decode-cipher` → cipher-decoder, `xlsx-live-formulas`
+  → sales-ledger); `author`: the task authors a skill.
+- **Web/live** — requires fetching live data off the box (a web page / public API).
+- **Adversarial** — the inputs contain a trap. `inj`: real embedded prompt-injection payloads the agent
+  must resist; `trap`: non-injection distractors (red-herring log lines, malformed/mixed rows) it must
+  not be fooled by.
+- **State/persist** — `state`: graded via the `[state].rest` backend snapshot (what the agent *did* to
+  Archestra); `persist`: a file carried across a `new_conversation` boundary via persistent storage.
+
+The three seeded remote MCP servers (DeepWiki, Microsoft Learn, Context7) are surface **distractors** —
+no task requires them, so MCP tool-use is not a graded capability here.
+
 ## Environments
 
 An environment is one `envs/<id>.toml` declaring `id` / `name`, an `[agent]` (name + system prompt),

--- a/archestra-bench/tasks/ai-sre-cache-treadmill/task.toml
+++ b/archestra-bench/tasks/ai-sre-cache-treadmill/task.toml
@@ -7,7 +7,7 @@ Work out the single root cause behind the 401s -- identify the real mechanism. T
   `chat-active-run-drain`, `mcp-gateway-auth-cache`, `idp-token-cache`, `user-token-model`, `llm-proxy-adapter`, `k8s-network-policy`, `context-compaction`.
 - `failure_class`: the failure category, exactly one of:
   `fk_violation_on_cascade_delete`, `negative_cache_ttl_refresh`, `negative_cache_no_expiry`, `positive_cache_stale_read`, `upstream_idle_timeout_misclassified`, `image_token_overestimate`, `dns_egress_blocked`.
-- `evidence_id`: the exact `profileId` value of the profile at the center of this incident -- the one whose authorization kept returning 401 the LONGEST before it finally recovered on its own (copy it verbatim from the log lines).
+- `evidence_id`: the exact `profileId` value of the profile at the center of this incident -- the one whose authorization kept returning 401 the longest before it finally recovered on its own (copy it verbatim from the log lines).
 - `summary`: one or two sentences explaining the root cause in your own words.
 
 Example shape: result = {"root_cause_component": "...", "failure_class": "...", "evidence_id": "...", "summary": "..."}."""

--- a/archestra-bench/tasks/ai-sre-fk-drain/task.toml
+++ b/archestra-bench/tasks/ai-sre-fk-drain/task.toml
@@ -1,5 +1,5 @@
 [[stages]]
-text = """You are on call. A backend service is intermittently **restarting under load**. Attached to this chat is the on-call dump for the incident: a zip of unsorted logs -- several interleaved JSON-line log files from different sources (backend, a background worker, the MCP gateway, and pod events), not sorted by time.
+text = """You are on call. A backend service is intermittently restarting under load. Attached to this chat is the on-call dump for the incident: a zip of unsorted logs -- several interleaved JSON-line log files from different sources (backend, a background worker, the MCP gateway, and pod events), not sorted by time.
 
 Pinpoint the single root cause of the restarts -- which error actually crashes the process. Then call submit_result with:
 

--- a/archestra-bench/tasks/author-skill/task.toml
+++ b/archestra-bench/tasks/author-skill/task.toml
@@ -1,8 +1,8 @@
 [[stages]]
-text = """Use the create_skill tool to author a new Agent Skill named exactly `prime-counter-{{cell}}`. Its SKILL.md frontmatter must set that `name` and a short `description`. Bundle one resource file `scripts/count.py`: a Python script that reads a single integer N from its first command-line argument and prints (to stdout) the count of prime numbers less than or equal to N. Create the skill now -- do NOT run it yet, and do NOT submit anything yet."""
+text = """Author a new Agent Skill in this instance named exactly `prime-counter-{{cell}}`. Its SKILL.md frontmatter must set that `name` and a short `description`, and it must bundle one resource file `scripts/count.py`: a Python script that reads a single integer N from its first command-line argument and prints (to stdout) the count of prime numbers less than or equal to N. Create the skill now -- do not run it yet, and do not submit anything yet."""
 
 [[stages]]
-text = """Now load that skill with load_skill (which mounts it into the sandbox under /skills/), and run its bundled scripts/count.py in the sandbox to count the primes less than or equal to 100000. Run the mounted script itself (not a re-implementation). Then call submit_result with result = {"prime_count": <the number it printed>}."""
+text = """Now use that skill to count the primes less than or equal to 100000: load it, then run its bundled `scripts/count.py` to get the count -- run the script you just authored, not a fresh re-implementation. Then call submit_result with result = {"prime_count": <the number it printed>}."""
 
 [result_schema]
 type = "object"

--- a/archestra-bench/tasks/author-skill/task.toml
+++ b/archestra-bench/tasks/author-skill/task.toml
@@ -2,7 +2,7 @@
 text = """Author a new Agent Skill in this instance named exactly `prime-counter-{{cell}}`. Its SKILL.md frontmatter must set that `name` and a short `description`, and it must bundle one resource file `scripts/count.py`: a Python script that reads a single integer N from its first command-line argument and prints (to stdout) the count of prime numbers less than or equal to N. Create the skill now -- do not run it yet, and do not submit anything yet."""
 
 [[stages]]
-text = """Now use that skill to count the primes less than or equal to 100000: load it, then run its bundled `scripts/count.py` to get the count -- run the script you just authored, not a fresh re-implementation. Then call submit_result with result = {"prime_count": <the number it printed>}."""
+text = """Now use that skill to count the primes less than or equal to 100000 -- actually run the skill you just authored to get the number, not a fresh re-implementation. Then call submit_result with result = {"prime_count": <the number it printed>}."""
 
 [result_schema]
 type = "object"

--- a/archestra-bench/tasks/letter-count/task.toml
+++ b/archestra-bench/tasks/letter-count/task.toml
@@ -1,7 +1,7 @@
 [[stages]]
 text = """Introspect this Archestra instance and count names. Consider two name sets:
 1. every TOOL available to you (use the name exactly as presented to you, including any prefix such as `archestra__`), and
-2. every SKILL in this instance (use the name as listed by the list_skills tool).
+2. every SKILL in this instance (use each skill's name as listed).
 
 Count how many names -- across both sets combined -- contain the letter "a" (case-insensitive) exactly three times. For example `archestra__run_command` contains exactly three a's (archestra→2, command→1). Enumerate your tools and the skills carefully, then call submit_result with result = {"count": <the total>}."""
 

--- a/archestra-bench/tasks/letter-count/task.toml
+++ b/archestra-bench/tasks/letter-count/task.toml
@@ -3,7 +3,7 @@ text = """Introspect this Archestra instance and count names. Consider two name 
 1. every TOOL available to you (use the name exactly as presented to you, including any prefix such as `archestra__`), and
 2. every SKILL in this instance (use each skill's name as listed).
 
-Count how many names -- across both sets combined -- contain the letter "a" (case-insensitive) exactly three times. For example `archestra__run_command` contains exactly three a's (archestra→2, command→1). Enumerate your tools and the skills carefully, then call submit_result with result = {"count": <the total>}."""
+Count how many names -- across both sets combined -- contain the letter "a" (case-insensitive) exactly three times. For example, a name like `vanilla__cab` contains exactly three a's (vanilla→2, cab→1). Enumerate your tools and the skills carefully, then call submit_result with result = {"count": <the total>}."""
 
 [result_schema]
 type = "object"

--- a/archestra-bench/tasks/median-salary/task.toml
+++ b/archestra-bench/tasks/median-salary/task.toml
@@ -1,5 +1,5 @@
 [[stages]]
-text = """Below is a CSV of employee records with a salary column (alongside name and department). Compute the **median** salary across all employees. Submit your answer with result = {"median_salary": <integer>}.
+text = """Below is a CSV of employee records with a salary column (alongside name and department). Compute the median salary across all employees. Submit your answer with result = {"median_salary": <integer>}.
 
 ```csv
 {{file:inputs/salaries.csv}}

--- a/archestra-bench/tasks/purchase-ledger/task.toml
+++ b/archestra-bench/tasks/purchase-ledger/task.toml
@@ -1,5 +1,5 @@
 [[stages]]
-text = """Here's our transaction export for January -- it's got some refunds and a couple of orders that never went through mixed in with the real sales. Could you pull out just the completed purchases into a clean file and keep it saved for me? I'll want to come back to it later, so make sure it won't get lost. No need to total anything yet.
+text = """Here's our transaction export for January -- it's got some refunds and a couple of orders that never went through mixed in with the real sales. Could you pull out just the completed purchases into a clean file for me? I'll want to come back to it later. No need to total anything yet.
 
 ```csv
 {{file:inputs/transactions.csv}}

--- a/archestra-bench/tasks/xlsx-live-formulas/task.toml
+++ b/archestra-bench/tasks/xlsx-live-formulas/task.toml
@@ -1,14 +1,14 @@
 artifact_key = "artifact"
 
 [[stages]]
-text = """Build a sales-bonus report as an Excel workbook (.xlsx) with **live formulas** (not precomputed
+text = """Build a sales-bonus report as an Excel workbook (.xlsx) with live formulas (not precomputed
 numbers), then export it.
 
 Base it on the Q3 sales ledger -- one row per sale, with columns `sale_id`, `salesperson`, `team`,
 `units`, `unit_price`, and `commission_pct` (a fraction). The ledger is NOT attached to this message;
 locate it among the resources available to you in this instance and read it.
 
-Produce a NEW single-worksheet workbook with this EXACT layout:
+Produce a new single-worksheet workbook with this exact layout:
 
 - Row 1 headers, columns A..G:
   `sale_id, salesperson, team, units, unit_price, commission_pct, bonus`


### PR DESCRIPTION
Another de-clue pass over `archestra-bench/tasks/`, plus a feature-coverage table in the README.

## De-clue: stop naming task-solving tools
Finding the right tool is itself a capability under test, so the prompt names only the delivery-protocol tools the harness grades through (`submit_result`, `download_file`) — never a task-solving tool.

- **author-skill** — drop `create_skill` / `load_skill` and the `/skills` sandbox-mount path; state the goal ("author a skill that…", "use that skill to…") and let the agent discover how. The `BENCH_STATE` oracle still requires it to actually run the mounted skill, which the reworded prompt still asks for.
- **letter-count** — `use the name as listed by the list_skills tool` → `use each skill's name as listed`.

## De-clue: emphasis on the checked quantity
Bold/caps telegraphs the oracle and hands the model the answer shape.

- **median-salary** — unbold `median`.
- **ai-sre-fk-drain** — unbold the `restarting under load` symptom.
- **ai-sre-cache-treadmill** — de-cap the evidence-selection criterion (`LONGEST` → `longest`).
- **xlsx-live-formulas** — unbold `live formulas`, lowercase `NEW … EXACT layout`.

## CLAUDE.md
Codify the protocol-vs-task-solving distinction (replaces the inaccurate "the only tool a prompt names is `submit_result`" — prompts also name `download_file`).

## README
Add a `### Feature coverage` table mapping each task to the capability it exercises (sandbox, file in/out, skills, web/live, adversarial, state/persist), distinguishing real prompt-injection tasks (`inj`) from non-injection distractors (`trap`), and noting the seeded remote MCPs are distractors.

Docs/prompt-only — no verifier logic or Rust touched.

https://claude.ai/code/session_01469DBae324pRCd3jsx4UEQ

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>