### PR TITLE
fix: stop advertising the sandbox when it is unavailable for an agent

### DIFF
--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -184,7 +184,7 @@ exports[`skill and sandbox tool text > archestra__list_skills 1`] = `
 
 exports[`skill and sandbox tool text > archestra__load_skill 1`] = `
 {
-  "description": "Load a specialized Agent Skill — a reusable SKILL.md instruction set. Call list_skills first to discover what is available. Call load_skill with just a name to load the skill's instructions and its bundled-file list; load it before attempting the task it covers. Call it with a name and a path from that list to read one bundled file. To run a bundled script, use run_command (loaded skills are available under /skills).",
+  "description": "Load a specialized Agent Skill — a reusable SKILL.md instruction set. Call list_skills first to discover what is available. Call load_skill with just a name to load the skill's instructions and its bundled-file list; load it before attempting the task it covers. Call it with a name and a path from that list to read one bundled file.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {

--- a/platform/backend/src/archestra-mcp-server/skills.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.ts
@@ -159,8 +159,7 @@ const registry = defineArchestraTools([
       "Call list_skills first to discover what is available. Call load_skill " +
       "with just a name to load the skill's instructions and its bundled-file " +
       "list; load it before attempting the task it covers. Call it with a name " +
-      "and a path from that list to read one bundled file. To run a bundled " +
-      "script, use run_command (loaded skills are available under /skills).",
+      "and a path from that list to read one bundled file.",
     schema: LoadSkillSchema,
     async handler({ args, context }) {
       const ctx = requireOrgContext(context);

--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -689,6 +689,11 @@ async function tryCreateInContextCompaction(params: {
       params.provider,
       params.selectedModel,
     ).catch(() => null);
+    // Gate the sandbox pointers on the chat agent's availability, not the
+    // compaction model's tools: the summary feeds the main turn, whose agent
+    // can run the sandbox, so a faithful summary must reflect that the file is
+    // reachable there. When the agent can't use the sandbox, the pointer is
+    // suppressed just like on the main path.
     const sandboxAvailable = await isSkillSandboxAvailableForAgent({
       userId: params.userId,
       organizationId: params.organizationId,

--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -23,6 +23,7 @@ import {
   ATTR_GENAI_PROVIDER_NAME,
   ATTR_GENAI_REQUEST_MODEL,
 } from "@/observability/tracing";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import { renderSystemPrompt } from "@/templating";
 import { getTokenizer } from "@/tokenizers";
 import type { ChatMessage, ChatMessagePart } from "@/types";
@@ -688,13 +689,23 @@ async function tryCreateInContextCompaction(params: {
       params.provider,
       params.selectedModel,
     ).catch(() => null);
-    const materializedCompactable = await materializeAttachments(
-      params.compactableMessages,
-      params.conversationId,
-      getModelReadableMimeTypes(compactionModelRow?.inputModalities ?? null),
-      params.provider !== "anthropic" || anthropicNativeEndpoint,
-      params.provider === "anthropic" && !anthropicNativeEndpoint,
-    );
+    const sandboxAvailable = await isSkillSandboxAvailableForAgent({
+      userId: params.userId,
+      organizationId: params.organizationId,
+      agentId: params.agentId ?? undefined,
+    });
+    const materializedCompactable = await materializeAttachments({
+      messages: params.compactableMessages,
+      conversationId: params.conversationId,
+      ingestibleMimeTypes: getModelReadableMimeTypes(
+        compactionModelRow?.inputModalities ?? null,
+      ),
+      applyAnthropicCacheControl:
+        params.provider !== "anthropic" || anthropicNativeEndpoint,
+      rerouteBinaryDocsToSandbox:
+        params.provider === "anthropic" && !anthropicNativeEndpoint,
+      sandboxAvailable,
+    });
     const compactionMessages = buildInContextCompactionMessages({
       previousSummary: params.previousSummary,
       messages: materializedCompactable,

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
@@ -70,7 +70,10 @@ test("rehydrates ref to inline data: URL and adds Anthropic cache_control", asyn
     },
   ];
 
-  const output = await materializeAttachments(inputMessages, conversation.id);
+  const output = await materializeAttachments({
+    messages: inputMessages,
+    conversationId: conversation.id,
+  });
 
   const filePart = expectPresent(output[0].parts?.[1]);
   expect(filePart.type).toBe("file");
@@ -105,10 +108,10 @@ test("legacy inline data: URL file parts keep the url but get Anthropic cache_co
     },
   ];
 
-  const output = await materializeAttachments(
-    input,
-    "00000000-0000-4000-8000-000000000000",
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: "00000000-0000-4000-8000-000000000000",
+  });
   const filePart = expectPresent(output[0].parts?.[0]);
   // URL is preserved verbatim — we don't rewrite or re-encode the bytes.
   expect(filePart.url).toBe(dataUrl);
@@ -137,10 +140,10 @@ test("preserves existing providerMetadata on data: URL file parts when adding ca
       ],
     },
   ];
-  const output = await materializeAttachments(
-    input,
-    "00000000-0000-4000-8000-000000000000",
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: "00000000-0000-4000-8000-000000000000",
+  });
   const filePart = expectPresent(output[0].parts?.[0]);
   expect(filePart.providerMetadata).toMatchObject({
     openai: { detail: "high" },
@@ -163,10 +166,10 @@ test("missing or malformed refs do not crash and leave the part as-is", async ()
     },
   ];
 
-  const output = await materializeAttachments(
+  const output = await materializeAttachments({
     messages,
-    "00000000-0000-4000-8000-000000000000",
-  );
+    conversationId: "00000000-0000-4000-8000-000000000000",
+  });
   expect(expectPresent(output[0].parts?.[0]).url).toBe(
     "/api/chat/attachments/00000000-0000-4000-8000-000000000000/content",
   );
@@ -210,7 +213,10 @@ test("refs scoped to a DIFFERENT conversation are silently ignored", async ({
   ];
 
   // Request claims to be in requestConvo but references otherConvo's attachment.
-  const output = await materializeAttachments(input, requestConvo.id);
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: requestConvo.id,
+  });
   // Ref URL stays as-is — the bytes did NOT leak into the LLM call payload.
   const outputPart = expectPresent(output[0].parts?.[0]);
   expect(outputPart.url).toBe(`/api/chat/attachments/${row.id}/content`);
@@ -254,7 +260,10 @@ test("batch-loads multiple refs in a single message", async ({
     },
   ];
 
-  const output = await materializeAttachments(input, conversation.id);
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+  });
   for (let i = 0; i < ids.length; i++) {
     expect(expectPresent(output[0].parts?.[i]).url).toBe(
       `data:text/plain;base64,${Buffer.from(`f${i}`, "utf8").toString("base64")}`,
@@ -298,11 +307,12 @@ test("references a non-ingestible attachment in the sandbox instead of inlining 
     },
   ];
 
-  const output = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    sandboxAvailable: true,
+  });
 
   const part = expectPresent(output[0].parts?.[0]);
   expect(part.type).toBe("text");
@@ -312,6 +322,58 @@ test("references a non-ingestible attachment in the sandbox instead of inlining 
   expect(part.text).toContain(JSON.stringify(originalName));
   expect(part.text).toContain("application/octet-stream");
   // The bytes are NOT inlined into the model payload.
+  expect(part.text).not.toContain("data:");
+  expect(part.url).toBeUndefined();
+});
+
+test("a non-ingestible attachment is NOT pointed at the sandbox when it is unavailable for the agent", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.from("SQLite header bytes", "utf8");
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "orders.sqlite",
+    mimeType: "application/octet-stream",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "application/octet-stream",
+          filename: "orders.sqlite",
+        },
+      ],
+    },
+  ];
+
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    sandboxAvailable: false,
+  });
+
+  // The model can't read it inline and has no sandbox — it gets a neutral
+  // notice that never names the sandbox dir or run_command, and the bytes
+  // are not inlined.
+  const part = expectPresent(output[0].parts?.[0]);
+  expect(part.type).toBe("text");
+  expect(part.text).not.toContain("/home/sandbox/attachments");
+  expect(part.text).not.toContain("run_command");
   expect(part.text).not.toContain("data:");
   expect(part.url).toBeUndefined();
 });
