### PR TITLE
fix(chat): repair non-object tool-call input before provider replay

### DIFF
--- a/platform/backend/src/agents/a2a/a2a-manager.test.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.test.ts
@@ -987,3 +987,78 @@ describe("A2AManager.sendMessage", () => {
     });
   });
 });
+
+describe("A2AManager.sendMessage malformed tool input", () => {
+  test("coerces a poisoned tool input from context history before replay", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "a2a-coerce", teams: [] });
+    const manager = new A2AManager();
+
+    // Turn 1: the agent persists an assistant turn whose tool call carries a
+    // malformed (non-object) input, poisoning the context history.
+    executeA2AMessage.mockReturnValueOnce({
+      messageId: crypto.randomUUID(),
+      text: "built",
+      finishReason: "stop",
+      responseUiMessage: {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        parts: [
+          { type: "text", text: "built" },
+          {
+            type: "dynamic-tool",
+            toolName: "edit_app",
+            toolCallId: "call_poison",
+            state: "output-available",
+            output: "ok",
+            input: '{"old_str">x',
+          },
+        ],
+      },
+    });
+    const first = await sendTextMessage(manager, agent.id, "build it");
+    const contextId = first.message?.contextId;
+    if (!contextId) {
+      throw new Error("contextId should be defined");
+    }
+
+    // Turn 2: replays the poisoned history. Capture what the executor receives.
+    executeA2AMessage.mockReturnValueOnce({
+      messageId: crypto.randomUUID(),
+      text: "ok",
+      finishReason: "stop",
+      responseUiMessage: {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        parts: [{ type: "text", text: "ok" }],
+      },
+    });
+    await manager.sendMessage({
+      actor,
+      agentId: agent.id,
+      request: {
+        message: {
+          messageId: crypto.randomUUID(),
+          role: A2AProtocolRole.User,
+          contextId,
+          parts: [{ text: "change it" }],
+        },
+      },
+    });
+
+    const lastParams = executeA2AMessage.mock.calls.at(-1)?.[0] as {
+      originalUiMessages: {
+        parts?: { toolCallId?: string; input?: unknown }[];
+      }[];
+    };
+    const replayed = lastParams.originalUiMessages
+      .flatMap((m) => m.parts ?? [])
+      .find((p) => p.toolCallId === "call_poison");
+
+    expect(replayed).toBeDefined();
+    expect(typeof replayed?.input).toBe("object");
+    expect(replayed?.input).not.toBeNull();
+    expect(Array.isArray(replayed?.input)).toBe(false);
+  });
+});

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -195,12 +195,13 @@ export class A2AManager {
           : task && taskWasSwitchedToWorkingState
             ? task.history
             : [];
-      const contextUiMessages = contextDbMessages.map(
-        (m) => m.content as UIMessage,
+      // Repair malformed tool inputs at the source so both the provider request
+      // and the UI-continuation copy (`originalUiMessages` below) stay valid.
+      const contextUiMessages = coerceMalformedToolInputs(
+        contextDbMessages.map((m) => m.content as UIMessage),
       );
-      const requestMessages: ModelMessage[] = await convertToModelMessages(
-        coerceMalformedToolInputs(contextUiMessages),
-      );
+      const requestMessages: ModelMessage[] =
+        await convertToModelMessages(contextUiMessages);
 
       if (messageParts.length > 0) {
         // We need to separately push user message to both contextUiMessages and requestMessages.

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -1,3 +1,4 @@
+import { coerceMalformedToolInputs } from "@archestra/shared";
 import {
   convertToModelMessages,
   type FilePart,
@@ -197,8 +198,9 @@ export class A2AManager {
       const contextUiMessages = contextDbMessages.map(
         (m) => m.content as UIMessage,
       );
-      const requestMessages: ModelMessage[] =
-        await convertToModelMessages(contextUiMessages);
+      const requestMessages: ModelMessage[] = await convertToModelMessages(
+        coerceMalformedToolInputs(contextUiMessages),
+      );
 
       if (messageParts.length > 0) {
         // We need to separately push user message to both contextUiMessages and requestMessages.

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -560,6 +560,51 @@ describe("normalizeChatMessages malformed tool input", () => {
     }
   });
 
+  // A static (`tool-<name>`) tool keeps its unparsed args in `rawInput` with
+  // `input` left undefined; convertToModelMessages reads `input ?? rawInput`, so
+  // without coercion the malformed string would still reach the provider. This is
+  // the shape the production brick actually took (no Input block in the export).
+  test("convertToModelMessages emits an object input when malformed args are in rawInput", async () => {
+    const messages = [
+      {
+        id: "user1",
+        role: "user" as const,
+        parts: [{ type: "text", text: "go" }],
+      },
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "text", text: "editing" },
+          {
+            type: "tool-archestra__edit_app",
+            toolCallId: "call_1",
+            state: "output-error",
+            errorText: "JSON parsing failed",
+            rawInput: '{"old_str">x',
+          },
+        ],
+      },
+    ];
+
+    const normalized = normalizeChatMessages(messages);
+    const modelMessages = await convertToModelMessages(
+      normalized as unknown as UIMessage[],
+    );
+
+    const toolCalls = modelMessages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+      .filter((part) => part.type === "tool-call");
+
+    expect(toolCalls.length).toBeGreaterThan(0);
+    for (const call of toolCalls) {
+      expect(call.input).toBeTypeOf("object");
+      expect(call.input).not.toBeNull();
+      expect(Array.isArray(call.input)).toBe(false);
+    }
+  });
+
   // Pre-existing dedupe behavior (unchanged here): it keeps the FIRST part on a
   // signature that ignores `input`, so a malformed-first / valid-second pair
   // already drops the valid twin before coercion runs. We only assert the safety

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -1,3 +1,4 @@
+import { convertToModelMessages, type UIMessage } from "ai";
 import { describe, expect, test } from "vitest";
 import {
   normalizeChatMessages,
@@ -480,5 +481,141 @@ describe("normalizeChatMessagesForPersistence", () => {
     expect(
       normalizeChatMessagesForPersistence(messages).map((m) => m.id),
     ).toEqual(["user1", "assistant1"]);
+  });
+});
+
+describe("normalizeChatMessages malformed tool input", () => {
+  test("repairs a poisoned output-error tool part, preserving the rest of the turn", () => {
+    const messages = [
+      {
+        id: "user1",
+        role: "user" as const,
+        parts: [{ type: "text", text: "go" }],
+      },
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "text", text: "editing" },
+          {
+            type: "tool-archestra__edit_app",
+            toolCallId: "call_1",
+            state: "output-error",
+            errorText: "JSON parsing failed",
+            input: undefined,
+          },
+        ],
+      },
+    ];
+
+    const result = normalizeChatMessages(messages);
+    const toolPart = result[1].parts?.find((p) => p.toolCallId === "call_1");
+
+    expect(toolPart?.input).toEqual({});
+    expect(toolPart?.state).toBe("output-error");
+    expect(toolPart?.errorText).toBe("JSON parsing failed");
+    expect(result[1].parts?.[0]).toEqual({ type: "text", text: "editing" });
+  });
+
+  // The real failing path: assert the actual AI SDK converter never emits a
+  // non-object tool_use input for a previously-poisoned conversation.
+  test("convertToModelMessages emits an object input for every tool_use", async () => {
+    const messages = [
+      {
+        id: "user1",
+        role: "user" as const,
+        parts: [{ type: "text", text: "go" }],
+      },
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          { type: "text", text: "editing" },
+          {
+            type: "tool-archestra__edit_app",
+            toolCallId: "call_1",
+            state: "output-error",
+            errorText: "JSON parsing failed",
+            input: '{"old_str">x',
+          },
+        ],
+      },
+    ];
+
+    const normalized = normalizeChatMessages(messages);
+    const modelMessages = await convertToModelMessages(
+      normalized as unknown as UIMessage[],
+    );
+
+    const toolCalls = modelMessages
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+      .filter((part) => part.type === "tool-call");
+
+    expect(toolCalls.length).toBeGreaterThan(0);
+    for (const call of toolCalls) {
+      expect(call.input).toBeTypeOf("object");
+      expect(call.input).not.toBeNull();
+      expect(Array.isArray(call.input)).toBe(false);
+    }
+  });
+
+  // Dedupe keeps the first part on a signature that ignores `input`; recovering
+  // the dropped twin's real arguments is out of scope — the kept malformed input
+  // is repaired to an empty object.
+  test("duplicate tool parts: the kept malformed input is coerced to an object", () => {
+    const messages = [
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-x",
+            toolCallId: "call_1",
+            state: "output-available",
+            output: "ok",
+            input: "garbage",
+          },
+          {
+            type: "tool-x",
+            toolCallId: "call_1",
+            state: "output-available",
+            output: "ok",
+            input: { valid: true },
+          },
+        ],
+      },
+    ];
+
+    const result = normalizeChatMessages(messages);
+    const toolParts = result[0].parts ?? [];
+
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0].input).toEqual({});
+  });
+
+  test("leaves a clean conversation unchanged", () => {
+    const messages = [
+      {
+        id: "user1",
+        role: "user" as const,
+        parts: [{ type: "text", text: "go" }],
+      },
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-x",
+            toolCallId: "call_1",
+            state: "output-available",
+            output: "ok",
+            input: { appId: "x" },
+          },
+        ],
+      },
+    ];
+
+    expect(normalizeChatMessages(messages)).toEqual(messages);
   });
 });

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.test.ts
@@ -560,10 +560,13 @@ describe("normalizeChatMessages malformed tool input", () => {
     }
   });
 
