### PR TITLE
fix(mcp): hide registry card Chat button when no installation exists

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/chat-button-visibility.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/chat-button-visibility.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowMcpCardChatButton } from "./chat-button-visibility";
+
+describe("shouldShowMcpCardChatButton", () => {
+  it("hides when the catalog item has no discovered tools", () => {
+    expect(
+      shouldShowMcpCardChatButton({
+        toolsCount: 0,
+        isBuiltin: false,
+        hasInstallation: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides a non-builtin card with tools but no installation (the bug: tools persist after uninstall)", () => {
+    // After every installation is removed the catalog's discovered tool rows
+    // stay behind, so `toolsCount` is still > 0. The chat button must not show
+    // because there is nothing reachable to chat with.
+    expect(
+      shouldShowMcpCardChatButton({
+        toolsCount: 7,
+        isBuiltin: false,
+        hasInstallation: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows a non-builtin card when an installation is reachable", () => {
+    expect(
+      shouldShowMcpCardChatButton({
+        toolsCount: 7,
+        isBuiltin: false,
+        hasInstallation: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("always shows a built-in (Archestra) card with tools, even with no installation", () => {
+    // The built-in Archestra MCP server has no install rows; it is always
+    // available, so it stays chat-enabled whenever it exposes tools.
+    expect(
+      shouldShowMcpCardChatButton({
+        toolsCount: 12,
+        isBuiltin: true,
+        hasInstallation: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides a built-in card that has no tools", () => {
+    expect(
+      shouldShowMcpCardChatButton({
+        toolsCount: 0,
+        isBuiltin: true,
+        hasInstallation: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/chat-button-visibility.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/chat-button-visibility.ts
@@ -1,0 +1,34 @@
+/**
+ * Decides whether an MCP registry card shows its "Chat" button.
+ *
+ * The button must not appear just because the catalog item has discovered
+ * tools: a catalog item's tool rows are keyed by catalog id and are
+ * deliberately retained when its installations are removed (so reconnecting
+ * restores assignments/policies — see `McpServerModel.delete`). So
+ * `toolsCount > 0` survives uninstall and is NOT a reliable signal that
+ * there is anything to chat with.
+ *
+ * Chat routes through the gateway, which resolves a catalog tool to a
+ * concrete install at call time (`pickInstallForCaller`): the caller's
+ * personal install, then a team install of a team they belong to, then an
+ * org-scoped install. With zero reachable installs the call dead-ends in an
+ * `auth_required` error. So a non-builtin card only offers Chat when an
+ * installation reachable by the viewer exists.
+ *
+ * The built-in (Archestra) server is the exception: it has no install rows
+ * and is always available, so it stays chat-enabled whenever it has tools.
+ */
+export function shouldShowMcpCardChatButton({
+  toolsCount,
+  isBuiltin,
+  hasInstallation,
+}: {
+  /** Discovered tools for the catalog item (`item.toolCount`). */
+  toolsCount: number;
+  /** The Archestra built-in MCP server (card variant `"builtin"`). */
+  isBuiltin: boolean;
+  /** An installation for this catalog item is reachable by the viewer. */
+  hasInstallation: boolean;
+}): boolean {
+  return toolsCount > 0 && (isBuiltin || hasInstallation);
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -70,6 +70,7 @@ import {
   setCatalogEditParam,
 } from "./catalog-edit-link";
 import { resolveCatalogEnvironmentLabel } from "./catalog-environment-label";
+import { shouldShowMcpCardChatButton } from "./chat-button-visibility";
 import {
   computeDeploymentStatusSummary,
   DeploymentStatusDot,
@@ -609,19 +610,22 @@ export function McpServerCard({
   );
   const toolsCount = item.toolCount ?? 0;
 
-  const chatButton =
-    toolsCount > 0 ? (
-      <Button
-        variant="outline"
-        size="sm"
-        className="flex-1"
-        disabled={isChatCreating}
-        onClick={handleChatWithMcpServer}
-      >
-        <MessageSquare className="h-4 w-4" />
-        {isChatCreating ? "Creating..." : "Chat"}
-      </Button>
-    ) : null;
+  const chatButton = shouldShowMcpCardChatButton({
+    toolsCount,
+    isBuiltin: isBuiltinVariant,
+    hasInstallation: allServersForCatalog.length > 0,
+  }) ? (
+    <Button
+      variant="outline"
+      size="sm"
+      className="flex-1"
+      disabled={isChatCreating}
+      onClick={handleChatWithMcpServer}
+    >
+      <MessageSquare className="h-4 w-4" />
+      {isChatCreating ? "Creating..." : "Chat"}
+    </Button>
+  ) : null;
 
   const settingsButton = (
     <Button

--- a/platform/frontend/src/app/mcp/registry/beta/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/mcp-server-card.tsx
@@ -66,6 +66,7 @@ import { useAssignableTeams } from "@/lib/teams/team.query";
 import { useCanModifyCatalogItem } from "../../_parts/catalog-edit-access";
 import { clearCatalogEditParam } from "../../_parts/catalog-edit-link";
 import { resolveCatalogEnvironmentLabel } from "../../_parts/catalog-environment-label";
+import { shouldShowMcpCardChatButton } from "../../_parts/chat-button-visibility";
 import {
   computeDeploymentStatusSummary,
   DeploymentStatusDot,
@@ -505,19 +506,22 @@ export function McpServerCard({
   );
   const toolsCount = item.toolCount ?? 0;
 
-  const chatButton =
-    toolsCount > 0 ? (
-      <Button
-        variant="outline"
-        size="sm"
-        className="flex-1"
-        disabled={isChatCreating}
-        onClick={handleChatWithMcpServer}
-      >
-        <MessageSquare className="h-4 w-4" />
-        {isChatCreating ? "Creating..." : "Chat"}
-      </Button>
-    ) : null;
+  const chatButton = shouldShowMcpCardChatButton({
+    toolsCount,
+    isBuiltin: isBuiltinVariant,
+    hasInstallation: allServersForCatalog.length > 0,
+  }) ? (
+    <Button
+      variant="outline"
+      size="sm"
+      className="flex-1"
+      disabled={isChatCreating}
+      onClick={handleChatWithMcpServer}
+    >
+      <MessageSquare className="h-4 w-4" />
+      {isChatCreating ? "Creating..." : "Chat"}
+    </Button>
+  ) : null;
 
   const settingsButton = (
     <Button


### PR DESCRIPTION
## Problem

Removing **all** MCP server installations still left a **Chat** button on the registry card. Clicking it created an agent and dropped into a chat where every tool call dead-ended in an `auth_required` error (the gateway has no reachable install to route to).

## Root cause

The Chat button was gated only on `item.toolCount > 0`. A catalog item's discovered tool rows are keyed by `catalogId` and are **deliberately retained on uninstall** (so reconnecting restores tool assignments/policies — `McpServerModel.delete`), and there's no FK from tools to installations. So `toolCount` stays `> 0` after every installation is removed — even on a fresh query — and the gate never reflected installation state.

## Fix

Gate the button on a reachable installation too: show it only when the catalog has discovered tools **AND** (it is the always-available built-in Archestra server **OR** an installation visible to the viewer exists, `allServersForCatalog.length > 0`).

- `allServersForCatalog` comes from `useMcpServers()`, which is refetched on uninstall, so the button disappears immediately.
- For non-admins this mirrors the gateway's `pickInstallForCaller` reachability set (personal + your-teams + org).
- For admins it is strictly *fewer* Chat buttons than today (the old gate showed Chat on every card with tools, install or not) — no regression.

The decision is extracted into a pure, unit-tested helper (`chat-button-visibility.ts`) shared by the current and `beta` card copies.

## Testing

- New unit test (5 cases) for `shouldShowMcpCardChatButton`.
- Registry `_parts` suite: 15 files / 204 tests pass, no regressions.
- `pnpm type-check`, Biome, and `pnpm knip` all clean.