### PR TITLE
fix(guardrails): restore sanitize_with_dual_llm to policy-config auto-config

### DIFF
--- a/platform/backend/src/database/seed.test.ts
+++ b/platform/backend/src/database/seed.test.ts
@@ -5,6 +5,7 @@ import {
   CHAT_TITLE_GENERATION_SYSTEM_PROMPT,
   CONTEXT_COMPACTION_SYSTEM_PROMPT,
   POLICY_CONFIG_SYSTEM_PROMPT,
+  PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT,
 } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach } from "vitest";
@@ -71,6 +72,41 @@ describe("syncBuiltInAgents", () => {
       description:
         "Analyzes tool metadata with AI to generate deterministic security policies for handling untrusted data",
       systemPrompt: LEGACY_POLICY_CONFIG_SYSTEM_PROMPT,
+      builtInAgentConfig: {
+        name: BUILT_IN_AGENT_IDS.POLICY_CONFIG,
+        autoConfigureOnToolDiscovery: false,
+      },
+    });
+
+    await syncBuiltInAgents();
+
+    const builtInAgent = await AgentModel.getBuiltInAgent(
+      BUILT_IN_AGENT_IDS.POLICY_CONFIG,
+      organization.id,
+    );
+
+    expect(builtInAgent?.systemPrompt).toBe(POLICY_CONFIG_SYSTEM_PROMPT);
+  });
+
+  test("upgrades the previous (pre-dual-llm) policy configuration prompt", async ({
+    makeOrganization,
+  }) => {
+    // Guards that the snapshot is a genuine prior revision, so the upgrade below
+    // is a real change rather than a no-op.
+    expect(PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT).not.toBe(
+      POLICY_CONFIG_SYSTEM_PROMPT,
+    );
+
+    const organization = await makeOrganization();
+
+    await db.insert(schema.agentsTable).values({
+      organizationId: organization.id,
+      name: BUILT_IN_AGENT_NAMES.POLICY_CONFIG,
+      agentType: "agent",
+      scope: "org",
+      description:
+        "Analyzes tool metadata with AI to generate deterministic security policies for handling untrusted data",
+      systemPrompt: PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT,
       builtInAgentConfig: {
         name: BUILT_IN_AGENT_IDS.POLICY_CONFIG,
         autoConfigureOnToolDiscovery: false,

--- a/platform/backend/src/database/seed.test.ts
+++ b/platform/backend/src/database/seed.test.ts
@@ -5,7 +5,6 @@ import {
   CHAT_TITLE_GENERATION_SYSTEM_PROMPT,
   CONTEXT_COMPACTION_SYSTEM_PROMPT,
   POLICY_CONFIG_SYSTEM_PROMPT,
-  PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT,
 } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach } from "vitest";
@@ -91,8 +90,9 @@ describe("syncBuiltInAgents", () => {
   test("upgrades the previous (pre-dual-llm) policy configuration prompt", async ({
     makeOrganization,
   }) => {
-    // Guards that the snapshot is a genuine prior revision, so the upgrade below
-    // is a real change rather than a no-op.
+    // Seed from an independent local copy of the previous shipped prompt (below),
+    // not the exported snapshot the migration matches against, so a future drift
+    // between the two fails this test instead of silently skipping the upgrade.
     expect(PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT).not.toBe(
       POLICY_CONFIG_SYSTEM_PROMPT,
     );
@@ -182,6 +182,47 @@ Examples:
 - File writes: invocation="block_always", result="mark_as_trusted"
 - External APIs (raw data): invocation="block_when_context_is_untrusted", result="mark_as_untrusted"
 - Code execution: invocation="block_always", result="mark_as_untrusted"`;
+
+// Independent copy of the previous shipped POLICY_CONFIG_SYSTEM_PROMPT (the
+// revision before sanitize_with_dual_llm was restored), rendered with its
+// Handlebars expressions resolved, exactly as existing orgs stored it. Kept
+// separate from the shared snapshot so the migration test catches any drift.
+const PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT = `Analyze this MCP tool and determine security policies.
+
+The primary security goal is to PREVENT LEAKING SENSITIVE DATA FROM INTERNAL SYSTEMS TO EXTERNAL SERVICES. Internal systems (Jira, GitHub, databases, etc.) contain sensitive organizational data. External-facing tools (browsers, web scrapers, email senders, etc.) can transmit data outside the organization. Policies must ensure sensitive internal data never flows outward through external tools.
+
+Tool: {{tool.name}}
+Description: {{tool.description}}
+MCP Server: {{mcpServerName}}
+Parameters: {{tool.parameters}}
+Annotations: {{tool.annotations}}
+
+Determine two policies:
+
+1. toolInvocationAction — Controls WHEN the tool may be invoked based on whether the conversation context contains sensitive data.
+   - "allow_when_context_is_sensitive": The tool is safe to invoke even when the context contains sensitive data. Use for tools that CANNOT leak context externally — they only read from internal systems. Examples: internal API reads, database reads, self-hosted service integrations.
+   - "block_when_context_is_sensitive": The tool must be BLOCKED when the context contains sensitive data because it could transmit that data externally. Use for tools that send data to external services or the open internet. Examples: browsers, web search, email, external APIs, code execution sandboxes.
+   - "require_approval": The tool requires user confirmation before executing in chat; in autonomous agent sessions (A2A, API, MS Teams, subagents) the call is blocked. Use for tools that mutate state with non-trivial consequences but are NOT obviously destructive — create/update/send/post/charge operations on internal systems. Examples: jira__create_issue, github__merge_pr, email__send, payment__charge.
+   - "block_always": The tool must NEVER be invoked automatically. Use for obviously destructive operations that delete or destroy data — see CRITICAL RULES below.
+
+2. trustedDataAction — Controls HOW the tool's returned results are treated, based on whether they could contain sensitive or adversarial content.
+   - "mark_as_safe": Results are fully trusted. Use only for internal dev/config tools returning non-sensitive metadata (e.g., list-endpoints, get-config, health checks).
+   - "mark_as_sensitive": Results contain sensitive data that must be protected from leaking to external tools. Use for ANY tool that reads from internal self-hosted systems (Jira, GitHub, GitLab, Confluence, databases, internal APIs, file systems) — their results contain organizational data.
+   - "block_always": Results are too dangerous to surface. Rarely used.
+
+CRITICAL RULES:
+- Obviously destructive tools → ALWAYS block_always invocation. A tool is obviously destructive ONLY if its NAME (not parameters or description) is solely dedicated to deleting or destroying data. Keywords in the tool name: delete, remove, destroy, drop, purge, truncate, erase, wipe. Multi-purpose tools that support destructive operations as one of several modes (e.g., a tool named "write" or "manage" that has a "remove" parameter option) are NOT obviously destructive — classify them based on their primary purpose.
+- Mutating tools that are NOT obviously destructive → require_approval. Tool names with create/update/edit/modify/send/post/publish/charge/merge that change state in internal systems should require user approval rather than auto-execute.
+- Read-only tools with annotations "readOnlyHint": true → safe for invocation, never block_always or require_approval unless they also have "destructiveHint": true.
+- Internal self-hosted READ tools (Jira reads, GitHub reads, GitLab reads, Confluence reads, database reads, internal wikis) → allow_when_context_is_sensitive (safe to call) + mark_as_sensitive (results contain org data that must not leak).
+- External-facing tools (browsers, Playwright, web search, email, external APIs) → block_when_context_is_sensitive (could leak context) + mark_as_safe (their results are controlled by us, not sensitive org data).
+
+Examples — one per outcome; apply the rules above to classify any tool, not just these:
+- jira__get_issue: invocation="allow_when_context_is_sensitive", result="mark_as_sensitive" (read-only internal)
+- playwright__navigate: invocation="block_when_context_is_sensitive", result="mark_as_safe" (external-facing)
+- jira__create_issue: invocation="require_approval", result="mark_as_sensitive" (mutating internal write, not destructive)
+- email__send: invocation="require_approval", result="mark_as_safe" (sends data outward, needs human confirmation)
+- database__drop_table: invocation="block_always", result="mark_as_safe" (destructive: name dedicated to deletion)`;
 
 describe("syncBuiltInSkills", () => {
   // These cases assert on the always-on built-in skills, so pin the apps feature

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -12,6 +12,7 @@ import {
   PLAYWRIGHT_MCP_ICON,
   PLAYWRIGHT_MCP_SERVER_NAME,
   POLICY_CONFIG_SYSTEM_PROMPT,
+  PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT,
   PROVIDERS_REQUIRING_BASE_URL,
   type PredefinedRoleName,
   providerRequiresPerUserCredential,
@@ -919,7 +920,7 @@ function shouldSyncBuiltInAgentSystemPrompt(params: {
 
   return (
     params.builtInAgentId === BUILT_IN_AGENT_IDS.POLICY_CONFIG &&
-    params.systemPrompt === LEGACY_POLICY_CONFIG_SYSTEM_PROMPT
+    SUPERSEDED_POLICY_CONFIG_SYSTEM_PROMPTS.includes(params.systemPrompt)
   );
 }
 
@@ -951,3 +952,12 @@ Examples:
 - File writes: invocation="block_always", result="mark_as_trusted"
 - External APIs (raw data): invocation="block_when_context_is_untrusted", result="mark_as_untrusted"
 - Code execution: invocation="block_always", result="mark_as_untrusted"`;
+
+// Shipped policy-config prompts we have since replaced. An org still on any of
+// these is pristine (never customized) and is auto-upgraded to the current
+// POLICY_CONFIG_SYSTEM_PROMPT on startup; any other stored prompt is treated as
+// admin-edited and left untouched.
+const SUPERSEDED_POLICY_CONFIG_SYSTEM_PROMPTS: readonly string[] = [
+  LEGACY_POLICY_CONFIG_SYSTEM_PROMPT,
+  PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT,
+];

--- a/platform/backend/src/types/agent.ts
+++ b/platform/backend/src/types/agent.ts
@@ -340,9 +340,9 @@ export const PolicyConfigSchema = z.object({
     ])
     .describe(
       "How should the tool's results be treated? " +
-        "'mark_as_safe' - Results are safe and can be used directly (internal systems, databases, dev tools). " +
-        "'mark_as_sensitive' - Results are sensitive and will restrict subsequent tool usage (external/filesystem data where exact values are safe). " +
-        "'sanitize_with_dual_llm' - Results are processed through dual LLM security pattern (sensitive data that needs summarization). " +
+        "'mark_as_safe' - Results are fully trusted and used directly (internal dev/config metadata, or external action tools that return no third-party content). " +
+        "'mark_as_sensitive' - Results contain organizational data from internal self-hosted systems (Jira, GitHub, databases, internal APIs, file systems) that must not leak to external tools. " +
+        "'sanitize_with_dual_llm' - Results come from untrusted external/third-party sources and may carry injected instructions; they are summarized through the Dual LLM workflow so the raw content never reaches the privileged model (web search, scraping/fetching arbitrary pages, untrusted inbound messages). " +
         "'block_always' - Results are blocked entirely (highly sensitive or dangerous output).",
     ),
   reasoning: z

--- a/platform/shared/built-in-agents.ts
+++ b/platform/shared/built-in-agents.ts
@@ -30,6 +30,55 @@ export const BUILT_IN_AGENT_IDS = {
  */
 export const POLICY_CONFIG_SYSTEM_PROMPT = `Analyze this MCP tool and determine security policies.
 
+The primary security goal is to PREVENT LEAKING SENSITIVE DATA FROM INTERNAL SYSTEMS TO EXTERNAL SERVICES. Internal systems (Jira, GitHub, databases, etc.) contain sensitive organizational data. External-facing tools (browsers, web scrapers, email senders, etc.) can transmit data outside the organization. Policies must ensure sensitive internal data never flows outward through external tools. A second goal is to neutralize indirect prompt injection: results fetched from the open internet or other untrusted third parties can carry adversarial instructions, so such results are summarized through the Dual LLM workflow instead of reaching the model verbatim.
+
+Tool: ${POLICY_CONFIG_SYSTEM_PROMPT_EXPRESSIONS.toolName}
+Description: ${POLICY_CONFIG_SYSTEM_PROMPT_EXPRESSIONS.toolDescription}
+MCP Server: ${POLICY_CONFIG_SYSTEM_PROMPT_EXPRESSIONS.mcpServerName}
+Parameters: ${POLICY_CONFIG_SYSTEM_PROMPT_EXPRESSIONS.toolParameters}
+Annotations: ${POLICY_CONFIG_SYSTEM_PROMPT_EXPRESSIONS.toolAnnotations}
+
+Determine two policies:
+
+1. toolInvocationAction — Controls WHEN the tool may be invoked based on whether the conversation context contains sensitive data.
+   - "allow_when_context_is_sensitive": The tool is safe to invoke even when the context contains sensitive data. Use for tools that CANNOT leak context externally — they only read from internal systems. Examples: internal API reads, database reads, self-hosted service integrations.
+   - "block_when_context_is_sensitive": The tool must be BLOCKED when the context contains sensitive data because it could transmit that data externally. Use for tools that send data to external services or the open internet. Examples: browsers, web search, email, external APIs, code execution sandboxes.
+   - "require_approval": The tool requires user confirmation before executing in chat; in autonomous agent sessions (A2A, API, MS Teams, subagents) the call is blocked. Use for tools that mutate state with non-trivial consequences but are NOT obviously destructive — create/update/send/post/charge operations on internal systems. Examples: jira__create_issue, github__merge_pr, email__send, payment__charge.
+   - "block_always": The tool must NEVER be invoked automatically. Use for obviously destructive operations that delete or destroy data — see CRITICAL RULES below.
+
+2. trustedDataAction — Controls HOW the tool's returned results are treated, based on whether they could contain sensitive or adversarial content.
+   - "mark_as_safe": Results are fully trusted. Use for internal dev/config tools returning non-sensitive metadata (e.g., list-endpoints, get-config, health checks), and for external action tools that perform an effect without surfacing third-party content (e.g., navigate, click, send).
+   - "mark_as_sensitive": Results contain sensitive data that must be protected from leaking to external tools. Use for ANY tool that reads from internal self-hosted systems (Jira, GitHub, GitLab, Confluence, databases, internal APIs, file systems) — their results contain organizational data.
+   - "sanitize_with_dual_llm": Results come from untrusted external or third-party sources and may carry adversarial instructions (indirect prompt injection). Use for tools that return open-internet or third-party content where the exact text is not needed verbatim downstream — the result is summarized through the Dual LLM workflow so injected instructions never reach the privileged model. Examples: web search, web scraping or fetching arbitrary pages, reading untrusted inbound messages.
+   - "block_always": Results are too dangerous to surface. Rarely used.
+
+CRITICAL RULES:
+- Obviously destructive tools → ALWAYS block_always invocation. A tool is obviously destructive ONLY if its NAME (not parameters or description) is solely dedicated to deleting or destroying data. Keywords in the tool name: delete, remove, destroy, drop, purge, truncate, erase, wipe. Multi-purpose tools that support destructive operations as one of several modes (e.g., a tool named "write" or "manage" that has a "remove" parameter option) are NOT obviously destructive — classify them based on their primary purpose.
+- Mutating tools that are NOT obviously destructive → require_approval. Tool names with create/update/edit/modify/send/post/publish/charge/merge that change state in internal systems should require user approval rather than auto-execute.
+- Read-only tools with annotations "readOnlyHint": true → safe for invocation, never block_always or require_approval unless they also have "destructiveHint": true.
+- Internal self-hosted READ tools (Jira reads, GitHub reads, GitLab reads, Confluence reads, database reads, internal wikis) → allow_when_context_is_sensitive (safe to call) + mark_as_sensitive (results contain org data that must not leak).
+- External-facing tools that RETURN open-internet or third-party content (web search, web scraping/fetching, reading untrusted inbound messages) → block_when_context_is_sensitive (could leak context) + sanitize_with_dual_llm (their results are untrusted and may contain injected instructions).
+- External-facing action tools that do NOT surface third-party content (navigate, click, send) → block_when_context_is_sensitive (could leak context) + mark_as_safe (no untrusted content returned).
+
+Examples — one per outcome; apply the rules above to classify any tool, not just these:
+- jira__get_issue: invocation="allow_when_context_is_sensitive", result="mark_as_sensitive" (read-only internal)
+- web_search: invocation="block_when_context_is_sensitive", result="sanitize_with_dual_llm" (returns untrusted open-internet content)
+- playwright__navigate: invocation="block_when_context_is_sensitive", result="mark_as_safe" (external action, no third-party content returned)
+- jira__create_issue: invocation="require_approval", result="mark_as_sensitive" (mutating internal write, not destructive)
+- email__send: invocation="require_approval", result="mark_as_safe" (sends data outward, needs human confirmation)
+- database__drop_table: invocation="block_always", result="mark_as_safe" (destructive: name dedicated to deletion)`;
+
+/**
+ * Frozen snapshot of the immediately-previous POLICY_CONFIG_SYSTEM_PROMPT — the
+ * revision that omitted "sanitize_with_dual_llm" from trustedDataAction. Kept so
+ * the startup sync can recognise orgs still on this shipped default and upgrade
+ * them to the current prompt, while leaving admin-edited prompts untouched. It
+ * uses the same expression interpolation as the live prompt, so it reproduces
+ * byte-for-byte what those orgs already store. Do not edit; prune once no org can
+ * still be on this revision.
+ */
+export const PREVIOUS_POLICY_CONFIG_SYSTEM_PROMPT = `Analyze this MCP tool and determine security policies.
+
 The primary security goal is to PREVENT LEAKING SENSITIVE DATA FROM INTERNAL SYSTEMS TO EXTERNAL SERVICES. Internal systems (Jira, GitHub, databases, etc.) contain sensitive organizational data. External-facing tools (browsers, web scrapers, email senders, etc.) can transmit data outside the organization. Policies must ensure sensitive internal data never flows outward through external tools.
 
 Tool: ${POLICY_CONFIG_SYSTEM_PROMPT_EXPRESSIONS.toolName}

--- a/platform/shared/built-in-agents.ts
+++ b/platform/shared/built-in-agents.ts
@@ -47,7 +47,7 @@ Determine two policies:
    - "block_always": The tool must NEVER be invoked automatically. Use for obviously destructive operations that delete or destroy data — see CRITICAL RULES below.
 
 2. trustedDataAction — Controls HOW the tool's returned results are treated, based on whether they could contain sensitive or adversarial content.
-   - "mark_as_safe": Results are fully trusted. Use for internal dev/config tools returning non-sensitive metadata (e.g., list-endpoints, get-config, health checks), and for external action tools that perform an effect without surfacing third-party content (e.g., navigate, click, send).
+   - "mark_as_safe": Results are fully trusted. Use for internal dev/config tools returning non-sensitive metadata (e.g., list-endpoints, get-config, health checks), and for external action tools that perform an effect and return only a status, not third-party content (e.g., posting a message, sending a notification).
    - "mark_as_sensitive": Results contain sensitive data that must be protected from leaking to external tools. Use for ANY tool that reads from internal self-hosted systems (Jira, GitHub, GitLab, Confluence, databases, internal APIs, file systems) — their results contain organizational data.
    - "sanitize_with_dual_llm": Results come from untrusted external or third-party sources and may carry adversarial instructions (indirect prompt injection). Use for tools that return open-internet or third-party content where the exact text is not needed verbatim downstream — the result is summarized through the Dual LLM workflow so injected instructions never reach the privileged model. Examples: web search, web scraping or fetching arbitrary pages, reading untrusted inbound messages.
    - "block_always": Results are too dangerous to surface. Rarely used.
@@ -57,13 +57,13 @@ CRITICAL RULES:
 - Mutating tools that are NOT obviously destructive → require_approval. Tool names with create/update/edit/modify/send/post/publish/charge/merge that change state in internal systems should require user approval rather than auto-execute.
 - Read-only tools with annotations "readOnlyHint": true → safe for invocation, never block_always or require_approval unless they also have "destructiveHint": true.
 - Internal self-hosted READ tools (Jira reads, GitHub reads, GitLab reads, Confluence reads, database reads, internal wikis) → allow_when_context_is_sensitive (safe to call) + mark_as_sensitive (results contain org data that must not leak).
-- External-facing tools that RETURN open-internet or third-party content (web search, web scraping/fetching, reading untrusted inbound messages) → block_when_context_is_sensitive (could leak context) + sanitize_with_dual_llm (their results are untrusted and may contain injected instructions).
-- External-facing action tools that do NOT surface third-party content (navigate, click, send) → block_when_context_is_sensitive (could leak context) + mark_as_safe (no untrusted content returned).
+- External-facing tools that RETURN open-internet or third-party content (web search, web scraping/fetching, browsing or navigating pages, reading untrusted inbound messages) → block_when_context_is_sensitive (could leak context) + sanitize_with_dual_llm (their results are untrusted and may contain injected instructions).
+- External-facing action tools that only perform an effect and return a status, not third-party content (e.g., posting a message, sending a notification) → block_when_context_is_sensitive (could leak context) + mark_as_safe (no untrusted content returned).
 
 Examples — one per outcome; apply the rules above to classify any tool, not just these:
 - jira__get_issue: invocation="allow_when_context_is_sensitive", result="mark_as_sensitive" (read-only internal)
 - web_search: invocation="block_when_context_is_sensitive", result="sanitize_with_dual_llm" (returns untrusted open-internet content)
-- playwright__navigate: invocation="block_when_context_is_sensitive", result="mark_as_safe" (external action, no third-party content returned)
+- playwright__navigate: invocation="block_when_context_is_sensitive", result="sanitize_with_dual_llm" (browser navigation returns untrusted page content)
 - jira__create_issue: invocation="require_approval", result="mark_as_sensitive" (mutating internal write, not destructive)
 - email__send: invocation="require_approval", result="mark_as_safe" (sends data outward, needs human confirmation)
 - database__drop_table: invocation="block_always", result="mark_as_safe" (destructive: name dedicated to deletion)`;


### PR DESCRIPTION
## Problem

The Dual LLM runtime is correctly isolated, but the March refactor (#3455) that moved the policy-configuration subagent into a built-in agent degraded its **activation surface**: it dropped `sanitize_with_dual_llm` from the subagent's prompt `trustedDataAction` menu, and left the Zod `PolicyConfigSchema` description for `mark_as_sensitive` contradicting the prompt. Both the prompt and the schema descriptions are model-facing (the schema is passed via `Output.object` in `policy-configuration.ts`), so auto-configured tools effectively never received the Dual LLM action — the pattern stayed dormant on the auto-config path.

## Change

- **Restore the option in both model-facing sources.** List `sanitize_with_dual_llm` in `POLICY_CONFIG_SYSTEM_PROMPT` and realign the `trustedDataAction` Zod description with the prompt. Classification rule: tools returning untrusted external/third-party content (web search, scraping, browsing/navigating pages, untrusted inbound messages) → `sanitize_with_dual_llm`; internal self-hosted reads → `mark_as_sensitive`; external action tools that return only a status → `mark_as_safe`.
- **Auto-upgrade pristine orgs.** Orgs still on a prior shipped default prompt are upgraded to the restored prompt on startup (admin-edited prompts untouched), via `SUPERSEDED_POLICY_CONFIG_SYSTEM_PROMPTS`. The previous prompt is snapshotted verbatim for byte-exact recognition (verified identical to `main`).

## Scope

Fixes only the auto-config activation regression. Other verified Dual LLM activation gaps are **out of scope** here: permissive-by-default global policy, the sensitive-context bypass (#4225), and the KB/RAG bypass (#4348).

## Tests

- New `seed.test.ts` case: an org on the previous prompt is upgraded; seeded from an independent local copy so snapshot drift fails the test rather than silently skipping the upgrade. Existing legacy-upgrade and customized-preserve cases unchanged.
- Runtime application of the action is already covered by `policy-configuration.test.ts`.
- Validated: workspace type-check, targeted tests (30), biome, knip (dev+production).

https://claude.ai/code/session_012fvVneTcGNaN5t1jpZk7Mi

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>