### PR TITLE
fix(migration-kit): rename skills via frontmatter, validate offline, flag dangling refs

### DIFF
--- a/migration-kit/SKILL.md
+++ b/migration-kit/SKILL.md
@@ -70,6 +70,8 @@ Using `references/entity-mapping.md`, turn the inventory into `migration_plan.js
                    "user_answers": { } } ] }
 ```
 You author **decisions only** — never raw API payloads; `apply.py` builds and validates those.
+`target_kind` is required for `migrate` decisions (it drives the build); a `skip`/`manual` decision
+may omit it.
 
 Use `AskUserQuestion` only for genuine ambiguities, e.g.:
 - the single default scope (`personal`/`team`/`org`), plus any per-item exceptions;

--- a/migration-kit/SKILL.md
+++ b/migration-kit/SKILL.md
@@ -75,16 +75,16 @@ may omit it.
 
 Use `AskUserQuestion` only for genuine ambiguities, e.g.:
 - the single default scope (`personal`/`team`/`org`), plus any per-item exceptions;
-- if any decision uses `team` scope, which concrete Archestra team ids should own it. Put them in
-  `user_answers.teamIds`; otherwise use `personal` or `org` scope. Team-scoped agents, skills, and
-  MCP catalog items use `teamIds`; team-scoped MCP installs and LLM keys use `teamId` (or the single
-  value from `teamIds`). A team-scoped decision with no team id is invalid and `apply.py` will not
-  touch the network;
+- if any decision uses `team` scope, which concrete Archestra team ids should own it. Give them in
+  `user_answers`: as `teamIds` (a list) for agents, skills, and MCP catalog items; as `teamId` (a
+  single id, or the lone value from `teamIds`) for MCP installs and LLM keys. `apply.py` maps each to
+  the correct API field. Otherwise use `personal` or `org` scope. A team-scoped decision with no team
+  id is invalid and `apply.py` will not touch the network;
 - whether each subagent should be a `skill` (default) or a full `agent`;
 - whether to also **install** each MCP server now (`mcp_install`) or just register the catalog item
   (installing a local stdio server spins a K8s pod). If you emit both a `mcp_catalog` and a
   `mcp_install` decision for one server, give them the **same** `name`/`name_override` — the install
-  resolves its catalog item by name. `apply.py` attaches installs to the primary migrated agent by
+  resolves its catalog item by name. `apply.py` attaches installs to the primary agent by
   default; use `user_answers.agentIds` only for extra explicit agent assignments;
 - which LLM keys to migrate — and have the user paste each secret into `user_answers.apiKey`
   (with `provider`). Never read a secret out of their files.
