### PR TITLE
fix(chat): refresh the project Files panel when a project chat creates files

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -91,6 +91,7 @@ import {
 } from "@/lib/chat/app-diagnostics-store";
 import {
   fetchConversationEnabledTools,
+  invalidateConversationFileQueries,
   useClearChatErrors,
   useCompactConversation,
   useConversation,
@@ -1237,11 +1238,9 @@ export function ChatPageContent({
     if (!isWaitingForAssistant) return;
 
     const interval = setInterval(() => {
-      queryClient.invalidateQueries({
-        queryKey: ["conversation", conversationId],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["conversation-files", conversationId],
+      invalidateConversationFileQueries(queryClient, {
+        conversationId,
+        projectId: conversation?.projectId,
       });
     }, 3000);
 
@@ -1249,6 +1248,7 @@ export function ChatPageContent({
   }, [
     conversationId,
     conversation?.messages,
+    conversation?.projectId,
     messages.length,
     status,
     queryClient,
@@ -1260,13 +1260,11 @@ export function ChatPageContent({
   // Files panel can follow the latest output.
   useEffect(() => {
     if (!conversationId || status !== "ready") return;
-    queryClient.invalidateQueries({
-      queryKey: ["conversation-files", conversationId],
+    invalidateConversationFileQueries(queryClient, {
+      conversationId,
+      projectId: conversation?.projectId,
     });
-    queryClient.invalidateQueries({
-      queryKey: ["conversation", conversationId],
-    });
-  }, [status, conversationId, queryClient]);
+  }, [status, conversationId, conversation?.projectId, queryClient]);
 
   // Auto-focus textarea when status becomes ready (message sent or stream finished)
   // or when conversation loads (e.g., new chat created, hard refresh)

--- a/platform/frontend/src/lib/chat/chat.query.test.tsx
+++ b/platform/frontend/src/lib/chat/chat.query.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, test, vi } from "vitest";
 import { handleApiError } from "@/lib/utils";
 import {
+  invalidateConversationFileQueries,
   mergeUpdatedConversationIntoCache,
   useConversation,
   useConversationEnabledTools,
@@ -286,6 +287,46 @@ describe("mergeUpdatedConversationIntoCache", () => {
     expect(merged.agentId).toBe("agent-a");
     expect(merged.chatApiKeyId).toBe("key-openai");
     expect(merged.modelId).toBe("model-gpt41");
+  });
+});
+
+describe("invalidateConversationFileQueries", () => {
+  test("refreshes the project Files panel for a project chat", () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateConversationFileQueries(queryClient, {
+      conversationId: "c1",
+      projectId: "p1",
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: ["conversation-files", "c1"],
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ["conversation", "c1"] });
+    // The fix: a file created in a project chat must mark the project's Files
+    // list stale so navigating to the project view refetches it.
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: ["projects", "p1", "files"],
+    });
+  });
+
+  test("leaves project queries untouched for a non-project chat", () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateConversationFileQueries(queryClient, {
+      conversationId: "c1",
+      projectId: null,
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: ["conversation-files", "c1"],
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ["conversation", "c1"] });
+    // Only the two conversation keys — no `["projects", …]` invalidation that
+    // would refetch an unrelated project's files for a plain chat.
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -6,6 +6,7 @@ import {
 } from "@archestra/shared";
 import {
   keepPreviousData,
+  type QueryClient,
   useMutation,
   useQuery,
   useQueryClient,
@@ -51,6 +52,37 @@ const {
   deleteChatAttachment,
   deleteSkillSandboxArtifact,
 } = archestraApiSdk;
+
+/**
+ * Invalidate every cache entry that should refresh when a chat turn produces or
+ * rewrites files. Always refreshes the chat's own Files panel
+ * (`["conversation-files", id]`) and the conversation (for a rewritten
+ * artifact); when the chat belongs to a project, also refreshes that project's
+ * Files panel (`["projects", projectId, "files"]`).
+ *
+ * The project cross-invalidation is the symmetric counterpart to the
+ * project-side mutations that invalidate `["conversation-files"]`. Without it, a
+ * file created inside a project chat stays invisible in the project's Files
+ * panel until a hard reload — navigating there via the breadcrumb keeps the
+ * cached (stale) list because the query was never marked stale.
+ */
+export function invalidateConversationFileQueries(
+  queryClient: QueryClient,
+  {
+    conversationId,
+    projectId,
+  }: { conversationId: string; projectId?: string | null },
+) {
+  queryClient.invalidateQueries({
+    queryKey: ["conversation-files", conversationId],
+  });
+  queryClient.invalidateQueries({ queryKey: ["conversation", conversationId] });
+  if (projectId) {
+    queryClient.invalidateQueries({
+      queryKey: ["projects", projectId, "files"],
+    });
+  }
+}
 
 export function mergeUpdatedConversationIntoCache(
   oldConversation:


### PR DESCRIPTION
## Problem

When a user creates files inside a **project's chat** and clicks the project breadcrumb (in the chat header) to navigate to the project view, the newly created files do **not** appear in the project's Files panel until the page is hard-refreshed.

## Root cause

On each turn settle, the chat page invalidated only the chat-side file queries — `["conversation-files", id]` and `["conversation", id]` — and never the project-side files key `["projects", projectId, "files"]`, even though `conversation.projectId` is in scope.

The project Files panel (`useProjectFiles`) reads that separate key. Clicking the breadcrumb is a **client-side** navigation (Next `<Link>`), so the React Query cache is preserved. With the global `staleTime: 60s`, the cached project-files entry is often still "fresh" on arrival, so `refetchOnMount` is skipped and the stale list renders. A hard reload starts from an empty cache, which is why only a refresh surfaced the files.

The propagation was asymmetric: project-side mutations (`useUploadProjectFiles` / `useDeleteProjectFiles`) already cross-invalidate `["conversation-files"]`, but the chat side had no counterpart.

## Fix

Add `invalidateConversationFileQueries(queryClient, { conversationId, projectId })` in `chat.query.ts` (mirrors the existing `invalidateToolAssignmentQueries` helper). It invalidates the two conversation keys and, **only for project chats**, also `["projects", projectId, "files"]`. The chat page's end-of-turn effect and mid-stream poll now call it, passing `conversation?.projectId`.

Because `invalidateQueries` marks the (inactive) project-files query stale regardless of `staleTime`, navigating to the project page now triggers `refetchOnMount` immediately — files appear without a manual refresh. This is the symmetric counterpart to the project→chat invalidation that already exists.

## Scope / behavior notes

- The chat's *own* Files panel (`["conversation-files", id]`) still refetches live in the chat on each turn — unchanged.
- The project-files key isn't mounted in an established `/chat/<id>` view, so its invalidation only marks it stale → it refetches when you land on the project page (exactly the reported flow).
- A non-project chat invalidates only the two conversation keys (no stray project refetch).

## Tests

- `chat.query.test.tsx`: a project chat invalidates all three keys; a plain chat invalidates only the two conversation keys (`toHaveBeenCalledTimes(2)`). Written test-first (RED → GREEN).
- `pnpm type-check`, `pnpm knip`, and biome lint on the changed files all pass.

No e2e or render-based component tests added, per repo preferences.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>