### PR TITLE
fix(oauth): return to originating chat after a remote MCP OAuth connect

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -75,8 +75,8 @@ import { Version } from "@/components/version";
 import { useDefaultAgentId, useInternalAgents } from "@/lib/agent.query";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import {
-  clearOAuthReauthChatResume,
-  getOAuthReauthChatResume,
+  clearOAuthPendingChatResume,
+  getOAuthPendingChatResume,
 } from "@/lib/auth/oauth-session";
 import {
   clearSsoSignInRedirectPath,
@@ -1713,11 +1713,11 @@ export function ChatPageContent({
   ]);
 
   useEffect(() => {
-    const pendingReauthResume = getOAuthReauthChatResume();
+    const pendingChatResume = getOAuthPendingChatResume();
     if (
       oauthReauthResumeTriggeredRef.current ||
-      !pendingReauthResume ||
-      pendingReauthResume.conversationId !== conversationId ||
+      !pendingChatResume ||
+      pendingChatResume.conversationId !== conversationId ||
       !sendMessage ||
       status !== "ready"
     ) {
@@ -1725,10 +1725,10 @@ export function ChatPageContent({
     }
 
     oauthReauthResumeTriggeredRef.current = true;
-    clearOAuthReauthChatResume();
+    clearOAuthPendingChatResume();
     sendMessage({
       role: "user",
-      parts: [{ type: "text", text: pendingReauthResume.message }],
+      parts: [{ type: "text", text: pendingChatResume.message }],
       metadata: { createdAt: new Date().toISOString() },
     });
   }, [conversationId, sendMessage, status]);

--- a/platform/frontend/src/app/oauth-callback/page.tsx
+++ b/platform/frontend/src/app/oauth-callback/page.tsx
@@ -16,7 +16,7 @@ import { useHandleOAuthCallback } from "@/lib/auth/oauth.query";
 import {
   clearCallbackProcessing,
   clearInstallContext,
-  clearOAuthReauthChatResume,
+  clearOAuthPendingChatResume,
   clearOAuthReturnUrl,
   clearReauthContext,
   getOAuthEnvironmentValues,
@@ -30,6 +30,7 @@ import {
   isCallbackProcessed,
   markCallbackProcessing,
   setOAuthInstallationCompleteCatalogId,
+  setOAuthInstallChatResume,
   setOAuthReauthChatResume,
 } from "@/lib/auth/oauth-session";
 import {
@@ -131,9 +132,23 @@ function OAuthCallbackContent() {
           });
 
           const isFirstInstallation = getOAuthIsFirstInstallation();
+          const returnUrl = getOAuthReturnUrl();
 
           clearCallbackProcessing(code, state);
           clearInstallContext();
+          clearOAuthReturnUrl();
+
+          // If the install was started from inside a chat conversation, return
+          // the user there (and queue the conversation to continue) instead of
+          // dropping them on the registry. No-op for installs started
+          // elsewhere (e.g. the MCP registry itself).
+          if (
+            returnUrl &&
+            setOAuthInstallChatResume({ returnUrl, serverName: name })
+          ) {
+            replaceBrowserUrl(returnUrl);
+            return;
+          }
 
           // Store flag to open assignments dialog after redirect (only for first installation)
           if (isFirstInstallation) {
@@ -146,7 +161,7 @@ function OAuthCallbackContent() {
         router.push("/mcp/registry");
       } catch (error) {
         console.error("OAuth completion error:", error);
-        clearOAuthReauthChatResume();
+        clearOAuthPendingChatResume();
         // The mutation's onError handler will show the error toast
         // Redirect back to catalog
         router.push("/mcp/registry");

--- a/platform/frontend/src/lib/auth/oauth-session.test.ts
+++ b/platform/frontend/src/lib/auth/oauth-session.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-  clearOAuthReauthChatResume,
-  getOAuthReauthChatResume,
+  clearOAuthPendingChatResume,
+  getOAuthPendingChatResume,
   getOAuthUserConfigValues,
+  setOAuthInstallChatResume,
   setOAuthReauthChatResume,
   setOAuthUserConfigValues,
 } from "./oauth-session";
@@ -13,12 +14,13 @@ describe("oauth-session reauth chat resume", () => {
   });
 
   it("stores a pending chat resume message for chat return URLs", () => {
-    setOAuthReauthChatResume({
+    const conversationId = setOAuthReauthChatResume({
       returnUrl: "http://localhost:3000/chat/conv_123",
       serverName: "PostHog",
     });
 
-    expect(getOAuthReauthChatResume()).toEqual({
+    expect(conversationId).toBe("conv_123");
+    expect(getOAuthPendingChatResume()).toEqual({
       conversationId: "conv_123",
       message:
         'I re-authenticated the "PostHog" connection. Please retry the last failed tool call and continue from where we left off.',
@@ -26,12 +28,13 @@ describe("oauth-session reauth chat resume", () => {
   });
 
   it("ignores non-chat return URLs", () => {
-    setOAuthReauthChatResume({
+    const conversationId = setOAuthReauthChatResume({
       returnUrl: "http://localhost:3000/mcp/registry",
       serverName: "PostHog",
     });
 
-    expect(getOAuthReauthChatResume()).toBeNull();
+    expect(conversationId).toBeNull();
+    expect(getOAuthPendingChatResume()).toBeNull();
   });
 
   it("clears the pending chat resume message", () => {
@@ -40,9 +43,39 @@ describe("oauth-session reauth chat resume", () => {
       serverName: "PostHog",
     });
 
-    clearOAuthReauthChatResume();
+    clearOAuthPendingChatResume();
 
-    expect(getOAuthReauthChatResume()).toBeNull();
+    expect(getOAuthPendingChatResume()).toBeNull();
+  });
+});
+
+describe("oauth-session install chat resume", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("stores an install-specific resume message and returns the conversation id for chat return URLs", () => {
+    const conversationId = setOAuthInstallChatResume({
+      returnUrl: "http://localhost:3000/chat/conv_456",
+      serverName: "Atlassian",
+    });
+
+    expect(conversationId).toBe("conv_456");
+    expect(getOAuthPendingChatResume()).toEqual({
+      conversationId: "conv_456",
+      message:
+        'I connected the "Atlassian" integration. Please retry what I asked and continue from where we left off.',
+    });
+  });
+
+  it("does not store a resume (and returns null) for non-chat return URLs", () => {
+    const conversationId = setOAuthInstallChatResume({
+      returnUrl: "http://localhost:3000/mcp/registry",
+      serverName: "Atlassian",
+    });
+
+    expect(conversationId).toBeNull();
+    expect(getOAuthPendingChatResume()).toBeNull();
   });
 });
 

--- a/platform/frontend/src/lib/auth/oauth-session.ts
+++ b/platform/frontend/src/lib/auth/oauth-session.ts
@@ -26,7 +26,7 @@ const OAUTH_ENVIRONMENT_VALUES = "oauth_environment_values";
 const OAUTH_USER_CONFIG_VALUES = "oauth_user_config_values";
 const OAUTH_PENDING_AFTER_ENV_VARS = "oauth_pending_after_env_vars";
 const OAUTH_RETURN_URL = "oauth_return_url";
-const OAUTH_REAUTH_CHAT_RESUME = "oauth_reauth_chat_resume";
+const OAUTH_CHAT_RESUME = "oauth_chat_resume";
 
 // Dynamic key prefix (combined with code + state to deduplicate callbacks)
 const OAUTH_PROCESSING_PREFIX = "oauth_processing_";
@@ -234,29 +234,33 @@ export function clearOAuthReturnUrl() {
   sessionStorage.removeItem(OAUTH_RETURN_URL);
 }
 
+/** Queue a chat resume after re-authenticating an existing connection. */
 export function setOAuthReauthChatResume(params: {
   returnUrl: string;
   serverName: string;
-}) {
-  const conversationId = extractConversationIdFromChatUrl(params.returnUrl);
-  if (!conversationId) {
-    return;
-  }
-
-  sessionStorage.setItem(
-    OAUTH_REAUTH_CHAT_RESUME,
-    JSON.stringify({
-      conversationId,
-      message: `I re-authenticated the "${params.serverName}" connection. Please retry the last failed tool call and continue from where we left off.`,
-    }),
+}): string | null {
+  return writeChatResume(
+    params.returnUrl,
+    `I re-authenticated the "${params.serverName}" connection. Please retry the last failed tool call and continue from where we left off.`,
   );
 }
 
-export function getOAuthReauthChatResume(): {
+/** Queue a chat resume after connecting a new integration mid-conversation. */
+export function setOAuthInstallChatResume(params: {
+  returnUrl: string;
+  serverName: string;
+}): string | null {
+  return writeChatResume(
+    params.returnUrl,
+    `I connected the "${params.serverName}" integration. Please retry what I asked and continue from where we left off.`,
+  );
+}
+
+export function getOAuthPendingChatResume(): {
   conversationId: string;
   message: string;
 } | null {
-  const json = sessionStorage.getItem(OAUTH_REAUTH_CHAT_RESUME);
+  const json = sessionStorage.getItem(OAUTH_CHAT_RESUME);
   if (!json) {
     return null;
   }
@@ -282,8 +286,8 @@ export function getOAuthReauthChatResume(): {
   }
 }
 
-export function clearOAuthReauthChatResume() {
-  sessionStorage.removeItem(OAUTH_REAUTH_CHAT_RESUME);
+export function clearOAuthPendingChatResume() {
+  sessionStorage.removeItem(OAUTH_CHAT_RESUME);
 }
 
 // ─── Cleanup ─────────────────────────────────────────────────────────
@@ -314,6 +318,25 @@ export function clearInstallationCompleteCatalogId() {
 /** Remove the "pending after env vars" flag. */
 export function clearPendingAfterEnvVars() {
   sessionStorage.removeItem(OAUTH_PENDING_AFTER_ENV_VARS);
+}
+
+/**
+ * Persist a message to auto-send once the user lands back on a chat
+ * conversation after an OAuth redirect. Only applies when `returnUrl` points at
+ * a chat conversation (`/chat/:id`); returns the conversation id when a resume
+ * was stored, or null otherwise (e.g. flows started from the MCP registry).
+ */
+function writeChatResume(returnUrl: string, message: string): string | null {
+  const conversationId = extractConversationIdFromChatUrl(returnUrl);
+  if (!conversationId) {
+    return null;
+  }
+
+  sessionStorage.setItem(
+    OAUTH_CHAT_RESUME,
+    JSON.stringify({ conversationId, message }),
+  );
+  return conversationId;
 }
 
 function extractConversationIdFromChatUrl(url: string): string | null {

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
@@ -113,4 +113,36 @@ describe("useMcpInstallOrchestrator", () => {
       "https://posthog.example.com/oauth/authorize",
     );
   });
+
+  it("captures the return URL when starting OAuth for a first-time install", async () => {
+    const { result } = renderHook(() => useMcpInstallOrchestrator());
+
+    // Opening the OAuth confirmation dialog should not start OAuth yet.
+    act(() => {
+      result.current.triggerInstallByCatalogId("catalog-posthog");
+    });
+    expect(redirectBrowserToUrlMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.handleOAuthConfirm({
+        scope: "personal",
+        teamId: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        catalogId: "catalog-posthog",
+      });
+    });
+
+    // New behavior: first-time installs remember where they started so the
+    // callback can return the user there (e.g. a chat conversation) instead of
+    // the registry. This is not a re-auth flow.
+    expect(setOAuthReturnUrlMock).toHaveBeenCalledWith(window.location.href);
+    expect(setOAuthMcpServerIdMock).not.toHaveBeenCalled();
+    expect(redirectBrowserToUrlMock).toHaveBeenCalledWith(
+      "https://posthog.example.com/oauth/authorize",
+    );
+  });
 });

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -100,6 +100,9 @@ export function useMcpInstallOrchestrator(options?: { enabled?: boolean }) {
             (server) => server.catalogId === params.catalogItem.id,
           );
           setOAuthIsFirstInstallation(isFirstInstallation);
+          // Remember where the install was started (e.g. a chat conversation)
+          // so the callback can return the user there instead of the registry.
+          setOAuthReturnUrl(window.location.href);
         }
 
         redirectBrowserToUrl(authorizationUrl);


### PR DESCRIPTION
## Problem

When a user connects a remote MCP server (OAuth 2.1) **from inside a chat conversation**, the OAuth callback for a **first-time install** always did `router.push("/mcp/registry")` — dropping the user out of their conversation onto the registry page after completing the provider consent flow.

The return-to-origin plumbing already existed, but was only wired into the **re-authentication** path (`oauth-callback/page.tsx` → reauth branch reads the stored return URL and `replaceBrowserUrl`s back). The **new-installation** path never captured a return URL and unconditionally redirected to the registry.

## Fix (frontend-only)

1. **Capture the origin on first-time install.** `useMcpInstallOrchestrator.initiateOAuthRedirect` now stores `window.location.href` in the non-reauth branch too. Since the install dialog runs in-page (chat wires `onInstallMcp`/`onReauthMcp` to the orchestrator), this is the chat conversation URL when started from chat.

2. **Honor it in the callback.** The new-installation branch returns the user to the originating chat conversation (and queues it to auto-continue) when the captured return URL is a `/chat/:id` URL. Installs started elsewhere (e.g. the MCP registry itself) are a no-op and still land on `/mcp/registry` with the assignments dialog — unchanged behavior.

3. **Generalized the chat-resume helpers** so both reauth and install reuse one mechanism:
   - `setOAuthReauthChatResume` / new `setOAuthInstallChatResume` (install-specific message), both delegating to a private `writeChatResume` and returning the conversation id (or `null` for non-chat URLs).
   - `getOAuthReauthChatResume` → `getOAuthPendingChatResume`, `clearOAuthReauthChatResume` → `clearOAuthPendingChatResume` (now serve both flows).

No backend change: the return context lives entirely in `sessionStorage`; the backend OAuth `state` carries no origin and doesn't need to.

## Behavior matrix

| Started from | Before | After |
| --- | --- | --- |
| Chat conversation (first connect) | Lands on `/mcp/registry` | Returns to the conversation, auto-continues |
| Chat conversation (re-auth) | Returns to conversation (already worked) | Unchanged |
| MCP registry | Lands on `/mcp/registry` + assignments dialog | Unchanged |