### PR TITLE
fix(bench): preflight sandbox so a broken run fails fast, not 161 rollouts

### DIFF
--- a/archestra-bench/runner/src/lifecycle.rs
+++ b/archestra-bench/runner/src/lifecycle.rs
@@ -609,6 +609,37 @@ async fn compose_up(
     Ok(())
 }
 
+/// Assert the run-wide sandbox preconditions once, before any rollout boots a backend: the managed
+/// bench Postgres must come up and the Dagger runner host must resolve. A broken sandbox aborts the
+/// whole run here with a single error instead of every per-(task × lane) backend boot failing the
+/// same way and fanning out one `agent_error` result each. Reuses the same memoized resolution as
+/// [`Instance::start`] (`BENCH_PG_READY` / `RESOLVED_RUNNER_HOST` / `BENCH_DAGGER_READY`), so a
+/// healthy run pays nothing — the per-instance calls that follow are cache hits. Asserts
+/// preconditions only: it must not create a database, migrate, or spawn a backend. An external
+/// `ARCHESTRA_BENCH_DATABASE_URL` is not probed here (it is first reached at `create_database`).
+pub async fn preflight(
+    repo_root: &Path,
+    platform_dir: Option<&Path>,
+) -> Result<(), LifecycleError> {
+    let platform = platform_dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| repo_root.join("platform"));
+    let env_path = platform.join(".env");
+    if !env_path.is_file() {
+        return Err(LifecycleError::Config(format!(
+            "{} not found; create it from platform/.env.example or start the dev stack",
+            env_path.display()
+        )));
+    }
+    let (_bench_db_url, managed) = resolve_bench_db_url(&parse_env_file(&env_path)?);
+    let bench_dev = repo_root.join("archestra-bench").join("dev");
+    if managed {
+        ensure_bench_postgres(&bench_dev.join("docker-compose.bench-pg.yml")).await?;
+    }
+    resolve_runner_host(&bench_dev.join("docker-compose.bench-dagger.yml")).await?;
+    Ok(())
+}
+
 async fn ensure_bench_postgres(compose_file: &Path) -> Result<(), LifecycleError> {
     BENCH_PG_READY
         .get_or_try_init(|| async {
@@ -1085,5 +1116,15 @@ mod tests {
         let env = parse_env_file(&path).unwrap();
         assert_eq!(env.get("FOO"), Some(&"bar".to_string()));
         assert_eq!(env.get("REF"), Some(&"bar/qux".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_preflight_missing_env_is_config_error() {
+        // A missing platform `.env` is rejected before any Docker/Postgres I/O, mirroring
+        // `Instance::start`'s check — so this exercises the preflight's error mapping with no
+        // process boundaries to mock.
+        let tmp = tempfile::tempdir().unwrap();
+        let err = preflight(tmp.path(), Some(tmp.path())).await.unwrap_err();
+        assert!(matches!(err, LifecycleError::Config(_)), "got {err:?}");
     }
 }

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -164,6 +164,16 @@ pub async fn run(
     };
     let prices = Arc::new(prices);
 
+    let selected = select_envs(&envs, env_filter, task_filter)?;
+    let plan = build_run_plan(selected, lane_list);
+
+    // Preflight the sandbox once, before any artifact is written: a broken sandbox (managed bench
+    // Postgres can't come up, Dagger runner host won't resolve) aborts the whole run here with a
+    // single error instead of every backend boot failing the same way and fanning out one
+    // agent_error per (task × lane). Warms the same OnceCells `Instance::start` reads, so a healthy
+    // run pays nothing.
+    crate::lifecycle::preflight(&repo_root(), platform_dir).await?;
+
     // An explicit `--run-dir` is reused (create_dir_all); an auto dir must be brand-new — the base name
     // is seconds-granular, so two runs started in the same second would otherwise share a root and
     // overwrite each other's config.json/aggregate.json.
@@ -174,9 +184,6 @@ pub async fn run(
         }
         None => create_fresh_run_dir(bench_dir).await?,
     };
-
-    let selected = select_envs(&envs, env_filter, task_filter)?;
-    let plan = build_run_plan(selected, lane_list);
 
     write_run_config(
         &root_run_dir,


### PR DESCRIPTION
## Problem

A `full --env basic …` run reported `0/161 passed · agent_error=161`. Not a model failure: the runner-managed Dagger engine couldn't bind `:1245` (a stale orphan container held the port), so every backend boot hit `LifecycleError::DaggerUnavailable`. The fail-fast *detected* it once, but the *handling* fanned it out — `setup_shared_env`/`run_isolated_lane` turned the error into one `agent_error` row per (task × lane), `run()` still returned `Ok`, and `full` then ran the glm reduce over 161 empty trajectories.

## Fix

Add `lifecycle::preflight(repo_root, platform_dir)` that asserts the sandbox-wide preconditions once — managed bench Postgres up (when managed) + Dagger runner host resolves — and call it in `run()` before any artifact is written. A broken sandbox now aborts the whole run with a single `RunError::Lifecycle` (the CLI exits non-zero and skips the reduce). It reuses the same OnceCell-memoized resolvers `Instance::start` uses, so a healthy run's per-instance calls are cache hits — no behavior change.

Env selection moves above run-dir creation too, so a bad `--env`/`--task` filter or a broken sandbox leaves no orphaned `experiments/<id>/`.

Out of scope (deferred): external-DB (`ARCHESTRA_BENCH_DATABASE_URL`) reachability still fans out (first probed at `create_database`); probe-first reuse of an already-listening `:1245` engine; a reduce-skip backstop for partial fanout.

## Validation

- `cargo clippy --all-targets -- -D warnings` clean; `cargo test` green (incl. new `test_preflight_missing_env_is_config_error`).
- Live repro: with `:1245` occupied, preflight returns `dagger unavailable` and aborts (exit 3, no fanout); with `:1245` free it returns OK and brings up the managed engine.

https://claude.ai/code/session_01H3Yayj5hDiCrt9G7CjNRG6

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>