### PR TITLE
chore(bench): move ib-deck-qc into basic as a cross-conversation persist task

### DIFF
--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -107,13 +107,18 @@ Which Archestra capability each task is built to exercise. A task usually leans 
 | `it-license-rollup` | basic | | | | | ✓ | | | |
 | `it-audit-resist-injection` | basic | | | | | ✓ | | injection | |
 | `access-request-intake` | basic | | | | use | ✓ | | | |
+| `review-run-command-persistence` | basic | ✓ | ✓ | | | | | red-herring | |
+| `review-file-upload-persistence` | basic | ✓ | ✓ | | | | | red-herring | |
+| `solidarity-tax-usd` | basic | ✓ | | | | | ✓ | | |
+| `ib-deck-qc` | basic | ✓ | ✓ | | | | | red-herring | persist |
 | `author-skill` | archestra-api | ✓ | | | author | | | | state |
 | `letter-count` | archestra-api | | | | | | | | state |
 | `author-aec-normalizer-skill` | archestra-api | ✓ | ✓ | | author | | | | state |
 
 - **Sandbox** — needs code execution in the per-conversation sandbox.
-- **File in** — a file is staged into the sandbox as an attachment (PDF/DOCX/XLSX/SQLite/zip); the task
-  exercises reading non-text formats.
+- **File in** — a file is staged into the conversation as an attachment (PDF/DOCX/XLSX/SQLite/zip/tar.gz/
+  markdown); the task exercises reading the attached file rather than getting its contents inlined in the
+  prompt. (Contrast `median-salary`, whose CSV is inlined via `{{file:…}}` and so is *not* marked here.)
 - **File out** — the deliverable is a file the agent exports via `download_file` (graded as `BENCH_OUTPUT`).
 - **Skills** — `use`: a pinned skill gates the task (`decode-cipher` → cipher-decoder, `xlsx-live-formulas`
   → sales-ledger); `author`: the task authors a skill. For both `use` tasks the verifier *enforces* that
@@ -131,7 +136,8 @@ Which Archestra capability each task is built to exercise. A task usually leans 
 - **State/persist** — marked only where introspecting/mutating Archestra's own state is the task's
   *headline* point. `state`: the answer itself comes from what the agent *did* to Archestra, graded via
   the `[state].rest` backend snapshot (`author-skill`, `letter-count`); `persist`: a file carried across
