### PR TITLE
fix: remove name field requirement from Knowledge page LLM provider key form

### DIFF
--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -21,6 +21,7 @@ import { LlmProviderApiKeyDropdown } from "@/components/llm-provider-api-key-dro
 import {
   LLM_PROVIDER_API_KEY_PLACEHOLDER,
   LlmProviderApiKeyForm,
+  PROVIDER_CONFIG,
   type LlmProviderApiKeyFormValues,
 } from "@/components/llm-provider-api-key-form";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
@@ -141,7 +142,6 @@ function AddApiKeyDialog({
   const formValues = form.watch();
   const isValid =
     formValues.apiKey !== LLM_PROVIDER_API_KEY_PLACEHOLDER &&
-    formValues.name &&
     (formValues.scope !== "team" || formValues.teamId) &&
     (byosEnabled
       ? formValues.vaultSecretPath && formValues.vaultSecretKey
@@ -155,7 +155,7 @@ function AddApiKeyDialog({
       values.provider === "bedrock" && values.bedrockAuthMethod === "sigv4";
     try {
       await createMutation.mutateAsync({
-        name: values.name,
+        name: values.name?.trim() || PROVIDER_CONFIG[values.provider].name,
         provider: values.provider,
         apiKey: isBedrockSigV4 ? undefined : values.apiKey || undefined,
         baseUrl: values.baseUrl || undefined,


### PR DESCRIPTION
## Summary

Fixes #4369

The Name field in the Add LLM Provider Key dialog on the Knowledge page (`/settings/knowledge`) was labeled "(optional)" but required by the form validation. This caused the "Test & Create" button to be disabled when the Name field was left empty.

## Root Cause

The Knowledge page had its own validation: `formValues.name &&` which required the name field. The Model Providers page (`CreateLlmProviderApiKeyDialog`) correctly treats it as optional and falls back to provider name.

## Changes

- **Remove** `formValues.name` from the Knowledge page validation (line 144)
- **Add** provider name fallback: `name?.trim() || PROVIDER_CONFIG[provider].name` (line 158)
- **Import** `PROVIDER_CONFIG` for the fallback

## Before/After

**Before:** Form validation required Name despite "(optional)" label → button disabled
**After:** Name is truly optional with auto-fill fallback to provider name → button enabled

/claim #4369

🤖 Generated with [Claude Code](https://claude.com/claude-code)