### PR TITLE
feat(apps): make App backings assignable in the gateway capabilities picker

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -138732,6 +138732,16 @@
           "MCP Catalog"
         ],
         "description": "Get all Internal MCP catalog items\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`mcpRegistry:read`: Browse the MCP server registry",
+        "parameters": [
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "includeApps",
+            "required": false
+          }
+        ],
         "responses": {
           "200": {
             "description": "Default Response",

--- a/platform/backend/src/models/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.test.ts
@@ -799,5 +799,31 @@ describe("InternalMcpCatalogModel", () => {
       expect(searchedIds).toContain(remote.id);
       expect(searchedIds).not.toContain(app.id);
     });
+
+    test("findAllWithApps includes serverType:'app' catalogs alongside the rest", async () => {
+      const remote = await InternalMcpCatalogModel.create({
+        name: "Visible Remote ABC",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+      });
+      const app = await InternalMcpCatalogModel.create({
+        name: "Assignable App ABC",
+        serverType: "app",
+        scope: "org",
+      });
+
+      const withAppIds = (await InternalMcpCatalogModel.findAllWithApps()).map(
+        (c) => c.id,
+      );
+      expect(withAppIds).toContain(remote.id);
+      expect(withAppIds).toContain(app.id);
+
+      // The registry list still omits the app — only the picker opts in.
+      const registryIds = (await InternalMcpCatalogModel.findAll()).map(
+        (c) => c.id,
+      );
+      expect(registryIds).toContain(remote.id);
+      expect(registryIds).not.toContain(app.id);
+    });
   });
 });

