### PR TITLE
fix(apps): fullscreen to panel flow

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1844,7 +1844,7 @@ export function ChatPageContent({
   return (
     <AppsProvider
       apps={mcpApps}
-      onShowInSidebar={() => openRightPanelTab("apps" as RightPanelTab)}
+      onShowInPanel={() => openRightPanelTab("apps" as RightPanelTab)}
     >
       <div className="flex h-full w-full min-h-0">
         <div className="flex-1 flex flex-col min-w-0 min-h-0">

--- a/platform/frontend/src/components/chat/apps-context.tsx
+++ b/platform/frontend/src/components/chat/apps-context.tsx
@@ -39,7 +39,7 @@ interface AppsContextValue {
   portalTarget: HTMLElement | null;
   setPortalTarget: (el: HTMLElement | null) => void;
   /** Open the panel on the Apps tab and select this app. Wired by the chat page. */
-  showInSidebar: (toolCallId: string) => void;
+  showInPanel: (toolCallId: string) => void;
 }
 
 const AppsContext = createContext<AppsContextValue | null>(null);
@@ -50,18 +50,18 @@ const NOOP_VALUE: AppsContextValue = {
   select: () => {},
   portalTarget: null,
   setPortalTarget: () => {},
-  showInSidebar: () => {},
+  showInPanel: () => {},
 };
 
 export function AppsProvider({
   apps,
-  onShowInSidebar,
+  onShowInPanel,
   children,
 }: {
   /** Apps for this conversation, derived from its messages by the caller. */
   apps: PanelApp[];
   /** Called when an app requests to be shown in the panel — wire this to open the panel and switch to the Apps tab. */
-  onShowInSidebar?: (toolCallId: string) => void;
+  onShowInPanel?: (toolCallId: string) => void;
   children: ReactNode;
 }) {
   const [explicitSelection, setExplicitSelection] = useState<string | null>(
@@ -93,12 +93,12 @@ export function AppsProvider({
     setExplicitSelection(toolCallId);
   }, []);
 
-  const showInSidebar = useCallback(
+  const showInPanel = useCallback(
     (toolCallId: string) => {
       setExplicitSelection(toolCallId);
-      onShowInSidebar?.(toolCallId);
+      onShowInPanel?.(toolCallId);
     },
-    [onShowInSidebar],
+    [onShowInPanel],
   );
 
   const value = useMemo<AppsContextValue>(
@@ -108,9 +108,9 @@ export function AppsProvider({
       select,
       portalTarget,
       setPortalTarget,
-      showInSidebar,
+      showInPanel,
     }),
-    [apps, selectedToolCallId, select, portalTarget, showInSidebar],
+    [apps, selectedToolCallId, select, portalTarget, showInPanel],
   );
 
   return <AppsContext.Provider value={value}>{children}</AppsContext.Provider>;

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -289,8 +289,8 @@ describe("McpAppContainer inline height (via McpAppSection)", () => {
     vi.clearAllMocks();
   });
 
-  // Drives the app into the sidebar portal so renderInSidebar becomes true.
-  function SidebarDriver({ target }: { target: HTMLElement }) {
+  // Drives the app into the panel portal so renderInPanel becomes true.
+  function PanelDriver({ target }: { target: HTMLElement }) {
     const { setPortalTarget, select } = useApps();
     useEffect(() => {
       setPortalTarget(target);
@@ -304,7 +304,7 @@ describe("McpAppContainer inline height (via McpAppSection)", () => {
   // proxy is a true process boundary, so faking its ready message is legitimate.
   async function renderReadyApp(
     viewportHeight: number,
-    { sidebar = false }: { sidebar?: boolean } = {},
+    { panel = false }: { panel?: boolean } = {},
   ) {
     Object.defineProperty(window, "innerHeight", {
       value: viewportHeight,
@@ -345,7 +345,7 @@ describe("McpAppContainer inline height (via McpAppSection)", () => {
 
     await act(async () => {
       render(
-        sidebar ? (
+        panel ? (
           <AppsProvider
             apps={[
               {
@@ -356,7 +356,7 @@ describe("McpAppContainer inline height (via McpAppSection)", () => {
               },
             ]}
           >
-            <SidebarDriver target={document.body} />
+            <PanelDriver target={document.body} />
             <McpAppSection
               {...defaultProps}
               toolCallId="tc1"
@@ -434,13 +434,13 @@ describe("McpAppContainer inline height (via McpAppSection)", () => {
     expect(lastGuestContainerDimensions(bridge)).toEqual({ maxHeight: 1200 });
   });
 
-  it("hints no cap to the guest when the app fills the sidebar", async () => {
-    const bridge = await renderReadyApp(2000, { sidebar: true });
+  it("hints no cap to the guest when the app fills the panel", async () => {
+    const bridge = await renderReadyApp(2000, { panel: true });
     expect(lastGuestContainerDimensions(bridge)).toEqual({});
   });
 });
 
-describe("McpAppSection sidebar hosting", () => {
+describe("McpAppSection panel hosting", () => {
   const APP_ID = "947051c7-ea8e-48ed-8077-a3cc904d9d61";
 
   beforeEach(() => {
@@ -448,9 +448,9 @@ describe("McpAppSection sidebar hosting", () => {
     clearAllAppDiagnostics();
   });
 
-  // Opens the sidebar app host (portalTarget) so the selected owned-app section
+  // Opens the panel app host (portalTarget) so the selected owned-app section
   // portals its iframe into the target.
-  function SidebarHost({ target }: { target: HTMLElement }) {
+  function PanelHost({ target }: { target: HTMLElement }) {
     const { setPortalTarget } = useApps();
     useEffect(() => {
       setPortalTarget(target);
@@ -458,7 +458,7 @@ describe("McpAppSection sidebar hosting", () => {
     return null;
   }
 
-  it("hosts an owned-app render in the sidebar app host", async () => {
+  it("hosts an owned-app render in the panel app host", async () => {
     const target = document.createElement("div");
     document.body.appendChild(target);
 
@@ -474,7 +474,7 @@ describe("McpAppSection sidebar hosting", () => {
             },
           ]}
         >
-          <SidebarHost target={target} />
+          <PanelHost target={target} />
           <McpAppSection
             {...defaultProps}
             appId={APP_ID}
@@ -486,9 +486,9 @@ describe("McpAppSection sidebar hosting", () => {
     });
 
     // Opening the app host auto-selects the sole app, portaling the live
-    // owned-app iframe into the sidebar target (not left inline).
+    // owned-app iframe into the panel target (not left inline).
     expect(target.querySelector("iframe")).toBeInTheDocument();
-    expect(screen.getByText(/showing in sidebar/i)).toBeInTheDocument();
+    expect(screen.getByText(/showing in panel/i)).toBeInTheDocument();
 
     target.remove();
   });
@@ -496,7 +496,7 @@ describe("McpAppSection sidebar hosting", () => {
   it("keeps the diagnostics badge out of the stretched app wrapper when hosted", async () => {
     // The error badge must not share the fill-container wrapper with the iframe:
     // that wrapper applies `[&>div]:!h-full`, so a badge inside it gets stretched
-    // to full height and shoves the iframe below the sidebar fold (blank render).
+    // to full height and shoves the iframe below the panel fold (blank render).
     reportAppDiagnostic(APP_ID, 1, {
       type: "csp-violation",
       message: "script-src blocked eval",
@@ -516,7 +516,7 @@ describe("McpAppSection sidebar hosting", () => {
             },
           ]}
         >
-          <SidebarHost target={target} />
+          <PanelHost target={target} />
           <McpAppSection
             {...defaultProps}
             appId={APP_ID}
@@ -573,7 +573,7 @@ describe("McpAppSection sidebar hosting", () => {
             },
           ]}
         >
-          <SidebarHost target={target} />
+          <PanelHost target={target} />
           <McpAppSection
             {...defaultProps}
             appId={APP_ID}
@@ -585,21 +585,21 @@ describe("McpAppSection sidebar hosting", () => {
     });
 
     // tc1 is auto-selected and hosted in the panel. The unselected tc2 keeps
-    // rendering live inline (not a placeholder) and is NOT shown in the sidebar,
-    // while still offering its own Show in sidebar control.
-    const showButton = screen.getByRole("button", { name: /show in sidebar/i });
+    // rendering live inline (not a placeholder) and is NOT shown in the panel,
+    // while still offering its own Show in panel control.
+    const showButton = screen.getByRole("button", { name: /show in panel/i });
     expect(target.querySelector("iframe")).not.toBeInTheDocument();
-    expect(screen.queryByText(/showing in sidebar/i)).not.toBeInTheDocument();
-    // tc2's live iframe renders inline (in the document, outside the sidebar target).
+    expect(screen.queryByText(/showing in panel/i)).not.toBeInTheDocument();
+    // tc2's live iframe renders inline (in the document, outside the panel target).
     expect(document.querySelector("iframe")).toBeInTheDocument();
 
-    // Clicking it selects tc2 and portals its iframe into the sidebar target.
+    // Clicking it selects tc2 and portals its iframe into the panel target.
     await act(async () => {
       await user.click(showButton);
     });
 
     expect(target.querySelector("iframe")).toBeInTheDocument();
-    expect(screen.getByText(/showing in sidebar/i)).toBeInTheDocument();
+    expect(screen.getByText(/showing in panel/i)).toBeInTheDocument();
 
     target.remove();
   });

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -25,8 +25,8 @@ import {
   McpAppAddressPill,
   McpAppChangelogPill,
   McpAppFullscreenExitButton,
+  McpAppPanelButton,
   McpAppRefreshButton,
-  McpAppSidebarButton,
   McpAppStandaloneButton,
   McpAppSwitcher,
   McpAppTopBar,
@@ -152,22 +152,22 @@ export function McpAppSection({
   const effectiveResourceState =
     resourceState.key === resourceKey ? resourceState.state : "unknown";
 
-  const { apps, selectedToolCallId, select, showInSidebar, portalTarget } =
+  const { apps, selectedToolCallId, select, showInPanel, portalTarget } =
     useApps();
 
   const headerName = appName || humanizeToolLabel(toolName);
   const isSelected = !!toolCallId && selectedToolCallId === toolCallId;
-  const sidebarHostingActive = portalTarget !== null;
-  // Only the *selected* app moves to the sidebar: its iframe is portaled into
+  const panelHostingActive = portalTarget !== null;
+  // Only the *selected* app moves to the panel: its iframe is portaled into
   // the panel and its inline spot becomes a placeholder. Every other inline app
   // keeps rendering live in the chat.
-  const renderInSidebar = sidebarHostingActive && isSelected;
+  const renderInPanel = panelHostingActive && isSelected;
 
   // Track the last inline body height while the app shows inline; once it moves
   // to the panel we stop updating, so the chat placeholder keeps that frozen
   // footprint and messages below it don't reflow.
   const lastInlineHeightRef = useRef(INITIAL_INLINE_HEIGHT);
-  if (!renderInSidebar) {
+  if (!renderInPanel) {
     lastInlineHeightRef.current = clampInlineHeight(
       size?.height ?? INITIAL_INLINE_HEIGHT,
       inlineCeiling,
@@ -188,9 +188,10 @@ export function McpAppSection({
     };
   }, [rawOutput, appId]);
 
-  const handleShowInSidebar = () => {
+  const handleShowInPanel = () => {
     if (!toolCallId) return;
-    showInSidebar(toolCallId);
+    setDisplayMode("inline"); // panel is the app's frame — never fullscreen there
+    showInPanel(toolCallId);
   };
 
   const handleResourceStateChange = useCallback(
@@ -264,10 +265,10 @@ export function McpAppSection({
         diagnostics={diagnosticsBadge}
         size={size}
         inlineCeiling={inlineCeiling}
-        fillContainer={renderInSidebar}
+        fillContainer={renderInPanel}
         topBar={
           // Pill carries refresh + open-standalone (owned apps). The right zone
-          // holds open-in-sidebar, prefixed by a minimize button while the
+          // holds open-in-panel, prefixed by a minimize button while the
           // app-requested fullscreen is active.
           <McpAppTopBar
             right={
@@ -275,13 +276,13 @@ export function McpAppSection({
                 {displayMode === "fullscreen" && (
                   <McpAppFullscreenExitButton onClick={toggleFullscreen} />
                 )}
-                {toolCallId && !renderInSidebar && (
-                  <McpAppSidebarButton onClick={handleShowInSidebar} />
+                {toolCallId && !renderInPanel && (
+                  <McpAppPanelButton onClick={handleShowInPanel} />
                 )}
               </>
             }
           >
-            {renderInSidebar && apps.length > 1 ? (
+            {renderInPanel && apps.length > 1 ? (
               <McpAppSwitcher
                 value={selectedToolCallId}
                 options={apps.map((app) => ({
@@ -319,9 +320,9 @@ export function McpAppSection({
           // While portaled into the panel (fill mode), don't report size: that
           // would overwrite the last inline size and make the card return at the
           // panel's height when the panel closes.
-          onSizeChange={renderInSidebar ? noopSizeChange : setSize}
+          onSizeChange={renderInPanel ? noopSizeChange : setSize}
           containerDimensions={
-            renderInSidebar ? undefined : { maxHeight: inlineCeiling }
+            renderInPanel ? undefined : { maxHeight: inlineCeiling }
           }
           // Seed the iframe + loading box at the last measured inline height so a
           // reload (e.g. closing the panel re-mounts it) doesn't collapse then grow.
@@ -340,7 +341,7 @@ export function McpAppSection({
     </McpAppErrorBoundary>
   );
 
-  if (renderInSidebar) {
+  if (renderInPanel) {
     return (
       <>
         <McpAppCard
@@ -355,7 +356,7 @@ export function McpAppSection({
             </McpAppTopBar>
           }
           placeholder={
-            <span className="text-muted-foreground">Showing in sidebar</span>
+            <span className="text-muted-foreground">Showing in panel</span>
           }
         />
         {portalTarget && createPortal(liveSurface, portalTarget)}

--- a/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
@@ -153,11 +153,11 @@ function McpAppIconButton({
   );
 }
 
-export function McpAppSidebarButton({ onClick }: { onClick: () => void }) {
+export function McpAppPanelButton({ onClick }: { onClick: () => void }) {
   return (
     <McpAppIconButton
       icon={PanelRight}
-      label="Show in sidebar"
+      label="Show in panel"
       onClick={onClick}
     />
   );


### PR DESCRIPTION
## Summary
- Bug fix — fullscreen → panel transition: when an app is moved into the side panel via "Show in panel", it now forces setDisplayMode("inline") first
- Terminology cleanup — "sidebar" → "panel" everywhere

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>