### PR TITLE
fix(query): retry state on detail pages + 404 parity for child-run lists

### DIFF
--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
@@ -28,6 +28,7 @@ import { FormDialog } from "@/components/form-dialog";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { MetadataItem } from "@/components/metadata-card";
 import { PageLayout } from "@/components/page-layout";
+import { QueryLoadError } from "@/components/query-load-error";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -112,7 +113,12 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
     },
   ];
 
-  const { data: connector, isPending } = useConnector(connectorId);
+  const {
+    data: connector,
+    isPending,
+    isLoadingError,
+    refetch,
+  } = useConnector(connectorId);
   const syncConnector = useSyncConnector();
   const forceResync = useForceResyncConnector();
   const testConnection = useTestConnectorConnection();
@@ -224,6 +230,17 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
 
   if (isPending) {
     return <LoadingSpinner />;
+  }
+
+  if (isLoadingError) {
+    return (
+      <div className="p-6">
+        <QueryLoadError
+          title="Couldn't load this connector"
+          onRetry={() => refetch()}
+        />
+      </div>
+    );
   }
 
   if (!connector) {

--- a/platform/frontend/src/app/llm/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/[id]/page.client.tsx
@@ -8,6 +8,7 @@ import { JsonCodeBlock } from "@/components/json-code-block";
 import { LoadingSpinner } from "@/components/loading";
 import MessageThread from "@/components/message-thread";
 import { MetadataCard, MetadataItem } from "@/components/metadata-card";
+import { QueryLoadError } from "@/components/query-load-error";
 import { Savings } from "@/components/savings";
 import { SourceBadge } from "@/components/source-badge";
 import {
@@ -51,13 +52,27 @@ function LogDetail({
   };
   id: string;
 }) {
-  const { data: dynamicInteraction, isPending } = useInteraction({
+  const {
+    data: dynamicInteraction,
+    isPending,
+    isLoadingError,
+    refetch,
+  } = useInteraction({
     interactionId: id,
     initialData: initialData?.interaction,
   });
 
   if (isPending) {
     return <LoadingSpinner />;
+  }
+
+  if (isLoadingError) {
+    return (
+      <QueryLoadError
+        title="Couldn't load this interaction"
+        onRetry={() => refetch()}
+      />
+    );
   }
 
   if (!dynamicInteraction) {

--- a/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from "@/app/_parts/error-boundary";
 import { JsonCodeBlock } from "@/components/json-code-block";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { MetadataCard, MetadataItem } from "@/components/metadata-card";
+import { QueryLoadError } from "@/components/query-load-error";
 import {
   Accordion,
   AccordionContent,
@@ -51,7 +52,12 @@ function McpToolCallDetail({
   };
   id: string;
 }) {
-  const { data: mcpToolCall, isPending } = useMcpToolCall({
+  const {
+    data: mcpToolCall,
+    isPending,
+    isLoadingError,
+    refetch,
+  } = useMcpToolCall({
     mcpToolCallId: id,
     initialData: initialData?.mcpToolCall,
   });
@@ -62,6 +68,15 @@ function McpToolCallDetail({
 
   if (isPending) {
     return <LoadingSpinner />;
+  }
+
+  if (isLoadingError) {
+    return (
+      <QueryLoadError
+        title="Couldn't load this tool call"
+        onRetry={() => refetch()}
+      />
+    );
   }
 
   if (!mcpToolCall) {

--- a/platform/frontend/src/app/mcp/registry/installation-requests/[id]/page.tsx
+++ b/platform/frontend/src/app/mcp/registry/installation-requests/[id]/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, CheckCircle, Loader2, Send, XCircle } from "lucide-react";
 import Link from "next/link";
 import { use, useCallback, useState } from "react";
 import Divider from "@/components/divider";
+import { QueryLoadError } from "@/components/query-load-error";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -27,7 +28,12 @@ export default function InstallationRequestDetailPage({
 }) {
   const { id } = use(params);
 
-  const { data: request, isLoading } = useMcpServerInstallationRequest(id);
+  const {
+    data: request,
+    isLoading,
+    isLoadingError,
+    refetch,
+  } = useMcpServerInstallationRequest(id);
   const approveMutation = useApproveMcpServerInstallationRequest();
   const declineMutation = useDeclineMcpServerInstallationRequest();
   const addNoteMutation = useAddMcpServerInstallationRequestNote();
@@ -87,6 +93,17 @@ export default function InstallationRequestDetailPage({
             </Card>
           </div>
         </div>
+      </div>
+    );
+  }
+
+  if (isLoadingError) {
+    return (
+      <div>
+        <QueryLoadError
+          title="Couldn't load this request"
+          onRetry={() => refetch()}
+        />
       </div>
     );
   }

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -36,6 +36,7 @@ import { SelectableFileList } from "@/components/chat/selectable-file-list";
 import { FileDropZone } from "@/components/files/file-drop-zone";
 import { PageLayout } from "@/components/page-layout";
 import { EditProjectDialog } from "@/components/projects/edit-project-dialog";
+import { QueryLoadError } from "@/components/query-load-error";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -73,7 +74,7 @@ export default function ProjectDetailPageClient() {
 function ProjectDetail() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
-  const { data: project, isPending } = useProject(id);
+  const { data: project, isPending, isLoadingError, refetch } = useProject(id);
   // Chats are hidden from admin oversight, so don't even fetch them there.
   const { data: conversations } = useProjectConversations(id, {
     enabled: !!project && project.viewerRole !== "admin",
@@ -97,6 +98,16 @@ function ProjectDetail() {
         <p className="py-12 text-center text-sm text-muted-foreground">
           Loading…
         </p>
+      </PageLayout>
+    );
+  }
+  if (isLoadingError) {
+    return (
+      <PageLayout title="Project" description="">
+        <QueryLoadError
+          title="Couldn't load this project"
+          onRetry={() => refetch()}
+        />
       </PageLayout>
     );
   }

--- a/platform/frontend/src/app/scheduled-tasks/schedule-trigger-run-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-trigger-run-client.tsx
@@ -24,6 +24,7 @@ import ArchestraPromptInput from "@/app/chat/prompt-input";
 import { ChatMessages } from "@/components/chat/chat-messages";
 import { ConversationArtifactPanel } from "@/components/chat/conversation-artifact";
 import { LoadingSpinner } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import { StatusBadge } from "@/components/scheduled-tasks/status-badge";
 import { Button } from "@/components/ui/button";
 import { useInternalAgents } from "@/lib/agent.query";
@@ -98,14 +99,15 @@ export function ScheduleTriggerRunPage({
       refetchInterval: 5_000,
     },
   );
-  const { data: run, isLoading: runLoading } = useScheduleTriggerRun(
-    triggerId,
-    runId,
-    {
-      enabled: !!triggerId && !!runId,
-      refetchInterval: 3_000,
-    },
-  );
+  const {
+    data: run,
+    isLoading: runLoading,
+    isLoadingError: isRunLoadError,
+    refetch: refetchRun,
+  } = useScheduleTriggerRun(triggerId, runId, {
+    enabled: !!triggerId && !!runId,
+    refetchInterval: 3_000,
+  });
   const ensureConversationMutation = useCreateScheduleTriggerRunConversation();
   const conversationId =
     run?.chatConversationId ?? bootstrappedConversationId ?? undefined;
@@ -403,6 +405,15 @@ export function ScheduleTriggerRunPage({
         <Loader2 className="h-4 w-4 animate-spin" />
         Loading scheduled run...
       </div>
+    );
+  }
+
+  if (isRunLoadError) {
+    return (
+      <QueryLoadError
+        title="Couldn't load this run"
+        onRetry={() => refetchRun()}
+      />
     );
   }
 

--- a/platform/frontend/src/app/scheduled-tasks/schedule-trigger-run-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-trigger-run-client.tsx
@@ -92,13 +92,15 @@ export function ScheduleTriggerRunPage({
   const [showDetails, setShowDetails] = useState(false);
   const [isArtifactOpen, setIsArtifactOpen] = useState(false);
 
-  const { data: trigger, isLoading: triggerLoading } = useScheduleTrigger(
-    triggerId,
-    {
-      enabled: !!triggerId,
-      refetchInterval: 5_000,
-    },
-  );
+  const {
+    data: trigger,
+    isLoading: triggerLoading,
+    isLoadingError: isTriggerLoadError,
+    refetch: refetchTrigger,
+  } = useScheduleTrigger(triggerId, {
+    enabled: !!triggerId,
+    refetchInterval: 5_000,
+  });
   const {
     data: run,
     isLoading: runLoading,
@@ -408,11 +410,14 @@ export function ScheduleTriggerRunPage({
     );
   }
 
-  if (isRunLoadError) {
+  if (isRunLoadError || isTriggerLoadError) {
     return (
       <QueryLoadError
         title="Couldn't load this run"
-        onRetry={() => refetchRun()}
+        onRetry={() => {
+          refetchRun();
+          refetchTrigger();
+        }}
       />
     );
   }

--- a/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
+++ b/platform/frontend/src/app/scheduled-tasks/schedule-triggers-client.tsx
@@ -605,7 +605,12 @@ export function ScheduleTriggerDetailPage({
     () => new Set(userTeams.map((t) => t.id)),
     [userTeams],
   );
-  const { data: trigger, isLoading } = useScheduleTrigger(triggerId, {
+  const {
+    data: trigger,
+    isLoading,
+    isLoadingError: isTriggerLoadError,
+    refetch: refetchTrigger,
+  } = useScheduleTrigger(triggerId, {
     refetchInterval: 5_000,
   });
   const { data: agents = [], isLoading: agentsLoading } = useProfiles({
@@ -742,6 +747,15 @@ export function ScheduleTriggerDetailPage({
         <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
         <span className="text-sm text-muted-foreground">Loading...</span>
       </div>
+    );
+  }
+
+  if (isTriggerLoadError) {
+    return (
+      <QueryLoadError
+        title="Couldn't load this scheduled task"
+        onRetry={() => refetchTrigger()}
+      />
     );
   }
 

--- a/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
@@ -16,6 +16,7 @@ import { useForm } from "react-hook-form";
 import { ExpirationDateTimeField } from "@/components/expiration-date-time-field";
 import { FormDialog } from "@/components/form-dialog";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import {
   SettingsSaveBar,
   SettingsSectionStack,
@@ -75,8 +76,12 @@ export default function ServiceAccountDetailPage({
   const { data: canUpdateServiceAccounts } = useHasPermissions({
     serviceAccount: ["update"],
   });
-  const { data: serviceAccount, isPending } =
-    useServiceAccount(serviceAccountId);
+  const {
+    data: serviceAccount,
+    isPending,
+    isLoadingError,
+    refetch,
+  } = useServiceAccount(serviceAccountId);
   const updateMutation = useUpdateServiceAccount();
   const createTokenMutation = useCreateServiceAccountToken();
   const updateTokenMutation = useUpdateServiceAccountToken();
@@ -285,7 +290,12 @@ export default function ServiceAccountDetailPage({
 
   return (
     <LoadingWrapper isPending={isPending} loadingFallback={<LoadingSpinner />}>
-      {!serviceAccount ? (
+      {isLoadingError ? (
+        <QueryLoadError
+          title="Couldn't load this service account"
+          onRetry={() => refetch()}
+        />
+      ) : !serviceAccount ? (
         <Alert variant="destructive">
           <AlertTitle>Service account not found</AlertTitle>
           <AlertDescription>

--- a/platform/frontend/src/lib/knowledge/connector-runs-not-found.test.tsx
+++ b/platform/frontend/src/lib/knowledge/connector-runs-not-found.test.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetConnectorRuns, mockToastError } = vi.hoisted(() => ({
+  mockGetConnectorRuns: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("@archestra/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@archestra/shared")>();
+  return {
+    ...actual,
+    archestraApiSdk: {
+      ...actual.archestraApiSdk,
+      getConnectorRuns: (...args: unknown[]) => mockGetConnectorRuns(...args),
+    },
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: mockToastError, success: vi.fn() },
+}));
+
+import { useConnectorRuns } from "./connector.query";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useConnectorRuns — missing parent (404)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves to null (no error, no toast) when the connector is not found", async () => {
+    mockGetConnectorRuns.mockResolvedValue({
+      error: { type: "api_not_found_error" },
+    });
+
+    const { result } = renderHook(
+      () => useConnectorRuns({ connectorId: "gone" }),
+      { wrapper },
+    );
+
+    // A 404 must NOT enter the error state and must NOT trip react-query's own
+    // "data is undefined" throw — it resolves successfully with a null result.
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+    expect(result.current.isError).toBe(false);
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("still surfaces a non-404 failure as an error", async () => {
+    mockGetConnectorRuns.mockResolvedValue({
+      error: { type: "api_internal_error", message: "boom" },
+    });
+
+    const { result } = renderHook(
+      () => useConnectorRuns({ connectorId: "c1" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/platform/frontend/src/lib/knowledge/connector.query.ts
+++ b/platform/frontend/src/lib/knowledge/connector.query.ts
@@ -268,8 +268,11 @@ export function useConnectorRuns(params: {
         path: { id: connectorId },
         query: { limit, offset },
       });
-      throwOnApiError(error);
-      return data;
+      // A deleted/missing connector 404s here; degrade to a null result rather
+      // than an error. Return null (not bare data) so react-query doesn't throw
+      // its own "data is undefined" when the 404 path skips the throw.
+      throwOnApiError(error, { allowNotFound: true });
+      return data ?? null;
     },
     enabled: !!connectorId,
     refetchInterval: (query) => {

--- a/platform/frontend/src/lib/schedule-trigger.query.ts
+++ b/platform/frontend/src/lib/schedule-trigger.query.ts
@@ -242,7 +242,9 @@ export function useScheduleTriggerRuns(
           ...(queryParams.status ? { status: queryParams.status } : {}),
         },
       });
-      throwOnApiError(response.error);
+      // A deleted/missing parent trigger 404s here; degrade to an empty runs
+      // list rather than an error state.
+      throwOnApiError(response.error, { allowNotFound: true });
       return (
         (response.data as PaginatedResponse<ScheduleTriggerRun>) ??
         emptyResponse


### PR DESCRIPTION
Follow-up to the fail-loud query work (#5977), closing two gaps found in post-merge review.

## Problem

After queries started failing loud, two cases still misrepresented a failed fetch as a benign state:

1. **By-id detail pages showed "X not found" for *any* load failure** — an outage, 401/403, or 500 rendered "deleted / not found / no access" instead of an actionable retry. Same misleading-state bug class as the original, just on detail pages.
2. **Two child-list hooks threw on a missing-parent 404** instead of returning an empty list (`useConnectorRuns`, `useScheduleTriggerRuns`), where the old behavior was a graceful empty.

## Fix

- **8 detail pages** branch on `isLoadingError` and render a `QueryLoadError` retry panel, keeping the existing "not found" branch only for a genuine 404. With `allowNotFound`, a real 404 resolves to `null` (query succeeds → "not found"); only a non-404 failure sets `isLoadingError`. Pages: projects, connectors, service accounts, schedule-trigger detail + run detail, LLM logs, MCP tool-call logs, installation-request. The run-detail page gates on both its run and parent-trigger queries.
- **`useConnectorRuns` + `useScheduleTriggerRuns`** pass `allowNotFound: true`. `useConnectorRuns` returns `data ?? null` so the 404 path doesn't trip react-query's own "data is undefined" throw.

## Tests

New real-path test (`connector-runs-not-found.test.tsx`) runs the actual `queryFn`: a 404 resolves to `null` (success, no toast), a non-404 still surfaces as an error. Full frontend suite passes (2172); type-check, lint, knip clean.

## Note

`llm/logs/[id]` and `mcp/logs/[id]` receive SSR `initialData`, so a refetch failure keeps stale content (`isRefetchError`); their panel fires only on a cold client-side navigation with no prefetched data — intentional, so loaded logs aren't wiped on a transient blip.

https://claude.ai/code/session_01V1n6PVjL9bXbiywFEvj4yo

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>