### PR TITLE
fix(query): fail loud on fetch errors + load-error retry UI (fixes offline "Add an LLM Provider Key")

### DIFF
--- a/.claude/skills/archestra-dev-frontend/SKILL.md
+++ b/.claude/skills/archestra-dev-frontend/SKILL.md
@@ -39,8 +39,9 @@ pnpm knip   # flags unused exports; part of frontend check:ci
 
 - Handle toasts in `.query.ts` files, not in components.
 - Define mutation success/error toasts in `onSuccess` and `onError` callbacks.
-- Never throw on HTTP errors in query or mutation functions.
-- Use `handleApiError(error)` for user notification and return an appropriate default such as `null`, `[]`, or `{}`.
+- Queries must fail loud: call `throwOnApiError(error)` after the SDK call so the query enters its error state, then keep the existing success return (`return data ?? []`). Swallowing an error into a default makes an outage indistinguishable from a genuinely empty result, which is how an offline app showed "Add an LLM Provider Key".
+- `throwOnApiError(error)` toasts via `handleApiError` by default. Screens that render their own error state (e.g. a `QueryLoadError` retry panel gated on `isLoadingError`) pass `{ toastOnError: false }` to avoid a redundant toast and a fresh toast on every retry. Detail endpoints where a 404 means "does not exist" rather than an outage pass `{ allowNotFound: true }` and keep returning their `null` default for that case.
+- Mutations keep `handleApiError(error)` + `throw toApiError(error)` in the `mutationFn`.
 - Components should not use `try`/`catch` for API calls; API error handling belongs in `.query.ts` files.
 
 ## UI components

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -29,6 +29,7 @@ import { ImportAgentDialog } from "@/components/import-agent-dialog";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
 import { PermissionRequirementHint } from "@/components/permission-requirement-hint";
+import { QueryLoadError } from "@/components/query-load-error";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { SearchInput } from "@/components/search-input";
 import { Button } from "@/components/ui/button";
@@ -135,7 +136,12 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
   const sortBy = sortByFromUrl || DEFAULT_SORT_BY;
   const sortDirection = sortDirectionFromUrl || DEFAULT_SORT_DIRECTION;
 
