### PR TITLE
fix(mcp): scope search_tools/run_tool discovery to the caller's own installs

### DIFF
--- a/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
@@ -702,4 +702,67 @@ describe("dynamic discovery is scoped to the caller's own installs", () => {
       "github__search_repositories",
     );
   });
+
+  test("includes a tool backed by an install for a team the caller belongs to", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTeam,
+    makeTeamMember,
+    makeTool,
+  }) => {
+    const team = await makeTeam(organizationId, userId);
+    await makeTeamMember(team.id, userId);
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      scope: "org",
+    });
+    await makeTool({
+      name: "github__search_repositories",
+      catalogId: catalog.id,
+    });
+    await makeMcpServer({
+      catalogId: catalog.id,
+      scope: "team",
+      teamId: team.id,
+    });
+
+    const tools = await getUnassignedDiscoverableTools({
+      assignedToolNames: new Set(),
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tools.map((tool) => tool.name)).toContain(
+      "github__search_repositories",
+    );
+  });
+
+  test("excludes a visible catalog that has no install at all, even for an admin caller", async ({
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    // The caller is an org admin (see beforeEach): catalog visibility is broad,
+    // but admins do not bypass the install requirement. With no install of the
+    // catalog, its tools must not enter the discovery space.
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      scope: "org",
+    });
+    await makeTool({
+      name: "github__search_repositories",
+      catalogId: catalog.id,
+    });
+
+    const tools = await getUnassignedDiscoverableTools({
+      assignedToolNames: new Set(),
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tools.map((tool) => tool.name)).not.toContain(
+      "github__search_repositories",
+    );
+  });
 });

--- a/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@archestra/shared";
 import config from "@/config";
 import { KnowledgeBaseConnectorModel, ToolModel } from "@/models";
