### PR TITLE
feat(dev-stack): share one Dagger engine across parallel worktrees

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -339,6 +339,10 @@ ARCHESTRA_CODE_RUNTIME_ENABLED=false
 # examples:
 # kube-pod://dagger-runtime-engine-0?namespace=dagger&container=dagger-engine
 # tcp://dagger-runtime.dagger.svc.cluster.local:1234
+# Setting this in a Tilt dev stack also makes Tilt SKIP deploying its own engine
+# + port-forward and point the backend at the engine you name. Use it to share
+# one engine across worktrees — e.g. a parallel `dev:stack:up` reusing the main
+# stack's engine: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST=tcp://127.0.0.1:1234
 # ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST=
 # Set "true" when ARCHESTRA_DAGGER_RUNTIME_IMAGE points at a pre-baked sandbox
 # base (the `sandbox_base/` image, which already contains the apt toolbelt + uv

--- a/platform/dev/Tiltfile.coderuntime
+++ b/platform/dev/Tiltfile.coderuntime
@@ -15,41 +15,50 @@
 # than the kube-context default would strand the Service (and break the
 # port-forward below). Since this runtime is dev-only, a dedicated namespace
 # buys nothing here.
-k8s_yaml(local(
-  'helm template dagger-runtime ../helm/dagger-runtime --namespace default ' +
-  '--set networkPolicy.create=false ' +
-  '--set service.create=true ' +
-  '--set dagger.engine.port=1234 ' +
-  # the production default request (8Gi) does not fit a default colima VM;
-  # 4Gi is plenty for local code-runtime use.
-  '--set dagger.engine.resources.requests.memory=4Gi ' +
-  '--set dagger.engine.readinessProbeSettings.periodSeconds=60 ' +
-  '--set dagger.engine.livenessProbeSettings.periodSeconds=120',
-  quiet=True,
-))
+# When ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST is set in .env the backend is
+# pointed at an already-running engine (e.g. a parallel worktree stack sharing
+# the main stack's engine on :1234). Deploying a second engine then would only
+# collide — same `default`-namespace helm release and the same :1234
+# port-forward — so skip the engine + port-forward and just build the napi addon
+# below. A single Dagger engine is session-multiplexed, so sharing one is fine.
+external_engine = bool(os.getenv('ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST'))
 
-# the backend reaches this service through the local port-forward below.
-k8s_resource(
-  'dagger-runtime-engine',
-  new_name='dagger-engine',
-  labels=['code-runtime'],
-  # bundle the chart's free-floating objects into this resource so Tilt groups
-  # them with the engine instead of leaving them in `uncategorized`. the Service
-  # auto-attaches via its selector on the StatefulSet, so it is not listed here.
-  objects=[
-    'dagger-runtime:serviceaccount',
-    'dagger-runtime-engine-config:configmap',
-  ],
-)
+if not external_engine:
+  k8s_yaml(local(
+    'helm template dagger-runtime ../helm/dagger-runtime --namespace default ' +
+    '--set networkPolicy.create=false ' +
+    '--set service.create=true ' +
+    '--set dagger.engine.port=1234 ' +
+    # the production default request (8Gi) does not fit a default colima VM;
+    # 4Gi is plenty for local code-runtime use.
+    '--set dagger.engine.resources.requests.memory=4Gi ' +
+    '--set dagger.engine.readinessProbeSettings.periodSeconds=60 ' +
+    '--set dagger.engine.livenessProbeSettings.periodSeconds=120',
+    quiet=True,
+  ))
 
