### PR TITLE
chore(frontend): rename 'Allow in safe context' policy label to 'Block in sensitive context'

### DIFF
--- a/docs/pages/platform-ai-tool-guardrails.md
+++ b/docs/pages/platform-ai-tool-guardrails.md
@@ -91,7 +91,7 @@ Tool call policies control whether a tool may run in the current context.
 Available actions:
 
 - **Allow always**: The tool can run even when the current context is marked sensitive or untrusted.
-- **Allow in safe context**: The tool can run only while the current context is still safe.
+- **Block in sensitive context**: The tool is blocked when the current context is sensitive. The context becomes sensitive once a tool with a "Results are: Sensitive" policy has been called previously.
 - **Require approval**: The tool requires explicit user approval in chat. In autonomous execution contexts, the call is blocked.
 - **Block always**: The tool is never allowed to run automatically.
 

--- a/platform/backend/src/types/agent.ts
+++ b/platform/backend/src/types/agent.ts
@@ -335,7 +335,7 @@ export const PolicyConfigSchema = z.object({
     .describe(
       "When should this tool be allowed to be invoked? " +
         "'allow_when_context_is_sensitive' - Allow invocation even when sensitive data is present (safe read-only tools). " +
-        "'block_when_context_is_sensitive' - Allow only when context is safe, block when sensitive data is present (tools that could leak data). " +
+        "'block_when_context_is_sensitive' - Block when sensitive data is present, allow only when context is safe (tools that could leak data). " +
         "'require_approval' - Require user confirmation before executing in chat; block in autonomous sessions (write/mutating tools that are not outright destructive: create/update/send/post/charge). " +
         "'block_always' - Never allow automatic invocation (obviously destructive tools whose name is solely dedicated to deleting or destroying data).",
     ),

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -923,7 +923,7 @@ export function AssignedToolsTable({
                         Allow always
                       </SelectItem>
                       <SelectItem value="block_when_context_is_untrusted">
-                        Allow in safe context
+                        Block in sensitive context
                       </SelectItem>
                       <SelectItem
                         value="require_approval"
@@ -1057,7 +1057,7 @@ export function AssignedToolsTable({
                         Allow always
                       </SelectItem>
                       <SelectItem value="block_when_context_is_untrusted">
-                        Allow in safe context
+                        Block in sensitive context
                       </SelectItem>
                       <SelectItem
                         value="require_approval"

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/call-policy-toggle.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/call-policy-toggle.tsx
@@ -22,7 +22,7 @@ const CALL_POLICY_OPTIONS: { value: CallPolicyAction; label: string }[] = [
   { value: "allow_when_context_is_untrusted", label: "Allow always" },
   {
     value: "block_when_context_is_untrusted",
-    label: "Allow in safe context",
+    label: "Block in sensitive context",
   },
   { value: "require_approval", label: "Require approval" },
   { value: "block_always", label: "Block always" },
@@ -116,7 +116,7 @@ export function CallPolicyToggle({
               <Handshake className="h-3.5 w-3.5" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Allow in safe context</TooltipContent>
+          <TooltipContent>Block in sensitive context</TooltipContent>
         </Tooltip>
       </TooltipProvider>
       <TooltipProvider delayDuration={100}>

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/tool-call-policies.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/tool-call-policies.tsx
@@ -224,7 +224,7 @@ export function ToolCallPolicies({ tool }: { tool: ToolForPolicies }) {
                     },
                     {
                       value: "block_when_context_is_untrusted",
-                      label: "Allow in safe context",
+                      label: "Block in sensitive context",
                     },
                     {
                       value: "require_approval",


### PR DESCRIPTION
## What

Renames the tool call policy option **"Allow in safe context"** to **"Block in sensitive context"** everywhere the copy appears. The underlying enum value (`block_when_context_is_untrusted`) and all engine/evaluation logic are unchanged — this is a copy-only change so the label describes the *block* condition rather than the *allow* condition.

## Surfaces updated

- **UI** (`platform/frontend/src/app/mcp/tool-guardrails/_parts/`)
  - `call-policy-toggle.tsx` — dropdown option label + icon-button tooltip
  - `tool-call-policies.tsx` — per-policy select option
  - `assigned-tools-table.tsx` — bulk-action select (desktop + mobile)
- **Docs** (`docs/pages/platform-ai-tool-guardrails.md`) — relabeled, with a clarified description: the context becomes sensitive once a tool with a "Results are: Sensitive" policy has been called previously.
- **Auto-config LLM prompt** (`platform/backend/src/types/agent.ts`) — `block_when_context_is_sensitive` description reordered to lead with the block framing.

No remaining occurrences of the old `"Allow in safe context"` string exist in the repo.

## Out of scope

Intentionally excludes the unrelated `platform/dev/Tiltfile.database` working-tree change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>