--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -99,6 +99,36 @@ class InternalMcpCatalogModel {
     isAdmin?: boolean;
     organizationId?: string;
   }): Promise<ListInternalMcpCatalog[]> {
+    return InternalMcpCatalogModel.listAll(options, false);
+  }
+
+  /**
+   * Like {@link InternalMcpCatalogModel.findAll} but also returns app backing
+   * catalogs (`serverType: "app"`). The registry never uses this — only the
+   * gateway capabilities picker, where an app's launch tool is assignable like
+   * any other tool. Apps stay hidden from the registry list and the
+   * agent-callable {@link InternalMcpCatalogModel.searchByQuery}.
+   */
+  static async findAllWithApps(options?: {
+    expandSecrets?: boolean;
+    userId?: string;
+    isAdmin?: boolean;
+    organizationId?: string;
+  }): Promise<ListInternalMcpCatalog[]> {
+    return InternalMcpCatalogModel.listAll(options, true);
+  }
+
+  private static async listAll(
+    options:
+      | {
+          expandSecrets?: boolean;
+          userId?: string;
+          isAdmin?: boolean;
+          organizationId?: string;
+        }
+      | undefined,
+    includeApps: boolean,
+  ): Promise<ListInternalMcpCatalog[]> {
     const {
       expandSecrets = true,
       userId,
@@ -108,13 +138,16 @@ class InternalMcpCatalogModel {
 
     let dbItems: Array<typeof schema.internalMcpCatalogTable.$inferSelect>;
 
-    const baseListCondition = and(
+    const listConditions = [
       // Legacy preset rows (non-NULL parentCatalogItemId) are never surfaced.
       isNull(schema.internalMcpCatalogTable.parentCatalogItemId),
+    ];
+    if (!includeApps) {
       // App backing catalogs are managed on the Apps page, never surfaced in the
       // MCP registry (UI list or the agent-callable registry search).
-      ne(schema.internalMcpCatalogTable.serverType, "app"),
-    );
+      listConditions.push(ne(schema.internalMcpCatalogTable.serverType, "app"));
+    }
+    const baseListCondition = and(...listConditions);
 
     if (userId && !isAdmin && !organizationId) {
       return [];

--- a/platform/backend/src/routes/internal-mcp-catalog.list.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.list.test.ts
@@ -117,4 +117,62 @@ describe("GET /api/internal_mcp_catalog", () => {
     const ids = response.json().map((item: { id: string }) => item.id);
     expect(ids).not.toContain(personal.id);
   });
+
+  test("app backing catalogs are excluded by default but returned with includeApps", async () => {
+    const appCatalog = await InternalMcpCatalogModel.create(
+      {
+        name: "assignable-app-server",
+        serverType: "app",
+        scope: "org",
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const registry = await app.inject({
+      method: "GET",
+      url: "/api/internal_mcp_catalog",
+    });
+    expect(registry.statusCode).toBe(200);
+    expect(
+      registry.json().map((item: { id: string }) => item.id),
+    ).not.toContain(appCatalog.id);
+
+    const picker = await app.inject({
+      method: "GET",
+      url: "/api/internal_mcp_catalog?includeApps=true",
+    });
+    expect(picker.statusCode).toBe(200);
+    expect(picker.json().map((item: { id: string }) => item.id)).toContain(
+      appCatalog.id,
+    );
+  });
+
+  test("includeApps is ignored for a caller without app:read", async () => {
+    // Grant the route's own mcpRegistry probe but deny the app:read gate.
+    mockHasPermission.mockImplementation(
+      async (permissions: Record<string, unknown>) => ({
+        success: !("app" in permissions),
+        error: null,
+      }),
+    );
+
+    const appCatalog = await InternalMcpCatalogModel.create(
+      {
+        name: "gated-app-server",
+        serverType: "app",
+        scope: "org",
+      },
+      { organizationId, authorId: user.id },
+    );
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/internal_mcp_catalog?includeApps=true",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(
+      response.json().map((item: { id: string }) => item.id),
+    ).not.toContain(appCatalog.id);
+  });
 });

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -83,6 +83,11 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         operationId: RouteId.GetInternalMcpCatalog,
         description: "Get all Internal MCP catalog items",
         tags: ["MCP Catalog"],
+        querystring: z.object({
+          // Apps are hidden from the registry but assignable to a gateway, so the
+          // capabilities picker opts in to their backing catalogs here.
+          includeApps: z.coerce.boolean().optional(),
+        }),
         response: constructResponseSchema(
           z.array(ListInternalMcpCatalogSchema),
         ),
@@ -94,13 +99,21 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
         request.headers,
       );
       // Don't expand secrets for list view
+      const opts = {
+        expandSecrets: false,
+        userId: request.user.id,
+        isAdmin,
+        organizationId: request.organizationId,
+      };
+      // App backings are gated by `app:read`, not this route's `mcpRegistry:read`,
+      // so only surface them to callers who could see them on the Apps page.
+      const includeApps =
+        request.query.includeApps === true &&
+        (await hasPermission({ app: ["read"] }, request.headers)).success;
       return reply.send(
-        await InternalMcpCatalogModel.findAll({
-          expandSecrets: false,
-          userId: request.user.id,
-          isAdmin,
-          organizationId: request.organizationId,
-        }),
+        includeApps
+          ? await InternalMcpCatalogModel.findAllWithApps(opts)
+          : await InternalMcpCatalogModel.findAll(opts),
       );
     },
   );

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -1637,6 +1637,7 @@ export function AgentDialog({
                           agentEnvironmentName={agentEnvironmentName}
                           onConflictsChange={setMcpEnvConflicts}
                           openComboboxOnMount={openToolsCombobox}
+                          includeAppCatalogs={agentType === "mcp_gateway"}
                         />
                       </div>
                       <div className="space-y-2">

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -60,6 +60,15 @@ type InternalMcpCatalogItem =
   archestraApiTypes.GetInternalMcpCatalogResponses["200"][number];
 type CatalogTool =
   archestraApiTypes.GetInternalMcpCatalogToolsResponses["200"][number];
+
+/**
+ * Apps and built-in servers run in-process with no installed MCP server or stored
+ * credentials, so the picker neither gates their assignment on an installed
+ * server nor offers a credential selector for them.
+ */
+const isCredentialLessCatalogType = (
+  serverType: InternalMcpCatalogItem["serverType"],
+) => serverType === "builtin" || serverType === "app";
 type ResourceTool = archestraApiTypes.GetAgentToolsResponses["200"][number];
 type AssignedTool = {
   tool: ResourceTool;
@@ -115,6 +124,12 @@ interface AgentToolsEditorProps {
   layout?: "pills" | "cards";
   /** When true, the "Add MCP server" combobox starts open. */
   openComboboxOnMount?: boolean;
+  /**
+   * Include assignable App backing catalogs in the picker. Only the MCP gateway
+   * dialog sets this — Apps launch through a gateway, and the backend still
+   * gates their inclusion on `app:read`.
+   */
+  includeAppCatalogs?: boolean;
 }
 
 export const AgentToolsEditor = forwardRef<
@@ -132,6 +147,7 @@ export const AgentToolsEditor = forwardRef<
     onConflictsChange,
     layout = "pills",
     openComboboxOnMount,
+    includeAppCatalogs,
   },
   ref,
 ) {
@@ -147,6 +163,7 @@ export const AgentToolsEditor = forwardRef<
       onConflictsChange={onConflictsChange}
       layout={layout}
       openComboboxOnMount={openComboboxOnMount}
+      includeAppCatalogs={includeAppCatalogs}
       ref={ref}
     />
   );
@@ -167,6 +184,7 @@ const AgentToolsEditorContent = forwardRef<
     onConflictsChange,
     layout = "pills",
     openComboboxOnMount,
+    includeAppCatalogs = false,
   },
   ref,
 ) {
@@ -175,8 +193,11 @@ const AgentToolsEditorContent = forwardRef<
   const assignTool = useAssignTool();
   const unassignTool = useUnassignTool();
 
-  // Fetch catalog items (MCP servers in registry).
-  const { data: catalogItems = [], isPending } = useInternalMcpCatalog();
+  // Fetch catalog items (MCP servers in registry; the gateway dialog also opts
+  // in to assignable App backings via includeAppCatalogs).
+  const { data: catalogItems = [], isPending } = useInternalMcpCatalog({
+    includeApps: includeAppCatalogs,
+  });
 
   // Fetch all credentials grouped by catalog (for default credential on toggle)
   const allCredentials = useMcpServersGroupedByCatalog({
@@ -374,8 +395,11 @@ const AgentToolsEditorContent = forwardRef<
           changes.catalogItem.enterpriseManagedConfig != null;
 
         // Remove and add tools in parallel (skip invalidation, will do it once at the end)
+        // Apps resolve their launch tool in-process per viewer, so they bind
+        // dynamically like Playwright — there is no credential to pick.
         const useDynamicCredential =
           isPlaywrightCatalogItem(changes.catalogItem.id) ||
+          changes.catalogItem.serverType === "app" ||
           changes.credentialSourceId === DYNAMIC_CREDENTIAL_VALUE;
         const useEnterpriseManagedCredential =
           prefersEnterpriseManaged && useDynamicCredential;
@@ -584,7 +608,7 @@ const AgentToolsEditorContent = forwardRef<
       const totalCount = toolCountByCatalog.get(catalog.id) ?? 0;
       const hasNoTools = totalCount === 0;
       const hasNoCredentials =
-        catalog.serverType !== "builtin" &&
+        !isCredentialLessCatalogType(catalog.serverType) &&
         !allCredentials?.[catalog.id]?.length;
       const isEnvIncompatible =
         environmentScopingEnabled && !isEnvCompatible(catalog);
@@ -668,7 +692,7 @@ const AgentToolsEditorContent = forwardRef<
           const totalCount = toolCountByCatalog.get(catalog.id) ?? 0;
           const hasNoTools = totalCount === 0;
           const hasNoCredentials =
-            catalog.serverType !== "builtin" &&
+            !isCredentialLessCatalogType(catalog.serverType) &&
             !allCredentials?.[catalog.id]?.length;
           const isDisabled = hasNoTools || hasNoCredentials;
 
@@ -933,8 +957,12 @@ function McpServerPill({
     return false;
   }, [selectedToolIds, currentAssignedToolIds]);
 
-  // Don't show MCP server if no credentials are available (except for builtin servers)
-  if (catalogItem.serverType !== "builtin" && mcpServers.length === 0) {
+  // Don't show MCP server if no credentials are available (except for builtin
+  // servers and in-process Apps, which need neither an install nor credentials)
+  if (
+    !isCredentialLessCatalogType(catalogItem.serverType) &&
+    mcpServers.length === 0
+  ) {
     return null;
   }
 
@@ -945,10 +973,11 @@ function McpServerPill({
     : assignedCount;
   const isEmpty = displayedCount === 0;
 
-  // Show credential selector for non-builtin, non-Playwright servers that have credentials available
+  // Show credential selector for non-builtin, non-App, non-Playwright servers
+  // that have credentials available
   const isPlaywright = isPlaywrightCatalogItem(catalogItem.id);
   const showCredentialSelector =
-    catalogItem.serverType !== "builtin" &&
+    !isCredentialLessCatalogType(catalogItem.serverType) &&
     !isPlaywright &&
     mcpServers.length > 0;
   return (

--- a/platform/frontend/src/lib/mcp/internal-mcp-catalog.query.ts
+++ b/platform/frontend/src/lib/mcp/internal-mcp-catalog.query.ts
@@ -57,10 +57,24 @@ function catalogMutationError(body: {
   return error;
 }
 
-export function useInternalMcpCatalog(params?: InternalMcpCatalogParams) {
+/**
+ * `includeApps` adds App backing catalogs (whose launch tool is assignable from
+ * the gateway capabilities picker) to the result. Apps stay out of the registry,
+ * so registry surfaces omit it. The backend only honors it for callers with
+ * `app:read`, so a caller without that permission silently gets the app-free list.
+ */
+export function useInternalMcpCatalog(
+  params?: InternalMcpCatalogParams & { includeApps?: boolean },
+) {
+  const includeApps = params?.includeApps ?? false;
   return useQuery({
-    queryKey: ["mcp-catalog"],
-    queryFn: async () => (await getInternalMcpCatalog()).data ?? [],
+    queryKey: includeApps ? ["mcp-catalog", "with-apps"] : ["mcp-catalog"],
+    queryFn: async () =>
+      (
+        await getInternalMcpCatalog(
+          includeApps ? { query: { includeApps } } : {},
+        )
+      ).data ?? [],
     initialData: params?.initialData,
     enabled: params?.enabled,
   });

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -36480,7 +36480,9 @@ export type GetInteractionResponse = GetInteractionResponses[keyof GetInteractio
 export type GetInternalMcpCatalogData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        includeApps?: boolean;
+    };
     url: '/api/internal_mcp_catalog';
 };
 


### PR DESCRIPTION
## Summary

Platform Apps are first-class MCP servers backed by a `serverType: "app"` catalog, but they're deliberately hidden from the MCP registry. The only way an App's launch (`open`) tool reached a gateway was the automatic assignment to its creator's personal gateway — there was no way to attach it to any other gateway, because the catalog list that backs the "Edit MCP Gateway → Capabilities → Custom → Add" picker is the same one the registry uses, and that list filters out app backings.

This splits those two concerns. An App's backing catalog is now selectable in the gateway capabilities picker, so an App can be exposed through any gateway a user manages and rendered by a connected MCP client (e.g. Claude.ai). Apps remain hidden from the MCP registry list and the agent-callable registry search.

Behavior:

- The model gains `findAllWithApps` alongside the unchanged registry `findAll`; `GET /api/internal_mcp_catalog?includeApps=true` selects it, and the param is honored only for callers with `app:read` (the same boundary as the Apps surface) — a caller without it transparently gets the app-free list.
- Only the **MCP gateway** dialog opts in; profile/agent tool editors are unchanged.
- In the picker an App is treated like a built-in server — no install or credential required — and its launch tool binds dynamically, resolving per viewing user at call time.

App tool calls through a gateway stay fenced by environment isolation, exactly as before.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>