### PR TITLE
feat(bench): add OpenRouter lanes to CI benchmark

### DIFF
--- a/.github/bench/job.yaml
+++ b/.github/bench/job.yaml
@@ -62,7 +62,7 @@ spec:
             - name: BENCH_ENVS
               value: "basic"
             - name: BENCH_LANES
-              value: "glm"
+              value: "glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-54-nano,gpt-54-mini,claude-haiku-45,mimo-25,qwen36-35b-a3b,gpt-oss-120b"
             # Dagger runner host is resolved from the live staging Deployment by CI.
             - name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
               value: "${DAGGER_RUNNER_HOST}"
@@ -77,6 +77,12 @@ spec:
                 secretKeyRef:
                   name: archestra-bench-secrets
                   key: ZAI_API_KEY
+            # OpenRouter-served lanes (everything except glm) resolve their key from here.
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: archestra-bench-secrets
+                  key: OPENROUTER_API_KEY
             # Reporting: the pod exports TensorBoard scalars, uploads artifacts to GCS (auth via the
             # platform SA's Workload Identity), and posts the Slack summary itself.
             - name: GCS_BUCKET

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -143,13 +143,16 @@ jobs:
       - name: Create bench secret
         env:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           SLACK_BENCH_WEBHOOK_URL: ${{ secrets.SLACK_BENCH_WEBHOOK_URL }}
         run: |
           set -euo pipefail
-          # The pod reads both: the glm lane key and (optionally, empty when unset) the Slack webhook it
-          # posts the summary to. Recreated each run; left in place since the pod needs it after CI exits.
+          # The pod reads: the glm lane key, the OpenRouter key for the OR-served lanes, and (optionally,
+          # empty when unset) the Slack webhook it posts the summary to. Recreated each run; left in place
+          # since the pod needs it after CI exits.
           kubectl create secret generic archestra-bench-secrets -n archestra \
             --from-literal=ZAI_API_KEY="${ZAI_API_KEY}" \
+            --from-literal=OPENROUTER_API_KEY="${OPENROUTER_API_KEY}" \
             --from-literal=SLACK_BENCH_WEBHOOK_URL="${SLACK_BENCH_WEBHOOK_URL:-}" \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/archestra-bench/lanes.toml
+++ b/archestra-bench/lanes.toml
@@ -47,6 +47,36 @@ provider = "openrouter"
 model = "minimax/minimax-m2.7"
 
 [[lane]]
+name = "gpt-54-nano"
+provider = "openrouter"
+model = "openai/gpt-5.4-nano"
+
+[[lane]]
+name = "gpt-54-mini"
+provider = "openrouter"
+model = "openai/gpt-5.4-mini"
+
+[[lane]]
+name = "claude-haiku-45"
+provider = "openrouter"
+model = "anthropic/claude-haiku-4.5"
+
+[[lane]]
+name = "mimo-25"
+provider = "openrouter"
+model = "xiaomi/mimo-v2.5"
+
+[[lane]]
+name = "qwen36-35b-a3b"
+provider = "openrouter"
+model = "qwen/qwen3.6-35b-a3b"
+
+[[lane]]
+name = "gpt-oss-120b"
+provider = "openrouter"
+model = "openai/gpt-oss-120b"
+
+[[lane]]
 name = "kimi"
 provider = "anthropic"
 model = "kimi-for-coding"


### PR DESCRIPTION
Extends the CI benchmark to run more model lanes.

## Changes
- **`archestra-bench/lanes.toml`**: add 6 new OpenRouter lanes — `gpt-54-nano`, `gpt-54-mini`, `claude-haiku-45`, `mimo-25`, `qwen36-35b-a3b`, `gpt-oss-120b`. (`gemma-4-31b`, `qwen37-plus`, `deepseek-flash` already existed and are reused.)
- **`.github/bench/job.yaml`**: `BENCH_LANES` now runs the 9 requested lanes plus the `glm` baseline (10 total); inject `OPENROUTER_API_KEY` into the pod.
- **`.github/workflows/benchmark.yml`**: write `OPENROUTER_API_KEY` into the bench secret.

Concurrency stays ~4: no `--max-workers` is passed, so the runner auto-caps at `MAX_WORKERS_CAP = 4`.

Requires the `OPENROUTER_API_KEY` GitHub Actions secret (created).

https://claude.ai/code/session_01TvJ7tQeYuowimaTZrYjj59

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>