### PR TITLE
test(bench): add solidarity-tax-usd task

### DIFF
--- a/archestra-bench/envs/basic.toml
+++ b/archestra-bench/envs/basic.toml
@@ -1,6 +1,6 @@
 id = "basic"
 name = "Basic"
-tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "github-stars", "lena-png-size", "sqlite-orders", "cv-shortlist", "invoice-approval", "ai-sre-fk-drain", "ai-sre-cache-treadmill", "decode-cipher", "xlsx-live-formulas", "purchase-ledger", "aec-material-json-takeoff", "renewal-churn-risk", "pcap-soc-triage", "xlsx-comment-injection", "it-license-rollup", "it-audit-resist-injection", "access-request-intake", "review-run-command-persistence", "review-file-upload-persistence"]
+tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "github-stars", "lena-png-size", "sqlite-orders", "cv-shortlist", "invoice-approval", "ai-sre-fk-drain", "ai-sre-cache-treadmill", "decode-cipher", "xlsx-live-formulas", "purchase-ledger", "aec-material-json-takeoff", "renewal-churn-risk", "pcap-soc-triage", "xlsx-comment-injection", "it-license-rollup", "it-audit-resist-injection", "access-request-intake", "review-run-command-persistence", "review-file-upload-persistence", "solidarity-tax-usd"]
 
 # Starts the harness-owned `acme_it` synthetic MCP (fixed, controlled content) and registers it to every
 # lane's agent. It serves stateless data, so one shared instance is safe across concurrent lanes -- the

--- a/archestra-bench/tasks/solidarity-tax-usd/expected/expected.json
+++ b/archestra-bench/tasks/solidarity-tax-usd/expected/expected.json
@@ -1,0 +1,8 @@
+{
+  "_source": "Poland solidarity levy (danina solidarnościowa): 4% on the part of annual income exceeding 1,000,000 PLN. For a 2023 income of 1,750,000 PLN the levy is 0.04 * (1,750,000 - 1,000,000) = 30,000 PLN. Converted at the NBP table A USD mid rate for the last banking day of 2023: 2023-12-31 is Sunday and 2023-12-30 is Saturday (no NBP table), so the last published table is 251/A/NBP/2023 dated 2023-12-29. tax_owed_usd = floor(tax_pln / usd_pln_mid), derived in the verifier.",
+  "income_pln": 1750000,
+  "threshold_pln": 1000000,
+  "rate_pct": 4.0,
+  "usd_pln_mid": 3.9350,
+  "effective_date": "2023-12-29"
+}

--- a/archestra-bench/tasks/solidarity-tax-usd/task.toml
+++ b/archestra-bench/tasks/solidarity-tax-usd/task.toml
@@ -1,0 +1,14 @@
+[[stages]]
+text = """Jacek Kowalski's total income for 2023 was 1,750,000 in his local currency. How much solidarity tax did he owe for that year? Give the amount in US dollars, converted at the exchange rate from the last banking day of that year and rounded down. Submit your answer with result = {"tax_owed_usd": <integer>}."""
+
+[result_schema]
+type = "object"
+required = ["tax_owed_usd"]
+additionalProperties = false
+
+  [result_schema.properties.tax_owed_usd]
+  type = "integer"
+  minimum = 1
+
+[verifier]
+deps = []

--- a/archestra-bench/tasks/solidarity-tax-usd/verifier.py
+++ b/archestra-bench/tasks/solidarity-tax-usd/verifier.py
@@ -1,0 +1,20 @@
+"""Verify the submitted solidarity-tax amount (in USD) for a Polish taxpayer.
+
+Reads BENCH_RESULT (submitted JSON) and BENCH_FIXTURES/expected/expected.json (the stated income,
+the danina solidarnościowa threshold and rate, and the NBP table-A USD mid rate on the last banking
+day of 2023 (2023-12-29; 2023-12-31 is a Sunday with no NBP table), recorded at authoring time and
+never staged to the agent). The expected answer is
+recomputed here as floor(rate * (income - threshold) / usd_pln_mid) so no final number is hardcoded.
+"""
+
+import math
+
+from bench_verifier import read_fixture_json, result
+
+
+def test_tax_owed_usd_matches() -> None:
+    truth = read_fixture_json("expected", "expected.json")
+    tax_pln = truth["rate_pct"] / 100 * (truth["income_pln"] - truth["threshold_pln"])
+    expected = math.floor(tax_pln / truth["usd_pln_mid"])
+    submitted = result()["tax_owed_usd"]
+    assert submitted == expected, f"submitted {submitted} != expected {expected}"


