### PR TITLE
fix(apps): reject app backing catalogs in edit_mcp_config

### DIFF
--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -10,6 +10,7 @@ import {
   TOOL_APP_DATA_SET_SHORT_NAME,
   TOOL_DELETE_APP_SHORT_NAME,
   TOOL_EDIT_APP_SHORT_NAME,
+  TOOL_EDIT_MCP_CONFIG_SHORT_NAME,
   TOOL_GET_APP_DIAGNOSTICS_SHORT_NAME,
   TOOL_LIST_APPS_SHORT_NAME,
   TOOL_PREVIEW_APP_TOOL_SHORT_NAME,
@@ -179,6 +180,33 @@ describe("app tool execution", () => {
     expect(
       await InternalMcpCatalogModel.findById(catalogId as string),
     ).toBeNull();
+  });
+
+  test("edit_mcp_config refuses to reconfigure an app's backing catalog", async () => {
+    // An app author has modify rights on their own backing catalog; without the
+    // serverType:"app" guard they could flip it to a deployable local server and
+    // attach a command, escaping the Apps lifecycle and registry controls.
+    const created = await scaffold({ name: "Hijackable" });
+    const appId = structured(created).id as string;
+    const serverId = (await AppModel.findById(appId))?.mcpServerId;
+    const catalogId = (await McpServerModel.findById(serverId as string))
+      ?.catalogId;
+    expect(catalogId).toBeTruthy();
+
+    const attempt = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_EDIT_MCP_CONFIG_SHORT_NAME),
+      { id: catalogId, serverType: "local", command: "evil-binary" },
+      context,
+    );
+    expect(attempt.isError).toBe(true);
+    expect((attempt.content[0] as any).text).toContain(
+      "managed through the Apps API",
+    );
+
+    // The catalog is untouched: still an app, no deploy config attached.
+    const after = await InternalMcpCatalogModel.findById(catalogId as string);
+    expect(after?.serverType).toBe("app");
+    expect(after?.localConfig).toBeFalsy();
   });
 
   test("a plain member cannot create or mutate org-scoped apps", async ({

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -837,6 +837,16 @@ async function handleEditMcpConfig(
     if (!existing) {
       return errorResult("MCP server not found.");
     }
+    // App-backed catalogs have no deployable config and are managed through the
+    // Apps API. The schema blocks setting serverType TO "app", but without this
+    // an app author (who has modify rights on their own backing catalog) could
+    // flip it to local/remote and attach a command, escaping the Apps lifecycle
+    // and registry-creation controls. Mirrors the REST route's app-catalog guard.
+    if (existing.serverType === "app") {
+      return errorResult(
+        "App-backed catalog items are managed through the Apps API and cannot be configured here.",
+      );
+    }
 
     try {
       requireMcpCatalogModifyPermission({


### PR DESCRIPTION
Follow-up to #5834.

The `edit_mcp_config` MCP tool called `InternalMcpCatalogModel.update` without the `serverType:"app"` guard the REST route and the delete/install paths enforce. The input schema blocks setting `serverType` **to** `app`, but not editing an **existing** app backing catalog — so an app author (who holds modify rights on their own backing catalog) could flip it to `local`/`remote` and attach a `command`/`installationCommand`, converting the hidden app catalog into a generic deployable server and escaping the Apps lifecycle and registry-creation controls.

Reject `serverType:"app"` catalogs in `edit_mcp_config`, mirroring the REST route guard and the delete/install guards. Adds a regression test that the tool refuses to reconfigure a backing catalog and leaves it untouched.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>