### PR TITLE
feat(bench): report per-run price from OpenRouter

### DIFF
--- a/archestra-bench/core/src/lanes.rs
+++ b/archestra-bench/core/src/lanes.rs
@@ -66,12 +66,27 @@ pub struct Lane {
     pub model: String,
     pub base_url: Option<String>,
     pub api_key_env: Option<String>,
+    /// OpenRouter slug to price this lane against. For an `openrouter` lane the `model` already is the
+    /// slug, so this is only needed to map a lane served by another provider onto an OR offering.
+    pub openrouter_model: Option<String>,
 }
 
 impl Lane {
     /// Filesystem-safe handle for this lane's agent / log / artifact dir.
     pub fn slug(&self) -> String {
         slug(&self.name)
+    }
+
+    /// The OpenRouter slug whose pricing applies to this lane, if any: an explicit `openrouter_model`
+    /// wins; otherwise an `openrouter` lane prices off its own `model`; other providers have no slug
+    /// unless one is given (so their cost is reported as unknown rather than guessed).
+    pub fn price_model(&self) -> Option<String> {
+        self.openrouter_model
+            .clone()
+            .or_else(|| match self.provider {
+                Provider::Openrouter => Some(self.model.clone()),
+                _ => None,
+            })
     }
 
     /// Env var holding this lane's key, defaulting to `<PROVIDER>_API_KEY`.
@@ -107,6 +122,8 @@ struct RawLane {
     base_url: Option<String>,
     #[serde(default)]
     api_key_env: Option<String>,
+    #[serde(default)]
+    openrouter_model: Option<String>,
 }
 
 /// Load `[[lane]]` entries from a `lanes.toml`. With `select = Some("a,b")`, return exactly those
@@ -141,6 +158,7 @@ pub fn load_lanes(path: &Path, select: Option<&str>) -> Result<Vec<Lane>, LaneEr
             model: raw.model,
             base_url: raw.base_url,
             api_key_env: raw.api_key_env,
+            openrouter_model: raw.openrouter_model,
         });
     }
 
