### PR TITLE
test(mcp): full endpoint & branch coverage for internal-catalog and mcp-server routes

### DIFF
--- a/platform/backend/src/routes/internal-mcp-catalog.deployment-yaml.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.deployment-yaml.test.ts
@@ -1,0 +1,238 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  hasZodFastifySchemaValidationErrors,
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { type Mock, vi } from "vitest";
+import { hasPermission } from "@/auth";
+import { InternalMcpCatalogModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { ApiError, type User } from "@/types";
+import internalMcpCatalogRoutes from "./internal-mcp-catalog";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+const mockHasPermission = hasPermission as Mock;
+
+const UNKNOWN_ID = "00000000-0000-4000-8000-000000000000";
+
+const VALID_DEPLOYMENT_YAML = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example
+spec:
+  template:
+    spec:
+      containers:
+        - name: mcp
+          image: registry.example.com/mcp:latest
+`;
+
+describe("internal MCP catalog deployment YAML routes", () => {
+  let app: FastifyInstance;
+  let organizationId: string;
+  let user: User;
+
+  beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    user = await makeUser();
+    await makeMember(user.id, organization.id, { role: "admin" });
+
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply.status(error.statusCode).send({
+          error: { message: error.message, type: error.type },
+        });
+      }
+      if (hasZodFastifySchemaValidationErrors(error)) {
+        return reply.status(400).send({
+          error: { message: error.message, type: "api_validation_error" },
+        });
+      }
+      const err = error as Error & { statusCode?: number };
+      const status = err.statusCode ?? 500;
+      return reply.status(status).send({ error: { message: err.message } });
+    });
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).user = user;
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).organizationId = organization.id;
+    });
+    await app.register(internalMcpCatalogRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function makeLocalCatalog() {
+    return InternalMcpCatalogModel.create(
+      {
+        name: "local-server",
+        serverType: "local",
+        scope: "org",
+        localConfig: { dockerImage: "registry.example.com/mcp:latest" },
+      },
+      { organizationId, authorId: user.id },
+    );
+  }
+
+  describe("GET /api/internal_mcp_catalog/:id/deployment-yaml-preview", () => {
+    test("returns a generated YAML template for a local catalog", async () => {
+      const catalog = await makeLocalCatalog();
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/internal_mcp_catalog/${catalog.id}/deployment-yaml-preview`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const { yaml } = response.json();
+      expect(yaml).toContain("kind: Deployment");
+      expect(yaml).toContain("name: mcp-server");
+    });
+
+    test("returns 404 for an unknown catalog id", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/internal_mcp_catalog/${UNKNOWN_ID}/deployment-yaml-preview`,
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error.message).toBe("Catalog item not found");
+    });
+
+    test("rejects non-local catalogs with 400", async () => {
+      const catalog = await InternalMcpCatalogModel.create(
+        {
+          name: "remote-server",
+          serverType: "remote",
+          serverUrl: "https://example.com/mcp",
+          scope: "org",
+        },
+        { organizationId, authorId: user.id },
+      );
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/internal_mcp_catalog/${catalog.id}/deployment-yaml-preview`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "Deployment YAML preview is only available for local MCP servers",
+      );
+    });
+  });
+
+  describe("POST /api/internal_mcp_catalog/validate-deployment-yaml", () => {
+    test("returns valid:true for a well-formed Deployment manifest", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/internal_mcp_catalog/validate-deployment-yaml",
+        payload: { yaml: VALID_DEPLOYMENT_YAML },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        valid: true,
+        errors: [],
+        warnings: expect.any(Array),
+      });
+    });
+
+    test("returns valid:false with errors for a non-Deployment manifest", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/internal_mcp_catalog/validate-deployment-yaml",
+        payload: { yaml: "apiVersion: v1\nkind: ConfigMap\n" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.valid).toBe(false);
+      expect(body.errors).toContain('kind must be "Deployment"');
+    });
+
+    test("rejects an empty yaml body with 400", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/internal_mcp_catalog/validate-deployment-yaml",
+        payload: { yaml: "" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("POST /api/internal_mcp_catalog/:id/reset-deployment-yaml", () => {
+    test("clears a custom deployment spec and returns a fresh template", async () => {
+      const catalog = await InternalMcpCatalogModel.create(
+        {
+          name: "local-server-with-custom-yaml",
+          serverType: "local",
+          scope: "org",
+          localConfig: { dockerImage: "registry.example.com/mcp:latest" },
+          deploymentSpecYaml: "apiVersion: apps/v1\nkind: Deployment\n",
+        },
+        { organizationId, authorId: user.id },
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/internal_mcp_catalog/${catalog.id}/reset-deployment-yaml`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().yaml).toContain("kind: Deployment");
+      const reloaded = await InternalMcpCatalogModel.findById(catalog.id);
+      expect(reloaded?.deploymentSpecYaml).toBeNull();
+    });
+
+    test("returns 404 for an unknown catalog id", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/internal_mcp_catalog/${UNKNOWN_ID}/reset-deployment-yaml`,
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error.message).toBe("Catalog item not found");
+    });
+
+    test("rejects non-local catalogs with 400", async () => {
+      const catalog = await InternalMcpCatalogModel.create(
+        {
+          name: "remote-server",
+          serverType: "remote",
+          serverUrl: "https://example.com/mcp",
+          scope: "org",
+        },
+        { organizationId, authorId: user.id },
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/internal_mcp_catalog/${catalog.id}/reset-deployment-yaml`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "Deployment YAML reset is only available for local MCP servers",
+      );
+    });
+  });
+});

--- a/platform/backend/src/routes/internal-mcp-catalog.image-pull-secrets.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.image-pull-secrets.test.ts
@@ -1,0 +1,107 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { type Mock, vi } from "vitest";
+import { hasPermission } from "@/auth";
+import mcpServerRuntimeManager from "@/k8s/mcp-server-runtime/manager";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { ApiError, type User } from "@/types";
+import internalMcpCatalogRoutes from "./internal-mcp-catalog";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+const mockHasPermission = hasPermission as Mock;
+
+describe("GET /api/k8s/image-pull-secrets", () => {
+  let app: FastifyInstance;
+  let organizationId: string;
+  let user: User;
+  let listSecretsSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+    listSecretsSpy = vi
+      .spyOn(mcpServerRuntimeManager, "listDockerRegistrySecrets")
+      .mockResolvedValue([
+        { name: "registry-creds", registryServers: ["registry.example.com"] },
+      ]);
+
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    user = await makeUser();
+    await makeMember(user.id, organization.id, { role: "admin" });
+
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply.status(error.statusCode).send({
+          error: { message: error.message, type: error.type },
+        });
+      }
+      const err = error as Error & { statusCode?: number };
+      const status = err.statusCode ?? 500;
+      return reply.status(status).send({ error: { message: err.message } });
+    });
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).user = user;
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).organizationId = organization.id;
+    });
+    await app.register(internalMcpCatalogRoutes);
+  });
+
+  afterEach(async () => {
+    listSecretsSpy.mockRestore();
+    await app.close();
+  });
+
+  test("an admin lists secrets across the whole cluster", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/k8s/image-pull-secrets",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([
+      { name: "registry-creds", registryServers: ["registry.example.com"] },
+    ]);
+    expect(listSecretsSpy).toHaveBeenCalledWith({ isAdmin: true });
+  });
+
+  test("a non-admin lists secrets scoped to their team memberships", async ({
+    makeTeam,
+    makeUser,
+    makeMember,
+    makeTeamMember,
+  }) => {
+    const member = await makeUser();
+    await makeMember(member.id, organizationId, { role: "member" });
+    const team = await makeTeam(organizationId, member.id, { name: "core" });
+    await makeTeamMember(team.id, member.id);
+    user = member;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/k8s/image-pull-secrets",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(listSecretsSpy).toHaveBeenCalledWith({
+      teamIds: expect.arrayContaining([team.id]),
+    });
+    const callArg = listSecretsSpy.mock.calls[0][0];
+    expect(callArg).not.toHaveProperty("isAdmin");
+  });
+});

--- a/platform/backend/src/routes/internal-mcp-catalog.labels.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.labels.test.ts
@@ -1,0 +1,130 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { type Mock, vi } from "vitest";
+import { hasPermission } from "@/auth";
+import { InternalMcpCatalogModel, McpCatalogLabelModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { ApiError, type User } from "@/types";
+import internalMcpCatalogRoutes from "./internal-mcp-catalog";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+const mockHasPermission = hasPermission as Mock;
+
+describe("internal MCP catalog label routes", () => {
+  let app: FastifyInstance;
+  let organizationId: string;
+  let user: User;
+
+  beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    user = await makeUser();
+    await makeMember(user.id, organization.id, { role: "admin" });
+
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply.status(error.statusCode).send({
+          error: { message: error.message, type: error.type },
+        });
+      }
+      const err = error as Error & { statusCode?: number };
+      const status = err.statusCode ?? 500;
+      return reply.status(status).send({ error: { message: err.message } });
+    });
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).user = user;
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).organizationId = organization.id;
+    });
+    await app.register(internalMcpCatalogRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function seedLabels() {
+    const first = await InternalMcpCatalogModel.create(
+      {
+        name: "labelled-server-a",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "org",
+      },
+      { organizationId, authorId: user.id },
+    );
+    const second = await InternalMcpCatalogModel.create(
+      {
+        name: "labelled-server-b",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "org",
+      },
+      { organizationId, authorId: user.id },
+    );
+    await McpCatalogLabelModel.syncCatalogLabels(first.id, [
+      { key: "env", value: "prod" },
+      { key: "team", value: "core" },
+    ]);
+    await McpCatalogLabelModel.syncCatalogLabels(second.id, [
+      { key: "env", value: "staging" },
+    ]);
+  }
+
+  test("GET /labels/keys returns the distinct label keys in use", async () => {
+    await seedLabels();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/internal_mcp_catalog/labels/keys",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const keys = response.json();
+    expect(keys).toContain("env");
+    expect(keys).toContain("team");
+  });
+
+  test("GET /labels/values returns every value when no key filter is given", async () => {
+    await seedLabels();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/internal_mcp_catalog/labels/values",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const values = response.json();
+    expect(values).toEqual(expect.arrayContaining(["prod", "core", "staging"]));
+  });
+
+  test("GET /labels/values?key=env narrows results to that key", async () => {
+    await seedLabels();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/internal_mcp_catalog/labels/values?key=env",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const values = response.json();
+    expect(values).toEqual(expect.arrayContaining(["prod", "staging"]));
+    expect(values).not.toContain("core");
+  });
+});

--- a/platform/backend/src/routes/internal-mcp-catalog.list.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.list.test.ts
@@ -1,0 +1,120 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { type Mock, vi } from "vitest";
+import { hasPermission } from "@/auth";
+import { InternalMcpCatalogModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { ApiError, type User } from "@/types";
+import internalMcpCatalogRoutes from "./internal-mcp-catalog";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+const mockHasPermission = hasPermission as Mock;
+
+describe("GET /api/internal_mcp_catalog", () => {
+  let app: FastifyInstance;
+  let organizationId: string;
+  let user: User;
+
+  beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    user = await makeUser();
+    await makeMember(user.id, organization.id, { role: "admin" });
+
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply.status(error.statusCode).send({
+          error: { message: error.message, type: error.type },
+        });
+      }
+      const err = error as Error & { statusCode?: number };
+      const status = err.statusCode ?? 500;
+      return reply.status(status).send({ error: { message: err.message } });
+    });
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).user = user;
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).organizationId = organization.id;
+    });
+    await app.register(internalMcpCatalogRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("an admin sees another member's personal catalog item", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const author = await makeUser();
+    await makeMember(author.id, organizationId, { role: "member" });
+    const personal = await InternalMcpCatalogModel.create(
+      {
+        name: "authors-personal-server",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "personal",
+      },
+      { organizationId, authorId: author.id },
+    );
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/internal_mcp_catalog",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const ids = response.json().map((item: { id: string }) => item.id);
+    expect(ids).toContain(personal.id);
+  });
+
+  test("a non-admin does not see another member's personal catalog item", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const author = await makeUser();
+    await makeMember(author.id, organizationId, { role: "member" });
+    const personal = await InternalMcpCatalogModel.create(
+      {
+        name: "hidden-personal-server",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "personal",
+      },
+      { organizationId, authorId: author.id },
+    );
+
+    // Act as a different non-admin member: hasPermission resolves the admin
+    // probe to false, so findAll is scoped to the caller's accessible items.
+    const member = await makeUser();
+    await makeMember(member.id, organizationId, { role: "member" });
+    user = member;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/internal_mcp_catalog",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const ids = response.json().map((item: { id: string }) => item.id);
+    expect(ids).not.toContain(personal.id);
+  });
+});

--- a/platform/backend/src/routes/internal-mcp-catalog.permissions.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.permissions.test.ts
@@ -1,0 +1,212 @@
+import { ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { type Mock, vi } from "vitest";
+import { hasPermission } from "@/auth";
+import { InternalMcpCatalogModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { ApiError, type User } from "@/types";
+import internalMcpCatalogRoutes from "./internal-mcp-catalog";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+const mockHasPermission = hasPermission as Mock;
+
+const UNKNOWN_ID = "00000000-0000-4000-8000-000000000099";
+
+describe("internal MCP catalog built-in protection & ownership gates", () => {
+  let app: FastifyInstance;
+  let organizationId: string;
+  let user: User;
+
+  beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    user = await makeUser();
+    await makeMember(user.id, organization.id, { role: "admin" });
+
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply.status(error.statusCode).send({
+          error: { message: error.message, type: error.type },
+        });
+      }
+      const err = error as Error & { statusCode?: number };
+      const status = err.statusCode ?? 500;
+      return reply.status(status).send({ error: { message: err.message } });
+    });
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).user = user;
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).organizationId = organization.id;
+    });
+    await app.register(internalMcpCatalogRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("PUT rejects a built-in catalog item with 403", async () => {
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${ARCHESTRA_MCP_CATALOG_ID}`,
+      payload: { description: "should not be editable" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toBe(
+      "Built-in catalog items cannot be modified",
+    );
+  });
+
+  test("DELETE rejects a built-in catalog item with 403", async () => {
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/internal_mcp_catalog/${ARCHESTRA_MCP_CATALOG_ID}`,
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toBe(
+      "Built-in catalog items cannot be deleted",
+    );
+  });
+
+  test("DELETE returns 404 for an unknown catalog id", async () => {
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/internal_mcp_catalog/${UNKNOWN_ID}`,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.message).toBe("Catalog item not found");
+  });
+
+  test("GET returns 404 for an unknown catalog id", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/internal_mcp_catalog/${UNKNOWN_ID}`,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.message).toBe("Catalog item not found");
+  });
+
+  test("GET tools returns 404 for an unknown non-builtin catalog id", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/internal_mcp_catalog/${UNKNOWN_ID}/tools`,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.message).toBe("Catalog item not found");
+  });
+
+  test("DELETE lets a non-admin author remove their own personal item", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const member = await makeUser();
+    await makeMember(member.id, organizationId, { role: "member" });
+    const personal = await InternalMcpCatalogModel.create(
+      {
+        name: "members-personal-server",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "personal",
+      },
+      { organizationId, authorId: member.id },
+    );
+    user = member;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/internal_mcp_catalog/${personal.id}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true });
+    await expect(
+      InternalMcpCatalogModel.findById(personal.id),
+    ).resolves.toBeNull();
+  });
+
+  test("DELETE forbids a non-admin from removing an org-scoped item (403)", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const orgItem = await InternalMcpCatalogModel.create(
+      {
+        name: "org-shared-server",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "org",
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const member = await makeUser();
+    await makeMember(member.id, organizationId, { role: "member" });
+    user = member;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/internal_mcp_catalog/${orgItem.id}`,
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toBe(
+      "You can only delete your own personal catalog items",
+    );
+    await expect(
+      InternalMcpCatalogModel.findById(orgItem.id),
+    ).resolves.not.toBeNull();
+  });
+
+  test("DELETE by-name forbids a non-admin from removing an org-scoped item (403)", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    await InternalMcpCatalogModel.create(
+      {
+        name: "org-shared-by-name",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "org",
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const member = await makeUser();
+    await makeMember(member.id, organizationId, { role: "member" });
+    user = member;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/api/internal_mcp_catalog/by-name/org-shared-by-name",
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toBe(
+      "You can only delete your own personal catalog items",
+    );
+  });
+});

--- a/platform/backend/src/routes/internal-mcp-catalog.reinstall.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.reinstall.test.ts
@@ -1,0 +1,177 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { type Mock, vi } from "vitest";
+import { hasPermission } from "@/auth";
+import { InternalMcpCatalogModel } from "@/models";
+import { reinstallMultitenantCatalog } from "@/services/mcp-reinstall";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { ApiError, type User } from "@/types";
+import internalMcpCatalogRoutes from "./internal-mcp-catalog";
+
+vi.mock("@/auth", () => ({
+  hasPermission: vi.fn(),
+}));
+
+vi.mock("@/services/mcp-reinstall", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/services/mcp-reinstall")>();
+  return {
+    ...original,
+    reinstallMultitenantCatalog: vi.fn(),
+  };
+});
+
+const mockHasPermission = hasPermission as Mock;
+const mockReinstallMultitenantCatalog = reinstallMultitenantCatalog as Mock;
+
+const UNKNOWN_ID = "00000000-0000-4000-8000-000000000000";
+
+describe("POST /api/internal_mcp_catalog/:id/reinstall", () => {
+  let app: FastifyInstance;
+  let organizationId: string;
+  let user: User;
+
+  beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+    mockReinstallMultitenantCatalog.mockResolvedValue(undefined);
+
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    user = await makeUser();
+    await makeMember(user.id, organization.id, { role: "admin" });
+
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply.status(error.statusCode).send({
+          error: { message: error.message, type: error.type },
+        });
+      }
+      const err = error as Error & { statusCode?: number };
+      const status = err.statusCode ?? 500;
+      return reply.status(status).send({ error: { message: err.message } });
+    });
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).user = user;
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).organizationId = organization.id;
+    });
+    await app.register(internalMcpCatalogRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function makeMultitenantLocalCatalog(
+    overrides: { catalogReinstallRequired?: boolean } = {},
+  ) {
+    return InternalMcpCatalogModel.create(
+      {
+        name: "multitenant-local-server",
+        serverType: "local",
+        scope: "org",
+        multitenant: true,
+        catalogReinstallRequired: overrides.catalogReinstallRequired ?? true,
+        localConfig: { dockerImage: "registry.example.com/mcp:latest" },
+      },
+      { organizationId, authorId: user.id },
+    );
+  }
+
+  test("reinstalls a multi-tenant local catalog with a pending reinstall", async () => {
+    const catalog = await makeMultitenantLocalCatalog();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/internal_mcp_catalog/${catalog.id}/reinstall`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true });
+    expect(mockReinstallMultitenantCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ id: catalog.id }),
+    );
+  });
+
+  test("returns 404 when the catalog does not exist", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/internal_mcp_catalog/${UNKNOWN_ID}/reinstall`,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.message).toBe("Catalog item not found");
+    expect(mockReinstallMultitenantCatalog).not.toHaveBeenCalled();
+  });
+
+  test("rejects catalogs that are not multi-tenant local with 400", async () => {
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name: "remote-server",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "org",
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/internal_mcp_catalog/${catalog.id}/reinstall`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toBe(
+      "Catalog reinstall is only supported for multi-tenant local catalogs",
+    );
+    expect(mockReinstallMultitenantCatalog).not.toHaveBeenCalled();
+  });
+
+  test("returns 409 when there is no pending reinstall", async () => {
+    const catalog = await makeMultitenantLocalCatalog({
+      catalogReinstallRequired: false,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/internal_mcp_catalog/${catalog.id}/reinstall`,
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.message).toBe(
+      "Catalog has no pending reinstall",
+    );
+    expect(mockReinstallMultitenantCatalog).not.toHaveBeenCalled();
+  });
+
+  test("rejects non-editors of a shared catalog with 403", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const catalog = await makeMultitenantLocalCatalog();
+
+    const member = await makeUser();
+    await makeMember(member.id, organizationId, { role: "member" });
+    user = member;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/internal_mcp_catalog/${catalog.id}/reinstall`,
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(mockReinstallMultitenantCatalog).not.toHaveBeenCalled();
+  });
+});

