### PR TITLE
fix(chat): PDF attachments, create-conversation latency, and the 409 next-send race

### DIFF
--- a/platform/backend/src/models/agent.test.ts
+++ b/platform/backend/src/models/agent.test.ts
@@ -427,6 +427,83 @@ describe("AgentModel", () => {
       expect(foundAgent).toBeNull();
     });
 
+    test("findLlmSelectionFieldsById returns selection fields for an admin", async ({
+      makeAdmin,
+    }) => {
+      const admin = await makeAdmin();
+      const agent = await AgentModel.create({
+        name: "Test Agent",
+        teams: [],
+        scope: "org",
+      });
+
+      const fields = await AgentModel.findLlmSelectionFieldsById(
+        agent.id,
+        admin.id,
+        true,
+      );
+      expect(fields).not.toBeNull();
+      expect(fields).toEqual({ llmApiKeyId: null, modelId: null });
+    });
+
+    test("findLlmSelectionFieldsById returns selection fields for a user in an assigned team", async ({
+      makeUser,
+      makeAdmin,
+      makeOrganization,
+      makeTeam,
+    }) => {
+      const user = await makeUser();
+      const admin = await makeAdmin();
+      const org = await makeOrganization();
+
+      const team = await makeTeam(org.id, admin.id);
+      await TeamModel.addMember(team.id, user.id);
+
+      const agent = await AgentModel.create({
+        name: "Test Agent",
+        teams: [team.id],
+        scope: "team",
+      });
+
+      const fields = await AgentModel.findLlmSelectionFieldsById(
+        agent.id,
+        user.id,
+        false,
+      );
+      expect(fields).not.toBeNull();
+      expect(fields).toHaveProperty("llmApiKeyId");
+      expect(fields).toHaveProperty("modelId");
+    });
+
+    test("findLlmSelectionFieldsById returns null for a user not in assigned teams", async ({
+      makeUser,
+      makeAdmin,
+      makeOrganization,
+      makeTeam,
+    }) => {
+      const user1 = await makeUser();
+      const user2 = await makeUser();
+      const admin = await makeAdmin();
+      const org = await makeOrganization();
+
+      const team = await makeTeam(org.id, admin.id);
+      await TeamModel.addMember(team.id, user1.id);
+
+      const agent = await AgentModel.create({
+        name: "Test Agent",
+        teams: [team.id],
+        scope: "team",
+      });
+
+      // The access gate must hold for the narrow fetch exactly as for findById.
+      const fields = await AgentModel.findLlmSelectionFieldsById(
+        agent.id,
+        user2.id,
+        false,
+      );
+      expect(fields).toBeNull();
+    });
+
     test("update syncs team assignments correctly", async ({
       makeAdmin,
       makeOrganization,

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -1491,6 +1491,41 @@ class AgentModel {
     return result;
   }
 
+  /**
+   * Minimal agent lookup for opening a conversation: the SAME access gate as
+   * {@link findById}, but selecting only the LLM-selection fields that path uses
+   * (`llmApiKeyId`, `modelId`). Skips the tool join and the
+   * team/label/knowledge/connector/author/prompt/resolved-LLM hydration that
+   * dominate `findById`'s cost and are unused when creating a conversation.
+   */
+  static async findLlmSelectionFieldsById(
+    id: string,
+    userId?: string,
+    isAgentAdmin?: boolean,
+  ): Promise<{ llmApiKeyId: string | null; modelId: string | null } | null> {
+    if (userId && !isAgentAdmin) {
+      const hasAccess = await AgentTeamModel.userHasAgentAccess(
+        userId,
+        id,
+        false,
+      );
+      if (!hasAccess) {
+        return null;
+      }
+    }
+
+    const rows = await db
+      .select({
+        llmApiKeyId: schema.agentsTable.llmApiKeyId,
+        modelId: schema.agentsTable.modelId,
+      })
+      .from(schema.agentsTable)
+      .where(and(eq(schema.agentsTable.id, id), notDeleted(schema.agentsTable)))
+      .limit(1);
+
+    return rows[0] ?? null;
+  }
+
   static async findDeletedByIdForOrganization(
     id: string,
     organizationId: string,

--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -693,6 +693,7 @@ async function tryCreateInContextCompaction(params: {
       params.conversationId,
       getModelReadableMimeTypes(compactionModelRow?.inputModalities ?? null),
       params.provider !== "anthropic" || anthropicNativeEndpoint,
+      params.provider === "anthropic" && !anthropicNativeEndpoint,
     );
     const compactionMessages = buildInContextCompactionMessages({
       previousSummary: params.previousSummary,

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
@@ -766,6 +766,55 @@ test("keeps an image inlined on a non-native Anthropic endpoint", async ({
   expect(part.url).toBe(`data:image/png;base64,${bytes.toString("base64")}`);
 });
 
+test("keeps a text-inlineable, model-readable document inlined on a non-native Anthropic endpoint", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.from("just text", "utf8");
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "notes.txt",
+    mimeType: "text/plain",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "text/plain",
+          filename: "notes.txt",
+        },
+      ],
+    },
+  ];
+
+  // text/plain is in INGESTIBLE and is text-inlineable, so the binary-doc
+  // reroute must NOT touch it — it stays a file part (prepare-for-provider
+  // inlines it as text later).
+  const output = await materializeAttachments(
+    input,
+    conversation.id,
+    INGESTIBLE,
+    true,
+    true,
+  );
+  const part = expectPresent(output[0].parts?.[0]);
+  expect(part.type).toBe("file");
+  expect(part.url).toBe(`data:text/plain;base64,${bytes.toString("base64")}`);
+});
+
 test("an inline data: binary document is dropped with a notice on a non-native endpoint", async () => {
   const dataUrl = `data:application/pdf;base64,${Buffer.from("legacy", "utf8").toString("base64")}`;
   const input: ChatMessage[] = [

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
@@ -654,6 +654,148 @@ test("attachment routing is unchanged when cache_control is suppressed (non-inge
   }
 });
 
+test("reroutes a binary document to the sandbox on a non-native Anthropic endpoint, even when the model could read it inline", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.from("%PDF-1.4 body", "utf8");
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "report.pdf",
+    mimeType: "application/pdf",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        },
+      ],
+    },
+  ];
+
+  // INGESTIBLE includes application/pdf, so the model CAN read it — but a
+  // non-native Anthropic endpoint can't accept the document block, so reroute.
+  const nonNative = await materializeAttachments(
+    input,
+    conversation.id,
+    INGESTIBLE,
+    true,
+    true,
+  );
+  // Native endpoint: the document block is fine, so it stays inlined.
+  const native = await materializeAttachments(
+    input,
+    conversation.id,
+    INGESTIBLE,
+    true,
+    false,
+  );
+
+  const rerouted = expectPresent(nonNative[0].parts?.[0]);
+  expect(rerouted.type).toBe("text");
+  expect(rerouted.text).toContain("/home/sandbox/attachments");
+  expect(rerouted.text).not.toContain("data:");
+  expect(rerouted.url).toBeUndefined();
+
+  const inlined = expectPresent(native[0].parts?.[0]);
+  expect(inlined.type).toBe("file");
+  expect(inlined.url).toBe(
+    `data:application/pdf;base64,${bytes.toString("base64")}`,
+  );
+});
+
+test("keeps an image inlined on a non-native Anthropic endpoint", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.from("PNG body", "utf8");
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "chart.png",
+    mimeType: "image/png",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "image/png",
+          filename: "chart.png",
+        },
+      ],
+    },
+  ];
+
+  // Images travel as image blocks, which the endpoint accepts — not rerouted.
+  const output = await materializeAttachments(
+    input,
+    conversation.id,
+    INGESTIBLE,
+    true,
+    true,
+  );
+  const part = expectPresent(output[0].parts?.[0]);
+  expect(part.type).toBe("file");
+  expect(part.url).toBe(`data:image/png;base64,${bytes.toString("base64")}`);
+});
+
+test("an inline data: binary document is dropped with a notice on a non-native endpoint", async () => {
+  const dataUrl = `data:application/pdf;base64,${Buffer.from("legacy", "utf8").toString("base64")}`;
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: dataUrl,
+          mediaType: "application/pdf",
+          filename: "legacy.pdf",
+        },
+      ],
+    },
+  ];
+
+  const output = await materializeAttachments(
+    input,
+    "00000000-0000-4000-8000-000000000000",
+    undefined,
+    true,
+    true,
+  );
+  const part = expectPresent(output[0].parts?.[0]);
+  expect(part.type).toBe("text");
+  // The data: bytes are NOT emitted as a document block the endpoint rejects.
+  expect(part.text).not.toContain("data:");
+  expect(part.url).toBeUndefined();
+});
+
 test("no refs in messages returns a clone without DB hits", async () => {
   const messages: ChatMessage[] = [
     { role: "user", parts: [{ type: "text", text: "hello" }] },

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -37,6 +37,11 @@ export async function materializeAttachments(
   // when the call targets an Anthropic-compatible third-party endpoint that
   // rejects the marker with a turn-0 400. The caller knows the provider/endpoint.
   applyAnthropicCacheControl = true,
+  // True for an Anthropic-compatible third-party endpoint (custom base URL, non
+  // Claude model) that rejects an Anthropic `document` content block. A binary
+  // document (e.g. a PDF) that such an endpoint can't accept is rerouted to the
+  // sandbox instead of inlined as a block that 400s the whole turn.
+  rerouteBinaryDocsToSandbox = false,
 ): Promise<ChatMessage[]> {
   const refIds = collectRefIds(messages);
   // Even when there are no refs to rehydrate, we still walk every part —
@@ -69,6 +74,7 @@ export async function materializeAttachments(
           byId,
           ingestibleMimeTypes,
           applyAnthropicCacheControl,
+          rerouteBinaryDocsToSandbox,
         ),
       ),
     };
@@ -94,6 +100,7 @@ function materializePart(
   byId: Map<string, Attachment>,
   ingestibleMimeTypes: Set<string> | undefined,
   applyAnthropicCacheControl: boolean,
+  rerouteBinaryDocsToSandbox: boolean,
 ): ChatMessagePart | ChatMessagePart[] {
   if (part.type !== "file" || typeof part.url !== "string") {
     return { ...part };
@@ -106,6 +113,17 @@ function materializePart(
     // to prompt-cache the file across turns. Without this marker, the same
     // bytes get re-billed at full input price on every turn until reload.
     if (part.url.startsWith("data:")) {
+      // No attachment row backs an inline data URL, so it was never staged into
+      // the sandbox — a binary document an Anthropic-compatible endpoint rejects
+      // can't be rerouted, only dropped with a notice (better than a turn-0 400).
+      const mime = dataUrlMimeType(part);
+      if (
+        rerouteBinaryDocsToSandbox &&
+        mime !== undefined &&
+        isNonInlineableBinaryDocMimeType(mime)
+      ) {
+        return unavailableBinaryDocPart(part, mime);
+      }
       return applyAnthropicCacheControl
         ? withAnthropicCacheControl(part)
         : { ...part };
@@ -131,10 +149,20 @@ function materializePart(
     return { ...part };
   }
 
-  // A file type the selected model can't read must not be inlined as a
-  // document the provider would reject (which hard-errors the whole turn).
-  // It has already auto-staged into the sandbox, so reference it there instead.
-  if (ingestibleMimeTypes && !ingestibleMimeTypes.has(attachment.mimeType)) {
+  // A file the selected model can't read must not be inlined as a document the
+  // provider would reject (which hard-errors the whole turn). Two cases:
+  //   - the model's modalities don't cover this mime; or
+  //   - an Anthropic-compatible third-party endpoint can't accept the binary
+  //     `document` block this mime would become (PDF and other non-image,
+  //     non-text-inlineable types), regardless of the model's nominal modality.
+  // Either way the file has auto-staged into the sandbox, so reference it there.
+  const modelCannotRead =
+    ingestibleMimeTypes !== undefined &&
+    !ingestibleMimeTypes.has(attachment.mimeType);
+  const endpointRejectsBinaryDoc =
+    rerouteBinaryDocsToSandbox &&
+    isNonInlineableBinaryDocMimeType(attachment.mimeType);
+  if (modelCannotRead || endpointRejectsBinaryDoc) {
     return referenceSandboxFilePart(attachment);
   }
 
@@ -206,6 +234,46 @@ function dualAvailabilityPointer(
   return {
     type: "text",
     text: `[The attached file ${name} is also available in your sandbox under ${SKILL_SANDBOX_ATTACHMENTS_DIR} — run \`ls ${SKILL_SANDBOX_ATTACHMENTS_DIR}\` to find it (the filename may be sanitized), then process it with run_command.]`,
+  };
+}
+
+/**
+ * A mime that an Anthropic-compatible third-party endpoint can't accept inline.
+ * Such an endpoint takes images (as image blocks) and the text documents
+ * {@link prepareMessagesForProvider} inlines as text; everything else (PDF and
+ * other binaries) only travels as a `document` block the endpoint rejects.
+ */
+function isNonInlineableBinaryDocMimeType(mime: string): boolean {
+  return !mime.startsWith("image/") && !isInlineableTextDocumentMimeType(mime);
+}
+
+/** Mime of an inline `data:` file part, from `mediaType` or the URL prefix. */
+function dataUrlMimeType(part: ChatMessagePart): string | undefined {
+  if (part.type !== "file") return undefined;
+  if (typeof part.mediaType === "string" && part.mediaType.length > 0) {
+    return part.mediaType;
+  }
+  if (typeof part.url !== "string") return undefined;
+  return /^data:([^;,]+)[;,]/.exec(part.url)?.[1];
+}
+
+/**
+ * An inline `data:` binary document has no attachment row, so it was never
+ * staged into the sandbox and can't be referenced there. Drop it with a notice
+ * rather than emit a `document` block that 400s an Anthropic-compatible endpoint.
+ */
+function unavailableBinaryDocPart(
+  part: ChatMessagePart,
+  mime: string,
+): ChatMessagePart {
+  const filename =
+    part.type === "file" && typeof part.filename === "string"
+      ? part.filename
+      : "attachment";
+  const name = JSON.stringify(filename);
+  return {
+    type: "text",
+    text: `[Attachment ${name} (${mime}) can't be shown to this model this turn.]`,
   };
 }
 

--- a/platform/backend/src/routes/chat/prepare-model-messages.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.ts
@@ -143,6 +143,7 @@ async function buildModelMessagesForProvider(params: {
     params.conversationId,
     params.ingestibleMimeTypes,
     applyAnthropicCacheControl,
+    params.provider === "anthropic" && !anthropicNativeEndpoint,
   );
   const providerPreparedMessages = prepareMessagesForProvider({
     messages: materialized,

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -1818,8 +1818,13 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
         organizationId,
       });
 
-      // Validate that the agent exists and user has access to it
-      const agent = await AgentModel.findById(agentId, user.id, isAgentAdmin);
+      // Validate that the agent exists and the user has access to it. Only the
+      // LLM-selection fields are read below, so skip findById's full hydration.
+      const agent = await AgentModel.findLlmSelectionFieldsById(
+        agentId,
+        user.id,
+        isAgentAdmin,
+      );
 
       if (!agent) {
         throw new ApiError(404, "Agent not found");

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -234,6 +234,13 @@ function buildStreamErrorPayload(params: {
   return serialized;
 }
 
+// Upper bound on how long the response body's close waits for the active-run row
+// to be marked terminal. Terminalization is normally tens of milliseconds; this
+// cap keeps a wedged DB or notifier after stream-end from hanging the client EOF
+// indefinitely. Past it we release EOF and fall back to the pre-existing 409
+// window (which the stale reaper still cleans up).
+const TERMINAL_CLOSE_GATE_TIMEOUT_MS = 10_000;
+
 const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
   fastify.post(
     "/api/chat",
@@ -1291,7 +1298,22 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
             ).pipeThrough(
               new TransformStream<Uint8Array, Uint8Array>({
                 async flush() {
-                  await terminalReady;
+                  let timer: ReturnType<typeof setTimeout> | undefined;
+                  try {
+                    await Promise.race([
+                      terminalReady,
+                      new Promise<void>((resolve) => {
+                        timer = setTimeout(
+                          resolve,
+                          TERMINAL_CLOSE_GATE_TIMEOUT_MS,
+                        );
+                      }),
+                    ]);
+                  } finally {
+                    if (timer) {
+                      clearTimeout(timer);
+                    }
+                  }
                 },
               }),
             );

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -1232,7 +1232,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
             });
 
             const [responseStream, persistenceStream] = uiMessageStream.tee();
-            activeChatRunService.drainStreamToEvents({
+            const { terminalReady } = activeChatRunService.drainStreamToEvents({
               runId: activeRun.id,
               conversationId,
               stream: persistenceStream as ReadableStream<UIMessageChunk>,
@@ -1278,12 +1278,25 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
               reply.header(key, value);
             }
 
-            // Send the Response body stream directly
+            // Send the Response body stream directly, but hold its CLOSE (not
+            // its bytes — they stream through unchanged) until the active-run row
+            // is marked terminal. Without this, a client that fires its next
+            // message the instant this response ends races the async drain and
+            // 409s against a row still flagged running.
             if (!response.body) {
               throw new ApiError(400, "No response body");
             }
+            const gatedBody = (
+              response.body as ReadableStream<Uint8Array>
+            ).pipeThrough(
+              new TransformStream<Uint8Array, Uint8Array>({
+                async flush() {
+                  await terminalReady;
+                },
+              }),
+            );
             // biome-ignore lint/suspicious/noExplicitAny: Fastify reply.send accepts ReadableStream but TypeScript requires explicit cast
-            return reply.send(response.body as any);
+            return reply.send(gatedBody as any);
           },
         });
       } catch (error) {

--- a/platform/backend/src/services/active-chat-run.test.ts
+++ b/platform/backend/src/services/active-chat-run.test.ts
@@ -125,6 +125,48 @@ test("terminalReady resolves only once the run is terminal, so an immediate next
   expect(next).not.toBeNull();
 });
 
+test("terminalReady resolves on the error path too, so a next send after a failed run isn't 409-blocked", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  const { terminalReady } = activeChatRunService.drainStreamToEvents({
+    runId: run?.id ?? "",
+    conversationId: conversation.id,
+    // An error chunk, then the stream closes (the common provider-error case).
+    stream: createChunkStream([
+      { type: "start" },
+      { type: "error", errorText: "provider exploded" },
+    ]),
+    getTerminalStatus: async () => ({ status: "completed" }),
+  });
+
+  await terminalReady;
+
+  const terminalRun = await ActiveChatRunModel.findById(run?.id ?? "");
+  expect(terminalRun?.status).toBe("failed");
+  const next = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  expect(next).not.toBeNull();
+});
+
 test("drainStreamToEvents fails the run as soon as an error chunk arrives, even if the stream never closes", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/services/active-chat-run.test.ts
+++ b/platform/backend/src/services/active-chat-run.test.ts
@@ -71,6 +71,60 @@ test("drainStreamToEvents compacts adjacent text and reasoning deltas before mar
   expect(terminalRun?.status).toBe("completed");
 });
 
+test("terminalReady resolves only once the run is terminal, so an immediate next send is no longer 409-blocked", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  // While the run is `running`, a second send is rejected — this is the window
+  // a client used to hit when it sent the next message the instant the stream
+  // ended but the async drain hadn't flipped the row terminal yet.
+  const blocked = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  expect(blocked).toBeNull();
+
+  const { terminalReady } = activeChatRunService.drainStreamToEvents({
+    runId: run?.id ?? "",
+    conversationId: conversation.id,
+    stream: createChunkStream([
+      { type: "start" },
+      { type: "text-delta", id: "text-1", delta: "hi" },
+      { type: "finish", finishReason: "stop" },
+    ]),
+    getTerminalStatus: async () => ({ status: "completed" }),
+  });
+
+  // The route releases the client stream's close only after this resolves.
+  await terminalReady;
+
+  const terminalRun = await ActiveChatRunModel.findById(run?.id ?? "");
+  expect(terminalRun?.status).toBe("completed");
+  // The same send that was blocked above now succeeds — no 409.
+  const next = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  expect(next).not.toBeNull();
+});
+
 test("drainStreamToEvents fails the run as soon as an error chunk arrives, even if the stream never closes", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -155,7 +155,15 @@ export class ActiveChatRunService {
       error?: string | null;
     }>;
     abortController?: AbortController;
-  }): void {
+  }): { terminalReady: Promise<void> } {
+    // Resolves once the drain has attempted the terminal write on every path
+    // below (or found the run gone). The route awaits this before closing the
+    // client stream, so a client that sends its next message the instant the
+    // response ends doesn't race a row still flagged `running` into a 409.
+    let resolveTerminalReady!: () => void;
+    const terminalReady = new Promise<void>((resolve) => {
+      resolveTerminalReady = resolve;
+    });
     void (async () => {
       const reader = params.stream.getReader();
       // A timer-triggered flush can fail (or observe the run as gone) while the
@@ -251,12 +259,21 @@ export class ActiveChatRunService {
         });
         await this.notifyEvent(params.runId);
       }
-    })().catch((error) => {
-      logger.error(
-        { error, runId: params.runId, conversationId: params.conversationId },
-        "Unexpected active chat run drain failure",
-      );
-    });
+    })()
+      .catch((error) => {
+        logger.error(
+          { error, runId: params.runId, conversationId: params.conversationId },
+          "Unexpected active chat run drain failure",
+        );
+      })
+      // Resolves even on an unexpected failure so a waiting client EOF can never
+      // hang; markTerminal's running-only guard already makes a double write a
+      // no-op, and a genuinely stuck `running` row is backstopped by the reaper.
+      .finally(() => {
+        resolveTerminalReady();
+      });
+
+    return { terminalReady };
   }
 
   createReplayStream(runId: string): ReadableStream<UIMessageChunk> {


### PR DESCRIPTION
Three independent chat-reliability fixes, each in its own commit. All surfaced by the agent benchmark as `agent_error`s; none are upstream/provider faults.

## 1. Binary attachments 400 on non-native Anthropic endpoints
A PDF (or other binary) attached on an Anthropic-compatible third-party endpoint was emitted as an Anthropic `document` content block and 400'd the turn — ingestibility was decided from the model's input modalities, not the endpoint, which can't accept the block regardless. Non-image, non-text-inlineable file parts now reroute to the existing sandbox pointer on those endpoints (main chat path and in-context compaction); inline `data:` binaries get a notice instead of a rejected block. Native Anthropic, images, and text-document inlining are unchanged.

## 2. Create-conversation latency
`POST /api/chat/conversations` called `AgentModel.findById`, which hydrates tools, teams, labels, knowledge bases, connectors, author names, suggested prompts, and the resolved LLM, when the handler reads only `llmApiKeyId`/`modelId`. New `findLlmSelectionFieldsById` applies the same access gate but selects just those fields.

## 3. 409 on an immediate next message
The active-run row flips terminal in a fire-and-forget drain of the tee'd persistence stream, which can finish after the client already received the final chunk — a client sending its next message in that window 409'd. `drainStreamToEvents` now exposes a `terminalReady` promise (resolved in a `finally` on every path); the route gates the response body's *close* (not its bytes) on it, bounded by a 10s cap so a wedged drain can't hang the client EOF.

## Validation
- New behavior tests per fix (real DB, constructed streams as inputs); full suites for the touched areas pass.
- `type-check` and `lint` clean across the diff.
- Two adversarial review passes (external + internal); their should-fix findings (compaction reroute, EOF gate bound, error-path test) are folded into the final commit.

One unrelated pre-existing test failure (`stream-route.test.ts › passes compacted messages to streamText`, a cacheControl/compaction assertion) fails on `main` as well and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szv8bkrAD6d7rrdXscAfXE

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>