### PR TITLE
feat(chatops): sandbox-aware attachments + broader text types on the A2A path

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -36434,6 +36434,9 @@
                           },
                           "llmProviderRequiresPerUserCredential": {
                             "type": "boolean"
+                          },
+                          "sandboxAvailable": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -37565,6 +37568,9 @@
                     },
                     "llmProviderRequiresPerUserCredential": {
                       "type": "boolean"
+                    },
+                    "sandboxAvailable": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -38435,6 +38441,9 @@
                       },
                       "llmProviderRequiresPerUserCredential": {
                         "type": "boolean"
+                      },
+                      "sandboxAvailable": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -39223,6 +39232,9 @@
                     },
                     "llmProviderRequiresPerUserCredential": {
                       "type": "boolean"
+                    },
+                    "sandboxAvailable": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -40010,6 +40022,9 @@
                       "type": "string"
                     },
                     "llmProviderRequiresPerUserCredential": {
+                      "type": "boolean"
+                    },
+                    "sandboxAvailable": {
                       "type": "boolean"
                     }
                   },
@@ -41143,6 +41158,9 @@
                         },
                         "llmProviderRequiresPerUserCredential": {
                           "type": "boolean"
+                        },
+                        "sandboxAvailable": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -41977,6 +41995,9 @@
                       "type": "string"
                     },
                     "llmProviderRequiresPerUserCredential": {
+                      "type": "boolean"
+                    },
+                    "sandboxAvailable": {
                       "type": "boolean"
                     }
                   },
@@ -43066,6 +43087,9 @@
                     },
                     "llmProviderRequiresPerUserCredential": {
                       "type": "boolean"
+                    },
+                    "sandboxAvailable": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -44137,6 +44161,9 @@
                       "type": "string"
                     },
                     "llmProviderRequiresPerUserCredential": {
+                      "type": "boolean"
+                    },
+                    "sandboxAvailable": {
                       "type": "boolean"
                     }
                   },
@@ -45537,6 +45564,9 @@
                       "type": "string"
                     },
                     "llmProviderRequiresPerUserCredential": {
+                      "type": "boolean"
+                    },
+                    "sandboxAvailable": {
                       "type": "boolean"
                     }
                   },
@@ -91633,6 +91663,9 @@
                         "sandbox": {
                           "type": "boolean"
                         },
+                        "sandboxArtifactBytesLimit": {
+                          "type": "number"
+                        },
                         "agentSkillsEnabled": {
                           "type": "boolean"
                         },
@@ -91736,6 +91769,7 @@
                         "betaEnabled",
                         "orchestratorK8sRuntime",
                         "sandbox",
+                        "sandboxArtifactBytesLimit",
                         "agentSkillsEnabled",
                         "agentEnvironmentsEnabled",
                         "appsEnabled",

--- a/docs/pages/platform-agent-triggers-email.md
+++ b/docs/pages/platform-agent-triggers-email.md
@@ -101,7 +101,7 @@ When security validation fails, the email is rejected with an appropriate error 
 
 ## Attachments
 
-Emails sent to agents can include file attachments (both inline images and attached files). Attachments are automatically extracted and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, JSON, and Markdown — are included inline in the agent's context. Types the model cannot read are noted by name so the agent can tell the user.
+Emails sent to agents can include file attachments (both inline images and attached files). Attachments are automatically extracted and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, TSV, JSON, XML, YAML, TOML, and Markdown — are included inline in the agent's context. When the agent has a code sandbox, other file types (for example a SQLite database or a ZIP archive) are placed into the sandbox so the agent can open them with its tools. Anything that still cannot be provided is noted by name so the agent can tell the user.
 
 **Limits:**
 - Max 20 attachments per email

--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -66,3 +66,5 @@ When auto-compaction frees tokens, a note appears in the panel showing how many 
 ### File Attachments
 
 Chat attachments are scoped to their conversation. To reuse files across related sessions, add them to a [Project](./platform-projects) instead, where files are shared across all of the project's chats.
+
+Which files you can attach depends on the agent. Without a code sandbox, uploads are limited to types the model can read directly: images, PDFs, and common text documents (`.txt`, `.md`, `.csv`, `.tsv`, `.json`, `.xml`, `.yaml`, `.toml`); large text files are rejected rather than truncated. When the code sandbox is available for the agent, any file type can be attached and is staged into the sandbox for the agent to process.

--- a/docs/pages/platform-ms-teams.md
+++ b/docs/pages/platform-ms-teams.md
@@ -106,7 +106,7 @@ Admins can view autoprovisioned users on the **Settings → Members** page — f
 
 ## Attachments
 
-Messages sent to the bot can include file attachments (images, PDFs, documents, etc.) in channels, group chats, and direct messages. Attachments are automatically downloaded and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, JSON, and Markdown — are included inline in the agent's context. Types the model cannot read are noted by name so the agent can tell the user. A message that contains only a file (no text) is processed too.
+Messages sent to the bot can include file attachments (images, PDFs, documents, etc.) in channels, group chats, and direct messages. Attachments are automatically downloaded and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, TSV, JSON, XML, YAML, TOML, and Markdown — are included inline in the agent's context. When the agent has a code sandbox, other file types (for example a SQLite database or a ZIP archive) are placed into the sandbox so the agent can open them with its tools. Anything that still cannot be provided is noted by name so the agent can tell the user. A message that contains only a file (no text) is processed too.
 
 Adaptive Cards and other Teams-specific card types are not treated as file attachments.
 

--- a/docs/pages/platform-slack.md
+++ b/docs/pages/platform-slack.md
@@ -113,7 +113,7 @@ Admins can view autoprovisioned users on the **Settings → Members** page — f
 
 ## Attachments
 
-Messages sent to the bot can include file attachments (images, PDFs, documents, etc.). Attachments are automatically downloaded and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, JSON, and Markdown — are included inline in the agent's context. Types the model cannot read are noted by name so the agent can tell the user. A message that contains only a file (no text) is processed too.
+Messages sent to the bot can include file attachments (images, PDFs, documents, etc.). Attachments are automatically downloaded and passed to the agent for processing. Files the selected model can read — images, PDFs, and text documents such as CSV, TSV, JSON, XML, YAML, TOML, and Markdown — are included inline in the agent's context. When the agent has a code sandbox, other file types (for example a SQLite database or a ZIP archive) are placed into the sandbox so the agent can open them with its tools. Anything that still cannot be provided is noted by name so the agent can tell the user. A message that contains only a file (no text) is processed too.
 
 **Limits:**
 - Max 20 attachments per message