-# everything renders into `default`, so the Service has live endpoints (its pod
-# is in the same namespace) and we can port-forward the Service directly.
-local_resource(
-  'dagger-runtime-port-forward',
-  serve_cmd='while true; do kubectl -n default wait --for=condition=Ready pod -l name=dagger-runtime-engine --timeout=60s >/dev/null 2>&1 && kubectl -n default port-forward svc/dagger-runtime 1234:1234; sleep 2; done',
-  labels=['code-runtime'],
-  resource_deps=['dagger-engine'],
-)
+  # the backend reaches this service through the local port-forward below.
+  k8s_resource(
+    'dagger-runtime-engine',
+    new_name='dagger-engine',
+    labels=['code-runtime'],
+    # bundle the chart's free-floating objects into this resource so Tilt groups
+    # them with the engine instead of leaving them in `uncategorized`. the Service
+    # auto-attaches via its selector on the StatefulSet, so it is not listed here.
+    objects=[
+      'dagger-runtime:serviceaccount',
+      'dagger-runtime-engine-config:configmap',
+    ],
+  )
+
+  # everything renders into `default`, so the Service has live endpoints (its pod
+  # is in the same namespace) and we can port-forward the Service directly.
+  local_resource(
+    'dagger-runtime-port-forward',
+    serve_cmd='while true; do kubectl -n default wait --for=condition=Ready pod -l name=dagger-runtime-engine --timeout=60s >/dev/null 2>&1 && kubectl -n default port-forward svc/dagger-runtime 1234:1234; sleep 2; done',
+    labels=['code-runtime'],
+    resource_deps=['dagger-engine'],
+  )
 
 # Rebuild the native skill-sandbox addon (napi) when its Rust sources change.
 # Tilt has no other knowledge of the cargo build, and the compiled .node is

--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -65,7 +65,11 @@ code_runtime_enabled = os.getenv('ARCHESTRA_CODE_RUNTIME_ENABLED') == 'true'
 apps_enabled = os.getenv('ARCHESTRA_APPS_ENABLED') == 'true'
 backend_resource_deps = ['db-migrate']
 if code_runtime_enabled:
-  backend_resource_deps.append('dagger-runtime-port-forward')
+  # Skip the local port-forward dep when pointing at an external engine — that
+  # resource isn't created (see Tiltfile.coderuntime), so depending on it would
+  # wedge the backend waiting on a resource that never appears.
+  if not os.getenv('ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST'):
+    backend_resource_deps.append('dagger-runtime-port-forward')
   # build the napi addon before the backend boots, so it never loads a stale .node
   backend_resource_deps.append('sandbox-rs-build')
 if apps_enabled:


### PR DESCRIPTION
## Summary
Running the **code runtime** in a parallel `dev:stack:up` worktree currently can't work: the Dagger engine is helm-deployed into the shared `default` namespace under a fixed release name with a fixed `:1234` port-forward (`dev/Tiltfile.coderuntime`), and `dev-stack.sh` doesn't remap any of that — so a second stack collides on both the helm release and the `:1234` local port-forward.

A Dagger engine is **session-multiplexed** (one engine serves many concurrent clients), so the simplest fix is to let a parallel stack **reuse** the main stack's engine instead of standing up its own.

## Change
Treat **`ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST` being set in `.env`** as "use an external engine":
- `dev/Tiltfile.coderuntime` — skip the engine helm deploy, the `dagger-engine` resource, and the `dagger-runtime-port-forward` when a runner host is set. The napi addon build (`sandbox-rs-build`) still runs (the backend needs it either way).
- `dev/Tiltfile.dev` — only add `dagger-runtime-port-forward` to the backend's deps when we actually deploy it (otherwise the backend would wait forever on a resource that never appears).
- `.env.example` — document the behavior.

`run-backend-dev.sh` needs no change — it already honors a pre-set runner host and its `:1234` readiness wait passes against the main stack's port-forward. The normal single-stack flow is unchanged (it doesn't set a runner host, so the engine deploys as before).

## Usage
With the main stack running the code runtime (engine + `:1234` port-forward up), in a parallel worktree's `.env`:
```
ARCHESTRA_CODE_RUNTIME_ENABLED=true
ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST=tcp://127.0.0.1:1234
```
then `pnpm dev:stack:up`. `dev-stack.sh` leaves both vars untouched, so they persist across restarts.

## Verification
Brought up a parallel stack (`archestra-dev-feat-dev-stack-shared-dagger-engine`) with the runner host set:
- ✅ No Dagger engine pod in the parallel namespace (engine not redeployed); no `default`-release / `:1234` collision.
- ✅ Backend healthy and cleared the `:1234` readiness gate → connected to the shared engine; logged `Sandbox metrics initialized`, **no** `code runtime disabled`.
- ✅ Main stack's `dagger-runtime-engine-0` untouched.
- ✅ `sandbox-rs-build` still compiles the napi addon.

## Caveats (dev-only)
- The named engine must be up (the main stack owns it + the `:1234` port-forward); tearing main down removes the shared engine.
- Both stacks share one engine (its memory limit + build cache + concurrent sessions). Sandboxes stay isolated per session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>