--- a/platform/backend/src/routes/mcp-server-installation-requests.test.ts
+++ b/platform/backend/src/routes/mcp-server-installation-requests.test.ts
@@ -1,4 +1,5 @@
 import { type Mock, vi } from "vitest";
+import { McpServerInstallationRequestModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -568,5 +569,138 @@ describe("MCP server installation request routes", () => {
       expect(approved.status).toBe("approved");
       expect(approved.customServerConfig.serverType).toBe("remote");
     });
+  });
+});
+
+describe("MCP server installation request authorization & state transitions", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+
+  const UNKNOWN_ID = "00000000-0000-4000-8000-0000000000bb";
+
+  beforeEach(async ({ makeOrganization, makeUser }) => {
+    vi.clearAllMocks();
+    grantAdminPermissions();
+
+    user = await makeUser();
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (request as typeof request & { user: unknown }).user = user;
+      (request as typeof request & { organizationId: string }).organizationId =
+        organizationId;
+    });
+
+    const { default: routes } = await import(
+      "./mcp-server-installation-requests"
+    );
+    await app.register(routes);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  function denyAdminPermissions() {
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+  }
+
+  async function makeRequestOwnedBy(ownerId: string) {
+    return McpServerInstallationRequestModel.create(ownerId, {
+      externalCatalogId: `auth-test-${Date.now()}-${Math.random()}`,
+      customServerConfig: null,
+    });
+  }
+
+  test("GET /:id forbids a non-admin from viewing another member's request (403)", async ({
+    makeUser,
+  }) => {
+    const owner = await makeUser();
+    const request = await makeRequestOwnedBy(owner.id);
+    denyAdminPermissions();
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/mcp_server_installation_requests/${request.id}`,
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toBe("Forbidden");
+  });
+
+  test("PATCH /:id forbids a non-admin from setting status (403)", async () => {
+    const request = await makeRequestOwnedBy(user.id);
+    denyAdminPermissions();
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/mcp_server_installation_requests/${request.id}`,
+      payload: { status: "approved" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toBe(
+      "Only admins can approve or decline requests",
+    );
+  });
+
+  test("PATCH /:id returns 404 for an unknown request", async () => {
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/api/mcp_server_installation_requests/${UNKNOWN_ID}`,
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.message).toBe(
+      "Installation request not found",
+    );
+  });
+
+  test("POST /:id/notes forbids a non-admin from noting another member's request (403)", async ({
+    makeUser,
+  }) => {
+    const owner = await makeUser();
+    const request = await makeRequestOwnedBy(owner.id);
+    denyAdminPermissions();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server_installation_requests/${request.id}/notes`,
+      payload: { content: "please reconsider" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toBe("Forbidden");
+  });
+
+  test("POST /:id/approve is idempotent for an already-approved request", async () => {
+    const created = await makeRequestOwnedBy(user.id);
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server_installation_requests/${created.id}/approve`,
+      payload: { adminResponse: "ok" },
+    });
+    expect(first.statusCode).toBe(200);
+    expect(first.json().status).toBe("approved");
+
+    const second = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server_installation_requests/${created.id}/approve`,
+      payload: { adminResponse: "second attempt" },
+    });
+
+    expect(second.statusCode).toBe(200);
+    const body = second.json();
+    expect(body.id).toBe(created.id);
+    expect(body.status).toBe("approved");
+    // The short-circuit returns the already-approved row unchanged, so the
+    // second admin response is not applied.
+    expect(body.adminResponse).toBe("ok");
   });
 });

