### PR TITLE
fix(mcp): preserve tools & guardrails on connection loss; derive tool availability

### DIFF
--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -1557,6 +1557,8 @@ Required RBAC permission: None (no additional RBAC permission required)
 | `tools[].description` | `string \| null` | Yes | Short tool description, if available. |
 | `tools[].source` | `"archestra" \| "mcp" \| "agent_delegation"` | Yes | Where the tool comes from. |
 | `tools[].server` | `string \| null` | Yes | MCP server prefix for third-party MCP tools when available. |
+| `tools[].available` | `boolean` | Yes | False when the tool's MCP connection is not installed; it stays discoverable but cannot run until reconnected. |
+| `tools[].unavailableReason` | `string \| null` | Yes | Compact reason and recovery action when available is false; null otherwise. |
 | `tools[].params` | `string` | Yes | Compact one-line input signature — a summary, not the full schema. Parameters are joined by '; ', each rendered as `name<!\|?>:<type>` where `!` marks required and `?` optional. Object parameters are expanded up to two levels as `{child<!\|?>:type{grandchild<!\|?>:type}, …}`, enums as `enum(<json-values>)`, and a trailing ` — description` is added when available. A trailing `…` on a type marks an object whose content is not fully shown (freeform or more deeply nested) — consult the task instructions or the full schema for its shape. Empty string when the tool takes no input. Pass matching values inside tool_args when calling run_tool; if a call is rejected as invalid, the error describes the expected input (for third-party tools, the full input schema). |
 
 #### run_tool

--- a/platform/backend/src/archestra-mcp-server/search-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.test.ts
@@ -57,6 +57,8 @@ type SearchToolsStructuredContent = {
     description: string | null;
     source: "archestra" | "mcp" | "agent_delegation";
     server: string | null;
+    available: boolean;
+    unavailableReason: string | null;
     params: string;
   }>;
 };
