### PR TITLE
fix(sandbox): self-heal from dagger stale-attachables panic

### DIFF
--- a/platform/archestra-rs/sandbox-core/src/backend.rs
+++ b/platform/archestra-rs/sandbox-core/src/backend.rs
@@ -5,7 +5,7 @@
 //! every match site to handle it.
 
 use crate::backends::dagger::DaggerBackend;
-use crate::{ArtifactBytes, CommandExecution, Limits, ReplayStep, Result};
+use crate::{ArtifactBytes, CommandExecution, EngineFault, Limits, ReplayStep, Result};
 
 /// a materialise-and-run request handed to a backend. validated at the public
 /// core entry points before it reaches here. skill files and PYTHONPATH are no
@@ -75,6 +75,17 @@ impl Backend {
     pub(crate) async fn prewarm(&self) {
         match self {
             Backend::Dagger(b) => b.prewarm().await,
+        }
+    }
+
+    /// recover an engine fault from a handler panic payload. some backends (the
+    /// Dagger SDK) `unwrap()` transient engine errors deep in generated code, so
+    /// the failure escapes as a panic rather than a typed error; this lets the
+    /// backend-agnostic session layer re-tag the known-recoverable ones onto the
+    /// retry path without naming a concrete runtime.
+    pub(crate) fn engine_fault_from_panic(&self, message: &str) -> Option<EngineFault> {
+        match self {
+            Backend::Dagger(_) => crate::backends::dagger::engine_fault_from_panic(message),
         }
     }
 }

