### PR TITLE
feat(projects): project name+emoji in chat title; "Run manually" for schedules

### DIFF
--- a/platform/frontend/src/app/projects/[id]/project-schedules-section.tsx
+++ b/platform/frontend/src/app/projects/[id]/project-schedules-section.tsx
@@ -44,6 +44,7 @@ import {
   useDeleteScheduleTrigger,
   useDisableScheduleTrigger,
   useEnableScheduleTrigger,
+  useRunScheduleTriggerNow,
   useScheduleTriggerRuns,
   useScheduleTriggers,
   useUpdateScheduleTrigger,
@@ -105,11 +106,7 @@ export function ProjectSchedulesSection({
       ) : (
         <div className="space-y-2">
           {schedules.map((schedule) => (
-            <ScheduleRow
-              key={schedule.id}
-              schedule={schedule}
-              projectId={projectId}
-            />
+            <ScheduleRow key={schedule.id} schedule={schedule} />
           ))}
         </div>
       )}
@@ -119,18 +116,11 @@ export function ProjectSchedulesSection({
 
 // === internal components ===
 
-function ScheduleRow({
-  schedule,
-  projectId,
-}: {
-  schedule: ScheduleTrigger;
-  // The owning project id, guaranteed non-null here (the schedule's own
-  // projectId is nullable in the type); used for the runs-route link.
-  projectId: string;
-}) {
+function ScheduleRow({ schedule }: { schedule: ScheduleTrigger }) {
   const enableSchedule = useEnableScheduleTrigger();
   const disableSchedule = useDisableScheduleTrigger();
   const deleteSchedule = useDeleteScheduleTrigger();
+  const runNow = useRunScheduleTriggerNow();
   const [editOpen, setEditOpen] = useState(false);
 
   const { resolve, isResolving } = useResolveRunChat();
@@ -166,7 +156,9 @@ function ScheduleRow({
     ? runChatHref({ triggerId: schedule.id, run: lastRun })
     : null;
   // Last run has a chat → link straight to it. Last run without one (legacy) →
-  // create it on click, then open. No runs yet → the runs page (empty state).
+  // create it on click, then open. No runs/chats yet → plain label that does
+  // nothing (the empty runs page has nothing to show); "Run manually" in the
+  // overflow menu is how you kick off the first run.
   let nameNode: React.ReactNode;
   if (lastRunChatHref) {
     nameNode = (
@@ -187,12 +179,9 @@ function ScheduleRow({
     );
   } else {
     nameNode = (
-      <Link
-        href={`/projects/${projectId}/schedules/${schedule.id}`}
-        className={labelClassName}
-      >
+      <div className={cn("min-w-0 flex-1", !schedule.enabled && "opacity-60")}>
         {scheduleLabel}
-      </Link>
+      </div>
     );
   }
 
@@ -220,6 +209,13 @@ function ScheduleRow({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            disabled={runNow.isPending}
+            onSelect={() => runNow.mutate(schedule.id)}
+          >
+            <Play className="h-4 w-4" />
+            Run manually
+          </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() =>
               schedule.enabled

--- a/platform/frontend/src/components/chat/conversation-header.tsx
+++ b/platform/frontend/src/components/chat/conversation-header.tsx
@@ -12,6 +12,8 @@ import {
   Share2,
   Users,
 } from "lucide-react";
+import Link from "next/link";
+import { AgentIcon } from "@/components/agent-icon";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -22,6 +24,7 @@ import {
 import { TruncatedTooltip } from "@/components/ui/truncated-tooltip";
 import { TypingText } from "@/components/ui/typing-text";
 import { getConversationDisplayTitle } from "@/lib/chat/chat-utils";
+import { useProject } from "@/lib/projects/projects.query";
 import { cn } from "@/lib/utils";
 import type { RightPanelTab } from "./right-side-panel";
 
@@ -89,7 +92,13 @@ export function ConversationHeader({
         {/* Left side - conversation title + actions */}
         <div className="flex items-center gap-1 min-w-0">
           {conversationId && conversation && (
-            <div className="flex items-center flex-shrink min-w-0">
+            <div className="flex items-center flex-shrink min-w-0 gap-1">
+              {/* Project chats read as "{ProjectName}/{Chat title}" — the
+                  project segment (emoji + name, like the sidebar) links to the
+                  project. Hidden for viewers without project access. */}
+              {conversation.projectId && (
+                <ProjectTitlePrefix projectId={conversation.projectId} />
+              )}
               {/* Skip TruncatedTooltip while the title animates: its resize
                   measurement re-renders on every TypingText tick, which loops
                   past React's nested-update cap. */}
@@ -206,6 +215,36 @@ export function ConversationHeader({
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * Clickable "{emoji ProjectName} /" segment shown before the chat title when a
+ * conversation belongs to a project. Fetches the project so the emoji matches
+ * the sidebar; renders nothing while loading or when the viewer can't read the
+ * project (the query resolves to null on a not-found, so no error surfaces).
+ */
+function ProjectTitlePrefix({ projectId }: { projectId: string }) {
+  const { data: project } = useProject(projectId);
+
+  if (!project) {
+    return null;
+  }
+
+  return (
+    <>
+      <Link
+        href={`/projects/${projectId}`}
+        title={project.name}
+        className="flex items-center gap-1 min-w-0 max-w-[180px] text-base font-normal text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <AgentIcon icon={project.icon} fallbackType="project" size={16} />
+        <span className="truncate">{project.name}</span>
+      </Link>
+      <span className="text-muted-foreground/50 select-none" aria-hidden="true">
+        /
+      </span>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

Two small, independent project-related UX improvements (bundled in one PR per request):

### 1. Project name + emoji in the chat title
When a conversation belongs to a project, the chat header title now reads **`{emoji ProjectName} / {Chat title}`**:
- The project segment renders the project's emoji exactly like the sidebar (via `AgentIcon`, handling both emoji and uploaded-image icons).
- The project name links to the project page (`/projects/:id`).
- Project info is fetched with the existing `useProject` hook. `getProject` returns 404 for viewers without project access and `useProject` swallows 404 silently, so a shared-chat viewer who isn't a project member simply sees the plain chat title — no prefix, no error toast.
- The project name truncates independently so the chat title stays readable; works on desktop and mobile.

### 2. Schedules: "Run manually" + no empty-page navigation
In a project's **Schedules** list:
- A schedule with **no runs/chats** no longer navigates to the empty `/projects/:id/schedules/:id` page on click — its name is now a plain, non-interactive label.
- Added a **"Run manually"** item to the row's overflow (3-dot) menu, wired to the existing run-now mutation (`useRunScheduleTriggerNow`) — it queues a run, shows a "Run queued" toast, and refreshes the row (which then becomes clickable once a run exists).
- Removed the now-unused `projectId` prop from `ScheduleRow`.

## Notes
- Frontend-only; no API/backend changes (the run-now endpoint + hook already existed).
- "Run manually" uses the `Play` icon to match the app's existing "run now" surfaces; permissions aren't pre-gated in this menu (consistent with the existing Edit/Delete items — a member without `scheduledTask:admin`/ownership gets a 403 toast on click).

## Testing
- `pnpm type-check` and `biome check` pass for both files.
- No automated tests added: both changes are presentational JSX/wiring with no extracted non-trivial logic to unit-test.

## Manual verification
- [ ] Open a chat inside a project → header shows "emoji ProjectName / Chat title"; clicking the project segment opens the project.
- [ ] Open a non-project chat → header shows the plain title (no prefix).
- [ ] A schedule with no runs → clicking its name does nothing.
- [ ] "Run manually" from the 3-dot menu queues a run and the row updates.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>