@@ -65,6 +67,7 @@ describe("search_tools", () => {
   test("returns ranked matching tools with compact parameter summaries", async ({
     makeAgent,
     makeInternalMcpCatalog,
+    makeMcpServer,
     makeMember,
     makeOrganization,
     makeTool,
@@ -105,6 +108,7 @@ describe("search_tools", () => {
       },
     });
     await makeAgentTool(agent.id, githubTool.id);
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
     const context: ArchestraContext = {
       agent: { id: agent.id, name: agent.name },
@@ -129,6 +133,8 @@ describe("search_tools", () => {
       description: "Search repositories by topic, language, or owner.",
       source: "mcp",
       server: "github",
+      available: true,
+      unavailableReason: null,
       params:
         "query!:string — Repository search query string.; language?:string — Optional language filter.",
     });
@@ -147,6 +153,89 @@ describe("search_tools", () => {
     );
     expect(returnedToolNames).not.toContain(TOOL_SEARCH_TOOLS_FULL_NAME);
     expect(returnedToolNames).not.toContain(TOOL_RUN_TOOL_FULL_NAME);
+  });
+
+  test("marks tools without an installed connection as unavailable and ranks them last", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeMember,
+    makeOrganization,
+    makeTool,
+    makeAgentTool,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const agent = await makeAgent({
+      name: "Availability Agent",
+      organizationId: org.id,
+    });
+
+    const installedCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "Installed MCP",
+    });
+    const installedTool = await makeTool({
+      name: "installed__do_thing",
+      description: "widget action available now",
+      catalogId: installedCatalog.id,
+    });
+    await makeAgentTool(agent.id, installedTool.id);
+    await makeMcpServer({ catalogId: installedCatalog.id, scope: "org" });
+
+    // Same catalog shape but no installed connection -> retained, unavailable.
+    const removedCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "Removed MCP",
+    });
+    const removedTool = await makeTool({
+      name: "removed__do_thing",
+      description: "widget action pending reconnect",
+      catalogId: removedCatalog.id,
+    });
+    await makeAgentTool(agent.id, removedTool.id);
+
+    const context: ArchestraContext = {
+      agent: { id: agent.id, name: agent.name },
+      agentId: agent.id,
+      organizationId: org.id,
+      userId: user.id,
+    };
+
+    const result = await executeArchestraTool(
+      TOOL_SEARCH_TOOLS_FULL_NAME,
+      { query: "widget action", limit: 5 },
+      context,
+    );
+    expect(result.isError).toBe(false);
+    const content = result.structuredContent as SearchToolsStructuredContent;
+    const byName = new Map(content.tools.map((tool) => [tool.toolName, tool]));
+
+    expect(byName.get("installed__do_thing")).toMatchObject({
+      available: true,
+      unavailableReason: null,
+    });
+    expect(byName.get("removed__do_thing")?.available).toBe(false);
+    expect(byName.get("removed__do_thing")?.unavailableReason).toBeTruthy();
+
+    // Available ranks ahead of unavailable.
+    const names = content.tools.map((tool) => tool.toolName);
+    expect(names.indexOf("installed__do_thing")).toBeLessThan(
+      names.indexOf("removed__do_thing"),
+    );
+
+    // On truncation, the unavailable tool is dropped first.
+    const truncated = await executeArchestraTool(
+      TOOL_SEARCH_TOOLS_FULL_NAME,
+      { query: "widget action", limit: 1 },
+      context,
+    );
+    const truncatedContent =
+      truncated.structuredContent as SearchToolsStructuredContent;
+    expect(truncatedContent.tools).toHaveLength(1);
+    expect(truncatedContent.tools[0].toolName).toBe("installed__do_thing");
   });
 
   test("includes unassigned tools from catalogs the user can access when the agent allows dynamic access", async ({

--- a/platform/backend/src/archestra-mcp-server/search-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.ts
@@ -12,6 +12,7 @@ import logger from "@/logging";
 import {
   ConversationEnabledToolModel,
   InternalMcpCatalogModel,
+  McpServerModel,
   ToolModel,
 } from "@/models";
 import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
@@ -125,6 +126,18 @@ const SearchToolsOutputSchema = z.object({
         .describe(
           "MCP server prefix for third-party MCP tools when available.",
         ),
+      available: z
+        .boolean()
+        .describe(
+          "False when the tool's MCP connection is not installed; it stays " +
+            "discoverable but cannot run until reconnected.",
+        ),
+      unavailableReason: z
+        .string()
+        .nullable()
+        .describe(
+          "Compact reason and recovery action when available is false; null otherwise.",
+        ),
       params: z
         .string()
         .describe(
@@ -150,6 +163,7 @@ type SearchCandidate = {
   source: "archestra" | "mcp" | "agent_delegation";
   server: string | null;
   catalogName: string | null;
+  available: boolean;
   inputParameters: InputParameterSummary[];
   searchText: {
     name: string;
@@ -200,7 +214,15 @@ const registry = defineArchestraTools([
       }
 
       const matchCount = matches.length;
-      const tools = matches.slice(0, args.limit).map(toSearchResult);
+      // Available tools rank ahead of unavailable ones regardless of match
+      // strength, so an unavailable tool never displaces a usable match and is
+      // dropped first on truncation. Stable partition keeps relevance order
+      // within each group.
+      const ranked = [
+        ...matches.filter((candidate) => candidate.available),
+        ...matches.filter((candidate) => !candidate.available),
+      ];
+      const tools = ranked.slice(0, args.limit).map(toSearchResult);
       const truncated = matchCount > tools.length;
       // Only relevant to the zero-match hint, so resolve it lazily to avoid an
       // extra permission/assignment lookup on every successful search.
@@ -275,6 +297,7 @@ export const __test = {
       source: "mcp",
       server: null,
       catalogName: null,
+      available: true,
       inputParameters: [],
       searchText: buildSearchText({
         name: input.toolName,
@@ -333,6 +356,7 @@ async function getSearchableTools(params: {
       : [];
 
   const catalogNamesById = await getCatalogNamesById(filteredTools);
+  const catalogsWithInstalls = await getCatalogIdsWithInstalls(filteredTools);
   const candidates = new Map<string, SearchCandidate>();
   // First occurrence wins on duplicate names: assigned tools come before the
   // discoverable ones, and the discoverable set is ordered newest-first — the
@@ -350,6 +374,7 @@ async function getSearchableTools(params: {
           tool.catalogId != null
             ? (catalogNamesById.get(tool.catalogId) ?? null)
             : null,
+        catalogsWithInstalls,
       }),
     );
   }
@@ -379,11 +404,19 @@ function toAssignedToolCandidate(params: {
     catalogId: string | null;
   };
   catalogName: string | null;
+  catalogsWithInstalls: Set<string>;
 }): SearchCandidate {
-  const { catalogName, tool } = params;
+  const { catalogsWithInstalls, catalogName, tool } = params;
   const source = archestraMcpBranding.isToolName(tool.name)
     ? "archestra"
     : "mcp";
+  // Built-in Archestra tools and proxy-sniffed tools (no catalog) are always
+  // available; a third-party tool is available only while its catalog still
+  // has an installed connection.
+  const available =
+    source === "archestra" || tool.catalogId == null
+      ? true
+      : catalogsWithInstalls.has(tool.catalogId);
   const parsedToolName =
     source === "mcp" ? parseFullToolName(tool.name) : { serverName: null };
   const parameters = tool.parameters ?? {};
@@ -398,6 +431,7 @@ function toAssignedToolCandidate(params: {
     source,
     server: parsedToolName.serverName ?? null,
     catalogName: source === "mcp" ? catalogName : null,
+    available,
     inputParameters,
     searchText: buildSearchText({
       name: tool.name,
@@ -420,6 +454,7 @@ function toDelegationToolCandidate(tool: Tool): SearchCandidate {
     source: "agent_delegation",
     server: null,
     catalogName: null,
+    available: true,
     inputParameters,
     searchText: buildSearchText({
       name: tool.name,
@@ -443,6 +478,26 @@ async function getCatalogNamesById(
   const catalogs = await InternalMcpCatalogModel.getByIds(catalogIds);
   return new Map(
     Array.from(catalogs.values()).map((catalog) => [catalog.id, catalog.name]),
+  );
+}
+
+// A tool is runnable only while its catalog still has an installed connection;
+// this resolves, in one query, which of the given tools' catalogs do.
+async function getCatalogIdsWithInstalls(
+  tools: Array<{ catalogId: string | null }>,
+): Promise<Set<string>> {
+  const catalogIds = Array.from(
+    new Set(
+      tools
+        .map((tool) => tool.catalogId)
+        .filter((catalogId): catalogId is string => catalogId != null),
+    ),
+  );
+  const installs = await McpServerModel.findByCatalogIds(catalogIds);
+  return new Set(
+    installs
+      .map((server) => server.catalogId)
+      .filter((catalogId): catalogId is string => catalogId != null),
   );
 }
 
@@ -649,6 +704,10 @@ function toSearchResult(candidate: SearchCandidate) {
     description: candidate.description,
     source: candidate.source,
     server: candidate.server,
+    available: candidate.available,
+    unavailableReason: candidate.available
+      ? null
+      : "MCP connection not installed — reconnect the server to use this tool.",
     params: formatParamsSignature(candidate.inputParameters),
   };
 }

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -440,6 +440,40 @@ describe("McpClient", () => {
       ).toBe("unknown_tool");
     });
 
+    test("a retained static assignment whose connection was uninstalled returns a typed reconnect error", async () => {
+      // A catalog with no installed connection (the pinned install was removed).
+      const orphanCatalog = await InternalMcpCatalogModel.create({
+        name: "orphan-mcp-server",
+        serverType: "remote",
+        serverUrl: "https://example.invalid/mcp/",
+      });
+      const tool = await ToolModel.createToolIfNotExists({
+        name: "orphan-mcp-server__do_thing",
+        description: "needs a connection",
+        parameters: {},
+        catalogId: orphanCatalog.id,
+      });
+      // Retained assignment after uninstall: still static, but the server
+      // binding is null and the catalog has no install.
+      await AgentToolModel.create(agentId, tool.id, {
+        mcpServerId: null,
+        credentialResolutionMode: "static",
+      });
+
+      const result = await mcpClient.executeToolCallForOwner(
+        { id: "call_orphan", name: tool.name, arguments: {} },
+        agentOwner(agentId),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(
+        (result._meta as { archestraError?: { type?: string } } | undefined)
+          ?.archestraError?.type,
+      ).toBe("auth_required");
+      // The call is refused before any dispatch is attempted.
+      expect(mockCallTool).not.toHaveBeenCalled();
+    });
+
     test("declares MCP Apps and enterprise auth extensions during initialize", async () => {
       const tool = await ToolModel.createToolIfNotExists({
         name: "github-mcp-server__declared_extensions",

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -470,6 +470,9 @@ describe("McpClient", () => {
         (result._meta as { archestraError?: { type?: string } } | undefined)
           ?.archestraError?.type,
       ).toBe("auth_required");
+      // Reconnect-framed wording (not the "no credentials" auth message).
+      expect(result.error).toContain("reconnect");
+      expect(result.error).toContain("is not connected");
       // The call is refused before any dispatch is attempted.
       expect(mockCallTool).not.toHaveBeenCalled();
     });

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1470,10 +1470,9 @@ class McpClient {
         // The pinned install was uninstalled but the assignment is retained.
         // Route through a remaining install for the same catalog (a multi-tenant
         // sibling, or a reconnect not yet re-pinned), else return the typed
-        // "reconnect" result.
-        const installs = tool.catalogId
-          ? await McpServerModel.findByCatalogId(tool.catalogId)
-          : [];
+        // "reconnect" result. catalogItem is the resolved catalog for this tool,
+        // so use its id rather than the assignment's possibly-stale catalogId.
+        const installs = await McpServerModel.findByCatalogId(catalogItem.id);
         const resolved = await this.pickInstallForCaller(installs, tokenAuth);
         if (resolved) {
           return {
@@ -1483,7 +1482,7 @@ class McpClient {
         }
         const reconnectError = this.buildAuthRequiredMessage(
           tool.catalogName || catalogItem.name,
-          tool.catalogId ?? "",
+          catalogItem.id,
           tokenAuth,
         );
         return {

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -66,6 +66,7 @@ import type {
   EnterpriseManagedCredentialConfig,
   InternalMcpCatalog,
   MCPGatewayAuthMethod,
+  McpServer,
   McpToolAssignment,
   ToolOwner,
 } from "@/types";
@@ -1466,12 +1467,33 @@ class McpClient {
     // Static credential case: tool has a bound MCP server credential to use.
     if (tool.credentialResolutionMode === "static") {
       if (!tool.mcpServerId) {
+        // The pinned install was uninstalled but the assignment is retained.
+        // Route through a remaining install for the same catalog (a multi-tenant
+        // sibling, or a reconnect not yet re-pinned), else return the typed
+        // "reconnect" result.
+        const installs = tool.catalogId
+          ? await McpServerModel.findByCatalogId(tool.catalogId)
+          : [];
+        const resolved = await this.pickInstallForCaller(installs, tokenAuth);
+        if (resolved) {
+          return {
+            targetMcpServerId: resolved.id,
+            mcpServerName: resolved.name,
+          };
+        }
+        const reconnectError = this.buildAuthRequiredMessage(
+          tool.catalogName || catalogItem.name,
+          tool.catalogId ?? "",
+          tokenAuth,
+        );
         return {
           error: await this.createErrorResult(
             toolCall,
             owner,
-            "An MCP server installation is required for statically assigned MCP tools.",
+            reconnectError.message,
             fallbackName,
+            undefined,
+            reconnectError,
           ),
         };
       }
@@ -1593,105 +1615,23 @@ class McpClient {
     // user token -> personal, then a team the user belongs to, then org-scoped;
     // team token -> the team's connection, then org-scoped. Pinning a service
     // account (above) overrides this to force one connection for every caller.
-    if (tokenAuth.userId) {
-      // Priority 1: Personal credential owned by current user
-      const userServer = allServers.find(
-        (s) => s.ownerId === tokenAuth.userId && !s.teamId && s.scope !== "org",
+    const resolvedServer = await this.pickInstallForCaller(
+      allServers,
+      tokenAuth,
+    );
+    if (resolvedServer) {
+      logger.info(
+        {
+          toolName: toolCall.name,
+          catalogId: tool.catalogId,
+          serverId: resolvedServer.id,
+        },
+        `Dynamic resolution: using scoped install for tool ${toolCall.name}`,
       );
-      if (userServer) {
-        logger.info(
-          {
-            toolName: toolCall.name,
-            catalogId: tool.catalogId,
-            serverId: userServer.id,
-            userId: tokenAuth.userId,
-          },
-          `Dynamic resolution: using user-owned server for tool ${toolCall.name}`,
-        );
-        return {
-          targetMcpServerId: userServer.id,
-          mcpServerName: userServer.name,
-        };
-      }
-
-      // Priority 2: Team-owned server for a team the user is a member of
-      const userTeams = await TeamModel.getUserTeams(tokenAuth.userId);
-      const userTeamIds = new Set(userTeams.map((t) => t.id));
-      const teamServer = allServers.find(
-        (s) => s.teamId && userTeamIds.has(s.teamId),
-      );
-      if (teamServer) {
-        logger.info(
-          {
-            toolName: toolCall.name,
-            catalogId: tool.catalogId,
-            serverId: teamServer.id,
-            teamId: teamServer.teamId,
-            userId: tokenAuth.userId,
-          },
-          `Dynamic resolution: using team-owned server for user ${tokenAuth.userId}`,
-        );
-        return {
-          targetMcpServerId: teamServer.id,
-          mcpServerName: teamServer.name,
-        };
-      }
-
-      // Priority 3: Org-scoped install
-      const orgServer = allServers.find((s) => s.scope === "org");
-      if (orgServer) {
-        logger.info(
-          {
-            toolName: toolCall.name,
-            catalogId: tool.catalogId,
-            serverId: orgServer.id,
-            userId: tokenAuth.userId,
-          },
-          `Dynamic resolution: using org-scoped server for user ${tokenAuth.userId}`,
-        );
-        return {
-          targetMcpServerId: orgServer.id,
-          mcpServerName: orgServer.name,
-        };
-      }
-    }
-
-    // Team token: try team-owned servers for the token's team, then fall back
-    // to an org-scoped install.
-    if (tokenAuth.teamId) {
-      const teamServer = allServers.find((s) => s.teamId === tokenAuth.teamId);
-      if (teamServer) {
-        logger.info(
-          {
-            toolName: toolCall.name,
-            catalogId: tool.catalogId,
-            serverId: teamServer.id,
-            teamId: tokenAuth.teamId,
-          },
-          `Dynamic resolution: using team-owned server for team ${tokenAuth.teamId}`,
-        );
-        return {
-          targetMcpServerId: teamServer.id,
-          mcpServerName: teamServer.name,
-        };
-      }
-
-      const orgServer = allServers.find((s) => s.scope === "org");
-      if (orgServer) {
-        logger.info(
-          {
-            toolName: toolCall.name,
-            catalogId: tool.catalogId,
-            serverId: orgServer.id,
-            teamId: tokenAuth.teamId,
-          },
-          `Dynamic resolution: using org-scoped server for team ${tokenAuth.teamId}`,
-        );
-        return {
-          targetMcpServerId: orgServer.id,
-          mcpServerName: orgServer.name,
-        };
-      }
+      return {
+        targetMcpServerId: resolvedServer.id,
+        mcpServerName: resolvedServer.name,
+      };
     }
 
     // Org-wide token is incompatible with dynamic credential resolution
@@ -1740,6 +1680,44 @@ class McpClient {
         authError,
       ),
     };
+  }
+
+  // Picks which of a catalog's installs the calling identity routes through, using
+  // the runtime credential-resolution scope priority: a user token prefers its own
+  // personal install, then a team the user belongs to, then an org-scoped install;
+  // a team token prefers the team's install, then org-scoped. Returns undefined when
+  // none match. Shared by dynamic resolution and by a retained static assignment
+  // whose pinned install was uninstalled (its mcpServerId is null).
+  private async pickInstallForCaller(
+    allServers: McpServer[],
+    tokenAuth: TokenAuthContext | undefined,
+  ): Promise<McpServer | undefined> {
+    if (tokenAuth?.userId) {
+      const userServer = allServers.find(
+        (s) => s.ownerId === tokenAuth.userId && !s.teamId && s.scope !== "org",
+      );
+      if (userServer) return userServer;
+
+      const userTeams = await TeamModel.getUserTeams(tokenAuth.userId);
+      const userTeamIds = new Set(userTeams.map((t) => t.id));
+      const teamServer = allServers.find(
+        (s) => s.teamId && userTeamIds.has(s.teamId),
+      );
+      if (teamServer) return teamServer;
+
+      const orgServer = allServers.find((s) => s.scope === "org");
+      if (orgServer) return orgServer;
+    }
+
+    if (tokenAuth?.teamId) {
+      const teamServer = allServers.find((s) => s.teamId === tokenAuth.teamId);
+      if (teamServer) return teamServer;
+
+      const orgServer = allServers.find((s) => s.scope === "org");
+      if (orgServer) return orgServer;
+    }
+
+    return undefined;
   }
 
   /**

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1480,10 +1480,9 @@ class McpClient {
             mcpServerName: resolved.name,
           };
         }
-        const reconnectError = this.buildAuthRequiredMessage(
+        const reconnectError = this.buildReconnectRequiredMessage(
           tool.catalogName || catalogItem.name,
           catalogItem.id,
-          tokenAuth,
         );
         return {
           error: await this.createErrorResult(
@@ -2498,6 +2497,34 @@ class McpClient {
         url: installUrl,
         postAction:
           "Once you have completed authentication, retry this tool call.",
+      }),
+      catalogId,
+      catalogName: catalogDisplayName,
+      action: "install_mcp_credentials",
+      actionUrl: installUrl,
+    };
+  }
+
+  /**
+   * Like buildAuthRequiredMessage but worded for a retained tool whose MCP
+   * connection was uninstalled (no install remains for its catalog). Same typed
+   * shape/action so clients handle it identically; only the human-readable
+   * message is reconnect-framed, matching the search_tools "not installed —
+   * reconnect" wording rather than "no credentials".
+   */
+  private buildReconnectRequiredMessage(
+    catalogDisplayName: string,
+    catalogId: string,
+  ): AuthRequiredMcpToolError {
+    const installUrl = `${config.frontendBaseUrl}${MCP_CATALOG_INSTALL_PATH}?${MCP_CATALOG_INSTALL_QUERY_PARAM}=${catalogId}`;
+    return {
+      type: "auth_required",
+      message: formatActionableAuthError({
+        title: `"${catalogDisplayName}" is not connected`,
+        detail: `This tool's MCP connection has been uninstalled. Reconnect "${catalogDisplayName}" to use it.`,
+        actionLabel: "reconnect the connection",
+        url: installUrl,
+        postAction: "Once reconnected, retry this tool call.",
       }),
       catalogId,
       catalogName: catalogDisplayName,

--- a/platform/backend/src/models/agent-tool.ts
+++ b/platform/backend/src/models/agent-tool.ts
@@ -1089,27 +1089,6 @@ class AgentToolModel {
   }
 
   /**
-   * Delete all static agent-tool assignments that use a specific MCP server.
-   */
-  static async deleteByExecutionSourceMcpServerId(
-    mcpServerId: string,
-  ): Promise<number> {
-    const result = await db
-      .delete(schema.agentToolsTable)
-      .where(eq(schema.agentToolsTable.mcpServerId, mcpServerId));
-    return result.rowCount ?? 0;
-  }
-
-  /**
-   * Delete all static agent-tool assignments that use a specific MCP server.
-   */
-  static async deleteByCredentialSourceMcpServerId(
-    mcpServerId: string,
-  ): Promise<number> {
-    return AgentToolModel.deleteByExecutionSourceMcpServerId(mcpServerId);
-  }
-
-  /**
    * Clean up invalid static MCP server assignments when a user is removed from a team.
    * Sets mcpServerId to null for agent-tools where:
    * - The assigned MCP server is owned by the removed user

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -23,12 +23,11 @@ import type {
   ResourceVisibilityScope,
   UpdateMcpServer,
 } from "@/types";
-import AgentToolModel from "./agent-tool";
 import InternalMcpCatalogModel from "./internal-mcp-catalog";
 import McpCatalogTeamModel from "./mcp-catalog-team";
 import McpHttpSessionModel from "./mcp-http-session";
 import McpServerUserModel from "./mcp-server-user";
-import ToolModel, { toolUiResourceUriSql } from "./tool";
+import { toolUiResourceUriSql } from "./tool";
 
 // Alias for users table to avoid conflict with the owner LEFT JOIN
 const assignedUsersTable = alias(schema.usersTable, "assigned_users");
@@ -886,30 +885,11 @@ class McpServerModel {
       // Continue with deletion even if session cleanup fails
     }
 
-    // Clean up agent_tools that reference this server
-    // Must be done before deletion to ensure agents do not retain unusable tool assignments
-    // FK constraint would only null out the reference, not remove the assignment
-    try {
-      let deletedAgentTools = 0;
-      if (mcpServer.serverType === "local") {
-        deletedAgentTools =
-          await AgentToolModel.deleteByExecutionSourceMcpServerId(id);
-      } else {
-        deletedAgentTools =
-          await AgentToolModel.deleteByCredentialSourceMcpServerId(id);
-      }
-      if (deletedAgentTools > 0) {
-        logger.info(
-          `Deleted ${deletedAgentTools} agent tool assignments for MCP server: ${mcpServer.name}`,
-        );
-      }
-    } catch (error) {
-      logger.error(
-        { err: error },
-        `Failed to clean up agent tools for MCP server ${mcpServer.name}:`,
-      );
-      // Continue with deletion even if agent tool cleanup fails
-    }
+    // Uninstall retains the catalog's tools, their policies, and the agent ↔ tool
+    // assignments so reconnecting the catalog item restores them. The mcp_server
+    // delete below nulls each assignment's server binding via the agent_tools FK
+    // (onDelete: set null); a tool's availability is derived from whether the
+    // catalog still has an install, not from removing these rows.
 
     // For local servers, stop and remove the K8s deployment
     if (mcpServer.serverType === "local") {
@@ -938,33 +918,6 @@ class McpServerModel {
     // If the MCP server was deleted and it had an associated secret, delete the secret
     if (deleted && mcpServer.secretId) {
       await secretManager().deleteSecret(mcpServer.secretId);
-    }
-
-    // If the MCP server was deleted and had a catalogId, check if this was the last installation
-    // If so, clean up all tools for this catalog
-    if (deleted && mcpServer.catalogId) {
-      try {
-        // Check if any other servers exist for this catalog
-        const remainingServers = await McpServerModel.findByCatalogId(
-          mcpServer.catalogId,
-        );
-
-        if (remainingServers.length === 0) {
-          // No more servers for this catalog, delete all tools
-          const deletedToolsCount = await ToolModel.deleteByCatalogId(
-            mcpServer.catalogId,
-          );
-          logger.info(
-            `Deleted ${deletedToolsCount} tools for catalog ${mcpServer.catalogId} (last installation removed)`,
-          );
-        }
-      } catch (error) {
-        logger.error(
-          { err: error },
-          `Failed to clean up tools for catalog ${mcpServer.catalogId}:`,
-        );
-        // Don't fail the deletion if tool cleanup fails
-      }
     }
 
     return deleted;

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -1994,19 +1994,6 @@ class ToolModel {
   }
 
   /**
-   * Delete all tools for a specific catalog item
-   * Used when the last MCP server installation for a catalog is removed
-   * Returns the number of tools deleted
-   */
-  static async deleteByCatalogId(catalogId: string): Promise<number> {
-    const result = await db
-      .delete(schema.toolsTable)
-      .where(eq(schema.toolsTable.catalogId, catalogId));
-
-    return result.rowCount || 0;
-  }
-
-  /**
    * Sync tools for a catalog item - updates existing tools and creates new ones.
    * Unlike bulkCreateToolsIfNotExists, this method:
    * - Matches tools by their RAW name (the part after `__`), not the full slugified name

--- a/platform/backend/src/routes/mcp-gateway.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.test.ts
@@ -585,6 +585,26 @@ describe("MCP Gateway (stateless mode)", () => {
     expect(body.capabilities).toHaveProperty("tools", true);
   });
 
+  test("GET endpoint serves discovery info without tokenAuth for an invalid token", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders("archestra_invalid_token_12345"),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toHaveProperty("name", `archestra-agent-${agent.id}`);
+    expect(body).toHaveProperty("agentId", agent.id);
+    expect(body).toHaveProperty("transport", "http");
+    expect(body.capabilities).toHaveProperty("tools", true);
+    expect(body.tokenAuth).toBeUndefined();
+  });
+
   test("handles whoami tool call successfully after initialize", async ({
     makeAgent,
     makeOrganization,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -3055,6 +3055,100 @@ describe("mcp server core route coverage", () => {
       );
       await expect(McpServerModel.findById(builtin.id)).resolves.not.toBeNull();
     });
+
+    test("uninstalling the last connection retains tools, policies, and assignments (binding nulled)", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const { default: AgentModel } = await import("@/models/agent");
+
+      const catalog = await makeInternalMcpCatalog({
+        name: "Retain On Uninstall",
+        serverType: "remote",
+        serverUrl: "http://localhost:30082/mcp",
+      });
+
+      connectAndGetToolsMock.mockResolvedValueOnce([
+        {
+          name: "retained-tool",
+          description: "kept after uninstall",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
+
+      const installResponse = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: { name: "Retain On Uninstall", catalogId: catalog.id },
+      });
+      expect(installResponse.statusCode).toBe(200);
+      const installedServer = installResponse.json();
+
+      const toolsBefore = await db
+        .select()
+        .from(schema.toolsTable)
+        .where(eq(schema.toolsTable.catalogId, catalog.id));
+      expect(toolsBefore).toHaveLength(1);
+      const tool = toolsBefore[0];
+
+      const personalGateway = await AgentModel.getPersonalMcpGateway(
+        user.id,
+        organizationId,
+      );
+      if (!personalGateway) throw new Error("expected personal gateway");
+
+      const assignmentBefore = await db
+        .select({ mcpServerId: schema.agentToolsTable.mcpServerId })
+        .from(schema.agentToolsTable)
+        .where(
+          and(
+            eq(schema.agentToolsTable.agentId, personalGateway.id),
+            eq(schema.agentToolsTable.toolId, tool.id),
+          ),
+        );
+      expect(assignmentBefore).toHaveLength(1);
+      expect(assignmentBefore[0].mcpServerId).toBe(installedServer.id);
+
+      const policiesBefore = await db
+        .select()
+        .from(schema.toolInvocationPoliciesTable)
+        .where(eq(schema.toolInvocationPoliciesTable.toolId, tool.id));
+      expect(policiesBefore.length).toBeGreaterThan(0);
+
+      const deleteResponse = await app.inject({
+        method: "DELETE",
+        url: `/api/mcp_server/${installedServer.id}`,
+      });
+      expect(deleteResponse.statusCode).toBe(200);
+
+      // The connection is gone, but the catalog's capability is retained.
+      await expect(
+        McpServerModel.findById(installedServer.id),
+      ).resolves.toBeNull();
+
+      const toolsAfter = await db
+        .select()
+        .from(schema.toolsTable)
+        .where(eq(schema.toolsTable.catalogId, catalog.id));
+      expect(toolsAfter).toHaveLength(1);
+
+      const policiesAfter = await db
+        .select()
+        .from(schema.toolInvocationPoliciesTable)
+        .where(eq(schema.toolInvocationPoliciesTable.toolId, tool.id));
+      expect(policiesAfter).toHaveLength(policiesBefore.length);
+
+      const assignmentAfter = await db
+        .select({ mcpServerId: schema.agentToolsTable.mcpServerId })
+        .from(schema.agentToolsTable)
+        .where(
+          and(
+            eq(schema.agentToolsTable.agentId, personalGateway.id),
+            eq(schema.agentToolsTable.toolId, tool.id),
+          ),
+        );
+      expect(assignmentAfter).toHaveLength(1);
+      expect(assignmentAfter[0].mcpServerId).toBeNull();
+    });
   });
 
   describe("PATCH /api/mcp_server/:id/reauthenticate", () => {

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -3021,6 +3021,79 @@ describe("mcp server core route coverage", () => {
     });
   });
 
+  describe("GET /api/mcp_server/:id/installation-status", () => {
+    test("returns the installation status for an accessible server", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+      const server = await makeMcpServer({
+        ownerId: user.id,
+        catalogId: catalog.id,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp_server/${server.id}/installation-status`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        localInstallationStatus: "idle",
+        localInstallationError: null,
+      });
+    });
+  });
+
+  describe("GET /api/mcp_server/:id/tools", () => {
+    test("returns the catalog tools for an accessible server", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeTool,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+      const server = await makeMcpServer({
+        ownerId: user.id,
+        catalogId: catalog.id,
+      });
+      const tool = await makeTool({ catalogId: catalog.id });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp_server/${server.id}/tools`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const tools = response.json();
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toMatchObject({
+        id: tool.id,
+        name: tool.name,
+        assignedAgentCount: 0,
+        assignedAgents: [],
+      });
+    });
+
+    test("returns an empty list when the catalog has no tools", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+      const server = await makeMcpServer({
+        ownerId: user.id,
+        catalogId: catalog.id,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp_server/${server.id}/tools`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual([]);
+    });
+  });
+
   describe("DELETE /api/mcp_server/:id", () => {
     test("returns 404 for an unknown id", async () => {
       const response = await app.inject({
@@ -3149,6 +3222,32 @@ describe("mcp server core route coverage", () => {
       expect(assignmentAfter).toHaveLength(1);
       expect(assignmentAfter[0].mcpServerId).toBeNull();
     });
+
+    test("refuses to delete an app server with 400", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "app" });
+      const appServer = await McpServerModel.create({
+        name: "app-server",
+        catalogId: catalog.id,
+        serverType: "app",
+        scope: "org",
+        ownerId: user.id,
+      });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/mcp_server/${appServer.id}`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "App servers are managed via the Apps API; delete the app instead.",
+      );
+      await expect(
+        McpServerModel.findById(appServer.id),
+      ).resolves.not.toBeNull();
+    });
   });
 
   describe("PATCH /api/mcp_server/:id/reauthenticate", () => {
@@ -3175,6 +3274,30 @@ describe("mcp server core route coverage", () => {
       expect(response.statusCode).toBe(404);
       expect(response.json().error.message).toBe("MCP server not found");
     });
+
+    test("rejects re-authenticating an app server with 400", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "app" });
+      const appServer = await McpServerModel.create({
+        name: "app-server",
+        catalogId: catalog.id,
+        serverType: "app",
+        scope: "org",
+        ownerId: user.id,
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/mcp_server/${appServer.id}/reauthenticate`,
+        payload: { accessToken: "fresh-token" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "App servers are managed via the Apps API and have no credentials to re-authenticate.",
+      );
+    });
   });
 
   describe("POST /api/mcp_server/:id/reinstall", () => {
@@ -3188,6 +3311,30 @@ describe("mcp server core route coverage", () => {
       expect(response.statusCode).toBe(404);
       expect(response.json().error.message).toBe("MCP server not found");
     });
+
+    test("rejects reinstalling an app server with 400", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "app" });
+      const appServer = await McpServerModel.create({
+        name: "app-server",
+        catalogId: catalog.id,
+        serverType: "app",
+        scope: "org",
+        ownerId: user.id,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/mcp_server/${appServer.id}/reinstall`,
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "App servers run in-process and are not reinstallable; manage them via the Apps API.",
+      );
+    });
   });
 
   describe("POST /api/mcp_server", () => {
@@ -3200,6 +3347,23 @@ describe("mcp server core route coverage", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.json().error.message).toBe("Catalog item not found");
+    });
+
+    test("returns 400 when installing an app-type catalog item", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "app" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: { name: "app", catalogId: catalog.id, scope: "personal" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "App servers are managed via the Apps API and cannot be installed here.",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Removing the last MCP connection for a catalog item used to hard-delete the catalog's tools, and with them the tool-invocation and trusted-data policies ("guardrails") an admin authored and the agent gateway assignments — silently and unrecoverably. Re-adding the server rediscovered tools with default policies and no assignments. The same loss hit credential revocation on a remote (OAuth) server: tools vanished from the agent and the only recovery was finding the MCP page; nothing surfaced in chat.

This decouples authored configuration from a single connection's lifecycle. A tool's **availability** is now a derived fact — true while its catalog has at least one installed connection, false otherwise — rather than something destroyed on uninstall. The tools, guardrails, and assignments are retained across a disconnect; only deleting the catalog item purges them.

User-visible behavior change:
- Disconnecting an MCP server (including removing the last connection, and OAuth credential loss) no longer wipes guardrails or gateway assignments. Reconnecting the catalog item restores them with configuration intact and no re-defaulting.
- An unavailable tool stays discoverable: `search_tools` returns it marked `available: false` (ranked below usable matches, with a compact reason), and calling it through `run_tool`/the gateway returns a typed "reconnect the connection" result instead of "tool not found" — so a skill reports an actionable recovery step rather than silently failing.

Multi-tenant catalogs are unaffected (a retained assignment whose pinned install was removed resolves through a remaining sibling install via the same caller-scoped priority used for dynamic credentials).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>