@@ -350,11 +412,12 @@ test("keeps an ingestible attachment inlined even when an ingestible set is give
     },
   ];
 
-  const output = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    sandboxAvailable: true,
+  });
 
   const part = expectPresent(output[0].parts?.[0]);
   expect(part.type).toBe("file");
@@ -398,11 +461,12 @@ test("an over-limit non-ingestible attachment is reported as unavailable, not st
     },
   ];
 
-  const output = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    sandboxAvailable: true,
+  });
 
   const part = expectPresent(output[0].parts?.[0]);
   expect(part.type).toBe("text");
@@ -414,7 +478,7 @@ test("an over-limit non-ingestible attachment is reported as unavailable, not st
   expect(part.text).not.toContain("data:");
 });
 
-test("inlined text-document also gets a sandbox pointer when the sandbox is enabled", async ({
+test("inlined text-document also gets a sandbox pointer when the sandbox is available for the agent", async ({
   makeAgent,
   makeConversation,
 }) => {
@@ -449,14 +513,11 @@ test("inlined text-document also gets a sandbox pointer when the sandbox is enab
     },
   ];
 
-  const prevEnabled = config.skillsSandbox.enabled;
-  config.skillsSandbox.enabled = true;
-  let output: ChatMessage[];
-  try {
-    output = await materializeAttachments(input, conversation.id);
-  } finally {
-    config.skillsSandbox.enabled = prevEnabled;
-  }
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    sandboxAvailable: true,
+  });
 
   // The bytes are still inlined for in-context reading...
   const filePart = expectPresent(output[0].parts?.[0]);
@@ -473,7 +534,7 @@ test("inlined text-document also gets a sandbox pointer when the sandbox is enab
   expect(output[0].parts).toHaveLength(2);
 });
 
-test("inlined text-document gets NO sandbox pointer when the sandbox is disabled", async ({
+test("inlined text-document gets NO sandbox pointer when the sandbox is unavailable for the agent", async ({
   makeAgent,
   makeConversation,
 }) => {
@@ -507,14 +568,11 @@ test("inlined text-document gets NO sandbox pointer when the sandbox is disabled
     },
   ];
 
-  const prevEnabled = config.skillsSandbox.enabled;
-  config.skillsSandbox.enabled = false;
-  let output: ChatMessage[];
-  try {
-    output = await materializeAttachments(input, conversation.id);
-  } finally {
-    config.skillsSandbox.enabled = prevEnabled;
-  }
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    sandboxAvailable: false,
+  });
 
   expect(output[0].parts).toHaveLength(1);
   expect(expectPresent(output[0].parts?.[0]).type).toBe("file");
@@ -554,12 +612,11 @@ test("applyAnthropicCacheControl=false suppresses cache_control but still inline
     },
   ];
 
-  const output = await materializeAttachments(
-    input,
-    conversation.id,
-    undefined,
-    false,
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    applyAnthropicCacheControl: false,
+  });
 
   const filePart = expectPresent(output[0].parts?.[0]);
   // Bytes are still inlined — the data: content is NOT dropped...
@@ -586,12 +643,11 @@ test("applyAnthropicCacheControl=false suppresses cache_control on legacy inline
     },
   ];
 
