### PR TITLE
feat(frontend): offline connectivity status bar

### DIFF
--- a/platform/frontend/src/app/_parts/app-shell.tsx
+++ b/platform/frontend/src/app/_parts/app-shell.tsx
@@ -21,6 +21,7 @@ import {
   ConnectivityProvider,
   useConnectivity,
 } from "@/lib/config/connectivity";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { useActiveSiteNotification } from "@/lib/site-notification.query";
 import { cn } from "@/lib/utils";
 import { MaintenanceModeOverlay } from "./maintenance-mode-overlay";
@@ -92,70 +93,73 @@ export function AppShell({ children }: AppShellProps) {
     );
   }
 
-  // Wait for permission check before rendering sidebar to avoid flash.
-  // Don't render Version here — the full-width layout has a different center
-  // than the sidebar layout, causing the footer to visibly jump on load.
-  if (!permissionLoaded) {
-    return (
-      <main className="h-screen w-full flex flex-col bg-background min-w-0 relative">
-        <MaintenanceModeOverlay />
-        <div className="flex-1 min-w-0 flex flex-col">
-          <div className="flex-1 flex flex-col">{children}</div>
-        </div>
-        <Toaster />
-      </main>
-    );
-  }
-
-  // Normal mode: render full app shell with sidebar. ConnectivityProvider lives
-  // here (not in the root layout) so the /health poll only runs on the real
-  // shell, never on the auth/preview/runtime branches above.
+  // Authenticated shell. ConnectivityProvider wraps both the permission-loading
+  // skeleton and the full shell so /health polling and useConnectivity() are
+  // available on every page rendered here — including before the sidebar mounts
+  // (a page like /chat calls useConnectivity() unconditionally). The
+  // auth/preview/runtime branches above are intentionally outside it (no poll).
   return (
     <ConnectivityProvider>
-      <NavigationStatusProvider>
-        <SidebarProvider defaultOpen={!shouldCollapse}>
-          <AppSidebar />
-          <NavAwareSidebarCircleToggle />
+      {!permissionLoaded ? (
+        // Wait for the permission check before rendering the sidebar to avoid a
+        // flash. Don't render Version here — the full-width layout centers
+        // differently than the sidebar layout, so the footer would visibly jump.
+        <main className="h-screen w-full flex flex-col bg-background min-w-0 relative">
           <MaintenanceModeOverlay />
-          <main className="h-screen w-full flex flex-col bg-background min-w-0 relative overflow-y-auto">
-            <ConnectivityBar />
-            {notification && (
-              <SiteNotificationBar
-                content={notification.content}
-                notificationId={notification.id}
-              />
-            )}
-            <ImpersonationBanner />
-            <header className="h-14 border-b border-border flex md:hidden items-center justify-between px-6 bg-card/50 backdrop-blur supports-backdrop-filter:bg-card/50">
-              <SidebarTrigger className="cursor-pointer hover:bg-accent transition-colors rounded-md p-2 -ml-2" />
-              <div
-                id="mobile-header-actions"
-                className="flex items-center gap-2"
-              />
-            </header>
-            <div className="flex-1 min-h-0 min-w-0 flex flex-col">
-              <div
-                className={cn(
-                  "flex-1 flex flex-col",
-                  isViewportLocked && "min-h-0",
-                )}
-              >
-                {children}
-              </div>
-              <Version />
-            </div>
-          </main>
+          <div className="flex-1 min-w-0 flex flex-col">
+            <div className="flex-1 flex flex-col">{children}</div>
+          </div>
           <Toaster />
-          <ConversationSearchProvider />
-        </SidebarProvider>
-      </NavigationStatusProvider>
+        </main>
+      ) : (
+        <NavigationStatusProvider>
+          <SidebarProvider defaultOpen={!shouldCollapse}>
+            <AppSidebar />
+            <NavAwareSidebarCircleToggle />
+            <MaintenanceModeOverlay />
+            <main className="h-screen w-full flex flex-col bg-background min-w-0 relative overflow-y-auto">
+              <ConnectivityBar />
+              {notification && (
+                <SiteNotificationBar
+                  content={notification.content}
+                  notificationId={notification.id}
+                />
+              )}
+              <ImpersonationBanner />
+              <header className="h-14 border-b border-border flex md:hidden items-center justify-between px-6 bg-card/50 backdrop-blur supports-backdrop-filter:bg-card/50">
+                <SidebarTrigger className="cursor-pointer hover:bg-accent transition-colors rounded-md p-2 -ml-2" />
+                <div
+                  id="mobile-header-actions"
+                  className="flex items-center gap-2"
+                />
+              </header>
+              <div className="flex-1 min-h-0 min-w-0 flex flex-col">
+                <div
+                  className={cn(
+                    "flex-1 flex flex-col",
+                    isViewportLocked && "min-h-0",
+                  )}
+                >
+                  {children}
+                </div>
+                <Version />
+              </div>
+            </main>
+            <Toaster />
+            <ConversationSearchProvider />
+          </SidebarProvider>
+        </NavigationStatusProvider>
+      )}
     </ConnectivityProvider>
   );
 }
 
 function ConnectivityBar() {
   const { state, retry } = useConnectivity();
-  return <ConnectivityStatusBar state={state} onRetry={retry} />;
+  const appName = useAppName();
+  return (
+    <ConnectivityStatusBar state={state} onRetry={retry} appName={appName} />
+  );
 }
 
 function NavAwareSidebarCircleToggle() {

--- a/platform/frontend/src/app/_parts/app-shell.tsx
+++ b/platform/frontend/src/app/_parts/app-shell.tsx
@@ -2,6 +2,7 @@
 
 import type { Permissions } from "@archestra/shared/permission.types";
 import { usePathname } from "next/navigation";
+import { ConnectivityStatusBar } from "@/components/connectivity-status-bar";
 import { ConversationSearchProvider } from "@/components/conversation-search-provider";
 import { ImpersonationBanner } from "@/components/impersonation-banner";
 import {
@@ -16,6 +17,10 @@ import {
 import { Toaster } from "@/components/ui/sonner";
 import { Version } from "@/components/version";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import {
+  ConnectivityProvider,
+  useConnectivity,
+} from "@/lib/config/connectivity";
 import { useActiveSiteNotification } from "@/lib/site-notification.query";
 import { cn } from "@/lib/utils";
 import { MaintenanceModeOverlay } from "./maintenance-mode-overlay";
@@ -102,45 +107,55 @@ export function AppShell({ children }: AppShellProps) {
     );
   }
 
-  // Normal mode: render full app shell with sidebar
+  // Normal mode: render full app shell with sidebar. ConnectivityProvider lives
+  // here (not in the root layout) so the /health poll only runs on the real
+  // shell, never on the auth/preview/runtime branches above.
   return (
-    <NavigationStatusProvider>
-      <SidebarProvider defaultOpen={!shouldCollapse}>
-        <AppSidebar />
-        <NavAwareSidebarCircleToggle />
-        <MaintenanceModeOverlay />
-        <main className="h-screen w-full flex flex-col bg-background min-w-0 relative overflow-y-auto">
-          {notification && (
-            <SiteNotificationBar
-              content={notification.content}
-              notificationId={notification.id}
-            />
-          )}
-          <ImpersonationBanner />
-          <header className="h-14 border-b border-border flex md:hidden items-center justify-between px-6 bg-card/50 backdrop-blur supports-backdrop-filter:bg-card/50">
-            <SidebarTrigger className="cursor-pointer hover:bg-accent transition-colors rounded-md p-2 -ml-2" />
-            <div
-              id="mobile-header-actions"
-              className="flex items-center gap-2"
-            />
-          </header>
-          <div className="flex-1 min-h-0 min-w-0 flex flex-col">
-            <div
-              className={cn(
-                "flex-1 flex flex-col",
-                isViewportLocked && "min-h-0",
-              )}
-            >
-              {children}
+    <ConnectivityProvider>
+      <NavigationStatusProvider>
+        <SidebarProvider defaultOpen={!shouldCollapse}>
+          <AppSidebar />
+          <NavAwareSidebarCircleToggle />
+          <MaintenanceModeOverlay />
+          <main className="h-screen w-full flex flex-col bg-background min-w-0 relative overflow-y-auto">
+            <ConnectivityBar />
+            {notification && (
+              <SiteNotificationBar
+                content={notification.content}
+                notificationId={notification.id}
+              />
+            )}
+            <ImpersonationBanner />
+            <header className="h-14 border-b border-border flex md:hidden items-center justify-between px-6 bg-card/50 backdrop-blur supports-backdrop-filter:bg-card/50">
+              <SidebarTrigger className="cursor-pointer hover:bg-accent transition-colors rounded-md p-2 -ml-2" />
+              <div
+                id="mobile-header-actions"
+                className="flex items-center gap-2"
+              />
+            </header>
+            <div className="flex-1 min-h-0 min-w-0 flex flex-col">
+              <div
+                className={cn(
+                  "flex-1 flex flex-col",
+                  isViewportLocked && "min-h-0",
+                )}
+              >
+                {children}
+              </div>
+              <Version />
             </div>
-            <Version />
-          </div>
-        </main>
-        <Toaster />
-        <ConversationSearchProvider />
-      </SidebarProvider>
-    </NavigationStatusProvider>
+          </main>
+          <Toaster />
+          <ConversationSearchProvider />
+        </SidebarProvider>
+      </NavigationStatusProvider>
+    </ConnectivityProvider>
   );
+}
+
+function ConnectivityBar() {
+  const { state, retry } = useConnectivity();
+  return <ConnectivityStatusBar state={state} onRetry={retry} />;
 }
 
 function NavAwareSidebarCircleToggle() {

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -21,6 +21,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { toast } from "sonner";
 import { CreateProjectFromChatDialog } from "@/app/_parts/create-project-from-chat-dialog";
 import { scheduledRunContext } from "@/app/_parts/scheduled-run-sidebar.utils";
 import { CustomServerRequestDialog } from "@/app/mcp/registry/_parts/custom-server-request-dialog";
@@ -131,6 +132,7 @@ import {
 } from "@/lib/chat/use-chat-preferences";
 import { useInitialChatModelState } from "@/lib/chat/use-initial-chat-model-state.hook";
 import { useConfig, useFeature } from "@/lib/config/config.query";
+import { useConnectivity } from "@/lib/config/connectivity";
 import { useDialogs } from "@/lib/hooks/use-dialog";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
 import { useLlmModels, useLlmModelsByProvider } from "@/lib/llm-models.query";
@@ -445,6 +447,7 @@ export function ChatPageContent({
     initialMessages: persistedConversationMessages,
     enabled: shouldEnableChatSession,
   });
+  const connectivity = useConnectivity();
   const sharedConversationMessages = useMemo(
     () => (conversation?.messages ?? []) as PartialUIMessage[],
     [conversation?.messages],
@@ -1292,6 +1295,15 @@ export function ChatPageContent({
       throw new Error("stop-not-submit");
     }
 
+    if (connectivity.state.kind !== "online") {
+      toast.error(
+        "You're offline — your message wasn't sent. It'll send once you're back online.",
+      );
+      // Throw to keep the textarea and draft intact (onSubmit contract): the
+      // user keeps their message instead of losing it to a silent failure.
+      throw new Error("offline-not-submit");
+    }
+
     const hasText = message.text?.trim();
     const hasFiles = message.files && message.files.length > 0;
     // a skill slash command may be sent on its own, with no prompt or files
@@ -1695,9 +1707,16 @@ export function ChatPageContent({
     useCallback(
       (message, e, options) => {
         e.preventDefault();
+        if (connectivity.state.kind !== "online") {
+          toast.error(
+            "You're offline — your message wasn't sent. It'll send once you're back online.",
+          );
+          // Throw to keep the textarea and draft intact (onSubmit contract).
+          throw new Error("offline-not-submit");
+        }
         submitInitialMessage(message, options?.skill);
       },
-      [submitInitialMessage],
+      [submitInitialMessage, connectivity.state.kind],
     );
 
   // A chat started from a project page keeps the Files panel open when the

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1297,7 +1297,7 @@ export function ChatPageContent({
 
     if (connectivity.state.kind !== "online") {
       toast.error(
-        "You're offline — your message wasn't sent. It'll send once you're back online.",
+        "You're offline — your message wasn't sent. Try again once you're back online.",
       );
       // Throw to keep the textarea and draft intact (onSubmit contract): the
       // user keeps their message instead of losing it to a silent failure.
@@ -1709,7 +1709,7 @@ export function ChatPageContent({
         e.preventDefault();
         if (connectivity.state.kind !== "online") {
           toast.error(
-            "You're offline — your message wasn't sent. It'll send once you're back online.",
+            "You're offline — your message wasn't sent. Try again once you're back online.",
           );
           // Throw to keep the textarea and draft intact (onSubmit contract).
           throw new Error("offline-not-submit");

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -132,7 +132,10 @@ import {
 } from "@/lib/chat/use-chat-preferences";
 import { useInitialChatModelState } from "@/lib/chat/use-initial-chat-model-state.hook";
 import { useConfig, useFeature } from "@/lib/config/config.query";
-import { useConnectivity } from "@/lib/config/connectivity";
+import {
+  type ConnectivityState,
+  useConnectivity,
+} from "@/lib/config/connectivity";
 import { useDialogs } from "@/lib/hooks/use-dialog";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
 import { useLlmModels, useLlmModelsByProvider } from "@/lib/llm-models.query";
@@ -166,6 +169,19 @@ function parseRightPanelTab(value: string | null): RightPanelTab | null {
   return RIGHT_PANEL_TABS.includes(value as RightPanelTab)
     ? (value as RightPanelTab)
     : null;
+}
+
+// Copy for the chat-send guard, picked per failure mode so the message matches
+// reality (browser offline vs backend down, which is not "you're offline").
+function offlineSubmitMessage(
+  kind: Exclude<ConnectivityState["kind"], "online">,
+): string {
+  switch (kind) {
+    case "browser-offline":
+      return "You're offline — your message wasn't sent. Try again once you're back online.";
+    case "backend-unreachable":
+      return "Can't reach the server — your message wasn't sent. Try again in a moment.";
+  }
 }
 
 export function ChatPageContent({
@@ -1295,10 +1311,9 @@ export function ChatPageContent({
       throw new Error("stop-not-submit");
     }
 
-    if (connectivity.state.kind !== "online") {
-      toast.error(
-        "You're offline — your message wasn't sent. Try again once you're back online.",
-      );
+    const { kind: connectivityKind } = connectivity.state;
+    if (connectivityKind !== "online") {
+      toast.error(offlineSubmitMessage(connectivityKind));
       // Throw to keep the textarea and draft intact (onSubmit contract): the
       // user keeps their message instead of losing it to a silent failure.
       throw new Error("offline-not-submit");
@@ -1707,16 +1722,15 @@ export function ChatPageContent({
     useCallback(
       (message, e, options) => {
         e.preventDefault();
-        if (connectivity.state.kind !== "online") {
-          toast.error(
-            "You're offline — your message wasn't sent. Try again once you're back online.",
-          );
+        const { kind: connectivityKind } = connectivity.state;
+        if (connectivityKind !== "online") {
+          toast.error(offlineSubmitMessage(connectivityKind));
           // Throw to keep the textarea and draft intact (onSubmit contract).
           throw new Error("offline-not-submit");
         }
         submitInitialMessage(message, options?.skill);
       },
-      [submitInitialMessage, connectivity.state.kind],
+      [submitInitialMessage, connectivity.state],
     );
 
   // A chat started from a project page keeps the Files panel open when the

--- a/platform/frontend/src/components/connectivity-status-bar.test.tsx
+++ b/platform/frontend/src/components/connectivity-status-bar.test.tsx
@@ -6,7 +6,11 @@ import { ConnectivityStatusBar } from "./connectivity-status-bar";
 describe("ConnectivityStatusBar", () => {
   it("renders nothing while online", () => {
     const { container } = render(
-      <ConnectivityStatusBar state={{ kind: "online" }} onRetry={vi.fn()} />,
+      <ConnectivityStatusBar
+        state={{ kind: "online" }}
+        onRetry={vi.fn()}
+        appName="Acme"
+      />,
     );
     expect(container).toBeEmptyDOMElement();
   });
@@ -16,6 +20,7 @@ describe("ConnectivityStatusBar", () => {
       <ConnectivityStatusBar
         state={{ kind: "browser-offline" }}
         onRetry={vi.fn()}
+        appName="Acme"
       />,
     );
     const browserOfflineText = screen.getByTestId(
@@ -27,6 +32,7 @@ describe("ConnectivityStatusBar", () => {
       <ConnectivityStatusBar
         state={{ kind: "backend-unreachable" }}
         onRetry={vi.fn()}
+        appName="Acme"
       />,
     );
     const unreachableText = screen.getByTestId(
@@ -38,12 +44,26 @@ describe("ConnectivityStatusBar", () => {
     expect(unreachableText).not.toEqual(browserOfflineText);
   });
 
+  it("uses the white-label app name in the backend-unreachable message", () => {
+    render(
+      <ConnectivityStatusBar
+        state={{ kind: "backend-unreachable" }}
+        onRetry={vi.fn()}
+        appName="Acme"
+      />,
+    );
+    expect(screen.getByTestId("connectivity-status-bar").textContent).toContain(
+      "Acme",
+    );
+  });
+
   it("calls onRetry when the retry button is clicked", async () => {
     const onRetry = vi.fn();
     render(
       <ConnectivityStatusBar
         state={{ kind: "backend-unreachable" }}
         onRetry={onRetry}
+        appName="Acme"
       />,
     );
     await userEvent.click(screen.getByRole("button", { name: /retry/i }));

--- a/platform/frontend/src/components/connectivity-status-bar.test.tsx
+++ b/platform/frontend/src/components/connectivity-status-bar.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ConnectivityStatusBar } from "./connectivity-status-bar";
+
+describe("ConnectivityStatusBar", () => {
+  it("renders nothing while online", () => {
+    const { container } = render(
+      <ConnectivityStatusBar state={{ kind: "online" }} onRetry={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the bar for both non-online states, with distinct messages", () => {
+    const { rerender } = render(
+      <ConnectivityStatusBar
+        state={{ kind: "browser-offline" }}
+        onRetry={vi.fn()}
+      />,
+    );
+    const browserOfflineText = screen.getByTestId(
+      "connectivity-status-bar",
+    ).textContent;
+    expect(browserOfflineText).toBeTruthy();
+
+    rerender(
+      <ConnectivityStatusBar
+        state={{ kind: "backend-unreachable" }}
+        onRetry={vi.fn()}
+      />,
+    );
+    const unreachableText = screen.getByTestId(
+      "connectivity-status-bar",
+    ).textContent;
+
+    // The bar distinguishes the two failure modes rather than showing one
+    // generic message.
+    expect(unreachableText).not.toEqual(browserOfflineText);
+  });
+
+  it("calls onRetry when the retry button is clicked", async () => {
+    const onRetry = vi.fn();
+    render(
+      <ConnectivityStatusBar
+        state={{ kind: "backend-unreachable" }}
+        onRetry={onRetry}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/platform/frontend/src/components/connectivity-status-bar.tsx
+++ b/platform/frontend/src/components/connectivity-status-bar.tsx
@@ -5,11 +5,17 @@ import { RefreshCw, WifiOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ConnectivityState } from "@/lib/config/connectivity";
 
-const MESSAGES: Record<Exclude<ConnectivityState["kind"], "online">, string> = {
-  "browser-offline":
-    "You're offline. Some features won't work until you reconnect.",
-  "backend-unreachable": "Can't reach the Archestra server.",
-};
+function messageFor(
+  kind: Exclude<ConnectivityState["kind"], "online">,
+  appName: string,
+): string {
+  switch (kind) {
+    case "browser-offline":
+      return "You're offline. Some features won't work until you reconnect.";
+    case "backend-unreachable":
+      return `Can't reach the ${appName} server.`;
+  }
+}
 
 /**
  * Persistent banner for the authenticated shell, shown while the browser is
@@ -20,9 +26,11 @@ const MESSAGES: Record<Exclude<ConnectivityState["kind"], "online">, string> = {
 export function ConnectivityStatusBar({
   state,
   onRetry,
+  appName,
 }: {
   state: ConnectivityState;
   onRetry: () => void;
+  appName: string;
 }) {
   if (state.kind === "online") {
     return null;
@@ -35,7 +43,7 @@ export function ConnectivityStatusBar({
     >
       <span className="flex items-center gap-2 text-sm font-medium">
         <WifiOff className="h-4 w-4 shrink-0" />
-        {MESSAGES[state.kind]}
+        {messageFor(state.kind, appName)}
       </span>
       <Button
         size="sm"

--- a/platform/frontend/src/components/connectivity-status-bar.tsx
+++ b/platform/frontend/src/components/connectivity-status-bar.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { E2eTestId } from "@archestra/shared";
+import { RefreshCw, WifiOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ConnectivityState } from "@/lib/config/connectivity";
+
+const MESSAGES: Record<Exclude<ConnectivityState["kind"], "online">, string> = {
+  "browser-offline":
+    "You're offline. Some features won't work until you reconnect.",
+  "backend-unreachable": "Can't reach the Archestra server.",
+};
+
+/**
+ * Persistent banner for the authenticated shell, shown while the browser is
+ * offline or the backend is unreachable. Complements the per-screen
+ * QueryLoadError panels: those keep a blocked surface locally actionable, this
+ * explains the app-wide condition. Renders nothing while online.
+ */
+export function ConnectivityStatusBar({
+  state,
+  onRetry,
+}: {
+  state: ConnectivityState;
+  onRetry: () => void;
+}) {
+  if (state.kind === "online") {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid={E2eTestId.ConnectivityStatusBar}
+      className="bg-amber-100 dark:bg-amber-900/40 border-b border-amber-300 dark:border-amber-800 text-amber-900 dark:text-amber-100 px-4 py-2 flex items-center justify-between gap-4"
+    >
+      <span className="flex items-center gap-2 text-sm font-medium">
+        <WifiOff className="h-4 w-4 shrink-0" />
+        {MESSAGES[state.kind]}
+      </span>
+      <Button
+        size="sm"
+        variant="outline"
+        data-testid={E2eTestId.ConnectivityStatusBarRetry}
+        onClick={onRetry}
+      >
+        <RefreshCw className="h-4 w-4" />
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/platform/frontend/src/lib/config/connectivity.test.tsx
+++ b/platform/frontend/src/lib/config/connectivity.test.tsx
@@ -1,0 +1,120 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetHealth } = vi.hoisted(() => ({ mockGetHealth: vi.fn() }));
+
+vi.mock("@archestra/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@archestra/shared")>();
+  return {
+    ...actual,
+    archestraApiSdk: {
+      ...actual.archestraApiSdk,
+      getHealth: (...args: unknown[]) => mockGetHealth(...args),
+    },
+  };
+});
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { ConnectivityProvider, useConnectivity } from "./connectivity";
+
+const HEALTH_OK = { data: { name: "archestra", status: "ok", version: "1" } };
+const HEALTH_FAIL = { error: new Error("offline") };
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <ConnectivityProvider>{children}</ConnectivityProvider>
+    </QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+// Settle pending fetches/effects. Driving polls explicitly via retry() keeps
+// the test deterministic — TanStack's background refetchInterval is gated on
+// tab focus/visibility, which is unreliable under jsdom + fake timers.
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1);
+  });
+}
+
+describe("ConnectivityProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("needs two consecutive /health failures before reporting backend-unreachable", async () => {
+    mockGetHealth.mockResolvedValue(HEALTH_FAIL);
+    const { result } = renderHook(() => useConnectivity(), {
+      wrapper: makeWrapper().wrapper,
+    });
+
+    // Mount poll = failure #1 — still online under the hysteresis threshold.
+    await flush();
+    expect(result.current.state.kind).toBe("online");
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+
+    // Next poll = failure #2 — now unreachable.
+    act(() => result.current.retry());
+    await flush();
+    expect(result.current.state.kind).toBe("backend-unreachable");
+    expect(mockGetHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears unreachable and fires exactly one refetch wave when /health recovers", async () => {
+    mockGetHealth.mockResolvedValue(HEALTH_FAIL);
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useConnectivity(), { wrapper });
+
+    await flush();
+    act(() => result.current.retry());
+    await flush();
+    expect(result.current.state.kind).toBe("backend-unreachable");
+
+    mockGetHealth.mockResolvedValue(HEALTH_OK);
+    act(() => result.current.retry());
+    await flush();
+    expect(result.current.state.kind).toBe("online");
+
+    const activeInvalidations = invalidateSpy.mock.calls.filter(
+      ([arg]) => (arg as { type?: string } | undefined)?.type === "active",
+    );
+    expect(activeInvalidations).toHaveLength(1);
+  });
+
+  it("reports browser-offline immediately when navigator goes offline, independent of /health", async () => {
+    mockGetHealth.mockResolvedValue(HEALTH_OK);
+    const { result } = renderHook(() => useConnectivity(), {
+      wrapper: makeWrapper().wrapper,
+    });
+
+    await flush();
+    expect(result.current.state.kind).toBe("online");
+
+    const onLineSpy = vi
+      .spyOn(navigator, "onLine", "get")
+      .mockReturnValue(false);
+    await act(async () => {
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current.state.kind).toBe("browser-offline");
+
+    onLineSpy.mockReturnValue(true);
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+    });
+    await flush();
+    expect(result.current.state.kind).toBe("online");
+  });
+});

--- a/platform/frontend/src/lib/config/connectivity.test.tsx
+++ b/platform/frontend/src/lib/config/connectivity.test.tsx
@@ -117,4 +117,29 @@ describe("ConnectivityProvider", () => {
     await flush();
     expect(result.current.state.kind).toBe("online");
   });
+
+  it("fires exactly one refetch wave per offline→online transition, not while steady", async () => {
+    mockGetHealth.mockResolvedValue(HEALTH_OK);
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useConnectivity(), { wrapper });
+    await flush();
+
+    const onLineSpy = vi.spyOn(navigator, "onLine", "get");
+    const countActiveWaves = () =>
+      invalidateSpy.mock.calls.filter(
+        ([arg]) => (arg as { type?: string } | undefined)?.type === "active",
+      ).length;
+
+    for (let cycle = 1; cycle <= 2; cycle++) {
+      onLineSpy.mockReturnValue(false);
+      await act(async () => window.dispatchEvent(new Event("offline")));
+      onLineSpy.mockReturnValue(true);
+      await act(async () => window.dispatchEvent(new Event("online")));
+      await flush();
+      expect(result.current.state.kind).toBe("online");
+      // One wave per recovery, and none from the steady-online renders between.
+      expect(countActiveWaves()).toBe(cycle);
+    }
+  });
 });

--- a/platform/frontend/src/lib/config/connectivity.tsx
+++ b/platform/frontend/src/lib/config/connectivity.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -84,28 +85,35 @@ export function ConnectivityProvider({ children }: { children: ReactNode }) {
     };
   }, [refetch]);
 
-  const state: ConnectivityState = !browserOnline
-    ? { kind: "browser-offline" }
+  const kind: ConnectivityState["kind"] = !browserOnline
+    ? "browser-offline"
     : backendUnreachable
-      ? { kind: "backend-unreachable" }
-      : { kind: "online" };
+      ? "backend-unreachable"
+      : "online";
 
   // On the transition back to fully online, refetch everything once so screens
   // that errored while offline recover — a single wave, not a per-screen storm.
   const prevKindRef = useRef<ConnectivityState["kind"]>("online");
   useEffect(() => {
-    if (prevKindRef.current !== "online" && state.kind === "online") {
+    if (prevKindRef.current !== "online" && kind === "online") {
       void queryClient.invalidateQueries({ type: "active" });
     }
-    prevKindRef.current = state.kind;
-  }, [state.kind, queryClient]);
+    prevKindRef.current = kind;
+  }, [kind, queryClient]);
 
   const retry = useCallback(() => {
     void refetch();
   }, [refetch]);
 
+  // Memoized so consumers (the chat page among them) don't re-render on every
+  // poll settle, only when the connectivity kind actually changes.
+  const value = useMemo<ConnectivityContextValue>(
+    () => ({ state: { kind }, retry }),
+    [kind, retry],
+  );
+
   return (
-    <ConnectivityContext.Provider value={{ state, retry }}>
+    <ConnectivityContext.Provider value={value}>
       {children}
     </ConnectivityContext.Provider>
   );

--- a/platform/frontend/src/lib/config/connectivity.tsx
+++ b/platform/frontend/src/lib/config/connectivity.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useHealth } from "@/lib/config/health.query";
+
+const HEALTHY_POLL_MS = 30_000;
+const FAILING_POLL_MS = 5_000;
+// Consecutive failed /health polls before declaring the backend unreachable.
+// Hysteresis: a single blip must not flip the whole app to an error banner.
+const UNREACHABLE_FAILURE_THRESHOLD = 2;
+
+export type ConnectivityState =
+  | { kind: "online" }
+  | { kind: "browser-offline" }
+  | { kind: "backend-unreachable" };
+
+interface ConnectivityContextValue {
+  state: ConnectivityState;
+  retry: () => void;
+}
+
+const ConnectivityContext = createContext<ConnectivityContextValue | null>(
+  null,
+);
+
+export function ConnectivityProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  // SSR-safe: assume online during render, read the real value in an effect.
+  const [browserOnline, setBrowserOnline] = useState(true);
+  const [backendUnreachable, setBackendUnreachable] = useState(false);
+  const consecutiveFailuresRef = useRef(0);
+
+  // `/health` is unauthenticated, so its failures mean connectivity loss, never
+  // an expired session. Poll slowly when healthy, fast once a failure appears.
+  const { refetch, isSuccess, isError, errorUpdatedAt } = useHealth({
+    refetchOnReconnect: false,
+    // Poll speed follows the query's own error status (immediate), so a failing
+    // backend is re-probed quickly. The unreachable *threshold* below is a
+    // separate counter, so polling fast and declaring unreachable stay decoupled.
+    refetchInterval: (query) =>
+      query.state.status === "error" ? FAILING_POLL_MS : HEALTHY_POLL_MS,
+  });
+
+  // Fold each settled /health poll into the consecutive-failure counter that
+  // drives the unreachable state. `errorUpdatedAt` is a dep — not read in the
+  // body — because a second consecutive failure leaves `isError` already true,
+  // so only its changing timestamp re-runs the effect to keep counting.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: errorUpdatedAt is the re-trigger for repeated failures
+  useEffect(() => {
+    if (isSuccess) {
+      consecutiveFailuresRef.current = 0;
+      setBackendUnreachable(false);
+    } else if (isError) {
+      consecutiveFailuresRef.current += 1;
+      if (consecutiveFailuresRef.current >= UNREACHABLE_FAILURE_THRESHOLD) {
+        setBackendUnreachable(true);
+      }
+    }
+  }, [isSuccess, isError, errorUpdatedAt]);
+
+  // Track the browser's own connectivity, and re-probe the backend the moment
+  // it reports online (browser-online does not imply backend-reachable).
+  useEffect(() => {
+    setBrowserOnline(navigator.onLine);
+    const handleOnline = () => {
+      setBrowserOnline(true);
+      void refetch();
+    };
+    const handleOffline = () => setBrowserOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, [refetch]);
+
+  const state: ConnectivityState = !browserOnline
+    ? { kind: "browser-offline" }
+    : backendUnreachable
+      ? { kind: "backend-unreachable" }
+      : { kind: "online" };
+
+  // On the transition back to fully online, refetch everything once so screens
+  // that errored while offline recover — a single wave, not a per-screen storm.
+  const prevKindRef = useRef<ConnectivityState["kind"]>("online");
+  useEffect(() => {
+    if (prevKindRef.current !== "online" && state.kind === "online") {
+      void queryClient.invalidateQueries({ type: "active" });
+    }
+    prevKindRef.current = state.kind;
+  }, [state.kind, queryClient]);
+
+  const retry = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  return (
+    <ConnectivityContext.Provider value={{ state, retry }}>
+      {children}
+    </ConnectivityContext.Provider>
+  );
+}
+
+export function useConnectivity(): ConnectivityContextValue {
+  const ctx = useContext(ConnectivityContext);
+  if (!ctx) {
+    throw new Error(
+      "useConnectivity must be used within a ConnectivityProvider",
+    );
+  }
+  return ctx;
+}

--- a/platform/frontend/src/lib/config/health.query.ts
+++ b/platform/frontend/src/lib/config/health.query.ts
@@ -1,19 +1,29 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
-import { useQuery } from "@tanstack/react-query";
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import { throwOnApiError } from "@/lib/utils";
 
 const { getHealth } = archestraApiSdk;
 
-export function useHealth(params?: {
-  initialData?: archestraApiTypes.GetHealthResponses["200"];
-}) {
+type HealthData = archestraApiTypes.GetHealthResponses["200"] | null;
+
+export function useHealth(
+  params?: {
+    initialData?: archestraApiTypes.GetHealthResponses["200"];
+  } & Pick<
+    UseQueryOptions<HealthData>,
+    "refetchInterval" | "refetchOnReconnect" | "enabled"
+  >,
+) {
   return useQuery({
     queryKey: ["health"],
-    queryFn: async () => {
+    queryFn: async (): Promise<HealthData> => {
       const { data, error } = await getHealth();
       throwOnApiError(error, { toastOnError: false });
       return data ?? null;
     },
     initialData: params?.initialData,
+    refetchInterval: params?.refetchInterval,
+    refetchOnReconnect: params?.refetchOnReconnect,
+    enabled: params?.enabled,
   });
 }

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -127,6 +127,9 @@ export const E2eTestId = {
   McpLogsViewButton: "mcp-logs-view-button",
   McpLogsEditConfigButton: "mcp-logs-edit-config-button",
   McpLogsTab: "mcp-logs-tab",
+  // Connectivity / offline status bar
+  ConnectivityStatusBar: "connectivity-status-bar",
+  ConnectivityStatusBarRetry: "connectivity-status-bar-retry",
   // Role debugger / impersonation
   ImpersonationBanner: "impersonation-banner",
   ImpersonationStopButton: "impersonation-stop-button",


### PR DESCRIPTION
## What

Adds an app-wide offline status bar to the authenticated shell, and stops the offline chat-send from failing silently. Complements (does not replace) the per-screen `QueryLoadError` / `ApiKeyLoadError` panels from #5977.

| State | Behavior |
|-------|----------|
| Browser offline (`navigator.onLine` false) | Amber bar appears immediately: "You're offline…" |
| Backend unreachable (sustained `/health` failures) | Amber bar after 2 consecutive failures: "Can't reach the &lt;app&gt; server." + Retry |
| Connectivity restored | Bar clears, one `invalidateQueries({type:"active"})` refetch wave |
| Send a chat message while offline | Toast + draft preserved, instead of ~3s silent auto-retry → raw `Failed to fetch` |

## How

- **`lib/config/connectivity.tsx`** — `ConnectivityProvider` + `useConnectivity()`. `navigator.onLine` + `online`/`offline` events for the browser signal; `/health` polling (30s healthy, 5s while failing) with a 2-failure hysteresis counter for the backend signal. `/health` is unauthenticated, so a 401/session expiry can't be misread as offline. Single throttled refetch wave on reconnect.
- **`components/connectivity-status-bar.tsx`** — presentational amber banner (matches `ImpersonationBanner`), `WifiOff` + Retry, white-labeled via `useAppName()`.
- **`app/_parts/app-shell.tsx`** — provider wraps both authenticated branches (loading skeleton + full shell), so every page rendered there (incl. `/chat`) has it; auth/preview/runtime routes stay outside it (no polling).
- **`app/chat/page.tsx`** — submit handlers guard on connectivity: toast + `throw` (existing draft-preserving onSubmit contract). Message distinguishes browser-offline from backend-down.
- **`lib/config/health.query.ts`** — `useHealth` accepts `refetchInterval` / `refetchOnReconnect` / `enabled`.

## Tests

Provider tests (hysteresis, one-wave-per-reconnect, flapping, browser online/offline), bar tests (per-state rendering, white-label name, retry). `type-check`, `lint`, `knip` clean; full frontend suite green (2178).

## Not included

No Playwright e2e (test IDs added; backend-down case would use the MSW `/health` override). The bar is not shown during the brief permission-load skeleton (polling runs there, banner does not) — deliberate.

https://claude.ai/code/session_014hPGUJ46vr4QFzhCZ1Lwo7

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>