### PR TITLE
feat(chat): sandbox-aware attachment policy and broader text types

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -36434,6 +36434,9 @@
                           },
                           "llmProviderRequiresPerUserCredential": {
                             "type": "boolean"
+                          },
+                          "sandboxAvailable": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -37565,6 +37568,9 @@
                     },
                     "llmProviderRequiresPerUserCredential": {
                       "type": "boolean"
+                    },
+                    "sandboxAvailable": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -38435,6 +38441,9 @@
                       },
                       "llmProviderRequiresPerUserCredential": {
                         "type": "boolean"
+                      },
+                      "sandboxAvailable": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -39223,6 +39232,9 @@
                     },
                     "llmProviderRequiresPerUserCredential": {
                       "type": "boolean"
+                    },
+                    "sandboxAvailable": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -40010,6 +40022,9 @@
                       "type": "string"
                     },
                     "llmProviderRequiresPerUserCredential": {
+                      "type": "boolean"
+                    },
+                    "sandboxAvailable": {
                       "type": "boolean"
                     }
                   },
@@ -41143,6 +41158,9 @@
                         },
                         "llmProviderRequiresPerUserCredential": {
                           "type": "boolean"
+                        },
+                        "sandboxAvailable": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -41977,6 +41995,9 @@
                       "type": "string"
                     },
                     "llmProviderRequiresPerUserCredential": {
+                      "type": "boolean"
+                    },
+                    "sandboxAvailable": {
                       "type": "boolean"
                     }
                   },
@@ -43066,6 +43087,9 @@
                     },
                     "llmProviderRequiresPerUserCredential": {
                       "type": "boolean"
+                    },
+                    "sandboxAvailable": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -44137,6 +44161,9 @@
                       "type": "string"
                     },
                     "llmProviderRequiresPerUserCredential": {
+                      "type": "boolean"
+                    },
+                    "sandboxAvailable": {
                       "type": "boolean"
                     }
                   },
@@ -45537,6 +45564,9 @@
                       "type": "string"
                     },
                     "llmProviderRequiresPerUserCredential": {
+                      "type": "boolean"
+                    },
+                    "sandboxAvailable": {
                       "type": "boolean"
                     }
                   },
@@ -91633,6 +91663,9 @@
                         "sandbox": {
                           "type": "boolean"
                         },
+                        "sandboxArtifactBytesLimit": {
+                          "type": "number"
+                        },
                         "agentSkillsEnabled": {
                           "type": "boolean"
                         },
@@ -91736,6 +91769,7 @@
                         "betaEnabled",
                         "orchestratorK8sRuntime",
                         "sandbox",
+                        "sandboxArtifactBytesLimit",
                         "agentSkillsEnabled",
                         "agentEnvironmentsEnabled",
                         "appsEnabled",

--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -66,3 +66,5 @@ When auto-compaction frees tokens, a note appears in the panel showing how many 
 ### File Attachments
 
 Chat attachments are scoped to their conversation. To reuse files across related sessions, add them to a [Project](./platform-projects) instead, where files are shared across all of the project's chats.
+
+Which files you can attach depends on the agent. Without a code sandbox, uploads are limited to types the model can read directly: images, PDFs, and common text documents (`.txt`, `.md`, `.csv`, `.tsv`, `.json`, `.xml`, `.yaml`, `.toml`); large text files are rejected rather than truncated. When the code sandbox is available for the agent, any file type can be attached and is staged into the sandbox for the agent to process.

--- a/platform/backend/src/models/agent.test.ts
+++ b/platform/backend/src/models/agent.test.ts
@@ -111,6 +111,42 @@ describe("AgentModel", () => {
     });
   });
 