-  const output = await materializeAttachments(
-    input,
-    "00000000-0000-4000-8000-000000000000",
-    undefined,
-    false,
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: "00000000-0000-4000-8000-000000000000",
+    applyAnthropicCacheControl: false,
+  });
   const filePart = expectPresent(output[0].parts?.[0]);
   expect(filePart.url).toBe(dataUrl);
   expect(filePart.providerMetadata).toBeUndefined();
@@ -633,18 +689,20 @@ test("attachment routing is unchanged when cache_control is suppressed (non-inge
 
   // Suppressing cache_control must not add or remove the existing
   // non-ingestible → sandbox-pointer routing: same result as the cache-on path.
-  const off = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-    false,
-  );
-  const on = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-    true,
-  );
+  const off = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    applyAnthropicCacheControl: false,
+    sandboxAvailable: true,
+  });
+  const on = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    applyAnthropicCacheControl: true,
+    sandboxAvailable: true,
+  });
 
   for (const output of [off, on]) {
     const part = expectPresent(output[0].parts?.[0]);
@@ -690,21 +748,23 @@ test("reroutes a binary document to the sandbox on a non-native Anthropic endpoi
 
   // INGESTIBLE includes application/pdf, so the model CAN read it — but a
   // non-native Anthropic endpoint can't accept the document block, so reroute.
-  const nonNative = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-    true,
-    true,
-  );
+  const nonNative = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    applyAnthropicCacheControl: true,
+    rerouteBinaryDocsToSandbox: true,
+    sandboxAvailable: true,
+  });
   // Native endpoint: the document block is fine, so it stays inlined.
-  const native = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-    true,
-    false,
-  );
+  const native = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    applyAnthropicCacheControl: true,
+    rerouteBinaryDocsToSandbox: false,
+    sandboxAvailable: true,
+  });
 
   const rerouted = expectPresent(nonNative[0].parts?.[0]);
   expect(rerouted.type).toBe("text");
@@ -754,13 +814,14 @@ test("keeps an image inlined on a non-native Anthropic endpoint", async ({
   ];
 
   // Images travel as image blocks, which the endpoint accepts — not rerouted.
-  const output = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-    true,
-    true,
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    applyAnthropicCacheControl: true,
+    rerouteBinaryDocsToSandbox: true,
+    sandboxAvailable: true,
+  });
   const part = expectPresent(output[0].parts?.[0]);
   expect(part.type).toBe("file");
   expect(part.url).toBe(`data:image/png;base64,${bytes.toString("base64")}`);