@@ -158,7 +158,9 @@ From `migration_result.json`, write `report.md` using `references/report-templat
 for deciding whether the converted pilot is ready to try in Archestra, not for producing an exhaustive
 command transcript. For a `guard` hook you mapped to a `tool_policy` whose target tool doesn't exist yet,
 include the exact policy JSON to paste once it does. For hooks migrated as native lifecycle hooks, note
-the behavior differences (no matcher, Archestra tool names, sandbox `cwd`, dropped env/argv).
+the behavior differences (no matcher, Archestra tool names, sandbox `cwd`, dropped env/argv), and whether
+the agent-hooks feature is on: `apply.py` records a warning op when it is off, in which case migrated
+hooks are saved but never fire until an admin enables it.
 Tool-invocation policies only enforce when the org `globalToolPolicy` is `restrictive`;
 the scripts don't read that setting, so tell the user to verify it in Archestra settings. Also surface
 any `warnings` from the inventory (possible secrets left intact in migrated bodies). Summarize for the

--- a/migration-kit/references/archestra-api.md
+++ b/migration-kit/references/archestra-api.md
@@ -28,7 +28,8 @@ The `archestra_client.py` module wraps every call with typed payloads and raises
 - **MCP catalog**: `serverType` `local` (→ `localConfig{command, arguments[], environment[]}`) or
   `remote` (→ top-level `serverUrl`). For `scope:"team"`, send `teams[]`. A redacted env value becomes an `environment` entry with
   `type:"secret", promptOnInstallation:true` and no value — the user supplies it at install.
-- **MCP install**: references a catalog item by id; resolve the id by catalog name at apply time.
+- **MCP install**: `name` and `catalogId` are both required; resolve the catalog id by catalog name
+  at apply time and reuse that same name for the install.
   Installing a `local` server spins a K8s pod in the KinD cluster — only do it when the user opts in.
   For `scope:"team"`, send `teamId`. Send `agentIds[]` to attach discovered tools to migrated agents.
 - **LLM key**: `provider`, `scope`, `apiKey` (user-supplied; never read from the user's files silently),

--- a/migration-kit/references/archestra-api.md
+++ b/migration-kit/references/archestra-api.md
@@ -33,7 +33,7 @@ The `archestra_client.py` module wraps every call with typed payloads and raises
   Installing a `local` server spins a K8s pod in the KinD cluster — only do it when the user opts in.
   For `scope:"team"`, send `teamId`. Send `agentIds[]` to attach discovered tools to migrated agents.
 - **LLM key**: `provider`, `scope`, `apiKey` (user-supplied; never read from the user's files silently),
-  optional `baseUrl`, and `teamId` for `scope:"team"`.
+  optional `baseUrl`, optional `isPrimary`, and `teamId` for `scope:"team"`.
 - **Tool policy**: `toolId` (must be a tool that exists in Archestra), `conditions[]` of
   `{key, operator, value}` (operators incl. `regex`), `action` (`block_always` etc.), optional `reason`.
   Policies only enforce when the org `globalToolPolicy` is `restrictive` — surface that to the user.

--- a/migration-kit/references/entity-mapping.md
+++ b/migration-kit/references/entity-mapping.md
@@ -89,7 +89,7 @@ creating hooks and warns when the feature is off.
 - **unresolved** — a missing/escaping script or unparsable command; map it `manual`.
 
 What you author per hook decision (`target_kind:"hook"`): usually nothing. Optional `user_answers`:
-`agentId` (UUID; defaults to the primary migrated agent), `fileName` (override; must match the basename
+`agentId` (UUID; defaults to the primary agent), `fileName` (override; must match the basename
 regex), `requirements` (override the PEP-723 list; a `.sh` hook must have none). `apply.py` builds and
 validates the payload, attaches it to the primary agent, and skips an existing `(agentId, event, fileName)`.
 

--- a/migration-kit/references/entity-mapping.md
+++ b/migration-kit/references/entity-mapping.md
@@ -7,7 +7,7 @@ This is the canonical mapping the model applies when turning `inventory.json` in
 | Source (inventory `kind`) | `target_kind` | Confidence | Notes |
 |---|---|---|---|
 | `claude_md` (root CLAUDE.md) | `agent` | clean | becomes the **primary agent**'s systemPrompt; one per setup, no model binding (inherits org default) |
-| `skill` (`.claude/skills/*/SKILL.md`) | `skill` | clean | migrated verbatim with bundled files |
+| `skill` (`.claude/skills/*/SKILL.md`) | `skill` | clean | migrated verbatim with bundled files; a `name_override` is written into the SKILL.md frontmatter (Archestra derives the skill name from there) |
 | `subagent` (`.claude/agents/*.md`) | `skill` (preferred) or `agent` | best-effort | default to skill; tool allowlist is **documented, not enforced** |
 | `command` (`.claude/commands/*.md`) | `skill` | best-effort | slash command body → skill |
 | `local_tool` (`tools/*.py`) | `skill` | best-effort | per-script fallback; PREFER consolidating into one toolset skill — see "Local tools" below |

--- a/migration-kit/scripts/apply.py
+++ b/migration-kit/scripts/apply.py
@@ -53,7 +53,6 @@ from contracts import (
     CommandItem,
     ContractError,
     Decision,
-    FrontMatter,
     HookEvent,
     HookItem,
     Item,
@@ -85,7 +84,7 @@ from contracts import (
     to_jsonable,
     validate_requirements,
 )
-from frontmatter import emit_frontmatter, parse_frontmatter, set_name
+from frontmatter import emit_frontmatter, fm_str, parse_frontmatter, set_name
 
 # deterministic apply order: keys before the agent, skills/catalog next, install, then policies,
 # then hooks (they attach to the already-created primary agent).
@@ -117,19 +116,9 @@ def _outcome_label(outcome: Outcome) -> str:
 # --- built operations: a typed union of what _build_payload produces ----------------------
 
 
-@dataclass(frozen=True)
-class BuiltAgent:
-    payload: AgentCreate
-
-
-@dataclass(frozen=True)
-class BuiltSkill:
-    payload: SkillCreate
-
-
-@dataclass(frozen=True)
-class BuiltCatalog:
-    payload: CatalogCreate
+# a "ready" op is its own api payload (fully built offline). the three structs below instead
+# carry pre-resolution data because they need an id looked up at execute time -- a catalog id,
+# a tool id, or the primary agent id -- that the offline build cannot know yet.
 
 
 @dataclass(frozen=True)
@@ -139,11 +128,6 @@ class BuiltInstall:
     environment_values: dict[str, str]
     agent_ids: list[str]
     team_id: str | None = None
-
-
-@dataclass(frozen=True)
-class BuiltLlmKey:
-    payload: LlmKeyCreate
 
 
 @dataclass(frozen=True)
@@ -166,18 +150,13 @@ class BuiltHook:
 
 
 Built = Union[
-    BuiltAgent, BuiltSkill, BuiltCatalog, BuiltInstall, BuiltLlmKey, BuiltPolicy, BuiltHook
+    AgentCreate, SkillCreate, CatalogCreate, BuiltInstall, LlmKeyCreate, BuiltPolicy, BuiltHook
 ]
 
 
 def _nonmigrate_outcome(action: str) -> Outcome:
     """an intentional skip is 'skipped'; a deferred item is 'manual'."""
     return "skipped" if action == "skip" else "manual"
-
-
-def _fm_str(fm: FrontMatter, key: str) -> str | None:
-    value = fm.get(key)
-    return value if isinstance(value, str) else None
 
 
 # --- payload builders (offline, deterministic) -------------------------------------------
@@ -209,7 +188,7 @@ def _skill_content_for(item: Item, name: str) -> tuple[str, list[SkillFile]]:
                 )
             return emit_frontmatter(name, desc) + item.data.body + note, files
         case CommandItem():
-            desc = (_fm_str(item.data.frontmatter, "description") or "").strip() or f"migrated command {name}"
+            desc = (fm_str(item.data.frontmatter, "description") or "").strip() or f"migrated command {name}"
             return emit_frontmatter(name, desc.replace("\n", " ")) + item.data.body, files
         case LocalToolItem():
             entry = item.data.entrypoint
@@ -248,7 +227,7 @@ def _agent_source(item: Item) -> tuple[str | None, str | None]:
     """extract (system prompt body, description) from an agent-capable source item."""
     match item:
         case ClaudeMdItem():
-            return item.data.body or None, _fm_str(item.data.frontmatter, "description")
+            return item.data.body or None, fm_str(item.data.frontmatter, "description")
         case SubagentItem():
             return item.data.body or None, item.data.description
         case _:
@@ -345,21 +324,21 @@ def _build_payload(decision: Decision, item: Item) -> tuple[str, Built]:
             raise ContractError(f"{decision.source_id}: a migrate decision must declare a target_kind")
         case "agent":
             body, description = _agent_source(item)
-            return name, BuiltAgent(AgentCreate(
+            return name, AgentCreate(
                 name=name, scope=decision.scope, systemPrompt=body,
                 description=description or "Migrated from CLAUDE.md",
                 teams=_team_ids(decision, ctx=ctx) or [],
-            ))
+            )
 
         case "skill":
             content, files = _skill_content_for(item, name)
             _require_skill_frontmatter(content, ctx=decision.source_id)
-            return name, BuiltSkill(SkillCreate(
+            return name, SkillCreate(
                 content=content,
                 scope=decision.scope,
                 files=files,
                 teamIds=_team_ids(decision, ctx=ctx),
-            ))
+            )
 
         case "mcp_catalog":
             if not isinstance(item, McpServerItem):
@@ -376,7 +355,7 @@ def _build_payload(decision: Decision, item: Item) -> tuple[str, Built]:
                                     localConfig=LocalConfig(command=data.command or "",
                                                             arguments=data.args, environment=env),
                                     teams=_team_ids(decision, ctx=ctx) or [])
-            return name, BuiltCatalog(cfg)
+            return name, cfg
 
         case "mcp_install":
             # catalogId is resolved by name at execute time; carry the supplied env values.
@@ -392,12 +371,12 @@ def _build_payload(decision: Decision, item: Item) -> tuple[str, Built]:
             api_key = require_answer(answers, "apiKey", ctx=ctx)
             is_primary = answers.get("isPrimary")
             base_url = answers.get("baseUrl")
-            return name, BuiltLlmKey(LlmKeyCreate(
+            return name, LlmKeyCreate(
                 provider=provider, scope=decision.scope, apiKey=api_key, name=name,
                 isPrimary=is_primary if isinstance(is_primary, bool) else None,
                 baseUrl=base_url if isinstance(base_url, str) and base_url else None,
                 teamId=_team_id(decision, ctx=ctx),
-            ))
+            )
 
         case "tool_policy":
             # the model must extract the guard's semantics into user_answers.
@@ -503,7 +482,7 @@ def _scrub_url(url: str) -> str:
 def _redacted_for_print(built: Built) -> dict[str, JsonValue]:
     """strip user-supplied secrets before printing a built op in --dry-run."""
     match built:
-        case BuiltLlmKey(payload):
+        case LlmKeyCreate() as payload:
             shown = to_payload(payload)
             shown["apiKey"] = "<redacted>"
             return shown
@@ -511,9 +490,9 @@ def _redacted_for_print(built: Built) -> dict[str, JsonValue]:
             return {"catalog_name": built.catalog_name, "scope": built.scope,
                     "teamId": built.team_id, "agentIds": built.agent_ids,
                     "environmentValues": {k: "<redacted>" for k in built.environment_values}}
-        case BuiltAgent(payload) | BuiltSkill(payload):
+        case (AgentCreate() | SkillCreate()) as payload:
             return to_payload(payload)
-        case BuiltCatalog(payload):
+        case CatalogCreate() as payload:
             if payload.serverUrl is not None:
                 payload = replace(payload, serverUrl=_scrub_url(payload.serverUrl))
             local = payload.localConfig
@@ -543,13 +522,13 @@ def _redacted_for_print(built: Built) -> dict[str, JsonValue]:
 
 def _preview_detail(built: Built) -> str:
     match built:
-        case BuiltAgent(payload):
+        case AgentCreate() as payload:
             return f"scope={payload.scope}; inherits org default model"
-        case BuiltSkill(payload):
+        case SkillCreate() as payload:
             if payload.scope == "team":
                 return f"scope=team; team_ids={len(payload.teamIds or [])}; bundled_files={len(payload.files)}"
             return f"scope={payload.scope}; bundled_files={len(payload.files)}"
-        case BuiltCatalog(payload):
+        case CatalogCreate() as payload:
             match payload.serverType:
                 case "remote":
                     return f"scope={payload.scope}; remote MCP catalog item"
@@ -564,7 +543,7 @@ def _preview_detail(built: Built) -> str:
                 f"scope={built.scope}; catalog={built.catalog_name}; "
                 f"agent_ids={len(built.agent_ids)}{team}; supplied_env_values={len(built.environment_values)}"
             )
-        case BuiltLlmKey(payload):
+        case LlmKeyCreate() as payload:
             return f"scope={payload.scope}; provider={payload.provider}; api_key=<redacted>"
         case BuiltPolicy():
             return f"tool={built.tool_name}; action={built.action}; conditions={len(built.conditions)}"
@@ -585,7 +564,7 @@ def _execute(client: ArchestraClient, decision: Decision, name: str, built: Buil
                         outcome=outcome, archestra_id=archestra_id, error=error, detail=detail)
 
     match built:
-        case BuiltAgent(payload):
+        case AgentCreate() as payload:
             existing = client.list_agents(name=name, scope=payload.scope)
             if existing:
                 return op("skipped", archestra_id=require_str_field(existing[0], "id", ctx="agent"),
@@ -593,7 +572,7 @@ def _execute(client: ArchestraClient, decision: Decision, name: str, built: Buil
             created = client.create_agent(payload)
             return op("created", archestra_id=require_str_field(created, "id", ctx="agent create response"))
 
-        case BuiltSkill(payload):
+        case SkillCreate() as payload:
             existing = [
                 s for s in client.list_skills(search=name)
                 if s.get("name") == name and s.get("scope") == payload.scope
@@ -604,7 +583,7 @@ def _execute(client: ArchestraClient, decision: Decision, name: str, built: Buil
             created = client.create_skill(payload)
             return op("created", archestra_id=require_str_field(created, "id", ctx="skill create response"))
 
-        case BuiltCatalog(payload):
+        case CatalogCreate() as payload:
             existing = [c for c in client.list_catalog() if c.get("name") == name and c.get("scope") == payload.scope]
             if existing:
                 return op("skipped", archestra_id=require_str_field(existing[0], "id", ctx="catalog item"),
@@ -628,7 +607,7 @@ def _execute(client: ArchestraClient, decision: Decision, name: str, built: Buil
             ))
             return op("created", archestra_id=require_str_field(created, "id", ctx="install response"))
 
-        case BuiltLlmKey(payload):
+        case LlmKeyCreate() as payload:
             existing = [
                 k for k in client.list_llm_keys(search=name, provider=payload.provider)
                 if k.get("name") == name and k.get("scope") == payload.scope and k.get("teamId") == payload.teamId
@@ -799,13 +778,7 @@ def _run_apply(built: list[_Built], base_url: str, api_key: str) -> list[ResultO
                 continue
             built_op = b.built
             if isinstance(built_op, BuiltInstall) and not built_op.agent_ids and primary_agent_id:
-                built_op = BuiltInstall(
-                    catalog_name=built_op.catalog_name,
-                    scope=built_op.scope,
-                    environment_values=built_op.environment_values,
-                    agent_ids=[primary_agent_id],
-                    team_id=built_op.team_id,
-                )
+                built_op = replace(built_op, agent_ids=[primary_agent_id])
             if isinstance(built_op, BuiltHook) and built_op.agent_id is None and primary_agent_id:
                 built_op = replace(built_op, agent_id=primary_agent_id)
             try:

--- a/migration-kit/scripts/apply.py
+++ b/migration-kit/scripts/apply.py
@@ -325,6 +325,12 @@ def _build_agent_ids(answers: dict[str, JsonValue], *, ctx: str) -> list[str]:
     return _str_answers(raw, ctx=f"{ctx}.agentIds")
 
 
+def _report_kind(decision: Decision) -> str:
+    """the kind to show in results/preview. migrate decisions carry a real target_kind; skip/manual
+    ones may omit it, so fall back to the action ("manual"/"skip") rather than printing None."""
+    return decision.target_kind or decision.action
+
+
 def _build_payload(decision: Decision, item: Item) -> tuple[str, Built]:
     """return (display_name, typed built op) for a migrate decision.
     raises ContractError on anything that cannot be built deterministically."""
@@ -333,6 +339,10 @@ def _build_payload(decision: Decision, item: Item) -> tuple[str, Built]:
     ctx = f"{decision.source_id}.user_answers"
 
     match decision.target_kind:
+        case None:
+            # unreachable for a migrate decision (parse_decision requires the kind there); kept so
+            # the match stays exhaustive over TargetKind | None for the type checker.
+            raise ContractError(f"{decision.source_id}: a migrate decision must declare a target_kind")
         case "agent":
             body, description = _agent_source(item)
             return name, BuiltAgent(AgentCreate(
@@ -571,7 +581,7 @@ def _preview_detail(built: Built) -> str:
 def _execute(client: ArchestraClient, decision: Decision, name: str, built: Built) -> ResultOp:
     def op(outcome: Outcome, *, archestra_id: str | None = None, error: str | None = None,
            detail: str | None = None) -> ResultOp:
-        return ResultOp(source_id=decision.source_id, target_kind=decision.target_kind, name=name,
+        return ResultOp(source_id=decision.source_id, target_kind=_report_kind(decision), name=name,
                         outcome=outcome, archestra_id=archestra_id, error=error, detail=detail)
 
     match built:
@@ -612,7 +622,8 @@ def _execute(client: ArchestraClient, decision: Decision, name: str, built: Buil
                 return op("skipped", archestra_id=require_str_field(existing[0], "id", ctx="mcp server"),
                           detail="an install of this catalog item at this scope already exists")
             created = client.install_mcp_server(McpInstall(
-                catalogId=catalog_id, scope=built.scope, environmentValues=built.environment_values,
+                catalogId=catalog_id, name=built.catalog_name, scope=built.scope,
+                environmentValues=built.environment_values,
                 agentIds=built.agent_ids, teamId=built.team_id,
             ))
             return op("created", archestra_id=require_str_field(created, "id", ctx="install response"))
@@ -733,7 +744,7 @@ def main() -> int:
         except ContractError as exc:
             built.append(_Built(decision, decision.source_id, None, str(exc)))
     built = _flag_hook_collisions(built)
-    built.sort(key=lambda b: _ORDER.get(b.decision.target_kind, 99))
+    built.sort(key=lambda b: _ORDER.get(b.decision.target_kind or "", 99))
 
     if args.dry_run:
         return _finish(_run_validation(built, verbose=args.verbose, label="dry-run"), args.out)
@@ -758,15 +769,15 @@ def _run_validation(built: list[_Built], *, verbose: bool, label: str) -> list[R
             result = _nonmigrate_or_invalid(b)
             detail = result.detail or result.error or ""
             suffix = f" -- {detail}" if detail else ""
-            print(f"[{label}] {_outcome_label(result.outcome)}: {b.decision.target_kind}: {b.name}{suffix}")
+            print(f"[{label}] {_outcome_label(result.outcome)}: {_report_kind(b.decision)}: {b.name}{suffix}")
             results.append(result)
             continue
         detail = _preview_detail(b.built)
-        print(f"[{label}] {_outcome_label('planned')}: {b.decision.target_kind}: {b.name} -- {detail}")
+        print(f"[{label}] {_outcome_label('planned')}: {_report_kind(b.decision)}: {b.name} -- {detail}")
         if verbose:
             shown = _redacted_for_print(b.built)
             print(json.dumps(shown, indent=2))
-        results.append(ResultOp(source_id=b.decision.source_id, target_kind=b.decision.target_kind,
+        results.append(ResultOp(source_id=b.decision.source_id, target_kind=_report_kind(b.decision),
                                 name=b.name, outcome="planned"))
     return results
 
@@ -800,7 +811,7 @@ def _run_apply(built: list[_Built], base_url: str, api_key: str) -> list[ResultO
             try:
                 op = _execute(client, b.decision, b.name, built_op)
             except (ArchestraApiError, ContractError) as exc:
-                op = ResultOp(source_id=b.decision.source_id, target_kind=b.decision.target_kind,
+                op = ResultOp(source_id=b.decision.source_id, target_kind=_report_kind(b.decision),
                               name=b.name, outcome="failed", error=str(exc))
             results.append(op)
             if op.target_kind == "agent" and op.outcome in ("created", "skipped") and op.archestra_id:
@@ -906,9 +917,9 @@ def _sandbox_warning(detail: str) -> ResultOp:
 
 def _nonmigrate_or_invalid(b: _Built) -> ResultOp:
     if b.decision.action != "migrate":
-        return ResultOp(source_id=b.decision.source_id, target_kind=b.decision.target_kind, name=b.name,
+        return ResultOp(source_id=b.decision.source_id, target_kind=_report_kind(b.decision), name=b.name,
                         outcome=_nonmigrate_outcome(b.decision.action), detail=b.decision.notes)
-    return ResultOp(source_id=b.decision.source_id, target_kind=b.decision.target_kind, name=b.name,
+    return ResultOp(source_id=b.decision.source_id, target_kind=_report_kind(b.decision), name=b.name,
                     outcome="invalid", error=b.error)
 
 

--- a/migration-kit/scripts/apply.py
+++ b/migration-kit/scripts/apply.py
@@ -85,7 +85,7 @@ from contracts import (
     to_jsonable,
     validate_requirements,
 )
-from frontmatter import emit_frontmatter
+from frontmatter import emit_frontmatter, parse_frontmatter, set_name
 
 # deterministic apply order: keys before the agent, skills/catalog next, install, then policies,
 # then hooks (they attach to the already-created primary agent).
@@ -192,10 +192,12 @@ def _skill_content_for(item: Item, name: str) -> tuple[str, list[SkillFile]]:
     files = _skill_files(item)
     match item:
         case SkillItem():
-            # verbatim: the original SKILL.md already carries frontmatter.
-            return item.data.content, files
+            # the original SKILL.md carries its own frontmatter; archestra reads the skill name
+            # from there (SkillCreate has no name field), so apply the rename into the frontmatter.
+            # set_name is a no-op when the name already matches, keeping unchanged skills verbatim.
+            return set_name(item.data.content, name), files
         case SubagentItem():
-            desc = (item.data.description or f"migrated subagent {name}").replace("\n", " ")
+            desc = ((item.data.description or "").strip() or f"migrated subagent {name}").replace("\n", " ")
             note = ""
             tools = item.data.tools
             if tools:
@@ -207,8 +209,8 @@ def _skill_content_for(item: Item, name: str) -> tuple[str, list[SkillFile]]:
                 )
             return emit_frontmatter(name, desc) + item.data.body + note, files
         case CommandItem():
-            desc = (_fm_str(item.data.frontmatter, "description") or f"migrated command {name}").replace("\n", " ")
-            return emit_frontmatter(name, desc) + item.data.body, files
+            desc = (_fm_str(item.data.frontmatter, "description") or "").strip() or f"migrated command {name}"
+            return emit_frontmatter(name, desc.replace("\n", " ")) + item.data.body, files
         case LocalToolItem():
             entry = item.data.entrypoint
             body = (
@@ -220,6 +222,26 @@ def _skill_content_for(item: Item, name: str) -> tuple[str, list[SkillFile]]:
             return emit_frontmatter(name, f"Run the bundled {entry} script.") + body, files
         case _:
             raise ContractError(f"cannot build skill content from item kind {item.kind}")
+
+
+def _require_skill_frontmatter(content: str, *, ctx: str) -> None:
+    """fail offline on skill content the server would 400 on. archestra requires a SKILL.md to
+    start with a `---` frontmatter block carrying `name` and `description`; without this check a
+    frontmatter-less or description-less skill passes --dry-run and only fails at create time.
+
+    `name` is normally supplied upstream (set_name writes the override or the source dir name), so
+    in practice this is the gate on `description` -- which cannot be invented -- and on duplicate or
+    ambiguous keys the server's YAML would resolve differently than we do."""
+    if not content.startswith("---"):
+        raise ContractError(f"{ctx}: SKILL.md must start with a `---` frontmatter block")
+    doc = parse_frontmatter(content)
+    for key in ("name", "description"):
+        value = doc.frontmatter.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ContractError(f"{ctx}: SKILL.md frontmatter is missing `{key}`")
+    for line in doc.unparsed_lines:
+        if not line[:1].isspace() and line.split(":", 1)[0] in ("name", "description"):
+            raise ContractError(f"{ctx}: SKILL.md frontmatter has a duplicate/ambiguous `{line.split(':', 1)[0]}`")
 
 
 def _agent_source(item: Item) -> tuple[str | None, str | None]:
@@ -321,6 +343,7 @@ def _build_payload(decision: Decision, item: Item) -> tuple[str, Built]:
 
         case "skill":
             content, files = _skill_content_for(item, name)
+            _require_skill_frontmatter(content, ctx=decision.source_id)
             return name, BuiltSkill(SkillCreate(
                 content=content,
                 scope=decision.scope,

--- a/migration-kit/scripts/archestra_client.py
+++ b/migration-kit/scripts/archestra_client.py
@@ -103,6 +103,7 @@ class CatalogCreate:
 @dataclass(frozen=True)
 class McpInstall:
     catalogId: str
+    name: str
     scope: Scope
     environmentValues: dict[str, str] = field(default_factory=dict)
     agentIds: list[str] = field(default_factory=list)

--- a/migration-kit/scripts/contracts.py
+++ b/migration-kit/scripts/contracts.py
@@ -263,7 +263,9 @@ class Inventory:
 @dataclass(frozen=True)
 class Decision:
     source_id: str
-    target_kind: TargetKind
+    # required only when action == "migrate" (it drives the payload build); a skip/manual decision
+    # never builds a payload, so it may leave this None rather than declare a kind it won't use.
+    target_kind: TargetKind | None
     scope: Scope
     action: Literal["migrate", "skip", "manual"] = "migrate"
     name_override: str | None = None
@@ -322,6 +324,14 @@ def require_str_field(obj: Mapping[str, JsonValue], key: str, *, ctx: str) -> st
     value = obj.get(key)
     if not isinstance(value, str) or not value:
         raise ContractError(f"{ctx}: field {key!r} must be a non-empty string, got {value!r}")
+    return value
+
+
+def _require_str_present(obj: Mapping[str, JsonValue], key: str, *, ctx: str) -> str:
+    """a required string that may be empty (e.g. a bundled file body for an empty __init__.py)."""
+    value = obj.get(key)
+    if not isinstance(value, str):
+        raise ContractError(f"{ctx}: field {key!r} must be a string, got {value!r}")
     return value
 
 
@@ -501,7 +511,7 @@ def parse_bundled_file(value: object, *, ctx: str) -> BundledFile:
     obj = require_dict(value, ctx=ctx)
     return BundledFile(
         path=require_str_field(obj, "path", ctx=ctx),
-        content=require_str_field(obj, "content", ctx=ctx),
+        content=_require_str_present(obj, "content", ctx=ctx),
         encoding=_require_literal(
             require_str_field(obj, "encoding", ctx=ctx), _ENCODINGS, what="encoding", ctx=ctx
         ),
@@ -629,19 +639,28 @@ def parse_inventory(value: object, *, ctx: str = "inventory") -> Inventory:
 
 def parse_decision(value: object, *, ctx: str) -> Decision:
     obj = require_dict(value, ctx=ctx)
+    action = _require_literal(
+        obj.get("action", "migrate"), _PLAN_ACTIONS, what="action", ctx=f"{ctx}.action"
+    )
     return Decision(
         source_id=require_str_field(obj, "source_id", ctx=ctx),
-        target_kind=_require_literal(
-            obj.get("target_kind"), _TARGET_KINDS, what="target kind", ctx=f"{ctx}.target_kind"
-        ),
+        target_kind=_parse_target_kind(obj.get("target_kind"), action, ctx=f"{ctx}.target_kind"),
         scope=_require_literal(obj.get("scope"), _SCOPES, what="scope", ctx=f"{ctx}.scope"),
-        action=_require_literal(
-            obj.get("action", "migrate"), _PLAN_ACTIONS, what="action", ctx=f"{ctx}.action"
-        ),
+        action=action,
         name_override=_opt_str(obj, "name_override", ctx=ctx),
         notes=_opt_str(obj, "notes", ctx=ctx),
         user_answers=require_dict(obj.get("user_answers", {}), ctx=f"{ctx}.user_answers"),
     )
+
+
+def _parse_target_kind(
+    value: object, action: Literal["migrate", "skip", "manual"], *, ctx: str
+) -> TargetKind | None:
+    """a migrate decision must name the target kind it builds; a skip/manual one may omit it (but
+    a value is still validated if present, so an explicit kind on a manual decision stays legal)."""
+    if action != "migrate" and value is None:
+        return None
+    return _require_literal(value, _TARGET_KINDS, what="target kind", ctx=ctx)
 
 
 def parse_plan(value: object, *, ctx: str = "plan") -> MigrationPlan:

--- a/migration-kit/scripts/discover.py
+++ b/migration-kit/scripts/discover.py
@@ -39,7 +39,6 @@ from contracts import (
     CommandData,
     CommandItem,
     ContractError,
-    FrontMatter,
     HookData,
     HookIntent,
     HookItem,
@@ -65,7 +64,7 @@ from contracts import (
     to_jsonable,
     validate_requirements,
 )
-from frontmatter import parse_frontmatter
+from frontmatter import fm_str, parse_frontmatter
 
 # events whose hooks can block the action -- candidates for a tool-invocation policy.
 _BLOCKING_EVENTS = {"PreToolUse", "UserPromptSubmit", "PreCompact", "Stop", "SubagentStop"}
@@ -116,11 +115,6 @@ def _redact(value: JsonValue, ref: str, sink: list[str]) -> JsonValue:
             return "<redacted>"
         case _:
             return value
-
-
-def _meta_str(meta: FrontMatter, key: str) -> str | None:
-    value = meta.get(key)
-    return value if isinstance(value, str) else None
 
 
 def _as_opt_str(value: JsonValue) -> str | None:
@@ -207,11 +201,11 @@ def discover(root: Path) -> Inventory:
         if not _is_contained_file(f, root):
             continue
         doc = parse_frontmatter(read(f))
-        name = _meta_str(doc.frontmatter, "name") or f.stem
+        name = fm_str(doc.frontmatter, "name") or f.stem
         rel = f.relative_to(root).as_posix()
         note_unparsed(doc.unparsed_lines, rel)
         _warn_if_secret(doc.body, rel, inv.warnings)
-        description = _meta_str(doc.frontmatter, "description")
+        description = fm_str(doc.frontmatter, "description")
         tools = doc.frontmatter.get("tools")
         inv.items.append(SubagentItem(
             id=f"subagent:{name}", name=name, path=rel, summary=(description or "")[:200],
@@ -227,7 +221,7 @@ def discover(root: Path) -> Inventory:
         skill_dir = skill_md.parent
         content = read(skill_md)
         doc = parse_frontmatter(content)
-        name = _meta_str(doc.frontmatter, "name") or skill_dir.name
+        name = fm_str(doc.frontmatter, "name") or skill_dir.name
         rel = skill_md.relative_to(root).as_posix()
         note_unparsed(doc.unparsed_lines, rel)
         files = [
@@ -241,7 +235,7 @@ def discover(root: Path) -> Inventory:
                 _warn_if_secret(bf.content, f"{skill_dir.relative_to(root).as_posix()}/{bf.path}", inv.warnings)
         inv.items.append(SkillItem(
             id=f"skill:{name}", name=name, path=rel,
-            summary=(_meta_str(doc.frontmatter, "description") or "")[:200],
+            summary=(fm_str(doc.frontmatter, "description") or "")[:200],
             data=SkillData(content=content, frontmatter=doc.frontmatter), files=files,
         ))
         for p in skill_dir.rglob("*"):
@@ -252,13 +246,13 @@ def discover(root: Path) -> Inventory:
         if not _is_contained_file(f, root):
             continue
         doc = parse_frontmatter(read(f))
-        name = _meta_str(doc.frontmatter, "name") or f.stem
+        name = fm_str(doc.frontmatter, "name") or f.stem
         rel = f.relative_to(root).as_posix()
         note_unparsed(doc.unparsed_lines, rel)
         _warn_if_secret(doc.body, rel, inv.warnings)
         inv.items.append(CommandItem(
             id=f"command:{name}", name=name, path=rel,
-            summary=(_meta_str(doc.frontmatter, "description") or "")[:200],
+            summary=(fm_str(doc.frontmatter, "description") or "")[:200],
             data=CommandData(body=doc.body, frontmatter=doc.frontmatter),
         ))
         mark(f)

--- a/migration-kit/scripts/discover.py
+++ b/migration-kit/scripts/discover.py
@@ -319,6 +319,9 @@ def discover(root: Path) -> Inventory:
                 data=OpenclawData(config=config), redacted_refs=refs,
             ))
 
+    # 7.5 dangling references: warn when a migrated body points at a repo file not bundled with it.
+    _scan_dangling_refs(inv, root)
+
     # 8. unrecognized files under .claude/ -> surface for the model
     claude_dir = root / ".claude"
     if claude_dir.is_dir():
@@ -428,6 +431,68 @@ def _script_position(rest: list[str], root: Path) -> int | None:
 
 def _expand_project_dir(token: str, root: Path) -> str:
     return _PROJECT_DIR_RE.sub(str(root), token)
+
+
+# a file path a migrated body may reference: optional ./ or ../ segments then a path ending in a
+# known code/doc/config extension. used only to WARN about uncaptured repo files (never to alter a
+# body). limitations: extensionless refs (./check, `node x`) and env vars other than
+# $CLAUDE_PROJECT_DIR are not resolved, so they are not flagged.
+_REF_RE = re.compile(r"(?:\.{1,2}/)*[\w./-]+\.(?:py|sh|md|js|ts|mjs|cjs|json|ya?ml|txt)")
+
+
+def _dangling_refs(body: str, bases: list[Path], root: Path, bundled: set[Path]) -> list[str]:
+    """repo-relative paths referenced in `body` that exist on disk but do NOT travel with this
+    artifact (not in `bundled`) -- so they would dangle in the artifact's sandbox. each ref is
+    resolved against every dir in `bases` ($CLAUDE_PROJECT_DIR expanded first); a hit inside
+    `bundled` is safe. returns deduped repo-relative paths."""
+    out: list[str] = []
+    found: set[Path] = set()
+    for m in _REF_RE.finditer(_expand_project_dir(body, root)):
+        candidate = Path(m.group(0))
+        roots = [candidate] if candidate.is_absolute() else [base / candidate for base in bases]
+        for c in roots:
+            try:
+                resolved = c.resolve()
+            except OSError:
+                continue
+            if resolved in bundled:
+                break  # the ref points at a file that ships with this artifact -> safe
+            if resolved in found:
+                break
+            if resolved.is_file() and resolved.is_relative_to(root):
+                found.add(resolved)
+                out.append(resolved.relative_to(root).as_posix())
+                break
+    return out
+
+
+def _scan_dangling_refs(inv: Inventory, root: Path) -> None:
+    """warn when a migrate-candidate body points at a repo file that won't be in its sandbox. a ref
+    is safe only if it resolves to a file bundled WITH that artifact; a file captured by a different
+    item (e.g. a separate local_tool) still dangles, so it is flagged."""
+    for it in inv.items:
+        match it:
+            case ClaudeMdItem() | CommandItem() | SubagentItem():
+                bundled = {(root / it.path).resolve()}
+                bodies = [(it.data.body, [root])]
+            case HookItem():
+                bundled = {(root / bf.path).resolve() for bf in it.files}
+                bodies = [(it.data.command, [root])]
+            case SkillItem():
+                skill_dir = (root / it.path).parent
+                bundled = {(skill_dir / bf.path).resolve() for bf in it.files} | {(root / it.path).resolve()}
+                # a skill body may address files by the skill dir (bundled siblings) or the repo root.
+                bodies = [(it.data.content, [skill_dir, root])]
+                bodies += [(bf.content, [skill_dir / Path(bf.path).parent, root])
+                           for bf in it.files if bf.encoding == "utf8"]
+            case _:
+                continue
+        for body, bases in bodies:
+            for rel in _dangling_refs(body, bases, root, bundled):
+                inv.warnings.append(
+                    f"{it.path}: references {rel} which exists in the repo but is not bundled with "
+                    "this artifact; bundle it or rewrite the reference before applying"
+                )
 
 
 def _pep723_requirements(content: str, ref: str, warnings: list[str]) -> list[str]:

--- a/migration-kit/scripts/frontmatter.py
+++ b/migration-kit/scripts/frontmatter.py
@@ -29,7 +29,7 @@ import json
 import re
 from dataclasses import dataclass, field
 
-from contracts import FrontMatter, FrontMatterValue
+from contracts import ContractError, FrontMatter, FrontMatterValue
 
 _FENCE = "---"
 _KEY_LINE = re.compile(r"^([A-Za-z0-9_.-]+):(.*)$")
@@ -207,3 +207,50 @@ def emit_frontmatter(name: str, description: str) -> str:
     """emit a minimal, valid-YAML frontmatter block. json.dumps quoting means names or
     descriptions with YAML-significant characters cannot break the block."""
     return f"---\nname: {json.dumps(name)}\ndescription: {json.dumps(description)}\n---\n"
+
+
+# a leading scalar indicator means the value is a form we won't try to rewrite in place
+# (block scalar | >, anchor/alias & *, tag !, comment/null #, flow collection [ {).
+_UNREWRITABLE_NAME_VALUE = "|>&*!#[{"
+
+
+def set_name(content: str, name: str) -> str:
+    """return `content` with its top-level frontmatter `name` set to `name`.
+
+    archestra derives a migrated skill's name from the SKILL.md frontmatter (SkillCreate has no
+    name field), so a rename must edit the frontmatter, not a separate field. this is surgical:
+    it touches only the single non-indented `name:` line (or inserts/prepends one), leaving every
+    other line -- including unsupported-but-valid nested maps or block scalars -- verbatim.
+
+    no-op when the parsed top-level name already equals `name` (preserves the verbatim-skill
+    invariant). raises ContractError when an existing `name` value is a form we cannot safely
+    rewrite without risking the surrounding block."""
+    if parse_frontmatter(content).frontmatter.get("name") == name:
+        return content
+
+    name_line = f"name: {json.dumps(name)}"
+    lines = content.replace("\r\n", "\n").split("\n")
+    if not lines or lines[0] != _FENCE:
+        return f"{_FENCE}\n{name_line}\n{_FENCE}\n{content}"
+    close = next((i for i in range(1, len(lines)) if lines[i] == _FENCE), None)
+    if close is None:  # unterminated fence -> not real frontmatter; prepend a fresh block
+        return f"{_FENCE}\n{name_line}\n{_FENCE}\n{content}"
+
+    for i in range(1, close):
+        line = lines[i]
+        if line[:1].isspace():
+            continue
+        m = _KEY_LINE.match(line)
+        if m is None or m.group(1) != "name":
+            continue
+        value = m.group(2).strip()
+        if value == "" or value[0] in _UNREWRITABLE_NAME_VALUE:
+            raise ContractError(
+                f"cannot safely rewrite frontmatter name (value form {value!r}); "
+                "set the skill name in its SKILL.md by hand"
+            )
+        lines[i] = name_line
+        return "\n".join(lines)
+
+    lines.insert(1, name_line)
+    return "\n".join(lines)

--- a/migration-kit/scripts/frontmatter.py
+++ b/migration-kit/scripts/frontmatter.py
@@ -203,6 +203,12 @@ def _parse_single_quoted(token: str) -> str | None:
     return None  # unterminated
 
 
+def fm_str(fm: FrontMatter, key: str) -> str | None:
+    """the value of a frontmatter key when it is a string, else None (a list-valued or absent key)."""
+    value = fm.get(key)
+    return value if isinstance(value, str) else None
+
+
 def emit_frontmatter(name: str, description: str) -> str:
     """emit a minimal, valid-YAML frontmatter block. json.dumps quoting means names or
     descriptions with YAML-significant characters cannot break the block."""

--- a/migration-kit/tests/test_apply_build.py
+++ b/migration-kit/tests/test_apply_build.py
@@ -12,13 +12,9 @@ import pytest
 import yaml
 
 from apply import (
-    BuiltAgent,
-    BuiltCatalog,
     BuiltHook,
     BuiltInstall,
-    BuiltLlmKey,
     BuiltPolicy,
-    BuiltSkill,
     _build_payload,
     _Built,
     _execute,
@@ -26,7 +22,15 @@ from apply import (
     _redacted_for_print,
     _require_skill_frontmatter,
 )
-from archestra_client import ArchestraClient, CatalogCreate, LlmKeyCreate, LocalConfig, McpEnvVar
+from archestra_client import (
+    AgentCreate,
+    ArchestraClient,
+    CatalogCreate,
+    LlmKeyCreate,
+    LocalConfig,
+    McpEnvVar,
+    SkillCreate,
+)
 from contracts import (
     ContractError,
     Decision,
@@ -56,38 +60,38 @@ def _decide(index: dict[str, Item], source_id: str, target_kind: str, **kw: Any)
 
 def test_claude_md_builds_agent(index: dict[str, Item]) -> None:
     _, built = _decide(index, "claude_md", "agent")
-    assert isinstance(built, BuiltAgent)
-    assert built.payload.agentType == "agent"
-    assert built.payload.scope == "personal"
-    assert built.payload.systemPrompt is not None
-    assert "note assistant" in built.payload.systemPrompt.lower()
+    assert isinstance(built, AgentCreate)
+    assert built.agentType == "agent"
+    assert built.scope == "personal"
+    assert built.systemPrompt is not None
+    assert "note assistant" in built.systemPrompt.lower()
 
 
 def test_subagent_builds_skill_with_allowlist_note(index: dict[str, Item]) -> None:
     _, built = _decide(index, "subagent:fact-checker", "skill")
-    assert isinstance(built, BuiltSkill)
-    fm = yaml.safe_load(built.payload.content.split("---", 2)[1])
+    assert isinstance(built, SkillCreate)
+    fm = yaml.safe_load(built.content.split("---", 2)[1])
     assert fm["name"] == "fact-checker"
-    assert "not enforced" in built.payload.content.lower()
-    assert "Read, Bash, Skill" in built.payload.content
+    assert "not enforced" in built.content.lower()
+    assert "Read, Bash, Skill" in built.content
 
 
 def test_skill_is_verbatim(index: dict[str, Item]) -> None:
     _, built = _decide(index, "skill:summarize-text", "skill")
-    assert isinstance(built, BuiltSkill)
+    assert isinstance(built, SkillCreate)
     source = index["skill:summarize-text"]
     assert isinstance(source, SkillItem)
-    assert built.payload.content == source.data.content
-    assert {f.path for f in built.payload.files} == {"reference.md"}
+    assert built.content == source.data.content
+    assert {f.path for f in built.files} == {"reference.md"}
 
 
 def test_skill_name_override_renames_frontmatter(index: dict[str, Item]) -> None:
     # archestra reads the skill name from the content frontmatter, so a name_override must land
     # there -- and the returned display name must match it (idempotency keys on that name).
     name, built = _decide(index, "skill:summarize-text", "skill", name_override="proj-summarize")
-    assert isinstance(built, BuiltSkill)
+    assert isinstance(built, SkillCreate)
     assert name == "proj-summarize"
-    assert yaml.safe_load(built.payload.content.split("---", 2)[1])["name"] == "proj-summarize"
+    assert yaml.safe_load(built.content.split("---", 2)[1])["name"] == "proj-summarize"
 
 
 def _skill_item(content: str) -> SkillItem:
@@ -132,8 +136,8 @@ def test_build_skill_auto_supplies_missing_name() -> None:
     decision = Decision(source_id="skill:x", target_kind="skill", scope="personal",
                         name_override="proj-x")
     _, built = _build_payload(decision, _skill_item("---\ndescription: d\n---\nbody"))
-    assert isinstance(built, BuiltSkill)
-    assert yaml.safe_load(built.payload.content.split("---", 2)[1])["name"] == "proj-x"
+    assert isinstance(built, SkillCreate)
+    assert yaml.safe_load(built.content.split("---", 2)[1])["name"] == "proj-x"
 
 
 def test_team_scoped_skill_requires_team_ids(index: dict[str, Item]) -> None:
@@ -154,23 +158,23 @@ def test_team_scoped_skill_carries_team_ids(index: dict[str, Item]) -> None:
         ),
         index["skill:summarize-text"],
     )
-    assert isinstance(built, BuiltSkill)
-    assert built.payload.scope == "team"
-    assert built.payload.teamIds == ["team-a", "team-b"]
+    assert isinstance(built, SkillCreate)
+    assert built.scope == "team"
+    assert built.teamIds == ["team-a", "team-b"]
 
 
 def test_local_tool_builds_skill_bundling_script(index: dict[str, Item]) -> None:
     _, built = _decide(index, "local_tool:word_count", "skill")
-    assert isinstance(built, BuiltSkill)
-    assert "python3 tools/word_count.py" in built.payload.content
-    assert built.payload.files[0].path == "tools/word_count.py"
+    assert isinstance(built, SkillCreate)
+    assert "python3 tools/word_count.py" in built.content
+    assert built.files[0].path == "tools/word_count.py"
 
 
 def test_remote_mcp_builds_remote_catalog(index: dict[str, Item]) -> None:
     _, built = _decide(index, "mcp:weather", "mcp_catalog")
-    assert isinstance(built, BuiltCatalog)
-    assert built.payload.serverType == "remote"
-    assert built.payload.serverUrl == "https://mcp.example.com/weather"
+    assert isinstance(built, CatalogCreate)
+    assert built.serverType == "remote"
+    assert built.serverUrl == "https://mcp.example.com/weather"
 
 
 def test_team_scoped_agent_carries_team_ids(index: dict[str, Item]) -> None:
@@ -183,8 +187,8 @@ def test_team_scoped_agent_carries_team_ids(index: dict[str, Item]) -> None:
         ),
         index["claude_md"],
     )
-    assert isinstance(built, BuiltAgent)
-    assert built.payload.teams == ["team-a", "team-b"]
+    assert isinstance(built, AgentCreate)
+    assert built.teams == ["team-a", "team-b"]
 
 
 def test_team_scoped_install_uses_single_team_id(index: dict[str, Item]) -> None:
@@ -212,8 +216,8 @@ def test_team_scoped_llm_key_carries_team_id(index: dict[str, Item]) -> None:
         ),
         index["openclaw"],
     )
-    assert isinstance(built, BuiltLlmKey)
-    assert built.payload.teamId == "team-a"
+    assert isinstance(built, LlmKeyCreate)
+    assert built.teamId == "team-a"
 
 
 def test_team_answer_precedence_when_both_present(index: dict[str, Item]) -> None:
@@ -224,8 +228,8 @@ def test_team_answer_precedence_when_both_present(index: dict[str, Item]) -> Non
         Decision(source_id="claude_md", target_kind="agent", scope="team", user_answers=both),
         index["claude_md"],
     )
-    assert isinstance(built, BuiltAgent)
-    assert built.payload.teams == ["team-a", "team-b"]
+    assert isinstance(built, AgentCreate)
+    assert built.teams == ["team-a", "team-b"]
     _, built = _build_payload(
         Decision(
             source_id="mcp:github", target_kind="mcp_install", scope="team", user_answers=both,
@@ -238,10 +242,10 @@ def test_team_answer_precedence_when_both_present(index: dict[str, Item]) -> Non
 
 def test_stdio_mcp_redacted_env_becomes_prompted_secret(index: dict[str, Item]) -> None:
     _, built = _decide(index, "mcp:github", "mcp_catalog")
-    assert isinstance(built, BuiltCatalog)
-    assert built.payload.serverType == "local"
-    assert built.payload.localConfig is not None
-    env = {e.key: e for e in built.payload.localConfig.environment}
+    assert isinstance(built, CatalogCreate)
+    assert built.serverType == "local"
+    assert built.localConfig is not None
+    env = {e.key: e for e in built.localConfig.environment}
     assert env["GITHUB_TOKEN"].type == "secret"
     assert env["GITHUB_TOKEN"].promptOnInstallation is True
     assert env["GITHUB_TOKEN"].value is None  # secret value not carried
@@ -253,9 +257,9 @@ def test_llm_key_requires_user_supplied_secret(index: dict[str, Item]) -> None:
         _decide(index, "openclaw", "llm_key", user_answers={"provider": "anthropic"})
     _, built = _decide(index, "openclaw", "llm_key",
                        user_answers={"apiKey": "sk-ant-real", "provider": "anthropic"})
-    assert isinstance(built, BuiltLlmKey)
-    assert built.payload.apiKey == "sk-ant-real"
-    assert built.payload.provider == "anthropic"
+    assert isinstance(built, LlmKeyCreate)
+    assert built.apiKey == "sk-ant-real"
+    assert built.provider == "anthropic"
 
 
 def test_llm_key_rejects_unknown_provider(index: dict[str, Item]) -> None:
@@ -271,21 +275,21 @@ def test_generated_frontmatter_is_valid_yaml_with_hostile_name(index: dict[str, 
                  name_override='evil: name "with" #chars'),
         index["subagent:fact-checker"],
     )
-    assert isinstance(built, BuiltSkill)
-    fm = built.payload.content.split("---", 2)[1]
+    assert isinstance(built, SkillCreate)
+    fm = built.content.split("---", 2)[1]
     assert yaml.safe_load(fm)["name"] == 'evil: name "with" #chars'
 
 
 def test_dry_run_redaction_hides_user_secrets() -> None:
-    llm = _redacted_for_print(BuiltLlmKey(LlmKeyCreate(
-        provider="anthropic", scope="personal", apiKey="sk-real", name="k")))
+    llm = _redacted_for_print(LlmKeyCreate(
+        provider="anthropic", scope="personal", apiKey="sk-real", name="k"))
     assert llm["apiKey"] == "<redacted>"
     install = _redacted_for_print(BuiltInstall(
         catalog_name="fs", scope="personal", environment_values={"GITHUB_TOKEN": "ghp_real"}, agent_ids=[]))
     env = install["environmentValues"]
     assert isinstance(env, dict)
     assert env["GITHUB_TOKEN"] == "<redacted>"
-    catalog = _redacted_for_print(BuiltCatalog(CatalogCreate(
+    catalog = _redacted_for_print(CatalogCreate(
         name="github",
         serverType="local",
         scope="personal",
@@ -294,7 +298,7 @@ def test_dry_run_redaction_hides_user_secrets() -> None:
             arguments=["--key", "sk-argsecret00000000"],
             environment=[McpEnvVar(key="GITHUB_TOKEN", type="secret", value="ghp_real")],
         ),
-    )))
+    ))
     local = catalog["localConfig"]
     assert isinstance(local, dict)
     catalog_env = local["environment"]
@@ -305,9 +309,9 @@ def test_dry_run_redaction_hides_user_secrets() -> None:
     assert "ghp_commandsecret00000" not in json.dumps(catalog)
     assert "sk-argsecret00000000" not in json.dumps(catalog)
     # a remote server URL with basic-auth + a secret query param is scrubbed too.
-    remote = _redacted_for_print(BuiltCatalog(CatalogCreate(
+    remote = _redacted_for_print(CatalogCreate(
         name="weather", serverType="remote", scope="personal",
-        serverUrl="https://user:hunter2@mcp.example.com/w?api_key=plaintextsecret&region=us")))
+        serverUrl="https://user:hunter2@mcp.example.com/w?api_key=plaintextsecret&region=us"))
     shown_url = json.dumps(remote)
     assert "hunter2" not in shown_url
     assert "plaintextsecret" not in shown_url

--- a/migration-kit/tests/test_apply_build.py
+++ b/migration-kit/tests/test_apply_build.py
@@ -23,9 +23,19 @@ from apply import (
     _Built,
     _flag_hook_collisions,
     _redacted_for_print,
+    _require_skill_frontmatter,
 )
 from archestra_client import CatalogCreate, LlmKeyCreate, LocalConfig, McpEnvVar
-from contracts import ContractError, Decision, HookData, HookItem, Item, SkillItem, to_jsonable
+from contracts import (
+    ContractError,
+    Decision,
+    HookData,
+    HookItem,
+    Item,
+    SkillData,
+    SkillItem,
+    to_jsonable,
+)
 from discover import discover
 
 FIXTURE = Path(__file__).parent / "fixtures" / "sample-setup"
@@ -68,6 +78,61 @@ def test_skill_is_verbatim(index: dict[str, Item]) -> None:
     assert isinstance(source, SkillItem)
     assert built.payload.content == source.data.content
     assert {f.path for f in built.payload.files} == {"reference.md"}
+
+
+def test_skill_name_override_renames_frontmatter(index: dict[str, Item]) -> None:
+    # archestra reads the skill name from the content frontmatter, so a name_override must land
+    # there -- and the returned display name must match it (idempotency keys on that name).
+    name, built = _decide(index, "skill:summarize-text", "skill", name_override="proj-summarize")
+    assert isinstance(built, BuiltSkill)
+    assert name == "proj-summarize"
+    assert yaml.safe_load(built.payload.content.split("---", 2)[1])["name"] == "proj-summarize"
+
+
+def _skill_item(content: str) -> SkillItem:
+    return SkillItem(id="skill:x", name="x", path=".claude/skills/x/SKILL.md", summary="",
+                     data=SkillData(content=content, frontmatter={}), files=[])
+
+
+def test_require_skill_frontmatter_accepts_valid() -> None:
+    _require_skill_frontmatter("---\nname: x\ndescription: d\n---\nbody", ctx="t")  # no raise
+
+
+@pytest.mark.parametrize(
+    ("content", "match"),
+    [
+        ("no frontmatter at all", "must start with"),
+        ("---\ndescription: d\n---\nb", "missing `name`"),
+        ("---\nname: x\n---\nb", "missing `description`"),
+        ("---\nname: x\ndescription:   \n---\nb", "missing `description`"),
+    ],
+)
+def test_require_skill_frontmatter_rejects(content: str, match: str) -> None:
+    with pytest.raises(ContractError, match=match):
+        _require_skill_frontmatter(content, ctx="t")
+
+
+def test_require_skill_frontmatter_rejects_duplicate_name() -> None:
+    with pytest.raises(ContractError, match="duplicate/ambiguous"):
+        _require_skill_frontmatter("---\nname: a\nname: b\ndescription: d\n---\nbody", ctx="t")
+
+
+def test_build_skill_rejects_description_less_content() -> None:
+    # a description-less SKILL.md passes set_name (name present) but the server would 400 it;
+    # the build must fail offline so --dry-run reports it invalid rather than the network.
+    decision = Decision(source_id="skill:x", target_kind="skill", scope="personal")
+    with pytest.raises(ContractError, match="missing `description`"):
+        _build_payload(decision, _skill_item("---\nname: x\n---\nbody"))
+
+
+def test_build_skill_auto_supplies_missing_name() -> None:
+    # name is supplied from name_override (or the source dir) when the SKILL.md omits it; only
+    # description -- which cannot be invented -- gates the build.
+    decision = Decision(source_id="skill:x", target_kind="skill", scope="personal",
+                        name_override="proj-x")
+    _, built = _build_payload(decision, _skill_item("---\ndescription: d\n---\nbody"))
+    assert isinstance(built, BuiltSkill)
+    assert yaml.safe_load(built.payload.content.split("---", 2)[1])["name"] == "proj-x"
 
 
 def test_team_scoped_skill_requires_team_ids(index: dict[str, Item]) -> None:

--- a/migration-kit/tests/test_apply_build.py
+++ b/migration-kit/tests/test_apply_build.py
@@ -21,11 +21,12 @@ from apply import (
     BuiltSkill,
     _build_payload,
     _Built,
+    _execute,
     _flag_hook_collisions,
     _redacted_for_print,
     _require_skill_frontmatter,
 )
-from archestra_client import CatalogCreate, LlmKeyCreate, LocalConfig, McpEnvVar
+from archestra_client import ArchestraClient, CatalogCreate, LlmKeyCreate, LocalConfig, McpEnvVar
 from contracts import (
     ContractError,
     Decision,
@@ -490,3 +491,64 @@ def test_dry_run_writes_planned_result_without_network(tmp_path: Path) -> None:
     result = json.loads(result_path.read_text(encoding="utf-8"))
     assert result["summary"] == {"planned": 1}
     assert result["ops"][0]["target_kind"] == "agent"
+
+
+def test_dry_run_manual_decision_without_target_kind(tmp_path: Path) -> None:
+    """a manual decision needs no target_kind; it is reported by its action, not crashed."""
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("ARCHESTRA_BASE_URL", "ARCHESTRA_API_KEY")}
+    proc, result_path = _run_apply_cli(tmp_path, {
+        "schema_version": 1,
+        "default_scope": "personal",
+        "decisions": [{"source_id": "openclaw", "action": "manual", "scope": "personal",
+                       "notes": "port the openclaw config by hand"}],
+    }, "--dry-run", env=env)
+
+    assert proc.returncode == 0
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    op = result["ops"][0]
+    assert op["outcome"] == "manual"
+    assert op["target_kind"] == "manual"
+
+
+def test_install_execute_sends_catalog_name() -> None:
+    """apply wires the catalog item's name into the install payload (the live API requires `name`)."""
+    posted: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args: object) -> None:
+            pass
+
+        def _json(self, body: dict[str, object]) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(body).encode())
+
+        def do_GET(self) -> None:
+            if self.path == "/api/internal_mcp_catalog":
+                self._json({"items": [{"id": "cat-1", "name": "science-playwright", "scope": "personal"}]})
+            else:  # GET /api/mcp_server?catalogId=cat-1 -> no existing install
+                self._json({"items": []})
+
+        def do_POST(self) -> None:
+            raw = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            posted.append(json.loads(raw))
+            self._json({"id": "srv-1"})
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with ArchestraClient(f"http://127.0.0.1:{server.server_address[1]}") as client:
+            decision = Decision(source_id="mcp:playwright", target_kind="mcp_install", scope="personal")
+            built = BuiltInstall(catalog_name="science-playwright", scope="personal",
+                                 environment_values={}, agent_ids=[])
+            op = _execute(client, decision, "science-playwright", built)
+    finally:
+        server.shutdown()
+        thread.join()
+
+    assert op.outcome == "created"
+    assert posted[0]["catalogId"] == "cat-1"
+    assert posted[0]["name"] == "science-playwright"

--- a/migration-kit/tests/test_contracts.py
+++ b/migration-kit/tests/test_contracts.py
@@ -71,6 +71,39 @@ def test_parse_plan_rejects_bad_enums() -> None:
         c.parse_decision({**base, "target_kind": "agent", "action": "delete"}, ctx="d")
 
 
+def test_parse_bundled_file_allows_empty_content() -> None:
+    # an empty file (e.g. a package __init__.py) is legitimate and must survive the round-trip.
+    bf = c.parse_bundled_file({"path": "recipes/__init__.py", "content": "", "encoding": "utf8"}, ctx="t")
+    assert bf.content == ""
+    inv = c.Inventory(
+        source_root="/x",
+        items=[c.SkillItem(
+            id="skill:tools", name="tools", path=".claude/skills/tools/SKILL.md",
+            data=c.SkillData(content="---\nname: tools\ndescription: d\n---\n"),
+            files=[c.BundledFile(path="recipes/__init__.py", content="", encoding="utf8")])],
+    )
+    assert _roundtrip(inv) == inv
+
+
+def test_parse_bundled_file_still_requires_string_content() -> None:
+    with pytest.raises(c.ContractError, match="content"):
+        c.parse_bundled_file({"path": "p", "content": 123, "encoding": "utf8"}, ctx="t")
+
+
+def test_non_migrate_decision_may_omit_target_kind() -> None:
+    manual = c.parse_decision({"source_id": "openclaw", "action": "manual", "scope": "personal"}, ctx="d")
+    assert manual.target_kind is None and manual.action == "manual"
+    # an explicit kind on a non-migrate decision is still accepted (backward compatible).
+    skip = c.parse_decision(
+        {"source_id": "x", "action": "skip", "target_kind": "skill", "scope": "personal"}, ctx="d")
+    assert skip.target_kind == "skill"
+
+
+def test_migrate_decision_requires_target_kind() -> None:
+    with pytest.raises(c.ContractError, match="target kind"):
+        c.parse_decision({"source_id": "x", "action": "migrate", "scope": "personal"}, ctx="d")
+
+
 def test_user_answer_validators_reject_bad_values() -> None:
     with pytest.raises(c.ContractError, match="provider"):
         c.require_provider({"provider": "huggingface"}, ctx="a")

--- a/migration-kit/tests/test_discover.py
+++ b/migration-kit/tests/test_discover.py
@@ -17,6 +17,7 @@ from contracts import (
     to_jsonable,
 )
 from discover import (
+    _dangling_refs,
     _extract_dependencies_block,
     _parse_hook_command,
     _redact,
@@ -344,3 +345,72 @@ def test_symlinked_skill_dir_is_skipped(tmp_path: Path) -> None:
     blob = json.dumps(to_jsonable(inv))
     assert "EXTERNAL_SKILL_BODY" not in blob
     assert "EXTERNAL_BUNDLED_FILE" not in blob
+
+
+# --- dangling references: surface repo files a migrated body points at but we didn't capture ---
+
+
+def test_dangling_refs_flags_only_existing_unbundled_files(tmp_path: Path) -> None:
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "run.sh").write_text("echo hi")
+    body = "run `scripts/run.sh`, `scripts/missing.sh`, and `$CLAUDE_PROJECT_DIR/scripts/run.sh`"
+    refs = _dangling_refs(body, [tmp_path], tmp_path, bundled=set())
+    assert set(refs) == {"scripts/run.sh"}  # missing.sh skipped; the two run.sh refs dedupe to one
+
+
+def test_dangling_refs_skips_bundled_files(tmp_path: Path) -> None:
+    (tmp_path / "scripts").mkdir()
+    real = tmp_path / "scripts" / "run.sh"
+    real.write_text("echo hi")
+    # a file that travels with this artifact is safe even though it exists in the repo.
+    assert _dangling_refs("see scripts/run.sh", [tmp_path], tmp_path, bundled={real.resolve()}) == []
+
+
+def test_dangling_refs_resolves_against_multiple_bases(tmp_path: Path) -> None:
+    # a skill body may address a sibling by skill-dir-relative `../shared.md` OR a tool by
+    # repo-root-relative `tools/x.py`; both should resolve and flag.
+    skills = tmp_path / ".claude" / "skills"
+    (skills / "dcf").mkdir(parents=True)
+    (skills / "shared.md").write_text("shared")
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "x.py").write_text("x")
+    refs = _dangling_refs("read ../shared.md then run tools/x.py", [skills / "dcf", tmp_path],
+                          tmp_path, bundled=set())
+    assert set(refs) == {".claude/skills/shared.md", "tools/x.py"}
+
+
+def test_dangling_refs_ignores_root_escaping_ref(tmp_path: Path) -> None:
+    # ../../etc/x.sh resolves outside the repo -> never flagged (and never read).
+    assert _dangling_refs("see ../../outside.sh", [tmp_path], tmp_path, bundled=set()) == []
+
+
+def test_discover_warns_on_dangling_command_reference(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    (src / ".claude" / "commands").mkdir(parents=True)
+    (src / ".claude" / "commands" / "greet.md").write_text("Run `scripts/run.sh` to greet.")
+    (src / "scripts").mkdir()
+    (src / "scripts" / "run.sh").write_text("echo hi")  # exists but lives outside captured dirs
+
+    inv = discover(src)
+    assert any("scripts/run.sh" in w for w in inv.warnings)
+    assert len(inv.warnings) == 1  # no secrets in this fixture, so the dangle is the only warning
+
+
+def test_discover_flags_ref_captured_as_separate_item(tmp_path: Path) -> None:
+    # the cross-artifact break: a command points at a tool captured as its OWN local_tool, so the
+    # tool is NOT bundled into the command's skill -> it still dangles and must be flagged.
+    src = tmp_path / "src"
+    (src / ".claude" / "commands").mkdir(parents=True)
+    (src / ".claude" / "commands" / "run.md").write_text("Run `python3 tools/foo.py`.")
+    (src / "tools").mkdir()
+    (src / "tools" / "foo.py").write_text("print('hi')")  # captured separately as a local_tool
+
+    inv = discover(src)
+    assert any(it.id == "local_tool:foo" for it in inv.items)  # captured as its own item...
+    assert any("tools/foo.py" in w for w in inv.warnings)      # ...yet still flagged for the command
+
+
+def test_fixture_skill_flags_repo_root_tool_reference(inv: Inventory) -> None:
+    # summarize-text's SKILL.md runs `python3 tools/word_count.py`; that tool is captured as its
+    # own local_tool, not bundled into the skill, so the skill's reference dangles.
+    assert any("tools/word_count.py" in w for w in inv.warnings)

--- a/migration-kit/tests/test_frontmatter.py
+++ b/migration-kit/tests/test_frontmatter.py
@@ -1,7 +1,9 @@
 """tests for the zero-dependency frontmatter parser, with PyYAML as an oracle."""
+import pytest
 import yaml
 
-from frontmatter import emit_frontmatter, parse_frontmatter
+from contracts import ContractError
+from frontmatter import emit_frontmatter, parse_frontmatter, set_name
 
 
 def test_no_fence_is_all_body() -> None:
@@ -105,3 +107,58 @@ def test_indented_fence_does_not_close_frontmatter() -> None:
     assert doc.frontmatter.get("description") == "y"
     assert doc.body == "body"
     assert any("---" in line for line in doc.unparsed_lines)  # the indented line is surfaced
+
+
+# --- set_name: rename a skill's frontmatter name in place ----------------------------------
+
+
+def test_set_name_noop_when_already_matching() -> None:
+    # the verbatim-skill invariant: an unchanged name must not even requote the value.
+    content = "---\nname: summarize-text\ndescription: d\n---\nbody\n"
+    assert set_name(content, "summarize-text") == content
+
+
+def test_set_name_rewrites_existing_name() -> None:
+    content = "---\nname: old\ndescription: d\n---\nbody\n"
+    out = set_name(content, "new-prefix-old")
+    fm = yaml.safe_load(out.split("---", 2)[1])
+    assert fm == {"name": "new-prefix-old", "description": "d"}
+    assert parse_frontmatter(out).body == "body\n"  # body untouched
+
+
+def test_set_name_preserves_other_lines_including_unsupported() -> None:
+    # a nested map ships verbatim through the parser; renaming must not disturb it.
+    content = "---\nname: old\ndescription: d\nmetadata:\n  patterns:\n    - a\n---\nbody\n"
+    out = set_name(content, "renamed")
+    assert "metadata:\n  patterns:\n    - a" in out
+    assert yaml.safe_load(out.split("---", 2)[1])["name"] == "renamed"
+
+
+def test_set_name_inserts_when_name_absent() -> None:
+    content = "---\ndescription: d\n---\nbody\n"
+    out = set_name(content, "added")
+    fm = yaml.safe_load(out.split("---", 2)[1])
+    assert fm == {"name": "added", "description": "d"}
+
+
+def test_set_name_prepends_fence_when_no_frontmatter() -> None:
+    out = set_name("just a body\n", "added")
+    assert yaml.safe_load(out.split("---", 2)[1]) == {"name": "added"}
+    assert out.endswith("just a body\n")
+
+
+def test_set_name_quotes_yaml_hostile_names() -> None:
+    out = set_name("---\nname: old\n---\nb", 'has: colon "and" quotes')
+    assert yaml.safe_load(out.split("---", 2)[1])["name"] == 'has: colon "and" quotes'
+
+
+@pytest.mark.parametrize("value", ["|", ">", "&anchor val", "*alias"])
+def test_set_name_refuses_unrewritable_value_forms(value: str) -> None:
+    # never corrupt a block scalar / anchor by editing only its first line.
+    with pytest.raises(ContractError, match="cannot safely rewrite"):
+        set_name(f"---\nname: {value}\ndescription: d\n---\nb", "renamed")
+
+
+def test_set_name_noop_preserves_crlf() -> None:
+    content = "---\r\nname: x\r\ndescription: d\r\n---\r\nbody\r\n"
+    assert set_name(content, "x") == content  # no-op keeps the original line endings byte-for-byte


### PR DESCRIPTION
Six bugs in the `migrate-to-archestra` skill, surfaced by migrating real agentic repos, plus a small behavior-preserving cleanup pass.

## Fixes (first pass)
- **`name_override` now renames skills.** Archestra derives a skill's name from its SKILL.md frontmatter (`SkillCreate` has no `name` field), so the override previously neither renamed the skill nor matched the idempotency lookup — duplicating the skill on re-run. `frontmatter.set_name` writes the name into the frontmatter (no-op when unchanged; refuses block-scalar/anchor name values).
- **Malformed skill content fails offline.** A SKILL.md missing its frontmatter fence / `name` / `description`, or carrying duplicate keys, passed `apply.py --dry-run` but the server 400s it. `_require_skill_frontmatter` validates in the build phase so it surfaces as an `invalid` op offline instead of failing at create time.
- **Dangling references are made visible.** References to repo files outside the captured dirs dangled silently in the sandbox. `discover` now warns when a migrated body points at a repo file not bundled with that artifact — resolved against both the skill dir and repo root, so the canonical cross-skill break (`python3 tools/foo.py`) is caught even when the target is captured as a separate item.

## Fixes (second pass — four more repos)
- **MCP install no longer 400s.** `McpInstall` omitted the API-required `name`, so every `mcp_install` op failed against the live API on real apply (dry-run passed since it never hits the network). `McpInstall` now carries `name`, wired to the catalog item's name.
- **Empty bundled files no longer crash apply.** `parse_bundled_file` rejected empty content, so a legitimately empty bundled file (e.g. a package `__init__.py`) aborted the migration. Only `BundledFile.content` is relaxed to allow empty strings; skill and hook bodies still require non-empty content.
- **`target_kind` is migrate-only.** A `manual`/`skip` decision had to declare a `target_kind` it never uses, raising a `ContractError`. It is now required only for `migrate` decisions; non-migrate ops report their action in results.

## Cleanup (unify pass — behavior-preserving)
- **Dropped four single-field `Built*` wrappers.** `BuiltAgent`/`BuiltSkill`/`BuiltCatalog`/`BuiltLlmKey` only boxed an existing `*Create` payload; the `Built` union now holds those payloads directly. The three ops that need an id resolved at execute time (`BuiltInstall`/`BuiltPolicy`/`BuiltHook`) keep their struct. `match`-based dispatch and `ty` exhaustiveness are unchanged — no dispatch table/registry/visitor.
- **Deduped an identical helper.** `_fm_str` (apply) and `_meta_str` (discover) were byte-identical; collapsed into one `frontmatter.fm_str`.
- **`replace()` consistency.** The primary-agent install fallback used a field-by-field rebuild; now uses `dataclasses.replace`, matching the adjacent hook case.
- **Instruction text.** Clarified SKILL.md team-id guidance (these are `user_answers` keys that `apply.py` maps to the right API field), unified the "primary agent" term, documented `isPrimary`, and noted the agent-hooks feature gate in Step 5.

## Validation
- 152 tests pass; `ruff` and `ty` clean (after both the fixes and the cleanup pass).
- Verified end-to-end against a live instance: skill rename is idempotent, dangling warning fires on the classic break, and MCP install now creates instead of 400ing.
- The cleanup pass is behavior-preserving (CLI output, JSON shapes, API payloads, redaction, error strings byte-identical) — confirmed by two independent adversarial reviews.

## Out of scope (documented limitations)
- The reference scanner is extension-heuristic: extensionless refs and env vars other than `$CLAUDE_PROJECT_DIR` are not resolved.
- Local-tool bundled scripts are not scanned (path literals in executable code are too noisy).
- Catalog-by-name resolution and the install idempotency check take the first name match and don't filter by owner — on a shared/admin-key instance a duplicate catalog name could resolve the wrong item or false-positive the dedup. Pre-existing; left for a follow-up.

https://claude.ai/code/session_014obKn3R1gmxvQSVSsBG8EJ

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