--- a/platform/backend/src/routes/mcp-server-proxy.test.ts
+++ b/platform/backend/src/routes/mcp-server-proxy.test.ts
@@ -5,9 +5,22 @@ import {
   validatorCompiler,
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
+import { type Mock, vi } from "vitest";
 import { afterEach, describe, expect, test } from "@/test";
 import { ApiError } from "@/types";
+import { createServerScopedServer } from "./mcp-server-gateway.utils";
 import mcpServerProxyRoutes from "./mcp-server-proxy";
+
+// Stub the MCP transport boundary so a request that passes the access +
+// visibility gates surfaces as a 500 instead of hijacking the socket. A gate
+// *rejection* returns a 200 JSON-RPC error and never reaches this, which is
+// exactly what lets these tests assert "the request got through the gate".
+vi.mock("./mcp-server-gateway.utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./mcp-server-gateway.utils")>()),
+  createServerScopedServer: vi.fn(),
+}));
+
+const mockCreateServerScopedServer = createServerScopedServer as Mock;
 
 async function buildApp(
   userId: string,
@@ -175,5 +188,94 @@ describe("mcpServerProxyRoutes POST /api/mcp/server/:mcpServerId", () => {
       payload: rpc("tools/call", { name: "modelonly", arguments: {} }),
     });
     expect(res.json().error.code).toBe(-32601);
+  });
+});
+
+describe("mcpServerProxyRoutes gate pass-through", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    mockCreateServerScopedServer.mockReset();
+    if (app) await app.close();
+  });
+
+  test("an app-visible tools/call passes the gate and reaches the transport", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: ADMIN_ROLE_NAME });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+      scope: "org",
+    });
+    const server = await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+    await makeTool({
+      catalogId: catalog.id,
+      name: "appcallable",
+      meta: { _meta: { ui: { visibility: ["app"] } } },
+    });
+    mockCreateServerScopedServer.mockImplementation(() => {
+      throw new Error("transport unavailable in test");
+    });
+    app = await buildApp(user.id, org.id);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/mcp/server/${server.id}`,
+      headers: JSON_HEADERS,
+      payload: rpc("tools/call", { name: "appcallable", arguments: {} }),
+    });
+
+    // Passed the visibility gate (a rejection would be a 200 JSON-RPC error),
+    // so execution proceeded into the transport setup.
+    expect(res.statusCode).toBe(500);
+    expect(mockCreateServerScopedServer).toHaveBeenCalledWith({
+      mcpServerId: server.id,
+      catalogId: catalog.id,
+    });
+  });
+
+  test("a non-tools/call method bypasses the tool-visibility gate", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: ADMIN_ROLE_NAME });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+      scope: "org",
+    });
+    const server = await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+    mockCreateServerScopedServer.mockImplementation(() => {
+      throw new Error("transport unavailable in test");
+    });
+    app = await buildApp(user.id, org.id);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/mcp/server/${server.id}`,
+      headers: JSON_HEADERS,
+      payload: rpc("tools/list", {}),
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(mockCreateServerScopedServer).toHaveBeenCalledWith({
+      mcpServerId: server.id,
+      catalogId: catalog.id,
+    });
   });
 });

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -2,6 +2,7 @@ import { OAUTH_TOKEN_TYPE } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
 import { vi } from "vitest";
 import db, { schema } from "@/database";
