### PR TITLE
fix(chatops): guard Slack sends against msg_too_large

### DIFF
--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -892,6 +892,169 @@ describe("SlackProvider.sendReply", () => {
     // Subsequent posts thread under the first message's ts.
     expect(secondArgs.thread_ts).toBe("2000.000001");
   });
+
+  test("truncates the text fallback for large replies to avoid msg_too_large", async () => {
+    const provider = createProvider();
+    const postMessage = vi.fn().mockResolvedValue({ ts: "3333333333.000000" });
+    // biome-ignore lint/suspicious/noExplicitAny: test-only — mock Slack client
+    (provider as any).client = { chat: { postMessage } };
+
+    // 8,000 chars in a single paragraph → one chunk (under the 12k block cap),
+    // so the rendered markdown block carries the full text but the notification
+    // `text` fallback must be bounded.
+    const text = "A ".repeat(4000);
+    expect(text.length).toBe(8000);
+
+    await provider.sendReply({
+      originalMessage: {
+        messageId: "9999999999.000000",
+        channelId: "C12345",
+        workspaceId: "T12345",
+        threadId: "1111111111.000000",
+        senderId: "U_SENDER",
+        senderName: "Test User",
+        text: "long single paragraph",
+        rawText: "long single paragraph",
+        timestamp: new Date(),
+        isThreadReply: false,
+      },
+      text,
+    });
+
+    const args = postMessage.mock.calls[0][0];
+    // Fallback text is bounded well below Slack's text-length limit.
+    expect(args.text.length).toBeLessThanOrEqual(3000);
+    // Rendered content (the markdown block) is NOT truncated.
+    expect(args.blocks[0].text).toBe(text);
+  });
+});
+
+// =============================================================================
+// addApprovalRequestForm
+// =============================================================================
+
+describe("SlackProvider.addApprovalRequestForm", () => {
+  test("embeds only a slimmed-down original message in the button value (msg_too_large guard)", async () => {
+    const provider = createProvider();
+    const postMessage = vi.fn().mockResolvedValue({ ts: "4444444444.000000" });
+    // biome-ignore lint/suspicious/noExplicitAny: test-only — mock Slack client
+    (provider as any).client = { chat: { postMessage } };
+
+    await provider.addApprovalRequestForm({
+      channelId: "C1",
+      threadId: "T1",
+      approvalId: "appr-1",
+      taskId: "task-1",
+      toolName: "dangerous_tool",
+      originalMessage: {
+        messageId: "1234567890.123456",
+        channelId: "C1",
+        workspaceId: "W1",
+        threadId: "T1",
+        senderId: "U_SENDER",
+        senderEmail: "user@example.com",
+        senderName: "Test User",
+        text: "x".repeat(100_000),
+        rawText: "x".repeat(100_000),
+        timestamp: new Date(),
+        isThreadReply: false,
+      },
+    });
+
+    const callArgs = postMessage.mock.calls[0][0];
+    const actionsBlock = callArgs.blocks.find(
+      (b: { type: string }) => b.type === "actions",
+    );
+    expect(actionsBlock).toBeDefined();
+    expect(actionsBlock.elements.length).toBeGreaterThan(0);
+
+    for (const btn of actionsBlock.elements) {
+      const parsed = JSON.parse(btn.value);
+      expect(parsed.originalMessage.text).toBeUndefined();
+      expect(parsed.originalMessage.rawText).toBeUndefined();
+      expect(parsed.originalMessage.attachments).toBeUndefined();
+      expect(parsed.originalMessage.senderEmail).toBe("user@example.com");
+      expect(parsed.originalMessage.channelId).toBe("C1");
+      expect(parsed.originalMessage.threadId).toBe("T1");
+      expect(btn.value.length).toBeLessThan(2000);
+    }
+  });
+});
+
+// =============================================================================
+// parseApprovalPayload
+// =============================================================================
+
+describe("SlackProvider.parseApprovalPayload", () => {
+  test("reconstructs the original message from a slimmed button value, preserving sender email", () => {
+    const provider = createProvider();
+
+    const value = JSON.stringify({
+      taskId: "task-1",
+      approvalId: "appr-1",
+      toolName: "dangerous_tool",
+      approved: true,
+      originalMessage: {
+        channelId: "C1",
+        threadId: "T1",
+        senderEmail: "user@example.com",
+      },
+    });
+
+    const decision = provider.parseApprovalPayload({
+      type: "block_actions",
+      actions: [{ action_id: "approval_decision_appr-1_approve", value }],
+      channel: { id: "C1" },
+      team: { id: "W1" },
+      user: { id: "U2", name: "Approver" },
+      message: { ts: "9.9", thread_ts: "T1" },
+      response_url: "https://hooks.slack.test/x",
+    });
+
+    expect(decision).not.toBeNull();
+    expect(decision?.originalMessage.senderEmail).toBe("user@example.com");
+    expect(decision?.originalMessage.channelId).toBe("C1");
+    expect(decision?.originalMessage.threadId).toBe("T1");
+    expect(decision?.approved).toBe(true);
+    expect(decision?.taskId).toBe("task-1");
+  });
+
+  test("still parses a legacy full-message button value", () => {
+    const provider = createProvider();
+
+    const value = JSON.stringify({
+      taskId: "task-1",
+      approvalId: "appr-1",
+      toolName: "dangerous_tool",
+      approved: true,
+      originalMessage: {
+        messageId: "1234567890.123456",
+        channelId: "C1",
+        workspaceId: "W1",
+        threadId: "T1",
+        senderId: "U_SENDER",
+        senderEmail: "legacy@example.com",
+        senderName: "Legacy User",
+        text: "do the thing",
+        rawText: "do the thing",
+        timestamp: new Date(),
+        isThreadReply: false,
+      },
+    });
+
+    const decision = provider.parseApprovalPayload({
+      type: "block_actions",
+      actions: [{ action_id: "approval_decision_appr-1_approve", value }],
+      channel: { id: "C1" },
+      team: { id: "W1" },
+      user: { id: "U2", name: "Approver" },
+      message: { ts: "9.9", thread_ts: "T1" },
+      response_url: "https://hooks.slack.test/x",
+    });
+
+    expect(decision).not.toBeNull();
+    expect(decision?.originalMessage.senderEmail).toBe("legacy@example.com");
+  });
 });
 
 // =============================================================================

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -415,10 +415,11 @@ class SlackProvider implements ChatOpsProvider {
         });
       }
 
