### PR TITLE
fix(llm-logs): stop showing negative cost and >100% savings

### DIFF
--- a/platform/frontend/src/app/llm/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/[id]/page.client.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  type archestraApiTypes,
-  calculateCostSavings,
-  DynamicInteraction,
-} from "@archestra/shared";
+import { type archestraApiTypes, DynamicInteraction } from "@archestra/shared";
 import { ArrowLeft, Database, Layers } from "lucide-react";
 import Link from "next/link";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
@@ -156,29 +152,24 @@ function LogDetail({
             <MetadataItem label="Cost">
               <div className="font-mono">
                 {dynamicInteraction.cost ? (
-                  (() => {
-                    const savings = calculateCostSavings(dynamicInteraction);
-                    const effectiveCost = dynamicInteraction.cost;
-                    const effectiveBaselineCost =
-                      dynamicInteraction.baselineCost ||
-                      dynamicInteraction.cost;
-                    return (
-                      <TooltipProvider>
-                        <Savings
-                          cost={effectiveCost}
-                          baselineCost={effectiveBaselineCost}
-                          toonCostSavings={dynamicInteraction.toonCostSavings}
-                          toonTokensSaved={savings.toonTokensSaved}
-                          toonSkipReason={dynamicInteraction.toonSkipReason}
-                          format="percent"
-                          tooltip="always"
-                          variant="interaction"
-                          baselineModel={dynamicInteraction.baselineModel}
-                          actualModel={dynamicInteraction.model}
-                        />
-                      </TooltipProvider>
-                    );
-                  })()
+                  <TooltipProvider>
+                    <Savings
+                      cost={dynamicInteraction.cost}
+                      baselineCost={
+                        dynamicInteraction.baselineCost ||
+                        dynamicInteraction.cost
+                      }
+                      toonCostSavings={dynamicInteraction.toonCostSavings}
+                      toonTokensBefore={dynamicInteraction.toonTokensBefore}
+                      toonTokensAfter={dynamicInteraction.toonTokensAfter}
+                      toonSkipReason={dynamicInteraction.toonSkipReason}
+                      format="percent"
+                      tooltip="always"
+                      variant="interaction"
+                      baselineModel={dynamicInteraction.baselineModel}
+                      actualModel={dynamicInteraction.model}
+                    />
+                  </TooltipProvider>
                 ) : (
                   <span className="text-muted-foreground">—</span>
                 )}

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  calculateCostSavings,
-  DynamicInteraction,
-  getSessionClientLabel,
-} from "@archestra/shared";
+import { DynamicInteraction, getSessionClientLabel } from "@archestra/shared";
 import { ArrowLeft, Bot, Layers, Loader2, User } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -373,29 +369,23 @@ export default function SessionDetailPage({
                       </Badge>
                     </TableCell>
                     <TableCell className="font-mono text-xs">
-                      {(() => {
-                        const savings = calculateCostSavings(interaction);
-                        return (
-                          <TooltipProvider>
-                            <Savings
-                              cost={interaction.cost || "0"}
-                              baselineCost={
-                                interaction.baselineCost ||
-                                interaction.cost ||
-                                "0"
-                              }
-                              toonCostSavings={interaction.toonCostSavings}
-                              toonTokensSaved={savings.toonTokensSaved}
-                              toonSkipReason={interaction.toonSkipReason}
-                              format="percent"
-                              tooltip="hover"
-                              variant="interaction"
-                              baselineModel={interaction.baselineModel}
-                              actualModel={interaction.model}
-                            />
-                          </TooltipProvider>
-                        );
-                      })()}
+                      <TooltipProvider>
+                        <Savings
+                          cost={interaction.cost || "0"}
+                          baselineCost={
+                            interaction.baselineCost || interaction.cost || "0"
+                          }
+                          toonCostSavings={interaction.toonCostSavings}
+                          toonTokensBefore={interaction.toonTokensBefore}
+                          toonTokensAfter={interaction.toonTokensAfter}
+                          toonSkipReason={interaction.toonSkipReason}
+                          format="percent"
+                          tooltip="hover"
+                          variant="interaction"
+                          baselineModel={interaction.baselineModel}
+                          actualModel={interaction.model}
+                        />
+                      </TooltipProvider>
                     </TableCell>
                     <TableCell className="text-xs overflow-hidden">
                       <TruncatedText

--- a/platform/frontend/src/components/savings.tsx
+++ b/platform/frontend/src/components/savings.tsx
@@ -1,4 +1,7 @@
-import type { archestraApiTypes } from "@archestra/shared";
+import {
+  type archestraApiTypes,
+  calculateCostSavings,
+} from "@archestra/shared";
 import {
   Tooltip,
   TooltipContent,
@@ -10,7 +13,8 @@ export function Savings({
   cost,
   baselineCost,
   toonCostSavings,
-  toonTokensSaved,
+  toonTokensBefore,
+  toonTokensAfter,
   toonSkipReason,
   format = "percent",
   tooltip = "never",
@@ -22,7 +26,8 @@ export function Savings({
   cost: string;
   baselineCost: string;
   toonCostSavings?: string | null;
-  toonTokensSaved?: number | null;
+  toonTokensBefore?: number | null;
+  toonTokensAfter?: number | null;
   toonSkipReason?:
     | archestraApiTypes.GetInteractionResponses["200"]["toonSkipReason"]
     | null;
@@ -35,23 +40,22 @@ export function Savings({
   /** The actual model used after cost optimization */
   actualModel?: string | null;
 }) {
-  const costNum = Number.parseFloat(cost);
-  const baselineCostNum = Number.parseFloat(baselineCost);
-  const toonCostSavingsNum = toonCostSavings
-    ? Number.parseFloat(toonCostSavings)
-    : 0;
+  const {
+    costOptimizationSavings,
+    toonSavings: toonCostSavingsNum,
+    toonTokensSaved,
+    totalSavings,
+    estimatedCost,
+    actualCost,
+    savingsPercent: savingsPercentNum,
+  } = calculateCostSavings({
+    cost,
+    baselineCost,
+    toonCostSavings,
+    toonTokensBefore,
+    toonTokensAfter,
+  });
 
-  // Calculate cost optimization savings (from model selection)
-  const costOptimizationSavings = baselineCostNum - costNum;
-
-  // Calculate total savings (cost optimization + TOON compression)
-  const totalSavings = costOptimizationSavings + toonCostSavingsNum;
-
-  // Calculate actual cost after all savings
-  const actualCost = baselineCostNum - totalSavings;
-
-  const savingsPercentNum =
-    baselineCostNum > 0 ? (totalSavings / baselineCostNum) * 100 : 0;
   const savingsPercent =
     savingsPercentNum % 1 === 0
       ? savingsPercentNum.toFixed(0)
@@ -92,7 +96,7 @@ export function Savings({
             <div className="space-y-0.5">
               {totalSavings > 0 ? (
                 <>
-                  <div>Estimated Cost: {formatCost(baselineCostNum)}</div>
+                  <div>Estimated Cost: {formatCost(estimatedCost)}</div>
                   <div>Actual Cost: {formatCost(actualCost)}</div>
                   <div className="font-semibold">
                     Savings: {formatCost(totalSavings)}

--- a/platform/shared/interactions/interaction.utils.test.ts
+++ b/platform/shared/interactions/interaction.utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import { calculateCostSavings } from "./interaction.utils";
+
+describe("calculateCostSavings", () => {
+  test("treats the stored cost as the actual cost and never double-counts TOON savings", () => {
+    // Regression: previously `actualCost` was derived as
+    // `baselineCost - totalSavings`, which simplifies to `cost - toonCostSavings`.
+    // When TOON savings exceeded the (already TOON-reduced) cost this produced a
+    // negative actual cost and a savings percentage well above 100%.
+    const result = calculateCostSavings({
+      cost: "0.05",
+      baselineCost: "0.3926",
+      toonCostSavings: "1.8",
+      toonTokensBefore: 10_000,
+      toonTokensAfter: 1_000,
+    });
+
+    // Actual cost is exactly the stored spend — never negative.
+    expect(result.actualCost).toBeCloseTo(0.05, 10);
+    // Model optimization savings = baselineCost - cost.
+    expect(result.costOptimizationSavings).toBeCloseTo(0.3426, 10);
+    // Total savings = model optimization + TOON compression.
+    expect(result.totalSavings).toBeCloseTo(0.3426 + 1.8, 10);
+    // Estimated cost sits exactly totalSavings above the actual spend.
+    expect(result.estimatedCost).toBeCloseTo(0.05 + 0.3426 + 1.8, 10);
+    // Percentage is bounded to 0–100 for non-negative savings.
+    expect(result.savingsPercent).toBeGreaterThan(0);
+    expect(result.savingsPercent).toBeLessThan(100);
+    expect(result.toonTokensSaved).toBe(9_000);
+    expect(result.hasSavings).toBe(true);
+  });
+
+  test("reports no savings when there is no optimization or compression", () => {
+    const result = calculateCostSavings({
+      cost: "0.25",
+      baselineCost: "0.25",
+      toonCostSavings: "0",
+      toonTokensBefore: null,
+      toonTokensAfter: null,
+    });
+
+    expect(result.actualCost).toBeCloseTo(0.25, 10);
+    expect(result.estimatedCost).toBeCloseTo(0.25, 10);
+    expect(result.totalSavings).toBeCloseTo(0, 10);
+    expect(result.savingsPercent).toBe(0);
+    expect(result.toonTokensSaved).toBeNull();
+    expect(result.hasSavings).toBe(false);
+  });
+
+  test("handles only model-optimization savings (no TOON)", () => {
+    const result = calculateCostSavings({
+      cost: "0.10",
+      baselineCost: "0.40",
+      toonCostSavings: null,
+      toonTokensBefore: null,
+      toonTokensAfter: null,
+    });
+
+    expect(result.actualCost).toBeCloseTo(0.1, 10);
+    expect(result.costOptimizationSavings).toBeCloseTo(0.3, 10);
+    expect(result.totalSavings).toBeCloseTo(0.3, 10);
+    expect(result.estimatedCost).toBeCloseTo(0.4, 10);
+    // 0.3 / 0.4 = 75%
+    expect(result.savingsPercent).toBeCloseTo(75, 10);
+  });
+
+  test("guards against a zero estimated cost", () => {
+    const result = calculateCostSavings({
+      cost: null,
+      baselineCost: null,
+      toonCostSavings: null,
+      toonTokensBefore: null,
+      toonTokensAfter: null,
+    });
+
+    expect(result.actualCost).toBe(0);
+    expect(result.estimatedCost).toBe(0);
+    expect(result.savingsPercent).toBe(0);
+  });
+});

--- a/platform/shared/interactions/interaction.utils.ts
+++ b/platform/shared/interactions/interaction.utils.ts
@@ -73,11 +73,15 @@ export interface CostSavingsResult {
   toonTokensSaved: number | null;
   /** Total savings (costOptimization + toon) */
   totalSavings: number;
-  /** Baseline cost before any optimization */
-  baselineCost: number;
-  /** Actual cost after optimization */
+  /**
+   * Estimated cost: what the request would have cost without the optimizations
+   * we attribute (original model + uncompressed tool results). Equals
+   * `actualCost + totalSavings`.
+   */
+  estimatedCost: number;
+  /** Actual cost charged — the stored `cost`, already reflecting every optimization */
   actualCost: number;
-  /** Total savings as percentage of baseline */
+  /** Total savings as a percentage of the estimated cost (0–100) */
   savingsPercent: number;
   /** Whether there are any savings at all */
   hasSavings: boolean;
@@ -106,23 +110,35 @@ export function calculateCostSavings(
       ? input.toonTokensBefore - input.toonTokensAfter
       : null;
 
-  // Calculate cost optimization savings (from model selection)
+  // `cost` is the real spend. It already reflects every applied optimization
+  // (the cheaper model and TOON's reduced billed token count), so it is the
+  // true actual cost. It must never be re-derived by subtracting savings again
+  // — doing so double-counts the TOON savings already baked into `cost` and can
+  // produce a negative cost and a >100% savings percentage.
+  const actualCost = costNum;
+
+  // Savings from model selection: identical token usage priced at the original
+  // model vs. the model actually used.
   const costOptimizationSavings = baselineCostNum - costNum;
 
-  // Calculate total savings
+  // Total savings (model optimization + TOON compression).
   const totalSavings = costOptimizationSavings + toonCostSavingsNum;
 
-  // Calculate savings percentage
+  // The estimated (non-optimized) cost sits exactly `totalSavings` above the
+  // real spend, so the breakdown always reconciles and the percentage stays
+  // within 0–100% for any non-negative savings.
+  const estimatedCost = actualCost + totalSavings;
+
   const savingsPercent =
-    baselineCostNum > 0 ? (totalSavings / baselineCostNum) * 100 : 0;
+    estimatedCost > 0 ? (totalSavings / estimatedCost) * 100 : 0;
 
   return {
     costOptimizationSavings,
     toonSavings: toonCostSavingsNum,
     toonTokensSaved,
     totalSavings,
-    baselineCost: baselineCostNum,
-    actualCost: baselineCostNum - totalSavings,
+    estimatedCost,
+    actualCost,
     savingsPercent,
     hasSavings: totalSavings !== 0,
   };


### PR DESCRIPTION
## Problem

On `/llm/logs`, `/llm/logs/session/:id`, and `/llm/logs/:id` the cost column/tooltip sometimes showed a **negative actual cost** and a **savings percentage above 100%** (e.g. `Actual Cost: $-1.74`, `Savings: $2.1304 (-542.6%)`).

## Root cause

It was a frontend rendering/calculation bug, not bad backend data.

Both the `Savings` component and the shared `calculateCostSavings` util derived the actual cost as:

```
actualCost = baselineCost - totalSavings   // == cost - toonCostSavings
```

But the stored `cost` is the real spend and **already** reflects TOON's reduced billed token count. Subtracting `toonCostSavings` from it again double-counted those savings, so whenever TOON savings exceeded the (already TOON-reduced) cost, the actual cost went negative and the percentage (computed against `baselineCost`) blew past 100%.

The cost **statistics** page was already fixed with this exact reasoning (`backend/src/models/statistics.ts`) — these per-interaction views had simply not been updated.

## Fix

- `calculateCostSavings` (shared util) now treats the stored `cost` as the authoritative actual cost, derives `estimatedCost = actualCost + totalSavings`, and computes the percentage against `estimatedCost` (naturally bounded 0–100% for non-negative savings).
- The `Savings` component now **consumes** `calculateCostSavings` instead of re-implementing the same math inline.
- The detail and session pages no longer call `calculateCostSavings` separately just to pull `toonTokensSaved` — they pass the raw `toonTokensBefore`/`toonTokensAfter` to `<Savings>`, which computes everything once. This removes the duplicated cost/savings math across the three pages (single source of truth in `shared/interactions/interaction.utils.ts`).