@@ -803,13 +864,14 @@ test("keeps a text-inlineable, model-readable document inlined on a non-native A
   // text/plain is in INGESTIBLE and is text-inlineable, so the binary-doc
   // reroute must NOT touch it — it stays a file part (prepare-for-provider
   // inlines it as text later).
-  const output = await materializeAttachments(
-    input,
-    conversation.id,
-    INGESTIBLE,
-    true,
-    true,
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    applyAnthropicCacheControl: true,
+    rerouteBinaryDocsToSandbox: true,
+    sandboxAvailable: true,
+  });
   const part = expectPresent(output[0].parts?.[0]);
   expect(part.type).toBe("file");
   expect(part.url).toBe(`data:text/plain;base64,${bytes.toString("base64")}`);
@@ -831,13 +893,12 @@ test("an inline data: binary document is dropped with a notice on a non-native e
     },
   ];
 
-  const output = await materializeAttachments(
-    input,
-    "00000000-0000-4000-8000-000000000000",
-    undefined,
-    true,
-    true,
-  );
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: "00000000-0000-4000-8000-000000000000",
+    applyAnthropicCacheControl: true,
+    rerouteBinaryDocsToSandbox: true,
+  });
   const part = expectPresent(output[0].parts?.[0]);
   expect(part.type).toBe("text");
   // The data: bytes are NOT emitted as a document block the endpoint rejects.
