### PR TITLE
fix: Add namespace help text to environment editor form

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -585,6 +585,15 @@ function EnvironmentEditorDialog({
         </div>
         <div className="space-y-2">
           <Label htmlFor="environment-namespace">Namespace</Label>
+          <p className="text-xs text-muted-foreground">
+            The Kubernetes namespace where this environment's MCP server pods and
+            agent sandboxes run. Only namespaces the platform has been granted
+            RBAC for appear here — to add a new one, add it to the Helm chart's{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono">
+              rbac.environmentNamespaces
+            </code>{" "}
+            and redeploy. Leave as default to use the orchestrator's namespace.
+          </p>
           <Select
             value={
               trimmedNamespace === ""


### PR DESCRIPTION
The environment editor's Namespace dropdown only lists namespaces the platform has been granted RBAC for (Helm rbac.environmentNamespaces), so admins creating a new environment couldn't tell how to make a new namespace selectable. Add an inline description under the Namespace label explaining what the namespace controls and that adding a new one means wiring it into the Helm chart's rbac.environmentNamespaces and redeploying.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>