### PR TITLE
fix(llm): filter unusable Gemini models and badge old generations

### DIFF
--- a/platform/backend/src/models/llm-provider-api-key-model.test.ts
+++ b/platform/backend/src/models/llm-provider-api-key-model.test.ts
@@ -600,6 +600,13 @@ describe("LlmProviderApiKeyModelLinkModel", () => {
         expected: "gemini-2.5-flash",
       },
       {
+        // Current generation must outrank a legacy model so "best" is never a
+        // model the selector also badges "old".
+        provider: "gemini",
+        catalog: ["gemini-2.5-pro", "gemini-3.5-flash"],
+        expected: "gemini-3.5-flash",
+      },
+      {
         provider: "bedrock",
         catalog: ["anthropic.claude-sonnet-4-8"],
         expected: "anthropic.claude-sonnet-4-8",

--- a/platform/backend/src/routes/chat/model-fetchers/gemini.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/gemini.test.ts
@@ -21,7 +21,7 @@ describe("gemini model fetchers", () => {
   });
 
   describe("fetchGeminiModels", () => {
-    test("fetches Gemini models that support generateContent or embedContent", async () => {
+    test("keeps usable Gemini-family chat + embedding models and drops the rest", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
@@ -33,9 +33,24 @@ describe("gemini model fetchers", () => {
                 supportedGenerationMethods: ["generateContent"],
               },
               {
-                name: "models/gemini-2.5-flash",
-                displayName: "Gemini 2.5 Flash",
-                supportedGenerationMethods: ["generateContent", "countTokens"],
+                name: "models/gemini-1.5-pro",
+                displayName: "Gemini 1.5 Pro",
+                supportedGenerationMethods: ["generateContent"],
+              },
+              {
+                name: "models/gemini-2.5-flash-preview-tts",
+                displayName: "Gemini 2.5 Flash TTS",
+                supportedGenerationMethods: ["generateContent"],
+              },
+              {
+                name: "models/gemma-3-27b-it",
+                displayName: "Gemma 3 27B",
+                supportedGenerationMethods: ["generateContent"],
+              },
+              {
+                name: "models/gemma-2-9b-it",
+                displayName: "Gemma 2 9B",
+                supportedGenerationMethods: ["generateContent"],
               },
               {
                 name: "models/gemini-embedding-001",
@@ -50,6 +65,11 @@ describe("gemini model fetchers", () => {
                 displayName: "AQA",
                 supportedGenerationMethods: ["generateAnswer"],
               },
+              {
+                name: "models/learnlm-2.0-flash-experimental",
+                displayName: "LearnLM 2.0 Flash",
+                supportedGenerationMethods: ["generateContent"],
+              },
             ],
           }),
       });
@@ -63,8 +83,8 @@ describe("gemini model fetchers", () => {
           provider: "gemini",
         },
         {
-          id: "gemini-2.5-flash",
-          displayName: "Gemini 2.5 Flash",
+          id: "gemma-3-27b-it",
+          displayName: "Gemma 3 27B",
           provider: "gemini",
         },
         {
@@ -75,15 +95,15 @@ describe("gemini model fetchers", () => {
       ]);
     });
 
-    test("includes Gemini models that only advertise batchEmbedContents", async () => {
+    test("includes embedding models that only advertise batchEmbedContents", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
           Promise.resolve({
             models: [
               {
-                name: "models/gemini-batch-embedding-only",
-                displayName: "Gemini Batch Embedding Only",
+                name: "models/gemini-embedding-exp-03-07",
+                displayName: "Gemini Embedding Experimental",
                 supportedGenerationMethods: ["batchEmbedContents"],
               },
             ],
@@ -94,8 +114,8 @@ describe("gemini model fetchers", () => {
 
       expect(models).toEqual([
         {
-          id: "gemini-batch-embedding-only",
-          displayName: "Gemini Batch Embedding Only",
+          id: "gemini-embedding-exp-03-07",
+          displayName: "Gemini Embedding Experimental",
           provider: "gemini",
         },
       ]);
@@ -130,6 +150,16 @@ describe("gemini model fetchers", () => {
         {
           name: "publishers/google/models/gemini-embedding-001",
           version: "default",
+          tunedModelInfo: {},
+        },
+        {
+          name: "publishers/google/models/gemma-3-27b-it",
+          version: "default",
+          tunedModelInfo: {},
+        },
+        {
+          name: "publishers/google/models/gemini-1.5-pro-002",
+          version: "002",
           tunedModelInfo: {},
         },
         {
@@ -172,6 +202,11 @@ describe("gemini model fetchers", () => {
         {
           id: "gemini-embedding-001",
           displayName: "Gemini Embedding 001",
+          provider: "gemini",
+        },
+        {
+          id: "gemma-3-27b-it",
+          displayName: "Gemma 3 27b It",
           provider: "gemini",
         },
       ]);
@@ -256,7 +291,7 @@ describe("gemini model fetchers", () => {
       ]);
     });
 
-    test("merges fallback models when list only returns live audio Gemini", async () => {
+    test("drops non-text Gemini from the list and merges usable fallback models", async () => {
       const mockPager = {
         [Symbol.asyncIterator]: async function* () {
           yield {
@@ -273,9 +308,7 @@ describe("gemini model fetchers", () => {
           model === "gemini-embedding-2-preview" ||
           model === "gemini-2.5-pro" ||
           model === "gemini-2.5-flash" ||
-          model === "gemini-2.5-flash-lite" ||
-          model === "gemini-2.0-flash-001" ||
-          model === "gemini-2.0-flash-lite-001"
+          model === "gemini-2.5-flash-lite"
         ) {
           return {
             name: `publishers/google/models/${model}`,
@@ -297,12 +330,9 @@ describe("gemini model fetchers", () => {
 
       const models = await fetchGeminiModelsViaVertexAi();
 
+      // The live/audio model is filtered out entirely; only usable fallback
+      // models remain.
       expect(models).toEqual([
-        {
-          id: "gemini-live-2.5-flash-native-audio",
-          displayName: "Gemini Live 2.5 Flash Native Audio",
-          provider: "gemini",
-        },
         {
           id: "gemini-embedding-001",
           displayName: "Gemini Embedding 001",
@@ -326,16 +356,6 @@ describe("gemini model fetchers", () => {
         {
           id: "gemini-2.5-flash-lite",
           displayName: "Gemini 2.5 Flash Lite",
-          provider: "gemini",
-        },
-        {
-          id: "gemini-2.0-flash-001",
-          displayName: "Gemini 2.0 Flash 001",
-          provider: "gemini",
-        },
-        {
-          id: "gemini-2.0-flash-lite-001",
-          displayName: "Gemini 2.0 Flash Lite 001",
           provider: "gemini",
         },
       ]);

--- a/platform/backend/src/routes/chat/model-fetchers/gemini.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/gemini.ts
@@ -1,3 +1,4 @@
+import { isUsableGeminiCatalogModel } from "@archestra/shared";
 import { createGoogleGenAIClient } from "@/clients/gemini-client";
 import config from "@/config";
 import logger from "@/logging";
@@ -48,7 +49,8 @@ export async function fetchGeminiModels(
         displayName: model.displayName ?? modelId,
         provider: "gemini" as const,
       };
-    });
+    })
+    .filter((model) => isUsableGeminiCatalogModel(model.id));
 }
 
 export async function fetchGeminiModelsViaVertexAi(): Promise<ModelInfo[]> {
@@ -96,22 +98,17 @@ const VERTEX_GEMINI_FALLBACK_MODEL_IDS = [
   "gemini-2.5-pro",
   "gemini-2.5-flash",
   "gemini-2.5-flash-lite",
-  "gemini-2.0-flash-001",
-  "gemini-2.0-flash-lite-001",
-  "gemini-1.5-pro-002",
-  "gemini-1.5-flash-002",
 ];
 
 function extractVertexGeminiModel(model: {
   name?: string | null;
   displayName?: string | null;
 }): ModelInfo | null {
-  const modelName = model.name ?? "";
-  if (!modelName.includes("gemini")) {
+  const modelId = (model.name ?? "").replace("publishers/google/models/", "");
+  if (!isUsableGeminiCatalogModel(modelId)) {
     return null;
   }
 
-  const modelId = modelName.replace("publishers/google/models/", "");
   return {
     id: modelId,
     displayName: model.displayName ?? formatVertexGeminiDisplayName(modelId),

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -3,6 +3,7 @@
 import {
   compareModelsForDisplay,
   E2eTestId,
+  isLegacyGeminiModel,
   isOpenRouterLatestAlias,
   type ModelInputModality,
   providerDisplayNames,
@@ -39,6 +40,7 @@ import {
   ConnectAccountBadge,
   FreeModelBadge,
   LatestModelBadge,
+  OldModelBadge,
   UnknownCapabilitiesBadge,
 } from "@/components/model-badges";
 import { Button } from "@/components/ui/button";
@@ -894,6 +896,8 @@ export const ModelSelector = memo(function ModelSelector({
                       {isOpenRouterLatestAlias(provider, model.id) && (
                         <LatestModelBadge />
                       )}
+                      {provider === "gemini" &&
+                        isLegacyGeminiModel(model.id) && <OldModelBadge />}
                       <div className="ml-auto flex items-center gap-2">
                         <ModelCapabilityBadges
                           capabilities={model.capabilities}

--- a/platform/frontend/src/components/model-badges.tsx
+++ b/platform/frontend/src/components/model-badges.tsx
@@ -1,4 +1,4 @@
-import { Fingerprint, Github, Sparkles, Star, User } from "lucide-react";
+import { Clock, Fingerprint, Github, Sparkles, Star, User } from "lucide-react";
 import { InlineTag } from "@/components/ui/inline-tag";
 
 /**
@@ -44,6 +44,18 @@ export function FreeModelBadge() {
 export function LatestModelBadge() {
   return (
     <InlineTag className="text-muted-foreground bg-muted">latest</InlineTag>
+  );
+}
+
+/**
+ * Marks an older-generation model that is still selectable but superseded by a
+ * newer generation from the same provider.
+ */
+export function OldModelBadge() {
+  return (
+    <InlineTag icon={<Clock />} className="text-muted-foreground bg-muted">
+      old
+    </InlineTag>
   );
 }
 

--- a/platform/shared/gemini-models.test.ts
+++ b/platform/shared/gemini-models.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import {
+  isLegacyGeminiModel,
+  isUsableGeminiCatalogModel,
+} from "./gemini-models";
+
+describe("isUsableGeminiCatalogModel", () => {
+  test.each([
+    // Gemini chat models >= 2.5 are kept.
+    ["gemini-2.5-pro", true],
+    ["gemini-2.5-flash", true],
+    ["gemini-2.5-pro-preview-06-05", true],
+    ["gemini-2.10-flash", true],
+    ["gemini-3-pro", true],
+    ["gemini-3.1-pro-preview", true],
+    ["gemini-3.5-flash", true],
+    // First-class Gemini embeddings are kept regardless of version.
+    ["gemini-embedding-001", true],
+    ["gemini-embedding-2-preview", true],
+    // Recent gemma is kept; older gemma falls below the min version.
+    ["gemma-3-27b-it", true],
+    ["gemma-3n-e4b-it", true],
+    ["gemma-2-9b-it", false],
+    ["gemma-1.1-7b-it", false],
+    // Pre-2.5 Gemini is dropped.
+    ["gemini-2.0-flash", false],
+    ["gemini-1.5-pro", false],
+    ["gemini-1.0-pro-vision-latest", false],
+    ["gemini-pro", false],
+    ["gemini-pro-vision", false],
+    // Non-text output families are dropped.
+    ["gemini-2.5-flash-preview-tts", false],
+    ["gemini-2.5-flash-image", false],
+    ["gemini-2.0-flash-live-001", false],
+    ["gemini-live-2.5-flash-native-audio", false],
+    // Unbranded / non-Gemini families are dropped.
+    ["learnlm-2.0-flash-experimental", false],
+    ["aqa", false],
+    ["chat-bison-001", false],
+    ["embedding-001", false],
+    ["text-embedding-004", false],
+  ])("%s -> keep=%s", (modelId, expected) => {
+    expect(isUsableGeminiCatalogModel(modelId)).toBe(expected);
+  });
+
+  test("is case-insensitive", () => {
+    expect(isUsableGeminiCatalogModel("Gemini-2.5-Pro")).toBe(true);
+    expect(isUsableGeminiCatalogModel("GEMINI-1.5-PRO")).toBe(false);
+  });
+});
+
+describe("isLegacyGeminiModel", () => {
+  test.each([
+    // <= 3.0 is "old".
+    ["gemini-2.5-pro", true],
+    ["gemini-2.5-flash", true],
+    ["gemini-2.10-flash", true],
+    ["gemini-3-pro", true],
+    ["gemma-3-27b-it", true],
+    ["gemma-3n-e4b-it", true],
+    // > 3.0 is current.
+    ["gemini-3.1-pro-preview", false],
+    ["gemini-3.5-flash", false],
+    // Embeddings are never badged.
+    ["gemini-embedding-001", false],
+    ["gemini-embedding-2-preview", false],
+    // Unparsable / unbranded ids are not badged.
+    ["gemini-pro", false],
+    ["aqa", false],
+  ])("%s -> legacy=%s", (modelId, expected) => {
+    expect(isLegacyGeminiModel(modelId)).toBe(expected);
+  });
+});

--- a/platform/shared/gemini-models.ts
+++ b/platform/shared/gemini-models.ts
@@ -1,0 +1,96 @@
+/**
+ * Catalog rules for the Gemini provider family (`gemini-*` and `gemma-*`, both
+ * served through the Gemini provider). Pure functions of the model id, shared by
+ * the backend model fetcher (to filter the catalog) and the frontend model
+ * selector (to badge older generations) so both stay in sync.
+ *
+ * `GET /v1beta/models` returns many models that advertise `generateContent` but
+ * are not usable as chat (text-to-speech, image generation, audio/live), plus
+ * deprecated and non-Gemini families. We keep only text-output Gemini-family chat
+ * models at or above a minimum generation, plus first-class Gemini embeddings.
+ */
+
+/** Output-modality families that are not usable for text chat. */
+const NON_TEXT_GEMINI_PATTERNS = ["tts", "image", "audio", "live"];
+
+/** Lowest Gemini-family generation kept in the catalog. */
+const GEMINI_FAMILY_MIN_VERSION: GeminiVersion = [2, 5];
+
+/**
+ * Generations at or below this are labelled "old" in the model selector. Bump
+ * this (and {@link GEMINI_FAMILY_MIN_VERSION} if needed) when a new generation
+ * ships and the previous one becomes legacy.
+ */
+const GEMINI_FAMILY_LEGACY_MAX_VERSION: GeminiVersion = [3, 0];
+
+const GEMINI_EMBEDDING_PREFIX = "gemini-embedding-";
+
+/**
+ * True when the model should appear in the selectable catalog: first-class
+ * Gemini embeddings, or a text-output `gemini-`/`gemma-` chat model at or above
+ * {@link GEMINI_FAMILY_MIN_VERSION}. Drops TTS/image/audio/live variants and
+ * unbranded families (learnlm, aqa, *-bison, legacy embedding-001/text-embedding-*).
+ */
+export function isUsableGeminiCatalogModel(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+
+  if (id.startsWith(GEMINI_EMBEDDING_PREFIX)) {
+    return true;
+  }
+  if (NON_TEXT_GEMINI_PATTERNS.some((pattern) => id.includes(pattern))) {
+    return false;
+  }
+
+  const version = parseGeminiFamilyVersion(id);
+  return (
+    version !== null && compareVersion(version, GEMINI_FAMILY_MIN_VERSION) >= 0
+  );
+}
+
+/**
+ * True when a Gemini-family chat model is an older generation
+ * (≤ {@link GEMINI_FAMILY_LEGACY_MAX_VERSION}) and should carry an "old" badge.
+ * Embeddings are never badged.
+ */
+export function isLegacyGeminiModel(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+
+  if (id.startsWith(GEMINI_EMBEDDING_PREFIX)) {
+    return false;
+  }
+
+  const version = parseGeminiFamilyVersion(id);
+  return (
+    version !== null &&
+    compareVersion(version, GEMINI_FAMILY_LEGACY_MAX_VERSION) <= 0
+  );
+}
+
+// ===========================================================================
+// Internal helpers
+// ===========================================================================
+
+type GeminiVersion = readonly [major: number, minor: number];
+
+const GEMINI_FAMILY_VERSION_RE = /^(?:gemini|gemma)-(\d+)(?:\.(\d+))?/;
+
+/**
+ * Extracts the leading generation from a `gemini-`/`gemma-` id as a
+ * [major, minor] tuple (minor defaults to 0). Returns null for unbranded ids or
+ * ids without a numeric generation (e.g. bare `gemini-pro`, `gemini-exp-1206`).
+ * Tuple form avoids the `parseFloat` pitfall where `gemini-2.10` < `gemini-2.5`.
+ */
+function parseGeminiFamilyVersion(lowerId: string): GeminiVersion | null {
+  const match = GEMINI_FAMILY_VERSION_RE.exec(lowerId);
+  if (!match) {
+    return null;
+  }
+  return [Number(match[1]), match[2] ? Number(match[2]) : 0];
+}
+
+function compareVersion(a: GeminiVersion, b: GeminiVersion): number {
+  if (a[0] !== b[0]) {
+    return a[0] - b[0];
+  }
+  return a[1] - b[1];
+}

--- a/platform/shared/index.ts
+++ b/platform/shared/index.ts
@@ -9,6 +9,7 @@ export * from "./chat-error";
 export * from "./consts";
 export * from "./docs";
 export * from "./e2e-test-ids";
+export * from "./gemini-models";
 export { client as archestraApiClient } from "./hey-api/clients/api/client.gen";
 export * as archestraApiSdk from "./hey-api/clients/api/sdk.gen";
 export * as archestraApiTypes from "./hey-api/clients/api/types.gen";

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -240,7 +240,14 @@ export const MODEL_MARKER_PATTERNS: Record<SupportedProvider, string[]> = {
     "gpt-4.1",
     "gpt-4o",
   ],
-  gemini: ["gemini-3.1-pro-preview", "gemini-2.5-pro", "flash"],
+  gemini: [
+    "gemini-3.5-pro",
+    "gemini-3.5-flash",
+    "gemini-3.1-pro-preview",
+    "gemini-3-pro",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+  ],
   cerebras: ["zai-glm-4.7"],
   cohere: ["command-a-plus", "command-a", "command-r-plus", "command-r"],
   mistral: [


### PR DESCRIPTION
## What

`GET /v1beta/models` returns many Gemini models that advertise `generateContent` but aren't usable for chat (text-to-speech, image generation, audio/live), plus deprecated and non-Gemini families (`learnlm-*`, `aqa`, `*-bison`, legacy `embedding-001`/`text-embedding-004`). These leaked into the selectable model catalog.

This adds a shared, id-based predicate for the Gemini provider family (`gemini-*` and `gemma-*`) and applies it to both fetch paths:

- **Keep**: text-output chat models with version ≥ 2.5 (tuple version compare), plus first-class `gemini-embedding-*` models.
- **Drop**: non-text (`tts`/`image`/`audio`/`live`), pre-2.5, and unbranded families.
- **Badge "old"**: Gemini-family chat models with version ≤ 3.0 in the model selector. Computed client-side from the model id — not persisted, so no DB/migration/route changes.

The Vertex AI fetch path now shares the same predicate (previously a looser `name.includes("gemini")` check) and its fallback id list is trimmed to ≥ 2.5 + embeddings.

## Tests

- `shared/gemini-models.test.ts` — boundary cases for keep/drop and legacy classification.
- `gemini.test.ts` — both fetch paths updated for the new behavior.

## Out of scope (known, not addressed here)

- `MODEL_MARKER_PATTERNS.gemini` is stale relative to the current default model; best-model selection can pick a ≤3.0 model that then also shows the "old" badge.
- The chat route assumes tool support for all non-Perplexity providers (pre-existing), now also covering gemma via Vertex.

https://claude.ai/code/session_01Q3axhy1EDj3HGst6S4BXgH

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>