### PR TITLE
feat(apps): edit apps model context from the chat

### DIFF
--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -53,14 +53,27 @@ vi.mock("@/lib/config/config.query", () => ({
   useFeature: () => null,
 }));
 
+// Avoid pulling the real auth client / app query (and their network deps) into
+// the test; the edit pencil is covered by app-frame.test.tsx.
+vi.mock("@/lib/auth/auth.query", () => ({
+  useHasPermissions: () => ({ data: false }),
+}));
+
+vi.mock("@/lib/app.query", () => ({
+  useApp: vi.fn(() => ({ data: undefined })),
+}));
+
 // ── Import component under test after mocks ───────────────────────────────────
 
+import { useApp } from "@/lib/app.query";
 import {
   clearAllAppDiagnostics,
   reportAppDiagnostic,
 } from "@/lib/chat/app-diagnostics-store";
 import { AppsProvider, useApps } from "./apps-context";
 import { McpAppSection } from "./mcp-app-container";
+
+const mockUseApp = vi.mocked(useApp);
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -183,6 +196,28 @@ describe("McpAppSection", () => {
     });
 
     expect(document.querySelector("iframe")).toBeInTheDocument();
+  });
+
+  it("titles an owned app from the live query, not the captured appName prop", async () => {
+    // After an edit invalidates the app query, the address bar must reflect the
+    // new name even though the appName prop was captured at render time.
+    mockUseApp.mockReturnValue({
+      data: { name: "Renamed Dashboard" },
+    } as ReturnType<typeof useApp>);
+
+    await act(async () => {
+      render(
+        <McpAppSection
+          {...defaultProps}
+          appId="11111111-1111-1111-1111-111111111111"
+          appName="Stale Dashboard"
+          preloadedResource={preloadedResource}
+        />,
+      );
+    });
+
+    expect(screen.getByText("Renamed Dashboard")).toBeInTheDocument();
+    expect(screen.queryByText("Stale Dashboard")).not.toBeInTheDocument();
   });
 });
 

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -15,6 +15,7 @@ import {
   humanizeToolLabel,
   isSupersededRender,
 } from "@/components/chat/chat-messages.utils";
