### PR TITLE
fix(projects): let a project:admin manage any project they can see

### DIFF
--- a/platform/backend/src/routes/project/get.project.route.test.ts
+++ b/platform/backend/src/routes/project/get.project.route.test.ts
@@ -133,6 +133,51 @@ describe("GET /api/projects + GET /api/projects/:id", () => {
     expect(del.statusCode).toBe(200);
   });
 
+  test("a project admin can manage a project shared with them (not only owned/overseen)", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const otherOwner = await makeUser({ email: "proj-share-owner@test.com" });
+    await makeMember(otherOwner.id, organizationId, {});
+    const project = await projectService.create({
+      organizationId,
+      userId: otherOwner.id,
+      name: "shared-org-wide",
+      description: null,
+    });
+    await ProjectShareModel.upsert({
+      projectId: project.id,
+      organizationId,
+      createdByUserId: otherOwner.id,
+      visibility: "organization",
+      teamIds: [],
+    });
+
+    const admin = await makeUser({ email: "proj-admin-share@test.com" });
+    await makeMember(admin.id, organizationId, { role: ADMIN_ROLE_NAME });
+    actingUser = admin;
+
+    // The admin reaches it via the org share, so viewerRole is "shared" (not
+    // oversight) — but a project:admin may still manage it, so the detail exposes
+    // shareTeamIds (for the edit dialog) instead of null...
+    const detail = await app.inject({
+      method: "GET",
+      url: `/api/projects/${project.id}`,
+    });
+    expect(detail.statusCode).toBe(200);
+    expect(
+      detail.json<{ viewerRole: string; shareTeamIds: string[] | null }>(),
+    ).toMatchObject({ viewerRole: "shared", shareTeamIds: [] });
+
+    // ...and the edit goes through (requireManageable allows project:admin).
+    const edit = await app.inject({
+      method: "PATCH",
+      url: `/api/projects/${project.id}`,
+      payload: { description: "edited by admin via share" },
+    });
+    expect(edit.statusCode).toBe(200);
+  });
+
   test("a non-admin member cannot see or manage other members' projects", async ({
     makeUser,
     makeMember,

--- a/platform/backend/src/services/project.ts
+++ b/platform/backend/src/services/project.ts
@@ -211,9 +211,19 @@ class ProjectService {
       UserModel.getNamesByIds([project.userId]),
       ProjectShareModel.getShareTeamsForProjects([project.id]),
     ]);
-    // share targets are visible to those who can manage the project (so the
-    // edit dialog can populate sharing): the owner or a project admin.
-    const canManage = viewerRole === "owner" || viewerRole === "admin";
+    // Share targets are visible to whoever can manage the project (so the edit
+    // dialog can populate sharing): the owner, or a project admin — including on
+    // a project merely shared with them (viewerRole "shared"), so they still get
+    // the team list. requireManageable enforces the same gate on write.
+    const canManage =
+      viewerRole === "owner" ||
+      viewerRole === "admin" ||
+      (await userHasPermission(
+        params.userId,
+        params.organizationId,
+        "project",
+        "admin",
+      ));
     return {
       id: project.id,
       name: project.name,

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -60,7 +60,9 @@ import {
   type VisibilityOption,
   VisibilitySelector,
 } from "@/components/visibility-selector";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { buildProjectChatHandoffUrl } from "@/lib/projects/project-chat-handoff";
+import { canManageProject } from "@/lib/projects/project-permissions";
 import {
   useDeleteProject,
   usePinProject,
@@ -95,6 +97,7 @@ function ProjectDetail() {
   const pinProjectMutation = usePinProject();
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const { data: isProjectAdmin } = useHasPermissions({ project: ["admin"] });
 
   // Same as /chat: the Files sidebar owns the bottom edge, so the app shell's
   // version footer would float in the left column — hide it.
@@ -122,12 +125,14 @@ function ProjectDetail() {
     );
   }
 
-  // A project admin overseeing someone else's project can manage it (edit /
-  // delete / sharing) and read its files, but NOT its chats: no composer, no
-  // chats list, no pin, no new schedules. Existing schedules follow their
-  // scheduledTask permissions.
+  // A project admin can manage ANY project they can see — their own, one shared
+  // with them, or another member's they oversee (edit / delete / sharing /
+  // instructions), matching the backend's requireManageable.
+  const canManage = canManageProject(project.viewerRole, !!isProjectAdmin);
+  // The oversight-only view (a foreign project surfaced purely via project:admin)
+  // additionally hides chats: no composer, no chats list, no pin, no new
+  // schedules. A project merely shared with the admin keeps its chats.
   const isAdminView = project.viewerRole === "admin";
-  const canManage = project.viewerRole === "owner" || isAdminView;
   const canChat = !isAdminView;
 
   return (

--- a/platform/frontend/src/app/projects/page.client.test.tsx
+++ b/platform/frontend/src/app/projects/page.client.test.tsx
@@ -181,6 +181,10 @@ vi.mock("@/lib/llm-provider-api-keys.query", () => ({
   useHasAnyApiKey: () => ({ hasAnyApiKey: true, isLoading: false }),
 }));
 
+vi.mock("@/lib/auth/auth.query", () => ({
+  useHasPermissions: () => ({ data: false }),
+}));
+
 vi.mock("@/lib/projects/projects.query", () => ({
   useProjects: () => ({ data: mockProjects, isPending: false }),
   useCreateProject: () => ({ mutateAsync: vi.fn(), isPending: false }),

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -38,11 +38,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useHasAnyApiKey } from "@/lib/llm-provider-api-keys.query";
 import {
   parseProjectScope,
   toApiProjectScope,
 } from "@/lib/projects/project-list-scope";
+import { canManageProject } from "@/lib/projects/project-permissions";
 import { sortProjectsPinnedFirst } from "@/lib/projects/project-sort";
 import {
   useCreateProject,
@@ -251,6 +253,7 @@ function ProjectCard({
   onEdit: (project: ProjectListItem) => void;
   onDelete: (project: ProjectListItem) => void;
 }) {
+  const { data: isProjectAdmin } = useHasPermissions({ project: ["admin"] });
   return (
     <div className="rounded-lg border p-4 transition-colors hover:bg-muted/50">
       <div className="flex items-center justify-between gap-2">
@@ -287,9 +290,7 @@ function ProjectCard({
           <ProjectCardActions
             pinned={!!project.pinnedAt}
             canPin={project.viewerRole !== "admin"}
-            canManage={
-              project.viewerRole === "owner" || project.viewerRole === "admin"
-            }
+            canManage={canManageProject(project.viewerRole, !!isProjectAdmin)}
             onTogglePin={() => onTogglePin(project)}
             onEdit={() => onEdit(project)}
             onDelete={() => onDelete(project)}

--- a/platform/frontend/src/lib/projects/project-permissions.test.ts
+++ b/platform/frontend/src/lib/projects/project-permissions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { canManageProject } from "./project-permissions";
+
+describe("canManageProject", () => {
+  test("the owner can always manage", () => {
+    expect(canManageProject("owner", false)).toBe(true);
+    expect(canManageProject("owner", true)).toBe(true);
+  });
+
+  test("a project:admin can manage any project they can see", () => {
+    expect(canManageProject("shared", true)).toBe(true); // shared with them
+    expect(canManageProject("admin", true)).toBe(true); // overseen
+  });
+
+  test("a non-admin cannot manage a project merely shared with them", () => {
+    expect(canManageProject("shared", false)).toBe(false);
+  });
+
+  test("the oversight role implies manage even before the permission resolves", () => {
+    expect(canManageProject("admin", false)).toBe(true);
+  });
+});

--- a/platform/frontend/src/lib/projects/project-permissions.ts
+++ b/platform/frontend/src/lib/projects/project-permissions.ts
@@ -1,0 +1,19 @@
+/** A project's relationship to the viewer, as returned by the projects API. */
+export type ProjectViewerRole = "owner" | "shared" | "admin";
+
+/**
+ * Whether the viewer may manage a project — edit its details, sharing, and
+ * instructions, or delete it. Mirrors the backend's `requireManageable`: the
+ * owner always can, and a `project:admin` can manage ANY project they can see
+ * (one shared with them, or another member's they oversee), since `project:admin`
+ * is full oversight. A plain "shared" recipient without `project:admin` cannot.
+ *
+ * (`viewerRole === "admin"` already implies the caller holds `project:admin`, so
+ * it stays manageable even before the permission query resolves.)
+ */
+export function canManageProject(
+  viewerRole: ProjectViewerRole,
+  isProjectAdmin: boolean,
+): boolean {
+  return viewerRole === "owner" || viewerRole === "admin" || isProjectAdmin;
+}


### PR DESCRIPTION
## Problem

A project **shared** with you resolves to `viewerRole: "shared"`, and the frontend's `canManage` only allowed `owner`/`admin`. So the edit / delete / sharing UI was hidden for a project shared with an admin — even though the backend's `requireManageable` already lets a `project:admin` manage it. Net effect: *"as an admin I can't edit details of a project that's shared with me."*

## Fix

Align the UI to the backend — a `project:admin` can manage **any project they can see** (their own, one shared with them, or another member's they oversee):

- Extract **`canManageProject(viewerRole, isProjectAdmin)`** (single source of truth, unit-tested) and use it in the projects list card and the project detail page, gated by `useHasPermissions({ project: ["admin"] })`.
- Backend **`get`** now exposes `shareTeamIds` to a `project:admin` on a project merely *shared* with them (`viewerRole: "shared"`), so the sharing editor pre-populates its team list instead of receiving `null`.
- Write paths (`update` / `setShare` / `delete`) already permitted `project:admin` via `requireManageable` — no change.
- The oversight-only view (a *foreign* project surfaced purely via `project:admin`) still hides chats; a project genuinely shared with the admin keeps its chats.

## Testing

- New `canManageProject` unit test.
- New backend route test: a `project:admin` gets `shareTeamIds` and can `PATCH` a project shared with them.
- Updated the pre-existing list render test to mock the new permission hook.
- `type-check`, `knip`, `biome` clean on both backend and frontend; project test suites green (frontend 14, backend 35).

Follow-up to #5837.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>