### PR TITLE
fix(mcp): dedupe pod counter by deploymentName so multitenant cards show 1 pod

### DIFF
--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -663,6 +663,7 @@ describe("websocket MCP deployment statuses", () => {
             state: "running",
             message: "Deployment is running",
             error: null,
+            deploymentName: `mcp-${mcpServer1.id}`,
           },
           [mcpServer2.id]: {
             state: "not_created",

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -664,6 +664,7 @@ class WebSocketService {
             restartCount: deploymentStatus.restartCount,
             podAge: deploymentStatus.podAge,
             podName: deploymentStatus.podName,
+            deploymentName: deploymentStatus.deploymentName ?? undefined,
           };
         } else {
           result[serverId] = {

--- a/platform/frontend/src/app/mcp/registry/_parts/deployment-status.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/deployment-status.test.tsx
@@ -277,6 +277,170 @@ describe("computeDeploymentStatusSummary", () => {
       overallState: "running",
     });
   });
+
+  it("dedupes two entries that share a podName into one", () => {
+    const statuses = {
+      "server-1": {
+        state: "running" as const,
+        message: "Running",
+        error: null,
+        podName: "shared-pod",
+      },
+      "server-2": {
+        state: "running" as const,
+        message: "Running",
+        error: null,
+        podName: "shared-pod",
+      },
+    };
+    const result = computeDeploymentStatusSummary(
+      ["server-1", "server-2"],
+      statuses,
+    );
+    expect(result).toEqual({
+      total: 1,
+      running: 1,
+      pending: 0,
+      failed: 0,
+      overallState: "running",
+    });
+  });
+
+  it("counts two entries with distinct podNames separately", () => {
+    const statuses = {
+      "server-1": {
+        state: "running" as const,
+        message: "Running",
+        error: null,
+        podName: "pod-a",
+      },
+      "server-2": {
+        state: "running" as const,
+        message: "Running",
+        error: null,
+        podName: "pod-b",
+      },
+    };
+    const result = computeDeploymentStatusSummary(
+      ["server-1", "server-2"],
+      statuses,
+    );
+    expect(result).toEqual({
+      total: 2,
+      running: 2,
+      pending: 0,
+      failed: 0,
+      overallState: "running",
+    });
+  });
+
+  it("reports pending overallState when the only deployment is pending", () => {
+    const statuses = {
+      "server-1": {
+        state: "pending" as const,
+        message: "Starting",
+        error: null,
+      },
+    };
+    const result = computeDeploymentStatusSummary(["server-1"], statuses);
+    expect(result).toEqual({
+      total: 1,
+      running: 0,
+      pending: 1,
+      failed: 0,
+      overallState: "pending",
+    });
+  });
+
+  it("dedupes multi-tenant rows by deploymentName even before a podName resolves", () => {
+    // Fresh-install bug: server-2's pod has not scheduled yet (podName null),
+    // but both rows share one deployment, so the count must stay 1.
+    const statuses = {
+      "server-1": {
+        state: "running" as const,
+        message: "Running",
+        error: null,
+        podName: "pod-x",
+        deploymentName: "mcp-mt-shared",
+      },
+      "server-2": {
+        state: "pending" as const,
+        message: "Starting",
+        error: null,
+        deploymentName: "mcp-mt-shared",
+      },
+    };
+    const result = computeDeploymentStatusSummary(
+      ["server-1", "server-2"],
+      statuses,
+    );
+    expect(result).toEqual({
+      total: 1,
+      running: 1,
+      pending: 0,
+      failed: 0,
+      overallState: "running",
+    });
+  });
+
+  it("surfaces a failed alias when collapsing rows that share a deploymentName", () => {
+    const statuses = {
+      "server-1": {
+        state: "running" as const,
+        message: "Running",
+        error: null,
+        podName: "pod-x",
+        deploymentName: "mcp-mt-shared",
+      },
+      "server-2": {
+        state: "failed" as const,
+        message: "Error",
+        error: "crash",
+        deploymentName: "mcp-mt-shared",
+      },
+    };
+    const result = computeDeploymentStatusSummary(
+      ["server-1", "server-2"],
+      statuses,
+    );
+    expect(result).toEqual({
+      total: 1,
+      running: 0,
+      pending: 0,
+      failed: 1,
+      overallState: "failed",
+    });
+  });
+
+  it("counts entries with distinct deploymentNames separately (single-tenant)", () => {
+    const statuses = {
+      "server-1": {
+        state: "running" as const,
+        message: "Running",
+        error: null,
+        podName: "pod-1",
+        deploymentName: "mcp-server-1",
+      },
+      "server-2": {
+        state: "running" as const,
+        message: "Running",
+        error: null,
+        podName: "pod-2",
+        deploymentName: "mcp-server-2",
+      },
+    };
+    const result = computeDeploymentStatusSummary(
+      ["server-1", "server-2"],
+      statuses,
+    );
+    expect(result).toEqual({
+      total: 2,
+      running: 2,
+      pending: 0,
+      failed: 0,
+      overallState: "running",
+    });
+  });
 });
 
 describe("DeploymentStatusIndicator", () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/deployment-status.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/deployment-status.tsx
@@ -90,6 +90,16 @@ export interface DeploymentStatusSummary {
   overallState: DeploymentState;
 }
 
+// Highest observed state wins when collapsing entries that map to one pod, so
+// a failed alias still surfaces over a running/pending sibling.
+const STATE_PRIORITY: Record<string, number> = {
+  failed: 4,
+  running: 3,
+  succeeded: 3,
+  pending: 2,
+  not_created: 1,
+};
+
 /**
  * Compute an aggregate deployment status summary from a set of server IDs
  * and their individual deployment statuses.
@@ -100,21 +110,34 @@ export function computeDeploymentStatusSummary(
 ): DeploymentStatusSummary | null {
   if (serverIds.length === 0) return null;
 
-  // Multi-tenant catalogs alias one K8s pod across many mcp_server rows.
-  // Dedupe entries by podName so the count reflects pods, not callers.
-  // Entries without a podName count individually (no aliasing known).
-  const seenPodNames = new Set<string>();
-  const uniqueEntries: McpDeploymentStatusEntry[] = [];
+  // Dedupe entries that map to the same pod so the count reflects pods, not
+  // caller rows. A deployment's identity (deploymentName) is stable from
+  // install time — known before a pod is scheduled — so multi-tenant catalogs,
+  // which share one deployment across rows, collapse to a single pod even while
+  // a freshly-installed row's podName is still null. Fall back to podName, then
+  // count individually when neither identity is known.
+  const byKey = new Map<string, McpDeploymentStatusEntry>();
+  const unkeyed: McpDeploymentStatusEntry[] = [];
   for (const id of serverIds) {
     const entry = statuses[id];
     if (!entry || entry.state === "not_created") continue;
-    const podName = entry.podName;
-    if (podName) {
-      if (seenPodNames.has(podName)) continue;
-      seenPodNames.add(podName);
+    const key = entry.deploymentName ?? entry.podName;
+    if (!key) {
+      unkeyed.push(entry);
+      continue;
     }
-    uniqueEntries.push(entry);
+    const existing = byKey.get(key);
+    if (
+      !existing ||
+      (STATE_PRIORITY[entry.state] ?? 0) > (STATE_PRIORITY[existing.state] ?? 0)
+    ) {
+      byKey.set(key, entry);
+    }
   }
+  const uniqueEntries: McpDeploymentStatusEntry[] = [
+    ...byKey.values(),
+    ...unkeyed,
+  ];
 
   let total = 0;
   let running = 0;

--- a/platform/shared/websocket.ts
+++ b/platform/shared/websocket.ts
@@ -347,6 +347,10 @@ export type McpDeploymentStatusEntry = {
   restartCount?: number;
   podAge?: string; // e.g. "24m", "2h", "3d"
   podName?: string;
+  // Stable per-deployment identity, known at install time (before a pod is
+  // scheduled). Multi-tenant catalogs share one deployment across rows, so the
+  // UI dedupes by this to count pods, not caller rows.
+  deploymentName?: string;
 };
 
 export type McpDeploymentStatusesMessage = {


### PR DESCRIPTION
## Summary

On the MCP Registry, the pod counter on a multi-tenant catalog's card (the `{running}/{total}` badge) jumped from `1` to `2` right after a fresh install and stayed wrong until the pod scheduled or the user reloaded the browser.

Multi-tenant catalogs alias one shared Kubernetes pod across many `mcp_server` rows. The card deduped those rows by `podName` to count pods rather than caller rows — but a freshly-installed row has no `podName` until its pod is scheduled, so during that window it was counted as a separate pod and the badge over-reported.

This dedupes by `deploymentName` (falling back to `podName`). `deploymentName` is deterministic and known the instant a row is installed, so multi-tenant rows — which share one deployment name — collapse to a single pod immediately, even before any pod schedules. Single-tenant rows have distinct deployment names and are still counted separately, so a catalog with two real pods still reads `2`. When rows that share a deployment disagree on state, the most severe one wins (matching the existing per-row dot canonicalization), so a failed pod still surfaces.

The shared WebSocket deployment-status entry now carries `deploymentName`; the backend already computed it and was dropping it before sending.

## Follow-up

For a shared pod, a sibling row whose *install* failed (independent of pod health) can still make the badge read `failed`. That matches today's behavior and the existing per-row state canonicalization; distinguishing pod health from install-attempt outcome would mean emitting a canonical deployment-level state from the backend — left as a separate change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>