### PR TITLE
feat(mcp-registry): separate service accounts on the Credentials page

### DIFF
--- a/platform/frontend/src/app/mcp/registry/beta/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/[id]/page.client.tsx
@@ -580,9 +580,6 @@ function CatalogItemDetails({ item }: { item: CatalogItem }) {
         <Card>
           <CardHeader>
             <h2 className="text-base font-semibold">Credentials</h2>
-            <CardDescription>
-              Who is connected to this server and with which credentials.
-            </CardDescription>
           </CardHeader>
           <CardContent>
             <ManageUsersContent

--- a/platform/frontend/src/app/mcp/registry/beta/_parts/add-service-account-dialog.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/add-service-account-dialog.test.tsx
@@ -1,0 +1,90 @@
+import {
+  E2eTestId,
+  getManageCredentialsAddToTeamOptionTestId,
+} from "@archestra/shared";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AddServiceAccountDialog } from "./add-service-account-dialog";
+
+describe("AddServiceAccountDialog", () => {
+  it("explains that the shared key is used as a static key or an on-behalf-of fallback", () => {
+    render(
+      <AddServiceAccountDialog
+        open
+        onOpenChange={() => {}}
+        availableTeams={[]}
+        canAddOrg
+        onConfirm={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/This connection is shared/i)).toBeInTheDocument();
+    expect(screen.getByText("Static key")).toBeInTheDocument();
+    expect(screen.getByText("Fallback")).toBeInTheDocument();
+  });
+
+  it("confirms an organization service account (the default when org is allowed)", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+
+    render(
+      <AddServiceAccountDialog
+        open
+        onOpenChange={() => {}}
+        availableTeams={[{ id: "team-1", name: "Engineering" }]}
+        canAddOrg
+        onConfirm={onConfirm}
+      />,
+    );
+
+    await user.click(
+      screen.getByTestId(E2eTestId.AddServiceAccountConfirmButton),
+    );
+
+    expect(onConfirm).toHaveBeenCalledWith({ type: "org" });
+  });
+
+  it("confirms the specific team the user selects", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+
+    render(
+      <AddServiceAccountDialog
+        open
+        onOpenChange={() => {}}
+        availableTeams={[
+          { id: "team-1", name: "Engineering" },
+          { id: "team-2", name: "Sales" },
+        ]}
+        canAddOrg={false}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    await user.click(
+      screen.getByTestId(getManageCredentialsAddToTeamOptionTestId("Sales")),
+    );
+    await user.click(
+      screen.getByTestId(E2eTestId.AddServiceAccountConfirmButton),
+    );
+
+    expect(onConfirm).toHaveBeenCalledWith({ type: "team", teamId: "team-2" });
+  });
+
+  it("disables confirmation when there is no team or organization to add", () => {
+    render(
+      <AddServiceAccountDialog
+        open
+        onOpenChange={() => {}}
+        availableTeams={[]}
+        canAddOrg={false}
+        onConfirm={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByTestId(E2eTestId.AddServiceAccountConfirmButton),
+    ).toBeDisabled();
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/beta/_parts/add-service-account-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/add-service-account-dialog.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import {
+  DocsPage,
+  E2eTestId,
+  getDocsUrl,
+  getManageCredentialsAddToTeamOptionTestId,
+} from "@archestra/shared";
+import { AlertTriangle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ExternalDocsLink } from "@/components/external-docs-link";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+type ServiceAccountTarget = { type: "team"; teamId: string } | { type: "org" };
+
+const ORG_TARGET_VALUE = "__org__";
+
+interface AddServiceAccountDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Teams that don't yet have a service account for this server. */
+  availableTeams: Array<{ id: string; name: string }>;
+  /** Whether an organization-wide service account can still be added. */
+  canAddOrg: boolean;
+  onConfirm: (target: ServiceAccountTarget) => void;
+}
+
+export function AddServiceAccountDialog({
+  open,
+  onOpenChange,
+  availableTeams,
+  canAddOrg,
+  onConfirm,
+}: AddServiceAccountDialogProps) {
+  const defaultValue = canAddOrg
+    ? ORG_TARGET_VALUE
+    : (availableTeams[0]?.id ?? null);
+  const [selected, setSelected] = useState<string | null>(defaultValue);
+
+  // Reset the choice whenever the dialog (re)opens or the option set changes,
+  // so a stale selection from a previous open can't be submitted.
+  useEffect(() => {
+    if (open) {
+      setSelected(
+        canAddOrg ? ORG_TARGET_VALUE : (availableTeams[0]?.id ?? null),
+      );
+    }
+  }, [open, canAddOrg, availableTeams]);
+
+  const handleConfirm = () => {
+    if (!selected) return;
+    onConfirm(
+      selected === ORG_TARGET_VALUE
+        ? { type: "org" }
+        : { type: "team", teamId: selected },
+    );
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Add a service account
+          </DialogTitle>
+        </DialogHeader>
+
+        <DialogBody className="space-y-4">
+          <div className="space-y-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">
+              This connection is shared. Use it with care.
+            </p>
+            <p>It gets used in two ways:</p>
+            <ul className="list-disc space-y-1 pl-4">
+              <li>
+                <span className="font-medium text-foreground">Static key</span>{" "}
+                — when it's pinned as the server's single account, every call
+                uses it no matter who is chatting.
+              </li>
+              <li>
+                <span className="font-medium text-foreground">Fallback</span> —
+                during on-behalf-of, when someone chatting has no connection of
+                their own.
+              </li>
+            </ul>
+            <p>
+              Treat the credential like a shared secret.{" "}
+              <ExternalDocsLink
+                href={getDocsUrl(
+                  DocsPage.McpAuthentication,
+                  "resolve-at-call-time",
+                )}
+                className="underline"
+                showIcon={false}
+              >
+                Learn more
+              </ExternalDocsLink>
+            </p>
+          </div>
+
+          {(availableTeams.length > 0 || canAddOrg) && (
+            <div className="space-y-2">
+              <Label>Who should own this service account?</Label>
+              <RadioGroup
+                value={selected ?? ""}
+                onValueChange={setSelected}
+                className="gap-2"
+              >
+                {canAddOrg && (
+                  <Label
+                    htmlFor="service-account-org"
+                    className="flex cursor-pointer items-start gap-2.5 rounded-md border p-3 font-normal has-[:checked]:border-primary"
+                    data-testid={E2eTestId.ManageCredentialsAddToOrgButton}
+                  >
+                    <RadioGroupItem
+                      id="service-account-org"
+                      value={ORG_TARGET_VALUE}
+                      className="mt-0.5"
+                    />
+                    <span className="space-y-0.5">
+                      <span className="block text-sm font-medium">
+                        Organization
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        Everyone in the organization can use it.
+                      </span>
+                    </span>
+                  </Label>
+                )}
+                {availableTeams.map((team) => (
+                  <Label
+                    key={team.id}
+                    htmlFor={`service-account-team-${team.id}`}
+                    className="flex cursor-pointer items-start gap-2.5 rounded-md border p-3 font-normal has-[:checked]:border-primary"
+                    data-testid={getManageCredentialsAddToTeamOptionTestId(
+                      team.name,
+                    )}
+                  >
+                    <RadioGroupItem
+                      id={`service-account-team-${team.id}`}
+                      value={team.id}
+                      className="mt-0.5"
+                    />
+                    <span className="space-y-0.5">
+                      <span className="block text-sm font-medium">
+                        {team.name}
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        Members of this team can use it.
+                      </span>
+                    </span>
+                  </Label>
+                ))}
+              </RadioGroup>
+            </div>
+          )}
+        </DialogBody>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!selected}
+            onClick={handleConfirm}
+            data-testid={E2eTestId.AddServiceAccountConfirmButton}
+          >
+            Add service account
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/platform/frontend/src/app/mcp/registry/beta/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/manage-users-dialog.tsx
@@ -6,22 +6,19 @@ import {
   E2eTestId,
   formatSecretStorageType,
   getDocsUrl,
-  getManageCredentialsAddToTeamOptionTestId,
   type McpDeploymentStatusEntry,
 } from "@archestra/shared";
 import { format } from "date-fns";
 import {
   AlertTriangle,
-  ChevronDown,
   KeyRound,
-  PlugZap,
   Plus,
   RefreshCw,
   Trash,
   User,
   Zap,
 } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import { Badge } from "@/components/ui/badge";
@@ -34,19 +31,6 @@ import {
   DialogStickyFooter,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-} from "@/components/ui/empty";
 import {
   Select,
   SelectContent,
@@ -86,6 +70,7 @@ import {
   type DeploymentState,
   DeploymentStatusDot,
 } from "../../_parts/deployment-status";
+import { AddServiceAccountDialog } from "./add-service-account-dialog";
 
 interface ManageUsersDialogProps {
   isOpen: boolean;
@@ -186,6 +171,9 @@ export function ManageUsersContent({
   const { data: hasMcpServerAdminPermission } = useHasPermissions({
     mcpServerInstallation: ["admin"],
   });
+
+  const [serviceAccountDialogOpen, setServiceAccountDialogOpen] =
+    useState(false);
 
   // Use the first server for display purposes
   const firstServer = allServers?.[0];
@@ -380,6 +368,51 @@ export function ManageUsersContent({
     return mcpServer.ownerEmail || "Deleted user";
   };
 
+  const split = splitByScope(allServers);
+  const canonicalStateByPod = computeCanonicalStateByPod(
+    allServers,
+    deploymentStatuses,
+  );
+
+  const personalRows: ConnectionRow[] = [
+    ...(split.myPersonalServer
+      ? [{ server: split.myPersonalServer, isYou: true } as const]
+      : []),
+    ...split.otherPersonalServers.map((s) => ({ server: s, isYou: false })),
+  ];
+  const serviceAccountRows: ConnectionRow[] = [
+    ...split.teamServers.map((s) => ({ server: s, isYou: false })),
+    ...split.orgServers.map((s) => ({ server: s, isYou: false })),
+  ];
+
+  const canAddPersonal =
+    hasAddCallbacks && !!onAddPersonalConnection && !split.myPersonalServer;
+  const canAddTeam =
+    hasAddCallbacks &&
+    !!onAddSharedConnection &&
+    split.availableTeamsForShared.length > 0;
+  const canAddOrg =
+    hasAddCallbacks &&
+    !!onAddOrgConnection &&
+    !split.hasOrgConnection &&
+    !!hasMcpServerAdminPermission;
+  const canAddServiceAccount = canAddTeam || canAddOrg;
+
+  const rowProps: RowRenderProps = {
+    isOAuthServer,
+    deploymentStatuses,
+    canonicalStateByPod,
+    getCredentialOwnerName,
+    canReauthenticate,
+    getReauthTooltip,
+    canRevoke,
+    getRevokeTooltip,
+    handleReauthenticate,
+    handleRevoke,
+    isDeleting: deleteMcpServerMutation.isPending,
+    onOpenPodLogs,
+  };
+
   return (
     <>
       {!hideHeader && (
@@ -395,100 +428,83 @@ export function ManageUsersContent({
         </DialogHeader>
       )}
 
-      <div className={hideHeader ? "space-y-4" : "space-y-4 pb-4"}>
+      <div className={hideHeader ? "space-y-6" : "space-y-6 pb-4"}>
         {catalogItem && (
           <AgentConnectionsSection
             item={catalogItem}
             connections={allServers}
           />
         )}
-        {(() => {
-          const split = splitByScope(allServers);
-          const hasContent = allServers.length > 0;
 
-          const installMenu = (
-            <InstallMenuButton
-              onAddPersonal={
-                hasAddCallbacks &&
-                onAddPersonalConnection &&
-                !split.myPersonalServer
-                  ? () => {
-                      onClose();
-                      onAddPersonalConnection();
-                    }
-                  : undefined
-              }
-              onAddForTeam={
-                hasAddCallbacks && onAddSharedConnection
-                  ? (teamId) => {
-                      onClose();
-                      onAddSharedConnection(teamId);
-                    }
-                  : undefined
-              }
-              onAddForOrg={
-                hasAddCallbacks && onAddOrgConnection && !split.hasOrgConnection
-                  ? () => {
-                      onClose();
-                      onAddOrgConnection();
-                    }
-                  : undefined
-              }
-              availableTeamsForShared={split.availableTeamsForShared}
-              addOrgDisabled={!hasMcpServerAdminPermission}
-              addOrgDisabledReason={
-                !hasMcpServerAdminPermission
-                  ? "Only organization admins can install organization-wide"
-                  : undefined
-              }
-            />
-          );
+        {(personalRows.length > 0 || canAddPersonal) && (
+          <ConnectionsSection
+            title="Personal connections"
+            description="Each person connects their own account."
+            emptyText="No personal connections yet."
+            rows={personalRows}
+            tableTestId={E2eTestId.ManageCredentialsDialogTable}
+            action={
+              canAddPersonal ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => {
+                    onClose();
+                    onAddPersonalConnection?.();
+                  }}
+                >
+                  <Plus className="mr-1 h-3 w-3" />
+                  Connect my account
+                </Button>
+              ) : null
+            }
+            {...rowProps}
+          />
+        )}
 
-          return (
-            <div className="space-y-2">
-              {hideHeader ? (
-                <div className="flex justify-end">{installMenu}</div>
-              ) : (
-                <div className="flex items-center justify-between gap-4">
-                  <div className="space-y-0.5">
-                    <h4 className="text-sm font-medium">Connections</h4>
-                    <p className="text-sm text-muted-foreground">
-                      Accounts connected to this server.
-                    </p>
-                  </div>
-                  {installMenu}
-                </div>
-              )}
-              <div className="overflow-hidden rounded-lg border">
-                {hasContent ? (
-                  <UnifiedConnectionsTable
-                    myPersonalServer={split.myPersonalServer}
-                    otherPersonalServers={split.otherPersonalServers}
-                    teamServers={split.teamServers}
-                    orgServers={split.orgServers}
-                    isOAuthServer={isOAuthServer}
-                    getCredentialOwnerName={getCredentialOwnerName}
-                    canReauthenticate={canReauthenticate}
-                    getReauthTooltip={getReauthTooltip}
-                    canRevoke={canRevoke}
-                    getRevokeTooltip={getRevokeTooltip}
-                    handleReauthenticate={handleReauthenticate}
-                    handleRevoke={handleRevoke}
-                    isDeleting={deleteMcpServerMutation.isPending}
-                    deploymentStatuses={deploymentStatuses}
-                    onOpenPodLogs={onOpenPodLogs}
-                    availableTeamsForShared={split.availableTeamsForShared}
-                  />
-                ) : (
-                  <p className="text-sm text-muted-foreground px-4 py-3">
-                    No callers yet.
-                  </p>
-                )}
-              </div>
-            </div>
-          );
-        })()}
+        {(serviceAccountRows.length > 0 || canAddServiceAccount) && (
+          <ConnectionsSection
+            title="Service accounts"
+            description="Shared team & organization keys."
+            emptyText="No service accounts yet."
+            rows={serviceAccountRows}
+            tableTestId={E2eTestId.ManageServiceAccountsTable}
+            action={
+              canAddServiceAccount ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  data-testid={
+                    E2eTestId.ManageCredentialsAddServiceAccountButton
+                  }
+                  onClick={() => setServiceAccountDialogOpen(true)}
+                >
+                  <Plus className="mr-1 h-3 w-3" />
+                  Add service account
+                </Button>
+              ) : null
+            }
+            {...rowProps}
+          />
+        )}
       </div>
+
+      <AddServiceAccountDialog
+        open={serviceAccountDialogOpen}
+        onOpenChange={setServiceAccountDialogOpen}
+        availableTeams={canAddTeam ? split.availableTeamsForShared : []}
+        canAddOrg={canAddOrg}
+        onConfirm={(target) => {
+          onClose();
+          if (target.type === "org") {
+            onAddOrgConnection?.();
+          } else {
+            onAddSharedConnection?.(target.teamId);
+          }
+        }}
+      />
 
       {!hideHeader && (
         <DialogStickyFooter>
@@ -505,137 +521,12 @@ type ServerEntry = NonNullable<
   ReturnType<typeof useMcpServers>["data"]
 >[number];
 
-interface InstallMenuButtonProps {
-  onAddPersonal?: () => void;
-  onAddForTeam?: (teamId: string) => void;
-  onAddForOrg?: () => void;
-  availableTeamsForShared: Array<{ id: string; name: string }>;
-  addOrgDisabled?: boolean;
-  addOrgDisabledReason?: string;
-}
+type ConnectionRow = { server: ServerEntry; isYou: boolean };
 
-function InstallMenuButton({
-  onAddPersonal,
-  onAddForTeam,
-  onAddForOrg,
-  availableTeamsForShared,
-  addOrgDisabled,
-  addOrgDisabledReason,
-}: InstallMenuButtonProps) {
-  const teamItems =
-    onAddForTeam && availableTeamsForShared.length > 0
-      ? availableTeamsForShared.map((team) => ({
-          key: `team-${team.id}`,
-          label: `Install for ${team.name}`,
-          onClick: () => onAddForTeam(team.id),
-          testId: getManageCredentialsAddToTeamOptionTestId(team.name),
-        }))
-      : [];
-
-  const installItems = [
-    ...(onAddPersonal
-      ? [
-          {
-            key: "personal",
-            label: "Install for myself",
-            onClick: onAddPersonal,
-            testId: undefined as string | undefined,
-          },
-        ]
-      : []),
-    ...(onAddForOrg
-      ? [
-          {
-            key: "org",
-            label: "Install for organization",
-            onClick: onAddForOrg,
-            disabled: !!addOrgDisabled,
-            disabledReason: addOrgDisabledReason,
-            testId: E2eTestId.ManageCredentialsAddToOrgButton,
-          },
-        ]
-      : []),
-    ...teamItems,
-  ];
-
-  if (installItems.length === 0) return null;
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-xs"
-          data-testid={E2eTestId.ManageCredentialsAddToTeamButton}
-        >
-          <Plus className="mr-1 h-3 w-3" />
-          Install
-          <ChevronDown className="ml-1 h-3 w-3" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {installItems.map((item) => {
-          const disabled = "disabled" in item && item.disabled;
-          const reason =
-            "disabledReason" in item ? item.disabledReason : undefined;
-          const node = (
-            <DropdownMenuItem
-              key={item.key}
-              onClick={disabled ? undefined : item.onClick}
-              disabled={disabled}
-              data-testid={item.testId}
-            >
-              {item.label}
-            </DropdownMenuItem>
-          );
-          if (disabled && reason) {
-            return (
-              <TooltipProvider key={item.key}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div>{node}</div>
-                  </TooltipTrigger>
-                  <TooltipContent>{reason}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            );
-          }
-          return <div key={item.key}>{node}</div>;
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-function UnifiedConnectionsTable({
-  myPersonalServer,
-  otherPersonalServers,
-  teamServers,
-  orgServers,
-  isOAuthServer,
-  getCredentialOwnerName,
-  canReauthenticate,
-  getReauthTooltip,
-  canRevoke,
-  getRevokeTooltip,
-  handleReauthenticate,
-  handleRevoke,
-  isDeleting,
-  deploymentStatuses = {},
-  onOpenPodLogs,
-  onAddPersonal,
-  availableTeamsForShared,
-  onAddForTeam,
-  onAddForOrg,
-  addOrgDisabled,
-  addOrgDisabledReason,
-}: {
-  myPersonalServer: ServerEntry | null;
-  otherPersonalServers: ServerEntry[];
-  teamServers: ServerEntry[];
-  orgServers: ServerEntry[];
+interface RowRenderProps {
   isOAuthServer: boolean;
+  deploymentStatuses: Record<string, McpDeploymentStatusEntry>;
+  canonicalStateByPod: Map<string, string>;
   getCredentialOwnerName: (s: ServerEntry) => string;
   canReauthenticate: (s: ServerEntry) => boolean;
   getReauthTooltip: (s: ServerEntry) => string;
@@ -644,156 +535,70 @@ function UnifiedConnectionsTable({
   handleReauthenticate: (s: ServerEntry) => void;
   handleRevoke: (s: ServerEntry) => void;
   isDeleting: boolean;
-  deploymentStatuses?: Record<string, McpDeploymentStatusEntry>;
   onOpenPodLogs?: (serverId: string) => void;
-  onAddPersonal?: () => void;
-  availableTeamsForShared: Array<{ id: string; name: string }>;
-  onAddForTeam?: (teamId: string) => void;
-  onAddForOrg?: () => void;
-  addOrgDisabled?: boolean;
-  addOrgDisabledReason?: string;
-}) {
-  const rows = [
-    ...(myPersonalServer
-      ? [{ server: myPersonalServer, isYou: true } as const]
-      : []),
-    ...otherPersonalServers.map((s) => ({ server: s, isYou: false }) as const),
-    ...teamServers.map((s) => ({ server: s, isYou: false }) as const),
-    ...orgServers.map((s) => ({ server: s, isYou: false }) as const),
-  ];
+}
 
+function ConnectionsSection({
+  title,
+  description,
+  action,
+  rows,
+  emptyText,
+  tableTestId,
+  ...rowProps
+}: {
+  title: string;
+  description: string;
+  action: React.ReactNode;
+  rows: ConnectionRow[];
+  emptyText: string;
+  tableTestId: string;
+} & RowRenderProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-0.5">
+          <h4 className="text-sm font-medium">{title}</h4>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        {action}
+      </div>
+      <div className="overflow-hidden rounded-lg border">
+        {rows.length > 0 ? (
+          <ConnectionsTable rows={rows} testId={tableTestId} {...rowProps} />
+        ) : (
+          <p className="text-sm text-muted-foreground px-4 py-3">{emptyText}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConnectionsTable({
+  rows,
+  testId,
+  isOAuthServer,
+  deploymentStatuses,
+  canonicalStateByPod,
+  getCredentialOwnerName,
+  canReauthenticate,
+  getReauthTooltip,
+  canRevoke,
+  getRevokeTooltip,
+  handleReauthenticate,
+  handleRevoke,
+  isDeleting,
+  onOpenPodLogs,
+}: {
+  rows: ConnectionRow[];
+  testId: string;
+} & RowRenderProps) {
   const hasDeploymentStatuses = rows.some(
     (r) => deploymentStatuses[r.server.id],
   );
 
-  // Multi-tenant catalogs alias one pod across N caller rows. Each row's
-  // K8sDeployment instance tracks its own state independently, so the row
-  // that didn't observe the pod first stays "pending" while the other goes
-  // "failed". Pick a canonical state per podName so all rows agree.
-  const STATE_PRIORITY: Record<string, number> = {
-    failed: 4,
-    running: 3,
-    succeeded: 3,
-    pending: 2,
-    not_created: 1,
-  };
-  const canonicalStateByPod = new Map<string, string>();
-  for (const { server } of rows) {
-    const entry = deploymentStatuses[server.id];
-    if (!entry?.podName) continue;
-    const current = canonicalStateByPod.get(entry.podName);
-    if (
-      !current ||
-      (STATE_PRIORITY[entry.state] ?? 0) > (STATE_PRIORITY[current] ?? 0)
-    ) {
-      canonicalStateByPod.set(entry.podName, entry.state);
-    }
-  }
-
-  const teamItems =
-    onAddForTeam && availableTeamsForShared.length > 0
-      ? availableTeamsForShared.map((team) => ({
-          key: `team-${team.id}`,
-          label: `Install for ${team.name}`,
-          onClick: () => onAddForTeam(team.id),
-          testId: getManageCredentialsAddToTeamOptionTestId(team.name),
-        }))
-      : [];
-
-  const installItems = [
-    ...(onAddPersonal
-      ? [
-          {
-            key: "personal",
-            label: "Install for myself",
-            onClick: onAddPersonal,
-            testId: undefined as string | undefined,
-          },
-        ]
-      : []),
-    ...(onAddForOrg
-      ? [
-          {
-            key: "org",
-            label: "Install for organization",
-            onClick: onAddForOrg,
-            disabled: !!addOrgDisabled,
-            disabledReason: addOrgDisabledReason,
-            testId: E2eTestId.ManageCredentialsAddToOrgButton,
-          },
-        ]
-      : []),
-    ...teamItems,
-  ];
-
-  const installMenu =
-    installItems.length === 0 ? null : (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 text-xs"
-            data-testid={E2eTestId.ManageCredentialsAddToTeamButton}
-          >
-            <Plus className="mr-1 h-3 w-3" />
-            Install
-            <ChevronDown className="ml-1 h-3 w-3" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          {installItems.map((item) => {
-            const disabled = "disabled" in item && item.disabled;
-            const reason =
-              "disabledReason" in item ? item.disabledReason : undefined;
-            const node = (
-              <DropdownMenuItem
-                key={item.key}
-                onClick={disabled ? undefined : item.onClick}
-                disabled={disabled}
-                data-testid={item.testId}
-              >
-                {item.label}
-              </DropdownMenuItem>
-            );
-            if (disabled && reason) {
-              return (
-                <TooltipProvider key={item.key}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div>{node}</div>
-                    </TooltipTrigger>
-                    <TooltipContent>{reason}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              );
-            }
-            return <div key={item.key}>{node}</div>;
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    );
-
-  if (rows.length === 0) {
-    return (
-      <Empty className="border rounded-md py-8">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <PlugZap />
-          </EmptyMedia>
-          <EmptyDescription>No credentials yet.</EmptyDescription>
-        </EmptyHeader>
-        {installMenu && (
-          <EmptyContent className="flex-row justify-center">
-            {installMenu}
-          </EmptyContent>
-        )}
-      </Empty>
-    );
-  }
-
   return (
-    <Table data-testid={E2eTestId.ManageCredentialsDialogTable}>
+    <Table data-testid={testId}>
       <TableHeader>
         <TableRow>
           <TableHead className="whitespace-nowrap">Owner</TableHead>
@@ -959,6 +764,39 @@ function UnifiedConnectionsTable({
       </TableBody>
     </Table>
   );
+}
+
+// Multi-tenant catalogs alias one pod across N caller rows. Each row's
+// K8sDeployment instance tracks its own state independently, so the row that
+// didn't observe the pod first stays "pending" while the other goes "failed".
+// Pick a canonical state per podName (across every connection for the catalog,
+// so the personal and service-account tables agree) so all rows match.
+const DEPLOYMENT_STATE_PRIORITY: Record<string, number> = {
+  failed: 4,
+  running: 3,
+  succeeded: 3,
+  pending: 2,
+  not_created: 1,
+};
+
+function computeCanonicalStateByPod(
+  servers: ServerEntry[],
+  deploymentStatuses: Record<string, McpDeploymentStatusEntry>,
+): Map<string, string> {
+  const canonicalStateByPod = new Map<string, string>();
+  for (const server of servers) {
+    const entry = deploymentStatuses[server.id];
+    if (!entry?.podName) continue;
+    const current = canonicalStateByPod.get(entry.podName);
+    if (
+      !current ||
+      (DEPLOYMENT_STATE_PRIORITY[entry.state] ?? 0) >
+        (DEPLOYMENT_STATE_PRIORITY[current] ?? 0)
+    ) {
+      canonicalStateByPod.set(entry.podName, entry.state);
+    }
+  }
+  return canonicalStateByPod;
 }
 
 // The catalog-level "agent connections" setting as a standard settings row:

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -82,6 +82,10 @@ export const E2eTestId = {
   ManageCredentialsAddToOrgButton: "manage-credentials-add-to-org-button",
   ManageCredentialsAddToTeamButton: "manage-credentials-add-to-team-button",
   ManageCredentialsAddToTeamOption: "manage-credentials-add-to-team-option",
+  ManageCredentialsAddServiceAccountButton:
+    "manage-credentials-add-service-account-button",
+  AddServiceAccountConfirmButton: "add-service-account-confirm-button",
+  ManageServiceAccountsTable: "manage-service-accounts-table",
   ManageMembersButton: "manage-members-button",
   // Chat Settings
   ChatApiKeysTable: "chat-api-keys-table",


### PR DESCRIPTION
## What

On the beta MCP server detail page (`/mcp/registry/beta/[id]` → **Credentials**), the single connections table and combined **Install ▾** dropdown are split into two clearly separated sections:

- **Personal connections** — each person's own per-user connection, with a plain **Connect my account** button.
- **Service accounts** — shared **team/org** keys in their own table, added only through a deliberate **Add service account** action.

## Why

A personal connection is per-user (each person acts as themselves). A team/org connection is a **shared key** — everyone whose agent reaches the server acts through that one account, either because an admin pinned it as the server's single account (static key) or as an on-behalf-of fallback when the chatting user has no connection of their own. Burying both behind one "Install" dropdown hid that distinction. Now adding a shared key is a separate, explicit step.

## How

- **Add service account** opens a confirmation dialog (`AddServiceAccountDialog`) that explains the shared-key behavior (static-key pin + OBO fallback), lets you pick team or org (org gated to org-admins, already-connected teams filtered out), and requires an explicit confirm before continuing into the existing install flow.
- Extracts a shared `ConnectionsTable` row renderer so both sections reuse the same rows/actions; removes the old `InstallMenuButton`.
- Reuses the existing `splitByScope` / permission logic — no change to who can add what.

## Scope

- **Beta surface only.** The non-beta `/mcp/registry` modal is unchanged (and still drives the e2e suite, so no e2e changes were needed).
- Complementary to **T-365** (which hard-blocks *OAuth* team/org installs in the backend); that backend block is intentionally **not** part of this PR — here team/org service accounts stay available, just deliberate.

## Tests

- New component test for `AddServiceAccountDialog` (danger copy, org confirm, team-selection confirm, disabled-when-empty).
- `type-check`, `knip`, biome lint clean; **186 registry tests pass**.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>