### PR TITLE
fix(bench): count all agentic steps and cache-write tokens in cost

### DIFF
--- a/archestra-bench/runner/src/chat_stream.rs
+++ b/archestra-bench/runner/src/chat_stream.rs
@@ -9,6 +9,8 @@ use futures::Stream;
 use reqwest::Response;
 use serde_json::Value as JsonValue;
 
+use crate::interactions::RunUsage;
+
 #[derive(Debug, Clone, Default)]
 pub struct ChatRunResult {
     pub text: String,
@@ -16,16 +18,13 @@ pub struct ChatRunResult {
     pub tool_invocations: Vec<HashMap<String, JsonValue>>,
     pub turn_count: usize,
     pub finish_reason: Option<String>,
-    pub total_tokens: Option<i64>,
-    pub prompt_tokens: Option<i64>,
-    pub completion_tokens: Option<i64>,
-    /// Prompt tokens served from the provider's cache, billed cheaper. Disjoint from `prompt_tokens`
-    /// (the backend reports `prompt_tokens`/`inputTokens` already net of cache).
-    pub cache_read_tokens: Option<i64>,
-    pub stage_tokens: Option<i64>,
-    pub stage_prompt_tokens: Option<i64>,
-    pub stage_completion_tokens: Option<i64>,
-    pub stage_cache_read_tokens: Option<i64>,
+    /// Billable token usage, summed post-run from the persisted LLM-proxy interaction rows (one per
+    /// agentic step). Sourced from the rows rather than the chat SSE `data-token-usage` event, whose
+    /// final value reports only the last step of a multi-step turn.
+    pub usage: RunUsage,
+    /// Set when fetching a conversation's interaction rows failed, so a turn-taking rollout's usage is
+    /// incomplete and must be reported as unpriceable rather than silently under-summed.
+    pub usage_fetch_failed: bool,
     pub stream_error: Option<String>,
 }
 
@@ -73,21 +72,6 @@ pub fn apply_chat_event(result: &mut ChatRunResult, event: &HashMap<String, Json
         Some("finish") | Some("finish-step") => {
             if let Some(reason) = event.get("finishReason").and_then(|v| v.as_str()) {
                 result.finish_reason = Some(reason.to_string());
-            }
-        }
-        Some("data-token-usage") => {
-            // Co-read the whole split from the one event that also carries totalTokens. The backend
-            // emits this per agentic step plus once at stage end with the cumulative `result.usage`;
-            // overwrite-last keeps the final cumulative figures, and reading all fields together keeps
-            // the split consistent with the total the rest of the harness already trusts.
-            if let Some(data) = event.get("data").and_then(|v| v.as_object()) {
-                let field = |key: &str| data.get(key).and_then(|v| v.as_i64());
-                if let Some(total) = field("totalTokens") {
-                    result.stage_tokens = Some(total);
-                    result.stage_prompt_tokens = field("inputTokens");
-                    result.stage_completion_tokens = field("outputTokens");
-                    result.stage_cache_read_tokens = field("cacheReadTokens");
-                }
             }
         }
         Some("error") => {
@@ -259,51 +243,6 @@ mod tests {
         assert_eq!(sse_data_payload("data: hello"), Some("hello"));
         assert_eq!(sse_data_payload("data:  [DONE]"), Some("[DONE]"));
         assert_eq!(sse_data_payload("event: message"), None);
-    }
-
-    fn token_usage_event(
-        input: i64,
-        output: i64,
-        total: i64,
-        cache_read: i64,
-    ) -> HashMap<String, JsonValue> {
-        let event = serde_json::json!({
-            "type": "data-token-usage",
-            "data": {
-                "inputTokens": input,
-                "outputTokens": output,
-                "totalTokens": total,
-                "cacheReadTokens": cache_read,
-            }
-        });
-        serde_json::from_value(event).unwrap()
-    }
-
-    #[test]
-    fn token_usage_co_reads_split_and_overwrites_with_last() {
-        let mut run = ChatRunResult::default();
-        // Per-step event, then the larger stage-final cumulative event: overwrite-last wins, and the
-        // split is co-read from the same event so it stays consistent with the total.
-        apply_chat_event(&mut run, &token_usage_event(100, 10, 110, 0));
-        apply_chat_event(&mut run, &token_usage_event(300, 40, 340, 90));
-        assert_eq!(run.stage_tokens, Some(340));
-        assert_eq!(run.stage_prompt_tokens, Some(300));
-        assert_eq!(run.stage_completion_tokens, Some(40));
-        assert_eq!(run.stage_cache_read_tokens, Some(90));
-    }
-
-    #[test]
-    fn token_usage_without_split_keeps_total_only() {
-        let mut run = ChatRunResult::default();
-        let event: HashMap<String, JsonValue> = serde_json::from_value(serde_json::json!({
-            "type": "data-token-usage",
-            "data": { "totalTokens": 50 }
-        }))
-        .unwrap();
-        apply_chat_event(&mut run, &event);
-        assert_eq!(run.stage_tokens, Some(50));
-        assert_eq!(run.stage_prompt_tokens, None);
-        assert_eq!(run.stage_completion_tokens, None);
     }
 
     fn stream_from_chunks(chunks: Vec<Vec<u8>>) -> ChatRecordStream {

--- a/archestra-bench/runner/src/chat_stream.rs
+++ b/archestra-bench/runner/src/chat_stream.rs
@@ -28,6 +28,19 @@ pub struct ChatRunResult {
     pub stream_error: Option<String>,
 }
 
+impl ChatRunResult {
+    /// Usage trustworthy enough to publish as token totals: spend occurred, every conversation's rows
+    /// were fetched, and no chat row had a telemetry gap. Incomplete usage is reported as no
+    /// measurement (`None`) rather than a partial count masquerading as a complete one — the same
+    /// "loud, never silent" discipline the cost classification follows.
+    pub fn reliable_usage(&self) -> Option<&RunUsage> {
+        (self.usage.had_spend()
+            && !self.usage_fetch_failed
+            && self.usage.rows_with_null_tokens == 0)
+            .then_some(&self.usage)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ChatStreamRecord {
     pub kind: ChatRecordKind,

--- a/archestra-bench/runner/src/interactions.rs
+++ b/archestra-bench/runner/src/interactions.rs
@@ -145,8 +145,10 @@ pub fn sum_usage(interactions: &[Value]) -> RunUsage {
                 usage.prompt_tokens += input.max(0);
                 usage.completion_tokens += output.max(0);
                 usage.cache_read_tokens += token("cacheReadTokens").unwrap_or(0).max(0);
-                usage.cache_write_tokens += token("cacheWriteTokens").unwrap_or(0).max(0)
-                    + token("cacheWrite1hTokens").unwrap_or(0).max(0);
+                // `cacheWriteTokens` is the full cache-creation count; `cacheWrite1hTokens` is the
+                // 1h-TTL *subset* of it (the platform's premium-pricing breakdown), so it must not be
+                // added on top or the 1h portion is double-counted.
+                usage.cache_write_tokens += token("cacheWriteTokens").unwrap_or(0).max(0);
             }
             _ => usage.rows_with_null_tokens += 1,
         }
@@ -553,7 +555,7 @@ mod tests {
     }
 
     #[test]
-    fn sum_usage_sums_every_step_and_both_cache_write_tiers() {
+    fn sum_usage_sums_every_step_and_counts_cache_writes_once() {
         let rows = vec![
             usage_row("claude", 100, 10, 5, 200),
             json!({
@@ -567,9 +569,10 @@ mod tests {
         assert_eq!(u.prompt_tokens, 400);
         assert_eq!(u.completion_tokens, 50);
         assert_eq!(u.cache_read_tokens, 95);
-        // 200 + (50 + 25): the 1h tier folds into cache_write.
-        assert_eq!(u.cache_write_tokens, 275);
-        assert_eq!(u.total_tokens(), 400 + 50 + 95 + 275);
+        // 200 + 50: `cacheWriteTokens` is already the full cache-creation count; the 1h field (25) is
+        // a subset of the second row's 50 and must not be added again.
+        assert_eq!(u.cache_write_tokens, 250);
+        assert_eq!(u.total_tokens(), 400 + 50 + 95 + 250);
         assert_eq!(u.rows_with_null_tokens, 0);
         assert_eq!(u.models.len(), 1);
         assert!(u.had_spend());

--- a/archestra-bench/runner/src/interactions.rs
+++ b/archestra-bench/runner/src/interactions.rs
@@ -6,6 +6,8 @@
 //! bench conversation, so the normal result is exactly one [`EffectivePromptData`]; any variation, an
 //! unhandled provider shape, or a missing system prompt is reported in `errors`.
 
+use std::collections::BTreeSet;
+
 use archestra_bench_core::{EffectivePromptData, SamplingParams};
 use serde_json::Value;
 
@@ -72,6 +74,84 @@ pub fn extract_effective_prompts(interactions: &[Value]) -> ExtractionOutcome {
     }
 
     ExtractionOutcome { prompts, errors }
+}
+
+/// Billable token usage summed across a session's chat interaction rows. Each LLM-proxy row is one
+/// agentic step, so summing the rows recovers the full spend of a multi-step turn — unlike the chat
+/// SSE `data-token-usage` event, whose final value is only the *last* step. The four token categories
+/// are the platform's disjoint counts (`inputTokens` is already net of cache reads and cache writes).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunUsage {
+    pub prompt_tokens: i64,
+    pub completion_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_write_tokens: i64,
+    /// Non-embedding interaction rows seen — each is a billed LLM step. Zero means no recorded spend.
+    pub chat_rows: usize,
+    /// Chat rows missing the core `inputTokens`/`outputTokens` fields: a telemetry gap the caller
+    /// treats as unpriceable rather than a measured zero.
+    pub rows_with_null_tokens: usize,
+    /// Distinct `model` values across the chat rows; more than one means the session mixed models
+    /// (e.g. cost-optimization or dual-LLM), which a single lane slug cannot price.
+    pub models: BTreeSet<String>,
+}
+
+impl RunUsage {
+    pub fn add(&mut self, other: &RunUsage) {
+        self.prompt_tokens += other.prompt_tokens;
+        self.completion_tokens += other.completion_tokens;
+        self.cache_read_tokens += other.cache_read_tokens;
+        self.cache_write_tokens += other.cache_write_tokens;
+        self.chat_rows += other.chat_rows;
+        self.rows_with_null_tokens += other.rows_with_null_tokens;
+        self.models.extend(other.models.iter().cloned());
+    }
+
+    /// True when at least one billed LLM step was recorded. Distinguishes a real $0 (no call) from
+    /// measured usage.
+    pub fn had_spend(&self) -> bool {
+        self.chat_rows > 0
+    }
+
+    pub fn total_tokens(&self) -> i64 {
+        self.prompt_tokens
+            + self.completion_tokens
+            + self.cache_read_tokens
+            + self.cache_write_tokens
+    }
+}
+
+/// Sum billable usage across a session's interaction rows. Embedding rows carry no chat generation and
+/// are skipped (matching `extract_effective_prompts`); every other row is a billed step. Negative
+/// counts clamp to zero. A chat row missing `inputTokens`/`outputTokens` is recorded as a telemetry
+/// gap (`rows_with_null_tokens`) rather than summed as zero.
+pub fn sum_usage(interactions: &[Value]) -> RunUsage {
+    let mut usage = RunUsage::default();
+    for interaction in interactions {
+        let type_tag = interaction
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if type_tag.ends_with(":embeddings") {
+            continue;
+        }
+        usage.chat_rows += 1;
+        if let Some(model) = interaction.get("model").and_then(Value::as_str) {
+            usage.models.insert(model.to_string());
+        }
+        let token = |key: &str| interaction.get(key).and_then(Value::as_i64);
+        match (token("inputTokens"), token("outputTokens")) {
+            (Some(input), Some(output)) => {
+                usage.prompt_tokens += input.max(0);
+                usage.completion_tokens += output.max(0);
+                usage.cache_read_tokens += token("cacheReadTokens").unwrap_or(0).max(0);
+                usage.cache_write_tokens += token("cacheWriteTokens").unwrap_or(0).max(0)
+                    + token("cacheWrite1hTokens").unwrap_or(0).max(0);
+            }
+            _ => usage.rows_with_null_tokens += 1,
+        }
+    }
+    usage
 }
 
 // ===== Internal helpers =====
@@ -286,7 +366,10 @@ mod tests {
         assert!(out.errors.is_empty());
         assert_eq!(out.prompts[0].system_prompt, "denial rule");
         assert_eq!(out.prompts[0].tools, vec!["run_tool"]);
-        assert_eq!(out.prompts[0].sampling, sampling(Some(1.0), Some(4096), Some(0.9)));
+        assert_eq!(
+            out.prompts[0].sampling,
+            sampling(Some(1.0), Some(4096), Some(0.9))
+        );
     }
 
     #[test]
@@ -303,7 +386,10 @@ mod tests {
         assert!(out.errors.is_empty());
         assert_eq!(out.prompts[0].system_prompt, "sys a\nsys b");
         assert_eq!(out.prompts[0].tools, vec!["f1", "f2"]);
-        assert_eq!(out.prompts[0].sampling, sampling(Some(0.5), Some(2048), Some(0.8)));
+        assert_eq!(
+            out.prompts[0].sampling,
+            sampling(Some(0.5), Some(2048), Some(0.8))
+        );
     }
 
     #[test]
@@ -320,7 +406,10 @@ mod tests {
         assert!(out.errors.is_empty());
         assert_eq!(out.prompts[0].system_prompt, "responses sys");
         assert_eq!(out.prompts[0].tools, vec!["t1"]);
-        assert_eq!(out.prompts[0].sampling, sampling(Some(0.2), Some(1000), None));
+        assert_eq!(
+            out.prompts[0].sampling,
+            sampling(Some(0.2), Some(1000), None)
+        );
     }
 
     #[test]
@@ -450,5 +539,77 @@ mod tests {
         let out = extract_effective_prompts(&[it]);
         assert!(out.errors.is_empty());
         assert_eq!(out.prompts[0].tools, vec!["f1"]);
+    }
+
+    fn usage_row(model: &str, input: i64, output: i64, cache_read: i64, cache_write: i64) -> Value {
+        json!({
+            "type": "anthropic:messages",
+            "model": model,
+            "inputTokens": input,
+            "outputTokens": output,
+            "cacheReadTokens": cache_read,
+            "cacheWriteTokens": cache_write,
+        })
+    }
+
+    #[test]
+    fn sum_usage_sums_every_step_and_both_cache_write_tiers() {
+        let rows = vec![
+            usage_row("claude", 100, 10, 5, 200),
+            json!({
+                "type": "anthropic:messages", "model": "claude",
+                "inputTokens": 300, "outputTokens": 40,
+                "cacheReadTokens": 90, "cacheWriteTokens": 50, "cacheWrite1hTokens": 25,
+            }),
+        ];
+        let u = sum_usage(&rows);
+        assert_eq!(u.chat_rows, 2);
+        assert_eq!(u.prompt_tokens, 400);
+        assert_eq!(u.completion_tokens, 50);
+        assert_eq!(u.cache_read_tokens, 95);
+        // 200 + (50 + 25): the 1h tier folds into cache_write.
+        assert_eq!(u.cache_write_tokens, 275);
+        assert_eq!(u.total_tokens(), 400 + 50 + 95 + 275);
+        assert_eq!(u.rows_with_null_tokens, 0);
+        assert_eq!(u.models.len(), 1);
+        assert!(u.had_spend());
+    }
+
+    #[test]
+    fn sum_usage_skips_embeddings_but_counts_them_as_no_chat() {
+        let rows = vec![
+            json!({"type": "openai:embeddings", "model": "embed", "inputTokens": 999, "outputTokens": 0}),
+            usage_row("claude", 100, 10, 0, 0),
+        ];
+        let u = sum_usage(&rows);
+        assert_eq!(u.chat_rows, 1);
+        assert_eq!(u.prompt_tokens, 100);
+        assert!(!u.models.contains("embed"));
+    }
+
+    #[test]
+    fn sum_usage_flags_missing_token_fields_as_a_gap() {
+        // A chat row with no token fields is a telemetry gap, not a measured zero.
+        let rows = vec![json!({"type": "anthropic:messages", "model": "claude"})];
+        let u = sum_usage(&rows);
+        assert_eq!(u.chat_rows, 1);
+        assert_eq!(u.rows_with_null_tokens, 1);
+        assert_eq!(u.prompt_tokens, 0);
+    }
+
+    #[test]
+    fn sum_usage_clamps_negatives_and_unions_models() {
+        let rows = vec![usage_row("a", -5, -5, -5, -5), usage_row("b", 10, 10, 0, 0)];
+        let u = sum_usage(&rows);
+        assert_eq!(u.prompt_tokens, 10);
+        assert_eq!(u.completion_tokens, 10);
+        assert_eq!(u.models.len(), 2);
+    }
+
+    #[test]
+    fn sum_usage_empty_is_no_spend() {
+        let u = sum_usage(&[]);
+        assert!(!u.had_spend());
+        assert_eq!(u.total_tokens(), 0);
     }
 }

--- a/archestra-bench/runner/src/pricing.rs
+++ b/archestra-bench/runner/src/pricing.rs
@@ -12,11 +12,15 @@ const OPENROUTER_MODELS_URL: &str = "https://openrouter.ai/api/v1/models";
 
 /// Per-token USD prices for one model. `cache_read` is the discounted rate for cached prompt tokens,
 /// absent when OpenRouter publishes none (the caller then prices cache reads at the normal input rate).
+/// `cache_write` is the premium rate for writing prompt tokens into the cache; absent when OpenRouter
+/// publishes none, in which case a model that emitted cache-write tokens is left unpriced rather than
+/// charged a fabricated multiple of the input rate.
 #[derive(Debug, Clone, Copy, Serialize)]
 pub struct ModelPrice {
     pub input: f64,
     pub output: f64,
     pub cache_read: Option<f64>,
+    pub cache_write: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -32,24 +36,39 @@ impl PriceBook {
     /// USD cost of one run. `None` — reported as `n/a`, never `0` — when the lane has no slug, the slug
     /// is absent from the book, or token counts are missing.
     ///
-    /// `prompt` is the backend's `inputTokens`, which is already **net of** cache reads (the platform
-    /// emits a fully-cached request as `inputTokens == 0`, with the cache shown separately — see
-    /// `calculateCost` in the platform's cost-optimization). So input and cache tokens are disjoint and
-    /// summed, not subtracted. Cache reads are billed at the cache rate when OpenRouter publishes one,
-    /// else at the input rate (the conservative estimate when the discount is unknown).
+    /// `prompt` is the backend's `inputTokens`, which is already **net of** cache reads and cache
+    /// writes (the platform reports `inputTokens`, `cacheReadTokens`, and `cacheWriteTokens` as
+    /// disjoint counts — see `calculateInteractionCosts` in the platform's cost-optimization). So the
+    /// four categories are summed, not subtracted. Cache reads are billed at the cache-read rate when
+    /// OpenRouter publishes one, else at the input rate (the conservative estimate when the discount is
+    /// unknown). Cache writes are billed only at the published cache-write rate: a model that emitted
+    /// cache-write tokens but has no published write rate yields `None` (unpriceable, surfaced as
+    /// `n/a`) rather than a fabricated charge.
     pub fn cost(
         &self,
         prompt: Option<i64>,
         completion: Option<i64>,
         cache_read: Option<i64>,
+        cache_write: Option<i64>,
         slug: Option<&str>,
     ) -> Option<f64> {
         let price = self.models.get(slug?)?;
         let prompt = prompt?.max(0) as f64;
         let completion = completion?.max(0) as f64;
         let cache_read = cache_read.unwrap_or(0).max(0) as f64;
-        let cache_price = price.cache_read.unwrap_or(price.input);
-        Some(prompt * price.input + cache_read * cache_price + completion * price.output)
+        let cache_write = cache_write.unwrap_or(0).max(0) as f64;
+        let cache_read_price = price.cache_read.unwrap_or(price.input);
+        let cache_write_cost = if cache_write > 0.0 {
+            cache_write * price.cache_write?
+        } else {
+            0.0
+        };
+        Some(
+            prompt * price.input
+                + cache_read * cache_read_price
+                + cache_write_cost
+                + completion * price.output,
+        )
     }
 }
 
@@ -93,6 +112,7 @@ pub fn parse_price_book(models_json: &JsonValue) -> PriceBook {
                     input,
                     output,
                     cache_read: field("input_cache_read"),
+                    cache_write: field("input_cache_write"),
                 },
             );
         }
@@ -115,7 +135,8 @@ mod tests {
             "data": [
                 { "id": "vendor/cheap", "pricing": { "prompt": "0.000001", "completion": "0.000002" } },
                 { "id": "vendor/cached", "pricing": {
-                    "prompt": "0.000001", "completion": "0.000002", "input_cache_read": "0.0000001" } },
+                    "prompt": "0.000001", "completion": "0.000002",
+                    "input_cache_read": "0.0000001", "input_cache_write": "0.00000125" } },
                 { "id": "vendor/free", "pricing": { "prompt": "0", "completion": "0" } },
                 { "id": "vendor/dynamic", "pricing": { "prompt": "-1", "completion": "-1" } },
                 { "id": "vendor/partial", "pricing": { "prompt": "0.000001" } },
@@ -134,14 +155,19 @@ mod tests {
             book.get("vendor/cached").unwrap().cache_read,
             Some(0.0000001)
         );
+        assert_eq!(
+            book.get("vendor/cached").unwrap().cache_write,
+            Some(0.00000125)
+        );
         assert_eq!(book.get("vendor/cheap").unwrap().cache_read, None);
+        assert_eq!(book.get("vendor/cheap").unwrap().cache_write, None);
     }
 
     #[test]
     fn cost_uses_input_and_output_rates() {
         let book = book();
         // 1000 input * 1e-6 + 500 output * 2e-6 = 0.001 + 0.001
-        let cost = book.cost(Some(1000), Some(500), None, Some("vendor/cheap"));
+        let cost = book.cost(Some(1000), Some(500), None, None, Some("vendor/cheap"));
         assert_eq!(cost, Some(0.002));
     }
 
@@ -151,20 +177,59 @@ mod tests {
         // input (1000) is already net of cache; cache reads (200) are disjoint and priced separately:
         // 1000*1e-6 + 200*1e-7 + 500*2e-6
         let cost = book
-            .cost(Some(1000), Some(500), Some(200), Some("vendor/cached"))
+            .cost(
+                Some(1000),
+                Some(500),
+                Some(200),
+                None,
+                Some("vendor/cached"),
+            )
             .unwrap();
         assert!((cost - (0.001 + 0.00002 + 0.001)).abs() < 1e-12);
     }
 
     #[test]
+    fn cost_adds_cache_writes_at_cache_write_rate() {
+        let book = book();
+        // cache writes (400) are disjoint and billed at the published write rate (1.25e-6):
+        // 1000*1e-6 + 200*1e-7 + 400*1.25e-6 + 500*2e-6
+        let cost = book
+            .cost(
+                Some(1000),
+                Some(500),
+                Some(200),
+                Some(400),
+                Some("vendor/cached"),
+            )
+            .unwrap();
+        assert!((cost - (0.001 + 0.00002 + 0.0005 + 0.001)).abs() < 1e-12);
+    }
+
+    #[test]
     fn cache_reads_without_rate_priced_at_input() {
         let book = book();
-        // vendor/cheap has no cache rate → cache reads billed at the input rate, added on top of input.
+        // vendor/cheap has no cache-read rate → cache reads billed at the input rate, added on top.
         let with_cache = book
-            .cost(Some(1000), Some(500), Some(300), Some("vendor/cheap"))
+            .cost(Some(1000), Some(500), Some(300), None, Some("vendor/cheap"))
             .unwrap();
         // 1000*1e-6 + 300*1e-6 + 500*2e-6
         assert!((with_cache - (0.001 + 0.0003 + 0.001)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cache_writes_without_rate_are_unpriced() {
+        let book = book();
+        // vendor/cheap publishes no cache-write rate; cache-write tokens must NOT be charged a
+        // fabricated rate — the whole run is unpriceable instead.
+        assert_eq!(
+            book.cost(Some(1000), Some(500), None, Some(300), Some("vendor/cheap")),
+            None
+        );
+        // Zero cache-write tokens need no write rate, so pricing still succeeds.
+        assert!(
+            book.cost(Some(1000), Some(500), None, Some(0), Some("vendor/cheap"))
+                .is_some()
+        );
     }
 
     #[test]
@@ -172,7 +237,13 @@ mod tests {
         let book = book();
         // A malformed negative count must not produce a negative cost.
         let cost = book
-            .cost(Some(-5), Some(-5), Some(-5), Some("vendor/cached"))
+            .cost(
+                Some(-5),
+                Some(-5),
+                Some(-5),
+                Some(-5),
+                Some("vendor/cached"),
+            )
             .unwrap();
         assert_eq!(cost, 0.0);
     }
@@ -180,9 +251,18 @@ mod tests {
     #[test]
     fn unknown_slug_or_missing_tokens_is_none() {
         let book = book();
-        assert_eq!(book.cost(Some(10), Some(10), None, Some("nope")), None);
-        assert_eq!(book.cost(Some(10), Some(10), None, None), None);
-        assert_eq!(book.cost(None, Some(10), None, Some("vendor/cheap")), None);
-        assert_eq!(book.cost(Some(10), None, None, Some("vendor/cheap")), None);
+        assert_eq!(
+            book.cost(Some(10), Some(10), None, None, Some("nope")),
+            None
+        );
+        assert_eq!(book.cost(Some(10), Some(10), None, None, None), None);
+        assert_eq!(
+            book.cost(None, Some(10), None, None, Some("vendor/cheap")),
+            None
+        );
+        assert_eq!(
+            book.cost(Some(10), None, None, None, Some("vendor/cheap")),
+            None
+        );
     }
 }

--- a/archestra-bench/runner/src/results.rs
+++ b/archestra-bench/runner/src/results.rs
@@ -3,6 +3,19 @@ use std::collections::HashMap;
 // The outcome taxonomy is the shared run.json contract (analyzer reads the same strings).
 pub use archestra_bench_core::Outcome;
 
+/// A rollout's USD cost. The three states are kept distinct so unaccountable spend is never silently
+/// dropped: `Unpriced` means billable spend happened that we could not price (no lane slug, a slug
+/// absent from the price book, a model with cache-write tokens but no published write rate, mixed
+/// models in one session, or a telemetry gap), and it makes any aggregate it lands in *incomplete*;
+/// `NoSpend` is a real zero (no LLM call). serde_json cannot carry NaN, so the "loud" signal is the
+/// explicit `Unpriced` count, not a NaN sentinel.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RunCost {
+    Priced(f64),
+    Unpriced,
+    NoSpend,
+}
+
 #[derive(Debug, Clone)]
 pub struct RunResult {
     pub env_id: String,
@@ -18,10 +31,10 @@ pub struct RunResult {
     pub prompt_tokens: Option<i64>,
     pub completion_tokens: Option<i64>,
     pub cache_read_tokens: Option<i64>,
-    /// OpenRouter slug the run was priced against, and the resulting USD cost (both `None` when the
-    /// lane has no slug or the slug is absent from the price book).
+    pub cache_write_tokens: Option<i64>,
+    /// OpenRouter slug the run was priced against (`None` when the lane has no slug).
     pub price_model: Option<String>,
-    pub cost_usd: Option<f64>,
+    pub cost: RunCost,
     pub agent_error: Option<String>,
     pub stage_count: usize,
     pub format_attempts: usize,
@@ -68,9 +81,13 @@ pub struct GroupAggregate {
     /// have none, and folding them in as 0 would understate the average).
     pub tokens_n: usize,
     pub total_cost_usd: f64,
-    /// Rollouts that were priced — the denominator for `avg_cost_usd` (unpriced rollouts are excluded
-    /// rather than counted as $0).
+    /// Rollouts that were priced — the denominator for the cost total (no-spend and unpriced rollouts
+    /// are excluded rather than counted as $0).
     pub cost_n: usize,
+    /// Rollouts that incurred billable spend we could not price. When > 0 the group's cost total is
+    /// *incomplete*: it covers only the priced rollouts, so it is reported with a loud marker and
+    /// nulled in JSON rather than passed off as the full figure.
+    pub cost_unpriced_n: usize,
 }
 
 impl GroupAggregate {
@@ -98,11 +115,20 @@ impl GroupAggregate {
         }
     }
 
-    /// Total USD cost of this group's rollouts, or `None` when none were priced (so an unpriced group
-    /// reads as `n/a` rather than a misleading `$0`). Not averaged — with few lanes the per-lane total
-    /// is the figure worth seeing.
+    /// Total USD cost over the group's priced rollouts, or `None` when none were priced (so an
+    /// unpriced/no-spend group reads as `n/a` rather than a misleading `$0`). Not averaged — with few
+    /// lanes the per-lane total is the figure worth seeing.
     pub fn cost_usd(&self) -> Option<f64> {
         (self.cost_n > 0).then_some(self.total_cost_usd)
+    }
+
+    /// JSON cost: the priced total only when every spend-bearing rollout was priced. When any rollout
+    /// is unpriced the total is incomplete, so it is nulled — the `cost_unpriced_n` field carries the
+    /// loud signal that would otherwise be lost (serde_json renders a NaN sentinel as null anyway).
+    pub fn cost_usd_json(&self) -> Option<f64> {
+        (self.cost_unpriced_n == 0)
+            .then(|| self.cost_usd())
+            .flatten()
     }
 }
 
@@ -123,7 +149,8 @@ impl Aggregate {
             "pass_rate": o.pass_rate(),
             "avg_turns": o.avg_turns(),
             "avg_tokens": o.avg_tokens(),
-            "cost_usd": o.cost_usd(),
+            "cost_usd": o.cost_usd_json(),
+            "cost_unpriced_n": o.cost_unpriced_n,
             "total_turns": o.total_turns,
             "total_tokens": o.total_tokens,
             "outcomes": o.outcomes,
@@ -142,7 +169,8 @@ fn group_json(key_name: &str, g: &GroupAggregate) -> serde_json::Value {
         "pass_rate": g.pass_rate(),
         "avg_turns": g.avg_turns(),
         "avg_tokens": g.avg_tokens(),
-        "cost_usd": g.cost_usd(),
+        "cost_usd": g.cost_usd_json(),
+        "cost_unpriced_n": g.cost_unpriced_n,
         "total_turns": g.total_turns,
         "total_tokens": g.total_tokens,
         "outcomes": g.outcomes,
@@ -172,8 +200,21 @@ fn group_aggregate(key: String, rows: &[&RunResult]) -> GroupAggregate {
         total_turns: rows.iter().map(|r| r.turn_count).sum(),
         total_tokens: rows.iter().filter_map(|r| r.total_tokens).sum(),
         tokens_n: rows.iter().filter(|r| r.total_tokens.is_some()).count(),
-        total_cost_usd: rows.iter().filter_map(|r| r.cost_usd).sum(),
-        cost_n: rows.iter().filter(|r| r.cost_usd.is_some()).count(),
+        total_cost_usd: rows
+            .iter()
+            .filter_map(|r| match r.cost {
+                RunCost::Priced(c) => Some(c),
+                RunCost::Unpriced | RunCost::NoSpend => None,
+            })
+            .sum(),
+        cost_n: rows
+            .iter()
+            .filter(|r| matches!(r.cost, RunCost::Priced(_)))
+            .count(),
+        cost_unpriced_n: rows
+            .iter()
+            .filter(|r| matches!(r.cost, RunCost::Unpriced))
+            .count(),
     }
 }
 
@@ -232,10 +273,14 @@ fn stats(g: &GroupAggregate) -> String {
         .avg_tokens()
         .map(|t| format!("{t:.0}"))
         .unwrap_or_else(|| "n/a".to_string());
-    let cost = g
-        .cost_usd()
-        .map(|c| format!("${c:.4}"))
-        .unwrap_or_else(|| "n/a".to_string());
+    let cost = match (g.cost_n, g.cost_unpriced_n) {
+        (0, 0) => "n/a".to_string(),
+        (_, 0) => format!("${:.4}", g.total_cost_usd),
+        // Spend we could not price makes the total incomplete: show the priced subtotal (if any) with
+        // a loud unpriced count rather than passing it off as the full cost.
+        (0, n) => format!("incomplete ({n} unpriced)"),
+        (_, n) => format!("${:.4} (+{n} unpriced)", g.total_cost_usd),
+    };
     let failures = failure_summary(&g.outcomes);
     let tail = if failures.is_empty() {
         String::new()
@@ -286,8 +331,9 @@ mod tests {
             prompt_tokens: None,
             completion_tokens: None,
             cache_read_tokens: None,
+            cache_write_tokens: None,
             price_model: None,
-            cost_usd: None,
+            cost: RunCost::NoSpend,
             agent_error: None,
             stage_count: 1,
             format_attempts: 0,
@@ -326,19 +372,39 @@ mod tests {
     #[test]
     fn test_aggregate_sums_cost_over_priced_rollouts_only() {
         let mut a = result("basic", "t1", "l1", Outcome::Passed);
-        a.cost_usd = Some(0.01);
+        a.cost = RunCost::Priced(0.01);
         let mut b = result("basic", "t2", "l1", Outcome::Failed);
-        b.cost_usd = Some(0.03);
-        let c = result("basic", "t3", "l1", Outcome::AgentError); // unpriced rollout
+        b.cost = RunCost::Priced(0.03);
+        let c = result("basic", "t3", "l1", Outcome::AgentError); // no-spend rollout
         let agg = aggregate(&[a, b, c]);
         assert_eq!(agg.overall.cost_n, 2);
-        // Total over the priced rollouts (no averaging); the unpriced one contributes nothing.
+        assert_eq!(agg.overall.cost_unpriced_n, 0);
+        // Total over the priced rollouts (no averaging); the no-spend one contributes nothing.
         assert_eq!(agg.overall.cost_usd(), Some(0.04));
+        assert_eq!(agg.overall.cost_usd_json(), Some(0.04));
     }
 
     #[test]
-    fn test_aggregate_cost_is_none_when_unpriced() {
-        let agg = aggregate(&[result("basic", "t1", "l1", Outcome::Passed)]);
+    fn test_unpriced_spend_makes_total_incomplete_and_loud() {
+        let mut a = result("basic", "t1", "l1", Outcome::Passed);
+        a.cost = RunCost::Priced(0.01);
+        let mut b = result("basic", "t2", "l1", Outcome::Passed);
+        b.cost = RunCost::Unpriced; // billable spend we could not price
+        let agg = aggregate(&[a, b]);
+        assert_eq!(agg.overall.cost_n, 1);
+        assert_eq!(agg.overall.cost_unpriced_n, 1);
+        // The priced subtotal is still available, but JSON nulls it because the total is incomplete.
+        assert_eq!(agg.overall.cost_usd(), Some(0.01));
+        assert_eq!(agg.overall.cost_usd_json(), None);
+    }
+
+    #[test]
+    fn test_no_spend_rollouts_are_excluded_not_unpriced() {
+        // A rollout with no LLM call is a real $0, not an unpriceable gap: it must not inflate the
+        // unpriced count nor the priced denominator.
+        let agg = aggregate(&[result("basic", "t1", "l1", Outcome::AgentError)]);
+        assert_eq!(agg.overall.cost_n, 0);
+        assert_eq!(agg.overall.cost_unpriced_n, 0);
         assert_eq!(agg.overall.cost_usd(), None);
     }
 
@@ -346,7 +412,7 @@ mod tests {
     fn test_render_markdown_is_aggregate_only() {
         let mut a = result("basic", "t1", "l1", Outcome::Passed);
         a.total_tokens = Some(1500);
-        a.cost_usd = Some(0.0123);
+        a.cost = RunCost::Priced(0.0123);
         let md = render_markdown(&[a, result("basic", "t2", "l1", Outcome::Failed)]);
         assert!(
             !md.contains("Pass matrix"),
@@ -359,6 +425,19 @@ mod tests {
         assert!(!md.contains("avg cost"));
         assert!(md.contains("failed=1"), "failure reasons are reported");
         assert!(md.contains("## By task"));
+    }
+
+    #[test]
+    fn test_render_markdown_marks_unpriced_spend() {
+        let mut a = result("basic", "t1", "l1", Outcome::Passed);
+        a.cost = RunCost::Priced(0.05);
+        let mut b = result("basic", "t2", "l1", Outcome::Passed);
+        b.cost = RunCost::Unpriced;
+        let md = render_markdown(&[a, b]);
+        assert!(
+            md.contains("(+1 unpriced)"),
+            "incomplete total is loud: {md}"
+        );
     }
 
     #[test]

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -1691,23 +1691,21 @@ async fn grade_rollout(
     }
     run.usage = usage;
 
-    let token_meta = |value: i64| -> serde_json::Value {
-        // `None` keeps "never measured" (no LLM call) distinct from a measured zero.
-        if run.usage.had_spend() {
-            serde_json::Value::from(value)
-        } else {
-            serde_json::Value::Null
-        }
+    // Publish token totals only when the usage is reliable (complete fetch, no telemetry gap); an
+    // incomplete sum is reported as no measurement, never a partial count read as complete.
+    let reliable = run.reliable_usage().cloned();
+    let token_meta = |value: Option<i64>| -> serde_json::Value {
+        value.map_or(serde_json::Value::Null, serde_json::Value::from)
     };
     metadata["finish_reason"] =
         serde_json::to_value(&run.finish_reason).unwrap_or(serde_json::Value::Null);
     metadata["tool_call_count"] = serde_json::Value::Number((run.tool_calls.len() as i64).into());
     metadata["turn_count"] = serde_json::Value::Number((run.turn_count as i64).into());
-    metadata["total_tokens"] = token_meta(run.usage.total_tokens());
-    metadata["prompt_tokens"] = token_meta(run.usage.prompt_tokens);
-    metadata["completion_tokens"] = token_meta(run.usage.completion_tokens);
-    metadata["cache_read_tokens"] = token_meta(run.usage.cache_read_tokens);
-    metadata["cache_write_tokens"] = token_meta(run.usage.cache_write_tokens);
+    metadata["total_tokens"] = token_meta(reliable.as_ref().map(RunUsage::total_tokens));
+    metadata["prompt_tokens"] = token_meta(reliable.as_ref().map(|u| u.prompt_tokens));
+    metadata["completion_tokens"] = token_meta(reliable.as_ref().map(|u| u.completion_tokens));
+    metadata["cache_read_tokens"] = token_meta(reliable.as_ref().map(|u| u.cache_read_tokens));
+    metadata["cache_write_tokens"] = token_meta(reliable.as_ref().map(|u| u.cache_write_tokens));
 
     let submission = bench_mcp.take_submission(rollout_key).await;
     match submission {
@@ -2236,17 +2234,18 @@ async fn finish(
     agent_error: Option<String>,
     prices: &PriceBook,
 ) -> RunResult {
-    let usage = run.map(|r| &r.usage);
+    // Reported token totals come from reliable usage only, so an incomplete sum never skews the token
+    // aggregates; cost classification (run_cost) looks at the full usage independently.
     let (total_tokens, prompt_tokens, completion_tokens, cache_read_tokens, cache_write_tokens) =
-        match usage {
-            Some(u) if u.had_spend() => (
+        match run.and_then(ChatRunResult::reliable_usage) {
+            Some(u) => (
                 Some(u.total_tokens()),
                 Some(u.prompt_tokens),
                 Some(u.completion_tokens),
                 Some(u.cache_read_tokens),
                 Some(u.cache_write_tokens),
             ),
-            _ => (None, None, None, None, None),
+            None => (None, None, None, None, None),
         };
     let price_model = lane.price_model();
     let cost = run_cost(run, prices, price_model.as_deref());
@@ -3197,6 +3196,50 @@ mod tests {
                 .unwrap();
         assert_eq!(written["cost_status"], "unpriced");
         assert!(written["cost_usd"].is_null());
+    }
+
+    #[tokio::test]
+    async fn finish_withholds_token_totals_when_usage_is_incomplete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = RunArtifacts::new(tmp.path().join("e__t1__l1"))
+            .await
+            .unwrap();
+        let mut lane = dummy_lane("l1");
+        lane.provider = archestra_bench_core::Provider::Openrouter;
+        lane.model = "vendor/cheap".to_string();
+        let task = dummy_task("t1");
+        // A conversation's interaction fetch failed: the summed usage is partial, so neither cost nor
+        // token totals may be presented as complete.
+        let run = ChatRunResult {
+            turn_count: 2,
+            usage_fetch_failed: true,
+            usage: RunUsage {
+                prompt_tokens: 1000,
+                completion_tokens: 500,
+                chat_rows: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut metadata = serde_json::json!({
+            "finished_at": null, "outcome": null, "agent_error": null, "format_attempts": 0,
+        });
+        let result = finish(
+            "e",
+            &lane,
+            &task,
+            Outcome::Passed,
+            Some(&run),
+            &artifacts,
+            &mut metadata,
+            0,
+            None,
+            &priced_book(),
+        )
+        .await;
+        assert_eq!(result.cost, RunCost::Unpriced);
+        assert_eq!(result.total_tokens, None);
+        assert_eq!(result.prompt_tokens, None);
     }
 
     #[tokio::test]

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -18,12 +18,12 @@ use crate::client::{AgentCreate, EvalClient, FilePart};
 use crate::config::types::{EnvConfig, Stage, Task, ToolExposureMode};
 use crate::config::{Lane, load_envs, load_lanes};
 use crate::fixture_mcp::{FIXTURE_MCP_NAME, FixtureMcp};
-use crate::interactions::extract_effective_prompts;
+use crate::interactions::{RunUsage, extract_effective_prompts, sum_usage};
 use crate::lifecycle::Instance;
 use crate::mcp_lock;
 use crate::mcp_server::{BenchmarkMcp, Submission};
 use crate::pricing::{self, PriceBook};
-use crate::results::{Outcome, RunResult, render_markdown};
+use crate::results::{Outcome, RunCost, RunResult, render_markdown};
 use crate::seeding::{
     ResolvedModel, ensure_provider_and_models, register_remote_mcp, seed_mcp_fixtures,
     seed_skill_ref, tool_name,
@@ -999,8 +999,9 @@ fn infra_results_for_lane(
             prompt_tokens: None,
             completion_tokens: None,
             cache_read_tokens: None,
+            cache_write_tokens: None,
             price_model: None,
-            cost_usd: None,
+            cost: RunCost::NoSpend,
             agent_error: Some(format!("infra: {error}")),
             stage_count: task.stages.len(),
             format_attempts: 0,
@@ -1361,8 +1362,9 @@ async fn run_one(
                     prompt_tokens: None,
                     completion_tokens: None,
                     cache_read_tokens: None,
+                    cache_write_tokens: None,
                     price_model: None,
-                    cost_usd: None,
+                    cost: RunCost::NoSpend,
                     agent_error: Some(format!("artifact directory error: {e}")),
                     stage_count: task.stages.len(),
                     format_attempts: 0,
@@ -1432,9 +1434,8 @@ async fn run_one(
 /// loud `effective_prompt_error` event plus a warn log, but never propagated — a capture problem must
 /// not fail an otherwise-complete rollout.
 async fn capture_effective_prompts(
-    client: &EvalClient,
+    interactions: &[serde_json::Value],
     conversation_id: &str,
-    turn_count: usize,
     artifacts: &RunArtifacts,
 ) {
     // Every emitted event carries `conversation_id` so a multi-conversation rollout's captured prompts
@@ -1448,24 +1449,7 @@ async fn capture_effective_prompts(
             .await;
     };
 
-    let interactions = match client.fetch_session_interactions(conversation_id).await {
-        Ok(rows) => rows,
-        Err(e) => {
-            let msg = format!("failed to fetch interactions: {e}");
-            warn!("{msg}");
-            emit_error(&msg).await;
-            return;
-        }
-    };
-
-    if turn_count > 0 && interactions.is_empty() {
-        let msg = "no interactions found despite the conversation taking turns".to_string();
-        warn!("{msg}");
-        emit_error(&msg).await;
-        return;
-    }
-
-    let outcome = extract_effective_prompts(&interactions);
+    let outcome = extract_effective_prompts(interactions);
     for prompt in &outcome.prompts {
         match serde_json::to_value(prompt) {
             Ok(mut value) => {
@@ -1668,24 +1652,62 @@ async fn grade_rollout(
         .await?;
     }
 
-    // Capture every conversation the rollout drove, not just the last -- a `new_conversation` task
-    // splits its turns across several, and each one's effective prompts are worth recording.
+    // Source the rollout's billable usage from the persisted LLM-proxy interaction rows, summed across
+    // every conversation it drove -- one row per agentic step, so the total covers all steps rather
+    // than only the last one the chat SSE event reports, and includes cache-write tokens the event
+    // omits. A `new_conversation` task splits its turns across several conversations; each one's
+    // effective prompts are recorded too, from the same fetched rows.
+    let mut usage = RunUsage::default();
     for cid in &conversation_ids {
-        capture_effective_prompts(&client, cid, run.turn_count, artifacts).await;
+        match client.fetch_session_interactions(cid).await {
+            Ok(rows) => {
+                if run.turn_count > 0 && rows.is_empty() {
+                    let msg = "no interactions found despite the conversation taking turns";
+                    warn!("{msg}");
+                    artifacts
+                        .append(
+                            "effective_prompt_error",
+                            serde_json::json!({"conversation_id": cid, "error": msg}),
+                        )
+                        .await;
+                }
+                capture_effective_prompts(&rows, cid, artifacts).await;
+                usage.add(&sum_usage(&rows));
+            }
+            Err(e) => {
+                // A fetch failure leaves the rollout's usage incomplete; record it so cost is reported
+                // as unpriceable rather than silently under-summed.
+                let msg = format!("failed to fetch interactions: {e}");
+                warn!("{msg}");
+                artifacts
+                    .append(
+                        "effective_prompt_error",
+                        serde_json::json!({"conversation_id": cid, "error": msg}),
+                    )
+                    .await;
+                run.usage_fetch_failed = true;
+            }
+        }
     }
+    run.usage = usage;
 
+    let token_meta = |value: i64| -> serde_json::Value {
+        // `None` keeps "never measured" (no LLM call) distinct from a measured zero.
+        if run.usage.had_spend() {
+            serde_json::Value::from(value)
+        } else {
+            serde_json::Value::Null
+        }
+    };
     metadata["finish_reason"] =
         serde_json::to_value(&run.finish_reason).unwrap_or(serde_json::Value::Null);
     metadata["tool_call_count"] = serde_json::Value::Number((run.tool_calls.len() as i64).into());
     metadata["turn_count"] = serde_json::Value::Number((run.turn_count as i64).into());
-    metadata["total_tokens"] =
-        serde_json::to_value(run.total_tokens).unwrap_or(serde_json::Value::Null);
-    metadata["prompt_tokens"] =
-        serde_json::to_value(run.prompt_tokens).unwrap_or(serde_json::Value::Null);
-    metadata["completion_tokens"] =
-        serde_json::to_value(run.completion_tokens).unwrap_or(serde_json::Value::Null);
-    metadata["cache_read_tokens"] =
-        serde_json::to_value(run.cache_read_tokens).unwrap_or(serde_json::Value::Null);
+    metadata["total_tokens"] = token_meta(run.usage.total_tokens());
+    metadata["prompt_tokens"] = token_meta(run.usage.prompt_tokens);
+    metadata["completion_tokens"] = token_meta(run.usage.completion_tokens);
+    metadata["cache_read_tokens"] = token_meta(run.usage.cache_read_tokens);
+    metadata["cache_write_tokens"] = token_meta(run.usage.cache_write_tokens);
 
     let submission = bench_mcp.take_submission(rollout_key).await;
     match submission {
@@ -1984,10 +2006,6 @@ async fn drive_stage(
     let text = stage_message(&expand_runtime(&stage.text, runtime), submission_open);
     let mut stream_parse_error: Option<String> = None;
     let mut coalescer = StreamCoalescer::new(artifacts);
-    run.stage_tokens = None;
-    run.stage_prompt_tokens = None;
-    run.stage_completion_tokens = None;
-    run.stage_cache_read_tokens = None;
 
     let mut stream = client
         .stream_chat_records(conversation_id, prior_messages, &text, &files, turn_id)
@@ -2022,24 +2040,9 @@ async fn drive_stage(
         }
     }
     coalescer.flush().await;
-    // Sum each stage's final cumulative usage into the run totals, field by field, so the persisted
-    // split stays consistent with `total_tokens`.
-    if let Some(stage_tokens) = run.stage_tokens {
-        run.total_tokens = Some(run.total_tokens.unwrap_or(0) + stage_tokens);
-    }
-    add_stage_into(&mut run.prompt_tokens, run.stage_prompt_tokens);
-    add_stage_into(&mut run.completion_tokens, run.stage_completion_tokens);
-    add_stage_into(&mut run.cache_read_tokens, run.stage_cache_read_tokens);
-
+    // Token usage is no longer read from the stream: the run's billable totals are summed post-run from
+    // the persisted interaction rows (see grade_rollout), which capture every agentic step.
     Ok(combine_errors(run.stream_error.clone(), stream_parse_error))
-}
-
-/// Fold one stage's value into a run-level running total, leaving the total `None` until at least one
-/// stage reports (so "never measured" stays distinct from a measured zero).
-fn add_stage_into(total: &mut Option<i64>, stage: Option<i64>) {
-    if let Some(stage) = stage {
-        *total = Some(total.unwrap_or(0) + stage);
-    }
 }
 
 fn combine_errors(first: Option<String>, second: Option<String>) -> Option<String> {
@@ -2233,16 +2236,25 @@ async fn finish(
     agent_error: Option<String>,
     prices: &PriceBook,
 ) -> RunResult {
-    let prompt_tokens = run.and_then(|r| r.prompt_tokens);
-    let completion_tokens = run.and_then(|r| r.completion_tokens);
-    let cache_read_tokens = run.and_then(|r| r.cache_read_tokens);
+    let usage = run.map(|r| &r.usage);
+    let (total_tokens, prompt_tokens, completion_tokens, cache_read_tokens, cache_write_tokens) =
+        match usage {
+            Some(u) if u.had_spend() => (
+                Some(u.total_tokens()),
+                Some(u.prompt_tokens),
+                Some(u.completion_tokens),
+                Some(u.cache_read_tokens),
+                Some(u.cache_write_tokens),
+            ),
+            _ => (None, None, None, None, None),
+        };
     let price_model = lane.price_model();
-    let cost_usd = prices.cost(
-        prompt_tokens,
-        completion_tokens,
-        cache_read_tokens,
-        price_model.as_deref(),
-    );
+    let cost = run_cost(run, prices, price_model.as_deref());
+    let (cost_value, cost_status) = match cost {
+        RunCost::Priced(c) => (serde_json::Value::from(c), "priced"),
+        RunCost::Unpriced => (serde_json::Value::Null, "unpriced"),
+        RunCost::NoSpend => (serde_json::Value::Null, "no_spend"),
+    };
     if let serde_json::Value::Object(map) = metadata {
         map["finished_at"] = serde_json::Value::String(timestamp());
         map["outcome"] = serde_json::Value::String(outcome.value().to_string());
@@ -2254,9 +2266,10 @@ async fn finish(
             "price_model".to_string(),
             serde_json::to_value(&price_model).unwrap_or(serde_json::Value::Null),
         );
+        map.insert("cost_usd".to_string(), cost_value);
         map.insert(
-            "cost_usd".to_string(),
-            serde_json::to_value(cost_usd).unwrap_or(serde_json::Value::Null),
+            "cost_status".to_string(),
+            serde_json::Value::String(cost_status.to_string()),
         );
     }
     artifacts.write_run(metadata).await;
@@ -2270,16 +2283,49 @@ async fn finish(
         finish_reason: run.and_then(|r| r.finish_reason.clone()),
         tool_call_count: run.map(|r| r.tool_calls.len()).unwrap_or(0),
         turn_count: run.map(|r| r.turn_count).unwrap_or(0),
-        total_tokens: run.and_then(|r| r.total_tokens),
+        total_tokens,
         prompt_tokens,
         completion_tokens,
         cache_read_tokens,
+        cache_write_tokens,
         price_model,
-        cost_usd,
+        cost,
         agent_error,
         stage_count: task.stages.len(),
         format_attempts,
         artifact_dir: Some(artifacts.path.to_string_lossy().to_string()),
+    }
+}
+
+/// Classify a rollout's USD cost from its interaction-sourced usage. Billable spend that we cannot
+/// fully and faithfully price is `Unpriced` (loud), never silently dropped: an incomplete fetch, no
+/// recorded rows despite turns, a per-row telemetry gap, or a session that mixed models (which one
+/// lane slug cannot price) all unprice it, as does a slug absent from the price book. A rollout with
+/// no recorded LLM call is `NoSpend` (a real zero).
+fn run_cost(run: Option<&ChatRunResult>, prices: &PriceBook, price_model: Option<&str>) -> RunCost {
+    let Some(run) = run else {
+        return RunCost::NoSpend;
+    };
+    let usage = &run.usage;
+    // An incomplete fetch on a rollout that took turns means real spend we cannot fully account.
+    if run.turn_count > 0 && (run.usage_fetch_failed || usage.chat_rows == 0) {
+        return RunCost::Unpriced;
+    }
+    if !usage.had_spend() {
+        return RunCost::NoSpend;
+    }
+    if usage.rows_with_null_tokens > 0 || usage.models.len() > 1 {
+        return RunCost::Unpriced;
+    }
+    match prices.cost(
+        Some(usage.prompt_tokens),
+        Some(usage.completion_tokens),
+        Some(usage.cache_read_tokens),
+        Some(usage.cache_write_tokens),
+        price_model,
+    ) {
+        Some(c) => RunCost::Priced(c),
+        None => RunCost::Unpriced,
     }
 }
 
@@ -3064,8 +3110,14 @@ mod tests {
         lane.model = "vendor/cheap".to_string();
         let task = dummy_task("t1");
         let run = ChatRunResult {
-            prompt_tokens: Some(1000),
-            completion_tokens: Some(500),
+            turn_count: 2,
+            usage: RunUsage {
+                prompt_tokens: 1000,
+                completion_tokens: 500,
+                chat_rows: 2,
+                models: ["vendor/cheap".to_string()].into_iter().collect(),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let mut metadata = serde_json::json!({
@@ -3085,20 +3137,25 @@ mod tests {
         )
         .await;
         // 1000 * 1e-6 + 500 * 2e-6 = 0.002
-        assert_eq!(result.cost_usd, Some(0.002));
+        let RunCost::Priced(c) = result.cost else {
+            panic!("expected a priced cost, got {:?}", result.cost);
+        };
+        assert!((c - 0.002).abs() < 1e-12);
         assert_eq!(result.price_model.as_deref(), Some("vendor/cheap"));
         assert_eq!(result.prompt_tokens, Some(1000));
         assert_eq!(result.completion_tokens, Some(500));
-        // finish owns price_model/cost_usd in run.json (the token split is written upstream by grade_rollout).
+        assert_eq!(result.total_tokens, Some(1500));
+        // finish owns price_model/cost in run.json (the token split is written upstream by grade_rollout).
         let written: serde_json::Value =
             serde_json::from_slice(&std::fs::read(artifacts.path.join("run.json")).unwrap())
                 .unwrap();
         assert_eq!(written["cost_usd"], 0.002);
+        assert_eq!(written["cost_status"], "priced");
         assert_eq!(written["price_model"], "vendor/cheap");
     }
 
     #[tokio::test]
-    async fn finish_leaves_cost_null_without_price_model() {
+    async fn finish_marks_spend_unpriced_without_price_model() {
         let tmp = tempfile::tempdir().unwrap();
         let artifacts = RunArtifacts::new(tmp.path().join("e__t1__l1"))
             .await
@@ -3106,8 +3163,14 @@ mod tests {
         let lane = dummy_lane("l1"); // openai provider, no openrouter_model → no price_model
         let task = dummy_task("t1");
         let run = ChatRunResult {
-            prompt_tokens: Some(1000),
-            completion_tokens: Some(500),
+            turn_count: 2,
+            usage: RunUsage {
+                prompt_tokens: 1000,
+                completion_tokens: 500,
+                chat_rows: 2,
+                models: ["openai/gpt".to_string()].into_iter().collect(),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let mut metadata = serde_json::json!({
@@ -3126,8 +3189,49 @@ mod tests {
             &priced_book(),
         )
         .await;
-        assert_eq!(result.cost_usd, None);
+        // Spend happened but there is no slug to price it: unpriceable, not a silent zero.
+        assert_eq!(result.cost, RunCost::Unpriced);
         assert_eq!(result.price_model, None);
+        let written: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(artifacts.path.join("run.json")).unwrap())
+                .unwrap();
+        assert_eq!(written["cost_status"], "unpriced");
+        assert!(written["cost_usd"].is_null());
+    }
+
+    #[tokio::test]
+    async fn finish_reports_no_spend_when_no_llm_call() {
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = RunArtifacts::new(tmp.path().join("e__t1__l1"))
+            .await
+            .unwrap();
+        let mut lane = dummy_lane("l1");
+        lane.provider = archestra_bench_core::Provider::Openrouter;
+        lane.model = "vendor/cheap".to_string();
+        let task = dummy_task("t1");
+        let run = ChatRunResult::default(); // no turns, no interaction rows
+        let mut metadata = serde_json::json!({
+            "finished_at": null, "outcome": null, "agent_error": null, "format_attempts": 0,
+        });
+        let result = finish(
+            "e",
+            &lane,
+            &task,
+            Outcome::AgentError,
+            Some(&run),
+            &artifacts,
+            &mut metadata,
+            0,
+            Some("boom".to_string()),
+            &priced_book(),
+        )
+        .await;
+        assert_eq!(result.cost, RunCost::NoSpend);
+        assert_eq!(result.total_tokens, None);
+        let written: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(artifacts.path.join("run.json")).unwrap())
+                .unwrap();
+        assert_eq!(written["cost_status"], "no_spend");
     }
 
     #[tokio::test]

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -2306,8 +2306,14 @@ fn run_cost(run: Option<&ChatRunResult>, prices: &PriceBook, price_model: Option
         return RunCost::NoSpend;
     };
     let usage = &run.usage;
-    // An incomplete fetch on a rollout that took turns means real spend we cannot fully account.
-    if run.turn_count > 0 && (run.usage_fetch_failed || usage.chat_rows == 0) {
+    // A failed fetch leaves usage incomplete whenever there is any sign the rollout did LLM work
+    // (recorded turns or rows); recorded turns with no rows at all is the same incompleteness. Either
+    // way it is real spend we cannot fully account — kept consistent with `reliable_usage`, which
+    // withholds the token totals for exactly these cases.
+    if run.usage_fetch_failed && (run.turn_count > 0 || usage.chat_rows > 0) {
+        return RunCost::Unpriced;
+    }
+    if run.turn_count > 0 && usage.chat_rows == 0 {
         return RunCost::Unpriced;
     }
     if !usage.had_spend() {


### PR DESCRIPTION
## Problem

The benchmark undercounted per-task cost via two independent mechanisms:

1. **Only the last agentic step was counted.** Token usage was read from the chat SSE `data-token-usage` event, whose final value is AI SDK v6's `result.usage` — the *last step* of a multi-step server-side tool loop (`stepCountIs(MAX_AGENT_STEPS)`). All intermediate tool-calling steps were dropped.
2. **Cache-write tokens were never captured or priced.** Prompt caching is active (1h TTL), but `cacheWriteTokens`/`cacheWrite1hTokens` — billed at a premium and tracked by the platform's own cost math — were absent from both capture and pricing.

## Fix

Bench-only (Rust). Source per-task usage by summing the LLM-proxy `interactions` rows the bench already fetches (one row per agentic step), across all of a rollout's conversations — capturing every step and cache-write tokens, independent of the lossy SSE event.

- Extend the OpenRouter price book with `input_cache_write`. A model with cache-write tokens but no published write rate is left **unpriced** rather than charged a fabricated rate.
- Model a rollout's cost as `RunCost { Priced | Unpriced | NoSpend }` so unaccountable billable spend surfaces **loudly** (an explicit `cost_unpriced_n` + an incomplete-total marker) instead of being silently dropped. This also makes the retry snapshot-restore token loss moot: totals no longer flow through the wiped in-memory accumulation.
- Token totals are published only from reliable usage (complete fetch, no telemetry gap); an incomplete sum reports as no measurement.

Note: `cacheWriteTokens` is the full cache-creation count and `cacheWrite1hTokens` is the 1h-TTL subset of it (the platform's premium-pricing breakdown), so only `cacheWriteTokens` is counted. OpenRouter exposes a single cache-write rate, so 1h-write tokens are priced at that published rate — a published-rate approximation, not a fabricated coefficient.

## Validation

- `cargo clippy --all-targets -- -D warnings` clean
- 126 unit + 3 integration tests pass
- New tests cover: multi-step summation, cache-write pricing, the strict no-fallback rule, unpriced-row surfacing, the reliability gate, and the Priced/Unpriced/NoSpend classification

https://claude.ai/code/session_0177aqp5tg2s1qZshspSR1RX

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>