+import { McpServerModel } from "@/models";
 import McpServerUserModel from "@/models/mcp-server-user";
 import { secretManager } from "@/secrets-manager";
 import type { FastifyInstanceWithZod } from "@/server";
@@ -2949,5 +2950,162 @@ describe("mcp server inspect route", () => {
     expect(response.json().error.message).toContain(
       "You can only revoke connections for teams you are a member of",
     );
+  });
+});
+
+describe("mcp server core route coverage", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+
+  const UNKNOWN_ID = "00000000-0000-4000-8000-0000000000aa";
+
+  beforeEach(async ({ makeUser, makeOrganization, makeMember }) => {
+    user = await makeUser();
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    await makeMember(user.id, organization.id);
+    hasPermissionMock.mockResolvedValue({ success: true });
+    userHasPermissionMock.mockResolvedValue(true);
+    k8sStopServerMock.mockResolvedValue(undefined);
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).user = user;
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).organizationId = organizationId;
+    });
+
+    const { default: mcpServerRoutes } = await import("./mcp-server");
+    await app.register(mcpServerRoutes);
+  });
+
+  afterEach(async () => {
+    hasPermissionMock.mockReset();
+    userHasPermissionMock.mockReset();
+    k8sStopServerMock.mockReset();
+    await app.close();
+  });
+
+  describe("GET /api/mcp_server/:id", () => {
+    test("returns an MCP server the caller can access", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+      const server = await makeMcpServer({
+        ownerId: user.id,
+        catalogId: catalog.id,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp_server/${server.id}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().id).toBe(server.id);
+    });
+
+    test("returns 404 for an unknown id", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp_server/${UNKNOWN_ID}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error.message).toBe("MCP server not found");
+    });
+  });
+
+  describe("DELETE /api/mcp_server/:id", () => {
+    test("returns 404 for an unknown id", async () => {
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/mcp_server/${UNKNOWN_ID}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error.message).toBe("MCP server not found");
+    });
+
+    test("refuses to delete a built-in MCP server with 400", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "builtin" });
+      const builtin = await McpServerModel.create({
+        name: "builtin-server",
+        catalogId: catalog.id,
+        serverType: "builtin",
+        scope: "org",
+        ownerId: user.id,
+      });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/mcp_server/${builtin.id}`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "Cannot delete built-in MCP servers",
+      );
+      await expect(McpServerModel.findById(builtin.id)).resolves.not.toBeNull();
+    });
+  });
+
+  describe("PATCH /api/mcp_server/:id/reauthenticate", () => {
+    test("rejects a request with no credential fields (400)", async () => {
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/mcp_server/${UNKNOWN_ID}/reauthenticate`,
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "At least one credential field is required",
+      );
+    });
+
+    test("returns 404 for an unknown id when a credential is supplied", async () => {
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/mcp_server/${UNKNOWN_ID}/reauthenticate`,
+        payload: { accessToken: "fresh-token" },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error.message).toBe("MCP server not found");
+    });
+  });
+
+  describe("POST /api/mcp_server/:id/reinstall", () => {
+    test("returns 404 for an unknown id", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/mcp_server/${UNKNOWN_ID}/reinstall`,
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error.message).toBe("MCP server not found");
+    });
+  });
+
+  describe("POST /api/mcp_server", () => {
+    test("returns 400 when the referenced catalog item does not exist", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: { name: "ghost", catalogId: UNKNOWN_ID, scope: "personal" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe("Catalog item not found");
+    });
   });
 });


