### PR TITLE
fix(mcp): disable browser password autofill in install dialogs and OIDC secret fields

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/local-server-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/local-server-install-dialog.tsx
@@ -34,6 +34,10 @@ import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { useFeature } from "@/lib/config/config.query";
 import { useEnvironments } from "@/lib/environment.query";
+import {
+  MCP_CONFIG_AUTOCOMPLETE,
+  MCP_SECRET_AUTOCOMPLETE,
+} from "@/lib/mcp/mcp-form-autocomplete";
 import { useDefaultEnvironment } from "@/lib/organization.query";
 import { useTeamsWithVaultFolders } from "@/lib/teams/team.query";
 import {
@@ -680,6 +684,7 @@ export function LocalServerInstallDialog({
                         env.default !== undefined ? String(env.default) : "0"
                       }
                       className="font-mono"
+                      autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                       disabled={isInstalling}
                     />
                   ) : (
@@ -692,6 +697,7 @@ export function LocalServerInstallDialog({
                       }
                       placeholder={`Enter value for ${env.key}`}
                       className="font-mono"
+                      autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                       disabled={isInstalling}
                       aria-invalid={
                         envVarRegexError(env.key, env.type) ? true : undefined
@@ -782,6 +788,7 @@ export function LocalServerInstallDialog({
                             }
                             placeholder={`Enter value for ${env.key}`}
                             className="font-mono"
+                            autoComplete={MCP_SECRET_AUTOCOMPLETE}
                             disabled={isInstalling}
                           />
                         )}
@@ -974,6 +981,7 @@ export function LocalServerInstallDialog({
                               : "0"
                           }
                           className="font-mono"
+                          autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                           disabled={isInstalling}
                         />
                       ) : fieldConfig.sensitive ? (
@@ -986,6 +994,7 @@ export function LocalServerInstallDialog({
                           }
                           placeholder={`Enter value for ${fieldConfig.title || fieldName}`}
                           className="font-mono"
+                          autoComplete={MCP_SECRET_AUTOCOMPLETE}
                           disabled={isInstalling}
                         />
                       ) : (
@@ -998,6 +1007,7 @@ export function LocalServerInstallDialog({
                           }
                           placeholder={`Enter value for ${fieldConfig.title || fieldName}`}
                           className="font-mono"
+                          autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                           disabled={isInstalling}
                           aria-invalid={
                             !fieldConfig.sensitive &&

--- a/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/remote-server-install-dialog.tsx
@@ -20,6 +20,10 @@ import {
 } from "@/components/ui/select";
 import { useFeature } from "@/lib/config/config.query";
 import { useEnvironments } from "@/lib/environment.query";
+import {
+  MCP_CONFIG_AUTOCOMPLETE,
+  MCP_SECRET_AUTOCOMPLETE,
+} from "@/lib/mcp/mcp-form-autocomplete";
 import { useDefaultEnvironment } from "@/lib/organization.query";
 import { useTeamsWithVaultFolders } from "@/lib/teams/team.query";
 import {
@@ -526,6 +530,11 @@ export function RemoteServerInstallDialog({
                         : fieldConfig.type === "number"
                           ? "number"
                           : "text"
+                    }
+                    autoComplete={
+                      fieldConfig.sensitive
+                        ? MCP_SECRET_AUTOCOMPLETE
+                        : MCP_CONFIG_AUTOCOMPLETE
                     }
                     placeholder={
                       fieldConfig.default?.toString() || fieldConfig.description

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
@@ -292,6 +292,7 @@ export function OidcConfigForm({
                 <FormControl>
                   <Input
                     type="password"
+                    autoComplete="new-password"
                     placeholder="your-client-secret"
                     {...field}
                   />
@@ -655,7 +656,12 @@ function EnterpriseManagedCredentialsForm(props: {
             <FormItem>
               <FormLabel>Exchange Client Secret</FormLabel>
               <FormControl>
-                <Input type="password" placeholder="Optional" {...field} />
+                <Input
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="Optional"
+                  {...field}
+                />
               </FormControl>
               <FormDescription>
                 Only used when the exchange endpoint authenticates with a client


### PR DESCRIPTION
## Problem

The MCP server **installation dialogs** (both local and remote) and the **OIDC Client Secret** fields rendered `type="password"` / config inputs with no `autoComplete` value. Browsers therefore offered to save and autofill saved passwords over secret/config fields — noise at best, and a way to paste the wrong credential at worst.

## Fix

Applied the anti-autofill convention already used elsewhere in the app (e.g. `mcp-catalog-form.tsx`, `change-password-dialog.tsx`):

- **`local-server-install-dialog.tsx`** — all 6 env-var / user-config inputs now set `autoComplete`: secret fields use `MCP_SECRET_AUTOCOMPLETE` (`"new-password"` — the value Chrome reliably won't autofill), text/number fields use `MCP_CONFIG_AUTOCOMPLETE` (`"off"`).
- **`remote-server-install-dialog.tsx`** — the single dynamically-typed input picks `MCP_SECRET_AUTOCOMPLETE` when `fieldConfig.sensitive`, else `MCP_CONFIG_AUTOCOMPLETE`. (This field's `type` is computed at runtime, which is why it was easy to miss.)
- **`oidc-config-form.ee.tsx`** — both Client Secret password fields use `autoComplete="new-password"`, matching the non-MCP secret-field convention.

Login / sign-up / change-password flows are **untouched** — they keep autofill via their own explicit `autoComplete` values (`email`, `current-password`, etc.).

## Verification

- `pnpm type-check` ✅
- `pnpm lint` (biome) ✅
- Existing frontend tests pass (incl. `mcp-catalog-form.enterprise.test.tsx`, `oidc-config-form.ee.test.tsx`) ✅

## Tests

No new tests added: this is declarative attribute wiring reusing the `MCP_SECRET_AUTOCOMPLETE`/`MCP_CONFIG_AUTOCOMPLETE` constants already pinned by `mcp-catalog-form.enterprise.test.tsx`. A per-dialog assertion would be a render-based prop-plumbing test, which the repo's testing guidance says to skip.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>