### PR TITLE
test(e2e): scope apps run-page smoke check to header

### DIFF
--- a/platform/e2e-tests/tests/apps.spec.ts
+++ b/platform/e2e-tests/tests/apps.spec.ts
@@ -40,7 +40,12 @@ test("create an app from a template and run it standalone", async ({
 
   try {
     await goToPage(page, `/apps/${app.id}/run`);
-    await expect(page.getByText(name)).toBeVisible();
+    // The run page renders the app name in its own <header>. The surrounding
+    // app shell also surfaces the name (a muted chrome label that mounts a beat
+    // later), so an unscoped getByText(name) is a strict-mode race: fast PR runs
+    // resolve before that label exists, slow merge-queue runs match both. Scope
+    // the smoke check to the header so it stays unambiguous.
+    await expect(page.locator("header").getByText(name)).toBeVisible();
 
     const proxyFrame = page.frameLocator("iframe");
     const appFrame = proxyFrame.frameLocator("iframe");


### PR DESCRIPTION
## Problem

The `apps.spec.ts` "create an app from a template and run it standalone" test fails intermittently in the **merge queue** with a Playwright strict-mode violation:

```
Error: strict mode violation: getByText('e2e-app-…') resolved to 2 elements:
  1) <span class="truncate text-sm font-medium">e2e-app-…</span>        // run page <header>
  2) <span class="… text-xs text-muted-foreground">e2e-app-…</span>     // app-shell chrome label
```

The standalone run page (`/apps/[id]/run`) renders the app name once in its own `<header>`, but the surrounding app shell surfaces the same name a beat later in a muted chrome label. The unscoped `getByText(name)` smoke check is therefore a **timing race**: fast PR-level runs assert before that second label mounts (1 match, pass), slower/loaded merge-queue runs match both (fail).

This is why PR-level e2e runs stay green while merge_group runs flake on this test (observed on the merge-queue runs for #5725 and #5809 — neither of which touches app code).

## Fix

Scope the smoke check to the run page's own `<header>` (the only `<header>` containing the name — the shell's other header is mobile-only / `md:hidden`). Test-only change, behavior of the page is unchanged.

## Verification

- `biome check tests/apps.spec.ts` → clean
- Locator chain is type-correct (`Locator.getByText`)

## Note

This removes the deterministic `apps.spec.ts` flake. A separate, load-induced timeout flake in `static-credentials-management.spec.ts:47` (`openManageCredentialsDialog` exhausting its 30s `toPass`) was also seen in the same merge-queue run and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>