### PR TITLE
fix(chat): fail loud when MCP tool fetch fails instead of streaming empty tools

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -303,17 +303,20 @@ describe("chat-mcp-client health check", () => {
 
       await vi.advanceTimersByTimeAsync(1_001);
 
-      const tools = await chatClient.getChatMcpTools({
-        agentName: agent.name,
-        agentId: agent.id,
-        userId: user.id,
-        organizationId: org.id,
-        conversationId: "conv-1",
-      });
+      // The idle client is evicted and closed; the fresh connect then fails in
+      // the test env, so the fetch throws rather than streaming with empty tools.
+      await expect(
+        chatClient.getChatMcpTools({
+          agentName: agent.name,
+          agentId: agent.id,
+          userId: user.id,
+          organizationId: org.id,
+          conversationId: "conv-1",
+        }),
+      ).rejects.toBeInstanceOf(chatClient.McpToolsUnavailableError);
 
       expect(expiredClient.ping).not.toHaveBeenCalled();
       expect(expiredClient.close).toHaveBeenCalledTimes(1);
-      expect(tools).toEqual({});
 
       chatClient.clearChatMcpClient(agent.id);
       await chatClient.__test.clearToolCache(cacheKey);
@@ -353,15 +356,17 @@ describe("chat-mcp-client health check", () => {
       deadClient as unknown as Client,
     );
 
-    // getChatMcpTools should detect dead client via ping, discard it,
-    // and attempt to create a fresh client (which will fail in test env,
-    // resulting in empty tools - but the key behavior is ping was called)
-    const tools = await chatClient.getChatMcpTools({
-      agentName: agent.name,
-      agentId: agent.id,
-      userId: user.id,
-      organizationId: org.id,
-    });
+    // getChatMcpTools should detect the dead client via ping, discard it, and
+    // attempt a fresh client (which fails in the test env). The fetch throws
+    // rather than silently returning empty tools.
+    await expect(
+      chatClient.getChatMcpTools({
+        agentName: agent.name,
+        agentId: agent.id,
+        userId: user.id,
+        organizationId: org.id,
+      }),
+    ).rejects.toBeInstanceOf(chatClient.McpToolsUnavailableError);
 
     // Ping should have been called on the dead client
     expect(deadClient.ping).toHaveBeenCalledTimes(1);
@@ -369,8 +374,6 @@ describe("chat-mcp-client health check", () => {
     expect(deadClient.close).toHaveBeenCalledTimes(1);
     // listTools should NOT have been called on the dead client
     expect(deadClient.listTools).not.toHaveBeenCalled();
-    // Tools will be empty since we can't create a real client in tests
-    expect(tools).toEqual({});
 
     chatClient.clearChatMcpClient(agent.id);
     await chatClient.__test.clearToolCache(cacheKey);
@@ -460,20 +463,72 @@ describe("chat-mcp-client health check", () => {
         userId: user.id,
         organizationId: org.id,
       });
+      // Hold the rejection assertion so the pending promise stays handled while
+      // we advance the fake clock past the 5s ping timeout.
+      const rejection = expect(toolsPromise).rejects.toBeInstanceOf(
+        chatClient.McpToolsUnavailableError,
+      );
 
       await vi.advanceTimersByTimeAsync(5_000);
-      const tools = await toolsPromise;
+      await rejection;
 
       expect(hangingClient.ping).toHaveBeenCalledTimes(1);
       expect(hangingClient.close).toHaveBeenCalledTimes(1);
       expect(hangingClient.listTools).not.toHaveBeenCalled();
-      expect(tools).toEqual({});
 
       chatClient.clearChatMcpClient(agent.id);
       await chatClient.__test.clearToolCache(cacheKey);
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("getChatMcpTools failure-vs-empty contract", () => {
+  test("returns an empty set (no throw) when the gateway lists zero tools", async ({
+    makeAgent,
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    // A successful fetch that yields no tools is a legitimate state (e.g. a new
+    // agent) and must NOT be conflated with a fetch failure.
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const agent = await makeAgent({ teams: [team.id] });
+    await makeTeamMember(team.id, user.id);
+    await TeamTokenModel.createTeamToken(team.id, team.name);
+
+    const cacheKey = chatClient.__test.getCacheKey(agent.id, user.id);
+    chatClient.clearChatMcpClient(agent.id);
+    await chatClient.__test.clearToolCache(cacheKey);
+
+    const emptyClient = {
+      ping: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+      callTool: vi.fn(),
+      close: vi.fn(),
+    };
+    chatClient.__test.setCachedClient(
+      cacheKey,
+      emptyClient as unknown as Client,
+    );
+    chatClient.__test.setCachedClientLastValidatedAt(cacheKey, Date.now());
+
+    const tools = await chatClient.getChatMcpTools({
+      agentName: agent.name,
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
+    });
+
+    expect(emptyClient.listTools).toHaveBeenCalledTimes(1);
+    expect(tools).toEqual({});
+
+    chatClient.clearChatMcpClient(agent.id);
+    await chatClient.__test.clearToolCache(cacheKey);
   });
 });
 
@@ -1639,6 +1694,38 @@ describe("getChatMcpClient", () => {
       );
     expect(authorizationHeaders).toContain("Bearer external-idp-jwt");
     expect(authorizationHeaders).toContain("Bearer internal-fallback-token");
+  });
+
+  test("times out a hung connect instead of hanging indefinitely", async () => {
+    vi.useFakeTimers();
+    try {
+      mockConnect.mockReset();
+      // Never resolves: simulates a gateway that accepts the socket but stalls.
+      mockConnect.mockImplementation(() => new Promise(() => {}));
+      mockClose.mockReset();
+      vi.mocked(resolveSessionExternalIdpToken).mockResolvedValue(null);
+
+      const clientPromise = chatClient.getChatMcpClient(
+        crypto.randomUUID(),
+        crypto.randomUUID(),
+        crypto.randomUUID(),
+        undefined,
+        "internal-token",
+      );
+
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      // No fallback token here, so the timed-out connect yields a null client
+      // (which getChatMcpTools turns into a McpToolsUnavailableError).
+      expect(await clientPromise).toBeNull();
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      // The half-open client is closed on timeout so a late connect can't leak it.
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      mockConnect.mockReset();
+      mockConnect.mockRejectedValue(new Error("Connection closed"));
+    }
   });
 });
 

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -1715,7 +1715,9 @@ describe("getChatMcpClient", () => {
 
       await vi.advanceTimersByTimeAsync(15_000);
 
-      // No fallback token here, so the timed-out connect yields a null client
+      // With resolveSessionExternalIdpToken mocked to null, the passed
+      // "internal-token" is the sole (primary) connect token and there is no
+      // fallback token to retry — so the timed-out connect yields a null client
       // (which getChatMcpTools turns into a McpToolsUnavailableError).
       expect(await clientPromise).toBeNull();
       expect(mockConnect).toHaveBeenCalledTimes(1);

--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -753,19 +753,26 @@ describe("getChatMcpTools repeated-call circuit breaker", () => {
 });
 
 describe("getChatMcpTools failure and cache gating", () => {
-  test("returns no tools when the gateway listing fails", async () => {
+  test("throws and evicts the failing client when the gateway listing fails", async () => {
+    const failingClient = {
+      ping: vi.fn().mockResolvedValue({}),
+      listTools: vi.fn().mockRejectedValue(new Error("gateway down")),
+      callTool: vi.fn(),
+      close: vi.fn(),
+    };
     const { baseParams } = await setupChatToolEnv({
-      gatewayClient: {
-        ping: vi.fn().mockResolvedValue({}),
-        listTools: vi.fn().mockRejectedValue(new Error("gateway down")),
-        callTool: vi.fn(),
-        close: vi.fn(),
-      } as unknown as Client,
+      gatewayClient: failingClient as unknown as Client,
     });
 
-    const tools = await chatClient.getChatMcpTools(baseParams);
+    // A failed listing must surface as an error, not an empty tool set that
+    // would let the model stream against a tool-demanding system prompt.
+    await expect(chatClient.getChatMcpTools(baseParams)).rejects.toBeInstanceOf(
+      chatClient.McpToolsUnavailableError,
+    );
 
-    expect(tools).toEqual({});
+    // The failing session is evicted (closed) so the next turn rebuilds it
+    // rather than reusing a sticky failure until the idle TTL.
+    expect(failingClient.close).toHaveBeenCalledTimes(1);
   });
 
   test("abortSignal bypasses the tool cache; calls without it reuse the entry", async () => {

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -1010,7 +1010,7 @@ export async function getChatMcpTools({
     // gateway error text never reaches the API client.
     const cacheKey = getCacheKey(agentId, userId, scopeKey);
     try {
-      client.close();
+      await client.close();
     } catch (closeError) {
       logger.warn(
         { agentId, userId, closeError },

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -1,4 +1,5 @@
 import {
+  ApiError,
   isAgentTool,
   isBrowserMcpTool,
   MCP_APPS_CLIENT_EXTENSION_CAPABILITIES,
@@ -46,6 +47,23 @@ import { buildMcpClientInfo } from "@/utils/mcp-client-info";
  */
 const MCP_GATEWAY_BASE_URL = `http://localhost:${config.api.port}/v1/mcp`;
 
+/**
+ * Raised when the agent's MCP tool set could not be fetched (no gateway token,
+ * the gateway connection failed, or `tools/list` threw) — as distinct from an
+ * agent that genuinely exposes no model-visible tools. Callers must not stream
+ * the model with an empty tool set on failure: the agent's system prompt still
+ * demands tool calls, so the model hallucinates them as text. Surfaces as a 503
+ * through the Fastify error handler; `internalCode` discriminates it from other
+ * 503s for callers and tests.
+ *
+ * @public — thrown from getChatMcpTools, asserted in its tests
+ */
+export class McpToolsUnavailableError extends ApiError {
+  constructor(reason: string) {
+    super(503, `MCP tools unavailable: ${reason}`, "mcp_tools_unavailable");
+  }
+}
+
 // Idle TTL for conversation-scoped MCP clients. These sessions are expensive
 // enough that we do not want them to linger forever after a chat/browser tab
 // is abandoned, but they should survive normal pauses within an active session.
@@ -89,6 +107,7 @@ const clientCache = new LRUCacheManager<Client>({
 const TOOL_CACHE_TTL_MS = 30 * TimeInMs.Second;
 const CLIENT_PING_TIMEOUT_MS = 5 * TimeInMs.Second;
 const CLIENT_PING_VALIDATION_INTERVAL_MS = 30 * TimeInMs.Second;
+const CLIENT_CONNECT_TIMEOUT_MS = 15 * TimeInMs.Second;
 
 /**
  * Maximum tool cache size to prevent unbounded memory growth.
@@ -563,7 +582,39 @@ export async function getChatMcpClient(
       { agentId, userId, url: mcpGatewayUrl },
       "Connecting to MCP Gateway...",
     );
-    await client.connect(transport);
+    // Bound the connect: a loopback gateway that stalls (e.g. during a deploy)
+    // would otherwise hang this await indefinitely and wedge the chat turn. A
+    // timeout surfaces as a connect failure → token fallback → typed throw.
+    let connectTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        client.connect(transport),
+        new Promise<never>((_, reject) => {
+          connectTimer = setTimeout(() => {
+            reject(
+              new Error(
+                `MCP Gateway connect timeout after ${CLIENT_CONNECT_TIMEOUT_MS}ms`,
+              ),
+            );
+          }, CLIENT_CONNECT_TIMEOUT_MS);
+          connectTimer.unref?.();
+        }),
+      ]);
+    } catch (connectError) {
+      // The race only stops awaiting; close the half-open client so a connect
+      // that completes after the timeout can't leak its transport and socket.
+      try {
+        await client.close();
+      } catch (closeError) {
+        logger.warn(
+          { agentId, userId, closeError },
+          "Error closing timed-out MCP client (non-fatal)",
+        );
+      }
+      throw connectError;
+    } finally {
+      if (connectTimer) clearTimeout(connectTimer);
+    }
     return client;
   };
 
@@ -789,9 +840,9 @@ export async function getChatMcpTools({
   if (!mcpGwToken) {
     logger.warn(
       { agentId, userId },
-      "No valid team token available for user - cannot execute tools",
+      "No valid team token available for user - cannot fetch tools",
     );
-    return {};
+    throw new McpToolsUnavailableError("no gateway token for user");
   }
 
   // Still use MCP client for listing tools (via MCP Gateway)
@@ -808,9 +859,9 @@ export async function getChatMcpTools({
   if (!client) {
     logger.warn(
       { agentId, userId },
-      "No MCP client available, returning empty tools",
+      "No MCP client available - failing the turn instead of streaming with empty tools",
     );
-    return {}; // No tools available
+    throw new McpToolsUnavailableError("could not connect to MCP Gateway");
   }
 
   try {
@@ -828,10 +879,15 @@ export async function getChatMcpTools({
       return !(uiVisibility && !uiVisibility.includes("model"));
     });
 
+    // rawToolCount vs toolCount makes a successful-but-model-empty fetch
+    // diagnosable: when the gateway returns tools but every one is filtered out
+    // (all app-only, or stripped as agent tools), the model still sees nothing.
+    // That is a legitimate state (we don't throw), but the gap is worth logging.
     logger.info(
       {
         agentId,
         userId,
+        rawToolCount: mcpTools.length,
         toolCount: filteredMcpTools.length,
         toolNames: filteredMcpTools.map((t) => t.name),
       },
@@ -948,7 +1004,22 @@ export async function getChatMcpTools({
       { agentId, userId, error },
       "Failed to fetch tools from MCP Gateway",
     );
-    return {};
+    // Evict the client so a transient tools/list failure self-heals on the next
+    // turn instead of reusing the same failing session until the idle TTL. The
+    // detail stays in the log above; the thrown message is kept generic so raw
+    // gateway error text never reaches the API client.
+    const cacheKey = getCacheKey(agentId, userId, scopeKey);
+    try {
+      client.close();
+    } catch (closeError) {
+      logger.warn(
+        { agentId, userId, closeError },
+        "Error closing MCP client after tool fetch failure (non-fatal)",
+      );
+    }
+    clientCache.delete(cacheKey);
+    clientLastValidatedAt.delete(cacheKey);
+    throw new McpToolsUnavailableError("tool listing failed");
   }
 }
 


### PR DESCRIPTION
## Summary

`getChatMcpTools` returned an empty tool set (`{}`) both when an agent genuinely had no tools and when the gateway tool fetch *failed* (no gateway token, the connection failed, or `tools/list` threw). On failure the chat and A2A turn streamed anyway with no tools while the agent's system prompt still demanded tool calls — so the model resolved the contradiction by **hallucinating tool calls as plain text** instead of executing them. Users saw a fabricated tool flow rather than a real one or an error.

Now a fetch *failure* surfaces as a typed `McpToolsUnavailableError` (`ApiError`, 503): the chat turn ends with a visible inline error and a `failed` run, and A2A/scheduled/email runs record a failed run, instead of silently producing a hallucinated answer. A *successful* fetch that lists zero tools is unchanged — it still returns `{}` and streams normally, so a legitimately tool-less or all-app-only agent is unaffected.

Two robustness gaps on the same path are closed: the gateway `connect()` was unbounded and could hang a turn indefinitely — it now has a 15s timeout and the half-open client is closed on failure so a late-completing connect can't leak its socket; and a client whose `tools/list` failed is evicted from the cache so a transient gateway error self-heals on the next turn instead of being reused until the idle TTL.

The gateway is the same backend process over loopback and an IdP→internal token fallback already exists, so transient retry is intentionally not added here — only the connect timeout.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>