### PR TITLE
chore: upgrade pnpm to 11.9.0

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -127,7 +127,7 @@ runs:
           "${KUBE_ARGS[@]}" \
           "${ENV_ARGS[@]}" \
           "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
-          /bin/bash -c "corepack enable && corepack prepare pnpm@11.5.2 --activate && pnpm test:e2e -- --project=${PROJECTS} ${SHARD} ${EXTRA_ARGS}" \
+          /bin/bash -c "corepack enable && corepack prepare pnpm@11.9.0 --activate && pnpm test:e2e -- --project=${PROJECTS} ${SHARD} ${EXTRA_ARGS}" \
           2>&1 | tee "${WORKING_DIRECTORY}/playwright-output.txt"
 
     - name: Check for flaky tests

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Setup pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
-        version: 11.4.0
+        version: 11.9.0
         # https://github.com/pnpm/action-setup?tab=readme-ov-file#run_install
         run_install: false #  Crucial to prevent premature install before Node.js setup, improves pnpm caching
 

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -138,7 +138,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
-RUN corepack prepare pnpm@11.5.2 --activate
+RUN corepack prepare pnpm@11.9.0 --activate
 
 # Dependencies stage
 FROM base AS deps

--- a/platform/package.json
+++ b/platform/package.json
@@ -46,7 +46,7 @@
     "tsx": "^4.21.0",
     "turbo": "^2.9.14"
   },
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "croner": "^10.0.1"
   }

--- a/platform/scripts/e2e-local.sh
+++ b/platform/scripts/e2e-local.sh
@@ -109,7 +109,7 @@ docker run --rm \
   -v "$HOME/.kube:/root/.kube:ro" \
   -e KUBECONFIG=/root/.kube/config \
   "mcr.microsoft.com/playwright:v${PW_VERSION}-noble" \
-  /bin/bash -c "corepack enable && corepack prepare pnpm@11.5.2 --activate && pnpm test:e2e -- $PLAYWRIGHT_ARGS"
+  /bin/bash -c "corepack enable && corepack prepare pnpm@11.9.0 --activate && pnpm test:e2e -- $PLAYWRIGHT_ARGS"
 
 echo ""
 echo "=== E2E tests complete ==="


### PR DESCRIPTION
## Summary

Bumps the pinned pnpm version from 11.5.2 / 11.4.0 → **11.9.0** (latest) across every place it's hardcoded.

## Changes

| File | Change |
|---|---|
| `platform/package.json` | `packageManager: pnpm@11.9.0` |
| `platform/Dockerfile` | `corepack prepare pnpm@11.9.0` |
| `platform/scripts/e2e-local.sh` | `corepack prepare pnpm@11.9.0` |
| `.github/actions/setup-env/action.yml` | `pnpm/action-setup` `version: 11.9.0` |
| `.github/actions/run-e2e-tests/action.yml` | `corepack prepare pnpm@11.9.0` |