### PR TITLE
feat(bench): fail fast on a broken sandbox + local Dagger resolution ladder

### DIFF
--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -247,8 +247,9 @@ second backend runs the already-built `dist/server.mjs` the main stack keeps fre
 starts a competing `tsdown --watch`. Teardown always runs: the backend process group is killed and
 the benchmark database is dropped.
 
-**Dagger host resolution.** Before booting the backend, the runner resolves one Dagger host for the
-whole run (shared across lanes so they can't split across engines):
+**Dagger host resolution.** Before booting the backend, the runner resolves a Dagger host and shares
+the first successful result across lanes (so they can't split across engines; a failed attempt isn't
+cached and the next lane re-resolves):
 
 1. `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, when set, is used verbatim and the ladder is skipped
    (the prod-image / CI path supplies a `kube-pod://` host this way).

--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -237,15 +237,31 @@ three tasks —
 
 ## Lifecycle: fresh backend over shared infra
 
-The harness does not run its own Tilt stack. It reuses the developer's already-running stack's
-Dagger code-runtime engine, provisions a dedicated bench Postgres of its own (so DB traffic skips
+The harness does not run its own Tilt stack. It resolves a Dagger code-runtime engine (see the ladder
+below), provisions a dedicated bench Postgres of its own (so DB traffic skips
 Tilt's port-forward), and stands up only what must be isolated per env: a fresh database (migrated
 from scratch) plus a second backend **process** on a new port. The backend reads `process.env`
-directly, so benchmark overrides (fresh DB URL, new API/metrics ports, shared Dagger host) take
+directly, so benchmark overrides (fresh DB URL, new API/metrics ports, resolved Dagger host) take
 effect without a git worktree, a second Tilt, or any edit to `platform/.env`. The
 second backend runs the already-built `dist/server.mjs` the main stack keeps fresh, so it never
 starts a competing `tsdown --watch`. Teardown always runs: the backend process group is killed and
 the benchmark database is dropped.
+
+**Dagger host resolution.** Before booting the backend, the runner resolves one Dagger host for the
+whole run (shared across lanes so they can't split across engines):
+
+1. `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, when set, is used verbatim and the ladder is skipped
+   (the prod-image / CI path supplies a `kube-pod://` host this way).
+2. Otherwise, if Docker is running **and** the engine image is already pulled, the runner brings up a
+   managed engine (`dev/docker-compose.bench-dagger.yml`) on `tcp://127.0.0.1:1245` and uses it.
+3. Otherwise, if the dev stack's port-forward is listening on `tcp://127.0.0.1:1234`, that is used.
+4. Otherwise the run **aborts immediately** with a message naming each tier it tried and the remedy.
+
+The managed engine is privileged and left running between runs so its buildkit cache stays warm
+(the compose file documents how to stop it and prune the cache volume). The runner never pulls the
+image — pre-pull it once with `docker pull registry.dagger.io/engine:<tag>` (the tag is pinned in the
+compose file). A broken sandbox no longer wastes the readiness deadline: the backend's `GET /ready`
+reports a `sandbox` field, and the runner fails fast on `disabled`/`unreachable` instead of polling.
 
 ## Reproducibility
 
@@ -320,8 +336,11 @@ not the raw per-token SSE chunks), `run.json`,
 
 ## Prerequisites
 
-- A running Archestra dev stack (`tilt up` with `ARCHESTRA_CODE_RUNTIME_ENABLED=true`) providing the
-  Dagger engine (`tcp://127.0.0.1:1234`), with the backend built (`dist/server.mjs`).
+- A built backend (`dist/server.mjs`, kept fresh by `tilt up`) and a reachable Dagger engine. The
+  engine can be the runner-managed one (Docker + the engine image pre-pulled) or the dev stack's
+  port-forward on `tcp://127.0.0.1:1234` (`tilt up` with `ARCHESTRA_CODE_RUNTIME_ENABLED=true`); see
+  the resolution ladder under "Lifecycle". Set `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST` to bypass
+  resolution and point at an engine you manage.
 - Docker, so the runner can provision the dedicated bench Postgres (`dev/docker-compose.bench-pg.yml`,
   host-reachable on `localhost:5544`). This bypasses the dev stack's slow kubectl port-forward, but on
   macOS the host→Colima-VM path still crosses Colima's network proxy, which can drop a burst of idle

--- a/archestra-bench/dev/docker-compose.bench-dagger.yml
+++ b/archestra-bench/dev/docker-compose.bench-dagger.yml
@@ -1,0 +1,41 @@
+# Runner-managed Dagger engine for archestra-bench runs.
+#
+# The dev stack's Dagger engine is only reachable through Tilt's kubectl
+# port-forward on :1234, which (like the dev Postgres) throttles under
+# concurrent lanes and can be flat-out down — surfacing late, after the bench
+# has already waited out its readiness deadline. A directly-managed engine with
+# a published TCP port establishes immediately and lets the runner fail fast.
+#
+# Brought up idempotently by the runner (`docker compose up -d`) and left
+# running between runs so the buildkit cache stays warm. To stop it and reclaim
+# the cache:
+#
+#   docker compose -p archestra-bench-dagger -f dev/docker-compose.bench-dagger.yml down
+#   docker volume rm archestra-bench-dagger-data
+#
+# The engine version (`registry.dagger.io/engine:<tag>`) is the single source of
+# truth for the bench engine and is kept in lockstep with the Dockerfile, the
+# dagger-sdk crate, and the Helm charts by scripts/check-dagger-version-sync.sh.
+#
+# Spec mirrors the in-cluster engine (platform .../dagger-environment-runtime/
+# manager.ts): privileged, a persistent volume for the buildkit cache at
+# /var/lib/dagger, and a memory-backed socket dir at /run/dagger. The published
+# port binds to 127.0.0.1 only — the engine is privileged and must never be
+# reachable off-host.
+services:
+  bench-dagger:
+    image: registry.dagger.io/engine:v0.21.5
+    privileged: true
+    command:
+      - --addr
+      - tcp://0.0.0.0:1245
+      - --addr
+      - unix:///run/dagger/engine.sock
+    ports:
+      - "127.0.0.1:1245:1245"
+    volumes:
+      - bench-dagger-data:/var/lib/dagger
+    tmpfs:
+      - /run/dagger
+volumes:
+  bench-dagger-data:

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -1193,7 +1193,12 @@ enum SandboxReadiness {
 fn sandbox_readiness(body: &JsonValue) -> SandboxReadiness {
     match body.get("sandbox").and_then(|v| v.as_str()) {
         Some("ready") => SandboxReadiness::Ready,
-        None | Some("initializing") => SandboxReadiness::Pending,
+        Some("initializing") => SandboxReadiness::Pending,
+        // No field: a backend that predates it — e.g. a deployed image lagging this runner (the bench
+        // image layers a freshly-built runner over the live platform image). A current backend always
+        // emits the field, so absence can only mean "can't report it"; fall back to DB-only readiness
+        // and proceed rather than poll out the deadline.
+        None => SandboxReadiness::Ready,
         Some(other) => {
             let reason = body
                 .get("sandboxReason")
@@ -1219,10 +1224,10 @@ mod tests {
             sandbox_readiness(&json!({"sandbox": "initializing"})),
             SandboxReadiness::Pending
         );
-        // absent field (older backend) is treated as still-warming, not fatal.
+        // absent field (older/lagging backend) falls back to DB-only readiness: proceed, don't gate.
         assert_eq!(
             sandbox_readiness(&json!({"database": "connected"})),
-            SandboxReadiness::Pending
+            SandboxReadiness::Ready
         );
         assert_eq!(
             sandbox_readiness(&json!({"sandbox": "disabled", "sandboxReason": "disabled"})),

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -56,6 +56,9 @@ pub enum ClientError {
     Api(ArchestraApiError),
     Contract(ContractError),
     Config(String),
+    /// A terminal readiness failure that retrying cannot clear (the sandbox is disabled/unreachable).
+    /// Distinct from `Config` so callers fast-fail instead of polling out the readiness deadline.
+    SandboxFatal(String),
 }
 
 impl std::fmt::Display for ClientError {
@@ -64,6 +67,7 @@ impl std::fmt::Display for ClientError {
             ClientError::Api(e) => write!(f, "{e}"),
             ClientError::Contract(e) => write!(f, "{e}"),
             ClientError::Config(s) => write!(f, "config error: {s}"),
+            ClientError::SandboxFatal(s) => write!(f, "{s}"),
         }
     }
 }
@@ -299,9 +303,10 @@ impl EvalClient {
                             SandboxReadiness::Ready => return Ok(body),
                             // The sandbox is terminally broken (disabled/unreachable). Nothing runs a
                             // sandbox command during this poll, so the boot status is frozen and will
-                            // not recover — fail now instead of waiting out the deadline.
+                            // not recover — fail now instead of waiting out the deadline. A dedicated
+                            // variant (not Config) so the caller's retry loop treats this as terminal.
                             SandboxReadiness::Fatal(reason) => {
-                                return Err(ClientError::Config(format!(
+                                return Err(ClientError::SandboxFatal(format!(
                                     "{reason} — see backend log"
                                 )));
                             }

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -292,12 +292,26 @@ impl EvalClient {
         loop {
             match self.request(Method::GET, "ready", None, None).await {
                 Ok(body) => {
-                    if let Some(obj) = body.as_object()
-                        && obj.get("database").and_then(|v| v.as_str()) == Some("connected")
-                    {
-                        return Ok(body);
+                    let db_connected =
+                        body.get("database").and_then(|v| v.as_str()) == Some("connected");
+                    if db_connected {
+                        match sandbox_readiness(&body) {
+                            SandboxReadiness::Ready => return Ok(body),
+                            // The sandbox is terminally broken (disabled/unreachable). Nothing runs a
+                            // sandbox command during this poll, so the boot status is frozen and will
+                            // not recover — fail now instead of waiting out the deadline.
+                            SandboxReadiness::Fatal(reason) => {
+                                return Err(ClientError::Config(format!(
+                                    "{reason} — see backend log"
+                                )));
+                            }
+                            SandboxReadiness::Pending => {
+                                last = Some(format!("db connected, sandbox not ready yet: {body}"));
+                            }
+                        }
+                    } else {
+                        last = Some(format!("reachable but not connected: {body}"));
                     }
-                    last = Some(format!("reachable but not connected: {body}"));
                 }
                 Err(e) if (400..500).contains(&e.status) => {
                     return Err(ClientError::Api(e));
@@ -1158,9 +1172,67 @@ fn build_chat_body(
     })
 }
 
+/// What one `/ready` poll says about the code-execution sandbox.
+#[derive(Debug, PartialEq, Eq)]
+enum SandboxReadiness {
+    /// Still warming (or an older backend that predates the field) — keep polling.
+    Pending,
+    /// Usable now.
+    Ready,
+    /// Terminally unusable; the reason is carried for the error message.
+    Fatal(String),
+}
+
+/// Decide sandbox readiness from a `/ready` body. `ready` → Ready; `initializing` or an absent field
+/// → Pending; `disabled`/`unreachable` (or any unknown value) → Fatal, preferring `sandboxReason`.
+fn sandbox_readiness(body: &JsonValue) -> SandboxReadiness {
+    match body.get("sandbox").and_then(|v| v.as_str()) {
+        Some("ready") => SandboxReadiness::Ready,
+        None | Some("initializing") => SandboxReadiness::Pending,
+        Some(other) => {
+            let reason = body
+                .get("sandboxReason")
+                .and_then(|v| v.as_str())
+                .unwrap_or(other);
+            SandboxReadiness::Fatal(format!("sandbox {reason}"))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_sandbox_readiness_classifies_each_state() {
+        use serde_json::json;
+        assert_eq!(
+            sandbox_readiness(&json!({"sandbox": "ready"})),
+            SandboxReadiness::Ready
+        );
+        assert_eq!(
+            sandbox_readiness(&json!({"sandbox": "initializing"})),
+            SandboxReadiness::Pending
+        );
+        // absent field (older backend) is treated as still-warming, not fatal.
+        assert_eq!(
+            sandbox_readiness(&json!({"database": "connected"})),
+            SandboxReadiness::Pending
+        );
+        assert_eq!(
+            sandbox_readiness(&json!({"sandbox": "disabled", "sandboxReason": "disabled"})),
+            SandboxReadiness::Fatal("sandbox disabled".to_string())
+        );
+        assert_eq!(
+            sandbox_readiness(&json!({"sandbox": "unreachable", "sandboxReason": "error"})),
+            SandboxReadiness::Fatal("sandbox error".to_string())
+        );
+        // unreachable without a reason falls back to the status value itself.
+        assert_eq!(
+            sandbox_readiness(&json!({"sandbox": "unreachable"})),
+            SandboxReadiness::Fatal("sandbox unreachable".to_string())
+        );
+    }
 
     #[test]
     fn test_chat_body_pins_temperature() {

--- a/archestra-bench/runner/src/lifecycle.rs
+++ b/archestra-bench/runner/src/lifecycle.rs
@@ -120,7 +120,6 @@ async fn drop_database(db_created: &Arc<Mutex<bool>>, db_name: &str, maint_db_ur
     }
 }
 
-const DAGGER_RUNNER_HOST: &str = "tcp://127.0.0.1:1234";
 const DEV_AUTH_SECRET: &str = "better-auth-secret-12345678901234567890";
 const DEFAULT_ADMIN_EMAIL: &str = "admin@example.com";
 const DEFAULT_ADMIN_PASSWORD: &str = "password";
@@ -129,9 +128,30 @@ const DEFAULT_ADMIN_PASSWORD: &str = "password";
 const DEFAULT_BENCH_DATABASE_URL: &str = "postgres://postgres:postgres@localhost:5544/postgres";
 const BENCH_PG_COMPOSE_PROJECT: &str = "archestra-bench";
 
+/// Process-env override that, when set, names the Dagger runner host explicitly and skips the
+/// local resolution ladder (the prod-image / CI path supplies a `kube-pod://` host here).
+const RUNNER_HOST_ENV: &str = "ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST";
+/// Dagger host published by the dev stack's Tilt kubectl port-forward (the resolution fallback).
+const K8S_DAGGER_HOST: &str = "tcp://127.0.0.1:1234";
+const K8S_DAGGER_PROBE_ADDR: &str = "127.0.0.1:1234";
+/// Dagger host published by the runner-managed engine (`docker-compose.bench-dagger.yml`).
+const MANAGED_DAGGER_HOST: &str = "tcp://127.0.0.1:1245";
+const MANAGED_DAGGER_PROBE_ADDR: &str = "127.0.0.1:1245";
+const BENCH_DAGGER_COMPOSE_PROJECT: &str = "archestra-bench-dagger";
+/// The image whose presence gates the managed tier; the tag is read from the compose file so the
+/// engine version lives in exactly one place (kept in sync by scripts/check-dagger-version-sync.sh).
+const DAGGER_ENGINE_IMAGE: &str = "registry.dagger.io/engine";
+/// How long the managed engine has to start listening after `docker compose up` before we give up.
+const MANAGED_DAGGER_WAIT: Duration = Duration::from_secs(30);
+
 /// Provision the dedicated bench Postgres at most once per process. Isolated lanes call
 /// [`Instance::start`] concurrently, so this serializes the `docker compose up` across them.
 static BENCH_PG_READY: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+/// Provision the runner-managed Dagger engine at most once per process (same rationale as above).
+static BENCH_DAGGER_READY: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+/// The Dagger runner host, resolved once and shared across all lanes so they cannot split across
+/// tiers (e.g. one lane on the managed engine, another on the k8s port-forward) within a run.
+static RESOLVED_RUNNER_HOST: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::const_new();
 
 #[derive(Debug, thiserror::Error)]
 pub enum LifecycleError {
@@ -147,6 +167,8 @@ pub enum LifecycleError {
     EarlyExit { code: i32, message: String },
     #[error("config error: {0}")]
     Config(String),
+    #[error("dagger unavailable: {0}")]
+    DaggerUnavailable(String),
 }
 
 pub struct Instance {
@@ -166,6 +188,8 @@ pub struct Instance {
     api_port: u16,
     metrics_port: u16,
     bench_compose: PathBuf,
+    dagger_compose: PathBuf,
+    dagger_runner_host: String,
     teardown_id: Option<u64>,
 }
 
@@ -182,10 +206,9 @@ impl Instance {
     ) -> Self {
         let run_id = run_id.into();
         let platform = platform_dir.unwrap_or_else(|| repo_root.join("platform"));
-        let bench_compose = repo_root
-            .join("archestra-bench")
-            .join("dev")
-            .join("docker-compose.bench-pg.yml");
+        let bench_dev = repo_root.join("archestra-bench").join("dev");
+        let bench_compose = bench_dev.join("docker-compose.bench-pg.yml");
+        let dagger_compose = bench_dev.join("docker-compose.bench-dagger.yml");
         Self {
             run_id,
             log_path,
@@ -203,6 +226,8 @@ impl Instance {
             api_port: 0,
             metrics_port: 0,
             bench_compose,
+            dagger_compose,
+            dagger_runner_host: String::new(),
             teardown_id: None,
         }
     }
@@ -235,6 +260,11 @@ impl Instance {
         self.db_url = with_dbname(&self.maint_db_url, &self.db_name);
         self.api_port = free_port().await?;
         self.metrics_port = free_port().await?;
+
+        // Resolve the Dagger runner host before anything reads `backend_env()` (migrate, spawn). A
+        // broken sandbox fails fast here instead of booting a backend that can never run a command.
+        // No per-run side effect has happened yet, so a failure just propagates with nothing to undo.
+        self.dagger_runner_host = resolve_runner_host(&self.dagger_compose).await?;
 
         // Register teardown BEFORE the first side effect (database creation): an interruption during a
         // partial boot must still kill the process group and drop the database.
@@ -438,6 +468,7 @@ impl Instance {
             &self.db_url,
             &self.base_url,
             self.metrics_port,
+            &self.dagger_runner_host,
             &self
                 .platform
                 .join("dev")
@@ -576,6 +607,183 @@ pub fn bench_postgres_unavailable_message(
     }
 }
 
+/// Which Dagger host to use, decided purely from booleans so the ladder is unit-testable.
+#[derive(Debug, PartialEq, Eq)]
+enum RunnerChoice {
+    Explicit(String),
+    Managed,
+    K8s,
+    None,
+}
+
+/// The local resolution ladder (no I/O): an explicit override wins; else the runner-managed engine
+/// when Docker can run it and the image is already pulled; else the dev-stack port-forward when it is
+/// listening; else nothing.
+fn decide_runner(explicit: Option<String>, managed_runnable: bool, k8s_open: bool) -> RunnerChoice {
+    match (explicit, managed_runnable, k8s_open) {
+        (Some(host), _, _) => RunnerChoice::Explicit(host),
+        (None, true, _) => RunnerChoice::Managed,
+        (None, false, true) => RunnerChoice::K8s,
+        (None, false, false) => RunnerChoice::None,
+    }
+}
+
+/// Resolve the Dagger runner host once per process and share the result across all lanes, so a run
+/// cannot end up split across tiers. Memoized in [`RESOLVED_RUNNER_HOST`].
+async fn resolve_runner_host(dagger_compose: &Path) -> Result<String, LifecycleError> {
+    RESOLVED_RUNNER_HOST
+        .get_or_try_init(|| async {
+            let explicit = env_override(RUNNER_HOST_ENV);
+            // Read the engine tag up front: a misconfigured compose fails clearly here, and the
+            // `image_present` probe and the unavailable message then share one source of truth.
+            let tag = engine_tag(dagger_compose)?;
+            // Short-circuit the probes the ladder won't reach (don't run `docker info` when an
+            // explicit host is set, don't probe k8s once the managed engine is chosen).
+            let managed_runnable =
+                explicit.is_none() && docker_running().await && image_present(&tag).await;
+            let k8s_open = explicit.is_none()
+                && !managed_runnable
+                && tcp_open(K8S_DAGGER_PROBE_ADDR, Duration::from_secs(1)).await;
+            match decide_runner(explicit, managed_runnable, k8s_open) {
+                RunnerChoice::Explicit(host) => {
+                    info!("sandbox: explicit Dagger runner host {host} (ladder skipped)");
+                    Ok(host)
+                }
+                RunnerChoice::Managed => {
+                    ensure_bench_dagger(dagger_compose).await?;
+                    info!("sandbox: runner-managed Dagger engine on {MANAGED_DAGGER_HOST}");
+                    Ok(MANAGED_DAGGER_HOST.to_string())
+                }
+                RunnerChoice::K8s => {
+                    info!("sandbox: dev-stack Dagger port-forward on {K8S_DAGGER_HOST}");
+                    Ok(K8S_DAGGER_HOST.to_string())
+                }
+                RunnerChoice::None => Err(dagger_unavailable_resolution(&tag)),
+            }
+        })
+        .await
+        .cloned()
+}
+
+/// Provision the runner-managed Dagger engine at most once per process; left running between runs so
+/// the buildkit cache stays warm (`docker-compose.bench-dagger.yml` documents how to stop + prune).
+async fn ensure_bench_dagger(compose_file: &Path) -> Result<(), LifecycleError> {
+    BENCH_DAGGER_READY
+        .get_or_try_init(|| async {
+            info!(
+                "ensuring runner-managed Dagger engine ({})",
+                compose_file.display()
+            );
+            let compose = compose_file.to_string_lossy();
+            let output = Command::new("docker")
+                .args(["compose", "-p", BENCH_DAGGER_COMPOSE_PROJECT, "-f"])
+                .arg(compose.as_ref())
+                .args(["up", "-d"])
+                .output()
+                .await
+                .map_err(|e| {
+                    LifecycleError::DaggerUnavailable(format!(
+                        "failed to run `docker compose` for the managed Dagger engine (is Docker running?): {e}"
+                    ))
+                })?;
+            if !output.status.success() {
+                return Err(LifecycleError::DaggerUnavailable(format!(
+                    "could not start the runner-managed Dagger engine: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                )));
+            }
+            // `docker compose up` returns once the container is running, not once the engine has
+            // bound its TCP port; poll the published port directly (the engine image ships no usable
+            // in-container health tool to hang a compose `--wait` healthcheck on).
+            wait_tcp(MANAGED_DAGGER_PROBE_ADDR, MANAGED_DAGGER_WAIT).await
+        })
+        .await
+        .copied()
+}
+
+/// Names what the resolution ladder tried and how to fix it, in the style of
+/// [`bench_postgres_unavailable_message`].
+fn dagger_unavailable_resolution(tag: &str) -> LifecycleError {
+    LifecycleError::DaggerUnavailable(format!(
+        "no Dagger runner host available: the managed engine needs Docker running and \
+         `{DAGGER_ENGINE_IMAGE}:{tag}` pulled (`docker pull {DAGGER_ENGINE_IMAGE}:{tag}`), and the \
+         dev-stack port-forward was not listening on {K8S_DAGGER_PROBE_ADDR} (is `tilt up` running?). \
+         Set {RUNNER_HOST_ENV} to a Dagger engine you manage to bypass resolution"
+    ))
+}
+
+/// Read the engine image tag from the compose file so the version lives in exactly one place.
+fn engine_tag(compose_file: &Path) -> Result<String, LifecycleError> {
+    let contents = std::fs::read_to_string(compose_file).map_err(|e| {
+        LifecycleError::DaggerUnavailable(format!(
+            "cannot read the managed-engine compose file {}: {e}",
+            compose_file.display()
+        ))
+    })?;
+    let marker = format!("{DAGGER_ENGINE_IMAGE}:");
+    contents
+        .lines()
+        .find_map(|line| line.split_once(marker.as_str()))
+        .map(|(_, rest)| rest.trim().trim_matches('"').to_string())
+        .filter(|tag| !tag.is_empty())
+        .ok_or_else(|| {
+            LifecycleError::DaggerUnavailable(format!(
+                "could not find `{DAGGER_ENGINE_IMAGE}:<tag>` in {}",
+                compose_file.display()
+            ))
+        })
+}
+
+/// `docker info` succeeds only when the daemon is reachable.
+async fn docker_running() -> bool {
+    Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// `docker image inspect` succeeds only when the image is already pulled locally (we never pull).
+async fn image_present(tag: &str) -> bool {
+    let reference = format!("{DAGGER_ENGINE_IMAGE}:{tag}");
+    Command::new("docker")
+        .args(["image", "inspect", &reference])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// True if a TCP connection to `addr` completes within `timeout`.
+async fn tcp_open(addr: &str, timeout: Duration) -> bool {
+    matches!(
+        tokio::time::timeout(timeout, tokio::net::TcpStream::connect(addr)).await,
+        Ok(Ok(_))
+    )
+}
+
+/// Poll `addr` until it accepts a connection or `total` elapses.
+async fn wait_tcp(addr: &str, total: Duration) -> Result<(), LifecycleError> {
+    let deadline = tokio::time::Instant::now() + total;
+    loop {
+        if tcp_open(addr, Duration::from_secs(1)).await {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(LifecycleError::DaggerUnavailable(format!(
+                "managed Dagger engine did not start listening on {addr} within {}s",
+                total.as_secs()
+            )));
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+}
+
 pub fn redacted_db_location(db_url: &str) -> String {
     let parsed = url::Url::parse(db_url).ok();
     let host = parsed
@@ -599,6 +807,7 @@ pub fn build_backend_env(
     db_url: &str,
     api_base_url: &str,
     metrics_port: u16,
+    dagger_runner_host: &str,
     dagger_cli_bin: &str,
 ) -> HashMap<String, String> {
     let mut env: HashMap<String, String> = std::env::vars().collect();
@@ -621,11 +830,11 @@ pub fn build_backend_env(
     // These two keys are always force-set (the dev default points the backend at the local Dagger
     // engine), so `/app/.env` cannot steer them — the prod image delivers them through the process
     // env instead, which this honors over the dev default.
-    env.insert(
-        "ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST".to_string(),
-        env_override("ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST")
-            .unwrap_or_else(|| DAGGER_RUNNER_HOST.to_string()),
-    );
+    //
+    // The runner host arrives already resolved (`resolve_runner_host`): explicit process-env
+    // override, else the managed engine, else the k8s port-forward. The CLI-bin override still lives
+    // here because it has nothing to resolve — it is a plain process-env-or-default.
+    env.insert(RUNNER_HOST_ENV.to_string(), dagger_runner_host.to_string());
     env.insert(
         "ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN".to_string(),
         env_override("ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN")
@@ -748,19 +957,76 @@ mod tests {
     }
 
     #[test]
-    fn test_build_backend_env_dagger_defaults_when_unset() {
-        // No process-env override → the dev defaults stand (the `.env` base map cannot steer these two,
-        // so they are force-set; the override path swaps the default for a process-env value).
+    fn test_build_backend_env_force_sets_the_resolved_dagger_host() {
+        // The runner host arrives already resolved and is force-set verbatim (the `.env` base map
+        // cannot steer it); the CLI bin still falls back to the passed default when unset.
         let base = HashMap::new();
-        let env = build_backend_env(&base, "postgres://h/db", "http://localhost:1", 2, "/dev/dagger");
+        let env = build_backend_env(
+            &base,
+            "postgres://h/db",
+            "http://localhost:1",
+            2,
+            MANAGED_DAGGER_HOST,
+            "/dev/dagger",
+        );
         assert_eq!(
-            env.get("ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST"),
-            Some(&DAGGER_RUNNER_HOST.to_string())
+            env.get(RUNNER_HOST_ENV),
+            Some(&MANAGED_DAGGER_HOST.to_string())
         );
         assert_eq!(
             env.get("ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN"),
             Some(&"/dev/dagger".to_string())
         );
+    }
+
+    #[test]
+    fn test_decide_runner_prefers_explicit_then_managed_then_k8s() {
+        assert_eq!(
+            decide_runner(Some("kube-pod://x".to_string()), true, true),
+            RunnerChoice::Explicit("kube-pod://x".to_string())
+        );
+        assert_eq!(decide_runner(None, true, true), RunnerChoice::Managed);
+        assert_eq!(decide_runner(None, false, true), RunnerChoice::K8s);
+        assert_eq!(decide_runner(None, false, false), RunnerChoice::None);
+    }
+
+    #[test]
+    fn test_engine_tag_reads_the_compose_image() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("compose.yml");
+        std::fs::write(
+            &path,
+            "services:\n  bench-dagger:\n    image: registry.dagger.io/engine:v9.9.9\n",
+        )
+        .unwrap();
+        assert_eq!(engine_tag(&path).unwrap(), "v9.9.9");
+    }
+
+    #[test]
+    fn test_engine_tag_errors_when_image_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("compose.yml");
+        std::fs::write(
+            &path,
+            "services:\n  bench-dagger:\n    image: postgres:18\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            engine_tag(&path),
+            Err(LifecycleError::DaggerUnavailable(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_docker_image_probe_reports_absent_image() {
+        // Runtime-skip when Docker is not running so the suite never blocks on a daemon. When it is
+        // running, exercise the real `docker image inspect` path with a tag that cannot exist — no
+        // pull, no container, no leftover state. Booting the privileged engine end-to-end is left to
+        // manual validation (it would leave a running container + cache volume behind).
+        if !docker_running().await {
+            return;
+        }
+        assert!(!image_present("v0.0.0-does-not-exist").await);
     }
 
     #[test]

--- a/archestra-bench/runner/src/lifecycle.rs
+++ b/archestra-bench/runner/src/lifecycle.rs
@@ -625,24 +625,22 @@ pub fn bench_postgres_unavailable_message(
     }
 }
 
-/// Which Dagger host to use, decided purely from booleans so the ladder is unit-testable.
+/// Which local-ladder tier to use, decided purely from booleans so it is unit-testable. The explicit
+/// override is handled before this (it short-circuits the whole ladder), so it isn't a variant here.
 #[derive(Debug, PartialEq, Eq)]
 enum RunnerChoice {
-    Explicit(String),
     Managed,
     K8s,
     None,
 }
 
-/// The local resolution ladder (no I/O): an explicit override wins; else the runner-managed engine
-/// when Docker can run it and the image is already pulled; else the dev-stack port-forward when it is
-/// listening; else nothing.
-fn decide_runner(explicit: Option<String>, managed_runnable: bool, k8s_open: bool) -> RunnerChoice {
-    match (explicit, managed_runnable, k8s_open) {
-        (Some(host), _, _) => RunnerChoice::Explicit(host),
-        (None, true, _) => RunnerChoice::Managed,
-        (None, false, true) => RunnerChoice::K8s,
-        (None, false, false) => RunnerChoice::None,
+/// The local resolution ladder (no I/O): the runner-managed engine when Docker can run it and the
+/// image is already pulled; else the dev-stack port-forward when it is listening; else nothing.
+fn decide_runner(managed_runnable: bool, k8s_open: bool) -> RunnerChoice {
+    match (managed_runnable, k8s_open) {
+        (true, _) => RunnerChoice::Managed,
+        (false, true) => RunnerChoice::K8s,
+        (false, false) => RunnerChoice::None,
     }
 }
 
@@ -651,22 +649,20 @@ fn decide_runner(explicit: Option<String>, managed_runnable: bool, k8s_open: boo
 async fn resolve_runner_host(dagger_compose: &Path) -> Result<String, LifecycleError> {
     RESOLVED_RUNNER_HOST
         .get_or_try_init(|| async {
-            let explicit = env_override(RUNNER_HOST_ENV);
-            // Read the engine tag up front: a misconfigured compose fails clearly here, and the
-            // `image_present` probe and the unavailable message then share one source of truth.
+            // The explicit override wins outright and must not depend on the local compose file (the
+            // prod image sets a `kube-pod://` host and ships no compose), so return before reading it.
+            if let Some(host) = env_override(RUNNER_HOST_ENV) {
+                info!("sandbox: explicit Dagger runner host {host} (ladder skipped)");
+                return Ok(host);
+            }
+            // Only the local ladder needs the engine tag; reading it here lets a misconfigured compose
+            // fail clearly, and the `image_present` probe and the unavailable message share one source.
             let tag = engine_tag(dagger_compose)?;
-            // Short-circuit the probes the ladder won't reach (don't run `docker info` when an
-            // explicit host is set, don't probe k8s once the managed engine is chosen).
-            let managed_runnable =
-                explicit.is_none() && docker_running().await && image_present(&tag).await;
-            let k8s_open = explicit.is_none()
-                && !managed_runnable
-                && tcp_open(K8S_DAGGER_PROBE_ADDR, Duration::from_secs(1)).await;
-            match decide_runner(explicit, managed_runnable, k8s_open) {
-                RunnerChoice::Explicit(host) => {
-                    info!("sandbox: explicit Dagger runner host {host} (ladder skipped)");
-                    Ok(host)
-                }
+            let managed_runnable = docker_running().await && image_present(&tag).await;
+            // Don't probe k8s once the managed engine is chosen.
+            let k8s_open =
+                !managed_runnable && tcp_open(K8S_DAGGER_PROBE_ADDR, Duration::from_secs(1)).await;
+            match decide_runner(managed_runnable, k8s_open) {
                 RunnerChoice::Managed => {
                     ensure_bench_dagger(dagger_compose).await?;
                     info!("sandbox: runner-managed Dagger engine on {MANAGED_DAGGER_HOST}");
@@ -1018,14 +1014,11 @@ mod tests {
     }
 
     #[test]
-    fn test_decide_runner_prefers_explicit_then_managed_then_k8s() {
-        assert_eq!(
-            decide_runner(Some("kube-pod://x".to_string()), true, true),
-            RunnerChoice::Explicit("kube-pod://x".to_string())
-        );
-        assert_eq!(decide_runner(None, true, true), RunnerChoice::Managed);
-        assert_eq!(decide_runner(None, false, true), RunnerChoice::K8s);
-        assert_eq!(decide_runner(None, false, false), RunnerChoice::None);
+    fn test_decide_runner_prefers_managed_then_k8s_then_none() {
+        assert_eq!(decide_runner(true, true), RunnerChoice::Managed);
+        assert_eq!(decide_runner(true, false), RunnerChoice::Managed);
+        assert_eq!(decide_runner(false, true), RunnerChoice::K8s);
+        assert_eq!(decide_runner(false, false), RunnerChoice::None);
     }
 
     #[test]

--- a/archestra-bench/runner/src/lifecycle.rs
+++ b/archestra-bench/runner/src/lifecycle.rs
@@ -577,6 +577,38 @@ fn resolve_bench_db_url(env: &HashMap<String, String>) -> (String, bool) {
 /// Bring the dedicated bench Postgres up and block until it is healthy. Idempotent: `docker compose
 /// up -d --wait` reconciles an already-running container and returns fast, and [`BENCH_PG_READY`]
 /// collapses concurrent callers into a single invocation.
+/// Failure of [`compose_up`], split so each caller can map the two cases onto its own error type:
+/// Docker couldn't be invoked at all, or the `up` ran but exited non-zero (stderr carried).
+enum ComposeUpError {
+    Spawn(std::io::Error),
+    Exit(String),
+}
+
+/// `docker compose -p <project> -f <file> up -d [extra]`, left detached. The shared primitive behind
+/// both bench sidecars (Postgres and the managed Dagger engine); each wraps it with its own
+/// `OnceCell`, error variant, and readiness step.
+async fn compose_up(
+    project: &str,
+    compose_file: &Path,
+    extra: &[&str],
+) -> Result<(), ComposeUpError> {
+    let compose = compose_file.to_string_lossy();
+    let output = Command::new("docker")
+        .args(["compose", "-p", project, "-f"])
+        .arg(compose.as_ref())
+        .args(["up", "-d"])
+        .args(extra)
+        .output()
+        .await
+        .map_err(ComposeUpError::Spawn)?;
+    if !output.status.success() {
+        return Err(ComposeUpError::Exit(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    Ok(())
+}
+
 async fn ensure_bench_postgres(compose_file: &Path) -> Result<(), LifecycleError> {
     BENCH_PG_READY
         .get_or_try_init(|| async {
@@ -584,25 +616,16 @@ async fn ensure_bench_postgres(compose_file: &Path) -> Result<(), LifecycleError
                 "ensuring dedicated bench Postgres ({})",
                 compose_file.display()
             );
-            let compose = compose_file.to_string_lossy();
-            let output = Command::new("docker")
-                .args(["compose", "-p", BENCH_PG_COMPOSE_PROJECT, "-f"])
-                .arg(compose.as_ref())
-                .args(["up", "-d", "--wait"])
-                .output()
+            compose_up(BENCH_PG_COMPOSE_PROJECT, compose_file, &["--wait"])
                 .await
-                .map_err(|e| {
-                    LifecycleError::Config(format!(
+                .map_err(|e| match e {
+                    ComposeUpError::Spawn(e) => LifecycleError::Config(format!(
                         "failed to run `docker compose` for the bench Postgres (is Docker installed and running?): {e}"
-                    ))
-                })?;
-            if !output.status.success() {
-                return Err(LifecycleError::Postgres(format!(
-                    "could not start the dedicated bench Postgres: {}",
-                    String::from_utf8_lossy(&output.stderr).trim()
-                )));
-            }
-            Ok(())
+                    )),
+                    ComposeUpError::Exit(stderr) => LifecycleError::Postgres(format!(
+                        "could not start the dedicated bench Postgres: {stderr}"
+                    )),
+                })
         })
         .await
         .copied()
@@ -688,24 +711,16 @@ async fn ensure_bench_dagger(compose_file: &Path) -> Result<(), LifecycleError> 
                 "ensuring runner-managed Dagger engine ({})",
                 compose_file.display()
             );
-            let compose = compose_file.to_string_lossy();
-            let output = Command::new("docker")
-                .args(["compose", "-p", BENCH_DAGGER_COMPOSE_PROJECT, "-f"])
-                .arg(compose.as_ref())
-                .args(["up", "-d"])
-                .output()
+            compose_up(BENCH_DAGGER_COMPOSE_PROJECT, compose_file, &[])
                 .await
-                .map_err(|e| {
-                    LifecycleError::DaggerUnavailable(format!(
+                .map_err(|e| match e {
+                    ComposeUpError::Spawn(e) => LifecycleError::DaggerUnavailable(format!(
                         "failed to run `docker compose` for the managed Dagger engine (is Docker running?): {e}"
-                    ))
+                    )),
+                    ComposeUpError::Exit(stderr) => LifecycleError::DaggerUnavailable(format!(
+                        "could not start the runner-managed Dagger engine: {stderr}"
+                    )),
                 })?;
-            if !output.status.success() {
-                return Err(LifecycleError::DaggerUnavailable(format!(
-                    "could not start the runner-managed Dagger engine: {}",
-                    String::from_utf8_lossy(&output.stderr).trim()
-                )));
-            }
             // `docker compose up` returns once the container is running, not once the engine has
             // bound its TCP port; poll the published port directly (the engine image ships no usable
             // in-container health tool to hang a compose `--wait` healthcheck on).

--- a/archestra-bench/runner/src/lifecycle.rs
+++ b/archestra-bench/runner/src/lifecycle.rs
@@ -12,7 +12,7 @@ use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep};
 use tracing::{error, info};
 
-use crate::client::EvalClient;
+use crate::client::{ClientError, EvalClient};
 
 /// A self-contained teardown for one backend instance: the process-group child and the database
 /// handle, decoupled from the `Instance` so cleanup can run even after the orchestration future is
@@ -149,8 +149,9 @@ const MANAGED_DAGGER_WAIT: Duration = Duration::from_secs(30);
 static BENCH_PG_READY: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
 /// Provision the runner-managed Dagger engine at most once per process (same rationale as above).
 static BENCH_DAGGER_READY: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
-/// The Dagger runner host, resolved once and shared across all lanes so they cannot split across
-/// tiers (e.g. one lane on the managed engine, another on the k8s port-forward) within a run.
+/// The Dagger runner host. The first *successful* resolution is cached and shared across all lanes
+/// so they cannot split across tiers within a run; a failed attempt does not poison the cell
+/// (`get_or_try_init` leaves it empty on `Err`), so a transient hiccup lets the next lane re-resolve.
 static RESOLVED_RUNNER_HOST: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::const_new();
 
 #[derive(Debug, thiserror::Error)]
@@ -422,14 +423,10 @@ impl Instance {
                     message,
                 });
             }
-            match self.client.wait_ready(5.0, 1.0).await {
-                Ok(_) => break,
-                Err(crate::client::ClientError::Api(e)) if (400..500).contains(&e.status) => {
-                    return Err(LifecycleError::NotReady(e.to_string()));
-                }
-                Err(e) => {
-                    last = Some(e.to_string());
-                }
+            match classify_ready_poll(self.client.wait_ready(5.0, 1.0).await) {
+                ReadyPoll::Ready => break,
+                ReadyPoll::Terminal(msg) => return Err(LifecycleError::NotReady(msg)),
+                ReadyPoll::Retry(msg) => last = Some(msg),
             }
             if tokio::time::Instant::now() >= deadline {
                 return Err(LifecycleError::NotReady(format!(
@@ -476,6 +473,27 @@ impl Instance {
                 .join("dagger")
                 .to_string_lossy(),
         )
+    }
+}
+
+/// Outcome of one readiness poll inside `connect`'s loop. Split out so the terminal-vs-retry
+/// decision is unit-testable: a fatal sandbox must abort immediately, not retry until the deadline.
+enum ReadyPoll {
+    Ready,
+    Terminal(String),
+    Retry(String),
+}
+
+fn classify_ready_poll<T>(result: Result<T, ClientError>) -> ReadyPoll {
+    match result {
+        Ok(_) => ReadyPoll::Ready,
+        Err(ClientError::Api(e)) if (400..500).contains(&e.status) => {
+            ReadyPoll::Terminal(e.to_string())
+        }
+        // A broken sandbox cannot recover by retrying (the boot status is frozen during the poll),
+        // so abort now instead of burning the whole readiness deadline.
+        Err(e @ ClientError::SandboxFatal(_)) => ReadyPoll::Terminal(e.to_string()),
+        Err(e) => ReadyPoll::Retry(e.to_string()),
     }
 }
 
@@ -628,8 +646,8 @@ fn decide_runner(explicit: Option<String>, managed_runnable: bool, k8s_open: boo
     }
 }
 
-/// Resolve the Dagger runner host once per process and share the result across all lanes, so a run
-/// cannot end up split across tiers. Memoized in [`RESOLVED_RUNNER_HOST`].
+/// Resolve the Dagger runner host and share the first successful result across all lanes, so a run
+/// cannot end up split across tiers. Memoized in [`RESOLVED_RUNNER_HOST`] (failures are not cached).
 async fn resolve_runner_host(dagger_compose: &Path) -> Result<String, LifecycleError> {
     RESOLVED_RUNNER_HOST
         .get_or_try_init(|| async {
@@ -723,12 +741,17 @@ fn engine_tag(compose_file: &Path) -> Result<String, LifecycleError> {
     let marker = format!("{DAGGER_ENGINE_IMAGE}:");
     contents
         .lines()
+        .map(str::trim_start)
+        // Only the `image:` key — never a comment that mentions the image (the marker appears in
+        // this file's own header), and never a trailing comment on the value.
+        .filter(|line| line.starts_with("image:"))
         .find_map(|line| line.split_once(marker.as_str()))
-        .map(|(_, rest)| rest.trim().trim_matches('"').to_string())
+        .and_then(|(_, rest)| rest.split_whitespace().next())
+        .map(|tag| tag.trim_matches('"').to_string())
         .filter(|tag| !tag.is_empty())
         .ok_or_else(|| {
             LifecycleError::DaggerUnavailable(format!(
-                "could not find `{DAGGER_ENGINE_IMAGE}:<tag>` in {}",
+                "could not find an `image: {DAGGER_ENGINE_IMAGE}:<tag>` line in {}",
                 compose_file.display()
             ))
         })
@@ -980,6 +1003,21 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_ready_poll_fatal_sandbox_aborts_but_transient_retries() {
+        // The regression guard for the connect() loop: a fatal sandbox must be terminal (abort now),
+        // while a plain Config (the normal "not ready yet" / inner-timeout signal) must keep polling.
+        assert!(matches!(
+            classify_ready_poll::<()>(Err(ClientError::SandboxFatal("sandbox unreachable".into()))),
+            ReadyPoll::Terminal(_)
+        ));
+        assert!(matches!(
+            classify_ready_poll::<()>(Err(ClientError::Config("not ready yet".into()))),
+            ReadyPoll::Retry(_)
+        ));
+        assert!(matches!(classify_ready_poll(Ok(())), ReadyPoll::Ready));
+    }
+
+    #[test]
     fn test_decide_runner_prefers_explicit_then_managed_then_k8s() {
         assert_eq!(
             decide_runner(Some("kube-pod://x".to_string()), true, true),
@@ -991,12 +1029,14 @@ mod tests {
     }
 
     #[test]
-    fn test_engine_tag_reads_the_compose_image() {
+    fn test_engine_tag_reads_the_image_line_not_a_comment() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("compose.yml");
+        // A comment mentioning `registry.dagger.io/engine:<tag>` precedes the real image line (as in
+        // the actual compose header) and a trailing comment follows the value — neither must leak in.
         std::fs::write(
             &path,
-            "services:\n  bench-dagger:\n    image: registry.dagger.io/engine:v9.9.9\n",
+            "# see registry.dagger.io/engine:<tag>\nservices:\n  bench-dagger:\n    image: registry.dagger.io/engine:v9.9.9 # pinned\n",
         )
         .unwrap();
         assert_eq!(engine_tag(&path).unwrap(), "v9.9.9");

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -102707,13 +102707,26 @@
                         "connected",
                         "not_checked"
                       ]
+                    },
+                    "sandbox": {
+                      "type": "string",
+                      "enum": [
+                        "ready",
+                        "initializing",
+                        "disabled",
+                        "unreachable"
+                      ]
+                    },
+                    "sandboxReason": {
+                      "type": "string"
                     }
                   },
                   "required": [
                     "name",
                     "status",
                     "version",
-                    "database"
+                    "database",
+                    "sandbox"
                   ],
                   "additionalProperties": false
                 }

--- a/platform/backend/src/routes/health.test.ts
+++ b/platform/backend/src/routes/health.test.ts
@@ -1,0 +1,59 @@
+import config from "@/config";
+import { createFastifyInstance } from "@/server";
+import { afterEach, describe, expect, test } from "@/test";
+import healthRoutes, { mapSandboxStatus } from "./health";
+
+describe("mapSandboxStatus", () => {
+  test("ready and initializing carry no reason", () => {
+    expect(mapSandboxStatus("ready")).toEqual({ sandbox: "ready" });
+    expect(mapSandboxStatus("initializing")).toEqual({
+      sandbox: "initializing",
+    });
+  });
+
+  test("disabled reports itself as the reason", () => {
+    expect(mapSandboxStatus("disabled")).toEqual({
+      sandbox: "disabled",
+      sandboxReason: "disabled",
+    });
+  });
+
+  test("error and stopped both collapse to unreachable with the original state", () => {
+    expect(mapSandboxStatus("error")).toEqual({
+      sandbox: "unreachable",
+      sandboxReason: "error",
+    });
+    expect(mapSandboxStatus("stopped")).toEqual({
+      sandbox: "unreachable",
+      sandboxReason: "stopped",
+    });
+  });
+});
+
+describe("GET /ready", () => {
+  const originalMaintenanceMode = config.maintenanceMode;
+  afterEach(() => {
+    config.maintenanceMode = originalMaintenanceMode;
+  });
+
+  // Drive the DB-free maintenance 200 branch so the assertion exercises the real
+  // route's Zod serialization (the field would be silently stripped if it were
+  // missing from the response schema) without needing a live raw pg pool.
+  test("the 200 body carries the sandbox field (disabled when the runtime is off)", async () => {
+    config.maintenanceMode = "scheduled maintenance";
+    const app = createFastifyInstance();
+    await app.register(healthRoutes);
+
+    const response = await app.inject({ method: "GET", url: "/ready" });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.status).toBe("maintenance");
+    // The code runtime is not enabled in the test environment, so its boot
+    // status stays "disabled" and surfaces as a terminal-fail-fast signal.
+    expect(body.sandbox).toBe("disabled");
+    expect(body.sandboxReason).toBe("disabled");
+
+    await app.close();
+  });
+});

--- a/platform/backend/src/routes/health.ts
+++ b/platform/backend/src/routes/health.ts
@@ -70,20 +70,22 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async (request, reply) => {
-      // Read the cached boot status only — never trigger a sandbox probe here.
-      // Shared across both 200 branches so the sandbox field can't be carried by
-      // one and dropped by the other.
-      const ok200 = {
+      // Build the shared 200 fields at the moment of responding, reading the
+      // cached boot status only — never triggering a sandbox probe. A single
+      // definition keeps the two 200 branches from diverging; calling it per
+      // branch keeps the snapshot consistent with the response (no stale read
+      // held across the DB await below).
+      const ready200 = () => ({
         name,
         version,
         ...mapSandboxStatus(skillSandboxRuntimeService.bootStatus),
-      };
+      });
 
       // Maintenance mode must stay available while the database is offline or
       // being upgraded, so readiness intentionally skips the DB probe here.
       if (config.maintenanceMode) {
         return reply.send({
-          ...ok200,
+          ...ready200(),
           status: "maintenance",
           database: "not_checked",
         });
@@ -101,7 +103,7 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         });
       }
 
-      return reply.send({ ...ok200, status: "ok", database: "connected" });
+      return reply.send({ ...ready200(), status: "ok", database: "connected" });
     },
   );
 };

--- a/platform/backend/src/routes/health.ts
+++ b/platform/backend/src/routes/health.ts
@@ -71,17 +71,21 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async (request, reply) => {
       // Read the cached boot status only — never trigger a sandbox probe here.
-      const sandbox = mapSandboxStatus(skillSandboxRuntimeService.bootStatus);
+      // Shared across both 200 branches so the sandbox field can't be carried by
+      // one and dropped by the other.
+      const ok200 = {
+        name,
+        version,
+        ...mapSandboxStatus(skillSandboxRuntimeService.bootStatus),
+      };
 
       // Maintenance mode must stay available while the database is offline or
       // being upgraded, so readiness intentionally skips the DB probe here.
       if (config.maintenanceMode) {
         return reply.send({
-          name,
+          ...ok200,
           status: "maintenance",
-          version,
           database: "not_checked",
-          ...sandbox,
         });
       }
 
@@ -97,13 +101,7 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         });
       }
 
-      return reply.send({
-        name,
-        status: "ok",
-        version,
-        database: "connected",
-        ...sandbox,
-      });
+      return reply.send({ ...ok200, status: "ok", database: "connected" });
     },
   );
 };
@@ -134,5 +132,11 @@ export function mapSandboxStatus(status: SandboxRuntimeStatus): {
       return { sandbox: "unreachable", sandboxReason: "error" };
     case "stopped":
       return { sandbox: "unreachable", sandboxReason: "stopped" };
+    default:
+      return assertNever(status);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled sandbox runtime status "${value}".`);
 }

--- a/platform/backend/src/routes/health.ts
+++ b/platform/backend/src/routes/health.ts
@@ -2,6 +2,8 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import config from "@/config";
 import { isDatabaseHealthy } from "@/database";
+import type { SandboxRuntimeStatus } from "@/sandbox-runtime/sandbox-runtime-service";
+import { skillSandboxRuntimeService } from "@/skills-sandbox/skill-sandbox-runtime-service";
 import { HEALTH_PATH, READY_PATH } from "./route-paths";
 
 const { name, version } = config.api;
@@ -46,6 +48,17 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
             status: z.enum(["ok", "maintenance"]),
             version: z.string(),
             database: z.enum(["connected", "not_checked"]),
+            // Code-execution sandbox readiness. Consumers (e.g. the benchmark
+            // runner) fail fast on `disabled`/`unreachable` instead of waiting
+            // out their readiness deadline. `sandboxReason` carries the
+            // underlying boot state for triage.
+            sandbox: z.enum([
+              "ready",
+              "initializing",
+              "disabled",
+              "unreachable",
+            ]),
+            sandboxReason: z.string().optional(),
           }),
           503: z.object({
             name: z.string(),
@@ -57,6 +70,9 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async (request, reply) => {
+      // Read the cached boot status only — never trigger a sandbox probe here.
+      const sandbox = mapSandboxStatus(skillSandboxRuntimeService.bootStatus);
+
       // Maintenance mode must stay available while the database is offline or
       // being upgraded, so readiness intentionally skips the DB probe here.
       if (config.maintenanceMode) {
@@ -65,6 +81,7 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
           status: "maintenance",
           version,
           database: "not_checked",
+          ...sandbox,
         });
       }
 
@@ -85,9 +102,37 @@ const healthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         status: "ok",
         version,
         database: "connected",
+        ...sandbox,
       });
     },
   );
 };
 
 export default healthRoutes;
+
+type SandboxReadyState = "ready" | "initializing" | "disabled" | "unreachable";
+
+/**
+ * Map the sandbox runtime's internal boot status onto the `/ready` contract.
+ * `error` and `stopped` collapse to `unreachable` (a consumer cannot run the
+ * sandbox in either state); the original state is preserved in `sandboxReason`.
+ *
+ * @public — exported for unit tests.
+ */
+export function mapSandboxStatus(status: SandboxRuntimeStatus): {
+  sandbox: SandboxReadyState;
+  sandboxReason?: string;
+} {
+  switch (status) {
+    case "ready":
+      return { sandbox: "ready" };
+    case "initializing":
+      return { sandbox: "initializing" };
+    case "disabled":
+      return { sandbox: "disabled", sandboxReason: "disabled" };
+    case "error":
+      return { sandbox: "unreachable", sandboxReason: "error" };
+    case "stopped":
+      return { sandbox: "unreachable", sandboxReason: "stopped" };
+  }
+}

--- a/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
+++ b/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
@@ -16,7 +16,7 @@ function loadNative(): Promise<NativeBindings> {
   return nativeBindings;
 }
 
-type SandboxRuntimeStatus =
+export type SandboxRuntimeStatus =
   | "disabled"
   | "initializing"
   | "ready"
@@ -123,6 +123,13 @@ class SandboxRuntimeService {
 
   get isReady(): boolean {
     return this.status === "ready";
+  }
+
+  // Cached boot status for the /ready healthcheck. Never triggers init() or
+  // checkSession() — the poller reads a frozen snapshot, so an `error` here is
+  // terminal (nothing re-runs the 10s retry during a readiness poll).
+  get bootStatus(): SandboxRuntimeStatus {
+    return this.status;
   }
 
   async init(): Promise<void> {

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -13,6 +13,7 @@ import {
 import * as metrics from "@/observability/metrics";
 import {
   SandboxRuntimeError,
+  type SandboxRuntimeStatus,
   sandboxRuntimeService,
 } from "@/sandbox-runtime/sandbox-runtime-service";
 import { assertMountedSkillsReadable } from "@/skills/assert-mounted-skills-readable";
@@ -82,6 +83,13 @@ class SkillSandboxRuntimeService {
 
   get isReady(): boolean {
     return sandboxRuntimeService.isReady;
+  }
+
+  // Underlying Dagger runtime boot status for the /ready healthcheck. The skill
+  // feature flag and the runtime flag are coupled (config.ts), so the runtime's
+  // own status is the authoritative signal of whether the sandbox can run.
+  get bootStatus(): SandboxRuntimeStatus {
+    return sandboxRuntimeService.bootStatus;
   }
 
   async init(): Promise<void> {

--- a/platform/scripts/check-dagger-version-sync.sh
+++ b/platform/scripts/check-dagger-version-sync.sh
@@ -6,6 +6,7 @@ dockerfile="$root_dir/Dockerfile"
 cargo_toml="$root_dir/archestra-rs/sandbox-core/Cargo.toml"
 archestra_chart="$root_dir/helm/archestra/Chart.yaml"
 dagger_runtime_chart="$root_dir/helm/dagger-runtime/Chart.yaml"
+bench_dagger_compose="$root_dir/../archestra-bench/dev/docker-compose.bench-dagger.yml"
 
 # extract the dagger-helm dependency version from a Chart.yaml, tolerant of
 # field order and indentation within the dependency block.
@@ -25,17 +26,18 @@ cargo_version="$(sed -n 's/^dagger-sdk = "=\([0-9][^"]*\)"$/\1/p' "$cargo_toml")
 archestra_chart_version="$(dagger_helm_chart_version "$archestra_chart")"
 dagger_runtime_chart_version="$(dagger_helm_chart_version "$dagger_runtime_chart")"
 dagger_runtime_app_version="$(sed -n 's/^appVersion: "\([0-9][^"]*\)"$/\1/p' "$dagger_runtime_chart")"
+bench_dagger_version="$(sed -n 's#^[[:space:]]*image:[[:space:]]*registry.dagger.io/engine:v\{0,1\}\([0-9][^"[:space:]]*\)[[:space:]]*$#\1#p' "$bench_dagger_compose")"
 
-case "$docker_version:$cargo_version:$archestra_chart_version:$dagger_runtime_chart_version:$dagger_runtime_app_version" in
+case "$docker_version:$cargo_version:$archestra_chart_version:$dagger_runtime_chart_version:$dagger_runtime_app_version:$bench_dagger_version" in
   *::* | :* | *:)
-    echo "failed to read Dagger versions from Dockerfile, archestra-rs/sandbox-core/Cargo.toml, and Helm charts" >&2
+    echo "failed to read Dagger versions from Dockerfile, archestra-rs/sandbox-core/Cargo.toml, Helm charts, and archestra-bench/dev/docker-compose.bench-dagger.yml" >&2
     exit 1
     ;;
-  "$cargo_version:$cargo_version:$cargo_version:$cargo_version:$cargo_version")
+  "$cargo_version:$cargo_version:$cargo_version:$cargo_version:$cargo_version:$cargo_version")
     exit 0
     ;;
   *)
-    echo "Dagger version mismatch: Dockerfile has $docker_version, dagger-sdk has $cargo_version, archestra chart has $archestra_chart_version, dagger-runtime chart has $dagger_runtime_chart_version, dagger-runtime appVersion has $dagger_runtime_app_version" >&2
+    echo "Dagger version mismatch: Dockerfile has $docker_version, dagger-sdk has $cargo_version, archestra chart has $archestra_chart_version, dagger-runtime chart has $dagger_runtime_chart_version, dagger-runtime appVersion has $dagger_runtime_app_version, bench-dagger compose has $bench_dagger_version" >&2
     exit 1
     ;;
 esac

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -29052,6 +29052,8 @@ export type GetReadyResponses = {
         status: 'ok' | 'maintenance';
         version: string;
         database: 'connected' | 'not_checked';
+        sandbox: 'ready' | 'initializing' | 'disabled' | 'unreachable';
+        sandboxReason?: string;
     };
 };
 


### PR DESCRIPTION
## What

archestra-bench now exits early when the code-execution sandbox is broken, and prefers a directly-managed local Dagger engine over the dev-stack port-forward.

**`/ready` contract.** The backend's `GET /ready` 200 body gains `sandbox: "ready" | "initializing" | "disabled" | "unreachable"` + optional `sandboxReason`. Status code is unchanged (503 stays DB-only).

**Runner gating.** `wait_ready` now also requires `sandbox=="ready"`; `initializing`/absent keeps polling; `disabled`/`unreachable` aborts immediately instead of waiting out the readiness deadline.

**Dagger host resolution ladder** (one host per run, shared across lanes):
1. explicit `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST` → used verbatim, ladder skipped (prod/CI `kube-pod://` path; never reads the compose file).
2. else managed engine (`dev/docker-compose.bench-dagger.yml`, :1245) when Docker is up and the image is already pulled.
3. else dev-stack port-forward (:1234) when listening.
4. else abort, naming each tier tried.

The managed engine is privileged, left running between runs (warm buildkit cache, prunable), and never auto-pulled. `check-dagger-version-sync.sh` now also pins the compose engine tag.

## Design notes
- When Docker + image are present, the runner commits to the managed engine and aborts if it fails to start (no silent fall-through to k8s) — a failure there signals a real Docker/engine problem.
- The privileged engine actually booting on :1245 is validated manually, not in `cargo test`.

## Tests
- Backend: `mapSandboxStatus` (all states) + a `/ready` route test through real Zod serialization.
- Runner: `sandbox_readiness`, `classify_ready_poll` (the terminal-vs-retry split), `decide_runner`, `engine_tag` (incl. comment-before-image), a docker-gated image-probe test.
- `check-dagger-version-sync.sh` extended to a 6-way equality.

https://claude.ai/code/session_01MVpSsUtDwum6Gf2p8DT13M

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>