### PR TITLE
feat(bench): prefer lane API keys from platform/.env over global env

### DIFF
--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -349,8 +349,9 @@ not the raw per-token SSE chunks), `run.json`,
   retry-able flake). For the cleanest connection path, set `ARCHESTRA_BENCH_DATABASE_URL` to a **native
   host Postgres** (e.g. Postgres.app or `brew install postgresql@18 pgvector`), skipping docker and the
   VM entirely; the same override also points the bench at any Postgres you manage.
-- A real provider key in the environment for each lane you run (e.g. `OPENROUTER_API_KEY`,
-  `KIMI_API_KEY`, `ZAI_API_KEY`; see each lane's `api_key_env` in `lanes.toml`).
+- A real provider key for each lane you run (e.g. `OPENROUTER_API_KEY`, `KIMI_API_KEY`, `ZAI_API_KEY`;
+  see each lane's `api_key_env` in `lanes.toml`), in `platform/.env` or the process environment — a
+  non-empty `platform/.env` value wins over the same variable in the environment.
 - A Rust toolchain to build `archestra-bench`, and local `uv` for the ephemeral verifier environments.
 
 ## Checks

--- a/archestra-bench/runner/src/lifecycle.rs
+++ b/archestra-bench/runner/src/lifecycle.rs
@@ -238,7 +238,7 @@ impl Instance {
         log_path: PathBuf,
     ) -> Self {
         let run_id = run_id.into();
-        let platform = platform_dir.unwrap_or_else(|| repo_root.join("platform"));
+        let platform = resolve_platform_dir(platform_dir.as_deref(), &repo_root);
         let bench_dev = repo_root.join("archestra-bench").join("dev");
         let bench_compose = bench_dev.join("docker-compose.bench-pg.yml");
         let dagger_compose = bench_dev.join("docker-compose.bench-dagger.yml");
@@ -266,14 +266,7 @@ impl Instance {
     }
 
     pub async fn start(&mut self) -> Result<(), LifecycleError> {
-        let env_path = self.platform.join(".env");
-        if !env_path.is_file() {
-            return Err(LifecycleError::Config(format!(
-                "{} not found; create it from platform/.env.example or start the dev stack",
-                env_path.display()
-            )));
-        }
-        self.env = parse_env_file(&env_path)?;
+        self.env = load_platform_env(&self.platform)?;
         let (bench_db_url, managed) = resolve_bench_db_url(&self.env);
         self.db_managed = managed;
         info!(
@@ -544,6 +537,28 @@ fn expand_env_refs(value: &str, lookup: &HashMap<String, String>) -> String {
     .to_string()
 }
 
+/// Resolve the platform directory: an explicit `--platform-dir` (the prod image lays the app out at
+/// `/app`) wins, otherwise `<repo_root>/platform` for the dev tree.
+pub fn resolve_platform_dir(platform_dir: Option<&Path>, repo_root: &Path) -> PathBuf {
+    platform_dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| repo_root.join("platform"))
+}
+
+/// Load `<platform>/.env` into a map, requiring the file to exist. Centralizes the
+/// "missing `.env` is a config error, then parse" step shared by `start`, `preflight`, and the
+/// runner's lane-key resolution so the operator-facing message stays in one place.
+pub fn load_platform_env(platform: &Path) -> Result<HashMap<String, String>, LifecycleError> {
+    let env_path = platform.join(".env");
+    if !env_path.is_file() {
+        return Err(LifecycleError::Config(format!(
+            "{} not found; create it from platform/.env.example or start the dev stack",
+            env_path.display()
+        )));
+    }
+    parse_env_file(&env_path)
+}
+
 pub fn parse_env_file(path: &Path) -> Result<HashMap<String, String>, LifecycleError> {
     let text = std::fs::read_to_string(path)?;
     let mut env: HashMap<String, String> = HashMap::new();
@@ -653,17 +668,8 @@ pub async fn preflight(
     repo_root: &Path,
     platform_dir: Option<&Path>,
 ) -> Result<(), LifecycleError> {
-    let platform = platform_dir
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| repo_root.join("platform"));
-    let env_path = platform.join(".env");
-    if !env_path.is_file() {
-        return Err(LifecycleError::Config(format!(
-            "{} not found; create it from platform/.env.example or start the dev stack",
-            env_path.display()
-        )));
-    }
-    let (_bench_db_url, managed) = resolve_bench_db_url(&parse_env_file(&env_path)?);
+    let platform = resolve_platform_dir(platform_dir, repo_root);
+    let (_bench_db_url, managed) = resolve_bench_db_url(&load_platform_env(&platform)?);
     let bench_dev = repo_root.join("archestra-bench").join("dev");
     if managed {
         ensure_bench_postgres(&bench_dev.join("docker-compose.bench-pg.yml")).await?;
@@ -1277,6 +1283,13 @@ mod tests {
         let env = parse_env_file(&path).unwrap();
         assert_eq!(env.get("FOO"), Some(&"bar".to_string()));
         assert_eq!(env.get("REF"), Some(&"bar/qux".to_string()));
+    }
+
+    #[test]
+    fn test_load_platform_env_missing_is_config_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = load_platform_env(tmp.path()).unwrap_err();
+        assert!(matches!(err, LifecycleError::Config(_)), "got {err:?}");
     }
 
     #[tokio::test]

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -152,7 +152,12 @@ pub async fn run(
     let lane_list =
         load_lanes(lanes_path, lanes_filter).map_err(|e| RunError::Config(e.to_string()))?;
     let workers = resolve_workers(max_workers, lane_list.len());
-    let api_keys = lane_api_keys(&lane_list)?;
+    // Lane keys prefer `platform/.env` over the process env, so the same `.env` that configures the
+    // backend also seeds the bench's own provider clients. The `.env` is already a hard requirement of
+    // every run (preflight below also loads it).
+    let platform = crate::lifecycle::resolve_platform_dir(platform_dir, &repo_root());
+    let platform_env = crate::lifecycle::load_platform_env(&platform)?;
+    let api_keys = lane_api_keys(&lane_list, &platform_env)?;
 
     // Fetch OpenRouter prices once up front. A failure is non-fatal: every run then reports cost n/a.
     let (prices, price_status) = match pricing::fetch_price_book().await {
@@ -247,15 +252,34 @@ fn resolve_workers(requested: Option<usize>, lane_count: usize) -> usize {
     }
 }
 
-fn lane_api_keys(lanes: &[Lane]) -> Result<HashMap<String, String>, RunError> {
+/// Pick a lane key, preferring the `platform/.env` value over the process-env one. An empty or
+/// whitespace-only value counts as unset and falls through — the same empty-as-unset rule
+/// `resolve_bench_db_url` uses, though its precedence is deliberately the opposite (process env wins
+/// for the bench DB URL; `platform/.env` wins for provider keys).
+fn pick_key(platform: Option<&str>, process: Option<&str>) -> Option<String> {
+    [platform, process]
+        .into_iter()
+        .flatten()
+        .find(|v| !v.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn lane_api_keys(
+    lanes: &[Lane],
+    platform_env: &HashMap<String, String>,
+) -> Result<HashMap<String, String>, RunError> {
     let mut keys = HashMap::new();
     for lane in lanes {
-        let key = std::env::var(lane.key_env()).map_err(|_| {
+        let key_env = lane.key_env();
+        let process = std::env::var(&key_env).ok();
+        let key = pick_key(
+            platform_env.get(&key_env).map(String::as_str),
+            process.as_deref(),
+        )
+        .ok_or_else(|| {
             RunError::Config(format!(
-                "set {} to seed lane {:?} ({})",
-                lane.key_env(),
-                lane.name,
-                lane.provider
+                "set {} in platform/.env or the environment to seed lane {:?} ({})",
+                key_env, lane.name, lane.provider
             ))
         })?;
         keys.insert(lane.name.clone(), key);
@@ -2877,6 +2901,62 @@ mod tests {
         assert_eq!(resolve_workers(None, 2), 2);
         assert_eq!(resolve_workers(None, 10), 4);
         assert_eq!(resolve_workers(None, 0), 1);
+    }
+
+    #[test]
+    fn test_pick_key_prefers_platform_over_process() {
+        let cases = [
+            // platform/.env wins when both are set.
+            (Some("env"), Some("proc"), Some("env")),
+            // empty/whitespace platform value is unset and falls back to the process env.
+            (Some(""), Some("proc"), Some("proc")),
+            (Some("  "), Some("proc"), Some("proc")),
+            // missing platform falls back; missing process is fine when platform has a value.
+            (None, Some("proc"), Some("proc")),
+            (Some("env"), None, Some("env")),
+            // neither set (or both empty) yields nothing.
+            (None, None, None),
+            (Some(" "), Some(""), None),
+        ];
+        for (platform, process, expected) in cases {
+            assert_eq!(
+                pick_key(platform, process),
+                expected.map(str::to_string),
+                "platform={platform:?} process={process:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_lane_api_keys_prefers_platform_env() {
+        // A unique var, absent from the test process env and present only in platform_env, proves
+        // `lane_api_keys` consults and uses the parsed `.env`.
+        let mut lane = dummy_lane("l1");
+        lane.api_key_env = Some("ARCHESTRA_BENCH_TEST_LANE_KEY".to_string());
+        let platform_env = HashMap::from([(
+            "ARCHESTRA_BENCH_TEST_LANE_KEY".to_string(),
+            "from-dotenv".to_string(),
+        )]);
+        let keys = lane_api_keys(&[lane], &platform_env).unwrap();
+        assert_eq!(keys.get("l1"), Some(&"from-dotenv".to_string()));
+    }
+
+    #[test]
+    fn test_lane_api_keys_falls_back_to_process_env() {
+        // `PATH` is reliably set in the test process and absent from platform_env, so it exercises
+        // the process-env fallback (the prod-image CI path) without mutating global state.
+        let mut lane = dummy_lane("l1");
+        lane.api_key_env = Some("PATH".to_string());
+        let keys = lane_api_keys(&[lane], &HashMap::new()).unwrap();
+        assert_eq!(keys.get("l1"), std::env::var("PATH").ok().as_ref());
+    }
+
+    #[test]
+    fn test_lane_api_keys_missing_everywhere_is_config_error() {
+        let mut lane = dummy_lane("l1");
+        lane.api_key_env = Some("ARCHESTRA_BENCH_TEST_UNSET_LANE_KEY".to_string());
+        let err = lane_api_keys(&[lane], &HashMap::new()).unwrap_err();
+        assert!(matches!(err, RunError::Config(_)), "got {err:?}");
     }
 
     fn dummy_task(id: &str) -> Task {


### PR DESCRIPTION
## What

The bench resolved each lane's provider API key (`ANTHROPIC_API_KEY`, a lane's custom `api_key_env`, etc.) **only** from the process/global env, even though `platform/.env` was already parsed for the backend env and bench DB URL. This makes lane keys prefer `platform/.env`, falling back to the process env.

## Behavior

- A **non-empty** value in `platform/.env` for a lane's key var wins over the same variable in the process env.
- If the `.env` value is absent or empty/whitespace, fall back to the process env (empty = unset, matching the existing DB-URL / feature-flag convention).
- If neither has a non-empty value, fail with a config error naming the var and that it can be set in `platform/.env` or the environment.

Prod-image bench CI is unaffected: its provider keys arrive via process env and `/app/.env` doesn't contain them, so the fallback covers it.

## Changes

- `lifecycle::resolve_platform_dir` + `lifecycle::load_platform_env` centralize platform-dir resolution and the "missing `.env` → config error, then parse" step (previously duplicated across `Instance::new`, `start`, `preflight`).
- `run.rs`: `pick_key` (pure precedence policy) + `lane_api_keys` now take the parsed `.env` map.
- Note: lane-key precedence (`.env` wins) is deliberately the opposite of the bench DB URL (`resolve_bench_db_url`, process env wins); both keep the empty-as-unset rule.

## Tests

- `pick_key` precedence matrix (pure, no env mutation).
- `lane_api_keys`: platform-env wins, process-env fallback (via `PATH`), and missing-everywhere config error.
- `load_platform_env` missing-`.env` config error.

`cargo build` / `cargo test --workspace` / `cargo clippy --all-targets -- -D warnings` all pass.

https://claude.ai/code/session_01RTkkBSKaAaWKNSUCLXku65

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>