### PR TITLE
docs: interactive architecture diagram on overview page

### DIFF
--- a/docs/pages/platform-overview.md
+++ b/docs/pages/platform-overview.md
@@ -16,7 +16,7 @@ Archestra is a centralized AI Platform designed for organizations where software
 
 > Fun fact: The team behind Archestra.AI previously worked on Grafana OnCall.
 
-![Platform Architecture](/docs/platform-overview-architecture.webp)
+:::architecture-diagram:::
 
 ## Composable Components
 


### PR DESCRIPTION
Replaces the static `platform-overview-architecture.webp` on the **platform overview** page with the `:::architecture-diagram:::` directive, which mounts the interactive architecture figure rendered by the companion **archestra-ai/website** PR (#535).

The figure has an **Overview ⇄ Technical** toggle:
- *Overview*: non-technical → technical "user spectrum" of platform layers.
- *Technical*: clients → control plane → infrastructure, with a database cylinder and labeled auth/protocol arrows.

Both this and the website PR need to merge for the diagram to render at `/docs/platform-overview`. Supersedes the reverted #5969.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>