### PR TITLE
fix(agents): gate owner filter on resource admin, not member:read

### DIFF
--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -486,7 +486,11 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
                   searchFields={["name"]}
                   paramName="name"
                 />
-                <AgentScopeFilter showBuiltIn ownerLabelPlural="agents" />
+                <AgentScopeFilter
+                  showBuiltIn
+                  ownerLabelPlural="agents"
+                  adminPermission={{ agent: ["admin"] }}
+                />
                 <AgentDeletedStatusFilter
                   deletePermission={{ agent: ["delete"] }}
                 />
@@ -497,7 +501,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
                   permissions={[{ resource: "team", action: "read" }]}
                 />
               )}
-              <ActiveFilterBadges />
+              <ActiveFilterBadges adminPermission={{ agent: ["admin"] }} />
             </div>
 
             <div data-testid={E2eTestId.AgentsTable}>

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -395,7 +395,10 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
                   searchFields={["name"]}
                   paramName="name"
                 />
-                <AgentScopeFilter ownerLabelPlural="LLM proxies" />
+                <AgentScopeFilter
+                  ownerLabelPlural="LLM proxies"
+                  adminPermission={{ llmProxy: ["admin"] }}
+                />
                 <AgentDeletedStatusFilter
                   deletePermission={{ llmProxy: ["delete"] }}
                 />
@@ -406,7 +409,7 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
                   permissions={[{ resource: "team", action: "read" }]}
                 />
               )}
