### PR TITLE
fix(oauth): use white-label app name in remote MCP consent client name

### DIFF
--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -1,12 +1,13 @@
 import { createHash } from "node:crypto";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { type Mock, vi } from "vitest";
 import { CacheKey, cacheManager } from "@/cache-manager";
-import db from "@/database";
+import db, { schema } from "@/database";
 import { secretManager } from "@/secrets-manager";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { useRouteTestApp } from "@/test/route-test-app";
 import oauthRoutes, {
   buildDiscoveryUrls,
   discoverOAuthEndpoints,
@@ -893,5 +894,189 @@ describe("OAuth routes", () => {
     expect(requestBody.get("grant_type")).toBe("refresh_token");
     expect(requestBody.get("refresh_token")).toBe("stored-refresh-token");
     expect(requestBody.has("resource")).toBe(false);
+  });
+});
+
+describe("OAuth dynamic client registration client name", () => {
+  // Stubs an authenticated request context so request.organizationId resolves
+  // to a fresh org per test, which the brand-name resolution reads under
+  // white-labeling.
+  const ctx = useRouteTestApp(oauthRoutes);
+  const originalFetch = globalThis.fetch;
+  const REGISTRATION_ENDPOINT = "https://auth.example.com/register";
+
+  beforeEach(() => {
+    cacheManager.start();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // Every non-registration request resolves auth-server metadata advertising a
+  // registration endpoint; the registration POST returns a freshly issued
+  // client id. Returns the mock so the test can read back the client metadata
+  // that was sent.
+  const mockRegistrationFlow = (): Mock => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === REGISTRATION_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => ({ client_id: "registered-client-id" }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: REGISTRATION_ENDPOINT,
+        }),
+      };
+    }) as Mock;
+    globalThis.fetch = fetchMock;
+    return fetchMock;
+  };
+
+  const readRegisteredClientName = (fetchMock: Mock): string => {
+    const registrationCall = fetchMock.mock.calls.find(
+      ([input]) => String(input) === REGISTRATION_ENDPOINT,
+    );
+    return JSON.parse(String(registrationCall?.[1]?.body)).client_name;
+  };
+
+  // A catalog item without a client_id, so the initiate flow performs dynamic
+  // client registration (which is where the consent-screen client name is set).
+  const makeDcrCatalog = (
+    makeInternalMcpCatalog: (
+      overrides?: Record<string, unknown>,
+    ) => Promise<{ id: string; name: string }>,
+    name: string,
+  ) =>
+    makeInternalMcpCatalog({
+      organizationId: ctx.organizationId,
+      name,
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com/mcp",
+      oauthConfig: {
+        name,
+        server_url: "https://mcp.example.com/mcp",
+        grant_type: "authorization_code",
+        client_id: "",
+        redirect_uris: ["http://localhost:3000/oauth-callback"],
+        scopes: ["read"],
+        default_scopes: ["read"],
+        supports_resource_metadata: false,
+      },
+    });
+
+  test("ignores the org app name and uses the default brand when full white-labeling is off", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const config = (await import("@/config")).default;
+    const original = config.enterpriseFeatures.fullWhiteLabeling;
+    (
+      config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+    ).fullWhiteLabeling = false;
+    // App name is set, but without the white-labeling license it must not leak
+    // into the consent screen.
+    await db
+      .update(schema.organizationsTable)
+      .set({ appName: "Contoso Copilot" })
+      .where(eq(schema.organizationsTable.id, ctx.organizationId));
+
+    try {
+      const catalog = await makeDcrCatalog(
+        makeInternalMcpCatalog,
+        "Acme Cloud",
+      );
+      const fetchMock = mockRegistrationFlow();
+
+      const response = await ctx.app.inject({
+        method: "POST",
+        url: "/api/oauth/initiate",
+        payload: { catalogId: catalog.id },
+      });
+
+      expect(response.statusCode, response.body).toBe(200);
+      expect(readRegisteredClientName(fetchMock)).toBe(
+        "Archestra Platform - Acme Cloud",
+      );
+    } finally {
+      (
+        config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+      ).fullWhiteLabeling = original;
+    }
+  });
+
+  test("uses the organization's white-label app name when full white-labeling is on", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const config = (await import("@/config")).default;
+    const original = config.enterpriseFeatures.fullWhiteLabeling;
+    (
+      config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+    ).fullWhiteLabeling = true;
+    await db
+      .update(schema.organizationsTable)
+      .set({ appName: "Contoso Copilot" })
+      .where(eq(schema.organizationsTable.id, ctx.organizationId));
+
+    try {
+      const catalog = await makeDcrCatalog(
+        makeInternalMcpCatalog,
+        "Acme Cloud",
+      );
+      const fetchMock = mockRegistrationFlow();
+
+      const response = await ctx.app.inject({
+        method: "POST",
+        url: "/api/oauth/initiate",
+        payload: { catalogId: catalog.id },
+      });
+
+      expect(response.statusCode, response.body).toBe(200);
+      expect(readRegisteredClientName(fetchMock)).toBe(
+        "Contoso Copilot - Acme Cloud",
+      );
+    } finally {
+      (
+        config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+      ).fullWhiteLabeling = original;
+    }
+  });
+
+  test("falls back to the default brand when white-labeling is on but no app name is set", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const config = (await import("@/config")).default;
+    const original = config.enterpriseFeatures.fullWhiteLabeling;
+    (
+      config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+    ).fullWhiteLabeling = true;
+
+    try {
+      const catalog = await makeDcrCatalog(
+        makeInternalMcpCatalog,
+        "Acme Cloud",
+      );
+      const fetchMock = mockRegistrationFlow();
+
+      const response = await ctx.app.inject({
+        method: "POST",
+        url: "/api/oauth/initiate",
+        payload: { catalogId: catalog.id },
+      });
+
+      expect(response.statusCode, response.body).toBe(200);
+      expect(readRegisteredClientName(fetchMock)).toBe(
+        "Archestra Platform - Acme Cloud",
+      );
+    } finally {
+      (
+        config.enterpriseFeatures as { fullWhiteLabeling: boolean }
+      ).fullWhiteLabeling = original;
+    }
   });
 });

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -1,11 +1,12 @@
 import { createHash, randomBytes } from "node:crypto";
