### PR TITLE
ci(bench): 6h deadline, add qwen3.6-27b lane, drop gpt-oss-120b

### DIFF
--- a/.github/bench/job.yaml
+++ b/.github/bench/job.yaml
@@ -16,7 +16,7 @@ metadata:
     run: "${RUN_NUMBER}"
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: 7200
+  activeDeadlineSeconds: 21600
   ttlSecondsAfterFinished: 3600
   template:
     metadata:
@@ -24,8 +24,9 @@ spec:
         app: archestra-bench
         run: "${RUN_NUMBER}"
       annotations:
-        # The bench runs ~30 min; without this the cluster autoscaler evicts it on node scale-down
-        # mid-run (the pod has no controller to reschedule it, so the run is just lost).
+        # The bench can run for hours (slow reasoning lanes dominate wall-clock); without this the
+        # cluster autoscaler evicts it on node scale-down mid-run (the pod has no controller to
+        # reschedule it, so the run is just lost).
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       restartPolicy: Never
@@ -62,7 +63,7 @@ spec:
             - name: BENCH_ENVS
               value: "basic"
             - name: BENCH_LANES
-              value: "glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-54-nano,gpt-54-mini,claude-haiku-45,mimo-25,qwen36-35b-a3b,gpt-oss-120b"
+              value: "glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-54-nano,gpt-54-mini,claude-haiku-45,mimo-25,qwen36-35b-a3b,qwen36-27b"
             # Dagger runner host is resolved from the live staging Deployment by CI.
             - name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
               value: "${DAGGER_RUNNER_HOST}"

--- a/archestra-bench/lanes.toml
+++ b/archestra-bench/lanes.toml
@@ -72,6 +72,11 @@ provider = "openrouter"
 model = "qwen/qwen3.6-35b-a3b"
 
 [[lane]]
+name = "qwen36-27b"
+provider = "openrouter"
+model = "qwen/qwen3.6-27b"
+
+[[lane]]
 name = "gpt-oss-120b"
 provider = "openrouter"
 model = "openai/gpt-oss-120b"


### PR DESCRIPTION
## What

- **Deadline 2h → 6h** (`activeDeadlineSeconds` 7200 → 21600). Run #7 hit the 2h `DeadlineExceeded` kill with ~9 rollouts still going on the slow `qwen36-35b-a3b` lane. Because the SIGTERM landed mid-benchmark, the entrypoint never reached its reporting tail — no GCS upload, no Slack, no TensorBoard. 6h gives slow reasoning lanes room to drain so the run actually reports.
- **Add `qwen36-27b`** (`qwen/qwen3.6-27b`) — dense sibling of `qwen36-35b-a3b`; the 27B-vs-35B-A3B question is worth real numbers.
- **Drop `gpt-oss-120b`** from the run — its 39% was dominated by infra noise (6 provider-503 "empty response" errors + 5 unpriced rollouts), not model signal. Lane definition kept in `lanes.toml` for easy re-add.

Net lane count unchanged at 10 (253 → 230 rollouts).

Also refreshes the stale "~30 min" autoscaler comment.

## Note

This does not fix the silent-timeout gap: a deadline kill still produces no Slack, because reporting is the last step of `runner-entrypoint.sh` and there's no TERM trap. Worth a follow-up (trap → "run aborted" Slack) so future timeouts are audible.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>