### PR TITLE
fix(sandbox): fail fast on overlong replay logs instead of opaque overlay crash

### DIFF
--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -1061,14 +1061,18 @@ fn from_sdk(err: DaggerError) -> SandboxError {
 }
 
 /// the kernel rejects an overlay mount whose `lowerdir=a:b:c:...` option string
-/// outgrows its single-page limit; dagger reports it as a domain error naming the
-/// failed rootfs overlay mount. recognise that one failure — as narrowly as the
-/// stale-attachables classifier — so the replay backstop can relabel it.
+/// outgrows its single-page limit; dagger reports it as a domain error on the
+/// rootfs mount whose data carries the oversized `lowerdir=` and fails with
+/// `ENOENT`. key on that full signature (not a bare "overlay" mention) so an
+/// unrelated, retryable overlay mount failure is never made terminal — a too-
+/// narrow match just degrades to the previous engine-unreachable behaviour.
 fn is_overlay_mount_overflow(err: &DaggerError) -> bool {
     matches!(
         err,
         DaggerError::Query(GraphQLError::DomainError { message, .. })
-            if message.contains("mount rootfs") && message.contains("overlay")
+            if message.contains("mount rootfs")
+                && message.contains("lowerdir=")
+                && message.contains("no such file or directory")
     )
 }
 
@@ -1738,6 +1742,37 @@ mod tests {
         assert!(matches!(
             from_sdk(err),
             SandboxError::EngineUnreachable { .. }
+        ));
+    }
+
+    #[test]
+    fn from_sdk_does_not_relabel_a_generic_overlay_mount_failure() {
+        // a rootfs overlay mount that fails for a reason other than the oversized
+        // lowerdir (no ENOENT / no lowerdir data) is a different, possibly
+        // retryable failure and must stay engine-unreachable, not history-limit.
+        let err = domain_error(
+            "mount rootfs: mount source: \"overlay\", target: \"/tmp/rootfs9\", \
+             fstype: overlay, err: operation not permitted",
+            None,
+        );
+        assert!(matches!(
+            from_sdk(err),
+            SandboxError::EngineUnreachable { .. }
+        ));
+    }
+
+    #[test]
+    fn from_sdk_still_classifies_stale_attachables_after_the_overlay_check() {
+        let err = domain_error(
+            "waiting for client session attachables: context deadline exceeded",
+            None,
+        );
+        assert!(matches!(
+            from_sdk(err),
+            SandboxError::EngineUnreachable {
+                fault: EngineFault::StaleAttachables,
+                ..
+            }
         ));
     }
 }

--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -763,12 +763,64 @@ async fn checkpoint(client: &DaggerConn, container: Container) -> Result<Contain
         .map(|id| client.load_container_from_id(id))
 }
 