-  // Dedupe keeps the first part on a signature that ignores `input`; recovering
-  // the dropped twin's real arguments is out of scope — the kept malformed input
-  // is repaired to an empty object.
-  test("duplicate tool parts: the kept malformed input is coerced to an object", () => {
+  // Pre-existing dedupe behavior (unchanged here): it keeps the FIRST part on a
+  // signature that ignores `input`, so a malformed-first / valid-second pair
+  // already drops the valid twin before coercion runs. We only assert the safety
+  // invariant — the surviving input is a provider-valid object — not that losing
+  // the twin's args is desirable. Recovering them would mean changing dedupe,
+  // which is out of scope.
+  test("duplicate tool parts: the surviving input is coerced to an object", () => {
     const messages = [
       {
         id: "assistant1",
@@ -591,7 +594,10 @@ describe("normalizeChatMessages malformed tool input", () => {
     const toolParts = result[0].parts ?? [];
 
     expect(toolParts).toHaveLength(1);
-    expect(toolParts[0].input).toEqual({});
+    const input = toolParts[0].input;
+    expect(typeof input).toBe("object");
+    expect(input).not.toBeNull();
+    expect(Array.isArray(input)).toBe(false);
   });
 
   test("leaves a clean conversation unchanged", () => {

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -1,4 +1,5 @@
 import {
+  coerceMalformedToolInputs,
   hasPersistableAssistantContent,
   hasRenderableAssistantContent,
   stripDanglingToolCalls,
@@ -8,11 +9,17 @@ import type { ChatMessage, ChatMessagePart } from "@/types";
 import { stripImagesFromMessages } from "./strip-images-from-messages";
 
 export function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
-  return dropEmptyAssistantMessages(
-    stripOrphanedToolUiStartsFromMessages(
-      stripImagesFromMessages(
-        stripDanglingToolCallsFromMessages(
-          dedupeToolPartsFromMessages(messages),
+  // Coerce malformed tool inputs last, over the already-cleaned parts: dedupe
+  // keys on type/toolCallId/state and dangling-strip keys on state — neither
+  // reads `input` — so repairing input here can never drop a deduped twin or
+  // change which parts survive.
+  return coerceMalformedToolInputsFromMessages(
+    dropEmptyAssistantMessages(
+      stripOrphanedToolUiStartsFromMessages(
+        stripImagesFromMessages(
+          stripDanglingToolCallsFromMessages(
+            dedupeToolPartsFromMessages(messages),
+          ),
         ),
       ),
     ),
@@ -103,6 +110,45 @@ function stripDanglingToolCallsFromMessages(messages: ChatMessage[]) {
 
     return message;
   });
+}
+
+// repairs tool-call parts whose `input` is not a JSON object (a malformed-JSON
+// remnant the AI SDK couldn't parse) so replaying the history doesn't fail
+// provider validation. The pure transform lives in shared; this wrapper logs
+// each repair so a rising rate of malformed model output stays visible.
+function coerceMalformedToolInputsFromMessages(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  const repaired = coerceMalformedToolInputs(messages);
+
+  repaired.forEach((message, index) => {
+    const original = messages[index];
+    if (message === original) {
+      return;
+    }
+
+    message.parts?.forEach((part, partIndex) => {
+      const originalPart = original.parts?.[partIndex];
+      if (!originalPart || part === originalPart) {
+        return;
+      }
+
+      logger.warn(
+        {
+          messageId: message.id,
+          role: message.role,
+          toolCallId: part.toolCallId,
+          partType: part.type,
+          originalInputType: describeInputType(originalPart.input),
+          recoveredFromJson:
+            typeof originalPart.input === "string" && isRecord(part.input),
+        },
+        "[normalizeChatMessages] Coerced non-object tool-call input to an object",
+      );
+    });
+  });
+
+  return repaired;
 }
 
 // drops `data-tool-ui-start` markers whose tool call no longer survives — e.g. an
@@ -234,4 +280,18 @@ function getToolPartSignature(part: NonNullable<ChatMessage["parts"]>[number]) {
 }
 function getToolPartState(part: ChatMessagePart) {
   return typeof part.state === "string" ? part.state : "unknown";
+}
+
+function describeInputType(input: unknown): string {
+  if (input === null) {
+    return "null";
+  }
+  if (Array.isArray(input)) {
+    return "array";
+  }
+  return typeof input;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
+++ b/platform/backend/src/routes/chat/normalization/normalize-chat-messages.ts
@@ -141,7 +141,9 @@ function coerceMalformedToolInputsFromMessages(
           partType: part.type,
           originalInputType: describeInputType(originalPart.input),
           recoveredFromJson:
-            typeof originalPart.input === "string" && isRecord(part.input),
+            typeof originalPart.input === "string" &&
+            isRecord(part.input) &&
+            Object.keys(part.input).length > 0,
         },
         "[normalizeChatMessages] Coerced non-object tool-call input to an object",
       );

--- a/platform/shared/tool-call-normalization.test.ts
+++ b/platform/shared/tool-call-normalization.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { stripDanglingToolCalls } from "./tool-call-normalization";
+import {
+  coerceMalformedToolInputs,
+  stripDanglingToolCalls,
+} from "./tool-call-normalization";
 
 describe("stripDanglingToolCalls", () => {
   test("preserves multiple completed tool calls across multiple messages", () => {
@@ -203,5 +206,89 @@ describe("stripDanglingToolCalls", () => {
     ];
 
     expect(stripDanglingToolCalls(messages)).toEqual(messages);
+  });
+});
+
+describe("coerceMalformedToolInputs", () => {
+  const toolPart = (
+    input: unknown,
+    overrides: Record<string, unknown> = {},
+  ) => ({
+    type: "tool-archestra__edit_app",
+    toolCallId: "call_1",
+    state: "output-error",
+    errorText: "boom",
+    input,
+    ...overrides,
+  });
+
+  const wrap = (part: Record<string, unknown>) => [
+    { id: "a1", role: "assistant", parts: [part] },
+  ];
+
+  test("coerces an unparseable string input to an empty object", () => {
+    const result = coerceMalformedToolInputs(wrap(toolPart('{"old_str">x')));
+    expect(result[0].parts[0].input).toEqual({});
+  });
+
+  test("recovers a parsed object from a valid JSON-object string", () => {
+    const result = coerceMalformedToolInputs(wrap(toolPart('{"appId":"x"}')));
+    expect(result[0].parts[0].input).toEqual({ appId: "x" });
+  });
+
+  test("coerces a JSON-array string to an empty object", () => {
+    const result = coerceMalformedToolInputs(wrap(toolPart("[1,2]")));
+    expect(result[0].parts[0].input).toEqual({});
+  });
+
+  test.each([
+    ["null", null],
+    ["number", 42],
+    ["boolean", true],
+    ["array", [1, 2]],
+    ["undefined", undefined],
+  ])("coerces a non-object %s input to an empty object", (_label, input) => {
+    const result = coerceMalformedToolInputs(wrap(toolPart(input)));
+    expect(result[0].parts[0].input).toEqual({});
+  });
+
+  test("leaves an already-object input untouched (reference-equal)", () => {
+    const messages = wrap(toolPart({ appId: "x" }));
+    const result = coerceMalformedToolInputs(messages);
+    expect(result[0]).toBe(messages[0]);
+    expect(result[0].parts[0]).toBe(messages[0].parts[0]);
+  });
+
+  test("covers dynamic-tool parts", () => {
+    const result = coerceMalformedToolInputs(
+      wrap(toolPart("garbage", { type: "dynamic-tool" })),
+    );
+    expect(result[0].parts[0].input).toEqual({});
+  });
+
+  test("never adds an input to a tool-result part", () => {
+    const messages = wrap({
+      type: "tool-result",
+      toolCallId: "call_1",
+      input: "stray",
+    });
+    const result = coerceMalformedToolInputs(messages);
+    expect(result[0].parts[0]).toBe(messages[0].parts[0]);
+    expect(result[0].parts[0].input).toBe("stray");
+  });
+
+  test("does not coerce a still-streaming tool part", () => {
+    const messages = wrap(
+      toolPart("partial", { state: "input-streaming", errorText: undefined }),
+    );
+    const result = coerceMalformedToolInputs(messages);
+    expect(result[0].parts[0]).toBe(messages[0].parts[0]);
+  });
+
+  test("leaves a message with no coercible parts reference-equal", () => {
+    const messages = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+    ];
+    expect(coerceMalformedToolInputs(messages)[0]).toBe(messages[0]);
   });
 });

--- a/platform/shared/tool-call-normalization.ts
+++ b/platform/shared/tool-call-normalization.ts
@@ -4,6 +4,10 @@ type ToolPartLike = {
   type?: unknown;
 };
 
+type ToolInputPartLike = ToolPartLike & {
+  input?: unknown;
+};
+
 type MessageWithParts<TPart extends ToolPartLike> = {
   parts?: TPart[];
 };
@@ -53,6 +57,70 @@ function collectCompletedToolCallIds<
   }
 
   return completedToolCallIds;
+}
+
+// Anthropic (and other providers) require every `tool_use` block's `input` to be
+// a JSON object. A model can stream malformed tool-argument JSON that the AI SDK
+// fails to parse, leaving the persisted tool-call part with a non-object `input`
+// (a raw string, or nothing at all). Replaying that history then fails provider
+// validation on every turn, permanently bricking the conversation. Repair such
+// parts to an object so the history stays replayable: recover a parsed object
+// from a JSON string when possible, otherwise fall back to an empty object.
+export function coerceMalformedToolInputs<
+  TPart extends ToolInputPartLike,
+  TMessage extends MessageWithParts<TPart>,
+>(messages: TMessage[]): TMessage[] {
+  return messages.map((message) => {
+    if (!message.parts?.length) {
+      return message;
+    }
+
+    let changed = false;
+    const parts = message.parts.map((part) => {
+      if (!isCoercibleToolCallPart(part) || isPlainObject(part.input)) {
+        return part;
+      }
+      changed = true;
+      return { ...part, input: coerceToolInputValue(part.input) } as TPart;
+    });
+
+    return changed ? { ...message, parts } : message;
+  });
+}
+
+// A part that converts to a provider `tool_use` block and therefore needs an
+// object `input`. Excludes `tool-result` (it carries output, not input) and
+// `input-streaming` parts (still mid-stream, no complete input yet).
+function isCoercibleToolCallPart(part: ToolInputPartLike): boolean {
+  if (part.state === "input-streaming") {
+    return false;
+  }
+  if (part.type === "dynamic-tool") {
+    return true;
+  }
+  return (
+    typeof part.type === "string" &&
+    part.type.startsWith("tool-") &&
+    part.type !== "tool-result"
+  );
+}
+
+function coerceToolInputValue(input: unknown): Record<string, unknown> {
+  if (typeof input === "string") {
+    try {
+      const parsed: unknown = JSON.parse(input);
+      if (isPlainObject(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // unparseable remnant — fall through to an empty object
+    }
+  }
+  return {};
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isCompletedToolPart(part: ToolPartLike) {


### PR DESCRIPTION
## Problem

A malformed-JSON tool call — input the AI SDK can't parse — persists a tool-call part with a non-object `input`. Because chat replays the full history every turn, the AI SDK re-sends that part and the provider rejects the request (`messages.N.content.M.tool_use.input: Input should be an object`) on every message, permanently bricking the conversation with no recovery.

## Fix

- Shared `coerceMalformedToolInputs`: for any tool-call-shaped part whose `input` is not a plain object, repair it — recover a JSON object from a string when possible, otherwise `{}` — leaving everything else untouched.
- Wired as the last step of `normalizeChatMessages` (covers the chat replay, persist, and compaction paths) and into the A2A replay path (covers both the provider request and the UI-continuation copy).
- Affected conversations recover on their next turn; stored rows are left as-is, no migration. Each repair is logged.

## Tests

- Shared unit coverage (string / null / number / array / undefined / valid-JSON-object-string / passthrough / `tool-result` / `dynamic-tool` / `output-error` / `input-streaming`).
- A real `convertToModelMessages` regression asserting every replayed `tool_use.input` is an object.
- An A2A regression replaying a poisoned context history.

Recovering the dropped twin's args from a signature-colliding duplicate is a pre-existing dedupe limitation, left unchanged.

https://claude.ai/code/session_0192f3mmEdCHr6ySHUB8gRaC

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>