### PR TITLE
fix(chatops): deliver non-image file attachments to the agent

### DIFF
--- a/docs/pages/platform-agent-triggers-email.md
+++ b/docs/pages/platform-agent-triggers-email.md
@@ -101,7 +101,7 @@ When security validation fails, the email is rejected with an appropriate error 
 
 ## Attachments
 
-Emails sent to agents can include file attachments (both inline images and attached files). Attachments are automatically extracted and passed to the agent for processing. Image attachments are included inline in the agent's context; non-image attachments are noted but not processed as inline content.
+Emails sent to agents can include file attachments (both inline images and attached files). Attachments are automatically extracted and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, JSON, and Markdown — are included inline in the agent's context. Types the model cannot read are noted by name so the agent can tell the user.
 
 **Limits:**
 - Max 20 attachments per email

--- a/docs/pages/platform-ms-teams.md
+++ b/docs/pages/platform-ms-teams.md
@@ -106,7 +106,7 @@ Admins can view autoprovisioned users on the **Settings → Members** page — f
 
 ## Attachments
 
-Messages sent to the bot can include file attachments (images, PDFs, documents, etc.) in channels, group chats, and direct messages. Attachments are automatically downloaded and passed to the agent for processing. Image attachments are included inline in the agent's context; non-image attachments are noted but not processed as inline content.
+Messages sent to the bot can include file attachments (images, PDFs, documents, etc.) in channels, group chats, and direct messages. Attachments are automatically downloaded and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, JSON, and Markdown — are included inline in the agent's context. Types the model cannot read are noted by name so the agent can tell the user. A message that contains only a file (no text) is processed too.
 
 Adaptive Cards and other Teams-specific card types are not treated as file attachments.
 

--- a/docs/pages/platform-slack.md
+++ b/docs/pages/platform-slack.md
@@ -113,7 +113,7 @@ Admins can view autoprovisioned users on the **Settings → Members** page — f
 
 ## Attachments
 
-Messages sent to the bot can include file attachments (images, PDFs, documents, etc.). Attachments are automatically downloaded and passed to the agent for processing. Image attachments are included inline in the agent's context; non-image attachments are noted but not processed as inline content.
+Messages sent to the bot can include file attachments (images, PDFs, documents, etc.). Attachments are automatically downloaded and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, JSON, and Markdown — are included inline in the agent's context. Types the model cannot read are noted by name so the agent can tell the user. A message that contains only a file (no text) is processed too.
 
 **Limits:**
 - Max 20 attachments per message

