### PR TITLE
fix(cost-limits): attribute cost-limit blocks to Archestra and name the rule

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -77176,6 +77176,7 @@
                                   "type": "string",
                                   "enum": [
                                     "rate_limit",
+                                    "usage_limit_exceeded",
                                     "authentication",
                                     "permission_denied",
                                     "invalid_request",
@@ -77938,6 +77939,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",
@@ -78671,6 +78673,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",
@@ -79445,6 +79448,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",
@@ -81955,6 +81959,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",
@@ -83331,6 +83336,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -85020,6 +85026,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",
@@ -85777,6 +85784,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",
@@ -86526,6 +86534,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",
@@ -87285,6 +87294,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",
@@ -109991,6 +110001,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -110934,6 +110945,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -111585,6 +111597,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -112225,6 +112238,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -112740,6 +112754,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -113266,6 +113281,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -115739,6 +115755,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -116265,6 +116282,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -116791,6 +116809,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -117317,6 +117336,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -117843,6 +117863,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -118369,6 +118390,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -118895,6 +118917,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -119421,6 +119444,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -119936,6 +119960,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -120451,6 +120476,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -120977,6 +121003,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -121503,6 +121530,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -124195,6 +124223,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -124721,6 +124750,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -125480,6 +125510,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -126423,6 +126454,7 @@
                                           "type": "string",
                                           "enum": [
                                             "rate_limit",
+                                            "usage_limit_exceeded",
                                             "authentication",
                                             "permission_denied",
                                             "invalid_request",
@@ -128448,6 +128480,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -129391,6 +129424,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -130042,6 +130076,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -130682,6 +130717,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -131197,6 +131233,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -131723,6 +131760,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -134196,6 +134234,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -134722,6 +134761,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -135248,6 +135288,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -135774,6 +135815,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -136300,6 +136342,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -136826,6 +136869,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -137352,6 +137396,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -137878,6 +137923,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -138393,6 +138439,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -138908,6 +138955,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -139434,6 +139482,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -139960,6 +140009,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -142652,6 +142702,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -143178,6 +143229,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -143937,6 +143989,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -144880,6 +144933,7 @@
                                     "type": "string",
                                     "enum": [
                                       "rate_limit",
+                                      "usage_limit_exceeded",
                                       "authentication",
                                       "permission_denied",
                                       "invalid_request",
@@ -224235,6 +224289,7 @@
                                 "type": "string",
                                 "enum": [
                                   "rate_limit",
+                                  "usage_limit_exceeded",
                                   "authentication",
                                   "permission_denied",
                                   "invalid_request",

--- a/platform/backend/src/archestra-mcp-server/app-llm.ts
+++ b/platform/backend/src/archestra-mcp-server/app-llm.ts
@@ -133,10 +133,14 @@ async function runAppLlmCompletion(
     });
     return structuredSuccessResult({ text: result.text }, result.text);
   } catch (error) {
-    // 429 covers both the org token-cost limit and an upstream provider rate
-    // limit; both warrant the same app action (back off and retry), so the
-    // message does not assert a single cause.
-    if (APICallError.isInstance(error) && error.statusCode === 429) {
+    // 429 is an upstream provider rate limit; 402 is the Archestra token-cost
+    // limit block. Both surface to apps as llm_quota — the app-visible action
+    // (stop and back off) is the same, so the message does not assert a
+    // single cause.
+    if (
+      APICallError.isInstance(error) &&
+      (error.statusCode === 429 || error.statusCode === 402)
+    ) {
       return llmErrorResult(
         "llm_quota",
         "The LLM call was rate-limited or has reached its usage limit — back off and retry.",

--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -1318,7 +1318,7 @@ describe("LimitValidationService", () => {
       });
 
       expect(result).not.toBeNull();
-      expect(result?.[1]).toContain("virtual_key-level");
+      expect(result?.[1]).toContain("virtual key-level");
     });
 
     test("should check user limits before agent limits", async ({
@@ -1414,6 +1414,57 @@ describe("LimitValidationService", () => {
 
       expect(result).not.toBeNull();
       expect(result?.[1]).toContain("agent-level");
+    });
+
+    test("names the exact rule (Archestra, model scope, reset window) in the violation message", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({ name: "Rule Naming Agent" });
+
+      const limit = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "token_cost",
+        limitValue: 1,
+        model: ["gpt-4o"],
+        cleanupInterval: "24h",
+      });
+
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "gpt-4o",
+        1000000,
+        1000000,
+      );
+
+      // Prevent cleanup from resetting test data
+      await LimitModel.patch(limit.id, { lastCleanup: new Date() });
+
+      const result = await LimitValidationService.checkLimitsBeforeRequest({
+        agentId: agent.id,
+      });
+
+      expect(result).not.toBeNull();
+      const [refusalMessage, contentMessage] = result as unknown as [
+        string,
+        string,
+      ];
+
+      // The user-facing message must attribute the block to Archestra (not the
+      // provider) and name which rule fired: scope, model coverage, reset cadence.
+      expect(contentMessage).toContain("blocked by Archestra");
+      expect(contentMessage).toContain("agent-level cost limit");
+      expect(contentMessage).toContain("model gpt-4o");
+      expect(contentMessage).toContain("every 24 hours");
+
+      // The same details are mirrored in the metadata block the LLM can parse.
+      expect(refusalMessage).toContain(
+        "<archestra-limit-model-scope>model gpt-4o</archestra-limit-model-scope>",
+      );
+      expect(refusalMessage).toContain(
+        "<archestra-limit-reset-window>every 24 hours</archestra-limit-reset-window>",
+      );
     });
 
     test("should check team limits before organization limits", async ({
@@ -1515,7 +1566,8 @@ describe("LimitValidationService", () => {
       expect(refusalMessage).toContain("<archestra-limit-current-usage>");
       expect(refusalMessage).toContain("<archestra-limit-value>");
 
-      expect(contentMessage).toContain("token cost limit");
+      expect(contentMessage).toContain("blocked by Archestra");
+      expect(contentMessage).toContain("cost limit");
       expect(contentMessage).toContain("Current usage:");
       expect(contentMessage).toContain("Limit:");
     });
@@ -1802,7 +1854,7 @@ describe("LimitValidationService", () => {
       });
 
       expect(result).not.toBeNull();
-      expect(result?.[1]).toContain("virtual_key-level");
+      expect(result?.[1]).toContain("virtual key-level");
     });
 
     test("blocks request when org all-models limit is exceeded", async ({
@@ -2367,7 +2419,7 @@ describe("cleanupLimitsIfNeeded", () => {
       userId: user.id,
     });
     expect(result).not.toBeNull();
-    expect(result?.[1]).toContain("user-level token cost limit");
+    expect(result?.[1]).toContain("user-level cost limit");
   });
 
   test("custom user limits override the inherited default user limit", async ({

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -1152,6 +1152,8 @@ export class LimitValidationService {
           limitDescription,
           totalTokensIn,
           totalTokensOut,
+          cleanupInterval: limit.cleanupInterval,
+          models: limit.model,
         });
       }
 
@@ -1215,6 +1217,8 @@ export class LimitValidationService {
             limitDescription: "cost_dollars",
             totalTokensIn: usage.tokensIn,
             totalTokensOut: usage.tokensOut,
+            cleanupInterval: envDefault.cleanupInterval,
+            models: envDefault.model,
           });
         }
       }
@@ -1248,6 +1252,8 @@ export class LimitValidationService {
         limitDescription: "cost_dollars",
         totalTokensIn: usage.tokensIn,
         totalTokensOut: usage.tokensOut,
+        cleanupInterval: globalDefault.cleanupInterval,
+        models: globalDefault.model,
       });
     } catch (error) {
       logger.error(
@@ -1537,41 +1543,105 @@ function buildLimitViolationResponse(params: {
   limitDescription: "tokens" | "cost_dollars";
   totalTokensIn: number;
   totalTokensOut: number;
+  cleanupInterval?: LimitCleanupInterval | null;
+  models?: string[] | null;
 }): LimitViolationResponse {
   const totalTokens = params.totalTokensIn + params.totalTokensOut;
   const remaining = Math.max(0, params.limitValue - params.comparisonValue);
+  // Human-readable description of the exact rule that fired, so both the LLM
+  // (via the metadata block) and the end user (via the content message) can
+  // tell *which* Archestra limit blocked them rather than guessing.
+  const scopeLabel = formatLimitEntityType(params.entityType);
+  const modelScope = describeLimitModelScope(params.models);
+  const resetWindow = describeLimitResetWindow(params.cleanupInterval);
   const archestraMetadata = `
 <archestra-limit-type>token_cost</archestra-limit-type>
 <archestra-limit-entity-type>${params.entityType}</archestra-limit-entity-type>
 <archestra-limit-entity-id>${params.entityId}</archestra-limit-entity-id>
+<archestra-limit-model-scope>${modelScope}</archestra-limit-model-scope>
+<archestra-limit-reset-window>${resetWindow ?? "n/a"}</archestra-limit-reset-window>
 <archestra-limit-current-usage>${totalTokens}</archestra-limit-current-usage>
 <archestra-limit-value>${params.limitValue}</archestra-limit-value>
 <archestra-limit-remaining>${remaining}</archestra-limit-remaining>`;
 
-  const contentMessage =
+  // Lead with explicit Archestra attribution: the screenshots in the bug report
+  // showed clients framing this as a provider rate limit ("not your usage
+  // limit"), so the first line must make clear that Archestra enforced it.
+  const header = `This request was blocked by Archestra (not the AI provider): the ${scopeLabel} cost limit has been reached.`;
+  const ruleLine = `Rule: ${scopeLabel} cost limit, applied to ${modelScope}${
+    resetWindow ? `, resets ${resetWindow}` : ""
+  }.`;
+  const footer = resetWindow
+    ? `Contact your administrator to raise the limit, or wait for the usage to reset (${resetWindow}).`
+    : "Contact your administrator to raise the limit, or wait for the usage to reset.";
+
+  const usageBlock =
     params.limitDescription === "cost_dollars"
-      ? `
-I cannot process this request because the ${params.entityType}-level token cost limit has been exceeded.
-
-Current usage: $${params.comparisonValue.toFixed(2)}
+      ? `Current usage: $${params.comparisonValue.toFixed(2)}
 Limit: $${params.limitValue.toFixed(2)}
-Remaining: $${remaining.toFixed(2)}
-
-Please contact your administrator to increase the limit or wait for the usage to reset.`
-      : `
-I cannot process this request because the ${params.entityType}-level token cost limit has been exceeded.
-
-Current usage: ${totalTokens.toLocaleString()} tokens
+Remaining: $${remaining.toFixed(2)}`
+      : `Current usage: ${totalTokens.toLocaleString()} tokens
 Limit: ${params.limitValue.toLocaleString()} tokens
-Remaining: ${Math.max(0, params.limitValue - totalTokens).toLocaleString()} tokens
+Remaining: ${Math.max(0, params.limitValue - totalTokens).toLocaleString()} tokens`;
 
-Please contact your administrator to increase the limit or wait for the usage to reset.`;
+  const contentMessage = `
+${header}
+
+${ruleLine}
+
+${usageBlock}
+
+${footer}`;
 
   return [
     `${archestraMetadata}\n${contentMessage}`,
     contentMessage,
     { entityType: params.entityType, limitType: "token_cost" },
   ];
+}
+
+/** Render a limit's entity type for human display, e.g. "virtual_key" -> "virtual key-level". */
+function formatLimitEntityType(entityType: LimitEntityType): string {
+  return `${entityType.replace(/_/g, " ")}-level`;
+}
+
+/** Describe which models a limit covers, e.g. "all models" or "models gpt-4o, claude-3-5-sonnet". */
+function describeLimitModelScope(models?: string[] | null): string {
+  const normalized = normalizeLimitModels(models);
+  if (!normalized) {
+    return "all models";
+  }
+  return normalized.length === 1
+    ? `model ${normalized[0]}`
+    : `models ${normalized.join(", ")}`;
+}
+
+/** Turn a cleanup interval into a human reset cadence, e.g. "every 24 hours", "monthly (calendar month)". */
+function describeLimitResetWindow(
+  interval?: LimitCleanupInterval | null,
+): string | null {
+  switch (interval) {
+    case "1h":
+      return "every hour";
+    case "12h":
+      return "every 12 hours";
+    case "24h":
+      return "every 24 hours";
+    case "1w":
+      return "every week";
+    case "1m":
+      return "every month";
+    case "calendar_day":
+      return "daily (calendar day)";
+    case "calendar_week_sunday":
+      return "weekly (calendar week, Sunday start)";
+    case "calendar_week_monday":
+      return "weekly (calendar week, Monday start)";
+    case "calendar_month":
+      return "monthly (calendar month)";
+    default:
+      return null;
+  }
 }
 
 function normalizeLimitModels(models: string[] | null | undefined) {

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -249,7 +249,7 @@ describe("mapProviderError - OpenAI", () => {
       const error = createOpenAIError(
         429,
         OpenAIErrorTypes.RATE_LIMIT,
-        "I cannot process this request because the organization-level token cost limit has been exceeded.",
+        "This request was blocked by Archestra (not the AI provider): the organization-level cost limit has been reached.",
         "token_cost_limit_exceeded",
         undefined,
         {
@@ -259,11 +259,15 @@ describe("mapProviderError - OpenAI", () => {
       );
       const result = mapProviderError(error, "openai");
 
-      expect(result.code).toBe(ChatErrorCode.RateLimit);
+      // An Archestra budget block is reclassified off the retryable RateLimit
+      // code onto the dedicated, non-retryable UsageLimitExceeded code so the UI
+      // attributes it to Archestra and drops the retry affordance.
+      expect(result.code).toBe(ChatErrorCode.UsageLimitExceeded);
+      expect(result.isRetryable).toBe(false);
       expect(result.usageLimitExceeded).toBe(true);
       expect(result.usageLimitEntityType).toBe("organization");
       expect(result.message).toBe(
-        "The organization usage limit budget has been exceeded.",
+        "Archestra blocked this request because the organization usage limit has been reached.",
       );
     });
   });
@@ -1803,9 +1807,10 @@ describe("ProviderError", () => {
   it("preserves usage-limit metadata in the frontend error payload", () => {
     expect(
       sanitizeChatErrorForFrontend({
-        code: ChatErrorCode.RateLimit,
-        message: "The organization usage limit budget has been exceeded.",
-        isRetryable: true,
+        code: ChatErrorCode.UsageLimitExceeded,
+        message:
+          "Archestra blocked this request because the organization usage limit has been reached.",
+        isRetryable: false,
         usageLimitExceeded: true,
         usageLimitEntityType: "organization",
         originalError: {
@@ -1815,9 +1820,10 @@ describe("ProviderError", () => {
         },
       }),
     ).toEqual({
-      code: ChatErrorCode.RateLimit,
-      message: "The organization usage limit budget has been exceeded.",
-      isRetryable: true,
+      code: ChatErrorCode.UsageLimitExceeded,
+      message:
+        "Archestra blocked this request because the organization usage limit has been reached.",
+      isRetryable: false,
       usageLimitExceeded: true,
       usageLimitEntityType: "organization",
     });

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -246,9 +246,11 @@ describe("mapProviderError - OpenAI", () => {
     });
 
     it("marks usage-limit budget overages from the proxy", () => {
+      // The proxy returns Archestra budget blocks as 402 with type
+      // usage_limit_exceeded (deliberately NOT a 429/rate-limit shape).
       const error = createOpenAIError(
-        429,
-        OpenAIErrorTypes.RATE_LIMIT,
+        402,
+        "usage_limit_exceeded",
         "This request was blocked by Archestra (not the AI provider): the organization-level cost limit has been reached.",
         "token_cost_limit_exceeded",
         undefined,
@@ -259,9 +261,9 @@ describe("mapProviderError - OpenAI", () => {
       );
       const result = mapProviderError(error, "openai");
 
-      // An Archestra budget block is reclassified off the retryable RateLimit
-      // code onto the dedicated, non-retryable UsageLimitExceeded code so the UI
-      // attributes it to Archestra and drops the retry affordance.
+      // An Archestra budget block gets the dedicated, non-retryable
+      // UsageLimitExceeded code so the UI attributes it to Archestra and
+      // drops the retry affordance.
       expect(result.code).toBe(ChatErrorCode.UsageLimitExceeded);
       expect(result.isRetryable).toBe(false);
       expect(result.usageLimitExceeded).toBe(true);

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -1692,6 +1692,15 @@ export function mapProviderError(
     errorCode = ChatErrorCode.ContextTooLong;
   }
   const usageLimitError = extractUsageLimitError(responseBody);
+  // An Archestra usage-limit block arrives over the proxy envelope as an HTTP
+  // 429, which the per-provider mappers classify as a retryable RateLimit. That
+  // mislabels it as the provider throttling traffic ("not your usage limit" in
+  // some clients) and offers a pointless retry. Reclassify it to the dedicated,
+  // non-retryable UsageLimitExceeded code so the UI attributes it to Archestra
+  // and drops the retry affordance.
+  if (usageLimitError) {
+    errorCode = ChatErrorCode.UsageLimitExceeded;
+  }
 
   // Extract the most meaningful error message
   const errorMessage = extractErrorMessage(parsedError, responseBody, error);
@@ -1832,7 +1841,10 @@ export function sanitizeChatErrorForFrontend(
 
 function formatUsageLimitMessage(entityType: string | undefined): string {
   if (!entityType) {
-    return "A usage limit budget has been exceeded.";
+    return "Archestra blocked this request because a configured usage limit has been reached.";
   }
-  return `The ${entityType.replace(/_/g, " ")} usage limit budget has been exceeded.`;
+  return `Archestra blocked this request because the ${entityType.replace(
+    /_/g,
+    " ",
+  )} usage limit has been reached.`;
 }

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -617,11 +617,16 @@ export async function handleLLMProxy<
         { resolvedAgentId, reason: "token_cost_limit_exceeded" },
         `${providerName} request blocked due to token cost limit`,
       );
-      // Preserve the proxy-compatible error envelope so chat clients can read structured limit metadata.
+      // Preserve the proxy-compatible error envelope so chat clients can read
+      // structured limit metadata. Use an Archestra-specific error `type` rather
+      // than the provider-style "rate_limit_exceeded": this block is an Archestra
+      // budget enforcement, not the provider throttling traffic, and labelling it
+      // as a rate limit made clients frame it as "not your usage limit". The
+      // stable `code` keeps backward-compatible structured detection working.
       return reply.status(429).send({
         error: {
           message: contentMessage,
-          type: "rate_limit_exceeded",
+          type: "usage_limit_exceeded",
           code: "token_cost_limit_exceeded",
           usage_limit: limitMetadata
             ? {

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -618,12 +618,14 @@ export async function handleLLMProxy<
         `${providerName} request blocked due to token cost limit`,
       );
       // Preserve the proxy-compatible error envelope so chat clients can read
-      // structured limit metadata. Use an Archestra-specific error `type` rather
-      // than the provider-style "rate_limit_exceeded": this block is an Archestra
-      // budget enforcement, not the provider throttling traffic, and labelling it
-      // as a rate limit made clients frame it as "not your usage limit". The
-      // stable `code` keeps backward-compatible structured detection working.
-      return reply.status(429).send({
+      // structured limit metadata. This is Archestra budget enforcement, not the
+      // provider throttling traffic, so it must not look like a rate limit:
+      // a 429 makes every LLM SDK auto-retry a block that cannot clear on retry,
+      // and makes clients frame it as a provider limit ("not your usage limit").
+      // 402 Payment Required is non-retryable in all SDKs and semantically a
+      // budget stop. The Archestra-specific `type` plus the stable `code` keep
+      // structured detection working.
+      return reply.status(402).send({
         error: {
           message: contentMessage,
           type: "usage_limit_exceeded",

--- a/platform/backend/src/routes/proxy/routes/limit-integration.test.ts
+++ b/platform/backend/src/routes/proxy/routes/limit-integration.test.ts
@@ -118,7 +118,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
     return harness;
   }
 
-  test("blocks request with 429 when virtual_key limit is exceeded", async ({
+  test("blocks request with 402 when virtual_key limit is exceeded", async ({
     makeAgent,
     makeOrganization,
     makeSecret,
@@ -171,7 +171,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
@@ -183,7 +183,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
     });
   });
 
-  test("blocks request with 429 when user limit is exceeded", async ({
+  test("blocks request with 402 when user limit is exceeded", async ({
     makeAgent,
     makeUser,
     makeOrganization,
@@ -226,7 +226,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
@@ -238,7 +238,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
     });
   });
 
-  test("blocks request with 429 when default user limit is exceeded", async ({
+  test("blocks request with 402 when default user limit is exceeded", async ({
     makeAgent,
     makeUser,
     makeOrganization,
@@ -282,7 +282,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
@@ -378,7 +378,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(response.statusCode).toBe(200);
   });
 
-  test("blocks org-scoped agent with 429 when organization limit is exceeded", async ({
+  test("blocks org-scoped agent with 402 when organization limit is exceeded", async ({
     makeAgent,
     makeOrganization,
   }) => {
@@ -416,7 +416,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
@@ -560,7 +560,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     const body = response.json();
     expect(body.error.code).toBe("token_cost_limit_exceeded");
     // virtual_key is checked first (most specific), so error should mention it
@@ -707,7 +707,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(orgUsage[0].tokensOut).toBe(60);
   });
 
-  test("blocks request with 429 when team all-models limit is exceeded", async ({
+  test("blocks request with 402 when team all-models limit is exceeded", async ({
     makeAgent,
     makeOrganization,
     makeAdmin,
@@ -753,13 +753,13 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     const body = response.json();
     expect(body.error.code).toBe("token_cost_limit_exceeded");
     expect(body.error.message).toContain("team-level");
   });
 
-  test("blocks request with 429 when user all-models limit is exceeded", async ({
+  test("blocks request with 402 when user all-models limit is exceeded", async ({
     makeAgent,
     makeUser,
     makeOrganization,
@@ -804,13 +804,13 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     const body = response.json();
     expect(body.error.code).toBe("token_cost_limit_exceeded");
     expect(body.error.message).toContain("user-level");
   });
 
-  test("blocks request with 429 when virtual_key all-models limit is exceeded", async ({
+  test("blocks request with 402 when virtual_key all-models limit is exceeded", async ({
     makeAgent,
     makeOrganization,
     makeSecret,
@@ -863,13 +863,13 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     const body = response.json();
     expect(body.error.code).toBe("token_cost_limit_exceeded");
     expect(body.error.message).toContain("virtual key-level");
   });
 
-  test("blocks request with 429 when environment limit is exceeded", async ({
+  test("blocks request with 402 when environment limit is exceeded", async ({
     makeAgent,
     makeOrganization,
   }) => {
@@ -909,7 +909,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
@@ -964,7 +964,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(response.statusCode).toBe(200);
   });
 
-  test("blocks request with 429 when per-environment default user limit is exceeded", async ({
+  test("blocks request with 402 when per-environment default user limit is exceeded", async ({
     makeAgent,
     makeUser,
     makeOrganization,
@@ -1013,7 +1013,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     expect(response.json()).toMatchObject({
       error: {
         code: "token_cost_limit_exceeded",
@@ -1145,7 +1145,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
       payload: SIMPLE_PAYLOAD(),
     });
 
-    expect(response.statusCode).toBe(429);
+    expect(response.statusCode).toBe(402);
     expect(response.json()).toMatchObject({
       error: {
         usage_limit: {

--- a/platform/backend/src/routes/proxy/routes/limit-integration.test.ts
+++ b/platform/backend/src/routes/proxy/routes/limit-integration.test.ts
@@ -564,7 +564,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
     const body = response.json();
     expect(body.error.code).toBe("token_cost_limit_exceeded");
     // virtual_key is checked first (most specific), so error should mention it
-    expect(body.error.message).toContain("virtual_key-level");
+    expect(body.error.message).toContain("virtual key-level");
   });
 
   test("records usage in team all-models limit after successful request", async ({
@@ -866,7 +866,7 @@ describe("LLM proxy limit enforcement (integration)", () => {
     expect(response.statusCode).toBe(429);
     const body = response.json();
     expect(body.error.code).toBe("token_cost_limit_exceeded");
-    expect(body.error.message).toContain("virtual_key-level");
+    expect(body.error.message).toContain("virtual key-level");
   });
 
   test("blocks request with 429 when environment limit is exceeded", async ({

--- a/platform/backend/src/routes/proxy/routes/provider-matrix.test.ts
+++ b/platform/backend/src/routes/proxy/routes/provider-matrix.test.ts
@@ -2204,7 +2204,7 @@ describe("LLM proxy provider matrix", () => {
           }),
         });
 
-        expect(blockedResponse.statusCode).toBe(429);
+        expect(blockedResponse.statusCode).toBe(402);
         expect(blockedResponse.json()).toMatchObject({
           error: {
             code: "token_cost_limit_exceeded",

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -254,6 +254,13 @@ export const MinimaxErrorTypes = {
 export enum ChatErrorCode {
   /** Rate/quota exceeded - retryable after delay */
   RateLimit = "rate_limit",
+  /**
+   * An Archestra-configured cost/usage limit blocked the request. Distinct from
+   * RateLimit: this is Archestra enforcing a budget, not the provider throttling
+   * traffic, so it is NOT retryable — retrying re-hits the same cap. Pairs with
+   * the `usageLimitExceeded`/`usageLimitEntityType` fields below.
+   */
+  UsageLimitExceeded = "usage_limit_exceeded",
   /** Invalid or missing API key */
   Authentication = "authentication",
   /** API key lacks permissions for the requested resource */
@@ -296,6 +303,8 @@ export enum ChatErrorCode {
 export const ChatErrorMessages: Record<ChatErrorCode, string> = {
   [ChatErrorCode.RateLimit]:
     "Too many requests. Please wait a moment and try again.",
+  [ChatErrorCode.UsageLimitExceeded]:
+    "Archestra blocked this request because a configured usage limit has been reached. Contact your administrator to raise the limit or wait for it to reset.",
   [ChatErrorCode.Authentication]:
     "Invalid API key. Please check your Chat Settings.",
   [ChatErrorCode.PermissionDenied]:

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -22036,7 +22036,7 @@ export type GetChatConversationsResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -22199,7 +22199,7 @@ export type CreateChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -22443,7 +22443,7 @@ export type GetChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -22609,7 +22609,7 @@ export type UpdateChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -23208,7 +23208,7 @@ export type ForkChatConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -23556,7 +23556,7 @@ export type CompactChatConversationResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -23989,7 +23989,7 @@ export type GetSharedConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -24151,7 +24151,7 @@ export type ForkSharedConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -24315,7 +24315,7 @@ export type GenerateChatConversationTitleResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -24478,7 +24478,7 @@ export type UpdateChatMessageResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -31175,7 +31175,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -31371,7 +31371,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -31476,7 +31476,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -31579,7 +31579,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -31660,7 +31660,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -31743,7 +31743,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32250,7 +32250,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32333,7 +32333,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32416,7 +32416,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32499,7 +32499,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32582,7 +32582,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32665,7 +32665,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32748,7 +32748,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32831,7 +32831,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32912,7 +32912,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -32993,7 +32993,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -33076,7 +33076,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -33159,7 +33159,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -33883,7 +33883,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -33966,7 +33966,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -34116,7 +34116,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -34312,7 +34312,7 @@ export type GetInteractionsResponses = {
                 id: string;
                 conversationId: string;
                 error: {
-                    code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                    code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                     message: string;
                     isRetryable: boolean;
                     sessionId?: string;
@@ -34812,7 +34812,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -35008,7 +35008,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -35113,7 +35113,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -35216,7 +35216,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -35297,7 +35297,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -35380,7 +35380,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -35887,7 +35887,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -35970,7 +35970,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36053,7 +36053,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36136,7 +36136,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36219,7 +36219,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36302,7 +36302,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36385,7 +36385,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36468,7 +36468,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36549,7 +36549,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36630,7 +36630,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36713,7 +36713,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -36796,7 +36796,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -37520,7 +37520,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -37603,7 +37603,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -37753,7 +37753,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -37949,7 +37949,7 @@ export type GetInteractionResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;
@@ -58497,7 +58497,7 @@ export type CreateScheduleTriggerRunConversationResponses = {
             id: string;
             conversationId: string;
             error: {
-                code: 'rate_limit' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
+                code: 'rate_limit' | 'usage_limit_exceeded' | 'authentication' | 'permission_denied' | 'invalid_request' | 'not_found' | 'context_too_long' | 'request_too_large' | 'content_filtered' | 'server_error' | 'network_error' | 'empty_response' | 'incomplete_tool_call' | 'provider_auth_required' | 'unknown';
                 message: string;
                 isRetryable: boolean;
                 sessionId?: string;

--- a/platform/shared/hey-api/clients/archestra-catalog/types.gen.ts
+++ b/platform/shared/hey-api/clients/archestra-catalog/types.gen.ts
@@ -57,7 +57,7 @@ export type ArchestraMcpServerManifest = {
     display_name: string;
     instructions?: string;
     readme: string | null;
-    category: 'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General' | null;
+    category: 'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General' | 'MCP Apps Demo' | null;
     quality_score: number | null;
     archestra_config?: {
         client_config_permutations: {
@@ -177,7 +177,7 @@ export type SearchMcpServerCatalogData = {
         /**
          * Filter by category
          */
-        category?: 'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General';
+        category?: 'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General' | 'MCP Apps Demo';
         /**
          * Filter by programming language
          */
@@ -297,7 +297,7 @@ export type GetMcpServerCategoriesResponses = {
      * Successful response
      */
     200: {
-        categories: Array<'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General'>;
+        categories: Array<'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General' | 'MCP Apps Demo'>;
     };
 };
 


### PR DESCRIPTION
Fixes #5993

## Problem

A cost-limit block was returned as `429 / rate_limit_exceeded` — indistinguishable from provider throttling. SDKs auto-retry it (a budget block never clears on retry), Claude Code prints "Server is temporarily limiting requests (not your usage limit)", and the chat UI shows a retryable `rate_limit` error. Nothing said Archestra enforced it or which rule fired.

## Changes

- **Proxy returns `402` with `type: "usage_limit_exceeded"`** — no SDK retries 402, and clients stop framing it as a rate limit. `code: "token_cost_limit_exceeded"` and `usage_limit` metadata unchanged. The `archestra__llm` MCP app tool treats 402 as `llm_quota` alongside 429.
- **Violation message names the enforcer and the rule** — "This request was blocked by Archestra (not the AI provider): the agent-level cost limit has been reached. Rule: agent-level cost limit, applied to model gpt-4o, resets every 24 hours." + usage/limit/remaining figures. The `<archestra-limit-*>` metadata block gains model-scope and reset-window fields.
- **Chat UI**: new non-retryable `ChatErrorCode.UsageLimitExceeded` — the error card attributes the block to Archestra and drops the `rate_limit` badge, "Retryable" tag, and retry button. Detection keys on the body `code`, not the status.
- **Docs**: blocked-request shape documented in `platform-costs-and-limits.md`.

## ⚠️ Behavior change

Budget blocks: HTTP 429 → 402. Integrations special-casing 429 for budget stops must key on the unchanged `code` instead. Deliberate — SDK retry/framing is driven by the status code, so the bug isn't fixable while budget blocks masquerade as rate limits.

## Testing

354 tests pass across the five affected suites (new test pins the rule-naming message; 429/old-wording assertions updated). Type-check, biome, knip clean. Rebased onto latest main.