### PR TITLE
fix: faulty type cast in llm logs search query

### DIFF
--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -2055,6 +2055,62 @@ describe("InteractionModel", () => {
       expect(sessions.pagination.total).toBe(1);
       expect(sessions.data[0].sessionId).toBe(conversation.id);
     });
+
+    test("search tolerates a 36-char non-UUID session_id without failing the query", async ({
+      makeAdmin,
+    }) => {
+      // The interactions↔conversations join casts session_id to uuid. A bare
+      // LENGTH(session_id) = 36 guard is not enough: a 36-char NON-uuid session
+      // id (e.g. some a2a / external-agent ids) passes the length check and made
+      // `session_id::uuid` throw "invalid input syntax for type uuid", 500-ing
+      // the whole search query. This row reproduces that case.
+      const admin = await makeAdmin();
+      const agent = await AgentModel.create({
+        name: "Agent",
+        teams: [],
+        scope: "org",
+      });
+
+      // Exactly 36 characters, hyphenated like a UUID, but contains non-hex
+      // letters — so it is NOT castable to uuid.
+      const nonUuidSessionId = "abcdefgh-ijkl-mnop-qrst-uvwxyz012345";
+      expect(nonUuidSessionId).toHaveLength(36);
+
+      await InteractionModel.create({
+        profileId: agent.id,
+        sessionId: nonUuidSessionId,
+        request: {
+          model: "gpt-4",
+          messages: [
+            {
+              role: "user",
+              content: "trace token NonUuidSearchTok matches here",
+            },
+          ],
+        },
+        response: {
+          id: "r1",
+          object: "chat.completion",
+          created: Date.now(),
+          model: "gpt-4",
+          choices: [],
+        },
+        type: "openai:chatCompletions",
+      });
+
+      // Before the fix this throws during the conversations join; after, it
+      // returns the matching session (which simply joins no conversation).
+      const sessions = await InteractionModel.getSessions(
+        { limit: 100, offset: 0 },
+        admin.id,
+        true,
+        { search: "NonUuidSearchTok" },
+      );
+
+      expect(sessions.data).toHaveLength(1);
+      expect(sessions.data[0].sessionId).toBe(nonUuidSessionId);
+      expect(sessions.data[0].conversationTitle).toBeNull();
+    });
   });
 
   describe("getSessions source filtering", () => {

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -275,6 +275,25 @@ function stripNullBytes<T>(value: T): T {
   return value;
 }
 
+/**
+ * Join predicate linking an interaction's `session_id` (VARCHAR) to a
+ * conversation's `id` (UUID) — used for Archestra Chat sessions whose
+ * session_id IS the conversation id.
+ *
+ * The only reason a cast is needed at all is type compatibility: Postgres has no
+ * `varchar = uuid` operator. We cast the TRUSTED side (`conversations.id::text`,
+ * which can never fail) rather than the untrusted `session_id::uuid` — a non-uuid
+ * session_id (e.g. some a2a / external-agent ids) would otherwise throw
+ * "invalid input syntax for type uuid" and 500 the whole query (see utils/uuid.ts).
+ * Comparing as text, a non-conversation session_id simply matches no row, and the
+ * equality on the bare `session_id` column can use interactions_session_*_idx.
+ * Conversation ids are generated as canonical lowercase uuids, so they match the
+ * canonical lowercase form `id::text` produces.
+ */
+function sessionIdMatchesConversation(): SQL {
+  return sql`${schema.interactionsTable.sessionId} = ${schema.conversationsTable.id}::text`;
+}
+
 class InteractionModel {
   static async existsByExecutionId(executionId: string): Promise<boolean> {
     const [result] = await db
@@ -1059,10 +1078,7 @@ class InteractionModel {
       const byConversationTitle = db
         .select({ id: schema.interactionsTable.id })
         .from(schema.interactionsTable)
-        .innerJoin(
-          schema.conversationsTable,
-          sql`CASE WHEN LENGTH(${schema.interactionsTable.sessionId}) = 36 THEN ${schema.interactionsTable.sessionId}::uuid END = ${schema.conversationsTable.id}`,
-        )
+        .innerJoin(schema.conversationsTable, sessionIdMatchesConversation())
         .where(sql`${schema.conversationsTable.title} ILIKE ${searchPattern}`);
 
       conditions.push(
@@ -1134,13 +1150,7 @@ class InteractionModel {
           schema.usersTable,
           eq(schema.interactionsTable.userId, schema.usersTable.id),
         )
-        .leftJoin(
-          schema.conversationsTable,
-          // Only join when session_id is a valid UUID format (conversation IDs are UUIDs)
-          // Non-UUID session IDs (like "a2a-...") won't match any conversation
-          // Use CASE to safely handle the cast - only cast when length is 36 (UUID format)
-          sql`CASE WHEN LENGTH(${schema.interactionsTable.sessionId}) = 36 THEN ${schema.interactionsTable.sessionId}::uuid END = ${schema.conversationsTable.id}`,
-        )
+        .leftJoin(schema.conversationsTable, sessionIdMatchesConversation())
         .where(whereClause)
         .groupBy(
           sessionGroupExpr,
@@ -1153,11 +1163,7 @@ class InteractionModel {
       db
         .select({ total: sql<number>`COUNT(DISTINCT ${sessionGroupExpr})` })
         .from(schema.interactionsTable)
-        .leftJoin(
-          schema.conversationsTable,
-          // Only join when session_id is a valid UUID format (conversation IDs are UUIDs)
-          sql`CASE WHEN LENGTH(${schema.interactionsTable.sessionId}) = 36 THEN ${schema.interactionsTable.sessionId}::uuid END = ${schema.conversationsTable.id}`,
-        )
+        .leftJoin(schema.conversationsTable, sessionIdMatchesConversation())
         .where(whereClause),
     ]);
 


### PR DESCRIPTION


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>