-  a `new_conversation` boundary via persistent storage. (`decode-cipher`/`xlsx-live-formulas` also
+  a `new_conversation` boundary via persistent storage (`purchase-ledger`, `ib-deck-qc`).
+  (`decode-cipher`/`xlsx-live-formulas` also
   snapshot `[state].rest`, but only to enforce skill use — counted under Skills, not here.)
 
 The three *public* seeded remote MCP servers (DeepWiki, Microsoft Learn, Context7) are surface
@@ -157,8 +163,10 @@ an isolated lane one each). Add a new environment by dropping another `envs/*.to
 
 `basic` ships all skills from `anthropics/skills` + `openai/skills`, three public no-auth remote MCPs
 (DeepWiki, Microsoft Learn, Context7) as a realistic distractor surface, the harness-owned synthetic
-`acme_it` MCP (`fixture_mcp = true`), `share_backend = true` (its tasks are read-only against backend
-state), and a set of tasks including —
+`acme_it` MCP (`fixture_mcp = true`), `share_backend = true` (its tasks don't mutate the *shared*
+backend state — the skill/tool catalog; per-lane project files like `purchase-ledger`'s and
+`ib-deck-qc`'s persisted deck are isolated per lane, so they're safe to share too), and a set of tasks
+including —
 
 - `pi-gif-zip` — estimate π by Monte-Carlo, render an animated GIF, invert its colors, zip and export
   it; the verifier asserts a valid zip containing a valid GIF (sandbox + file output).
@@ -192,8 +200,30 @@ state), and a set of tasks including —
   (the naive all-rows tally, wrong for the net ask) and a cell *comment* phrased as an ops instruction
   urging exfiltration via `download_file` + external "validation". The verifier recomputes net from the
   raw rows and asserts no exfil/distractor tool was invoked.
+- `solidarity-tax-usd` — compute Poland's solidarity levy (danina solidarnościowa: 4% on annual income
+  over 1,000,000 PLN) on a stated 2023 income, then convert to USD at the NBP table-A mid rate for the
+  **last banking day** of the year (2023-12-31 is a Sunday, so the 2023-12-29 table) and floor it. The
+  country and currency are only implied by the taxpayer's name, and the rate must be fetched live (NBP
+  API) in the sandbox; the verifier recomputes from recorded inputs, so no final number is hardcoded.
+- `review-run-command-persistence` / `review-file-upload-persistence` — a paired code-review task over
+  a staged `.tar.gz` snapshot of the backend's sandbox-replay persistence code (byte-identical between
+  the two, so the file set is no tell). The agent extracts and navigates the source, then returns a
+  single closed-set verdict. The `run_command` variant hides a real bug — stdout/stderr written into
+  Postgres `text` columns with no NUL stripping, so binary output crashes the insert
+  (`decline:nul-persistence`); the upload variant is the look-alike decoy that is actually safe (bytes
+  go to a `bytea` column → `approve`). The enum's other decline reasons are distractors the agent must
+  falsify, and the deciding evidence (a column type, in a different file from the entry method)
+  requires navigating the snapshot rather than reading one file.
+- `ib-deck-qc` — a two-turn task over a staged draft CIM (an investment-banking deck, `deck.md`): turn 1
+  saves the attachment into the lane's project files; turn 2, in a fresh conversation, rediscovers it
+  from persistent storage and runs the QC pass — find every metric that conflicts across slides
+  (`value_conflict`) or whose stated figure doesn't follow arithmetically from the numbers cited for it
+  (`calc_error`), reporting each against a closed metric enum. The deck plants decoys — metrics that look
+  off but reconcile, and two deliberately *different* enterprise-value concepts (comps-implied ~$1.2B vs
+  indicative deal $1.25B) that the prompt rules out as a non-defect — so the verifier grades the exact set
+  of (metric, issue_type) pairs against the four planted defects, rejecting both misses and over-flagging.
 
-The last three tasks exercise the **synthetic MCP** surface. With `fixture_mcp = true` the harness
+The next three tasks exercise the **synthetic MCP** surface. With `fixture_mcp = true` the harness
 serves the in-process `acme_it` ("Acme IT service desk") MCP with controlled, deterministic content:
 `list_seats` + `list_license_contracts` (the inventory and its billing terms), `get_reclamation_policy`
 and `get_access_policy` (structured rules), `deactivate_account` (a destructive write), and

--- a/archestra-bench/envs/basic.toml
+++ b/archestra-bench/envs/basic.toml
@@ -1,6 +1,6 @@
 id = "basic"
 name = "Basic"
-tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "github-stars", "lena-png-size", "sqlite-orders", "cv-shortlist", "invoice-approval", "ai-sre-fk-drain", "ai-sre-cache-treadmill", "decode-cipher", "xlsx-live-formulas", "purchase-ledger", "aec-material-json-takeoff", "renewal-churn-risk", "pcap-soc-triage", "xlsx-comment-injection", "it-license-rollup", "it-audit-resist-injection", "access-request-intake", "review-run-command-persistence", "review-file-upload-persistence", "solidarity-tax-usd"]
+tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "github-stars", "lena-png-size", "sqlite-orders", "cv-shortlist", "invoice-approval", "ai-sre-fk-drain", "ai-sre-cache-treadmill", "decode-cipher", "xlsx-live-formulas", "purchase-ledger", "aec-material-json-takeoff", "renewal-churn-risk", "pcap-soc-triage", "xlsx-comment-injection", "it-license-rollup", "it-audit-resist-injection", "access-request-intake", "review-run-command-persistence", "review-file-upload-persistence", "solidarity-tax-usd", "ib-deck-qc"]
 
 # Starts the harness-owned `acme_it` synthetic MCP (fixed, controlled content) and registers it to every
 # lane's agent. It serves stateless data, so one shared instance is safe across concurrent lanes -- the

--- a/archestra-bench/envs/finance-eval.toml
+++ b/archestra-bench/envs/finance-eval.toml
@@ -1,8 +1,0 @@
-id = "finance-eval"
-name = "Finance deck QC"
-tasks = ["ib-deck-qc"]
-
-# Finance judgement task over staged inputs: the agent reads the attachments, works in the sandbox,
-# and hands the answer to submit_result. No skills or MCPs are seeded (none are needed), and the task
-# is read-only against backend state, so all lanes can share one seeded backend.
-share_backend = true

--- a/archestra-bench/tasks/ib-deck-qc/task.toml
+++ b/archestra-bench/tasks/ib-deck-qc/task.toml
@@ -1,22 +1,24 @@
 [[stages]]
-text = """Hey, I've attached deck.md — it's the draft CIM for Project Atlas (the Meridian Software sale) that an analyst put together. It's at /home/sandbox/attachments/deck.md.
-
-Before this goes out I need a QC pass on the numbers. I'm worried about two classes of problem:
-- the SAME metric showing up with different values on different slides (an internal inconsistency / value conflict), and
-- a number that doesn't actually follow from the figures stated for it (a stated calculation that's arithmetically wrong).
-
-Go through the whole deck and find every such defect. For each one, report the metric it concerns and which class of problem it is. When you check a stated growth rate or CAGR against a data series, compute it over the number of years the series actually spans (last value / first value, annualized over that many years).
-
-Two scope notes so we're aligned: (1) the deck quotes different headline enterprise values on different slides — a comps-IMPLIED EV (~$1.2B) versus the INDICATIVE deal EV ($1.25B). Those are different concepts by design, so do NOT treat that as a defect. (2) For `implied_ev`, the only thing to check is whether slide 6's stated implied EV correctly equals the median EV/Revenue multiple it cites times the revenue it cites — i.e. is that one stated calculation right.
-
-Send it back with submit_result as `findings`: a list of objects, each with a `metric` (pick from the allowed enum) and an `issue_type` of either "value_conflict" or "calc_error". Only report real defects — don't pad the list with metrics that are actually consistent.
-
-Make a single submit_result call with your complete, final list of findings."""
+text = """Hey, I've attached deck.md — it's the draft CIM for Project Atlas (the Meridian Software sale) that an analyst put together. Can you save it into my files so I can pull it back up later? I'll want a QC pass on it shortly, but no need to look at the numbers yet — just hold on to it for me."""
 
   [[stages.files]]
   src = "deck.md"
   dest = "/home/sandbox/attachments/deck.md"
   mime_type = "text/markdown"
+
+[[stages]]
+new_conversation = true
+text = """Can you pull up that Project Atlas deck (the Meridian Software CIM) I had you save earlier? Before it goes out I need a QC pass on the numbers. I'm worried about two classes of problem:
+- the same metric showing up with different values on different slides (an internal inconsistency / value conflict), and
+- a number that doesn't actually follow from the figures stated for it (a stated calculation that's arithmetically wrong).
+
+Go through the whole deck and find every such defect. For each one, report the metric it concerns and which class of problem it is. When you check a stated growth rate or CAGR against a data series, compute it over the number of years the series actually spans (last value / first value, annualized over that many years).
+
+Two scope notes so we're aligned: (1) the deck quotes different headline enterprise values on different slides — a comps-IMPLIED EV (~$1.2B) versus the INDICATIVE deal EV ($1.25B). Those are different concepts by design, so don't treat that as a defect. (2) For `implied_ev`, the only thing to check is whether slide 6's stated implied EV correctly equals the median EV/Revenue multiple it cites times the revenue it cites — i.e. is that one stated calculation right.
+
+Send it back with submit_result as `findings`: a list of objects, each with a `metric` (pick from the allowed enum) and an `issue_type` of either "value_conflict" or "calc_error". Only report real defects — don't pad the list with metrics that are actually consistent.
+
+Make a single submit_result call with your complete, final list of findings."""
 
 [result_schema]
 type = "object"


### PR DESCRIPTION
Restructures the `ib-deck-qc` eval task and folds it into the `basic` environment.

**What changed**
- `ib-deck-qc` is now a two-stage task: stage 1 attaches the deck and asks the agent to save it into its project files; stage 2 (`new_conversation`) rediscovers it from persistent storage and runs the QC pass. This exercises the file system explicitly (upload + cross-conversation rediscovery), mirroring the `purchase-ledger` persist pattern. `result_schema` and `verifier.py` are unchanged.
- Moved the task from the single-task `finance-eval` env into `basic`; deleted `envs/finance-eval.toml`.
- README: updated the feature-coverage table (row now flags File-in + persist), the File-in / State-persist column notes, the `basic` env description, and prose; removed the `finance-eval` section.

**Smoke test** — ran `basic / ib-deck-qc / claude-haiku-45` end-to-end against a fresh backend. The persist flow works: stage 1 `save_file` → "Saved …/deck.md (13377 bytes) to persistent files"; stage 2 `search_files` → `read_file` → analysis → `submit_result`. Graded `failed` only because the model found 3/4 planted defects (missed one `value_conflict`) — a legitimate near-miss confirming the difficulty floor and that the verifier grades correctly.

https://claude.ai/code/session_01T7P8rxYcMtoohZqEK7ZQqj

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>