-      const fallbackText =
+      const fallbackText = truncateFallbackText(
         isFinal && options.footer
           ? `${chunkText}\n\n${options.footer}`
-          : chunkText;
+          : chunkText,
+      );
 
       // Follow-ups thread under the first message when the original wasn't a
       // thread, so we don't spam the channel with N top-level posts.
@@ -468,11 +469,21 @@ class SlackProvider implements ChatOpsProvider {
           emoji: true,
         },
         action_id: `approval_decision_${options.approvalId}_${action}`,
+        // Slack caps a button `value` at 2,000 chars and rejects oversized
+        // chat.postMessage payloads with `msg_too_large`. Embedding the full
+        // original message (text, rawText, base64 attachments, metadata) here
+        // scales with user input and blew past that limit. The approve/decline
+        // click path only needs the requester's email (authz check, not
+        // recoverable from the click payload) plus channel/thread for replies.
         value: JSON.stringify({
           taskId: options.taskId,
           approvalId: options.approvalId,
           toolName: options.toolName,
-          originalMessage: options.originalMessage,
+          originalMessage: {
+            channelId: options.originalMessage.channelId,
+            threadId: options.originalMessage.threadId,
+            senderEmail: options.originalMessage.senderEmail,
+          },
           approved,
         }),
         style,