@@ -386,6 +404,34 @@ model = "qwen/qwen3.7-plus"
         // `.` is path-safe, so it survives normalization rather than erroring
         assert_eq!(lanes[0].name, "qwen3.7-plus");
         assert_eq!(load(body, Some("qwen3.7-plus")).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn price_model_prefers_override_then_openrouter_model() {
+        let lanes = load(
+            r#"
+[[lane]]
+name = "or"
+provider = "openrouter"
+model = "vendor/m"
+
+[[lane]]
+name = "gw"
+provider = "anthropic"
+model = "glm-5.2"
+openrouter_model = "z-ai/glm-5.2"
+
+[[lane]]
+name = "bare"
+provider = "anthropic"
+model = "glm-5.2"
+"#,
+            None,
+        )
+        .unwrap();
+        assert_eq!(lanes[0].price_model().as_deref(), Some("vendor/m"));
+        assert_eq!(lanes[1].price_model().as_deref(), Some("z-ai/glm-5.2"));
+        assert_eq!(lanes[2].price_model(), None);
     }
 
     #[test]

--- a/archestra-bench/core/src/lanes.rs
+++ b/archestra-bench/core/src/lanes.rs
@@ -111,7 +111,7 @@ struct RawLane {
 
 /// Load `[[lane]]` entries from a `lanes.toml`. With `select = Some("a,b")`, return exactly those
 /// lanes in the requested order; with `None`, return every lane in TOML declaration order (which the
-/// "first lane per provider is primary" rule depends on). Names are slug-validated and de-duplicated;
+/// "first lane per provider is primary" rule depends on). Names are slug-normalized and de-duplicated;
 /// a bad provider is reported with its lane name in scope.
 pub fn load_lanes(path: &Path, select: Option<&str>) -> Result<Vec<Lane>, LaneError> {
     let ctx = path
@@ -129,22 +129,14 @@ pub fn load_lanes(path: &Path, select: Option<&str>) -> Result<Vec<Lane>, LaneEr
     let mut catalog: Vec<Lane> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
     for raw in parsed.lane {
-        if !is_slug(&raw.name) {
-            return Err(LaneError(format!(
-                "{ctx}: lane name {:?} must be a slug ([A-Za-z0-9][A-Za-z0-9-]*)",
-                raw.name
-            )));
-        }
-        if !seen.insert(raw.name.clone()) {
-            return Err(LaneError(format!(
-                "{ctx}: duplicate lane name {:?}",
-                raw.name
-            )));
+        let name = slug(&raw.name);
+        if !seen.insert(name.clone()) {
+            return Err(LaneError(format!("{ctx}: duplicate lane name {:?}", name)));
         }
         let provider = Provider::from_str(&raw.provider)
-            .map_err(|e| LaneError(format!("{ctx}: lane {:?}: {e}", raw.name)))?;
+            .map_err(|e| LaneError(format!("{ctx}: lane {:?}: {e}", name)))?;
         catalog.push(Lane {
-            name: raw.name,
+            name,
             provider,
             model: raw.model,
             base_url: raw.base_url,
@@ -154,7 +146,8 @@ pub fn load_lanes(path: &Path, select: Option<&str>) -> Result<Vec<Lane>, LaneEr
 
     match split_names(select) {
         None => Ok(catalog),
-        Some(names) => {
+        Some(raw_names) => {
+            let names: Vec<String> = raw_names.iter().map(|n| slug(n)).collect();
             let unknown: Vec<String> = names
                 .iter()
                 .filter(|n| !seen.contains(*n))
@@ -187,7 +180,8 @@ pub fn load_lanes(path: &Path, select: Option<&str>) -> Result<Vec<Lane>, LaneEr
 
 /// Look up a lane by name, listing the known names when it is missing so a typo is actionable.
 pub fn find_lane<'a>(lanes: &'a [Lane], name: &str) -> Result<&'a Lane, LaneError> {
-    lanes.iter().find(|l| l.name == name).ok_or_else(|| {
+    let target = slug(name);
+    lanes.iter().find(|l| l.name == target).ok_or_else(|| {
         let known = lanes
             .iter()
             .map(|l| l.name.clone())
@@ -378,6 +372,20 @@ model = "o1"
         .unwrap_err()
         .to_string();
         assert!(err.contains("duplicate lane name"));
+    }
+
+    #[test]
+    fn dotted_lane_name_is_slug_normalized_and_selectable() {
+        let body = r#"
+[[lane]]
+name = "qwen3.7-plus"
+provider = "openrouter"
+model = "qwen/qwen3.7-plus"
+"#;
+        let lanes = load(body, None).unwrap();
+        // `.` is path-safe, so it survives normalization rather than erroring
+        assert_eq!(lanes[0].name, "qwen3.7-plus");
+        assert_eq!(load(body, Some("qwen3.7-plus")).unwrap().len(), 1);
     }
 
     #[test]

--- a/archestra-bench/lanes.toml
+++ b/archestra-bench/lanes.toml
@@ -5,8 +5,11 @@
 #   name         unique slug, the selection handle and the lane's agent / log / artifact dir
 #   provider     one of: anthropic, openai, gemini, openrouter (what the backend seeds the key as)
 #   model        the model id to resolve on that provider
-#   base_url     optional endpoint override (e.g. an Anthropic-compatible gateway)
-#   api_key_env  optional env var holding the key (default: <PROVIDER>_API_KEY)
+#   base_url         optional endpoint override (e.g. an Anthropic-compatible gateway)
+#   api_key_env      optional env var holding the key (default: <PROVIDER>_API_KEY)
+#   openrouter_model optional OpenRouter slug to price this lane against. An openrouter lane is priced
+#                    off its own model; set this only to map a lane served elsewhere onto an OR
+#                    offering. Unset on a non-openrouter lane ⇒ run cost is reported as n/a.
 
 # [[lane]]
 # name = "or-nex"
@@ -49,6 +52,7 @@ provider = "anthropic"
 model = "kimi-for-coding"
 base_url = "https://api.kimi.com/coding/"
 api_key_env = "KIMI_API_KEY"
+# openrouter_model = "moonshotai/kimi-..."  # set to price this lane
 
 [[lane]]
 name = "glm"
@@ -56,3 +60,4 @@ provider = "anthropic"
 model = "glm-5.2"
 base_url = "https://api.z.ai/api/anthropic"
 api_key_env = "ZAI_API_KEY"
+# openrouter_model = "z-ai/glm-..."  # set to price this lane

--- a/archestra-bench/lanes.toml
+++ b/archestra-bench/lanes.toml
@@ -19,32 +19,40 @@
 # model = "openrouter/owl-alpha"
 
 [[lane]]
-name = "minimax-3"
+name = "deepseek-flash"
 provider = "openrouter"
-model = "minimax/minimax-m3"
+model = "deepseek/deepseek-v4-flash"
+
+[[lane]]
+name = "qwen37-plus"
+provider = "openrouter"
+model = "qwen/qwen3.7-plus"
+
+[[lane]]
+name = "gemma-4-31b"
+provider = "openrouter"
+model = "google/gemma-4-31b-it"
+
+[[lane]]
+name = "gemini-35-flash"
+provider = "openrouter"
+model = "google/gemini-3.5-flash"
 
 [[lane]]
 name = "minimax-27"
 provider = "openrouter"
 model = "minimax/minimax-m2.7"
 
-# [[lane]]
-# name = "kimi"
-# provider = "anthropic"
-# model = "kimi-for-coding"
-# base_url = "https://api.kimi.com/coding/"
-# api_key_env = "KIMI_API_KEY"
+[[lane]]
+name = "kimi"
+provider = "anthropic"
+model = "kimi-for-coding"
+base_url = "https://api.kimi.com/coding/"
+api_key_env = "KIMI_API_KEY"
 
 [[lane]]
 name = "glm"
 provider = "anthropic"
 model = "glm-5.2"
-base_url = "https://api.z.ai/api/anthropic"
-api_key_env = "ZAI_API_KEY"
-
-[[lane]]
-name = "glm-flash"
-provider = "anthropic"
-model = "glm-4.5-air"
 base_url = "https://api.z.ai/api/anthropic"
 api_key_env = "ZAI_API_KEY"

--- a/archestra-bench/lanes.toml
+++ b/archestra-bench/lanes.toml
@@ -52,7 +52,7 @@ provider = "anthropic"
 model = "kimi-for-coding"
 base_url = "https://api.kimi.com/coding/"
 api_key_env = "KIMI_API_KEY"
-# openrouter_model = "moonshotai/kimi-..."  # set to price this lane
+openrouter_model = "moonshotai/kimi-k2.7-code"
 
 [[lane]]
 name = "glm"
@@ -60,4 +60,4 @@ provider = "anthropic"
 model = "glm-5.2"
 base_url = "https://api.z.ai/api/anthropic"
 api_key_env = "ZAI_API_KEY"
-# openrouter_model = "z-ai/glm-..."  # set to price this lane
+openrouter_model = "z-ai/glm-5.2"

--- a/archestra-bench/runner/src/chat_stream.rs
+++ b/archestra-bench/runner/src/chat_stream.rs
@@ -17,7 +17,14 @@ pub struct ChatRunResult {
     pub turn_count: usize,
     pub finish_reason: Option<String>,
     pub total_tokens: Option<i64>,
+    pub prompt_tokens: Option<i64>,
+    pub completion_tokens: Option<i64>,
+    /// Prompt tokens served from the provider's cache — a subset of `prompt_tokens`, billed cheaper.
+    pub cache_read_tokens: Option<i64>,
     pub stage_tokens: Option<i64>,
+    pub stage_prompt_tokens: Option<i64>,
+    pub stage_completion_tokens: Option<i64>,
+    pub stage_cache_read_tokens: Option<i64>,
     pub stream_error: Option<String>,
 }
 
@@ -68,10 +75,18 @@ pub fn apply_chat_event(result: &mut ChatRunResult, event: &HashMap<String, Json
             }
         }
         Some("data-token-usage") => {
-            if let Some(data) = event.get("data").and_then(|v| v.as_object())
-                && let Some(total) = data.get("totalTokens").and_then(|v| v.as_i64())
-            {
-                result.stage_tokens = Some(total);
+            // Co-read the whole split from the one event that also carries totalTokens. The backend
+            // emits this per agentic step plus once at stage end with the cumulative `result.usage`;
+            // overwrite-last keeps the final cumulative figures, and reading all fields together keeps
+            // the split consistent with the total the rest of the harness already trusts.
+            if let Some(data) = event.get("data").and_then(|v| v.as_object()) {
+                let field = |key: &str| data.get(key).and_then(|v| v.as_i64());
+                if let Some(total) = field("totalTokens") {
+                    result.stage_tokens = Some(total);
+                    result.stage_prompt_tokens = field("inputTokens");
+                    result.stage_completion_tokens = field("outputTokens");
+                    result.stage_cache_read_tokens = field("cacheReadTokens");
+                }
             }
         }
         Some("error") => {
@@ -243,6 +258,51 @@ mod tests {
         assert_eq!(sse_data_payload("data: hello"), Some("hello"));
         assert_eq!(sse_data_payload("data:  [DONE]"), Some("[DONE]"));
         assert_eq!(sse_data_payload("event: message"), None);
+    }
+
+    fn token_usage_event(
+        input: i64,
+        output: i64,
+        total: i64,
+        cache_read: i64,
+    ) -> HashMap<String, JsonValue> {
+        let event = serde_json::json!({
+            "type": "data-token-usage",
+            "data": {
+                "inputTokens": input,
+                "outputTokens": output,
+                "totalTokens": total,
+                "cacheReadTokens": cache_read,
+            }
+        });
+        serde_json::from_value(event).unwrap()
+    }
+
+    #[test]
+    fn token_usage_co_reads_split_and_overwrites_with_last() {
+        let mut run = ChatRunResult::default();
+        // Per-step event, then the larger stage-final cumulative event: overwrite-last wins, and the
+        // split is co-read from the same event so it stays consistent with the total.
+        apply_chat_event(&mut run, &token_usage_event(100, 10, 110, 0));
+        apply_chat_event(&mut run, &token_usage_event(300, 40, 340, 90));
+        assert_eq!(run.stage_tokens, Some(340));
+        assert_eq!(run.stage_prompt_tokens, Some(300));
+        assert_eq!(run.stage_completion_tokens, Some(40));
+        assert_eq!(run.stage_cache_read_tokens, Some(90));
+    }
+
+    #[test]
+    fn token_usage_without_split_keeps_total_only() {
+        let mut run = ChatRunResult::default();
+        let event: HashMap<String, JsonValue> = serde_json::from_value(serde_json::json!({
+            "type": "data-token-usage",
+            "data": { "totalTokens": 50 }
+        }))
+        .unwrap();
+        apply_chat_event(&mut run, &event);
+        assert_eq!(run.stage_tokens, Some(50));
+        assert_eq!(run.stage_prompt_tokens, None);
+        assert_eq!(run.stage_completion_tokens, None);
     }
 
     fn stream_from_chunks(chunks: Vec<Vec<u8>>) -> ChatRecordStream {

--- a/archestra-bench/runner/src/chat_stream.rs
+++ b/archestra-bench/runner/src/chat_stream.rs
@@ -19,7 +19,8 @@ pub struct ChatRunResult {
     pub total_tokens: Option<i64>,
     pub prompt_tokens: Option<i64>,
     pub completion_tokens: Option<i64>,
-    /// Prompt tokens served from the provider's cache — a subset of `prompt_tokens`, billed cheaper.
+    /// Prompt tokens served from the provider's cache, billed cheaper. Disjoint from `prompt_tokens`
+    /// (the backend reports `prompt_tokens`/`inputTokens` already net of cache).
     pub cache_read_tokens: Option<i64>,
     pub stage_tokens: Option<i64>,
     pub stage_prompt_tokens: Option<i64>,

--- a/archestra-bench/runner/src/lib.rs
+++ b/archestra-bench/runner/src/lib.rs
@@ -8,6 +8,7 @@ pub mod interactions;
 pub mod lifecycle;
 pub mod mcp_lock;
 pub mod mcp_server;
+pub mod pricing;
 pub mod results;
 pub mod run;
 pub mod seeding;

--- a/archestra-bench/runner/src/pricing.rs
+++ b/archestra-bench/runner/src/pricing.rs
@@ -1,0 +1,179 @@
+//! Per-run cost pricing sourced from OpenRouter's public model list. A [`PriceBook`] maps an
+//! OpenRouter model slug to its per-token USD prices; [`PriceBook::cost`] turns a run's token split
+//! into a dollar figure. Fetching (network) is kept separate from parsing so the parser and the cost
+//! math are unit-tested without HTTP. A slug we cannot price yields `None`, never a fabricated `0`.
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+const OPENROUTER_MODELS_URL: &str = "https://openrouter.ai/api/v1/models";
+
+/// Per-token USD prices for one model. `cache_read` is the discounted rate for cached prompt tokens,
+/// absent when OpenRouter publishes none (the caller then prices cache reads at the normal input rate).
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct ModelPrice {
+    pub input: f64,
+    pub output: f64,
+    pub cache_read: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PriceBook {
+    models: HashMap<String, ModelPrice>,
+}
+
+impl PriceBook {
+    pub fn get(&self, slug: &str) -> Option<&ModelPrice> {
+        self.models.get(slug)
+    }
+
+    /// USD cost of one run. `None` — reported as `n/a`, never `0` — when the lane has no slug, the slug
+    /// is absent from the book, or token counts are missing. Cache reads (a subset of `prompt`) are
+    /// clamped to `[0, prompt]` and billed at the cache rate when known, else at the input rate.
+    pub fn cost(
+        &self,
+        prompt: Option<i64>,
+        completion: Option<i64>,
+        cache_read: Option<i64>,
+        slug: Option<&str>,
+    ) -> Option<f64> {
+        let price = self.models.get(slug?)?;
+        let prompt = prompt?;
+        let completion = completion? as f64;
+        let cache_read = cache_read.unwrap_or(0).clamp(0, prompt) as f64;
+        let billable_input = prompt as f64 - cache_read;
+        let cache_price = price.cache_read.unwrap_or(price.input);
+        Some(billable_input * price.input + cache_read * cache_price + completion * price.output)
+    }
+}
+
+/// Fetch and parse OpenRouter's model list. Any failure is returned as an error string so the caller
+/// can record the fetch status once and fall back to an empty book (all costs `n/a`).
+pub async fn fetch_price_book() -> Result<PriceBook, String> {
+    let http = reqwest::Client::builder()
+        .build()
+        .map_err(|e| e.to_string())?;
+    let resp = http
+        .get(OPENROUTER_MODELS_URL)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .error_for_status()
+        .map_err(|e| e.to_string())?;
+    let json: JsonValue = resp.json().await.map_err(|e| e.to_string())?;
+    Ok(parse_price_book(&json))
+}
+
+/// Build a [`PriceBook`] from OpenRouter's `/models` payload. A model is included only when both
+/// `prompt` and `completion` parse to a non-negative per-token price; a `-1` (dynamic-router) or
+/// missing price drops the model so it reports as unknown rather than free.
+pub fn parse_price_book(models_json: &JsonValue) -> PriceBook {
+    let mut models = HashMap::new();
+    let Some(data) = models_json.get("data").and_then(|v| v.as_array()) else {
+        return PriceBook { models };
+    };
+    for model in data {
+        let Some(id) = model.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let pricing = model.get("pricing");
+        let field = |key: &str| pricing.and_then(|p| price_field(p.get(key)));
+        if let (Some(input), Some(output)) = (field("prompt"), field("completion")) {
+            models.insert(
+                id.to_string(),
+                ModelPrice {
+                    input,
+                    output,
+                    cache_read: field("input_cache_read"),
+                },
+            );
+        }
+    }
+    PriceBook { models }
+}
+
+/// OpenRouter quotes per-token USD as decimal strings; `"0"` is genuinely free, `"-1"` marks a dynamic
+/// router with no fixed price. Treat anything missing, unparseable, or negative as no price.
+fn price_field(value: Option<&JsonValue>) -> Option<f64> {
+    value?.as_str()?.parse::<f64>().ok().filter(|p| *p >= 0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn book() -> PriceBook {
+        parse_price_book(&serde_json::json!({
+            "data": [
+                { "id": "vendor/cheap", "pricing": { "prompt": "0.000001", "completion": "0.000002" } },
+                { "id": "vendor/cached", "pricing": {
+                    "prompt": "0.000001", "completion": "0.000002", "input_cache_read": "0.0000001" } },
+                { "id": "vendor/free", "pricing": { "prompt": "0", "completion": "0" } },
+                { "id": "vendor/dynamic", "pricing": { "prompt": "-1", "completion": "-1" } },
+                { "id": "vendor/partial", "pricing": { "prompt": "0.000001" } },
+            ]
+        }))
+    }
+
+    #[test]
+    fn parse_keeps_priced_models_and_drops_unpriced() {
+        let book = book();
+        assert!(book.get("vendor/cheap").is_some());
+        assert!(book.get("vendor/free").is_some()); // free is a real 0 price
+        assert!(book.get("vendor/dynamic").is_none()); // -1 dynamic router → unknown
+        assert!(book.get("vendor/partial").is_none()); // missing completion → unknown
+        assert_eq!(
+            book.get("vendor/cached").unwrap().cache_read,
+            Some(0.0000001)
+        );
+        assert_eq!(book.get("vendor/cheap").unwrap().cache_read, None);
+    }
+
+    #[test]
+    fn cost_uses_input_and_output_rates() {
+        let book = book();
+        // 1000 input * 1e-6 + 500 output * 2e-6 = 0.001 + 0.001
+        let cost = book.cost(Some(1000), Some(500), None, Some("vendor/cheap"));
+        assert_eq!(cost, Some(0.002));
+    }
+
+    #[test]
+    fn cost_is_cache_aware_when_rate_known() {
+        let book = book();
+        // 200 cache reads of 1000 input: 800*1e-6 + 200*1e-7 + 500*2e-6
+        let cost = book
+            .cost(Some(1000), Some(500), Some(200), Some("vendor/cached"))
+            .unwrap();
+        assert!((cost - (0.0008 + 0.00002 + 0.001)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cache_reads_without_rate_fall_back_to_input() {
+        let book = book();
+        // vendor/cheap has no cache rate, so cached tokens cost the same as input — equals the no-cache cost.
+        let with_cache = book.cost(Some(1000), Some(500), Some(300), Some("vendor/cheap"));
+        let without = book.cost(Some(1000), Some(500), None, Some("vendor/cheap"));
+        assert_eq!(with_cache, without);
+    }
+
+    #[test]
+    fn cache_reads_clamp_to_prompt() {
+        let book = book();
+        // cache_read > prompt must not produce negative billable input.
+        let cost = book
+            .cost(Some(100), Some(0), Some(10_000), Some("vendor/cached"))
+            .unwrap();
+        assert!((cost - 100.0 * 0.0000001).abs() < 1e-12);
+    }
+
+    #[test]
+    fn unknown_slug_or_missing_tokens_is_none() {
+        let book = book();
+        assert_eq!(book.cost(Some(10), Some(10), None, Some("nope")), None);
+        assert_eq!(book.cost(Some(10), Some(10), None, None), None);
+        assert_eq!(book.cost(None, Some(10), None, Some("vendor/cheap")), None);
+        assert_eq!(book.cost(Some(10), None, None, Some("vendor/cheap")), None);
+    }
+}

--- a/archestra-bench/runner/src/pricing.rs
+++ b/archestra-bench/runner/src/pricing.rs
@@ -30,8 +30,13 @@ impl PriceBook {
     }
 
     /// USD cost of one run. `None` — reported as `n/a`, never `0` — when the lane has no slug, the slug
-    /// is absent from the book, or token counts are missing. Cache reads (a subset of `prompt`) are
-    /// clamped to `[0, prompt]` and billed at the cache rate when known, else at the input rate.
+    /// is absent from the book, or token counts are missing.
+    ///
+    /// `prompt` is the backend's `inputTokens`, which is already **net of** cache reads (the platform
+    /// emits a fully-cached request as `inputTokens == 0`, with the cache shown separately — see
+    /// `calculateCost` in the platform's cost-optimization). So input and cache tokens are disjoint and
+    /// summed, not subtracted. Cache reads are billed at the cache rate when OpenRouter publishes one,
+    /// else at the input rate (the conservative estimate when the discount is unknown).
     pub fn cost(
         &self,
         prompt: Option<i64>,
@@ -40,19 +45,20 @@ impl PriceBook {
         slug: Option<&str>,
     ) -> Option<f64> {
         let price = self.models.get(slug?)?;
-        let prompt = prompt?;
-        let completion = completion? as f64;
-        let cache_read = cache_read.unwrap_or(0).clamp(0, prompt) as f64;
-        let billable_input = prompt as f64 - cache_read;
+        let prompt = prompt?.max(0) as f64;
+        let completion = completion?.max(0) as f64;
+        let cache_read = cache_read.unwrap_or(0).max(0) as f64;
         let cache_price = price.cache_read.unwrap_or(price.input);
-        Some(billable_input * price.input + cache_read * cache_price + completion * price.output)
+        Some(prompt * price.input + cache_read * cache_price + completion * price.output)
     }
 }
 
 /// Fetch and parse OpenRouter's model list. Any failure is returned as an error string so the caller
 /// can record the fetch status once and fall back to an empty book (all costs `n/a`).
 pub async fn fetch_price_book() -> Result<PriceBook, String> {
+    // Bounded so a hung models endpoint can't stall the whole benchmark before any rollout starts.
     let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| e.to_string())?;
     let resp = http
@@ -140,32 +146,35 @@ mod tests {
     }
 
     #[test]
-    fn cost_is_cache_aware_when_rate_known() {
+    fn cost_adds_cache_reads_at_cache_rate() {
         let book = book();
-        // 200 cache reads of 1000 input: 800*1e-6 + 200*1e-7 + 500*2e-6
+        // input (1000) is already net of cache; cache reads (200) are disjoint and priced separately:
+        // 1000*1e-6 + 200*1e-7 + 500*2e-6
         let cost = book
             .cost(Some(1000), Some(500), Some(200), Some("vendor/cached"))
             .unwrap();
-        assert!((cost - (0.0008 + 0.00002 + 0.001)).abs() < 1e-12);
+        assert!((cost - (0.001 + 0.00002 + 0.001)).abs() < 1e-12);
     }
 
     #[test]
-    fn cache_reads_without_rate_fall_back_to_input() {
+    fn cache_reads_without_rate_priced_at_input() {
         let book = book();
-        // vendor/cheap has no cache rate, so cached tokens cost the same as input — equals the no-cache cost.
-        let with_cache = book.cost(Some(1000), Some(500), Some(300), Some("vendor/cheap"));
-        let without = book.cost(Some(1000), Some(500), None, Some("vendor/cheap"));
-        assert_eq!(with_cache, without);
-    }
-
-    #[test]
-    fn cache_reads_clamp_to_prompt() {
-        let book = book();
-        // cache_read > prompt must not produce negative billable input.
-        let cost = book
-            .cost(Some(100), Some(0), Some(10_000), Some("vendor/cached"))
+        // vendor/cheap has no cache rate → cache reads billed at the input rate, added on top of input.
+        let with_cache = book
+            .cost(Some(1000), Some(500), Some(300), Some("vendor/cheap"))
             .unwrap();
-        assert!((cost - 100.0 * 0.0000001).abs() < 1e-12);
+        // 1000*1e-6 + 300*1e-6 + 500*2e-6
+        assert!((with_cache - (0.001 + 0.0003 + 0.001)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn negative_token_counts_clamp_to_zero() {
+        let book = book();
+        // A malformed negative count must not produce a negative cost.
+        let cost = book
+            .cost(Some(-5), Some(-5), Some(-5), Some("vendor/cached"))
+            .unwrap();
+        assert_eq!(cost, 0.0);
     }
 
     #[test]

--- a/archestra-bench/runner/src/results.rs
+++ b/archestra-bench/runner/src/results.rs
@@ -15,6 +15,13 @@ pub struct RunResult {
     pub tool_call_count: usize,
     pub turn_count: usize,
     pub total_tokens: Option<i64>,
+    pub prompt_tokens: Option<i64>,
+    pub completion_tokens: Option<i64>,
+    pub cache_read_tokens: Option<i64>,
+    /// OpenRouter slug the run was priced against, and the resulting USD cost (both `None` when the
+    /// lane has no slug or the slug is absent from the price book).
+    pub price_model: Option<String>,
+    pub cost_usd: Option<f64>,
     pub agent_error: Option<String>,
     pub stage_count: usize,
     pub format_attempts: usize,
@@ -60,6 +67,10 @@ pub struct GroupAggregate {
     /// Rollouts that reported a token count — the denominator for `avg_tokens` (infra/error rollouts
     /// have none, and folding them in as 0 would understate the average).
     pub tokens_n: usize,
+    pub total_cost_usd: f64,
+    /// Rollouts that were priced — the denominator for `avg_cost_usd` (unpriced rollouts are excluded
+    /// rather than counted as $0).
+    pub cost_n: usize,
 }
 
 impl GroupAggregate {
@@ -86,6 +97,14 @@ impl GroupAggregate {
             Some(self.total_tokens as f64 / self.tokens_n as f64)
         }
     }
+
+    pub fn avg_cost_usd(&self) -> Option<f64> {
+        if self.cost_n == 0 {
+            None
+        } else {
+            Some(self.total_cost_usd / self.cost_n as f64)
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -105,8 +124,10 @@ impl Aggregate {
             "pass_rate": o.pass_rate(),
             "avg_turns": o.avg_turns(),
             "avg_tokens": o.avg_tokens(),
+            "avg_cost_usd": o.avg_cost_usd(),
             "total_turns": o.total_turns,
             "total_tokens": o.total_tokens,
+            "total_cost_usd": o.total_cost_usd,
             "outcomes": o.outcomes,
             "per_env": self.per_env.iter().map(|g| group_json("env_id", g)).collect::<Vec<_>>(),
             "per_task": self.per_task.iter().map(|g| group_json("task_id", g)).collect::<Vec<_>>(),
@@ -123,8 +144,10 @@ fn group_json(key_name: &str, g: &GroupAggregate) -> serde_json::Value {
         "pass_rate": g.pass_rate(),
         "avg_turns": g.avg_turns(),
         "avg_tokens": g.avg_tokens(),
+        "avg_cost_usd": g.avg_cost_usd(),
         "total_turns": g.total_turns,
         "total_tokens": g.total_tokens,
+        "total_cost_usd": g.total_cost_usd,
         "outcomes": g.outcomes,
     })
 }
@@ -152,6 +175,8 @@ fn group_aggregate(key: String, rows: &[&RunResult]) -> GroupAggregate {
         total_turns: rows.iter().map(|r| r.turn_count).sum(),
         total_tokens: rows.iter().filter_map(|r| r.total_tokens).sum(),
         tokens_n: rows.iter().filter(|r| r.total_tokens.is_some()).count(),
+        total_cost_usd: rows.iter().filter_map(|r| r.cost_usd).sum(),
+        cost_n: rows.iter().filter(|r| r.cost_usd.is_some()).count(),
     }
 }
 
@@ -210,6 +235,10 @@ fn stats(g: &GroupAggregate) -> String {
         .avg_tokens()
         .map(|t| format!("{t:.0}"))
         .unwrap_or_else(|| "n/a".to_string());
+    let cost = g
+        .avg_cost_usd()
+        .map(|c| format!("${c:.4}"))
+        .unwrap_or_else(|| "n/a".to_string());
     let failures = failure_summary(&g.outcomes);
     let tail = if failures.is_empty() {
         String::new()
@@ -217,12 +246,13 @@ fn stats(g: &GroupAggregate) -> String {
         format!(" — {failures}")
     };
     format!(
-        "{}/{} passed ({:.0}%) · avg turns {:.1} · avg tokens {}{}",
+        "{}/{} passed ({:.0}%) · avg turns {:.1} · avg tokens {} · avg cost {}{}",
         g.passed,
         g.total,
         g.pass_rate() * 100.0,
         g.avg_turns(),
         tokens,
+        cost,
         tail
     )
 }
@@ -256,6 +286,11 @@ mod tests {
             tool_call_count: 0,
             turn_count: 1,
             total_tokens: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            cache_read_tokens: None,
+            price_model: None,
+            cost_usd: None,
             agent_error: None,
             stage_count: 1,
             format_attempts: 0,
@@ -292,9 +327,29 @@ mod tests {
     }
 
     #[test]
+    fn test_aggregate_sums_cost_over_priced_rollouts_only() {
+        let mut a = result("basic", "t1", "l1", Outcome::Passed);
+        a.cost_usd = Some(0.01);
+        let mut b = result("basic", "t2", "l1", Outcome::Failed);
+        b.cost_usd = Some(0.03);
+        let c = result("basic", "t3", "l1", Outcome::AgentError); // unpriced rollout
+        let agg = aggregate(&[a, b, c]);
+        assert!((agg.overall.total_cost_usd - 0.04).abs() < 1e-12);
+        assert_eq!(agg.overall.cost_n, 2);
+        assert_eq!(agg.overall.avg_cost_usd(), Some(0.02)); // averaged over the 2 priced, not 3
+    }
+
+    #[test]
+    fn test_aggregate_cost_is_none_when_unpriced() {
+        let agg = aggregate(&[result("basic", "t1", "l1", Outcome::Passed)]);
+        assert_eq!(agg.overall.avg_cost_usd(), None);
+    }
+
+    #[test]
     fn test_render_markdown_is_aggregate_only() {
         let mut a = result("basic", "t1", "l1", Outcome::Passed);
         a.total_tokens = Some(1500);
+        a.cost_usd = Some(0.0123);
         let md = render_markdown(&[a, result("basic", "t2", "l1", Outcome::Failed)]);
         assert!(
             !md.contains("Pass matrix"),
@@ -303,6 +358,7 @@ mod tests {
         assert!(md.contains("**overall**: 1/2 passed (50%)"));
         assert!(md.contains("avg turns"));
         assert!(md.contains("avg tokens"));
+        assert!(md.contains("avg cost $0.0123"));
         assert!(md.contains("failed=1"), "failure reasons are reported");
         assert!(md.contains("## By task"));
     }

--- a/archestra-bench/runner/src/results.rs
+++ b/archestra-bench/runner/src/results.rs
@@ -98,12 +98,11 @@ impl GroupAggregate {
         }
     }
 
-    pub fn avg_cost_usd(&self) -> Option<f64> {
-        if self.cost_n == 0 {
-            None
-        } else {
-            Some(self.total_cost_usd / self.cost_n as f64)
-        }
+    /// Total USD cost of this group's rollouts, or `None` when none were priced (so an unpriced group
+    /// reads as `n/a` rather than a misleading `$0`). Not averaged — with few lanes the per-lane total
+    /// is the figure worth seeing.
+    pub fn cost_usd(&self) -> Option<f64> {
+        (self.cost_n > 0).then_some(self.total_cost_usd)
     }
 }
 
@@ -124,10 +123,9 @@ impl Aggregate {
             "pass_rate": o.pass_rate(),
             "avg_turns": o.avg_turns(),
             "avg_tokens": o.avg_tokens(),
-            "avg_cost_usd": o.avg_cost_usd(),
+            "cost_usd": o.cost_usd(),
             "total_turns": o.total_turns,
             "total_tokens": o.total_tokens,
-            "total_cost_usd": o.total_cost_usd,
             "outcomes": o.outcomes,
             "per_env": self.per_env.iter().map(|g| group_json("env_id", g)).collect::<Vec<_>>(),
             "per_task": self.per_task.iter().map(|g| group_json("task_id", g)).collect::<Vec<_>>(),
@@ -144,10 +142,9 @@ fn group_json(key_name: &str, g: &GroupAggregate) -> serde_json::Value {
         "pass_rate": g.pass_rate(),
         "avg_turns": g.avg_turns(),
         "avg_tokens": g.avg_tokens(),
-        "avg_cost_usd": g.avg_cost_usd(),
+        "cost_usd": g.cost_usd(),
         "total_turns": g.total_turns,
         "total_tokens": g.total_tokens,
-        "total_cost_usd": g.total_cost_usd,
         "outcomes": g.outcomes,
     })
 }
@@ -236,7 +233,7 @@ fn stats(g: &GroupAggregate) -> String {
         .map(|t| format!("{t:.0}"))
         .unwrap_or_else(|| "n/a".to_string());
     let cost = g
-        .avg_cost_usd()
+        .cost_usd()
         .map(|c| format!("${c:.4}"))
         .unwrap_or_else(|| "n/a".to_string());
     let failures = failure_summary(&g.outcomes);
@@ -246,7 +243,7 @@ fn stats(g: &GroupAggregate) -> String {
         format!(" — {failures}")
     };
     format!(
-        "{}/{} passed ({:.0}%) · avg turns {:.1} · avg tokens {} · avg cost {}{}",
+        "{}/{} passed ({:.0}%) · avg turns {:.1} · avg tokens {} · cost {}{}",
         g.passed,
         g.total,
         g.pass_rate() * 100.0,
@@ -334,15 +331,15 @@ mod tests {
         b.cost_usd = Some(0.03);
         let c = result("basic", "t3", "l1", Outcome::AgentError); // unpriced rollout
         let agg = aggregate(&[a, b, c]);
-        assert!((agg.overall.total_cost_usd - 0.04).abs() < 1e-12);
         assert_eq!(agg.overall.cost_n, 2);
-        assert_eq!(agg.overall.avg_cost_usd(), Some(0.02)); // averaged over the 2 priced, not 3
+        // Total over the priced rollouts (no averaging); the unpriced one contributes nothing.
+        assert_eq!(agg.overall.cost_usd(), Some(0.04));
     }
 
     #[test]
     fn test_aggregate_cost_is_none_when_unpriced() {
         let agg = aggregate(&[result("basic", "t1", "l1", Outcome::Passed)]);
-        assert_eq!(agg.overall.avg_cost_usd(), None);
+        assert_eq!(agg.overall.cost_usd(), None);
     }
 
     #[test]
@@ -358,7 +355,8 @@ mod tests {
         assert!(md.contains("**overall**: 1/2 passed (50%)"));
         assert!(md.contains("avg turns"));
         assert!(md.contains("avg tokens"));
-        assert!(md.contains("avg cost $0.0123"));
+        assert!(md.contains("· cost $0.0123"));
+        assert!(!md.contains("avg cost"));
         assert!(md.contains("failed=1"), "failure reasons are reported");
         assert!(md.contains("## By task"));
     }

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -22,6 +22,7 @@ use crate::interactions::extract_effective_prompts;
 use crate::lifecycle::Instance;
 use crate::mcp_lock;
 use crate::mcp_server::{BenchmarkMcp, Submission};
+use crate::pricing::{self, PriceBook};
 use crate::results::{Outcome, RunResult, render_markdown};
 use crate::seeding::{
     ResolvedModel, ensure_provider_and_models, register_remote_mcp, seed_mcp_fixtures,
@@ -99,6 +100,8 @@ pub struct RunCtx {
     pub update_mcp_lock: bool,
     /// Platform directory override (the prod image lays the app out at `/app`); `None` → `<repo>/platform`.
     pub platform_dir: Option<PathBuf>,
+    /// OpenRouter prices for per-run cost; empty when the fetch failed (every cost then reports `n/a`).
+    pub prices: Arc<PriceBook>,
 }
 
 /// What a completed [`run`] produced: the per-rollout results plus the run directory they were written
@@ -151,6 +154,16 @@ pub async fn run(
     let workers = resolve_workers(max_workers, lane_list.len());
     let api_keys = lane_api_keys(&lane_list)?;
 
+    // Fetch OpenRouter prices once up front. A failure is non-fatal: every run then reports cost n/a.
+    let (prices, price_status) = match pricing::fetch_price_book().await {
+        Ok(book) => (book, "ok".to_string()),
+        Err(e) => {
+            warn!("OpenRouter price fetch failed, run costs will be n/a: {e}");
+            (PriceBook::default(), format!("failed: {e}"))
+        }
+    };
+    let prices = Arc::new(prices);
+
     // An explicit `--run-dir` is reused (create_dir_all); an auto dir must be brand-new — the base name
     // is seconds-granular, so two runs started in the same second would otherwise share a root and
     // overwrite each other's config.json/aggregate.json.
@@ -165,7 +178,15 @@ pub async fn run(
     let selected = select_envs(&envs, env_filter, task_filter)?;
     let plan = build_run_plan(selected, lane_list);
 
-    write_run_config(&root_run_dir, &run_id, &plan, workers).await?;
+    write_run_config(
+        &root_run_dir,
+        &run_id,
+        &plan,
+        workers,
+        &prices,
+        &price_status,
+    )
+    .await?;
 
     let ctx = RunCtx {
         root_run_dir,
@@ -174,6 +195,7 @@ pub async fn run(
         envs_dir,
         update_mcp_lock,
         platform_dir: platform_dir.map(Path::to_path_buf),
+        prices,
     };
 
     let results = execute_plan(plan, ctx.clone(), workers).await;
@@ -441,6 +463,7 @@ async fn execute_plan(plan: Vec<EnvPlan>, ctx: RunCtx, max_workers: usize) -> Ve
                                 ctx.root_run_dir.clone(),
                                 setup.resolved,
                                 progress.clone(),
+                                ctx.prices.clone(),
                             )
                             .await,
                         );
@@ -870,6 +893,7 @@ async fn run_isolated_lane(
         ctx.root_run_dir.clone(),
         resolved,
         progress,
+        ctx.prices.clone(),
     )
     .await;
     if let Some(fixture) = &fixture_mcp {
@@ -950,6 +974,11 @@ fn infra_results_for_lane(
             tool_call_count: 0,
             turn_count: 0,
             total_tokens: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            cache_read_tokens: None,
+            price_model: None,
+            cost_usd: None,
             agent_error: Some(format!("infra: {error}")),
             stage_count: task.stages.len(),
             format_attempts: 0,
@@ -1247,6 +1276,7 @@ async fn run_lane(
     root_run_dir: PathBuf,
     resolved: ResolvedModel,
     progress: ProgressBar,
+    prices: Arc<PriceBook>,
 ) -> Vec<RunResult> {
     let mut results = Vec::new();
     for task in tasks {
@@ -1265,6 +1295,7 @@ async fn run_lane(
             project_id.as_deref(),
             &task,
             &resolved,
+            &prices,
         )
         .await;
         progress.inc(1);
@@ -1287,6 +1318,7 @@ async fn run_one(
     project_id: Option<&str>,
     task: &Task,
     resolved: &ResolvedModel,
+    prices: &PriceBook,
 ) -> RunResult {
     let rollout_key = format!("{env_id}/{}/{}", task.id, lane.slug());
     let artifacts =
@@ -1304,6 +1336,11 @@ async fn run_one(
                     tool_call_count: 0,
                     turn_count: 0,
                     total_tokens: None,
+                    prompt_tokens: None,
+                    completion_tokens: None,
+                    cache_read_tokens: None,
+                    price_model: None,
+                    cost_usd: None,
                     agent_error: Some(format!("artifact directory error: {e}")),
                     stage_count: task.stages.len(),
                     format_attempts: 0,
@@ -1353,13 +1390,17 @@ async fn run_one(
         &artifacts,
         &mut metadata,
         &rollout_key,
+        prices,
     )
     .await
     {
         Ok(result) => result,
         Err(e) => {
             let error = format!("infra: {e}");
-            agent_error_result(env_id, lane, task, &error, &artifacts, metadata, None).await
+            agent_error_result(
+                env_id, lane, task, &error, &artifacts, metadata, None, prices,
+            )
+            .await
         }
     }
 }
@@ -1475,6 +1516,7 @@ async fn grade_rollout(
     artifacts: &RunArtifacts,
     metadata: &mut serde_json::Value,
     rollout_key: &str,
+    prices: &PriceBook,
 ) -> Result<RunResult, RunError> {
     bench_mcp
         .begin_task(rollout_key, &task.result_schema, task.max_format_attempts)
@@ -1616,6 +1658,12 @@ async fn grade_rollout(
     metadata["turn_count"] = serde_json::Value::Number((run.turn_count as i64).into());
     metadata["total_tokens"] =
         serde_json::to_value(run.total_tokens).unwrap_or(serde_json::Value::Null);
+    metadata["prompt_tokens"] =
+        serde_json::to_value(run.prompt_tokens).unwrap_or(serde_json::Value::Null);
+    metadata["completion_tokens"] =
+        serde_json::to_value(run.completion_tokens).unwrap_or(serde_json::Value::Null);
+    metadata["cache_read_tokens"] =
+        serde_json::to_value(run.cache_read_tokens).unwrap_or(serde_json::Value::Null);
 
     let submission = bench_mcp.take_submission(rollout_key).await;
     match submission {
@@ -1637,6 +1685,7 @@ async fn grade_rollout(
                 metadata,
                 failed.attempts,
                 None,
+                prices,
             )
             .await);
         }
@@ -1650,6 +1699,7 @@ async fn grade_rollout(
                     artifacts,
                     metadata.clone(),
                     Some(&run),
+                    prices,
                 )
                 .await);
             }
@@ -1663,6 +1713,7 @@ async fn grade_rollout(
                 metadata,
                 0,
                 None,
+                prices,
             )
             .await);
         }
@@ -1704,6 +1755,7 @@ async fn grade_rollout(
                             artifacts,
                             metadata.clone(),
                             Some(&run),
+                            prices,
                         )
                         .await);
                     }
@@ -1733,6 +1785,7 @@ async fn grade_rollout(
                             artifacts,
                             metadata.clone(),
                             Some(&run),
+                            prices,
                         )
                         .await);
                     }
@@ -1769,6 +1822,7 @@ async fn grade_rollout(
                 metadata,
                 accepted.attempts,
                 None,
+                prices,
             )
             .await);
         }
@@ -1909,6 +1963,9 @@ async fn drive_stage(
     let mut stream_parse_error: Option<String> = None;
     let mut coalescer = StreamCoalescer::new(artifacts);
     run.stage_tokens = None;
+    run.stage_prompt_tokens = None;
+    run.stage_completion_tokens = None;
+    run.stage_cache_read_tokens = None;
 
     let mut stream = client
         .stream_chat_records(conversation_id, prior_messages, &text, &files, turn_id)
@@ -1943,11 +2000,24 @@ async fn drive_stage(
         }
     }
     coalescer.flush().await;
+    // Sum each stage's final cumulative usage into the run totals, field by field, so the persisted
+    // split stays consistent with `total_tokens`.
     if let Some(stage_tokens) = run.stage_tokens {
         run.total_tokens = Some(run.total_tokens.unwrap_or(0) + stage_tokens);
     }
+    add_stage_into(&mut run.prompt_tokens, run.stage_prompt_tokens);
+    add_stage_into(&mut run.completion_tokens, run.stage_completion_tokens);
+    add_stage_into(&mut run.cache_read_tokens, run.stage_cache_read_tokens);
 
     Ok(combine_errors(run.stream_error.clone(), stream_parse_error))
+}
+
+/// Fold one stage's value into a run-level running total, leaving the total `None` until at least one
+/// stage reports (so "never measured" stays distinct from a measured zero).
+fn add_stage_into(total: &mut Option<i64>, stage: Option<i64>) {
+    if let Some(stage) = stage {
+        *total = Some(total.unwrap_or(0) + stage);
+    }
 }
 
 fn combine_errors(first: Option<String>, second: Option<String>) -> Option<String> {
@@ -2139,12 +2209,33 @@ async fn finish(
     metadata: &mut serde_json::Value,
     format_attempts: usize,
     agent_error: Option<String>,
+    prices: &PriceBook,
 ) -> RunResult {
+    let prompt_tokens = run.and_then(|r| r.prompt_tokens);
+    let completion_tokens = run.and_then(|r| r.completion_tokens);
+    let cache_read_tokens = run.and_then(|r| r.cache_read_tokens);
+    let price_model = lane.price_model();
+    let cost_usd = prices.cost(
+        prompt_tokens,
+        completion_tokens,
+        cache_read_tokens,
+        price_model.as_deref(),
+    );
     if let serde_json::Value::Object(map) = metadata {
         map["finished_at"] = serde_json::Value::String(timestamp());
         map["outcome"] = serde_json::Value::String(outcome.value().to_string());
         map["agent_error"] = serde_json::to_value(&agent_error).unwrap_or(serde_json::Value::Null);
         map["format_attempts"] = serde_json::Value::Number((format_attempts as i64).into());
+        // insert (not index-assign): unlike the keys above, run_one does not pre-seed these, and
+        // indexing a missing key on a serde_json Map panics.
+        map.insert(
+            "price_model".to_string(),
+            serde_json::to_value(&price_model).unwrap_or(serde_json::Value::Null),
+        );
+        map.insert(
+            "cost_usd".to_string(),
+            serde_json::to_value(cost_usd).unwrap_or(serde_json::Value::Null),
+        );
     }
     artifacts.write_run(metadata).await;
     RunResult {
@@ -2158,6 +2249,11 @@ async fn finish(
         tool_call_count: run.map(|r| r.tool_calls.len()).unwrap_or(0),
         turn_count: run.map(|r| r.turn_count).unwrap_or(0),
         total_tokens: run.and_then(|r| r.total_tokens),
+        prompt_tokens,
+        completion_tokens,
+        cache_read_tokens,
+        price_model,
+        cost_usd,
         agent_error,
         stage_count: task.stages.len(),
         format_attempts,
@@ -2173,6 +2269,7 @@ async fn agent_error_result(
     artifacts: &RunArtifacts,
     metadata: serde_json::Value,
     run: Option<&ChatRunResult>,
+    prices: &PriceBook,
 ) -> RunResult {
     artifacts.append_error("agent_error", error).await;
     let mut metadata = metadata;
@@ -2186,6 +2283,7 @@ async fn agent_error_result(
         &mut metadata,
         0,
         Some(error.to_string()),
+        prices,
     )
     .await
 }
@@ -2432,8 +2530,17 @@ impl<'a> StreamCoalescer<'a> {
                 if let Some(data) = event.get("data").and_then(|v| v.as_object())
                     && let Some(total) = data.get("totalTokens").and_then(|v| v.as_i64())
                 {
+                    let field = |key: &str| data.get(key).and_then(|v| v.as_i64());
                     self.artifacts
-                        .append("token_usage", serde_json::json!({"total_tokens": total}))
+                        .append(
+                            "token_usage",
+                            serde_json::json!({
+                                "total_tokens": total,
+                                "prompt_tokens": field("inputTokens"),
+                                "completion_tokens": field("outputTokens"),
+                                "cache_read_tokens": field("cacheReadTokens"),
+                            }),
+                        )
                         .await;
                 }
             }
@@ -2586,6 +2693,8 @@ async fn write_run_config(
     run_id: &str,
     plan: &[EnvPlan],
     max_workers: usize,
+    prices: &PriceBook,
+    price_status: &str,
 ) -> Result<(), RunError> {
     let environments: Vec<serde_json::Value> = plan
         .iter()
@@ -2607,11 +2716,15 @@ async fn write_run_config(
         .flat_map(|p| &p.lanes)
         .filter(|l| seen_lanes.insert(l.name.as_str()))
         .map(|l| {
+            let price_model = l.price_model();
+            let price = price_model.as_deref().and_then(|slug| prices.get(slug));
             serde_json::json!({
                 "name": l.name,
                 "provider": l.provider,
                 "model": l.model,
                 "base_url": l.base_url,
+                "price_model": price_model,
+                "price": price,
             })
         })
         .collect();
@@ -2637,6 +2750,11 @@ async fn write_run_config(
         "max_workers": max_workers,
         "git_commit": git_commit,
         "temperature": crate::client::BENCH_TEMPERATURE,
+        "pricing": {
+            "source": "openrouter",
+            "fetched_at": timestamp(),
+            "status": price_status,
+        },
     });
     fs::write(
         run_dir.join("config.json"),
@@ -2779,6 +2897,7 @@ mod tests {
             model: "gpt-4".to_string(),
             base_url: None,
             api_key_env: None,
+            openrouter_model: None,
         }
     }
 
@@ -2906,6 +3025,90 @@ mod tests {
         ));
     }
 
+    fn priced_book() -> PriceBook {
+        crate::pricing::parse_price_book(&serde_json::json!({
+            "data": [{ "id": "vendor/cheap", "pricing": { "prompt": "0.000001", "completion": "0.000002" } }]
+        }))
+    }
+
+    #[tokio::test]
+    async fn finish_writes_cost_to_run_json_and_result() {
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = RunArtifacts::new(tmp.path().join("e__t1__l1"))
+            .await
+            .unwrap();
+        let mut lane = dummy_lane("l1");
+        lane.provider = archestra_bench_core::Provider::Openrouter;
+        lane.model = "vendor/cheap".to_string();
+        let task = dummy_task("t1");
+        let run = ChatRunResult {
+            prompt_tokens: Some(1000),
+            completion_tokens: Some(500),
+            ..Default::default()
+        };
+        let mut metadata = serde_json::json!({
+            "finished_at": null, "outcome": null, "agent_error": null, "format_attempts": 0,
+        });
+        let result = finish(
+            "e",
+            &lane,
+            &task,
+            Outcome::Passed,
+            Some(&run),
+            &artifacts,
+            &mut metadata,
+            0,
+            None,
+            &priced_book(),
+        )
+        .await;
+        // 1000 * 1e-6 + 500 * 2e-6 = 0.002
+        // 1000 * 1e-6 + 500 * 2e-6 = 0.002
+        assert_eq!(result.cost_usd, Some(0.002));
+        assert_eq!(result.price_model.as_deref(), Some("vendor/cheap"));
+        assert_eq!(result.prompt_tokens, Some(1000));
+        assert_eq!(result.completion_tokens, Some(500));
+        // finish owns price_model/cost_usd in run.json (the token split is written upstream by grade_rollout).
+        let written: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(artifacts.path.join("run.json")).unwrap())
+                .unwrap();
+        assert_eq!(written["cost_usd"], 0.002);
+        assert_eq!(written["price_model"], "vendor/cheap");
+    }
+
+    #[tokio::test]
+    async fn finish_leaves_cost_null_without_price_model() {
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = RunArtifacts::new(tmp.path().join("e__t1__l1"))
+            .await
+            .unwrap();
+        let lane = dummy_lane("l1"); // openai provider, no openrouter_model → no price_model
+        let task = dummy_task("t1");
+        let run = ChatRunResult {
+            prompt_tokens: Some(1000),
+            completion_tokens: Some(500),
+            ..Default::default()
+        };
+        let mut metadata = serde_json::json!({
+            "finished_at": null, "outcome": null, "agent_error": null, "format_attempts": 0,
+        });
+        let result = finish(
+            "e",
+            &lane,
+            &task,
+            Outcome::Passed,
+            Some(&run),
+            &artifacts,
+            &mut metadata,
+            0,
+            None,
+            &priced_book(),
+        )
+        .await;
+        assert_eq!(result.cost_usd, None);
+        assert_eq!(result.price_model, None);
+    }
+
     #[tokio::test]
     async fn test_config_json_lists_each_lane_once_across_envs() {
         let envs = vec![
@@ -2921,7 +3124,9 @@ mod tests {
         let lanes = vec![dummy_lane("l1"), dummy_lane("l2")];
         let plan = build_run_plan(envs, lanes);
         let tmp = tempfile::tempdir().unwrap();
-        write_run_config(tmp.path(), "rid", &plan, 2).await.unwrap();
+        write_run_config(tmp.path(), "rid", &plan, 2, &PriceBook::default(), "ok")
+            .await
+            .unwrap();
         let config: serde_json::Value =
             serde_json::from_slice(&std::fs::read(tmp.path().join("config.json")).unwrap())
                 .unwrap();
@@ -2950,6 +3155,7 @@ mod tests {
             envs_dir: tmp.path().to_path_buf(),
             update_mcp_lock: false,
             platform_dir: None,
+            prices: Arc::new(PriceBook::default()),
         };
         let mut env = dummy_env("e", vec![dummy_task("t1")]);
         env.platform.tool_exposure_mode = crate::config::types::ToolExposureMode::Full;

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -3063,7 +3063,6 @@ mod tests {
         )
         .await;
         // 1000 * 1e-6 + 500 * 2e-6 = 0.002
-        // 1000 * 1e-6 + 500 * 2e-6 = 0.002
         assert_eq!(result.cost_usd, Some(0.002));
         assert_eq!(result.price_model.as_deref(), Some("vendor/cheap"));
         assert_eq!(result.prompt_tokens, Some(1000));

--- a/archestra-bench/scripts/export_tensorboard.py
+++ b/archestra-bench/scripts/export_tensorboard.py
@@ -65,7 +65,7 @@ def _write_overall(out: Path, aggregate: dict, step: int) -> int:
     n += _scalar(writer, "overall/total", aggregate.get("total"), step)
     n += _scalar(writer, "overall/avg_turns", aggregate.get("avg_turns"), step)
     n += _scalar(writer, "overall/avg_tokens", aggregate.get("avg_tokens"), step)
-    n += _scalar(writer, "overall/avg_cost_usd", aggregate.get("avg_cost_usd"), step)
+    n += _scalar(writer, "overall/cost_usd", aggregate.get("cost_usd"), step)
     for outcome, count in (aggregate.get("outcomes") or {}).items():
         n += _scalar(writer, f"outcomes/{outcome}", count, step)
     writer.close()
@@ -78,7 +78,7 @@ def _write_lane(out: Path, lane_aggregate: dict, rollouts: list[dict], step: int
     n += _scalar(writer, "pass_rate", lane_aggregate.get("pass_rate"), step)
     n += _scalar(writer, "passed", lane_aggregate.get("passed"), step)
     n += _scalar(writer, "total", lane_aggregate.get("total"), step)
-    n += _scalar(writer, "avg_cost_usd", lane_aggregate.get("avg_cost_usd"), step)
+    n += _scalar(writer, "cost_usd", lane_aggregate.get("cost_usd"), step)
     for rollout in rollouts:
         slot = f"{rollout['env_id']}/{rollout['task_id']}"
         outcome = rollout.get("outcome")

--- a/archestra-bench/scripts/export_tensorboard.py
+++ b/archestra-bench/scripts/export_tensorboard.py
@@ -65,6 +65,7 @@ def _write_overall(out: Path, aggregate: dict, step: int) -> int:
     n += _scalar(writer, "overall/total", aggregate.get("total"), step)
     n += _scalar(writer, "overall/avg_turns", aggregate.get("avg_turns"), step)
     n += _scalar(writer, "overall/avg_tokens", aggregate.get("avg_tokens"), step)
+    n += _scalar(writer, "overall/avg_cost_usd", aggregate.get("avg_cost_usd"), step)
     for outcome, count in (aggregate.get("outcomes") or {}).items():
         n += _scalar(writer, f"outcomes/{outcome}", count, step)
     writer.close()
@@ -77,12 +78,14 @@ def _write_lane(out: Path, lane_aggregate: dict, rollouts: list[dict], step: int
     n += _scalar(writer, "pass_rate", lane_aggregate.get("pass_rate"), step)
     n += _scalar(writer, "passed", lane_aggregate.get("passed"), step)
     n += _scalar(writer, "total", lane_aggregate.get("total"), step)
+    n += _scalar(writer, "avg_cost_usd", lane_aggregate.get("avg_cost_usd"), step)
     for rollout in rollouts:
         slot = f"{rollout['env_id']}/{rollout['task_id']}"
         outcome = rollout.get("outcome")
         n += _scalar(writer, f"pass/{slot}", 1.0 if outcome == "passed" else 0.0, step)
         n += _scalar(writer, f"turns/{slot}", rollout.get("turn_count"), step)
         n += _scalar(writer, f"tokens/{slot}", rollout.get("total_tokens"), step)
+        n += _scalar(writer, f"cost/{slot}", rollout.get("cost_usd"), step)
         n += _scalar(writer, f"tool_calls/{slot}", rollout.get("tool_call_count"), step)
         if outcome is not None:
             n += _scalar(writer, f"outcome/{outcome}/{slot}", 1.0, step)

--- a/archestra-bench/scripts/publish_run.py
+++ b/archestra-bench/scripts/publish_run.py
@@ -87,17 +87,21 @@ def _summarize(aggregate_path: Path) -> _Summary:
             text=f"⚠️ {passed}/{total} passed — harness likely broken · {outcomes}",
         )
     rate = int(pass_rate * 100)
-    cost = _cost_fragment(agg.get("avg_cost_usd"))
+    cost = _cost_fragment(agg.get("per_lane"))
     return _Summary(
-        healthy=True, text=f"✅ {passed}/{total} passed ({rate}%){cost} · {outcomes}"
+        healthy=True, text=f"✅ {passed}/{total} passed ({rate}%) · {outcomes}{cost}"
     )
 
 
-def _cost_fragment(avg_cost_usd: float | None) -> str:
-    # Omitted entirely when nothing was priced (older runs, or every lane unmapped).
-    if avg_cost_usd is None:
-        return ""
-    return f" · ~${avg_cost_usd:.4f}/run"
+def _cost_fragment(per_lane: list[dict] | None) -> str:
+    # Per-lane total spend (no average). Omitted entirely when nothing was priced (older runs, or
+    # every lane unmapped); unpriced lanes within a run are simply left out.
+    parts = [
+        f"{g['lane']}=${g['cost_usd']:.4f}"
+        for g in (per_lane or [])
+        if g.get("cost_usd") is not None
+    ]
+    return f" · cost {' '.join(parts)}" if parts else ""
 
 
 def _upload(run_id: str, *, tb: Path, run_dir: Path, tarball: Path) -> list[str]:

--- a/archestra-bench/scripts/publish_run.py
+++ b/archestra-bench/scripts/publish_run.py
@@ -87,9 +87,17 @@ def _summarize(aggregate_path: Path) -> _Summary:
             text=f"⚠️ {passed}/{total} passed — harness likely broken · {outcomes}",
         )
     rate = int(pass_rate * 100)
+    cost = _cost_fragment(agg.get("avg_cost_usd"))
     return _Summary(
-        healthy=True, text=f"✅ {passed}/{total} passed ({rate}%) · {outcomes}"
+        healthy=True, text=f"✅ {passed}/{total} passed ({rate}%){cost} · {outcomes}"
     )
+
+
+def _cost_fragment(avg_cost_usd: float | None) -> str:
+    # Omitted entirely when nothing was priced (older runs, or every lane unmapped).
+    if avg_cost_usd is None:
+        return ""
+    return f" · ~${avg_cost_usd:.4f}/run"
 
 
 def _upload(run_id: str, *, tb: Path, run_dir: Path, tarball: Path) -> list[str]:


### PR DESCRIPTION
Reports the USD price of each benchmark run, sourced live from OpenRouter, across every reporting surface (local + CI).

## What it does
- Captures the input/output/cache **token split** from the backend's `data-token-usage` SSE event (co-read with `totalTokens`, so the split stays consistent with the token count the harness already trusts).
- Fetches OpenRouter `/api/v1/models` **once per run** (30s timeout) and computes per-run cost. Cache-aware: `input·input_price + cache_read·cache_read_price + output·output_price`, matching the platform's own `calculateCost` (`inputTokens` is already net of cache; input and cache tokens are disjoint).
- Cost is `n/a` — never `0` or fabricated — when a lane has no resolvable OpenRouter slug, the slug is absent from the price book, or the fetch fails. A failed fetch never fails the run.
- Lanes get an optional `openrouter_model` slug to price non-OpenRouter lanes; OpenRouter lanes price off their model string. `glm` → `z-ai/glm-5.2`, `kimi` → `moonshotai/kimi-k2.7-code`.

## Where cost shows up
**Per-lane total spend, not an average** (with few lanes the per-lane total is the figure that matters):
- `run.json` — per-rollout `cost_usd` + token split + resolved `price_model`
- `aggregate.json` — `cost_usd` (nullable total) per lane/env/overall
- markdown report — `· cost $X.XXXX` per group (`n/a` when unpriced)
- TensorBoard — overall + per-lane total `cost_usd`, per-rollout `cost/{env}/{task}`
- Slack — per-lane totals (`· cost glm=$0.42 deepseek-flash=$0.05`); unpriced lanes omitted
- `config.json` — price snapshot (status + timestamp + per-lane resolved price) for reproducibility

## Also included
- Slug-normalize lane names instead of rejecting them (reuses the existing `crate::slug`), so dotted names like `qwen3.7-plus` work end-to-end.

## Tests
- `pricing` unit tests (parse, cache-aware cost, free/`-1`/missing prices, negative-clamp); `chat_stream` split-capture; `results` per-lane total cost; finish-level `run.json`+`RunResult` cost wiring. Python `_summarize`/`export` validated against priced+unpriced fixtures. `clippy --all-targets -D warnings` clean.

https://claude.ai/code/session_01E2W2CQK6Va6oTsxEEyyAue