### PR TITLE
fix(apps): give human readable names to external tools

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -10,6 +10,7 @@ import {
   filterOptimisticToolCalls,
   getAppRenderVerb,
   hasTextPart,
+  humanizeToolLabel,
   identifyCompactToolGroups,
   isSupersededOwnedRender,
 } from "./chat-messages.utils";
@@ -242,6 +243,28 @@ describe("collectBrowserToolCallIds", () => {
   });
 });
 
+describe("humanizeToolLabel", () => {
+  it("humanizes server and tool from a prefixed name", () => {
+    expect(humanizeToolLabel("system__get-system-stats")).toBe(
+      "System / Get System Stats",
+    );
+  });
+
+  it("handles underscore-separated tool names", () => {
+    expect(humanizeToolLabel("weather__get_forecast")).toBe(
+      "Weather / Get Forecast",
+    );
+  });
+
+  it("splits camelCase tool names", () => {
+    expect(humanizeToolLabel("fs__listFiles")).toBe("Fs / List Files");
+  });
+
+  it("humanizes a bare tool name with no server prefix", () => {
+    expect(humanizeToolLabel("render_app")).toBe("Render App");
+  });
+});
+
 describe("deriveAppsFromMessages", () => {
   it("returns an app for a tool call whose output carries _meta.ui.resourceUri", () => {
     const messages = [
@@ -264,7 +287,7 @@ describe("deriveAppsFromMessages", () => {
     expect(deriveAppsFromMessages(messages, {}, getToolShortName)).toEqual([
       {
         toolCallId: "call_1",
-        label: "show_board",
+        label: "Pm / Show Board",
         appId: null,
         version: null,
         createdAt: Date.parse("2026-05-29T18:13:52.000Z"),
@@ -303,7 +326,7 @@ describe("deriveAppsFromMessages", () => {
     ).toEqual([
       {
         toolCallId: "call_1",
-        label: "show_board",
+        label: "Pm / Show Board",
         appId: null,
         version: null,
         createdAt: 0,
@@ -343,7 +366,7 @@ describe("deriveAppsFromMessages", () => {
     expect(apps).toHaveLength(1);
     expect(apps[0]).toMatchObject({
       toolCallId: "call_1",
-      label: "show_board",
+      label: "Pm / Show Board",
     });
   });
 

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -12,6 +12,7 @@ import {
   TOOL_SCAFFOLD_APP_SHORT_NAME,
 } from "@archestra/shared";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
+import { startCase } from "lodash-es";
 import {
   getToolErrorText,
   isCompactEligible,
@@ -192,6 +193,18 @@ export function getAppRenderVerb(toolName: string): string | null {
  * toolCallId and version), so the panel defaults to the newest version. External
  * MCP-UI tool calls stay one entry per call — each is a distinct invocation.
  */
+
+/**
+ * Friendly label for an external MCP tool, derived from its full name.
+ * "system__get-system-stats" -> "System / Get System Stats"; "render_app" -> "Render App".
+ */
+export function humanizeToolLabel(fullToolName: string): string {
+  const { serverName, toolName } = parseFullToolName(fullToolName);
+  return serverName
+    ? `${startCase(serverName)} / ${startCase(toolName)}`
+    : startCase(toolName);
+}
+
 export function deriveAppsFromMessages(
   messages: UIMessage[],
   earlyToolUiStarts: Record<
@@ -231,10 +244,9 @@ export function deriveAppsFromMessages(
       if (!hasUiResource && !ownedApp) continue;
 
       seen.add(toolCallId);
-      const parsed = parseFullToolName(fullToolName);
       const entry: PanelApp = {
         toolCallId,
-        label: ownedApp?.appName ?? (parsed.toolName || fullToolName),
+        label: ownedApp?.appName ?? humanizeToolLabel(fullToolName),
         appId: ownedApp?.appId ?? null,
         version: ownedApp?.latestVersion ?? null,
         createdAt: createdAt ?? 0,

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -12,6 +12,7 @@ import { createPortal } from "react-dom";
 import { useApps } from "@/components/chat/apps-context";
 import {
   getAppRenderVerb,
+  humanizeToolLabel,
   isSupersededOwnedRender,
 } from "@/components/chat/chat-messages.utils";
 import {
@@ -154,9 +155,7 @@ export function McpAppSection({
   const { apps, selectedToolCallId, select, showInSidebar, portalTarget } =
     useApps();
 
-  const parsedToolName = parseFullToolName(toolName);
-  const shortToolName = parsedToolName.toolName ?? toolName;
-  const headerName = appName || shortToolName;
+  const headerName = appName || humanizeToolLabel(toolName);
   const isSelected = !!toolCallId && selectedToolCallId === toolCallId;
   const sidebarHostingActive = portalTarget !== null;
   // Only the *selected* app moves to the sidebar: its iframe is portaled into


### PR DESCRIPTION
## Summary

External MCP apps have no authored name, so the app frame showed the raw tool-call name (e.g. get-system-stats). 
Now it derives a friendly path-style label from the tool's full name, fitting the address-bar metaphor:
- system__get-system-stats → System / Get System Stats

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>