### PR TITLE
fix(projects): carry attachments into a chat started from a project

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -117,6 +117,10 @@ import {
 import { downloadConversationMarkdown } from "@/lib/chat/export-markdown";
 import { useChatSession, useGlobalChat } from "@/lib/chat/global-chat.context";
 import {
+  drainPendingChatHandoffFiles,
+  hasPendingChatHandoffFiles,
+} from "@/lib/chat/pending-chat-handoff-files";
+import {
   applyPendingActions,
   clearPendingActions,
   getPendingActions,
@@ -1694,8 +1698,16 @@ export function ChatPageContent({
 
   // Auto-send message from URL when conditions are met (deep link support)
   useEffect(() => {
-    // Skip if already triggered or no user_prompt in URL
-    if (autoSendTriggeredRef.current || !initialUserPrompt) return;
+    if (autoSendTriggeredRef.current) return;
+
+    // A handoff that stashed attachments stamps `attachments=1` and may carry no
+    // prompt (files-only), so it triggers the send too — but only when the files
+    // are actually still in memory, else a reloaded handoff URL (store cleared)
+    // would create an empty conversation.
+    const handoffHasAttachments = searchParams.get("attachments") === "1";
+    const handoffFilesReady =
+      handoffHasAttachments && hasPendingChatHandoffFiles();
+    if (!initialUserPrompt && !handoffFilesReady) return;
 
     // Skip if conversation already exists
     if (conversationId) return;
@@ -1713,8 +1725,13 @@ export function ChatPageContent({
       searchParams,
     });
 
-    // Store the message to send after conversation is created
+    // Store the message to send after conversation is created. Draining is
+    // gated on the URL marker so the shared auto-send path never pulls stashed
+    // files into an unrelated handoff (app / SSO / a2a / deep link).
     pendingPromptRef.current = initialUserPrompt;
+    pendingFilesRef.current = handoffHasAttachments
+      ? drainPendingChatHandoffFiles()
+      : [];
 
     createInitialConversation((newConversation) => {
       // the init effect on the /chat/<id> mount reads this preference and
@@ -2396,6 +2413,9 @@ function clearUserPromptQueryParam(params: {
 }) {
   const nextSearchParams = new URLSearchParams(params.searchParams.toString());
   nextSearchParams.delete("user_prompt");
+  // The attachments marker is one-shot too: drop it once consumed so a remount
+  // can't re-trigger a drain (which would now find an empty store).
+  nextSearchParams.delete("attachments");
   const nextUrl = nextSearchParams.toString()
     ? `${params.pathname}?${nextSearchParams.toString()}`
     : params.pathname;

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -673,8 +673,9 @@ describe("ArchestraPromptInput", () => {
       localStorage.setItem(draftKey, text);
       mockControllerState.value = text;
 
-      // Mirrors NewChatComposer rejecting a submit (e.g. attachment toast) by
-      // throwing synchronously after the user confirms "Send anyway".
+      // Mirrors a consumer rejecting a submit by throwing synchronously after
+      // the user confirms "Send anyway" (e.g. the main composer's
+      // "stop-not-submit" throw that keeps a half-typed follow-up).
       const onSubmit = vi.fn(() => {
         throw new Error("rejected");
       });

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -240,9 +240,14 @@ function ProjectChatInput({ projectId }: { projectId: string }) {
 
   return (
     <NewChatComposer
-      onSubmitPrompt={(text, agentId) =>
+      onSubmitPrompt={(text, agentId, hasAttachments) =>
         router.push(
-          buildProjectChatHandoffUrl({ projectId, prompt: text, agentId }),
+          buildProjectChatHandoffUrl({
+            projectId,
+            prompt: text,
+            agentId,
+            hasAttachments,
+          }),
         )
       }
     />

--- a/platform/frontend/src/components/chat/new-chat-composer.tsx
+++ b/platform/frontend/src/components/chat/new-chat-composer.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
-import { toast } from "sonner";
 import ArchestraPromptInput from "@/app/chat/prompt-input";
 import { useDefaultAgentId, useInternalAgents } from "@/lib/agent.query";
 import { useMemberDefaultModel } from "@/lib/chat/chat.query";
+import { setPendingChatHandoffFiles } from "@/lib/chat/pending-chat-handoff-files";
 import { useInitialChatModelState } from "@/lib/chat/use-initial-chat-model-state.hook";
 import { useLlmModels, useLlmModelsByProvider } from "@/lib/llm-models.query";
 import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
@@ -27,7 +27,11 @@ import { useOrganization } from "@/lib/organization.query";
 export function NewChatComposer({
   onSubmitPrompt,
 }: {
-  onSubmitPrompt: (text: string, agentId: string) => void;
+  onSubmitPrompt: (
+    text: string,
+    agentId: string,
+    hasAttachments: boolean,
+  ) => void;
 }) {
   const { data: internalAgents = [] } = useInternalAgents();
   const { data: defaultAgentId } = useDefaultAgentId();
@@ -76,16 +80,17 @@ export function NewChatComposer({
     <div className="w-full">
       <ArchestraPromptInput
         onSubmit={(message) => {
-          const text = message.text?.trim();
-          if (!text) return;
-          if (message.files && message.files.length > 0) {
-            toast.warning(
-              "Attachments can't be carried into the new chat yet — add them once the chat opens.",
-            );
-            // Reject the submit so the typed prompt (and its saved draft) survive.
-            throw new Error("attachments-not-supported");
-          }
-          onSubmitPrompt(text, agentId);
+          const text = message.text?.trim() ?? "";
+          const files = message.files ?? [];
+          // Nothing to start a chat with.
+          if (!text && files.length === 0) return;
+          // Data URLs are too large for the handoff URL, so stash the
+          // attachments in memory; `/chat` drains them into the first message
+          // (gated on the `attachments=1` marker the handoff URL carries).
+          // Always set — an empty array clears any abandoned prior set so a
+          // text-only handoff never inherits stale files.
+          setPendingChatHandoffFiles(files);
+          onSubmitPrompt(text, agentId, files.length > 0);
         }}
         status="ready"
         selectedModel={modelId}

--- a/platform/frontend/src/lib/chat/pending-chat-handoff-files.test.ts
+++ b/platform/frontend/src/lib/chat/pending-chat-handoff-files.test.ts
@@ -1,0 +1,56 @@
+import type { FileUIPart } from "ai";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  drainPendingChatHandoffFiles,
+  hasPendingChatHandoffFiles,
+  setPendingChatHandoffFiles,
+} from "./pending-chat-handoff-files";
+
+const file = (name: string): FileUIPart => ({
+  type: "file",
+  url: `data:text/plain;base64,${btoa(name)}`,
+  mediaType: "text/plain",
+  filename: name,
+});
+
+describe("pending-chat-handoff-files", () => {
+  // Module-level singleton: reset between tests so leakage shows up as a
+  // failure rather than carrying across cases.
+  beforeEach(() => {
+    drainPendingChatHandoffFiles();
+  });
+
+  it("starts empty", () => {
+    expect(hasPendingChatHandoffFiles()).toBe(false);
+    expect(drainPendingChatHandoffFiles()).toEqual([]);
+  });
+
+  it("drains the stashed files exactly once", () => {
+    const files = [file("a.txt"), file("b.txt")];
+    setPendingChatHandoffFiles(files);
+
+    expect(hasPendingChatHandoffFiles()).toBe(true);
+    expect(drainPendingChatHandoffFiles()).toEqual(files);
+
+    // Consumed: a second drain yields nothing, so a remount can't re-send.
+    expect(hasPendingChatHandoffFiles()).toBe(false);
+    expect(drainPendingChatHandoffFiles()).toEqual([]);
+  });
+
+  it("replaces the set wholesale so a later handoff can't inherit stale files", () => {
+    setPendingChatHandoffFiles([file("old.txt")]);
+    // A text-only handoff stashes an empty array, which must clear the prior set.
+    setPendingChatHandoffFiles([]);
+
+    expect(hasPendingChatHandoffFiles()).toBe(false);
+    expect(drainPendingChatHandoffFiles()).toEqual([]);
+  });
+
+  it("a peek does not consume", () => {
+    setPendingChatHandoffFiles([file("a.txt")]);
+
+    expect(hasPendingChatHandoffFiles()).toBe(true);
+    expect(hasPendingChatHandoffFiles()).toBe(true);
+    expect(drainPendingChatHandoffFiles()).toHaveLength(1);
+  });
+});

--- a/platform/frontend/src/lib/chat/pending-chat-handoff-files.ts
+++ b/platform/frontend/src/lib/chat/pending-chat-handoff-files.ts
@@ -1,0 +1,36 @@
+import type { FileUIPart } from "ai";
+
+/**
+ * In-memory carrier for chat attachments handed off from a surface that starts
+ * a chat elsewhere — e.g. the project page composer handing off to `/chat`.
+ *
+ * The files are already self-contained data URLs, but an attachment can be tens
+ * of MB, far past what a URL or `sessionStorage` (~5 MB quota) can hold. A
+ * module-level singleton survives the client-side handoff navigation (and the
+ * follow-up navigation to `/chat/<id>`) without a storage quota; a hard reload
+ * starts empty, which is acceptable for a one-shot handoff.
+ *
+ * Every handoff replaces the set wholesale, so an attachment-free handoff can
+ * never inherit a stale set left behind by an abandoned one. Draining is bound
+ * to the `attachments=1` handoff URL marker on the `/chat` side so the shared
+ * auto-send path never pulls these files into an unrelated handoff.
+ */
+
+let pendingFiles: FileUIPart[] = [];
+
+/** Stash the attachments for the next chat handoff, replacing any prior set. */
+export function setPendingChatHandoffFiles(files: FileUIPart[]): void {
+  pendingFiles = files;
+}
+
+/** Whether attachments are waiting — a peek that does not consume them. */
+export function hasPendingChatHandoffFiles(): boolean {
+  return pendingFiles.length > 0;
+}
+
+/** Return the stashed attachments and clear the store. */
+export function drainPendingChatHandoffFiles(): FileUIPart[] {
+  const files = pendingFiles;
+  pendingFiles = [];
+  return files;
+}

--- a/platform/frontend/src/lib/projects/project-chat-handoff.test.ts
+++ b/platform/frontend/src/lib/projects/project-chat-handoff.test.ts
@@ -38,4 +38,41 @@ describe("buildProjectChatHandoffUrl", () => {
 
     expect(url.startsWith("/chat?")).toBe(true);
   });
+
+  it("stamps the attachments marker only when files were stashed", () => {
+    const without = new URLSearchParams(
+      buildProjectChatHandoffUrl({
+        projectId: "proj-1",
+        prompt: "hi",
+        agentId: "agent-42",
+      }).split("?")[1],
+    );
+    expect(without.get("attachments")).toBeNull();
+
+    const withFiles = new URLSearchParams(
+      buildProjectChatHandoffUrl({
+        projectId: "proj-1",
+        prompt: "hi",
+        agentId: "agent-42",
+        hasAttachments: true,
+      }).split("?")[1],
+    );
+    expect(withFiles.get("attachments")).toBe("1");
+  });
+
+  it("omits the empty prompt param for a files-only handoff", () => {
+    // No caption: the attachments marker is what triggers the send on /chat, so
+    // an empty user_prompt would just be noise (and reads as falsy there).
+    const params = new URLSearchParams(
+      buildProjectChatHandoffUrl({
+        projectId: "proj-1",
+        prompt: "",
+        agentId: "agent-42",
+        hasAttachments: true,
+      }).split("?")[1],
+    );
+    expect(params.has("user_prompt")).toBe(false);
+    expect(params.get("attachments")).toBe("1");
+    expect(params.get("agentId")).toBe("agent-42");
+  });
 });

--- a/platform/frontend/src/lib/projects/project-chat-handoff.ts
+++ b/platform/frontend/src/lib/projects/project-chat-handoff.ts
@@ -6,16 +6,29 @@
  * priority in the chat agent-resolution chain, ahead of the org default agent
  * and the permission-gated saved pick that would otherwise override it — so
  * relying on the saved-agent store alone did not reliably respect the choice.
+ *
+ * `hasAttachments` stamps an `attachments=1` marker when the composer stashed
+ * files for this handoff (see `pending-chat-handoff-files`). `/chat` only drains
+ * those stashed files when the marker is present, which both binds them to this
+ * specific handoff (the auto-send path is shared by every handoff type) and
+ * triggers the send for a files-only handoff that carries no prompt.
  */
 export function buildProjectChatHandoffUrl(params: {
   projectId: string;
   prompt: string;
   agentId: string;
+  hasAttachments?: boolean;
 }): string {
   const search = new URLSearchParams({
     project: params.projectId,
-    user_prompt: params.prompt,
     agentId: params.agentId,
   });
+  // A files-only handoff carries no prompt; omit the empty param.
+  if (params.prompt) {
+    search.set("user_prompt", params.prompt);
+  }
+  if (params.hasAttachments) {
+    search.set("attachments", "1");
+  }
   return `/chat?${search.toString()}`;
 }


### PR DESCRIPTION
## Problem

Starting a chat from a project hands off to `/chat` through a **URL** (`buildProjectChatHandoffUrl` → `/chat?project=…&user_prompt=…&agentId=…`); the message is then auto-sent on the `/chat` side from those params. Attachments arrive as self-contained **data URLs** (up to 50 MB) that can't ride a URL, so the project composer rejected any attachment with:

> Attachments can't be carried into the new chat yet — add them once the chat opens.

This was a stubbed "not implemented yet," not a malfunction.

## Fix

Carry the files in a **module-level singleton** (`pending-chat-handoff-files.ts`, the same pattern as the existing `app-diagnostics-store`) that survives the client-side handoff navigation and the follow-up remount onto `/chat/<id>` without a storage quota (`sessionStorage`'s ~5 MB quota can't hold a 50 MB attachment). The chat page's existing **deferred-send** path already builds file parts from `pendingFilesRef`, so the drained files are simply placed there — no new send code.

### Key correctness detail
The `/chat` auto-send effect is **shared by every handoff type** (project, app, SSO, a2a, `/chat/new`). Draining a global store there unconditionally would leak stale files into an unrelated handoff chat. So draining is gated on an **`attachments=1` URL marker** that only the project-with-attachments handoff stamps. This:
- binds the stashed files to that specific handoff, and
- triggers the send for a **files-only** (no caption) handoff, which previously no-op'd silently.

`set` replaces the store wholesale and the marker is one-shot (cleared once consumed), so a stale set can't leak into a later attachment-free handoff or a remount.

## Tests
- New unit tests for the store (drain-once, replace-wholesale, peek-doesn't-consume).
- New handoff-URL-builder tests (marker present/absent, empty-prompt omission for files-only).
- Updated a stale comment in `prompt-input.test.tsx` that referenced the removed reject behavior.

No e2e or render-based component tests added (per repo testing preferences); the carry-and-clear contract is pinned at the store level.

## Verification
`type-check`, `lint`/biome, `knip`, and the affected unit tests (33 passing) all green. Codex review found no behavior-breaking issues.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>