### PR TITLE
test(mcp): cover app-server guards, server read endpoints, and gateway invalid-token discovery

### DIFF
--- a/platform/backend/src/routes/mcp-gateway.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.test.ts
@@ -585,6 +585,26 @@ describe("MCP Gateway (stateless mode)", () => {
     expect(body.capabilities).toHaveProperty("tools", true);
   });
 
+  test("GET endpoint serves discovery info without tokenAuth for an invalid token", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders("archestra_invalid_token_12345"),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toHaveProperty("name", `archestra-agent-${agent.id}`);
+    expect(body).toHaveProperty("agentId", agent.id);
+    expect(body).toHaveProperty("transport", "http");
+    expect(body.capabilities).toHaveProperty("tools", true);
+    expect(body.tokenAuth).toBeUndefined();
+  });
+
   test("handles whoami tool call successfully after initialize", async ({
     makeAgent,
     makeOrganization,

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -3021,6 +3021,79 @@ describe("mcp server core route coverage", () => {
     });
   });
 
+  describe("GET /api/mcp_server/:id/installation-status", () => {
+    test("returns the installation status for an accessible server", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+      const server = await makeMcpServer({
+        ownerId: user.id,
+        catalogId: catalog.id,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp_server/${server.id}/installation-status`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        localInstallationStatus: "idle",
+        localInstallationError: null,
+      });
+    });
+  });
+
+  describe("GET /api/mcp_server/:id/tools", () => {
+    test("returns the catalog tools for an accessible server", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeTool,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+      const server = await makeMcpServer({
+        ownerId: user.id,
+        catalogId: catalog.id,
+      });
+      const tool = await makeTool({ catalogId: catalog.id });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp_server/${server.id}/tools`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const tools = response.json();
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toMatchObject({
+        id: tool.id,
+        name: tool.name,
+        assignedAgentCount: 0,
+        assignedAgents: [],
+      });
+    });
+
+    test("returns an empty list when the catalog has no tools", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+      const server = await makeMcpServer({
+        ownerId: user.id,
+        catalogId: catalog.id,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/mcp_server/${server.id}/tools`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual([]);
+    });
+  });
+
   describe("DELETE /api/mcp_server/:id", () => {
     test("returns 404 for an unknown id", async () => {
       const response = await app.inject({
@@ -3055,6 +3128,32 @@ describe("mcp server core route coverage", () => {
       );
       await expect(McpServerModel.findById(builtin.id)).resolves.not.toBeNull();
     });
+
+    test("refuses to delete an app server with 400", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "app" });
+      const appServer = await McpServerModel.create({
+        name: "app-server",
+        catalogId: catalog.id,
+        serverType: "app",
+        scope: "org",
+        ownerId: user.id,
+      });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: `/api/mcp_server/${appServer.id}`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "App servers are managed via the Apps API; delete the app instead.",
+      );
+      await expect(
+        McpServerModel.findById(appServer.id),
+      ).resolves.not.toBeNull();
+    });
   });
 
   describe("PATCH /api/mcp_server/:id/reauthenticate", () => {
@@ -3081,6 +3180,30 @@ describe("mcp server core route coverage", () => {
       expect(response.statusCode).toBe(404);
       expect(response.json().error.message).toBe("MCP server not found");
     });
+
+    test("rejects re-authenticating an app server with 400", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "app" });
+      const appServer = await McpServerModel.create({
+        name: "app-server",
+        catalogId: catalog.id,
+        serverType: "app",
+        scope: "org",
+        ownerId: user.id,
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/mcp_server/${appServer.id}/reauthenticate`,
+        payload: { accessToken: "fresh-token" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "App servers are managed via the Apps API and have no credentials to re-authenticate.",
+      );
+    });
   });
 
   describe("POST /api/mcp_server/:id/reinstall", () => {
@@ -3094,6 +3217,30 @@ describe("mcp server core route coverage", () => {
       expect(response.statusCode).toBe(404);
       expect(response.json().error.message).toBe("MCP server not found");
     });
+
+    test("rejects reinstalling an app server with 400", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "app" });
+      const appServer = await McpServerModel.create({
+        name: "app-server",
+        catalogId: catalog.id,
+        serverType: "app",
+        scope: "org",
+        ownerId: user.id,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/mcp_server/${appServer.id}/reinstall`,
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "App servers run in-process and are not reinstallable; manage them via the Apps API.",
+      );
+    });
   });
 
   describe("POST /api/mcp_server", () => {
@@ -3106,6 +3253,23 @@ describe("mcp server core route coverage", () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.json().error.message).toBe("Catalog item not found");
+    });
+
+    test("returns 400 when installing an app-type catalog item", async ({
+      makeInternalMcpCatalog,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({ serverType: "app" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/mcp_server",
+        payload: { name: "app", catalogId: catalog.id, scope: "personal" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toBe(
+        "App servers are managed via the Apps API and cannot be installed here.",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Extends test coverage for the two MCP HTTP route handlers (`mcp-server.ts`, `mcp-gateway.ts`) by completing the empty cells in three combinatorial coverage matrices. No product code changes — these pin behavior that previously had no test.

The gaps were found by modeling each route's inputs as factors × levels and checking which combinations the existing tests exercised:

- **`operation` × `serverType`** — the `app` server-type rejection (HTTP 400) was untested on every lifecycle operation. Now covered for install, delete, reauthenticate, and reinstall, each asserting the distinct error message that operation emits, so an app-backed server can never be installed/deleted/reauthed/reinstalled through the generic server route without a regression surfacing.
- **read endpoint × accessibility** — `GET /:id/installation-status` and `GET /:id/tools` were only tested for the inaccessible (404) case; the success (200) response bodies — including the `assignedAgentCount`/`assignedAgents` aggregation and the empty-tools case — are now pinned.
- **`method` × `tokenState`** (gateway) — a `GET /v1/mcp/:profileId` with a present-but-invalid token returns discovery info with 200 and omits `tokenAuth`, where the POST handler 401s on the same input. That GET-vs-POST asymmetry now has an explicit test.

Deliberately out of scope: async/error-injection branches (K8s pod startup failure, background tool-fetch failure, post-hijack gateway error handling, passthrough-header extraction) that require heavy failure mocking for little signal.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>