--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -88,132 +88,101 @@ function renderableFullStream(): AsyncIterable<{ type: string }> {
 }
 
 describe("buildUserContent", () => {
-  test("returns null content when no attachments are provided", () => {
-    const { content, skippedNote } = buildUserContent("Hello");
+  // gemini passes file parts through unchanged, so kept attachments surface as
+  // `file` content parts with their original mediaType — the simplest provider
+  // to assert which attachments survived.
+  const geminiOpts = (ingestibleMimeTypes: Set<string>) => ({
+    provider: "gemini" as const,
+    anthropicNativeEndpoint: false,
+    ingestibleMimeTypes,
+  });
+  const PDF_AND_IMAGES = new Set([
+    "application/pdf",
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/gif",
+    "image/webp",
+    "image/svg+xml",
+  ]);
+
+  // Returns the mediaTypes of all `file` content parts produced.
+  function fileMediaTypes(content: unknown): string[] {
+    if (!Array.isArray(content)) {
+      return [];
+    }
+    return content
+      .filter(
+        (p): p is { type: "file"; mediaType: string } =>
+          typeof p === "object" &&
+          p !== null &&
+          (p as { type?: unknown }).type === "file",
+      )
+      .map((p) => p.mediaType);
+  }
+
+  test("returns null content when no attachments are provided", async () => {
+    const { content, skippedNote } = await buildUserContent(
+      "Hello",
+      undefined,
+      geminiOpts(PDF_AND_IMAGES),
+    );
     expect(content).toBeNull();
     expect(skippedNote).toBe("");
   });
 
-  test("returns null content when attachments array is empty", () => {
-    const { content, skippedNote } = buildUserContent("Hello", []);
+  test("returns null content when attachments array is empty", async () => {
+    const { content, skippedNote } = await buildUserContent(
+      "Hello",
+      [],
+      geminiOpts(PDF_AND_IMAGES),
+    );
     expect(content).toBeNull();
     expect(skippedNote).toBe("");
   });
 
-  test("returns null content with skipped note when attachments contain no images", () => {
+  test("keeps a PDF when the model can read it", async () => {
     const attachments: A2AAttachment[] = [
       {
         contentType: "application/pdf",
         contentBase64: "JVBERi0xLjQ=",
         name: "doc.pdf",
       },
+    ];
+
+    const { content, skippedNote } = await buildUserContent(
+      "Summarize this",
+      attachments,
+      geminiOpts(PDF_AND_IMAGES),
+    );
+
+    expect(fileMediaTypes(content)).toContain("application/pdf");
+    expect(skippedNote).toBe("");
+  });
+
+  test("drops a non-image the model cannot read and names it in the note", async () => {
+    const attachments: A2AAttachment[] = [
       {
-        contentType: "text/plain",
-        contentBase64: "SGVsbG8=",
-        name: "note.txt",
+        contentType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        contentBase64: "AAAA",
+        name: "report.docx",
       },
     ];
 
-    const { content, skippedNote } = buildUserContent("Hello", attachments);
+    const { content, skippedNote } = await buildUserContent(
+      "Read this",
+      attachments,
+      // Model reads PDFs/images but not docx.
+      geminiOpts(PDF_AND_IMAGES),
+    );
 
     expect(content).toBeNull();
-    expect(skippedNote).toContain("2 attachment(s)");
-    expect(skippedNote).toContain("doc.pdf");
-    expect(skippedNote).toContain("note.txt");
+    expect(skippedNote).toContain("1 attachment(s)");
+    expect(skippedNote).toContain("report.docx");
   });
 
-  test("builds content parts with a single image attachment", () => {
-    const attachments: A2AAttachment[] = [
-      {
-        contentType: "image/png",
-        contentBase64: VALID_IMAGE_BASE64,
-        name: "photo.png",
-      },
-    ];
-
-    const { content } = buildUserContent("Describe this image", attachments);
-
-    expect(content).toHaveLength(2);
-    expect(content?.[0]).toEqual({ type: "text", text: "Describe this image" });
-    expect(content?.[1]).toHaveProperty("type", "file");
-    expect(content?.[1]).toHaveProperty("mediaType", "image/png");
-    expect(content?.[1]).toHaveProperty("data");
-    // Verify the data is a Buffer with the correct decoded bytes
-    const filePart = content?.[1] as { data: Buffer; mediaType: string };
-    expect(Buffer.isBuffer(filePart.data)).toBe(true);
-    expect(filePart.data.toString("base64")).toBe(VALID_IMAGE_BASE64);
-  });
-
-  test("builds content parts with multiple image attachments", () => {
-    const pngBase64 = "B".repeat(3000);
-    const jpegBase64 = "C".repeat(3000);
-    const attachments: A2AAttachment[] = [
-      {
-        contentType: "image/png",
-        contentBase64: pngBase64,
-        name: "image1.png",
-      },
-      {
-        contentType: "image/jpeg",
-        contentBase64: jpegBase64,
-        name: "image2.jpg",
-      },
-    ];
-
-    const { content } = buildUserContent(
-      "What's in these photos?",
-      attachments,
-    );
-
-    expect(content).toHaveLength(3); // 1 text + 2 files
-    expect(content?.[0]).toEqual({
-      type: "text",
-      text: "What's in these photos?",
-    });
-    expect(content?.[1]).toHaveProperty("type", "file");
-    expect(content?.[1]).toHaveProperty("mediaType", "image/png");
-    expect(content?.[2]).toHaveProperty("type", "file");
-    expect(content?.[2]).toHaveProperty("mediaType", "image/jpeg");
-  });
-
-  test("filters out non-image attachments from mixed set and appends note", () => {
-    const attachments: A2AAttachment[] = [
-      {
-        contentType: "application/pdf",
-        contentBase64: "JVBERi0xLjQ=",
-        name: "doc.pdf",
-      },
-      {
-        contentType: "image/png",
-        contentBase64: VALID_IMAGE_BASE64,
-        name: "photo.png",
-      },
-      {
-        contentType: "text/plain",
-        contentBase64: "SGVsbG8=",
-        name: "note.txt",
-      },
-    ];
-
-    const { content, skippedNote } = buildUserContent(
-      "Check this",
-      attachments,
-    );
-
-    expect(content).toHaveLength(2); // 1 text + 1 file
-    expect(content?.[0]).toHaveProperty("type", "text");
-    // The text part should include the skipped note
-    expect((content?.[0] as { text: string }).text).toContain("Check this");
-    expect((content?.[0] as { text: string }).text).toContain(
-      "2 attachment(s)",
-    );
-    expect(content?.[1]).toHaveProperty("type", "file");
-    expect(content?.[1]).toHaveProperty("mediaType", "image/png");
-    expect(skippedNote).toContain("doc.pdf");
-    expect(skippedNote).toContain("note.txt");
-  });
-
-  test("handles various image MIME types", () => {
+  test("keeps images regardless of the readable mime set, including image/jpg", async () => {
     const attachments: A2AAttachment[] = [
       {
         contentType: "image/png",
@@ -221,72 +190,87 @@ describe("buildUserContent", () => {
         name: "a.png",
       },
       {
-        contentType: "image/jpeg",
+        // Non-standard mime that is NOT in the model-readable set; images must
+        // still pass via the broad image/* check.
+        contentType: "image/jpg",
         contentBase64: VALID_IMAGE_BASE64,
         name: "b.jpg",
       },
-      {
-        contentType: "image/gif",
-        contentBase64: VALID_IMAGE_BASE64,
-        name: "c.gif",
-      },
-      {
-        contentType: "image/webp",
-        contentBase64: VALID_IMAGE_BASE64,
-        name: "d.webp",
-      },
-      {
-        contentType: "image/svg+xml",
-        contentBase64: VALID_IMAGE_BASE64,
-        name: "e.svg",
-      },
     ];
 
-    const { content } = buildUserContent("Describe", attachments);
+    const { content, skippedNote } = await buildUserContent(
+      "Describe",
+      attachments,
+      // Deliberately omit image/jpg from the readable set.
+      geminiOpts(new Set(["application/pdf"])),
+    );
 
-    expect(content).toHaveLength(6); // 1 text + 5 files
-    expect(content?.[0]).toHaveProperty("type", "text");
-    for (let i = 1; i < (content?.length ?? 0); i++) {
-      expect(content?.[i]).toHaveProperty("type", "file");
-    }
+    const mediaTypes = fileMediaTypes(content);
+    expect(mediaTypes).toContain("image/png");
+    expect(mediaTypes).toContain("image/jpg");
+    expect(skippedNote).toBe("");
   });
 
-  test("works with attachments that have no name", () => {
-    const attachments: A2AAttachment[] = [
-      {
-        contentType: "image/png",
-        contentBase64: VALID_IMAGE_BASE64,
-      },
-    ];
-
-    const { content } = buildUserContent("What is this?", attachments);
-
-    expect(content).toHaveLength(2);
-    expect(content?.[0]).toEqual({ type: "text", text: "What is this?" });
-    expect(content?.[1]).toHaveProperty("type", "file");
-    expect(content?.[1]).toHaveProperty("mediaType", "image/png");
-  });
-
-  test("skipped note uses 'unnamed' for attachments without names", () => {
+  test("keeps readable attachments and notes unreadable ones in a mixed set", async () => {
     const attachments: A2AAttachment[] = [
       {
         contentType: "application/pdf",
         contentBase64: "JVBERi0xLjQ=",
+        name: "doc.pdf",
+      },
+      {
+        contentType: "image/png",
+        contentBase64: VALID_IMAGE_BASE64,
+        name: "photo.png",
+      },
+      {
+        contentType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        contentBase64: "AAAA",
+        name: "report.docx",
       },
     ];
 
-    const { skippedNote } = buildUserContent("Hello", attachments);
+    const { content, skippedNote } = await buildUserContent(
+      "Check this",
+      attachments,
+      geminiOpts(PDF_AND_IMAGES),
+    );
 
-    expect(skippedNote).toContain("unnamed (application/pdf)");
+    const mediaTypes = fileMediaTypes(content);
+    expect(mediaTypes).toContain("application/pdf");
+    expect(mediaTypes).toContain("image/png");
+    expect(skippedNote).toContain("report.docx");
+    expect(skippedNote).toContain("1 attachment(s)");
+    // The note travels on the kept turn's text part too.
+    const textPart = (content as { type: string; text?: string }[]).find(
+      (p) => p.type === "text",
+    );
+    expect(textPart?.text).toContain("Check this");
+    expect(textPart?.text).toContain("report.docx");
   });
 
-  test("filters out tiny image attachments below MIN_IMAGE_ATTACHMENT_SIZE", () => {
-    // Create a tiny image (~988 bytes, like broken Outlook inline references)
-    // Base64 length of ~1317 chars → ~988 decoded bytes (below 2KB threshold)
-    const tinyBase64 = "A".repeat(1317);
+  test("skipped note uses 'unnamed' for attachments without names", async () => {
+    const attachments: A2AAttachment[] = [
+      {
+        contentType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        contentBase64: "AAAA",
+      },
+    ];
 
-    // Create a valid-sized image (above 2KB threshold)
-    // Base64 length of ~2732 chars → ~2048 decoded bytes
+    const { skippedNote } = await buildUserContent(
+      "Hello",
+      attachments,
+      geminiOpts(PDF_AND_IMAGES),
+    );
+
+    expect(skippedNote).toContain("unnamed");
+  });
+
+  test("filters out tiny image attachments below MIN_IMAGE_ATTACHMENT_SIZE", async () => {
+    // ~988 decoded bytes (below the 2KB threshold), like broken inline refs.
+    const tinyBase64 = "A".repeat(1317);
     const validBase64 = "B".repeat(2732);
 
     const attachments: A2AAttachment[] = [
@@ -302,44 +286,42 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { content, skippedNote } = buildUserContent(
+    const { content, skippedNote } = await buildUserContent(
       "Check this",
       attachments,
+      geminiOpts(PDF_AND_IMAGES),
     );
 
-    // Should include only the valid image
-    expect(content).toHaveLength(2); // 1 text + 1 file
-    expect(content?.[1]).toHaveProperty("type", "file");
-    expect(content?.[1]).toHaveProperty("mediaType", "image/jpeg");
-
-    // Skipped note should mention the filtered tiny image
+    expect(fileMediaTypes(content)).toEqual(["image/jpeg"]);
     expect(skippedNote).toContain("broken-inline-ref.png");
     expect(skippedNote).toContain("1 attachment(s)");
   });
 
-  test("returns null content when all images are below minimum size", () => {
-    const tinyBase64 = "A".repeat(100); // ~75 bytes
-
+  test("returns null content when all images are below minimum size", async () => {
     const attachments: A2AAttachment[] = [
       {
         contentType: "image/png",
-        contentBase64: tinyBase64,
+        contentBase64: "A".repeat(100), // ~75 bytes
         name: "tiny.png",
       },
     ];
 
-    const { content, skippedNote } = buildUserContent("Hello", attachments);
+    const { content, skippedNote } = await buildUserContent(
+      "Hello",
+      attachments,
+      geminiOpts(PDF_AND_IMAGES),
+    );
 
     expect(content).toBeNull();
     expect(skippedNote).toContain("tiny.png");
   });
 
-  test("does not filter images at or above the minimum size threshold", () => {
-    // Create an image exactly at the threshold (2048 bytes = MIN_IMAGE_ATTACHMENT_SIZE)
-    // 2048 bytes → base64 length = ceil(2048 * 4/3) = 2731 chars
+  test("does not filter images at or above the minimum size threshold", async () => {
+    // 2048 bytes = MIN_IMAGE_ATTACHMENT_SIZE → base64 length 2731 chars.
     const thresholdBase64 = "C".repeat(2731);
-    const estimatedBytes = Math.ceil((2731 * 3) / 4);
-    expect(estimatedBytes).toBeGreaterThanOrEqual(MIN_IMAGE_ATTACHMENT_SIZE);
+    expect(Math.ceil((2731 * 3) / 4)).toBeGreaterThanOrEqual(
+      MIN_IMAGE_ATTACHMENT_SIZE,
+    );
 
     const attachments: A2AAttachment[] = [
       {
@@ -349,10 +331,114 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { content } = buildUserContent("Test", attachments);
+    const { content } = await buildUserContent(
+      "Test",
+      attachments,
+      geminiOpts(PDF_AND_IMAGES),
+    );
 
-    expect(content).toHaveLength(2); // 1 text + 1 file
-    expect(content?.[1]).toHaveProperty("type", "file");
+    expect(fileMediaTypes(content)).toEqual(["image/png"]);
+  });
+});
+
+describe("executeA2AMessage current turn assembly", () => {
+  function primeStreamMocks() {
+    mockGetChatMcpTools.mockResolvedValue({});
+    mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
+      chatApiKeyId: "org-key",
+      selectedModel: "claude-sonnet-4-6",
+      selectedProvider: "anthropic",
+    });
+    mockCreateLLMModelForAgent.mockResolvedValue({
+      model: { provider: "mock" },
+      provider: "anthropic",
+      apiKeySource: "org",
+      anthropicNativeEndpoint: true,
+    });
+    mockStreamText.mockReturnValue({
+      toUIMessageStream: vi.fn((options) => {
+        const responseMessage = {
+          id: "msg-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "ok" }],
+        };
+        options?.onFinish?.({
+          messages: [responseMessage],
+          isContinuation: false,
+          isAborted: false,
+          responseMessage,
+          finishReason: "stop",
+        });
+        return new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        });
+      }),
+      fullStream: renderableFullStream(),
+      text: Promise.resolve("ok"),
+      usage: Promise.resolve(undefined),
+      finishReason: Promise.resolve("stop"),
+    });
+  }
+
+  test("appends exactly one current user turn to the provided history", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+    });
+    primeStreamMocks();
+
+    const history = [
+      { role: "user" as const, content: "prior question" },
+      { role: "assistant" as const, content: "earlier reply" },
+    ];
+    await executeA2AMessage({
+      agentId: agent.id,
+      message: "current question",
+      messages: history,
+      organizationId: org.id,
+      userId: "user-1",
+      conversationId: "conv-1",
+    });
+
+    const config = mockStreamText.mock.calls[0]?.[0];
+    expect(config.messages).toHaveLength(history.length + 1);
+    expect(config.messages.at(-1)).toEqual({
+      role: "user",
+      content: "current question",
+    });
+  });
+
+  test("uses history as-is when the current turn has no text or attachments", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      systemPrompt: "Handle the task.",
+    });
+    primeStreamMocks();
+
+    const history = [{ role: "user" as const, content: "prior question" }];
+    await executeA2AMessage({
+      agentId: agent.id,
+      message: "",
+      messages: history,
+      organizationId: org.id,
+      userId: "user-1",
+      conversationId: "conv-1",
+    });
+
+    const config = mockStreamText.mock.calls[0]?.[0];
+    expect(config.messages).toEqual(history);
   });
 });
 

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -1,11 +1,14 @@
 import crypto from "node:crypto";
 import {
+  getModelReadableMimeTypes,
   type InteractionSource,
   PLAYWRIGHT_MCP_CATALOG_ID,
+  type SupportedProvider,
 } from "@archestra/shared";
 import type { ModelMessage, UIMessage, UserContent } from "ai";
 import {
   consumeStream as consumeReadableStream,
+  convertToModelMessages,
   NoOutputGeneratedError,
   stepCountIs,
   type streamText,
@@ -23,14 +26,16 @@ import {
   ToolCallRepeatTracker,
 } from "@/clients/tool-call-repeat-tracker";
 import logger from "@/logging";
-import { AgentModel, McpServerModel } from "@/models";
+import { AgentModel, McpServerModel, ModelModel } from "@/models";
 import {
   formatUnavailableToolErrorDetails,
   getUnavailableToolErrorDetails,
   mapProviderError,
   ProviderError,
 } from "@/routes/chat/errors";
+import { prepareMessagesForProvider } from "@/routes/chat/normalization/prepare-for-provider";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
+import type { ChatMessage } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
 
 /**
@@ -249,7 +254,7 @@ export async function executeA2AMessage(
     // Pass sessionId to group A2A requests with the calling session
     // Pass delegationChain as externalAgentId so agent names appear in logs
     // Pass agent's llmApiKeyId so it can be used without user access check
-    const { model } = await createLLMModelForAgent({
+    const { model, anthropicNativeEndpoint } = await createLLMModelForAgent({
       organizationId,
       userId,
       agentId: agent.id,
@@ -262,11 +267,26 @@ export async function executeA2AMessage(
       contextIsTrusted: parentContextIsTrusted,
     });
 
-    // Build multimodal user content when image attachments are present
-    const { content: userContent, skippedNote } = buildUserContent(
+    // Which attachment mime types this model can read. A missing model row
+    // (lookup failure or unknown model) falls back to the safe default set
+    // (text + images + PDF) rather than dropping everything.
+    const modelRow = await ModelModel.findByProviderAndModelId(
+      provider,
+      selectedModel,
+    ).catch(() => null);
+    const ingestibleMimeTypes = getModelReadableMimeTypes(
+      modelRow?.inputModalities ?? null,
+    );
+
+    // Build the current user turn from the message + attachments, gated by the
+    // model's capabilities and normalized for the provider. `params.messages`
+    // carries only prior context; this turn is appended to it below.
+    const { content: userContent, skippedNote } = await buildUserContent(
       message,
       attachments,
+      { provider, anthropicNativeEndpoint, ingestibleMimeTypes },
     );
+    const currentTurnText = message + skippedNote;
 
     // Execute via the shared agent-run primitive: it owns the streamText call
     // and transparently recovers empty/abortive/context-length turns before any
@@ -275,8 +295,12 @@ export async function executeA2AMessage(
     // previously had no recovery — a clean-but-empty turn returned an empty
     // success. It now retries and, on exhaustion, throws (mapped to a
     // ProviderError below), matching the interactive chat path.
-    // Prefer the explicit `messages` param; otherwise use a `messages` user turn
-    // when images are present, falling back to a plain `prompt` for text only.
+    // The executor owns the current user turn: `params.messages` (when present)
+    // is prior context only, and the turn built from `message`/`attachments` is
+    // appended to it. When there is no current turn (e.g. an approval-decision
+    // message with no text or attachments), the context is used as-is. Callers
+    // without context (delegation, scheduled, A2A v1) fall back to a plain
+    // `prompt` for text, or a single `messages` turn when attachments survive.
     const baseConfig = {
       model,
       system: systemPrompt,
@@ -287,15 +311,23 @@ export async function executeA2AMessage(
       ],
       abortSignal,
     };
+    const currentTurn: { role: "user"; content: UserContent } | null =
+      userContent !== null
+        ? { role: "user", content: userContent }
+        : currentTurnText.trim().length > 0
+          ? { role: "user", content: currentTurnText }
+          : null;
     const config: Parameters<typeof streamText>[0] =
       params.messages !== undefined
-        ? { ...baseConfig, messages: params.messages }
-        : userContent
-          ? {
-              ...baseConfig,
-              messages: [{ role: "user" as const, content: userContent }],
-            }
-          : { ...baseConfig, prompt: message + skippedNote };
+        ? {
+            ...baseConfig,
+            messages: currentTurn
+              ? [...params.messages, currentTurn]
+              : params.messages,
+          }
+        : currentTurn
+          ? { ...baseConfig, messages: [currentTurn] }
+          : { ...baseConfig, prompt: currentTurnText };
 
     let finalText: string;
     let usage: Awaited<ReturnType<typeof streamText>["usage"]>;
@@ -441,22 +473,30 @@ export async function executeA2AMessage(
 // ============================================================================
 
 /**
- * Build AI SDK UserContent from a text message and optional attachments.
- * Returns `content: null` when there are no image attachments (caller should use plain `prompt` instead).
- * Returns `skippedNote` with a human-readable note about non-image attachments that were dropped,
- * so the caller can append it to the prompt for the LLM to mention.
+ * Build the current user turn's AI SDK content from a text message and optional
+ * attachments, gated by what the target model can read — mirroring the regular
+ * chat upload path.
  *
- * Only image attachments are currently supported as inline content parts.
- * Non-image attachments are noted so the LLM can inform the user.
+ * Images are always kept (subject to the tiny-broken-image filter). Non-image
+ * attachments are kept only when the model's input modalities include their
+ * mime type; otherwise they are dropped and named in `skippedNote` so the LLM
+ * can tell the user. Kept attachments are normalized for the provider via
+ * `prepareMessagesForProvider` and converted to AI SDK content. Returns
+ * `content: null` when no attachment survives, so the caller falls back to a
+ * plain text turn carrying `skippedNote`.
  * @public — exported for testability
  */
-export function buildUserContent(
+export async function buildUserContent(
   message: string,
-  attachments?: A2AAttachment[],
-): { content: UserContent | null; skippedNote: string } {
+  attachments: A2AAttachment[] | undefined,
+  opts: {
+    provider: SupportedProvider;
+    anthropicNativeEndpoint: boolean;
+    ingestibleMimeTypes: Set<string>;
+  },
+): Promise<{ content: UserContent | null; skippedNote: string }> {
   const allAttachments = attachments ?? [];
 
-  // Split into image and non-image attachments
   const imageAttachments = allAttachments.filter((a) =>
     a.contentType.startsWith("image/"),
   );
@@ -475,6 +515,14 @@ export function buildUserContent(
     return estimatedBytes < MIN_IMAGE_ATTACHMENT_SIZE;
   });
 
+  // Non-image attachments only reach the model when it can read their mime type.
+  const readableNonImageAttachments = nonImageAttachments.filter((a) =>
+    opts.ingestibleMimeTypes.has(a.contentType),
+  );
+  const unreadableNonImageAttachments = nonImageAttachments.filter(
+    (a) => !opts.ingestibleMimeTypes.has(a.contentType),
+  );
+
   if (tinyImageAttachments.length > 0) {
     logger.debug(
       {
@@ -489,40 +537,65 @@ export function buildUserContent(
     );
   }
 
-  if (nonImageAttachments.length > 0) {
+  if (unreadableNonImageAttachments.length > 0) {
     logger.debug(
       {
-        skippedCount: nonImageAttachments.length,
-        skippedTypes: nonImageAttachments.map(
+        skippedCount: unreadableNonImageAttachments.length,
+        skippedTypes: unreadableNonImageAttachments.map(
           (a) => `${a.name ?? "unnamed"} (${a.contentType})`,
         ),
       },
-      "Skipping non-image attachments in buildUserContent (only image/* is currently supported)",
+      "Skipping attachments the target model cannot read in buildUserContent",
     );
   }
 
   // Build a note about all skipped attachments so the LLM can mention them
-  const allSkipped = [...nonImageAttachments, ...tinyImageAttachments];
+  const allSkipped = [
+    ...unreadableNonImageAttachments,
+    ...tinyImageAttachments,
+  ];
   const skippedNote =
     allSkipped.length > 0
       ? `\n\n[Note: This message also included ${allSkipped.length} attachment(s) that could not be processed: ${allSkipped.map((a) => `${a.name ?? "unnamed"} (${a.contentType})`).join(", ")}]`
       : "";
 
-  if (validImageAttachments.length === 0) {
+  const keptAttachments = [
+    ...validImageAttachments,
+    ...readableNonImageAttachments,
+  ];
+  if (keptAttachments.length === 0) {
     return { content: null, skippedNote };
   }
 
-  return {
-    content: [
-      { type: "text" as const, text: message + skippedNote },
-      ...validImageAttachments.map((a) => ({
-        type: "file" as const,
-        data: Buffer.from(a.contentBase64, "base64"),
+  // Hand the kept attachments to the chat provider-normalization pipeline as a
+  // synthetic user message (data: URL file parts), so each provider's SDK
+  // receives documents in the shape it accepts (Anthropic documents, decoded
+  // text for OpenAI-compatible endpoints, etc.).
+  const text = message + skippedNote;
+  const userMessage: ChatMessage = {
+    role: "user",
+    parts: [
+      ...(text.length > 0 ? [{ type: "text", text }] : []),
+      ...keptAttachments.map((a) => ({
+        type: "file",
+        url: `data:${a.contentType};base64,${a.contentBase64}`,
         mediaType: a.contentType,
+        filename: a.name,
       })),
     ],
-    skippedNote,
   };
+
+  const [preparedMessage] = prepareMessagesForProvider({
+    messages: [userMessage],
+    provider: opts.provider,
+    anthropicNativeEndpoint: opts.anthropicNativeEndpoint,
+  });
+  const modelMessages = await convertToModelMessages([
+    preparedMessage,
+  ] as unknown as Omit<UIMessage, "id">[]);
+
+  const content = (modelMessages[0]?.content ?? null) as UserContent | null;
+  return { content, skippedNote };
 }
 
 // ============================================================================

--- a/platform/backend/src/agents/a2a/a2a-helper.test.ts
+++ b/platform/backend/src/agents/a2a/a2a-helper.test.ts
@@ -8,13 +8,14 @@ describe("buildAttachmentsMessageParts", () => {
     expect(parts).toHaveLength(0);
   });
 
-  test("simple", () => {
+  test("maps every attachment to a protocol part, preserving mediaType, bytes and filename", () => {
     const imageBase64 = "A".repeat(2732);
+    const pdfBase64 = Buffer.from("%PDF-1.4", "utf8").toString("base64");
 
     const parts = buildAttachmentsMessageParts([
       {
         contentType: "application/pdf",
-        contentBase64: Buffer.from("%PDF-1.4", "utf8").toString("base64"),
+        contentBase64: pdfBase64,
         name: "doc.pdf",
       },
       {
@@ -24,12 +25,24 @@ describe("buildAttachmentsMessageParts", () => {
       },
     ]);
 
-    expect(parts).toHaveLength(1);
+    // Type/capability filtering happens later in the executor, so this is a
+    // straight byte mapping that keeps both attachments.
+    expect(parts).toHaveLength(2);
     expect(parts[0]).toMatchObject({
+      mediaType: "application/pdf",
+      filename: "doc.pdf",
+    });
+    expect(parts[1]).toMatchObject({
       mediaType: "image/png",
+      filename: "image.png",
     });
     expect(
       Buffer.from(parts[0].raw as WithImplicitCoercion<Buffer>).toString(
+        "base64",
+      ),
+    ).toBe(pdfBase64);
+    expect(
+      Buffer.from(parts[1].raw as WithImplicitCoercion<Buffer>).toString(
         "base64",
       ),
     ).toBe(imageBase64);

--- a/platform/backend/src/agents/a2a/a2a-helper.ts
+++ b/platform/backend/src/agents/a2a/a2a-helper.ts
@@ -1,4 +1,4 @@
-import { type A2AAttachment, buildUserContent } from "../a2a-executor";
+import type { A2AAttachment } from "../a2a-executor";
 import type {
   A2AArchestraApprovalRequest,
   A2AArchestraTaskApprovalDecision,
@@ -47,29 +47,20 @@ export function buildApprovalDecisionSendMessageRequest(params: {
   };
 }
 
+/**
+ * Convert source-agnostic attachments into A2A protocol file parts. Attachment
+ * type/capability filtering and provider normalization happen later in the
+ * executor (which knows the target model), so this is a straight byte mapping
+ * that preserves mediaType and filename.
+ */
 export function buildAttachmentsMessageParts(
   attachments: A2AAttachment[],
 ): A2AProtocolPart[] {
-  const parts = buildUserContent("", attachments).content;
-  if (!Array.isArray(parts) || parts.length === 0) {
-    return [];
-  }
-
-  const protocolParts: A2AProtocolPart[] = [];
-  parts.forEach((part) => {
-    if (part.type !== "file") {
-      return;
-    }
-    if (part.data instanceof Uint8Array) {
-      protocolParts.push({
-        raw: part.data,
-        mediaType: part.mediaType,
-      });
-      return;
-    }
-  });
-
-  return protocolParts;
+  return attachments.map((a) => ({
+    raw: Buffer.from(a.contentBase64, "base64"),
+    mediaType: a.contentType,
+    filename: a.name,
+  }));
 }
 
 export function extractApprovalRequestsFromSendMessageResult(

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -19,7 +19,7 @@ import { RouteCategory, startActiveChatSpan } from "@/observability/tracing";
 import { validateMCPGatewayToken } from "@/routes/mcp-gateway.utils";
 import type { A2AContext } from "@/types";
 import type { InteractionSource } from "../../../../shared";
-import { executeA2AMessage } from "../a2a-executor";
+import { type A2AAttachment, executeA2AMessage } from "../a2a-executor";
 import { type A2AActor, A2AError, A2AErrorKind } from "./a2a-base";
 import {
   A2AContextManager,
@@ -203,23 +203,40 @@ export class A2AManager {
       const requestMessages: ModelMessage[] =
         await convertToModelMessages(contextUiMessages);
 
+      // The executor owns building the current user turn: it applies
+      // model-aware, provider-specific attachment handling, so we pass the
+      // turn's text + attachments rather than baking it into `requestMessages`
+      // (which stays prior-context only). Attachments are reconstructed from the
+      // protocol file parts, preserving filenames.
+      const currentTurnAttachments: A2AAttachment[] = (
+        request.message.parts || []
+      )
+        .filter((p) => p.raw !== undefined && p.mediaType !== undefined)
+        .map((p) => ({
+          contentType: p.mediaType as string,
+          contentBase64: Buffer.from(p.raw as Uint8Array).toString("base64"),
+          name: p.filename,
+        }));
+      const currentTurnText = messageParts
+        .filter((part): part is TextPart => part.type === "text")
+        .map((part) => part.text)
+        .join("\n");
+
       if (messageParts.length > 0) {
-        // We need to separately push user message to both contextUiMessages and requestMessages.
-        // Full contextUiMessages are passed to executeA2AMessage for proper processing of final uiMessage
-        // requestMessages are passed to executeA2AMessage for the agent execution.
+        // Mirror the current turn's text into contextUiMessages so the
+        // generated final UIMessage continues from it. Files are not supported
+        // in UI history, so only text parts are carried here.
         const uiMessageParts: TextUIPart[] = [];
         messageParts.forEach((part) => {
           if (part.type === "text") {
             uiMessageParts.push({ type: "text" as const, text: part.text });
           }
-          // Files are currently not supported in history.
         });
         contextUiMessages.push({
           id: request.message.messageId,
           parts: uiMessageParts,
           role: "user",
         });
-        requestMessages.push({ role: "user", content: messageParts });
       }
 
       const sessionId = systemParams?.sessionId ?? context?.id;
@@ -242,7 +259,11 @@ export class A2AManager {
         callback: async () => {
           return executeA2AMessage({
             agentId,
-            message: "",
+            message: currentTurnText,
+            attachments:
+              currentTurnAttachments.length > 0
+                ? currentTurnAttachments
+                : undefined,
             messages: requestMessages,
             organizationId: actor.organizationId,
             userId: actor.kind === "user" ? actor.id : "system",

--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -19,7 +19,10 @@ import {
   ChatOpsManager,
   matchesAgentName,
 } from "./chatops-manager";
-import { CHATOPS_NO_REPLY_SENTINEL } from "./constants";
+import {
+  CHATOPS_ATTACHMENT_LIMITS,
+  CHATOPS_NO_REPLY_SENTINEL,
+} from "./constants";
 
 describe("matchesAgentName", () => {
   test("matches exact name", () => {
@@ -1640,9 +1643,7 @@ describe("ChatOpsManager attachment passthrough", () => {
         name: "screenshot.png",
       },
       {
-        // Don't use PDF because A2A message executor doesn't support it right now
-        // contentType: "application/pdf",
-        contentType: "image/jpg",
+        contentType: "application/pdf",
         contentBase64: Buffer.alloc(10_000).toString("base64"),
         name: "report.pdf",
       },
@@ -1655,20 +1656,19 @@ describe("ChatOpsManager attachment passthrough", () => {
     });
 
     expect(result.success).toBe(true);
+    // The manager forwards the attachments to the executor via the `attachments`
+    // param (preserving mime type + filename); model-capability gating and
+    // provider normalization happen inside the executor.
     expect(executorSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        messages: expect.arrayContaining([
+        attachments: expect.arrayContaining([
           expect.objectContaining({
-            content: expect.arrayContaining([
-              expect.objectContaining({
-                type: "file",
-                mediaType: "image/png",
-              }),
-              expect.objectContaining({
-                type: "file",
-                mediaType: "image/jpg",
-              }),
-            ]),
+            contentType: "image/png",
+            name: "screenshot.png",
+          }),
+          expect.objectContaining({
+            contentType: "application/pdf",
+            name: "report.pdf",
           }),
         ]),
       }),
@@ -1726,11 +1726,7 @@ describe("ChatOpsManager attachment passthrough", () => {
     await manager.processMessage({ message, provider: mockProvider });
 
     const callArg = executorSpy.mock.calls[0][0];
-    for (const message of callArg.messages || []) {
-      expect(message.content).not.toEqual(
-        expect.arrayContaining([expect.objectContaining({ type: "file" })]),
-      );
-    }
+    expect(callArg.attachments).toBeUndefined();
   });
 
   test("includes image attachments from thread history in follow-up messages", async ({
@@ -1828,20 +1824,245 @@ describe("ChatOpsManager attachment passthrough", () => {
     });
 
     expect(result.success).toBe(true);
-    // The image from thread history should be included in the A2A call
+    // The image from thread history should be forwarded to the executor via the
+    // `attachments` param.
     expect(executorSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        messages: expect.arrayContaining([
+        attachments: expect.arrayContaining([
           expect.objectContaining({
-            content: expect.arrayContaining([
-              expect.objectContaining({
-                type: "file",
-                mediaType: historyImageAttachment.contentType,
-              }),
-            ]),
+            contentType: historyImageAttachment.contentType,
           }),
         ]),
       }),
+    );
+  });
+
+  test("includes non-image attachments (PDF) from thread history within budget", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const downloadedPdf = {
+      contentType: "application/pdf",
+      contentBase64: Buffer.alloc(10_000).toString("base64"),
+      name: "history.pdf",
+    };
+
+    const executorSpy = vi
+      .spyOn(a2aExecutor, "executeA2AMessage")
+      .mockResolvedValue({
+        text: "I read the PDF from earlier",
+        messageId: "msg-3",
+        finishReason: "stop",
+        responseUiMessage: {
+          id: "msg-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "response" }],
+        },
+      });
+
+    const user = await makeUser({ email: "pdf-history@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: agent.id,
+    });
+
+    const mockProvider = createMockProvider({
+      getUserEmail: async () => "pdf-history@example.com",
+    });
+    mockProvider.getThreadHistory = async () => [
+      {
+        messageId: "earlier-msg",
+        senderId: "test-sender-aad-id",
+        senderName: "Test User",
+        text: "Here is the report",
+        timestamp: new Date(Date.now() - 60_000),
+        isFromBot: false,
+        files: [
+          {
+            url: "https://files.slack.com/files-pri/T123/report.pdf",
+            mimetype: "application/pdf",
+            name: "history.pdf",
+            size: 1024,
+          },
+        ],
+      },
+    ];
+    const downloadFilesSpy = vi.fn().mockResolvedValue([downloadedPdf]);
+    mockProvider.downloadFiles = downloadFilesSpy;
+
+    const manager = new ChatOpsManager();
+    (
+      manager as unknown as { msTeamsProvider: ChatOpsProvider }
+    ).msTeamsProvider = mockProvider;
+
+    const message = createMockMessage({
+      threadId: "thread-123",
+      isThreadReply: true,
+      text: "Summarize the report",
+    });
+
+    const result = await manager.processMessage({
+      message,
+      provider: mockProvider,
+    });
+
+    expect(result.success).toBe(true);
+    // The PDF history file must be eligible for re-download (image-only filter removed)
+    expect(downloadFilesSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          mimetype: "application/pdf",
+          name: "history.pdf",
+        }),
+      ]),
+    );
+    // And, being within budget, it must be forwarded to the executor.
+    const forwardedAttachments =
+      executorSpy.mock.calls[0]?.[0]?.attachments ?? [];
+    expect(forwardedAttachments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          contentType: "application/pdf",
+          name: "history.pdf",
+        }),
+      ]),
+    );
+  });
+
+  test("skips a non-image history attachment that exceeds the total budget", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    // Current message already consumes almost the entire total budget, leaving
+    // only a tiny remainder for thread-history replay.
+    const currentPdf = {
+      contentType: "application/pdf",
+      contentBase64: Buffer.alloc(
+        CHATOPS_ATTACHMENT_LIMITS.MAX_TOTAL_ATTACHMENTS_SIZE - 2000,
+      ).toString("base64"),
+      name: "current.pdf",
+    };
+    // The downloaded history file is well within the per-file size limit but
+    // larger than the remaining total budget, so it must be trimmed.
+    const downloadedHistoryPdf = {
+      contentType: "application/pdf",
+      contentBase64: Buffer.alloc(10_000).toString("base64"),
+      name: "history.pdf",
+    };
+
+    const executorSpy = vi
+      .spyOn(a2aExecutor, "executeA2AMessage")
+      .mockResolvedValue({
+        text: "ok",
+        messageId: "msg-3",
+        finishReason: "stop",
+        responseUiMessage: {
+          id: "msg-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "response" }],
+        },
+      });
+
+    const user = await makeUser({ email: "pdf-budget@example.com" });
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+    await makeTeamMember(team.id, user.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: agent.id,
+    });
+
+    const mockProvider = createMockProvider({
+      getUserEmail: async () => "pdf-budget@example.com",
+    });
+    mockProvider.getThreadHistory = async () => [
+      {
+        messageId: "earlier-msg",
+        senderId: "test-sender-aad-id",
+        senderName: "Test User",
+        text: "Here is the report",
+        timestamp: new Date(Date.now() - 60_000),
+        isFromBot: false,
+        files: [
+          {
+            url: "https://files.slack.com/files-pri/T123/report.pdf",
+            mimetype: "application/pdf",
+            name: "history.pdf",
+            size: 1024,
+          },
+        ],
+      },
+    ];
+    const downloadFilesSpy = vi.fn().mockResolvedValue([downloadedHistoryPdf]);
+    mockProvider.downloadFiles = downloadFilesSpy;
+
+    const manager = new ChatOpsManager();
+    (
+      manager as unknown as { msTeamsProvider: ChatOpsProvider }
+    ).msTeamsProvider = mockProvider;
+
+    const message = createMockMessage({
+      threadId: "thread-123",
+      isThreadReply: true,
+      text: "Summarize both reports",
+      attachments: [currentPdf],
+    });
+
+    const result = await manager.processMessage({
+      message,
+      provider: mockProvider,
+    });
+
+    expect(result.success).toBe(true);
+    // It is still eligible (download happens before budget trimming)...
+    expect(downloadFilesSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          mimetype: "application/pdf",
+          name: "history.pdf",
+        }),
+      ]),
+    );
+    // ...but it must NOT survive the total-budget trim, while the current
+    // attachment is preserved.
+    const forwardedAttachments =
+      executorSpy.mock.calls[0]?.[0]?.attachments ?? [];
+    expect(forwardedAttachments).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "history.pdf" }),
+      ]),
+    );
+    expect(forwardedAttachments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "current.pdf" }),
+      ]),
     );
   });
 

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -1031,11 +1031,10 @@ export class ChatOpsManager {
         return `${sender}: ${text}`;
       });
 
-      // Collect image files from non-bot user messages in history
+      // Collect files from non-bot user messages in history
       const historyFiles = history
         .filter((msg) => !msg.isFromBot && msg.files && msg.files.length > 0)
-        .flatMap((msg) => msg.files ?? [])
-        .filter((f) => f.mimetype.startsWith("image/"));
+        .flatMap((msg) => msg.files ?? []);
 
       const historyAttachments: Array<{
         contentType: string;
@@ -1078,7 +1077,7 @@ export class ChatOpsManager {
                   downloadedCount: historyAttachments.length,
                   totalHistoryFiles: historyFiles.length,
                 },
-                "[ChatOps] Downloaded image attachments from thread history",
+                "[ChatOps] Downloaded attachments from thread history",
               );
             }
           } catch (error) {

--- a/platform/backend/src/agents/chatops/ms-teams-provider.test.ts
+++ b/platform/backend/src/agents/chatops/ms-teams-provider.test.ts
@@ -242,6 +242,66 @@ describe("MSTeamsProvider file attachment downloads", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  test("file-only message (empty text + file attachment) is parsed with attachments", async () => {
+    const provider = createProvider();
+    const fileContent = Buffer.from("file-only teams message");
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(fileContent, { status: 200 }),
+    );
+
+    const result = await provider.parseWebhookNotification(
+      makeActivity({
+        text: undefined,
+        attachments: [
+          {
+            contentType: "application/pdf",
+            contentUrl: "https://teams.blob.core.windows.net/files/report.pdf",
+            name: "report.pdf",
+          },
+        ],
+      }),
+      {},
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("");
+    expect(result?.attachments).toHaveLength(1);
+    expect(result?.attachments?.[0].name).toBe("report.pdf");
+  });
+
+  test("message with neither text nor attachments returns null", async () => {
+    const provider = createProvider();
+
+    const result = await provider.parseWebhookNotification(
+      makeActivity({ text: undefined, attachments: undefined }),
+      {},
+    );
+
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("card-only message with empty text returns null (cards are not files)", async () => {
+    const provider = createProvider();
+
+    const result = await provider.parseWebhookNotification(
+      makeActivity({
+        text: undefined,
+        attachments: [
+          {
+            contentType: "application/vnd.microsoft.card.adaptive",
+            content: JSON.stringify({ type: "AdaptiveCard" }),
+          },
+        ],
+      }),
+      {},
+    );
+
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   test("downloads file attachment and returns base64 content", async () => {
     const provider = createProvider();
     const fileContent = Buffer.from("image bytes here");

--- a/platform/backend/src/agents/chatops/ms-teams-provider.test.ts
+++ b/platform/backend/src/agents/chatops/ms-teams-provider.test.ts
@@ -282,6 +282,29 @@ describe("MSTeamsProvider file attachment downloads", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  test("file-only message whose download fails is dropped (no empty turn)", async () => {
+    const provider = createProvider();
+
+    // The download fails (e.g. expired/oversized), so no attachment survives.
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    const result = await provider.parseWebhookNotification(
+      makeActivity({
+        text: undefined,
+        attachments: [
+          {
+            contentType: "application/pdf",
+            contentUrl: "https://teams.blob.core.windows.net/files/report.pdf",
+            name: "report.pdf",
+          },
+        ],
+      }),
+      {},
+    );
+
+    expect(result).toBeNull();
+  });
+
   test("card-only message with empty text returns null (cards are not files)", async () => {
     const provider = createProvider();
 

--- a/platform/backend/src/agents/chatops/ms-teams-provider.ts
+++ b/platform/backend/src/agents/chatops/ms-teams-provider.ts
@@ -283,6 +283,13 @@ class MSTeamsProvider implements ChatOpsProvider {
       activity.serviceUrl,
     );
 
+    // A file-only message (empty text) is kept only when a file actually
+    // survived download — oversized, expired, or failed downloads must not
+    // leave the bot answering an empty turn.
+    if (!cleanedText && attachments.length === 0) {
+      return null;
+    }
+
     return {
       messageId: activity.id || `teams-${Date.now()}`,
       channelId,

--- a/platform/backend/src/agents/chatops/ms-teams-provider.ts
+++ b/platform/backend/src/agents/chatops/ms-teams-provider.ts
@@ -220,7 +220,25 @@ class MSTeamsProvider implements ChatOpsProvider {
       "[MSTeamsProvider] Parsing activity",
     );
 
-    if (activity.type !== ActivityTypes.Message || !activity.text) {
+    if (activity.type !== ActivityTypes.Message) {
+      return null;
+    }
+
+    // A file-only message (empty text but with a real file attachment) is still
+    // meaningful, so accept it; only drop messages that carry neither text nor
+    // a downloadable file. Adaptive Cards / hero cards are not files (and are
+    // filtered out before download), so a card-only message stays dropped.
+    // Addressing/mention gating is enforced by the webhook route, not here, so
+    // this does not widen who the bot responds to.
+    const hasFileAttachment = Boolean(
+      activity.attachments?.some(
+        (a) =>
+          a.contentUrl &&
+          a.contentType &&
+          !a.contentType.startsWith("application/vnd.microsoft.card."),
+      ),
+    );
+    if (!activity.text && !hasFileAttachment) {
       return null;
     }
 
@@ -239,10 +257,10 @@ class MSTeamsProvider implements ChatOpsProvider {
     }
 
     const cleanedText = cleanBotMention(
-      activity.text,
+      activity.text ?? "",
       activity.recipient?.name,
     );
-    if (!cleanedText) {
+    if (!cleanedText && !hasFileAttachment) {
       return null;
     }
 
@@ -273,7 +291,7 @@ class MSTeamsProvider implements ChatOpsProvider {
       senderId: activity.from?.aadObjectId || activity.from?.id || "unknown",
       senderName: activity.from?.name || "Unknown User",
       text: cleanedText,
-      rawText: activity.text,
+      rawText: activity.text ?? "",
       timestamp: activity.timestamp ? new Date(activity.timestamp) : new Date(),
       isThreadReply,
       metadata: {

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -1107,6 +1107,104 @@ describe("SlackProvider file attachment downloads", () => {
     expect(result?.attachments).toBeUndefined();
   });
 
+  test("file-only DM (empty text + files) is parsed with attachments", async () => {
+    const provider = createProviderWithConfig();
+    const fileContent = Buffer.from("file-only dm");
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(fileContent, { status: 200 }),
+    );
+
+    const payload = makeEventPayload(
+      {},
+      {
+        type: "message",
+        channel: "D_FILE_ONLY",
+        channel_type: "im",
+        text: "",
+        files: [
+          {
+            id: "F_DM",
+            name: "report.pdf",
+            mimetype: "application/pdf",
+            size: fileContent.length,
+            url_private: "https://files.slack.com/files-pri/T123/report.pdf",
+          },
+        ],
+      },
+    );
+
+    const result = await provider.parseWebhookNotification(payload, {});
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("");
+    expect(result?.attachments).toHaveLength(1);
+    expect(result?.attachments?.[0].name).toBe("report.pdf");
+  });
+
+  test("file-only app_mention (empty text + files) is parsed with attachments", async () => {
+    const provider = createProviderWithConfig();
+    const fileContent = Buffer.from("file-only mention");
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(fileContent, { status: 200 }),
+    );
+
+    const payload = makeEventPayload(
+      {},
+      {
+        type: "app_mention",
+        text: "<@UBOT123>",
+        files: [
+          {
+            id: "F_MENTION",
+            name: "diagram.png",
+            mimetype: "image/png",
+            size: fileContent.length,
+            url_private: "https://files.slack.com/files-pri/T123/diagram.png",
+          },
+        ],
+      },
+    );
+
+    const result = await provider.parseWebhookNotification(payload, {});
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("");
+    expect(result?.attachments).toHaveLength(1);
+    expect(result?.attachments?.[0].name).toBe("diagram.png");
+  });
+
+  test("file-only UNADDRESSED channel message (no mention, inactive thread) is dropped", async () => {
+    const provider = createProviderWithConfig();
+
+    const payload = makeEventPayload(
+      {},
+      {
+        type: "message",
+        channel: "C_FILE_ONLY_UNADDRESSED",
+        channel_type: "channel",
+        text: "",
+        thread_ts: "7777777777.000001",
+        files: [
+          {
+            id: "F_UNADDRESSED",
+            name: "leak.png",
+            mimetype: "image/png",
+            size: 100,
+            url_private: "https://files.slack.com/files-pri/T123/leak.png",
+          },
+        ],
+      },
+    );
+
+    const result = await provider.parseWebhookNotification(payload, {});
+
+    expect(result).toBeNull();
+    // Dropped before any download is attempted.
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   test("downloads file and returns attachment with base64 content", async () => {
     const provider = createProviderWithConfig();
     const fileContent = Buffer.from("hello image data");

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -1142,6 +1142,36 @@ describe("SlackProvider file attachment downloads", () => {
     expect(result?.attachments?.[0].name).toBe("report.pdf");
   });
 
+  test("file-only DM whose download fails is dropped (no empty turn)", async () => {
+    const provider = createProviderWithConfig();
+
+    // The download fails (e.g. expired/oversized), so no attachment survives.
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    const payload = makeEventPayload(
+      {},
+      {
+        type: "message",
+        channel: "D_FILE_ONLY",
+        channel_type: "im",
+        text: "",
+        files: [
+          {
+            id: "F_DM",
+            name: "report.pdf",
+            mimetype: "application/pdf",
+            size: 1234,
+            url_private: "https://files.slack.com/files-pri/T123/report.pdf",
+          },
+        ],
+      },
+    );
+
+    const result = await provider.parseWebhookNotification(payload, {});
+
+    expect(result).toBeNull();
+  });
+
   test("file-only app_mention (empty text + files) is parsed with attachments", async () => {
     const provider = createProviderWithConfig();
     const fileContent = Buffer.from("file-only mention");

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -302,17 +302,20 @@ class SlackProvider implements ChatOpsProvider {
     }
 
     const cleanedText = this.cleanBotMention(text);
-    // A file-only message (empty text but with attachments) is still meaningful
-    // — let it through in the same addressed contexts a text message would
-    // (DMs, or active/mentioned channel threads, already gated above). Only
-    // genuinely empty, attachment-less messages are dropped here.
-    const hasFiles = Boolean(event.files?.length);
-    if (!cleanedText && event.type !== "app_mention" && !hasFiles) {
+
+    // Download file attachments first (we're already in an addressed context —
+    // DM, mention, or active thread — gated above). A file-only message (empty
+    // text) is kept only when a file actually survived download: oversized,
+    // expired, or failed downloads must not leave the bot answering an empty
+    // turn. Genuinely empty, attachment-less messages are dropped here.
+    const attachments = await this.downloadSlackFiles(event.files);
+    if (
+      !cleanedText &&
+      event.type !== "app_mention" &&
+      attachments.length === 0
+    ) {
       return null;
     }
-
-    // Download file attachments if present
-    const attachments = await this.downloadSlackFiles(event.files);
 
     // Resolve display names in one LRU-cached batch: the sender (so prompts
     // say "ildar", not "U0966V5MTM4"), the bot itself (so the agent

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -302,7 +302,12 @@ class SlackProvider implements ChatOpsProvider {
     }
 
     const cleanedText = this.cleanBotMention(text);
-    if (!cleanedText && event.type !== "app_mention") {
+    // A file-only message (empty text but with attachments) is still meaningful
+    // — let it through in the same addressed contexts a text message would
+    // (DMs, or active/mentioned channel threads, already gated above). Only
+    // genuinely empty, attachment-less messages are dropped here.
+    const hasFiles = Boolean(event.files?.length);
+    if (!cleanedText && event.type !== "app_mention" && !hasFiles) {
       return null;
     }
 


### PR DESCRIPTION
## Problem

Agents could not see file attachments sent from chatops (Slack/MS Teams) messages. The A2A attachment builder only ever forwarded `image/*` content to the model — a long-standing design limitation (present since the original email-attachment feature, not a regression). On the chatops path even the "could not be processed" note was discarded, so the agent received the user's text and nothing else.

## Fix

Reuses the regular chat upload pipeline so attachments are delivered to the model exactly the way chat delivers uploads.

- **`a2a-executor.ts`** — the executor now owns the current user turn and builds it model-aware: images are always kept (subject to the tiny-broken-image filter); non-image files (PDF, CSV, JSON, Markdown, text) are kept when the target model can read them (`getModelReadableMimeTypes`) and normalized per provider via `prepareMessagesForProvider`; types the model cannot read are named in a model-visible note. The model-row lookup is non-fatal (falls back to the default readable set).
- **`a2a/a2a-manager.ts` + `a2a/a2a-helper.ts`** — prior context is passed as `messages`; the current turn's text/files travel via `message`/`attachments`, so the executor appends exactly one current turn. `buildAttachmentsMessageParts` is now a pure `A2AAttachment → protocol-part` map preserving filenames.
- **Slack/Teams providers** — messages whose only content is a file (empty text) are processed, **gated on successfully downloaded attachments** so failed/oversized/expired downloads don't trigger an empty reply. Teams ignores Adaptive/hero cards (they are not files).
- **`chatops-manager.ts`** — non-image files from earlier in a thread are replayed as context (existing size budget unchanged).
- **docs** — Slack/Teams/email attachment sections updated.

This change unifies the chatops, email, and A2A v2 attachment paths onto one model-aware builder.

## Validation

- `pnpm type-check`, `biome check`, `pnpm knip` clean.
- 215 tests across the affected suites pass (a2a-executor, a2a-helper, chatops providers + manager), including new behavior tests for: PDF/text kept when readable, unreadable types noted, `image/jpg` preserved, exactly-one current turn, file-only messages, failed-download drop, and non-image history replay.

## Known follow-ups (out of scope here)

- External A2A v2 protocol clients can send raw file parts with no per-file size cap (pre-existing; the chatops path itself is size-gated).
- Chatops/email attachments reach the model inline but are not staged into the skill sandbox for tool access (separate feature; chatops has no default-sandbox in this path).

https://claude.ai/code/session_01MAGQSHtQM6gjx7Zdn2mukA

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>