### PR TITLE
fix(chat): model selector no longer stuck on "Loading models…" for disabled queries

### DIFF
--- a/platform/frontend/src/components/chat/model-selector.test.tsx
+++ b/platform/frontend/src/components/chat/model-selector.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ModelSelector } from "./model-selector";
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as typeof ResizeObserver;
+
+const { useLlmModelsByProviderMock } = vi.hoisted(() => ({
+  useLlmModelsByProviderMock: vi.fn(
+    (): Record<string, unknown> => ({ modelsByProvider: {} }),
+  ),
+}));
+
+vi.mock("@/lib/llm-models.query", () => ({
+  useLlmModelsByProvider: useLlmModelsByProviderMock,
+}));
+
+// The dropdown internals are Radix-based and irrelevant to the branches under
+// test; render only the trigger so assertions target the visible button text.
+vi.mock("@/components/ai-elements/model-selector", () => ({
+  ModelSelector: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ModelSelectorTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ModelSelectorContent: () => null,
+  ModelSelectorList: () => null,
+  ModelSelectorEmpty: () => null,
+  ModelSelectorGroup: () => null,
+  ModelSelectorItem: () => null,
+  ModelSelectorInput: () => null,
+  ModelSelectorLogo: () => null,
+  ModelSelectorName: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+vi.mock("@/components/ai-elements/prompt-input", () => ({
+  PromptInputButton: ({ children, ...props }: { children: ReactNode }) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+type QueryShape = {
+  modelsByProvider: Record<string, unknown[]>;
+  isPending: boolean;
+  isFetching: boolean;
+  isLoading: boolean;
+  isPlaceholderData: boolean;
+};
+
+function setQuery(overrides: Partial<QueryShape>) {
+  useLlmModelsByProviderMock.mockReturnValue({
+    modelsByProvider: {},
+    isPending: false,
+    isFetching: false,
+    isLoading: false,
+    isPlaceholderData: false,
+    ...overrides,
+  });
+}
+
+const model = (over: Record<string, unknown> = {}) => ({
+  dbId: "m1",
+  displayName: "GPT-4o",
+  provider: "openai",
+  isBest: true,
+  ...over,
+});
+
+function renderSelector(
+  props: Partial<React.ComponentProps<typeof ModelSelector>> = {},
+) {
+  const onModelChange = vi.fn();
+  render(
+    <ModelSelector selectedModel="" onModelChange={onModelChange} {...props} />,
+  );
+  return { onModelChange };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setQuery({});
+});
+
+describe("ModelSelector coverage matrix", () => {
+  it("shows the loading spinner while a real fetch is in flight", () => {
+    setQuery({ isPending: true, isFetching: true, isLoading: true });
+    renderSelector({ variant: "default" });
+    expect(screen.getByText("Loading models...")).toBeInTheDocument();
+  });
+
+  // A disabled query is `isPending` yet never fetches, so it must not render the
+  // spinner; with no cached models it falls through to the empty state.
+  it("does not spin forever for a disabled, never-fetching query", () => {
+    setQuery({ isPending: true, isFetching: false, isLoading: false });
+    renderSelector({ variant: "outline", enabled: false });
+    expect(screen.queryByText("Loading models...")).not.toBeInTheDocument();
+    expect(screen.getByText("No models available")).toBeInTheDocument();
+  });
+
+  it("renders the selected model's display name when it is available", () => {
+    setQuery({ modelsByProvider: { openai: [model()] } });
+    renderSelector({ selectedModel: "m1", variant: "default" });
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+  });
+
+  it("auto-selects the best model when the selected one is unavailable", async () => {
+    setQuery({ modelsByProvider: { openai: [model({ isBest: true })] } });
+    const { onModelChange } = renderSelector({
+      selectedModel: "stale-id",
+      variant: "default",
+    });
+    await waitFor(() => expect(onModelChange).toHaveBeenCalledWith("m1"));
+  });
+
+  it("renders the empty-selection placeholder and does not auto-select", () => {
+    setQuery({ modelsByProvider: { openai: [model()] } });
+    const { onModelChange } = renderSelector({
+      selectedModel: "",
+      variant: "outline",
+    });
+    expect(screen.getByText("Best available model")).toBeInTheDocument();
+    expect(onModelChange).not.toHaveBeenCalled();
+  });
+
+  it("renders 'No models available' when the query returns no models", () => {
+    setQuery({ modelsByProvider: {} });
+    renderSelector({ variant: "default" });
+    expect(screen.getByText("No models available")).toBeInTheDocument();
+  });
+
+  it("does not auto-select while showing placeholder data", () => {
+    setQuery({
+      modelsByProvider: { openai: [model()] },
+      isFetching: true,
+      isPlaceholderData: true,
+    });
+    const { onModelChange } = renderSelector({
+      selectedModel: "stale-id",
+      variant: "default",
+    });
+    expect(onModelChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps the pinned model and shows the fallback name when auto-select is suppressed", () => {
+    setQuery({ modelsByProvider: { openai: [model()] } });
+    const { onModelChange } = renderSelector({
+      selectedModel: "pinned-id",
+      suppressAutoSelect: true,
+      fallbackModelName: "Pinned Model",
+      variant: "default",
+    });
+    expect(screen.getByText("Pinned Model")).toBeInTheDocument();
+    expect(onModelChange).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -543,17 +543,11 @@ export const ModelSelector = memo(function ModelSelector({
   suppressAutoSelect = false,
   fallbackModelName,
 }: ModelSelectorProps) {
-  const {
-    modelsByProvider,
-    // `isLoading` (isPending && isFetching) is true only during a real in-flight
-    // fetch. A disabled query (enabled:false) is `isPending` but never fetches,
-    // so keying off `isPending` would spin forever.
-    isLoading,
-    isPlaceholderData,
-  } = useLlmModelsByProvider({
-    apiKeyId: apiKeyId ?? undefined,
-    enabled,
-  });
+  const { modelsByProvider, isLoading, isPlaceholderData } =
+    useLlmModelsByProvider({
+      apiKeyId: apiKeyId ?? undefined,
+      enabled,
+    });
   const [open, setOpen] = useState(false);
   const [filters, setFilters] = useState<ModelFilters>(INITIAL_FILTERS);
 

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -545,7 +545,10 @@ export const ModelSelector = memo(function ModelSelector({
 }: ModelSelectorProps) {
   const {
     modelsByProvider,
-    isPending: isLoading,
+    // `isLoading` (isPending && isFetching) is true only during a real in-flight
+    // fetch. A disabled query (enabled:false) is `isPending` but never fetches,
+    // so keying off `isPending` would spin forever.
+    isLoading,
     isPlaceholderData,
   } = useLlmModelsByProvider({
     apiKeyId: apiKeyId ?? undefined,


### PR DESCRIPTION
The chat/agent model selector keyed its loading state on TanStack Query's `isPending`. In v5, `isPending` is `true` for any query without data — including a **disabled** query (`enabled: false`) that never fetches. So whenever the selector was rendered with its query disabled, it showed a "Loading models…" spinner that never resolved:

- the agent editor when no provider API key is selected (organization default),
- a viewer without `llmModels:read` permission,
- built-in agents, whose dialog never warms the models cache.

The chat still worked (the model resolves server-side), but the selector sat on the spinner indefinitely with no way out.

It now keys on the real in-flight signal — `isLoading` (`isPending && isFetching`), which is `true` only during a genuine first fetch. A disabled query falls through to the existing disabled "No models available" state instead of spinning forever; a real in-flight fetch still shows the spinner.

Behavior is pinned by a new coverage-matrix unit test over the selector's loading / empty / disabled / auto-select states.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>