### PR TITLE
chore(claude): deny agent Read of the generated OpenAPI spec

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,8 +5,7 @@
   },
   "permissions": {
     "deny": [
-      "Read(./**/*.gen.ts)",
-      "Read(./docs/openapi.json)"
+      "Read(/docs/openapi.json)"
     ]
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,12 @@
     "commit": "",
     "pr": ""
   },
+  "permissions": {
+    "deny": [
+      "Read(./**/*.gen.ts)",
+      "Read(./docs/openapi.json)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary

`docs/openapi.json` is a 12 MB generated artifact. Reading it returns the `Read` tool's 2000-line cap — about 89 KB, ~25k tokens — of spec JSON that answers nothing on its own: the source of truth is the Drizzle/Zod schemas it is generated from, and the readable view of the same surface is the hey-api client. Interrogating it usefully means `jq`, which a `Read` deny leaves untouched. Closing the `Read` path pushes agents to the schemas instead of burning a fifth of a small context window on generated output.

The rule uses a single leading `/`, which anchors at the settings source — the project root — rather than at the session's working directory. `Read(./docs/openapi.json)` would resolve to `<cwd>/docs/openapi.json` and match nothing at all in a session started from `platform/`, where `platform/CLAUDE.md` directs most work to happen.

Two side effects are worth knowing about. A `Read` deny also blocks `Edit` on the same path, and it covers the file commands Claude Code recognises in Bash (`cat`, `head`, `tail`, `sed`). Neither reaches codegen or the Release Please version bump, since both write the file from a subprocess and deny rules don't apply to those.

Generated `*.gen.ts` files are deliberately left readable. Only `types.gen.ts` is big enough to matter — 26 of the 28 matching files are under 320 lines — and `Read` deny rules are best-effort applied to Grep, so a blanket rule would block looking up a generated type name, which is the one thing those files are good for.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
