### PR TITLE
feat(files): label file scope and rework Files panel chrome

### DIFF
--- a/platform/frontend/src/components/chat/conversation-files-panel.tsx
+++ b/platform/frontend/src/components/chat/conversation-files-panel.tsx
@@ -28,8 +28,10 @@ import {
   useDeleteConversationFile,
 } from "@/lib/chat/chat.query";
 import {
+  ATTACHMENTS_SECTION,
   assembleFileSections,
   type ConversationFileItem,
+  persistentFilesSection,
 } from "@/lib/chat/conversation-files";
 import { printMarkdownElementAsPdf } from "@/lib/chat/print-markdown";
 import { useFileDeletion } from "@/lib/chat/use-file-deletion";
@@ -76,8 +78,10 @@ export function ConversationFilesPanel({
   );
   const [expanded, setExpanded] = useState(false);
 
-  // This chat's own outputs and the project's files are one group ("Results");
-  // only attachments stand apart.
+  // This chat's own outputs and the project's files are one persistent group —
+  // labeled "Project files" in a project chat, "Chat files" otherwise. Uploaded
+  // attachments stand apart, since they're transient inputs rather than saved
+  // work products.
   const results = [...generated, ...projectFiles];
   const all = [...results, ...attachments];
   const selected = all.find((f) => f.id === selectedId) ?? null;
@@ -259,8 +263,8 @@ export function ConversationFilesPanel({
       >
         <SelectableFileList<ConversationFileItem>
           sections={[
-            { title: "Results", items: results },
-            { title: "Attachments", items: attachments },
+            { ...persistentFilesSection(projectId), items: results },
+            { ...ATTACHMENTS_SECTION, items: attachments },
           ]}
           canManage={canManageFiles}
           selectedId={selectedId}

--- a/platform/frontend/src/components/chat/file-list-section.tsx
+++ b/platform/frontend/src/components/chat/file-list-section.tsx
@@ -36,12 +36,13 @@ export type FileListItem = {
 /**
  * The chat Files panel's list section, shared so every files surface (chat
  * sidebar, project pages) renders identically: icon per file type, row click
- * selects/previews, trailing download link. The title header is shown only when
- * a `title` is given — callers omit it when the panel holds a single group, so
- * a lone set of files needs no header to tell it apart.
+ * selects/previews, trailing download link. The title header (and its optional
+ * `description` subtitle) is shown only when a `title` is given — the project
+ * page passes a single untitled group, so its lone list needs no header.
  */
 export function FileSection({
   title,
+  description,
   items,
   selectedId,
   onSelect,
@@ -50,6 +51,8 @@ export function FileSection({
   selection,
 }: {
   title?: string;
+  /** A secondary line under the title (e.g. the group's persistence scope). */
+  description?: string;
   items: FileListItem[];
   selectedId: string | null;
   onSelect: (id: string) => void;
@@ -75,13 +78,19 @@ export function FileSection({
   if (items.length === 0 && !leading) return null;
   const selecting = selection != null;
   return (
-    <div className="mb-4">
+    <div className="mb-5">
       {title && (
-        <p className="mb-1 px-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-          {title}
-        </p>
+        // One quiet line — the group name, then its persistence scope after a
+        // middot — echoing the inline "name · description" of the pinned
+        // instructions row below it.
+        <div className="mb-1.5 flex items-baseline gap-1 px-1 text-[11px] leading-none">
+          <span className="font-medium text-muted-foreground">{title}</span>
+          {description && (
+            <span className="text-muted-foreground/60">· {description}</span>
+          )}
+        </div>
       )}
-      <div className="overflow-hidden rounded-md border">
+      <div className="overflow-hidden rounded-lg border border-border/60">
         {leading}
         {items.map((item, i) => {
           const customActions = renderActions?.(item) ?? null;

--- a/platform/frontend/src/components/chat/selectable-file-list.tsx
+++ b/platform/frontend/src/components/chat/selectable-file-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, MoreHorizontal, Trash2 } from "lucide-react";
+import { Download, ListChecks, MoreHorizontal, Trash2 } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import {
   type FileListItem,
@@ -21,11 +21,13 @@ import {
   selectionCheckState,
   toggleSelectedId,
 } from "@/lib/chat/file-selection";
+import { cn } from "@/lib/utils";
 
 /**
- * The list-view body shared by the chat and project Files panels: a "Select"
- * toggle, row checkboxes + "Select all", a bottom Download/Delete bar, and a
- * per-row "⋯" menu. The list/detail navigation and the delete confirm live in
+ * The list-view body shared by the chat and project Files panels. Multi-select
+ * is entered from a file's "⋯" menu ("Select", which also pre-checks that row);
+ * doing so reveals a "Select all"/Cancel bar at the top and a Download/Delete
+ * bar at the bottom. The list/detail navigation and the delete confirm live in
  * the caller; this component reports opens via `onOpen` and delete requests via
  * `onRequestDelete`.
  *
@@ -43,7 +45,7 @@ export function SelectableFileList<T extends FileListItem>({
   onRequestDelete,
   renderItemActions,
 }: {
-  sections: { title?: string; items: T[] }[];
+  sections: { title?: string; description?: string; items: T[] }[];
   leading?: ReactNode;
   canManage: boolean;
   /** The open file's id, highlighted in the list while it previews beside it. */
@@ -81,6 +83,12 @@ export function SelectableFileList<T extends FileListItem>({
     setSelectionMode(false);
     setSelectedIds(new Set());
   };
+  // Entering selection from a row's "⋯" menu pre-checks that row, so the action
+  // that started the selection isn't lost.
+  const enterSelectionWith = (id: string) => {
+    setSelectionMode(true);
+    setSelectedIds(new Set([id]));
+  };
   const selection = selectionMode
     ? {
         selectedIds,
@@ -96,79 +104,71 @@ export function SelectableFileList<T extends FileListItem>({
       else setSelectedIds(new Set(failedIds));
     });
 
-  // Headers only earn their place when more than one non-empty group shows.
-  const showHeaders = sections.filter((s) => s.items.length > 0).length > 1;
-
   const renderActions = (item: FileListItem): ReactNode => {
     const custom = renderItemActions?.(item as T);
     if (custom != null) return custom;
     if (!canManage || !isManageable(item)) return null;
     return (
-      <FileRowMenu item={item} onDelete={() => onRequestDelete([item as T])} />
+      <FileRowMenu
+        item={item}
+        onSelect={() => enterSelectionWith(item.id)}
+        onDelete={() => onRequestDelete([item as T])}
+      />
     );
   };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex shrink-0 items-center justify-between gap-2 px-3 pt-3 pb-2">
-        {selectionMode ? (
-          <>
-            <label
-              htmlFor="files-select-all"
-              className="flex items-center gap-2 text-xs text-muted-foreground"
-            >
-              <Checkbox
-                id="files-select-all"
-                checked={
-                  allChecked ? true : someChecked ? "indeterminate" : false
-                }
-                onCheckedChange={() =>
-                  setSelectedIds(
-                    selectAllIds(
-                      allChecked,
-                      managed.map((f) => f.id),
-                    ),
-                  )
-                }
-                aria-label="Select all files"
-              />
-              Select all
-            </label>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-xs"
-              onClick={exitSelection}
-            >
-              Cancel
-            </Button>
-          </>
-        ) : (
-          <>
-            <span className="text-xs text-muted-foreground">
-              {managedCount} {managedCount === 1 ? "file" : "files"}
-            </span>
-            {canManage && managedCount > 0 && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 px-2 text-xs"
-                onClick={() => setSelectionMode(true)}
-              >
-                Select
-              </Button>
-            )}
-          </>
-        )}
-      </div>
+      {/* No idle toolbar — the list fills the panel and multi-select is entered
+          from a row's "⋯" menu. The "Select all"/Cancel bar appears only while
+          selecting, so nothing floats in an otherwise-empty band. */}
+      {selectionMode && (
+        <div className="flex shrink-0 items-center justify-between gap-2 px-3 pt-3 pb-2">
+          <label
+            htmlFor="files-select-all"
+            className="flex items-center gap-2 text-xs text-muted-foreground"
+          >
+            <Checkbox
+              id="files-select-all"
+              checked={
+                allChecked ? true : someChecked ? "indeterminate" : false
+              }
+              onCheckedChange={() =>
+                setSelectedIds(
+                  selectAllIds(
+                    allChecked,
+                    managed.map((f) => f.id),
+                  ),
+                )
+              }
+              aria-label="Select all files"
+            />
+            Select all
+          </label>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={exitSelection}
+          >
+            Cancel
+          </Button>
+        </div>
+      )}
 
       {/* The open file's row stays highlighted while it previews beside the
           list (split view); harmless when expanded (list hidden) or idle. */}
-      <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+      <div
+        className={cn(
+          "min-h-0 flex-1 overflow-y-auto px-3 pb-3",
+          !selectionMode && "pt-3",
+        )}
+      >
         {sections.map((section, i) => (
           <FileSection
             key={section.title ?? `section-${i}`}
-            title={showHeaders ? section.title : undefined}
+            title={section.title}
+            description={section.description}
             items={section.items}
             selectedId={selectedId ?? null}
             onSelect={onOpen}
@@ -219,12 +219,18 @@ function isManageable(item: FileListItem): boolean {
   return item.contentUrl !== "";
 }
 
-/** A "⋯" menu of single-file actions (Download + Delete) for a managed file. */
+/**
+ * A "⋯" menu of single-file actions for a managed file: Download, Select (enter
+ * multi-select), and Delete. "Select" is the entry point into selection mode,
+ * since the panel has no standing toolbar.
+ */
 function FileRowMenu({
   item,
+  onSelect,
   onDelete,
 }: {
   item: FileListItem;
+  onSelect: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -248,6 +254,15 @@ function FileRowMenu({
             </a>
           </DropdownMenuItem>
         )}
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault();
+            onSelect();
+          }}
+        >
+          <ListChecks className="h-4 w-4" />
+          Select
+        </DropdownMenuItem>
         <DropdownMenuItem
           className="text-destructive focus:text-destructive"
           onSelect={(e) => {

--- a/platform/frontend/src/lib/chat/conversation-files.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.test.ts
@@ -3,6 +3,7 @@ import {
   assembleFileSections,
   type ConversationFileItem,
   deleteTargetFor,
+  persistentFilesSection,
 } from "@/lib/chat/conversation-files";
 
 function fileItem(
@@ -112,6 +113,26 @@ describe("assembleFileSections", () => {
         source: "project",
       },
     ]);
+  });
+});
+
+describe("persistentFilesSection", () => {
+  it("labels a project chat's persistent files as shared with the project", () => {
+    expect(persistentFilesSection("proj_1")).toEqual({
+      title: "Project files",
+      description: "Shared with the project",
+    });
+  });
+
+  it("labels a personal chat's persistent files as chat-scoped", () => {
+    expect(persistentFilesSection(null)).toEqual({
+      title: "Chat files",
+      description: "Created in this chat",
+    });
+    expect(persistentFilesSection(undefined)).toEqual({
+      title: "Chat files",
+      description: "Created in this chat",
+    });
   });
 });
 

--- a/platform/frontend/src/lib/chat/conversation-files.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.ts
@@ -77,6 +77,28 @@ export function assembleFileSections(params: {
 }
 
 /**
+ * Header label + persistence-scope subtitle for the chat panel's group of
+ * persistent files (this chat's saved outputs, plus the project's shared files
+ * in a project chat). A project chat's files live with the project and are seen
+ * by everyone with access; a personal chat's files stay with the conversation.
+ * Attachments are labeled separately — see {@link ATTACHMENTS_SECTION}.
+ */
+export function persistentFilesSection(projectId: string | null | undefined): {
+  title: string;
+  description: string;
+} {
+  return projectId != null
+    ? { title: "Project files", description: "Shared with the project" }
+    : { title: "Chat files", description: "Created in this chat" };
+}
+
+/** Header label + subtitle for the user's uploaded inputs to a chat. */
+export const ATTACHMENTS_SECTION = {
+  title: "Attachments",
+  description: "Your uploads",
+} as const;
+
+/**
  * Which delete endpoint removes a given file. Attachments have their own chat
  * route; generated and project files are both persisted artifacts behind the
  * skill-sandbox artifact route.


### PR DESCRIPTION
## What & why

Polish of the chat **Files** sidebar so persistent files are visually and semantically separated from attachments, and the panel chrome is less cluttered.

### Scope labels
- The persistent-files group is now labeled by context, each with a one-line persistence-scope subtitle:
  - Personal chat → **Chat files · Created in this chat**
  - Project chat → **Project files · Shared with the project**
- Attachments stand apart as **Attachments · Your uploads**.
- The group name + scope render on a single line (echoing the inline `instructions.md · guidance for every chat` pattern), and the header now always shows so the scope is explained even with no attachments.

### Panel chrome
- Removed the file counter and the standing **Select** toolbar — the list now fills the panel from the first group header.
- Multi-select is entered from a row's `⋯` menu (**Download · Select · Delete**). Choosing **Select** enters selection mode *and* pre-checks that row.
- The **Select all / Cancel** (top) and **N selected · Download / Delete** (bottom) bars appear only while selecting, so nothing floats in an empty band.

### Misc
- Softened the shared file cards (`rounded-lg`, lighter border). This shared `FileSection`/`SelectableFileList` change carries to the project detail page too, keeping both surfaces consistent.

## Tests
- Added unit tests for the new `persistentFilesSection()` label helper (project vs. personal, incl. `null`/`undefined`).
- `lint`, `type-check`, `knip` all pass. The 2 red tests in `llm/(costs)/limits` are pre-existing date-dependent failures on `main`, unrelated to this change (confirmed failing with these changes stashed).

## Verification
Verified live in the running app: idle panel starts cleanly at the scope header, the `⋯` menu offers **Select**, and selecting pre-checks the row with the correct Select-all/Cancel + bottom action bars.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>