### PR TITLE
fix(sandbox): clarify file tool descriptions, search_files list-all, download_file overwrite

### DIFF
--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -348,14 +348,14 @@ exports[`skill and sandbox tool text > archestra__save_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__search_files 1`] = `
 {
-  "description": "List or search THIS conversation's persistent files (in a project chat, the project's files). The query is a case-insensitive substring matched against filenames only, not contents — omit it (or pass empty) to list every file, the reliable way to find a file whose exact name you don't know. Returns metadata only — each result carries a stable \`ref\`. To work on a found file, pass its \`ref\` to read_file (read its content), or to upload_file's my_file source (copy it into the sandbox). Requires \`sandbox:execute\`.",
+  "description": "List or search THIS conversation's persistent files (in a project chat, the project's files). The query is a case-insensitive substring matched against filenames only, not contents — omit it (or pass empty) to list the files (the first 200; narrow with a substring if there are more), the way to find a file whose exact name you don't know. Returns metadata only — each result carries a stable \`ref\`. To work on a found file, pass its \`ref\` to read_file (read its content), or to upload_file's my_file source (copy it into the sandbox). Requires \`sandbox:execute\`.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "List or search this conversation's persistent files by filename substring; omit the query to list every file. In a project chat, the project's files instead.",
+    "description": "List or search this conversation's persistent files by filename substring; omit the query to list the files (the first 200). In a project chat, the project's files instead.",
     "properties": {
       "query": {
-        "description": "Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list every file.",
+        "description": "Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list the files (the first 200).",
         "type": "string",
       },
     },

--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -83,7 +83,7 @@ exports[`skill and sandbox tool text > archestra__delete_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__download_file 1`] = `
 {
-  "description": "Copy a file that already exists at a path in the conversation's sandbox into the conversation's persistent files, where it shows up in the chat's Files panel. Use this for anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat attachment under /home/sandbox/attachments/ — the bytes move server-side, so you never read them back or re-type them. To read a skill's own source files, use load_skill with a path instead. Requires \`sandbox:execute\`.",
+  "description": "Copy a file that already exists at a path in the conversation's sandbox into the conversation's persistent files, where it shows up in the chat's Files panel. Use this for anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat attachment under /home/sandbox/attachments/ — the bytes move server-side, so you never read them back or re-type them. Pass \`overwrite: true\` to replace an existing same-named persistent file in place. To read a skill's own source files, use load_skill with a path instead. Requires \`sandbox:execute\`.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
@@ -93,6 +93,11 @@ exports[`skill and sandbox tool text > archestra__download_file 1`] = `
         "description": "Optional MIME type recorded with the file. Sniffed from the bytes when omitted.",
         "minLength": 1,
         "type": "string",
+      },
+      "overwrite": {
+        "default": false,
+        "description": "Replace an existing same-named persistent file in place, keeping its id. Default false errors if the name is already taken.",
+        "type": "boolean",
       },
       "path": {
         "description": "Path to the file inside the container — absolute, or relative to the sandbox's working directory.",
@@ -127,7 +132,7 @@ exports[`skill and sandbox tool text > archestra__download_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__edit_file 1`] = `
 {
-  "description": "Edit an existing persistent file by replacing a snippet, keeping its id and filename. Give the exact \`old_string\` to find (read the file first with read_file) and the \`new_string\` to put in its place; set \`replace_all\` to change every occurrence. Identify the file by \`id\` (from search_files / save_file) or by \`filename\`. Text files only — to replace a binary file, use save_file with overwrite. In a project chat only the project's files can be edited. Requires \`sandbox:execute\`.",
+  "description": "Edit an existing persistent file by replacing a snippet, keeping its id and filename. Give the exact \`old_string\` to find (read the file first with read_file) and the \`new_string\` to put in its place; set \`replace_all\` to change every occurrence. Identify the file by \`id\` (from search_files / save_file) or by \`filename\`. Text files only — to replace a binary file, use save_file with overwrite for inline content, or download_file with overwrite for a file in the sandbox. In a project chat only the project's files can be edited. Requires \`sandbox:execute\`.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,

--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -83,11 +83,11 @@ exports[`skill and sandbox tool text > archestra__delete_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__download_file 1`] = `
 {
-  "description": "Copy a file out of the conversation's sandbox into the conversation's persistent files, where it shows up in the chat's Files panel. Use this for any binary or generated output — run_command only returns text. To read a skill's own source files, use load_skill with a path instead. Requires \`sandbox:execute\`.",
+  "description": "Copy a file that already exists at a path in the conversation's sandbox into the conversation's persistent files, where it shows up in the chat's Files panel. Use this for anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat attachment under /home/sandbox/attachments/ — the bytes move server-side, so you never read them back or re-type them. To read a skill's own source files, use load_skill with a path instead. Requires \`sandbox:execute\`.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Copy a file out of the sandbox into the conversation's persistent files, where it shows up in the chat's Files panel. Use this for any binary or generated output — run_command only returns text. In a project chat the file is saved to the project. (To read a skill's source files, use load_skill with a path.)",
+    "description": "Copy a file that already exists at a path in the sandbox into the conversation's persistent files, where it shows up in the chat's Files panel. Use this for anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat attachment — the bytes move server-side, so you never read them back. In a project chat the file is saved to the project. (To read a skill's source files, use load_skill with a path.)",
     "properties": {
       "mimeType": {
         "description": "Optional MIME type recorded with the file. Sniffed from the bytes when omitted.",
@@ -299,11 +299,11 @@ exports[`skill and sandbox tool text > archestra__run_command 1`] = `
 
 exports[`skill and sandbox tool text > archestra__save_file 1`] = `
 {
-  "description": "Save content you already have — inline text or base64 — straight to the conversation's persistent files (no sandbox needed); it then shows up in the chat's Files panel. Good for results produced in the conversation itself (text, markdown, small data files). Pass \`overwrite: true\` to replace an existing same-named file in place (e.g. a full rewrite); otherwise a duplicate name is rejected. In a project chat the file is saved to the project. For a file that already exists at a path inside the sandbox, use download_file instead. Requires \`sandbox:execute\`.",
+  "description": "Write bytes you are providing inline in this call — text or base64 included in the arguments — to the conversation's persistent files, where they show up in the chat's Files panel. Use this for content that originates in your reply: a summary or note you wrote, a short snippet you are typing out. If the file already exists at a path in the sandbox — you wrote it with a command, or the user attached it — do not read it back and paste its bytes here; export it with download_file by its path instead, so the bytes never pass through the conversation. Pass \`overwrite: true\` to replace an existing same-named file in place (e.g. a full rewrite); otherwise a duplicate name is rejected. In a project chat the file is saved to the project. Requires \`sandbox:execute\`.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Save content you already have (inline text or base64) straight to the conversation's persistent files — no sandbox needed. In a project chat the file is saved to the project.",
+    "description": "Write bytes you provide inline in this call (text or base64 in the arguments) to the conversation's persistent files — for content originating in your reply. If the file already exists at a path in the sandbox (you wrote it, or the user attached it), export it with download_file by its path instead. In a project chat the file is saved to the project.",
     "properties": {
       "content": {
         "description": "UTF-8 text content of the file.",
@@ -343,15 +343,14 @@ exports[`skill and sandbox tool text > archestra__save_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__search_files 1`] = `
 {
-  "description": "Search the persistent files of THIS conversation: files exported with download_file or written with save_file here. Returns metadata only — each result carries a stable \`ref\`. To work on a found file, pass its \`ref\` to read_file (read its content), or to upload_file's my_file source (copy it into the sandbox). In a project chat, searches the project's files instead. Requires \`sandbox:execute\`.",
+  "description": "List or search THIS conversation's persistent files (in a project chat, the project's files). The query is a case-insensitive substring matched against filenames only, not contents — omit it (or pass empty) to list every file, the reliable way to find a file whose exact name you don't know. Returns metadata only — each result carries a stable \`ref\`. To work on a found file, pass its \`ref\` to read_file (read its content), or to upload_file's my_file source (copy it into the sandbox). Requires \`sandbox:execute\`.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Search this conversation's persistent files: files exported with download_file or written with save_file. In a project chat, searches the project's files instead.",
+    "description": "List or search this conversation's persistent files by filename substring; omit the query to list every file. In a project chat, the project's files instead.",
     "properties": {
       "query": {
-        "description": "Case-insensitive substring matched against filenames. Omit to list everything.",
-        "minLength": 1,
+        "description": "Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list every file.",
         "type": "string",
       },
     },

--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -57,11 +57,11 @@ exports[`skill and sandbox tool text > archestra__create_skill 1`] = `
 
 exports[`skill and sandbox tool text > archestra__delete_file 1`] = `
 {
-  "description": "Permanently delete a persistent file, identified by \`id\` (from search_files / save_file) or by \`filename\`. In a project chat only the project's files can be deleted. Requires \`sandbox:execute\`.",
+  "description": "Permanently delete a persistent file, identified by \`id\` (from search_files / save_file) or by \`filename\`.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Permanently delete a persistent file. In a project chat only the project's files can be deleted.",
+    "description": "Permanently delete a persistent file.",
     "properties": {
       "filename": {
         "description": "Filename to delete instead of \`id\`; rejected as ambiguous if more than one file shares the name.",
@@ -83,11 +83,11 @@ exports[`skill and sandbox tool text > archestra__delete_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__download_file 1`] = `
 {
-  "description": "Copy a file that already exists at a path in the conversation's sandbox into the conversation's persistent files, where it shows up in the chat's Files panel. Use this for anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat attachment under /home/sandbox/attachments/ — the bytes move server-side, so you never read them back or re-type them. Pass \`overwrite: true\` to replace an existing same-named persistent file in place. To read a skill's own source files, use load_skill with a path instead. Requires \`sandbox:execute\`.",
+  "description": "Copy a file that already exists at a path in the conversation's sandbox into the conversation's persistent files. Use this for anything on the sandbox's disk — a file run_command wrote (text or binary) or a staged attachment under /home/sandbox/attachments/ — its bytes are not returned to you, so you never read them back or re-type them. Pass \`overwrite: true\` to replace an existing same-named persistent file in place.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Copy a file that already exists at a path in the sandbox into the conversation's persistent files, where it shows up in the chat's Files panel. Use this for anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat attachment — the bytes move server-side, so you never read them back. In a project chat the file is saved to the project. (To read a skill's source files, use load_skill with a path.)",
+    "description": "Copy a file that already exists at a path in the sandbox into the conversation's persistent files. Use this for anything on the sandbox's disk — a file run_command wrote (text or binary) or a staged attachment — its bytes are not returned to you, so you never read them back.",
     "properties": {
       "mimeType": {
         "description": "Optional MIME type recorded with the file. Sniffed from the bytes when omitted.",
@@ -132,11 +132,11 @@ exports[`skill and sandbox tool text > archestra__download_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__edit_file 1`] = `
 {
-  "description": "Edit an existing persistent file by replacing a snippet, keeping its id and filename. Give the exact \`old_string\` to find (read the file first with read_file) and the \`new_string\` to put in its place; set \`replace_all\` to change every occurrence. Identify the file by \`id\` (from search_files / save_file) or by \`filename\`. Text files only — to replace a binary file, use save_file with overwrite for inline content, or download_file with overwrite for a file in the sandbox. In a project chat only the project's files can be edited. Requires \`sandbox:execute\`.",
+  "description": "Edit an existing persistent file by replacing a snippet, keeping its id and filename. Give the exact \`old_string\` to find (read the file first with read_file) and the \`new_string\` to put in its place; set \`replace_all\` to change every occurrence. Identify the file by \`id\` (from search_files / save_file) or by \`filename\`. Text files only — to replace a binary file, use save_file with overwrite for inline content, or download_file with overwrite for a file in the sandbox.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Edit an existing persistent file by replacing a snippet, keeping its id and filename. Give the exact \`old_string\` to find and the \`new_string\` to put in its place; set \`replace_all\` to change every occurrence. Text files only — to replace a binary file, use save_file with overwrite. In a project chat only the project's files can be edited.",
+    "description": "Edit an existing persistent file by replacing a snippet, keeping its id and filename. Give the exact \`old_string\` to find and the \`new_string\` to put in its place; set \`replace_all\` to change every occurrence. Text files only — to replace a binary file, use save_file with overwrite.",
     "properties": {
       "filename": {
         "description": "Filename to edit instead of \`id\`; rejected as ambiguous if more than one file shares the name.",
@@ -215,11 +215,11 @@ exports[`skill and sandbox tool text > archestra__load_skill 1`] = `
 
 exports[`skill and sandbox tool text > archestra__read_file 1`] = `
 {
-  "description": "Read a persistent file directly — no sandbox roundtrip. Text files come back as numbered lines; images (PNG, JPEG, WebP, GIF) are returned inline so you can see them. Identify the file by \`id\` (from search_files / save_file) or by \`filename\`. Page large text files with \`offset\`/\`limit\`. For other binary types, copy the file into the sandbox with upload_file and inspect it with run_command. Only this conversation's files are visible (in a project chat, the project's files). Requires \`sandbox:execute\`.",
+  "description": "Read a persistent file directly, without copying it into the sandbox. Text files come back as numbered lines; images (PNG, JPEG, WebP, GIF) are returned inline so you can view them. Identify the file by \`id\` (the \`id\` or \`ref\` from search_files / save_file) or by \`filename\`. Page large text files with \`offset\`/\`limit\`. For other binary types, copy the file into the sandbox with upload_file and inspect it with run_command.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Read a persistent file directly — no sandbox roundtrip. Text files come back as numbered lines (\`<n>\\t<line>\`); images (PNG, JPEG, WebP, GIF) are returned inline so you can see them. Identify the file by \`id\` (from search_files / save_file) or by \`filename\`. Page large text files with \`offset\`/\`limit\`. For other binary types (PDF, archives, …), copy the file into the sandbox with upload_file + run_command. Only this conversation's files are visible (in a project chat, the project's files). Requires \`sandbox:execute\`.",
+    "description": "Read a persistent file directly, without copying it into the sandbox. Text files come back as numbered lines (\`<n>\\t<line>\`); images (PNG, JPEG, WebP, GIF) are returned inline so you can view them. Identify the file by \`id\` (the \`id\` or \`ref\` from search_files / save_file) or by \`filename\`. Page large text files with \`offset\`/\`limit\`. For other binary types (PDF, archives, …), copy the file into the sandbox with upload_file + run_command.",
     "properties": {
       "filename": {
         "description": "Filename to read instead of \`id\`; rejected as ambiguous if more than one file shares the name.",
@@ -253,7 +253,7 @@ exports[`skill and sandbox tool text > archestra__read_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__run_command 1`] = `
 {
-  "description": "Execute a shell command in the conversation's sandbox (Debian, working dir /home/sandbox). Created on first use and persists across calls — files written by one command are visible to the next. Python runs in a uv project at /home/sandbox: \`python3\` is the project venv; install packages with \`uv add --project /home/sandbox <pkg>\` (pip is disabled). Files the user attached to the chat are auto-staged under /home/sandbox/attachments/. Loaded skills are mounted under /skills and are on PYTHONPATH, so their modules import directly. Returns stdout, stderr, exit code, and timing (text only — use download_file for generated files). Requires \`sandbox:execute\`.",
+  "description": "Execute a shell command in the conversation's sandbox (Debian, working dir /home/sandbox). Created on first use and persists across calls — files written by one command are visible to the next. Python runs in a uv project at /home/sandbox: \`python3\` is the project venv; install packages with \`uv add --project /home/sandbox <pkg>\` (pip is disabled). Files the user attached to the conversation are staged under /home/sandbox/attachments/. Loaded skills are mounted under /skills and are on PYTHONPATH, so their modules import directly. Returns stdout, stderr, exit code, and timing (text only — use download_file for generated files).",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
@@ -304,11 +304,11 @@ exports[`skill and sandbox tool text > archestra__run_command 1`] = `
 
 exports[`skill and sandbox tool text > archestra__save_file 1`] = `
 {
-  "description": "Write bytes you are providing inline in this call — text or base64 included in the arguments — to the conversation's persistent files, where they show up in the chat's Files panel. Use this for content that originates in your reply: a summary or note you wrote, a short snippet you are typing out. If the file already exists at a path in the sandbox — you wrote it with a command, or the user attached it — do not read it back and paste its bytes here; export it with download_file by its path instead, so the bytes never pass through the conversation. Pass \`overwrite: true\` to replace an existing same-named file in place (e.g. a full rewrite); otherwise a duplicate name is rejected. In a project chat the file is saved to the project. Requires \`sandbox:execute\`.",
+  "description": "Write bytes you are providing inline in this call — text or base64 included in the arguments — to the conversation's persistent files. Use this for content that originates in your reply: a summary or note you wrote, a short snippet you are typing out. If the content already exists as a file in the sandbox — you wrote it with a command, or the user attached it — do not read it back and paste its bytes here; export it with download_file by its path instead, so the bytes never enter your context. Pass \`overwrite: true\` to replace an existing same-named file in place (e.g. a full rewrite); otherwise a duplicate name is rejected.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Write bytes you provide inline in this call (text or base64 in the arguments) to the conversation's persistent files — for content originating in your reply. If the file already exists at a path in the sandbox (you wrote it, or the user attached it), export it with download_file by its path instead. In a project chat the file is saved to the project.",
+    "description": "Write bytes you provide inline in this call (text or base64 in the arguments) to the conversation's persistent files — for content originating in your reply. If the content already exists as a file in the sandbox (you wrote it, or the user attached it), export it with download_file by its path instead, so the bytes never enter your context.",
     "properties": {
       "content": {
         "description": "UTF-8 text content of the file.",
@@ -348,11 +348,11 @@ exports[`skill and sandbox tool text > archestra__save_file 1`] = `
 
 exports[`skill and sandbox tool text > archestra__search_files 1`] = `
 {
-  "description": "List or search THIS conversation's persistent files (in a project chat, the project's files). The query is a case-insensitive substring matched against filenames only, not contents — omit it (or pass empty) to list the files (the first 200; narrow with a substring if there are more), the way to find a file whose exact name you don't know. Returns metadata only — each result carries a stable \`ref\`. To work on a found file, pass its \`ref\` to read_file (read its content), or to upload_file's my_file source (copy it into the sandbox). Requires \`sandbox:execute\`.",
+  "description": "List or search the conversation's persistent files. The query is a case-insensitive substring matched against filenames only, not contents — omit it (or pass empty) to list the files (the first 200; narrow with a substring if there are more). Returns metadata only — each result carries a stable \`ref\` you pass to read_file, edit_file, or delete_file, or to upload_file to copy the file into the sandbox.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "List or search this conversation's persistent files by filename substring; omit the query to list the files (the first 200). In a project chat, the project's files instead.",
+    "description": "List or search the conversation's persistent files by filename substring; omit the query to list the files (the first 200). Filenames only, not contents.",
     "properties": {
       "query": {
         "description": "Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list the files (the first 200).",
@@ -429,11 +429,11 @@ exports[`skill and sandbox tool text > archestra__update_skill 1`] = `
 
 exports[`skill and sandbox tool text > archestra__upload_file 1`] = `
 {
-  "description": "Upload a file into the conversation's sandbox from a chat attachment, inline base64, inline text, or a file from the user's persistent files (the my_file source). The bytes become part of the sandbox recipe, so the file is present on every later run_command and download_file call. Note: files the user attached to the chat are already auto-staged under /home/sandbox/attachments/ — use this tool to write inline content, place a file at a specific path, or upload into a non-default sandbox. Requires \`sandbox:execute\`.",
+  "description": "Place a file into the conversation's sandbox at a path, from a chat attachment, inline base64, inline text, or one of your persistent files. The file then persists in the sandbox for later commands. Files the user attached to the conversation are already staged under /home/sandbox/attachments/ — use this tool to write inline content, place a file at a specific path, or target a non-default sandbox.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Upload a file into the conversation's sandbox. The bytes become part of the sandbox recipe, so the file is present on every subsequent run_command and download_file call.",
+    "description": "Place a file into the conversation's sandbox. The file persists in the sandbox for every later command.",
     "properties": {
       "path": {
         "description": "Destination path inside the container — absolute under /skills or /home/sandbox, or relative to the sandbox's working directory.",
@@ -448,7 +448,7 @@ exports[`skill and sandbox tool text > archestra__upload_file 1`] = `
             "description": "Copy bytes from a file the user attached to this conversation.",
             "properties": {
               "attachmentId": {
-                "description": "Id of an attachment in the CURRENT conversation. The bytes are read server-side; they never pass through the model context.",
+                "description": "Id of an attachment in the current conversation. The bytes are copied directly and never enter your context.",
                 "minLength": 1,
                 "type": "string",
               },

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -743,6 +743,7 @@ describe("sandbox tools (runtime enabled)", () => {
           mimeType: "text/plain",
           sizeBytes: 42,
           stagingNotices: [],
+          overwritten: false,
         });
 
       const result = await executeArchestraTool(
@@ -788,6 +789,7 @@ describe("sandbox tools (runtime enabled)", () => {
         mimeType: "image/png",
         sizeBytes: 256,
         stagingNotices: [],
+        overwritten: false,
       });
 
       const result = await executeArchestraTool(
@@ -847,6 +849,114 @@ describe("sandbox tools (runtime enabled)", () => {
       await expect(
         skillSandboxRuntimeService.exportArtifact(params),
       ).rejects.toBeInstanceOf(FileNameExistsError);
+    });
+
+    // overwrite replaces the same-named persistent file in place (keeps its id)
+    // instead of colliding, so a regenerated sandbox file can supersede the one
+    // exported earlier. Only the Dagger boundary is stubbed.
+    test("exportArtifact with overwrite replaces an existing file in place", async () => {
+      const sandbox = await SkillSandboxModel.create({
+        organizationId,
+        userId,
+        conversationId: null,
+        defaultCwd: "/home/sandbox",
+      });
+      vi.spyOn(sandboxRuntimeService, "isEnabled", "get").mockReturnValue(true);
+      const readSpy = vi.spyOn(sandboxRuntimeService, "readArtifact");
+
+      const params = {
+        sandboxId: asSandboxId(sandbox.id),
+        caller: { userId, organizationId },
+        path: "out/result.txt",
+        projectId: null,
+      };
+
+      readSpy.mockResolvedValue({
+        dataBase64: Buffer.from("v1").toString("base64"),
+        sizeBytes: 2,
+      });
+      const first = await skillSandboxRuntimeService.exportArtifact(params);
+      expect(first.overwritten).toBe(false);
+
+      readSpy.mockResolvedValue({
+        dataBase64: Buffer.from("version-two").toString("base64"),
+        sizeBytes: 11,
+      });
+      const second = await skillSandboxRuntimeService.exportArtifact({
+        ...params,
+        overwrite: true,
+      });
+      expect(second.overwritten).toBe(true);
+      expect(second.artifactId).toBe(first.artifactId);
+      expect(second.sizeBytes).toBe(Buffer.from("version-two").byteLength);
+    });
+
+    // Conversation scope resolves the existing file via resolveMyFileRef (not the
+    // orphan path) before replacing it in place.
+    test("exportArtifact overwrite replaces in place within a conversation scope", async () => {
+      const conversation = await ConversationModel.create({
+        userId,
+        organizationId,
+        agentId: agent.id,
+        title: "overwrite conv",
+      });
+      const sandbox = await SkillSandboxModel.create({
+        organizationId,
+        userId,
+        conversationId: conversation.id,
+        defaultCwd: "/home/sandbox",
+      });
+      vi.spyOn(sandboxRuntimeService, "isEnabled", "get").mockReturnValue(true);
+      const readSpy = vi.spyOn(sandboxRuntimeService, "readArtifact");
+      const params = {
+        sandboxId: asSandboxId(sandbox.id),
+        caller: { userId, organizationId },
+        path: "out/data.txt",
+        projectId: null,
+      };
+
+      readSpy.mockResolvedValue({
+        dataBase64: Buffer.from("one").toString("base64"),
+        sizeBytes: 3,
+      });
+      const first = await skillSandboxRuntimeService.exportArtifact(params);
+
+      readSpy.mockResolvedValue({
+        dataBase64: Buffer.from("two!").toString("base64"),
+        sizeBytes: 4,
+      });
+      const second = await skillSandboxRuntimeService.exportArtifact({
+        ...params,
+        overwrite: true,
+      });
+      expect(second.overwritten).toBe(true);
+      expect(second.artifactId).toBe(first.artifactId);
+      expect(second.sizeBytes).toBe(4);
+    });
+
+    // overwrite with no existing same-named file creates it (overwritten: false),
+    // exercising the not-found → create fall-through.
+    test("exportArtifact overwrite creates the file when none exists", async () => {
+      const sandbox = await SkillSandboxModel.create({
+        organizationId,
+        userId,
+        conversationId: null,
+        defaultCwd: "/home/sandbox",
+      });
+      vi.spyOn(sandboxRuntimeService, "isEnabled", "get").mockReturnValue(true);
+      vi.spyOn(sandboxRuntimeService, "readArtifact").mockResolvedValue({
+        dataBase64: Buffer.from("fresh").toString("base64"),
+        sizeBytes: 5,
+      });
+
+      const result = await skillSandboxRuntimeService.exportArtifact({
+        sandboxId: asSandboxId(sandbox.id),
+        caller: { userId, organizationId },
+        path: "out/new.txt",
+        projectId: null,
+        overwrite: true,
+      });
+      expect(result.overwritten).toBe(false);
     });
   });
 
@@ -1364,6 +1474,7 @@ describe("PFS tools (search_files, my_file source, download_file project)", () =
           mimeType: "text/plain",
           sizeBytes: 3,
           stagingNotices: [],
+          overwritten: false,
         });
 
       const result = await executeArchestraTool(
@@ -1400,6 +1511,7 @@ describe("PFS tools (search_files, my_file source, download_file project)", () =
           mimeType: "text/plain",
           sizeBytes: 3,
           stagingNotices: [],
+          overwritten: false,
         });
 
       const result = await executeArchestraTool(

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -1229,6 +1229,22 @@ describe("PFS tools (search_files, my_file source, download_file project)", () =
       ]);
       expect(allOut.files.every((f) => f.id)).toBe(true);
 
+      // A model that passes an empty string instead of omitting the query must browse,
+      // not hit a validation error: the schema accepts "" and lists every file.
+      const emptyQuery = await executeArchestraTool(
+        TOOL_SEARCH_FILES_FULL_NAME,
+        { query: "" },
+        ctx,
+      );
+      expect(emptyQuery.isError).toBe(false);
+      const emptyOut = structuredOf<{ files: Array<{ filename: string }> }>(
+        emptyQuery,
+      );
+      expect(emptyOut.files.map((f) => f.filename).sort()).toEqual([
+        "notes.txt",
+        "q2-report.txt",
+      ]);
+
       const filtered = await executeArchestraTool(
         TOOL_SEARCH_FILES_FULL_NAME,
         { query: "REPORT" },

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -2815,7 +2815,6 @@ describe("projects feature gating (search_files / save_file / my_file)", () => {
         { ...context, conversationId: conversation.id },
       );
       expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain("my_file");
       expect(spy).not.toHaveBeenCalled();
     });
   });

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -205,10 +205,9 @@ const DownloadFileSchema = z
   })
   .describe(
     "Copy a file that already exists at a path in the sandbox into the conversation's persistent " +
-      "files, where it shows up in the chat's Files panel. Use this for anything on the sandbox's " +
-      "disk — a file run_command wrote (text or binary) or a chat attachment — the bytes move " +
-      "server-side, so you never read them back. In a project chat the file is saved to the " +
-      "project. (To read a skill's source files, use load_skill with a path.)",
+      "files. Use this for anything on the sandbox's disk — a file run_command wrote (text or " +
+      "binary) or a staged attachment — its bytes are not returned to you, so you never read " +
+      "them back.",
   );
 
 const DownloadFileOutputSchema = z.object({
@@ -240,8 +239,8 @@ const UploadSourceSchema = z.discriminatedUnion("type", [
           "must be the attachment's id, not its filename",
         )
         .describe(
-          "Id of an attachment in the CURRENT conversation. The bytes are " +
-            "read server-side; they never pass through the model context.",
+          "Id of an attachment in the current conversation. The bytes are " +
+            "copied directly and never enter your context.",
         ),
     })
     .describe("Copy bytes from a file the user attached to this conversation."),
@@ -314,9 +313,8 @@ const UploadFileSchema = z
     target: SandboxTargetSchema,
   })
   .describe(
-    "Upload a file into the conversation's sandbox. The bytes become part of " +
-      "the sandbox recipe, so the file is present on every subsequent " +
-      "run_command and download_file call.",
+    "Place a file into the conversation's sandbox. The file persists in the " +
+      "sandbox for every later command.",
   );
 
 const UploadFileOutputSchema = z.object({
@@ -337,8 +335,8 @@ const SearchFilesSchema = z
       ),
   })
   .describe(
-    "List or search this conversation's persistent files by filename substring; " +
-      "omit the query to list the files (the first 200). In a project chat, the project's files instead.",
+    "List or search the conversation's persistent files by filename substring; " +
+      "omit the query to list the files (the first 200). Filenames only, not contents.",
   );
 
 const SearchFilesOutputSchema = z.object({
@@ -399,14 +397,12 @@ const ReadFileSchema = z
     message: "provide exactly one of `id` or `filename`",
   })
   .describe(
-    "Read a persistent file directly — no sandbox roundtrip. Text " +
+    "Read a persistent file directly, without copying it into the sandbox. Text " +
       "files come back as numbered lines (`<n>\\t<line>`); images (PNG, JPEG, " +
-      "WebP, GIF) are returned inline so you can see them. Identify the file by " +
-      "`id` (from search_files / save_file) or by `filename`. Page large text " +
-      "files with `offset`/`limit`. For other binary types (PDF, archives, …), " +
-      "copy the file into the sandbox with upload_file + run_command. Only this " +
-      "conversation's files are visible (in a project chat, the project's " +
-      "files). Requires `sandbox:execute`.",
+      "WebP, GIF) are returned inline so you can view them. Identify the file by " +
+      "`id` (the `id` or `ref` from search_files / save_file) or by `filename`. Page " +
+      "large text files with `offset`/`limit`. For other binary types (PDF, archives, " +
+      "…), copy the file into the sandbox with upload_file + run_command.",
   );
 
 const ReadFileOutputSchema = z.object({
@@ -469,9 +465,9 @@ const SaveFileSchema = z
   })
   .describe(
     "Write bytes you provide inline in this call (text or base64 in the arguments) to the " +
-      "conversation's persistent files — for content originating in your reply. If the file " +
-      "already exists at a path in the sandbox (you wrote it, or the user attached it), export it " +
-      "with download_file by its path instead. In a project chat the file is saved to the project.",
+      "conversation's persistent files — for content originating in your reply. If the content " +
+      "already exists as a file in the sandbox (you wrote it, or the user attached it), export it " +
+      "with download_file by its path instead, so the bytes never enter your context.",
   );
 
 const SaveFileOutputSchema = z.object({
@@ -533,7 +529,7 @@ const EditFileSchema = z
       "its id and filename. Give the exact `old_string` to find and the " +
       "`new_string` to put in its place; set `replace_all` to change every " +
       "occurrence. Text files only — to replace a binary file, use save_file " +
-      "with overwrite. In a project chat only the project's files can be edited.",
+      "with overwrite.",
   );
 
 const EditFileOutputSchema = z.object({
@@ -564,10 +560,7 @@ const DeleteFileSchema = z
   .refine((v) => (v.id != null) !== (v.filename != null), {
     message: "provide exactly one of `id` or `filename`",
   })
-  .describe(
-    "Permanently delete a persistent file. In a project chat only " +
-      "the project's files can be deleted.",
-  );
+  .describe("Permanently delete a persistent file.");
 
 const DeleteFileOutputSchema = z.object({
   fileId: z.string(),
@@ -585,11 +578,11 @@ const registry = defineArchestraTools([
       "calls — files written by one command are visible to the next. Python " +
       "runs in a uv project at /home/sandbox: `python3` is the project venv; " +
       "install packages with `uv add --project /home/sandbox <pkg>` (pip is " +
-      `disabled). Files the user attached to the chat are auto-staged under ${SKILL_SANDBOX_ATTACHMENTS_DIR}/. ` +
+      `disabled). Files the user attached to the conversation are staged under ${SKILL_SANDBOX_ATTACHMENTS_DIR}/. ` +
       "Loaded skills are mounted under /skills and are on PYTHONPATH, so " +
       "their modules import directly. Returns stdout, stderr, " +
       "exit code, and timing (text only — use download_file for generated " +
-      "files). Requires `sandbox:execute`.",
+      "files).",
     schema: RunCommandSchema,
     outputSchema: RunCommandOutputSchema,
     async handler({ args, context }) {
@@ -641,12 +634,11 @@ const registry = defineArchestraTools([
     title: "Download File",
     description:
       "Copy a file that already exists at a path in the conversation's sandbox into the " +
-      "conversation's persistent files, where it shows up in the chat's Files panel. Use this for " +
-      "anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat " +
-      `attachment under ${SKILL_SANDBOX_ATTACHMENTS_DIR}/ — the bytes move server-side, so you ` +
-      "never read them back or re-type them. Pass `overwrite: true` to replace an existing " +
-      "same-named persistent file in place. To read a skill's own source files, use load_skill " +
-      "with a path instead. Requires `sandbox:execute`.",
+      "conversation's persistent files. Use this for anything on the sandbox's disk — a file " +
+      "run_command wrote (text or binary) or a staged attachment under " +
+      `${SKILL_SANDBOX_ATTACHMENTS_DIR}/ — its bytes are not returned to you, so you never read ` +
+      "them back or re-type them. Pass `overwrite: true` to replace an existing same-named " +
+      "persistent file in place.",
     schema: DownloadFileSchema,
     outputSchema: DownloadFileOutputSchema,
     async handler({ args, context }) {
@@ -704,7 +696,7 @@ const registry = defineArchestraTools([
             overwritten: result.overwritten,
           },
           withStagingNotices(
-            `${result.overwritten ? "Replaced" : "Saved"} ${result.path} (${result.sizeBytes} bytes). It is available in the Files panel.`,
+            `${result.overwritten ? "Replaced" : "Saved"} ${result.path} (${result.sizeBytes} bytes) to the conversation's persistent files.`,
             result.stagingNotices,
           ),
         );
@@ -717,13 +709,12 @@ const registry = defineArchestraTools([
     shortName: TOOL_UPLOAD_FILE_SHORT_NAME,
     title: "Upload File",
     description:
-      "Upload a file into the conversation's sandbox from a chat attachment, " +
-      "inline base64, inline text, or a file from the user's persistent " +
-      "files (the my_file source). The bytes become part of the sandbox " +
-      "recipe, so the file is present on every later run_command and " +
-      `download_file call. Note: files the user attached to the chat are already auto-staged under ${SKILL_SANDBOX_ATTACHMENTS_DIR}/ — use this tool ` +
-      "to write inline content, place a file at a specific path, or upload " +
-      "into a non-default sandbox. Requires `sandbox:execute`.",
+      "Place a file into the conversation's sandbox at a path, from a chat " +
+      "attachment, inline base64, inline text, or one of your persistent " +
+      "files. The file then persists in the sandbox for later commands. " +
+      `Files the user attached to the conversation are already staged under ${SKILL_SANDBOX_ATTACHMENTS_DIR}/ — use this tool ` +
+      "to write inline content, place a file at a specific path, or target a " +
+      "non-default sandbox.",
     schema: UploadFileSchema,
     outputSchema: UploadFileOutputSchema,
     async handler({ args, context }) {
@@ -732,7 +723,7 @@ const registry = defineArchestraTools([
 
       if (!config.projects.enabled && args.source.type === "my_file") {
         return errorResult(
-          "Referencing persistent files (the my_file source) is not available on this deployment.",
+          "Copying one of the user's saved files into the sandbox is not available on this deployment.",
         );
       }
 
@@ -796,14 +787,12 @@ const registry = defineArchestraTools([
     shortName: TOOL_SEARCH_FILES_SHORT_NAME,
     title: "Search Files",
     description:
-      "List or search THIS conversation's persistent files (in a project chat, the " +
-      "project's files). The query is a case-insensitive substring matched against " +
-      "filenames only, not contents — omit it (or pass empty) to list the files (the " +
-      "first 200; narrow with a substring if there are more), the way to find a file " +
-      "whose exact name you don't know. Returns metadata only — each result carries a " +
-      "stable `ref`. To work on a found file, pass its `ref` to read_file (read its " +
-      "content), or to upload_file's my_file source (copy it into the sandbox). " +
-      "Requires `sandbox:execute`.",
+      "List or search the conversation's persistent files. The query is a " +
+      "case-insensitive substring matched against filenames only, not contents — omit " +
+      "it (or pass empty) to list the files (the first 200; narrow with a substring if " +
+      "there are more). Returns metadata only — each result carries a stable `ref` you " +
+      "pass to read_file, edit_file, or delete_file, or to upload_file to copy the file " +
+      "into the sandbox.",
     schema: SearchFilesSchema,
     outputSchema: SearchFilesOutputSchema,
     async handler({ args, context }) {
@@ -870,14 +859,12 @@ const registry = defineArchestraTools([
     shortName: TOOL_READ_FILE_SHORT_NAME,
     title: "Read File",
     description:
-      "Read a persistent file directly — no sandbox roundtrip. Text " +
+      "Read a persistent file directly, without copying it into the sandbox. Text " +
       "files come back as numbered lines; images (PNG, JPEG, WebP, GIF) are " +
-      "returned inline so you can see them. Identify the file by `id` (from " +
-      "search_files / save_file) or by `filename`. Page large text files with " +
-      "`offset`/`limit`. For other binary types, copy " +
-      "the file into the sandbox with upload_file and inspect it with " +
-      "run_command. Only this conversation's files are visible (in a project " +
-      "chat, the project's files). Requires `sandbox:execute`.",
+      "returned inline so you can view them. Identify the file by `id` (the `id` or " +
+      "`ref` from search_files / save_file) or by `filename`. Page large text files " +
+      "with `offset`/`limit`. For other binary types, copy the file into the sandbox " +
+      "with upload_file and inspect it with run_command.",
     schema: ReadFileSchema,
     outputSchema: ReadFileOutputSchema,
     async handler({ args, context }) {
@@ -1059,14 +1046,13 @@ const registry = defineArchestraTools([
     title: "Save File",
     description:
       "Write bytes you are providing inline in this call — text or base64 included in the " +
-      "arguments — to the conversation's persistent files, where they show up in the chat's Files " +
-      "panel. Use this for content that originates in your reply: a summary or note you wrote, a " +
-      "short snippet you are typing out. If the file already exists at a path in the sandbox — you " +
-      "wrote it with a command, or the user attached it — do not read it back and paste its bytes " +
-      "here; export it with download_file by its path instead, so the bytes never pass through the " +
-      "conversation. Pass `overwrite: true` to replace an existing same-named file in place (e.g. a " +
-      "full rewrite); otherwise a duplicate name is rejected. In a project chat the file is saved " +
-      "to the project. Requires `sandbox:execute`.",
+      "arguments — to the conversation's persistent files. Use this for content that originates " +
+      "in your reply: a summary or note you wrote, a short snippet you are typing out. If the " +
+      "content already exists as a file in the sandbox — you wrote it with a command, or the user " +
+      "attached it — do not read it back and paste its bytes here; export it with download_file by " +
+      "its path instead, so the bytes never enter your context. Pass `overwrite: true` to replace " +
+      "an existing same-named file in place (e.g. a full rewrite); otherwise a duplicate name is " +
+      "rejected.",
     schema: SaveFileSchema,
     outputSchema: SaveFileOutputSchema,
     async handler({ args, context }) {
@@ -1202,8 +1188,7 @@ const registry = defineArchestraTools([
       "set `replace_all` to change every occurrence. Identify the file by `id` " +
       "(from search_files / save_file) or by `filename`. Text files only — to " +
       "replace a binary file, use save_file with overwrite for inline content, or " +
-      "download_file with overwrite for a file in the sandbox. In a project chat " +
-      "only the project's files can be edited. Requires `sandbox:execute`.",
+      "download_file with overwrite for a file in the sandbox.",
     schema: EditFileSchema,
     outputSchema: EditFileOutputSchema,
     async handler({ args, context }) {
@@ -1326,8 +1311,7 @@ const registry = defineArchestraTools([
     title: "Delete File",
     description:
       "Permanently delete a persistent file, identified by `id` " +
-      "(from search_files / save_file) or by `filename`. In a project chat " +
-      "only the project's files can be deleted. Requires `sandbox:execute`.",
+      "(from search_files / save_file) or by `filename`.",
     schema: DeleteFileSchema,
     outputSchema: DeleteFileOutputSchema,
     async handler({ args, context }) {

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -196,9 +196,10 @@ const DownloadFileSchema = z
     target: SandboxTargetSchema,
   })
   .describe(
-    "Copy a file out of the sandbox into the conversation's persistent files, where it shows up in " +
-      "the chat's Files panel. Use this for any binary or generated output — " +
-      "run_command only returns text. In a project chat the file is saved to the " +
+    "Copy a file that already exists at a path in the sandbox into the conversation's persistent " +
+      "files, where it shows up in the chat's Files panel. Use this for anything on the sandbox's " +
+      "disk — a file run_command wrote (text or binary) or a chat attachment — the bytes move " +
+      "server-side, so you never read them back. In a project chat the file is saved to the " +
       "project. (To read a skill's source files, use load_skill with a path.)",
   );
 
@@ -319,16 +320,14 @@ const SearchFilesSchema = z
   .strictObject({
     query: z
       .string()
-      .min(1)
       .optional()
       .describe(
-        "Case-insensitive substring matched against filenames. Omit to list everything.",
+        "Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list every file.",
       ),
   })
   .describe(
-    "Search this conversation's persistent files: files exported with " +
-      "download_file or written with save_file. In a project chat, searches the " +
-      "project's files instead.",
+    "List or search this conversation's persistent files by filename substring; " +
+      "omit the query to list every file. In a project chat, the project's files instead.",
   );
 
 const SearchFilesOutputSchema = z.object({
@@ -458,9 +457,10 @@ const SaveFileSchema = z
     message: "provide exactly one of `content` or `contentBase64`",
   })
   .describe(
-    "Save content you already have (inline text or base64) straight to the " +
-      "conversation's persistent files — no sandbox needed. In a project chat " +
-      "the file is saved to the project.",
+    "Write bytes you provide inline in this call (text or base64 in the arguments) to the " +
+      "conversation's persistent files — for content originating in your reply. If the file " +
+      "already exists at a path in the sandbox (you wrote it, or the user attached it), export it " +
+      "with download_file by its path instead. In a project chat the file is saved to the project.",
   );
 
 const SaveFileOutputSchema = z.object({
@@ -629,10 +629,12 @@ const registry = defineArchestraTools([
     shortName: TOOL_DOWNLOAD_FILE_SHORT_NAME,
     title: "Download File",
     description:
-      "Copy a file out of the conversation's sandbox into the conversation's persistent files, where " +
-      "it shows up in the chat's Files panel. Use this for any binary or " +
-      "generated output — run_command only returns text. To read a skill's own " +
-      "source files, use load_skill with a path instead. Requires `sandbox:execute`.",
+      "Copy a file that already exists at a path in the conversation's sandbox into the " +
+      "conversation's persistent files, where it shows up in the chat's Files panel. Use this for " +
+      "anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat " +
+      `attachment under ${SKILL_SANDBOX_ATTACHMENTS_DIR}/ — the bytes move server-side, so you ` +
+      "never read them back or re-type them. To read a skill's own source files, use load_skill " +
+      "with a path instead. Requires `sandbox:execute`.",
     schema: DownloadFileSchema,
     outputSchema: DownloadFileOutputSchema,
     async handler({ args, context }) {
@@ -780,12 +782,13 @@ const registry = defineArchestraTools([
     shortName: TOOL_SEARCH_FILES_SHORT_NAME,
     title: "Search Files",
     description:
-      "Search the persistent files of THIS conversation: files exported with " +
-      "download_file or written with save_file here. Returns metadata only — " +
-      "each result carries a stable `ref`. To work on a found file, pass its " +
-      "`ref` to read_file (read its content), or to upload_file's my_file source " +
-      "(copy it into the sandbox). In a project chat, searches the project's " +
-      "files instead. Requires `sandbox:execute`.",
+      "List or search THIS conversation's persistent files (in a project chat, the " +
+      "project's files). The query is a case-insensitive substring matched against " +
+      "filenames only, not contents — omit it (or pass empty) to list every file, " +
+      "the reliable way to find a file whose exact name you don't know. Returns " +
+      "metadata only — each result carries a stable `ref`. To work on a found file, " +
+      "pass its `ref` to read_file (read its content), or to upload_file's my_file " +
+      "source (copy it into the sandbox). Requires `sandbox:execute`.",
     schema: SearchFilesSchema,
     outputSchema: SearchFilesOutputSchema,
     async handler({ args, context }) {
@@ -820,8 +823,11 @@ const registry = defineArchestraTools([
         query: args.query,
       });
 
+      // Cap an empty/broad query so a large project can't dump its whole file list into context.
+      const MAX_LISTED_FILES = 200;
+      const shown = matches.slice(0, MAX_LISTED_FILES);
       const result = {
-        files: matches.map((f) => ({
+        files: shown.map((f) => ({
           id: f.id,
           ref: f.downloadRef,
           filename: f.filename,
@@ -833,12 +839,15 @@ const registry = defineArchestraTools([
       const summary =
         matches.length === 0
           ? "No persistent files matched."
-          : matches
+          : shown
               .map(
                 (f) =>
                   `${f.filename} (${f.mimeType}, ${f.sizeBytes} bytes) ref=${f.downloadRef}`,
               )
-              .join("\n");
+              .join("\n") +
+            (matches.length > MAX_LISTED_FILES
+              ? `\n(showing the first ${MAX_LISTED_FILES} of ${matches.length}; narrow with a filename substring.)`
+              : "");
       return structuredSuccessResult(result, summary);
     },
   }),
@@ -1034,14 +1043,15 @@ const registry = defineArchestraTools([
     shortName: TOOL_SAVE_FILE_SHORT_NAME,
     title: "Save File",
     description:
-      "Save content you already have — inline text or base64 — straight to the " +
-      "conversation's persistent files (no sandbox needed); it then shows up in " +
-      "the chat's Files panel. Good for results produced in the conversation " +
-      "itself (text, markdown, small data files). Pass `overwrite: true` to " +
-      "replace an existing same-named file in place (e.g. a full rewrite); " +
-      "otherwise a duplicate name is rejected. In a project chat the file is " +
-      "saved to the project. For a file that already exists at a path inside the " +
-      "sandbox, use download_file instead. Requires `sandbox:execute`.",
+      "Write bytes you are providing inline in this call — text or base64 included in the " +
+      "arguments — to the conversation's persistent files, where they show up in the chat's Files " +
+      "panel. Use this for content that originates in your reply: a summary or note you wrote, a " +
+      "short snippet you are typing out. If the file already exists at a path in the sandbox — you " +
+      "wrote it with a command, or the user attached it — do not read it back and paste its bytes " +
+      "here; export it with download_file by its path instead, so the bytes never pass through the " +
+      "conversation. Pass `overwrite: true` to replace an existing same-named file in place (e.g. a " +
+      "full rewrite); otherwise a duplicate name is rejected. In a project chat the file is saved " +
+      "to the project. Requires `sandbox:execute`.",
     schema: SaveFileSchema,
     outputSchema: SaveFileOutputSchema,
     async handler({ args, context }) {

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -193,6 +193,14 @@ const DownloadFileSchema = z
         "Optional MIME type recorded with the file. Sniffed from the bytes " +
           "when omitted.",
       ),
+    overwrite: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Replace an existing same-named persistent file in place, keeping its id. " +
+          "Default false errors if the name is already taken.",
+      ),
     target: SandboxTargetSchema,
   })
   .describe(
@@ -215,6 +223,9 @@ const DownloadFileOutputSchema = z.object({
       "Notices about chat attachments that could not be auto-staged (e.g. too " +
         "large). Empty when all attachments are available in the sandbox.",
     ),
+  overwritten: z
+    .boolean()
+    .describe("True when an existing same-named file was replaced in place."),
 });
 
 const UploadSourceSchema = z.discriminatedUnion("type", [
@@ -633,7 +644,8 @@ const registry = defineArchestraTools([
       "conversation's persistent files, where it shows up in the chat's Files panel. Use this for " +
       "anything on the sandbox's disk — a file run_command wrote (text or binary) or a chat " +
       `attachment under ${SKILL_SANDBOX_ATTACHMENTS_DIR}/ — the bytes move server-side, so you ` +
-      "never read them back or re-type them. To read a skill's own source files, use load_skill " +
+      "never read them back or re-type them. Pass `overwrite: true` to replace an existing " +
+      "same-named persistent file in place. To read a skill's own source files, use load_skill " +
       "with a path instead. Requires `sandbox:execute`.",
     schema: DownloadFileSchema,
     outputSchema: DownloadFileOutputSchema,
@@ -666,6 +678,7 @@ const registry = defineArchestraTools([
           path: args.path,
           mimeType: args.mimeType,
           projectId: scope?.projectId ?? null,
+          overwrite: args.overwrite,
           environment: await resolveEnvironmentTarget(context),
         });
 
@@ -688,9 +701,10 @@ const registry = defineArchestraTools([
             mimeType: result.mimeType,
             sizeBytes: result.sizeBytes,
             stagingNotices: result.stagingNotices,
+            overwritten: result.overwritten,
           },
           withStagingNotices(
-            `Saved ${result.path} (${result.sizeBytes} bytes). It is available in the Files panel.`,
+            `${result.overwritten ? "Replaced" : "Saved"} ${result.path} (${result.sizeBytes} bytes). It is available in the Files panel.`,
             result.stagingNotices,
           ),
         );
@@ -1186,7 +1200,8 @@ const registry = defineArchestraTools([
       "the file first with read_file) and the `new_string` to put in its place; " +
       "set `replace_all` to change every occurrence. Identify the file by `id` " +
       "(from search_files / save_file) or by `filename`. Text files only — to " +
-      "replace a binary file, use save_file with overwrite. In a project chat " +
+      "replace a binary file, use save_file with overwrite for inline content, or " +
+      "download_file with overwrite for a file in the sandbox. In a project chat " +
       "only the project's files can be edited. Requires `sandbox:execute`.",
     schema: EditFileSchema,
     outputSchema: EditFileOutputSchema,

--- a/platform/backend/src/archestra-mcp-server/sandbox.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.ts
@@ -333,12 +333,12 @@ const SearchFilesSchema = z
       .string()
       .optional()
       .describe(
-        "Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list every file.",
+        "Case-insensitive substring matched against filenames only. Omit it (or pass empty) to list the files (the first 200).",
       ),
   })
   .describe(
     "List or search this conversation's persistent files by filename substring; " +
-      "omit the query to list every file. In a project chat, the project's files instead.",
+      "omit the query to list the files (the first 200). In a project chat, the project's files instead.",
   );
 
 const SearchFilesOutputSchema = z.object({
@@ -798,11 +798,12 @@ const registry = defineArchestraTools([
     description:
       "List or search THIS conversation's persistent files (in a project chat, the " +
       "project's files). The query is a case-insensitive substring matched against " +
-      "filenames only, not contents — omit it (or pass empty) to list every file, " +
-      "the reliable way to find a file whose exact name you don't know. Returns " +
-      "metadata only — each result carries a stable `ref`. To work on a found file, " +
-      "pass its `ref` to read_file (read its content), or to upload_file's my_file " +
-      "source (copy it into the sandbox). Requires `sandbox:execute`.",
+      "filenames only, not contents — omit it (or pass empty) to list the files (the " +
+      "first 200; narrow with a substring if there are more), the way to find a file " +
+      "whose exact name you don't know. Returns metadata only — each result carries a " +
+      "stable `ref`. To work on a found file, pass its `ref` to read_file (read its " +
+      "content), or to upload_file's my_file source (copy it into the sandbox). " +
+      "Requires `sandbox:execute`.",
     schema: SearchFilesSchema,
     outputSchema: SearchFilesOutputSchema,
     async handler({ args, context }) {

--- a/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
+++ b/platform/backend/src/skills-sandbox/skill-sandbox-runtime-service.ts
@@ -248,6 +248,69 @@ class SkillSandboxRuntimeService {
         buffer: data,
         claimed: params.mimeType,
       });
+      const filename = storageFilename({
+        originalName: null,
+        path: resolvedPath,
+      });
+
+      // Overwrite: replace an existing same-named persistent file in this scope
+      // in place, keeping its id — the export-side counterpart of save_file's
+      // overwrite, so a regenerated sandbox file can replace the one it produced
+      // earlier. Falls through to create when none exists.
+      if (params.overwrite) {
+        const ownerScope =
+          params.projectId != null
+            ? { kind: "project" as const, projectId: params.projectId }
+            : sandbox.conversationId != null
+              ? {
+                  kind: "conversation" as const,
+                  conversationId: sandbox.conversationId,
+                }
+              : null;
+        const existing = ownerScope
+          ? await fileStore.resolveMyFileRef({
+              organizationId: sandbox.organizationId,
+              userId: sandbox.userId,
+              filename,
+              scope: ownerScope,
+            })
+          : await fileStore.resolveOrphanRef({
+              organizationId: sandbox.organizationId,
+              userId: sandbox.userId,
+              filename,
+            });
+        if (!("error" in existing)) {
+          const updated = await fileStore.update({
+            file: existing,
+            mimeType,
+            sizeBytes: data.byteLength,
+            data,
+          });
+          if (updated) {
+            return {
+              artifactId: updated.id,
+              sandboxId: params.sandboxId,
+              path: resolvedPath,
+              mimeType: updated.mimeType,
+              sizeBytes: updated.sizeBytes,
+              stagingNotices,
+              overwritten: true,
+            };
+          }
+          // Row vanished between resolve and update — update already wrote the
+          // replacement bytes, so mirror save_file and surface a retryable error
+          // instead of re-creating (which could orphan bytes or false-collide).
+          throw new SkillSandboxError(
+            `The persistent file "${filename}" changed during export; run the export again.`,
+          );
+        } else if (existing.error !== "not_found") {
+          throw new SkillSandboxError(
+            `Could not replace "${filename}": more than one persistent file shares that name. Remove the duplicate or export under a new name.`,
+          );
+        }
+        // not_found → create below.
+      }
+
       let row: Awaited<ReturnType<typeof fileStore.put>>;
       try {
         row = await fileStore.put({
@@ -256,7 +319,7 @@ class SkillSandboxRuntimeService {
           projectId: params.projectId ?? null,
           conversationId: sandbox.conversationId,
           sandboxId: params.sandboxId,
-          filename: storageFilename({ originalName: null, path: resolvedPath }),
+          filename,
           mimeType,
           sizeBytes: data.byteLength,
           data,
@@ -282,6 +345,7 @@ class SkillSandboxRuntimeService {
         mimeType: row.mimeType,
         sizeBytes: row.sizeBytes,
         stagingNotices,
+        overwritten: false,
       };
     });
   }

--- a/platform/backend/src/skills-sandbox/types.ts
+++ b/platform/backend/src/skills-sandbox/types.ts
@@ -80,6 +80,8 @@ export interface ExportArtifactParams {
   mimeType?: string;
   /** Owning project for the exported file; null = the author's own file. */
   projectId?: string | null;
+  /** Replace an existing same-named persistent file in this scope in place, keeping its id. */
+  overwrite?: boolean;
   /**
    * The agent's environment isolation target. Artifact extraction replays the
    * recorded commands, so it must target the same engine the sandbox ran on.
@@ -96,6 +98,8 @@ export interface ArtifactRef {
   sizeBytes: number;
   /** See {@link CommandResult.stagingNotices}. */
   stagingNotices: string[];
+  /** True when an existing same-named persistent file was replaced in place. */
+  overwritten: boolean;
 }
 
 export interface UploadFileParams {


### PR DESCRIPTION
## What

Three changes to the sandbox file tools (`platform/backend/src/archestra-mcp-server/sandbox.ts`):

1. **`save_file` / `download_file` descriptions** rewritten to be self-contained around each tool's
   own input shape — `download_file` = a file that already exists at a sandbox path (text or binary,
   including attachments under `/home/sandbox/attachments/`); `save_file` = bytes you author inline —
   with an active `download_file` pointer for on-disk files so a model that just wrote a file doesn't
   read it back and re-send its bytes through context.
2. **`search_files`**: an empty query now lists every file (was a raw validation error), the listing
   is capped at 200 with a narrow-it notice, and the description states the query matches filenames
   only, not contents.
3. **`download_file` overwrite**: a sandbox-resident file can now replace an existing same-named
   persistent file in place (mirrors `save_file`'s overwrite), closing the
   `edit_file → save_file → download_file` binary-replace loop where `download_file` could only create.

## Why

Derived from agent benchmark trajectories. For files already on disk, models reliably reach for
`download_file` already, so (1) is primarily a clarity/orthogonality change that avoids a behavioral
regression (removing the cross-pointer entirely made a stronger model start re-reading on-disk files).
The higher-impact fix is (2): models thrashed locating a saved file in a fresh conversation because
filename-only search plus an empty-query error left no reliable "list everything" path.

## Validation

- `pnpm --filter @archestra/backend test` green; new tests pin empty-query list-all and
  `download_file` overwrite (create-when-absent, replace-in-place, conversation scope).
- type-check, biome, and the model-facing-string snapshot all updated/clean.

## Follow-ups (not in this PR)

- `search_files` content matching was considered and deliberately skipped (expensive, breaks on
  binary); list-all robustly solves the observed thrash.

https://claude.ai/code/session_01Wpz5VvAR9XsTuMVwggTXLx

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>