@@ -902,7 +913,7 @@ class SlackProvider implements ChatOpsProvider {
       approvalId?: string;
       approved?: boolean;
       toolName?: string;
-      originalMessage: IncomingChatMessage;
+      originalMessage?: Partial<IncomingChatMessage>;
     };
     try {
       parsedValue = JSON.parse(action.value) as {
@@ -910,7 +921,7 @@ class SlackProvider implements ChatOpsProvider {
         approvalId?: string;
         approved?: boolean;
         toolName?: string;
-        originalMessage: IncomingChatMessage;
+        originalMessage?: Partial<IncomingChatMessage>;
       };
     } catch {
       return null;
@@ -930,6 +941,28 @@ class SlackProvider implements ChatOpsProvider {
       return null;
     }
 
+    // The button value now carries only a slimmed-down original message (see
+    // addApprovalRequestForm). Reconstruct a complete IncomingChatMessage,
+    // falling back to the live interactive payload for ids and to safe defaults
+    // for fields the click path doesn't read. Older in-flight buttons that
+    // still carry a full message keep working unchanged.
+    const embedded = parsedValue.originalMessage;
+    const originalMessage: IncomingChatMessage = {
+      messageId: embedded.messageId ?? "",
+      channelId: embedded.channelId ?? p.channel?.id ?? "",
+      workspaceId: embedded.workspaceId ?? p.team?.id ?? null,
+      threadId: embedded.threadId ?? p.message?.thread_ts ?? p.message?.ts,
+      senderId: embedded.senderId ?? "",
+      senderEmail: embedded.senderEmail,
+      senderName: embedded.senderName ?? "",
+      text: embedded.text ?? "",
+      rawText: embedded.rawText ?? "",
+      timestamp: new Date(),
+      isThreadReply: embedded.isThreadReply ?? false,
+      metadata: embedded.metadata,
+      attachments: embedded.attachments,
+    };
+
     return {
       taskId: parsedValue.taskId,
       approvalId: parsedValue.approvalId,
@@ -942,7 +975,7 @@ class SlackProvider implements ChatOpsProvider {
       userId: p.user?.id || "unknown",
       userName: p.user?.name || "Unknown",
       responseUrl: p.response_url || "",
-      originalMessage: parsedValue.originalMessage,
+      originalMessage,
     };
   }
 
@@ -1782,6 +1815,17 @@ function decodeSlackEntities(text: string): string {
 
 // Slack's `markdown` block has a 12,000-char limit per block.
 const MARKDOWN_BLOCK_CHAR_LIMIT = 12_000;
+
+// Slack's chat.postMessage `text` is only a notification/accessibility fallback
+// — the rendered reply lives in `blocks`. Slack rejects oversized payloads with
+// `msg_too_large`, so cap the fallback well below Slack's ~40,000-char text
+// limit instead of duplicating the full (already block-rendered) chunk into it.
+const SLACK_FALLBACK_TEXT_LIMIT = 3_000;
+
+function truncateFallbackText(text: string): string {
+  if (text.length <= SLACK_FALLBACK_TEXT_LIMIT) return text;
+  return `${text.slice(0, SLACK_FALLBACK_TEXT_LIMIT - 1)}…`;
+}
 
 // Slack rejects chat.postMessage with more than 50 expanded blocks. Each
 // sendReply message reserves 1 slot for a context footer (continuation hint


### PR DESCRIPTION
## Problem

Slack bot replies could fail with `An API error occurred: msg_too_large`, shown to the user as a generic "Sorry, I encountered an error processing your request." (the Slack error code is surfaced as the footer).

`msg_too_large` is a genuine Slack API rejection. The trigger is the **approval flow**: after posting the "Approval required…" message, the bot calls `addApprovalRequestForm`, which serialized the **entire `originalMessage` into the Block Kit button `value`** — including `attachments[].contentBase64` (raw base64 file content), full `text`/`rawText`, and `metadata`. Slack caps a button `value` at 2,000 chars and rejects oversized payloads with `msg_too_large`, so any approval triggered by a message with an attachment or large body failed.

## Fix

- **Slim the approval button value** to only the fields the approve/decline click path actually reads — `channelId`, `threadId`, `senderEmail` — instead of the whole message. This drops the base64 attachment content that scaled with user input.
- **`parseApprovalPayload` reconstructs** a full `IncomingChatMessage` from the slim value, falling back to the live interactive payload for ids and to safe defaults for unused fields. Legacy full-message buttons (in-flight approvals) still parse unchanged.
- **Cap the `chat.postMessage` `text` fallback** at 3,000 chars — it's only a notification/accessibility fallback (the rendered reply lives in `blocks`), so there's no reason to duplicate the full chunk and risk the text-length limit.

This is safe because after approval only routing/authz fields are used; the agent continuation re-sends the approval decision to the A2A task, which already holds conversation state.