### PR TITLE
feat: convert chat to scheduled task

### DIFF
--- a/platform/frontend/src/app/_parts/create-schedule-trigger-from-chat-dialog.test.tsx
+++ b/platform/frontend/src/app/_parts/create-schedule-trigger-from-chat-dialog.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CreateScheduleTriggerFromChatDialog } from "./create-schedule-trigger-from-chat-dialog";
+
+vi.mock("@/lib/auth/auth.query", () => ({
+  useHasPermissions: () => ({ data: true }),
+  useSession: () => ({ data: { user: { id: "user-1" } } }),
+}));
+
+vi.mock("@/lib/agent.query", () => ({
+  useProfiles: () => ({
+    data: [{ id: "agent-1", name: "Agent 1", scope: "org" }],
+  }),
+}));
+
+const mockMutateAsync = vi.fn().mockResolvedValue({ id: "schedule-1" });
+vi.mock("@/lib/schedule-trigger.query", () => ({
+  useCreateScheduleTrigger: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/components/agent-selector", () => ({
+  AgentSelector: ({ value, onValueChange }: any) => (
+    <select
+      data-testid="agent-select"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      <option value="agent-1">Agent 1</option>
+    </select>
+  ),
+}));
+
+vi.mock("@/components/ui/cron-expression-picker", () => ({
+  CronExpressionPicker: ({ value, onChange }: any) => (
+    <input
+      data-testid="cron-picker"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+  DEFAULT_CRON_PRESET_OPTIONS: [],
+}));
+
+vi.mock("@/components/ui/timezone-picker", () => ({
+  TimezonePicker: ({ value, onValueChange }: any) => (
+    <input
+      data-testid="timezone-picker"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    />
+  ),
+}));
+
+describe("CreateScheduleTriggerFromChatDialog", () => {
+  const conversation = {
+    id: "conv-1",
+    title: "Test Conversation",
+    agentId: "agent-1",
+    projectId: "project-1",
+    messages: [
+      { id: "m1", role: "user", content: "Hello Agent!" },
+      { id: "m2", role: "assistant", content: "Hi there!" },
+    ],
+  } as any;
+
+  it("pre-fills form state from the conversation and submits", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <CreateScheduleTriggerFromChatDialog
+        conversationId="conv-1"
+        conversation={conversation}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    expect(screen.getByLabelText(/Name/i)).toHaveValue(
+      "Schedule for Test Conversation",
+    );
+    expect(screen.getByLabelText(/Task prompt/i)).toHaveValue("Hello Agent!");
+
+    const nameInput = screen.getByLabelText(/Name/i);
+    fireEvent.change(nameInput, { target: { value: "Custom Schedule Name" } });
+
+    const form = screen
+      .getByRole("button", { name: /Create/i })
+      .closest("form");
+    expect(form).toBeDefined();
+
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        name: "Custom Schedule Name",
+        messageTemplate: "Hello Agent!",
+        cronExpression: "0 9 * * 1-5",
+        timezone: expect.any(String),
+        agentId: "agent-1",
+        projectId: "project-1",
+      });
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/platform/frontend/src/app/_parts/create-schedule-trigger-from-chat-dialog.tsx
+++ b/platform/frontend/src/app/_parts/create-schedule-trigger-from-chat-dialog.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  DEFAULT_FORM_STATE,
+  isValidCronExpression,
+  type ScheduleTriggerFormState,
+} from "@/app/scheduled-tasks/schedule-trigger.utils";
+import { AgentSelector } from "@/components/agent-selector";
+import { StandardFormDialog } from "@/components/standard-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  CronExpressionPicker,
+  DEFAULT_CRON_PRESET_OPTIONS,
+} from "@/components/ui/cron-expression-picker";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { TimezonePicker } from "@/components/ui/timezone-picker";
+import { useProfiles } from "@/lib/agent.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useCreateScheduleTrigger } from "@/lib/schedule-trigger.query";
+import type { archestraApiTypes } from "@archestra/shared";
+
+type Conversation = archestraApiTypes.GetChatConversationResponses["200"];
+
+export function CreateScheduleTriggerFromChatDialog({
+  conversationId,
+  conversation,
+  open,
+  onOpenChange,
+}: {
+  conversationId: string | null;
+  conversation: Conversation | null | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data: canReadAgents } = useHasPermissions({ agent: ["read"] });
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
+  const { data: agents = [] } = useProfiles({
+    filters: { agentType: "agent" },
+    enabled: canReadAgents === true,
+  });
+  const createSchedule = useCreateScheduleTrigger();
+
+  const selectableAgents = useMemo(
+    () =>
+      agents.filter(
+        (agent) =>
+          agent.scope !== "personal" || agent.authorId === currentUserId,
+      ),
+    [agents, currentUserId],
+  );
+
+  const lastUserMessage = useMemo(() => {
+    return [...((conversation?.messages as any) ?? [])]
+      .reverse()
+      .find((m: any) => m.role === "user");
+  }, [conversation]);
+
+  const defaultMessageTemplate = (lastUserMessage as any)?.content || "";
+  const defaultName = conversation?.title
+    ? `Schedule for ${conversation.title}`
+    : "New schedule";
+  const defaultAgentId =
+    conversation?.agentId || conversation?.agent?.id || "";
+
+  const [form, setForm] = useState<ScheduleTriggerFormState>(DEFAULT_FORM_STATE);
+
+  useEffect(() => {
+    if (open) {
+      setForm({
+        name: defaultName,
+        agentId: defaultAgentId,
+        cronExpression: "0 9 * * 1-5",
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+        messageTemplate: defaultMessageTemplate,
+      });
+    }
+  }, [open, defaultName, defaultAgentId, defaultMessageTemplate]);
+
+  const update = (patch: Partial<ScheduleTriggerFormState>) =>
+    setForm((current) => ({ ...current, ...patch }));
+
+  const isValid =
+    form.name.trim().length > 0 &&
+    form.messageTemplate.trim().length > 0 &&
+    isValidCronExpression(form.cronExpression) &&
+    (canReadAgents !== true || form.agentId.length > 0);
+  const isPending = createSchedule.isPending;
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isValid || !conversationId) return;
+
+    const agentFields =
+      canReadAgents === true && form.agentId ? { agentId: form.agentId } : {};
+    const fields = {
+      name: form.name.trim(),
+      messageTemplate: form.messageTemplate.trim(),
+      cronExpression: form.cronExpression.trim(),
+      timezone: form.timezone.trim(),
+      ...agentFields,
+    };
+
+    const result = await createSchedule.mutateAsync({
+      ...fields,
+      projectId: conversation?.projectId || undefined,
+    });
+    if (result) {
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <StandardFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Convert to scheduled task"
+      description="Run an agent on a recurring schedule. Each run starts a chat in this project/workspace."
+      size="medium"
+      onSubmit={onSubmit}
+      bodyClassName="space-y-3"
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isPending || !isValid}>
+            Create
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="schedule-name">Name</Label>
+        <Input
+          id="schedule-name"
+          value={form.name}
+          onChange={(e) => update({ name: e.target.value })}
+          placeholder="Weekly summary"
+          maxLength={256}
+        />
+      </div>
+
+      {canReadAgents === true && (
+        <div className="space-y-1.5">
+          <Label>Agent</Label>
+          <AgentSelector
+            mode="single"
+            flat
+            agents={selectableAgents}
+            value={form.agentId}
+            onValueChange={(value) => update({ agentId: value })}
+            placeholder="Select an agent"
+            className="w-full"
+          />
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <Label htmlFor="schedule-prompt">Task prompt</Label>
+        <Textarea
+          id="schedule-prompt"
+          value={form.messageTemplate}
+          onChange={(e) => update({ messageTemplate: e.target.value })}
+          placeholder="What should the agent do on each run?"
+          rows={6}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>Schedule</Label>
+        <CronExpressionPicker
+          value={form.cronExpression}
+          onChange={(value) => update({ cronExpression: value })}
+          presets={DEFAULT_CRON_PRESET_OPTIONS}
+          className="w-full"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>Timezone</Label>
+        <TimezonePicker
+          value={form.timezone}
+          onValueChange={(value) => update({ timezone: value })}
+          className="w-full"
+        />
+      </div>
+    </StandardFormDialog>
+  );
+}

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -22,6 +22,7 @@ import {
   useState,
 } from "react";
 import { CreateProjectFromChatDialog } from "@/app/_parts/create-project-from-chat-dialog";