-import { RouteId } from "@archestra/shared";
+import { DEFAULT_APP_NAME, RouteId } from "@archestra/shared";
 import { exchangeAuthorization } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { CacheKey, cacheManager } from "@/cache-manager";
+import config from "@/config";
 import logger from "@/logging";
-import { InternalMcpCatalogModel } from "@/models";
+import { InternalMcpCatalogModel, OrganizationModel } from "@/models";
 import { isByosEnabled, secretManager } from "@/secrets-manager";
 import { ApiError, constructResponseSchema, UuidIdSchema } from "@/types";
 
@@ -694,7 +695,7 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ),
       },
     },
-    async ({ body: { catalogId } }, reply) => {
+    async ({ body: { catalogId }, organizationId }, reply) => {
       // Get catalog item to retrieve OAuth configuration (with resolved secrets for runtime)
       const catalogItem =
         await InternalMcpCatalogModel.findByIdWithResolvedSecrets(catalogId);
@@ -789,7 +790,7 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
             "Attempting dynamic client registration",
           );
           registrationResult = await registerOAuthClient(registrationEndpoint, {
-            client_name: `Archestra Platform - ${catalogItem.name}`,
+            client_name: `${await resolveOAuthClientBrandName(organizationId)} - ${catalogItem.name}`,
             redirect_uris: [redirectUri],
             grant_types: ["authorization_code", "refresh_token"],
             response_types: ["code"],
@@ -1171,6 +1172,28 @@ function tryParseOAuthResourceUrl(oauthResource: string): URL | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the brand name used as the OAuth client name during dynamic client
+ * registration. This is the name remote MCP servers surface in their consent
+ * screens (e.g. "Archestra Platform - Atlassian Cloud MCP"). When enterprise
+ * full white-labeling is active and the organization has configured an app
+ * name, that name is used instead so the consent flow reflects the deployment's
+ * own branding. Falls back to the default product name otherwise.
+ */
+async function resolveOAuthClientBrandName(
+  organizationId: string,
+): Promise<string> {
+  const defaultBrandName = `${DEFAULT_APP_NAME} Platform`;
+
+  if (!config.enterpriseFeatures.fullWhiteLabeling) {
+    return defaultBrandName;
+  }
+
+  const organization = await OrganizationModel.getById(organizationId);
+  const appName = organization?.appName?.trim();
+  return appName || defaultBrandName;
 }
 
 export default oauthRoutes;


### PR DESCRIPTION
## Problem

When a user sets up an OAuth 2.1 remote MCP server, the consent screen shown by the remote server (during dynamic client registration) displayed a hardcoded client name:

> `Archestra Platform - <MCP server name>`

The `Archestra Platform` prefix was hardcoded in `backend/src/routes/oauth.ts`, so deployments running under enterprise **full white-labeling** still leaked the default product name into the third-party consent flow instead of the org's own app name.

## Fix

`client_name` used during dynamic client registration is now resolved through a small helper that respects white-labeling:

- **Full white-labeling on** + org has a configured app name → uses `<App Name> - <MCP server name>`
- **White-labeling off**, or no app name configured → falls back to the existing default (`Archestra Platform - <MCP server name>`)

This mirrors the existing white-labeling gating used elsewhere (`config.enterpriseFeatures.fullWhiteLabeling` + `organization.appName`).