@@ -851,10 +912,10 @@ test("no refs in messages returns a clone without DB hits", async () => {
     { role: "assistant", parts: [{ type: "text", text: "hi" }] },
   ];
 
-  const output = await materializeAttachments(
+  const output = await materializeAttachments({
     messages,
-    "00000000-0000-4000-8000-000000000000",
-  );
+    conversationId: "00000000-0000-4000-8000-000000000000",
+  });
   expect(output).toEqual(messages);
   // Confirm deep copy: mutating output does not affect input
   expectPresent(output[0].parts?.[0]).text = "mutated";

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -28,10 +28,10 @@ type Attachment = Awaited<
  * Does NOT mutate the input — the caller retains refs in the persisted
  * messages.
  */
-export async function materializeAttachments(
-  messages: ChatMessage[],
-  conversationId: string,
-  ingestibleMimeTypes?: Set<string>,
+export async function materializeAttachments({
+  messages,
+  conversationId,
+  ingestibleMimeTypes,
   // Anthropic `cache_control` is an Anthropic-only request-body feature. Emit it
   // by default (it is inert metadata for non-Anthropic SDKs), but suppress it
   // when the call targets an Anthropic-compatible third-party endpoint that
@@ -42,7 +42,19 @@ export async function materializeAttachments(
   // document (e.g. a PDF) that such an endpoint can't accept is rerouted to the
   // sandbox instead of inlined as a block that 400s the whole turn.
   rerouteBinaryDocsToSandbox = false,
-): Promise<ChatMessage[]> {
+  // Whether the sandbox is genuinely usable for this agent
+  // (`isSkillSandboxAvailableForAgent`). When false, never point the model at
+  // the sandbox or `run_command`: a file it can't read inline gets a neutral
+  // "not processed this turn" notice instead. Fail-closed (defaults off).
+  sandboxAvailable = false,
+}: {
+  messages: ChatMessage[];
+  conversationId: string;
+  ingestibleMimeTypes?: Set<string>;
+  applyAnthropicCacheControl?: boolean;
+  rerouteBinaryDocsToSandbox?: boolean;
+  sandboxAvailable?: boolean;
+}): Promise<ChatMessage[]> {
   const refIds = collectRefIds(messages);
   // Even when there are no refs to rehydrate, we still walk every part —
   // data: URL file parts (legacy messages or same-tab follow-ups whose FE
@@ -75,6 +87,7 @@ export async function materializeAttachments(
           ingestibleMimeTypes,
           applyAnthropicCacheControl,
           rerouteBinaryDocsToSandbox,
+          sandboxAvailable,
         ),
       ),
     };
@@ -101,6 +114,7 @@ function materializePart(
   ingestibleMimeTypes: Set<string> | undefined,
   applyAnthropicCacheControl: boolean,
   rerouteBinaryDocsToSandbox: boolean,
+  sandboxAvailable: boolean,
 ): ChatMessagePart | ChatMessagePart[] {
   if (part.type !== "file" || typeof part.url !== "string") {
     return { ...part };
@@ -163,7 +177,7 @@ function materializePart(
     rerouteBinaryDocsToSandbox &&
     isNonInlineableBinaryDocMimeType(attachment.mimeType);
   if (modelCannotRead || endpointRejectsBinaryDoc) {
-    return referenceSandboxFilePart(attachment);
+    return referenceSandboxFilePart(attachment, sandboxAvailable);
   }
 
   // findByIdsWithData normalizes bytea to Buffer at the model boundary
@@ -199,7 +213,7 @@ function materializePart(
   // Dual availability: a text-document that is shown inline is ALSO auto-staged
   // into the sandbox (same byte limit), so the model can both read it in context
   // and process it with run_command. Point it there alongside the inline copy.
-  const pointer = dualAvailabilityPointer(attachment);
+  const pointer = dualAvailabilityPointer(attachment, sandboxAvailable);
   return pointer ? [filePart, pointer] : filePart;
 }
 
@@ -209,17 +223,22 @@ function materializePart(
  * {@link SKILL_SANDBOX_ATTACHMENTS_DIR}. Return a text part telling the model the
  * inlined file is ALSO available there (distinct from
  * {@link referenceSandboxFilePart}, which replaces an attachment the model can't
- * see inline). Returns null when the sandbox is off, the file is over the limit
- * (not staged), or the mime type is not an inlineable text-document.
+ * see inline). Returns null when the sandbox is not usable for this agent, the
+ * file is over the limit (not staged), or the mime type is not an inlineable
+ * text-document.
  *
  * `originalName` is client-controlled, so it is JSON-encoded to keep a crafted
  * filename from breaking out of this platform-generated notice.
  */
 function dualAvailabilityPointer(
   attachment: Attachment,
+  sandboxAvailable: boolean,
 ): ChatMessagePart | null {
+  // `sandboxAvailable` already implies the feature flag is on; gating on it (not
+  // just the flag) keeps the pointer from advertising a sandbox the agent can't
+  // reach. The inline copy still goes through, so nothing is lost.
   if (
-    !config.skillsSandbox.enabled ||
+    !sandboxAvailable ||
     !isInlineableTextDocumentMimeType(attachment.mimeType)
   ) {
     return null;
@@ -278,22 +297,35 @@ function unavailableBinaryDocPart(
 }
 
 /**
- * Replace a non-ingestible attachment file part with a text part that points
- * the model at the file in its sandbox. Within the auto-staging size limit the
- * file lives under {@link SKILL_SANDBOX_ATTACHMENTS_DIR} — we name the directory
- * (not an exact path, since the staged filename is sanitized and deduplicated
- * by the runtime) and tell the model to list it. Over the limit the file is not
- * staged at all, so the model is told it is unavailable this turn rather than
- * pointed at a session-authed URL it cannot fetch from the sandbox.
+ * Replace a non-ingestible attachment file part with a text part. When the
+ * sandbox is usable for this agent and the file is within the auto-staging size
+ * limit, it lives under {@link SKILL_SANDBOX_ATTACHMENTS_DIR} — we name the
+ * directory (not an exact path, since the staged filename is sanitized and
+ * deduplicated by the runtime) and tell the model to list it. Over the limit the
+ * file is not staged, so the model is told it is unavailable this turn rather
+ * than pointed at a session-authed URL it cannot fetch from the sandbox. When
+ * the sandbox is not usable at all, there is no fallback surface, so the model is
+ * told the file could not be processed (so it can relay that to the user) — never
+ * pointed at a sandbox or `run_command` it cannot reach.
  *
  * `originalName` is client-controlled, so it is JSON-encoded to keep a crafted
  * filename from breaking out of this platform-generated notice.
  */
-function referenceSandboxFilePart(attachment: Attachment): ChatMessagePart {
+function referenceSandboxFilePart(
+  attachment: Attachment,
+  sandboxAvailable: boolean,
+): ChatMessagePart {
   const sizeBytes = attachment.fileData.byteLength;
   const name = JSON.stringify(attachment.originalName ?? "attachment");
   const label = `${name} (${attachment.mimeType}, ${sizeBytes} bytes)`;
   const limit = config.skillsSandbox.artifactBytesLimit;
+
+  if (!sandboxAvailable) {
+    return {
+      type: "text",
+      text: `[Attachment ${label} can't be read by this model and no code sandbox is available to process it this turn. Let the user know the file could not be used.]`,
+    };
+  }
 
   if (sizeBytes > limit) {
     return {

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -218,8 +218,8 @@ function materializePart(
 }
 
 /**
- * When the skill sandbox is enabled and a text-document attachment is within the
- * auto-staging size limit, it has been staged under
+ * When the sandbox is usable for this agent and a text-document attachment is
+ * within the auto-staging size limit, it has been staged under
  * {@link SKILL_SANDBOX_ATTACHMENTS_DIR}. Return a text part telling the model the
  * inlined file is ALSO available there (distinct from
  * {@link referenceSandboxFilePart}, which replaces an attachment the model can't

--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -99,6 +99,7 @@ test("anthropic non-native endpoint: bytes inlined as text, no cache_control, no
       conversationId: conversation.id,
       ingestibleMimeTypes: INGESTIBLE,
       anthropicNativeEndpoint: false,
+      sandboxAvailable: false,
     });
   } finally {
     config.skillsSandbox.enabled = prevEnabled;
@@ -137,6 +138,7 @@ test("native Anthropic (default flag): document file part survives with cache_co
       conversationId: conversation.id,
       ingestibleMimeTypes: INGESTIBLE,
       anthropicNativeEndpoint: true,
+      sandboxAvailable: false,
     });
   } finally {
     config.skillsSandbox.enabled = prevEnabled;

--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -3,7 +3,7 @@ import config from "@/config";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import { expect, test } from "@/test";
 import type { ChatMessage } from "@/types";
-import { __test } from "./prepare-model-messages";
+import { __test, buildModelMessages } from "./prepare-model-messages";
 
 const CSV = "a,b,c\n1,2,3";
 const INGESTIBLE = new Set(["text/csv"]);
@@ -147,4 +147,96 @@ test("native Anthropic (default flag): document file part survives with cache_co
   // Native path keeps the document as a file part and marks it for caching.
   expect(hasFilePart(modelMessages)).toBe(true);
   expect(anthropicCacheControlSeen(modelMessages)).toBe(true);
+});
+
+// End-to-end through the public entry point: buildModelMessages must resolve
+// the agent's sandbox availability itself and thread it into materialization,
+// so the sandbox pointer follows the agent — not just the global feature flag.
+test("buildModelMessages emits the sandbox pointer when the agent can use the sandbox", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeCustomRole,
+  makeAgent,
+  makeConversation,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  const role = await makeCustomRole(org.id, {
+    permission: { sandbox: ["execute"] },
+  });
+  await makeMember(user.id, org.id, { role: role.role });
+  // accessAllTools makes the sandbox usable via dynamic dispatch, so this also
+  // covers the predicate's dynamic-access branch end-to-end.
+  const agent = await makeAgent({
+    organizationId: org.id,
+    accessAllTools: true,
+  });
+  const conversation = await makeConversation(agent.id, {
+    organizationId: org.id,
+  });
+  const messages = await csvRefMessage(conversation.id, user.id, org.id);
+
+  const prevEnabled = config.skillsSandbox.enabled;
+  config.skillsSandbox.enabled = true;
+  let modelMessages: ModelMessage[];
+  try {
+    modelMessages = await buildModelMessages({
+      messages,
+      conversationId: conversation.id,
+      organizationId: org.id,
+      userId: user.id,
+      agentId: agent.id,
+      provider: "anthropic",
+      selectedModel: "claude-test-model",
+      emit: () => {},
+    });
+  } finally {
+    config.skillsSandbox.enabled = prevEnabled;
+  }
+
+  expect(textContent(modelMessages)).toContain("/home/sandbox/attachments");
+});
+
+test("buildModelMessages omits the sandbox pointer when the agent cannot use the sandbox", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeCustomRole,
+  makeAgent,
+  makeConversation,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  const role = await makeCustomRole(org.id, {
+    permission: { sandbox: ["execute"] },
+  });
+  await makeMember(user.id, org.id, { role: role.role });
+  // No assigned sandbox tools and no accessAllTools: the agent can't run it,
+  // even though the feature flag is on below.
+  const agent = await makeAgent({ organizationId: org.id });
+  const conversation = await makeConversation(agent.id, {
+    organizationId: org.id,
+  });
+  const messages = await csvRefMessage(conversation.id, user.id, org.id);
+
+  const prevEnabled = config.skillsSandbox.enabled;
+  config.skillsSandbox.enabled = true;
+  let modelMessages: ModelMessage[];
+  try {
+    modelMessages = await buildModelMessages({
+      messages,
+      conversationId: conversation.id,
+      organizationId: org.id,
+      userId: user.id,
+      agentId: agent.id,
+      provider: "anthropic",
+      selectedModel: "claude-test-model",
+      emit: () => {},
+    });
+  } finally {
+    config.skillsSandbox.enabled = prevEnabled;
+  }
+
+  expect(textContent(modelMessages)).not.toContain("/home/sandbox/attachments");
 });

--- a/platform/backend/src/routes/chat/prepare-model-messages.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.ts
@@ -5,6 +5,7 @@ import {
   type SupportedProvider,
 } from "@archestra/shared";
 import { convertToModelMessages, type ModelMessage, type UIMessage } from "ai";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import type { ChatMessage } from "@/types";
 import {
   buildContextCompactionStreamData,
@@ -99,6 +100,14 @@ export async function buildModelMessages(params: {
     });
   }
 
+  // One availability lookup per LLM call (the system-prompt path pays the same),
+  // so attachment sandbox pointers are only emitted when the agent can run them.
+  const sandboxAvailable = await isSkillSandboxAvailableForAgent({
+    userId: compaction.userId,
+    organizationId: compaction.organizationId,
+    agentId: compaction.agentId ?? undefined,
+  });
+
   return applyPromptCacheBreakpoints({
     provider,
     model: selectedModel,
@@ -109,6 +118,7 @@ export async function buildModelMessages(params: {
       conversationId,
       ingestibleMimeTypes: getModelReadableMimeTypes(inputModalities),
       anthropicNativeEndpoint,
+      sandboxAvailable,
     }),
   });
 }
@@ -126,6 +136,7 @@ async function buildModelMessagesForProvider(params: {
   conversationId: string;
   ingestibleMimeTypes?: Set<string>;
   anthropicNativeEndpoint?: boolean;
+  sandboxAvailable: boolean;
 }) {
   const anthropicNativeEndpoint = params.anthropicNativeEndpoint ?? true;
   // `cache_control` is inert for non-Anthropic SDKs, so keep emitting it there;
@@ -138,13 +149,15 @@ async function buildModelMessagesForProvider(params: {
   // attachment id. Legacy inline data URLs pass through unchanged. Returns a
   // deep copy — the original messages keep their refs for any subsequent
   // persistence step.
-  const materialized = await materializeAttachments(
-    params.messages,
-    params.conversationId,
-    params.ingestibleMimeTypes,
+  const materialized = await materializeAttachments({
+    messages: params.messages,
+    conversationId: params.conversationId,
+    ingestibleMimeTypes: params.ingestibleMimeTypes,
     applyAnthropicCacheControl,
-    params.provider === "anthropic" && !anthropicNativeEndpoint,
-  );
+    rerouteBinaryDocsToSandbox:
+      params.provider === "anthropic" && !anthropicNativeEndpoint,
+    sandboxAvailable: params.sandboxAvailable,
+  });
   const providerPreparedMessages = prepareMessagesForProvider({
     messages: materialized,
     provider: params.provider,

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -577,6 +577,7 @@ describe("buildModelMessagesForProvider", () => {
     const modelMessages = await __prepareTest.buildModelMessagesForProvider({
       provider: "openai",
       conversationId,
+      sandboxAvailable: false,
       messages: [
         { role: "user", parts: [{ type: "text", text: "hi" }] },
         {
@@ -601,6 +602,7 @@ describe("buildModelMessagesForProvider", () => {
     const modelMessages = await __prepareTest.buildModelMessagesForProvider({
       provider: "openai",
       conversationId,
+      sandboxAvailable: false,
       messages: [
         { role: "user", parts: [{ type: "text", text: "search please" }] },
         {

--- a/platform/backend/src/skills/skill-sandbox-availability.test.ts
+++ b/platform/backend/src/skills/skill-sandbox-availability.test.ts
@@ -66,6 +66,62 @@ describe("isSkillSandboxAvailableForAgent", () => {
     ).toBe(false);
   });
 
+  test("true via accessAllTools dynamic access even without the sandbox tools assigned", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeCustomRole,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const role = await makeCustomRole(org.id, {
+      permission: { sandbox: ["execute"] },
+    });
+    await makeMember(user.id, org.id, { role: role.role });
+    // No sandbox tools assigned, but accessAllTools lets a real user run them
+    // via dynamic dispatch, so the sandbox is genuinely usable.
+    const agent = await makeAgent({
+      name: "Access-all Agent",
+      accessAllTools: true,
+    });
+
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+      }),
+    ).toBe(true);
+  });
+
+  test("false for accessAllTools without sandbox:execute", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeCustomRole,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const role = await makeCustomRole(org.id, {
+      permission: { skill: ["read"] },
+    });
+    await makeMember(user.id, org.id, { role: role.role });
+    const agent = await makeAgent({
+      name: "Access-all Agent",
+      accessAllTools: true,
+    });
+
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+      }),
+    ).toBe(false);
+  });
+
   test("false when the feature is disabled, even with tools assigned", async ({
     makeOrganization,
     makeUser,

--- a/platform/backend/src/skills/skill-sandbox-availability.test.ts
+++ b/platform/backend/src/skills/skill-sandbox-availability.test.ts
@@ -82,6 +82,7 @@ describe("isSkillSandboxAvailableForAgent", () => {
     // No sandbox tools assigned, but accessAllTools lets a real user run them
     // via dynamic dispatch, so the sandbox is genuinely usable.
     const agent = await makeAgent({
+      organizationId: org.id,
       name: "Access-all Agent",
       accessAllTools: true,
     });
@@ -109,6 +110,7 @@ describe("isSkillSandboxAvailableForAgent", () => {
     });
     await makeMember(user.id, org.id, { role: role.role });
     const agent = await makeAgent({
+      organizationId: org.id,
       name: "Access-all Agent",
       accessAllTools: true,
     });

--- a/platform/backend/src/skills/skill-sandbox-availability.ts
+++ b/platform/backend/src/skills/skill-sandbox-availability.ts
@@ -5,6 +5,7 @@ import {
   TOOL_UPLOAD_FILE_SHORT_NAME,
 } from "@archestra/shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
+import { dynamicAccessContext } from "@/archestra-mcp-server/dynamic-tools";
 import { userHasPermission } from "@/auth/utils";
 import config from "@/config";
 import { ToolModel } from "@/models";
@@ -13,7 +14,9 @@ import { ToolModel } from "@/models";
  * Whether the code execution sandbox is genuinely usable for a given agent:
  *   1. the feature is enabled on this deployment,
  *   2. the caller holds `sandbox:execute`, and
- *   3. the sandbox tools are assigned to the agent.
+ *   3. the agent can actually invoke the sandbox tools — either they are
+ *      assigned to it, or it has `accessAllTools` on (which lets a real user
+ *      discover and run them dynamically, see `dynamicAccessContext`).
  *
  * The assignment check mirrors what `tools/list` exposes (it reads the same
  * `getMcpToolsByAgent` source), so we never advertise the sandbox path to a
@@ -38,6 +41,17 @@ export async function isSkillSandboxAvailableForAgent(params: {
     "execute",
   );
   if (!allowed) return false;
+
+  // `accessAllTools` agents run the sandbox tools via dynamic dispatch without a
+  // manual assignment; `dynamicAccessContext` is the canonical gate for that
+  // path (real authenticated user, agent opt-in), so reuse it rather than
+  // re-deriving the rule here.
+  const dynamicAccess = await dynamicAccessContext({
+    agentId: params.agentId,
+    userId: params.userId,
+    organizationId: params.organizationId,
+  });
+  if (dynamicAccess) return true;
 
   const assigned = new Set(
     (await ToolModel.getMcpToolsByAgent(params.agentId)).map((t) => t.name),


### PR DESCRIPTION
## Problem

Sandbox instruction text (`run_command`, `/skills`, "your sandbox", the attachments dir) reached the model even when the code-execution sandbox was not usable for the agent.

Three model-facing surfaces emitted sandbox references without the per-agent availability gate (`isSkillSandboxAvailableForAgent`) that every other sandbox surface already used:

- the static `load_skill` tool description named `run_command`/`/skills` unconditionally;
- the attachment "also available in your sandbox" pointer was gated only on the global feature flag;
- the non-ingestible attachment replacement pointed at the sandbox with no availability gate at all.

Staging only happens lazily when a sandbox op runs (which an agent without the sandbox tools can never trigger), so these pointers named a file that was never staged and a `run_command` tool the agent does not have.

## Fix

- Remove the `run_command`/`/skills` sentence from the static `load_skill` description. The agent-aware hint still reaches the model via the `load_skill` result and skill catalog, gated on availability.
- Thread a precomputed `sandboxAvailable` flag into `materializeAttachments` (now an object param). When unavailable, no sandbox pointer is emitted and a non-readable file gets a neutral "no code sandbox available" notice instead.
- Compute `sandboxAvailable` at both callers (`prepare-model-messages.ts`, `context-compaction.ts`).
- Extend `isSkillSandboxAvailableForAgent` so `accessAllTools` agents — which run the sandbox tools via dynamic dispatch without explicit assignment — count as having it available, keeping every sandbox-advertising surface consistent.

## Validation

`pnpm type-check`, `pnpm knip`, biome, and 171 tests across the affected suites pass. New coverage: the predicate's dynamic-access branch, the attachment unavailable-notice path, and caller-level `buildModelMessages` threading (positive case also exercises `accessAllTools` end-to-end).

https://claude.ai/code/session_011vh3FRL7Kh4GpVoENvNJZu

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>