### PR TITLE
docs: enable ARCHESTRA_BETA in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ docker pull archestra/platform:latest
 docker run \
   -p 127.0.0.1:9000:9000 -p 127.0.0.1:3000:3000 \
   -e ARCHESTRA_QUICKSTART=true \
+  -e ARCHESTRA_BETA=true \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v archestra-postgres-data:/var/lib/postgresql/data \
   -v archestra-app-data:/app/data \


### PR DESCRIPTION
Adds `-e ARCHESTRA_BETA=true` to the README quickstart command so beta is on by default.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>