### PR TITLE
fix(chat): detect context-overflow 400s across provider message wordings (#3219)

### DIFF
--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -310,8 +310,11 @@ function extractArchestraInternalCode(
   try {
     const parsed = JSON.parse(responseBody);
     const code = parsed?.error?.internal_code;
-    if (code === ArchestraInternalErrorCode.ContextLengthExceeded) {
-      return ArchestraInternalErrorCode.ContextLengthExceeded;
+    if (
+      code === ArchestraInternalErrorCode.ContextLengthExceeded ||
+      code === ArchestraInternalErrorCode.RequestTooLarge
+    ) {
+      return code;
     }
   } catch {
     // Not JSON — fall through.
@@ -1678,6 +1681,8 @@ export function mapProviderError(
   const normalizedCode = extractArchestraInternalCode(responseBody);
   if (normalizedCode === ArchestraInternalErrorCode.ContextLengthExceeded) {
     errorCode = ChatErrorCode.ContextTooLong;
+  } else if (normalizedCode === ArchestraInternalErrorCode.RequestTooLarge) {
+    errorCode = ChatErrorCode.RequestTooLarge;
   }
   const usageLimitError = extractUsageLimitError(responseBody);
 

--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -750,7 +750,7 @@ describe("extractInternalCode", () => {
           "Invalid request: Your request exceeded model token limit: 262144 (requested: 566084)",
       },
     };
-    expect(anthropicAdapterFactory.extractInternalCode?.(error)).toBe(
+    expect(anthropicAdapterFactory.extractInternalCode(error)).toBe(
       ArchestraInternalErrorCode.ContextLengthExceeded,
     );
   });
@@ -763,7 +763,7 @@ describe("extractInternalCode", () => {
         },
       },
     };
-    expect(anthropicAdapterFactory.extractInternalCode?.(error)).toBe(
+    expect(anthropicAdapterFactory.extractInternalCode(error)).toBe(
       ArchestraInternalErrorCode.ContextLengthExceeded,
     );
   });
@@ -772,7 +772,7 @@ describe("extractInternalCode", () => {
     const error = {
       error: { message: "total message size 3275158 exceeds limit 2097152" },
     };
-    expect(anthropicAdapterFactory.extractInternalCode?.(error)).toBe(
+    expect(anthropicAdapterFactory.extractInternalCode(error)).toBe(
       ArchestraInternalErrorCode.RequestTooLarge,
     );
   });
@@ -781,8 +781,6 @@ describe("extractInternalCode", () => {
     const error = {
       error: { message: "messages: at least one message is required" },
     };
-    expect(
-      anthropicAdapterFactory.extractInternalCode?.(error),
-    ).toBeUndefined();
+    expect(anthropicAdapterFactory.extractInternalCode(error)).toBeUndefined();
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -1,4 +1,5 @@
 import AnthropicProvider from "@anthropic-ai/sdk";
+import { ArchestraInternalErrorCode } from "@archestra/shared";
 import { vi } from "vitest";
 import { describe, expect, test } from "@/test";
 import type { Anthropic } from "@/types";
@@ -736,5 +737,52 @@ describe("anthropicAdapterFactory.execute", () => {
 
     expect(post).toHaveBeenCalled();
     expect(response.content[0]).toMatchObject({ type: "text", text: "ok" });
+  });
+});
+
+describe("extractInternalCode", () => {
+  test("classifies a Kimi-style 'exceeded model token limit' message as overflow", () => {
+    // Kimi's Anthropic-compatible gateway phrases overflow differently from
+    // Anthropic's own "prompt is too long" — this is the #3219 regression.
+    const error = {
+      error: {
+        message:
+          "Invalid request: Your request exceeded model token limit: 262144 (requested: 566084)",
+      },
+    };
+    expect(anthropicAdapterFactory.extractInternalCode?.(error)).toBe(
+      ArchestraInternalErrorCode.ContextLengthExceeded,
+    );
+  });
+
+  test("still classifies Anthropic's native 'prompt is too long'", () => {
+    const error = {
+      error: {
+        error: {
+          message: "prompt is too long: 201381 tokens > 200000 maximum",
+        },
+      },
+    };
+    expect(anthropicAdapterFactory.extractInternalCode?.(error)).toBe(
+      ArchestraInternalErrorCode.ContextLengthExceeded,
+    );
+  });
+
+  test("classifies an upstream byte-size limit as request-too-large", () => {
+    const error = {
+      error: { message: "total message size 3275158 exceeds limit 2097152" },
+    };
+    expect(anthropicAdapterFactory.extractInternalCode?.(error)).toBe(
+      ArchestraInternalErrorCode.RequestTooLarge,
+    );
+  });
+
+  test("leaves an unrelated 400 unclassified", () => {
+    const error = {
+      error: { message: "messages: at least one message is required" },
+    };
+    expect(
+      anthropicAdapterFactory.extractInternalCode?.(error),
+    ).toBeUndefined();
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1,5 +1,5 @@
 import AnthropicProvider from "@anthropic-ai/sdk";
-import { ArchestraInternalErrorCode } from "@archestra/shared";
+import type { ArchestraInternalErrorCode } from "@archestra/shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
 import {
@@ -34,6 +34,7 @@ import {
   isMcpImageBlock,
 } from "../utils/mcp-image";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 
 // =============================================================================
 // TYPE ALIASES
@@ -1247,19 +1248,12 @@ export const anthropicAdapterFactory: LLMProvider<
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {
-    // Anthropic returns 400 invalid_request_error when the prompt exceeds
-    // the model's context window, with a message like "prompt is too long:
-    // X tokens > Y maximum". There is no structured code — message sniffing
-    // is the only signal.
+    // Anthropic and its compatible gateways (e.g. third-party Anthropic-shaped
+    // endpoints) signal context overflow only via the message, with no structured
+    // code, and each phrases it differently. Classify against the shared vocabulary.
     const message: unknown =
       get(error, "error.error.message") ?? get(error, "error.message");
-    if (
-      typeof message === "string" &&
-      message.toLowerCase().includes("prompt is too long")
-    ) {
-      return ArchestraInternalErrorCode.ContextLengthExceeded;
-    }
-    return undefined;
+    return internalCodeFromProviderMessage(message);
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -38,6 +38,7 @@ import type {
   UsageView,
 } from "@/types";
 import { ApiError, createStreamAccumulatorState } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 
 type AzureResponsesRequest = Azure.Types.ResponsesRequest;
 type AzureResponsesResponse = Azure.Types.ResponsesResponse;
@@ -169,7 +170,7 @@ export const azureResponsesAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/azure.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.ts
@@ -37,6 +37,7 @@ import type {
   LLMStreamAdapter,
 } from "@/types";
 import { ApiError } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 import {
   OpenAIRequestAdapter,
   OpenAIResponseAdapter,
@@ -335,7 +336,7 @@ export const azureAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/cohere.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { ArchestraInternalErrorCode } from "@archestra/shared";
+import type { ArchestraInternalErrorCode } from "@archestra/shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
 import config from "@/config";
@@ -26,6 +26,7 @@ import type {
 import { extractCommonMessageText } from "@/types";
 import type { ToolCompressionStats as CompressionStats } from "../utils/toon-conversion";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 
 // =============================================================================
 // TYPE ALIASES
@@ -930,17 +931,11 @@ function extractErrorMessage(error: unknown): string {
 function extractInternalCode(
   error: unknown,
 ): ArchestraInternalErrorCode | undefined {
-  // Cohere 400 bodies are `{ message: string }` and the context-overflow
-  // messages start with "too many tokens: total number of tokens in the
-  // prompt cannot exceed N". No structured code in the public error schema.
-  const message: unknown = get(error, "error.message") ?? get(error, "message");
-  if (
-    typeof message === "string" &&
-    message.toLowerCase().includes("too many tokens")
-  ) {
-    return ArchestraInternalErrorCode.ContextLengthExceeded;
-  }
-  return undefined;
+  // Cohere 400 bodies are `{ message: string }` with no structured code; the
+  // overflow messages read "too many tokens: …". Classify via the shared vocabulary.
+  return internalCodeFromProviderMessage(
+    get(error, "error.message") ?? get(error, "message"),
+  );
 }
 
 export function getUsageTokens(usage: Cohere.Types.Usage) {

--- a/platform/backend/src/routes/proxy/adapters/context-overflow-patterns.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/context-overflow-patterns.test.ts
@@ -1,15 +1,10 @@
 import { ArchestraInternalErrorCode } from "@archestra/shared";
 import { describe, expect, test } from "vitest";
-import {
-  internalCodeFromProviderMessage,
-  isContextOverflowMessage,
-  isRequestTooLargeMessage,
-} from "./context-overflow-patterns";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 
-describe("isContextOverflowMessage", () => {
+describe("internalCodeFromProviderMessage", () => {
   // Real wordings captured from live providers/gateways plus the phrasings the
-  // per-adapter sniffs already relied on. These are the strings that must classify
-  // as context overflow.
+  // per-adapter sniffs already relied on — all must classify as context overflow.
   test.each([
     // Anthropic native + Bedrock Claude
     "prompt is too long: 201381 tokens > 200000 maximum",
@@ -24,61 +19,51 @@ describe("isContextOverflowMessage", () => {
     "input prompt too long",
     // MiniMax Anthropic-compatible
     "context window exceeds limit (2013)",
-    // Cohere
-    "too many tokens for this model",
+    // Cohere (real full message)
+    "too many tokens: total number of tokens in the prompt cannot exceed 4096",
   ])("classifies overflow: %s", (message) => {
-    expect(isContextOverflowMessage(message)).toBe(true);
     expect(internalCodeFromProviderMessage(message)).toBe(
       ArchestraInternalErrorCode.ContextLengthExceeded,
     );
   });
 
-  // Messages that must NOT be classified as context overflow — guards the
-  // conservative pattern set against false positives.
-  test.each([
-    "total message size 3275158 exceeds limit 2097152", // byte-size, not tokens
-    "Rate limit exceeded, please try again later",
-    "rate_limit_exceeded",
-    "Invalid API key provided",
-    "There was an issue with your request. Please try again.",
-    "stop sequences must be non-empty strings",
-    "Input is too long for requested model", // bare "too long" — intentionally excluded
-  ])("does not classify as overflow: %s", (message) => {
-    expect(isContextOverflowMessage(message)).toBe(false);
-  });
-
-  test("ignores non-string input", () => {
-    expect(isContextOverflowMessage(undefined)).toBe(false);
-    expect(isContextOverflowMessage(null)).toBe(false);
-    expect(isContextOverflowMessage({ message: "prompt is too long" })).toBe(
-      false,
-    );
-  });
-});
-
-describe("isRequestTooLargeMessage", () => {
+  // Request-payload byte-size limits classify as request-too-large, not overflow.
   test.each([
     "total message size 3275158 exceeds limit 2097152",
     "Request Entity Too Large",
     "payload too large",
     "request body exceeds the maximum allowed request size",
   ])("classifies request-too-large: %s", (message) => {
-    expect(isRequestTooLargeMessage(message)).toBe(true);
     expect(internalCodeFromProviderMessage(message)).toBe(
       ArchestraInternalErrorCode.RequestTooLarge,
     );
   });
 
+  // Must stay unclassified — guards the conservative patterns against false
+  // positives, especially token *rate*/quota limits that are not context overflow.
   test.each([
-    "prompt is too long: 201381 tokens > 200000 maximum",
-    "maximum context length is 8192 tokens",
+    "Rate limit exceeded, please try again later",
+    "rate_limit_exceeded",
+    "You have exceeded your token limit for this minute",
+    "too many tokens per minute, slow down",
+    "You've used too many tokens this month; upgrade your plan",
     "Invalid API key provided",
-  ])("does not classify as request-too-large: %s", (message) => {
-    expect(isRequestTooLargeMessage(message)).toBe(false);
+    "There was an issue with your request. Please try again.",
+    "stop sequences must be non-empty strings",
+    "Input is too long for requested model", // bare "too long" — intentionally excluded
+  ])("does not classify: %s", (message) => {
+    expect(internalCodeFromProviderMessage(message)).toBeUndefined();
+  });
+
+  test("ignores non-string input", () => {
+    expect(internalCodeFromProviderMessage(undefined)).toBeUndefined();
+    expect(internalCodeFromProviderMessage(null)).toBeUndefined();
+    expect(
+      internalCodeFromProviderMessage({ message: "prompt is too long" }),
+    ).toBeUndefined();
   });
 
   test("context overflow wins when both could match", () => {
-    // Defensive: a hypothetical message hitting both lists resolves to overflow.
     const message = "maximum context length exceeded; payload too large";
     expect(internalCodeFromProviderMessage(message)).toBe(
       ArchestraInternalErrorCode.ContextLengthExceeded,

--- a/platform/backend/src/routes/proxy/adapters/context-overflow-patterns.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/context-overflow-patterns.test.ts
@@ -1,0 +1,87 @@
+import { ArchestraInternalErrorCode } from "@archestra/shared";
+import { describe, expect, test } from "vitest";
+import {
+  internalCodeFromProviderMessage,
+  isContextOverflowMessage,
+  isRequestTooLargeMessage,
+} from "./context-overflow-patterns";
+
+describe("isContextOverflowMessage", () => {
+  // Real wordings captured from live providers/gateways plus the phrasings the
+  // per-adapter sniffs already relied on. These are the strings that must classify
+  // as context overflow.
+  test.each([
+    // Anthropic native + Bedrock Claude
+    "prompt is too long: 201381 tokens > 200000 maximum",
+    // Kimi via its Anthropic-compatible gateway
+    "Invalid request: Your request exceeded model token limit: 262144 (requested: 566084)",
+    // OpenRouter (MiniMax-M2.7 / DeepSeek-V4-Flash)
+    "This endpoint's maximum context length is 204800 tokens. However, you requested about 309977 tokens (303247 of text input, 6730 of tool input). Please reduce the length of either one.",
+    // OpenAI structured-message variant
+    "This model's maximum context length is 8192 tokens. However, your messages resulted in 8904 tokens.",
+    // Ollama
+    "exceeded max context length",
+    "input prompt too long",
+    // MiniMax Anthropic-compatible
+    "context window exceeds limit (2013)",
+    // Cohere
+    "too many tokens for this model",
+  ])("classifies overflow: %s", (message) => {
+    expect(isContextOverflowMessage(message)).toBe(true);
+    expect(internalCodeFromProviderMessage(message)).toBe(
+      ArchestraInternalErrorCode.ContextLengthExceeded,
+    );
+  });
+
+  // Messages that must NOT be classified as context overflow — guards the
+  // conservative pattern set against false positives.
+  test.each([
+    "total message size 3275158 exceeds limit 2097152", // byte-size, not tokens
+    "Rate limit exceeded, please try again later",
+    "rate_limit_exceeded",
+    "Invalid API key provided",
+    "There was an issue with your request. Please try again.",
+    "stop sequences must be non-empty strings",
+    "Input is too long for requested model", // bare "too long" — intentionally excluded
+  ])("does not classify as overflow: %s", (message) => {
+    expect(isContextOverflowMessage(message)).toBe(false);
+  });
+
+  test("ignores non-string input", () => {
+    expect(isContextOverflowMessage(undefined)).toBe(false);
+    expect(isContextOverflowMessage(null)).toBe(false);
+    expect(isContextOverflowMessage({ message: "prompt is too long" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("isRequestTooLargeMessage", () => {
+  test.each([
+    "total message size 3275158 exceeds limit 2097152",
+    "Request Entity Too Large",
+    "payload too large",
+    "request body exceeds the maximum allowed request size",
+  ])("classifies request-too-large: %s", (message) => {
+    expect(isRequestTooLargeMessage(message)).toBe(true);
+    expect(internalCodeFromProviderMessage(message)).toBe(
+      ArchestraInternalErrorCode.RequestTooLarge,
+    );
+  });
+
+  test.each([
+    "prompt is too long: 201381 tokens > 200000 maximum",
+    "maximum context length is 8192 tokens",
+    "Invalid API key provided",
+  ])("does not classify as request-too-large: %s", (message) => {
+    expect(isRequestTooLargeMessage(message)).toBe(false);
+  });
+
+  test("context overflow wins when both could match", () => {
+    // Defensive: a hypothetical message hitting both lists resolves to overflow.
+    const message = "maximum context length exceeded; payload too large";
+    expect(internalCodeFromProviderMessage(message)).toBe(
+      ArchestraInternalErrorCode.ContextLengthExceeded,
+    );
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/context-overflow-patterns.ts
+++ b/platform/backend/src/routes/proxy/adapters/context-overflow-patterns.ts
@@ -6,10 +6,12 @@ import { ArchestraInternalErrorCode } from "@archestra/shared";
  * them phrase the same condition differently, so keeping one audited pattern list
  * here stops the per-adapter sniffs from drifting (the cause of #3219).
  *
- * Patterns are deliberately conservative: each pairs a context/token noun with an
+ * Patterns are deliberately conservative: each pairs a context/prompt noun with an
  * exceed/limit verb. Bare "too long", "context length", and "reduce the length"
- * are intentionally excluded — they appear in unrelated 400s (field validation,
- * remediation prose) and would misclassify them.
+ * are excluded — they appear in unrelated 400s. The token-budget phrasings
+ * ("token limit", "too many tokens") are anchored to a context/prompt word so a
+ * token *rate*-limit ("exceeded your token limit this minute") is not misread as
+ * context overflow, since this runs on every provider error regardless of status.
  */
 const CONTEXT_OVERFLOW_MESSAGE_PATTERNS: RegExp[] = [
   /prompt is too long/i, // Anthropic native
@@ -19,8 +21,8 @@ const CONTEXT_OVERFLOW_MESSAGE_PATTERNS: RegExp[] = [
   /context length exceeded/i,
   /context window exceed(?:s|ed)?/i, // MiniMax "context window exceeds limit"
   /exceed(?:s|ed)? (?:the |your )?context window/i,
-  /exceed[a-z]* (?:the |your )?(?:model )?token limit/i, // Kimi "exceeded model token limit"
-  /too many tokens/i, // Cohere
+  /exceed(?:s|ed)? (?:the |your )?model token limit/i, // Kimi "exceeded model token limit"
+  /too many tokens\b.*\b(?:prompt|context|input|cannot exceed|maximum)/i, // Cohere
 ];
 
 /**
@@ -34,14 +36,14 @@ const REQUEST_TOO_LARGE_MESSAGE_PATTERNS: RegExp[] = [
   /exceeds the maximum (?:allowed )?(?:request |payload )?size/i,
 ];
 
-export function isContextOverflowMessage(message: unknown): boolean {
+function isContextOverflowMessage(message: unknown): boolean {
   return (
     typeof message === "string" &&
     CONTEXT_OVERFLOW_MESSAGE_PATTERNS.some((p) => p.test(message))
   );
 }
 
-export function isRequestTooLargeMessage(message: unknown): boolean {
+function isRequestTooLargeMessage(message: unknown): boolean {
   return (
     typeof message === "string" &&
     REQUEST_TOO_LARGE_MESSAGE_PATTERNS.some((p) => p.test(message))

--- a/platform/backend/src/routes/proxy/adapters/context-overflow-patterns.ts
+++ b/platform/backend/src/routes/proxy/adapters/context-overflow-patterns.ts
@@ -1,0 +1,66 @@
+import { ArchestraInternalErrorCode } from "@archestra/shared";
+
+/**
+ * Shared vocabulary for classifying a provider's 400 message into a normalized
+ * internal code. Providers and the OpenAI/Anthropic-compatible gateways fronting
+ * them phrase the same condition differently, so keeping one audited pattern list
+ * here stops the per-adapter sniffs from drifting (the cause of #3219).
+ *
+ * Patterns are deliberately conservative: each pairs a context/token noun with an
+ * exceed/limit verb. Bare "too long", "context length", and "reduce the length"
+ * are intentionally excluded — they appear in unrelated 400s (field validation,
+ * remediation prose) and would misclassify them.
+ */
+const CONTEXT_OVERFLOW_MESSAGE_PATTERNS: RegExp[] = [
+  /prompt is too long/i, // Anthropic native
+  /prompt too long/i, // Ollama
+  /maximum context length/i, // OpenAI / OpenRouter / vLLM
+  /exceeded max(?:imum)? context length/i, // Ollama
+  /context length exceeded/i,
+  /context window exceed(?:s|ed)?/i, // MiniMax "context window exceeds limit"
+  /exceed(?:s|ed)? (?:the |your )?context window/i,
+  /exceed[a-z]* (?:the |your )?(?:model )?token limit/i, // Kimi "exceeded model token limit"
+  /too many tokens/i, // Cohere
+];
+
+/**
+ * Request-payload byte-size limits, distinct from context-window overflow: the fix
+ * is to shrink/split the payload, not the conversation. Maps to RequestTooLarge.
+ */
+const REQUEST_TOO_LARGE_MESSAGE_PATTERNS: RegExp[] = [
+  /message size \d+ exceeds limit/i, // e.g. "total message size 3275158 exceeds limit 2097152"
+  /request (?:entity )?too large/i,
+  /payload too large/i,
+  /exceeds the maximum (?:allowed )?(?:request |payload )?size/i,
+];
+
+export function isContextOverflowMessage(message: unknown): boolean {
+  return (
+    typeof message === "string" &&
+    CONTEXT_OVERFLOW_MESSAGE_PATTERNS.some((p) => p.test(message))
+  );
+}
+
+export function isRequestTooLargeMessage(message: unknown): boolean {
+  return (
+    typeof message === "string" &&
+    REQUEST_TOO_LARGE_MESSAGE_PATTERNS.some((p) => p.test(message))
+  );
+}
+
+/**
+ * Classify a raw provider error message into a normalized internal code. Context
+ * overflow wins over request-size when both somehow match, since shrinking the
+ * conversation is the more actionable hint.
+ */
+export function internalCodeFromProviderMessage(
+  message: unknown,
+): ArchestraInternalErrorCode | undefined {
+  if (isContextOverflowMessage(message)) {
+    return ArchestraInternalErrorCode.ContextLengthExceeded;
+  }
+  if (isRequestTooLargeMessage(message)) {
+    return ArchestraInternalErrorCode.RequestTooLarge;
+  }
+  return undefined;
+}

--- a/platform/backend/src/routes/proxy/adapters/groq.ts
+++ b/platform/backend/src/routes/proxy/adapters/groq.ts
@@ -22,6 +22,7 @@ import type {
   LLMResponseAdapter,
   LLMStreamAdapter,
 } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 import {
   OpenAIRequestAdapter,
   OpenAIResponseAdapter,
@@ -274,7 +275,7 @@ export const groqAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/mistral.ts
+++ b/platform/backend/src/routes/proxy/adapters/mistral.ts
@@ -26,6 +26,7 @@ import type {
   LLMStreamAdapter,
   Mistral,
 } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 import {
   OpenAIRequestAdapter,
   OpenAIResponseAdapter,
@@ -285,7 +286,7 @@ export const mistralAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/ollama.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama.ts
@@ -5,12 +5,13 @@
  * configured for Ollama via createOpenAiCompatibleAdapterFactory.
  * See: https://github.com/ollama/ollama/blob/main/docs/openai.md
  */
-import { ArchestraInternalErrorCode } from "@archestra/shared";
+import type { ArchestraInternalErrorCode } from "@archestra/shared";
 import { get } from "lodash-es";
 import OpenAIProvider from "openai";
 import config from "@/config";
 import { metrics } from "@/observability";
 import type { CreateClientOptions } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
 
 export const ollamaAdapterFactory = createOpenAiCompatibleAdapterFactory({
@@ -40,16 +41,6 @@ export const ollamaAdapterFactory = createOpenAiCompatibleAdapterFactory({
   },
   // Ollama returns a plain message (no structured error.code) on context overflow.
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {
-    const message: unknown = get(error, "error.message");
-    if (typeof message === "string") {
-      const msg = message.toLowerCase();
-      if (
-        msg.includes("exceeded max context length") ||
-        msg.includes("prompt too long")
-      ) {
-        return ArchestraInternalErrorCode.ContextLengthExceeded;
-      }
-    }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 });

--- a/platform/backend/src/routes/proxy/adapters/openai-compatible-adapter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-compatible-adapter.ts
@@ -26,6 +26,7 @@ import type {
   LLMStreamAdapter,
   OpenAi,
 } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 import {
   OpenAIRequestAdapter,
   OpenAIResponseAdapter,
@@ -51,8 +52,8 @@ interface OpenAiCompatibleAdapterOptions {
   ) => OpenAIProvider;
   /**
    * Override context-overflow detection. The default matches OpenAI's structured
-   * `error.code === "context_length_exceeded"`; providers that only return a plain
-   * message (vLLM, Ollama) supply their own substring check.
+   * `error.code === "context_length_exceeded"` and falls back to the shared
+   * message vocabulary; providers that signal overflow another way supply their own.
    */
   extractInternalCode?: (
     error: unknown,
@@ -65,7 +66,9 @@ function defaultExtractInternalCode(
   if (get(error, "error.code") === "context_length_exceeded") {
     return ArchestraInternalErrorCode.ContextLengthExceeded;
   }
-  return undefined;
+  return internalCodeFromProviderMessage(
+    get(error, "error.message") ?? get(error, "message"),
+  );
 }
 
 export function createOpenAiCompatibleAdapterFactory(

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -29,6 +29,7 @@ import type {
   UsageView,
 } from "@/types";
 import { ApiError, createStreamAccumulatorState } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 
 type OpenAiResponsesRequest = OpenAi.Types.ResponsesRequest;
 type OpenAiResponsesResponse = OpenAi.Types.ResponsesResponse;
@@ -135,7 +136,7 @@ export const openAiResponsesAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -44,6 +44,7 @@ import {
 } from "../utils/mcp-image";
 import { stripBrowserToolsResults } from "../utils/summarize-tool-results";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 
 // =============================================================================
 // TYPE ALIASES
@@ -1546,7 +1547,7 @@ export const openaiAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "@archestra/shared";
+import { ApiError, ArchestraInternalErrorCode } from "@archestra/shared";
 import { describe, expect, test } from "@/test";
 import type { Openrouter } from "@/types";
 import { openrouterAdapterFactory } from "./openrouter";
@@ -108,5 +108,35 @@ describe("OpenrouterStreamAdapter", () => {
         choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
       }),
     ).not.toThrow();
+  });
+});
+
+describe("extractInternalCode", () => {
+  test("classifies OpenRouter's uncoded 'maximum context length' message as overflow", () => {
+    // OpenRouter returns a descriptive 400 with no structured error.code — the
+    // structured-only check missed it (#3219).
+    const error = {
+      error: {
+        message:
+          "This endpoint's maximum context length is 204800 tokens. However, you requested about 309977 tokens (303247 of text input, 6730 of tool input). Please reduce the length of either one.",
+      },
+    };
+    expect(openrouterAdapterFactory.extractInternalCode?.(error)).toBe(
+      ArchestraInternalErrorCode.ContextLengthExceeded,
+    );
+  });
+
+  test("still classifies the structured context_length_exceeded code", () => {
+    const error = { error: { code: "context_length_exceeded" } };
+    expect(openrouterAdapterFactory.extractInternalCode?.(error)).toBe(
+      ArchestraInternalErrorCode.ContextLengthExceeded,
+    );
+  });
+
+  test("leaves an unrelated 400 unclassified", () => {
+    const error = { error: { message: "invalid model specified" } };
+    expect(
+      openrouterAdapterFactory.extractInternalCode?.(error),
+    ).toBeUndefined();
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.test.ts
@@ -121,22 +121,20 @@ describe("extractInternalCode", () => {
           "This endpoint's maximum context length is 204800 tokens. However, you requested about 309977 tokens (303247 of text input, 6730 of tool input). Please reduce the length of either one.",
       },
     };
-    expect(openrouterAdapterFactory.extractInternalCode?.(error)).toBe(
+    expect(openrouterAdapterFactory.extractInternalCode(error)).toBe(
       ArchestraInternalErrorCode.ContextLengthExceeded,
     );
   });
 
   test("still classifies the structured context_length_exceeded code", () => {
     const error = { error: { code: "context_length_exceeded" } };
-    expect(openrouterAdapterFactory.extractInternalCode?.(error)).toBe(
+    expect(openrouterAdapterFactory.extractInternalCode(error)).toBe(
       ArchestraInternalErrorCode.ContextLengthExceeded,
     );
   });
 
   test("leaves an unrelated 400 unclassified", () => {
     const error = { error: { message: "invalid model specified" } };
-    expect(
-      openrouterAdapterFactory.extractInternalCode?.(error),
-    ).toBeUndefined();
+    expect(openrouterAdapterFactory.extractInternalCode(error)).toBeUndefined();
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -23,6 +23,7 @@ import type {
   Openrouter,
   StreamAccumulatorState,
 } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 import {
   OpenAIRequestAdapter,
   OpenAIResponseAdapter,
@@ -301,7 +302,7 @@ export const openrouterAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/perplexity.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity.ts
@@ -37,6 +37,7 @@ import type {
   UsageView,
 } from "@/types";
 import { extractCommonMessageText } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 
 // =============================================================================
 // TYPE ALIASES
@@ -533,7 +534,7 @@ export const perplexityAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/backend/src/routes/proxy/adapters/vllm.ts
+++ b/platform/backend/src/routes/proxy/adapters/vllm.ts
@@ -5,12 +5,13 @@
  * configured for vLLM via createOpenAiCompatibleAdapterFactory.
  * See: https://docs.vllm.ai/en/latest/features/openai_api.html
  */
-import { ArchestraInternalErrorCode } from "@archestra/shared";
+import type { ArchestraInternalErrorCode } from "@archestra/shared";
 import { get } from "lodash-es";
 import OpenAIProvider from "openai";
 import config from "@/config";
 import { metrics } from "@/observability";
 import type { CreateClientOptions } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
 
 export const vllmAdapterFactory = createOpenAiCompatibleAdapterFactory({
@@ -40,13 +41,6 @@ export const vllmAdapterFactory = createOpenAiCompatibleAdapterFactory({
   },
   // vLLM returns a plain message (no structured error.code) on context overflow.
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {
-    const message: unknown = get(error, "error.message");
-    if (
-      typeof message === "string" &&
-      message.toLowerCase().includes("maximum context length")
-    ) {
-      return ArchestraInternalErrorCode.ContextLengthExceeded;
-    }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 });

--- a/platform/backend/src/routes/proxy/adapters/xai.ts
+++ b/platform/backend/src/routes/proxy/adapters/xai.ts
@@ -22,6 +22,7 @@ import type {
   LLMStreamAdapter,
   Xai,
 } from "@/types";
+import { internalCodeFromProviderMessage } from "./context-overflow-patterns";
 import {
   OpenAIRequestAdapter,
   OpenAIResponseAdapter,
@@ -272,7 +273,7 @@ export const xaiAdapterFactory: LLMProvider<
     if (get(error, "error.code") === "context_length_exceeded") {
       return ArchestraInternalErrorCode.ContextLengthExceeded;
     }
-    return undefined;
+    return internalCodeFromProviderMessage(get(error, "error.message"));
   },
 
   extractErrorMessage(error: unknown): string {

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -22,6 +22,7 @@ import {
  */
 export const ArchestraInternalErrorCode = {
   ContextLengthExceeded: "context_length_exceeded",
+  RequestTooLarge: "request_too_large",
 } as const;
 
 export type ArchestraInternalErrorCode =


### PR DESCRIPTION
Fixes #3219.

## Problem
When a prompt exceeds the model's context window, providers/gateways return a 400 that should classify as `ContextTooLong` (so the user sees "Your conversation is too long…"). Detection lived per-adapter in `extractInternalCode` and only matched each provider's *exact expected* signal — Anthropic's literal `"prompt is too long"` or a structured `error.code === "context_length_exceeded"`. Gateways fronting these providers phrase it differently, so real overflows fell through to the generic `invalid_request` ("There was an issue with your request").

Reproduced live across three models (each genuinely classified as the generic error):
| Model | Upstream message |
|---|---|
| Kimi K2 (Anthropic-compatible gateway) | `Your request exceeded model token limit: 262144 (requested: 566084)` |
| MiniMax M2.7 (OpenRouter) | `maximum context length is 204800 tokens. However, you requested about 309977 tokens…` |
| DeepSeek V4 Flash (OpenRouter) | `maximum context length is 1048576 tokens. However, you requested about 1159977 tokens…` |

## Change
- Add one conservative, audited message vocabulary in `proxy/adapters/context-overflow-patterns.ts` and route every OpenAI- and Anthropic-compatible adapter's `extractInternalCode` through it (structured `error.code` check still wins; message is the fallback). Feeds the existing `internal_code → ContextTooLong` mapping unchanged.
- Token-budget phrasings (`model token limit`, `too many tokens`) are anchored to a context/prompt word so a token *rate*-limit ("exceeded your token limit this minute") is not misread as context overflow — the matcher runs on every provider error regardless of HTTP status.
- Classify upstream byte-size limits (`total message size N exceeds limit M`) as the existing `ChatErrorCode.RequestTooLarge`, via a new `ArchestraInternalErrorCode.RequestTooLarge`.
- Adapters with provider-specific structured/native signals (bedrock, minimax, gemini, zhipuai) left unchanged.

## Tests
- New matcher tests: real captured Kimi/OpenRouter/Cohere strings as positives; quota/rate-limit/byte-size phrasings as negatives.
- Adapter-level wiring tests through `anthropic` and `openrouter` `extractInternalCode`.
- Full proxy suite green; no `errors.test.ts` regression.

https://claude.ai/code/session_01Kij7RShLk7vGyntsN3Yb7C

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>