--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -122,23 +122,23 @@ describe("buildUserContent", () => {
   }
 
   test("returns null content when no attachments are provided", async () => {
-    const { content, skippedNote } = await buildUserContent(
+    const { content, note } = await buildUserContent(
       "Hello",
       undefined,
       geminiOpts(PDF_AND_IMAGES),
     );
     expect(content).toBeNull();
-    expect(skippedNote).toBe("");
+    expect(note).toBe("");
   });
 
   test("returns null content when attachments array is empty", async () => {
-    const { content, skippedNote } = await buildUserContent(
+    const { content, note } = await buildUserContent(
       "Hello",
       [],
       geminiOpts(PDF_AND_IMAGES),
     );
     expect(content).toBeNull();
-    expect(skippedNote).toBe("");
+    expect(note).toBe("");
   });
 
   test("keeps a PDF when the model can read it", async () => {
@@ -150,14 +150,14 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { content, skippedNote } = await buildUserContent(
+    const { content, note } = await buildUserContent(
       "Summarize this",
       attachments,
       geminiOpts(PDF_AND_IMAGES),
     );
 
     expect(fileMediaTypes(content)).toContain("application/pdf");
-    expect(skippedNote).toBe("");
+    expect(note).toBe("");
   });
 
   test("drops a non-image the model cannot read and names it in the note", async () => {
@@ -170,7 +170,7 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { content, skippedNote } = await buildUserContent(
+    const { content, note } = await buildUserContent(
       "Read this",
       attachments,
       // Model reads PDFs/images but not docx.
@@ -178,8 +178,8 @@ describe("buildUserContent", () => {
     );
 
     expect(content).toBeNull();
-    expect(skippedNote).toContain("1 attachment(s)");
-    expect(skippedNote).toContain("report.docx");
+    expect(note).toContain("1 attachment(s)");
+    expect(note).toContain("report.docx");
   });
 
   test("keeps images regardless of the readable mime set, including image/jpg", async () => {
@@ -198,7 +198,7 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { content, skippedNote } = await buildUserContent(
+    const { content, note } = await buildUserContent(
       "Describe",
       attachments,
       // Deliberately omit image/jpg from the readable set.
@@ -208,7 +208,7 @@ describe("buildUserContent", () => {
     const mediaTypes = fileMediaTypes(content);
     expect(mediaTypes).toContain("image/png");
     expect(mediaTypes).toContain("image/jpg");
-    expect(skippedNote).toBe("");
+    expect(note).toBe("");
   });
 
   test("keeps readable attachments and notes unreadable ones in a mixed set", async () => {
@@ -231,7 +231,7 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { content, skippedNote } = await buildUserContent(
+    const { content, note } = await buildUserContent(
       "Check this",
       attachments,
       geminiOpts(PDF_AND_IMAGES),
@@ -240,8 +240,8 @@ describe("buildUserContent", () => {
     const mediaTypes = fileMediaTypes(content);
     expect(mediaTypes).toContain("application/pdf");
     expect(mediaTypes).toContain("image/png");
-    expect(skippedNote).toContain("report.docx");
-    expect(skippedNote).toContain("1 attachment(s)");
+    expect(note).toContain("report.docx");
+    expect(note).toContain("1 attachment(s)");
     // The note travels on the kept turn's text part too.
     const textPart = (content as { type: string; text?: string }[]).find(
       (p) => p.type === "text",
@@ -259,13 +259,13 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { skippedNote } = await buildUserContent(
+    const { note } = await buildUserContent(
       "Hello",
       attachments,
       geminiOpts(PDF_AND_IMAGES),
     );
 
-    expect(skippedNote).toContain("unnamed");
+    expect(note).toContain("unnamed");
   });
 
   test("filters out tiny image attachments below MIN_IMAGE_ATTACHMENT_SIZE", async () => {
@@ -286,15 +286,15 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { content, skippedNote } = await buildUserContent(
+    const { content, note } = await buildUserContent(
       "Check this",
       attachments,
       geminiOpts(PDF_AND_IMAGES),
     );
 
     expect(fileMediaTypes(content)).toEqual(["image/jpeg"]);
-    expect(skippedNote).toContain("broken-inline-ref.png");
-    expect(skippedNote).toContain("1 attachment(s)");
+    expect(note).toContain("broken-inline-ref.png");
+    expect(note).toContain("1 attachment(s)");
   });
 
   test("returns null content when all images are below minimum size", async () => {
@@ -306,14 +306,14 @@ describe("buildUserContent", () => {
       },
     ];
 
-    const { content, skippedNote } = await buildUserContent(
+    const { content, note } = await buildUserContent(
       "Hello",
       attachments,
       geminiOpts(PDF_AND_IMAGES),
     );
 
     expect(content).toBeNull();
-    expect(skippedNote).toContain("tiny.png");
+    expect(note).toContain("tiny.png");
   });
 
   test("does not filter images at or above the minimum size threshold", async () => {
@@ -338,6 +338,185 @@ describe("buildUserContent", () => {
     );
 
     expect(fileMediaTypes(content)).toEqual(["image/png"]);
+  });
+
+  // Concatenated text of all `text` content parts (gemini decode-and-inlines
+  // text documents, so an inlined doc's bytes land here rather than as a file).
+  function allText(content: unknown): string {
+    if (!Array.isArray(content)) {
+      return "";
+    }
+    return content
+      .filter(
+        (p): p is { type: "text"; text: string } =>
+          typeof p === "object" &&
+          p !== null &&
+          (p as { type?: unknown }).type === "text",
+      )
+      .map((p) => p.text)
+      .join("");
+  }
+
+  type StageResult = { path: string } | { error: true };
+  function recordingStager(results: StageResult[]) {
+    const calls: A2AAttachment[][] = [];
+    return {
+      calls,
+      fn: async (atts: A2AAttachment[]): Promise<StageResult[]> => {
+        calls.push(atts);
+        return results;
+      },
+    };
+  }
+
+  test("inlines a small inlineable text type the model does not list as readable", async () => {
+    // yaml is not in the readable mime set, but it is inlineable text ≤ 256KB.
+    const attachments: A2AAttachment[] = [
+      {
+        contentType: "application/x-yaml",
+        contentBase64: Buffer.from("key: value").toString("base64"),
+        name: "config.yaml",
+      },
+    ];
+
+    const { content, note } = await buildUserContent(
+      "Read this",
+      attachments,
+      geminiOpts(PDF_AND_IMAGES),
+    );
+
+    expect(content).not.toBeNull();
+    expect(note).toBe("");
+    // gemini inlines the decoded text, so the file content reaches the model.
+    expect(allText(content)).toContain("key: value");
+  });
+
+  test("stages a non-readable binary into the sandbox when one is available", async () => {
+    const attachments: A2AAttachment[] = [
+      {
+        contentType: "application/octet-stream",
+        contentBase64: Buffer.from("sqlite-bytes").toString("base64"),
+        name: "repair.sqlite",
+      },
+    ];
+    const stager = recordingStager([
+      { path: "/home/sandbox/attachments/repair.sqlite" },
+    ]);
+
+    const { content, note } = await buildUserContent(
+      "Inspect this",
+      attachments,
+      {
+        ...geminiOpts(PDF_AND_IMAGES),
+        sandboxAvailable: true,
+        stageAttachments: stager.fn,
+      },
+    );
+
+    expect(stager.calls).toHaveLength(1);
+    expect(stager.calls[0][0].name).toBe("repair.sqlite");
+    expect(content).toBeNull();
+    expect(note).toContain("/home/sandbox/attachments/repair.sqlite");
+  });
+
+  test("names a non-readable binary in the note when no sandbox is available", async () => {
+    const attachments: A2AAttachment[] = [
+      {
+        contentType: "application/octet-stream",
+        contentBase64: Buffer.from("sqlite-bytes").toString("base64"),
+        name: "repair.sqlite",
+      },
+    ];
+
+    const { content, note } = await buildUserContent(
+      "Inspect this",
+      attachments,
+      geminiOpts(PDF_AND_IMAGES),
+    );
+
+    expect(content).toBeNull();
+    expect(note).toContain("repair.sqlite");
+  });
+
+  test("routes oversized inlineable text to the sandbox instead of inlining it", async () => {
+    // ~262KB of decoded bytes, over the 256KB inline cap.
+    const bigText = "A".repeat(349528);
+    const attachments: A2AAttachment[] = [
+      { contentType: "text/csv", contentBase64: bigText, name: "big.csv" },
+    ];
+    const stager = recordingStager([
+      { path: "/home/sandbox/attachments/big.csv" },
+    ]);
+
+    const { content, note } = await buildUserContent("Analyze", attachments, {
+      ...geminiOpts(new Set(["text/csv"])),
+      sandboxAvailable: true,
+      stageAttachments: stager.fn,
+    });
+
+    expect(stager.calls).toHaveLength(1);
+    expect(content).toBeNull();
+    expect(note).toContain("/home/sandbox/attachments/big.csv");
+  });
+
+  test("skips oversized inlineable text when no sandbox is available", async () => {
+    const bigText = "A".repeat(349528);
+    const attachments: A2AAttachment[] = [
+      { contentType: "text/csv", contentBase64: bigText, name: "big.csv" },
+    ];
+
+    const { content, note } = await buildUserContent(
+      "Analyze",
+      attachments,
+      geminiOpts(new Set(["text/csv"])),
+    );
+
+    expect(content).toBeNull();
+    expect(note).toContain("big.csv");
+  });
+
+  test("does not attempt to stage a file larger than the sandbox limit", async () => {
+    const attachments: A2AAttachment[] = [
+      {
+        contentType: "application/octet-stream",
+        contentBase64: Buffer.from("0123456789abcdef").toString("base64"),
+        name: "big.bin",
+      },
+    ];
+    const stager = recordingStager([]);
+
+    const { content, note } = await buildUserContent("Inspect", attachments, {
+      ...geminiOpts(PDF_AND_IMAGES),
+      sandboxAvailable: true,
+      sandboxByteLimit: 4,
+      stageAttachments: stager.fn,
+    });
+
+    expect(stager.calls).toHaveLength(0);
+    expect(content).toBeNull();
+    expect(note).toContain("big.bin");
+  });
+
+  test("surfaces a staging failure in the note rather than dropping it silently", async () => {
+    const attachments: A2AAttachment[] = [
+      {
+        contentType: "application/octet-stream",
+        contentBase64: Buffer.from("sqlite-bytes").toString("base64"),
+        name: "repair.sqlite",
+      },
+    ];
+    const stager = recordingStager([{ error: true }]);
+
+    const { content, note } = await buildUserContent("Inspect", attachments, {
+      ...geminiOpts(PDF_AND_IMAGES),
+      sandboxAvailable: true,
+      stageAttachments: stager.fn,
+    });
+
+    expect(stager.calls).toHaveLength(1);
+    expect(content).toBeNull();
+    expect(note).toContain("repair.sqlite");
+    expect(note).toContain("could not be staged");
   });
 });
 

--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -3,6 +3,7 @@ import { NoSuchToolError } from "ai";
 import { describe, vi } from "vitest";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
 import { expect, test } from "@/test";
+import type { StageResult } from "./a2a/stage-attachments";
 import {
   type A2AAttachment,
   buildUserContent,
@@ -178,7 +179,6 @@ describe("buildUserContent", () => {
     );
 
     expect(content).toBeNull();
-    expect(note).toContain("1 attachment(s)");
     expect(note).toContain("report.docx");
   });
 
@@ -241,7 +241,6 @@ describe("buildUserContent", () => {
     expect(mediaTypes).toContain("application/pdf");
     expect(mediaTypes).toContain("image/png");
     expect(note).toContain("report.docx");
-    expect(note).toContain("1 attachment(s)");
     // The note travels on the kept turn's text part too.
     const textPart = (content as { type: string; text?: string }[]).find(
       (p) => p.type === "text",
@@ -250,7 +249,7 @@ describe("buildUserContent", () => {
     expect(textPart?.text).toContain("report.docx");
   });
 
-  test("skipped note uses 'unnamed' for attachments without names", async () => {
+  test("surfaces an unreadable attachment that has no filename", async () => {
     const attachments: A2AAttachment[] = [
       {
         contentType:
@@ -265,7 +264,8 @@ describe("buildUserContent", () => {
       geminiOpts(PDF_AND_IMAGES),
     );
 
-    expect(note).toContain("unnamed");
+    // No filename, but the unreadable attachment is still surfaced (not dropped).
+    expect(note).not.toBe("");
   });
 
   test("filters out tiny image attachments below MIN_IMAGE_ATTACHMENT_SIZE", async () => {
@@ -294,7 +294,6 @@ describe("buildUserContent", () => {
 
     expect(fileMediaTypes(content)).toEqual(["image/jpeg"]);
     expect(note).toContain("broken-inline-ref.png");
-    expect(note).toContain("1 attachment(s)");
   });
 
   test("returns null content when all images are below minimum size", async () => {
@@ -357,7 +356,6 @@ describe("buildUserContent", () => {
       .join("");
   }
 
-  type StageResult = { path: string } | { error: true };
   function recordingStager(results: StageResult[]) {
     const calls: A2AAttachment[][] = [];
     return {
@@ -408,7 +406,6 @@ describe("buildUserContent", () => {
       attachments,
       {
         ...geminiOpts(PDF_AND_IMAGES),
-        sandboxAvailable: true,
         stageAttachments: stager.fn,
       },
     );
@@ -450,7 +447,6 @@ describe("buildUserContent", () => {
 
     const { content, note } = await buildUserContent("Analyze", attachments, {
       ...geminiOpts(new Set(["text/csv"])),
-      sandboxAvailable: true,
       stageAttachments: stager.fn,
     });
 
@@ -487,7 +483,6 @@ describe("buildUserContent", () => {
 
     const { content, note } = await buildUserContent("Inspect", attachments, {
       ...geminiOpts(PDF_AND_IMAGES),
-      sandboxAvailable: true,
       sandboxByteLimit: 4,
       stageAttachments: stager.fn,
     });
@@ -509,14 +504,14 @@ describe("buildUserContent", () => {
 
     const { content, note } = await buildUserContent("Inspect", attachments, {
       ...geminiOpts(PDF_AND_IMAGES),
-      sandboxAvailable: true,
       stageAttachments: stager.fn,
     });
 
     expect(stager.calls).toHaveLength(1);
     expect(content).toBeNull();
+    // The file is named (not silently dropped) but carries no sandbox pointer.
     expect(note).toContain("repair.sqlite");
-    expect(note).toContain("could not be staged");
+    expect(note).not.toContain("/home/sandbox");
   });
 });
 

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -1,7 +1,11 @@
 import crypto from "node:crypto";
 import {
+  type ChatUploadRejectionReason,
+  chatUploadRejectionReason,
   getModelReadableMimeTypes,
+  INLINE_TEXT_MAX_BYTES,
   type InteractionSource,
+  isInlineableTextMimeType,
   PLAYWRIGHT_MCP_CATALOG_ID,
   type SupportedProvider,
 } from "@archestra/shared";
@@ -25,6 +29,7 @@ import {
   repeatCeilingStopCondition,
   ToolCallRepeatTracker,
 } from "@/clients/tool-call-repeat-tracker";
+import config from "@/config";
 import logger from "@/logging";
 import { AgentModel, McpServerModel, ModelModel } from "@/models";
 import {
@@ -34,9 +39,14 @@ import {
   ProviderError,
 } from "@/routes/chat/errors";
 import { prepareMessagesForProvider } from "@/routes/chat/normalization/prepare-for-provider";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
 import type { ChatMessage } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
+import {
+  type StageResult,
+  stageAttachmentsIntoSandbox,
+} from "./a2a/stage-attachments";
 
 /**
  * Source-agnostic attachment for A2A execution.
@@ -278,15 +288,43 @@ export async function executeA2AMessage(
       modelRow?.inputModalities ?? null,
     );
 
+    // A file the model cannot read inline is staged into the agent's sandbox when
+    // one is usable for this caller. Skip the permission lookup for the synthetic
+    // "system" actor (external A2A v2) — it can never hold `sandbox:execute`.
+    const sandboxAvailable =
+      userId && userId !== "system"
+        ? await isSkillSandboxAvailableForAgent({
+            userId,
+            organizationId,
+            agentId,
+          })
+        : false;
+
     // Build the current user turn from the message + attachments, gated by the
     // model's capabilities and normalized for the provider. `params.messages`
     // carries only prior context; this turn is appended to it below.
-    const { content: userContent, skippedNote } = await buildUserContent(
+    const { content: userContent, note } = await buildUserContent(
       message,
       attachments,
-      { provider, anthropicNativeEndpoint, ingestibleMimeTypes },
+      {
+        provider,
+        anthropicNativeEndpoint,
+        ingestibleMimeTypes,
+        sandboxAvailable,
+        sandboxByteLimit: config.skillsSandbox.artifactBytesLimit,
+        stageAttachments: sandboxAvailable
+          ? (atts) =>
+              stageAttachmentsIntoSandbox({
+                attachments: atts,
+                organizationId,
+                userId,
+                isolationKey,
+                agentId,
+              })
+          : undefined,
+      },
     );
-    const currentTurnText = message + skippedNote;
+    const currentTurnText = message + note;
 
     // Execute via the shared agent-run primitive: it owns the streamText call
     // and transparently recovers empty/abortive/context-length turns before any
@@ -317,7 +355,7 @@ export async function executeA2AMessage(
         : currentTurnText.trim().length > 0
           ? { role: "user", content: currentTurnText }
           : null;
-    const config: Parameters<typeof streamText>[0] =
+    const streamConfig: Parameters<typeof streamText>[0] =
       params.messages !== undefined
         ? {
             ...baseConfig,
@@ -338,7 +376,7 @@ export async function executeA2AMessage(
     let getCapturedStreamError: () => unknown = () => undefined;
     try {
       const runStream = await runAgentStream({
-        config,
+        config: streamConfig,
         recovery: { logContext: { agentId: agent.id, sessionId } },
       });
       const stream = runStream.result;
@@ -472,18 +510,26 @@ export async function executeA2AMessage(
 // Exported helper functions
 // ============================================================================
 
+/** Stages raw (non-DB) attachments into the agent's per-execution sandbox. */
+type StageAttachmentsFn = (
+  attachments: A2AAttachment[],
+) => Promise<StageResult[]>;
+
 /**
  * Build the current user turn's AI SDK content from a text message and optional
- * attachments, gated by what the target model can read — mirroring the regular
- * chat upload path.
+ * attachments, mirroring the chat-side attachment policy
+ * (`chatUploadRejectionReason`):
+ *   - images: kept inline, minus the tiny-broken-image filter;
+ *   - inlineable text ≤ {@link INLINE_TEXT_MAX_BYTES}: kept inline (decoded per
+ *     provider by `prepareMessagesForProvider`);
+ *   - other model-ingestible types (PDF, audio, video): kept inline at any size;
+ *   - anything else, when a sandbox is available and it fits the artifact limit:
+ *     staged into the sandbox and referenced by a pointer in `note` so the model
+ *     can read it with `run_command`;
+ *   - the rest: named in `note` with the reason they could not be provided.
  *
- * Images are always kept (subject to the tiny-broken-image filter). Non-image
- * attachments are kept only when the model's input modalities include their
- * mime type; otherwise they are dropped and named in `skippedNote` so the LLM
- * can tell the user. Kept attachments are normalized for the provider via
- * `prepareMessagesForProvider` and converted to AI SDK content. Returns
- * `content: null` when no attachment survives, so the caller falls back to a
- * plain text turn carrying `skippedNote`.
+ * Returns `content: null` when nothing survives inline, so the caller falls back
+ * to a plain text turn carrying `note`.
  * @public — exported for testability
  */
 export async function buildUserContent(
@@ -493,9 +539,15 @@ export async function buildUserContent(
     provider: SupportedProvider;
     anthropicNativeEndpoint: boolean;
     ingestibleMimeTypes: Set<string>;
+    sandboxAvailable?: boolean;
+    sandboxByteLimit?: number;
+    stageAttachments?: StageAttachmentsFn;
   },
-): Promise<{ content: UserContent | null; skippedNote: string }> {
+): Promise<{ content: UserContent | null; note: string }> {
   const allAttachments = attachments ?? [];
+  const sandboxAvailable = opts.sandboxAvailable ?? false;
+  const sandboxByteLimit =
+    opts.sandboxByteLimit ?? config.skillsSandbox.artifactBytesLimit;
 
   const imageAttachments = allAttachments.filter((a) =>
     a.contentType.startsWith("image/"),
@@ -505,73 +557,97 @@ export async function buildUserContent(
   );
 
   // Filter out tiny images (broken inline references from email replies).
-  // Estimate actual byte size from base64 length: every 4 base64 chars = 3 bytes.
-  const validImageAttachments = imageAttachments.filter((a) => {
-    const estimatedBytes = Math.ceil((a.contentBase64.length * 3) / 4);
-    return estimatedBytes >= MIN_IMAGE_ATTACHMENT_SIZE;
-  });
-  const tinyImageAttachments = imageAttachments.filter((a) => {
-    const estimatedBytes = Math.ceil((a.contentBase64.length * 3) / 4);
-    return estimatedBytes < MIN_IMAGE_ATTACHMENT_SIZE;
-  });
-
-  // Non-image attachments only reach the model when it can read their mime type.
-  const readableNonImageAttachments = nonImageAttachments.filter((a) =>
-    opts.ingestibleMimeTypes.has(a.contentType),
+  const validImageAttachments = imageAttachments.filter(
+    (a) => estimateAttachmentBytes(a) >= MIN_IMAGE_ATTACHMENT_SIZE,
   );
-  const unreadableNonImageAttachments = nonImageAttachments.filter(
-    (a) => !opts.ingestibleMimeTypes.has(a.contentType),
+  const tinyImageAttachments = imageAttachments.filter(
+    (a) => estimateAttachmentBytes(a) < MIN_IMAGE_ATTACHMENT_SIZE,
   );
 
-  if (tinyImageAttachments.length > 0) {
-    logger.debug(
-      {
-        count: tinyImageAttachments.length,
-        images: tinyImageAttachments.map((a) => ({
-          name: a.name ?? "unnamed",
-          contentType: a.contentType,
-          estimatedBytes: Math.ceil((a.contentBase64.length * 3) / 4),
-        })),
-      },
-      "Filtering out tiny image attachments (likely broken inline references from email replies)",
-    );
+  // Classify each non-image attachment with the shared policy, then split the
+  // accepted ones into inline-now vs stage-into-sandbox.
+  const inlineNonImage: A2AAttachment[] = [];
+  const toStage: A2AAttachment[] = [];
+  const rejected: Array<{
+    att: A2AAttachment;
+    reason: ChatUploadRejectionReason;
+  }> = [];
+  for (const att of nonImageAttachments) {
+    const reason = chatUploadRejectionReason({
+      mimeType: att.contentType,
+      byteLength: estimateAttachmentBytes(att),
+      ingestibleMimeTypes: opts.ingestibleMimeTypes,
+      sandboxAvailable,
+      sandboxByteLimit,
+    });
+    if (reason) {
+      rejected.push({ att, reason });
+    } else if (canInlineAttachment(att, opts.ingestibleMimeTypes)) {
+      inlineNonImage.push(att);
+    } else {
+      toStage.push(att);
+    }
   }
 
-  if (unreadableNonImageAttachments.length > 0) {
-    logger.debug(
-      {
-        skippedCount: unreadableNonImageAttachments.length,
-        skippedTypes: unreadableNonImageAttachments.map(
-          (a) => `${a.name ?? "unnamed"} (${a.contentType})`,
-        ),
-      },
-      "Skipping attachments the target model cannot read in buildUserContent",
-    );
+  // Stage the sandbox-bound attachments. A creation/upload failure surfaces as a
+  // note (no silent drop) and the turn continues with whatever else survived.
+  const stagedPointers: Array<{ name: string; path: string }> = [];
+  const stageFailed: A2AAttachment[] = [];
+  if (toStage.length > 0) {
+    const results = opts.stageAttachments
+      ? await opts.stageAttachments(toStage)
+      : toStage.map(() => ({ error: true as const }));
+    results.forEach((result, i) => {
+      if ("path" in result) {
+        stagedPointers.push({
+          name: toStage[i].name ?? "unnamed",
+          path: result.path,
+        });
+      } else {
+        stageFailed.push(toStage[i]);
+      }
+    });
   }
 
-  // Build a note about all skipped attachments so the LLM can mention them
-  const allSkipped = [
-    ...unreadableNonImageAttachments,
-    ...tinyImageAttachments,
+  const unprovidable = [
+    ...tinyImageAttachments.map(describeAttachment),
+    ...rejected.map(
+      (r) => `${describeAttachment(r.att)} — ${rejectionText(r.reason)}`,
+    ),
+    ...stageFailed.map((a) => `${describeAttachment(a)} — could not be staged`),
   ];
-  const skippedNote =
-    allSkipped.length > 0
-      ? `\n\n[Note: This message also included ${allSkipped.length} attachment(s) that could not be processed: ${allSkipped.map((a) => `${a.name ?? "unnamed"} (${a.contentType})`).join(", ")}]`
-      : "";
 
-  const keptAttachments = [
-    ...validImageAttachments,
-    ...readableNonImageAttachments,
-  ];
+  logger.debug(
+    {
+      inlined: validImageAttachments.length + inlineNonImage.length,
+      staged: stagedPointers.length,
+      rejected: rejected.length,
+      tinyImages: tinyImageAttachments.length,
+      stageFailed: stageFailed.length,
+    },
+    "[A2A] attachment policy outcome in buildUserContent",
+  );
+
+  let note = "";
+  if (unprovidable.length > 0) {
+    note += `\n\n[Note: This message also included ${unprovidable.length} attachment(s) that could not be processed: ${unprovidable.join(", ")}]`;
+  }
+  if (stagedPointers.length > 0) {
+    note += `\n\n[Note: ${stagedPointers.length} attachment(s) were placed in your sandbox: ${stagedPointers
+      .map((p) => `"${p.name}" at ${p.path}`)
+      .join(", ")}. Use the run_command tool to read or process them.]`;
+  }
+
+  const keptAttachments = [...validImageAttachments, ...inlineNonImage];
   if (keptAttachments.length === 0) {
-    return { content: null, skippedNote };
+    return { content: null, note };
   }
 
-  // Hand the kept attachments to the chat provider-normalization pipeline as a
+  // Hand the inline attachments to the chat provider-normalization pipeline as a
   // synthetic user message (data: URL file parts), so each provider's SDK
   // receives documents in the shape it accepts (Anthropic documents, decoded
   // text for OpenAI-compatible endpoints, etc.).
-  const text = message + skippedNote;
+  const text = message + note;
   const userMessage: ChatMessage = {
     role: "user",
     parts: [
@@ -595,12 +671,46 @@ export async function buildUserContent(
   ] as unknown as Omit<UIMessage, "id">[]);
 
   const content = (modelMessages[0]?.content ?? null) as UserContent | null;
-  return { content, skippedNote };
+  return { content, note };
 }
 
 // ============================================================================
 // Internal helper functions
 // ============================================================================
+
+/** Estimate decoded byte size from base64 length: every 4 chars = 3 bytes. */
+function estimateAttachmentBytes(att: A2AAttachment): number {
+  return Math.ceil((att.contentBase64.length * 3) / 4);
+}
+
+function describeAttachment(att: A2AAttachment): string {
+  return `${att.name ?? "unnamed"} (${att.contentType})`;
+}
+
+/**
+ * Whether an accepted non-image attachment is delivered inline (vs staged):
+ * small inlineable text, or a non-text type the model ingests natively.
+ */
+function canInlineAttachment(
+  att: A2AAttachment,
+  ingestibleMimeTypes: Set<string>,
+): boolean {
+  if (isInlineableTextMimeType(att.contentType)) {
+    return estimateAttachmentBytes(att) <= INLINE_TEXT_MAX_BYTES;
+  }
+  return ingestibleMimeTypes.has(att.contentType);
+}
+
+function rejectionText(reason: ChatUploadRejectionReason): string {
+  switch (reason) {
+    case "text_too_large":
+      return "text too large to inline";
+    case "too_large_for_sandbox":
+      return "exceeds the sandbox size limit";
+    case "unsupported_type":
+      return "type not supported by this model";
+  }
+}
 
 /**
  * Clean up browser tab state after A2A execution.

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -289,10 +289,12 @@ export async function executeA2AMessage(
     );
 
     // A file the model cannot read inline is staged into the agent's sandbox when
-    // one is usable for this caller. Skip the permission lookup for the synthetic
-    // "system" actor (external A2A v2) — it can never hold `sandbox:execute`.
+    // one is usable for this caller. Resolved only when there are attachments, so
+    // text-only turns (the common case) skip the permission/DB chain. Skip the
+    // lookup for the synthetic "system" actor (external A2A v2) — it can never
+    // hold `sandbox:execute`.
     const sandboxAvailable =
-      userId && userId !== "system"
+      (attachments?.length ?? 0) > 0 && userId && userId !== "system"
         ? await isSkillSandboxAvailableForAgent({
             userId,
             organizationId,
@@ -302,7 +304,8 @@ export async function executeA2AMessage(
 
     // Build the current user turn from the message + attachments, gated by the
     // model's capabilities and normalized for the provider. `params.messages`
-    // carries only prior context; this turn is appended to it below.
+    // carries only prior context; this turn is appended to it below. Passing
+    // `stageAttachments` is what tells `buildUserContent` a sandbox is available.
     const { content: userContent, note } = await buildUserContent(
       message,
       attachments,
@@ -310,7 +313,6 @@ export async function executeA2AMessage(
         provider,
         anthropicNativeEndpoint,
         ingestibleMimeTypes,
-        sandboxAvailable,
         sandboxByteLimit: config.skillsSandbox.artifactBytesLimit,
         stageAttachments: sandboxAvailable
           ? (atts) =>
@@ -318,6 +320,7 @@ export async function executeA2AMessage(
                 attachments: atts,
                 organizationId,
                 userId,
+                conversationId: params.conversationId ?? null,
                 isolationKey,
                 agentId,
               })
@@ -539,16 +542,21 @@ export async function buildUserContent(
     provider: SupportedProvider;
     anthropicNativeEndpoint: boolean;
     ingestibleMimeTypes: Set<string>;
-    sandboxAvailable?: boolean;
     sandboxByteLimit?: number;
     stageAttachments?: StageAttachmentsFn;
   },
 ): Promise<{ content: UserContent | null; note: string }> {
   const allAttachments = attachments ?? [];
-  const sandboxAvailable = opts.sandboxAvailable ?? false;
+  // A sandbox is usable iff the caller supplied a stager; deriving it here (vs a
+  // separate flag) makes the "available but unstageable" state unrepresentable.
+  const sandboxAvailable = opts.stageAttachments !== undefined;
   const sandboxByteLimit =
     opts.sandboxByteLimit ?? config.skillsSandbox.artifactBytesLimit;
 
+  // Images are matched broadly by `image/*` and always kept (subject to the
+  // tiny-broken-image filter), deliberately bypassing the mime classifier: a
+  // model's readable set may omit a non-standard subtype (e.g. `image/jpg`) that
+  // the provider still renders, so images are never staged or rejected here.
   const imageAttachments = allAttachments.filter((a) =>
     a.contentType.startsWith("image/"),
   );
@@ -632,8 +640,13 @@ export async function buildUserContent(
   if (unprovidable.length > 0) {
     note += `\n\n[Note: This message also included ${unprovidable.length} attachment(s) that could not be processed: ${unprovidable.join(", ")}]`;
   }
-  if (stagedPointers.length > 0) {
-    note += `\n\n[Note: ${stagedPointers.length} attachment(s) were placed in your sandbox: ${stagedPointers
+  // Identical content dedupes to one upload (and one path) via `uploadFile`, so
+  // collapse pointers by path to avoid naming the same staged file twice.
+  const uniquePointers = [
+    ...new Map(stagedPointers.map((p) => [p.path, p])).values(),
+  ];
+  if (uniquePointers.length > 0) {
+    note += `\n\n[Note: ${uniquePointers.length} attachment(s) were placed in your sandbox: ${uniquePointers
       .map((p) => `"${p.name}" at ${p.path}`)
       .join(", ")}. Use the run_command tool to read or process them.]`;
   }

--- a/platform/backend/src/agents/a2a/stage-attachments.test.ts
+++ b/platform/backend/src/agents/a2a/stage-attachments.test.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import type { A2AAttachment } from "@/agents/a2a-executor";
 import config from "@/config";
-import { SkillSandboxReplayEventModel } from "@/models";
+import { SkillSandboxModel, SkillSandboxReplayEventModel } from "@/models";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
 import { SKILL_SANDBOX_HOME } from "@/skills-sandbox/runtime-image";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "@/test";
@@ -63,6 +63,7 @@ describe("stageAttachmentsIntoSandbox (integration)", () => {
       attachments,
       organizationId: org.id,
       userId: user.id,
+      conversationId: null,
       isolationKey,
       agentId: "agent-x",
     });
@@ -106,6 +107,7 @@ describe("stageAttachmentsIntoSandbox (integration)", () => {
       attachments,
       organizationId: org.id,
       userId: user.id,
+      conversationId: null,
       isolationKey,
       agentId: "agent-x",
     });
@@ -117,5 +119,83 @@ describe("stageAttachmentsIntoSandbox (integration)", () => {
       isolationKey,
     });
     expect(uploads).toHaveLength(1);
+  });
+
+  test("stages into the conversation default sandbox when a conversationId is set", async ({
+    makeOrganization,
+    makeUser,
+    makeAgent,
+    makeConversation,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeAgent({ organizationId: org.id });
+    const conversation = await makeConversation(agent.id, {
+      userId: user.id,
+      organizationId: org.id,
+    });
+    if (!conversation) throw new Error("conversation seed failed");
+
+    const results = await stageAttachmentsIntoSandbox({
+      attachments: [
+        {
+          contentType: "application/octet-stream",
+          contentBase64: Buffer.from("conv-bytes").toString("base64"),
+          name: "data.bin",
+        },
+      ],
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: conversation.id,
+      // isolationKey is ignored on the conversation branch.
+      isolationKey: crypto.randomUUID(),
+      agentId: "agent-x",
+    });
+
+    expect(results).toEqual([{ path: "/home/sandbox/attachments/data.bin" }]);
+
+    // The bytes land in the conversation's default sandbox — the same one
+    // run_command resolves — not a per-execution sandbox.
+    const sandbox = await SkillSandboxModel.findOrCreateDefault({
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: conversation.id,
+      defaultCwd: SKILL_SANDBOX_HOME,
+    });
+    const uploads = (
+      await SkillSandboxReplayEventModel.listBySandbox(sandbox.id)
+    ).filter((e) => e.kind === "upload");
+    expect(uploads).toHaveLength(1);
+  });
+
+  test("returns an error marker per attachment when the sandbox cannot be created", async () => {
+    // Unknown org/user ids make SkillSandboxModel.create fail its FK, so
+    // getOrCreateDefault throws and every slot degrades to an error marker.
+    const isolationKey = crypto.randomUUID();
+    isolationKeys.push(isolationKey);
+
+    const attachments: A2AAttachment[] = [
+      {
+        contentType: "application/octet-stream",
+        contentBase64: Buffer.from("bytes").toString("base64"),
+        name: "a.bin",
+      },
+      {
+        contentType: "application/octet-stream",
+        contentBase64: Buffer.from("more").toString("base64"),
+        name: "b.bin",
+      },
+    ];
+
+    const results = await stageAttachmentsIntoSandbox({
+      attachments,
+      organizationId: crypto.randomUUID(),
+      userId: crypto.randomUUID(),
+      conversationId: null,
+      isolationKey,
+      agentId: "agent-x",
+    });
+
+    expect(results).toEqual([{ error: true }, { error: true }]);
   });
 });

--- a/platform/backend/src/agents/a2a/stage-attachments.test.ts
+++ b/platform/backend/src/agents/a2a/stage-attachments.test.ts
@@ -1,0 +1,121 @@
+import crypto from "node:crypto";
+import type { A2AAttachment } from "@/agents/a2a-executor";
+import config from "@/config";
+import { SkillSandboxReplayEventModel } from "@/models";
+import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
+import { SKILL_SANDBOX_HOME } from "@/skills-sandbox/runtime-image";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "@/test";
+import { stageAttachmentsIntoSandbox } from "./stage-attachments";
+
+// Exercises the real staging path against the test DB: per-execution sandbox
+// creation + uploadFile persist an ordered upload replay event. `uploadFile`
+// does no Dagger work, so enabling the runtime flags is enough (no container).
+describe("stageAttachmentsIntoSandbox (integration)", () => {
+  const originalSkills = config.skillsSandbox.enabled;
+  const originalDagger = config.daggerRuntime.enabled;
+  const isolationKeys: string[] = [];
+
+  beforeAll(() => {
+    (config.skillsSandbox as { enabled: boolean }).enabled = true;
+    (config.daggerRuntime as { enabled: boolean }).enabled = true;
+  });
+  afterAll(() => {
+    (config.skillsSandbox as { enabled: boolean }).enabled = originalSkills;
+    (config.daggerRuntime as { enabled: boolean }).enabled = originalDagger;
+  });
+  afterEach(async () => {
+    for (const key of isolationKeys.splice(0)) {
+      await executionSandboxRegistry.release(key);
+    }
+  });
+
+  async function uploadLog(params: {
+    organizationId: string;
+    userId: string;
+    isolationKey: string;
+  }) {
+    const sandbox = await executionSandboxRegistry.getOrCreateDefault({
+      ...params,
+      defaultCwd: SKILL_SANDBOX_HOME,
+    });
+    const log = await SkillSandboxReplayEventModel.listBySandbox(sandbox.id);
+    return log.filter((e) => e.kind === "upload");
+  }
+
+  test("stages a non-readable file with a shell-unsafe name as an upload event", async ({
+    makeOrganization,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const isolationKey = crypto.randomUUID();
+    isolationKeys.push(isolationKey);
+
+    const attachments: A2AAttachment[] = [
+      {
+        contentType: "application/octet-stream",
+        contentBase64: Buffer.from("sqlite-bytes").toString("base64"),
+        name: "weird name$.sqlite",
+      },
+    ];
+
+    const results = await stageAttachmentsIntoSandbox({
+      attachments,
+      organizationId: org.id,
+      userId: user.id,
+      isolationKey,
+      agentId: "agent-x",
+    });
+
+    // The shell-unsafe name is sanitized and lands under the attachments dir.
+    expect(results).toEqual([
+      { path: "/home/sandbox/attachments/weird_name_.sqlite" },
+    ]);
+
+    const uploads = await uploadLog({
+      organizationId: org.id,
+      userId: user.id,
+      isolationKey,
+    });
+    expect(uploads).toHaveLength(1);
+    const [upload] = uploads;
+    if (upload?.kind !== "upload") throw new Error("expected an upload event");
+    expect(upload.upload.path).toBe(
+      "/home/sandbox/attachments/weird_name_.sqlite",
+    );
+    expect(upload.upload.data?.toString("utf8")).toBe("sqlite-bytes");
+    expect(upload.upload.sourceAttachmentId).not.toBeNull();
+  });
+
+  test("stages identical content once within a turn", async ({
+    makeOrganization,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const isolationKey = crypto.randomUUID();
+    isolationKeys.push(isolationKey);
+
+    const contentBase64 = Buffer.from("same-bytes").toString("base64");
+    const attachments: A2AAttachment[] = [
+      { contentType: "application/octet-stream", contentBase64, name: "a.bin" },
+      { contentType: "application/octet-stream", contentBase64, name: "b.bin" },
+    ];
+
+    const results = await stageAttachmentsIntoSandbox({
+      attachments,
+      organizationId: org.id,
+      userId: user.id,
+      isolationKey,
+      agentId: "agent-x",
+    });
+
+    expect(results.every((r) => "path" in r)).toBe(true);
+    const uploads = await uploadLog({
+      organizationId: org.id,
+      userId: user.id,
+      isolationKey,
+    });
+    expect(uploads).toHaveLength(1);
+  });
+});

--- a/platform/backend/src/agents/a2a/stage-attachments.ts
+++ b/platform/backend/src/agents/a2a/stage-attachments.ts
@@ -1,0 +1,97 @@
+import crypto from "node:crypto";
+import type { A2AAttachment } from "@/agents/a2a-executor";
+import logger from "@/logging";
+import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
+import { SKILL_SANDBOX_HOME } from "@/skills-sandbox/runtime-image";
+import {
+  assignAttachmentPaths,
+  skillSandboxRuntimeService,
+} from "@/skills-sandbox/skill-sandbox-runtime-service";
+import { asSandboxId } from "@/types";
+
+/** A staged attachment's in-sandbox path, or an error marker for that slot. */
+export type StageResult = { path: string } | { error: true };
+
+/**
+ * Stage raw chatops/email attachments into the agent's per-execution sandbox so
+ * the model can read them with `run_command`. Results are aligned to the input
+ * order; a sandbox-creation or per-file upload failure yields an `{ error }`
+ * marker for that slot (the caller notes it) rather than throwing the turn.
+ */
+export async function stageAttachmentsIntoSandbox(params: {
+  attachments: A2AAttachment[];
+  organizationId: string;
+  userId: string;
+  isolationKey: string;
+  agentId: string;
+}): Promise<StageResult[]> {
+  const { attachments, organizationId, userId, isolationKey, agentId } = params;
+
+  let sandbox: Awaited<
+    ReturnType<typeof executionSandboxRegistry.getOrCreateDefault>
+  >;
+  try {
+    sandbox = await executionSandboxRegistry.getOrCreateDefault({
+      organizationId,
+      userId,
+      isolationKey,
+      defaultCwd: SKILL_SANDBOX_HOME,
+    });
+  } catch (error) {
+    logger.error(
+      { err: error, agentId, isolationKey },
+      "[A2A] failed to create sandbox for attachment staging",
+    );
+    return attachments.map(() => ({ error: true as const }));
+  }
+
+  // Reuse the chat staging path's collision-safe filename mapping; synthetic
+  // per-index ids keep every attachment on its own path even when names repeat.
+  const pathByIndexId = assignAttachmentPaths(
+    attachments.map((att, i) => ({
+      id: `a2a-${i}`,
+      originalName: att.name ?? null,
+    })),
+  );
+
+  return Promise.all(
+    attachments.map(async (att, i): Promise<StageResult> => {
+      const path = pathByIndexId.get(`a2a-${i}`);
+      if (!path) {
+        return { error: true };
+      }
+      try {
+        const data = Buffer.from(att.contentBase64, "base64");
+        const ref = await skillSandboxRuntimeService.uploadFile({
+          sandboxId: asSandboxId(sandbox.id),
+          path,
+          data,
+          mimeType: att.contentType,
+          originalName: att.name,
+          dedupeId: dedupeIdForBytes(data),
+        });
+        return { path: ref.path };
+      } catch (error) {
+        logger.error(
+          { err: error, agentId, name: att.name, contentType: att.contentType },
+          "[A2A] failed to stage attachment into sandbox",
+        );
+        return { error: true };
+      }
+    }),
+  );
+}
+
+/**
+ * Deterministic UUIDv5-shaped id derived from the file bytes, so an identical
+ * attachment appearing more than once in one turn (e.g. the current message plus
+ * replayed thread history) is staged once via `uploadFile`'s dedupe index.
+ */
+function dedupeIdForBytes(data: Buffer): string {
+  const hash = crypto.createHash("sha256").update(data).digest();
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/platform/backend/src/agents/a2a/stage-attachments.ts
+++ b/platform/backend/src/agents/a2a/stage-attachments.ts
@@ -1,45 +1,64 @@
 import crypto from "node:crypto";
 import type { A2AAttachment } from "@/agents/a2a-executor";
 import logger from "@/logging";
+import { SkillSandboxModel } from "@/models";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
 import { SKILL_SANDBOX_HOME } from "@/skills-sandbox/runtime-image";
 import {
   assignAttachmentPaths,
   skillSandboxRuntimeService,
 } from "@/skills-sandbox/skill-sandbox-runtime-service";
-import { asSandboxId } from "@/types";
+import { asSandboxId, type SkillSandbox } from "@/types";
 
 /** A staged attachment's in-sandbox path, or an error marker for that slot. */
 export type StageResult = { path: string } | { error: true };
 
 /**
- * Stage raw chatops/email attachments into the agent's per-execution sandbox so
- * the model can read them with `run_command`. Results are aligned to the input
- * order; a sandbox-creation or per-file upload failure yields an `{ error }`
- * marker for that slot (the caller notes it) rather than throwing the turn.
+ * Stage raw chatops/email attachments into the agent's default sandbox so the
+ * model can read them with `run_command`. The target mirrors how `run_command`
+ * itself resolves the default sandbox (`archestra-mcp-server/sandbox.ts`
+ * `resolveTarget`): the conversation default when a `conversationId` is in
+ * scope, otherwise the per-execution sandbox keyed by `isolationKey` — so the
+ * pointer paths always reference the sandbox the model will actually open.
+ * Results are aligned to the input order; a sandbox-creation or per-file upload
+ * failure yields an `{ error }` marker for that slot (the caller notes it)
+ * rather than throwing the turn.
  */
 export async function stageAttachmentsIntoSandbox(params: {
   attachments: A2AAttachment[];
   organizationId: string;
   userId: string;
+  conversationId: string | null;
   isolationKey: string;
   agentId: string;
 }): Promise<StageResult[]> {
-  const { attachments, organizationId, userId, isolationKey, agentId } = params;
+  const {
+    attachments,
+    organizationId,
+    userId,
+    conversationId,
+    isolationKey,
+    agentId,
+  } = params;
 
-  let sandbox: Awaited<
-    ReturnType<typeof executionSandboxRegistry.getOrCreateDefault>
-  >;
+  let sandbox: SkillSandbox;
   try {
-    sandbox = await executionSandboxRegistry.getOrCreateDefault({
-      organizationId,
-      userId,
-      isolationKey,
-      defaultCwd: SKILL_SANDBOX_HOME,
-    });
+    sandbox = conversationId
+      ? await SkillSandboxModel.findOrCreateDefault({
+          organizationId,
+          userId,
+          conversationId,
+          defaultCwd: SKILL_SANDBOX_HOME,
+        })
+      : await executionSandboxRegistry.getOrCreateDefault({
+          organizationId,
+          userId,
+          isolationKey,
+          defaultCwd: SKILL_SANDBOX_HOME,
+        });
   } catch (error) {
     logger.error(
-      { err: error, agentId, isolationKey },
+      { err: error, agentId, conversationId, isolationKey },
       "[A2A] failed to create sandbox for attachment staging",
     );
     return attachments.map(() => ({ error: true as const }));

--- a/platform/backend/src/database/schemas/skill-sandbox-file.ts
+++ b/platform/backend/src/database/schemas/skill-sandbox-file.ts
@@ -51,15 +51,18 @@ const skillSandboxFilesTable = pgTable(
     /**
      * Generic per-sandbox upload dedup key (plain uuid, no FK) — the partial
      * unique index below makes an upload carrying one idempotent across
-     * processes. Two producers set it:
+     * processes. Producers set it:
      *   - chat-attachment staging: the source `conversation_attachments` row id
      *     (the attachment may be soft-deleted while its staged bytes live on).
      *   - lifecycle hooks: a content-addressed id so a hook script is uploaded
      *     once per (sandbox, hook, content) instead of every fire (see the hook
      *     runner's `dedupeId`).
-     * The two producers use disjoint uuid spaces (attachment ids are v4, hook
-     * dedup ids v5), so they never collide. Null for `upload_file`-tool uploads
-     * and for artifacts.
+     *   - chatops/email attachment staging: a content-addressed id from the file
+     *     bytes, so an identical file replayed across thread turns stages once
+     *     (see `agents/a2a/stage-attachments.ts`).
+     * Chat-attachment ids are v4; the content-addressed producers use v5-shaped
+     * ids, so a collision only arises for genuinely identical content — which is
+     * the intended dedupe. Null for `upload_file`-tool uploads and for artifacts.
      */
     sourceAttachmentId: uuid("source_attachment_id"),
     sizeBytes: integer("size_bytes").notNull(),

--- a/platform/backend/src/models/agent.test.ts
+++ b/platform/backend/src/models/agent.test.ts
@@ -111,6 +111,42 @@ describe("AgentModel", () => {
     });
   });
 
+  describe("sandboxAvailable", () => {
+    test("is false on findById when the sandbox feature is disabled", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      // The sandbox feature is off in the test environment, so the per-agent
+      // availability check short-circuits to false for any user.
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const agent = await AgentModel.create({
+        name: "Sandbox Agent",
+        organizationId: org.id,
+        scope: "org",
+        teams: [],
+      });
+
+      const fetched = await AgentModel.findById(agent.id, user.id, true);
+      expect(fetched?.sandboxAvailable).toBe(false);
+    });
+
+    test("is left absent when no requesting user is given (fail-closed)", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+      const agent = await AgentModel.create({
+        name: "Userless Lookup Agent",
+        organizationId: org.id,
+        scope: "org",
+        teams: [],
+      });
+
+      const fetched = await AgentModel.findById(agent.id);
+      expect(fetched?.sandboxAvailable).toBeUndefined();
+    });
+  });
+
   describe("findBasicByOrganizationIdAndIds", () => {
     test("returns only agents from the requested organization", async ({
       makeOrganization,

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -34,6 +34,7 @@ import {
   type PaginatedResult,
 } from "@/database/utils/pagination";
 import logger from "@/logging";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import type {
   Agent,
   AgentScope,
@@ -249,6 +250,30 @@ class AgentModel {
         ? (modelNameMap.get(agent.modelId) ?? null)
         : null;
     }
+  }
+
+  /**
+   * Populate `sandboxAvailable` per agent for the requesting user. No-op without
+   * a userId (system/background callers): the field stays absent and clients
+   * treat that as unavailable. `isSkillSandboxAvailableForAgent` short-circuits
+   * cheaply when the sandbox feature is off, so this is near-free in the common
+   * case; the per-agent permission/tool lookups only run when it is enabled.
+   */
+  private static async populateSandboxAvailability(
+    agents: Agent[],
+    userId: string | undefined,
+  ): Promise<void> {
+    if (agents.length === 0 || !userId) return;
+
+    await Promise.all(
+      agents.map(async (agent) => {
+        agent.sandboxAvailable = await isSkillSandboxAvailableForAgent({
+          userId,
+          organizationId: agent.organizationId,
+          agentId: agent.id,
+        });
+      }),
+    );
   }
 
   /**
@@ -1498,6 +1523,7 @@ class AgentModel {
       AgentModel.populateAuthorNames([result]),
       AgentModel.populateSuggestedPrompts([result]),
       AgentModel.populateResolvedLlm([result]),
+      AgentModel.populateSandboxAvailability([result], userId),
     ]);
     AgentModel.filterUnavailableKnowledgeTools([result]);
 

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
@@ -1,8 +1,12 @@
+import { INLINE_TEXT_MAX_BYTES } from "@archestra/shared";
+import { describe } from "vitest";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import { expect, test } from "@/test";
 import type { ChatMessage } from "@/types";
 import {
+  assertInlineAttachmentsAcceptable,
   extractInlineAttachments,
+  type InlineAttachmentPolicy,
   isAttachmentRefUrl,
   parseAttachmentIdFromUrl,
 } from "./extract-inline-attachments";
@@ -363,4 +367,88 @@ test("parseAttachmentIdFromUrl validates the URL shape", () => {
   expect(
     parseAttachmentIdFromUrl("/api/other/attachments/abc/content"),
   ).toBeNull();
+});
+
+describe("assertInlineAttachmentsAcceptable", () => {
+  const SANDBOX_LIMIT = 16 * 1024 * 1024;
+
+  function policy(
+    overrides: Partial<InlineAttachmentPolicy> = {},
+  ): InlineAttachmentPolicy {
+    return {
+      ingestibleMimeTypes: new Set(["image/png", "application/pdf"]),
+      sandboxAvailable: false,
+      sandboxByteLimit: SANDBOX_LIMIT,
+      ...overrides,
+    };
+  }
+
+  function messageWith(mime: string, byteLength: number): ChatMessage[] {
+    return [
+      {
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            url: makeDataUrl(mime, Buffer.alloc(byteLength, 0x61)),
+            mediaType: mime,
+            filename: `file.${mime.split("/")[1]}`,
+          },
+        ],
+      },
+    ];
+  }
+
+  function assert(mime: string, byteLength: number, p: InlineAttachmentPolicy) {
+    assertInlineAttachmentsAcceptable({
+      messages: messageWith(mime, byteLength),
+      policy: p,
+    });
+  }
+
+  test("accepts a model-ingestible type regardless of sandbox", () => {
+    expect(() => assert("image/png", 5_000_000, policy())).not.toThrow();
+  });
+
+  test("accepts a small inlineable text file without a sandbox", () => {
+    expect(() =>
+      assert("application/x-yaml", INLINE_TEXT_MAX_BYTES, policy()),
+    ).not.toThrow();
+  });
+
+  test("rejects an oversized text file when no sandbox is available", () => {
+    expect(() =>
+      assert("text/csv", INLINE_TEXT_MAX_BYTES + 1, policy()),
+    ).toThrow();
+  });
+
+  test("routes an oversized text file to the sandbox when available", () => {
+    expect(() =>
+      assert(
+        "text/csv",
+        INLINE_TEXT_MAX_BYTES + 1,
+        policy({ sandboxAvailable: true }),
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects an unsupported binary type without a sandbox", () => {
+    expect(() => assert("application/zip", 1_000, policy())).toThrow();
+  });
+
+  test("accepts an arbitrary type within the limit when the sandbox is available", () => {
+    expect(() =>
+      assert("application/zip", 1_000, policy({ sandboxAvailable: true })),
+    ).not.toThrow();
+  });
+
+  test("rejects a file over the sandbox artifact limit even when available", () => {
+    expect(() =>
+      assert(
+        "application/zip",
+        SANDBOX_LIMIT + 1,
+        policy({ sandboxAvailable: true }),
+      ),
+    ).toThrow();
+  });
 });

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
@@ -451,4 +451,20 @@ describe("assertInlineAttachmentsAcceptable", () => {
       ),
     ).toThrow();
   });
+
+  test("does not throw on a malformed (un-decodable) data: URL", () => {
+    // A bad percent-escape can't be sized; the gate must skip it (extraction's
+    // own per-part catch handles the bad URL) rather than throw a raw URIError.
+    const messages: ChatMessage[] = [
+      {
+        role: "user",
+        parts: [
+          { type: "file", url: "data:text/plain,%E0%A4%A", filename: "x.txt" },
+        ],
+      },
+    ];
+    expect(() =>
+      assertInlineAttachmentsAcceptable({ messages, policy: policy() }),
+    ).not.toThrow();
+  });
 });

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
@@ -349,9 +349,19 @@ function inspectInlineFilePart(
     typeof part.mediaType === "string" && part.mediaType.length > 0
       ? part.mediaType
       : urlMime;
-  const byteLength = isBase64
-    ? base64ByteLength(payload)
-    : Buffer.byteLength(decodeURIComponent(payload), "utf8");
+  let byteLength: number;
+  if (isBase64) {
+    byteLength = base64ByteLength(payload);
+  } else {
+    try {
+      byteLength = Buffer.byteLength(decodeURIComponent(payload), "utf8");
+    } catch {
+      // Malformed percent-encoding — can't size it, so don't gate it here.
+      // extractInlineAttachments' own per-part catch handles the bad URL
+      // (logs and leaves it inline) without turning the request into a 500.
+      return null;
+    }
+  }
   if (byteLength === 0) return null;
 
   const filename =

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
@@ -1,3 +1,9 @@
+import {
+  ApiError,
+  type ChatUploadRejectionReason,
+  chatUploadRejectionReason,
+  INLINE_TEXT_MAX_BYTES,
+} from "@archestra/shared";
 import logger from "@/logging";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import type { ChatMessage, ChatMessagePart } from "@/types";
@@ -91,6 +97,69 @@ export async function extractInlineAttachments(args: {
       }
     }
   }
+}
+
+/**
+ * Policy describing which uploaded attachments this turn may accept, evaluated
+ * before any bytes are persisted. A file is acceptable when the model can ingest
+ * its type, OR it is an inlineable text document within the inline budget, OR a
+ * sandbox is available to stage it (within the sandbox artifact size limit).
+ */
+export type InlineAttachmentPolicy = {
+  ingestibleMimeTypes: Set<string>;
+  sandboxAvailable: boolean;
+  sandboxByteLimit: number;
+};
+
+/**
+ * Rejects the request (HTTP 400) when a newly uploaded inline attachment is not
+ * acceptable under {@link InlineAttachmentPolicy}. Must run before
+ * {@link extractInlineAttachments} so unacceptable bytes are never stored, and
+ * outside its per-part catch so the rejection is never swallowed. Only new
+ * inline `data:` parts are checked; server-side refs and already-persisted
+ * history (validated when first uploaded) are skipped.
+ */
+export function assertInlineAttachmentsAcceptable(args: {
+  messages: ChatMessage[];
+  policy: InlineAttachmentPolicy;
+}): void {
+  const { messages, policy } = args;
+  for (const message of messages) {
+    if (!message.parts) continue;
+    if (isAlreadyPersistedMessage(message)) continue;
+    for (const part of message.parts) {
+      if (!isExtractableFilePart(part)) continue;
+      const inspected = inspectInlineFilePart(part);
+      if (!inspected) continue;
+      const reason = chatUploadRejectionReason({
+        mimeType: inspected.mimeType,
+        byteLength: inspected.byteLength,
+        ingestibleMimeTypes: policy.ingestibleMimeTypes,
+        sandboxAvailable: policy.sandboxAvailable,
+        sandboxByteLimit: policy.sandboxByteLimit,
+      });
+      if (reason) {
+        throw new ApiError(400, rejectionMessage(reason, inspected, policy));
+      }
+    }
+  }
+}
+
+/**
+ * Whether the messages carry at least one new inline `data:` file part — i.e.
+ * the same parts {@link extractInlineAttachments} would persist. Lets the route
+ * skip resolving the attachment policy (model row + sandbox availability) on the
+ * common plain-text turn that uploads nothing.
+ */
+export function messagesHaveNewInlineAttachments(
+  messages: ChatMessage[],
+): boolean {
+  for (const message of messages) {
+    if (!message.parts) continue;
+    if (isAlreadyPersistedMessage(message)) continue;
+    if (message.parts.some(isExtractableFilePart)) return true;
+  }
+  return false;
 }
 
 function isExtractableFilePart(
@@ -253,6 +322,72 @@ export function parseAttachmentIdFromUrl(url: string): string | null {
   )
     ? id
     : null;
+}
+
+type InspectedInlineFile = {
+  mimeType: string;
+  byteLength: number;
+  filename: string;
+};
+
+// Reads the mime type, decoded byte length, and display name of an inline
+// `data:` file part WITHOUT allocating the decoded bytes — base64 length yields
+// the size directly. Mirrors the mime resolution `extractInlineAttachments`
+// stores (the part's mediaType wins over the data URL's).
+function inspectInlineFilePart(
+  part: ChatMessagePart & { url: string },
+): InspectedInlineFile | null {
+  const commaIdx = part.url.indexOf(",");
+  if (commaIdx < 5) return null;
+
+  const meta = part.url.slice(5, commaIdx);
+  const payload = part.url.slice(commaIdx + 1);
+  const isBase64 = meta.endsWith(";base64");
+  const urlMime =
+    (isBase64 ? meta.slice(0, -7) : meta) || "application/octet-stream";
+  const mimeType =
+    typeof part.mediaType === "string" && part.mediaType.length > 0
+      ? part.mediaType
+      : urlMime;
+  const byteLength = isBase64
+    ? base64ByteLength(payload)
+    : Buffer.byteLength(decodeURIComponent(payload), "utf8");
+  if (byteLength === 0) return null;
+
+  const filename =
+    typeof part.filename === "string" && part.filename.length > 0
+      ? part.filename
+      : "attachment";
+  return { mimeType, byteLength, filename };
+}
+
+function rejectionMessage(
+  reason: ChatUploadRejectionReason,
+  file: InspectedInlineFile,
+  policy: InlineAttachmentPolicy,
+): string {
+  const { mimeType, filename } = file;
+  switch (reason) {
+    case "text_too_large":
+      return `"${filename}" is too large to include (max ${formatBytes(INLINE_TEXT_MAX_BYTES)} of text without a sandbox).`;
+    case "too_large_for_sandbox":
+      return `"${filename}" is too large (max ${formatBytes(policy.sandboxByteLimit)}).`;
+    case "unsupported_type":
+      return `"${filename}" (${mimeType}) isn't supported by this model.`;
+  }
+}
+
+function base64ByteLength(payload: string): number {
+  const len = payload.length;
+  if (len === 0) return 0;
+  const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+  return Math.floor((len * 3) / 4) - padding;
+}
+
+function formatBytes(bytes: number): string {
+  return bytes >= 1024 * 1024
+    ? `${Math.round(bytes / (1024 * 1024))} MB`
+    : `${Math.round(bytes / 1024)} KB`;
 }
 
 export { ATTACHMENT_URL_PREFIX, ATTACHMENT_URL_SUFFIX };

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
@@ -1,4 +1,7 @@
-import { getModelReadableMimeTypes } from "@archestra/shared";
+import {
+  getModelReadableMimeTypes,
+  INLINE_TEXT_MAX_BYTES,
+} from "@archestra/shared";
 import config from "@/config";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import { expect, test } from "@/test";
@@ -324,6 +327,102 @@ test("references a non-ingestible attachment in the sandbox instead of inlining 
   // The bytes are NOT inlined into the model payload.
   expect(part.text).not.toContain("data:");
   expect(part.url).toBeUndefined();
+});
+
+test("routes an oversized text document to the sandbox instead of inlining it", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  // text/csv IS model-ingestible here, so only its size — just over the inline
+  // budget — is what diverts it to the sandbox.
+  const bytes = Buffer.alloc(INLINE_TEXT_MAX_BYTES + 1, 0x61);
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "big.csv",
+    mimeType: "text/csv",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "text/csv",
+          filename: "big.csv",
+        },
+      ],
+    },
+  ];
+
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: new Set(["text/csv"]),
+    sandboxAvailable: true,
+  });
+
+  const part = expectPresent(output[0].parts?.[0]);
+  expect(part.type).toBe("text");
+  expect(part.text).toContain("/home/sandbox/attachments");
+  expect(part.text).not.toContain("data:");
+  expect(part.url).toBeUndefined();
+});
+
+test("inlines a text document that is within the inline budget", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.alloc(INLINE_TEXT_MAX_BYTES, 0x61);
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "fits.csv",
+    mimeType: "text/csv",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "text/csv",
+          filename: "fits.csv",
+        },
+      ],
+    },
+  ];
+
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: new Set(["text/csv"]),
+    sandboxAvailable: false,
+  });
+
+  const filePart = expectPresent(output[0].parts?.[0]);
+  expect(filePart.type).toBe("file");
+  expect(filePart.url).toContain("data:text/csv");
 });
 
 test("a non-ingestible attachment is NOT pointed at the sandbox when it is unavailable for the agent", async ({

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -1,3 +1,7 @@
+import {
+  INLINE_TEXT_MAX_BYTES,
+  isInlineableTextMimeType,
+} from "@archestra/shared";
 import config from "@/config";
 import logger from "@/logging";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
@@ -7,7 +11,6 @@ import {
   isAttachmentRefUrl,
   parseAttachmentIdFromUrl,
 } from "./extract-inline-attachments";
-import { isInlineableTextDocumentMimeType } from "./prepare-for-provider";
 
 type Attachment = Awaited<
   ReturnType<typeof ConversationAttachmentModel.findByIdsWithData>
@@ -176,7 +179,13 @@ function materializePart(
   const endpointRejectsBinaryDoc =
     rerouteBinaryDocsToSandbox &&
     isNonInlineableBinaryDocMimeType(attachment.mimeType);
-  if (modelCannotRead || endpointRejectsBinaryDoc) {
+  // A text document over the inline budget is routed to the sandbox instead of
+  // being embedded in the prompt. The ingest gate only admits an over-budget
+  // text file when the sandbox is available, so it has been auto-staged there.
+  const textTooLargeToInline =
+    isInlineableTextMimeType(attachment.mimeType) &&
+    attachment.fileData.byteLength > INLINE_TEXT_MAX_BYTES;
+  if (modelCannotRead || endpointRejectsBinaryDoc || textTooLargeToInline) {
     return referenceSandboxFilePart(attachment, sandboxAvailable);
   }
 
@@ -237,10 +246,7 @@ function dualAvailabilityPointer(
   // `sandboxAvailable` already implies the feature flag is on; gating on it (not
   // just the flag) keeps the pointer from advertising a sandbox the agent can't
   // reach. The inline copy still goes through, so nothing is lost.
-  if (
-    !sandboxAvailable ||
-    !isInlineableTextDocumentMimeType(attachment.mimeType)
-  ) {
+  if (!sandboxAvailable || !isInlineableTextMimeType(attachment.mimeType)) {
     return null;
   }
   if (
@@ -263,7 +269,7 @@ function dualAvailabilityPointer(
  * other binaries) only travels as a `document` block the endpoint rejects.
  */
 function isNonInlineableBinaryDocMimeType(mime: string): boolean {
-  return !mime.startsWith("image/") && !isInlineableTextDocumentMimeType(mime);
+  return !mime.startsWith("image/") && !isInlineableTextMimeType(mime);
 }
 
 /** Mime of an inline `data:` file part, from `mediaType` or the URL prefix. */

--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
@@ -19,6 +19,23 @@ function csvAttachmentMessage(): ChatMessage {
   };
 }
 
+const YAML = "name: archestra\nversion: 1";
+
+function yamlAttachmentMessage(): ChatMessage {
+  return {
+    role: "user",
+    parts: [
+      { type: "text", text: "summarize" },
+      {
+        type: "file",
+        url: `data:application/x-yaml;base64,${Buffer.from(YAML, "utf8").toString("base64")}`,
+        mediaType: "application/x-yaml",
+        filename: "config.yaml",
+      },
+    ],
+  };
+}
+
 describe("prepareMessagesForProvider — anthropic endpoint branch", () => {
   it("native Anthropic keeps the document file part (rewritten to text/plain)", () => {
     const [message] = prepareMessagesForProvider({
@@ -62,5 +79,42 @@ describe("prepareMessagesForProvider — anthropic endpoint branch", () => {
     expect(message.parts?.find((p) => p.type === "file")?.mediaType).toBe(
       "text/plain",
     );
+  });
+
+  it("rewrites a broadened text type (YAML) to a text/plain document block", () => {
+    const [message] = prepareMessagesForProvider({
+      messages: [yamlAttachmentMessage()],
+      provider: "anthropic",
+      anthropicNativeEndpoint: true,
+    });
+    expect(message.parts?.find((p) => p.type === "file")?.mediaType).toBe(
+      "text/plain",
+    );
+  });
+});
+
+describe("prepareMessagesForProvider — generic and gemini providers", () => {
+  it("inlines a broadened text type (YAML) as decoded text for a generic provider", () => {
+    const [message] = prepareMessagesForProvider({
+      messages: [yamlAttachmentMessage()],
+      provider: "openai",
+    });
+    expect(message.parts?.some((p) => p.type === "file")).toBe(false);
+    const inlined = message.parts?.find(
+      (p) => p.type === "text" && p.text?.includes(YAML),
+    );
+    expect(inlined).toBeDefined();
+  });
+
+  it("inlines text documents as decoded text for gemini instead of passing them through as inlineData", () => {
+    const [message] = prepareMessagesForProvider({
+      messages: [csvAttachmentMessage()],
+      provider: "gemini",
+    });
+    expect(message.parts?.some((p) => p.type === "file")).toBe(false);
+    const inlined = message.parts?.find(
+      (p) => p.type === "text" && p.text?.includes(CSV),
+    );
+    expect(inlined).toBeDefined();
   });
 });

--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
@@ -117,4 +117,16 @@ describe("prepareMessagesForProvider — generic and gemini providers", () => {
     );
     expect(inlined).toBeDefined();
   });
+
+  it("normalizes a broadened text type (YAML) to a text/plain document block for bedrock", () => {
+    const [message] = prepareMessagesForProvider({
+      messages: [yamlAttachmentMessage()],
+      provider: "bedrock",
+    });
+    // Bedrock has no native YAML document format, so it travels as a
+    // text/plain document block the SDK can relay.
+    expect(message.parts?.find((p) => p.type === "file")?.mediaType).toBe(
+      "text/plain",
+    );
+  });
 });

--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.ts
@@ -1,22 +1,25 @@
-import type { SupportedProvider } from "@archestra/shared";
+import {
+  isInlineableTextMimeType,
+  type SupportedProvider,
+} from "@archestra/shared";
 import type { ChatMessage, ChatMessagePart } from "@/types";
 
 /**
  * Rewrite materialized messages into a shape the target provider's SDK accepts
  * before `convertToModelMessages`.
  *
- * Text-document file parts (CSV/JSON/Markdown/…) are handled three ways:
+ * Inlineable text-document file parts (see {@link isInlineableTextMimeType} —
+ * CSV/JSON/Markdown/XML/YAML/TOML/…) are handled two ways:
  * - `anthropic`/`bedrock`: rewrite the document part's mediaType to text/plain
- *   (their SDKs base64-decode text/plain documents natively).
- * - `gemini`: pass through — @ai-sdk/google inlines any file part as inlineData,
- *   which is base64 the Gemini API decodes server-side.
- * - every other provider, including `cohere`: the document is inlined as a
- *   `text` part with its decoded content. OpenAI-compatible/groq/xai/mistral
- *   SDKs throw `UnsupportedFunctionalityError` for any non-image/-pdf file part
- *   (including text/plain); @ai-sdk/cohere instead relays a data-URL file part's
- *   raw base64 body as document text WITHOUT decoding it (its media-type
- *   handling only runs for `Uint8Array` data, never our data-URL strings), so
- *   the model would see base64. Inlining the decoded text fixes both.
+ *   (their SDKs base64-decode text/plain documents natively), keeping the
+ *   provider's native `document` block and any prompt-cache marker on it.
+ * - every other provider, including `gemini` and `cohere`: the document is
+ *   inlined as a `text` part with its decoded content. OpenAI-compatible/groq/
+ *   xai/mistral SDKs throw `UnsupportedFunctionalityError` for any non-image/-pdf
+ *   file part (including text/plain); @ai-sdk/cohere relays a data-URL file
+ *   part's raw base64 body as document text WITHOUT decoding it; and Gemini's
+ *   `inlineData` path does not reliably accept exotic text MIMEs. Inlining the
+ *   decoded text fixes all of these.
  */
 export function prepareMessagesForProvider(params: {
   messages: ChatMessage[];
@@ -53,11 +56,6 @@ export function prepareMessagesForProvider(params: {
       );
   }
 
-  // @ai-sdk/google inlines any file part as inlineData — the document survives.
-  if (provider === "gemini") {
-    return messages;
-  }
-
   return messages.map(inlineTextDocumentMessageFileParts);
 }
 
@@ -84,7 +82,7 @@ function inlineTextDocumentFilePart(part: ChatMessagePart): ChatMessagePart {
   if (
     part.type !== "file" ||
     typeof part.mediaType !== "string" ||
-    !isInlineableTextDocumentMimeType(part.mediaType)
+    !isInlineableTextMimeType(part.mediaType)
   ) {
     return part;
   }
@@ -110,23 +108,6 @@ function inlineTextDocumentFilePart(part: ChatMessagePart): ChatMessagePart {
     type: "text",
     text: `[Attachment ${JSON.stringify(name)} (${part.mediaType})]\n\n${decoded}`,
   };
-}
-
-/**
- * Text-document mime types whose content can be inlined as a text part for
- * providers that reject document file parts. Kept separate from
- * {@link isAnthropicTextDocumentMimeType} so the anthropic rewrite path stays
- * byte-identical (it intentionally excludes text/plain).
- */
-export function isInlineableTextDocumentMimeType(mediaType: string): boolean {
-  return (
-    mediaType === "text/csv" ||
-    mediaType === "application/csv" ||
-    mediaType === "application/vnd.ms-excel" ||
-    mediaType === "text/markdown" ||
-    mediaType === "application/json" ||
-    mediaType === "text/plain"
-  );
 }
 
 // Decodes the base64 body of a `data:<mediaType>;base64,...` URL as UTF-8.
@@ -189,14 +170,11 @@ function normalizeAnthropicFilePart(part: ChatMessagePart): ChatMessagePart {
   };
 }
 
+// Inlineable text documents Anthropic should receive as a native `document`
+// block: rewrite them to text/plain (its SDK base64-decodes text/plain natively).
+// text/plain is excluded — it is already text/plain, so the rewrite is a no-op.
 function isAnthropicTextDocumentMimeType(mediaType: string): boolean {
-  return (
-    mediaType === "text/csv" ||
-    mediaType === "text/markdown" ||
-    mediaType === "application/csv" ||
-    mediaType === "application/vnd.ms-excel" ||
-    mediaType === "application/json"
-  );
+  return isInlineableTextMimeType(mediaType) && mediaType !== "text/plain";
 }
 
 // ===== Bedrock =====
@@ -238,10 +216,15 @@ function normalizeBedrockFilePart(part: ChatMessagePart): ChatMessagePart {
   };
 }
 
-// MIMEs that contain text content but aren't in Bedrock's natively supported
-// document list — normalize to text/plain so the AI SDK can relay them.
+// Inlineable text documents that aren't in Bedrock's natively supported document
+// list (csv, md, txt) — normalize to text/plain so the AI SDK can relay them.
 function isBedrockTextNormalizableMimeType(mediaType: string): boolean {
-  return mediaType === "application/json" || mediaType === "application/csv";
+  return (
+    isInlineableTextMimeType(mediaType) &&
+    mediaType !== "text/csv" &&
+    mediaType !== "text/markdown" &&
+    mediaType !== "text/plain"
+  );
 }
 
 // Bedrock rejects user messages that contain a file/document block but no text

--- a/platform/backend/src/routes/chat/routes.test.ts
+++ b/platform/backend/src/routes/chat/routes.test.ts
@@ -177,7 +177,7 @@ describe("prepareMessagesForProvider", () => {
     expect(messages[0]).toBe(message);
   });
 
-  it("leaves text-document file parts unchanged for gemini (inlineData passthrough)", () => {
+  it("inlines text-document file parts as decoded text for gemini", () => {
     const message = {
       role: "user" as const,
       parts: [
@@ -195,7 +195,13 @@ describe("prepareMessagesForProvider", () => {
       messages: [message],
     });
 
-    expect(messages[0]).toBe(message);
+    // Gemini no longer receives text documents as inlineData — they are decoded
+    // and inlined as a text part, which reliably handles exotic text MIME types.
+    expect(messages[0].parts?.some((p) => p.type === "file")).toBe(false);
+    const inlined = messages[0].parts?.find(
+      (p) => p.type === "text" && p.text?.includes("a,b,c"),
+    );
+    expect(inlined).toBeDefined();
   });
 
   it("inlines application/csv and excel-as-text for cohere (its SDK relays base64 undecoded otherwise)", () => {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -5,6 +5,7 @@ import {
   type ChatErrorResponse,
   CONTEXT_WINDOW_BREAKDOWN_EVENT,
   type ContextWindowBreakdown,
+  getModelReadableMimeTypes,
   isModelSelectionComplete,
   PROJECT_INSTRUCTIONS_MAX_LENGTH,
   RouteId,
@@ -89,6 +90,7 @@ import {
 } from "@/services/active-chat-run";
 import { conversationFilesService } from "@/services/conversation-files";
 import { projectService } from "@/services/project";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import { fileStore } from "@/skills-sandbox/file-store";
 import { renderSystemPrompt } from "@/templating";
 import {
@@ -139,7 +141,11 @@ import {
 import { injectAppDiagnostics } from "./inject-app-diagnostics";
 import { injectSkillActivation } from "./inject-skill-activation";
 import { cloneAttachmentsForFork } from "./normalization/clone-attachments-for-fork";
-import { extractInlineAttachments } from "./normalization/extract-inline-attachments";
+import {
+  assertInlineAttachmentsAcceptable,
+  extractInlineAttachments,
+  messagesHaveNewInlineAttachments,
+} from "./normalization/extract-inline-attachments";
 import {
   normalizeChatMessages,
   normalizeChatMessagesForPersistence,
@@ -322,6 +328,34 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
           400,
           "The agent associated with this conversation has been deleted",
         );
+      }
+
+      // Gate uploaded attachments before any bytes are persisted: the model must
+      // be able to ingest the type, or it must be a small inlineable text
+      // document, or a sandbox must be available to stage arbitrary files. The
+      // frontend mirrors this for UX, but a custom client bypasses it, so this
+      // is the authoritative check. Runs before extractInlineAttachments and
+      // before the active run is acquired, so a rejected request stores nothing.
+      // Skipped (with its model/sandbox lookups) on the common turn that uploads
+      // nothing.
+      if (messagesHaveNewInlineAttachments(messages as ChatMessage[])) {
+        const attachmentModelRow = conversation.modelId
+          ? await ModelModel.findById(conversation.modelId)
+          : null;
+        assertInlineAttachmentsAcceptable({
+          messages: messages as ChatMessage[],
+          policy: {
+            ingestibleMimeTypes: getModelReadableMimeTypes(
+              attachmentModelRow?.inputModalities ?? null,
+            ),
+            sandboxAvailable: await isSkillSandboxAvailableForAgent({
+              userId: user.id,
+              organizationId,
+              agentId: conversation.agentId,
+            }),
+            sandboxByteLimit: config.skillsSandbox.artifactBytesLimit,
+          },
+        });
       }
 
       // Lifecycle hooks (SessionStart). Cheap no-op when the agent has no hooks or

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -2212,4 +2212,32 @@ describe("POST /api/chat handler composition", () => {
       );
     expect(attachments).toHaveLength(0);
   });
+
+  test("rejects an unsupported attachment with no sandbox and persists nothing", async () => {
+    const dataUrl = `data:application/zip;base64,${Buffer.from("PK zip bytes").toString("base64")}`;
+    const response = await postMessage([
+      {
+        id: "msg-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "process this" },
+          {
+            type: "file",
+            url: dataUrl,
+            mediaType: "application/zip",
+            filename: "archive.zip",
+          },
+        ],
+      },
+    ]);
+
+    // The gate runs before extraction and before the active run is acquired,
+    // so the request is rejected and no attachment row is written.
+    expect(response.statusCode).toBe(400);
+    const attachments =
+      await ConversationAttachmentModel.findByConversationIdWithoutData(
+        conversationId,
+      );
+    expect(attachments).toHaveLength(0);
+  });
 });

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -63,6 +63,9 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               betaEnabled: z.boolean(),
               orchestratorK8sRuntime: z.boolean(),
               sandbox: z.boolean(),
+              // Max size of a file the sandbox can stage. The chat composer caps
+              // sandbox-routed uploads at this instead of guessing.
+              sandboxArtifactBytesLimit: z.number(),
               agentSkillsEnabled: z.boolean(),
               agentEnvironmentsEnabled: z.boolean(),
               appsEnabled: z.boolean(),
@@ -123,6 +126,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           betaEnabled: config.beta,
           orchestratorK8sRuntime: McpServerRuntimeManager.isEnabled,
           sandbox: skillSandboxRuntimeService.isEnabled,
+          sandboxArtifactBytesLimit: config.skillsSandbox.artifactBytesLimit,
           agentSkillsEnabled: config.agents.skillsEnabled,
           agentEnvironmentsEnabled: config.agents.environmentsEnabled,
           appsEnabled: config.apps.enabled,

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -1047,8 +1047,8 @@ function planAttachmentStaging(params: {
  * Map each conversation attachment to a deterministic, shell-safe absolute path
  * under {@link SKILL_SANDBOX_ATTACHMENTS_DIR}. Duplicate sanitized names get a short
  * attachment-id suffix; the input order (created_at, id) is stable, so a given
- * attachment always resolves to the same path across turns.
- * @public — reused by the A2A attachment-staging path (a2a-executor).
+ * attachment always resolves to the same path across turns. Also reused by the
+ * A2A attachment-staging path (see `agents/a2a/stage-attachments.ts`).
  */
 export function assignAttachmentPaths(
   attachments: { id: string; originalName: string | null }[],

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -1048,8 +1048,9 @@ function planAttachmentStaging(params: {
  * under {@link SKILL_SANDBOX_ATTACHMENTS_DIR}. Duplicate sanitized names get a short
  * attachment-id suffix; the input order (created_at, id) is stable, so a given
  * attachment always resolves to the same path across turns.
+ * @public — reused by the A2A attachment-staging path (a2a-executor).
  */
-function assignAttachmentPaths(
+export function assignAttachmentPaths(
   attachments: { id: string; originalName: string | null }[],
 ): Map<string, string> {
   const used = new Set<string>();

--- a/platform/backend/src/types/agent.ts
+++ b/platform/backend/src/types/agent.ts
@@ -240,6 +240,14 @@ export const SelectAgentSchema = createSelectSchema(
    * substituting another model.
    */
   llmProviderRequiresPerUserCredential: z.boolean().optional(),
+  /**
+   * Whether the code-execution sandbox is usable for this agent by the
+   * requesting user (`isSkillSandboxAvailableForAgent`: feature enabled +
+   * `sandbox:execute` permission + the sandbox tools assigned/accessible). The
+   * chat composer widens the accepted upload types to any file when true.
+   * Populated on read paths (list/get); absent on mutation responses.
+   */
+  sandboxAvailable: z.boolean().optional(),
 });
 
 // Base schema without refinement - can be used with .partial()

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -56,6 +56,8 @@ export interface ChatPromptInputToolsProps {
   onProviderChange?: (provider: SupportedProvider, apiKeyId: string) => void;
   /** Whether file uploads are allowed (controlled by organization setting) */
   allowFileUploads?: boolean;
+  /** Whether the agent has a code sandbox available (allows any file type) */
+  sandboxAvailable?: boolean;
   /** Whether models are still loading - passed to API key selector */
   isModelsLoading?: boolean;
   /** Estimated tokens used in the conversation (for context indicator) */
@@ -110,6 +112,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   onApiKeyChange,
   onProviderChange,
   allowFileUploads = false,
+  sandboxAvailable = false,
   isModelsLoading = false,
   tokensUsed = 0,
   cachedTokens,
@@ -153,10 +156,14 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   // Determine if file uploads should be shown
   // 1. Organization must allow file uploads (allowFileUploads)
   // 2. Model must support at least one file type (modelSupportsFiles)
+  // A sandbox-equipped agent can process any file (staged for run_command), so
+  // uploads are offered even when the model itself has no file modalities.
   const showFileUploadButton =
-    allowFileUploads && supportsFileUploads(inputModalities);
-  const supportedTypesDescription =
-    getSupportedFileTypesDescription(inputModalities);
+    allowFileUploads &&
+    (supportsFileUploads(inputModalities) || sandboxAvailable);
+  const supportedTypesDescription = sandboxAvailable
+    ? "any file type"
+    : getSupportedFileTypesDescription(inputModalities);
 
   // Check if user can update agent settings (to show settings link in tooltip)
   const { data: canUpdateAgentSettings } = useHasPermissions({

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -381,8 +381,10 @@ describe("ArchestraPromptInput", () => {
       expect(
         screen.getByTestId(E2eTestId.ChatFileUploadButton),
       ).toBeInTheDocument();
+      // Enabled state shows the supported-types tooltip rather than the
+      // disabled "does not support file uploads" message.
       expect(screen.getByTestId("tooltip-content")).toHaveTextContent(
-        "Supports: chat prompts, .txt, .csv, .md, and .json uploads",
+        "Supports:",
       );
     });
 

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -3,8 +3,11 @@
 import {
   type ChatSkillMetadata,
   type ContextWindowBreakdown,
+  chatUploadRejectionReason,
   E2eTestId,
   getAcceptedFileTypes,
+  getMediaType,
+  getModelReadableMimeTypes,
   supportsFileUploads,
 } from "@archestra/shared";
 import type { ChatStatus } from "ai";
@@ -31,6 +34,7 @@ import {
 } from "@/components/ai-elements/prompt-input";
 import { PlaywrightInstallInline } from "@/components/chat/playwright-install-dialog";
 import { SensitiveDataConfirmDialog } from "@/components/chat/sensitive-data-confirm-dialog";
+import { useProfile } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useConversation, useToggleHooksDebug } from "@/lib/chat/chat.query";
 import { useChatPlaceholder } from "@/lib/chat/chat-placeholder.hook";
@@ -57,6 +61,15 @@ import {
 
 const CHAT_ATTACHMENT_MAX_BYTES = 50 * 1024 * 1024;
 const CHAT_ATTACHMENT_MAX_MB = CHAT_ATTACHMENT_MAX_BYTES / (1024 * 1024);
+// Fallback sandbox artifact limit when /api/config has not loaded yet (mirrors
+// the backend default). Only consulted when a sandbox is available.
+const DEFAULT_SANDBOX_ARTIFACT_BYTES = 16 * 1024 * 1024;
+
+function formatBytes(bytes: number): string {
+  return bytes >= 1024 * 1024
+    ? `${Math.round(bytes / (1024 * 1024))} MB`
+    : `${Math.round(bytes / 1024)} KB`;
+}
 
 export interface ArchestraPromptInputProps
   extends Omit<ChatPromptInputToolsProps, "textareaRef"> {
@@ -141,8 +154,10 @@ const PromptInputContent = ({
   onResetModelOverride,
   agentRequiresPerUserConnect,
   agentModelDisplayName,
+  sandboxAvailable,
 }: Omit<ArchestraPromptInputProps, "onSubmit"> & {
   onSubmit: ArchestraPromptInputProps["onSubmit"];
+  sandboxAvailable: boolean;
 }) => {
   const internalTextareaRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = externalTextareaRef ?? internalTextareaRef;
@@ -153,10 +168,16 @@ const PromptInputContent = ({
     string | null
   >(null);
 
-  // Derive file upload capabilities from model input modalities
+  // Derive file upload capabilities from model input modalities. When the agent
+  // has a sandbox available, any file type is allowed (it is staged for
+  // run_command), so uploads are offered even for a non-multimodal model and the
+  // OS picker is unrestricted.
   const showFileUploadButton =
-    allowFileUploads && supportsFileUploads(inputModalities);
-  const acceptedFileTypes = getAcceptedFileTypes(inputModalities);
+    allowFileUploads &&
+    (supportsFileUploads(inputModalities) || sandboxAvailable);
+  const acceptedFileTypes = sandboxAvailable
+    ? undefined
+    : getAcceptedFileTypes(inputModalities);
 
   // Chat placeholders from organization settings
   const { data: orgData } = useOrganization();
@@ -646,6 +667,7 @@ const PromptInputContent = ({
             onApiKeyChange={onApiKeyChange}
             onProviderChange={onProviderChange}
             allowFileUploads={allowFileUploads}
+            sandboxAvailable={sandboxAvailable}
             isModelsLoading={isModelsLoading}
             tokensUsed={tokensUsed}
             cachedTokens={cachedTokens}
@@ -719,9 +741,39 @@ const ArchestraPromptInput = ({
   agentRequiresPerUserConnect,
   agentModelDisplayName,
 }: ArchestraPromptInputProps) => {
+  const { data: activeAgent } = useProfile(agentId);
+  const sandboxAvailable = activeAgent?.sandboxAvailable ?? false;
+  const sandboxByteLimit =
+    useFeature("sandboxArtifactBytesLimit") ?? DEFAULT_SANDBOX_ARTIFACT_BYTES;
+
+  // Per-file policy mirroring the backend ingest gate (which is authoritative).
+  // Returns a friendly reason to drop the file, or null to accept it.
+  const validateFile = useCallback(
+    (file: File): string | null => {
+      const reason = chatUploadRejectionReason({
+        mimeType: getMediaType(file),
+        byteLength: file.size,
+        ingestibleMimeTypes: getModelReadableMimeTypes(inputModalities),
+        sandboxAvailable,
+        sandboxByteLimit,
+      });
+      switch (reason) {
+        case null:
+          return null;
+        case "text_too_large":
+          return `"${file.name}" is too large to include as text. Enable the sandbox to work with larger files.`;
+        case "too_large_for_sandbox":
+          return `"${file.name}" exceeds the maximum size of ${formatBytes(sandboxByteLimit)}.`;
+        case "unsupported_type":
+          return `This model can't read "${file.name}". Enable the sandbox to use any file type.`;
+      }
+    },
+    [inputModalities, sandboxAvailable, sandboxByteLimit],
+  );
+
   const handleProviderFileError = useCallback(
     (err: {
-      code: "max_files" | "max_file_size" | "accept";
+      code: "max_files" | "max_file_size" | "accept" | "rejected";
       message: string;
     }) => {
       if (err.code === "max_file_size") {
@@ -730,6 +782,10 @@ const ArchestraPromptInput = ({
         );
       } else if (err.code === "max_files") {
         toast.error("Too many files attached.");
+      } else if (err.code === "rejected") {
+        // Policy rejection (unsupported type / too large to inline). Gentle,
+        // not an error toast — the message already explains the next step.
+        toast(err.message);
       }
     },
     [],
@@ -739,6 +795,7 @@ const ArchestraPromptInput = ({
     <div className="flex size-full flex-col justify-end">
       <PromptInputProvider
         maxFileSize={CHAT_ATTACHMENT_MAX_BYTES}
+        validateFile={validateFile}
         onError={handleProviderFileError}
       >
         <PromptInputContent
@@ -774,6 +831,7 @@ const ArchestraPromptInput = ({
           onResetModelOverride={onResetModelOverride}
           agentRequiresPerUserConnect={agentRequiresPerUserConnect}
           agentModelDisplayName={agentModelDisplayName}
+          sandboxAvailable={sandboxAvailable}
         />
       </PromptInputProvider>
     </div>

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -8,6 +8,7 @@ import {
   getAcceptedFileTypes,
   getMediaType,
   getModelReadableMimeTypes,
+  INLINE_TEXT_MAX_BYTES,
   supportsFileUploads,
 } from "@archestra/shared";
 import type { ChatStatus } from "ai";
@@ -761,7 +762,7 @@ const ArchestraPromptInput = ({
         case null:
           return null;
         case "text_too_large":
-          return `"${file.name}" is too large to include as text. Enable the sandbox to work with larger files.`;
+          return `"${file.name}" is too large to include as text (max ${formatBytes(INLINE_TEXT_MAX_BYTES)}). Enable the sandbox to work with larger files.`;
         case "too_large_for_sandbox":
           return `"${file.name}" exceeds the maximum size of ${formatBytes(sandboxByteLimit)}.`;
         case "unsupported_type":

--- a/platform/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/platform/frontend/src/components/ai-elements/prompt-input.tsx
@@ -146,8 +146,14 @@ const useOptionalProviderAttachments = () =>
 export type PromptInputProviderProps = PropsWithChildren<{
   initialInput?: string;
   maxFileSize?: number;
+  /**
+   * Per-file policy check beyond the MIME `accept` and `maxFileSize` constraints.
+   * Returns a human-readable reason to reject the file, or null to accept it.
+   * Rejected files are dropped and reported via `onError` with code `rejected`.
+   */
+  validateFile?: (file: File) => string | null;
   onError?: (err: {
-    code: "max_files" | "max_file_size" | "accept";
+    code: "max_files" | "max_file_size" | "accept" | "rejected";
     message: string;
   }) => void;
 }>;
@@ -159,6 +165,7 @@ export type PromptInputProviderProps = PropsWithChildren<{
 export function PromptInputProvider({
   initialInput: initialTextInput = "",
   maxFileSize,
+  validateFile,
   onError,
   children,
 }: PromptInputProviderProps) {
@@ -198,6 +205,20 @@ export function PromptInputProvider({
         }
       }
 
+      if (validateFile) {
+        accepted = accepted.filter((f) => {
+          const rejection = validateFile(f);
+          if (rejection) {
+            onError?.({ code: "rejected", message: rejection });
+            return false;
+          }
+          return true;
+        });
+        if (accepted.length === 0) {
+          return;
+        }
+      }
+
       setAttachmentFiles((prev) =>
         prev.concat(
           accepted.map((file) => ({
@@ -210,7 +231,7 @@ export function PromptInputProvider({
         ),
       );
     },
-    [maxFileSize, onError],
+    [maxFileSize, validateFile, onError],
   );
 
   const remove = useCallback((id: string) => {

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -29,6 +29,7 @@ export function makeConfig(
       betaEnabled: false,
       orchestratorK8sRuntime: false,
       sandbox: false,
+      sandboxArtifactBytesLimit: 16 * 1024 * 1024,
       agentSkillsEnabled: false,
       agentEnvironmentsEnabled: false,
       appsEnabled: false,

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -3,12 +3,16 @@ import {
   CONTEXT_WINDOW_BREAKDOWN_EVENT,
   CONTEXT_WINDOW_CATEGORIES,
   ContextWindowBreakdownSchema,
+  chatUploadRejectionReason,
   getAcceptedFileTypes,
   getMediaType,
+  getModelReadableMimeTypes,
   getSupportedFileTypesDescription,
   hasPersistableAssistantContent,
   hasRenderableAssistantContent,
+  INLINE_TEXT_MAX_BYTES,
   INPUT_MODALITY_OPTIONS,
+  isInlineableTextMimeType,
   OUTPUT_MODALITY_OPTIONS,
   supportsFileUploads,
 } from "./chat";
@@ -148,34 +152,33 @@ describe("CONTEXT_WINDOW_CATEGORIES", () => {
 });
 
 describe("chat file upload helpers", () => {
-  test("treats text modality as supporting txt, md, csv, and json uploads", () => {
+  const TEXT_MODALITY_MIME_TYPES = [
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "text/tab-separated-values",
+    "application/json",
+    "text/xml",
+    "application/xml",
+    "application/x-yaml",
+    "text/yaml",
+    "application/toml",
+    "text/x-toml",
+    "application/csv",
+    "application/vnd.ms-excel",
+  ];
+
+  test("treats text modality as supporting the inlineable text document types", () => {
     expect(getAcceptedFileTypes(["text"])).toBe(
-      [
-        "text/plain",
-        "text/markdown",
-        "text/csv",
-        "application/csv",
-        "application/vnd.ms-excel",
-        "application/json",
-      ].join(","),
+      TEXT_MODALITY_MIME_TYPES.join(","),
     );
     expect(supportsFileUploads(["text"])).toBe(true);
-    expect(getSupportedFileTypesDescription(["text"])).toBe(
-      "chat prompts, .txt, .csv, .md, and .json uploads",
-    );
+    expect(getSupportedFileTypesDescription(["text"])).not.toBeNull();
   });
 
   test("deduplicates mime types across modalities", () => {
     expect(getAcceptedFileTypes(["text", "text", "pdf"])).toBe(
-      [
-        "text/plain",
-        "text/markdown",
-        "text/csv",
-        "application/csv",
-        "application/vnd.ms-excel",
-        "application/json",
-        "application/pdf",
-      ].join(","),
+      [...TEXT_MODALITY_MIME_TYPES, "application/pdf"].join(","),
     );
   });
 
@@ -187,11 +190,9 @@ describe("chat file upload helpers", () => {
     expect(getSupportedFileTypesDescription(undefined)).toBeNull();
   });
 
-  test("builds a readable description for multiple upload modalities", () => {
-    expect(
-      getSupportedFileTypesDescription(["text", "image", "pdf", "audio"]),
-    ).toBe(
-      "chat prompts, .txt, .csv, .md, and .json uploads, images, PDFs, audio",
+  test("joins per-modality descriptions for multiple upload modalities", () => {
+    expect(getSupportedFileTypesDescription(["image", "pdf", "audio"])).toBe(
+      "images, PDFs, audio",
     );
   });
 
@@ -206,8 +207,43 @@ describe("chat file upload helpers", () => {
       "application/pdf",
     );
     expect(getMediaType({ name: "table.csv", type: "" })).toBe("text/csv");
+    expect(getMediaType({ name: "data.tsv", type: "" })).toBe(
+      "text/tab-separated-values",
+    );
     expect(getMediaType({ name: "README.md", type: "" })).toBe("text/markdown");
     expect(getMediaType({ name: "readme.txt", type: "" })).toBe("text/plain");
+    expect(getMediaType({ name: "config.yaml", type: "" })).toBe(
+      "application/x-yaml",
+    );
+    expect(getMediaType({ name: "config.yml", type: "" })).toBe(
+      "application/x-yaml",
+    );
+    expect(getMediaType({ name: "Cargo.toml", type: "" })).toBe(
+      "application/toml",
+    );
+  });
+
+  test("recognizes inlineable text document mime types", () => {
+    for (const mimeType of [
+      "text/plain",
+      "text/markdown",
+      "text/csv",
+      "text/tab-separated-values",
+      "application/json",
+      "text/xml",
+      "application/xml",
+      "application/x-yaml",
+      "application/toml",
+    ]) {
+      expect(isInlineableTextMimeType(mimeType)).toBe(true);
+    }
+    for (const mimeType of [
+      "application/pdf",
+      "image/png",
+      "application/octet-stream",
+    ]) {
+      expect(isInlineableTextMimeType(mimeType)).toBe(false);
+    }
   });
 
   test("defaults unknown extensions to application/octet-stream", () => {
@@ -232,6 +268,105 @@ describe("chat file upload helpers", () => {
       "image",
       "audio",
     ]);
+  });
+});
+
+describe("chatUploadRejectionReason", () => {
+  const base = {
+    ingestibleMimeTypes: new Set(["image/png", "application/pdf"]),
+    sandboxAvailable: false,
+    sandboxByteLimit: 16 * 1024 * 1024,
+  };
+
+  test("accepts a model-ingestible type at any size", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "image/png",
+        byteLength: 8_000_000,
+      }),
+    ).toBeNull();
+  });
+
+  test("accepts a small inlineable text file without a sandbox", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "application/toml",
+        byteLength: INLINE_TEXT_MAX_BYTES,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects oversized text without a sandbox, accepts it with one", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES + 1,
+      }),
+    ).toBe("text_too_large");
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        sandboxAvailable: true,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES + 1,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects an unsupported type without a sandbox, accepts within the limit with one", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "application/zip",
+        byteLength: 1_000,
+      }),
+    ).toBe("unsupported_type");
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        sandboxAvailable: true,
+        mimeType: "application/zip",
+        byteLength: 1_000,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects a file over the sandbox limit even when available", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        sandboxAvailable: true,
+        mimeType: "application/zip",
+        byteLength: base.sandboxByteLimit + 1,
+      }),
+    ).toBe("too_large_for_sandbox");
+  });
+
+  test("size-gates inlineable text even when the model lists it as ingestible", () => {
+    // A text-capable model's readable set includes text MIMEs, so the generic
+    // ingestible check would otherwise accept an arbitrarily large text file.
+    const ingestibleMimeTypes = getModelReadableMimeTypes(["text"]);
+    expect(ingestibleMimeTypes.has("text/csv")).toBe(true);
+
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        ingestibleMimeTypes,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES,
+      }),
+    ).toBeNull();
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        ingestibleMimeTypes,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES + 1,
+      }),
+    ).toBe("text_too_large");
   });
 });
 

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -161,6 +161,7 @@ describe("chat file upload helpers", () => {
     "text/xml",
     "application/xml",
     "application/x-yaml",
+    "application/yaml",
     "text/yaml",
     "application/toml",
     "text/x-toml",

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -412,7 +412,9 @@ export type SupportedChatUploadMimeType =
   | "application/json"
   | "application/octet-stream"
   | "application/pdf"
+  | "application/toml"
   | "application/vnd.ms-excel"
+  | "application/x-yaml"
   | "application/xml"
   | "audio/flac"
   | "audio/mpeg"
@@ -430,6 +432,10 @@ export type SupportedChatUploadMimeType =
   | "text/csv"
   | "text/markdown"
   | "text/plain"
+  | "text/tab-separated-values"
+  | "text/x-toml"
+  | "text/xml"
+  | "text/yaml"
   | "video/avi"
   | "video/mp4"
   | "video/quicktime"
@@ -438,6 +444,93 @@ export type SupportedChatUploadMimeType =
 // ============================================================================
 // File Type Utilities
 // ============================================================================
+
+/**
+ * Source of truth for inlineable text document MIME types. A text file of one of
+ * these types that is small enough (see {@link INLINE_TEXT_MAX_BYTES}) is embedded
+ * directly into the prompt as decoded text. The same list gates which non-image
+ * uploads the composer accepts and which file parts the provider-prep path inlines,
+ * so it must stay the single definition shared across frontend and backend.
+ */
+const INLINEABLE_TEXT_MIME_TYPES = [
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "text/tab-separated-values",
+  "application/json",
+  "text/xml",
+  "application/xml",
+  "application/x-yaml",
+  "text/yaml",
+  "application/toml",
+  "text/x-toml",
+  // Legacy CSV aliases some browsers and operating systems report.
+  "application/csv",
+  "application/vnd.ms-excel",
+] as const satisfies readonly SupportedChatUploadMimeType[];
+
+const INLINEABLE_TEXT_MIME_TYPE_SET: ReadonlySet<string> = new Set(
+  INLINEABLE_TEXT_MIME_TYPES,
+);
+
+/**
+ * Whether a MIME type is an inlineable text document — embeddable in the prompt as
+ * decoded text on any provider, rather than handed off as a binary attachment.
+ */
+export function isInlineableTextMimeType(mimeType: string): boolean {
+  return INLINEABLE_TEXT_MIME_TYPE_SET.has(mimeType);
+}
+
+/**
+ * Upper size bound for embedding a text document directly into the prompt. Larger
+ * text files are routed to the sandbox when available, otherwise rejected at ingest.
+ */
+export const INLINE_TEXT_MAX_BYTES = 256 * 1024;
+
+/**
+ * Why an upload is not acceptable, or `null` when it is. Single source of truth
+ * for the attachment policy shared by the backend ingest gate (authoritative)
+ * and the frontend composer (mirrors it for UX). A file is acceptable when the
+ * model can ingest its type, OR it is a small inlineable text document, OR a
+ * sandbox is available to stage it within the sandbox artifact size limit.
+ */
+export type ChatUploadRejectionReason =
+  | "text_too_large"
+  | "too_large_for_sandbox"
+  | "unsupported_type";
+
+export function chatUploadRejectionReason(params: {
+  mimeType: string;
+  byteLength: number;
+  ingestibleMimeTypes: Set<string>;
+  sandboxAvailable: boolean;
+  sandboxByteLimit: number;
+}): ChatUploadRejectionReason | null {
+  const {
+    mimeType,
+    byteLength,
+    ingestibleMimeTypes,
+    sandboxAvailable,
+    sandboxByteLimit,
+  } = params;
+
+  const fitsSandbox = sandboxAvailable && byteLength <= sandboxByteLimit;
+
+  // Inlineable text is size-gated even though a text-capable model lists these
+  // MIMEs as readable: a large text file would otherwise blow the context
+  // window. Checked before the generic ingestible short-circuit for that reason.
+  if (isInlineableTextMimeType(mimeType)) {
+    if (byteLength <= INLINE_TEXT_MAX_BYTES || fitsSandbox) return null;
+    return sandboxAvailable ? "too_large_for_sandbox" : "text_too_large";
+  }
+
+  // Non-text types the model can ingest natively (images, PDFs, …) carry no
+  // inline-text budget; the request body limit is the only size bound.
+  if (ingestibleMimeTypes.has(mimeType)) return null;
+
+  if (fitsSandbox) return null;
+  return sandboxAvailable ? "too_large_for_sandbox" : "unsupported_type";
+}
 
 /**
  * Mapping from input modalities to accepted MIME type patterns.
@@ -449,15 +542,8 @@ const MODALITY_TO_MIME_TYPES: Record<
   ModelInputModality,
   SupportedChatUploadMimeType[] | null
 > = {
-  // Text-capable models can accept plain text, CSV, and JSON documents.
-  text: [
-    "text/plain",
-    "text/markdown",
-    "text/csv",
-    "application/csv",
-    "application/vnd.ms-excel",
-    "application/json",
-  ],
+  // Text-capable models accept the inlineable text document types.
+  text: [...INLINEABLE_TEXT_MIME_TYPES],
   // Image formats commonly supported by vision models
   image: [
     "image/jpeg",
@@ -482,7 +568,7 @@ const MODALITY_TO_MIME_TYPES: Record<
 };
 
 const MODALITY_TO_FILE_TYPE_DESCRIPTION: Record<ModelInputModality, string> = {
-  text: "chat prompts, .txt, .csv, .md, and .json uploads",
+  text: "chat prompts and text files (.txt, .md, .csv, .tsv, .json, .xml, .yaml, .toml)",
   image: "images",
   audio: "audio",
   video: "video",
@@ -581,10 +667,15 @@ export function getMediaType(file: FileLikeWithMediaType): string {
     avi: "video/avi",
     pdf: "application/pdf",
     csv: "text/csv",
+    tsv: "text/tab-separated-values",
     md: "text/markdown",
+    markdown: "text/markdown",
     txt: "text/plain",
     json: "application/json",
     xml: "application/xml",
+    yaml: "application/x-yaml",
+    yml: "application/x-yaml",
+    toml: "application/toml",
   };
 
   return ext

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -415,6 +415,7 @@ export type SupportedChatUploadMimeType =
   | "application/toml"
   | "application/vnd.ms-excel"
   | "application/x-yaml"
+  | "application/yaml"
   | "application/xml"
   | "audio/flac"
   | "audio/mpeg"
@@ -461,6 +462,7 @@ const INLINEABLE_TEXT_MIME_TYPES = [
   "text/xml",
   "application/xml",
   "application/x-yaml",
+  "application/yaml",
   "text/yaml",
   "application/toml",
   "text/x-toml",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -11008,6 +11008,7 @@ export type GetAgentsResponses = {
             resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             resolvedLlmModelName?: string | null;
             llmProviderRequiresPerUserCredential?: boolean;
+            sandboxAvailable?: boolean;
         }>;
         pagination: {
             currentPage: number;
@@ -11248,6 +11249,7 @@ export type CreateAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -11453,6 +11455,7 @@ export type GetAllAgentsResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     }>;
 };
 
@@ -11633,6 +11636,7 @@ export type GetDefaultMcpGatewayResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -11813,6 +11817,7 @@ export type GetDefaultLlmProxyResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -12072,6 +12077,7 @@ export type ImportAgentResponses = {
             resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
             resolvedLlmModelName?: string | null;
             llmProviderRequiresPerUserCredential?: boolean;
+            sandboxAvailable?: boolean;
         };
         warnings: Array<{
             type: 'tool' | 'knowledgeBase' | 'connector' | 'delegation';
@@ -12345,6 +12351,7 @@ export type GetAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -12578,6 +12585,7 @@ export type UpdateAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -12760,6 +12768,7 @@ export type CloneAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -13103,6 +13112,7 @@ export type RestoreAgentResponses = {
         resolvedLlmProvider?: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot';
         resolvedLlmModelName?: string | null;
         llmProviderRequiresPerUserCredential?: boolean;
+        sandboxAvailable?: boolean;
     };
 };
 
@@ -25724,6 +25734,7 @@ export type GetConfigResponses = {
             betaEnabled: boolean;
             orchestratorK8sRuntime: boolean;
             sandbox: boolean;
+            sandboxArtifactBytesLimit: number;
             agentSkillsEnabled: boolean;
             agentEnvironmentsEnabled: boolean;
             appsEnabled: boolean;


### PR DESCRIPTION
> Stacks on #6006 — merge after it lands. Diff/review against `feat/sandbox-aware-attachments` until then.

## What

Brings the chatops/email/A2A attachment path to parity with the chat-side policy (#6006).

- Inlineable text types broadened to `csv/tsv/json/xml/yaml/toml/md`, delivered as decoded text on every provider. Inlined text is bounded by `INLINE_TEXT_MAX_BYTES` (256KB); over-limit text routes to the sandbox or is named in the note.
- Files the model cannot read inline (e.g. a SQLite database) are staged into the agent's default sandbox when one is available, referenced by a pointer so the model can open them with `run_command`. Gated on `isSkillSandboxAvailableForAgent` (feature enabled + `sandbox:execute` + the agent owns the sandbox tools), and resolved only when the turn has attachments.
- Classification reuses the shared `chatUploadRejectionReason`. The staging target mirrors how `run_command` resolves its default sandbox (conversation default when a `conversationId` is in scope, else the per-execution sandbox).

## Changes

- `a2a-executor.ts` — `buildUserContent` is the single classify/inline/stage/skip site; executor wires availability + the staging closure.
- `a2a/stage-attachments.ts` (new) — staging helper (sandbox resolution + `uploadFile`, collision-safe paths, content-hash dedupe, per-file error isolation; failures are noted, never thrown).
- `skill-sandbox-runtime-service.ts` — `assignAttachmentPaths` exported for reuse.
- Docs: Slack / MS Teams / email attachment sections.

## Tests

- Policy unit tests (inline new types, 256KB cap → stage/skip, sqlite staged vs noted, oversized-for-sandbox, staging-failure surfaced).
- Real-DB integration tests for the staging helper: sanitized path, within-turn dedupe, conversation-sandbox target, sandbox-creation-failure.
- type-check, biome, knip (dev+production) clean.

https://claude.ai/code/session_01Af2G8i4GryrgJkaEvsKJcN

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>