### PR DESCRIPTION
## Summary

The internal MCP catalog and MCP server route groups had several endpoints with zero request-level tests and many "covered" endpoints whose error/permission branches were never exercised — so authorization regressions (a dropped 403, a missing built-in guard, a broken not-found path) could ship without any test failing. This adds request-level coverage so every endpoint in these groups is hit and the meaningful branches — auth denials, not-found, conflict/validation, and distinct business forks — are pinned.

What is now exercised that wasn't before:

- **Internal MCP catalog** — the list endpoint (admin-vs-scoped filtering), multi-tenant `reinstall` (404 / non-multitenant 400 / no-pending 409 / non-editor 403), deployment-YAML `preview` / `validate` / `reset`, `image-pull-secrets` (admin-wide vs team-scoped call), label `keys` / `values` (with the key filter actually narrowing), built-in-item protection on PUT/DELETE, and the non-admin delete ownership gates.
- **MCP server core** — `GET /:id` (accessible + not-found), `DELETE` not-found and built-in protection, `reauthenticate` no-credentials and not-found, `reinstall` not-found, and install rejecting an unknown catalog.
- **Installation requests** — the admin-only authorization branches that the existing suite never reached because its harness always granted admin (403 on viewing/patching/noting another member's request, 404 on patching a missing request) plus the idempotent re-approve short-circuit.
- **Proxy** — the tool-visibility gate's positive path: an app-visible `tools/call` and a non-`tools/call` method both pass the gate and reach the transport (a rejection would short-circuit first).

Tests only; no production behavior changes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>