### PR TITLE
feat(chat): flip resolved MCP install-auth card to a connected state

### DIFF
--- a/platform/frontend/src/components/chat/auth-error-tool.tsx
+++ b/platform/frontend/src/components/chat/auth-error-tool.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, KeyRound } from "lucide-react";
+import { Check, ExternalLink, KeyRound } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,6 +16,11 @@ export interface AuthErrorToolProps {
   onAction?: () => void;
   actionTooltipText?: string;
   openInNewTab?: boolean;
+  /**
+   * "success" flips the card to a resolved/connected look (green check, no
+   * action). Defaults to "error" — the outstanding-auth state.
+   */
+  variant?: "error" | "success";
 }
 
 export function AuthErrorTool({
@@ -26,11 +31,16 @@ export function AuthErrorTool({
   onAction,
   actionTooltipText,
   openInNewTab = true,
+  variant = "error",
 }: AuthErrorToolProps) {
   return (
     <div className="mt-3 rounded-xl border border-border px-5 py-4">
       <div className="flex flex-wrap items-start gap-3 text-sm">
-        <KeyRound className="mt-0.5 size-4 flex-none text-amber-600" />
+        {variant === "success" ? (
+          <Check className="mt-0.5 size-4 flex-none text-emerald-600" />
+        ) : (
+          <KeyRound className="mt-0.5 size-4 flex-none text-amber-600" />
+        )}
         <div className="min-w-0 flex-1 text-muted-foreground">
           <span className="font-medium text-foreground">{title}:</span>{" "}
           <span>{description}</span>

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -189,6 +189,7 @@ vi.mock("@/lib/mcp/mcp-install-orchestrator.hook", () => ({
   useMcpInstallOrchestrator: () => ({
     triggerInstallByCatalogId: vi.fn(),
     triggerReauthByCatalogIdAndServerId: vi.fn(),
+    connectedCatalogIds: new Set<string>(),
   }),
 }));
 

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -80,6 +80,7 @@ import { useGlobalChat } from "@/lib/chat/global-chat.context";
 import {
   hasToolPartsWithAuthErrors,
   isAuthInstructionText,
+  isInstallAuthResolved,
   parsePolicyDenied,
   resolveAssistantTextAuthState,
   resolveToolAuthState,
@@ -679,6 +680,8 @@ export function ChatMessages({
                           const authToolPart = renderAssistantAuthPart({
                             toolName: "authentication",
                             authState: assistantAuthState,
+                            connectedCatalogIds:
+                              orchestrator.connectedCatalogIds,
                             onInstallMcp:
                               orchestrator.triggerInstallByCatalogId,
                             onReauthMcp:
@@ -1079,6 +1082,9 @@ export function ChatMessages({
                               onReauthMcp={
                                 orchestrator.triggerReauthByCatalogIdAndServerId
                               }
+                              connectedCatalogIds={
+                                orchestrator.connectedCatalogIds
+                              }
                               getToolShortName={getToolShortName}
                               toolIconMap={toolIconMap}
                               earlyToolUiData={
@@ -1179,6 +1185,9 @@ export function ChatMessages({
                                 onReauthMcp={
                                   orchestrator.triggerReauthByCatalogIdAndServerId
                                 }
+                                connectedCatalogIds={
+                                  orchestrator.connectedCatalogIds
+                                }
                                 getToolShortName={getToolShortName}
                                 toolIconMap={toolIconMap}
                                 onSendMessage={(text) =>
@@ -1252,6 +1261,9 @@ export function ChatMessages({
                                 onReauthMcp={
                                   orchestrator.triggerReauthByCatalogIdAndServerId
                                 }
+                                connectedCatalogIds={
+                                  orchestrator.connectedCatalogIds
+                                }
                                 getToolShortName={getToolShortName}
                                 toolIconMap={toolIconMap}
                                 earlyToolUiData={
@@ -1319,6 +1331,7 @@ export function ChatMessages({
               onToolApprovalResponse={onToolApprovalResponse}
               onInstallMcp={orchestrator.triggerInstallByCatalogId}
               onReauthMcp={orchestrator.triggerReauthByCatalogIdAndServerId}
+              connectedCatalogIds={orchestrator.connectedCatalogIds}
               getToolShortName={getToolShortName}
               toolIconMap={toolIconMap}
             />
@@ -1468,6 +1481,7 @@ const MessageTool = memo(
     onToolApprovalResponse,
     onInstallMcp,
     onReauthMcp,
+    connectedCatalogIds,
     getToolShortName,
     onSendMessage,
     earlyToolUiData,
@@ -1486,6 +1500,7 @@ const MessageTool = memo(
     }) => void;
     onInstallMcp?: (catalogId: string) => void;
     onReauthMcp?: (catalogId: string, serverId: string) => void;
+    connectedCatalogIds: ReadonlySet<string>;
     getToolShortName: (toolName: string) => ArchestraToolShortName | null;
     onSendMessage?: (text: string) => void;
     toolIconMap?: ToolIconMap;
@@ -1605,6 +1620,7 @@ const MessageTool = memo(
     const authToolBody = renderToolAuthPart({
       toolName,
       authState: toolAuthState,
+      connectedCatalogIds,
       onInstallMcp,
       onReauthMcp,
     });
@@ -2439,10 +2455,25 @@ function isMessagePositionBefore(params: {
 function authCardProps(params: {
   toolName: string;
   authState: ToolAuthState | null;
+  connectedCatalogIds: ReadonlySet<string>;
   onInstall?: () => void;
   onReauth?: () => void;
 }): AuthErrorToolProps | null {
-  const { authState, toolName, onInstall, onReauth } = params;
+  const { authState, toolName, connectedCatalogIds, onInstall, onReauth } =
+    params;
+
+  // Once the user connects a server for this catalog, the install prompt is
+  // resolved — flip it to a connected state instead of an outstanding error.
+  if (
+    authState?.kind === "auth-required" &&
+    isInstallAuthResolved({ authState, connectedCatalogIds })
+  ) {
+    return {
+      title: "Authentication successful",
+      description: <>Connected to &ldquo;{authState.catalogName}&rdquo;.</>,
+      variant: "success",
+    };
+  }
 
   switch (authState?.kind) {
     case "auth-expired": {
@@ -2536,18 +2567,31 @@ function resolveAuthActions(params: {
 function renderToolAuthPart(params: {
   toolName: string;
   authState: ReturnType<typeof resolveToolAuthState>;
+  connectedCatalogIds: ReadonlySet<string>;
   onInstallMcp?: (catalogId: string) => void;
   onReauthMcp?: (catalogId: string, serverId: string) => void;
 }) {
-  const { authState, toolName, onInstallMcp, onReauthMcp } = params;
+  const {
+    authState,
+    toolName,
+    connectedCatalogIds,
+    onInstallMcp,
+    onReauthMcp,
+  } = params;
   const actions = resolveAuthActions({ authState, onInstallMcp, onReauthMcp });
-  const props = authCardProps({ toolName, authState, ...actions });
+  const props = authCardProps({
+    toolName,
+    authState,
+    connectedCatalogIds,
+    ...actions,
+  });
   return props ? <AuthErrorTool {...props} /> : null;
 }
 
 function renderAssistantAuthPart(params: {
   toolName: string;
   authState: ReturnType<typeof resolveAssistantTextAuthState>;
+  connectedCatalogIds: ReadonlySet<string>;
   onInstallMcp?: (catalogId: string) => void;
   onReauthMcp?: (catalogId: string, serverId: string) => void;
 }) {

--- a/platform/frontend/src/lib/chat/mcp-error-ui.test.ts
+++ b/platform/frontend/src/lib/chat/mcp-error-ui.test.ts
@@ -5,11 +5,13 @@ import {
   extractIdsFromReauthUrl,
   hasToolPartsWithAuthErrors,
   isAuthInstructionText,
+  isInstallAuthResolved,
   parseAuthRequired,
   parseExpiredAuth,
   parsePolicyDenied,
   resolveAssistantTextAuthState,
   resolveToolAuthState,
+  type ToolAuthState,
 } from "./mcp-error-ui";
 
 describe("parsePolicyDenied", () => {
@@ -506,5 +508,81 @@ describe("extractIdsFromReauthUrl", () => {
       catalogId: null,
       serverId: null,
     });
+  });
+});
+
+describe("isInstallAuthResolved", () => {
+  const installState: ToolAuthState = {
+    kind: "auth-required",
+    catalogName: "Atlassian Cloud MCP",
+    actionUrl: "http://localhost:3000/mcp/registry?install=cat_1",
+    action: "install_mcp_credentials",
+    providerId: null,
+    catalogId: "cat_1",
+  };
+
+  it("treats an install prompt as resolved once a server for its catalog is connected", () => {
+    expect(
+      isInstallAuthResolved({
+        authState: installState,
+        connectedCatalogIds: new Set(["cat_1"]),
+      }),
+    ).toBe(true);
+  });
+
+  it("stays unresolved while no server for the catalog is connected", () => {
+    expect(
+      isInstallAuthResolved({
+        authState: installState,
+        connectedCatalogIds: new Set(["other-catalog"]),
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores identity-provider connect prompts even when the catalog is connected", () => {
+    expect(
+      isInstallAuthResolved({
+        authState: {
+          ...installState,
+          action: "connect_identity_provider",
+          providerId: "EntraID",
+        },
+        connectedCatalogIds: new Set(["cat_1"]),
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores expired/re-auth prompts even when the catalog is connected", () => {
+    expect(
+      isInstallAuthResolved({
+        authState: {
+          kind: "auth-expired",
+          catalogName: "Atlassian Cloud MCP",
+          reauthUrl:
+            "http://localhost:3000/mcp/registry?reauth=cat_1&server=s_1",
+          catalogId: "cat_1",
+          serverId: "s_1",
+        },
+        connectedCatalogIds: new Set(["cat_1"]),
+      }),
+    ).toBe(false);
+  });
+
+  it("stays unresolved when the prompt carries no catalog id", () => {
+    expect(
+      isInstallAuthResolved({
+        authState: { ...installState, catalogId: null },
+        connectedCatalogIds: new Set(["cat_1"]),
+      }),
+    ).toBe(false);
+  });
+
+  it("stays unresolved when there is no auth state", () => {
+    expect(
+      isInstallAuthResolved({
+        authState: null,
+        connectedCatalogIds: new Set(["cat_1"]),
+      }),
+    ).toBe(false);
   });
 });

--- a/platform/frontend/src/lib/chat/mcp-error-ui.ts
+++ b/platform/frontend/src/lib/chat/mcp-error-ui.ts
@@ -261,6 +261,27 @@ export function resolveAssistantTextAuthState(
   return null;
 }
 
+/**
+ * An "Authentication Required" install prompt is resolved once a server for its
+ * catalog has been connected — at that point the card should read as connected
+ * rather than as an outstanding error. Scoped deliberately to the install case
+ * (`install_mcp_credentials`): identity-provider connect, expired/re-auth, and
+ * assigned-credential-unavailable cards are NOT covered, since "a server exists"
+ * is not a valid resolution signal for those.
+ */
+export function isInstallAuthResolved(params: {
+  authState: ToolAuthState | null;
+  connectedCatalogIds: ReadonlySet<string>;
+}): boolean {
+  const { authState, connectedCatalogIds } = params;
+  return (
+    authState?.kind === "auth-required" &&
+    authState.action === "install_mcp_credentials" &&
+    authState.catalogId !== null &&
+    connectedCatalogIds.has(authState.catalogId)
+  );
+}
+
 export function hasToolPartsWithAuthErrors(
   parts: Array<{ output?: unknown; errorText?: string }> | undefined,
 ): boolean {

--- a/platform/frontend/src/lib/mcp/connected-catalogs.test.ts
+++ b/platform/frontend/src/lib/mcp/connected-catalogs.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { getUsableConnectedCatalogIds } from "./connected-catalogs";
+
+const me = "user-me";
+const other = "user-other";
+
+describe("getUsableConnectedCatalogIds", () => {
+  it("counts the current user's own personal server", () => {
+    const result = getUsableConnectedCatalogIds({
+      servers: [{ catalogId: "cat_1", scope: "personal", ownerId: me }],
+      currentUserId: me,
+    });
+    expect(result.has("cat_1")).toBe(true);
+  });
+
+  it("does NOT count another user's personal server (admin viewing others' installs)", () => {
+    const result = getUsableConnectedCatalogIds({
+      servers: [{ catalogId: "cat_1", scope: "personal", ownerId: other }],
+      currentUserId: me,
+    });
+    expect(result.has("cat_1")).toBe(false);
+  });
+
+  it("counts org-scoped servers regardless of owner", () => {
+    const result = getUsableConnectedCatalogIds({
+      servers: [{ catalogId: "cat_1", scope: "org", ownerId: other }],
+      currentUserId: me,
+    });
+    expect(result.has("cat_1")).toBe(true);
+  });
+
+  it("counts team-scoped servers", () => {
+    const result = getUsableConnectedCatalogIds({
+      servers: [{ catalogId: "cat_1", scope: "team", ownerId: other }],
+      currentUserId: me,
+    });
+    expect(result.has("cat_1")).toBe(true);
+  });
+
+  it("counts a catalog when the user owns one of several servers for it", () => {
+    const result = getUsableConnectedCatalogIds({
+      servers: [
+        { catalogId: "cat_1", scope: "personal", ownerId: other },
+        { catalogId: "cat_1", scope: "personal", ownerId: me },
+      ],
+      currentUserId: me,
+    });
+    expect(result.has("cat_1")).toBe(true);
+  });
+
+  it("ignores servers without a catalog id", () => {
+    const result = getUsableConnectedCatalogIds({
+      servers: [{ catalogId: null, scope: "org", ownerId: me }],
+      currentUserId: me,
+    });
+    expect(result.size).toBe(0);
+  });
+
+  it("excludes personal servers while the session/user id is still unknown", () => {
+    const result = getUsableConnectedCatalogIds({
+      servers: [
+        { catalogId: "cat_personal", scope: "personal", ownerId: me },
+        { catalogId: "cat_org", scope: "org", ownerId: other },
+      ],
+      currentUserId: undefined,
+    });
+    expect(result.has("cat_personal")).toBe(false);
+    expect(result.has("cat_org")).toBe(true);
+  });
+
+  it("returns an empty set for missing servers", () => {
+    expect(
+      getUsableConnectedCatalogIds({ servers: undefined, currentUserId: me })
+        .size,
+    ).toBe(0);
+  });
+});

--- a/platform/frontend/src/lib/mcp/connected-catalogs.ts
+++ b/platform/frontend/src/lib/mcp/connected-catalogs.ts
@@ -1,0 +1,39 @@
+import type { ResourceVisibilityScope } from "@archestra/shared";
+
+/**
+ * Catalog ids the given user can actually *use* a connected server for — the
+ * same owner/team/org resolution the MCP gateway applies when picking a
+ * credential. A server the user can merely *see* does not count: admins (and
+ * MCP-server admins) receive every org server unfiltered, including other
+ * users' personal installs, and treating those as "connected" would flip an
+ * install prompt to success even though the failed tool call still can't
+ * resolve a usable credential.
+ *
+ * Personal servers therefore only count when owned by the current user; team
+ * and org servers count (non-admins already only see team servers for their own
+ * teams, and org servers are usable by everyone).
+ */
+export function getUsableConnectedCatalogIds(params: {
+  servers:
+    | ReadonlyArray<{
+        catalogId: string | null;
+        scope: ResourceVisibilityScope;
+        ownerId: string | null;
+      }>
+    | undefined;
+  currentUserId: string | undefined;
+}): Set<string> {
+  const { servers, currentUserId } = params;
+  const catalogIds = new Set<string>();
+  for (const server of servers ?? []) {
+    if (!server.catalogId) {
+      continue;
+    }
+    const usableByCurrentUser =
+      server.scope !== "personal" || server.ownerId === currentUserId;
+    if (usableByCurrentUser) {
+      catalogIds.add(server.catalogId);
+    }
+  }
+  return catalogIds;
+}

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
@@ -44,6 +44,10 @@ vi.mock("@/lib/mcp/mcp-server.query", () => ({
   }),
 }));
 
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: () => ({ data: { user: { id: "test-user" } } }),
+}));
+
 vi.mock("@/lib/auth/oauth.query", () => ({
   useInitiateOAuth: () => ({
     mutateAsync: mutateAsyncMock,

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import type { LocalServerInstallResult } from "@/app/mcp/registry/_parts/local-server-install-dialog";
 import type { CatalogItem } from "@/app/mcp/registry/_parts/mcp-server-card";
@@ -49,6 +49,20 @@ export function useMcpInstallOrchestrator(options?: { enabled?: boolean }) {
   const installMutation = useInstallMcpServer();
   const reauthMutation = useReauthenticateMcpServer();
   const initiateOAuthMutation = useInitiateOAuth();
+
+  // Catalogs the user has a connected server for. An "Authentication Required"
+  // install card flips to a connected state once its catalog appears here (the
+  // install/reauth mutations and the OAuth callback both invalidate
+  // `useMcpServers`, so this refreshes when a connection completes).
+  const connectedCatalogIds = useMemo(
+    () =>
+      new Set(
+        (installedServers ?? [])
+          .map((server) => server.catalogId)
+          .filter((catalogId): catalogId is string => !!catalogId),
+      ),
+    [installedServers],
+  );
 
   const { isDialogOpened, openDialog, closeDialog } = useDialogs<DialogKey>();
 
@@ -372,6 +386,7 @@ export function useMcpInstallOrchestrator(options?: { enabled?: boolean }) {
     // Public API
     triggerInstallByCatalogId,
     triggerReauthByCatalogIdAndServerId,
+    connectedCatalogIds,
 
     // Dialog state (for rendering)
     isDialogOpened,

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -6,6 +6,7 @@ import type { NoAuthInstallResult } from "@/app/mcp/registry/_parts/no-auth-inst
 import type { RemoteServerInstallResult } from "@/app/mcp/registry/_parts/remote-server-install-dialog";
 import type { McpServerInstallScope } from "@/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams";
 import type { OAuthInstallResult } from "@/components/oauth-confirmation-dialog";
+import { useSession } from "@/lib/auth/auth.query";
 import { useInitiateOAuth } from "@/lib/auth/oauth.query";
 import {
   clearPendingAfterEnvVars,
@@ -23,6 +24,7 @@ import {
   setOAuthUserConfigValues,
 } from "@/lib/auth/oauth-session";
 import { useDialogs } from "@/lib/hooks/use-dialog";
+import { getUsableConnectedCatalogIds } from "@/lib/mcp/connected-catalogs";
 import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
 import {
   useInstallMcpServer,
@@ -50,18 +52,22 @@ export function useMcpInstallOrchestrator(options?: { enabled?: boolean }) {
   const reauthMutation = useReauthenticateMcpServer();
   const initiateOAuthMutation = useInitiateOAuth();
 
-  // Catalogs the user has a connected server for. An "Authentication Required"
-  // install card flips to a connected state once its catalog appears here (the
-  // install/reauth mutations and the OAuth callback both invalidate
-  // `useMcpServers`, so this refreshes when a connection completes).
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
+
+  // Catalogs the current user can use a connected server for. An "Authentication
+  // Required" install card flips to a connected state once its catalog appears
+  // here (the install/reauth mutations and the OAuth callback both invalidate
+  // `useMcpServers`, so this refreshes when a connection completes). Scoped to
+  // servers the user can actually use — not merely see — so an admin viewing
+  // another user's personal install does not falsely resolve the prompt.
   const connectedCatalogIds = useMemo(
     () =>
-      new Set(
-        (installedServers ?? [])
-          .map((server) => server.catalogId)
-          .filter((catalogId): catalogId is string => !!catalogId),
-      ),
-    [installedServers],
+      getUsableConnectedCatalogIds({
+        servers: installedServers,
+        currentUserId,
+      }),
+    [installedServers, currentUserId],
   );
 
   const { isDialogOpened, openDialog, closeDialog } = useDialogs<DialogKey>();


### PR DESCRIPTION
Follow-up to #5860 (which fixed the catalog **name** shown in the auth card). This makes the card stop looking like an unresolved error once the user actually connects.

## What

The "Authentication Required" card is a persisted part of the chat transcript, so after the user connected the MCP server it kept looking like an outstanding error — the only signal it was handled was the separate auto-sent "I connected … please retry" bubble.

Now, once the user has a **usable** connected server for the card's catalog, the card flips in place to a success state:

> ✓ **Authentication successful:** Connected to "Atlassian Cloud MCP".

— green check, no action button. The auto-retry bubble is left as-is.

## How (no new plumbing)

The signal is derived from the install orchestrator's existing `useMcpServers` data — install/reauth/the OAuth callback all invalidate that query, so the card flips when the connection lands and the state survives a refresh. No OAuth-resume/sessionStorage changes.

## Scope (deliberately narrow)

- Only the **install** prompt (`auth_required` + `install_mcp_credentials`). Identity-provider connect, expired/re-auth, and assigned-credential-unavailable cards are untouched — "a server exists" isn't a valid resolution signal for those.
- Counts only servers the current user can **use**, mirroring the gateway's owner/team/org credential resolution: personal servers count only when owned by the current user; team and org servers count. This prevents an admin who can *see* another user's personal install from falsely resolving the prompt. (Addresses a Codex review finding.)

## Tests

- `isInstallAuthResolved()` — pure predicate for the flip decision (install-only; rejects IdP-connect / expired / null cases).
- `getUsableConnectedCatalogIds()` — pure helper scoping the connected set to usable servers (rejects another user's personal install; accepts org/team/own-personal).
- Frontend `type-check`, `biome`, `knip` clean; affected suites pass (mcp-error-ui, connected-catalogs, orchestrator, chat-messages, auth-error-tool).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>