### PR TITLE
docs(readme): swap demo video to new user-attachments URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ OpenTelemetry traces, and Prometheus metrics — first-class, not bolted on.*
 
 <br />
 
-<video src="https://github.com/user-attachments/assets/5d0b5675-95f0-4177-92aa-6f6048c16eaa" controls playsinline width="800"></video>
+<video src="https://github.com/user-attachments/assets/4d85aa84-eff0-4d9b-a13b-3c6dc479852b" controls playsinline width="800"></video>
 
 </div>
 


### PR DESCRIPTION
Replaces the previous demo video src.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>