--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -1136,6 +1136,50 @@ mod tests {
         std::fs::remove_file(&script).ok();
     }
 
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn shutdown_does_not_reap_a_child_that_refuses_to_exit() {
+        // Characterises the teardown-reap limitation behind the dagger zombie.
+        // `DaggerSessionProc::shutdown` (dagger-sdk =0.21.5) only broadcasts to
+        // our in-process reader tasks and then *awaits* the child's voluntary
+        // exit — it sends no signal and never closes the child's stdin. Against a
+        // `dagger session` that keeps running (the reconnect-loop shape), it
+        // blocks and never reaps the process. Only dropping the proc force-kills
+        // it via kill_on_drop, and the post-ready teardown path calls shutdown(),
+        // not drop — so retiring a session does not, on its own, guarantee its
+        // CLI child dies.
+        let script = write_fake_session("#!/bin/sh\nsleep 120\n");
+        let mut cmd = build_session_command(&script, Path::new("/"), None);
+        let child = cmd.spawn().unwrap();
+        let pid = child.id().expect("a spawned child has a pid");
+        let proc: DaggerSessionProc = child.into();
+
+        // shutdown() blocks on the child's own exit, which never comes.
+        let returned = tokio::time::timeout(Duration::from_secs(2), proc.shutdown()).await;
+        assert!(
+            returned.is_err(),
+            "shutdown() returned for a child that never exits — SDK reaping semantics changed"
+        );
+        assert!(
+            !process_finished(pid),
+            "shutdown() left the child alive: it does not forcibly reap"
+        );
+
+        // Dropping the proc IS the forceful reaper (kill_on_drop); the post-ready
+        // teardown path never reaches a drop while shutdown() is still pending.
+        drop(proc);
+        let mut reaped = false;
+        for _ in 0..100 {
+            if process_finished(pid) {
+                reaped = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(reaped, "child {pid} should be reaped once the proc is dropped");
+        std::fs::remove_file(&script).ok();
+    }
+
     #[test]
     fn runtime_target_host_builds_a_kube_pod_address_for_an_environment() {
         assert_eq!(runtime_target_host(&RuntimeTarget::Default), None);

--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -924,6 +924,26 @@ fn classify_engine_fault(err: &DaggerError) -> EngineFault {
     }
 }
 
+/// recover an engine fault from a *panic* payload. dagger-sdk 0.21.5 `unwrap()`s
+/// GraphQL errors inside generated lazy-arg resolvers (`gen.rs` `into_id().unwrap()`),
+/// which resolve during exec evaluation — so a stale-attachables timeout reaches
+/// us as a panic rather than a typed `DaggerError`, bypassing [`from_sdk`] /
+/// [`classify_engine_fault`]. the panic message still embeds the engine's text,
+/// enough to route it back onto the existing stale-attachables respawn path
+/// instead of wedging the session.
+///
+/// the match is intentionally as narrow as the typed path: *only* the
+/// attachables timeout maps to a fault. the engine emits that text when it gave
+/// up waiting for the client's attachables *before* running the query, so a
+/// command-executing `run` can be retried safely (nothing ran). a generic
+/// transport panic carries no fault and stays a fatal `Internal`, preserving the
+/// session layer's mid-flight non-retry guard for `run` / `read_artifact`.
+pub(crate) fn engine_fault_from_panic(message: &str) -> Option<EngineFault> {
+    message
+        .contains(SESSION_ATTACHABLES_WAIT_ERROR)
+        .then_some(EngineFault::StaleAttachables)
+}
+
 /// pull a process exit code out of the engine's typed `EXEC_ERROR` extension.
 /// falls back to scraping the message because signal-killed execs (e.g. SIGXFSZ
 /// -> 153) can surface the code only in the message even under `ReturnType::Any`.
@@ -1209,6 +1229,36 @@ mod tests {
 
         let generic = domain_error("connection reset", None);
         assert_eq!(classify_engine_fault(&generic), EngineFault::Unreachable);
+    }
+
+    #[test]
+    fn engine_fault_from_panic_recovers_only_the_attachables_timeout() {
+        // the dagger SDK unwraps the GraphQL error, so it reaches us as the
+        // `Debug` rendering of the failed `Result` inside a panic payload.
+        let attachables = "called `Result::unwrap()` on an `Err` value: \
+             Query(DomainError { message: \"waiting for client session attachables: \
+             context deadline exceeded\" })";
+        assert_eq!(
+            engine_fault_from_panic(attachables),
+            Some(EngineFault::StaleAttachables)
+        );
+
+        // an unrelated panic must stay fatal (no respawn/retry).
+        assert_eq!(
+            engine_fault_from_panic("index out of bounds: the len is 0 but the index is 1"),
+            None
+        );
+
+        // a generic transport/engine panic carries no fault either: it is
+        // ambiguous about whether the command already ran, so it must NOT be
+        // re-tagged for retry — that ambiguity is exactly why only the
+        // pre-execution attachables timeout qualifies.
+        assert_eq!(
+            engine_fault_from_panic(
+                "called `Result::unwrap()` on an `Err` value: Query(HttpError(\"connection reset\"))"
+            ),
+            None
+        );
     }
 
     #[test]

--- a/platform/archestra-rs/sandbox-core/src/session.rs
+++ b/platform/archestra-rs/sandbox-core/src/session.rs
@@ -447,21 +447,21 @@ pub(crate) async fn run_loop(backend: Arc<Backend>, mut rx: mpsc::Receiver<Sessi
 async fn handle(backend: Arc<Backend>, msg: SessionMsg) {
     match msg {
         SessionMsg::Run { req, reply } => {
-            let result = catch_panic(backend.run(req)).await;
+            let result = catch_panic(&backend, backend.run(req)).await;
             let _ = reply.send(result);
         }
         SessionMsg::ReadArtifact { req, reply } => {
-            let result = catch_panic(backend.read_artifact(req)).await;
+            let result = catch_panic(&backend, backend.read_artifact(req)).await;
             let _ = reply.send(result);
         }
         SessionMsg::CheckSession { traceparent, reply } => {
-            let result = catch_panic(backend.check_session(traceparent)).await;
+            let result = catch_panic(&backend, backend.check_session(traceparent)).await;
             let _ = reply.send(result);
         }
     }
 }
 
-async fn catch_panic<T, Fut>(fut: Fut) -> Result<T>
+async fn catch_panic<T, Fut>(backend: &Backend, fut: Fut) -> Result<T>
 where
     Fut: std::future::Future<Output = Result<T>>,
 {
@@ -470,9 +470,44 @@ where
         .await
         .unwrap_or_else(|payload| {
             let message = panic_message(payload.as_ref());
-            tracing::error!(panic = message, "recovered a panic in a sandbox handler");
-            Err(SandboxError::Internal(format!("rust panic: {message}")))
+            Err(panic_to_error(backend.engine_fault_from_panic(message), message))
         })
+}
+
+/// classify a recovered handler panic. a backend that `unwrap()`s a transient
+/// engine fault (e.g. the dagger SDK on a stale-attachables timeout) escapes as
+/// a panic instead of a typed error; re-tag the recognised faults as
+/// `EngineUnreachable` so the respawn/retry path fires, and keep everything else
+/// a fatal `Internal` so genuine bugs aren't silently retried.
+///
+/// both arms carry a low-cardinality `recovered` field so the two outcomes are
+/// queryable without grepping free text: the fault classifier is a substring
+/// match against an upstream message, so if that wording ever drifts a panic
+/// that used to recover silently flips to `recovered = false` here — that shift
+/// is the regression signal to alert on.
+fn panic_to_error(fault: Option<EngineFault>, message: &str) -> SandboxError {
+    match fault {
+        Some(fault) => {
+            tracing::warn!(
+                panic = message,
+                ?fault,
+                recovered = true,
+                "recovered an engine fault from a sandbox handler panic"
+            );
+            SandboxError::EngineUnreachable {
+                fault,
+                message: format!("rust panic: {message}"),
+            }
+        }
+        None => {
+            tracing::error!(
+                panic = message,
+                recovered = false,
+                "recovered a panic in a sandbox handler"
+            );
+            SandboxError::Internal(format!("rust panic: {message}"))
+        }
+    }
 }
 
 fn panic_message(payload: &(dyn Any + Send)) -> &str {
@@ -585,6 +620,29 @@ mod tests {
         // read_artifact replays the command log before exporting, so a generic
         // engine error (which may have run some of that history) is not retried.
         assert_eq!(retry_reason(SessionOperation::ReadArtifact, &err), None);
+        assert_eq!(retry_reason(SessionOperation::Run, &err), None);
+    }
+
+    #[test]
+    fn panic_to_error_retags_recovered_engine_fault_for_retry() {
+        // dagger-sdk panics (instead of returning a typed error) on a
+        // stale-attachables timeout; the recovered fault must re-enter the
+        // respawn/retry path even for command execution.
+        let err = panic_to_error(
+            Some(EngineFault::StaleAttachables),
+            "called `Result::unwrap()` on an `Err` value: waiting for client session attachables",
+        );
+        assert!(is_stale_attachables_error(&err));
+        assert_eq!(
+            retry_reason(SessionOperation::Run, &err),
+            Some(RetryReason::StaleAttachables),
+        );
+    }
+
+    #[test]
+    fn panic_to_error_keeps_unrecognised_panic_fatal() {
+        let err = panic_to_error(None, "index out of bounds: the len is 0 but the index is 1");
+        assert!(matches!(err, SandboxError::Internal(_)));
         assert_eq!(retry_reason(SessionOperation::Run, &err), None);
     }
 


### PR DESCRIPTION
## Problem

The skill sandbox works for the first few minutes, then every `run_command` returns `engine unreachable` for the rest of the process — it never self-heals.

A stale-attachables timeout (`waiting for client session attachables`) surfaces as a dagger-sdk `unwrap()` panic (the SDK unwraps GraphQL errors inside generated lazy-arg resolvers, resolved during exec evaluation). `catch_panic` downgraded that panic to `SandboxError::Internal`, which `retry_reason` never retries — so it **bypassed the existing `EngineFault::StaleAttachables` respawn/retry path** and the wedged session persisted for the whole process.

Staging evidence: across a ~4.8h window the shared engine created **2099 sessions; exactly one** hit the attachables timeout (on its first `run_command`), and that single panic wedged the backend process. The trigger is a rare transient; the damage is the un-recovered wedge.

## Fix

Route the recovered panic back onto the existing recovery path:

- `backends/dagger.rs` — `engine_fault_from_panic` recovers the fault from the panic payload, reusing the same `SESSION_ATTACHABLES_WAIT_ERROR` discriminator as the typed `classify_engine_fault`. Narrow by design: only the attachables timeout (emitted *before* the query runs, so retrying `run` is safe) qualifies; generic transport panics stay fatal.
- `backend.rs` — `Backend::engine_fault_from_panic` delegates per-variant so `session.rs` stays backend-agnostic.
- `session.rs` — `catch_panic` re-tags recognized panics as `EngineUnreachable { StaleAttachables }`, which the existing invalidate → respawn → retry path handles: the wedged handle is retired and the request retries on a fresh session. A low-cardinality `recovered` field on both panic events makes upstream wording drift observable.

Effect: the backend **self-heals from the timeout** — the next `run_command` succeeds on a fresh session instead of the process staying wedged.

## Scope / known limitation

This fixes the platform-side wedge (the dominant impact). It does **not** forcibly reap the orphaned `dagger session` CLI child. Retiring the handle ends the actor loop and calls `DaggerSessionProc::shutdown`, but in dagger-sdk 0.21.5 `shutdown` only *awaits* the child's voluntary exit (it sends no signal and never closes stdin), and `kill_on_drop` covers only the connect-abort path — not post-ready teardown. So a child stuck reconnecting can keep hitting the shared engine until the backend process exits. Verified by `shutdown_does_not_reap_a_child_that_refuses_to_exit` (shutdown blocks; the child survives until dropped). Tracked as a follow-up (force-kill the child on teardown).

## Tests

- `engine_fault_from_panic_recovers_only_the_attachables_timeout` — recovers the attachables panic; unrelated and generic engine-shaped panics stay fatal.
- `panic_to_error_retags_recovered_engine_fault_for_retry` / `panic_to_error_keeps_unrecognised_panic_fatal` — re-tagged fault re-enters the `Run` retry path; unrecognized panics do not.
- `shutdown_does_not_reap_a_child_that_refuses_to_exit` — characterizes the teardown-reap limitation above.

`cargo test -p sandbox_core` (45 tests) and `cargo clippy -p sandbox_core --all-targets -- -D warnings` pass on Linux.

https://claude.ai/code/session_01PsNEpR9q9NgATTgVmXUFXN