-              <ActiveFilterBadges />
+              <ActiveFilterBadges adminPermission={{ llmProxy: ["admin"] }} />
             </div>
 
             <div data-testid={E2eTestId.AgentsTable}>

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -468,7 +468,10 @@ function McpGateways({
                   searchFields={["name"]}
                   paramName="name"
                 />
-                <AgentScopeFilter ownerLabelPlural="MCP gateways" />
+                <AgentScopeFilter
+                  ownerLabelPlural="MCP gateways"
+                  adminPermission={{ mcpGateway: ["admin"] }}
+                />
                 <AgentDeletedStatusFilter
                   deletePermission={{ mcpGateway: ["delete"] }}
                 />
@@ -479,7 +482,7 @@ function McpGateways({
                   permissions={[{ resource: "team", action: "read" }]}
                 />
               )}
-              <ActiveFilterBadges />
+              <ActiveFilterBadges adminPermission={{ mcpGateway: ["admin"] }} />
             </div>
 
             <div data-testid={E2eTestId.AgentsTable}>

--- a/platform/frontend/src/components/agent-scope-filter.test.tsx
+++ b/platform/frontend/src/components/agent-scope-filter.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Radix Select relies on pointer-capture / scrollIntoView, which jsdom omits.
+Element.prototype.scrollIntoView = vi.fn();
+Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+Element.prototype.setPointerCapture = vi.fn();
+Element.prototype.releasePointerCapture = vi.fn();
+
+const mockUseHasPermissions = vi.fn();
+const mockUseSession = vi.fn();
+const mockUseSearchParams = vi.fn();
+
+vi.mock("@/lib/auth/auth.query", () => ({
+  useHasPermissions: (...args: unknown[]) => mockUseHasPermissions(...args),
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: (...args: unknown[]) => mockUseSearchParams(...args),
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/agents",
+}));
+
+vi.mock("@/lib/agent.query", () => ({
+  useLabelKeys: () => ({ data: [] }),
+  useLabelValues: () => ({ data: [] }),
+}));
+
+vi.mock("@/lib/organization.query", () => ({
+  useOrganizationMembers: () => ({ data: [] }),
+}));
+
+vi.mock("@/lib/teams/team.query", () => ({
+  useTeams: () => ({ data: [] }),
+}));
+
+// Stub the sibling controls so the only `combobox` roles in the tree are the
+// scope select and the (conditional) owner select under test.
+vi.mock("@/components/label-select", () => ({
+  LabelSelect: () => null,
+  LabelFilterBadges: () => null,
+  LabelKeyRowBase: () => null,
+  parseLabelsParam: () => null,
+  serializeLabels: () => "",
+}));
+vi.mock("@/components/ui/multi-select", () => ({ MultiSelect: () => null }));
+vi.mock("@/components/user-searchable-multi-select", () => ({
+  UserSearchableMultiSelect: () => null,
+}));
+vi.mock("@/components/permission-requirement-hint", () => ({
+  PermissionRequirementHint: () => null,
+}));
+
+import { AgentScopeFilter } from "./agent-scope-filter";
+
+describe("AgentScopeFilter owner selector gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSession.mockReturnValue({ data: { user: { id: "user-1" } } });
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("scope=personal"));
+  });
+
+  it("hides the owner selector for a non-admin even if they have member:read", async () => {
+    mockUseHasPermissions.mockImplementation(
+      (permissions: Record<string, unknown>) => {
+        // Has member:read and team:read, but NOT agent:admin.
+        if ("agent" in permissions) return { data: false };
+        return { data: true };
+      },
+    );
+
+    render(<AgentScopeFilter adminPermission={{ agent: ["admin"] }} />);
+
+    expect(screen.getAllByRole("combobox")).toHaveLength(1);
+    expect(screen.queryByText("Other users")).not.toBeInTheDocument();
+  });
+
+  it("shows the owner selector for a resource admin", async () => {
+    mockUseHasPermissions.mockImplementation(
+      (permissions: Record<string, unknown>) => {
+        if ("agent" in permissions) return { data: true };
+        return { data: true };
+      },
+    );
+
+    render(<AgentScopeFilter adminPermission={{ agent: ["admin"] }} />);
+
+    const comboboxes = screen.getAllByRole("combobox");
+    expect(comboboxes).toHaveLength(2);
+
+    await userEvent.click(comboboxes[1]);
+    expect(await screen.findByText("Other users")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/agent-scope-filter.tsx
+++ b/platform/frontend/src/components/agent-scope-filter.tsx
@@ -35,9 +35,11 @@ type StatusValue = "active" | "deleted";
 export function AgentScopeFilter({
   showBuiltIn = false,
   ownerLabelPlural = "agents",
+  adminPermission,
 }: {
   showBuiltIn?: boolean;
   ownerLabelPlural?: string;
+  adminPermission: Permissions;
 }) {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -61,7 +63,7 @@ export function AgentScopeFilter({
   );
 
   const { data: labelKeys } = useLabelKeys();
-  const { data: isAdmin } = useHasPermissions({ member: ["read"] });
+  const { data: isAdmin } = useHasPermissions(adminPermission);
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
   const { data: teams } = useTeams({ enabled: !!canReadTeams });
 
@@ -281,7 +283,11 @@ export function AgentDeletedStatusFilter({
   );
 }
 
-export function ActiveFilterBadges() {
+export function ActiveFilterBadges({
+  adminPermission,
+}: {
+  adminPermission: Permissions;
+}) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -294,7 +300,7 @@ export function ActiveFilterBadges() {
   const currentUserId = session?.user?.id;
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
   const { data: teams } = useTeams({ enabled: !!canReadTeams });
-  const { data: isAdmin } = useHasPermissions({ member: ["read"] });
+  const { data: isAdmin } = useHasPermissions(adminPermission);
 
   // Users badge only shows when the author filter names specific other users,
   // not when it's just the implicit "mine" selection.


### PR DESCRIPTION
## Summary

On the Agents, LLM Proxies, and MCP Gateways list pages, choosing the **Personal** scope revealed a "My X / Other users" owner selector (and, on Agents, a **Built-in** scope option). These controls were gated on `member:read`, but the backend only honors cross-user/owner filtering — and built-in visibility — for callers with `<resource>:admin`. As a result, editors and any custom role holding `member:read` without the resource admin permission saw a filter that always returned nothing.

These controls now appear only for the resource admin on each page, matching what the backend will actually serve. The gate is a required `adminPermission` prop (mirroring the existing `deletePermission` prop on `AgentDeletedStatusFilter`), supplied per page as `agent` / `llmProxy` / `mcpGateway` admin. Making it required means a missing or wrong gate is a compile error rather than a silent default.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>