### PR TITLE
feat(apps): group the app Tools tab by MCP server

### DIFF
--- a/platform/frontend/src/app/apps/_parts/app-tools-tab.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-tab.test.tsx
@@ -1,0 +1,176 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Radix Accordion/Checkbox measure layout and use pointer capture, which jsdom
+// doesn't implement.
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = vi.fn();
+Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+Element.prototype.setPointerCapture = vi.fn();
+Element.prototype.releasePointerCapture = vi.fn();
+
+const {
+  assignMutate,
+  unassignMutate,
+  useAppMock,
+  useAppToolsMock,
+  useHasPermissionsMock,
+  useInternalMcpCatalogMock,
+  fetchCatalogToolsMock,
+} = vi.hoisted(() => ({
+  assignMutate: vi.fn(),
+  unassignMutate: vi.fn(),
+  useAppMock: vi.fn(),
+  useAppToolsMock: vi.fn(),
+  useHasPermissionsMock: vi.fn(),
+  useInternalMcpCatalogMock: vi.fn(),
+  fetchCatalogToolsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/app.query", () => ({
+  useApp: useAppMock,
+  useAppTools: useAppToolsMock,
+  useAssignToolToApp: () => ({ mutate: assignMutate }),
+  useUnassignToolFromApp: () => ({ mutate: unassignMutate }),
+}));
+
+vi.mock("@/lib/auth/auth.query", () => ({
+  useHasPermissions: useHasPermissionsMock,
+}));
+
+vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
+  useInternalMcpCatalog: useInternalMcpCatalogMock,
+  fetchCatalogTools: fetchCatalogToolsMock,
+}));
+
+// The catalog icon pulls in white-label app-name hooks the bare render lacks.
+vi.mock("@/components/mcp-catalog-icon", () => ({
+  McpCatalogIcon: () => null,
+}));
+
+import { AppToolsTab } from "./app-tools-tab";
+
+const APP_ID = "app-1";
+const JIRA_CATALOG_ID = "jira-catalog";
+
+function makeCatalog(over: Record<string, unknown> = {}) {
+  return {
+    id: JIRA_CATALOG_ID,
+    name: "JIRA",
+    icon: null,
+    serverType: "local",
+    environmentId: null,
+    ...over,
+    // biome-ignore lint/suspicious/noExplicitAny: test fixture
+  } as any;
+}
+
+function makeTool(id: string, name: string) {
+  // biome-ignore lint/suspicious/noExplicitAny: test fixture
+  return { id, name, description: null, catalogId: JIRA_CATALOG_ID } as any;
+}
+
+function renderTab() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AppToolsTab appId={APP_ID} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AppToolsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAppMock.mockReturnValue({ data: { environmentId: null } });
+    useHasPermissionsMock.mockReturnValue({ data: true });
+    useInternalMcpCatalogMock.mockReturnValue({ data: [makeCatalog()] });
+    // create_issue is already assigned; delete_issue is available but not.
+    useAppToolsMock.mockReturnValue({
+      data: [makeTool("t-create", "create_issue")],
+      isPending: false,
+    });
+    fetchCatalogToolsMock.mockResolvedValue([
+      makeTool("t-create", "create_issue"),
+      makeTool("t-delete", "delete_issue"),
+    ]);
+  });
+
+  it("groups an app's tools under their MCP server and reflects the assigned set", async () => {
+    renderTab();
+
+    // The server (catalog) heading renders, with the assigned-count badge.
+    expect(await screen.findByText("JIRA")).toBeInTheDocument();
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+
+    // Tools load into the default-open section; the assigned one is checked.
+    const created = await screen.findByLabelText("create_issue");
+    const deleted = await screen.findByLabelText("delete_issue");
+    expect(created).toBeChecked();
+    expect(deleted).not.toBeChecked();
+  });
+
+  it("assigns a tool with dynamic credentials when checked", async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    await user.click(await screen.findByLabelText("delete_issue"));
+
+    expect(assignMutate).toHaveBeenCalledWith({
+      appId: APP_ID,
+      toolId: "t-delete",
+      body: { credentialResolutionMode: "dynamic" },
+    });
+    expect(unassignMutate).not.toHaveBeenCalled();
+  });
+
+  it("unassigns a tool when unchecked", async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    await user.click(await screen.findByLabelText("create_issue"));
+
+    expect(unassignMutate).toHaveBeenCalledWith({
+      appId: APP_ID,
+      toolId: "t-create",
+    });
+    expect(assignMutate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an assignment with no listed MCP server as a removable fallback", async () => {
+    const user = userEvent.setup();
+    // Catalog list unavailable (e.g. failed/partial fetch): the assigned tool's
+    // server isn't listed, so it can't be grouped — it must stay removable.
+    useInternalMcpCatalogMock.mockReturnValue({ data: [] });
+    renderTab();
+
+    expect(await screen.findByText("create_issue")).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove create_issue" }),
+    );
+    expect(unassignMutate).toHaveBeenCalledWith({
+      appId: APP_ID,
+      toolId: "t-create",
+    });
+  });
+
+  it("shows a read-only assigned list without edit affordances for viewers", async () => {
+    useHasPermissionsMock.mockReturnValue({ data: false });
+    renderTab();
+
+    // Assigned tool is listed, but no checkbox (no editing) is rendered.
+    expect(await screen.findByText("create_issue")).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(fetchCatalogToolsMock).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/app/apps/_parts/app-tools-tab.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-tab.tsx
@@ -1,131 +1,365 @@
 "use client";
 
-import { ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
-import { Plus, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import {
+  ARCHESTRA_MCP_CATALOG_ID,
+  type archestraApiTypes,
+  isPlaywrightCatalogItem,
+} from "@archestra/shared";
+import { useQueries } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
+import { useMemo } from "react";
+import { ToolChecklist } from "@/components/agent-tools-editor";
+import {
+  isCatalogInEnvironment,
+  sortCatalogItems,
+} from "@/components/agent-tools-editor.utils";
 import { LoadingWrapper } from "@/components/loading";
+import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
+  useApp,
   useAppTools,
   useAssignToolToApp,
   useUnassignToolFromApp,
 } from "@/lib/app.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
-import { useTools } from "@/lib/tools/tool.query";
+import {
+  fetchCatalogTools,
+  useInternalMcpCatalog,
+} from "@/lib/mcp/internal-mcp-catalog.query";
 
-// An app's assignable upstream tools. The App Data Store tools are always
-// available to a running app and aren't listed here. Assignment uses dynamic
-// credentials (resolved per-call), matching the safe default for shared apps.
+type CatalogItem =
+  archestraApiTypes.GetInternalMcpCatalogResponses["200"][number];
+type CatalogTool =
+  archestraApiTypes.GetInternalMcpCatalogToolsResponses["200"][number];
+type AssignedTool = archestraApiTypes.GetAppToolsResponses["200"][number];
+
+const EMPTY_TOOLS: CatalogTool[] = [];
+
+/**
+ * An app's assignable upstream tools, grouped by their MCP server (catalog) to
+ * mirror the agent tool selector. Assignment uses dynamic credentials (resolved
+ * per viewer at call time) — the only resolution mode that fits an app shared
+ * across an org. Built-in Archestra tools (incl. the always-available App Data
+ * Store) aren't assignable and are omitted. Only servers in the app's bound
+ * environment are offered; a server an existing assignment has left is still
+ * shown so the stale assignment can be removed.
+ */
 export function AppToolsTab({ appId }: { appId: string }) {
+  const { data: app } = useApp(appId);
   const { data: assigned, isPending } = useAppTools(appId);
-  const { data: allTools } = useTools({});
+  const { data: catalogs = [] } = useInternalMcpCatalog();
   const { data: canEdit } = useHasPermissions({ app: ["update"] });
-  const assignTool = useAssignToolToApp();
-  const unassignTool = useUnassignToolFromApp();
-  const [pickerOpen, setPickerOpen] = useState(false);
 
-  const assignedIds = useMemo(
-    () => new Set((assigned ?? []).map((t) => t.id)),
-    [assigned],
-  );
-  // Candidates are upstream tools not yet assigned. Archestra built-ins (incl.
-  // the App Data Store tools, already available to a running app) aren't
-  // app-assignable, so drop the Archestra catalog.
+  const appEnvironmentId = app?.environmentId ?? null;
+
+  const assignedIdsByCatalog = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const tool of assigned ?? []) {
+      if (!tool.catalogId) continue;
+      let set = map.get(tool.catalogId);
+      if (!set) {
+        set = new Set();
+        map.set(tool.catalogId, set);
+      }
+      set.add(tool.id);
+    }
+    return map;
+  }, [assigned]);
+
+  // Candidate servers: every one in the app's environment (Playwright is
+  // environment-agnostic like a builtin), plus any server a current assignment
+  // already references so it can be cleaned up. The Archestra builtin catalog is
+  // never assignable.
   const candidates = useMemo(
     () =>
-      (allTools ?? []).filter(
-        (t) =>
-          !assignedIds.has(t.id) && t.catalogId !== ARCHESTRA_MCP_CATALOG_ID,
-      ),
-    [allTools, assignedIds],
+      catalogs.filter((c) => {
+        if (c.id === ARCHESTRA_MCP_CATALOG_ID) return false;
+        const inEnv =
+          isPlaywrightCatalogItem(c.id) ||
+          isCatalogInEnvironment(c, appEnvironmentId);
+        return inEnv || assignedIdsByCatalog.has(c.id);
+      }),
+    [catalogs, appEnvironmentId, assignedIdsByCatalog],
+  );
+
+  // Editors get the interactive checklist, so load each candidate's tools to
+  // group, count, and render them. Viewers only see assigned tools (below) and
+  // don't fetch catalog tools.
+  const toolQueries = useQueries({
+    queries: candidates.map((c) => ({
+      queryKey: ["mcp-catalog", c.id, "tools"] as const,
+      queryFn: () => fetchCatalogTools(c.id),
+      enabled: canEdit === true,
+    })),
+  });
+
+  const toolsByCatalog = useMemo(() => {
+    const map = new Map<string, CatalogTool[]>();
+    candidates.forEach((c, i) => {
+      map.set(c.id, (toolQueries[i]?.data as CatalogTool[] | undefined) ?? []);
+    });
+    return map;
+  }, [candidates, toolQueries]);
+
+  // Hide servers with no tools unless an assignment depends on them.
+  const visibleCatalogs = useMemo(() => {
+    const withTools = candidates.filter(
+      (c) =>
+        (toolsByCatalog.get(c.id)?.length ?? 0) > 0 ||
+        assignedIdsByCatalog.has(c.id),
+    );
+    return sortCatalogItems(
+      withTools,
+      (c) => assignedIdsByCatalog.get(c.id)?.size ?? 0,
+      (c) => toolsByCatalog.get(c.id)?.length ?? 0,
+    );
+  }, [candidates, toolsByCatalog, assignedIdsByCatalog]);
+
+  const defaultOpen = useMemo(
+    () =>
+      visibleCatalogs
+        .filter((c) => assignedIdsByCatalog.has(c.id))
+        .map((c) => c.id),
+    [visibleCatalogs, assignedIdsByCatalog],
+  );
+
+  // Assigned tools that map to no listed catalog (server removed, or the
+  // catalog list failed/has not loaded) would otherwise be invisible and
+  // unremovable in the grouped view; surface them as a removable fallback.
+  const orphanedAssigned = useMemo(() => {
+    const catalogIds = new Set(catalogs.map((c) => c.id));
+    return (assigned ?? []).filter(
+      (t) => !t.catalogId || !catalogIds.has(t.catalogId),
+    );
+  }, [assigned, catalogs]);
+
+  const toolsLoading = toolQueries.some((q) => q.isLoading);
+
+  if (canEdit !== true) {
+    return (
+      <AssignedToolsReadOnly
+        isPending={isPending && !assigned}
+        assigned={assigned ?? []}
+        catalogs={catalogs}
+      />
+    );
+  }
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-4">
+      <LoadingWrapper isPending={isPending && !assigned}>
+        {visibleCatalogs.length === 0 && orphanedAssigned.length === 0 ? (
+          candidates.length > 0 && toolsLoading ? (
+            <p className="text-sm text-muted-foreground">Loading tools…</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No MCP servers are available in this app's environment. The app
+              can still use its data store.
+            </p>
+          )
+        ) : (
+          <>
+            {visibleCatalogs.length > 0 ? (
+              <Accordion type="multiple" defaultValue={defaultOpen}>
+                {visibleCatalogs.map((catalog) => {
+                  const assignedCount =
+                    assignedIdsByCatalog.get(catalog.id)?.size ?? 0;
+                  const outOfEnv =
+                    !isPlaywrightCatalogItem(catalog.id) &&
+                    !isCatalogInEnvironment(catalog, appEnvironmentId);
+                  return (
+                    <AccordionItem key={catalog.id} value={catalog.id}>
+                      <AccordionTrigger>
+                        <div className="flex w-full items-center gap-2 pr-2">
+                          <McpCatalogIcon
+                            icon={catalog.icon}
+                            catalogId={catalog.id}
+                            size={20}
+                          />
+                          <span className="truncate font-medium">
+                            {catalog.name}
+                          </span>
+                          {outOfEnv ? (
+                            <span className="shrink-0 text-xs font-normal text-muted-foreground">
+                              (outside this environment)
+                            </span>
+                          ) : null}
+                          {assignedCount > 0 ? (
+                            <Badge variant="secondary" className="ml-auto">
+                              {assignedCount} selected
+                            </Badge>
+                          ) : null}
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent>
+                        <div className="flex max-h-96 flex-col rounded-md border">
+                          <AppCatalogToolList
+                            appId={appId}
+                            tools={
+                              toolsByCatalog.get(catalog.id) ?? EMPTY_TOOLS
+                            }
+                            assignedToolIds={
+                              assignedIdsByCatalog.get(catalog.id) ?? null
+                            }
+                          />
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                  );
+                })}
+              </Accordion>
+            ) : null}
+            {orphanedAssigned.length > 0 ? (
+              <OrphanedAssignedTools appId={appId} tools={orphanedAssigned} />
+            ) : null}
+          </>
+        )}
+      </LoadingWrapper>
+    </div>
+  );
+}
+
+function OrphanedAssignedTools({
+  appId,
+  tools,
+}: {
+  appId: string;
+  tools: AssignedTool[];
+}) {
+  const unassignTool = useUnassignToolFromApp();
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-muted-foreground">
+        Other assigned tools, not part of a listed MCP server.
+      </p>
+      <ul className="divide-y rounded-lg border">
+        {tools.map((tool) => (
+          <li
+            key={tool.id}
+            className="flex items-center justify-between gap-2 px-4 py-3"
+          >
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">{tool.name}</div>
+              {tool.description ? (
+                <div className="truncate text-xs text-muted-foreground">
+                  {tool.description}
+                </div>
+              ) : null}
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground hover:text-destructive"
+              aria-label={`Remove ${tool.name}`}
+              onClick={() => unassignTool.mutate({ appId, toolId: tool.id })}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AppCatalogToolList({
+  appId,
+  tools,
+  assignedToolIds,
+}: {
+  appId: string;
+  tools: CatalogTool[];
+  assignedToolIds: Set<string> | null;
+}) {
+  const assignTool = useAssignToolToApp();
+  const unassignTool = useUnassignToolFromApp();
+
+  const selectedToolIds = useMemo(
+    () => new Set(assignedToolIds ?? []),
+    [assignedToolIds],
+  );
+
+  // ToolChecklist emits the full next selection; assign/unassign only the delta.
+  // Each mutation invalidates the app's tools query, so the checkboxes track
+  // server state rather than optimistic local state.
+  const handleSelectionChange = (next: Set<string>) => {
+    for (const id of next) {
+      if (!selectedToolIds.has(id)) {
+        assignTool.mutate({
+          appId,
+          toolId: id,
+          body: { credentialResolutionMode: "dynamic" },
+        });
+      }
+    }
+    for (const id of selectedToolIds) {
+      if (!next.has(id)) {
+        unassignTool.mutate({ appId, toolId: id });
+      }
+    }
+  };
+
+  if (tools.length === 0) {
+    return (
+      <p className="px-4 py-3 text-sm text-muted-foreground">
+        This server exposes no tools yet.
+      </p>
+    );
+  }
+
+  return (
+    <ToolChecklist
+      tools={tools}
+      selectedToolIds={selectedToolIds}
+      onSelectionChange={handleSelectionChange}
+    />
+  );
+}
+
+function AssignedToolsReadOnly({
+  isPending,
+  assigned,
+  catalogs,
+}: {
+  isPending: boolean;
+  assigned: AssignedTool[];
+  catalogs: CatalogItem[];
+}) {
+  const catalogNameById = useMemo(
+    () => new Map(catalogs.map((c) => [c.id, c.name])),
+    [catalogs],
   );
 
   return (
     <div className="flex max-w-2xl flex-col gap-4">
-      {canEdit ? (
-        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
-          <PopoverTrigger asChild>
-            <Button variant="outline" className="self-start">
-              <Plus className="h-4 w-4" />
-              Add tool
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[360px] p-0" align="start">
-            <Command>
-              <CommandInput placeholder="Search tools…" />
-              <CommandList>
-                <CommandEmpty>No tools found.</CommandEmpty>
-                <CommandGroup>
-                  {candidates.map((tool) => (
-                    <CommandItem
-                      key={tool.id}
-                      value={tool.name}
-                      onSelect={() => {
-                        assignTool.mutate({
-                          appId,
-                          toolId: tool.id,
-                          body: { credentialResolutionMode: "dynamic" },
-                        });
-                        setPickerOpen(false);
-                      }}
-                    >
-                      <span className="truncate">{tool.name}</span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-      ) : null}
-
-      <LoadingWrapper isPending={isPending && !assigned}>
-        {!assigned || assigned.length === 0 ? (
+      <LoadingWrapper isPending={isPending}>
+        {assigned.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             No tools assigned. The app can still use its data store.
           </p>
         ) : (
           <ul className="divide-y rounded-lg border">
             {assigned.map((tool) => (
-              <li
-                key={tool.id}
-                className="flex items-center justify-between gap-2 px-4 py-3"
-              >
-                <div className="min-w-0">
-                  <div className="truncate text-sm font-medium">
-                    {tool.name}
+              <li key={tool.id} className="px-4 py-3">
+                <div className="truncate text-sm font-medium">{tool.name}</div>
+                {tool.catalogId && catalogNameById.has(tool.catalogId) ? (
+                  <div className="text-xs text-muted-foreground">
+                    {catalogNameById.get(tool.catalogId)}
                   </div>
-                  {tool.description ? (
-                    <div className="truncate text-xs text-muted-foreground">
-                      {tool.description}
-                    </div>
-                  ) : null}
-                </div>
-                {canEdit ? (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                    aria-label={`Remove ${tool.name}`}
-                    onClick={() =>
-                      unassignTool.mutate({ appId, toolId: tool.id })
-                    }
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                ) : null}
+                {tool.description ? (
+                  <div className="truncate text-xs text-muted-foreground">
+                    {tool.description}
+                  </div>
                 ) : null}
               </li>
             ))}


### PR DESCRIPTION
The app Tools tab previously listed assignable tools as one flat searchable popover, so a user picking tools for an app had no sense of which MCP server each tool came from — and could try to attach tools from servers outside the app's environment only to have the backend reject them. This brings the app tool selector in line with the agent tool selector: tools are grouped under their MCP server in an accordion of checklists, scoped to the app's bound environment.

Behavior a user sees:
- Tools are grouped by MCP server; each server expands to a checklist with Select All / Deselect All and search. Selection is custom-only and applies instantly per toggle — no Save step.
- Only servers in the app's bound environment are offered (the built-in Archestra catalog is never assignable). An assignment whose server has left the app's environment, or is no longer listed at all, stays visible and removable rather than silently disappearing.
- Assignments use dynamic (per-viewer) credential resolution, the only mode that fits a tool an org-shared app calls as the viewing user.
- Users without `app:update` get a read-only assigned list.

The grouped checklist reuses the existing shared `ToolChecklist` leaf, leaving the agent tool editor untouched.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>