-  const { data: agentsResponse, isPending } = useProfilesPaginated({
+  const {
+    data: agentsResponse,
+    isPending,
+    isLoadingError: isAgentsLoadError,
+    refetch: refetchAgents,
+  } = useProfilesPaginated({
     initialData: initialData?.agents ?? undefined,
     limit: pageSize,
     offset,
@@ -442,6 +448,25 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
       },
     },
   ];
+
+  if (isAgentsLoadError) {
+    return (
+      <PageLayout
+        title="Agents"
+        description={
+          <p className="text-sm text-muted-foreground">
+            Agents are AI assistants with system prompts, tools, knowledge
+            sources, and integrations like ChatOps, email, and A2A.
+          </p>
+        }
+      >
+        <QueryLoadError
+          title="Couldn't load your agents"
+          onRetry={() => refetchAgents()}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <LoadingWrapper

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -15,6 +15,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import { LoadingWrapper } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
+import { QueryLoadError } from "@/components/query-load-error";
 import { scopeStyles } from "@/components/resource-visibility-badge";
 import { SearchInput } from "@/components/search-input";
 import { Button } from "@/components/ui/button";
@@ -41,7 +42,7 @@ export default function AppsPage() {
 
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
-  const { data, isPending } = useApps({
+  const { data, isPending, isLoadingError, refetch } = useApps({
     limit: PAGE_SIZE,
     offset: 0,
     search: search || undefined,
@@ -165,7 +166,12 @@ export default function AppsPage() {
       </div>
 
       <LoadingWrapper isPending={isPending && !data}>
-        {filtered.length === 0 && !showCreateCard ? (
+        {isLoadingError ? (
+          <QueryLoadError
+            title="Couldn't load your apps"
+            onRetry={() => refetch()}
+          />
+        ) : filtered.length === 0 && !showCreateCard ? (
           <div className="flex min-h-[40vh] flex-col items-center justify-center text-center">
             <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border bg-background shadow-sm">
               <AppWindow className="h-6 w-6 text-primary" />

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -42,11 +42,14 @@ export default function AppsPage() {
 
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
-  const { data, isPending, isLoadingError, refetch } = useApps({
-    limit: PAGE_SIZE,
-    offset: 0,
-    search: search || undefined,
-  });
+  const { data, isPending, isLoadingError, refetch } = useApps(
+    {
+      limit: PAGE_SIZE,
+      offset: 0,
+      search: search || undefined,
+    },
+    { toastOnError: false },
+  );
   const [createOpen, setCreateOpen] = useState(false);
 
   const apps = useMemo(() => data?.data ?? [], [data]);

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.test.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.test.tsx
@@ -112,6 +112,15 @@ function withEmpty() {
   };
 }
 
+function withLoadError(refetch = vi.fn()) {
+  return {
+    data: undefined,
+    isFetching: false,
+    isLoadingError: true,
+    refetch,
+  };
+}
+
 function renderTable() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -337,6 +346,21 @@ describe("AuditLogTable", () => {
     expect(
       screen.getByText(/No audit events recorded yet/i),
     ).toBeInTheDocument();
+  });
+
+  it("shows a retry panel (not the empty state) when the query fails to load", async () => {
+    const refetch = vi.fn();
+    mockUseAuditLogs.mockReturnValue(withLoadError(refetch));
+
+    renderTable();
+
+    // A failed fetch must not be misread as "no events recorded".
+    expect(
+      screen.queryByText(/No audit events recorded yet/i),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 
   it("renders When / Where headers and surfaces the client IP in the grid", () => {

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
@@ -4,6 +4,7 @@ import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { ChevronDown, ChevronUp, User } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { TableFilters } from "@/components/table-filters";
 import { TruncatedText } from "@/components/truncated-text";
@@ -171,7 +172,12 @@ export function AuditLogTable() {
     ? (actorTypeFromUrl as AuditActorType)
     : undefined;
 
-  const { data: response, isFetching } = useAuditLogs({
+  const {
+    data: response,
+    isFetching,
+    isLoadingError: isAuditLogsLoadError,
+    refetch: refetchAuditLogs,
+  } = useAuditLogs({
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
     sortDirection,
@@ -370,6 +376,17 @@ export function AuditLogTable() {
       page: "1",
     });
   }, [dateTimePicker, updateUrlParams]);
+
+  if (isAuditLogsLoadError) {
+    return (
+      <div className="space-y-4">
+        <QueryLoadError
+          title="Couldn't load audit events"
+          onRetry={() => refetchAuditLogs()}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1854,9 +1854,12 @@ export function ChatPageContent({
     );
   }
 
-  // The keys request failed (e.g. offline). Show a retry state rather than the
-  // setup prompt, which would wrongly imply the user has no keys configured.
-  if (isApiKeysError) {
+  // The keys request failed and we have no usable list to fall back on (e.g.
+  // offline cold start). Show a retry state rather than the setup prompt, which
+  // would wrongly imply the user has no keys configured. When a prior fetch
+  // succeeded, react-query keeps that data through a failed background refetch,
+  // so keep showing the real UI instead of flipping to this error screen.
+  if (isApiKeysError && !hasAnyApiKey) {
     return <ApiKeyLoadError onRetry={() => refetchApiKeys()} />;
   }
 

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -27,6 +27,7 @@ import { CustomServerRequestDialog } from "@/app/mcp/registry/_parts/custom-serv
 import { AgentDialog } from "@/components/agent-dialog";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { Suggestion } from "@/components/ai-elements/suggestion";
+import { ApiKeyLoadError } from "@/components/api-key-load-error";
 import { AppLogo } from "@/components/app-logo";
 import { ButtonWithTooltip } from "@/components/button-with-tooltip";
 import { AppsProvider } from "@/components/chat/apps-context";
@@ -309,8 +310,15 @@ export function ChatPageContent({
   // Fetch profiles and models for initial chat (no conversation)
   const { modelsByProvider, isPending: isModelsLoading } =
     useLlmModelsByProvider({ enabled: canUseProviderSettings });
-  const { data: chatApiKeys = [], isLoading: isLoadingApiKeys } =
-    useLlmProviderApiKeys({ enabled: hasChatAccess && canUseProviderSettings });
+  const {
+    data: chatApiKeys = [],
+    isLoading: isLoadingApiKeys,
+    isError: isApiKeysError,
+    refetch: refetchApiKeys,
+  } = useLlmProviderApiKeys({
+    enabled: hasChatAccess && canUseProviderSettings,
+    toastOnError: false,
+  });
   const { data: organization, isPending: isOrgLoading } = useOrganization();
   // The user's saved default (model, key) pair — top of the resolution chain
   // for a new chat ("member" level).
@@ -1844,6 +1852,12 @@ export function ChatPageContent({
         <LoadingSpinner />
       </div>
     );
+  }
+
+  // The keys request failed (e.g. offline). Show a retry state rather than the
+  // setup prompt, which would wrongly imply the user has no keys configured.
+  if (isApiKeysError) {
+    return <ApiKeyLoadError onRetry={() => refetchApiKeys()} />;
   }
 
   // If API key is not configured, show setup prompt with inline creation dialog

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -313,7 +313,7 @@ export function ChatPageContent({
   const {
     data: chatApiKeys = [],
     isLoading: isLoadingApiKeys,
-    isError: isApiKeysError,
+    isLoadingError: isApiKeysLoadError,
     refetch: refetchApiKeys,
   } = useLlmProviderApiKeys({
     enabled: hasChatAccess && canUseProviderSettings,
@@ -1854,12 +1854,12 @@ export function ChatPageContent({
     );
   }
 
-  // The keys request failed and we have no usable list to fall back on (e.g.
-  // offline cold start). Show a retry state rather than the setup prompt, which
-  // would wrongly imply the user has no keys configured. When a prior fetch
-  // succeeded, react-query keeps that data through a failed background refetch,
-  // so keep showing the real UI instead of flipping to this error screen.
-  if (isApiKeysError && !hasAnyApiKey) {
+  // The first keys fetch failed with no cached list (e.g. offline cold start).
+  // Show a retry state rather than the setup prompt, which would wrongly imply
+  // the user has no keys configured. `isLoadingError` is scoped to the
+  // first-fetch failure: a failed background refetch keeps the last successful
+  // result, so we don't flip a working or known-empty screen to this one.
+  if (isApiKeysLoadError) {
     return <ApiKeyLoadError onRetry={() => refetchApiKeys()} />;
   }
 

--- a/platform/frontend/src/app/knowledge/connectors/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/page.client.tsx
@@ -17,6 +17,7 @@ import { ConnectorStatusBadge } from "@/app/knowledge/knowledge-bases/_parts/con
 import { CreateConnectorDialog } from "@/app/knowledge/knowledge-bases/_parts/create-connector-dialog";
 import { EditConnectorDialog } from "@/app/knowledge/knowledge-bases/_parts/edit-connector-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { DataTable } from "@/components/ui/data-table";
@@ -76,6 +77,8 @@ function ConnectorsList() {
     data: connectors,
     isPending,
     isFetching,
+    isLoadingError: isConnectorsLoadError,
+    refetch: refetchConnectors,
   } = useConnectorsPaginated({
     limit: pageSize,
     offset,
@@ -250,25 +253,32 @@ function ConnectorsList() {
           </div>
         </div>
 
-        <DataTable
-          columns={columns}
-          data={items}
-          getRowId={(row) => row.id}
-          emptyMessage="No connectors found"
-          hasActiveFilters={!!search || connectorTypeFilter !== "all"}
-          onClearFilters={clearFilters}
-          filteredEmptyMessage="No connectors match your filters. Try adjusting your search."
-          hideSelectedCount
-          manualPagination
-          pagination={{
-            pageIndex,
-            pageSize,
-            total: pagination?.total ?? 0,
-          }}
-          onPaginationChange={handlePaginationChange}
-          isLoading={isFetching || isPending}
-          onRowClick={(row) => router.push(`/knowledge/connectors/${row.id}`)}
-        />
+        {isConnectorsLoadError ? (
+          <QueryLoadError
+            title="Couldn't load your connectors"
+            onRetry={() => refetchConnectors()}
+          />
+        ) : (
+          <DataTable
+            columns={columns}
+            data={items}
+            getRowId={(row) => row.id}
+            emptyMessage="No connectors found"
+            hasActiveFilters={!!search || connectorTypeFilter !== "all"}
+            onClearFilters={clearFilters}
+            filteredEmptyMessage="No connectors match your filters. Try adjusting your search."
+            hideSelectedCount
+            manualPagination
+            pagination={{
+              pageIndex,
+              pageSize,
+              total: pagination?.total ?? 0,
+            }}
+            onPaginationChange={handlePaginationChange}
+            isLoading={isFetching || isPending}
+            onRowClick={(row) => router.push(`/knowledge/connectors/${row.id}`)}
+          />
+        )}
 
         <CreateConnectorDialog
           open={isCreateDialogOpen}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -20,6 +20,7 @@ import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { KnowledgePageLayout } from "@/app/knowledge/_parts/knowledge-page-layout";
 import { ConnectorStatusBadge } from "@/app/knowledge/knowledge-bases/_parts/connector-status-badge";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { SmallTeamTierBanner } from "@/components/small-team-tier-banner";
 import { StandardDialog } from "@/components/standard-dialog";
@@ -50,6 +51,9 @@ import { EditKnowledgeBaseDialog } from "./_parts/edit-knowledge-base-dialog";
 type KnowledgeBaseItem =
   archestraApiTypes.GetKnowledgeBasesResponses["200"]["data"][number];
 
+const KNOWLEDGE_BASES_DESCRIPTION =
+  "A knowledge base is a searchable collection of content, grouped from one or more connectors, that your agents can retrieve answers from.";
+
 export default function KnowledgeBasesPage() {
   return (
     <div className="w-full h-full">
@@ -76,6 +80,8 @@ function KnowledgeBasesList() {
     data: knowledgeBases,
     isPending,
     isFetching,
+    isLoadingError: isKnowledgeBasesLoadError,
+    refetch: refetchKnowledgeBases,
   } = useKnowledgeBasesPaginated({
     limit: pageSize,
     offset,
@@ -176,10 +182,27 @@ function KnowledgeBasesList() {
     },
   ];
 
+  if (isKnowledgeBasesLoadError) {
+    return (
+      <KnowledgePageLayout
+        title="Knowledge Bases"
+        description={KNOWLEDGE_BASES_DESCRIPTION}
+        createLabel="Create Knowledge Base"
+        onCreateClick={() => setIsCreateDialogOpen(true)}
+        isPending={false}
+      >
+        <QueryLoadError
+          title="Couldn't load your knowledge bases"
+          onRetry={() => refetchKnowledgeBases()}
+        />
+      </KnowledgePageLayout>
+    );
+  }
+
   return (
     <KnowledgePageLayout
       title="Knowledge Bases"
-      description="A knowledge base is a searchable collection of content, grouped from one or more connectors, that your agents can retrieve answers from."
+      description={KNOWLEDGE_BASES_DESCRIPTION}
       createLabel="Create Knowledge Base"
       onCreateClick={() => setIsCreateDialogOpen(true)}
       isPending={isPending && !knowledgeBases}

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -190,51 +190,23 @@ export default function LimitsPage() {
     isLoadingError: isLimitsLoadError,
     refetch: refetchLimits,
   } = useLimits();
-  const {
-    data: teams = [],
-    isLoadingError: isTeamsLoadError,
-    refetch: refetchTeams,
-  } = useTeams();
+  const { data: teams = [] } = useTeams();
   const { data: organization } = useOrganization();
-  const {
-    data: members = [],
-    isLoadingError: isMembersLoadError,
-    refetch: refetchMembers,
-  } = useOrganizationMembers();
+  const { data: members = [] } = useOrganizationMembers();
   const { data: defaultUserLimits = [] } = useDefaultUserLimits();
-  const {
-    data: virtualKeysData,
-    isLoadingError: isVirtualKeysLoadError,
-    refetch: refetchVirtualKeys,
-  } = useAllVirtualApiKeys({
+  const { data: virtualKeysData } = useAllVirtualApiKeys({
     limit: LIMITS_ENTITY_SELECTOR_PAGE_SIZE,
   });
   const virtualKeys = virtualKeysData?.data ?? [];
-  const {
-    data: agents = [],
-    isLoadingError: isAgentsLoadError,
-    refetch: refetchAgents,
-  } = useProfiles({
+  const { data: agents = [] } = useProfiles({
     filters: { agentTypes: ["agent"] },
   });
-  const {
-    data: llmProxies = [],
-    isLoadingError: isLlmProxiesLoadError,
-    refetch: refetchLlmProxies,
-  } = useProfiles({
+  const { data: llmProxies = [] } = useProfiles({
     filters: { agentTypes: ["llm_proxy"] },
   });
-  const {
-    data: environmentsData,
-    isLoadingError: isEnvironmentsLoadError,
-    refetch: refetchEnvironments,
-  } = useEnvironments();
+  const { data: environmentsData } = useEnvironments();
   const environments = environmentsData?.environments ?? [];
-  const {
-    data: modelsWithApiKeys = [],
-    isLoadingError: isModelsLoadError,
-    refetch: refetchModels,
-  } = useModelsWithApiKeys();
+  const { data: modelsWithApiKeys = [] } = useModelsWithApiKeys();
   const createLimit = useCreateLimit();
   const updateLimit = useUpdateLimit();
   const deleteLimit = useDeleteLimit();
@@ -683,31 +655,15 @@ export default function LimitsPage() {
     (formState.isAllModels || formState.models.length > 0) &&
     (formState.entityType === "organization" || formState.entityId.length > 0);
 
-  const isLoadError =
-    isLimitsLoadError ||
-    isTeamsLoadError ||
-    isMembersLoadError ||
-    isVirtualKeysLoadError ||
-    isAgentsLoadError ||
-    isLlmProxiesLoadError ||
-    isEnvironmentsLoadError ||
-    isModelsLoadError;
-
-  if (isLoadError) {
+  // Gate the page on the limits list itself. The entity selectors (teams,
+  // members, virtual keys, agents, environments, models) degrade locally if
+  // their own fetch fails, so a secondary failure doesn't blank the page.
+  if (isLimitsLoadError) {
     return (
       <div className="space-y-4">
         <QueryLoadError
           title="Couldn't load usage limits"
-          onRetry={() => {
-            refetchLimits();
-            refetchTeams();
-            refetchMembers();
-            refetchVirtualKeys();
-            refetchAgents();
-            refetchLlmProxies();
-            refetchEnvironments();
-            refetchModels();
-          }}
+          onRetry={() => refetchLimits()}
         />
       </div>
     );

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -31,6 +31,7 @@ import {
 import { LlmModelPicker } from "@/components/llm-model-picker";
 import { LlmModelSearchableSelect } from "@/components/llm-model-select";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -183,24 +184,57 @@ function formatNumericInput(value: string) {
 
 export default function LimitsPage() {
   const setActionButton = useSetCostsAction();
-  const { data: limits = [], isPending } = useLimits();
-  const { data: teams = [] } = useTeams();
+  const {
+    data: limits = [],
+    isPending,
+    isLoadingError: isLimitsLoadError,
+    refetch: refetchLimits,
+  } = useLimits();
+  const {
+    data: teams = [],
+    isLoadingError: isTeamsLoadError,
+    refetch: refetchTeams,
+  } = useTeams();
   const { data: organization } = useOrganization();
-  const { data: members = [] } = useOrganizationMembers();
+  const {
+    data: members = [],
+    isLoadingError: isMembersLoadError,
+    refetch: refetchMembers,
+  } = useOrganizationMembers();
   const { data: defaultUserLimits = [] } = useDefaultUserLimits();
-  const { data: virtualKeysData } = useAllVirtualApiKeys({
+  const {
+    data: virtualKeysData,
+    isLoadingError: isVirtualKeysLoadError,
+    refetch: refetchVirtualKeys,
+  } = useAllVirtualApiKeys({
     limit: LIMITS_ENTITY_SELECTOR_PAGE_SIZE,
   });
   const virtualKeys = virtualKeysData?.data ?? [];
-  const { data: agents = [] } = useProfiles({
+  const {
+    data: agents = [],
+    isLoadingError: isAgentsLoadError,
+    refetch: refetchAgents,
+  } = useProfiles({
     filters: { agentTypes: ["agent"] },
   });
-  const { data: llmProxies = [] } = useProfiles({
+  const {
+    data: llmProxies = [],
+    isLoadingError: isLlmProxiesLoadError,
+    refetch: refetchLlmProxies,
+  } = useProfiles({
     filters: { agentTypes: ["llm_proxy"] },
   });
-  const { data: environmentsData } = useEnvironments();
+  const {
+    data: environmentsData,
+    isLoadingError: isEnvironmentsLoadError,
+    refetch: refetchEnvironments,
+  } = useEnvironments();
   const environments = environmentsData?.environments ?? [];
-  const { data: modelsWithApiKeys = [] } = useModelsWithApiKeys();
+  const {
+    data: modelsWithApiKeys = [],
+    isLoadingError: isModelsLoadError,
+    refetch: refetchModels,
+  } = useModelsWithApiKeys();
   const createLimit = useCreateLimit();
   const updateLimit = useUpdateLimit();
   const deleteLimit = useDeleteLimit();
@@ -648,6 +682,36 @@ export default function LimitsPage() {
     Number(formState.limitValue) > 0 &&
     (formState.isAllModels || formState.models.length > 0) &&
     (formState.entityType === "organization" || formState.entityId.length > 0);
+
+  const isLoadError =
+    isLimitsLoadError ||
+    isTeamsLoadError ||
+    isMembersLoadError ||
+    isVirtualKeysLoadError ||
+    isAgentsLoadError ||
+    isLlmProxiesLoadError ||
+    isEnvironmentsLoadError ||
+    isModelsLoadError;
+
+  if (isLoadError) {
+    return (
+      <div className="space-y-4">
+        <QueryLoadError
+          title="Couldn't load usage limits"
+          onRetry={() => {
+            refetchLimits();
+            refetchTeams();
+            refetchMembers();
+            refetchVirtualKeys();
+            refetchAgents();
+            refetchLlmProxies();
+            refetchEnvironments();
+            refetchModels();
+          }}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/platform/frontend/src/app/llm/(costs)/optimization-rules/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/optimization-rules/page.tsx
@@ -11,6 +11,7 @@ import { FormDialog } from "@/components/form-dialog";
 import { LlmModelSearchableSelect } from "@/components/llm-model-select";
 import { LlmProviderOptionLabel } from "@/components/llm-provider-select-items";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -78,7 +79,12 @@ function getProviderLogoName(provider: keyof typeof providerDisplayNames) {
 
 export default function OptimizationRulesPage() {
   const setActionButton = useSetCostsAction();
-  const { data: rules = [], isPending } = useOptimizationRules();
+  const {
+    data: rules = [],
+    isPending,
+    isLoadingError: isRulesLoadError,
+    refetch: refetchRules,
+  } = useOptimizationRules();
   const { data: modelsWithApiKeys = [] } = useModelsWithApiKeys();
   const { data: teams = [] } = useTeams();
   const { data: organization } = useOrganization();
@@ -355,20 +361,27 @@ export default function OptimizationRulesPage() {
         isPending={isPending}
         loadingFallback={<LoadingSpinner />}
       >
-        <DataTable
-          columns={columns}
-          data={filteredRules}
-          emptyMessage="No optimization rules configured yet"
-          hasActiveFilters={hasActiveFilters}
-          filteredEmptyMessage="No optimization rules match your filters. Try adjusting your search."
-          onClearFilters={() =>
-            updateQueryParams({
-              appliedTo: null,
-              provider: null,
-              targetModel: null,
-            })
-          }
-        />
+        {isRulesLoadError ? (
+          <QueryLoadError
+            title="Couldn't load your optimization rules"
+            onRetry={() => refetchRules()}
+          />
+        ) : (
+          <DataTable
+            columns={columns}
+            data={filteredRules}
+            emptyMessage="No optimization rules configured yet"
+            hasActiveFilters={hasActiveFilters}
+            filteredEmptyMessage="No optimization rules match your filters. Try adjusting your search."
+            onClearFilters={() =>
+              updateQueryParams({
+                appliedTo: null,
+                provider: null,
+                targetModel: null,
+              })
+            }
+          />
+        )}
       </LoadingWrapper>
 
       <FormDialog

--- a/platform/frontend/src/app/llm/credentials/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/oauth-clients/page.tsx
@@ -19,6 +19,7 @@ import {
   providerApiKeyMapToArray,
 } from "@/components/provider-key-mappings-field";
 import { ProviderKeyAccessFields } from "@/components/proxy-auth-provider-key-fields";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
@@ -91,10 +92,16 @@ export default function OAuthClientsPage() {
   const search = searchParams.get("search") || "";
   const providerApiKeyIdFilter = searchParams.get("providerApiKeyId") || "all";
 
-  const { data: oauthClients = [], isPending } = useLlmOauthClients({
+  const {
+    data: oauthClients = [],
+    isPending,
+    isLoadingError: isOauthClientsLoadError,
+    refetch: refetchOauthClients,
+  } = useLlmOauthClients({
     search: search || undefined,
     providerApiKeyId:
       providerApiKeyIdFilter === "all" ? undefined : providerApiKeyIdFilter,
+    toastOnError: false,
   });
   const { data: llmProxies = [] } = useProfiles({
     filters: { agentTypes: ["llm_proxy"] },
@@ -255,21 +262,28 @@ export default function OAuthClientsPage() {
         />
       </div>
 
-      <DataTable
-        columns={columns}
-        data={oauthClients}
-        isLoading={isPending}
-        emptyMessage="No OAuth clients registered. Create one for backend services or bots that call LLM proxies."
-        hasActiveFilters={Boolean(search || providerApiKeyIdFilter !== "all")}
-        filteredEmptyMessage="No OAuth clients match your filters. Try adjusting your search."
-        onClearFilters={() =>
-          updateQueryParams({
-            search: null,
-            providerApiKeyId: null,
-            page: "1",
-          })
-        }
-      />
+      {isOauthClientsLoadError ? (
+        <QueryLoadError
+          title="Couldn't load your OAuth clients"
+          onRetry={() => refetchOauthClients()}
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={oauthClients}
+          isLoading={isPending}
+          emptyMessage="No OAuth clients registered. Create one for backend services or bots that call LLM proxies."
+          hasActiveFilters={Boolean(search || providerApiKeyIdFilter !== "all")}
+          filteredEmptyMessage="No OAuth clients match your filters. Try adjusting your search."
+          onClearFilters={() =>
+            updateQueryParams({
+              search: null,
+              providerApiKeyId: null,
+              page: "1",
+            })
+          }
+        />
+      )}
 
       <CreateOAuthClientDialog
         open={isCreateDialogOpen}

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
@@ -30,6 +30,7 @@ import {
   providerApiKeyMapToArray,
 } from "@/components/provider-key-mappings-field";
 import { ProviderKeyAccessFields } from "@/components/proxy-auth-provider-key-fields";
+import { QueryLoadError } from "@/components/query-load-error";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
@@ -117,7 +118,12 @@ export default function VirtualKeysPage() {
   const providerApiKeyIdFilter = searchParams.get("providerApiKeyId") || "all";
   const keyTypeFilter = searchParams.get("keyType") || "all";
 
-  const { data: response, isPending } = useAllVirtualApiKeys({
+  const {
+    data: response,
+    isPending,
+    isLoadingError: isVirtualKeysLoadError,
+    refetch: refetchVirtualKeys,
+  } = useAllVirtualApiKeys({
     limit: pageSize,
     offset,
     search: search || undefined,
@@ -348,37 +354,46 @@ export default function VirtualKeysPage() {
         </Select>
       </div>
 
-      <DataTable
-        columns={columns}
-        data={virtualKeys}
-        getRowId={(row) => row.id}
-        hideSelectedCount
-        isLoading={isPending}
-        emptyMessage={
-          parentableKeys.length === 0
-            ? "Add an API key first to create virtual keys"
-            : "No virtual keys yet"
-        }
-        manualPagination
-        pagination={{
-          pageIndex,
-          pageSize,
-          total: paginationMeta?.total ?? 0,
-        }}
-        onPaginationChange={setPagination}
-        hasActiveFilters={Boolean(
-          search || providerApiKeyIdFilter !== "all" || keyTypeFilter !== "all",
-        )}
-        filteredEmptyMessage="No virtual keys match your filters. Try adjusting your search."
-        onClearFilters={() =>
-          updateQueryParams({
-            search: null,
-            providerApiKeyId: null,
-            keyType: null,
-            page: "1",
-          })
-        }
-      />
+      {isVirtualKeysLoadError ? (
+        <QueryLoadError
+          title="Couldn't load your virtual keys"
+          onRetry={() => refetchVirtualKeys()}
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={virtualKeys}
+          getRowId={(row) => row.id}
+          hideSelectedCount
+          isLoading={isPending}
+          emptyMessage={
+            parentableKeys.length === 0
+              ? "Add an API key first to create virtual keys"
+              : "No virtual keys yet"
+          }
+          manualPagination
+          pagination={{
+            pageIndex,
+            pageSize,
+            total: paginationMeta?.total ?? 0,
+          }}
+          onPaginationChange={setPagination}
+          hasActiveFilters={Boolean(
+            search ||
+              providerApiKeyIdFilter !== "all" ||
+              keyTypeFilter !== "all",
+          )}
+          filteredEmptyMessage="No virtual keys match your filters. Try adjusting your search."
+          onClearFilters={() =>
+            updateQueryParams({
+              search: null,
+              providerApiKeyId: null,
+              keyType: null,
+              page: "1",
+            })
+          }
+        />
+      )}
 
       <CreateVirtualKeyDialog
         open={isCreateDialogOpen}

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/page.tsx
@@ -131,6 +131,7 @@ export default function VirtualKeysPage() {
       providerApiKeyIdFilter === "all" ? undefined : providerApiKeyIdFilter,
     keyType:
       keyTypeFilter === "all" ? undefined : (keyTypeFilter as VirtualKeyType),
+    toastOnError: false,
   });
   const virtualKeys = response?.data ?? [];
   const paginationMeta = response?.pagination;

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -250,6 +250,7 @@ function SessionsTable({
     startDate: dateTimePicker.startDateParam,
     endDate: dateTimePicker.endDateParam,
     search: searchFromUrl || undefined,
+    toastOnError: false,
   });
 
   const { data: agents } = useProfiles({

--- a/platform/frontend/src/app/llm/logs/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/page.client.tsx
@@ -20,6 +20,7 @@ import {
   SourceFilterOption,
   UserFilterOption,
 } from "@/components/log-filter-option";
+import { QueryLoadError } from "@/components/query-load-error";
 import { Savings } from "@/components/savings";
 import { SearchInput } from "@/components/search-input";
 import { SourceBadge } from "@/components/source-badge";
@@ -230,7 +231,12 @@ function SessionsTable({
     [updateQueryParams],
   );
 
-  const { data: sessionsResponse, isFetching } = useInteractionSessions({
+  const {
+    data: sessionsResponse,
+    isFetching,
+    isLoadingError,
+    refetch: refetchSessions,
+  } = useInteractionSessions({
     limit: pageSize,
     offset,
     profileId: profileFilter !== "all" ? profileFilter : undefined,
@@ -508,6 +514,19 @@ function SessionsTable({
     ],
     [agents],
   );
+
+  // A failed fetch leaves no rows; show a retry state instead of the table's
+  // "No LLM proxy logs found" empty message, which would misrepresent the error.
+  if (isLoadingError) {
+    return (
+      <div className="space-y-4">
+        <QueryLoadError
+          title="Couldn't load logs"
+          onRetry={() => refetchSessions()}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -97,7 +97,7 @@ export default function ModelsPage() {
     isPending,
     isLoadingError: isModelsLoadError,
     refetch,
-  } = useModelsWithApiKeys();
+  } = useModelsWithApiKeys({ toastOnError: false });
   const { data: apiKeys = [] } = useLlmProviderApiKeys();
   const syncModelsMutation = useSyncLlmModels();
   const updateModel = useUpdateModel();

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -39,6 +39,7 @@ import {
   UnknownCapabilitiesBadge,
 } from "@/components/model-badges";
 import { PageLayout } from "@/components/page-layout";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { StandardFormDialog } from "@/components/standard-dialog";
 import { TableRowActions } from "@/components/table-row-actions";
@@ -91,7 +92,12 @@ import {
 } from "./models-page-utils";
 
 export default function ModelsPage() {
-  const { data: models = [], isPending, refetch } = useModelsWithApiKeys();
+  const {
+    data: models = [],
+    isPending,
+    isLoadingError: isModelsLoadError,
+    refetch,
+  } = useModelsWithApiKeys();
   const { data: apiKeys = [] } = useLlmProviderApiKeys();
   const syncModelsMutation = useSyncLlmModels();
   const updateModel = useUpdateModel();
@@ -363,6 +369,22 @@ export default function ModelsPage() {
     ],
     [updateModel],
   );
+
+  if (isModelsLoadError) {
+    return (
+      <PageLayout
+        title="Models"
+        description='Models available from your configured providers. Use "Refresh Models" to re-fetch models and capabilities from providers.'
+        tabs={MODEL_NAV_TABS}
+        actionButton={refreshModelsButton}
+      >
+        <QueryLoadError
+          title="Couldn't load your models"
+          onRetry={() => refetch()}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <PageLayout

--- a/platform/frontend/src/app/mcp/credentials/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/mcp/credentials/oauth-clients/page.tsx
@@ -11,6 +11,7 @@ import {
 import { CopyableCode } from "@/components/copyable-code";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { FormDialog } from "@/components/form-dialog";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Badge } from "@/components/ui/badge";
@@ -81,7 +82,12 @@ export default function OAuthClientsPage() {
   const { searchParams, updateQueryParams } = useDataTableQueryParams();
   const search = searchParams.get("search") || "";
 
-  const { data: oauthClients = [], isPending } = useMcpOauthClients({
+  const {
+    data: oauthClients = [],
+    isPending,
+    isLoadingError: isOauthClientsLoadError,
+    refetch: refetchOauthClients,
+  } = useMcpOauthClients({
     search: search || undefined,
   });
   const { data: gateways = [] } = useProfiles({
@@ -202,20 +208,27 @@ export default function OAuthClientsPage() {
         />
       </div>
 
-      <DataTable
-        columns={columns}
-        data={oauthClients}
-        isLoading={isPending}
-        emptyMessage="No OAuth clients registered. Create one for an application that calls MCP gateways."
-        hasActiveFilters={Boolean(search)}
-        filteredEmptyMessage="No OAuth clients match your filters. Try adjusting your search."
-        onClearFilters={() =>
-          updateQueryParams({
-            search: null,
-            page: "1",
-          })
-        }
-      />
+      {isOauthClientsLoadError ? (
+        <QueryLoadError
+          title="Couldn't load your OAuth clients"
+          onRetry={() => refetchOauthClients()}
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={oauthClients}
+          isLoading={isPending}
+          emptyMessage="No OAuth clients registered. Create one for an application that calls MCP gateways."
+          hasActiveFilters={Boolean(search)}
+          filteredEmptyMessage="No OAuth clients match your filters. Try adjusting your search."
+          onClearFilters={() =>
+            updateQueryParams({
+              search: null,
+              page: "1",
+            })
+          }
+        />
+      )}
 
       <CreateOAuthClientDialog
         open={isCreateDialogOpen}

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -20,6 +20,7 @@ import { ExternalDocsLink } from "@/components/external-docs-link";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
 import { PermissionRequirementHint } from "@/components/permission-requirement-hint";
+import { QueryLoadError } from "@/components/query-load-error";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { SearchInput } from "@/components/search-input";
 import { Badge } from "@/components/ui/badge";
@@ -140,7 +141,12 @@ function McpGateways({
       : ["mcp_gateway", "profile"]
     : ["mcp_gateway"];
 
-  const { data: agentsResponse, isPending } = useProfilesPaginated({
+  const {
+    data: agentsResponse,
+    isPending,
+    isLoadingError: isGatewaysLoadError,
+    refetch: refetchGateways,
+  } = useProfilesPaginated({
     initialData: initialData?.agents ?? undefined,
     limit: pageSize,
     offset,
@@ -422,6 +428,37 @@ function McpGateways({
       },
     },
   ];
+
+  if (isGatewaysLoadError) {
+    return (
+      <PageLayout
+        title="MCP Gateways"
+        description={
+          <p className="text-sm text-muted-foreground">
+            MCP Gateways provide a unified MCP endpoint for your AI agents to
+            access tools and subagents.
+            {docsUrl && (
+              <>
+                {" "}
+                <ExternalDocsLink
+                  href={docsUrl}
+                  className="underline hover:text-foreground"
+                  showIcon={false}
+                >
+                  Read more in the docs
+                </ExternalDocsLink>
+              </>
+            )}
+          </p>
+        }
+      >
+        <QueryLoadError
+          title="Couldn't load your MCP gateways"
+          onRetry={() => refetchGateways()}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <LoadingWrapper

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -6,6 +6,7 @@ import { ChevronDown, ChevronUp, User } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ProfileFilterOption } from "@/components/log-filter-option";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { TableFilters } from "@/components/table-filters";
 import { TruncatedText } from "@/components/truncated-text";
@@ -165,7 +166,12 @@ function McpToolCallsTable({
         ? "createdAt"
         : undefined;
 
-  const { data: mcpToolCallsResponse, isFetching } = useMcpToolCalls({
+  const {
+    data: mcpToolCallsResponse,
+    isFetching,
+    isLoadingError: isMcpToolCallsLoadError,
+    refetch: refetchMcpToolCalls,
+  } = useMcpToolCalls({
     agentId: profileFilter !== "all" ? profileFilter : undefined,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
@@ -424,6 +430,17 @@ function McpToolCallsTable({
       paramName="search"
     />
   );
+
+  if (isMcpToolCallsLoadError) {
+    return (
+      <div className="space-y-4">
+        <QueryLoadError
+          title="Couldn't load logs"
+          onRetry={() => refetchMcpToolCalls()}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/platform/frontend/src/app/messaging-channels/_components/channels-section.tsx
+++ b/platform/frontend/src/app/messaging-channels/_components/channels-section.tsx
@@ -17,6 +17,7 @@ import { useCallback, useMemo, useState } from "react";
 import { AgentBadge } from "@/components/agent-badge";
 import Divider from "@/components/divider";
 import { LoadingSpinner } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -104,6 +105,8 @@ export function ChannelsSection({
     data: bindingsResponse,
     isLoading,
     isFetching,
+    isLoadingError,
+    refetch: refetchBindings,
   } = useChatOpsBindings({
     provider: providerConfig.provider,
     limit: pageSize,
@@ -352,6 +355,11 @@ export function ChannelsSection({
 
       {isLoading && !bindingsResponse ? (
         <ChannelTableSkeleton />
+      ) : isLoadingError ? (
+        <QueryLoadError
+          title="Couldn't load your channels"
+          onRetry={() => refetchBindings()}
+        />
       ) : hasAnyChannels ? (
         <>
           {/* Search + filters + bulk assign */}

--- a/platform/frontend/src/app/projects/page.client.test.tsx
+++ b/platform/frontend/src/app/projects/page.client.test.tsx
@@ -8,6 +8,14 @@ const mockPinMutate = vi.fn();
 
 let mockProjects: ProjectFixture[] = [];
 
+type ApiKeyState = {
+  hasAnyApiKey: boolean;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+};
+let mockApiKeyState: ApiKeyState;
+
 type ProjectFixture = {
   id: string;
   name: string;
@@ -178,7 +186,15 @@ vi.mock("@/components/ui/textarea", () => ({
 }));
 
 vi.mock("@/lib/llm-provider-api-keys.query", () => ({
-  useHasAnyApiKey: () => ({ hasAnyApiKey: true, isLoading: false }),
+  useHasAnyApiKey: () => mockApiKeyState,
+}));
+
+vi.mock("@/components/api-key-load-error", () => ({
+  ApiKeyLoadError: ({ onRetry }: { onRetry: () => void }) => (
+    <button type="button" data-testid="api-key-load-error" onClick={onRetry}>
+      retry
+    </button>
+  ),
 }));
 
 vi.mock("@/lib/auth/auth.query", () => ({
@@ -225,6 +241,12 @@ describe("ProjectsPageClient", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProjects = [];
+    mockApiKeyState = {
+      hasAnyApiKey: true,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
     mockDeleteMutateAsync.mockResolvedValue(true);
     mockUpdateMutateAsync.mockResolvedValue(true);
   });
@@ -285,6 +307,38 @@ describe("ProjectsPageClient", () => {
 
     fireEvent.click(screen.getByText("Delete"));
     expect(screen.getByText("Delete Owner project?")).toBeInTheDocument();
+  });
+
+  it("shows the load-error retry state, not the add-key prompt, when the keys request fails", () => {
+    mockApiKeyState = {
+      hasAnyApiKey: false,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    };
+
+    render(<ProjectsPageClient />);
+
+    expect(screen.getByTestId("api-key-load-error")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Connect an LLM provider to start a project"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the add-key prompt when the keys request succeeds with no keys", () => {
+    mockApiKeyState = {
+      hasAnyApiKey: false,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
+
+    render(<ProjectsPageClient />);
+
+    expect(
+      screen.getByText("Connect an LLM provider to start a project"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("api-key-load-error")).not.toBeInTheDocument();
   });
 
   it("shows unpin in pinned project card menus", () => {

--- a/platform/frontend/src/app/projects/page.client.test.tsx
+++ b/platform/frontend/src/app/projects/page.client.test.tsx
@@ -11,7 +11,7 @@ let mockProjects: ProjectFixture[] = [];
 type ApiKeyState = {
   hasAnyApiKey: boolean;
   isLoading: boolean;
-  isError: boolean;
+  isLoadError: boolean;
   refetch: () => void;
 };
 let mockApiKeyState: ApiKeyState;
@@ -242,7 +242,7 @@ describe("ProjectsPageClient", () => {
     mockApiKeyState = {
       hasAnyApiKey: true,
       isLoading: false,
-      isError: false,
+      isLoadError: false,
       refetch: vi.fn(),
     };
     mockDeleteMutateAsync.mockResolvedValue(true);
@@ -312,7 +312,7 @@ describe("ProjectsPageClient", () => {
     mockApiKeyState = {
       hasAnyApiKey: false,
       isLoading: false,
-      isError: true,
+      isLoadError: true,
       refetch,
     };
 
@@ -329,7 +329,7 @@ describe("ProjectsPageClient", () => {
     mockApiKeyState = {
       hasAnyApiKey: false,
       isLoading: false,
-      isError: false,
+      isLoadError: false,
       refetch: vi.fn(),
     };
 
@@ -340,10 +340,12 @@ describe("ProjectsPageClient", () => {
   });
 
   it("keeps showing projects when a refetch fails but cached keys remain", () => {
+    // A failed background refetch after a prior success is not a load error,
+    // so the cached keys keep the project list on screen.
     mockApiKeyState = {
       hasAnyApiKey: true,
       isLoading: false,
-      isError: true,
+      isLoadError: false,
       refetch: vi.fn(),
     };
     mockProjects = [makeProject({ id: "plain", name: "Plain project" })];

--- a/platform/frontend/src/app/projects/page.client.test.tsx
+++ b/platform/frontend/src/app/projects/page.client.test.tsx
@@ -87,9 +87,7 @@ vi.mock("@/components/page-layout", () => ({
 }));
 
 vi.mock("@/components/no-api-key-setup", () => ({
-  NoApiKeySetup: ({ description }: { description: string }) => (
-    <p>{description}</p>
-  ),
+  NoApiKeySetup: () => <div data-testid="no-api-key-setup" />,
 }));
 
 vi.mock("@/components/agent-icon", () => ({
@@ -310,19 +308,21 @@ describe("ProjectsPageClient", () => {
   });
 
   it("shows the load-error retry state, not the add-key prompt, when the keys request fails", () => {
+    const refetch = vi.fn();
     mockApiKeyState = {
       hasAnyApiKey: false,
       isLoading: false,
       isError: true,
-      refetch: vi.fn(),
+      refetch,
     };
 
     render(<ProjectsPageClient />);
 
     expect(screen.getByTestId("api-key-load-error")).toBeInTheDocument();
-    expect(
-      screen.queryByText("Connect an LLM provider to start a project"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("no-api-key-setup")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("api-key-load-error"));
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 
   it("shows the add-key prompt when the keys request succeeds with no keys", () => {
@@ -335,10 +335,24 @@ describe("ProjectsPageClient", () => {
 
     render(<ProjectsPageClient />);
 
-    expect(
-      screen.getByText("Connect an LLM provider to start a project"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("no-api-key-setup")).toBeInTheDocument();
     expect(screen.queryByTestId("api-key-load-error")).not.toBeInTheDocument();
+  });
+
+  it("keeps showing projects when a refetch fails but cached keys remain", () => {
+    mockApiKeyState = {
+      hasAnyApiKey: true,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    };
+    mockProjects = [makeProject({ id: "plain", name: "Plain project" })];
+
+    render(<ProjectsPageClient />);
+
+    expect(screen.queryByTestId("api-key-load-error")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("no-api-key-setup")).not.toBeInTheDocument();
+    expect(screen.getByText("Plain project")).toBeInTheDocument();
   });
 
   it("shows unpin in pinned project card menus", () => {

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -21,6 +21,7 @@ import { useForm } from "react-hook-form";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { AgentIcon } from "@/components/agent-icon";
 import { AgentIconPicker } from "@/components/agent-icon-picker";
+import { ApiKeyLoadError } from "@/components/api-key-load-error";
 import { NoApiKeySetup } from "@/components/no-api-key-setup";
 import { PageLayout } from "@/components/page-layout";
 import { ProjectScopeFilter } from "@/components/project-scope-filter";
@@ -85,7 +86,12 @@ function ProjectsList() {
     authorIds,
     excludeAuthorIds,
   });
-  const { hasAnyApiKey, isLoading: isApiKeyLoading } = useHasAnyApiKey();
+  const {
+    hasAnyApiKey,
+    isLoading: isApiKeyLoading,
+    isError: isApiKeyError,
+    refetch: refetchApiKeys,
+  } = useHasAnyApiKey();
   const [createOpen, setCreateOpen] = useState(false);
   const [editingProject, setEditingProject] = useState<ProjectListItem | null>(
     null,
@@ -107,6 +113,16 @@ function ProjectsList() {
     !!teamIds ||
     !!authorIds ||
     !!excludeAuthorIds;
+
+  // The keys request failed (e.g. offline). Show a retry state rather than the
+  // setup prompt, which would wrongly imply the user has no keys configured.
+  if (!isApiKeyLoading && isApiKeyError) {
+    return (
+      <PageLayout title="Projects" description={PROJECTS_DESCRIPTION}>
+        <ApiKeyLoadError onRetry={refetchApiKeys} />
+      </PageLayout>
+    );
+  }
 
   // Mirror the new-chat screen: with no usable LLM key there's nothing to run a
   // project on, so prompt to add one instead of offering project creation.

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -91,6 +91,7 @@ function ProjectsList() {
     teamIds,
     authorIds,
     excludeAuthorIds,
+    toastOnError: false,
   });
   const {
     hasAnyApiKey,

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -114,9 +114,11 @@ function ProjectsList() {
     !!authorIds ||
     !!excludeAuthorIds;
 
-  // The keys request failed (e.g. offline). Show a retry state rather than the
-  // setup prompt, which would wrongly imply the user has no keys configured.
-  if (!isApiKeyLoading && isApiKeyError) {
+  // The keys request failed and we have no usable list to fall back on (e.g.
+  // offline cold start). Show a retry state rather than the setup prompt, which
+  // would wrongly imply the user has no keys configured. A failed background
+  // refetch after a prior success keeps the cached keys, so it falls through.
+  if (!isApiKeyLoading && isApiKeyError && !hasAnyApiKey) {
     return (
       <PageLayout title="Projects" description={PROJECTS_DESCRIPTION}>
         <ApiKeyLoadError onRetry={refetchApiKeys} />

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -27,6 +27,7 @@ import { PageLayout } from "@/components/page-layout";
 import { ProjectScopeFilter } from "@/components/project-scope-filter";
 import { EditProjectDialog } from "@/components/projects/edit-project-dialog";
 import { ProjectVisibilityBadge } from "@/components/projects/project-visibility-badge";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { StandardFormDialog } from "@/components/standard-dialog";
 import { Badge } from "@/components/ui/badge";
@@ -79,7 +80,12 @@ function ProjectsList() {
   const teamIds = csvParam("teamIds");
   const authorIds = csvParam("authorIds");
   const excludeAuthorIds = csvParam("excludeAuthorIds");
-  const { data, isPending } = useProjects({
+  const {
+    data,
+    isPending,
+    isLoadingError: isProjectsLoadError,
+    refetch: refetchProjects,
+  } = useProjects({
     scope: toApiProjectScope(scope),
     search,
     teamIds,
@@ -132,6 +138,19 @@ function ProjectsList() {
     return (
       <PageLayout title="Projects" description={PROJECTS_DESCRIPTION}>
         <NoApiKeySetup description="Connect an LLM provider to start a project" />
+      </PageLayout>
+    );
+  }
+
+  // The projects list fetch failed with no cached data. Show a retry state so a
+  // failed fetch isn't misread as "No projects yet".
+  if (isProjectsLoadError) {
+    return (
+      <PageLayout title="Projects" description={PROJECTS_DESCRIPTION}>
+        <QueryLoadError
+          title="Couldn't load your projects"
+          onRetry={() => refetchProjects()}
+        />
       </PageLayout>
     );
   }

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -89,7 +89,7 @@ function ProjectsList() {
   const {
     hasAnyApiKey,
     isLoading: isApiKeyLoading,
-    isError: isApiKeyError,
+    isLoadError: isApiKeyLoadError,
     refetch: refetchApiKeys,
   } = useHasAnyApiKey();
   const [createOpen, setCreateOpen] = useState(false);
@@ -114,11 +114,11 @@ function ProjectsList() {
     !!authorIds ||
     !!excludeAuthorIds;
 
-  // The keys request failed and we have no usable list to fall back on (e.g.
-  // offline cold start). Show a retry state rather than the setup prompt, which
-  // would wrongly imply the user has no keys configured. A failed background
-  // refetch after a prior success keeps the cached keys, so it falls through.
-  if (!isApiKeyLoading && isApiKeyError && !hasAnyApiKey) {
+  // The first keys fetch failed with no cached list (e.g. offline cold start).
+  // Show a retry state rather than the setup prompt, which would wrongly imply
+  // the user has no keys configured. `isLoadError` is scoped to the first-fetch
+  // failure, so a failed background refetch keeps the cached state instead.
+  if (!isApiKeyLoading && isApiKeyLoadError) {
     return (
       <PageLayout title="Projects" description={PROJECTS_DESCRIPTION}>
         <ApiKeyLoadError onRetry={refetchApiKeys} />

--- a/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
@@ -137,6 +137,7 @@ export function ScheduleTriggersIndexPage() {
         ? selectedAuthorIds
         : undefined,
     refetchInterval: 5_000,
+    toastOnError: false,
   });
   const { data: agents = [], isLoading: agentsLoading } = useProfiles({
     filters: { agentType: "agent" },

--- a/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
@@ -20,6 +20,7 @@ import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AgentIcon } from "@/components/agent-icon";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -120,7 +121,12 @@ export function ScheduleTriggersIndexPage() {
         })),
     [members, currentUserId],
   );
-  const { data: triggersResponse, isLoading } = useScheduleTriggers({
+  const {
+    data: triggersResponse,
+    isLoading,
+    isLoadingError: isTriggersLoadError,
+    refetch: refetchTriggers,
+  } = useScheduleTriggers({
     limit: pageSize,
     offset: pageIndex * pageSize,
     name: searchName || undefined,
@@ -400,6 +406,17 @@ export function ScheduleTriggersIndexPage() {
     ],
     [agents, openEditComposer, showOtherUsers],
   );
+
+  if (isTriggersLoadError) {
+    return (
+      <div className="flex w-full flex-col gap-5">
+        <QueryLoadError
+          title="Couldn't load your scheduled tasks"
+          onRetry={() => refetchTriggers()}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="flex w-full flex-col gap-5">

--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AgentSelector } from "@/components/agent-selector";
 import { LlmModelSearchableSelect } from "@/components/llm-model-select";
 import { LlmProviderApiKeyDropdown } from "@/components/llm-provider-api-key-dropdown";
+import { QueryLoadError } from "@/components/query-load-error";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import {
   SettingsBlock,
@@ -49,7 +50,11 @@ export default function AgentSettingsPage() {
   const { getToolName } = useArchestraMcpIdentity();
   const appName = useAppName();
   const { data: organization } = useOrganization();
-  const { data: apiKeys } = useAvailableLlmProviderApiKeys();
+  const {
+    data: apiKeys,
+    isLoadingError: isApiKeysLoadError,
+    refetch: refetchApiKeys,
+  } = useAvailableLlmProviderApiKeys();
   const { data: orgAgents } = useOrgScopedAgents();
 
   const [selectedApiKeyId, setSelectedApiKeyId] = useState<string>("");
@@ -69,9 +74,16 @@ export default function AgentSettingsPage() {
     fileUploads: "enabled" as FileUploadsEnabled,
   });
 
-  const { data: allModels, isPending: modelsLoading } = useLlmModels({
+  const {
+    data: allModels,
+    isPending: modelsLoading,
+    isLoadingError: isModelsLoadError,
+    refetch: refetchModels,
+  } = useLlmModels({
     apiKeyId: selectedApiKeyId || undefined,
   });
+
+  const isLoadError = isApiKeysLoadError || isModelsLoadError;
 
   const updateAgentMutation = useUpdateAgentSettings(
     "Agent settings updated",
@@ -189,60 +201,71 @@ export default function AgentSettingsPage() {
             permissions={{ agentSettings: ["update"] }}
             noPermissionHandle="tooltip"
           >
-            {({ hasPermission }) => (
-              <div className="flex flex-col gap-2 w-80">
-                <LlmProviderApiKeyDropdown
-                  availableKeys={availableKeys}
-                  selectedApiKeyId={selectedApiKeyId || null}
-                  disabled={isSaving || !hasPermission}
-                  open={apiKeySelectorOpen}
-                  onOpenChange={setApiKeySelectorOpen}
-                  onSelectKey={(value) => {
-                    setSelectedApiKeyId(value);
-                    setDefaultModel("");
-                    setApiKeySelectorOpen(false);
-                  }}
-                  triggerVariant="select"
-                  triggerClassName="w-80"
-                  popoverClassName="w-80"
-                  emptyTriggerLabel="Select API key..."
-                />
-                <LlmModelSearchableSelect
-                  value={defaultModel}
-                  onValueChange={setDefaultModel}
-                  options={modelItems}
-                  freeFilterable={canFilterFreeModels}
-                  placeholder={
-                    !selectedApiKeyId
-                      ? "Select API key first..."
-                      : modelsLoading
-                        ? "Loading models..."
-                        : "Select model..."
-                  }
+            {({ hasPermission }) =>
+              isLoadError ? (
+                <QueryLoadError
+                  title="Couldn't load your LLM providers"
                   className="w-80"
-                  disabled={
-                    isSaving ||
-                    !hasPermission ||
-                    modelsLoading ||
-                    !selectedApiKeyId
-                  }
+                  onRetry={() => {
+                    refetchApiKeys();
+                    refetchModels();
+                  }}
                 />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="self-end"
-                  onClick={handleResetDefaultModel}
-                  disabled={
-                    isSaving ||
-                    !hasPermission ||
-                    (!selectedApiKeyId && !defaultModel)
-                  }
-                >
-                  Reset
-                </Button>
-              </div>
-            )}
+              ) : (
+                <div className="flex flex-col gap-2 w-80">
+                  <LlmProviderApiKeyDropdown
+                    availableKeys={availableKeys}
+                    selectedApiKeyId={selectedApiKeyId || null}
+                    disabled={isSaving || !hasPermission}
+                    open={apiKeySelectorOpen}
+                    onOpenChange={setApiKeySelectorOpen}
+                    onSelectKey={(value) => {
+                      setSelectedApiKeyId(value);
+                      setDefaultModel("");
+                      setApiKeySelectorOpen(false);
+                    }}
+                    triggerVariant="select"
+                    triggerClassName="w-80"
+                    popoverClassName="w-80"
+                    emptyTriggerLabel="Select API key..."
+                  />
+                  <LlmModelSearchableSelect
+                    value={defaultModel}
+                    onValueChange={setDefaultModel}
+                    options={modelItems}
+                    freeFilterable={canFilterFreeModels}
+                    placeholder={
+                      !selectedApiKeyId
+                        ? "Select API key first..."
+                        : modelsLoading
+                          ? "Loading models..."
+                          : "Select model..."
+                    }
+                    className="w-80"
+                    disabled={
+                      isSaving ||
+                      !hasPermission ||
+                      modelsLoading ||
+                      !selectedApiKeyId
+                    }
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="self-end"
+                    onClick={handleResetDefaultModel}
+                    disabled={
+                      isSaving ||
+                      !hasPermission ||
+                      (!selectedApiKeyId && !defaultModel)
+                    }
+                  >
+                    Reset
+                  </Button>
+                </div>
+              )
+            }
           </WithPermissions>
         }
       />

--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -54,7 +54,7 @@ export default function AgentSettingsPage() {
     data: apiKeys,
     isLoadingError: isApiKeysLoadError,
     refetch: refetchApiKeys,
-  } = useAvailableLlmProviderApiKeys();
+  } = useAvailableLlmProviderApiKeys({ toastOnError: false });
   const { data: orgAgents } = useOrgScopedAgents();
 
   const [selectedApiKeyId, setSelectedApiKeyId] = useState<string>("");

--- a/platform/frontend/src/app/settings/api-keys/page.tsx
+++ b/platform/frontend/src/app/settings/api-keys/page.tsx
@@ -9,6 +9,7 @@ import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExpirationDateTimeField } from "@/components/expiration-date-time-field";
 import { FormDialog } from "@/components/form-dialog";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -50,7 +51,12 @@ export default function ApiKeysSettingsPage() {
   const setActionButton = useSetSettingsAction();
   const { data: canReadApiKeys, isPending: isCheckingPermissions } =
     useHasPermissions({ apiKey: ["read"] });
-  const { data: apiKeys = [], isPending } = useApiKeys();
+  const {
+    data: apiKeys = [],
+    isPending,
+    isLoadingError: isApiKeysLoadError,
+    refetch: refetchApiKeys,
+  } = useApiKeys();
   const { data: canDeleteApiKeys } = useHasPermissions({ apiKey: ["delete"] });
   const createApiKeyMutation = useCreateApiKey();
   const deleteApiKeyMutation = useDeleteApiKey();
@@ -218,16 +224,23 @@ export default function ApiKeysSettingsPage() {
               objectNamePlural="API keys"
               searchFields={["key name"]}
             />
-            <DataTable
-              columns={columns}
-              data={filteredApiKeys}
-              emptyMessage="No API keys yet"
-              hasActiveFilters={search.trim().length > 0}
-              filteredEmptyMessage="No API keys match your search. Try adjusting your search."
-              onClearFilters={() =>
-                updateQueryParams({ search: null, page: "1" })
-              }
-            />
+            {isApiKeysLoadError ? (
+              <QueryLoadError
+                title="Couldn't load your API keys"
+                onRetry={() => refetchApiKeys()}
+              />
+            ) : (
+              <DataTable
+                columns={columns}
+                data={filteredApiKeys}
+                emptyMessage="No API keys yet"
+                hasActiveFilters={search.trim().length > 0}
+                filteredEmptyMessage="No API keys match your search. Try adjusting your search."
+                onClearFilters={() =>
+                  updateQueryParams({ search: null, page: "1" })
+                }
+              />
+            )}
           </div>
         </LoadingWrapper>
       )}

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -24,6 +24,7 @@ import {
   type LlmProviderApiKeyFormValues,
 } from "@/components/llm-provider-api-key-form";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import {
   SettingsSaveBar,
@@ -440,8 +441,12 @@ function DropEmbeddingConfigDialog({
 
 function KnowledgeSettingsContent() {
   const { data: organization, isPending } = useOrganization();
-  const { data: apiKeys, isPending: areApiKeysPending } =
-    useAvailableLlmProviderApiKeys();
+  const {
+    data: apiKeys,
+    isPending: areApiKeysPending,
+    isLoadingError: isApiKeysLoadError,
+    refetch: refetchApiKeys,
+  } = useAvailableLlmProviderApiKeys();
   const updateKnowledgeSettings = useUpdateKnowledgeSettings(
     "Knowledge settings updated",
     "Failed to update knowledge settings",
@@ -459,7 +464,11 @@ function KnowledgeSettingsContent() {
   const [rerankerModel, setRerankerModel] = useState<string | null>(null);
 
   const { data: embeddingModels } = useEmbeddingModels(embeddingChatApiKeyId);
-  const { data: modelsWithApiKeys } = useModelsWithApiKeys();
+  const {
+    data: modelsWithApiKeys,
+    isLoadingError: isModelsWithApiKeysLoadError,
+    refetch: refetchModelsWithApiKeys,
+  } = useModelsWithApiKeys();
   const embeddingCapableKeyIds = useMemo(() => {
     const ids = new Set<string>();
     for (const model of modelsWithApiKeys ?? []) {
@@ -560,6 +569,20 @@ function KnowledgeSettingsContent() {
       setRerankerModel(null);
     }
   };
+
+  const isLoadError = isApiKeysLoadError || isModelsWithApiKeysLoadError;
+
+  if (!isInitialLoading && isLoadError) {
+    return (
+      <QueryLoadError
+        title="Couldn't load your knowledge settings"
+        onRetry={() => {
+          refetchApiKeys();
+          refetchModelsWithApiKeys();
+        }}
+      />
+    );
+  }
 
   return (
     <LoadingWrapper

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -446,7 +446,7 @@ function KnowledgeSettingsContent() {
     isPending: areApiKeysPending,
     isLoadingError: isApiKeysLoadError,
     refetch: refetchApiKeys,
-  } = useAvailableLlmProviderApiKeys();
+  } = useAvailableLlmProviderApiKeys({ toastOnError: false });
   const updateKnowledgeSettings = useUpdateKnowledgeSettings(
     "Knowledge settings updated",
     "Failed to update knowledge settings",
@@ -468,7 +468,7 @@ function KnowledgeSettingsContent() {
     data: modelsWithApiKeys,
     isLoadingError: isModelsWithApiKeysLoadError,
     refetch: refetchModelsWithApiKeys,
-  } = useModelsWithApiKeys();
+  } = useModelsWithApiKeys({ toastOnError: false });
   const embeddingCapableKeyIds = useMemo(() => {
     const ids = new Set<string>();
     for (const model of modelsWithApiKeys ?? []) {

--- a/platform/frontend/src/app/settings/roles/page.tsx
+++ b/platform/frontend/src/app/settings/roles/page.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import { useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { DisabledEnterpriseSection } from "@/components/disabled-enterprise-section";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SmallTeamTierBanner } from "@/components/small-team-tier-banner";
 import { Button } from "@/components/ui/button";
 import { UserSearchableSelect } from "@/components/user-searchable-select";
@@ -25,7 +26,12 @@ const RolesListEnterprise = dynamic(() =>
 
 function RoleDebuggerCallout() {
   const canImpersonate = useCanImpersonate();
-  const { data: candidates, isLoading } = useImpersonationCandidates();
+  const {
+    data: candidates,
+    isLoading,
+    isLoadingError: isCandidatesLoadError,
+    refetch: refetchCandidates,
+  } = useImpersonationCandidates();
   const { mutate: impersonate, isPending } = useImpersonateUser();
   const [selectedUserId, setSelectedUserId] = useState<string>("");
   const userOptions = (candidates ?? []).map((candidate) => ({
@@ -45,36 +51,44 @@ function RoleDebuggerCallout() {
         Pick a user and view the app as them. The session expires after one hour
         or when you click <em>Return to admin</em> in the banner.
       </p>
-      <div className="mt-3 flex items-center gap-2">
-        <UserSearchableSelect
-          value={selectedUserId}
-          onValueChange={setSelectedUserId}
-          users={userOptions}
-          disabled={isLoading || !candidates || candidates.length === 0}
-          placeholder={
-            isLoading
-              ? "Loading users..."
-              : !candidates || candidates.length === 0
-                ? "No users available"
-                : "Select a user"
-          }
-          searchPlaceholder="Search users by name or email"
-          className="w-72"
-          emptyMessage="No matching users found."
+      {isCandidatesLoadError ? (
+        <QueryLoadError
+          className="mt-3"
+          title="Couldn't load users to impersonate"
+          onRetry={() => refetchCandidates()}
         />
-        <Button
-          size="sm"
-          variant="outline"
-          data-testid={E2eTestId.ImpersonationViewAsButton}
-          disabled={!selectedUserId || isPending}
-          onClick={() => {
-            if (selectedUserId) impersonate(selectedUserId);
-          }}
-        >
-          <Eye className="mr-2 h-4 w-4" />
-          View as user
-        </Button>
-      </div>
+      ) : (
+        <div className="mt-3 flex items-center gap-2">
+          <UserSearchableSelect
+            value={selectedUserId}
+            onValueChange={setSelectedUserId}
+            users={userOptions}
+            disabled={isLoading || !candidates || candidates.length === 0}
+            placeholder={
+              isLoading
+                ? "Loading users..."
+                : !candidates || candidates.length === 0
+                  ? "No users available"
+                  : "Select a user"
+            }
+            searchPlaceholder="Search users by name or email"
+            className="w-72"
+            emptyMessage="No matching users found."
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            data-testid={E2eTestId.ImpersonationViewAsButton}
+            disabled={!selectedUserId || isPending}
+            onClick={() => {
+              if (selectedUserId) impersonate(selectedUserId);
+            }}
+          >
+            <Eye className="mr-2 h-4 w-4" />
+            View as user
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/platform/frontend/src/app/settings/service-accounts/page.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/page.tsx
@@ -9,6 +9,7 @@ import { useForm } from "react-hook-form";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { FormDialog } from "@/components/form-dialog";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -57,7 +58,12 @@ export default function ServiceAccountsSettingsPage() {
   const { data: canDeleteServiceAccounts } = useHasPermissions({
     serviceAccount: ["delete"],
   });
-  const { data: serviceAccounts = [], isPending } = useServiceAccounts();
+  const {
+    data: serviceAccounts = [],
+    isPending,
+    isLoadingError: isServiceAccountsLoadError,
+    refetch: refetchServiceAccounts,
+  } = useServiceAccounts();
   const createMutation = useCreateServiceAccount();
   const deleteMutation = useDeleteServiceAccount();
 
@@ -222,21 +228,28 @@ export default function ServiceAccountsSettingsPage() {
               objectNamePlural="service accounts"
               searchFields={["name"]}
             />
-            <DataTable
-              columns={columns}
-              data={filteredServiceAccounts}
-              onRowClick={(account, event) => {
-                const target = event.target as HTMLElement;
-                if (target.closest("a,button")) return;
-                router.push(`/settings/service-accounts/${account.id}`);
-              }}
-              emptyMessage="No service accounts yet"
-              hasActiveFilters={search.trim().length > 0}
-              filteredEmptyMessage="No service accounts match your search. Try adjusting your search."
-              onClearFilters={() =>
-                updateQueryParams({ search: null, page: "1" })
-              }
-            />
+            {isServiceAccountsLoadError ? (
+              <QueryLoadError
+                title="Couldn't load your service accounts"
+                onRetry={() => refetchServiceAccounts()}
+              />
+            ) : (
+              <DataTable
+                columns={columns}
+                data={filteredServiceAccounts}
+                onRowClick={(account, event) => {
+                  const target = event.target as HTMLElement;
+                  if (target.closest("a,button")) return;
+                  router.push(`/settings/service-accounts/${account.id}`);
+                }}
+                emptyMessage="No service accounts yet"
+                hasActiveFilters={search.trim().length > 0}
+                filteredEmptyMessage="No service accounts match your search. Try adjusting your search."
+                onClearFilters={() =>
+                  updateQueryParams({ search: null, page: "1" })
+                }
+              />
+            )}
           </div>
         </LoadingWrapper>
       )}

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -87,12 +87,15 @@ function SkillsList() {
     isFetching,
     isLoadingError: isSkillsLoadError,
     refetch: refetchSkills,
-  } = useSkillsPaginated({
-    limit: pageSize,
-    offset: pageIndex * pageSize,
-    search: search || undefined,
-    sourceRepo: sourceRepo || undefined,
-  });
+  } = useSkillsPaginated(
+    {
+      limit: pageSize,
+      offset: pageIndex * pageSize,
+      search: search || undefined,
+      sourceRepo: sourceRepo || undefined,
+    },
+    { toastOnError: false },
+  );
   const { data: sourceReposData } = useSkillSourceRepos();
   const sourceRepos = sourceReposData?.repos ?? [];
 

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -18,6 +18,7 @@ import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
+import { QueryLoadError } from "@/components/query-load-error";
 import { ResourceVisibilityBadge } from "@/components/resource-visibility-badge";
 import { SearchInput } from "@/components/search-input";
 import {
@@ -84,6 +85,8 @@ function SkillsList() {
     data: skills,
     isPending,
     isFetching,
+    isLoadingError: isSkillsLoadError,
+    refetch: refetchSkills,
   } = useSkillsPaginated({
     limit: pageSize,
     offset: pageIndex * pageSize,
@@ -266,6 +269,17 @@ function SkillsList() {
       },
     },
   ];
+
+  if (isSkillsLoadError) {
+    return (
+      <PageLayout title="Skills" description="">
+        <QueryLoadError
+          title="Couldn't load your skills"
+          onRetry={() => refetchSkills()}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <LoadingWrapper

--- a/platform/frontend/src/components/api-key-load-error.tsx
+++ b/platform/frontend/src/components/api-key-load-error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { E2eTestId } from "@archestra/shared";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+/**
+ * Shown when the LLM provider keys request fails to load (e.g. no internet),
+ * on the surfaces that otherwise gate on "user has no keys". Distinct from the
+ * "Add an LLM Provider Key" empty state so a failed fetch isn't misread as a
+ * missing-key setup step.
+ */
+export function ApiKeyLoadError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Empty className="h-full">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <AlertTriangle />
+        </EmptyMedia>
+        <EmptyTitle>Couldn&apos;t load your LLM providers</EmptyTitle>
+        <EmptyDescription>
+          Check your internet connection and try again.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button
+          data-testid={E2eTestId.ApiKeysLoadErrorRetry}
+          variant="outline"
+          onClick={onRetry}
+        >
+          <RefreshCw className="h-4 w-4" />
+          Retry
+        </Button>
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/platform/frontend/src/components/api-key-load-error.tsx
+++ b/platform/frontend/src/components/api-key-load-error.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import { E2eTestId } from "@archestra/shared";
-import { AlertTriangle, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty";
+import { QueryLoadError } from "@/components/query-load-error";
 
 /**
  * Shown when the LLM provider keys request fails to load (e.g. no internet),
@@ -20,26 +11,10 @@ import {
  */
 export function ApiKeyLoadError({ onRetry }: { onRetry: () => void }) {
   return (
-    <Empty className="h-full">
-      <EmptyHeader>
-        <EmptyMedia variant="icon">
-          <AlertTriangle />
-        </EmptyMedia>
-        <EmptyTitle>Couldn&apos;t load your LLM providers</EmptyTitle>
-        <EmptyDescription>
-          Check your internet connection and try again.
-        </EmptyDescription>
-      </EmptyHeader>
-      <EmptyContent>
-        <Button
-          data-testid={E2eTestId.ApiKeysLoadErrorRetry}
-          variant="outline"
-          onClick={onRetry}
-        >
-          <RefreshCw className="h-4 w-4" />
-          Retry
-        </Button>
-      </EmptyContent>
-    </Empty>
+    <QueryLoadError
+      title="Couldn't load your LLM providers"
+      onRetry={onRetry}
+      retryTestId={E2eTestId.ApiKeysLoadErrorRetry}
+    />
   );
 }

--- a/platform/frontend/src/components/query-load-error.test.tsx
+++ b/platform/frontend/src/components/query-load-error.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { QueryLoadError } from "./query-load-error";
+
+describe("QueryLoadError", () => {
+  it("renders the given title and calls onRetry when the retry button is clicked", async () => {
+    const onRetry = vi.fn();
+    render(
+      <QueryLoadError title="Custom load error title" onRetry={onRetry} />,
+    );
+
+    expect(screen.getByText("Custom load error title")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes the retry button under the provided test id", () => {
+    render(
+      <QueryLoadError title="t" onRetry={vi.fn()} retryTestId="my-retry-id" />,
+    );
+
+    expect(screen.getByTestId("my-retry-id")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/query-load-error.tsx
+++ b/platform/frontend/src/components/query-load-error.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+/**
+ * Shown when a query fails to load (e.g. no internet) on a surface that
+ * otherwise gates on emptiness. Keeps a failed fetch from being misread as a
+ * genuinely empty result. Pair with a query's `isLoadingError`/`isError` and a
+ * `refetch` so the user can retry without a full reload.
+ */
+export function QueryLoadError({
+  title,
+  description = "Check your internet connection and try again.",
+  onRetry,
+  retryTestId,
+  className = "h-full",
+}: {
+  title: string;
+  description?: string;
+  onRetry: () => void;
+  retryTestId?: string;
+  className?: string;
+}) {
+  return (
+    <Empty className={className}>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <AlertTriangle />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button data-testid={retryTestId} variant="outline" onClick={onRetry}>
+          <RefreshCw className="h-4 w-4" />
+          Retry
+        </Button>
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/platform/frontend/src/components/roles/roles-list.ee.tsx
+++ b/platform/frontend/src/components/roles/roles-list.ee.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { useSetSettingsAction } from "@/app/settings/layout";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { FormDialog } from "@/components/form-dialog";
+import { QueryLoadError } from "@/components/query-load-error";
 import { RoleTypeIcon } from "@/components/role-type-icon";
 import { SearchInput } from "@/components/search-input";
 import {
@@ -58,7 +59,12 @@ export function RolesList() {
     updateQueryParams,
   } = useDataTableQueryParams();
   const nameFilter = searchParams.get("name") || undefined;
-  const { data: rolesResponse, isLoading } = useRolesPaginated({
+  const {
+    data: rolesResponse,
+    isLoading,
+    isLoadingError,
+    refetch,
+  } = useRolesPaginated({
     limit: pageSize,
     offset,
     name: nameFilter,
@@ -325,27 +331,34 @@ export function RolesList() {
           paramName="name"
         />
 
-        <DataTable
-          columns={columns}
-          data={allRoles}
-          isLoading={isLoading}
-          manualPagination
-          pagination={{
-            pageIndex,
-            pageSize,
-            total,
-          }}
-          onPaginationChange={setPagination}
-          hasActiveFilters={Boolean(nameFilter)}
-          onClearFilters={() =>
-            updateQueryParams({
-              name: null,
-              page: "1",
-            })
-          }
-          emptyMessage="No roles found"
-          hideSelectedCount
-        />
+        {isLoadingError ? (
+          <QueryLoadError
+            title="Couldn't load your roles"
+            onRetry={() => refetch()}
+          />
+        ) : (
+          <DataTable
+            columns={columns}
+            data={allRoles}
+            isLoading={isLoading}
+            manualPagination
+            pagination={{
+              pageIndex,
+              pageSize,
+              total,
+            }}
+            onPaginationChange={setPagination}
+            hasActiveFilters={Boolean(nameFilter)}
+            onClearFilters={() =>
+              updateQueryParams({
+                name: null,
+                page: "1",
+              })
+            }
+            emptyMessage="No roles found"
+            hideSelectedCount
+          />
+        )}
       </div>
 
       {/* Create Role Dialog */}

--- a/platform/frontend/src/lib/agent-tools.query.ts
+++ b/platform/frontend/src/lib/agent-tools.query.ts
@@ -5,7 +5,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { getApiErrorMessage, handleApiError } from "./utils";
+import { getApiErrorMessage, handleApiError, throwOnApiError } from "./utils";
 
 const {
   assignToolToAgent,
@@ -83,9 +83,7 @@ export function useAllProfileTools({
           skipPagination,
         },
       });
-      if (result.error) {
-        handleApiError(result.error);
-      }
+      throwOnApiError(result.error);
       return (
         result.data ?? {
           data: [],
@@ -377,9 +375,7 @@ export function useAgentDelegations(
     queryFn: async () => {
       if (!agentId) return [];
       const response = await getAgentDelegations({ path: { agentId } });
-      if (response.error) {
-        handleApiError(response.error);
-      }
+      throwOnApiError(response.error);
       return response.data ?? [];
     },
     enabled: !!agentId && (params?.enabled ?? true),

--- a/platform/frontend/src/lib/agent.query.ts
+++ b/platform/frontend/src/lib/agent.query.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_TABLE_LIMIT,
 } from "@/consts";
 import { incomingEmailKeys } from "@/lib/chatops/incoming-email.query";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   createAgent,
@@ -36,10 +36,11 @@ export const internalAgentsQueryKey = [
 ] as const;
 
 export async function fetchInternalAgents() {
-  const response = await getAllAgents({
+  const { data, error } = await getAllAgents({
     query: { agentType: "agent", excludeBuiltIn: true },
   });
-  return response.data ?? [];
+  throwOnApiError(error, { toastOnError: false });
+  return data ?? [];
 }
 
 // Returns all agents as an array
@@ -57,8 +58,9 @@ export function useProfiles(
   return useQuery({
     queryKey: ["agents", "all", filters],
     queryFn: async () => {
-      const response = await getAllAgents({ query: filters });
-      return response.data ?? [];
+      const { data, error } = await getAllAgents({ query: filters });
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
     },
     initialData: params?.initialData,
     enabled: params?.enabled,
@@ -198,26 +200,27 @@ export function useProfilesPaginated(
         status,
       },
     ],
-    queryFn: async () =>
-      (
-        await getAgents({
-          query: {
-            limit,
-            offset,
-            sortBy,
-            sortDirection,
-            name,
-            agentTypes,
-            scope,
-            teamIds,
-            authorIds,
-            excludeAuthorIds,
-            excludeOtherPersonalAgents,
-            labels,
-            status,
-          },
-        })
-      ).data ?? null,
+    queryFn: async () => {
+      const { data, error } = await getAgents({
+        query: {
+          limit,
+          offset,
+          sortBy,
+          sortDirection,
+          name,
+          agentTypes,
+          scope,
+          teamIds,
+          authorIds,
+          excludeAuthorIds,
+          excludeOtherPersonalAgents,
+          labels,
+          status,
+        },
+      });
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
+    },
     initialData: useInitialData ? initialData : undefined,
   });
 }
@@ -227,7 +230,11 @@ export function useDefaultMcpGateway(params?: {
 }) {
   return useQuery({
     queryKey: ["mcp-gateways", "default"],
-    queryFn: async () => (await getDefaultMcpGateway()).data ?? null,
+    queryFn: async () => {
+      const { data, error } = await getDefaultMcpGateway();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
+    },
     initialData: params?.initialData,
   });
 }
@@ -238,8 +245,9 @@ export function useDefaultLlmProxy(params?: {
   return useQuery({
     queryKey: ["llm-proxy", "default"],
     queryFn: async () => {
-      const response = await getDefaultLlmProxy();
-      return response.data ?? null;
+      const { data, error } = await getDefaultLlmProxy();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
     },
     initialData: params?.initialData,
   });
@@ -250,8 +258,9 @@ export function useProfile(id: string | undefined) {
     queryKey: ["agents", id],
     queryFn: async () => {
       if (!id) return null;
-      const response = await getAgent({ path: { id } });
-      return response.data ?? null;
+      const { data, error } = await getAgent({ path: { id } });
+      throwOnApiError(error, { allowNotFound: true, toastOnError: false });
+      return data ?? null;
     },
     enabled: !!id,
     staleTime: 5 * 60 * 1000,
@@ -364,7 +373,11 @@ export function useRestoreProfile() {
 export function useLabelKeys() {
   return useQuery({
     queryKey: ["agents", "labels", "keys"],
-    queryFn: async () => (await getLabelKeys()).data ?? [],
+    queryFn: async () => {
+      const { data, error } = await getLabelKeys();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
+    },
   });
 }
 
@@ -372,8 +385,13 @@ export function useLabelValues(params?: { key?: string }) {
   const { key } = params || {};
   return useQuery({
     queryKey: ["agents", "labels", "values", key],
-    queryFn: async () =>
-      (await getLabelValues({ query: key ? { key } : {} })).data ?? [],
+    queryFn: async () => {
+      const { data, error } = await getLabelValues({
+        query: key ? { key } : {},
+      });
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
+    },
     enabled: key !== undefined,
   });
 }
@@ -385,8 +403,9 @@ export function useDefaultAgentId() {
   return useQuery({
     queryKey: ["member-default-agent"],
     queryFn: async () => {
-      const response = await getMemberDefaultAgent();
-      return response.data?.defaultAgentId ?? null;
+      const { data, error } = await getMemberDefaultAgent();
+      throwOnApiError(error, { toastOnError: false });
+      return data?.defaultAgentId ?? null;
     },
   });
 }
@@ -408,10 +427,11 @@ export function useOrgScopedAgents() {
       { agentType: "agent", excludeBuiltIn: true, scope: "org" as const },
     ],
     queryFn: async () => {
-      const response = await getAllAgents({
+      const { data, error } = await getAllAgents({
         query: { agentType: "agent", excludeBuiltIn: true, scope: "org" },
       });
-      return response.data ?? [];
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
     },
   });
 }

--- a/platform/frontend/src/lib/api-key.query.ts
+++ b/platform/frontend/src/lib/api-key.query.ts
@@ -15,7 +15,7 @@ export function useApiKeys() {
     queryKey: ["api-keys"],
     queryFn: async () => {
       const { data, error } = await getApiKeys();
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError: false });
 
       return data ?? [];
     },

--- a/platform/frontend/src/lib/api-key.query.ts
+++ b/platform/frontend/src/lib/api-key.query.ts
@@ -2,7 +2,7 @@ import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useHasPermissions } from "@/lib/auth/auth.query";
-import { handleApiError, toApiError } from "./utils";
+import { handleApiError, throwOnApiError, toApiError } from "./utils";
 
 export type UserApiKey = archestraApiTypes.GetApiKeysResponses["200"][number];
 
@@ -15,10 +15,7 @@ export function useApiKeys() {
     queryKey: ["api-keys"],
     queryFn: async () => {
       const { data, error } = await getApiKeys();
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
 
       return data ?? [];
     },

--- a/platform/frontend/src/lib/app.query.ts
+++ b/platform/frontend/src/lib/app.query.ts
@@ -21,14 +21,18 @@ type AppsParams = Pick<AppsQuery, "limit" | "offset" | "search">;
 
 // ===== Query hooks =====
 
-export function useApps(params: AppsParams, options?: { enabled?: boolean }) {
+export function useApps(
+  params: AppsParams,
+  options?: { enabled?: boolean; toastOnError?: boolean },
+) {
+  const toastOnError = options?.toastOnError;
   return useQuery({
     queryKey: ["apps", "paginated", params],
     enabled: options?.enabled ?? true,
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getApps({ query: params });
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError });
       return data;
     },
   });

--- a/platform/frontend/src/lib/app.query.ts
+++ b/platform/frontend/src/lib/app.query.ts
@@ -45,7 +45,7 @@ export function useExternalApp(catalogId: string | null) {
         path: { catalogId: catalogId as string },
       });
       throwOnApiError(error, { allowNotFound: true });
-      return data;
+      return data ?? null;
     },
   });
 }
@@ -59,7 +59,7 @@ export function useApp(appId: string | null) {
         path: { appId: appId as string },
       });
       throwOnApiError(error, { allowNotFound: true });
-      return data;
+      return data ?? null;
     },
   });
 }
@@ -72,8 +72,8 @@ export function useAppVersions(appId: string | null) {
       const { data, error } = await getAppVersions({
         path: { appId: appId as string },
       });
-      throwOnApiError(error);
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? [];
     },
   });
 }
@@ -86,8 +86,8 @@ export function useAppTools(appId: string | null) {
       const { data, error } = await getAppTools({
         path: { appId: appId as string },
       });
-      throwOnApiError(error);
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? [];
     },
   });
 }

--- a/platform/frontend/src/lib/app.query.ts
+++ b/platform/frontend/src/lib/app.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   getApps,
@@ -28,10 +28,7 @@ export function useApps(params: AppsParams, options?: { enabled?: boolean }) {
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getApps({ query: params });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
   });
@@ -47,10 +44,7 @@ export function useExternalApp(catalogId: string | null) {
       const { data, error } = await getExternalApp({
         path: { catalogId: catalogId as string },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error, { allowNotFound: true });
       return data;
     },
   });
@@ -64,10 +58,7 @@ export function useApp(appId: string | null) {
       const { data, error } = await getApp({
         path: { appId: appId as string },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error, { allowNotFound: true });
       return data;
     },
   });
@@ -81,10 +72,7 @@ export function useAppVersions(appId: string | null) {
       const { data, error } = await getAppVersions({
         path: { appId: appId as string },
       });
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data;
     },
   });
@@ -98,10 +86,7 @@ export function useAppTools(appId: string | null) {
       const { data, error } = await getAppTools({
         path: { appId: appId as string },
       });
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data;
     },
   });

--- a/platform/frontend/src/lib/audit-log/audit-log.query.ts
+++ b/platform/frontend/src/lib/audit-log/audit-log.query.ts
@@ -3,7 +3,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
-import { handleApiError } from "@/lib/utils";
+import { throwOnApiError } from "@/lib/utils";
 
 const { getAuditLogs } = archestraApiSdk;
 
@@ -87,10 +87,7 @@ export function useAuditLogs({
           ...(search ? { search } : {}),
         },
       });
-      if (response.error) {
-        handleApiError(response.error);
-        return EMPTY_RESPONSE(limit);
-      }
+      throwOnApiError(response.error);
       return response.data ?? EMPTY_RESPONSE(limit);
     },
   });

--- a/platform/frontend/src/lib/audit-log/audit-log.query.ts
+++ b/platform/frontend/src/lib/audit-log/audit-log.query.ts
@@ -87,7 +87,8 @@ export function useAuditLogs({
           ...(search ? { search } : {}),
         },
       });
-      throwOnApiError(response.error);
+      // Screen renders its own QueryLoadError panel; don't also toast.
+      throwOnApiError(response.error, { toastOnError: false });
       return response.data ?? EMPTY_RESPONSE(limit);
     },
   });

--- a/platform/frontend/src/lib/auth/auth.query.ts
+++ b/platform/frontend/src/lib/auth/auth.query.ts
@@ -2,6 +2,7 @@ import { archestraApiSdk, type Permissions } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
 import { hasPermissions } from "@/lib/auth/auth.utils";
 import { authClient } from "@/lib/clients/auth/auth-client";
+import { throwOnApiError } from "@/lib/utils";
 
 export const authQueryKeys = {
   all: ["auth"] as const,
@@ -123,7 +124,8 @@ export function useAllPermissions() {
   return useQuery({
     queryKey: authQueryKeys.userPermissions(),
     queryFn: async () => {
-      const { data } = await archestraApiSdk.getUserPermissions();
+      const { data, error } = await archestraApiSdk.getUserPermissions();
+      throwOnApiError(error, { toastOnError: false });
       return data;
     },
     retry: false,
@@ -164,7 +166,9 @@ export function useDefaultCredentialsEnabled() {
   return useQuery({
     queryKey: authQueryKeys.defaultCredentialsEnabled(),
     queryFn: async () => {
-      const { data } = await archestraApiSdk.getDefaultCredentialsStatus();
+      const { data, error } =
+        await archestraApiSdk.getDefaultCredentialsStatus();
+      throwOnApiError(error, { toastOnError: false });
       return data?.enabled ?? false;
     },
     // Refetch when window is focused to catch password changes

--- a/platform/frontend/src/lib/auth/identity-provider-read.query.ts
+++ b/platform/frontend/src/lib/auth/identity-provider-read.query.ts
@@ -4,6 +4,7 @@ import {
   useEnterpriseFeature,
   usePublicEnterpriseCoreActive,
 } from "@/lib/config/config.query";
+import { throwOnApiError } from "@/lib/utils";
 
 export const identityProviderReadKeys = {
   all: ["identity-provider"] as const,
@@ -16,7 +17,9 @@ export function usePublicIdentityProviders() {
   return useQuery({
     queryKey: identityProviderReadKeys.public,
     queryFn: async () => {
-      const { data } = await archestraApiSdk.getPublicIdentityProviders();
+      const { data, error } =
+        await archestraApiSdk.getPublicIdentityProviders();
+      throwOnApiError(error, { toastOnError: false });
       return data ?? [];
     },
     retry: false,
@@ -30,7 +33,8 @@ export function useIdentityProviders(params?: { enabled?: boolean }) {
   return useQuery({
     queryKey: identityProviderReadKeys.all,
     queryFn: async () => {
-      const { data } = await archestraApiSdk.getIdentityProviders();
+      const { data, error } = await archestraApiSdk.getIdentityProviders();
+      throwOnApiError(error, { toastOnError: false });
       return data ?? [];
     },
     retry: false,

--- a/platform/frontend/src/lib/auth/invitation.query.ts
+++ b/platform/frontend/src/lib/auth/invitation.query.ts
@@ -1,6 +1,6 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
-import { handleApiError } from "@/lib/utils";
+import { throwOnApiError } from "@/lib/utils";
 
 const { checkInvitation } = archestraApiSdk;
 
@@ -14,10 +14,7 @@ export function useInvitationCheck(invitationId: string | null | undefined) {
       if (!invitationId) return null;
 
       const response = await checkInvitation({ path: { id: invitationId } });
-      if (response.error) {
-        handleApiError(response.error);
-        return null;
-      }
+      throwOnApiError(response.error, { allowNotFound: true });
       return response.data ?? null;
     },
     enabled: !!invitationId,

--- a/platform/frontend/src/lib/auth/oauth.query.ts
+++ b/platform/frontend/src/lib/auth/oauth.query.ts
@@ -45,7 +45,7 @@ export function useOAuthClientInfo(clientId: string | null) {
         allowNotFound: true,
         toastOnError: false,
       });
-      return response.data;
+      return response.data ?? null;
     },
     enabled: !!clientId,
   });

--- a/platform/frontend/src/lib/auth/oauth.query.ts
+++ b/platform/frontend/src/lib/auth/oauth.query.ts
@@ -1,5 +1,6 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { throwOnApiError } from "@/lib/utils";
 
 const {
   initiateOAuth,
@@ -40,9 +41,10 @@ export function useOAuthClientInfo(clientId: string | null) {
       const response = await getOAuthClientInfo({
         query: { client_id: clientId },
       });
-      if (response.error) {
-        return null;
-      }
+      throwOnApiError(response.error, {
+        allowNotFound: true,
+        toastOnError: false,
+      });
       return response.data;
     },
     enabled: !!clientId,

--- a/platform/frontend/src/lib/chatops/chatops-config.query.ts
+++ b/platform/frontend/src/lib/chatops/chatops-config.query.ts
@@ -1,12 +1,16 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 export function useNgrokConfig(enabled = true) {
   return useQuery({
     queryKey: ["chatops", "ngrok-config"],
-    queryFn: async () => (await archestraApiSdk.getNgrokConfig()).data ?? null,
+    queryFn: async () => {
+      const { data, error } = await archestraApiSdk.getNgrokConfig();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
+    },
     enabled,
   });
 }

--- a/platform/frontend/src/lib/chatops/chatops.query.ts
+++ b/platform/frontend/src/lib/chatops/chatops.query.ts
@@ -6,17 +6,14 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 export function useChatOpsStatus() {
   return useQuery({
     queryKey: ["chatops", "status"],
     queryFn: async () => {
       const { data, error } = await archestraApiSdk.getChatOpsStatus();
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data?.providers || [];
     },
   });
@@ -41,10 +38,7 @@ export function useChatOpsBindings(
           status: params.status,
         },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
   });

--- a/platform/frontend/src/lib/chatops/chatops.query.ts
+++ b/platform/frontend/src/lib/chatops/chatops.query.ts
@@ -38,7 +38,8 @@ export function useChatOpsBindings(
           status: params.status,
         },
       });
-      throwOnApiError(error);
+      // Screen renders its own QueryLoadError panel; don't also toast.
+      throwOnApiError(error, { toastOnError: false });
       return data;
     },
   });

--- a/platform/frontend/src/lib/chatops/incoming-email.query.ts
+++ b/platform/frontend/src/lib/chatops/incoming-email.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   getIncomingEmailStatus,
@@ -23,10 +23,7 @@ export function useIncomingEmailStatus() {
     queryKey: incomingEmailKeys.status(),
     queryFn: async () => {
       const { data, error } = await getIncomingEmailStatus();
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data as archestraApiTypes.GetIncomingEmailStatusResponses["200"];
     },
   });
@@ -106,10 +103,7 @@ export function useAgentEmailAddress(agentId: string | null) {
       const { data, error } = await getAgentEmailAddress({
         path: { agentId },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error, { allowNotFound: true });
       return data as archestraApiTypes.GetAgentEmailAddressResponses["200"];
     },
     enabled: !!agentId,

--- a/platform/frontend/src/lib/config/config.query.ts
+++ b/platform/frontend/src/lib/config/config.query.ts
@@ -1,6 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
+import { throwOnApiError } from "@/lib/utils";
 import appConfig, { DEFAULT_BACKEND_URL } from "./config";
 
 const { getConfig } = archestraApiSdk;
@@ -14,7 +15,11 @@ export function useConfig() {
   const isAuthenticated = useIsAuthenticated();
   return useQuery({
     queryKey: ["config"],
-    queryFn: async () => (await getConfig()).data ?? null,
+    queryFn: async () => {
+      const { data, error } = await getConfig();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
+    },
     staleTime: 5 * 60 * 1000,
     enabled: isAuthenticated,
   });
@@ -23,7 +28,11 @@ export function useConfig() {
 export function usePublicConfig() {
   return useQuery({
     queryKey: ["public-config"],
-    queryFn: async () => (await archestraApiSdk.getPublicConfig()).data ?? null,
+    queryFn: async () => {
+      const { data, error } = await archestraApiSdk.getPublicConfig();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
+    },
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/platform/frontend/src/lib/config/health.query.ts
+++ b/platform/frontend/src/lib/config/health.query.ts
@@ -1,5 +1,6 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
+import { throwOnApiError } from "@/lib/utils";
 
 const { getHealth } = archestraApiSdk;
 
@@ -8,7 +9,11 @@ export function useHealth(params?: {
 }) {
   return useQuery({
     queryKey: ["health"],
-    queryFn: async () => (await getHealth()).data ?? null,
+    queryFn: async () => {
+      const { data, error } = await getHealth();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
+    },
     initialData: params?.initialData,
   });
 }

--- a/platform/frontend/src/lib/default-user-limit.query.ts
+++ b/platform/frontend/src/lib/default-user-limit.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   listDefaultUserLimits,
@@ -26,10 +26,7 @@ export function useDefaultUserLimits() {
     queryKey: QUERY_KEY,
     queryFn: async () => {
       const { data, error } = await listDefaultUserLimits();
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data ?? [];
     },
   });

--- a/platform/frontend/src/lib/environment.query.ts
+++ b/platform/frontend/src/lib/environment.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 export const environmentKeys = {
   all: ["environments"] as const,
@@ -26,10 +26,7 @@ export function useEnvironments(enabled = true) {
     queryKey: environmentKeys.list(),
     queryFn: async () => {
       const { data, error } = await archestraApiSdk.listEnvironments();
-      if (error) {
-        handleApiError(error);
-        return EMPTY_ENVIRONMENT_LIST;
-      }
+      throwOnApiError(error);
       return data ?? EMPTY_ENVIRONMENT_LIST;
     },
     enabled,
@@ -42,10 +39,7 @@ export function useK8sCapabilities(enabled = true) {
     queryKey: environmentKeys.k8sCapabilities(),
     queryFn: async () => {
       const { data, error } = await archestraApiSdk.getK8sCapabilities();
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data ?? null;
     },
     enabled,

--- a/platform/frontend/src/lib/github-app-config.query.ts
+++ b/platform/frontend/src/lib/github-app-config.query.ts
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
 import { useHasPermissions } from "@/lib/auth/auth.query";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   listGithubAppConfigs,
@@ -32,6 +32,7 @@ export function useGithubAppConfigs() {
     queryKey: githubAppConfigKeys.lists(),
     queryFn: async () => {
       const response = await listGithubAppConfigs();
+      throwOnApiError(response.error, { toastOnError: false });
       return response.data ?? [];
     },
     enabled: isAuthenticated && !!canRead,

--- a/platform/frontend/src/lib/hook.query.ts
+++ b/platform/frontend/src/lib/hook.query.ts
@@ -3,7 +3,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "./utils";
+import { handleApiError, throwOnApiError } from "./utils";
 
 const { getHooks, createHook, updateHook, deleteHook } = archestraApiSdk;
 
@@ -29,10 +29,7 @@ export function useAgentHooks(agentId: string | undefined) {
       const response = await getHooks({
         query: { agentId: agentId as string },
       });
-      if (response.error) {
-        handleApiError(response.error);
-        return [];
-      }
+      throwOnApiError(response.error);
       return response.data ?? [];
     },
     enabled: !!agentId,

--- a/platform/frontend/src/lib/impersonation.query.ts
+++ b/platform/frontend/src/lib/impersonation.query.ts
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
-import { handleApiError } from "@/lib/utils";
+import { throwOnApiError } from "@/lib/utils";
 
 // better-auth's admin plugin gates impersonateUser on `users.role === "admin"`
 // (the system-level role, not the org membership role). Org-admins whose
@@ -27,10 +27,7 @@ export function useImpersonationCandidates() {
     queryKey: impersonationKeys.candidates(),
     queryFn: async () => {
       const response = await archestraApiSdk.getImpersonableUsers();
-      if (response.error) {
-        handleApiError(response.error);
-        return [];
-      }
+      throwOnApiError(response.error);
       return response.data ?? [];
     },
     enabled: isAuthenticated && !!canManage,

--- a/platform/frontend/src/lib/interactions/interaction.query.ts
+++ b/platform/frontend/src/lib/interactions/interaction.query.ts
@@ -175,6 +175,7 @@ export function useInteractionSessions({
   limit = DEFAULT_TABLE_LIMIT,
   offset = 0,
   initialData,
+  toastOnError,
 }: {
   profileId?: string;
   userId?: string;
@@ -187,6 +188,7 @@ export function useInteractionSessions({
   limit?: number;
   offset?: number;
   initialData?: archestraApiTypes.GetInteractionSessionsResponses["200"];
+  toastOnError?: boolean;
 } = {}) {
   // If the search value is a sessionId, we want to treat it as a sessionId search instead
   const isSessionIdSearch = search ? isSessionId(search) : false;
@@ -236,7 +238,7 @@ export function useInteractionSessions({
         },
       };
 
-      throwOnApiError(response.error);
+      throwOnApiError(response.error, { toastOnError });
       return response.data ?? emptyResponse;
     },
     initialData:

--- a/platform/frontend/src/lib/interactions/interaction.query.ts
+++ b/platform/frontend/src/lib/interactions/interaction.query.ts
@@ -8,7 +8,7 @@ import {
 } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
-import { handleApiError } from "@/lib/utils";
+import { throwOnApiError } from "@/lib/utils";
 
 const {
   getInteraction,
@@ -98,10 +98,7 @@ export function useInteractions({
           hasPrev: false,
         },
       };
-      if (response.error) {
-        handleApiError(response.error);
-        return emptyResponse;
-      }
+      throwOnApiError(response.error);
       return response.data ?? emptyResponse;
     },
     enabled,
@@ -136,10 +133,7 @@ export function useInteraction({
     queryKey: ["interactions", interactionId],
     queryFn: async () => {
       const response = await getInteraction({ path: { interactionId } });
-      if (response.error) {
-        handleApiError(response.error);
-        return null;
-      }
+      throwOnApiError(response.error, { allowNotFound: true });
       return response.data ?? null;
     },
     initialData,
@@ -152,10 +146,7 @@ export function useUniqueExternalAgentIds() {
     queryKey: ["interactions", "externalAgentIds"],
     queryFn: async () => {
       const response = await getUniqueExternalAgentIds();
-      if (response.error) {
-        handleApiError(response.error);
-        return [];
-      }
+      throwOnApiError(response.error);
       return response.data ?? [];
     },
   });
@@ -166,10 +157,7 @@ export function useUniqueUserIds() {
     queryKey: ["interactions", "userIds"],
     queryFn: async () => {
       const response = await getUniqueUserIds();
-      if (response.error) {
-        handleApiError(response.error);
-        return [];
-      }
+      throwOnApiError(response.error);
       return response.data ?? [];
     },
   });
@@ -248,10 +236,7 @@ export function useInteractionSessions({
         },
       };
 
-      if (response.error) {
-        handleApiError(response.error);
-        return emptyResponse;
-      }
+      throwOnApiError(response.error);
       return response.data ?? emptyResponse;
     },
     initialData:

--- a/platform/frontend/src/lib/knowledge/connector.query.ts
+++ b/platform/frontend/src/lib/knowledge/connector.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   getConnectors,
@@ -53,10 +53,7 @@ export function useConnectors(params?: string | Partial<ConnectorsListParams>) {
           offset: offset ?? 0,
         },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data?.data ?? [];
     },
     enabled,
@@ -75,10 +72,7 @@ export function useConnectorsPaginated(params: ConnectorsPaginatedParams) {
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getConnectors({ query: params });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
   });
@@ -89,11 +83,8 @@ export function useConnector(id: string) {
     queryKey: ["connectors", id],
     queryFn: async () => {
       const { data, error } = await getConnector({ path: { id } });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
     enabled: !!id,
     refetchInterval: (query) => {
@@ -109,10 +100,7 @@ export function useConnectorKnowledgeBases(connectorId: string) {
       const { data, error } = await getConnectorKnowledgeBases({
         path: { id: connectorId },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
     enabled: !!connectorId,
@@ -279,10 +267,7 @@ export function useConnectorRuns(params: {
         path: { id: connectorId },
         query: { limit, offset },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
     enabled: !!connectorId,
@@ -311,11 +296,8 @@ export function useConnectorRun(params: {
       const { data, error } = await getConnectorRun({
         path: { id: connectorId, runId },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
     enabled: !!connectorId && !!runId,
     refetchInterval: (query) => {

--- a/platform/frontend/src/lib/knowledge/connector.query.ts
+++ b/platform/frontend/src/lib/knowledge/connector.query.ts
@@ -72,7 +72,7 @@ export function useConnectorsPaginated(params: ConnectorsPaginatedParams) {
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getConnectors({ query: params });
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError: false });
       return data;
     },
   });

--- a/platform/frontend/src/lib/knowledge/connector.query.ts
+++ b/platform/frontend/src/lib/knowledge/connector.query.ts
@@ -100,7 +100,8 @@ export function useConnectorKnowledgeBases(connectorId: string) {
       const { data, error } = await getConnectorKnowledgeBases({
         path: { id: connectorId },
       });
-      throwOnApiError(error);
+      // A deleted connector 404s here; degrade gracefully instead of erroring.
+      throwOnApiError(error, { allowNotFound: true });
       return data;
     },
     enabled: !!connectorId,

--- a/platform/frontend/src/lib/knowledge/knowledge-base.query.ts
+++ b/platform/frontend/src/lib/knowledge/knowledge-base.query.ts
@@ -2,7 +2,7 @@ import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useOrganization } from "@/lib/organization.query";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   getKnowledgeBases,
@@ -56,10 +56,7 @@ export function useKnowledgeBases(params?: KnowledgeBasesListParams) {
           search: params?.query?.search,
         },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data?.data ?? [];
     },
     enabled: params?.enabled,
@@ -74,10 +71,7 @@ export function useKnowledgeBasesPaginated(
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getKnowledgeBases({ query: params });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
   });
@@ -88,11 +82,8 @@ export function useKnowledgeBase(id: string) {
     queryKey: ["knowledge-bases", id],
     queryFn: async () => {
       const { data, error } = await getKnowledgeBase({ path: { id } });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
     enabled: !!id,
   });
@@ -103,11 +94,8 @@ export function useKnowledgeBaseHealth(id: string) {
     queryKey: ["knowledge-bases", id, "health"],
     queryFn: async () => {
       const { data, error } = await getKnowledgeBaseHealth({ path: { id } });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
     enabled: false, // Only fetch on demand
   });

--- a/platform/frontend/src/lib/knowledge/knowledge-base.query.ts
+++ b/platform/frontend/src/lib/knowledge/knowledge-base.query.ts
@@ -71,7 +71,8 @@ export function useKnowledgeBasesPaginated(
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getKnowledgeBases({ query: params });
-      throwOnApiError(error);
+      // Screen renders its own QueryLoadError panel; don't also toast.
+      throwOnApiError(error, { toastOnError: false });
       return data;
     },
   });

--- a/platform/frontend/src/lib/limits.query.ts
+++ b/platform/frontend/src/lib/limits.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const { getLimits, createLimit, getLimit, updateLimit, deleteLimit } =
   archestraApiSdk;
@@ -16,7 +16,7 @@ export function useLimits(params?: LimitsParams) {
   return useQuery({
     queryKey: ["limits", params],
     queryFn: async () => {
-      const response = await getLimits({
+      const { data, error } = await getLimits({
         query: params
           ? {
               ...(params.entityType && { entityType: params.entityType }),
@@ -25,7 +25,8 @@ export function useLimits(params?: LimitsParams) {
             }
           : undefined,
       });
-      return response.data ?? [];
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
     },
     // Automatically refetch every 5 seconds to keep usage data fresh
     refetchInterval: 5000,
@@ -38,8 +39,9 @@ export function useLimit(id: string) {
   return useQuery({
     queryKey: ["limits", id],
     queryFn: async () => {
-      const response = await getLimit({ path: { id } });
-      return response.data;
+      const { data, error } = await getLimit({ path: { id } });
+      throwOnApiError(error, { allowNotFound: true });
+      return data;
     },
     enabled: !!id,
   });

--- a/platform/frontend/src/lib/limits.query.ts
+++ b/platform/frontend/src/lib/limits.query.ts
@@ -41,7 +41,7 @@ export function useLimit(id: string) {
     queryFn: async () => {
       const { data, error } = await getLimit({ path: { id } });
       throwOnApiError(error, { allowNotFound: true });
-      return data;
+      return data ?? null;
     },
     enabled: !!id,
   });

--- a/platform/frontend/src/lib/llm-models.query.ts
+++ b/platform/frontend/src/lib/llm-models.query.ts
@@ -14,7 +14,7 @@ import {
 } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const { getLlmModels, getModelsWithApiKeys, updateModel, syncLlmModels } =
   archestraApiSdk;
@@ -53,10 +53,7 @@ export function useLlmModels(params?: LlmModelsParams) {
       const { data, error, response } = await getLlmModels({
         query: apiKeyId ? { apiKeyId } : undefined,
       });
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       scheduleRefetchAfterLazyModelSync({ queryClient, queryKey, response });
       return data ?? [];
     },
@@ -81,10 +78,7 @@ export function useEmbeddingModels(apiKeyId: string | null) {
       const { data, error, response } = await getLlmModels({
         query: { apiKeyId, isEmbedding: "true" },
       });
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       scheduleRefetchAfterLazyModelSync({ queryClient, queryKey, response });
       return data ?? [];
     },
@@ -128,10 +122,7 @@ export function useModelsWithApiKeys() {
     queryKey: ["models-with-api-keys"],
     queryFn: async (): Promise<ModelWithApiKeys[]> => {
       const { data, error } = await getModelsWithApiKeys();
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data ?? [];
     },
   });

--- a/platform/frontend/src/lib/llm-models.query.ts
+++ b/platform/frontend/src/lib/llm-models.query.ts
@@ -117,12 +117,13 @@ export function useLlmModelsByProvider(params?: LlmModelsParams) {
   };
 }
 
-export function useModelsWithApiKeys() {
+export function useModelsWithApiKeys(options?: { toastOnError?: boolean }) {
+  const toastOnError = options?.toastOnError;
   return useQuery({
     queryKey: ["models-with-api-keys"],
     queryFn: async (): Promise<ModelWithApiKeys[]> => {
       const { data, error } = await getModelsWithApiKeys();
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError });
       return data ?? [];
     },
   });

--- a/platform/frontend/src/lib/llm-oauth-clients.query.ts
+++ b/platform/frontend/src/lib/llm-oauth-clients.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError, toApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError, toApiError } from "@/lib/utils";
 
 const {
   getLlmOauthClients,
@@ -30,10 +30,7 @@ export function useLlmOauthClients(params?: LlmOauthClientsParams) {
           providerApiKeyId: providerApiKeyId || undefined,
         },
       });
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data ?? [];
     },
     enabled: params?.enabled,

--- a/platform/frontend/src/lib/llm-oauth-clients.query.ts
+++ b/platform/frontend/src/lib/llm-oauth-clients.query.ts
@@ -15,6 +15,7 @@ type LlmOauthClientsParams = {
   search?: string;
   providerApiKeyId?: string;
   enabled?: boolean;
+  toastOnError?: boolean;
 };
 
 export function useLlmOauthClients(params?: LlmOauthClientsParams) {
@@ -30,7 +31,7 @@ export function useLlmOauthClients(params?: LlmOauthClientsParams) {
           providerApiKeyId: providerApiKeyId || undefined,
         },
       });
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError: params?.toastOnError ?? true });
       return data ?? [];
     },
     enabled: params?.enabled,

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.test.tsx
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.test.tsx
@@ -3,10 +3,12 @@ import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetLlmProviderApiKeys, mockToastError } = vi.hoisted(() => ({
-  mockGetLlmProviderApiKeys: vi.fn(),
-  mockToastError: vi.fn(),
-}));
+const { mockGetLlmProviderApiKeys, mockToastError, mockHasPermissions } =
+  vi.hoisted(() => ({
+    mockGetLlmProviderApiKeys: vi.fn(),
+    mockToastError: vi.fn(),
+    mockHasPermissions: vi.fn(),
+  }));
 
 vi.mock("@archestra/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@archestra/shared")>();
@@ -24,7 +26,14 @@ vi.mock("sonner", () => ({
   toast: { error: mockToastError, success: vi.fn() },
 }));
 
-import { useLlmProviderApiKeys } from "./llm-provider-api-keys.query";
+vi.mock("@/lib/auth/auth.query", () => ({
+  useHasPermissions: () => mockHasPermissions(),
+}));
+
+import {
+  useHasAnyApiKey,
+  useLlmProviderApiKeys,
+} from "./llm-provider-api-keys.query";
 
 function wrapper({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient({
@@ -81,5 +90,42 @@ describe("useLlmProviderApiKeys", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.isError).toBe(false);
     expect(result.current.data).toEqual([]);
+  });
+});
+
+describe("useHasAnyApiKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasPermissions.mockReturnValue({ data: true });
+  });
+
+  it("reports a load error when the first keys fetch fails", async () => {
+    mockGetLlmProviderApiKeys.mockResolvedValue({
+      error: new Error("Network request failed"),
+    });
+
+    const { result } = renderHook(() => useHasAnyApiKey(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoadError).toBe(true));
+    expect(result.current.hasAnyApiKey).toBe(false);
+  });
+
+  it("does not run the query or report a load error without read permission", async () => {
+    mockHasPermissions.mockReturnValue({ data: false });
+
+    const { result } = renderHook(() => useHasAnyApiKey(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isLoadError).toBe(false);
+    expect(mockGetLlmProviderApiKeys).not.toHaveBeenCalled();
+  });
+
+  it("reports a configured key when the fetch succeeds with keys", async () => {
+    mockGetLlmProviderApiKeys.mockResolvedValue({ data: [{ id: "key-1" }] });
+
+    const { result } = renderHook(() => useHasAnyApiKey(), { wrapper });
+
+    await waitFor(() => expect(result.current.hasAnyApiKey).toBe(true));
+    expect(result.current.isLoadError).toBe(false);
   });
 });

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.test.tsx
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.test.tsx
@@ -50,6 +50,9 @@ describe("useLlmProviderApiKeys", () => {
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+    // First-fetch failure with no cached data — the signal the gating screens
+    // branch on to show the load-error state.
+    expect(result.current.isLoadingError).toBe(true);
     expect(result.current.data).toBeUndefined();
     expect(mockToastError).toHaveBeenCalledTimes(1);
   });

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.test.tsx
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetLlmProviderApiKeys, mockToastError } = vi.hoisted(() => ({
+  mockGetLlmProviderApiKeys: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("@archestra/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@archestra/shared")>();
+  return {
+    ...actual,
+    archestraApiSdk: {
+      ...actual.archestraApiSdk,
+      getLlmProviderApiKeys: (...args: unknown[]) =>
+        mockGetLlmProviderApiKeys(...args),
+    },
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: mockToastError, success: vi.fn() },
+}));
+
+import { useLlmProviderApiKeys } from "./llm-provider-api-keys.query";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useLlmProviderApiKeys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enters the error state when the request fails (instead of returning [])", async () => {
+    mockGetLlmProviderApiKeys.mockResolvedValue({
+      error: new Error("Network request failed"),
+    });
+
+    const { result } = renderHook(() => useLlmProviderApiKeys({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not toast on failure when toastOnError is false", async () => {
+    mockGetLlmProviderApiKeys.mockResolvedValue({
+      error: new Error("Network request failed"),
+    });
+
+    const { result } = renderHook(
+      () => useLlmProviderApiKeys({ toastOnError: false }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("returns the keys on success without an error", async () => {
+    mockGetLlmProviderApiKeys.mockResolvedValue({ data: [] });
+
+    const { result } = renderHook(() => useLlmProviderApiKeys({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.ts
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.ts
@@ -23,6 +23,14 @@ type AvailableLlmProviderApiKeysQuery = NonNullable<
 >;
 type LlmProviderApiKeysQueryParams = Partial<LlmProviderApiKeysQuery> & {
   enabled?: boolean;
+  /**
+   * Toast on fetch failure. Default true so list/dialog callers fail loud.
+   * Callers that render their own error state (the new-chat and projects
+   * gates) pass false to avoid a redundant toast-plus-screen and a fresh
+   * toast on every retry. The query throws regardless, so `isError` is always
+   * available to branch on.
+   */
+  toastOnError?: boolean;
 };
 type AvailableLlmProviderApiKeysParams =
   Partial<AvailableLlmProviderApiKeysQuery> & {
@@ -40,6 +48,7 @@ const {
 export function useLlmProviderApiKeys(params?: LlmProviderApiKeysQueryParams) {
   const search = params?.search;
   const provider = params?.provider;
+  const toastOnError = params?.toastOnError ?? true;
 
   return useQuery({
     queryKey: ["llm-provider-api-keys", search, provider],
@@ -50,9 +59,15 @@ export function useLlmProviderApiKeys(params?: LlmProviderApiKeysQueryParams) {
           search: search || undefined,
         },
       });
+      // Throw rather than swallowing into [] so the query enters its error
+      // state: a failed fetch (e.g. offline) must be distinguishable from a
+      // successful "no keys configured" response, which gates the new-chat and
+      // projects "Add an LLM Provider Key" prompt.
       if (error) {
-        handleApiError(error);
-        return [];
+        if (toastOnError) {
+          handleApiError(error);
+        }
+        throw toApiError(error);
       }
       return data ?? [];
     },
@@ -70,18 +85,29 @@ export function useLlmProviderApiKeys(params?: LlmProviderApiKeysQueryParams) {
 export function useHasAnyApiKey(): {
   hasAnyApiKey: boolean;
   isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
 } {
   const { data: canReadKeys } = useHasPermissions({
     llmProviderApiKey: ["read"],
   });
   const { data: canReadModels } = useHasPermissions({ llmModel: ["read"] });
   const enabled = canReadKeys === true && canReadModels === true;
-  const { data: keys = [], isLoading } = useLlmProviderApiKeys({ enabled });
+  const {
+    data: keys = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useLlmProviderApiKeys({ enabled, toastOnError: false });
   const permissionsResolving =
     canReadKeys === undefined || canReadModels === undefined;
   return {
     hasAnyApiKey: keys.length > 0,
     isLoading: permissionsResolving || (enabled && isLoading),
+    isError: enabled && isError,
+    refetch: () => {
+      void refetch();
+    },
   };
 }
 

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.ts
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.ts
@@ -29,6 +29,12 @@ type LlmProviderApiKeysQueryParams = Partial<LlmProviderApiKeysQuery> & {
    * gates) pass false to avoid a redundant toast-plus-screen and a fresh
    * toast on every retry. The query throws regardless, so `isError` is always
    * available to branch on.
+   *
+   * Best-effort under react-query's shared fetches: observers with the same
+   * query key share one request, so the toast follows whichever observer
+   * triggers the fetch (e.g. a gating screen's own retry uses its `false`).
+   * The gating screens don't rely on suppression for correctness — they show
+   * their inline error from `isError` either way.
    */
   toastOnError?: boolean;
 };

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.ts
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.ts
@@ -91,7 +91,7 @@ export function useLlmProviderApiKeys(params?: LlmProviderApiKeysQueryParams) {
 export function useHasAnyApiKey(): {
   hasAnyApiKey: boolean;
   isLoading: boolean;
-  isError: boolean;
+  isLoadError: boolean;
   refetch: () => void;
 } {
   const { data: canReadKeys } = useHasPermissions({
@@ -102,7 +102,7 @@ export function useHasAnyApiKey(): {
   const {
     data: keys = [],
     isLoading,
-    isError,
+    isLoadingError,
     refetch,
   } = useLlmProviderApiKeys({ enabled, toastOnError: false });
   const permissionsResolving =
@@ -110,7 +110,10 @@ export function useHasAnyApiKey(): {
   return {
     hasAnyApiKey: keys.length > 0,
     isLoading: permissionsResolving || (enabled && isLoading),
-    isError: enabled && isError,
+    // Only the first-fetch failure (no cached list). A failed background
+    // refetch keeps the last successful result — empty or not — so we don't
+    // hide a known "no keys" or working state behind the load-error screen.
+    isLoadError: enabled && isLoadingError,
     refetch: () => {
       void refetch();
     },

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.ts
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.ts
@@ -7,7 +7,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useHasPermissions } from "@/lib/auth/auth.query";
-import { handleApiError, toApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError, toApiError } from "@/lib/utils";
 
 export type { SupportedProvider };
 
@@ -65,16 +65,7 @@ export function useLlmProviderApiKeys(params?: LlmProviderApiKeysQueryParams) {
           search: search || undefined,
         },
       });
-      // Throw rather than swallowing into [] so the query enters its error
-      // state: a failed fetch (e.g. offline) must be distinguishable from a
-      // successful "no keys configured" response, which gates the new-chat and
-      // projects "Add an LLM Provider Key" prompt.
-      if (error) {
-        if (toastOnError) {
-          handleApiError(error);
-        }
-        throw toApiError(error);
-      }
+      throwOnApiError(error, { toastOnError });
       return data ?? [];
     },
     enabled: params?.enabled,
@@ -140,10 +131,7 @@ export function useAvailableLlmProviderApiKeys(
       const { data, error } = await getAvailableLlmProviderApiKeys({
         query: Object.keys(query).length > 0 ? query : undefined,
       });
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data ?? [];
     },
     enabled: params?.enabled,

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.ts
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.ts
@@ -41,6 +41,7 @@ type LlmProviderApiKeysQueryParams = Partial<LlmProviderApiKeysQuery> & {
 type AvailableLlmProviderApiKeysParams =
   Partial<AvailableLlmProviderApiKeysQuery> & {
     enabled?: boolean;
+    toastOnError?: boolean;
   };
 
 const {
@@ -116,6 +117,7 @@ export function useAvailableLlmProviderApiKeys(
 ) {
   const provider = params?.provider;
   const includeKeyId = params?.includeKeyId;
+  const toastOnError = params?.toastOnError;
 
   return useQuery({
     queryKey: ["available-llm-provider-api-keys", provider, includeKeyId],
@@ -131,7 +133,7 @@ export function useAvailableLlmProviderApiKeys(
       const { data, error } = await getAvailableLlmProviderApiKeys({
         query: Object.keys(query).length > 0 ? query : undefined,
       });
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError });
       return data ?? [];
     },
     enabled: params?.enabled,

--- a/platform/frontend/src/lib/mcp-oauth-clients.query.ts
+++ b/platform/frontend/src/lib/mcp-oauth-clients.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError, toApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError, toApiError } from "@/lib/utils";
 
 const {
   getMcpOauthClients,
@@ -27,10 +27,7 @@ export function useMcpOauthClients(params?: McpOauthClientsParams) {
           search: search || undefined,
         },
       });
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data ?? [];
     },
     enabled: params?.enabled,

--- a/platform/frontend/src/lib/mcp-oauth-clients.query.ts
+++ b/platform/frontend/src/lib/mcp-oauth-clients.query.ts
@@ -27,7 +27,7 @@ export function useMcpOauthClients(params?: McpOauthClientsParams) {
           search: search || undefined,
         },
       });
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError: false });
       return data ?? [];
     },
     enabled: params?.enabled,

--- a/platform/frontend/src/lib/mcp/external-mcp-catalog.query.ts
+++ b/platform/frontend/src/lib/mcp/external-mcp-catalog.query.ts
@@ -4,7 +4,7 @@ import {
 } from "@archestra/shared";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import type { SelectedCategory } from "@/app/mcp/registry/_parts/CatalogFilters";
-import { handleApiError } from "@/lib/utils";
+import { throwOnApiError } from "@/lib/utils";
 
 type SearchResponse =
   archestraCatalogTypes.SearchMcpServerCatalogResponses[200];
@@ -30,7 +30,7 @@ export function useMcpRegistryServersInfinite(
       limit,
     ],
     queryFn: async ({ pageParam = 0 }): Promise<SearchResponse> => {
-      const response = await archestraCatalogSdk.searchMcpServerCatalog({
+      const { data, error } = await archestraCatalogSdk.searchMcpServerCatalog({
         query: {
           q: search?.trim(),
           category: categoryParam,
@@ -40,19 +40,16 @@ export function useMcpRegistryServersInfinite(
           worksInArchestra: true,
         },
       });
-      if (!response.data) {
-        handleApiError({
-          error: new Error("No data returned from the catalog"),
-        });
-        return {
+      throwOnApiError(error);
+      return (
+        data ?? {
           servers: [],
           totalCount: 0,
           limit,
           offset: pageParam,
           hasMore: false,
-        };
-      }
-      return response.data;
+        }
+      );
     },
     getNextPageParam: (lastPage) => {
       return lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined;
@@ -70,15 +67,13 @@ export function useMcpRegistryServer(serverName: string | null) {
       if (!serverName) {
         return null;
       }
-      const response = await archestraCatalogSdk.getMcpServer({
+      const { data, error } = await archestraCatalogSdk.getMcpServer({
         path: {
           name: serverName,
         },
       });
-      if (!response.data) {
-        return null;
-      }
-      return response.data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
   });
 }
@@ -89,14 +84,10 @@ export function useMcpServerCategories() {
     queryFn: async (): Promise<
       archestraCatalogTypes.GetMcpServerCategoriesResponse["categories"]
     > => {
-      const response = await archestraCatalogSdk.getMcpServerCategories();
-      if (!response.data) {
-        handleApiError({
-          error: new Error("No categories returned from the catalog"),
-        });
-        return [];
-      }
-      return response.data.categories;
+      const { data, error } =
+        await archestraCatalogSdk.getMcpServerCategories();
+      throwOnApiError(error);
+      return data?.categories ?? [];
     },
   });
 }

--- a/platform/frontend/src/lib/mcp/internal-mcp-catalog.query.ts
+++ b/platform/frontend/src/lib/mcp/internal-mcp-catalog.query.ts
@@ -2,6 +2,7 @@ import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { environmentKeys } from "@/lib/environment.query";
+import { throwOnApiError } from "@/lib/utils";
 
 const {
   createInternalMcpCatalogItem,
@@ -69,12 +70,13 @@ export function useInternalMcpCatalog(
   const includeApps = params?.includeApps ?? false;
   return useQuery({
     queryKey: includeApps ? ["mcp-catalog", "with-apps"] : ["mcp-catalog"],
-    queryFn: async () =>
-      (
-        await getInternalMcpCatalog(
-          includeApps ? { query: { includeApps } } : {},
-        )
-      ).data ?? [],
+    queryFn: async () => {
+      const { data, error } = await getInternalMcpCatalog(
+        includeApps ? { query: { includeApps } } : {},
+      );
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
+    },
     initialData: params?.initialData,
     enabled: params?.enabled,
   });
@@ -83,7 +85,11 @@ export function useInternalMcpCatalog(
 export function useMcpCatalogLabelKeys() {
   return useQuery({
     queryKey: ["mcp-catalog", "labels", "keys"],
-    queryFn: async () => (await getInternalMcpCatalogLabelKeys()).data ?? [],
+    queryFn: async () => {
+      const { data, error } = await getInternalMcpCatalogLabelKeys();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
+    },
   });
 }
 
@@ -93,9 +99,13 @@ export function useMcpCatalogLabelValues(
   const { key } = params || {};
   return useQuery({
     queryKey: ["mcp-catalog", "labels", "values", key],
-    queryFn: async () =>
-      (await getInternalMcpCatalogLabelValues({ query: key ? { key } : {} }))
-        .data ?? [],
+    queryFn: async () => {
+      const { data, error } = await getInternalMcpCatalogLabelValues({
+        query: key ? { key } : {},
+      });
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
+    },
     enabled: !!key,
   });
 }
@@ -283,10 +293,11 @@ export function useGetDeploymentYamlPreview(catalogId: string | null) {
     queryKey: ["mcp-catalog", catalogId, "deployment-yaml-preview"],
     queryFn: async () => {
       if (!catalogId) return null;
-      const response = await getDeploymentYamlPreview({
+      const { data, error } = await getDeploymentYamlPreview({
         path: { id: catalogId },
       });
-      return response.data;
+      throwOnApiError(error, { toastOnError: false });
+      return data;
     },
     enabled: !!catalogId,
   });
@@ -340,8 +351,9 @@ export function useK8sImagePullSecrets() {
   return useQuery({
     queryKey: ["k8s-image-pull-secrets"],
     queryFn: async () => {
-      const response = await getK8sImagePullSecrets();
-      return response.data ?? [];
+      const { data, error } = await getK8sImagePullSecrets();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
     },
   });
 }

--- a/platform/frontend/src/lib/mcp/mcp-server-installation-request.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server-installation-request.query.ts
@@ -1,6 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { throwOnApiError } from "@/lib/utils";
 
 const {
   addMcpServerInstallationRequestNote,
@@ -40,10 +41,11 @@ export function useMcpServerInstallationRequests(
   return useQuery({
     queryKey: ["mcp-server-installation-requests", params?.status],
     queryFn: async () => {
-      const response = await getMcpServerInstallationRequests({
+      const { data, error } = await getMcpServerInstallationRequests({
         query: params?.status ? { status: params.status } : undefined,
       });
-      return response.data ?? null;
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
     },
   });
 }
@@ -52,10 +54,11 @@ export function useMcpServerInstallationRequest(id: string) {
   return useQuery({
     queryKey: ["mcp-server-installation-request", id],
     queryFn: async () => {
-      const response = await getMcpServerInstallationRequest({
+      const { data, error } = await getMcpServerInstallationRequest({
         path: { id },
       });
-      return response.data ?? null;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
     enabled: !!id,
   });

--- a/platform/frontend/src/lib/mcp/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.ts
@@ -239,8 +239,9 @@ export function useMcpServerTools(mcpServerId: string | null) {
       const { data, error } = await getMcpServerTools({
         path: { id: mcpServerId },
       });
-      // toastOnError is false to prevent "MCP server not found" error from being shown
-      throwOnApiError(error, { toastOnError: false });
+      // A not-yet-connected server 404s here; treat that as an empty tool list
+      // (no error state, no toast) rather than a failure.
+      throwOnApiError(error, { allowNotFound: true, toastOnError: false });
       return data ?? [];
     },
     enabled: !!mcpServerId,

--- a/platform/frontend/src/lib/mcp/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.ts
@@ -11,7 +11,7 @@ import { toast } from "sonner";
 import { invalidateToolAssignmentQueries } from "@/lib/agent-tools.hook";
 import { useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 import websocketService from "@/lib/websocket/websocket";
 
 const {
@@ -45,7 +45,7 @@ export function useMcpServers(params?: McpServersParams) {
       },
     ],
     queryFn: async () => {
-      const response = await getMcpServers({
+      const { data, error } = await getMcpServers({
         query:
           params?.catalogId ||
           params?.assignmentScope ||
@@ -61,7 +61,8 @@ export function useMcpServers(params?: McpServersParams) {
               }
             : undefined,
       });
-      return response.data ?? [];
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
     },
     initialData: params?.initialData,
     enabled: params?.enabled,
@@ -238,11 +239,8 @@ export function useMcpServerTools(mcpServerId: string | null) {
       const { data, error } = await getMcpServerTools({
         path: { id: mcpServerId },
       });
-      if (error) {
-        // handleApiError not used to prevent "MCP server not found" error from being shown
-        console.error("Failed to fetch MCP server tools:", error);
-        return [];
-      }
+      // toastOnError is false to prevent "MCP server not found" error from being shown
+      throwOnApiError(error, { toastOnError: false });
       return data ?? [];
     },
     enabled: !!mcpServerId,

--- a/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
@@ -77,7 +77,8 @@ export function useMcpToolCalls({
           sortDirection,
         },
       });
-      throwOnApiError(response.error);
+      // Screen renders its own QueryLoadError panel; don't also toast.
+      throwOnApiError(response.error, { toastOnError: false });
       return (
         response.data ?? {
           data: [],

--- a/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
@@ -3,7 +3,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
-import { handleApiError } from "@/lib/utils";
+import { throwOnApiError } from "@/lib/utils";
 
 type MCPGatewayAuthMethod =
   archestraApiTypes.GetMcpToolCallResponses["200"]["authMethod"];
@@ -77,20 +77,7 @@ export function useMcpToolCalls({
           sortDirection,
         },
       });
-      if (response.error) {
-        handleApiError(response.error);
-        return {
-          data: [],
-          pagination: {
-            currentPage: 1,
-            limit,
-            total: 0,
-            totalPages: 0,
-            hasNext: false,
-            hasPrev: false,
-          },
-        };
-      }
+      throwOnApiError(response.error);
       return (
         response.data ?? {
           data: [],
@@ -131,10 +118,7 @@ export function useMcpToolCall({
     queryKey: ["mcpToolCalls", mcpToolCallId],
     queryFn: async () => {
       const response = await getMcpToolCall({ path: { mcpToolCallId } });
-      if (response.error) {
-        handleApiError(response.error);
-        return null;
-      }
+      throwOnApiError(response.error, { allowNotFound: true });
       return response.data ?? null;
     },
     initialData,

--- a/platform/frontend/src/lib/member.query.ts
+++ b/platform/frontend/src/lib/member.query.ts
@@ -6,6 +6,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { authClient } from "@/lib/clients/auth/auth-client";
+import { throwOnApiError } from "@/lib/utils";
 import { useActiveOrganization } from "./organization.query";
 
 const { getMembers } = archestraApiSdk;
@@ -65,6 +66,7 @@ export function useMembersPaginated(
     queryKey: memberKeys.paginated(query),
     queryFn: async () => {
       const response = await getMembers({ query });
+      throwOnApiError(response.error, { toastOnError: false });
       return (
         response.data ?? {
           data: [] as Member[],

--- a/platform/frontend/src/lib/optimization-rule.query.ts
+++ b/platform/frontend/src/lib/optimization-rule.query.ts
@@ -3,7 +3,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "./utils";
+import { handleApiError, throwOnApiError } from "./utils";
 
 const {
   getOptimizationRules,
@@ -29,9 +29,7 @@ export function useOptimizationRules() {
     queryKey: ["optimization-rules"],
     queryFn: async () => {
       const response = await getOptimizationRules();
-      if (response.error) {
-        handleApiError(response.error);
-      }
+      throwOnApiError(response.error);
       return response.data ?? [];
     },
   });

--- a/platform/frontend/src/lib/optimization-rule.query.ts
+++ b/platform/frontend/src/lib/optimization-rule.query.ts
@@ -29,7 +29,8 @@ export function useOptimizationRules() {
     queryKey: ["optimization-rules"],
     queryFn: async () => {
       const response = await getOptimizationRules();
-      throwOnApiError(response.error);
+      // Screen renders its own QueryLoadError panel; don't also toast.
+      throwOnApiError(response.error, { toastOnError: false });
       return response.data ?? [];
     },
   });

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -21,8 +21,8 @@ export const appearanceKeys = {
  * Hook to fetch public appearance settings.
  * Used on login/auth pages where the user is not yet authenticated.
  * Returns theme, customFont, and logo without requiring authentication.
- * On API failure, returns null so React Query has a defined cache value while
- * callers keep using local fallback appearance values.
+ * On API failure the query enters its error state (no toast, since this is a
+ * pre-auth surface); callers keep using their local fallback appearance values.
  */
 export function useAppearanceSettings(enabled = true) {
   return useQuery({

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -10,7 +10,7 @@ import { toast } from "sonner";
 import { useSession } from "@/lib/auth/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { environmentKeys } from "./environment.query";
-import { handleApiError } from "./utils";
+import { handleApiError, throwOnApiError } from "./utils";
 
 export const appearanceKeys = {
   all: ["appearance"] as const,
@@ -29,12 +29,8 @@ export function useAppearanceSettings(enabled = true) {
     queryKey: appearanceKeys.public(),
     queryFn: async () => {
       const { data, error } = await archestraApiSdk.getAppearanceSettings();
-
-      if (error || !data) {
-        return null;
-      }
-
-      return data;
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
     },
     enabled,
     staleTime: 5 * 60 * 1000,
@@ -260,7 +256,8 @@ export function useOrganization(enabled = true) {
   return useQuery({
     queryKey: organizationKeys.details(),
     queryFn: async () => {
-      const { data } = await archestraApiSdk.getOrganization();
+      const { data, error } = await archestraApiSdk.getOrganization();
+      throwOnApiError(error, { toastOnError: false });
       return data;
     },
     // Only fetch when user is authenticated to prevent 403 errors during initial auth check
@@ -284,14 +281,7 @@ export function useOrganizationOnboardingStatus(enabled: boolean) {
     queryFn: async () => {
       const { data, error } = await archestraApiSdk.getOnboardingStatus();
 
-      if (error) {
-        handleApiError(error);
-        return {
-          hasProfilesConfigured: false,
-          hasToolsConfigured: false,
-          isComplete: false,
-        };
-      }
+      throwOnApiError(error);
 
       return (
         data ?? {
@@ -659,10 +649,7 @@ export function useOrganizationMembers(enabled = true) {
     queryKey: [...organizationKeys.all, "members"],
     queryFn: async () => {
       const { data, error } = await archestraApiSdk.getOrganizationMembers();
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data ?? [];
     },
     enabled,
@@ -687,9 +674,7 @@ export function useMemberSignupStatus() {
     queryKey: organizationKeys.memberSignupStatus(),
     queryFn: async () => {
       const { data, error } = await archestraApiSdk.getMemberSignupStatus();
-      if (error) {
-        return { pendingSignupMembers: [] as PendingSignupMember[] };
-      }
+      throwOnApiError(error, { toastOnError: false });
       return data ?? { pendingSignupMembers: [] as PendingSignupMember[] };
     },
   });

--- a/platform/frontend/src/lib/policy.query.ts
+++ b/platform/frontend/src/lib/policy.query.ts
@@ -28,7 +28,7 @@ import {
   transformToolInvocationPolicies,
   transformToolResultPolicies,
 } from "./policy.utils";
-import { handleApiError } from "./utils";
+import { handleApiError, throwOnApiError } from "./utils";
 
 export function useToolInvocationPolicies(
   initialData?: ReturnType<typeof transformToolInvocationPolicies>,
@@ -36,8 +36,9 @@ export function useToolInvocationPolicies(
   return useQuery({
     queryKey: ["tool-invocation-policies"],
     queryFn: async () => {
-      const all = (await getToolInvocationPolicies()).data ?? [];
-      return transformToolInvocationPolicies(all);
+      const { data, error } = await getToolInvocationPolicies();
+      throwOnApiError(error, { toastOnError: false });
+      return transformToolInvocationPolicies(data ?? []);
     },
     initialData,
   });
@@ -46,7 +47,11 @@ export function useToolInvocationPolicies(
 export function useOperators() {
   return useQuery({
     queryKey: ["operators"],
-    queryFn: async () => (await getOperators()).data ?? [],
+    queryFn: async () => {
+      const { data, error } = await getOperators();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
+    },
   });
 }
 
@@ -120,8 +125,9 @@ export function useToolResultPolicies(
   return useQuery({
     queryKey: ["tool-result-policies"],
     queryFn: async () => {
-      const all = (await getTrustedDataPolicies()).data ?? [];
-      return transformToolResultPolicies(all);
+      const { data, error } = await getTrustedDataPolicies();
+      throwOnApiError(error, { toastOnError: false });
+      return transformToolResultPolicies(data ?? []);
     },
     initialData,
   });

--- a/platform/frontend/src/lib/projects/projects.query.ts
+++ b/platform/frontend/src/lib/projects/projects.query.ts
@@ -12,17 +12,7 @@ import {
   type UploadOutcome,
   validateUploadFile,
 } from "@/lib/files/file-upload";
-import { getApiErrorType, handleApiError } from "@/lib/utils";
-
-/**
- * A project the user is viewing can vanish — deleted in this tab, or by someone
- * else who shared it. The detail page already renders that gracefully ("Project
- * not found."), so a not-found is an expected empty state, not an error worth a
- * toast + Sentry capture. Other failures still surface normally.
- */
-function isProjectNotFound(error: unknown): boolean {
-  return getApiErrorType(error) === "api_not_found_error";
-}
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   createProject,
@@ -78,10 +68,7 @@ export function useProjects(
       const { data, error } = await getProjects({
         query: { scope, search, teamIds, authorIds, excludeAuthorIds },
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
   });
@@ -95,11 +82,8 @@ export function useProject(id: string | undefined) {
       const { data, error } = await getProject({
         path: { id: id as string },
       });
-      if (error) {
-        if (!isProjectNotFound(error)) handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
   });
 }
@@ -115,11 +99,8 @@ export function useProjectConversations(
       const { data, error } = await getProjectConversations({
         path: { id: id as string },
       });
-      if (error) {
-        if (!isProjectNotFound(error)) handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
   });
 }
@@ -134,11 +115,8 @@ export function useProjectFiles(id: string | undefined) {
       const { data, error } = await getProjectFiles({
         path: { id: id as string },
       });
-      if (error) {
-        if (!isProjectNotFound(error)) handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
   });
 }
@@ -152,11 +130,8 @@ export function useProjectInstructions(id: string | undefined) {
       const { data, error } = await getProjectInstructions({
         path: { id: id as string },
       });
-      if (error) {
-        if (!isProjectNotFound(error)) handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
   });
 }

--- a/platform/frontend/src/lib/projects/projects.query.ts
+++ b/platform/frontend/src/lib/projects/projects.query.ts
@@ -44,13 +44,14 @@ type ProjectListFilters = NonNullable<
  * cache entry.
  */
 export function useProjects(
-  options?: { enabled?: boolean } & ProjectListFilters,
+  options?: { enabled?: boolean; toastOnError?: boolean } & ProjectListFilters,
 ) {
   const scope = options?.scope;
   const search = options?.search?.trim() || undefined;
   const teamIds = options?.teamIds;
   const authorIds = options?.authorIds;
   const excludeAuthorIds = options?.excludeAuthorIds;
+  const toastOnError = options?.toastOnError;
   return useQuery({
     queryKey: [
       "projects",
@@ -68,7 +69,7 @@ export function useProjects(
       const { data, error } = await getProjects({
         query: { scope, search, teamIds, authorIds, excludeAuthorIds },
       });
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError });
       return data;
     },
   });

--- a/platform/frontend/src/lib/role.query.ts
+++ b/platform/frontend/src/lib/role.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const { getRoles, createRole, getRole, updateRole, deleteRole } =
   archestraApiSdk;
@@ -31,6 +31,7 @@ export function useRoles(params?: {
       const response = await getRoles({
         query: { limit: DEFAULT_TABLE_LIMIT, offset: 0 },
       });
+      throwOnApiError(response.error, { toastOnError: false });
       return response.data?.data ?? [];
     },
     initialData: params?.initialData,
@@ -42,6 +43,7 @@ export function useRolesPaginated(params: RolesPaginatedParams) {
     queryKey: [...roleKeys.lists(), "paginated", params],
     queryFn: async () => {
       const response = await getRoles({ query: params });
+      throwOnApiError(response.error, { toastOnError: false });
       return (
         response.data ?? {
           data: [],
@@ -65,7 +67,14 @@ export function useRolesPaginated(params: RolesPaginatedParams) {
 export function useRole(roleId: string) {
   return useQuery({
     queryKey: roleKeys.detail(roleId),
-    queryFn: async () => (await getRole({ path: { roleId } })).data ?? null,
+    queryFn: async () => {
+      const response = await getRole({ path: { roleId } });
+      throwOnApiError(response.error, {
+        allowNotFound: true,
+        toastOnError: false,
+      });
+      return response.data ?? null;
+    },
     enabled: !!roleId,
   });
 }

--- a/platform/frontend/src/lib/schedule-trigger.query.ts
+++ b/platform/frontend/src/lib/schedule-trigger.query.ts
@@ -180,7 +180,8 @@ export function useScheduleTriggers(params?: {
           ...(queryParams.showAll ? { showAll: queryParams.showAll } : {}),
         },
       });
-      throwOnApiError(response.error);
+      // Screen renders its own QueryLoadError panel; don't also toast.
+      throwOnApiError(response.error, { toastOnError: false });
       return (
         (response.data as PaginatedResponse<ScheduleTrigger>) ?? emptyResponse
       );

--- a/platform/frontend/src/lib/schedule-trigger.query.ts
+++ b/platform/frontend/src/lib/schedule-trigger.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type PaginationMeta } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "./utils";
+import { handleApiError, throwOnApiError } from "./utils";
 
 const {
   getScheduleTriggers,
@@ -180,10 +180,7 @@ export function useScheduleTriggers(params?: {
           ...(queryParams.showAll ? { showAll: queryParams.showAll } : {}),
         },
       });
-      if (response.error) {
-        handleApiError(response.error);
-        return emptyResponse;
-      }
+      throwOnApiError(response.error);
       return (
         (response.data as PaginatedResponse<ScheduleTrigger>) ?? emptyResponse
       );
@@ -207,10 +204,7 @@ export function useScheduleTrigger(
       const response = await getScheduleTrigger({
         path: { id: triggerId as string },
       });
-      if (response.error) {
-        handleApiError(response.error);
-        return null;
-      }
+      throwOnApiError(response.error, { allowNotFound: true });
       return (response.data as ScheduleTrigger) ?? null;
     },
     enabled: !!triggerId && (params?.enabled ?? true),
@@ -247,10 +241,7 @@ export function useScheduleTriggerRuns(
           ...(queryParams.status ? { status: queryParams.status } : {}),
         },
       });
-      if (response.error) {
-        handleApiError(response.error);
-        return emptyResponse;
-      }
+      throwOnApiError(response.error);
       return (
         (response.data as PaginatedResponse<ScheduleTriggerRun>) ??
         emptyResponse
@@ -270,10 +261,7 @@ export function useHasActiveScheduleTriggers() {
       const response = await getScheduleTriggers({
         query: { enabled: true, limit: 1, offset: 0 },
       });
-      if (response.error) {
-        handleApiError(response.error);
-        return false;
-      }
+      throwOnApiError(response.error);
       const data = response.data as
         | PaginatedResponse<ScheduleTrigger>
         | undefined;
@@ -296,10 +284,7 @@ export function useScheduleTriggerRun(
       const response = await getScheduleTriggerRun({
         path: { id: triggerId as string, runId: runId as string },
       });
-      if (response.error) {
-        handleApiError(response.error);
-        return null;
-      }
+      throwOnApiError(response.error, { allowNotFound: true });
       return (response.data as ScheduleTriggerRun) ?? null;
     },
     enabled: !!triggerId && !!runId && (params?.enabled ?? true),

--- a/platform/frontend/src/lib/schedule-trigger.query.ts
+++ b/platform/frontend/src/lib/schedule-trigger.query.ts
@@ -150,6 +150,7 @@ export function useScheduleTriggers(params?: {
   projectId?: string;
   showAll?: boolean;
   refetchInterval?: number | false;
+  toastOnError?: boolean;
 }) {
   const queryParams = getScheduleTriggerListQueryParams(params);
   const emptyResponse: PaginatedResponse<ScheduleTrigger> = {
@@ -180,8 +181,7 @@ export function useScheduleTriggers(params?: {
           ...(queryParams.showAll ? { showAll: queryParams.showAll } : {}),
         },
       });
-      // Screen renders its own QueryLoadError panel; don't also toast.
-      throwOnApiError(response.error, { toastOnError: false });
+      throwOnApiError(response.error, { toastOnError: params?.toastOnError });
       return (
         (response.data as PaginatedResponse<ScheduleTrigger>) ?? emptyResponse
       );

--- a/platform/frontend/src/lib/secrets.query.ts
+++ b/platform/frontend/src/lib/secrets.query.ts
@@ -4,7 +4,7 @@ import {
   SecretsManagerType,
 } from "@archestra/shared";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { handleApiError } from "./utils";
+import { handleApiError, throwOnApiError } from "./utils";
 
 const { getSecretsType, checkSecretsConnectivity, getSecret } = archestraApiSdk;
 
@@ -19,7 +19,8 @@ export function useSecretsType() {
   return useQuery({
     queryKey: secretsKeys.type(),
     queryFn: async () => {
-      const { data } = await getSecretsType();
+      const { data, error } = await getSecretsType();
+      throwOnApiError(error, { toastOnError: false });
       return data;
     },
   });
@@ -42,10 +43,7 @@ export function useGetSecret(secretId: string | null | undefined) {
         return null;
       }
       const response = await getSecret({ path: { id: secretId } });
-      if (response.error) {
-        handleApiError(response.error);
-        return null;
-      }
+      throwOnApiError(response.error, { allowNotFound: true });
       return response.data;
     },
     enabled: !!secretId && byosEnabled,

--- a/platform/frontend/src/lib/service-account.query.ts
+++ b/platform/frontend/src/lib/service-account.query.ts
@@ -30,7 +30,8 @@ export function useServiceAccounts() {
     queryKey: ["service-accounts"],
     queryFn: async () => {
       const { data, error } = await getServiceAccounts();
-      throwOnApiError(error);
+      // Screen renders its own QueryLoadError panel; don't also toast.
+      throwOnApiError(error, { toastOnError: false });
 
       return data ?? [];
     },

--- a/platform/frontend/src/lib/service-account.query.ts
+++ b/platform/frontend/src/lib/service-account.query.ts
@@ -2,7 +2,7 @@ import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useHasPermissions } from "@/lib/auth/auth.query";
-import { handleApiError, toApiError } from "./utils";
+import { handleApiError, throwOnApiError, toApiError } from "./utils";
 
 export type ServiceAccount =
   archestraApiTypes.GetServiceAccountsResponses["200"][number];
@@ -30,10 +30,7 @@ export function useServiceAccounts() {
     queryKey: ["service-accounts"],
     queryFn: async () => {
       const { data, error } = await getServiceAccounts();
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
 
       return data ?? [];
     },
@@ -51,10 +48,7 @@ export function useServiceAccount(id: string | null) {
     queryFn: async () => {
       if (!id) return null;
       const { data, error } = await getServiceAccount({ path: { id } });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error, { allowNotFound: true });
 
       return data ?? null;
     },

--- a/platform/frontend/src/lib/site-notification.query.ts
+++ b/platform/frontend/src/lib/site-notification.query.ts
@@ -6,7 +6,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "./utils";
+import { handleApiError, throwOnApiError } from "./utils";
 
 export const siteNotificationKeys = {
   all: ["site-notification"] as const,
@@ -36,9 +36,7 @@ export function useActiveSiteNotification(
     queryKey: siteNotificationKeys.active(),
     queryFn: async () => {
       const { data, error } = await archestraApiSdk.getSiteNotification();
-      if (error) {
-        return null;
-      }
+      throwOnApiError(error, { toastOnError: false });
       return data as SiteNotification | null;
     },
     staleTime: 60 * 1000,
@@ -58,9 +56,7 @@ export function useSiteNotification(
     queryFn: async () => {
       const { data, error } =
         await archestraApiSdk.getSiteNotificationSettings();
-      if (error) {
-        return null;
-      }
+      throwOnApiError(error, { toastOnError: false });
       return data as SiteNotification | null;
     },
     staleTime: 60 * 1000,

--- a/platform/frontend/src/lib/skills/skill-share.query.ts
+++ b/platform/frontend/src/lib/skills/skill-share.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
   getSkillShareLinks,
@@ -24,10 +24,7 @@ export function useListSkillShareLinks(skillId?: string | null) {
       const { data, error } = await getSkillShareLinks({
         query: skillId ? { skillId } : undefined,
       });
-      if (error) {
-        handleApiError(error);
-        return { links: [] as SkillShareLink[] };
-      }
+      throwOnApiError(error);
       return data;
     },
   });

--- a/platform/frontend/src/lib/skills/skill.query.ts
+++ b/platform/frontend/src/lib/skills/skill.query.ts
@@ -35,16 +35,16 @@ type SkillsPaginatedParams = Pick<
 
 export function useSkillsPaginated(
   params: SkillsPaginatedParams,
-  options?: { enabled?: boolean },
+  options?: { enabled?: boolean; toastOnError?: boolean },
 ) {
+  const toastOnError = options?.toastOnError;
   return useQuery({
     queryKey: ["skills", "paginated", params],
     enabled: options?.enabled ?? true,
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getSkills({ query: params });
-      // Screen renders its own QueryLoadError panel; don't also toast.
-      throwOnApiError(error, { toastOnError: false });
+      throwOnApiError(error, { toastOnError });
       return data;
     },
   });

--- a/platform/frontend/src/lib/skills/skill.query.ts
+++ b/platform/frontend/src/lib/skills/skill.query.ts
@@ -1,7 +1,11 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { getApiErrorMessage, handleApiError } from "@/lib/utils";
+import {
+  getApiErrorMessage,
+  handleApiError,
+  throwOnApiError,
+} from "@/lib/utils";
 
 const {
   getSkills,
@@ -39,10 +43,7 @@ export function useSkillsPaginated(
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getSkills({ query: params });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
   });
@@ -53,10 +54,7 @@ export function useSkillSourceRepos() {
     queryKey: ["skills", "source-repos"],
     queryFn: async () => {
       const { data, error } = await getSkillSourceRepos();
-      if (error) {
-        handleApiError(error);
-        return { repos: [] as string[] };
-      }
+      throwOnApiError(error);
       return data;
     },
   });
@@ -89,11 +87,8 @@ export function useSkill(id: string | null) {
     queryKey: ["skills", id],
     queryFn: async () => {
       const { data, error } = await getSkill({ path: { id: id as string } });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
-      return data;
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
     enabled: !!id,
   });
@@ -216,10 +211,7 @@ export function usePreviewGithubSkill(
       const { data, error } = await previewGithubSkill({
         body: body as archestraApiTypes.PreviewGithubSkillData["body"],
       });
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data;
     },
   });

--- a/platform/frontend/src/lib/skills/skill.query.ts
+++ b/platform/frontend/src/lib/skills/skill.query.ts
@@ -43,7 +43,8 @@ export function useSkillsPaginated(
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getSkills({ query: params });
-      throwOnApiError(error);
+      // Screen renders its own QueryLoadError panel; don't also toast.
+      throwOnApiError(error, { toastOnError: false });
       return data;
     },
   });

--- a/platform/frontend/src/lib/statistics.query.ts
+++ b/platform/frontend/src/lib/statistics.query.ts
@@ -6,6 +6,7 @@ import {
   type StatisticsTimeFrame,
 } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
+import { throwOnApiError } from "@/lib/utils";
 
 const {
   getTeamStatistics,
@@ -25,10 +26,11 @@ export function useTeamStatistics({
   return useQuery({
     queryKey: ["statistics", "teams", timeframe],
     queryFn: async () => {
-      const response = await getTeamStatistics({
+      const { data, error } = await getTeamStatistics({
         query: { timeframe },
       });
-      return response.data;
+      throwOnApiError(error, { toastOnError: false });
+      return data;
     },
     initialData,
     refetchInterval: 30_000, // Refresh every 30 seconds
@@ -45,10 +47,11 @@ export function useProfileStatistics({
   return useQuery({
     queryKey: ["statistics", "agents", timeframe],
     queryFn: async () => {
-      const response = await getAgentStatistics({
+      const { data, error } = await getAgentStatistics({
         query: { timeframe },
       });
-      return response.data;
+      throwOnApiError(error, { toastOnError: false });
+      return data;
     },
     initialData,
     refetchInterval: 30_000, // Refresh every 30 seconds
@@ -65,10 +68,11 @@ export function useModelStatistics({
   return useQuery({
     queryKey: ["statistics", "models", timeframe],
     queryFn: async () => {
-      const response = await getModelStatistics({
+      const { data, error } = await getModelStatistics({
         query: { timeframe },
       });
-      return response.data;
+      throwOnApiError(error, { toastOnError: false });
+      return data;
     },
     initialData,
     refetchInterval: 30_000, // Refresh every 30 seconds
@@ -85,10 +89,11 @@ export function useOverviewStatistics({
   return useQuery({
     queryKey: ["statistics", "overview", timeframe],
     queryFn: async () => {
-      const response = await getOverviewStatistics({
+      const { data, error } = await getOverviewStatistics({
         query: { timeframe },
       });
-      return response.data;
+      throwOnApiError(error, { toastOnError: false });
+      return data;
     },
     initialData,
     refetchInterval: 30_000, // Refresh every 30 seconds
@@ -105,10 +110,11 @@ export function useCostSavingsStatistics({
   return useQuery({
     queryKey: ["statistics", "cost-savings", timeframe],
     queryFn: async () => {
-      const response = await getCostSavingsStatistics({
+      const { data, error } = await getCostSavingsStatistics({
         query: { timeframe },
       });
-      return response.data;
+      throwOnApiError(error, { toastOnError: false });
+      return data;
     },
     initialData,
     refetchInterval: 30_000, // Refresh every 30 seconds

--- a/platform/frontend/src/lib/teams/team-token.query.ts
+++ b/platform/frontend/src/lib/teams/team-token.query.ts
@@ -1,6 +1,6 @@
 import { archestraApiSdk } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { handleApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const { getTokens, getTokenValue, rotateToken } = archestraApiSdk;
 
@@ -51,9 +51,7 @@ export function useTokens(params?: { profileId?: string; enabled?: boolean }) {
     queryKey: ["tokens", { profileId }],
     queryFn: async () => {
       const response = await getTokens({ query: { profileId } });
-      if (response.error) {
-        handleApiError(response.error);
-      }
+      throwOnApiError(response.error);
       const data = response.data as TokensListResponse | undefined;
       return {
         tokens: data?.tokens ?? [],
@@ -76,6 +74,7 @@ export function useTokenValue(tokenId: string | undefined) {
     queryFn: async () => {
       if (!tokenId) return null;
       const response = await getTokenValue({ path: { tokenId } });
+      throwOnApiError(response.error, { toastOnError: false });
       return response.data as { value: string };
     },
     enabled: false, // Only fetch on demand

--- a/platform/frontend/src/lib/teams/team.query.ts
+++ b/platform/frontend/src/lib/teams/team.query.ts
@@ -1,6 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useFeature } from "@/lib/config/config.query";
+import { throwOnApiError } from "@/lib/utils";
 
 const { getTeams, getTeamVaultFolder, getTeamLabelKeys, getTeamLabelValues } =
   archestraApiSdk;
@@ -36,7 +37,7 @@ export function useTeams(params?: {
       ...(name || labels ? [{ name, labels }] : []),
     ],
     queryFn: async () => {
-      const { data } = await getTeams({
+      const { data, error } = await getTeams({
         query: {
           limit: 100,
           offset: 0,
@@ -45,6 +46,7 @@ export function useTeams(params?: {
           ...(labels ? { labels } : {}),
         },
       });
+      throwOnApiError(error, { toastOnError: false });
       return data?.data ?? [];
     },
     initialData: params?.initialData as Team[] | undefined,
@@ -55,7 +57,11 @@ export function useTeams(params?: {
 export function useTeamLabelKeys() {
   return useQuery({
     queryKey: ["teams", "labels", "keys"],
-    queryFn: async () => (await getTeamLabelKeys()).data ?? [],
+    queryFn: async () => {
+      const { data, error } = await getTeamLabelKeys();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
+    },
   });
 }
 
@@ -63,8 +69,13 @@ export function useTeamLabelValues(params?: { key?: string }) {
   const { key } = params || {};
   return useQuery({
     queryKey: ["teams", "labels", "values", key],
-    queryFn: async () =>
-      (await getTeamLabelValues({ query: key ? { key } : {} })).data ?? [],
+    queryFn: async () => {
+      const { data, error } = await getTeamLabelValues({
+        query: key ? { key } : {},
+      });
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? [];
+    },
     enabled: key !== undefined,
   });
 }
@@ -94,7 +105,8 @@ export function useTeamsPaginated(params: TeamsPaginatedParams) {
   return useQuery({
     queryKey: ["teams", "paginated", params],
     queryFn: async () => {
-      const { data } = await getTeams({ query: params });
+      const { data, error } = await getTeams({ query: params });
+      throwOnApiError(error, { toastOnError: false });
       return (
         data ?? {
           data: [] as Team[],

--- a/platform/frontend/src/lib/tools/tool.query.ts
+++ b/platform/frontend/src/lib/tools/tool.query.ts
@@ -1,5 +1,6 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
+import { throwOnApiError } from "@/lib/utils";
 
 const { getTools, getToolsWithAssignments } = archestraApiSdk;
 
@@ -19,7 +20,11 @@ export function useTools({
 }) {
   return useQuery({
     queryKey: ["tools"],
-    queryFn: async () => (await getTools()).data ?? null,
+    queryFn: async () => {
+      const { data, error } = await getTools();
+      throwOnApiError(error, { toastOnError: false });
+      return data ?? null;
+    },
     initialData,
   });
 }
@@ -72,6 +77,7 @@ export function useToolsWithAssignments({
           excludeArchestraTools: filters?.excludeArchestraTools,
         },
       });
+      throwOnApiError(result.error, { toastOnError: false });
       return (
         result.data ?? {
           data: [],

--- a/platform/frontend/src/lib/user-token.query.ts
+++ b/platform/frontend/src/lib/user-token.query.ts
@@ -1,6 +1,6 @@
 import { archestraApiSdk } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { handleApiError } from "./utils";
+import { handleApiError, throwOnApiError } from "./utils";
 
 const { getUserToken, getUserTokenValue, rotateUserToken } = archestraApiSdk;
 
@@ -24,10 +24,7 @@ export function useUserToken() {
     queryKey: ["userToken"],
     queryFn: async () => {
       const { data, error } = await getUserToken();
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
+      throwOnApiError(error);
       return data as UserToken;
     },
     retry: false,
@@ -42,9 +39,7 @@ export function useUserTokenValue() {
     queryKey: ["userTokenValue"],
     queryFn: async () => {
       const response = await getUserTokenValue();
-      if (response.error) {
-        handleApiError(response.error);
-      }
+      throwOnApiError(response.error);
       return response.data as { value: string };
     },
     enabled: false, // Only fetch on demand

--- a/platform/frontend/src/lib/utils/api.test.ts
+++ b/platform/frontend/src/lib/utils/api.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockToastError } = vi.hoisted(() => ({ mockToastError: vi.fn() }));
+
+vi.mock("sonner", () => ({
+  toast: { error: mockToastError, success: vi.fn() },
+}));
+
+import { throwOnApiError } from "./api";
+
+describe("throwOnApiError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does nothing when there is no error", () => {
+    expect(() => throwOnApiError(null)).not.toThrow();
+    expect(() => throwOnApiError(undefined)).not.toThrow();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("throws and toasts on a real error by default", () => {
+    expect(() => throwOnApiError({ message: "boom" })).toThrow();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws without toasting when toastOnError is false", () => {
+    expect(() =>
+      throwOnApiError({ message: "boom" }, { toastOnError: false }),
+    ).toThrow();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("treats a not-found as a non-error when allowNotFound is set", () => {
+    expect(() =>
+      throwOnApiError(
+        { error: { type: "api_not_found_error" } },
+        { allowNotFound: true },
+      ),
+    ).not.toThrow();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("still throws on a not-found when allowNotFound is not set", () => {
+    expect(() =>
+      throwOnApiError({ error: { type: "api_not_found_error" } }),
+    ).toThrow();
+  });
+
+  it("still throws on non-not-found errors even when allowNotFound is set", () => {
+    expect(() =>
+      throwOnApiError(
+        { error: { type: "api_internal_error" } },
+        { allowNotFound: true, toastOnError: false },
+      ),
+    ).toThrow();
+  });
+});

--- a/platform/frontend/src/lib/utils/api.ts
+++ b/platform/frontend/src/lib/utils/api.ts
@@ -95,3 +95,40 @@ export function handleApiError(error: ApiSdkError) {
     .catch(() => undefined);
   console.error(sentryError);
 }
+
+/**
+ * Fail a query loud when the generated SDK returns an error, so the query
+ * enters its error state instead of swallowing a failed fetch into a default
+ * value. A swallowed error makes an outage indistinguishable from a genuinely
+ * empty result, which is how "Add an LLM Provider Key" showed up offline.
+ *
+ * Call right after the SDK call and keep the existing success return:
+ *
+ *   const { data, error } = await getApiKeys();
+ *   throwOnApiError(error);
+ *   return data ?? [];
+ *
+ * Toasts via `handleApiError` by default; screens that render their own error
+ * state (and would otherwise double-notify, plus re-toast on every retry) pass
+ * `toastOnError: false`. Detail endpoints where a 404 is a legitimate "does not
+ * exist" rather than an outage pass `allowNotFound: true` so the caller keeps
+ * returning its null default for that case.
+ */
+export function throwOnApiError(
+  error: unknown,
+  options?: { toastOnError?: boolean; allowNotFound?: boolean },
+): void {
+  if (!error) {
+    return;
+  }
+  if (
+    options?.allowNotFound &&
+    getApiErrorType(error) === "api_not_found_error"
+  ) {
+    return;
+  }
+  if (options?.toastOnError ?? true) {
+    handleApiError(error);
+  }
+  throw toApiError(error);
+}

--- a/platform/frontend/src/lib/utils/index.ts
+++ b/platform/frontend/src/lib/utils/index.ts
@@ -2,6 +2,7 @@ export {
   getApiErrorMessage,
   getApiErrorType,
   handleApiError,
+  throwOnApiError,
   toApiError,
 } from "./api";
 export {

--- a/platform/frontend/src/lib/virtual-api-keys.query.ts
+++ b/platform/frontend/src/lib/virtual-api-keys.query.ts
@@ -1,7 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { handleApiError, toApiError } from "@/lib/utils";
+import { handleApiError, throwOnApiError, toApiError } from "@/lib/utils";
 
 type AllVirtualApiKeysQuery = NonNullable<
   archestraApiTypes.GetAllVirtualApiKeysData["query"]
@@ -29,10 +29,7 @@ export function useVirtualApiKeys(providerApiKeyId: string | null) {
           offset: 0,
         },
       });
-      if (error) {
-        handleApiError(error);
-        return [];
-      }
+      throwOnApiError(error);
       return data?.data ?? [];
     },
     enabled: !!providerApiKeyId,
@@ -150,20 +147,7 @@ export function useAllVirtualApiKeys(params?: AllVirtualApiKeysParams) {
           keyType: keyType || undefined,
         },
       });
-      if (error) {
-        handleApiError(error);
-        return {
-          data: [],
-          pagination: {
-            currentPage: 1,
-            limit,
-            total: 0,
-            totalPages: 0,
-            hasNext: false,
-            hasPrev: false,
-          },
-        };
-      }
+      throwOnApiError(error);
       return (
         data ?? {
           data: [],

--- a/platform/frontend/src/lib/virtual-api-keys.query.ts
+++ b/platform/frontend/src/lib/virtual-api-keys.query.ts
@@ -8,6 +8,7 @@ type AllVirtualApiKeysQuery = NonNullable<
 >;
 type AllVirtualApiKeysParams = Partial<AllVirtualApiKeysQuery> & {
   enabled?: boolean;
+  toastOnError?: boolean;
 };
 
 const {
@@ -128,6 +129,7 @@ export function useAllVirtualApiKeys(params?: AllVirtualApiKeysParams) {
   const search = params?.search;
   const providerApiKeyId = params?.providerApiKeyId;
   const keyType = params?.keyType;
+  const toastOnError = params?.toastOnError;
   return useQuery({
     queryKey: [
       "all-virtual-api-keys",
@@ -147,7 +149,7 @@ export function useAllVirtualApiKeys(params?: AllVirtualApiKeysParams) {
           keyType: keyType || undefined,
         },
       });
-      throwOnApiError(error);
+      throwOnApiError(error, { toastOnError });
       return (
         data ?? {
           data: [],

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -119,6 +119,7 @@ export const E2eTestId = {
   ChatModelSelectorTrigger: "chat-model-selector-trigger",
   ChatPromptTextarea: "chat-prompt-textarea",
   QuickstartAddApiKeyButton: "quickstart-add-api-key-button",
+  ApiKeysLoadErrorRetry: "api-keys-load-error-retry",
   // MCP Logs
   McpLogsDialog: "mcp-logs-dialog",
   McpLogsContent: "mcp-logs-content",


### PR DESCRIPTION
## Problem

Opening Archestra offline — or any failed first request — showed misleading "you have nothing, set it up" states, most visibly **"Add an LLM Provider Key"**. Query hooks caught the SDK error, toasted, and returned a default (`[]` / `null` / `{}`). Because the shared HTTP client is `throwOnError:false`, a network failure arrives as `{ error }`, and returning a default made TanStack Query mark the query **successful with empty data** — so screens read "empty" as "nothing configured" and couldn't tell a failed fetch from a genuinely empty result.

## Fix

- **`throwOnApiError(error, { toastOnError?, allowNotFound? })`** (`lib/utils/api.ts`): queries now **fail loud** (enter their error state) instead of swallowing. Migrated ~50 query hooks to it; the existing success return (`return data ?? []`) is unchanged. Mutations, better-auth wrappers, and raw-`fetch` calls are untouched.
- **`QueryLoadError`** (an `Empty` state + Retry) now renders on ~20 screens that gated on emptiness, branched on **`isLoadingError`** (first-load failure only) — so a failed *background* refetch keeps the last good data on screen instead of flipping to the error panel.
- **`toastOnError` is caller-controlled**: a screen that renders its own panel passes `false` to suppress the redundant toast, while every other consumer of the same hook keeps failing loud. **`allowNotFound`** lets by-id detail endpoints treat a 404 as a legitimate "not found" rather than an outage.
- A failed background refetch now **keeps the last successful data** instead of wiping it to a default.
- Updated the `archestra-dev-frontend` skill's query-error convention to match.

## Behavior

| Case | Before | After |
|------|--------|-------|
| Offline cold start (keys, models, lists, …) | "Add an LLM Provider Key" / "No X yet" | "Couldn't load …" + Retry |
| Successful empty response | empty / add-X prompt | unchanged |
| Cached data + transient refetch failure | wiped to empty | stays usable |

## Tests

`throwOnApiError` contract, `QueryLoadError` component, `useHasAnyApiKey` mapping, and an audit-log error-branch case. Full frontend suite passes (2175); `type-check`, `lint`, `knip` clean.

## Scope

Not included (documented): the chat `callApi` helper's separate swallow path, best-effort `prefetchQuery` calls, and intentionally-silent GitHub community-chrome fetches.

https://claude.ai/code/session_01V1n6PVjL9bXbiywFEvj4yo

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
