### PR TITLE
fix(bench): repin basic-env skills to commits on main

### DIFF
--- a/archestra-bench/envs/basic.toml
+++ b/archestra-bench/envs/basic.toml
@@ -38,19 +38,18 @@ ref = "a8924c2a35cfa290458852c4fad17c9133054c2e"
 [[skills]]
 repo = "github.com/archestra-ai/archestra"
 path = "archestra-bench/skills/cipher-decoder"
-ref = "5ae74172add0f2e3beb0d783dc132e1d8803b6e2"
+ref = "981571f262a68965152f24f1fa7e28f042774e9e"
 
 [[skills]]
 repo = "github.com/archestra-ai/archestra"
 path = "archestra-bench/skills/sales-ledger"
 ref = "08f9b3033d20597fb3ea85d35223772300bb90dc"
 
-# Drives the access-request-intake elicitation flow. Pinned to a pushed SHA so the GitHub import
-# resolves; retarget to the merge SHA after this lands.
+# Drives the access-request-intake elicitation flow. Pinned to its latest change on main.
 [[skills]]
 repo = "github.com/archestra-ai/archestra"
 path = "archestra-bench/skills/access-request-intake"
-ref = "506e9d1108afd8b241eba37a8bf692e816164ef6"
+ref = "6fab157c0716377d4df459bb7ba959918277ac94"
 
 # Three public, no-auth remote MCP servers, registered as part of the surface (distractors; no task
 # requires them). Each must list tools without auth or env setup hard-fails naming it.


### PR DESCRIPTION
Two benchmark-owned skills in `archestra-bench/envs/basic.toml` were pinned to commit SHAs that are not on `main`, so the GitHub skill import can't resolve them:

- **cipher-decoder** `5ae7417` → `981571f` — that SHA isn't on main; content is identical to its latest main commit, so this is a pure dangling-pin fix.
- **access-request-intake** `506e9d1` → `6fab157` — that SHA isn't on main; repin to its latest main commit, which picks up the #5904 hardening (the comment already said to retarget to the merge SHA once it landed).

`sales-ledger` was already pinned to a commit on main and is left unchanged. All three archestra-owned pins now resolve as ancestors of `main`.

https://claude.ai/code/session_01Ta8ZjYVspUcpGpyh4mb46y

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>