### PR TITLE
chore(projects): simplify project files panel header

### DIFF
--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -5,7 +5,6 @@ import {
   CalendarClock,
   Download,
   Eye,
-  FileText,
   MessageCircle,
   MoreHorizontal,
   Pencil,
@@ -41,7 +40,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useFileDeletion } from "@/lib/chat/use-file-deletion";
 import { buildProjectChatHandoffUrl } from "@/lib/projects/project-chat-handoff";
@@ -224,7 +222,6 @@ function ProjectDetail() {
       <div className="hidden md:flex h-full min-h-0">
         <ProjectFilesSidebar
           projectId={project.id}
-          projectName={project.name}
           canManageProject={canManage}
         />
       </div>
@@ -342,17 +339,16 @@ function ChatsList({
 }
 
 /**
- * The project's files as a full-height right sidebar — the exact chat-page
- * Files panel: same resizable shell, same tab header, same stacked
- * list-over-preview body.
+ * The project's files as a full-height right sidebar — the same resizable shell
+ * and stacked list-over-preview body as the chat-page Files panel, minus the tab
+ * header: Files is the only view here, and the project name already shows in the
+ * page title, so both are dropped.
  */
 function ProjectFilesSidebar({
   projectId,
-  projectName,
   canManageProject,
 }: {
   projectId: string;
-  projectName: string;
   /** Owner / project-admin — gates editing the pinned instructions. */
   canManageProject: boolean;
 }) {
@@ -414,21 +410,7 @@ function ProjectFilesSidebar({
 
   return (
     <ResizableRightPanel>
-      <Tabs value="files" className="flex-1 min-h-0 flex flex-col gap-0">
-        <div className="flex items-center gap-2 border-b px-2 py-2">
-          <div className="min-w-0 flex-1 overflow-x-auto">
-            <TabsList className="h-8 w-max">
-              <TabsTrigger value="files" className="text-xs px-3">
-                <FileText className="h-3 w-3" />
-                Files
-              </TabsTrigger>
-            </TabsList>
-          </div>
-          <span className="shrink-0 truncate pr-1 text-xs text-muted-foreground">
-            {projectName}
-          </span>
-        </div>
-
+      <div className="flex-1 min-h-0 flex flex-col gap-0">
         <div className="flex-1 min-h-0 overflow-hidden relative">
           <div className="flex h-full flex-col">
             {/* The list fills the panel when nothing is open, is capped above
@@ -508,7 +490,7 @@ function ProjectFilesSidebar({
             ) : null}
           </div>
         </div>
-      </Tabs>
+      </div>
       {deleteDialog}
     </ResizableRightPanel>
   );


### PR DESCRIPTION
## What

Cleans up the right-side **Files** panel on the project detail page (`/projects/[id]`).

Before, the panel header rendered:
- a single-tab strip with one **Files** tab (and a `FileText` icon), and
- the project name on the right.

Both are redundant on this page:
- **Files is the only view** — `ProjectFilesSidebar` hardcoded `<Tabs value="files">` with exactly one `TabsTrigger`, so the tab strip never switched anything.
- **The project name already shows in the page title** (the `hello` heading at the top-left).

## Change

- Remove the header bar entirely (the Files tab + project name).
- Swap the now-purposeless `Tabs` wrapper for a plain `div`.
- Remove the now-unused `projectName` prop (component signature + call site) and the unused `FileText` / `Tabs*` imports.
- Update the component doc comment to explain the header is intentionally dropped.

Only the **project** page is affected — the `/chat` `RightSidePanel`, which has a real multi-tab Files/Browser/Apps strip, is untouched.

## Before / after

The panel now shows just the file list, topped by its own existing `"N files · Select"` toolbar.

## Testing

- `pnpm type-check` — clean
- Biome lint on the changed file — clean
- Verified visually in a local stack: the "Files" label and project name are gone, file list renders correctly and aligns with the page header.

No tests added: presentational removal with no extracted logic to pin (consistent with avoiding render-only component tests).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>