+import { CreateScheduleTriggerFromChatDialog } from "@/app/_parts/create-schedule-trigger-from-chat-dialog";
 import { scheduledRunContext } from "@/app/_parts/scheduled-run-sidebar.utils";
 import { CustomServerRequestDialog } from "@/app/mcp/registry/_parts/custom-server-request-dialog";
 import { AgentDialog } from "@/components/agent-dialog";
@@ -219,6 +220,7 @@ export function ChatPageContent({
 
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
+  const [isCreateScheduleTriggerOpen, setIsCreateScheduleTriggerOpen] = useState(false);
   const [isForkDialogOpen, setIsForkDialogOpen] = useState(false);
   const [forkAgentId, setForkAgentId] = useState<string | null>(null);
   const [manualCompactionFeedback, setManualCompactionFeedback] = useState<{
@@ -266,6 +268,9 @@ export function ChatPageContent({
     });
   const { data: canCreateProjectPerm } = useHasPermissions({
     project: ["create"],
+  });
+  const { data: canCreateScheduleTask } = useHasPermissions({
+    scheduledTask: ["create"],
   });
   const projectsEnabled = useFeature("projectsEnabled") === true;
   const { data: teams } = useTeams({ enabled: !!canReadTeams });
@@ -417,6 +422,11 @@ export function ChatPageContent({
       hasCreatePermission: canCreateProjectPerm === true,
       conversation,
     });
+  const canScheduleTaskFromThisChat =
+    !!conversationId &&
+    !!conversation &&
+    canCreateScheduleTask === true &&
+    conversation.agent?.agentType === "agent";
   const isShared = !!conversation?.share;
   const isReadOnlyConversation =
     !!conversationId &&
@@ -1921,9 +1931,11 @@ export function ChatPageContent({
               canManageShare={canManageShare}
               isShared={isShared}
               canCreateProject={canCreateProjectFromThisChat}
+              canScheduleTask={canScheduleTaskFromThisChat}
               onShare={() => setIsShareDialogOpen(true)}
               onExportMarkdown={handleExportMarkdown}
               onCreateProject={() => setIsCreateProjectOpen(true)}
+              onScheduleTask={() => setIsCreateScheduleTriggerOpen(true)}
               panel={{
                 isOpen: isRightPanelOpen,
                 isArtifactOpen,
@@ -2338,6 +2350,13 @@ export function ChatPageContent({
           }
           open={isCreateProjectOpen}
           onOpenChange={setIsCreateProjectOpen}
+        />
+
+        <CreateScheduleTriggerFromChatDialog
+          conversationId={conversationId ?? null}
+          conversation={conversation}
+          open={isCreateScheduleTriggerOpen}
+          onOpenChange={setIsCreateScheduleTriggerOpen}
         />
 
         <StandardDialog

--- a/platform/frontend/src/components/chat/conversation-header.tsx
+++ b/platform/frontend/src/components/chat/conversation-header.tsx
@@ -2,6 +2,7 @@
 
 import type { archestraApiTypes } from "@archestra/shared";
 import {
+  CalendarClock,
   Download,
   FileText,
   FolderPlus,
@@ -49,9 +50,11 @@ interface ConversationHeaderProps {
   isShared: boolean;
   /** Whether this chat is eligible to be turned into a project. */
   canCreateProject: boolean;
+  canScheduleTask: boolean;
   onShare: () => void;
   onExportMarkdown: () => void;
   onCreateProject: () => void;
+  onScheduleTask: () => void;
   panel: PanelControls;
 }
 
@@ -63,19 +66,23 @@ export function ConversationHeader({
   canManageShare,
   isShared,
   canCreateProject,
+  canScheduleTask,
   onShare,
   onExportMarkdown,
   onCreateProject,
+  onScheduleTask,
   panel,
 }: ConversationHeaderProps) {
   const actionsProps = {
     canManageShare,
     isShared,
     canCreateProject,
+    canScheduleTask,
     messageCount,
     onShare,
     onExportMarkdown,
     onCreateProject,
+    onScheduleTask,
   };
 
   return (
@@ -214,18 +221,22 @@ function ChatActionItems({
   canManageShare,
   isShared,
   canCreateProject,
+  canScheduleTask,
   messageCount,
   onShare,
   onExportMarkdown,
   onCreateProject,
+  onScheduleTask,
 }: {
   canManageShare: boolean;
   isShared: boolean;
   canCreateProject: boolean;
+  canScheduleTask: boolean;
   messageCount: number;
   onShare: () => void;
   onExportMarkdown: () => void;
   onCreateProject: () => void;
+  onScheduleTask: () => void;
 }) {
   return (
     <>
@@ -248,6 +259,12 @@ function ChatActionItems({
         <DropdownMenuItem onSelect={onCreateProject}>
           <FolderPlus className="h-4 w-4" />
           Create project
+        </DropdownMenuItem>
+      )}
+      {canScheduleTask && (
+        <DropdownMenuItem onSelect={onScheduleTask}>
+          <CalendarClock className="h-4 w-4" />
+          Schedule task
         </DropdownMenuItem>
       )}
       {messageCount > 0 && (


### PR DESCRIPTION
This PR adds a button in the chat conversation header actions to convert the current chat into a scheduled task/cron job. Prefills the scheduled task name with the chat title, selected agent, project scope if any, and last user prompt as the task template.