### PR TITLE
feat: import MCP server config from pasted JSON

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -103,6 +103,7 @@ import {
   transformCatalogItemToFormValues,
   transformFormToApiData,
 } from "./mcp-catalog-form.utils";
+import { McpConfigImportDialog } from "./mcp-config-import-dialog";
 
 const ExternalSecretSelector = lazy(
   () =>
@@ -719,6 +720,13 @@ export function McpCatalogForm({
     { mode: "add" } | { mode: "edit"; index: number } | null
   >(null);
 
+  // Paste-to-create: import an MCP server config (issue #3859) and pre-fill the
+  // form. Imported keys overwrite their fields; everything else keeps its value.
+  const [isImportOpen, setIsImportOpen] = useState(false);
+  const handleImportConfig = (values: Partial<McpCatalogFormValues>) => {
+    form.reset({ ...form.getValues(), ...values });
+  };
+
   // Fetch available k8s docker-registry secrets for the "existing" dropdown
   const { data: k8sSecrets = [] } = useK8sImagePullSecrets();
   const imagePullSecretItems = useMemo(
@@ -890,6 +898,25 @@ export function McpCatalogForm({
           >
             {notice}
             {catalogButton}
+
+            {mode === "create" && (
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsImportOpen(true)}
+                >
+                  <Code className="mr-1 h-4 w-4" />
+                  Import from JSON
+                </Button>
+              </div>
+            )}
+            <McpConfigImportDialog
+              open={isImportOpen}
+              onOpenChange={setIsImportOpen}
+              onImport={handleImportConfig}
+            />
 
             <div className="space-y-4">
               <div className="flex items-stretch gap-3">

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-config-import-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-config-import-dialog.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import { toast } from "sonner";
+import { StandardFormDialog } from "@/components/standard-dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
+import { McpConfigParseError, parseMcpServerConfig } from "./mcp-config-parser";
+
+const EXAMPLE_CONFIG = `{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_TOKEN_HERE" }
+    }
+  }
+}`;
+
+interface McpConfigImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with parsed form values when the user imports a valid config. */
+  onImport: (values: Partial<McpCatalogFormValues>) => void;
+}
+
+/**
+ * Lets the user paste an MCP server configuration (the `mcpServers` JSON used by
+ * most catalogs, a bare server object, or an official-registry `server.json`)
+ * and pre-fill the create form from it. See `mcp-config-parser.ts`.
+ */
+export function McpConfigImportDialog({
+  open,
+  onOpenChange,
+  onImport,
+}: McpConfigImportDialogProps) {
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Clear transient state whenever the dialog closes so a reopen starts fresh.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setText("");
+      setError(null);
+    }
+    onOpenChange(next);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const { values, warnings } = parseMcpServerConfig(text);
+      onImport(values);
+      for (const warning of warnings) {
+        toast.warning(warning);
+      }
+      toast.success("Imported configuration into the form.");
+      handleOpenChange(false);
+    } catch (caught) {
+      setError(
+        caught instanceof McpConfigParseError
+          ? caught.message
+          : "Couldn't import that configuration.",
+      );
+    }
+  };
+
+  return (
+    <StandardFormDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Import from JSON"
+      description="Paste an MCP server configuration to pre-fill the form. Secrets and placeholders become prompt-on-install fields."
+      size="medium"
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={text.trim() === ""}>
+            Import
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-2">
+        <Textarea
+          aria-label="MCP server configuration JSON"
+          value={text}
+          onChange={(event) => {
+            setText(event.target.value);
+            if (error) setError(null);
+          }}
+          placeholder={EXAMPLE_CONFIG}
+          className="min-h-60 font-mono text-xs"
+          spellCheck={false}
+        />
+        {error ? (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </StandardFormDialog>
+  );
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-config-parser.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-config-parser.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import { McpConfigParseError, parseMcpServerConfig } from "./mcp-config-parser";
+
+describe("parseMcpServerConfig", () => {
+  it("imports a standard mcpServers local server with a secret-keyed placeholder env", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        mcpServers: {
+          github: {
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-github"],
+            env: { GITHUB_PERSONAL_ACCESS_TOKEN: "YOUR_TOKEN_HERE" },
+          },
+        },
+      }),
+    );
+
+    expect(result.serverName).toBe("github");
+    expect(result.values.name).toBe("github");
+    expect(result.values.serverType).toBe("local");
+    expect(result.values.localConfig?.command).toBe("npx");
+    expect(result.values.localConfig?.arguments).toBe(
+      "-y\n@modelcontextprotocol/server-github",
+    );
+    expect(result.values.localConfig?.environment).toEqual([
+      {
+        key: "GITHUB_PERSONAL_ACCESS_TOKEN",
+        type: "secret",
+        value: undefined,
+        promptOnInstallation: true,
+        required: true,
+        description: "",
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("keeps a concrete, non-secret env value as a static plain_text default", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        mcpServers: {
+          t: { command: "node", args: ["s.js"], env: { LOG_LEVEL: "info" } },
+        },
+      }),
+    );
+
+    expect(result.values.localConfig?.environment).toEqual([
+      {
+        key: "LOG_LEVEL",
+        type: "plain_text",
+        value: "info",
+        promptOnInstallation: false,
+        required: false,
+        description: "",
+      },
+    ]);
+  });
+
+  it("treats placeholder env values as prompt-on-install with no value", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        mcpServers: {
+          t: {
+            command: "node",
+            env: { A: "<token>", B: "$" + "{ENV}", C: "", D: "changeme" },
+          },
+        },
+      }),
+    );
+
+    for (const entry of result.values.localConfig?.environment ?? []) {
+      expect(entry.promptOnInstallation).toBe(true);
+      expect(entry.value).toBeUndefined();
+    }
+  });
+
+  it("imports the first of several servers and warns about the rest", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        mcpServers: {
+          a: { command: "node", args: ["a.js"] },
+          b: { command: "node" },
+        },
+      }),
+    );
+
+    expect(result.serverName).toBe("a");
+    expect(result.warnings[0]).toMatch(/Found 2 servers; imported "a"/);
+  });
+
+  it("accepts a single bare server object without the mcpServers wrapper", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({ command: "uvx", args: ["mcp-server-time"] }),
+    );
+
+    expect(result.values.serverType).toBe("local");
+    expect(result.values.localConfig?.command).toBe("uvx");
+    expect(result.values.localConfig?.arguments).toBe("mcp-server-time");
+  });
+
+  it("detects a remote server from its url", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({ type: "http", url: "https://api.example.com/mcp" }),
+    );
+
+    expect(result.values.serverType).toBe("remote");
+    expect(result.values.serverUrl).toBe("https://api.example.com/mcp");
+  });
+
+  it("flags remote headers for manual auth setup instead of importing them", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        mcpServers: {
+          x: { url: "https://x/mcp", headers: { Authorization: "Bearer T" } },
+        },
+      }),
+    );
+
+    expect(result.values.serverType).toBe("remote");
+    expect(result.values.additionalHeaders).toBeUndefined();
+    expect(result.warnings.join(" ")).toMatch(/header/i);
+  });
+
+  it("reuses the docker parser for a `docker run` command", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        mcpServers: {
+          grafana: {
+            command: "docker",
+            args: [
+              "run",
+              "-i",
+              "--rm",
+              "-e",
+              "GF_TOKEN",
+              "mcp/grafana",
+              "-t",
+              "stdio",
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result.values.localConfig?.dockerImage).toBe("mcp/grafana");
+    expect(result.values.localConfig?.command).toBe("");
+    expect(result.values.localConfig?.arguments).toBe("-t\nstdio");
+  });
+
+  it("imports an official registry npm package with a required secret env var", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        name: "io.github.foo/bar",
+        description: "d",
+        packages: [
+          {
+            registry_type: "npm",
+            identifier: "@foo/bar-mcp",
+            version: "1.2.3",
+            transport: { type: "stdio" },
+            environment_variables: [
+              {
+                name: "API_KEY",
+                description: "key",
+                is_required: true,
+                is_secret: true,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(result.values.name).toBe("bar");
+    expect(result.serverName).toBe("io.github.foo/bar");
+    expect(result.values.serverType).toBe("local");
+    expect(result.values.localConfig?.command).toBe("npx");
+    expect(result.values.localConfig?.arguments).toBe("-y\n@foo/bar-mcp@1.2.3");
+    expect(result.values.localConfig?.environment?.[0]).toMatchObject({
+      key: "API_KEY",
+      type: "secret",
+      required: true,
+      promptOnInstallation: true,
+    });
+  });
+
+  it("maps an official registry oci package to a docker image", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        name: "x",
+        packages: [
+          {
+            registry_type: "oci",
+            identifier: "mcp/redis",
+            version: "latest",
+            transport: { type: "stdio" },
+          },
+        ],
+      }),
+    );
+
+    expect(result.values.localConfig?.dockerImage).toBe("mcp/redis:latest");
+  });
+
+  it("falls back to an official registry remote when there are no packages", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        name: "x",
+        remotes: [{ type: "streamable-http", url: "https://r/mcp" }],
+      }),
+    );
+
+    expect(result.values.serverType).toBe("remote");
+    expect(result.values.serverUrl).toBe("https://r/mcp");
+  });
+
+  it("warns when a registry package has structured runtime/package arguments", () => {
+    const result = parseMcpServerConfig(
+      JSON.stringify({
+        name: "x",
+        packages: [
+          {
+            registry_type: "npm",
+            identifier: "p",
+            package_arguments: [{ value: "--flag" }],
+          },
+        ],
+      }),
+    );
+
+    expect(result.warnings.join(" ")).toMatch(/runtime\/package arguments/);
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => parseMcpServerConfig("{ not json")).toThrow(
+      McpConfigParseError,
+    );
+  });
+
+  it("throws on empty input", () => {
+    expect(() => parseMcpServerConfig("   ")).toThrow(
+      /Paste an MCP server configuration/,
+    );
+  });
+
+  it("throws on a non-object JSON value", () => {
+    expect(() => parseMcpServerConfig("[1,2,3]")).toThrow(
+      /Expected a JSON object/,
+    );
+  });
+
+  it("throws when the object isn't a recognizable server config", () => {
+    expect(() =>
+      parseMcpServerConfig(JSON.stringify({ foo: 1, bar: 2 })),
+    ).toThrow(/Couldn't recognize/);
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-config-parser.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-config-parser.ts
@@ -1,0 +1,527 @@
+import { parseDockerArgsToLocalConfig } from "./docker-args-parser";
+import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
+
+type LocalConfig = NonNullable<McpCatalogFormValues["localConfig"]>;
+type EnvironmentEntry = NonNullable<LocalConfig["environment"]>[number];
+
+/**
+ * Result of importing a pasted MCP server configuration.
+ */
+export interface ParsedMcpServerConfig {
+  /**
+   * Partial form values to merge onto the create-form defaults. Only the
+   * fields the pasted config actually describes are populated — everything
+   * else is left to the form's existing defaults.
+   */
+  values: Partial<McpCatalogFormValues>;
+  /** The server key/name detected in the config, if any. */
+  serverName?: string;
+  /**
+   * Non-fatal notes worth surfacing to the user — e.g. when the pasted blob
+   * held several servers and only the first was imported, or when a field
+   * needs manual attention.
+   */
+  warnings: string[];
+}
+
+/** Thrown when the pasted text can't be recognized as an MCP server config. */
+export class McpConfigParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpConfigParseError";
+  }
+}
+
+// Transport `type` values that mean "this is a remote (HTTP-reachable) server".
+const REMOTE_TRANSPORT_TYPES = new Set([
+  "http",
+  "https",
+  "sse",
+  "streamable-http",
+  "streamablehttp",
+  "streamable_http",
+  "ws",
+  "websocket",
+]);
+
+// Env var keys whose values are credentials — never stored statically in a
+// (shared) catalog item; always turned into a prompt-on-install field instead.
+const SECRET_KEY_PATTERN =
+  /(token|secret|password|passwd|pwd|api[_-]?key|access[_-]?key|client[_-]?secret|private[_-]?key|credential|auth)/i;
+
+// Heuristics for "this value is a placeholder, not a real value" — copy-pasted
+// configs from docs are full of these. A placeholder becomes a prompt-on-install
+// field with no baked-in value.
+const PLACEHOLDER_PATTERNS: RegExp[] = [
+  /^<.*>$/, // <your-token>
+  /^\$\{.*\}$/, // ${ENV_VAR}
+  /^\$[A-Za-z_][A-Za-z0-9_]*$/, // $ENV_VAR
+  /your[_-]?\w*[_-]?(token|key|secret|password|id|value|name)/i, // YOUR_API_KEY
+  /\b(here|placeholder|change[_-]?me|replace[_-]?me|todo|example|insert)\b/i,
+  /^x{3,}$/i, // xxxx
+];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function looksLikePlaceholder(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed === "") return true;
+  return PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+/**
+ * Maps one `env`/`environment_variables` entry to a form environment row.
+ * Secret-looking keys and placeholder values become prompt-on-install fields
+ * (no value persisted); concrete non-secret values are kept as static defaults.
+ */
+function buildEnvironmentEntry(
+  key: string,
+  rawValue: unknown,
+  options: { required?: boolean; description?: string } = {},
+): EnvironmentEntry {
+  const value =
+    typeof rawValue === "string"
+      ? rawValue
+      : rawValue == null
+        ? ""
+        : String(rawValue);
+  const isSecret = SECRET_KEY_PATTERN.test(key);
+  const isPlaceholder = looksLikePlaceholder(value);
+  const promptOnInstallation = isSecret || isPlaceholder;
+  return {
+    key,
+    type: isSecret ? "secret" : "plain_text",
+    value: promptOnInstallation ? undefined : value,
+    promptOnInstallation,
+    required: options.required ?? promptOnInstallation,
+    description: options.description ?? "",
+  };
+}
+
+// Tidy a server name for the catalog's required Name field. Registry ids like
+// "io.github.owner/server" collapse to their last path segment.
+function tidyName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.includes("/")) {
+    const last = trimmed.split("/").filter(Boolean).pop();
+    if (last) return last;
+  }
+  return trimmed;
+}
+
+// Best-effort extraction of the image from a raw `docker run …` arg list, so we
+// can hand it to the repo's existing `parseDockerArgsToLocalConfig`.
+const DOCKER_VALUE_FLAGS = new Set([
+  "-e",
+  "--env",
+  "-v",
+  "--volume",
+  "--mount",
+  "--name",
+  "-p",
+  "--publish",
+  "-w",
+  "--workdir",
+  "--network",
+  "--entrypoint",
+  "-u",
+  "--user",
+]);
+
+function guessDockerImage(args: string[]): string | undefined {
+  const runIndex = args.indexOf("run");
+  const search = runIndex >= 0 ? args.slice(runIndex + 1) : args;
+  for (let i = 0; i < search.length; i++) {
+    const token = search[i];
+    if (token.startsWith("-")) {
+      if (DOCKER_VALUE_FLAGS.has(token)) i++; // skip the flag's value
+      continue;
+    }
+    return token; // first bare token after the flags is the image
+  }
+  return undefined;
+}
+
+/**
+ * Normalizes one "standard" server entry — the shape used by Claude Desktop /
+ * Cursor / VS Code `mcpServers` configs and most catalogs:
+ *   local:  { command, args?, env? }
+ *   remote: { url | type:"http"|"sse"|…, headers? }
+ */
+function normalizeStandardServer(
+  name: string,
+  rawEntry: unknown,
+): { values: Partial<McpCatalogFormValues>; warnings: string[] } {
+  if (!isPlainObject(rawEntry)) {
+    throw new McpConfigParseError(`Server "${name}" is not a JSON object.`);
+  }
+  const entry = rawEntry;
+  const warnings: string[] = [];
+  const values: Partial<McpCatalogFormValues> = {};
+
+  const displayName = readString(entry.name) ?? name;
+  if (displayName) values.name = tidyName(displayName);
+  const description = readString(entry.description);
+  if (description) values.description = description;
+
+  const transportRecord = isPlainObject(entry.transport) ? entry.transport : {};
+  const transportType = (
+    readString(entry.type) ?? readString(transportRecord.type)
+  )?.toLowerCase();
+  const url =
+    readString(entry.url) ??
+    readString(transportRecord.url) ??
+    readString(entry.serverUrl);
+  const isRemote =
+    Boolean(url) ||
+    (transportType ? REMOTE_TRANSPORT_TYPES.has(transportType) : false);
+
+  if (isRemote) {
+    values.serverType = "remote";
+    if (url) {
+      values.serverUrl = url;
+    } else {
+      warnings.push(
+        "Remote server had no URL — add the Server URL before saving.",
+      );
+    }
+    const headers = isPlainObject(entry.headers) ? entry.headers : {};
+    const headerNames = Object.keys(headers);
+    if (headerNames.length > 0) {
+      // Header → auth mapping is deliberately left to the user: the form has
+      // dedicated, validated Authentication controls, and silently importing an
+      // Authorization header can collide with them. Flag, don't guess.
+      warnings.push(
+        `Detected ${headerNames.length} header(s) (${headerNames.join(", ")}). Configure them under Authentication.`,
+      );
+    }
+    return { values, warnings };
+  }
+
+  // Local (stdio / self-hosted) server.
+  const command = readString(entry.command);
+  const args = readStringArray(entry.args);
+  const env = isPlainObject(entry.env) ? entry.env : {};
+  const environment = Object.entries(env).map(([key, value]) =>
+    buildEnvironmentEntry(key, value),
+  );
+
+  let localCommand = command ?? "";
+  let argumentList = args;
+  let dockerImage =
+    readString(entry.dockerImage) ?? readString(entry.docker_image) ?? "";
+  let localTransport: "stdio" | "streamable-http" = "stdio";
+  let httpPort = "";
+
+  // Reuse the repo's tested docker parser when this is a `docker run …` command.
+  if (command === "docker") {
+    const image = dockerImage || guessDockerImage(args);
+    const parsed = image
+      ? parseDockerArgsToLocalConfig(command, args, image)
+      : null;
+    if (parsed) {
+      localCommand = parsed.command ?? "";
+      argumentList = parsed.arguments ?? [];
+      dockerImage = parsed.dockerImage;
+      if (parsed.transportType) localTransport = parsed.transportType;
+      if (parsed.httpPort != null) httpPort = String(parsed.httpPort);
+    }
+  }
+
+  if (!localCommand && !dockerImage) {
+    warnings.push("No command or Docker image found — set one before saving.");
+  }
+
+  values.serverType = "local";
+  values.localConfig = {
+    command: localCommand,
+    arguments: argumentList.join("\n"),
+    environment,
+    envFrom: [],
+    dockerImage,
+    transportType: localTransport,
+    httpPort,
+    httpPath: "/mcp",
+    serviceAccount: "",
+    imagePullSecrets: [],
+  };
+  return { values, warnings };
+}
+
+/**
+ * Normalizes an official MCP Registry `server.json`
+ * (https://registry.modelcontextprotocol.io). Best-effort: imports the first
+ * package (or first remote) plus its environment variables, and flags advanced
+ * runtime/package arguments for manual review rather than guessing their order.
+ */
+function normalizeOfficialRegistry(root: Record<string, unknown>): {
+  values: Partial<McpCatalogFormValues>;
+  warnings: string[];
+  serverName?: string;
+} {
+  const warnings: string[] = [];
+  const values: Partial<McpCatalogFormValues> = {};
+
+  const registryName = readString(root.name);
+  if (registryName) values.name = tidyName(registryName);
+  const description = readString(root.description);
+  if (description) values.description = description;
+
+  const packages = Array.isArray(root.packages) ? root.packages : [];
+  const remotes = Array.isArray(root.remotes) ? root.remotes : [];
+
+  if (packages.length > 1) {
+    warnings.push(
+      `Found ${packages.length} packages; imported the first. Import the others separately.`,
+    );
+  }
+
+  const pkg = packages.find(isPlainObject);
+  if (pkg) {
+    const registryType = readString(pkg.registry_type)?.toLowerCase();
+    const identifier = readString(pkg.identifier) ?? "";
+    const version = readString(pkg.version);
+    const runtimeHint = readString(pkg.runtime_hint);
+    const transportRecord = isPlainObject(pkg.transport) ? pkg.transport : {};
+    const transportType = readString(transportRecord.type)?.toLowerCase();
+
+    const environment = (
+      Array.isArray(pkg.environment_variables) ? pkg.environment_variables : []
+    )
+      .filter(isPlainObject)
+      .map((variable) => {
+        const key = readString(variable.name) ?? "";
+        const isSecret = variable.is_secret === true;
+        const isRequired = variable.is_required === true;
+        const defaultValue = variable.default;
+        const value =
+          !isSecret && typeof defaultValue === "string"
+            ? defaultValue
+            : undefined;
+        const promptOnInstallation = isSecret || isRequired || value == null;
+        return {
+          key,
+          type: isSecret ? "secret" : "plain_text",
+          value: promptOnInstallation ? undefined : value,
+          promptOnInstallation,
+          required: isRequired,
+          description: readString(variable.description) ?? "",
+        } as EnvironmentEntry;
+      })
+      .filter((entry) => entry.key !== "");
+
+    if (
+      (Array.isArray(pkg.runtime_arguments) && pkg.runtime_arguments.length) ||
+      (Array.isArray(pkg.package_arguments) && pkg.package_arguments.length)
+    ) {
+      warnings.push(
+        "Package has structured runtime/package arguments — review the Arguments field after importing.",
+      );
+    }
+
+    values.serverType = "local";
+
+    if (registryType === "oci" || registryType === "docker") {
+      const image = version ? `${identifier}:${version}` : identifier;
+      values.localConfig = makeLocalConfig({
+        dockerImage: image,
+        transportType:
+          transportType === "streamable-http" ? "streamable-http" : "stdio",
+        environment,
+      });
+    } else {
+      const { command, args } = runtimeInvocation(
+        registryType,
+        runtimeHint,
+        identifier,
+        version,
+      );
+      values.localConfig = makeLocalConfig({
+        command,
+        argumentList: args,
+        transportType:
+          transportType === "streamable-http" ? "streamable-http" : "stdio",
+        environment,
+      });
+    }
+    return { values, warnings, serverName: registryName };
+  }
+
+  const remote = remotes.find(isPlainObject);
+  if (remote) {
+    values.serverType = "remote";
+    const url = readString(remote.url);
+    if (url) {
+      values.serverUrl = url;
+    } else {
+      warnings.push(
+        "Remote entry had no URL — add the Server URL before saving.",
+      );
+    }
+    if (Array.isArray(remote.headers) && remote.headers.length > 0) {
+      warnings.push(
+        "Remote entry declares headers — configure them under Authentication.",
+      );
+    }
+    return { values, warnings, serverName: registryName };
+  }
+
+  throw new McpConfigParseError(
+    "Registry server has no importable packages or remotes.",
+  );
+}
+
+// npm/pypi/etc. → a (command, args) pair. Only the package identifier is wired
+// up; structured runtime/package arguments are surfaced as a warning instead.
+function runtimeInvocation(
+  registryType: string | undefined,
+  runtimeHint: string | undefined,
+  identifier: string,
+  version: string | undefined,
+): { command: string; args: string[] } {
+  const versioned =
+    version && registryType === "npm" ? `${identifier}@${version}` : identifier;
+  if (registryType === "npm") {
+    return { command: runtimeHint || "npx", args: ["-y", versioned] };
+  }
+  if (registryType === "pypi") {
+    return { command: runtimeHint || "uvx", args: [identifier] };
+  }
+  // Unknown registry type: pass the hint/identifier through as-is.
+  return { command: runtimeHint || identifier, args: [] };
+}
+
+function makeLocalConfig(params: {
+  command?: string;
+  argumentList?: string[];
+  dockerImage?: string;
+  transportType?: "stdio" | "streamable-http";
+  environment?: EnvironmentEntry[];
+}): LocalConfig {
+  return {
+    command: params.command ?? "",
+    arguments: (params.argumentList ?? []).join("\n"),
+    environment: params.environment ?? [],
+    envFrom: [],
+    dockerImage: params.dockerImage ?? "",
+    transportType: params.transportType ?? "stdio",
+    httpPort: "",
+    httpPath: "/mcp",
+    serviceAccount: "",
+    imagePullSecrets: [],
+  };
+}
+
+/**
+ * Parses a pasted MCP server configuration (in any of the common "wild"
+ * formats) into partial catalog-form values, so a user can copy-paste a config
+ * from the internet and create a server without re-typing every field.
+ *
+ * Supported inputs:
+ *  - `{ "mcpServers": { "<name>": {…} } }` (also `{ "servers": {…} }`)
+ *  - a single bare server object: `{ command, args, env }` or `{ url, type }`
+ *  - an official MCP Registry `server.json` (`{ name, packages, remotes }`)
+ *
+ * @throws {McpConfigParseError} when the text is empty, not JSON, or not a
+ *   recognizable server config.
+ */
+export function parseMcpServerConfig(input: string): ParsedMcpServerConfig {
+  const trimmed = input.trim();
+  if (trimmed === "") {
+    throw new McpConfigParseError(
+      "Paste an MCP server configuration to import.",
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(trimmed);
+  } catch {
+    throw new McpConfigParseError(
+      "That doesn't look like valid JSON — paste the server configuration as JSON.",
+    );
+  }
+
+  if (!isPlainObject(json)) {
+    throw new McpConfigParseError(
+      "Expected a JSON object describing an MCP server.",
+    );
+  }
+  const root = json;
+
+  // 1. `{ "mcpServers": {…} }` / `{ "servers": {…} }` map.
+  const mapKey = isPlainObject(root.mcpServers)
+    ? "mcpServers"
+    : isPlainObject(root.servers)
+      ? "servers"
+      : undefined;
+  if (mapKey) {
+    const entries = Object.entries(root[mapKey] as Record<string, unknown>);
+    if (entries.length === 0) {
+      throw new McpConfigParseError(
+        `"${mapKey}" was empty — there is no server to import.`,
+      );
+    }
+    const [name, entry] = entries[0];
+    const result = normalizeStandardServer(name, entry);
+    const warnings = result.warnings;
+    if (entries.length > 1) {
+      warnings.unshift(
+        `Found ${entries.length} servers; imported "${name}". Import the others separately.`,
+      );
+    }
+    return { values: result.values, serverName: name, warnings };
+  }
+
+  // 2. Official MCP Registry server.json.
+  if (Array.isArray(root.packages) || Array.isArray(root.remotes)) {
+    return normalizeOfficialRegistry(root);
+  }
+
+  // 3. A single bare server object.
+  if (
+    "command" in root ||
+    "url" in root ||
+    "type" in root ||
+    "transport" in root
+  ) {
+    const name = readString(root.name) ?? "imported-server";
+    const result = normalizeStandardServer(name, root);
+    return {
+      values: result.values,
+      serverName: readString(root.name),
+      warnings: result.warnings,
+    };
+  }
+
+  // 4. A bare `{ "<name>": {…} }` map without the `mcpServers` wrapper.
+  const objectEntries = Object.entries(root).filter(([, value]) =>
+    isPlainObject(value),
+  );
+  if (objectEntries.length > 0) {
+    const [name, entry] = objectEntries[0];
+    const result = normalizeStandardServer(name, entry);
+    const warnings = result.warnings;
+    if (objectEntries.length > 1) {
+      warnings.unshift(
+        `Found ${objectEntries.length} servers; imported "${name}". Import the others separately.`,
+      );
+    }
+    return { values: result.values, serverName: name, warnings };
+  }
+
+  throw new McpConfigParseError(
+    "Couldn't recognize this as an MCP server configuration.",
+  );
+}


### PR DESCRIPTION
## What

Adds a **paste-to-create** flow to the MCP server create form. An **Import from JSON** button opens a dialog where you paste an MCP server configuration, and the form is pre-filled from it — so you can copy a config from the internet and create a server without re-typing every field.

Closes #3859.

## Supported formats

- **`mcpServers` JSON** (Claude Desktop / Cursor / VS Code style), plus the `servers` variant
- A **bare single server object** — `{ command, args, env }` (stdio) or `{ url, type }` (remote)
- An **official MCP Registry `server.json`** (`{ name, packages, remotes }`) — npm / pypi / oci packages, and remotes
- `docker run …` commands reuse the existing `parseDockerArgsToLocalConfig`

## Smart, safe defaults

- Env vars with **secret-looking keys** (`token` / `secret` / `password` / `api_key` / …) or **placeholder values** (`YOUR_TOKEN_HERE`, `${VAR}`, `<token>`, empty, `changeme`, …) become **prompt-on-install** fields with no value baked into the (shared) catalog item. Concrete, non-secret values are kept as static defaults.
- Multiple servers → the first is imported and the rest are surfaced as a warning toast.
- Remote `headers` are **flagged for manual setup** instead of being silently mapped, to avoid colliding with the form's dedicated Authentication controls.

## Tests

`mcp-config-parser.test.ts` adds 16 vitest cases covering every supported format, the secret/placeholder heuristics, docker handling, multi-server warnings, and all error branches. `pnpm test`, `biome check`, and `tsgo --noEmit` pass for the changed files locally.

## Notes / possible follow-ups

- Structured `runtime_arguments` / `package_arguments` in registry packages are flagged for manual review rather than guessed.
- Remote header → auth mapping is intentionally left to the user for now.

/claim #3859