+/// each replayed command/upload/mount appends overlay layers to the rootfs, and
+/// the checkpoint (which flattens the GraphQL query, not the filesystem) never
+/// squashes them. once the `lowerdir=a:b:c:...` chain grows past the kernel's
+/// single-page (~4 KB) mount-options limit, `mount(2)` rejects the overlay with
+/// an opaque `ENOENT`. fail fast with a clear terminal error well before that.
+///
+/// this is a heuristic: the real limit is on the lowerdir *string length*, not a
+/// fixed entry count, and BuildKit's content-addressed dedup means the layer-op
+/// count over-estimates the distinct layers actually chained — so the guard errs
+/// toward firing early. a rare zero-dedup session could still exceed the kernel
+/// limit below this count, in which case the raw overlay error surfaces as today.
+const MAX_REPLAY_FS_LAYERS: usize = 256;
+
+/// overlay layers a replay step appends to the rootfs (`with_exec`/`with_new_file`
+/// each snapshot the filesystem; `with_workdir`/`with_user`/env changes don't).
+fn replay_step_fs_layers(step: &ReplayStep) -> usize {
+    match step {
+        // with_exec
+        ReplayStep::Command(_) => 1,
+        // with_new_file + with_exec
+        ReplayStep::File(_) => 2,
+        // with_new_file per file (base64 also runs a decode exec) + one chown exec
+        ReplayStep::SkillMount(mount) => {
+            mount
+                .files
+                .iter()
+                .map(|file| if file.encoding == "utf8" { 1 } else { 2 })
+                .sum::<usize>()
+                + 1
+        }
+    }
+}
+
+fn replay_fs_layers(steps: &[ReplayStep]) -> usize {
+    steps.iter().map(replay_step_fs_layers).sum()
+}
+
+/// reject a replay log that would overflow the overlay mount before any container
+/// work happens, turning the opaque kernel `ENOENT` into a diagnosable error.
+fn check_replay_layer_budget(steps: &[ReplayStep]) -> Result<()> {
+    let layers = replay_fs_layers(steps);
+    if layers > MAX_REPLAY_FS_LAYERS {
+        return Err(SandboxError::HistoryLimitReached {
+            layers,
+            limit: MAX_REPLAY_FS_LAYERS,
+        });
+    }
+    Ok(())
+}
+
 #[tracing::instrument(
     name = "sandbox.materialize",
     skip_all,
     fields(replay.len = req.replay_steps.len())
 )]
 async fn materialize(client: &DaggerConn, warm: Container, req: &RunRequest) -> Result<Container> {
+    check_replay_layer_budget(&req.replay_steps)?;
+
     let mut container = warm;
     let mut budget = ChainBudget::new();
 
@@ -1065,6 +1117,7 @@ mod tests {
     use std::ffi::OsStr;
 
     use super::*;
+    use crate::{ReplayCommand, ReplaySkillMount};
     use dagger_sdk::core::gql_client::GraphQLErrorMessage;
 
     #[test]
@@ -1573,5 +1626,72 @@ mod tests {
         );
         // a file directly under root `/` has no parent dir to create.
         assert_eq!(ancestor_dirs("/file"), Vec::<String>::new());
+    }
+
+    fn command_step() -> ReplayStep {
+        ReplayStep::Command(ReplayCommand {
+            command: "echo hi".to_string(),
+            cwd: None,
+            timeout_seconds: 1,
+        })
+    }
+
+    #[test]
+    fn replay_fs_layers_weights_each_step_kind() {
+        let utf8_file = SnapshotFile {
+            skill_name: "s".to_string(),
+            path: "a.py".to_string(),
+            encoding: "utf8".to_string(),
+            content: String::new(),
+        };
+        let base64_file = SnapshotFile {
+            encoding: "base64".to_string(),
+            ..utf8_file.clone()
+        };
+        let steps = vec![
+            command_step(),
+            ReplayStep::File(ReplayInputFile {
+                path: "/home/sandbox/x".to_string(),
+                encoding: "utf8".to_string(),
+                content: String::new(),
+            }),
+            ReplayStep::SkillMount(ReplaySkillMount {
+                skill_name: "s".to_string(),
+                files: vec![utf8_file, base64_file],
+            }),
+        ];
+        // command(1) + file(2) + mount(utf8 1 + base64 2 + chown 1 = 4)
+        assert_eq!(replay_fs_layers(&steps), 7);
+    }
+
+    #[test]
+    fn check_replay_layer_budget_passes_at_the_limit() {
+        let steps = vec![command_step(); MAX_REPLAY_FS_LAYERS];
+        assert_eq!(replay_fs_layers(&steps), MAX_REPLAY_FS_LAYERS);
+        assert!(check_replay_layer_budget(&steps).is_ok());
+    }
+
+    #[test]
+    fn check_replay_layer_budget_rejects_above_the_limit() {
+        let steps = vec![command_step(); MAX_REPLAY_FS_LAYERS + 1];
+        match check_replay_layer_budget(&steps) {
+            Err(SandboxError::HistoryLimitReached { layers, limit }) => {
+                assert_eq!(layers, MAX_REPLAY_FS_LAYERS + 1);
+                assert_eq!(limit, MAX_REPLAY_FS_LAYERS);
+            }
+            other => panic!("expected HistoryLimitReached, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn history_limit_error_is_a_distinct_actionable_code() {
+        let err = SandboxError::HistoryLimitReached {
+            layers: 300,
+            limit: MAX_REPLAY_FS_LAYERS,
+        };
+        assert_eq!(err.code(), "ARCHESTRA_SANDBOX_HISTORY_LIMIT");
+        let message = err.to_string();
+        assert!(message.contains("300"));
+        assert!(message.contains(&MAX_REPLAY_FS_LAYERS.to_string()));
     }
 }

--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -769,10 +769,12 @@ async fn checkpoint(client: &DaggerConn, container: Container) -> Result<Contain
 /// single-page (~4 KB) mount-options limit, `mount(2)` rejects the overlay with
 /// an opaque `ENOENT`. fail fast with a clear terminal error well before that.
 ///
-/// this is a heuristic: the real limit is on the lowerdir *string length*, not a
-/// fixed entry count, and BuildKit's content-addressed dedup means the layer-op
-/// count over-estimates the distinct layers actually chained — so the guard errs
-/// toward firing early. a rare zero-dedup session could still exceed the kernel
+/// this is a heuristic, not an exact bound, in three ways: the real limit is on
+/// the lowerdir *string length*, not a fixed entry count; BuildKit's
+/// content-addressed dedup means the layer-op count over-estimates the distinct
+/// layers actually chained (so the guard errs toward firing early); and the warm
+/// base's own image + setup layers consume the same mount-options budget but are
+/// not counted here. so a rare zero-dedup session can still exceed the kernel
 /// limit below this count, in which case the raw overlay error surfaces as today.
 const MAX_REPLAY_FS_LAYERS: usize = 256;
 
@@ -800,15 +802,25 @@ fn replay_fs_layers(steps: &[ReplayStep]) -> usize {
     steps.iter().map(replay_step_fs_layers).sum()
 }
 
+/// build the terminal history-limit error with consistent, actionable wording;
+/// `detail` names why we tripped (the layer estimate, or the overlay mount).
+fn history_limit_error(detail: &str) -> SandboxError {
+    SandboxError::HistoryLimitReached {
+        message: format!(
+            "sandbox command history is too long to replay ({detail}); \
+             start a fresh sandbox to continue"
+        ),
+    }
+}
+
 /// reject a replay log that would overflow the overlay mount before any container
 /// work happens, turning the opaque kernel `ENOENT` into a diagnosable error.
 fn check_replay_layer_budget(steps: &[ReplayStep]) -> Result<()> {
     let layers = replay_fs_layers(steps);
     if layers > MAX_REPLAY_FS_LAYERS {
-        return Err(SandboxError::HistoryLimitReached {
-            layers,
-            limit: MAX_REPLAY_FS_LAYERS,
-        });
+        return Err(history_limit_error(&format!(
+            "{layers}/{MAX_REPLAY_FS_LAYERS} filesystem layers"
+        )));
     }
     Ok(())
 }
@@ -1029,16 +1041,35 @@ fn any_exit_opts<'a>() -> ContainerWithExecOpts<'a> {
 /// `CommandFailed`; everything else is a real transport/engine failure, tagged
 /// with the specific fault so the session layer can pick a retry policy.
 fn from_sdk(err: DaggerError) -> SandboxError {
-    match exec_exit_code(&err) {
-        Some(exit_code) => SandboxError::CommandFailed {
+    if let Some(exit_code) = exec_exit_code(&err) {
+        return SandboxError::CommandFailed {
             exit_code,
             message: err.to_string(),
-        },
-        None => SandboxError::EngineUnreachable {
-            fault: classify_engine_fault(&err),
-            message: err.to_string(),
-        },
+        };
     }
+    // backstop for the replay-layer budget: an overlong chain whose layer
+    // estimate slipped under the budget still fails at the kernel overlay mount.
+    // relabel that exact failure so it surfaces as the terminal, per-call history
+    // limit instead of a phantom engine outage (which would trip the cooldown).
+    if is_overlay_mount_overflow(&err) {
+        return history_limit_error("overlay mount-options limit reached");
+    }
+    SandboxError::EngineUnreachable {
+        fault: classify_engine_fault(&err),
+        message: err.to_string(),
+    }
+}
+
+/// the kernel rejects an overlay mount whose `lowerdir=a:b:c:...` option string
+/// outgrows its single-page limit; dagger reports it as a domain error naming the
+/// failed rootfs overlay mount. recognise that one failure — as narrowly as the
+/// stale-attachables classifier — so the replay backstop can relabel it.
+fn is_overlay_mount_overflow(err: &DaggerError) -> bool {
+    matches!(
+        err,
+        DaggerError::Query(GraphQLError::DomainError { message, .. })
+            if message.contains("mount rootfs") && message.contains("overlay")
+    )
 }
 
 /// build an engine-unreachable error from a non-exec SDK failure (warm-base
@@ -1675,23 +1706,38 @@ mod tests {
     fn check_replay_layer_budget_rejects_above_the_limit() {
         let steps = vec![command_step(); MAX_REPLAY_FS_LAYERS + 1];
         match check_replay_layer_budget(&steps) {
-            Err(SandboxError::HistoryLimitReached { layers, limit }) => {
-                assert_eq!(layers, MAX_REPLAY_FS_LAYERS + 1);
-                assert_eq!(limit, MAX_REPLAY_FS_LAYERS);
+            Err(err @ SandboxError::HistoryLimitReached { .. }) => {
+                assert_eq!(err.code(), "ARCHESTRA_SANDBOX_HISTORY_LIMIT");
+                let message = err.to_string();
+                // the actual over-budget count is reported for diagnosis.
+                assert!(message.contains(&(MAX_REPLAY_FS_LAYERS + 1).to_string()));
+                assert!(message.contains(&MAX_REPLAY_FS_LAYERS.to_string()));
             }
             other => panic!("expected HistoryLimitReached, got {other:?}"),
         }
     }
 
     #[test]
-    fn history_limit_error_is_a_distinct_actionable_code() {
-        let err = SandboxError::HistoryLimitReached {
-            layers: 300,
-            limit: MAX_REPLAY_FS_LAYERS,
-        };
-        assert_eq!(err.code(), "ARCHESTRA_SANDBOX_HISTORY_LIMIT");
-        let message = err.to_string();
-        assert!(message.contains("300"));
-        assert!(message.contains(&MAX_REPLAY_FS_LAYERS.to_string()));
+    fn from_sdk_relabels_the_overlay_mount_overflow_as_a_history_limit() {
+        // the memo's verbatim kernel failure: the replay chain's lowerdir string
+        // outgrew the page limit and mount(2) rejected the rootfs overlay.
+        let err = domain_error(
+            "mount rootfs: mount source: \"overlay\", target: \"/tmp/rootfs1234567\", \
+             fstype: overlay, flags: 0, data: \"...lowerdir=6946/fs:6940/fs:...\", \
+             err: no such file or directory",
+            None,
+        );
+        let mapped = from_sdk(err);
+        assert_eq!(mapped.code(), "ARCHESTRA_SANDBOX_HISTORY_LIMIT");
+    }
+
+    #[test]
+    fn from_sdk_keeps_unrelated_domain_errors_as_engine_unreachable() {
+        // a domain error that isn't the overlay rootfs mount must not be relabeled.
+        let err = domain_error("some other engine domain failure", None);
+        assert!(matches!(
+            from_sdk(err),
+            SandboxError::EngineUnreachable { .. }
+        ));
     }
 }

--- a/platform/archestra-rs/sandbox-core/src/lib.rs
+++ b/platform/archestra-rs/sandbox-core/src/lib.rs
@@ -44,6 +44,14 @@ pub enum SandboxError {
         path: String,
         message: String,
     },
+    /// the replay log is long enough that re-materialising it would overflow the
+    /// kernel's single-page overlay mount-options limit (`lowerdir=a:b:c:...`).
+    /// terminal and per-call: a fresh sandbox is required, and unlike
+    /// `EngineUnreachable` it must not flip the runtime into an engine outage.
+    HistoryLimitReached {
+        layers: usize,
+        limit: usize,
+    },
     InvalidInput(String),
     Internal(String),
 }
@@ -69,6 +77,7 @@ impl SandboxError {
             Self::CommandFailed { .. } => "ARCHESTRA_COMMAND_FAILED",
             Self::ArtifactTooLarge { .. } => "ARCHESTRA_ARTIFACT_TOO_LARGE",
             Self::ArtifactNotFound { .. } => "ARCHESTRA_ARTIFACT_NOT_FOUND",
+            Self::HistoryLimitReached { .. } => "ARCHESTRA_SANDBOX_HISTORY_LIMIT",
             Self::InvalidInput(_) => "ARCHESTRA_INVALID_INPUT",
             Self::Internal(_) => "ARCHESTRA_INTERNAL",
         }
@@ -88,6 +97,11 @@ impl fmt::Display for SandboxError {
             | Self::ArtifactNotFound { message, .. }
             | Self::InvalidInput(message)
             | Self::Internal(message) => write!(f, "{message}"),
+            Self::HistoryLimitReached { layers, limit } => write!(
+                f,
+                "sandbox command history is too long to replay ({layers}/{limit} \
+                 filesystem layers); start a fresh sandbox to continue"
+            ),
         }
     }
 }

--- a/platform/archestra-rs/sandbox-core/src/lib.rs
+++ b/platform/archestra-rs/sandbox-core/src/lib.rs
@@ -46,11 +46,12 @@ pub enum SandboxError {
     },
     /// the replay log is long enough that re-materialising it would overflow the
     /// kernel's single-page overlay mount-options limit (`lowerdir=a:b:c:...`).
-    /// terminal and per-call: a fresh sandbox is required, and unlike
-    /// `EngineUnreachable` it must not flip the runtime into an engine outage.
+    /// raised proactively by the replay-layer budget, and as a backstop when the
+    /// overlay mount itself fails. terminal and per-call: a fresh sandbox is
+    /// required, and unlike `EngineUnreachable` it must not flip the runtime into
+    /// an engine outage.
     HistoryLimitReached {
-        layers: usize,
-        limit: usize,
+        message: String,
     },
     InvalidInput(String),
     Internal(String),
@@ -96,12 +97,8 @@ impl fmt::Display for SandboxError {
             | Self::ArtifactTooLarge { message, .. }
             | Self::ArtifactNotFound { message, .. }
             | Self::InvalidInput(message)
-            | Self::Internal(message) => write!(f, "{message}"),
-            Self::HistoryLimitReached { layers, limit } => write!(
-                f,
-                "sandbox command history is too long to replay ({layers}/{limit} \
-                 filesystem layers); start a fresh sandbox to continue"
-            ),
+            | Self::Internal(message)
+            | Self::HistoryLimitReached { message } => write!(f, "{message}"),
         }
     }
 }

--- a/platform/archestra-rs/sandbox-core/src/session.rs
+++ b/platform/archestra-rs/sandbox-core/src/session.rs
@@ -627,6 +627,19 @@ mod tests {
     }
 
     #[test]
+    fn history_limit_is_terminal_for_every_operation() {
+        // the overlay history limit is a per-call dead end: a fresh sandbox is
+        // required, so retrying the same log on a new session can't recover it.
+        let err = SandboxError::HistoryLimitReached {
+            layers: 300,
+            limit: 256,
+        };
+        assert_eq!(retry_reason(SessionOperation::Run, &err), None);
+        assert_eq!(retry_reason(SessionOperation::ReadArtifact, &err), None);
+        assert_eq!(retry_reason(SessionOperation::CheckSession, &err), None);
+    }
+
+    #[test]
     fn panic_to_error_retags_recovered_engine_fault_for_retry() {
         // dagger-sdk panics (instead of returning a typed error) on a
         // stale-attachables timeout; the recovered fault must re-enter the

--- a/platform/archestra-rs/sandbox-core/src/session.rs
+++ b/platform/archestra-rs/sandbox-core/src/session.rs
@@ -631,8 +631,7 @@ mod tests {
         // the overlay history limit is a per-call dead end: a fresh sandbox is
         // required, so retrying the same log on a new session can't recover it.
         let err = SandboxError::HistoryLimitReached {
-            layers: 300,
-            limit: 256,
+            message: "sandbox command history is too long to replay".to_string(),
         };
         assert_eq!(retry_reason(SessionOperation::Run, &err), None);
         assert_eq!(retry_reason(SessionOperation::ReadArtifact, &err), None);

--- a/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
+++ b/platform/backend/src/sandbox-runtime/sandbox-runtime-service.ts
@@ -42,7 +42,8 @@ type NativeSandboxErrorCode =
   | "ARCHESTRA_COMMAND_FAILED"
   | "ARCHESTRA_ENGINE_UNREACHABLE"
   | "ARCHESTRA_INTERNAL"
-  | "ARCHESTRA_INVALID_INPUT";
+  | "ARCHESTRA_INVALID_INPUT"
+  | "ARCHESTRA_SANDBOX_HISTORY_LIMIT";
 
 interface LimitOverrides {
   outputBytesLimit?: number;
@@ -405,6 +406,9 @@ class SandboxRuntimeService {
       case "ARCHESTRA_ARTIFACT_TOO_LARGE":
       case "ARCHESTRA_COMMAND_FAILED":
       case "ARCHESTRA_INVALID_INPUT":
+      // a per-session replay limit, not an engine outage — surface the actionable
+      // message and leave runtime status untouched (no cooldown gate).
+      case "ARCHESTRA_SANDBOX_HISTORY_LIMIT":
         return new SandboxRuntimeError(native.message, native.code);
       case "ARCHESTRA_ENGINE_UNREACHABLE":
         // genuine engine outage — flip status so the cooldown gate kicks in.
@@ -471,6 +475,7 @@ function getNativeSandboxError(error: unknown): {
     case "ARCHESTRA_ENGINE_UNREACHABLE":
     case "ARCHESTRA_INTERNAL":
     case "ARCHESTRA_INVALID_INPUT":
+    case "ARCHESTRA_SANDBOX_HISTORY_LIMIT":
       return { code, message: error.message };
     default:
       return { code: null, message: error.message };

--- a/platform/backend/src/skills-sandbox/README.md
+++ b/platform/backend/src/skills-sandbox/README.md
@@ -125,6 +125,13 @@ can tune them via env vars:
 Fixed API limits live in `types.ts` (`SKILL_SANDBOX_LIMITS`), including command
 input length and the per-sandbox pending queue length.
 
+There is also a ceiling on **replay length**: every replayed step adds overlay
+filesystem layers, and a long enough chain overflows the kernel's overlay
+mount-options limit. The native core (`archestra-rs/sandbox-core`) guards against
+this and fails such a `run_command` with a terminal, per-sandbox
+`ARCHESTRA_SANDBOX_HISTORY_LIMIT` error telling the model to start a fresh
+sandbox — rather than the opaque mount failure it would otherwise surface.
+
 The sandbox always runs as the non-root user from `runtime-image.ts`, with no
 host mounts and no backend env exposed inside the container. Network access is
 enabled because npm/uv/npx require it; this is documented in the activation

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/models";
 import { afterEach, describe, expect, test, vi } from "@/test";
 import { asSandboxId } from "@/types";
+import { SandboxRuntimeError } from "../sandbox-runtime/sandbox-runtime-service";
 import {
   __internals,
   skillSandboxRuntimeService,
@@ -427,6 +428,22 @@ describe("__internals", () => {
     expect(notices).toHaveLength(1);
     expect(notices[0]).toContain("huge.bin");
     expect(notices[0]).toContain("exceeds");
+  });
+
+  test("a history-limit failure is not recorded as a synthetic replay row", () => {
+    // recording the failing command would append yet another replay step and
+    // make the over-limit sandbox permanently unrecoverable. only genuine
+    // mid-stream engine failures (INTERNAL) get a synthetic row.
+    expect(
+      __internals.shouldRecordOnFailure(
+        new SandboxRuntimeError("too long", "ARCHESTRA_SANDBOX_HISTORY_LIMIT"),
+      ),
+    ).toBe(false);
+    expect(
+      __internals.shouldRecordOnFailure(
+        new SandboxRuntimeError("boom", "ARCHESTRA_INTERNAL"),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -681,6 +681,11 @@ class SkillSandboxRuntimeService {
           return new SkillSandboxError(
             "the skill sandbox runtime is not enabled",
           );
+        case "ARCHESTRA_SANDBOX_HISTORY_LIMIT":
+          // The replay log is too long to re-materialize. Surface the native
+          // message verbatim so the model knows to start a fresh sandbox; this
+          // is a per-session dead end, not an engine outage.
+          return new SkillSandboxError(error.message);
         case "ARCHESTRA_ENGINE_UNREACHABLE":
         case "ARCHESTRA_INTERNAL":
           logger.error({ err: error }, "[SkillSandbox] runtime error");
@@ -1093,4 +1098,5 @@ export const __internals = {
   planAttachmentStaging,
   assignAttachmentPaths,
   sanitizeAttachmentName,
+  shouldRecordOnFailure,
 };


### PR DESCRIPTION
## Problem

Each `run_command` re-materializes the sandbox by replaying every prior step, and every replayed command appends overlay filesystem layers. The existing checkpoint flattens the **GraphQL query depth**, not the filesystem, so the overlay `lowerdir=a:b:c:...` chain grows unbounded. Past the kernel's single-page (~4 KB) mount-options limit, `mount(2)` rejects the rootfs overlay with an opaque `ENOENT`.

That failure was classified as `EngineUnreachable`, which on the backend **flips global runtime status into a cooldown** — so one runaway session's overflow gated all sandbox calls.

## Fix

Two layers, both routed to a single terminal, per-call error:

1. **Proactive budget** — `materialize()` rejects an over-budget replay log up front (`replay_fs_layers` / `check_replay_layer_budget`, `MAX_REPLAY_FS_LAYERS = 256`) before any container work. The count is a deliberately conservative heuristic (content-addressed dedup + uncounted warm-base layers mean it errs toward firing early).
2. **Backstop** — `from_sdk` recognizes the actual kernel overlay overflow by its full signature (`mount rootfs` + `lowerdir=` + `ENOENT`) and relabels it to the same error, so anything the heuristic misses still gets a clean failure instead of the opaque `ENOENT` + cooldown. Intentionally narrow: unknown wording degrades safely to the prior engine-unreachable path.

New `SandboxError::HistoryLimitReached` (`ARCHESTRA_SANDBOX_HISTORY_LIMIT`) is terminal (never retried) and surfaces through the TS boundary as a per-call failure — so it does **not** flip runtime status and is **not** recorded back into the replay log (which would make the over-limit state permanent). The model is told to start a fresh sandbox.

## Validation

- Rust: 50 tests (boundary, relabel, generic-overlay/stale-attachables negatives), `clippy --all-targets -D warnings` clean, workspace builds.
- TS: type-check + biome clean; 32 skill-sandbox tests pass (incl. an anti-compounding test that a history-limit failure is not recorded).
- Docs: replay-length ceiling noted in the skills-sandbox README.

## Scope notes

- The backstop covers the typed checkpoint-sync error path (the likely interception point), not the rarer SDK-panic path.
- Out of scope: real rootfs squash, and the no-progress agent-loop guard (designed separately).

https://claude.ai/code/session_01LhLnJwjtcH4316ak1auEde

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>