+import McpServerUserModel from "@/models/mcp-server-user";
 import {
   afterAll,
   beforeAll,
@@ -72,6 +73,7 @@ describe("resolveDynamicTool", () => {
 
   test("resolves an accessible catalog tool when the agent allows dynamic access", async ({
     makeInternalMcpCatalog,
+    makeMcpServer,
     makeTool,
   }) => {
     const catalog = await makeInternalMcpCatalog({ organizationId });
@@ -79,6 +81,7 @@ describe("resolveDynamicTool", () => {
       name: "github__search_repositories",
       catalogId: catalog.id,
     });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
     const tool = await resolveDynamicTool({
       toolName: "github__search_repositories",
@@ -94,6 +97,7 @@ describe("resolveDynamicTool", () => {
   test("resolves for a user who cannot modify the agent (no agent mutation involved)", async ({
     makeCustomRole,
     makeInternalMcpCatalog,
+    makeMcpServer,
     makeMember,
     makeTool,
     makeUser,
@@ -108,6 +112,7 @@ describe("resolveDynamicTool", () => {
       name: "github__search_repositories",
       catalogId: catalog.id,
     });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
     const tool = await resolveDynamicTool({
       toolName: "github__search_repositories",
@@ -448,6 +453,7 @@ describe("getUnassignedDiscoverableTools", () => {
 
   test("includes accessible catalog tools that are not assigned", async ({
     makeInternalMcpCatalog,
+    makeMcpServer,
     makeTool,
   }) => {
     const catalog = await makeInternalMcpCatalog({ organizationId });
@@ -456,6 +462,7 @@ describe("getUnassignedDiscoverableTools", () => {
       catalogId: catalog.id,
     });
     await makeTool({ name: "github__create_issue", catalogId: catalog.id });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
     const tools = await getUnassignedDiscoverableTools({
       assignedToolNames: new Set(["github__create_issue"]),
@@ -540,5 +547,159 @@ describe("getUnassignedDiscoverableTools", () => {
       getArchestraToolFullName(TOOL_WHOAMI_SHORT_NAME),
     );
     expect(names).not.toContain("agent__leaked_artifact");
+  });
+});
+
+// Catalog visibility is not install access: an org-scoped catalog is visible to
+// every member, but its tools must only be discoverable/runnable by users who
+// have an accessible install of it (own personal, team, or org) — never via
+// another user's personal install.
+describe("dynamic discovery is scoped to the caller's own installs", () => {
+  let agent: Agent;
+  let organizationId: string;
+  let userId: string;
+
+  beforeEach(async ({ makeAgent, makeMember, makeOrganization, makeUser }) => {
+    const org = await makeOrganization();
+    organizationId = org.id;
+    const user = await makeUser();
+    userId = user.id;
+    await makeMember(user.id, org.id, { role: "admin" });
+    agent = await makeAgent({
+      name: "Dynamic Agent",
+      organizationId: org.id,
+      accessAllTools: true,
+    });
+  });
+
+  test("getUnassignedDiscoverableTools excludes a tool whose only install is another user's personal server", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+    makeUser,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      scope: "org",
+    });
+    await makeTool({
+      name: "github__search_repositories",
+      catalogId: catalog.id,
+    });
+    const otherUser = await makeUser();
+    const otherInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      scope: "personal",
+      ownerId: otherUser.id,
+    });
+    await McpServerUserModel.assignUserToMcpServer(
+      otherInstall.id,
+      otherUser.id,
+    );
+
+    const tools = await getUnassignedDiscoverableTools({
+      assignedToolNames: new Set(),
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tools.map((tool) => tool.name)).not.toContain(
+      "github__search_repositories",
+    );
+  });
+
+  test("resolveDynamicTool returns null for a tool whose only install is another user's personal server", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+    makeUser,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      scope: "org",
+    });
+    await makeTool({
+      name: "github__search_repositories",
+      catalogId: catalog.id,
+    });
+    const otherUser = await makeUser();
+    const otherInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      scope: "personal",
+      ownerId: otherUser.id,
+    });
+    await McpServerUserModel.assignUserToMcpServer(
+      otherInstall.id,
+      otherUser.id,
+    );
+
+    const tool = await resolveDynamicTool({
+      toolName: "github__search_repositories",
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tool).toBeNull();
+  });
+
+  test("includes a tool the caller has their own personal install of", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      scope: "org",
+    });
+    await makeTool({
+      name: "github__search_repositories",
+      catalogId: catalog.id,
+    });
+    const ownInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      scope: "personal",
+      ownerId: userId,
+    });
+    await McpServerUserModel.assignUserToMcpServer(ownInstall.id, userId);
+
+    const tools = await getUnassignedDiscoverableTools({
+      assignedToolNames: new Set(),
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tools.map((tool) => tool.name)).toContain(
+      "github__search_repositories",
+    );
+  });
+
+  test("includes a tool backed by an org-scoped install", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      scope: "org",
+    });
+    await makeTool({
+      name: "github__search_repositories",
+      catalogId: catalog.id,
+    });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+
+    const tools = await getUnassignedDiscoverableTools({
+      assignedToolNames: new Set(),
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tools.map((tool) => tool.name)).toContain(
+      "github__search_repositories",
+    );
   });
 });

--- a/platform/backend/src/archestra-mcp-server/run-tool.test.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.test.ts
@@ -530,6 +530,7 @@ describe("run_tool", () => {
 
     test("executes an accessible-but-unassigned tool dynamically without assigning it", async ({
       makeInternalMcpCatalog,
+      makeMcpServer,
       makeTool,
     }) => {
       const catalog = await makeInternalMcpCatalog({
@@ -539,6 +540,7 @@ describe("run_tool", () => {
         name: "github__search_repositories",
         catalogId: catalog.id,
       });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
       vi.mocked(mcpClient.executeToolCallForOwner).mockResolvedValueOnce({
         content: [{ type: "text", text: "Dynamic response" }],
         isError: false,
@@ -579,6 +581,7 @@ describe("run_tool", () => {
 
     test("executes for a user who cannot modify the agent (no agent mutation involved)", async ({
       makeInternalMcpCatalog,
+      makeMcpServer,
       makeMember,
       makeTool,
       makeUser,
@@ -594,6 +597,7 @@ describe("run_tool", () => {
         name: "github__search_repositories",
         catalogId: catalog.id,
       });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
       vi.mocked(mcpClient.executeToolCallForOwner).mockResolvedValueOnce({
         content: [{ type: "text", text: "Dynamic response" }],
         isError: false,
@@ -645,6 +649,7 @@ describe("run_tool", () => {
     test("does not run when the conversation's custom tool selection blocks the tool", async ({
       makeAgentTool,
       makeInternalMcpCatalog,
+      makeMcpServer,
       makeTool,
     }) => {
       const catalog = await makeInternalMcpCatalog({
@@ -663,6 +668,7 @@ describe("run_tool", () => {
         name: "giphy__image_search",
         catalogId: catalog.id,
       });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
       const result = await executeArchestraTool(
         TOOL_RUN_TOOL_FULL_NAME,
@@ -740,6 +746,7 @@ describe("run_tool", () => {
     test("evaluates invocation policies for dynamically resolved tools", async ({
       makeAgent,
       makeInternalMcpCatalog,
+      makeMcpServer,
       makeMember,
       makeOrganization,
       makeTool,
@@ -760,6 +767,7 @@ describe("run_tool", () => {
         name: "workspace__export_data",
         catalogId: catalog.id,
       });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
       await makeToolPolicy(tool.id, {
         action: "block_always",
         reason: "External export blocked",
@@ -1711,6 +1719,7 @@ describe("run_tool", () => {
     test("returns the full schema for a dynamically-resolved invalid call (no dispatch)", async ({
       makeAgent,
       makeInternalMcpCatalog,
+      makeMcpServer,
       makeTool,
     }) => {
       const dynamicAgent = await makeAgent({
@@ -1726,6 +1735,7 @@ describe("run_tool", () => {
         catalogId: catalog.id,
         parameters: submitResultSchema,
       });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
       const result = await executeArchestraTool(
         TOOL_RUN_TOOL_FULL_NAME,

--- a/platform/backend/src/archestra-mcp-server/search-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.test.ts
@@ -152,6 +152,7 @@ describe("search_tools", () => {
   test("includes unassigned tools from catalogs the user can access when the agent allows dynamic access", async ({
     makeAgent,
     makeInternalMcpCatalog,
+    makeMcpServer,
     makeMember,
     makeOrganization,
     makeTool,
@@ -176,6 +177,7 @@ describe("search_tools", () => {
       description: "Search repositories by topic, language, or owner.",
       catalogId: catalog.id,
     });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
     const context: ArchestraContext = {
       agent: { id: agent.id, name: agent.name },

--- a/platform/backend/src/models/mcp-server.test.ts
+++ b/platform/backend/src/models/mcp-server.test.ts
@@ -908,5 +908,53 @@ describe("McpServerModel", () => {
       );
       expect(ids.has(catalog.id)).toBe(false);
     });
+
+    test("returns a catalog backed by an install for a team the user belongs to", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeOrganization,
+      makeTeam,
+      makeTeamMember,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const team = await makeTeam(org.id, user.id);
+      await makeTeamMember(team.id, user.id);
+      const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+      await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "team",
+        teamId: team.id,
+      });
+
+      const ids = await McpServerModel.getAccessibleInstallCatalogIds(user.id);
+      expect(ids.has(catalog.id)).toBe(true);
+    });
+
+    test("excludes a team install for a user who is not a member of that team", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeOrganization,
+      makeTeam,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const teamOwner = await makeUser();
+      const outsider = await makeUser();
+      // makeTeam does not enroll the creator; nobody is a member of this team.
+      const team = await makeTeam(org.id, teamOwner.id);
+      const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+      await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "team",
+        teamId: team.id,
+      });
+
+      const ids = await McpServerModel.getAccessibleInstallCatalogIds(
+        outsider.id,
+      );
+      expect(ids.has(catalog.id)).toBe(false);
+    });
   });
 });

--- a/platform/backend/src/models/mcp-server.test.ts
+++ b/platform/backend/src/models/mcp-server.test.ts
@@ -882,34 +882,31 @@ describe("McpServerModel", () => {
       });
       await McpServerUserModel.assignUserToMcpServer(install.id, user.id);
 
-      const ids = await McpServerModel.getAccessibleInstallCatalogIds(
-        user.id,
-        org.id,
-      );
+      const ids = await McpServerModel.getAccessibleInstallCatalogIds(user.id);
       expect(ids.has(catalog.id)).toBe(true);
     });
 
-    test("excludes another org's org-scoped install (org-scoped installs are not organization-filtered on their own)", async ({
+    test("excludes a catalog whose only install is another user's personal server", async ({
       makeInternalMcpCatalog,
       makeMcpServer,
       makeOrganization,
       makeUser,
     }) => {
-      // org-scoped installs of org A's catalog must not count as installed for
-      // a user in org B, even though getOrgScopedMcpServerIds is org-blind.
-      const orgA = await makeOrganization();
-      const orgB = await makeOrganization();
-      const userB = await makeUser();
-      const catalogA = await makeInternalMcpCatalog({
-        organizationId: orgA.id,
+      const org = await makeOrganization();
+      const owner = await makeUser();
+      const otherUser = await makeUser();
+      const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+      const install = await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "personal",
+        ownerId: owner.id,
       });
-      await makeMcpServer({ catalogId: catalogA.id, scope: "org" });
+      await McpServerUserModel.assignUserToMcpServer(install.id, owner.id);
 
       const ids = await McpServerModel.getAccessibleInstallCatalogIds(
-        userB.id,
-        orgB.id,
+        otherUser.id,
       );
-      expect(ids.has(catalogA.id)).toBe(false);
+      expect(ids.has(catalog.id)).toBe(false);
     });
   });
 });

--- a/platform/backend/src/models/mcp-server.test.ts
+++ b/platform/backend/src/models/mcp-server.test.ts
@@ -864,4 +864,52 @@ describe("McpServerModel", () => {
       expect(cleared?.oauthRefreshFailedAt).toBeNull();
     });
   });
+
+  describe("getAccessibleInstallCatalogIds", () => {
+    test("returns catalogs the user has an own personal install of", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+      const install = await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "personal",
+        ownerId: user.id,
+      });
+      await McpServerUserModel.assignUserToMcpServer(install.id, user.id);
+
+      const ids = await McpServerModel.getAccessibleInstallCatalogIds(
+        user.id,
+        org.id,
+      );
+      expect(ids.has(catalog.id)).toBe(true);
+    });
+
+    test("excludes another org's org-scoped install (org-scoped installs are not organization-filtered on their own)", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeOrganization,
+      makeUser,
+    }) => {
+      // org-scoped installs of org A's catalog must not count as installed for
+      // a user in org B, even though getOrgScopedMcpServerIds is org-blind.
+      const orgA = await makeOrganization();
+      const orgB = await makeOrganization();
+      const userB = await makeUser();
+      const catalogA = await makeInternalMcpCatalog({
+        organizationId: orgA.id,
+      });
+      await makeMcpServer({ catalogId: catalogA.id, scope: "org" });
+
+      const ids = await McpServerModel.getAccessibleInstallCatalogIds(
+        userB.id,
+        orgB.id,
+      );
+      expect(ids.has(catalogA.id)).toBe(false);
+    });
+  });
 });

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -570,38 +570,20 @@ class McpServerModel {
 
   /**
    * Catalog ids the caller has an accessible install of (own personal + team +
-   * org), fenced to the caller's organization. Distinct from catalog
-   * *visibility* (McpCatalogTeamModel): an org-scoped catalog is visible to
-   * every member, but if its only install is another user's personal server it
-   * is absent here. The org fence matters because org-scoped installs are not
-   * organization-filtered on their own — an install's tenant is its catalog's
-   * organization, so we join through the catalog and keep only this org's
-   * catalogs (plus global, organization-less ones). Scopes the search_tools /
-   * run_tool dynamic-discovery space so it cannot reach another user's servers
-   * or another tenant's installs.
+   * org). Distinct from catalog *visibility* (McpCatalogTeamModel): an
+   * org-scoped catalog is visible to every member, but if its only install is
+   * another user's personal server it is absent here. Scopes the search_tools /
+   * run_tool dynamic-discovery space so it cannot reach another user's servers.
    */
   static async getAccessibleInstallCatalogIds(
     userId: string,
-    organizationId: string,
   ): Promise<Set<string>> {
     const installIds = await McpServerModel.getAccessibleInstallIds(userId);
     if (installIds.length === 0) return new Set();
     const rows = await db
       .select({ catalogId: schema.mcpServersTable.catalogId })
       .from(schema.mcpServersTable)
-      .innerJoin(
-        schema.internalMcpCatalogTable,
-        eq(schema.mcpServersTable.catalogId, schema.internalMcpCatalogTable.id),
-      )
-      .where(
-        and(
-          inArray(schema.mcpServersTable.id, installIds),
-          or(
-            eq(schema.internalMcpCatalogTable.organizationId, organizationId),
-            isNull(schema.internalMcpCatalogTable.organizationId),
-          ),
-        ),
-      );
+      .where(inArray(schema.mcpServersTable.id, installIds));
     const catalogIds = new Set<string>();
     for (const row of rows) {
       if (row.catalogId) catalogIds.add(row.catalogId);

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -568,6 +568,47 @@ class McpServerModel {
     }));
   }
 
+  /**
+   * Catalog ids the caller has an accessible install of (own personal + team +
+   * org), fenced to the caller's organization. Distinct from catalog
+   * *visibility* (McpCatalogTeamModel): an org-scoped catalog is visible to
+   * every member, but if its only install is another user's personal server it
+   * is absent here. The org fence matters because org-scoped installs are not
+   * organization-filtered on their own — an install's tenant is its catalog's
+   * organization, so we join through the catalog and keep only this org's
+   * catalogs (plus global, organization-less ones). Scopes the search_tools /
+   * run_tool dynamic-discovery space so it cannot reach another user's servers
+   * or another tenant's installs.
+   */
+  static async getAccessibleInstallCatalogIds(
+    userId: string,
+    organizationId: string,
+  ): Promise<Set<string>> {
+    const installIds = await McpServerModel.getAccessibleInstallIds(userId);
+    if (installIds.length === 0) return new Set();
+    const rows = await db
+      .select({ catalogId: schema.mcpServersTable.catalogId })
+      .from(schema.mcpServersTable)
+      .innerJoin(
+        schema.internalMcpCatalogTable,
+        eq(schema.mcpServersTable.catalogId, schema.internalMcpCatalogTable.id),
+      )
+      .where(
+        and(
+          inArray(schema.mcpServersTable.id, installIds),
+          or(
+            eq(schema.internalMcpCatalogTable.organizationId, organizationId),
+            isNull(schema.internalMcpCatalogTable.organizationId),
+          ),
+        ),
+      );
+    const catalogIds = new Set<string>();
+    for (const row of rows) {
+      if (row.catalogId) catalogIds.add(row.catalogId);
+    }
+    return catalogIds;
+  }
+
   /** Distinct scopes of the caller's accessible installs, keyed by catalog. */
   private static async getAccessibleInstallScopesByCatalog(params: {
     userId: string;

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -633,10 +633,7 @@ class ToolModel {
     // run_tool cannot reach another user's personal server. The built-in
     // Archestra catalog runs in-process with no install row, so it stays in.
     const installedCatalogIds =
-      await McpServerModel.getAccessibleInstallCatalogIds(
-        params.userId,
-        params.organizationId,
-      );
+      await McpServerModel.getAccessibleInstallCatalogIds(params.userId);
     const scopedCatalogIds = catalogIds.filter(
       (id) => id === ARCHESTRA_MCP_CATALOG_ID || installedCatalogIds.has(id),
     );

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -626,6 +626,24 @@ class ToolModel {
       return [];
     }
 
+    // Catalog visibility is broader than install access: an org-scoped catalog
+    // is visible to every member, but its only installs may be other users'
+    // personal servers. Narrow the discovery space to catalogs the caller has
+    // an accessible install of (own personal + team + org) so search_tools /
+    // run_tool cannot reach another user's personal server. The built-in
+    // Archestra catalog runs in-process with no install row, so it stays in.
+    const installedCatalogIds =
+      await McpServerModel.getAccessibleInstallCatalogIds(
+        params.userId,
+        params.organizationId,
+      );
+    const scopedCatalogIds = catalogIds.filter(
+      (id) => id === ARCHESTRA_MCP_CATALOG_ID || installedCatalogIds.has(id),
+    );
+    if (scopedCatalogIds.length === 0) {
+      return [];
+    }
+
     // Secondary sort on id keeps the ordering deterministic when createdAt
     // ties (bulk-inserted MCP tools share a timestamp), so search_tools and
     // run_tool auto-assignment resolve a duplicate name to the same row.
@@ -634,7 +652,7 @@ class ToolModel {
       .from(schema.toolsTable)
       .where(
         and(
-          inArray(schema.toolsTable.catalogId, catalogIds),
+          inArray(schema.toolsTable.catalogId, scopedCatalogIds),
           eq(schema.toolsTable.clonedPendingDiscovery, false),
           toolInEnvironmentPredicate(params.environmentId),
           params.name !== undefined

--- a/platform/backend/src/services/environments/environment-isolation.test.ts
+++ b/platform/backend/src/services/environments/environment-isolation.test.ts
@@ -182,6 +182,7 @@ test("getMcpToolsAccessibleToUser: dynamic discovery is scoped to the agent's en
   makeOrganization,
   makeUser,
   makeInternalMcpCatalog,
+  makeMcpServer,
   makeTool,
 }) => {
   const org = await makeOrganization();
@@ -200,6 +201,8 @@ test("getMcpToolsAccessibleToUser: dynamic discovery is scoped to the agent's en
   });
   const prodTool = await makeTool({ catalogId: prodCatalog.id });
   const defaultTool = await makeTool({ catalogId: defaultCatalog.id });
+  await makeMcpServer({ catalogId: prodCatalog.id, scope: "org" });
+  await makeMcpServer({ catalogId: defaultCatalog.id, scope: "org" });
 
   const prodNames = (
     await ToolModel.getMcpToolsAccessibleToUser({


### PR DESCRIPTION
## Summary

Dynamic tool discovery — the `search_tools` / `run_tool` widening that activates when an agent's *access-all-tools* setting is on — decided which tools a user could find and run from catalog **visibility** alone. An org-scoped catalog is visible to every member of the org, so when the only install of that catalog was another user's **personal** MCP server, that server's tools still showed up in discovery and could be invoked by anyone in the org. The effect: one user's personal MCP servers (and their credentials, via the resolved install) were reachable by the whole organization.

The fix tightens the discovery chokepoint, `ToolModel.getMcpToolsAccessibleToUser`, to intersect the catalogs a user can *see* with the catalogs the user actually has an **accessible install** of — their own personal installs, their teams' installs, and org-scoped installs. The built-in Archestra catalog has no install row (its tools run in-process) and is kept explicitly. After the change, a user discovers and runs only tools backed by a server they can legitimately use.

The new install-access helper is `McpServerModel.getAccessibleInstallCatalogIds`.