### PR TITLE
fix(mcp-registry): stop 'Open in new tab' button label from overflowing

### DIFF
--- a/platform/frontend/src/app/mcp/registry/beta/_parts/app-backing-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/app-backing-card.tsx
@@ -142,25 +142,35 @@ export function AppBackingCard({ item }: { item: CatalogItem }) {
             />
           </div>
           {item.appId && (
-            <div className="flex items-center gap-2">
-              <Button asChild variant="outline" size="sm" className="flex-1">
+            <div className="flex items-stretch gap-2">
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="h-auto min-h-8 flex-1 whitespace-normal py-1.5 text-center leading-tight"
+              >
                 <Link
                   href={buildAppChatHandoffUrl({
                     appId: item.appId,
                     appName: item.name,
                   })}
                 >
-                  <MessageSquare className="h-4 w-4" />
+                  <MessageSquare className="h-4 w-4 shrink-0" />
                   Chat
                 </Link>
               </Button>
-              <Button asChild variant="outline" size="sm" className="flex-1">
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="h-auto min-h-8 flex-1 whitespace-normal py-1.5 text-center leading-tight"
+              >
                 <Link
                   href={`/a/${item.appId}`}
                   target="_blank"
                   rel="noreferrer"
                 >
-                  <ExternalLink className="h-4 w-4" />
+                  <ExternalLink className="h-4 w-4 shrink-0" />
                   Open in new tab
                 </Link>
               </Button>


### PR DESCRIPTION
## What

In the MCP Registry, the `Open in new tab` action button on app-backing cards rendered with broken styling on narrower viewports — the label wrapped but spilled outside the button border and beyond the card.

## Why

The two action buttons (`Chat` and `Open in new tab`) are forced to equal width via `flex-1`, while keeping the fixed `h-8` height from the `sm` size variant. The long `Open in new tab` label wraps when the card is narrow, but the fixed height meant the wrapped text overflowed the button vertically (the word "Open" floating above the icon, overflowing the card).

## Fix

In `app-backing-card.tsx`:
- Container alignment `items-center` → `items-stretch` so both buttons share equal height.
- Both buttons: `h-auto min-h-8` (grow instead of fixed height), `whitespace-normal`, `text-center`, `leading-tight`, and `py-1.5` so the label wraps cleanly and stays contained.