### PR TITLE
docs: restore interactive architecture diagram on overview page

### DIFF
--- a/docs/pages/platform-overview.md
+++ b/docs/pages/platform-overview.md
@@ -35,3 +35,7 @@ Archestra is built as a set of composable components. Most organizations already
 **[Security & Guardrails](/docs/platform-lethal-trifecta)** and **[Observability](/docs/platform-observability)** — Deterministic tool invocation policies and trusted data policies that cannot be bypassed by prompt injection. Prometheus metrics, OpenTelemetry tracing, and [per-team cost tracking](/docs/platform-costs-and-limits).
 
 See [Pricing Model](/docs/platform-pricing-model) for licensing details.
+
+## Architecture
+
+:::architecture-diagram:::


### PR DESCRIPTION
Re-adds the React Flow architecture diagram (removed in the unified connect page change) to the docs site as an interactive embed.

## What
- `docs/pages/platform-overview.md`: the static overview image stays at the top; the interactive diagram is added under a new **## Architecture** section after *Composable Components*, via a `:::architecture-diagram:::` directive.

## Note
The diagram component itself lives in the website repo — see the companion PR in `archestra-ai/website` (`restore-architecture-diagram`). This branch is just the docs markdown that triggers it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>