### PR TITLE
feat(files): unify the project Files panel with chat's select/delete

### DIFF
--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -428,10 +428,12 @@ function ProjectFilesSidebar({
               <SelectableFileList<FileListItem>
                 sections={[{ items }]}
                 canManage
+                selectedId={selectedId}
                 onOpen={openFile}
                 onRequestDelete={requestDelete}
                 leading={
                   <InstructionsRow
+                    selected={instructionsSelected}
                     onSelect={() => openFile(INSTRUCTIONS_SELECTION)}
                   />
                 }

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -20,10 +20,7 @@ import { useEffect, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { ProjectSchedulesSection } from "@/app/projects/[id]/project-schedules-section";
 import { AgentIcon } from "@/components/agent-icon";
-import {
-  type FileListItem,
-  FileSection,
-} from "@/components/chat/file-list-section";
+import type { FileListItem } from "@/components/chat/file-list-section";
 import { FilePreview } from "@/components/chat/file-preview";
 import { NewChatComposer } from "@/components/chat/new-chat-composer";
 import {
@@ -32,6 +29,7 @@ import {
   ProjectInstructionsPanel,
 } from "@/components/chat/project-instructions";
 import { ResizableRightPanel } from "@/components/chat/resizable-right-panel";
+import { SelectableFileList } from "@/components/chat/selectable-file-list";
 import { PageLayout } from "@/components/page-layout";
 import { EditProjectDialog } from "@/components/projects/edit-project-dialog";
 import { Badge } from "@/components/ui/badge";
@@ -44,10 +42,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFileDeletion } from "@/lib/chat/use-file-deletion";
 import { buildProjectChatHandoffUrl } from "@/lib/projects/project-chat-handoff";
 import { canManageProject } from "@/lib/projects/project-permissions";
 import {
   useDeleteProject,
+  useDeleteProjectFiles,
   usePinProject,
   useProject,
   useProjectConversations,
@@ -223,7 +223,7 @@ function ProjectDetail() {
         <ProjectFilesSidebar
           projectId={project.id}
           projectName={project.name}
-          isOwner={canManage}
+          canManageProject={canManage}
         />
       </div>
     </div>
@@ -329,11 +329,12 @@ function ChatsList({
 function ProjectFilesSidebar({
   projectId,
   projectName,
-  isOwner,
+  canManageProject,
 }: {
   projectId: string;
   projectName: string;
-  isOwner: boolean;
+  /** Owner / project-admin — gates editing the pinned instructions. */
+  canManageProject: boolean;
 }) {
   const { data: files } = useProjectFiles(projectId);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -373,6 +374,18 @@ function ProjectFilesSidebar({
     }
   }, [selectedMissing]);
 
+  // Every viewer of a project has project access, which the backend's artifact
+  // delete authorizes — so file select/delete is available to anyone here (the
+  // chat panel gates on conversation ownership; the project surface on access).
+  const deleteProjectFiles = useDeleteProjectFiles(projectId);
+  const { requestDelete, dialog: deleteDialog } = useFileDeletion<FileListItem>(
+    {
+      deleteItems: (toDelete) => deleteProjectFiles.mutateAsync(toDelete),
+      describe: () =>
+        "This file is part of the project and will be removed for everyone with access to it. This can't be undone.",
+    },
+  );
+
   return (
     <ResizableRightPanel>
       <Tabs value="files" className="flex-1 min-h-0 flex flex-col gap-0">
@@ -393,23 +406,17 @@ function ProjectFilesSidebar({
         <div className="flex-1 min-h-0 overflow-hidden relative">
           <div className="flex h-full flex-col">
             {view === "list" ? (
-              <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
-                <FileSection
-                  items={items}
-                  selectedId={null}
-                  onSelect={openFile}
-                  leading={
-                    <InstructionsRow
-                      onSelect={() => openFile(INSTRUCTIONS_SELECTION)}
-                    />
-                  }
-                />
-                {items.length === 0 && (
-                  <p className="px-1 pt-3 text-xs text-muted-foreground">
-                    Results the agent saves in this project will appear here.
-                  </p>
-                )}
-              </div>
+              <SelectableFileList<FileListItem>
+                sections={[{ items }]}
+                canManage
+                onOpen={openFile}
+                onRequestDelete={requestDelete}
+                leading={
+                  <InstructionsRow
+                    onSelect={() => openFile(INSTRUCTIONS_SELECTION)}
+                  />
+                }
+              />
             ) : (
               <>
                 <div className="flex shrink-0 items-center gap-1 border-b px-2 py-1.5">
@@ -429,22 +436,41 @@ function ProjectFilesSidebar({
                   >
                     {detailName}
                   </span>
-                  {selected && !instructionsSelected && selected.contentUrl && (
-                    <a
-                      href={selected.contentUrl}
-                      download={selected.name}
-                      title={`Download ${selected.name}`}
-                      className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-                    >
-                      <Download className="h-4 w-4" />
-                      <span className="sr-only">Download {selected.name}</span>
-                    </a>
+                  {selected && !instructionsSelected && (
+                    <div className="flex shrink-0 items-center">
+                      {selected.contentUrl && (
+                        <a
+                          href={selected.contentUrl}
+                          download={selected.name}
+                          title={`Download ${selected.name}`}
+                          className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                        >
+                          <Download className="h-4 w-4" />
+                          <span className="sr-only">
+                            Download {selected.name}
+                          </span>
+                        </a>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          requestDelete([selected], (failedIds) => {
+                            if (!failedIds.includes(selected.id)) backToList();
+                          })
+                        }
+                        title={`Delete ${selected.name}`}
+                        className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        <span className="sr-only">Delete {selected.name}</span>
+                      </button>
+                    </div>
                   )}
                 </div>
                 {instructionsSelected ? (
                   <ProjectInstructionsPanel
                     projectId={projectId}
-                    isOwner={isOwner}
+                    isOwner={canManageProject}
                     onClose={backToList}
                   />
                 ) : selected ? (
@@ -455,6 +481,7 @@ function ProjectFilesSidebar({
           </div>
         </div>
       </Tabs>
+      {deleteDialog}
     </ResizableRightPanel>
   );
 }

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -405,7 +405,13 @@ function ProjectFilesSidebar({
 
         <div className="flex-1 min-h-0 overflow-hidden relative">
           <div className="flex h-full flex-col">
-            {view === "list" ? (
+            {/* Kept mounted (hidden in detail) so an in-progress multi-selection
+                survives drilling into a file and coming back. */}
+            <div
+              className={
+                view === "list" ? "flex min-h-0 flex-1 flex-col" : "hidden"
+              }
+            >
               <SelectableFileList<FileListItem>
                 sections={[{ items }]}
                 canManage
@@ -417,7 +423,8 @@ function ProjectFilesSidebar({
                   />
                 }
               />
-            ) : (
+            </div>
+            {view === "detail" && (
               <>
                 <div className="flex shrink-0 items-center gap-1 border-b px-2 py-1.5">
                   <Button

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -3,7 +3,6 @@
 import { PROJECT_INSTRUCTIONS_FILENAME } from "@archestra/shared";
 import {
   CalendarClock,
-  ChevronLeft,
   Download,
   Eye,
   FileText,
@@ -20,6 +19,7 @@ import { useEffect, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { ProjectSchedulesSection } from "@/app/projects/[id]/project-schedules-section";
 import { AgentIcon } from "@/components/agent-icon";
+import { FileDetailHeader } from "@/components/chat/file-detail-header";
 import type { FileListItem } from "@/components/chat/file-list-section";
 import { FilePreview } from "@/components/chat/file-preview";
 import { NewChatComposer } from "@/components/chat/new-chat-composer";
@@ -54,6 +54,7 @@ import {
   useProjectFiles,
 } from "@/lib/projects/projects.query";
 import { sandboxArtifactUrl } from "@/lib/skills-sandbox/sandbox-file-preview";
+import { cn } from "@/lib/utils";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 import { ProjectDeleteConfirmDialog } from "../project-delete-confirm-dialog";
 
@@ -338,7 +339,8 @@ function ProjectFilesSidebar({
 }) {
   const { data: files } = useProjectFiles(projectId);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [view, setView] = useState<"list" | "detail">("list");
+  // Opening a file shows it below the list (split); `expanded` fills the panel.
+  const [expanded, setExpanded] = useState(false);
 
   // The instructions file is surfaced only as the pinned entry, so keep it out
   // of the ordinary list (filtered from `items` below).
@@ -354,15 +356,20 @@ function ProjectFilesSidebar({
     }));
   const selected = items.find((i) => i.id === selectedId) ?? null;
   const instructionsSelected = selectedId === INSTRUCTIONS_SELECTION;
+  const previewing = selected !== null || instructionsSelected;
   const detailName = instructionsSelected
     ? PROJECT_INSTRUCTIONS_FILENAME
     : (selected?.name ?? "");
 
   const openFile = (id: string) => {
     setSelectedId(id);
-    setView("detail");
+    setExpanded(false);
   };
-  const backToList = () => setView("list");
+  const collapse = () => setExpanded(false);
+  const deselect = () => {
+    setSelectedId(null);
+    setExpanded(false);
+  };
 
   // If the open file disappears (e.g. deleted elsewhere), fall back to the list.
   const selectedMissing =
@@ -370,7 +377,7 @@ function ProjectFilesSidebar({
   useEffect(() => {
     if (selectedMissing) {
       setSelectedId(null);
-      setView("list");
+      setExpanded(false);
     }
   }, [selectedMissing]);
 
@@ -405,12 +412,18 @@ function ProjectFilesSidebar({
 
         <div className="flex-1 min-h-0 overflow-hidden relative">
           <div className="flex h-full flex-col">
-            {/* Kept mounted (hidden in detail) so an in-progress multi-selection
-                survives drilling into a file and coming back. */}
+            {/* The list fills the panel when nothing is open, is capped above
+                the preview in the split, and is hidden when expanded. Kept
+                mounted so an in-progress multi-selection survives previewing. */}
             <div
-              className={
-                view === "list" ? "flex min-h-0 flex-1 flex-col" : "hidden"
-              }
+              className={cn(
+                "flex flex-col",
+                previewing
+                  ? expanded
+                    ? "hidden"
+                    : "max-h-[45%] shrink-0 overflow-hidden border-b"
+                  : "min-h-0 flex-1",
+              )}
             >
               <SelectableFileList<FileListItem>
                 sections={[{ items }]}
@@ -424,67 +437,54 @@ function ProjectFilesSidebar({
                 }
               />
             </div>
-            {view === "detail" && (
-              <>
-                <div className="flex shrink-0 items-center gap-1 border-b px-2 py-1.5">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 shrink-0 gap-1 px-2 text-xs text-muted-foreground"
-                    onClick={backToList}
-                  >
-                    <ChevronLeft className="h-4 w-4" />
-                    Files
-                  </Button>
-                  <span className="shrink-0 text-muted-foreground">·</span>
-                  <span
-                    className="min-w-0 flex-1 truncate text-sm font-medium"
-                    title={detailName}
-                  >
-                    {detailName}
-                  </span>
-                  {selected && !instructionsSelected && (
-                    <div className="flex shrink-0 items-center">
-                      {selected.contentUrl && (
-                        <a
-                          href={selected.contentUrl}
-                          download={selected.name}
-                          title={`Download ${selected.name}`}
-                          className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-                        >
-                          <Download className="h-4 w-4" />
-                          <span className="sr-only">
-                            Download {selected.name}
-                          </span>
-                        </a>
-                      )}
-                      <button
-                        type="button"
-                        onClick={() =>
-                          requestDelete([selected], (failedIds) => {
-                            if (!failedIds.includes(selected.id)) backToList();
-                          })
-                        }
-                        title={`Delete ${selected.name}`}
-                        className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-destructive"
+            {previewing && (
+              <FileDetailHeader
+                title={detailName}
+                expanded={expanded}
+                onExpand={() => setExpanded(true)}
+                onCollapse={collapse}
+              >
+                {selected && !instructionsSelected && (
+                  <div className="flex shrink-0 items-center">
+                    {selected.contentUrl && (
+                      <a
+                        href={selected.contentUrl}
+                        download={selected.name}
+                        title={`Download ${selected.name}`}
+                        className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
                       >
-                        <Trash2 className="h-4 w-4" />
-                        <span className="sr-only">Delete {selected.name}</span>
-                      </button>
-                    </div>
-                  )}
-                </div>
-                {instructionsSelected ? (
-                  <ProjectInstructionsPanel
-                    projectId={projectId}
-                    isOwner={canManageProject}
-                    onClose={backToList}
-                  />
-                ) : selected ? (
-                  <FilePreview file={selected} onClose={backToList} />
-                ) : null}
-              </>
+                        <Download className="h-4 w-4" />
+                        <span className="sr-only">
+                          Download {selected.name}
+                        </span>
+                      </a>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        requestDelete([selected], (failedIds) => {
+                          if (!failedIds.includes(selected.id)) deselect();
+                        })
+                      }
+                      title={`Delete ${selected.name}`}
+                      className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span className="sr-only">Delete {selected.name}</span>
+                    </button>
+                  </div>
+                )}
+              </FileDetailHeader>
             )}
+            {previewing && instructionsSelected ? (
+              <ProjectInstructionsPanel
+                projectId={projectId}
+                isOwner={canManageProject}
+                onClose={deselect}
+              />
+            ) : previewing && selected ? (
+              <FilePreview file={selected} onClose={deselect} />
+            ) : null}
           </div>
         </div>
       </Tabs>

--- a/platform/frontend/src/components/chat/conversation-files-panel.tsx
+++ b/platform/frontend/src/components/chat/conversation-files-panel.tsx
@@ -226,7 +226,11 @@ export function ConversationFilesPanel({
 
   return (
     <div className="flex h-full flex-col">
-      {view === "list" && (
+      {/* Kept mounted (hidden in detail) so an in-progress multi-selection
+          survives drilling into a file and coming back. */}
+      <div
+        className={view === "list" ? "flex min-h-0 flex-1 flex-col" : "hidden"}
+      >
         <SelectableFileList<ConversationFileItem>
           sections={[
             { title: "Results", items: results },
@@ -251,7 +255,7 @@ export function ConversationFilesPanel({
             ) : undefined
           }
         />
-      )}
+      </div>
 
       {view === "detail" && (
         <div className="flex shrink-0 items-center gap-1 border-b px-2 py-1.5">

--- a/platform/frontend/src/components/chat/conversation-files-panel.tsx
+++ b/platform/frontend/src/components/chat/conversation-files-panel.tsx
@@ -99,7 +99,6 @@ export function ConversationFilesPanel({
   const generatedFileIds = generated
     .filter((f) => f.source === "generated")
     .map((f) => f.id);
-  const newestGeneratedId = generatedFileIds.at(-1);
   const generatedKey = generatedFileIds.join("|");
   const filesLoaded = files !== undefined;
 
@@ -114,17 +113,6 @@ export function ConversationFilesPanel({
       setExpanded(false);
     }
   }, [selectedMissing]);
-
-  // Keep a valid preview target when nothing is selected (artifact first, then
-  // the newest generated file). Opens in the split (never forces `expanded`).
-  useEffect(() => {
-    if (selectedId !== null) return;
-    if (hasArtifact) {
-      setSelectedId("artifact");
-    } else if (newestGeneratedId) {
-      setSelectedId(newestGeneratedId);
-    }
-  }, [selectedId, hasArtifact, newestGeneratedId]);
 
   // Follow the latest produced output: when the artifact is (re)written switch
   // back to it, when a download_file output is created switch to that file. It
@@ -214,7 +202,7 @@ export function ConversationFilesPanel({
   }
 
   const detailName = instructionsSelected
-    ? "Instructions"
+    ? PROJECT_INSTRUCTIONS_FILENAME
     : (selected?.name ?? "");
 
   return (

--- a/platform/frontend/src/components/chat/conversation-files-panel.tsx
+++ b/platform/frontend/src/components/chat/conversation-files-panel.tsx
@@ -226,11 +226,13 @@ export function ConversationFilesPanel({
             { title: "Attachments", items: attachments },
           ]}
           canManage={canManageFiles}
+          selectedId={selectedId}
           onOpen={openFile}
           onRequestDelete={requestDelete}
           leading={
             showInstructions ? (
               <InstructionsRow
+                selected={instructionsSelected}
                 onSelect={() => openFile(INSTRUCTIONS_SELECTION)}
               />
             ) : undefined

--- a/platform/frontend/src/components/chat/conversation-files-panel.tsx
+++ b/platform/frontend/src/components/chat/conversation-files-panel.tsx
@@ -1,16 +1,10 @@
 "use client";
 
 import { PROJECT_INSTRUCTIONS_FILENAME } from "@archestra/shared";
-import {
-  Check,
-  ChevronLeft,
-  Copy,
-  Download,
-  File as FileIcon,
-  Trash2,
-} from "lucide-react";
+import { Check, Copy, Download, File as FileIcon, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ConversationArtifactPanel } from "@/components/chat/conversation-artifact";
+import { FileDetailHeader } from "@/components/chat/file-detail-header";
 import { FilePreview } from "@/components/chat/file-preview";
 import {
   INSTRUCTIONS_SELECTION,
@@ -18,7 +12,6 @@ import {
   ProjectInstructionsPanel,
 } from "@/components/chat/project-instructions";
 import { SelectableFileList } from "@/components/chat/selectable-file-list";
-import { Button } from "@/components/ui/button";
 import {
   useBulkDeleteConversationFiles,
   useConversationFiles,
@@ -66,14 +59,12 @@ export function ConversationFilesPanel({
   );
   const hasArtifact = !!artifact && artifact.trim().length > 0;
 
-  // Default to previewing the artifact when one exists as the panel opens, in
-  // the full-height detail view.
+  // Default to previewing the artifact when one exists as the panel opens.
+  // Opening a file shows it below the list (split); `expanded` fills the panel.
   const [selectedId, setSelectedId] = useState<string | null>(() =>
     hasArtifact ? "artifact" : null,
   );
-  const [view, setView] = useState<"list" | "detail">(() =>
-    hasArtifact ? "detail" : "list",
-  );
+  const [expanded, setExpanded] = useState(false);
 
   // This chat's own outputs and the project's files are one group ("Results");
   // only attachments stand apart.
@@ -90,11 +81,19 @@ export function ConversationFilesPanel({
   const instructionsSelectedRef = useRef(false);
   instructionsSelectedRef.current = instructionsSelected;
 
+  // Something is open (file, artifact, or the pinned instructions) → show the
+  // preview. Split by default; `expanded` hides the list and fills the panel.
+  const previewing = selected !== null || instructionsSelected;
+
   const openFile = (id: string) => {
     setSelectedId(id);
-    setView("detail");
+    setExpanded(false);
   };
-  const backToList = () => setView("list");
+  const collapse = () => setExpanded(false);
+  const deselect = () => {
+    setSelectedId(null);
+    setExpanded(false);
+  };
 
   // download_file outputs only (the artifact has its own default handling).
   const generatedFileIds = generated
@@ -112,14 +111,12 @@ export function ConversationFilesPanel({
   useEffect(() => {
     if (selectedMissing) {
       setSelectedId(null);
-      setView("list");
+      setExpanded(false);
     }
   }, [selectedMissing]);
 
   // Keep a valid preview target when nothing is selected (artifact first, then
-  // the newest generated file). This does NOT force the detail view, so going
-  // back to the list — or deleting the open file — doesn't yank the user back
-  // into a preview.
+  // the newest generated file). Opens in the split (never forces `expanded`).
   useEffect(() => {
     if (selectedId !== null) return;
     if (hasArtifact) {
@@ -130,11 +127,10 @@ export function ConversationFilesPanel({
   }, [selectedId, hasArtifact, newestGeneratedId]);
 
   // Follow the latest produced output: when the artifact is (re)written switch
-  // back to it, when a download_file output is created switch to that file —
-  // popping the full-height detail view to the newest result. The first loaded
-  // set is captured as a baseline so existing files don't hijack the view when
-  // the panel opens (the initial artifact is handled by the state initializer;
-  // a no-artifact chat opens its newest file here).
+  // back to it, when a download_file output is created switch to that file. It
+  // previews in the split (collapsing any expanded view) rather than taking
+  // over the panel. The first loaded set is captured as a baseline so existing
+  // files don't hijack the view when the panel opens.
   const prevArtifactRef = useRef<string | null | undefined>(undefined);
   const seenGeneratedRef = useRef<Set<string> | null>(null);
   useEffect(() => {
@@ -145,10 +141,7 @@ export function ConversationFilesPanel({
     seenGeneratedRef.current = new Set(ids);
     prevArtifactRef.current = artifact;
     if (prevGenerated === null) {
-      if (!hasArtifact && ids.length > 0) {
-        setSelectedId(ids[ids.length - 1]);
-        setView("detail");
-      }
+      if (!hasArtifact && ids.length > 0) setSelectedId(ids[ids.length - 1]);
       return; // baseline only
     }
     // Don't yank the view away from the instructions editor (and its unsaved
@@ -157,19 +150,19 @@ export function ConversationFilesPanel({
 
     if (hasArtifact && artifact !== prevArtifact) {
       setSelectedId("artifact");
-      setView("detail");
+      setExpanded(false);
       return;
     }
     const fresh = ids.filter((id) => !prevGenerated.has(id));
     if (fresh.length > 0) {
       setSelectedId(fresh[fresh.length - 1]);
-      setView("detail");
+      setExpanded(false);
     }
   }, [filesLoaded, generatedKey, artifact, hasArtifact]);
 
   // The artifact is rendered once and kept mounted whenever it exists, so the
   // row / detail-header "Download as PDF" button has rendered content to print
-  // even when the artifact isn't the open file. It fills the detail body when
+  // even when the artifact isn't the open file. It fills the preview area when
   // selected, and is hidden otherwise.
   const artifactRef = useRef<HTMLDivElement>(null);
   const handleDownloadArtifactPdf = () =>
@@ -226,10 +219,18 @@ export function ConversationFilesPanel({
 
   return (
     <div className="flex h-full flex-col">
-      {/* Kept mounted (hidden in detail) so an in-progress multi-selection
-          survives drilling into a file and coming back. */}
+      {/* The list fills the panel when nothing is open, is capped above the
+          preview in the split, and is hidden when the preview is expanded.
+          Kept mounted so an in-progress multi-selection survives previewing. */}
       <div
-        className={view === "list" ? "flex min-h-0 flex-1 flex-col" : "hidden"}
+        className={cn(
+          "flex flex-col",
+          previewing
+            ? expanded
+              ? "hidden"
+              : "max-h-[45%] shrink-0 overflow-hidden border-b"
+            : "min-h-0 flex-1",
+        )}
       >
         <SelectableFileList<ConversationFileItem>
           sections={[
@@ -257,24 +258,13 @@ export function ConversationFilesPanel({
         />
       </div>
 
-      {view === "detail" && (
-        <div className="flex shrink-0 items-center gap-1 border-b px-2 py-1.5">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 shrink-0 gap-1 px-2 text-xs text-muted-foreground"
-            onClick={backToList}
-          >
-            <ChevronLeft className="h-4 w-4" />
-            Files
-          </Button>
-          <span className="shrink-0 text-muted-foreground">·</span>
-          <span
-            className="min-w-0 flex-1 truncate text-sm font-medium"
-            title={detailName}
-          >
-            {detailName}
-          </span>
+      {previewing && (
+        <FileDetailHeader
+          title={detailName}
+          expanded={expanded}
+          onExpand={() => setExpanded(true)}
+          onCollapse={collapse}
+        >
           {artifactSelected ? (
             <ArtifactRowActions
               content={artifact ?? ""}
@@ -299,7 +289,7 @@ export function ConversationFilesPanel({
                     type="button"
                     onClick={() =>
                       requestDelete([selected], (failedIds) => {
-                        if (!failedIds.includes(selected.id)) backToList();
+                        if (!failedIds.includes(selected.id)) deselect();
                       })
                     }
                     title={`Delete ${selected.name}`}
@@ -312,30 +302,26 @@ export function ConversationFilesPanel({
               </div>
             )
           )}
-        </div>
+        </FileDetailHeader>
       )}
 
-      {view === "detail" &&
-        !artifactSelected &&
-        instructionsSelected &&
-        projectId && (
-          <ProjectInstructionsPanel
-            projectId={projectId}
-            isOwner={isProjectOwner}
-            onClose={backToList}
-          />
-        )}
+      {previewing && !artifactSelected && instructionsSelected && projectId && (
+        <ProjectInstructionsPanel
+          projectId={projectId}
+          isOwner={isProjectOwner}
+          onClose={deselect}
+        />
+      )}
 
-      {view === "detail" &&
-        !artifactSelected &&
-        !instructionsSelected &&
-        selected && <FilePreview file={selected} onClose={backToList} />}
+      {previewing && !artifactSelected && !instructionsSelected && selected && (
+        <FilePreview file={selected} onClose={deselect} />
+      )}
 
       {hasArtifact && (
         <div
           ref={artifactRef}
           className={cn(
-            view === "detail" && artifactSelected
+            previewing && artifactSelected
               ? "min-h-0 flex-1 overflow-auto"
               : "hidden",
           )}

--- a/platform/frontend/src/components/chat/conversation-files-panel.tsx
+++ b/platform/frontend/src/components/chat/conversation-files-panel.tsx
@@ -7,30 +7,18 @@ import {
   Copy,
   Download,
   File as FileIcon,
-  MoreVertical,
   Trash2,
 } from "lucide-react";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ConversationArtifactPanel } from "@/components/chat/conversation-artifact";
-import {
-  type FileListItem,
-  FileSection,
-} from "@/components/chat/file-list-section";
 import { FilePreview } from "@/components/chat/file-preview";
 import {
   INSTRUCTIONS_SELECTION,
   InstructionsRow,
   ProjectInstructionsPanel,
 } from "@/components/chat/project-instructions";
-import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
+import { SelectableFileList } from "@/components/chat/selectable-file-list";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   useBulkDeleteConversationFiles,
   useConversationFiles,
@@ -39,10 +27,9 @@ import {
 import {
   assembleFileSections,
   type ConversationFileItem,
-  isManagedFile,
 } from "@/lib/chat/conversation-files";
-import { downloadFiles } from "@/lib/chat/download-files";
 import { printMarkdownElementAsPdf } from "@/lib/chat/print-markdown";
+import { useFileDeletion } from "@/lib/chat/use-file-deletion";
 import { useProject } from "@/lib/projects/projects.query";
 import { cn } from "@/lib/utils";
 
@@ -63,8 +50,7 @@ export function ConversationFilesPanel({
   const { data: files } = useConversationFiles(conversationId);
   const { data: project } = useProject(projectId ?? undefined);
   // Editing instructions requires manage rights; in a chat the participant is
-  // the owner (a shared member sees them read-only). viewerRole replaces the old
-  // isOwner flag.
+  // the owner (a shared member sees them read-only).
   const isProjectOwner = project?.viewerRole === "owner";
   const sections = assembleFileSections({ files, artifact });
   const { generated, attachments } = sections;
@@ -88,18 +74,12 @@ export function ConversationFilesPanel({
   const [view, setView] = useState<"list" | "detail">(() =>
     hasArtifact ? "detail" : "list",
   );
-  const [selectionMode, setSelectionMode] = useState(false);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [pendingDelete, setPendingDelete] = useState<
-    ConversationFileItem[] | null
-  >(null);
 
   // This chat's own outputs and the project's files are one group ("Results");
   // only attachments stand apart.
   const results = [...generated, ...projectFiles];
   const all = [...results, ...attachments];
   const selected = all.find((f) => f.id === selectedId) ?? null;
-  const byId = new Map(all.map((f) => [f.id, f]));
 
   // The pinned instructions entry only exists in a project chat. Its sentinel
   // selection is not a file, so it must be excluded from the "selected file"
@@ -110,41 +90,11 @@ export function ConversationFilesPanel({
   const instructionsSelectedRef = useRef(false);
   instructionsSelectedRef.current = instructionsSelected;
 
-  // The Results header only earns its place when attachments sit beside it; a
-  // lone group needs no label to tell it apart.
-  const showHeaders = results.length > 0 && attachments.length > 0;
-
-  // Files the user can select / download / delete (everything but the in-memory
-  // artifact and the pinned instructions row).
-  const managed = all.filter(isManagedFile);
-  const managedCount = managed.length;
-  const managedKey = managed.map((f) => f.id).join("|");
-  const selectedItems = managed.filter((f) => selectedIds.has(f.id));
-  const allChecked = managedCount > 0 && selectedItems.length === managedCount;
-  const someChecked = selectedItems.length > 0 && !allChecked;
-
-  const deleteFile = useDeleteConversationFile(conversationId);
-  const bulkDelete = useBulkDeleteConversationFiles(conversationId);
-  const deletePending = deleteFile.isPending || bulkDelete.isPending;
-
   const openFile = (id: string) => {
     setSelectedId(id);
     setView("detail");
   };
   const backToList = () => setView("list");
-  const toggleSelect = (id: string) =>
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  const toggleAll = () =>
-    setSelectedIds(allChecked ? new Set() : new Set(managed.map((f) => f.id)));
-  const exitSelection = () => {
-    setSelectionMode(false);
-    setSelectedIds(new Set());
-  };
 
   // download_file outputs only (the artifact has its own default handling).
   const generatedFileIds = generated
@@ -153,17 +103,6 @@ export function ConversationFilesPanel({
   const newestGeneratedId = generatedFileIds.at(-1);
   const generatedKey = generatedFileIds.join("|");
   const filesLoaded = files !== undefined;
-
-  // Drop selections whose files have disappeared after a refetch so counts and
-  // "select all" stay honest.
-  useEffect(() => {
-    setSelectedIds((prev) => {
-      if (prev.size === 0) return prev;
-      const ids = new Set(managedKey ? managedKey.split("|") : []);
-      const next = new Set([...prev].filter((id) => ids.has(id)));
-      return next.size === prev.size ? prev : next;
-    });
-  }, [managedKey]);
 
   // Clear the preview if the selected file disappears (e.g. artifact cleared or
   // the open file was deleted) and fall back to the list. The instructions
@@ -237,66 +176,34 @@ export function ConversationFilesPanel({
     printMarkdownElementAsPdf(artifactRef.current, "Artifact");
   const artifactSelected = selected?.source === "artifact";
 
-  const requestDelete = (items: ConversationFileItem[]) =>
-    setPendingDelete(items);
-
-  const handleConfirmDelete = async () => {
-    const items = pendingDelete;
-    if (!items || items.length === 0) return;
-    const openId = selectedId;
-    // Collect the ids that failed so we don't navigate away from, or deselect,
-    // files that are still there.
-    let failed = new Set<string>();
-    if (items.length === 1) {
-      try {
-        await deleteFile.mutateAsync(items[0]);
-      } catch {
-        failed = new Set([items[0].id]);
-      }
-    } else {
-      const { failedIds } = await bulkDelete.mutateAsync(items);
-      failed = new Set(failedIds);
-    }
-    setPendingDelete(null);
-    if (selectionMode) {
-      if (failed.size === 0) exitSelection();
-      else setSelectedIds(failed); // keep only the failures selected
-    }
-    // Leave the detail view only if the open file was actually deleted.
-    if (openId && items.some((i) => i.id === openId) && !failed.has(openId)) {
-      setSelectedId(null);
-      setView("list");
-    }
-  };
-
-  // Trailing per-row actions: the artifact keeps Copy / Download-as-PDF; managed
-  // files get a "⋯" menu (Download + Delete) when the user can manage them, and
-  // otherwise fall back to FileSection's plain download link.
-  const renderRowActions = (item: FileListItem): ReactNode => {
-    if (item.source === "artifact") {
-      return (
-        <ArtifactRowActions
-          content={artifact ?? ""}
-          onDownloadPdf={handleDownloadArtifactPdf}
-        />
-      );
-    }
-    if (!canManageFiles) return null;
-    const file = byId.get(item.id);
-    if (!file) return null;
-    return <FileRowMenu item={file} onDelete={() => requestDelete([file])} />;
-  };
-
-  const selection = selectionMode
-    ? {
-        selectedIds,
-        onToggle: toggleSelect,
-        isSelectable: (id: string) => {
-          const f = byId.get(id);
-          return !!f && isManagedFile(f);
-        },
-      }
-    : undefined;
+  // Shared confirm + delete flow. The chat surface keeps its own delete hooks
+  // (which own the toast + cache invalidation) and routes each file by source.
+  const deleteFile = useDeleteConversationFile(conversationId);
+  const bulkDelete = useBulkDeleteConversationFiles(conversationId);
+  const { requestDelete, dialog: deleteDialog } =
+    useFileDeletion<ConversationFileItem>({
+      deleteItems: async (items) => {
+        if (items.length === 1) {
+          try {
+            await deleteFile.mutateAsync(items[0]);
+            return { failedIds: [] };
+          } catch {
+            return { failedIds: [items[0].id] };
+          }
+        }
+        return bulkDelete.mutateAsync(items);
+      },
+      describe: (items) =>
+        // A project file — or a file generated in a project chat — is shared, so
+        // deleting it removes it for everyone with access to the project.
+        items.some(
+          (i) =>
+            i.source === "project" ||
+            (i.source === "generated" && projectId != null),
+        )
+          ? "This file is part of the project and will be removed for everyone with access to it. This can't be undone."
+          : "This can't be undone.",
+    });
 
   // A project chat always shows the pinned instructions row, so the empty state
   // only applies to non-project chats with nothing to show.
@@ -320,111 +227,30 @@ export function ConversationFilesPanel({
   return (
     <div className="flex h-full flex-col">
       {view === "list" && (
-        <div className="flex min-h-0 flex-1 flex-col">
-          <div className="flex shrink-0 items-center justify-between gap-2 px-3 pt-3 pb-2">
-            {selectionMode ? (
-              <>
-                <label
-                  htmlFor="files-select-all"
-                  className="flex items-center gap-2 text-xs text-muted-foreground"
-                >
-                  <Checkbox
-                    id="files-select-all"
-                    checked={
-                      allChecked ? true : someChecked ? "indeterminate" : false
-                    }
-                    onCheckedChange={toggleAll}
-                    aria-label="Select all files"
-                  />
-                  Select all
-                </label>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 px-2 text-xs"
-                  onClick={exitSelection}
-                >
-                  Cancel
-                </Button>
-              </>
-            ) : (
-              <>
-                <span className="text-xs text-muted-foreground">
-                  {managedCount} {managedCount === 1 ? "file" : "files"}
-                </span>
-                {canManageFiles && managedCount > 0 && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2 text-xs"
-                    onClick={() => setSelectionMode(true)}
-                  >
-                    Select
-                  </Button>
-                )}
-              </>
-            )}
-          </div>
-
-          {/* The list never highlights a "current" row: opening a file drills
-              into the full-height detail view, so there's no list-beside-preview
-              for a selection marker to point at. Pass selectedId={null}. */}
-          <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
-            <FileSection
-              title={showHeaders ? "Results" : undefined}
-              items={results}
-              selectedId={null}
-              onSelect={openFile}
-              selection={selection}
-              leading={
-                showInstructions && !selectionMode ? (
-                  <InstructionsRow
-                    onSelect={() => openFile(INSTRUCTIONS_SELECTION)}
-                  />
-                ) : undefined
-              }
-              renderActions={renderRowActions}
-            />
-            <FileSection
-              title={showHeaders ? "Attachments" : undefined}
-              items={attachments}
-              selectedId={null}
-              onSelect={openFile}
-              selection={selection}
-              renderActions={renderRowActions}
-            />
-          </div>
-
-          {selectionMode && (
-            <div className="flex shrink-0 items-center justify-between gap-2 border-t px-3 py-2">
-              <span className="text-xs text-muted-foreground">
-                {selectedItems.length} selected
-              </span>
-              <div className="flex gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1 px-2 text-xs"
-                  disabled={selectedItems.length === 0}
-                  onClick={() => downloadFiles(selectedItems)}
-                >
-                  <Download className="h-4 w-4" />
-                  Download
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1 px-2 text-xs text-destructive hover:text-destructive"
-                  disabled={selectedItems.length === 0}
-                  onClick={() => requestDelete(selectedItems)}
-                >
-                  <Trash2 className="h-4 w-4" />
-                  Delete
-                </Button>
-              </div>
-            </div>
-          )}
-        </div>
+        <SelectableFileList<ConversationFileItem>
+          sections={[
+            { title: "Results", items: results },
+            { title: "Attachments", items: attachments },
+          ]}
+          canManage={canManageFiles}
+          onOpen={openFile}
+          onRequestDelete={requestDelete}
+          leading={
+            showInstructions ? (
+              <InstructionsRow
+                onSelect={() => openFile(INSTRUCTIONS_SELECTION)}
+              />
+            ) : undefined
+          }
+          renderItemActions={(item) =>
+            item.source === "artifact" ? (
+              <ArtifactRowActions
+                content={artifact ?? ""}
+                onDownloadPdf={handleDownloadArtifactPdf}
+              />
+            ) : undefined
+          }
+        />
       )}
 
       {view === "detail" && (
@@ -467,7 +293,11 @@ export function ConversationFilesPanel({
                 {canManageFiles && (
                   <button
                     type="button"
-                    onClick={() => requestDelete([selected])}
+                    onClick={() =>
+                      requestDelete([selected], (failedIds) => {
+                        if (!failedIds.includes(selected.id)) backToList();
+                      })
+                    }
                     title={`Delete ${selected.name}`}
                     className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-destructive"
                   >
@@ -516,30 +346,7 @@ export function ConversationFilesPanel({
         </div>
       )}
 
-      <DeleteConfirmDialog
-        open={pendingDelete !== null}
-        onOpenChange={(open) => {
-          if (!open) setPendingDelete(null);
-        }}
-        title={
-          (pendingDelete?.length ?? 0) === 1
-            ? `Delete “${pendingDelete?.[0]?.name}”?`
-            : `Delete ${pendingDelete?.length ?? 0} files?`
-        }
-        description={
-          // A project file — or a file generated in a project chat — is shared,
-          // so deleting it removes it for everyone with access to the project.
-          pendingDelete?.some(
-            (i) =>
-              i.source === "project" ||
-              (i.source === "generated" && projectId != null),
-          )
-            ? "This file is part of the project and will be removed for everyone with access to it. This can't be undone."
-            : "This can't be undone."
-        }
-        isPending={deletePending}
-        onConfirm={handleConfirmDelete}
-      />
+      {deleteDialog}
     </div>
   );
 }
@@ -591,49 +398,5 @@ function ArtifactRowActions({
         <span className="sr-only">Download artifact as PDF</span>
       </button>
     </div>
-  );
-}
-
-/** A "⋯" menu of single-file actions (Download + Delete) for a managed file. */
-function FileRowMenu({
-  item,
-  onDelete,
-}: {
-  item: ConversationFileItem;
-  onDelete: () => void;
-}) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          title="More actions"
-          className="mr-1 flex h-8 w-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          <MoreVertical className="h-4 w-4" />
-          <span className="sr-only">Actions for {item.name}</span>
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {item.contentUrl && (
-          <DropdownMenuItem asChild>
-            <a href={item.contentUrl} download={item.name}>
-              <Download className="h-4 w-4" />
-              Download
-            </a>
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuItem
-          className="text-destructive focus:text-destructive"
-          onSelect={(e) => {
-            e.preventDefault();
-            onDelete();
-          }}
-        >
-          <Trash2 className="h-4 w-4" />
-          Delete
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
   );
 }

--- a/platform/frontend/src/components/chat/file-detail-header.tsx
+++ b/platform/frontend/src/components/chat/file-detail-header.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ChevronLeft, Maximize2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Header for an open file in the Files panels. In the default split view it
+ * shows the name + an Expand (⤢) button that fills the panel; once expanded it
+ * shows a "‹ Files" button that collapses back to the split (the file stays
+ * selected). `children` are the right-aligned per-file actions (download/delete,
+ * or the artifact's copy/PDF). Shared so the chat and project panels match.
+ */
+export function FileDetailHeader({
+  title,
+  expanded,
+  onExpand,
+  onCollapse,
+  children,
+}: {
+  title: string;
+  expanded: boolean;
+  onExpand: () => void;
+  onCollapse: () => void;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-1 border-b px-2 py-1.5">
+      {expanded && (
+        <>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 shrink-0 gap-1 px-2 text-xs text-muted-foreground"
+            onClick={onCollapse}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Files
+          </Button>
+          <span className="shrink-0 text-muted-foreground">·</span>
+        </>
+      )}
+      <span
+        className="min-w-0 flex-1 truncate text-sm font-medium"
+        title={title}
+      >
+        {title}
+      </span>
+      {!expanded && (
+        <button
+          type="button"
+          onClick={onExpand}
+          title="Expand to full panel"
+          className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Maximize2 className="h-4 w-4" />
+          <span className="sr-only">Expand to full panel</span>
+        </button>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/platform/frontend/src/components/chat/project-instructions.tsx
+++ b/platform/frontend/src/components/chat/project-instructions.tsx
@@ -25,12 +25,23 @@ import { cn } from "@/lib/utils";
 export const INSTRUCTIONS_SELECTION = "__project_instructions__";
 
 /** The always-present, pinned instructions entry at the top of the file list. */
-export function InstructionsRow({ onSelect }: { onSelect: () => void }) {
+export function InstructionsRow({
+  selected = false,
+  onSelect,
+}: {
+  selected?: boolean;
+  onSelect: () => void;
+}) {
   return (
     <button
       type="button"
       onClick={onSelect}
-      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-muted/50"
+      className={cn(
+        "flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors",
+        selected
+          ? "bg-accent font-medium text-accent-foreground"
+          : "hover:bg-muted/50",
+      )}
     >
       {/* Single line, same muted-icon treatment as a regular .md file row — the
           instructions entry looks like the rest of the list, only pinned and

--- a/platform/frontend/src/components/chat/selectable-file-list.tsx
+++ b/platform/frontend/src/components/chat/selectable-file-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, MoreVertical, Trash2 } from "lucide-react";
+import { Download, MoreHorizontal, Trash2 } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import {
   type FileListItem,
@@ -235,7 +235,7 @@ function FileRowMenu({
           title="More actions"
           className="mr-1 flex h-8 w-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
         >
-          <MoreVertical className="h-4 w-4" />
+          <MoreHorizontal className="h-4 w-4" />
           <span className="sr-only">Actions for {item.name}</span>
         </button>
       </DropdownMenuTrigger>

--- a/platform/frontend/src/components/chat/selectable-file-list.tsx
+++ b/platform/frontend/src/components/chat/selectable-file-list.tsx
@@ -38,6 +38,7 @@ export function SelectableFileList<T extends FileListItem>({
   sections,
   leading,
   canManage,
+  selectedId,
   onOpen,
   onRequestDelete,
   renderItemActions,
@@ -45,6 +46,8 @@ export function SelectableFileList<T extends FileListItem>({
   sections: { title?: string; items: T[] }[];
   leading?: ReactNode;
   canManage: boolean;
+  /** The open file's id, highlighted in the list while it previews beside it. */
+  selectedId?: string | null;
   onOpen: (id: string) => void;
   /** `onComplete` receives the ids that failed, so the caller can reconcile. */
   onRequestDelete: (
@@ -159,16 +162,15 @@ export function SelectableFileList<T extends FileListItem>({
         )}
       </div>
 
-      {/* The list never highlights a "current" row: opening a file drills into
-          the full-height detail view, so there's no list-beside-preview for a
-          selection marker to point at. */}
+      {/* The open file's row stays highlighted while it previews beside the
+          list (split view); harmless when expanded (list hidden) or idle. */}
       <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
         {sections.map((section, i) => (
           <FileSection
             key={section.title ?? `section-${i}`}
             title={showHeaders ? section.title : undefined}
             items={section.items}
-            selectedId={null}
+            selectedId={selectedId ?? null}
             onSelect={onOpen}
             selection={selection}
             leading={i === 0 && !selectionMode ? leading : undefined}

--- a/platform/frontend/src/components/chat/selectable-file-list.tsx
+++ b/platform/frontend/src/components/chat/selectable-file-list.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { Download, MoreVertical, Trash2 } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+import {
+  type FileListItem,
+  FileSection,
+} from "@/components/chat/file-list-section";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { downloadFiles } from "@/lib/chat/download-files";
+import {
+  pruneSelectedIds,
+  selectAllIds,
+  selectionCheckState,
+  toggleSelectedId,
+} from "@/lib/chat/file-selection";
+
+/**
+ * The list-view body shared by the chat and project Files panels: a "Select"
+ * toggle, row checkboxes + "Select all", a bottom Download/Delete bar, and a
+ * per-row "⋯" menu. The list/detail navigation and the delete confirm live in
+ * the caller; this component reports opens via `onOpen` and delete requests via
+ * `onRequestDelete`.
+ *
+ * A row is "manageable" (selectable / downloadable / deletable) when it has a
+ * byte endpoint (`contentUrl`); the in-memory artifact row (empty `contentUrl`)
+ * and the pinned instructions `leading` row are never selected. Generic over the
+ * item type so callers keep their own richer item shape without casts.
+ */
+export function SelectableFileList<T extends FileListItem>({
+  sections,
+  leading,
+  canManage,
+  onOpen,
+  onRequestDelete,
+  renderItemActions,
+}: {
+  sections: { title?: string; items: T[] }[];
+  leading?: ReactNode;
+  canManage: boolean;
+  onOpen: (id: string) => void;
+  /** `onComplete` receives the ids that failed, so the caller can reconcile. */
+  onRequestDelete: (
+    items: T[],
+    onComplete?: (failedIds: string[]) => void,
+  ) => void;
+  /** Custom trailing actions for a row (e.g. the artifact's copy/PDF). */
+  renderItemActions?: (item: T) => ReactNode;
+}) {
+  const managed = sections.flatMap((s) => s.items).filter(isManageable);
+  const managedCount = managed.length;
+  const managedKey = managed.map((f) => f.id).join("|");
+
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const selectedItems = managed.filter((f) => selectedIds.has(f.id));
+  const { allChecked, someChecked } = selectionCheckState(
+    selectedItems.length,
+    managedCount,
+  );
+
+  // Drop selections whose files vanished after a refetch so counts/"select all"
+  // stay honest.
+  useEffect(() => {
+    setSelectedIds((prev) =>
+      pruneSelectedIds(prev, managedKey ? managedKey.split("|") : []),
+    );
+  }, [managedKey]);
+
+  const exitSelection = () => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  };
+  const selection = selectionMode
+    ? {
+        selectedIds,
+        onToggle: (id: string) =>
+          setSelectedIds((prev) => toggleSelectedId(prev, id)),
+        isSelectable: (id: string) => managed.some((f) => f.id === id),
+      }
+    : undefined;
+
+  const handleBulkDelete = () =>
+    onRequestDelete(selectedItems, (failedIds) => {
+      if (failedIds.length === 0) exitSelection();
+      else setSelectedIds(new Set(failedIds));
+    });
+
+  // Headers only earn their place when more than one non-empty group shows.
+  const showHeaders = sections.filter((s) => s.items.length > 0).length > 1;
+
+  const renderActions = (item: FileListItem): ReactNode => {
+    const custom = renderItemActions?.(item as T);
+    if (custom != null) return custom;
+    if (!canManage || !isManageable(item)) return null;
+    return (
+      <FileRowMenu item={item} onDelete={() => onRequestDelete([item as T])} />
+    );
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-2 px-3 pt-3 pb-2">
+        {selectionMode ? (
+          <>
+            <label
+              htmlFor="files-select-all"
+              className="flex items-center gap-2 text-xs text-muted-foreground"
+            >
+              <Checkbox
+                id="files-select-all"
+                checked={
+                  allChecked ? true : someChecked ? "indeterminate" : false
+                }
+                onCheckedChange={() =>
+                  setSelectedIds(
+                    selectAllIds(
+                      allChecked,
+                      managed.map((f) => f.id),
+                    ),
+                  )
+                }
+                aria-label="Select all files"
+              />
+              Select all
+            </label>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs"
+              onClick={exitSelection}
+            >
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <>
+            <span className="text-xs text-muted-foreground">
+              {managedCount} {managedCount === 1 ? "file" : "files"}
+            </span>
+            {canManage && managedCount > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() => setSelectionMode(true)}
+              >
+                Select
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* The list never highlights a "current" row: opening a file drills into
+          the full-height detail view, so there's no list-beside-preview for a
+          selection marker to point at. */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+        {sections.map((section, i) => (
+          <FileSection
+            key={section.title ?? `section-${i}`}
+            title={showHeaders ? section.title : undefined}
+            items={section.items}
+            selectedId={null}
+            onSelect={onOpen}
+            selection={selection}
+            leading={i === 0 && !selectionMode ? leading : undefined}
+            renderActions={renderActions}
+          />
+        ))}
+      </div>
+
+      {selectionMode && (
+        <div className="flex shrink-0 items-center justify-between gap-2 border-t px-3 py-2">
+          <span className="text-xs text-muted-foreground">
+            {selectedItems.length} selected
+          </span>
+          <div className="flex gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              disabled={selectedItems.length === 0}
+              onClick={() => downloadFiles(selectedItems)}
+            >
+              <Download className="h-4 w-4" />
+              Download
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs text-destructive hover:text-destructive"
+              disabled={selectedItems.length === 0}
+              onClick={handleBulkDelete}
+            >
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// === internal ===
+
+/** A row has actions worth managing once it has a byte endpoint to act on. */
+function isManageable(item: FileListItem): boolean {
+  return item.contentUrl !== "";
+}
+
+/** A "⋯" menu of single-file actions (Download + Delete) for a managed file. */
+function FileRowMenu({
+  item,
+  onDelete,
+}: {
+  item: FileListItem;
+  onDelete: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          title="More actions"
+          className="mr-1 flex h-8 w-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <MoreVertical className="h-4 w-4" />
+          <span className="sr-only">Actions for {item.name}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {item.contentUrl && (
+          <DropdownMenuItem asChild>
+            <a href={item.contentUrl} download={item.name}>
+              <Download className="h-4 w-4" />
+              Download
+            </a>
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive"
+          onSelect={(e) => {
+            e.preventDefault();
+            onDelete();
+          }}
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/platform/frontend/src/lib/chat/conversation-files.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.test.ts
@@ -3,7 +3,6 @@ import {
   assembleFileSections,
   type ConversationFileItem,
   deleteTargetFor,
-  isManagedFile,
 } from "@/lib/chat/conversation-files";
 
 function fileItem(
@@ -113,15 +112,6 @@ describe("assembleFileSections", () => {
         source: "project",
       },
     ]);
-  });
-});
-
-describe("isManagedFile", () => {
-  it("excludes the in-memory artifact, includes the rest", () => {
-    expect(isManagedFile(fileItem("artifact"))).toBe(false);
-    expect(isManagedFile(fileItem("generated"))).toBe(true);
-    expect(isManagedFile(fileItem("project"))).toBe(true);
-    expect(isManagedFile(fileItem("attachment"))).toBe(true);
   });
 });
 

--- a/platform/frontend/src/lib/chat/conversation-files.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.ts
@@ -77,15 +77,6 @@ export function assembleFileSections(params: {
 }
 
 /**
- * A file the user can select/download/delete. The synthesized `artifact.md` row
- * is rendered from in-memory markdown and has no byte endpoint, so it's
- * excluded from selection and bulk actions.
- */
-export function isManagedFile(item: ConversationFileItem): boolean {
-  return item.source !== "artifact";
-}
-
-/**
  * Which delete endpoint removes a given file. Attachments have their own chat
  * route; generated and project files are both persisted artifacts behind the
  * skill-sandbox artifact route.

--- a/platform/frontend/src/lib/chat/download-files.test.ts
+++ b/platform/frontend/src/lib/chat/download-files.test.ts
@@ -45,15 +45,7 @@ describe("downloadFiles", () => {
       .spyOn(HTMLAnchorElement.prototype, "click")
       .mockImplementation(() => {});
 
-    const started = downloadFiles([
-      {
-        id: "artifact",
-        name: "artifact.md",
-        mimeType: "text/markdown",
-        contentUrl: "",
-        source: "artifact",
-      },
-    ]);
+    const started = downloadFiles([{ name: "artifact.md", contentUrl: "" }]);
 
     expect(started).toBe(0);
     expect(clickSpy).not.toHaveBeenCalled();

--- a/platform/frontend/src/lib/chat/download-files.ts
+++ b/platform/frontend/src/lib/chat/download-files.ts
@@ -1,12 +1,12 @@
-import type { ConversationFileItem } from "@/lib/chat/conversation-files";
-
 /**
  * Start a browser download for each file that has a byte endpoint. There is no
  * zip endpoint, so this fires one download per file (the browser may prompt to
- * allow multiple downloads). Files without a `contentUrl` — the in-memory
+ * allow multiple downloads). Files without a `contentUrl` — e.g. the in-memory
  * `artifact.md` row — are skipped. Returns how many downloads were started.
  */
-export function downloadFiles(items: ConversationFileItem[]): number {
+export function downloadFiles(
+  items: Array<{ name: string; contentUrl: string }>,
+): number {
   let started = 0;
   for (const item of items) {
     if (!item.contentUrl) continue;

--- a/platform/frontend/src/lib/chat/file-selection.test.ts
+++ b/platform/frontend/src/lib/chat/file-selection.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  pruneSelectedIds,
+  selectAllIds,
+  selectionCheckState,
+  toggleSelectedId,
+} from "@/lib/chat/file-selection";
+
+describe("toggleSelectedId", () => {
+  it("adds an absent id and removes a present one (new set each time)", () => {
+    const a = toggleSelectedId(new Set<string>(), "x");
+    expect([...a]).toEqual(["x"]);
+    const b = toggleSelectedId(a, "x");
+    expect([...b]).toEqual([]);
+    expect(b).not.toBe(a);
+  });
+});
+
+describe("selectAllIds", () => {
+  it("selects all when not all checked, clears when all checked", () => {
+    expect([...selectAllIds(false, ["a", "b"])]).toEqual(["a", "b"]);
+    expect([...selectAllIds(true, ["a", "b"])]).toEqual([]);
+  });
+});
+
+describe("pruneSelectedIds", () => {
+  it("drops ids no longer present", () => {
+    expect([...pruneSelectedIds(new Set(["a", "gone"]), ["a", "b"])]).toEqual([
+      "a",
+    ]);
+  });
+
+  it("returns the same reference when nothing changed", () => {
+    const sel = new Set(["a"]);
+    expect(pruneSelectedIds(sel, ["a", "b"])).toBe(sel);
+    expect(pruneSelectedIds(new Set(), ["a"])).toBeInstanceOf(Set);
+  });
+});
+
+describe("selectionCheckState", () => {
+  it("derives all/some checked", () => {
+    expect(selectionCheckState(0, 3)).toEqual({
+      allChecked: false,
+      someChecked: false,
+    });
+    expect(selectionCheckState(2, 3)).toEqual({
+      allChecked: false,
+      someChecked: true,
+    });
+    expect(selectionCheckState(3, 3)).toEqual({
+      allChecked: true,
+      someChecked: false,
+    });
+    expect(selectionCheckState(0, 0)).toEqual({
+      allChecked: false,
+      someChecked: false,
+    });
+  });
+});

--- a/platform/frontend/src/lib/chat/file-selection.ts
+++ b/platform/frontend/src/lib/chat/file-selection.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure selection math for a multi-select file list (shared by the chat and
+ * project Files panels via `SelectableFileList`). Kept side-effect-free so it
+ * can be unit-tested without rendering.
+ */
+
+/** Toggle one id in/out of the selection, returning a new set. */
+export function toggleSelectedId(
+  selectedIds: Set<string>,
+  id: string,
+): Set<string> {
+  const next = new Set(selectedIds);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+}
+
+/** "Select all" / "deselect all": empties when all are checked, else selects all. */
+export function selectAllIds(
+  allChecked: boolean,
+  managedIds: string[],
+): Set<string> {
+  return allChecked ? new Set() : new Set(managedIds);
+}
+
+/**
+ * Drop selected ids whose files no longer exist (e.g. after a refetch), so the
+ * count and "select all" stay honest. Returns the same set reference when
+ * nothing changed, so it's safe to feed straight back into setState.
+ */
+export function pruneSelectedIds(
+  selectedIds: Set<string>,
+  managedIds: string[],
+): Set<string> {
+  if (selectedIds.size === 0) return selectedIds;
+  const valid = new Set(managedIds);
+  const next = new Set([...selectedIds].filter((id) => valid.has(id)));
+  return next.size === selectedIds.size ? selectedIds : next;
+}
+
+/** Header checkbox state from how many of the managed files are selected. */
+export function selectionCheckState(
+  selectedCount: number,
+  managedCount: number,
+): { allChecked: boolean; someChecked: boolean } {
+  const allChecked = managedCount > 0 && selectedCount === managedCount;
+  const someChecked = selectedCount > 0 && !allChecked;
+  return { allChecked, someChecked };
+}

--- a/platform/frontend/src/lib/chat/use-file-deletion.tsx
+++ b/platform/frontend/src/lib/chat/use-file-deletion.tsx
@@ -26,7 +26,6 @@ export function useFileDeletion<T extends DeletableFile>({
     onComplete?: (failedIds: string[]) => void,
   ) => void;
   dialog: ReactNode;
-  isPending: boolean;
 } {
   const [pending, setPending] = useState<{
     items: T[];
@@ -45,10 +44,13 @@ export function useFileDeletion<T extends DeletableFile>({
     if (!pending) return;
     const { items, onComplete } = pending;
     setIsPending(true);
-    const { failedIds } = await deleteItems(items);
-    setIsPending(false);
-    setPending(null);
-    onComplete?.(failedIds);
+    try {
+      const { failedIds } = await deleteItems(items);
+      setPending(null);
+      onComplete?.(failedIds);
+    } finally {
+      setIsPending(false);
+    }
   };
 
   const count = pending?.items.length ?? 0;
@@ -71,5 +73,5 @@ export function useFileDeletion<T extends DeletableFile>({
     />
   );
 
-  return { requestDelete, dialog, isPending };
+  return { requestDelete, dialog };
 }

--- a/platform/frontend/src/lib/chat/use-file-deletion.tsx
+++ b/platform/frontend/src/lib/chat/use-file-deletion.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { type ReactNode, useState } from "react";
+import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
+
+/** A file the deletion flow can act on: identified, named, and removable. */
+type DeletableFile = { id: string; name: string };
+
+/**
+ * The shared delete-confirm flow for the Files panels: opens a confirm dialog,
+ * runs the caller's `deleteItems`, and reports the ids that failed so the call
+ * site can reconcile its own state (keep failed rows selected, stay on a still-
+ * present open file). `deleteItems` owns the actual deletes, toasts, and cache
+ * invalidation; this hook owns only the confirm UI and the count-based title.
+ */
+export function useFileDeletion<T extends DeletableFile>({
+  deleteItems,
+  describe,
+}: {
+  deleteItems: (items: T[]) => Promise<{ failedIds: string[] }>;
+  /** Confirm-dialog body for the given items (e.g. a shared-file warning). */
+  describe?: (items: T[]) => string;
+}): {
+  requestDelete: (
+    items: T[],
+    onComplete?: (failedIds: string[]) => void,
+  ) => void;
+  dialog: ReactNode;
+  isPending: boolean;
+} {
+  const [pending, setPending] = useState<{
+    items: T[];
+    onComplete?: (failedIds: string[]) => void;
+  } | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const requestDelete = (
+    items: T[],
+    onComplete?: (failedIds: string[]) => void,
+  ) => {
+    if (items.length > 0) setPending({ items, onComplete });
+  };
+
+  const handleConfirm = async () => {
+    if (!pending) return;
+    const { items, onComplete } = pending;
+    setIsPending(true);
+    const { failedIds } = await deleteItems(items);
+    setIsPending(false);
+    setPending(null);
+    onComplete?.(failedIds);
+  };
+
+  const count = pending?.items.length ?? 0;
+  const dialog = (
+    <DeleteConfirmDialog
+      open={pending !== null}
+      onOpenChange={(open) => {
+        if (!open) setPending(null);
+      }}
+      title={
+        count === 1
+          ? `Delete “${pending?.items[0]?.name}”?`
+          : `Delete ${count} files?`
+      }
+      description={
+        pending ? (describe?.(pending.items) ?? "This can't be undone.") : ""
+      }
+      isPending={isPending}
+      onConfirm={handleConfirm}
+    />
+  );
+
+  return { requestDelete, dialog, isPending };
+}

--- a/platform/frontend/src/lib/projects/projects.query.ts
+++ b/platform/frontend/src/lib/projects/projects.query.ts
@@ -16,6 +16,7 @@ function isProjectNotFound(error: unknown): boolean {
 const {
   createProject,
   deleteProject,
+  deleteSkillSandboxArtifact,
   getProject,
   getProjectConversations,
   getProjectFiles,
@@ -288,6 +289,48 @@ export function useDeleteProject() {
       // queries (`["projects", id, …]`), which are still mounted for the instant
       // before we navigate away and would 404 on the now-gone id.
       queryClient.invalidateQueries({ queryKey: ["projects", "list"] });
+    },
+  });
+}
+
+/**
+ * Delete one or more project files (persisted skill-sandbox artifacts). Runs the
+ * deletes concurrently and reports a single summary toast and the ids that
+ * failed. Deleting a project file removes it project-wide, so it also refreshes
+ * any chat Files panels (`["conversation-files", …]`) that list project files.
+ */
+export function useDeleteProjectFiles(projectId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (items: Array<{ id: string }>) => {
+      const results = await Promise.allSettled(
+        items.map((item) =>
+          deleteSkillSandboxArtifact({ path: { artifactId: item.id } }),
+        ),
+      );
+      const failedIds = items
+        .filter((_, i) => {
+          const r = results[i];
+          return r.status === "rejected" || r.value.error != null;
+        })
+        .map((item) => item.id);
+      return { total: items.length, failedIds };
+    },
+    onSuccess: ({ total, failedIds }) => {
+      const deleted = total - failedIds.length;
+      if (failedIds.length === 0) {
+        toast.success(total === 1 ? "File deleted" : `Deleted ${total} files`);
+      } else {
+        toast.error(
+          `Deleted ${deleted} of ${total}; ${failedIds.length} failed`,
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["projects", projectId, "files"],
+      });
+      queryClient.invalidateQueries({ queryKey: ["conversation-files"] });
     },
   });
 }


### PR DESCRIPTION
## Summary
The project Files panel and the chat Files panel had diverged: chat had a **Select mode + per-row delete**, the project panel didn't. This unifies them onto **one shared select/delete implementation** so the project panel gains the same controls.

Per /unify: the chat rewrite is behavior-preserving; the only new behavior is the approved addition of select/delete to the project surface.

## Shared units (consumed by both panels)
- **`SelectableFileList`** (`components/chat/selectable-file-list.tsx`) — the list-view select UI: "Select" toggle, row checkboxes + "Select all", bottom Download/Delete bar, per-row `⋯` menu. Generic over the item type; a row is manageable when it has a byte endpoint (`contentUrl`), so the in-memory `artifact.md` and the pinned instructions `leading` row are never selectable.
- **`useFileDeletion`** (`lib/chat/use-file-deletion.tsx`) — the confirm dialog + delete flow; reports failed ids so each call site reconciles its own state. `deleteItems` (toast + cache invalidation) stays per-surface.
- Selection math extracted to `lib/chat/file-selection.ts` (unit-tested).

## Per surface
- **Chat** (`conversation-files-panel.tsx`) — rewired to consume the shared units; keeps its own shell (artifact copy/PDF + kept-mounted PDF, auto-follow-newest, Results/Attachments grouping). Delete still routes by source via the existing chat hooks. Behavior-preserving.
- **Project** (`ProjectFilesSidebar`) — wired to the shared units + a new `useDeleteProjectFiles` (deletes via the existing `deleteSkillSandboxArtifact`; one summary toast; invalidates `["projects", id, "files"]` **and** `["conversation-files"]` so an open chat panel doesn't show a just-deleted project file). File select/delete is available to any project viewer (the backend authorizes project-access members + admins, and refuses the instructions file → 409); editing the pinned instructions stays gated on project manage rights.

## Cleanup
- Removed the now-dead `isManagedFile` (+ its test) — superseded by the `contentUrl` check.
- `downloadFiles` generalized to a minimal `{name, contentUrl}` shape.
- Dropped the project panel's separate empty hint so it matches the chat panel (instructions row + "0 files").

## Review
Dual adversarial review (Codex + internal). Fixes folded in:
- Keep `SelectableFileList` mounted (hidden in detail) on both panels so an in-progress multi-selection survives drilling into a file and back.
- `useFileDeletion` resets pending state in a `finally` so a rejecting `deleteItems` can't wedge the dialog.

## Tests / validation
- `pnpm type-check`, `pnpm lint`, `pnpm knip` clean. Frontend lib/chat + projects: 329 tests pass (incl. new `file-selection` unit tests). No render tests / e2e (project convention).
- Manual smoke worth doing before un-drafting: chat panel unchanged (select, bulk dl/delete, ⋯, detail delete, artifact copy/PDF, auto-follow); project panel gains the same, instructions row never selectable/deletable, deleting a project file warns it's project-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>