### PR TITLE
fix: preserve full chatops message body containing a ">"

### DIFF
--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -764,6 +764,136 @@ describe("ChatOpsManager security validation", () => {
       sendMessageSpy.mockRestore();
     }
   });
+
+  test("delivers the full Slack message body when a link contains a '>'", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const executeSpy = mockA2AExecutor();
+
+    const user = await makeUser({ email: "linker@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "slack",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: agent.id,
+    });
+
+    const slackProvider: ChatOpsProvider = {
+      providerId: "slack",
+      displayName: "Slack",
+      isConfigured: () => true,
+      initialize: async () => {},
+      cleanup: async () => {},
+      validateWebhookRequest: async () => true,
+      handleValidationChallenge: () => null,
+      parseWebhookNotification: async () => null,
+      sendReply: async () => "reply-id",
+      parseInteractivePayload: () => null,
+      sendAgentSelectionCard: async () => {},
+      getThreadHistory: async () => [],
+      getUserEmail: async () => "linker@example.com",
+      getChannelName: async () => "test-channel",
+      getWorkspaceId: () => "test-workspace-id",
+      getWorkspaceName: () => "Test Workspace",
+      hasMissingScopes: () => false,
+      notifyMissingScopes: async () => {},
+      downloadFiles: async () => [],
+      discoverChannels: async () => [],
+      addApprovalRequestForm: async () => {},
+      updateApprovalRequest: async () => {},
+    };
+    const manager = new ChatOpsManager();
+    (manager as unknown as { slackProvider: ChatOpsProvider }).slackProvider =
+      slackProvider;
+
+    // Slack renders a URL as <https://example.com>, which ends in ">", the same
+    // character used for the "AgentName > message" switch. The text before it
+    // is not an agent name, so the whole message must reach the agent.
+    const body =
+      'add "review the PR (<https://example.com/pull/123>)" as a task';
+    const result = await manager.processMessage({
+      message: createMockMessage({ text: body }),
+      provider: slackProvider,
+    });
+
+    expect(result.success).toBe(true);
+    expect(executeSpy).toHaveBeenCalled();
+    // The text before the link and the link itself must arrive contiguously;
+    // the pre-fix code dropped everything up to the link's ">".
+    const delivered = JSON.stringify(executeSpy.mock.calls[0]);
+    expect(delivered).toContain(
+      "review the PR (<https://example.com/pull/123>)",
+    );
+    expect(delivered).toContain("as a task");
+  });
+
+  test("routes a valid 'AgentName > message' switch to the named agent and strips the prefix", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const executeSpy = mockA2AExecutor();
+
+    const user = await makeUser({ email: "switcher@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const defaultAgent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    const namedAgent = await makeInternalAgent({
+      organizationId: org.id,
+      name: "Helper",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(defaultAgent.id, [team.id]);
+    await AgentTeamModel.assignTeamsToAgent(namedAgent.id, [team.id]);
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: defaultAgent.id,
+    });
+
+    const mockProvider = createMockProvider({
+      getUserEmail: async () => "switcher@example.com",
+    });
+    const manager = new ChatOpsManager();
+    (
+      manager as unknown as { msTeamsProvider: ChatOpsProvider }
+    ).msTeamsProvider = mockProvider;
+
+    // When the text before ">" is a real agent name it is a genuine switch, so
+    // the message routes to that agent with the "AgentName >" prefix stripped.
+    const result = await manager.processMessage({
+      message: createMockMessage({ text: "Helper > do the thing" }),
+      provider: mockProvider,
+    });
+
+    expect(result.success).toBe(true);
+    expect(executeSpy).toHaveBeenCalled();
+    const delivered = JSON.stringify(executeSpy.mock.calls[0]);
+    expect(delivered).toContain(namedAgent.id);
+    expect(delivered).toContain("do the thing");
+    expect(delivered).not.toContain("Helper >");
+  });
 });
 
 describe("ChatOpsManager.getAccessibleChatopsAgents", () => {

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -980,10 +980,11 @@ export class ChatOpsManager {
       }
     }
 
-    // No known agent matched - return fallback with the message after delimiter
+    // No agent name matched, so treat the ">" as message content (e.g. a
+    // Slack-formatted link like <https://example.com>) and keep the full text.
     return {
       agentToUse: defaultAgent,
-      cleanedMessageText: messageAfterDelimiter || messageText,
+      cleanedMessageText: messageText,
     };
   }
 


### PR DESCRIPTION
## Problem

A Slack message addressed to a ChatOps agent that contains a link is delivered to
the agent truncated, starting with stray characters like `)"`. Reported in #5104.

## Root cause

ChatOps supports an inline agent switch with the syntax `AgentName > message`.
`resolveInlineAgentMention()` locates the delimiter with `messageText.indexOf(">")`
and treats everything before the first `>` as the target agent name.

Slack renders links in mrkdwn as `<https://example.com>`, which ends in `>`. So:

```
add "review the PR (<https://example.com/pull/123>)" as a task
```

splits at the link's closing `>`. The text before it is not a known agent, but the
no-match fallback still returned the part *after* the delimiter, so the agent
received `)" as a task` instead of the full instruction.

## Fix

In the no-agent-matched branch, return the original message text instead of the
post-delimiter tail. The genuine `AgentName > message` switch (the matched branch)
is unchanged.

```diff
-    cleanedMessageText: messageAfterDelimiter || messageText,
+    cleanedMessageText: messageText,
```

## Tests

- `delivers the full Slack message body when a link contains a ">"`: drives
  `processMessage` through a Slack binding with the message from the issue and
  asserts the whole body reaches the agent. Fails on the pre-fix code (the agent
  receives only `)" as a task`).
- `routes a valid 'AgentName > message' switch to the named agent and strips the
  prefix`: pins the matched branch so the disambiguation can't silently regress.

Fixes #5104
