### PR TITLE
feat(apps): friendly "Open <app>" title for app launch tools in the gateway

### DIFF
--- a/platform/backend/src/routes/mcp-gateway.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.test.ts
@@ -210,6 +210,85 @@ describe("MCP Gateway (stateless mode)", () => {
     }
   });
 
+  test("derives a human 'Open <app>' title for an app launch tool, leaving its slug name and other tools' titles untouched", async ({
+    makeAgent,
+    makeOrganization,
+    makeInternalMcpCatalog,
+    makeTool,
+    makeAgentTool,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      toolExposureMode: "full",
+      accessAllTools: false,
+    });
+
+    // An app backing (serverType "app") whose catalog name is the human app name.
+    const appCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "Bug Tracker",
+      serverType: "app",
+      scope: "org",
+    });
+    // The launch tool keeps its unique, id-suffixed slug name and stores no title.
+    const launchTool = await makeTool({
+      catalogId: appCatalog.id,
+      name: "bug_tracker-1a2b3c4d__open",
+      description: 'Open the "Bug Tracker" app and render its UI.',
+      meta: { _meta: { ui: { resourceUri: "ui://archestra/app/1a2b3c4d" } } },
+    });
+    await makeAgentTool(agent.id, launchTool.id, {
+      credentialResolutionMode: "dynamic",
+    });
+
+    // A regular (non-app) tool to prove the derivation is app-only.
+    const remoteCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "Linear",
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+      scope: "org",
+    });
+    const remoteTool = await makeTool({
+      catalogId: remoteCatalog.id,
+      name: "linear_search_issues",
+    });
+    await makeAgentTool(agent.id, remoteTool.id, {
+      credentialResolutionMode: "dynamic",
+    });
+
+    const token = await TeamTokenModel.create({
+      organizationId: org.id,
+      name: "Org Token",
+      teamId: null,
+      isOrganizationToken: true,
+    });
+
+    await initializeMcpSession({ app, agentId: agent.id, token: token.value });
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(token.value),
+      payload: { jsonrpc: "2.0", method: "tools/list", params: {}, id: 2 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const tools: Array<{ name: string; title?: string }> =
+      response.json().result.tools;
+
+    const launch = tools.find((t) => t.name === "bug_tracker-1a2b3c4d__open");
+    expect(launch).toBeDefined();
+    // Slug name is preserved for invocation; only the display title is friendly.
+    expect(launch?.title).toBe("Open Bug Tracker");
+
+    const remote = tools.find((t) => t.name === "linear_search_issues");
+    expect(remote).toBeDefined();
+    // A non-app tool's title still falls back to its name — derivation is app-only.
+    expect(remote?.title).toBe("linear_search_issues");
+  });
+
   test("returns 401 with WWW-Authenticate header for missing authorization header", async ({
     makeAgent,
   }) => {

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -221,17 +221,42 @@ export async function createAgentServer(
       tools: candidateTools.filter((t) => permittedNames.has(t.name)),
     });
 
+    // Resolve the backing catalogs of the assigned tools once: their names feed
+    // both the search_tools description and the app launch-tool titles below.
+    const catalogsById = await InternalMcpCatalogModel.getByIds([
+      ...new Set(
+        mcpTools
+          .map((tool) => tool.catalogId)
+          .filter(
+            (id): id is string =>
+              Boolean(id) && id !== ARCHESTRA_MCP_CATALOG_ID,
+          ),
+      ),
+    ]);
+
+    // An app's launch tool keeps its unique slug `name` for invocation, but a
+    // gateway client should show a human label. Derive "Open <app>" from the
+    // backing catalog name (kept in lockstep with the app) so it never goes
+    // stale; non-app tools keep their existing title.
+    const appLaunchTitle = (
+      catalogId: string | null | undefined,
+    ): string | undefined => {
+      const catalog = catalogId ? catalogsById.get(catalogId) : undefined;
+      return catalog?.serverType === "app" ? `Open ${catalog.name}` : undefined;
+    };
+
     // Dynamically enrich the knowledge sources tool description with
     // the agent's actual knowledge base names and connector types
     const [kbToolDescription, searchToolsDescription] = await Promise.all([
       buildKnowledgeSourcesDescription(agentId),
-      buildSearchToolsDescription(mcpTools),
+      buildSearchToolsDescription(mcpTools, catalogsById),
     ]);
 
     const toolsList: McpListTool[] = permittedTools.map(
-      ({ name, description, parameters, meta }) => ({
+      ({ name, description, parameters, meta, catalogId }) => ({
         name,
-        title: archestraToolTitles.get(name) || name,
+        title:
+          archestraToolTitles.get(name) || appLaunchTitle(catalogId) || name,
         description:
           name ===
             archestraMcpBranding.getToolName(
@@ -1650,6 +1675,9 @@ function dedupeToolsByName<T extends { name: string }>(tools: T[]) {
 
 async function buildSearchToolsDescription(
   mcpTools: McpToolForSearchDescription[],
+  prefetchedCatalogs?: Awaited<
+    ReturnType<typeof InternalMcpCatalogModel.getByIds>
+  >,
 ) {
   const searchTool = getArchestraMcpTools().find(
     (tool) =>
@@ -1676,7 +1704,8 @@ async function buildSearchToolsDescription(
     return baseDescription;
   }
 
-  const catalogs = await InternalMcpCatalogModel.getByIds(catalogIds);
+  const catalogs =
+    prefetchedCatalogs ?? (await InternalMcpCatalogModel.getByIds(catalogIds));
   const catalogSummaries = catalogIds
     .map((catalogId) => catalogs.get(catalogId))
     .filter((catalog) => catalog !== undefined)


### PR DESCRIPTION
## Summary

A platform App's launch tool carries an id-suffixed slug as its MCP `name` (e.g. `bug_tracker-1a2b3c4d__open`) — deliberately unique so two apps' launch tools never collide on one gateway. But the gateway's `tools/list` set each tool's display `title` to that same slug, so an MCP client connected to the gateway (Claude Desktop, MCPJam, etc.) showed users the raw `bug_tracker-1a2b3c4d__open` in its tool list and permission prompts.

This derives a human title — **`Open <app name>`** — for app launch tools in the gateway `tools/list` response. The slug stays the `name` (the model still invokes by it, uniqueness preserved); only the human-facing `title` becomes friendly. The title is computed live from the backing catalog's name, which is kept in lockstep with the app, so it stays correct after an app rename rather than freezing a copy. Non-app tools are unaffected — their title still falls back to the tool name.

Follows up #5868, which made app backings assignable to gateways in the first place.

The catalog lookup reuses the fetch the gateway already performs to build the `search_tools` description, so this adds no query to the `tools/list` path.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>