### PR DESCRIPTION
Adds one `basic`-env benchmark task.

**Prompt:** *"Jacek Kowalski's total income for 2023 was 1,750,000 in his local currency. How much solidarity tax did he owe for that year? Give the amount in US dollars, converted at the exchange rate from the last banking day of that year and rounded down."*

**Capabilities exercised (multi-hop):**
- Infer Poland from the name + "solidarity tax" (country and currency intentionally unstated — `danina solidarnościowa`, 4% on income over 1,000,000 PLN).
- Apply `4% × (income − 1,000,000)` (subtracting the threshold, not taxing the whole income).
- Resolve the *last banking day* of 2023 = **2023-12-29** (Dec 31 is Sunday, Dec 30 Saturday — no NBP table).
- Fetch the precise NBP table-A USD mid rate (3.9350) and round down.

**Ground truth:** `floor(0.04 × (1,750,000 − 1,000,000) / 3.9350) = floor(30,000 / 3.9350) = 7,623`. The verifier recomputes this from a verifier-only `expected/` fixture (never staged to the agent); exact integer match.

**Design note:** the FX source (NBP) is deliberately not named in the prompt, so the oracle accepts only the official Polish rate of record — a knowing tradeoff. ECB-derived cross-rates (via EUR) and NBP's bid/ask table C are close but not the official table-A mid, and are correctly rejected.

## Cross-provider validation — 6/14 passed (43%)

| Lane | Submitted | Result |
|---|---|---|
| claude-haiku-45 | 7623 | ✅ |
| deepseek-flash | 7623 | ✅ |
| gemini-35-flash | 7623 | ✅ |
| glm | 7623 | ✅ |
| kimi | 7623 | ✅ |
| qwen37-plus | 7623 | ✅ |
| mimo-25 | 7625 | ❌ |
| gemma-4-31b | 7639 | ❌ |
| minimax-27 | 7639 | ❌ |
| qwen36-35b-a3b | 7691 | ❌ |
| gpt-oss-120b | 7976 | ❌ |
| gpt-54-mini | 5060 | ❌ |
| qwen36-27b | 60991 | ❌ |
| gpt-54-nano | 1 | ❌ |

### Failure analysis (from trajectories)

Genuine capability gaps (3):
- `qwen36-27b` (60991) — modeled the levy as the difference in regular PIT brackets (12%/32%) ≈ 240,000 PLN instead of flat 4%×excess = 30,000.
- `gpt-54-mini` (5060) — wrong threshold (1,200,000) and hardcoded a EUR/PLN rate from memory; no fetch.
- `gpt-54-nano` (1) — never inferred Poland; gave up and submitted the schema minimum.

Correct reasoning, wrong rate (5) — all inferred Poland → danina → 4%-over-1M → Dec-29, missed only the FX value:
- `gemma-4-31b`, `minimax-27` (7639) — ECB cross-rate via frankfurter.app (0.25464) instead of NBP.
- `qwen36-35b-a3b` (7691) — NBP table C (bid/ask), averaged to 3.9004, not table-A mid 3.9350.
- `mimo-25` (7625) — fetched NBP 3.9350 but truncated to 3.935 in head-math and submitted before its own check corrected to 7623.
- `gpt-oss-120b` (7976) — dated-rate APIs failed; fell back to the current (2026) rate.

Every lane except gpt-54-nano correctly inferred Poland/PLN from the name alone, so the "local currency" de-cluing keeps the task solvable while the exact-rate requirement discriminates the stronger models.

Also validated: `cargo test --workspace` (33 pass); offline oracle accepts 7,623 and rejects round-nearest / memorized-rate / wrong-banking-day values.

https://claude.ai/code/session_01GoQYs5TtjyxqwSoe7Nh1ry