### PR TITLE
ci(bench): add report/details links to Slack summary

### DIFF
--- a/.github/bench/README.md
+++ b/.github/bench/README.md
@@ -41,6 +41,11 @@ PLATFORM_GSA=$(kubectl get sa archestra-platform -n archestra \
   -o jsonpath='{.metadata.annotations.iam\.gke\.io/gcp-service-account}')
 gcloud storage buckets add-iam-policy-binding gs://archestra-bench-history \
   --member="serviceAccount:${PLATFORM_GSA}" --role="roles/storage.objectAdmin"
+
+# So the Slack `report` / `details` links (storage.cloud.google.com authenticated URLs) open for any
+# signed-in org member — read-only, org domain only, not allUsers/public.
+gcloud storage buckets add-iam-policy-binding gs://archestra-bench-history \
+  --member="domain:archestra.ai" --role="roles/storage.objectViewer"
 ```
 
 ### 2. GitHub secrets

--- a/archestra-bench/scripts/publish_run.py
+++ b/archestra-bench/scripts/publish_run.py
@@ -27,10 +27,19 @@ logger = logging.getLogger(__name__)
 
 
 def main() -> int:
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
     parser = argparse.ArgumentParser()
-    parser.add_argument("--tb", type=Path, required=True, help="TensorBoard event dir to publish")
-    parser.add_argument("--run-dir", type=Path, required=True, help="bench run dir (aggregate.json, report.md)")
+    parser.add_argument(
+        "--tb", type=Path, required=True, help="TensorBoard event dir to publish"
+    )
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        required=True,
+        help="bench run dir (aggregate.json, report.md)",
+    )
     parser.add_argument("--tarball", type=Path, required=True, help="packaged run.tgz")
     args = parser.parse_args()
 
@@ -73,9 +82,14 @@ def _summarize(aggregate_path: Path) -> _Summary:
         logger.exception("could not parse %s", aggregate_path)
         return failed
     if total == 0 or passed == 0:
-        return _Summary(healthy=False, text=f"⚠️ {passed}/{total} passed — harness likely broken · {outcomes}")
+        return _Summary(
+            healthy=False,
+            text=f"⚠️ {passed}/{total} passed — harness likely broken · {outcomes}",
+        )
     rate = int(pass_rate * 100)
-    return _Summary(healthy=True, text=f"✅ {passed}/{total} passed ({rate}%) · {outcomes}")
+    return _Summary(
+        healthy=True, text=f"✅ {passed}/{total} passed ({rate}%) · {outcomes}"
+    )
 
 
 def _upload(run_id: str, *, tb: Path, run_dir: Path, tarball: Path) -> list[str]:
@@ -91,8 +105,16 @@ def _upload(run_id: str, *, tb: Path, run_dir: Path, tarball: Path) -> list[str]
     # report.md / aggregate.json from rendering as latin-1 (mojibake) when opened via the browser URL.
     for local, remote, content_type in (
         (tarball, f"runs/{run_id}/run.tgz", None),
-        (run_dir / "aggregate.json", f"runs/{run_id}/aggregate.json", "application/json; charset=utf-8"),
-        (run_dir / "report.md", f"runs/{run_id}/report.md", "text/plain; charset=utf-8"),
+        (
+            run_dir / "aggregate.json",
+            f"runs/{run_id}/aggregate.json",
+            "application/json; charset=utf-8",
+        ),
+        (
+            run_dir / "report.md",
+            f"runs/{run_id}/report.md",
+            "text/plain; charset=utf-8",
+        ),
     ):
         if not local.is_file():
             warnings.append(f"missing {local.name}")
@@ -110,7 +132,9 @@ def _upload(run_id: str, *, tb: Path, run_dir: Path, tarball: Path) -> list[str]
     return warnings
 
 
-def _upload_one(bucket: storage.Bucket, local: Path, remote: str, *, content_type: str | None = None) -> bool:
+def _upload_one(
+    bucket: storage.Bucket, local: Path, remote: str, *, content_type: str | None = None
+) -> bool:
     try:
         bucket.blob(remote).upload_from_filename(str(local), content_type=content_type)
         logger.info("uploaded %s -> %s", local, remote)
@@ -120,7 +144,9 @@ def _upload_one(bucket: storage.Bucket, local: Path, remote: str, *, content_typ
         return False
 
 
-def _post_slack(summary: _Summary, warnings: list[str], *, links: dict[str, str]) -> None:
+def _post_slack(
+    summary: _Summary, warnings: list[str], *, links: dict[str, str]
+) -> None:
     webhook = os.environ.get("SLACK_BENCH_WEBHOOK_URL", "").strip()
     if not webhook:
         logger.info("no Slack webhook configured; skipping")
@@ -134,7 +160,9 @@ def _post_slack(summary: _Summary, warnings: list[str], *, links: dict[str, str]
     if run_url:
         text += f" · <{run_url}|run>"
     payload = json.dumps({"text": text}).encode()
-    request = urllib.request.Request(webhook, data=payload, headers={"Content-Type": "application/json"})
+    request = urllib.request.Request(
+        webhook, data=payload, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             logger.info("posted Slack summary (%s)", response.status)

--- a/archestra-bench/scripts/publish_run.py
+++ b/archestra-bench/scripts/publish_run.py
@@ -41,7 +41,12 @@ def main() -> int:
     if os.environ.get("BENCH_TB_EXPORT_OK", "1") != "1":
         warnings.append("TensorBoard export failed")
     warnings += _upload(run_id, tb=args.tb, run_dir=args.run_dir, tarball=args.tarball)
-    _post_slack(summary, warnings)
+    gcs_bucket = os.environ["GCS_BUCKET"]
+    links = {
+        "report": _https_url(gcs_bucket, f"runs/{run_id}/report.md"),
+        "details": _https_url(gcs_bucket, f"runs/{run_id}/aggregate.json"),
+    }
+    _post_slack(summary, warnings, links=links)
 
     return 0 if summary.healthy and not warnings else 1
 
@@ -82,15 +87,16 @@ def _upload(run_id: str, *, tb: Path, run_dir: Path, tarball: Path) -> list[str]
         return ["GCS upload unavailable"]
 
     warnings: list[str] = []
-    # Required: the run's record. Missing one is a real failure to surface.
-    for local, remote in (
-        (tarball, f"runs/{run_id}/run.tgz"),
-        (run_dir / "aggregate.json", f"runs/{run_id}/aggregate.json"),
-        (run_dir / "report.md", f"runs/{run_id}/report.md"),
+    # Required: the run's record. Missing one is a real failure to surface. The explicit charset keeps
+    # report.md / aggregate.json from rendering as latin-1 (mojibake) when opened via the browser URL.
+    for local, remote, content_type in (
+        (tarball, f"runs/{run_id}/run.tgz", None),
+        (run_dir / "aggregate.json", f"runs/{run_id}/aggregate.json", "application/json; charset=utf-8"),
+        (run_dir / "report.md", f"runs/{run_id}/report.md", "text/plain; charset=utf-8"),
     ):
         if not local.is_file():
             warnings.append(f"missing {local.name}")
-        elif not _upload_one(bucket, local, remote):
+        elif not _upload_one(bucket, local, remote, content_type=content_type):
             warnings.append(f"upload failed: {remote}")
 
     # Optional: the TensorBoard event tree (overall/ and lane=<lane>/), uploaded verbatim.
@@ -104,9 +110,9 @@ def _upload(run_id: str, *, tb: Path, run_dir: Path, tarball: Path) -> list[str]
     return warnings
 
 
-def _upload_one(bucket: storage.Bucket, local: Path, remote: str) -> bool:
+def _upload_one(bucket: storage.Bucket, local: Path, remote: str, *, content_type: str | None = None) -> bool:
     try:
-        bucket.blob(remote).upload_from_filename(str(local))
+        bucket.blob(remote).upload_from_filename(str(local), content_type=content_type)
         logger.info("uploaded %s -> %s", local, remote)
         return True
     except Exception:
@@ -114,7 +120,7 @@ def _upload_one(bucket: storage.Bucket, local: Path, remote: str) -> bool:
         return False
 
 
-def _post_slack(summary: _Summary, warnings: list[str]) -> None:
+def _post_slack(summary: _Summary, warnings: list[str], *, links: dict[str, str]) -> None:
     webhook = os.environ.get("SLACK_BENCH_WEBHOOK_URL", "").strip()
     if not webhook:
         logger.info("no Slack webhook configured; skipping")
@@ -122,6 +128,8 @@ def _post_slack(summary: _Summary, warnings: list[str]) -> None:
     text = summary.text
     if warnings:
         text += " · ⚠️ " + "; ".join(warnings)
+    for label, url in links.items():
+        text += f" · <{url}|{label}>"
     run_url = os.environ.get("RUN_URL", "").strip()
     if run_url:
         text += f" · <{run_url}|run>"
@@ -134,9 +142,17 @@ def _post_slack(summary: _Summary, warnings: list[str]) -> None:
         logger.exception("failed to post Slack summary")
 
 
+def _bucket_name(gcs_bucket: str) -> str:
+    return urlparse(gcs_bucket).netloc if gcs_bucket.startswith("gs://") else gcs_bucket
+
+
 def _bucket(gcs_bucket: str) -> storage.Bucket:
-    name = urlparse(gcs_bucket).netloc if gcs_bucket.startswith("gs://") else gcs_bucket
-    return storage.Client().bucket(name)
+    return storage.Client().bucket(_bucket_name(gcs_bucket))
+
+
+def _https_url(gcs_bucket: str, remote: str) -> str:
+    # Authenticated browser URL (bucket members only); gs:// isn't clickable in Slack.
+    return f"https://storage.cloud.google.com/{_bucket_name(gcs_bucket)}/{remote}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The daily benchmark Slack summary posted only the pass-rate and a GitHub `run` link — no pointer to the per-run artifacts it uploads to GCS.

## Changes
- **Slack summary** now appends two authenticated GCS URLs: `report` (`report.md`) and `details` (`aggregate.json`), so a click lands you on the per-task breakdown.
- **Encoding fix**: `report.md` / `aggregate.json` are now uploaded with `charset=utf-8` content-types (`text/plain` / `application/json`). Without it the browser decoded them as latin-1 (`Â·`, `â€"`). Affects future runs only.
- **Access**: `domain:archestra.ai` granted `roles/storage.objectViewer` on the bucket so the links open for any signed-in org member (read-only, org domain only, not public). Documented in `.github/bench/README.md` alongside the existing IAM grant.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>