### PR TITLE
fix: clear persisted chat errors on message regenerate

### DIFF
--- a/platform/backend/src/models/conversation-chat-error.test.ts
+++ b/platform/backend/src/models/conversation-chat-error.test.ts
@@ -113,6 +113,43 @@ describe("ConversationChatErrorModel", () => {
     expect(result.code).toBe(ChatErrorCode.Unknown);
     expect(result.message).toContain('"a":1');
   });
+
+  test("deleteByConversation removes all rows for the conversation", async ({
+    makeAgent,
+    makeConversation,
+  }) => {
+    const agent = await makeAgent();
+    const conversation = await makeConversation(agent.id);
+    const otherConversation = await makeConversation(agent.id);
+
+    const error: ChatErrorResponse = {
+      code: ChatErrorCode.ServerError,
+      message: "Boom",
+      isRetryable: true,
+    };
+    await ConversationChatErrorModel.create({
+      conversationId: conversation.id,
+      error,
+    });
+    await ConversationChatErrorModel.create({
+      conversationId: conversation.id,
+      error,
+    });
+    await ConversationChatErrorModel.create({
+      conversationId: otherConversation.id,
+      error,
+    });
+
+    await ConversationChatErrorModel.deleteByConversation(conversation.id);
+
+    expect(
+      await ConversationChatErrorModel.findByConversation(conversation.id),
+    ).toEqual([]);
+    // Other conversations' errors are untouched.
+    expect(
+      await ConversationChatErrorModel.findByConversation(otherConversation.id),
+    ).toHaveLength(1);
+  });
 });
 
 async function createErrorAndRead(params: {

--- a/platform/backend/src/models/conversation-chat-error.ts
+++ b/platform/backend/src/models/conversation-chat-error.ts
@@ -11,6 +11,10 @@ import type {
   InsertConversationChatError,
 } from "@/types";
 
+type DbExecutor =
+  | typeof db
+  | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
 class ConversationChatErrorModel {
   static async create(
     data: InsertConversationChatError,
@@ -38,6 +42,23 @@ class ConversationChatErrorModel {
       ...chatError,
       error: normalizeChatErrorResponse(chatError.error),
     }));
+  }
+
+  /**
+   * Delete all persisted chat-error rows for a conversation. Accepts an
+   * optional executor so a regenerate can clear the stale error in the same
+   * transaction that replaces the trailing turn, keeping the timeline and the
+   * error banner consistent.
+   */
+  static async deleteByConversation(
+    conversationId: string,
+    executor: DbExecutor = db,
+  ): Promise<void> {
+    await executor
+      .delete(schema.conversationChatErrorsTable)
+      .where(
+        eq(schema.conversationChatErrorsTable.conversationId, conversationId),
+      );
   }
 }
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2849,6 +2849,10 @@ async function persistRegeneratedTurn(params: {
   await withDbTransaction(async (tx) => {
     await MessageModel.deleteByIds(staleIds, tx);
     await MessageModel.bulkCreate(newRows, tx);
+    // The stale turn we just replaced may have left a persisted chat-error row
+    // that renders as a stuck error banner. Clear it atomically so a successful
+    // regenerate doesn't leave a phantom error on screen.
+    await ConversationChatErrorModel.deleteByConversation(conversationId, tx);
   });
 
   logger.info(


### PR DESCRIPTION
When an LLM turn fails, the backend persists a conversation_chat_errors row that renders as a stale error banner. persistRegeneratedTurn deleted the stale messages but never the stale error rows, leaving a phantom error after a successful regenerate. Add ConversationChatErrorModel.deleteByConversation and call it inside the regenerate transaction so the error is cleared atomically with the trailing-turn replacement.
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>