### PR TITLE
ci: fix invalid workflow file in build-native-multi-arch-image.yml

### DIFF
--- a/.github/workflows/build-native-multi-arch-image.yml
+++ b/.github/workflows/build-native-multi-arch-image.yml
@@ -82,18 +82,13 @@ concurrency:
 jobs:
   build-image:
     name: Build ${{ inputs.image_name }} (${{ matrix.os_and_arch }})
-    runs-on: ${{ matrix.platform }}
-    # Skip the arm64 leg when the caller only needs amd64 (e.g. staging). The
-    # amd64 leg still runs, and merge-manifests publishes a single-arch tag.
-    if: ${{ !inputs.amd64_only || matrix.os_and_arch != 'linux/arm64' }}
+    # Pick the runner matching the arch.
+    runs-on: ${{ matrix.os_and_arch == 'linux/arm64' && 'blacksmith-16vcpu-ubuntu-2404-arm' || 'blacksmith-16vcpu-ubuntu-2404' }}
     strategy:
       fail-fast: false
+      # Build both arches, or amd64 only when amd64_only is set.
       matrix:
-        include:
-          - platform: blacksmith-16vcpu-ubuntu-2404
-            os_and_arch: linux/amd64
-          - platform: blacksmith-16vcpu-ubuntu-2404-arm
-            os_and_arch: linux/arm64
+        os_and_arch: ${{ inputs.amd64_only && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64"]') }}
     permissions:
       contents: read # Required to checkout the repository and build the image.
       id-token: write # Required for Workload Identity Federation when pushing images.


### PR DESCRIPTION
## Issue
The `build-native-multi-arch-image.yml` workflow could not be parsed (caused by https://github.com/archestra-ai/archestra/pull/5725), so it broke `on-commits-to-main`:

```
Unrecognized named-value: 'matrix'
!inputs.amd64_only || matrix.os_and_arch != 'linux/arm64'
```

Skipping of the arm64 build was done using a job-level `if:` that read `matrix`. GitHub Actions does not allow `matrix` inside a job `if:`, so the file was invalid.


## Fix
Instead of skipping the arm64 build with an `if:`, we just don't add arm64 to the matrix when `amd64_only` is set:

```yaml
matrix:
  os_and_arch: ${{ inputs.amd64_only && fromJSON('["linux/amd64"]') ||
fromJSON('["linux/amd64", "linux/arm64"]') }}
```

runs-on is allowed to read matrix and instead of creating a leg for `amd64_only` and then cancelling it, we just never create it.

Nothing changes about behavior: staging (push to main) still builds amd64 only, and dev/release builds still build both arches.

<img width="814" height="487" alt="Screenshot 2026-06-23 at 10 32 28 PM" src="https://github.com/user-attachments/assets/ed5c6637-0d13-427d-9990-05ff3cc51b31" />

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>