+  describe("sandboxAvailable", () => {
+    test("is false on findById when the sandbox feature is disabled", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      // The sandbox feature is off in the test environment, so the per-agent
+      // availability check short-circuits to false for any user.
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const agent = await AgentModel.create({
+        name: "Sandbox Agent",
+        organizationId: org.id,
+        scope: "org",
+        teams: [],
+      });
+
+      const fetched = await AgentModel.findById(agent.id, user.id, true);
+      expect(fetched?.sandboxAvailable).toBe(false);
+    });
+
+    test("is left absent when no requesting user is given (fail-closed)", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+      const agent = await AgentModel.create({
+        name: "Userless Lookup Agent",
+        organizationId: org.id,
+        scope: "org",
+        teams: [],
+      });
+
+      const fetched = await AgentModel.findById(agent.id);
+      expect(fetched?.sandboxAvailable).toBeUndefined();
+    });
+  });
+
   describe("findBasicByOrganizationIdAndIds", () => {
     test("returns only agents from the requested organization", async ({
       makeOrganization,

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -34,6 +34,7 @@ import {
   type PaginatedResult,
 } from "@/database/utils/pagination";
 import logger from "@/logging";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import type {
   Agent,
   AgentScope,
@@ -249,6 +250,30 @@ class AgentModel {
         ? (modelNameMap.get(agent.modelId) ?? null)
         : null;
     }
+  }
+
+  /**
+   * Populate `sandboxAvailable` per agent for the requesting user. No-op without
+   * a userId (system/background callers): the field stays absent and clients
+   * treat that as unavailable. `isSkillSandboxAvailableForAgent` short-circuits
+   * cheaply when the sandbox feature is off, so this is near-free in the common
+   * case; the per-agent permission/tool lookups only run when it is enabled.
+   */
+  private static async populateSandboxAvailability(
+    agents: Agent[],
+    userId: string | undefined,
+  ): Promise<void> {
+    if (agents.length === 0 || !userId) return;
+
+    await Promise.all(
+      agents.map(async (agent) => {
+        agent.sandboxAvailable = await isSkillSandboxAvailableForAgent({
+          userId,
+          organizationId: agent.organizationId,
+          agentId: agent.id,
+        });
+      }),
+    );
   }
 
   /**
@@ -1498,6 +1523,7 @@ class AgentModel {
       AgentModel.populateAuthorNames([result]),
       AgentModel.populateSuggestedPrompts([result]),
       AgentModel.populateResolvedLlm([result]),
+      AgentModel.populateSandboxAvailability([result], userId),
     ]);
     AgentModel.filterUnavailableKnowledgeTools([result]);
 

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
@@ -1,8 +1,12 @@
+import { INLINE_TEXT_MAX_BYTES } from "@archestra/shared";
+import { describe } from "vitest";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import { expect, test } from "@/test";
 import type { ChatMessage } from "@/types";
 import {
+  assertInlineAttachmentsAcceptable,
   extractInlineAttachments,
+  type InlineAttachmentPolicy,
   isAttachmentRefUrl,
   parseAttachmentIdFromUrl,
 } from "./extract-inline-attachments";
@@ -363,4 +367,88 @@ test("parseAttachmentIdFromUrl validates the URL shape", () => {
   expect(
     parseAttachmentIdFromUrl("/api/other/attachments/abc/content"),
   ).toBeNull();
+});
+
+describe("assertInlineAttachmentsAcceptable", () => {
+  const SANDBOX_LIMIT = 16 * 1024 * 1024;
+
+  function policy(
+    overrides: Partial<InlineAttachmentPolicy> = {},
+  ): InlineAttachmentPolicy {
+    return {
+      ingestibleMimeTypes: new Set(["image/png", "application/pdf"]),
+      sandboxAvailable: false,
+      sandboxByteLimit: SANDBOX_LIMIT,
+      ...overrides,
+    };
+  }
+
+  function messageWith(mime: string, byteLength: number): ChatMessage[] {
+    return [
+      {
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            url: makeDataUrl(mime, Buffer.alloc(byteLength, 0x61)),
+            mediaType: mime,
+            filename: `file.${mime.split("/")[1]}`,
+          },
+        ],
+      },
+    ];
+  }
+
+  function assert(mime: string, byteLength: number, p: InlineAttachmentPolicy) {
+    assertInlineAttachmentsAcceptable({
+      messages: messageWith(mime, byteLength),
+      policy: p,
+    });
+  }
+
+  test("accepts a model-ingestible type regardless of sandbox", () => {
+    expect(() => assert("image/png", 5_000_000, policy())).not.toThrow();
+  });
+
+  test("accepts a small inlineable text file without a sandbox", () => {
+    expect(() =>
+      assert("application/x-yaml", INLINE_TEXT_MAX_BYTES, policy()),
+    ).not.toThrow();
+  });
+
+  test("rejects an oversized text file when no sandbox is available", () => {
+    expect(() =>
+      assert("text/csv", INLINE_TEXT_MAX_BYTES + 1, policy()),
+    ).toThrow();
+  });
+
+  test("routes an oversized text file to the sandbox when available", () => {
+    expect(() =>
+      assert(
+        "text/csv",
+        INLINE_TEXT_MAX_BYTES + 1,
+        policy({ sandboxAvailable: true }),
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects an unsupported binary type without a sandbox", () => {
+    expect(() => assert("application/zip", 1_000, policy())).toThrow();
+  });
+
+  test("accepts an arbitrary type within the limit when the sandbox is available", () => {
+    expect(() =>
+      assert("application/zip", 1_000, policy({ sandboxAvailable: true })),
+    ).not.toThrow();
+  });
+
+  test("rejects a file over the sandbox artifact limit even when available", () => {
+    expect(() =>
+      assert(
+        "application/zip",
+        SANDBOX_LIMIT + 1,
+        policy({ sandboxAvailable: true }),
+      ),
+    ).toThrow();
+  });
 });

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
@@ -451,4 +451,20 @@ describe("assertInlineAttachmentsAcceptable", () => {
       ),
     ).toThrow();
   });
+
+  test("does not throw on a malformed (un-decodable) data: URL", () => {
+    // A bad percent-escape can't be sized; the gate must skip it (extraction's
+    // own per-part catch handles the bad URL) rather than throw a raw URIError.
+    const messages: ChatMessage[] = [
+      {
+        role: "user",
+        parts: [
+          { type: "file", url: "data:text/plain,%E0%A4%A", filename: "x.txt" },
+        ],
+      },
+    ];
+    expect(() =>
+      assertInlineAttachmentsAcceptable({ messages, policy: policy() }),
+    ).not.toThrow();
+  });
 });

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
@@ -349,9 +349,19 @@ function inspectInlineFilePart(
     typeof part.mediaType === "string" && part.mediaType.length > 0
       ? part.mediaType
       : urlMime;
-  const byteLength = isBase64
-    ? base64ByteLength(payload)
-    : Buffer.byteLength(decodeURIComponent(payload), "utf8");
+  let byteLength: number;
+  if (isBase64) {
+    byteLength = base64ByteLength(payload);
+  } else {
+    try {
+      byteLength = Buffer.byteLength(decodeURIComponent(payload), "utf8");
+    } catch {
+      // Malformed percent-encoding — can't size it, so don't gate it here.
+      // extractInlineAttachments' own per-part catch handles the bad URL
+      // (logs and leaves it inline) without turning the request into a 500.
+      return null;
+    }
+  }
   if (byteLength === 0) return null;
 
   const filename =

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
@@ -1,3 +1,9 @@
+import {
+  ApiError,
+  type ChatUploadRejectionReason,
+  chatUploadRejectionReason,
+  INLINE_TEXT_MAX_BYTES,
+} from "@archestra/shared";
 import logger from "@/logging";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import type { ChatMessage, ChatMessagePart } from "@/types";
@@ -91,6 +97,69 @@ export async function extractInlineAttachments(args: {
       }
     }
   }
+}
+
+/**
+ * Policy describing which uploaded attachments this turn may accept, evaluated
+ * before any bytes are persisted. A file is acceptable when the model can ingest
+ * its type, OR it is an inlineable text document within the inline budget, OR a
+ * sandbox is available to stage it (within the sandbox artifact size limit).
+ */
+export type InlineAttachmentPolicy = {
+  ingestibleMimeTypes: Set<string>;
+  sandboxAvailable: boolean;
+  sandboxByteLimit: number;
+};
+
+/**
+ * Rejects the request (HTTP 400) when a newly uploaded inline attachment is not
+ * acceptable under {@link InlineAttachmentPolicy}. Must run before
+ * {@link extractInlineAttachments} so unacceptable bytes are never stored, and
+ * outside its per-part catch so the rejection is never swallowed. Only new
+ * inline `data:` parts are checked; server-side refs and already-persisted
+ * history (validated when first uploaded) are skipped.
+ */
+export function assertInlineAttachmentsAcceptable(args: {
+  messages: ChatMessage[];
+  policy: InlineAttachmentPolicy;
+}): void {
+  const { messages, policy } = args;
+  for (const message of messages) {
+    if (!message.parts) continue;
+    if (isAlreadyPersistedMessage(message)) continue;
+    for (const part of message.parts) {
+      if (!isExtractableFilePart(part)) continue;
+      const inspected = inspectInlineFilePart(part);
+      if (!inspected) continue;
+      const reason = chatUploadRejectionReason({
+        mimeType: inspected.mimeType,
+        byteLength: inspected.byteLength,
+        ingestibleMimeTypes: policy.ingestibleMimeTypes,
+        sandboxAvailable: policy.sandboxAvailable,
+        sandboxByteLimit: policy.sandboxByteLimit,
+      });
+      if (reason) {
+        throw new ApiError(400, rejectionMessage(reason, inspected, policy));
+      }
+    }
+  }
+}
+
+/**
+ * Whether the messages carry at least one new inline `data:` file part — i.e.
+ * the same parts {@link extractInlineAttachments} would persist. Lets the route
+ * skip resolving the attachment policy (model row + sandbox availability) on the
+ * common plain-text turn that uploads nothing.
+ */
+export function messagesHaveNewInlineAttachments(
+  messages: ChatMessage[],
+): boolean {
+  for (const message of messages) {
+    if (!message.parts) continue;
+    if (isAlreadyPersistedMessage(message)) continue;
+    if (message.parts.some(isExtractableFilePart)) return true;
+  }
+  return false;
 }
 
 function isExtractableFilePart(
@@ -253,6 +322,72 @@ export function parseAttachmentIdFromUrl(url: string): string | null {
   )
     ? id
     : null;
+}
+
+type InspectedInlineFile = {
+  mimeType: string;
+  byteLength: number;
+  filename: string;
+};
+
+// Reads the mime type, decoded byte length, and display name of an inline
+// `data:` file part WITHOUT allocating the decoded bytes — base64 length yields
+// the size directly. Mirrors the mime resolution `extractInlineAttachments`
+// stores (the part's mediaType wins over the data URL's).
+function inspectInlineFilePart(
+  part: ChatMessagePart & { url: string },
+): InspectedInlineFile | null {
+  const commaIdx = part.url.indexOf(",");
+  if (commaIdx < 5) return null;
+
+  const meta = part.url.slice(5, commaIdx);
+  const payload = part.url.slice(commaIdx + 1);
+  const isBase64 = meta.endsWith(";base64");
+  const urlMime =
+    (isBase64 ? meta.slice(0, -7) : meta) || "application/octet-stream";
+  const mimeType =
+    typeof part.mediaType === "string" && part.mediaType.length > 0
+      ? part.mediaType
+      : urlMime;
+  const byteLength = isBase64
+    ? base64ByteLength(payload)
+    : Buffer.byteLength(decodeURIComponent(payload), "utf8");
+  if (byteLength === 0) return null;
+
+  const filename =
+    typeof part.filename === "string" && part.filename.length > 0
+      ? part.filename
+      : "attachment";
+  return { mimeType, byteLength, filename };
+}
+
+function rejectionMessage(
+  reason: ChatUploadRejectionReason,
+  file: InspectedInlineFile,
+  policy: InlineAttachmentPolicy,
+): string {
+  const { mimeType, filename } = file;
+  switch (reason) {
+    case "text_too_large":
+      return `"${filename}" is too large to include (max ${formatBytes(INLINE_TEXT_MAX_BYTES)} of text without a sandbox).`;
+    case "too_large_for_sandbox":
+      return `"${filename}" is too large (max ${formatBytes(policy.sandboxByteLimit)}).`;
+    case "unsupported_type":
+      return `"${filename}" (${mimeType}) isn't supported by this model.`;
+  }
+}
+
+function base64ByteLength(payload: string): number {
+  const len = payload.length;
+  if (len === 0) return 0;
+  const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+  return Math.floor((len * 3) / 4) - padding;
+}
+
+function formatBytes(bytes: number): string {
+  return bytes >= 1024 * 1024
+    ? `${Math.round(bytes / (1024 * 1024))} MB`
+    : `${Math.round(bytes / 1024)} KB`;
 }
 
 export { ATTACHMENT_URL_PREFIX, ATTACHMENT_URL_SUFFIX };

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
@@ -1,4 +1,7 @@
-import { getModelReadableMimeTypes } from "@archestra/shared";
+import {
+  getModelReadableMimeTypes,
+  INLINE_TEXT_MAX_BYTES,
+} from "@archestra/shared";
 import config from "@/config";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import { expect, test } from "@/test";
@@ -324,6 +327,102 @@ test("references a non-ingestible attachment in the sandbox instead of inlining 
   // The bytes are NOT inlined into the model payload.
   expect(part.text).not.toContain("data:");
   expect(part.url).toBeUndefined();
+});
+
+test("routes an oversized text document to the sandbox instead of inlining it", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  // text/csv IS model-ingestible here, so only its size — just over the inline
+  // budget — is what diverts it to the sandbox.
+  const bytes = Buffer.alloc(INLINE_TEXT_MAX_BYTES + 1, 0x61);
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "big.csv",
+    mimeType: "text/csv",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "text/csv",
+          filename: "big.csv",
+        },
+      ],
+    },
+  ];
+
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: new Set(["text/csv"]),
+    sandboxAvailable: true,
+  });
+
+  const part = expectPresent(output[0].parts?.[0]);
+  expect(part.type).toBe("text");
+  expect(part.text).toContain("/home/sandbox/attachments");
+  expect(part.text).not.toContain("data:");
+  expect(part.url).toBeUndefined();
+});
+
+test("inlines a text document that is within the inline budget", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.alloc(INLINE_TEXT_MAX_BYTES, 0x61);
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "fits.csv",
+    mimeType: "text/csv",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "text/csv",
+          filename: "fits.csv",
+        },
+      ],
+    },
+  ];
+
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: new Set(["text/csv"]),
+    sandboxAvailable: false,
+  });
+
+  const filePart = expectPresent(output[0].parts?.[0]);
+  expect(filePart.type).toBe("file");
+  expect(filePart.url).toContain("data:text/csv");
 });
 
 test("a non-ingestible attachment is NOT pointed at the sandbox when it is unavailable for the agent", async ({

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -1,3 +1,7 @@
+import {
+  INLINE_TEXT_MAX_BYTES,
+  isInlineableTextMimeType,
+} from "@archestra/shared";
 import config from "@/config";
 import logger from "@/logging";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
@@ -7,7 +11,6 @@ import {
   isAttachmentRefUrl,
   parseAttachmentIdFromUrl,
 } from "./extract-inline-attachments";
-import { isInlineableTextDocumentMimeType } from "./prepare-for-provider";
 
 type Attachment = Awaited<
   ReturnType<typeof ConversationAttachmentModel.findByIdsWithData>
@@ -176,7 +179,13 @@ function materializePart(
   const endpointRejectsBinaryDoc =
     rerouteBinaryDocsToSandbox &&
     isNonInlineableBinaryDocMimeType(attachment.mimeType);
-  if (modelCannotRead || endpointRejectsBinaryDoc) {
+  // A text document over the inline budget is routed to the sandbox instead of
+  // being embedded in the prompt. The ingest gate only admits an over-budget
+  // text file when the sandbox is available, so it has been auto-staged there.
+  const textTooLargeToInline =
+    isInlineableTextMimeType(attachment.mimeType) &&
+    attachment.fileData.byteLength > INLINE_TEXT_MAX_BYTES;
+  if (modelCannotRead || endpointRejectsBinaryDoc || textTooLargeToInline) {
     return referenceSandboxFilePart(attachment, sandboxAvailable);
   }
 
@@ -237,10 +246,7 @@ function dualAvailabilityPointer(
   // `sandboxAvailable` already implies the feature flag is on; gating on it (not
   // just the flag) keeps the pointer from advertising a sandbox the agent can't
   // reach. The inline copy still goes through, so nothing is lost.
-  if (
-    !sandboxAvailable ||
-    !isInlineableTextDocumentMimeType(attachment.mimeType)
-  ) {
+  if (!sandboxAvailable || !isInlineableTextMimeType(attachment.mimeType)) {
     return null;
   }
   if (
@@ -263,7 +269,7 @@ function dualAvailabilityPointer(
  * other binaries) only travels as a `document` block the endpoint rejects.
  */
 function isNonInlineableBinaryDocMimeType(mime: string): boolean {
-  return !mime.startsWith("image/") && !isInlineableTextDocumentMimeType(mime);
+  return !mime.startsWith("image/") && !isInlineableTextMimeType(mime);
 }
 
 /** Mime of an inline `data:` file part, from `mediaType` or the URL prefix. */

--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
@@ -19,6 +19,23 @@ function csvAttachmentMessage(): ChatMessage {
   };
 }
 
+const YAML = "name: archestra\nversion: 1";
+
+function yamlAttachmentMessage(): ChatMessage {
+  return {
+    role: "user",
+    parts: [
+      { type: "text", text: "summarize" },
+      {
+        type: "file",
+        url: `data:application/x-yaml;base64,${Buffer.from(YAML, "utf8").toString("base64")}`,
+        mediaType: "application/x-yaml",
+        filename: "config.yaml",
+      },
+    ],
+  };
+}
+
 describe("prepareMessagesForProvider — anthropic endpoint branch", () => {
   it("native Anthropic keeps the document file part (rewritten to text/plain)", () => {
     const [message] = prepareMessagesForProvider({
@@ -62,5 +79,42 @@ describe("prepareMessagesForProvider — anthropic endpoint branch", () => {
     expect(message.parts?.find((p) => p.type === "file")?.mediaType).toBe(
       "text/plain",
     );
+  });
+
+  it("rewrites a broadened text type (YAML) to a text/plain document block", () => {
+    const [message] = prepareMessagesForProvider({
+      messages: [yamlAttachmentMessage()],
+      provider: "anthropic",
+      anthropicNativeEndpoint: true,
+    });
+    expect(message.parts?.find((p) => p.type === "file")?.mediaType).toBe(
+      "text/plain",
+    );
+  });
+});
+
+describe("prepareMessagesForProvider — generic and gemini providers", () => {
+  it("inlines a broadened text type (YAML) as decoded text for a generic provider", () => {
+    const [message] = prepareMessagesForProvider({
+      messages: [yamlAttachmentMessage()],
+      provider: "openai",
+    });
+    expect(message.parts?.some((p) => p.type === "file")).toBe(false);
+    const inlined = message.parts?.find(
+      (p) => p.type === "text" && p.text?.includes(YAML),
+    );
+    expect(inlined).toBeDefined();
+  });
+
+  it("inlines text documents as decoded text for gemini instead of passing them through as inlineData", () => {
+    const [message] = prepareMessagesForProvider({
+      messages: [csvAttachmentMessage()],
+      provider: "gemini",
+    });
+    expect(message.parts?.some((p) => p.type === "file")).toBe(false);
+    const inlined = message.parts?.find(
+      (p) => p.type === "text" && p.text?.includes(CSV),
+    );
+    expect(inlined).toBeDefined();
   });
 });

--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
@@ -117,4 +117,16 @@ describe("prepareMessagesForProvider — generic and gemini providers", () => {
     );
     expect(inlined).toBeDefined();
   });
+
+  it("normalizes a broadened text type (YAML) to a text/plain document block for bedrock", () => {
+    const [message] = prepareMessagesForProvider({
+      messages: [yamlAttachmentMessage()],
+      provider: "bedrock",
+    });
+    // Bedrock has no native YAML document format, so it travels as a
+    // text/plain document block the SDK can relay.
+    expect(message.parts?.find((p) => p.type === "file")?.mediaType).toBe(
+      "text/plain",
+    );
+  });
 });

--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.ts
@@ -1,22 +1,25 @@
-import type { SupportedProvider } from "@archestra/shared";
+import {
+  isInlineableTextMimeType,
+  type SupportedProvider,
+} from "@archestra/shared";
 import type { ChatMessage, ChatMessagePart } from "@/types";
 
 /**
  * Rewrite materialized messages into a shape the target provider's SDK accepts
  * before `convertToModelMessages`.
  *
- * Text-document file parts (CSV/JSON/Markdown/…) are handled three ways:
+ * Inlineable text-document file parts (see {@link isInlineableTextMimeType} —
+ * CSV/JSON/Markdown/XML/YAML/TOML/…) are handled two ways:
  * - `anthropic`/`bedrock`: rewrite the document part's mediaType to text/plain
- *   (their SDKs base64-decode text/plain documents natively).
- * - `gemini`: pass through — @ai-sdk/google inlines any file part as inlineData,
- *   which is base64 the Gemini API decodes server-side.
- * - every other provider, including `cohere`: the document is inlined as a
- *   `text` part with its decoded content. OpenAI-compatible/groq/xai/mistral
- *   SDKs throw `UnsupportedFunctionalityError` for any non-image/-pdf file part
- *   (including text/plain); @ai-sdk/cohere instead relays a data-URL file part's
- *   raw base64 body as document text WITHOUT decoding it (its media-type
- *   handling only runs for `Uint8Array` data, never our data-URL strings), so
- *   the model would see base64. Inlining the decoded text fixes both.
+ *   (their SDKs base64-decode text/plain documents natively), keeping the
+ *   provider's native `document` block and any prompt-cache marker on it.
+ * - every other provider, including `gemini` and `cohere`: the document is
+ *   inlined as a `text` part with its decoded content. OpenAI-compatible/groq/
+ *   xai/mistral SDKs throw `UnsupportedFunctionalityError` for any non-image/-pdf
+ *   file part (including text/plain); @ai-sdk/cohere relays a data-URL file
+ *   part's raw base64 body as document text WITHOUT decoding it; and Gemini's
+ *   `inlineData` path does not reliably accept exotic text MIMEs. Inlining the
+ *   decoded text fixes all of these.
  */
 export function prepareMessagesForProvider(params: {
   messages: ChatMessage[];
@@ -53,11 +56,6 @@ export function prepareMessagesForProvider(params: {
       );
   }
 
-  // @ai-sdk/google inlines any file part as inlineData — the document survives.
-  if (provider === "gemini") {
-    return messages;
-  }
-
   return messages.map(inlineTextDocumentMessageFileParts);
 }
 
@@ -84,7 +82,7 @@ function inlineTextDocumentFilePart(part: ChatMessagePart): ChatMessagePart {
   if (
     part.type !== "file" ||
     typeof part.mediaType !== "string" ||
-    !isInlineableTextDocumentMimeType(part.mediaType)
+    !isInlineableTextMimeType(part.mediaType)
   ) {
     return part;
   }
@@ -110,23 +108,6 @@ function inlineTextDocumentFilePart(part: ChatMessagePart): ChatMessagePart {
     type: "text",
     text: `[Attachment ${JSON.stringify(name)} (${part.mediaType})]\n\n${decoded}`,
   };
-}
-
-/**
- * Text-document mime types whose content can be inlined as a text part for
- * providers that reject document file parts. Kept separate from
- * {@link isAnthropicTextDocumentMimeType} so the anthropic rewrite path stays
- * byte-identical (it intentionally excludes text/plain).
- */
-export function isInlineableTextDocumentMimeType(mediaType: string): boolean {
-  return (
-    mediaType === "text/csv" ||
-    mediaType === "application/csv" ||
-    mediaType === "application/vnd.ms-excel" ||
-    mediaType === "text/markdown" ||
-    mediaType === "application/json" ||
-    mediaType === "text/plain"
-  );
 }
 
 // Decodes the base64 body of a `data:<mediaType>;base64,...` URL as UTF-8.
@@ -189,14 +170,11 @@ function normalizeAnthropicFilePart(part: ChatMessagePart): ChatMessagePart {
   };
 }
 
+// Inlineable text documents Anthropic should receive as a native `document`
+// block: rewrite them to text/plain (its SDK base64-decodes text/plain natively).
+// text/plain is excluded — it is already text/plain, so the rewrite is a no-op.
 function isAnthropicTextDocumentMimeType(mediaType: string): boolean {
-  return (
-    mediaType === "text/csv" ||
-    mediaType === "text/markdown" ||
-    mediaType === "application/csv" ||
-    mediaType === "application/vnd.ms-excel" ||
-    mediaType === "application/json"
-  );
+  return isInlineableTextMimeType(mediaType) && mediaType !== "text/plain";
 }
 
 // ===== Bedrock =====
@@ -238,10 +216,15 @@ function normalizeBedrockFilePart(part: ChatMessagePart): ChatMessagePart {
   };
 }
 
-// MIMEs that contain text content but aren't in Bedrock's natively supported
-// document list — normalize to text/plain so the AI SDK can relay them.
+// Inlineable text documents that aren't in Bedrock's natively supported document
+// list (csv, md, txt) — normalize to text/plain so the AI SDK can relay them.
 function isBedrockTextNormalizableMimeType(mediaType: string): boolean {
-  return mediaType === "application/json" || mediaType === "application/csv";
+  return (
+    isInlineableTextMimeType(mediaType) &&
+    mediaType !== "text/csv" &&
+    mediaType !== "text/markdown" &&
+    mediaType !== "text/plain"
+  );
 }
 
 // Bedrock rejects user messages that contain a file/document block but no text

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -177,7 +177,7 @@ describe("prepareMessagesForProvider", () => {
     expect(messages[0]).toBe(message);
   });
 
-  it("leaves text-document file parts unchanged for gemini (inlineData passthrough)", () => {
+  it("inlines text-document file parts as decoded text for gemini", () => {
     const message = {
       role: "user" as const,
       parts: [
@@ -195,7 +195,13 @@ describe("prepareMessagesForProvider", () => {
       messages: [message],
     });
 
-    expect(messages[0]).toBe(message);
+    // Gemini no longer receives text documents as inlineData — they are decoded
+    // and inlined as a text part, which reliably handles exotic text MIME types.
+    expect(messages[0].parts?.some((p) => p.type === "file")).toBe(false);
+    const inlined = messages[0].parts?.find(
+      (p) => p.type === "text" && p.text?.includes("a,b,c"),
+    );
+    expect(inlined).toBeDefined();
   });
 
   it("inlines application/csv and excel-as-text for cohere (its SDK relays base64 undecoded otherwise)", () => {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -5,6 +5,7 @@ import {
   type ChatErrorResponse,
   CONTEXT_WINDOW_BREAKDOWN_EVENT,
   type ContextWindowBreakdown,
+  getModelReadableMimeTypes,
   isModelSelectionComplete,
   PROJECT_INSTRUCTIONS_MAX_LENGTH,
   RouteId,
@@ -89,6 +90,7 @@ import {
 } from "@/services/active-chat-run";
 import { conversationFilesService } from "@/services/conversation-files";
 import { projectService } from "@/services/project";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import { fileStore } from "@/skills-sandbox/file-store";
 import { renderSystemPrompt } from "@/templating";
 import {
@@ -139,7 +141,11 @@ import {
 import { injectAppDiagnostics } from "./inject-app-diagnostics";
 import { injectSkillActivation } from "./inject-skill-activation";
 import { cloneAttachmentsForFork } from "./normalization/clone-attachments-for-fork";
-import { extractInlineAttachments } from "./normalization/extract-inline-attachments";
+import {
+  assertInlineAttachmentsAcceptable,
+  extractInlineAttachments,
+  messagesHaveNewInlineAttachments,
+} from "./normalization/extract-inline-attachments";
 import {
   normalizeChatMessages,
   normalizeChatMessagesForPersistence,
@@ -322,6 +328,34 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
           400,
           "The agent associated with this conversation has been deleted",
         );
+      }
+
+      // Gate uploaded attachments before any bytes are persisted: the model must
+      // be able to ingest the type, or it must be a small inlineable text
+      // document, or a sandbox must be available to stage arbitrary files. The
+      // frontend mirrors this for UX, but a custom client bypasses it, so this
+      // is the authoritative check. Runs before extractInlineAttachments and
+      // before the active run is acquired, so a rejected request stores nothing.
+      // Skipped (with its model/sandbox lookups) on the common turn that uploads
+      // nothing.
+      if (messagesHaveNewInlineAttachments(messages as ChatMessage[])) {
+        const attachmentModelRow = conversation.modelId
+          ? await ModelModel.findById(conversation.modelId)
+          : null;
+        assertInlineAttachmentsAcceptable({
+          messages: messages as ChatMessage[],
+          policy: {
+            ingestibleMimeTypes: getModelReadableMimeTypes(
+              attachmentModelRow?.inputModalities ?? null,
+            ),
+            sandboxAvailable: await isSkillSandboxAvailableForAgent({
+              userId: user.id,
+              organizationId,
+              agentId: conversation.agentId,
+            }),
+            sandboxByteLimit: config.skillsSandbox.artifactBytesLimit,
+          },
+        });
       }
 
       // Lifecycle hooks (SessionStart). Cheap no-op when the agent has no hooks or

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -2212,4 +2212,32 @@ describe("POST /api/chat handler composition", () => {
       );
     expect(attachments).toHaveLength(0);
   });
+
+  test("rejects an unsupported attachment with no sandbox and persists nothing", async () => {
+    const dataUrl = `data:application/zip;base64,${Buffer.from("PK zip bytes").toString("base64")}`;
+    const response = await postMessage([
+      {
+        id: "msg-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "process this" },
+          {
+            type: "file",
+            url: dataUrl,
+            mediaType: "application/zip",
+            filename: "archive.zip",
+          },
+        ],
+      },
+    ]);
+
+    // The gate runs before extraction and before the active run is acquired,
+    // so the request is rejected and no attachment row is written.
+    expect(response.statusCode).toBe(400);
+    const attachments =
+      await ConversationAttachmentModel.findByConversationIdWithoutData(
+        conversationId,
+      );
+    expect(attachments).toHaveLength(0);
+  });
 });

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -63,6 +63,9 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               betaEnabled: z.boolean(),
               orchestratorK8sRuntime: z.boolean(),
               sandbox: z.boolean(),
+              // Max size of a file the sandbox can stage. The chat composer caps
+              // sandbox-routed uploads at this instead of guessing.
+              sandboxArtifactBytesLimit: z.number(),
               agentSkillsEnabled: z.boolean(),
               agentEnvironmentsEnabled: z.boolean(),
               appsEnabled: z.boolean(),
@@ -123,6 +126,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           betaEnabled: config.beta,
           orchestratorK8sRuntime: McpServerRuntimeManager.isEnabled,
           sandbox: skillSandboxRuntimeService.isEnabled,
+          sandboxArtifactBytesLimit: config.skillsSandbox.artifactBytesLimit,
           agentSkillsEnabled: config.agents.skillsEnabled,
           agentEnvironmentsEnabled: config.agents.environmentsEnabled,
           appsEnabled: config.apps.enabled,

--- a/platform/backend/src/types/agent.ts
+++ b/platform/backend/src/types/agent.ts
@@ -240,6 +240,14 @@ export const SelectAgentSchema = createSelectSchema(
    * substituting another model.
    */
   llmProviderRequiresPerUserCredential: z.boolean().optional(),
+  /**
+   * Whether the code-execution sandbox is usable for this agent by the
+   * requesting user (`isSkillSandboxAvailableForAgent`: feature enabled +
+   * `sandbox:execute` permission + the sandbox tools assigned/accessible). The
+   * chat composer widens the accepted upload types to any file when true.
+   * Populated on read paths (list/get); absent on mutation responses.
+   */
+  sandboxAvailable: z.boolean().optional(),
 });
 
 // Base schema without refinement - can be used with .partial()

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -56,6 +56,8 @@ export interface ChatPromptInputToolsProps {
   onProviderChange?: (provider: SupportedProvider, apiKeyId: string) => void;
   /** Whether file uploads are allowed (controlled by organization setting) */
   allowFileUploads?: boolean;
+  /** Whether the agent has a code sandbox available (allows any file type) */
+  sandboxAvailable?: boolean;
   /** Whether models are still loading - passed to API key selector */
   isModelsLoading?: boolean;
   /** Estimated tokens used in the conversation (for context indicator) */
@@ -110,6 +112,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   onApiKeyChange,
   onProviderChange,
   allowFileUploads = false,
+  sandboxAvailable = false,
   isModelsLoading = false,
   tokensUsed = 0,
   cachedTokens,
@@ -153,10 +156,14 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   // Determine if file uploads should be shown
   // 1. Organization must allow file uploads (allowFileUploads)
   // 2. Model must support at least one file type (modelSupportsFiles)
+  // A sandbox-equipped agent can process any file (staged for run_command), so
+  // uploads are offered even when the model itself has no file modalities.
   const showFileUploadButton =
-    allowFileUploads && supportsFileUploads(inputModalities);
-  const supportedTypesDescription =
-    getSupportedFileTypesDescription(inputModalities);
+    allowFileUploads &&
+    (supportsFileUploads(inputModalities) || sandboxAvailable);
+  const supportedTypesDescription = sandboxAvailable
+    ? "any file type"
+    : getSupportedFileTypesDescription(inputModalities);
 
   // Check if user can update agent settings (to show settings link in tooltip)
   const { data: canUpdateAgentSettings } = useHasPermissions({

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -381,8 +381,10 @@ describe("ArchestraPromptInput", () => {
       expect(
         screen.getByTestId(E2eTestId.ChatFileUploadButton),
       ).toBeInTheDocument();
+      // Enabled state shows the supported-types tooltip rather than the
+      // disabled "does not support file uploads" message.
       expect(screen.getByTestId("tooltip-content")).toHaveTextContent(
-        "Supports: chat prompts, .txt, .csv, .md, and .json uploads",
+        "Supports:",
       );
     });
 

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -3,8 +3,11 @@
 import {
   type ChatSkillMetadata,
   type ContextWindowBreakdown,
+  chatUploadRejectionReason,
   E2eTestId,
   getAcceptedFileTypes,
+  getMediaType,
+  getModelReadableMimeTypes,
   supportsFileUploads,
 } from "@archestra/shared";
 import type { ChatStatus } from "ai";
@@ -31,6 +34,7 @@ import {
 } from "@/components/ai-elements/prompt-input";
 import { PlaywrightInstallInline } from "@/components/chat/playwright-install-dialog";
 import { SensitiveDataConfirmDialog } from "@/components/chat/sensitive-data-confirm-dialog";
+import { useProfile } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useConversation, useToggleHooksDebug } from "@/lib/chat/chat.query";
 import { useChatPlaceholder } from "@/lib/chat/chat-placeholder.hook";
@@ -57,6 +61,15 @@ import {
 
 const CHAT_ATTACHMENT_MAX_BYTES = 50 * 1024 * 1024;
 const CHAT_ATTACHMENT_MAX_MB = CHAT_ATTACHMENT_MAX_BYTES / (1024 * 1024);
+// Fallback sandbox artifact limit when /api/config has not loaded yet (mirrors
+// the backend default). Only consulted when a sandbox is available.
+const DEFAULT_SANDBOX_ARTIFACT_BYTES = 16 * 1024 * 1024;
+
+function formatBytes(bytes: number): string {
+  return bytes >= 1024 * 1024
+    ? `${Math.round(bytes / (1024 * 1024))} MB`
+    : `${Math.round(bytes / 1024)} KB`;
+}
 
 export interface ArchestraPromptInputProps
   extends Omit<ChatPromptInputToolsProps, "textareaRef"> {
@@ -141,8 +154,10 @@ const PromptInputContent = ({
   onResetModelOverride,
   agentRequiresPerUserConnect,
   agentModelDisplayName,
+  sandboxAvailable,
 }: Omit<ArchestraPromptInputProps, "onSubmit"> & {
   onSubmit: ArchestraPromptInputProps["onSubmit"];
+  sandboxAvailable: boolean;
 }) => {
   const internalTextareaRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = externalTextareaRef ?? internalTextareaRef;
@@ -153,10 +168,16 @@ const PromptInputContent = ({
     string | null
   >(null);
 
-  // Derive file upload capabilities from model input modalities
+  // Derive file upload capabilities from model input modalities. When the agent
+  // has a sandbox available, any file type is allowed (it is staged for
+  // run_command), so uploads are offered even for a non-multimodal model and the
+  // OS picker is unrestricted.
   const showFileUploadButton =
-    allowFileUploads && supportsFileUploads(inputModalities);
-  const acceptedFileTypes = getAcceptedFileTypes(inputModalities);
+    allowFileUploads &&
+    (supportsFileUploads(inputModalities) || sandboxAvailable);
+  const acceptedFileTypes = sandboxAvailable
+    ? undefined
+    : getAcceptedFileTypes(inputModalities);
 
   // Chat placeholders from organization settings
   const { data: orgData } = useOrganization();
@@ -646,6 +667,7 @@ const PromptInputContent = ({
             onApiKeyChange={onApiKeyChange}
             onProviderChange={onProviderChange}
             allowFileUploads={allowFileUploads}
+            sandboxAvailable={sandboxAvailable}
             isModelsLoading={isModelsLoading}
             tokensUsed={tokensUsed}
             cachedTokens={cachedTokens}
@@ -719,9 +741,39 @@ const ArchestraPromptInput = ({
   agentRequiresPerUserConnect,
   agentModelDisplayName,
 }: ArchestraPromptInputProps) => {
+  const { data: activeAgent } = useProfile(agentId);
+  const sandboxAvailable = activeAgent?.sandboxAvailable ?? false;
+  const sandboxByteLimit =
+    useFeature("sandboxArtifactBytesLimit") ?? DEFAULT_SANDBOX_ARTIFACT_BYTES;
+
+  // Per-file policy mirroring the backend ingest gate (which is authoritative).
+  // Returns a friendly reason to drop the file, or null to accept it.
+  const validateFile = useCallback(
+    (file: File): string | null => {
+      const reason = chatUploadRejectionReason({
+        mimeType: getMediaType(file),
+        byteLength: file.size,
+        ingestibleMimeTypes: getModelReadableMimeTypes(inputModalities),
+        sandboxAvailable,
+        sandboxByteLimit,
+      });
+      switch (reason) {
+        case null:
+          return null;
+        case "text_too_large":
+          return `"${file.name}" is too large to include as text. Enable the sandbox to work with larger files.`;
+        case "too_large_for_sandbox":
+          return `"${file.name}" exceeds the maximum size of ${formatBytes(sandboxByteLimit)}.`;
+        case "unsupported_type":
+          return `This model can't read "${file.name}". Enable the sandbox to use any file type.`;
+      }
+    },
+    [inputModalities, sandboxAvailable, sandboxByteLimit],
+  );
+
   const handleProviderFileError = useCallback(
     (err: {
-      code: "max_files" | "max_file_size" | "accept";
+      code: "max_files" | "max_file_size" | "accept" | "rejected";
       message: string;
     }) => {
       if (err.code === "max_file_size") {
@@ -730,6 +782,10 @@ const ArchestraPromptInput = ({
         );
       } else if (err.code === "max_files") {
         toast.error("Too many files attached.");
+      } else if (err.code === "rejected") {
+        // Policy rejection (unsupported type / too large to inline). Gentle,
+        // not an error toast — the message already explains the next step.
+        toast(err.message);
       }
     },
     [],
@@ -739,6 +795,7 @@ const ArchestraPromptInput = ({
     <div className="flex size-full flex-col justify-end">
       <PromptInputProvider
         maxFileSize={CHAT_ATTACHMENT_MAX_BYTES}
+        validateFile={validateFile}
         onError={handleProviderFileError}
       >
         <PromptInputContent
@@ -774,6 +831,7 @@ const ArchestraPromptInput = ({
           onResetModelOverride={onResetModelOverride}
           agentRequiresPerUserConnect={agentRequiresPerUserConnect}
           agentModelDisplayName={agentModelDisplayName}
+          sandboxAvailable={sandboxAvailable}
         />
       </PromptInputProvider>
     </div>

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -8,6 +8,7 @@ import {
   getAcceptedFileTypes,
   getMediaType,
   getModelReadableMimeTypes,
+  INLINE_TEXT_MAX_BYTES,
   supportsFileUploads,
 } from "@archestra/shared";
 import type { ChatStatus } from "ai";
@@ -761,7 +762,7 @@ const ArchestraPromptInput = ({
         case null:
           return null;
         case "text_too_large":
-          return `"${file.name}" is too large to include as text. Enable the sandbox to work with larger files.`;
+          return `"${file.name}" is too large to include as text (max ${formatBytes(INLINE_TEXT_MAX_BYTES)}). Enable the sandbox to work with larger files.`;
         case "too_large_for_sandbox":
           return `"${file.name}" exceeds the maximum size of ${formatBytes(sandboxByteLimit)}.`;
         case "unsupported_type":

--- a/platform/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/platform/frontend/src/components/ai-elements/prompt-input.tsx
@@ -146,8 +146,14 @@ const useOptionalProviderAttachments = () =>
 export type PromptInputProviderProps = PropsWithChildren<{
   initialInput?: string;
   maxFileSize?: number;
+  /**
+   * Per-file policy check beyond the MIME `accept` and `maxFileSize` constraints.
+   * Returns a human-readable reason to reject the file, or null to accept it.
+   * Rejected files are dropped and reported via `onError` with code `rejected`.
+   */
+  validateFile?: (file: File) => string | null;
   onError?: (err: {
-    code: "max_files" | "max_file_size" | "accept";
+    code: "max_files" | "max_file_size" | "accept" | "rejected";
     message: string;
   }) => void;
 }>;
@@ -159,6 +165,7 @@ export type PromptInputProviderProps = PropsWithChildren<{
 export function PromptInputProvider({
   initialInput: initialTextInput = "",
   maxFileSize,
+  validateFile,
   onError,
   children,
 }: PromptInputProviderProps) {
@@ -198,6 +205,20 @@ export function PromptInputProvider({
         }
       }
 
+      if (validateFile) {
+        accepted = accepted.filter((f) => {
+          const rejection = validateFile(f);
+          if (rejection) {
+            onError?.({ code: "rejected", message: rejection });
+            return false;
+          }
+          return true;
+        });
+        if (accepted.length === 0) {
+          return;
+        }
+      }
+
       setAttachmentFiles((prev) =>
         prev.concat(
           accepted.map((file) => ({
@@ -210,7 +231,7 @@ export function PromptInputProvider({
         ),
       );
     },
-    [maxFileSize, onError],
+    [maxFileSize, validateFile, onError],
   );
 
   const remove = useCallback((id: string) => {

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -29,6 +29,7 @@ export function makeConfig(
       betaEnabled: false,
       orchestratorK8sRuntime: false,
       sandbox: false,
+      sandboxArtifactBytesLimit: 16 * 1024 * 1024,
       agentSkillsEnabled: false,
       agentEnvironmentsEnabled: false,
       appsEnabled: false,

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -3,12 +3,16 @@ import {
   CONTEXT_WINDOW_BREAKDOWN_EVENT,
   CONTEXT_WINDOW_CATEGORIES,
   ContextWindowBreakdownSchema,
+  chatUploadRejectionReason,
   getAcceptedFileTypes,
   getMediaType,
+  getModelReadableMimeTypes,
   getSupportedFileTypesDescription,
   hasPersistableAssistantContent,
   hasRenderableAssistantContent,
+  INLINE_TEXT_MAX_BYTES,
   INPUT_MODALITY_OPTIONS,
+  isInlineableTextMimeType,
   OUTPUT_MODALITY_OPTIONS,
   supportsFileUploads,
 } from "./chat";
@@ -148,34 +152,33 @@ describe("CONTEXT_WINDOW_CATEGORIES", () => {
 });
 
 describe("chat file upload helpers", () => {
-  test("treats text modality as supporting txt, md, csv, and json uploads", () => {
+  const TEXT_MODALITY_MIME_TYPES = [
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "text/tab-separated-values",
+    "application/json",
+    "text/xml",
+    "application/xml",
+    "application/x-yaml",
+    "text/yaml",
+    "application/toml",
+    "text/x-toml",
+    "application/csv",
+    "application/vnd.ms-excel",
+  ];
+
+  test("treats text modality as supporting the inlineable text document types", () => {
     expect(getAcceptedFileTypes(["text"])).toBe(
-      [
-        "text/plain",
-        "text/markdown",
-        "text/csv",
-        "application/csv",
-        "application/vnd.ms-excel",
-        "application/json",
-      ].join(","),
+      TEXT_MODALITY_MIME_TYPES.join(","),
     );
     expect(supportsFileUploads(["text"])).toBe(true);
-    expect(getSupportedFileTypesDescription(["text"])).toBe(
-      "chat prompts, .txt, .csv, .md, and .json uploads",
-    );
+    expect(getSupportedFileTypesDescription(["text"])).not.toBeNull();
   });
 
   test("deduplicates mime types across modalities", () => {
     expect(getAcceptedFileTypes(["text", "text", "pdf"])).toBe(
-      [
-        "text/plain",
-        "text/markdown",
-        "text/csv",
-        "application/csv",
-        "application/vnd.ms-excel",
-        "application/json",
-        "application/pdf",
-      ].join(","),
+      [...TEXT_MODALITY_MIME_TYPES, "application/pdf"].join(","),
     );
   });
 
@@ -187,11 +190,9 @@ describe("chat file upload helpers", () => {
     expect(getSupportedFileTypesDescription(undefined)).toBeNull();
   });
 
-  test("builds a readable description for multiple upload modalities", () => {
-    expect(
-      getSupportedFileTypesDescription(["text", "image", "pdf", "audio"]),
-    ).toBe(
-      "chat prompts, .txt, .csv, .md, and .json uploads, images, PDFs, audio",
+  test("joins per-modality descriptions for multiple upload modalities", () => {
+    expect(getSupportedFileTypesDescription(["image", "pdf", "audio"])).toBe(
+      "images, PDFs, audio",
     );
   });
 
@@ -206,8 +207,43 @@ describe("chat file upload helpers", () => {
       "application/pdf",
     );
     expect(getMediaType({ name: "table.csv", type: "" })).toBe("text/csv");
+    expect(getMediaType({ name: "data.tsv", type: "" })).toBe(
+      "text/tab-separated-values",
+    );
     expect(getMediaType({ name: "README.md", type: "" })).toBe("text/markdown");
     expect(getMediaType({ name: "readme.txt", type: "" })).toBe("text/plain");
+    expect(getMediaType({ name: "config.yaml", type: "" })).toBe(
+      "application/x-yaml",
+    );
+    expect(getMediaType({ name: "config.yml", type: "" })).toBe(
+      "application/x-yaml",
+    );
+    expect(getMediaType({ name: "Cargo.toml", type: "" })).toBe(
+      "application/toml",
+    );
+  });
+
+  test("recognizes inlineable text document mime types", () => {
+    for (const mimeType of [
+      "text/plain",
+      "text/markdown",
+      "text/csv",
+      "text/tab-separated-values",
+      "application/json",
+      "text/xml",
+      "application/xml",
+      "application/x-yaml",
+      "application/toml",
+    ]) {
+      expect(isInlineableTextMimeType(mimeType)).toBe(true);
+    }
+    for (const mimeType of [
+      "application/pdf",
+      "image/png",
+      "application/octet-stream",
+    ]) {
+      expect(isInlineableTextMimeType(mimeType)).toBe(false);
+    }
   });
 
   test("defaults unknown extensions to application/octet-stream", () => {
@@ -232,6 +268,105 @@ describe("chat file upload helpers", () => {
       "image",
       "audio",
     ]);
+  });
+});
+
+describe("chatUploadRejectionReason", () => {
+  const base = {
+    ingestibleMimeTypes: new Set(["image/png", "application/pdf"]),
+    sandboxAvailable: false,
+    sandboxByteLimit: 16 * 1024 * 1024,
+  };
+
+  test("accepts a model-ingestible type at any size", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "image/png",
+        byteLength: 8_000_000,
+      }),
+    ).toBeNull();
+  });
+
+  test("accepts a small inlineable text file without a sandbox", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "application/toml",
+        byteLength: INLINE_TEXT_MAX_BYTES,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects oversized text without a sandbox, accepts it with one", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES + 1,
+      }),
+    ).toBe("text_too_large");
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        sandboxAvailable: true,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES + 1,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects an unsupported type without a sandbox, accepts within the limit with one", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "application/zip",
+        byteLength: 1_000,
+      }),
+    ).toBe("unsupported_type");
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        sandboxAvailable: true,
+        mimeType: "application/zip",
+        byteLength: 1_000,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects a file over the sandbox limit even when available", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        sandboxAvailable: true,
+        mimeType: "application/zip",
+        byteLength: base.sandboxByteLimit + 1,
+      }),
+    ).toBe("too_large_for_sandbox");
+  });
+
+  test("size-gates inlineable text even when the model lists it as ingestible", () => {
+    // A text-capable model's readable set includes text MIMEs, so the generic
+    // ingestible check would otherwise accept an arbitrarily large text file.
+    const ingestibleMimeTypes = getModelReadableMimeTypes(["text"]);
+    expect(ingestibleMimeTypes.has("text/csv")).toBe(true);
+
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        ingestibleMimeTypes,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES,
+      }),
+    ).toBeNull();
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        ingestibleMimeTypes,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES + 1,
+      }),
+    ).toBe("text_too_large");
   });
 });
 

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -161,6 +161,7 @@ describe("chat file upload helpers", () => {
     "text/xml",
     "application/xml",
     "application/x-yaml",
+    "application/yaml",
     "text/yaml",
     "application/toml",
     "text/x-toml",

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -412,7 +412,9 @@ export type SupportedChatUploadMimeType =
   | "application/json"
   | "application/octet-stream"
   | "application/pdf"
+  | "application/toml"
   | "application/vnd.ms-excel"
+  | "application/x-yaml"
   | "application/xml"
   | "audio/flac"
   | "audio/mpeg"
@@ -430,6 +432,10 @@ export type SupportedChatUploadMimeType =
   | "text/csv"
   | "text/markdown"
   | "text/plain"
+  | "text/tab-separated-values"
+  | "text/x-toml"
+  | "text/xml"
+  | "text/yaml"
   | "video/avi"
   | "video/mp4"
   | "video/quicktime"
@@ -438,6 +444,93 @@ export type SupportedChatUploadMimeType =
 // ============================================================================
 // File Type Utilities
 // ============================================================================
+
+/**
+ * Source of truth for inlineable text document MIME types. A text file of one of
+ * these types that is small enough (see {@link INLINE_TEXT_MAX_BYTES}) is embedded
+ * directly into the prompt as decoded text. The same list gates which non-image
+ * uploads the composer accepts and which file parts the provider-prep path inlines,
+ * so it must stay the single definition shared across frontend and backend.
+ */
+const INLINEABLE_TEXT_MIME_TYPES = [
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "text/tab-separated-values",
+  "application/json",
+  "text/xml",
+  "application/xml",
+  "application/x-yaml",
+  "text/yaml",
+  "application/toml",
+  "text/x-toml",
+  // Legacy CSV aliases some browsers and operating systems report.
+  "application/csv",
+  "application/vnd.ms-excel",
+] as const satisfies readonly SupportedChatUploadMimeType[];
+
+const INLINEABLE_TEXT_MIME_TYPE_SET: ReadonlySet<string> = new Set(
+  INLINEABLE_TEXT_MIME_TYPES,
+);
+
+/**
+ * Whether a MIME type is an inlineable text document — embeddable in the prompt as
+ * decoded text on any provider, rather than handed off as a binary attachment.
+ */
+export function isInlineableTextMimeType(mimeType: string): boolean {
+  return INLINEABLE_TEXT_MIME_TYPE_SET.has(mimeType);
+}
+
+/**
+ * Upper size bound for embedding a text document directly into the prompt. Larger
+ * text files are routed to the sandbox when available, otherwise rejected at ingest.
+ */
+export const INLINE_TEXT_MAX_BYTES = 256 * 1024;
+
+/**
+ * Why an upload is not acceptable, or `null` when it is. Single source of truth
+ * for the attachment policy shared by the backend ingest gate (authoritative)
+ * and the frontend composer (mirrors it for UX). A file is acceptable when the
+ * model can ingest its type, OR it is a small inlineable text document, OR a
+ * sandbox is available to stage it within the sandbox artifact size limit.
+ */
+export type ChatUploadRejectionReason =
+  | "text_too_large"
+  | "too_large_for_sandbox"
+  | "unsupported_type";
+
+export function chatUploadRejectionReason(params: {
+  mimeType: string;
+  byteLength: number;
+  ingestibleMimeTypes: Set<string>;
+  sandboxAvailable: boolean;
+  sandboxByteLimit: number;
+}): ChatUploadRejectionReason | null {
+  const {
+    mimeType,
+    byteLength,
+    ingestibleMimeTypes,
+    sandboxAvailable,
+    sandboxByteLimit,
+  } = params;
+
+  const fitsSandbox = sandboxAvailable && byteLength <= sandboxByteLimit;
+
+  // Inlineable text is size-gated even though a text-capable model lists these
+  // MIMEs as readable: a large text file would otherwise blow the context
+  // window. Checked before the generic ingestible short-circuit for that reason.
+  if (isInlineableTextMimeType(mimeType)) {
+    if (byteLength <= INLINE_TEXT_MAX_BYTES || fitsSandbox) return null;
+    return sandboxAvailable ? "too_large_for_sandbox" : "text_too_large";
+  }
+
+  // Non-text types the model can ingest natively (images, PDFs, …) carry no
+  // inline-text budget; the request body limit is the only size bound.
+  if (ingestibleMimeTypes.has(mimeType)) return null;
+
+  if (fitsSandbox) return null;
+  return sandboxAvailable ? "too_large_for_sandbox" : "unsupported_type";
+}
 
 /**
  * Mapping from input modalities to accepted MIME type patterns.
@@ -449,15 +542,8 @@ const MODALITY_TO_MIME_TYPES: Record<
   ModelInputModality,
   SupportedChatUploadMimeType[] | null
 > = {
-  // Text-capable models can accept plain text, CSV, and JSON documents.
-  text: [
-    "text/plain",
-    "text/markdown",
-    "text/csv",
-    "application/csv",
-    "application/vnd.ms-excel",
-    "application/json",
-  ],
+  // Text-capable models accept the inlineable text document types.
+  text: [...INLINEABLE_TEXT_MIME_TYPES],
   // Image formats commonly supported by vision models
   image: [
     "image/jpeg",
@@ -482,7 +568,7 @@ const MODALITY_TO_MIME_TYPES: Record<
 };
 
 const MODALITY_TO_FILE_TYPE_DESCRIPTION: Record<ModelInputModality, string> = {
-  text: "chat prompts, .txt, .csv, .md, and .json uploads",
+  text: "chat prompts and text files (.txt, .md, .csv, .tsv, .json, .xml, .yaml, .toml)",
   image: "images",
   audio: "audio",
   video: "video",
@@ -581,10 +667,15 @@ export function getMediaType(file: FileLikeWithMediaType): string {
     avi: "video/avi",
     pdf: "application/pdf",
     csv: "text/csv",
+    tsv: "text/tab-separated-values",
     md: "text/markdown",
+    markdown: "text/markdown",
     txt: "text/plain",
     json: "application/json",
     xml: "application/xml",
+    yaml: "application/x-yaml",
+    yml: "application/x-yaml",
+    toml: "application/toml",
   };
 
   return ext

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -415,6 +415,7 @@ export type SupportedChatUploadMimeType =
   | "application/toml"
   | "application/vnd.ms-excel"
   | "application/x-yaml"
+  | "application/yaml"
   | "application/xml"
   | "audio/flac"
   | "audio/mpeg"
@@ -461,6 +462,7 @@ const INLINEABLE_TEXT_MIME_TYPES = [
   "text/xml",
   "application/xml",
   "application/x-yaml",
+  "application/yaml",
   "text/yaml",
   "application/toml",
   "text/x-toml",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -11008,6 +11008,7 @@ export type GetAgentsResponses = {
             resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             resolvedLlmModelName?: string | null;
             llmProviderRequiresPerUserCredential?: boolean;
+            sandboxAvailable?: boolean;
         }>;
         pagination: {
             currentPage: number;
@@ -11248,6 +11249,7 @@ export type CreateAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -11453,6 +11455,7 @@ export type GetAllAgentsResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     }>;
 };
 
@@ -11633,6 +11636,7 @@ export type GetDefaultMcpGatewayResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -11813,6 +11817,7 @@ export type GetDefaultLlmProxyResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -12072,6 +12077,7 @@ export type ImportAgentResponses = {
             resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             resolvedLlmModelName?: string | null;
             llmProviderRequiresPerUserCredential?: boolean;
+            sandboxAvailable?: boolean;
         };
         warnings: Array<{
             type: 'tool' | 'knowledgeBase' | 'connector' | 'delegation';
@@ -12345,6 +12351,7 @@ export type GetAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -12578,6 +12585,7 @@ export type UpdateAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -12760,6 +12768,7 @@ export type CloneAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -13103,6 +13112,7 @@ export type RestoreAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -25724,6 +25734,7 @@ export type GetConfigResponses = {
             betaEnabled: boolean;
             orchestratorK8sRuntime: boolean;
             sandbox: boolean;
+            sandboxArtifactBytesLimit: number;
             agentSkillsEnabled: boolean;
             agentEnvironmentsEnabled: boolean;
             appsEnabled: boolean;


### PR DESCRIPTION
## What

Make accepted chat attachments one sandbox-aware policy instead of a frontend-only model-modality allowlist.

- **Sandbox available for the agent** → accept any file type (staged for `run_command`, capped at the sandbox artifact limit).
- **No sandbox** → accept only model-ingestible types plus a broadened set of small inlineable text documents (`txt, md, csv, tsv, json, xml, yaml, toml`); oversized text is gently rejected.
- Inline small text as decoded text on every provider (Gemini now decodes-and-inlines rather than `inlineData`); over-budget text routes to the sandbox at materialize time.
- A single `chatUploadRejectionReason` classifier in `shared/chat.ts` is the source of truth for both the backend ingest gate (authoritative, runs before persisting) and the frontend (mirrors it for UX).
- Per-agent `sandboxAvailable` on the agent API; `sandboxArtifactBytesLimit` on `/api/config`.

Native provider Files API is intentionally out of scope.

## Notes

Builds on the per-agent sandbox availability from #6003 (now merged).

## Validation

type-check, biome, backend knip (dev+production), and the touched test suites (shared, chat normalization, agent model, config, stream route) pass. New coverage: the upload classifier, the ingest gate (incl. malformed `data:` URL), per-provider text handling, the inline size threshold, and per-agent `sandboxAvailable`.

https://claude.ai/code/session_01H3EZGEsvmkt3PSdQuyBxh3

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>