+import { AppEditModelContextDialog } from "@/components/mcp-app/app-edit-model-context-dialog.lazy";
 import {
   clampInlineHeight,
   INITIAL_INLINE_HEIGHT,
@@ -24,6 +25,7 @@ import { McpAppCard } from "@/components/mcp-app/mcp-app-card";
 import {
   McpAppAddressPill,
   McpAppChangelogPill,
+  McpAppEditButton,
   McpAppFullscreenExitButton,
   McpAppPanelButton,
   McpAppRefreshButton,
@@ -39,6 +41,8 @@ import {
   type McpCallToolResult,
 } from "@/components/mcp-app/mcp-app-view";
 import { useAppRuntimeControls } from "@/components/mcp-app/use-app-runtime-controls";
+import { useApp } from "@/lib/app.query";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import {
   getAppDiagnosticCounts,
   subscribeAppDiagnostics,
@@ -155,7 +159,14 @@ export function McpAppSection({
   const { apps, selectedToolCallId, select, showInPanel, portalTarget } =
     useApps();
 
-  const headerName = appName || humanizeToolLabel(toolName);
+  // Owned apps can be renamed/re-described from the address bar. Read the live
+  // app so the title stays in sync after an edit (the appName prop is captured
+  // at render time) and to seed the edit dialog.
+  const { data: canEdit } = useHasPermissions({ app: ["update"] });
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const { data: ownedApp } = useApp(appId ?? null);
+
+  const headerName = ownedApp?.name || appName || humanizeToolLabel(toolName);
   const isSelected = !!toolCallId && selectedToolCallId === toolCallId;
   const panelHostingActive = portalTarget !== null;
   // Only the *selected* app moves to the panel: its iframe is portaled into
@@ -250,12 +261,15 @@ export function McpAppSection({
       </div>
     ) : null;
 
-  const pillActions = (
-    <>
-      <McpAppRefreshButton onClick={reload} />
-      {appId && <McpAppStandaloneButton appId={appId} />}
-    </>
-  );
+  let pillActions: React.ReactNode = null;
+  if (appId) {
+    pillActions = <McpAppStandaloneButton appId={appId} />;
+  }
+
+  let editPencil: React.ReactNode = null;
+  if (appId && canEdit) {
+    editPencil = <McpAppEditButton onClick={() => setEditDialogOpen(true)} />;
+  }
 
   const liveSurface = (
     <McpAppErrorBoundary>
@@ -267,10 +281,8 @@ export function McpAppSection({
         inlineCeiling={inlineCeiling}
         fillContainer={renderInPanel}
         topBar={
-          // Pill carries refresh + open-standalone (owned apps). The right zone
-          // holds open-in-panel, prefixed by a minimize button while the
-          // app-requested fullscreen is active.
           <McpAppTopBar
+            left={<McpAppRefreshButton onClick={reload} />}
             right={
               <>
                 {displayMode === "fullscreen" && (
@@ -290,10 +302,15 @@ export function McpAppSection({
                   label: app.label,
                 }))}
                 onChange={select}
+                leading={editPencil}
                 actions={pillActions}
               />
             ) : (
-              <McpAppAddressPill label={headerName} actions={pillActions} />
+              <McpAppAddressPill
+                label={headerName}
+                leading={editPencil}
+                actions={pillActions}
+              />
             )}
           </McpAppTopBar>
         }
@@ -341,28 +358,39 @@ export function McpAppSection({
     </McpAppErrorBoundary>
   );
 
-  if (renderInPanel) {
-    return (
-      <>
-        <McpAppCard
-          displayMode="inline"
-          onToggleFullscreen={toggleFullscreen}
-          size={size}
-          inlineCeiling={inlineCeiling}
-          frozenHeight={lastInlineHeightRef.current}
-          topBar={
-            <McpAppTopBar>
-              <McpAppAddressPill label={headerName} />
-            </McpAppTopBar>
-          }
-          placeholder={
-            <span className="text-muted-foreground">Showing in panel</span>
-          }
-        />
-        {portalTarget && createPortal(liveSurface, portalTarget)}
-      </>
-    );
-  }
+  const surface = renderInPanel ? (
+    <>
+      <McpAppCard
+        displayMode="inline"
+        onToggleFullscreen={toggleFullscreen}
+        size={size}
+        inlineCeiling={inlineCeiling}
+        frozenHeight={lastInlineHeightRef.current}
+        topBar={
+          <McpAppTopBar>
+            <McpAppAddressPill label={headerName} />
+          </McpAppTopBar>
+        }
+        placeholder={
+          <span className="text-muted-foreground">Showing in panel</span>
+        }
+      />
+      {portalTarget && createPortal(liveSurface, portalTarget)}
+    </>
+  ) : (
+    liveSurface
+  );
 
-  return liveSurface;
+  return (
+    <>
+      {surface}
+      {editDialogOpen && ownedApp && (
+        <AppEditModelContextDialog
+          app={ownedApp}
+          open
+          onOpenChange={setEditDialogOpen}
+        />
+      )}
+    </>
+  );
 }

--- a/platform/frontend/src/components/mcp-app/app-edit-model-context-dialog.lazy.tsx
+++ b/platform/frontend/src/components/mcp-app/app-edit-model-context-dialog.lazy.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Lazy boundary shared by the app frame and the chat app container so the
+// dialog's react-hook-form + dialog deps stay out of their initial bundles —
+// the chunk is fetched on first pencil click. Importing this module is cheap;
+// it does not statically pull in the dialog implementation.
+export const AppEditModelContextDialog = dynamic(
+  async () =>
+    (await import("@/components/mcp-app/app-edit-model-context-dialog"))
+      .AppEditModelContextDialog,
+  { ssr: false },
+);

--- a/platform/frontend/src/components/mcp-app/app-edit-model-context-dialog.tsx
+++ b/platform/frontend/src/components/mcp-app/app-edit-model-context-dialog.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { archestraApiTypes } from "@archestra/shared";
+import { useForm } from "react-hook-form";
+import { StandardFormDialog } from "@/components/standard-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useUpdateApp } from "@/lib/app.query";
+
+type App = archestraApiTypes.GetAppResponses["200"];
+
+type EditFormValues = {
+  name: string;
+  description: string;
+};
+
+// Name + description are the app's model-facing metadata (what the LLM reads).
+// This is the trimmed variant of AppEditConfigDialog without the environment
+// selector — used from the app frame's address-bar pencil.
+export function AppEditModelContextDialog({
+  app,
+  open,
+  onOpenChange,
+}: {
+  app: App;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const updateApp = useUpdateApp();
+  const form = useForm<EditFormValues>({
+    defaultValues: { name: app.name, description: app.description ?? "" },
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const result = await updateApp.mutateAsync({
+      appId: app.id,
+      body: {
+        name: values.name.trim(),
+        description: values.description.trim() || null,
+      },
+    });
+    if (result) onOpenChange(false);
+  });
+
+  return (
+    <StandardFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit model context"
+      description="What the model reads to decide whether this app is relevant and when to open it."
+      size="medium"
+      onSubmit={onSubmit}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={updateApp.isPending}>
+            {updateApp.isPending ? "Saving…" : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="edit-app-name">Name</Label>
+          <Input
+            id="edit-app-name"
+            {...form.register("name", { required: true, maxLength: 100 })}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="edit-app-description">Description</Label>
+          <Textarea
+            id="edit-app-description"
+            {...form.register("description", { maxLength: 500 })}
+          />
+        </div>
+      </div>
+    </StandardFormDialog>
+  );
+}

--- a/platform/frontend/src/components/mcp-app/app-frame.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-frame.test.tsx
@@ -1,11 +1,17 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/link", () => ({
   default: ({ children, ...props }: { children: ReactNode }) => (
     <a {...props}>{children}</a>
   ),
+}));
+
+// Stub the lazily-loaded edit dialog so the test asserts the open/close
+// contract without crossing the next/dynamic async boundary.
+vi.mock("next/dynamic", () => ({
+  default: () => () => <div data-testid="edit-dialog" />,
 }));
 
 // Stub the runtime (sandboxed iframe + bridge) so the frame is tested in
@@ -16,14 +22,27 @@ vi.mock("@/components/mcp-app/mcp-app-view", () => ({
 }));
 
 vi.mock("@/lib/app.query", () => ({ useApp: vi.fn() }));
+vi.mock("@/lib/auth/auth.query", () => ({ useHasPermissions: vi.fn() }));
 
 import { useApp } from "@/lib/app.query";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { AppFrame } from "./app-frame";
 import { McpAppStandaloneButton } from "./mcp-app-chrome";
 
 const mockUseApp = vi.mocked(useApp);
+const mockUseHasPermissions = vi.mocked(useHasPermissions);
+
+function setCanEdit(canEdit: boolean) {
+  mockUseHasPermissions.mockReturnValue({ data: canEdit } as ReturnType<
+    typeof useHasPermissions
+  >);
+}
 
 describe("AppFrame", () => {
+  beforeEach(() => {
+    setCanEdit(false);
+  });
+
   it("renders a bare runtime with no card chrome for external servers", () => {
     mockUseApp.mockReturnValue({ data: undefined } as ReturnType<
       typeof useApp
@@ -84,5 +103,54 @@ describe("AppFrame", () => {
     render(<AppFrame endpoint={{ kind: "app", appId: "app-1" }} />);
 
     expect(screen.queryByTestId("runtime")).not.toBeInTheDocument();
+  });
+
+  it("shows an edit pencil that opens the dialog when the user may edit the app", () => {
+    setCanEdit(true);
+    mockUseApp.mockReturnValue({
+      data: { name: "Dashboard", latestVersion: 3 },
+    } as ReturnType<typeof useApp>);
+
+    render(<AppFrame endpoint={{ kind: "app", appId: "app-1" }} />);
+
+    const editButton = screen.getByRole("button", { name: /edit app/i });
+    expect(editButton).toBeInTheDocument();
+    // Dialog is only rendered once opened.
+    expect(screen.queryByTestId("edit-dialog")).not.toBeInTheDocument();
+
+    fireEvent.click(editButton);
+    expect(screen.getByTestId("edit-dialog")).toBeInTheDocument();
+  });
+
+  it("hides the edit pencil when the user lacks app update permission", () => {
+    setCanEdit(false);
+    mockUseApp.mockReturnValue({
+      data: { name: "Dashboard", latestVersion: 3 },
+    } as ReturnType<typeof useApp>);
+
+    render(<AppFrame endpoint={{ kind: "app", appId: "app-1" }} />);
+
+    expect(
+      screen.queryByRole("button", { name: /edit app/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("never shows the edit pencil for external servers", () => {
+    setCanEdit(true);
+    mockUseApp.mockReturnValue({ data: undefined } as ReturnType<
+      typeof useApp
+    >);
+
+    render(
+      <AppFrame
+        endpoint={{ kind: "server", mcpServerId: "server-1" }}
+        resourceUri="ui://external/app"
+        chrome={false}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /edit app/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/mcp-app/app-frame.tsx
+++ b/platform/frontend/src/components/mcp-app/app-frame.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { getArchestraAppResourceUri } from "@archestra/shared";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
+import { AppEditModelContextDialog } from "@/components/mcp-app/app-edit-model-context-dialog.lazy";
 import { useInlineCeiling } from "@/components/mcp-app/app-height";
 import { McpAppCard } from "@/components/mcp-app/mcp-app-card";
 import {
   McpAppAddressPill,
+  McpAppEditButton,
   McpAppFullscreenExitButton,
   McpAppRefreshButton,
   McpAppTopBar,
@@ -14,6 +16,7 @@ import {
 import { McpAppRuntime } from "@/components/mcp-app/mcp-app-view";
 import { useAppRuntimeControls } from "@/components/mcp-app/use-app-runtime-controls";
 import { useApp } from "@/lib/app.query";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { cn } from "@/lib/utils";
 
 /** Stable no-op size reporter: page surfaces fill their own layout. */
@@ -72,9 +75,16 @@ export function AppFrame({
 
   const appId = endpoint.kind === "app" ? endpoint.appId : null;
   const { data: app } = useApp(appId);
+  const { data: canEdit } = useHasPermissions({ app: ["update"] });
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
   const resolvedResourceUri = appId
     ? getArchestraAppResourceUri(appId)
     : resourceUri;
+
+  let editPencil: ReactNode = null;
+  if (appId && canEdit) {
+    editPencil = <McpAppEditButton onClick={() => setEditDialogOpen(true)} />;
+  }
 
   const runtime = resolvedResourceUri ? (
     <McpAppRuntime
@@ -119,6 +129,7 @@ export function AppFrame({
           fillContainer={fillContainer}
           topBar={
             <McpAppTopBar
+              left={<McpAppRefreshButton onClick={reload} />}
               right={
                 displayMode === "fullscreen" ? (
                   <McpAppFullscreenExitButton onClick={toggleFullscreen} />
@@ -127,12 +138,8 @@ export function AppFrame({
             >
               <McpAppAddressPill
                 label={label ?? app.name}
-                actions={
-                  <>
-                    <McpAppRefreshButton onClick={reload} />
-                    {actions}
-                  </>
-                }
+                leading={editPencil}
+                actions={actions}
               />
             </McpAppTopBar>
           }
@@ -144,6 +151,13 @@ export function AppFrame({
         >
           {runtime}
         </McpAppCard>
+      )}
+      {editDialogOpen && app && (
+        <AppEditModelContextDialog
+          app={app}
+          open
+          onOpenChange={setEditDialogOpen}
+        />
       )}
       {resourceState === "empty" && EMPTY_MESSAGE}
     </div>

--- a/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
@@ -5,6 +5,7 @@ import {
   type LucideIcon,
   Minimize2,
   PanelRight,
+  Pencil,
   RefreshCw,
   SquareArrowOutUpRight,
 } from "lucide-react";
@@ -61,13 +62,20 @@ function PillActions({ children }: { children?: React.ReactNode }) {
 /** Static address pill: the app name with optional inline action buttons. */
 export function McpAppAddressPill({
   label,
+  leading,
   actions,
 }: {
   label?: React.ReactNode;
+  leading?: React.ReactNode;
   actions?: React.ReactNode;
 }) {
   return (
     <div className={PILL_CLASS}>
+      {leading ? (
+        <div className="relative z-10 flex shrink-0 items-center">
+          {leading}
+        </div>
+      ) : null}
       <span className="pointer-events-none min-w-0 flex-1 truncate px-1 text-xs text-muted-foreground">
         {label}
       </span>
@@ -86,11 +94,13 @@ export function McpAppSwitcher({
   value,
   options,
   onChange,
+  leading,
   actions,
 }: {
   value: string | null;
   options: { value: string; label: string }[];
   onChange: (value: string) => void;
+  leading?: React.ReactNode;
   actions?: React.ReactNode;
 }) {
   const selectedLabel = options.find((o) => o.value === value)?.label;
@@ -98,7 +108,7 @@ export function McpAppSwitcher({
     <Select value={value ?? undefined} onValueChange={onChange}>
       <div className={cn(PILL_CLASS, "relative cursor-pointer")}>
         {/* Transparent trigger fills the pill so clicking the name/icon
-            (pointer-events-none) opens the dropdown; the action buttons
+            (pointer-events-none) opens the dropdown; the leading/action buttons
             above it (z-10) keep their own clicks. */}
         <SelectPrimitive.Trigger
           aria-label="Switch app"
@@ -108,6 +118,11 @@ export function McpAppSwitcher({
             <SelectPrimitive.Value />
           </span>
         </SelectPrimitive.Trigger>
+        {leading ? (
+          <div className="relative z-10 flex shrink-0 items-center">
+            {leading}
+          </div>
+        ) : null}
         <span className="pointer-events-none min-w-0 flex-1 truncate px-1 text-xs text-muted-foreground">
           {selectedLabel}
         </span>
@@ -167,6 +182,10 @@ export function McpAppRefreshButton({ onClick }: { onClick: () => void }) {
   return (
     <McpAppIconButton icon={RefreshCw} label="Reload app" onClick={onClick} />
   );
+}
+
+export function McpAppEditButton({ onClick }: { onClick: () => void }) {
+  return <McpAppIconButton icon={Pencil} label="Edit app" onClick={onClick} />;
 }
 
 export function McpAppFullscreenExitButton({


### PR DESCRIPTION
## Summary
Adds a pencil icon before the app name in the MCP App frame's address bar. Clicking it opens an "Edit model context" dialog to change the app's name and description (the metadata the model reads to decide relevance). Shown wherever the frame renders — app detail, standalone run page, and chat — gated on owned apps + `app:update` permission.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>