### PR TITLE
feat(chatops): hint at thread mute on the bot's first reply

### DIFF
--- a/docs/pages/platform-ms-teams.md
+++ b/docs/pages/platform-ms-teams.md
@@ -46,7 +46,7 @@ The bot responds with an **Adaptive Card dropdown** to select which agent handle
 
 In channels the bot stays silent until it is @mentioned. Once mentioned in a thread, it keeps replying to every message in that thread without further mentions. Starting a new thread needs a fresh mention. Direct messages and group chats always get a reply, no mention required.
 
-To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again.
+To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again. As a reminder, the bot adds a short hint about this to its first reply in each thread.
 
 ### Commands
 

--- a/docs/pages/platform-slack.md
+++ b/docs/pages/platform-slack.md
@@ -52,7 +52,7 @@ The bot responds with a list of options to choose which agent will handle messag
 
 In channels the bot stays silent until it is @mentioned. Once mentioned in a thread, it keeps replying to every message in that thread without further mentions. Starting a new thread needs a fresh mention. Direct messages always get a reply, no mention required.
 
-To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again.
+To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again. As a reminder, the bot adds a short hint about this to its first reply in each thread.
 
 ### Commands
 

--- a/platform/backend/src/agents/chatops/channel-activation.test.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.test.ts
@@ -21,6 +21,7 @@ vi.mock("@/cache-manager", async (importOriginal) => {
 });
 
 import {
+  claimThreadMuteHint,
   clearChannelThreadActive,
   isChannelThreadActive,
   isMuteReaction,
@@ -120,6 +121,58 @@ describe("channel-activation (sticky channel auto-reply)", () => {
     expect(await clearChannelThreadActive(TEAMS)).toBe(true);
     // Second clear (e.g. a redelivered event) is a no-op transition.
     expect(await clearChannelThreadActive(TEAMS)).toBe(false);
+  });
+});
+
+describe("claimThreadMuteHint", () => {
+  beforeEach(() => {
+    mockCache.clear();
+    mockSetCalls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  test("returns true the first time and false thereafter (one hint per thread)", async () => {
+    expect(await claimThreadMuteHint(TEAMS)).toBe(true);
+    expect(await claimThreadMuteHint(TEAMS)).toBe(false);
+    expect(await claimThreadMuteHint(TEAMS)).toBe(false);
+  });
+
+  test("records the claim with the sticky auto-reply TTL", async () => {
+    await claimThreadMuteHint(TEAMS);
+
+    expect(mockSetCalls).toHaveLength(1);
+    const [key, value, ttl] = mockSetCalls[0];
+    expect(key).toContain(CHANNEL);
+    expect(value).toBe(true);
+    expect(ttl).toBe(CHATOPS_CHANNEL_AUTO_REPLY.ACTIVE_TTL_MS);
+  });
+
+  test("is scoped per (provider, channel, thread)", async () => {
+    expect(await claimThreadMuteHint(TEAMS)).toBe(true);
+
+    // Same channel/thread, other provider → independent claim.
+    expect(await claimThreadMuteHint({ ...TEAMS, provider: "slack" })).toBe(
+      true,
+    );
+    // Same channel, different thread → independent claim.
+    expect(
+      await claimThreadMuteHint({ ...TEAMS, threadId: "other-thread" }),
+    ).toBe(true);
+    // Different channel, same thread → independent claim.
+    expect(
+      await claimThreadMuteHint({
+        ...TEAMS,
+        channelId: "19:other@thread.tacv2",
+      }),
+    ).toBe(true);
+  });
+
+  test("its key does not collide with the activation key (mute ≠ hint)", async () => {
+    await markChannelThreadActive(TEAMS);
+    // The hint slot is still unclaimed even though the thread is active.
+    expect(await claimThreadMuteHint(TEAMS)).toBe(true);
+    // ...and claiming the hint does not deactivate the thread.
+    expect(await isChannelThreadActive(TEAMS)).toBe(true);
   });
 });
 

--- a/platform/backend/src/agents/chatops/channel-activation.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.ts
@@ -59,6 +59,36 @@ export async function clearChannelThreadActive(params: {
 }
 
 /**
+ * Claim the one-time "you can mute me" hint slot for a channel thread.
+ *
+ * Returns true the FIRST time it's called for a given thread (and records that
+ * the hint was shown), false thereafter — so the subtle mute hint rides only
+ * the bot's first reply in a thread, not every reply. Shares the sticky
+ * auto-reply TTL: once a thread goes idle long enough to stop auto-replying, a
+ * later revival is effectively a fresh conversation worth hinting again.
+ *
+ * Get-then-set (not atomic): a rare race could show the hint twice, which is
+ * harmless. Callers should only claim on a reply they're actually posting.
+ *
+ * A purely decorative hint must never break a reply, so a cache failure is
+ * swallowed and treated as "don't hint" rather than propagated.
+ */
+export async function claimThreadMuteHint(params: {
+  provider: ChatOpsProviderType;
+  channelId: string;
+  threadId: string;
+}): Promise<boolean> {
+  const key = muteHintKey(params);
+  try {
+    if ((await cacheManager.get<boolean>(key)) === true) return false;
+    await cacheManager.set(key, true, CHATOPS_CHANNEL_AUTO_REPLY.ACTIVE_TTL_MS);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Whether a message is a request to mute the bot in the current channel thread.
  *
  * The match is against the whole mention-stripped message, normalized to lower
@@ -161,6 +191,18 @@ function activationKey(params: {
     params.provider === "slack"
       ? CacheKey.SlackThreadActive
       : CacheKey.TeamsThreadActive;
+  return `${prefix}-${params.channelId}::${params.threadId}`;
+}
+
+function muteHintKey(params: {
+  provider: ChatOpsProviderType;
+  channelId: string;
+  threadId: string;
+}): AllowedCacheKey {
+  const prefix =
+    params.provider === "slack"
+      ? CacheKey.SlackThreadMuteHint
+      : CacheKey.TeamsThreadMuteHint;
   return `${prefix}-${params.channelId}::${params.threadId}`;
 }
 

--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -1,3 +1,19 @@
+import { vi } from "vitest";
+
+// Control the one-time mute-hint claim per test (the real one hits the
+// distributed cache, which isn't started in this suite). The `mock`-prefixed
+// name is referenced lazily inside the factory so it survives vi.mock hoisting.
+const mockClaimThreadMuteHint = vi.fn();
+vi.mock("./channel-activation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./channel-activation")>();
+  return {
+    ...actual,
+    claimThreadMuteHint: (
+      ...args: Parameters<typeof actual.claimThreadMuteHint>
+    ) => mockClaimThreadMuteHint(...args),
+  };
+});
+
 import { eq } from "drizzle-orm";
 import { A2AManager } from "@/agents/a2a/a2a-manager";
 import * as a2aExecutor from "@/agents/a2a-executor";
@@ -8,7 +24,7 @@ import {
   ChatOpsConfigModel,
   ChatOpsThreadAgentOverrideModel,
 } from "@/models";
-import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type {
   ChatOpsApprovalDecision,
   ChatOpsProvider,
@@ -24,6 +40,7 @@ import {
 import {
   CHATOPS_ATTACHMENT_LIMITS,
   CHATOPS_NO_REPLY_SENTINEL,
+  THREAD_MUTE_HINT,
 } from "./constants";
 
 describe("matchesAgentName", () => {
@@ -382,6 +399,157 @@ describe("ChatOpsManager security validation", () => {
         text: expect.stringContaining("/settings"),
       }),
     );
+  });
+
+  // ===========================================================================
+  // One-time "you can mute me" hint: rides the bot's first reply in a channel
+  // thread (where sticky auto-reply applies), and nowhere else.
+  // ===========================================================================
+
+  // A channel whose sender is a known, authorized team member, so replies
+  // reach the agent-response path (where the hint lives) rather than an
+  // access-denied/onboarding branch.
+  async function bindAuthorizedChannel(ctx: {
+    makeOrganization: (...args: never[]) => Promise<{ id: string }>;
+    makeUser: (opts: { email: string }) => Promise<{ id: string }>;
+    makeTeam: (orgId: string, userId: string) => Promise<{ id: string }>;
+    makeTeamMember: (teamId: string, userId: string) => Promise<unknown>;
+    makeInternalAgent: (opts: {
+      organizationId: string;
+      teams: string[];
+    }) => Promise<{ id: string }>;
+  }): Promise<{ senderEmail: string }> {
+    const senderEmail = "member@example.com";
+    const org = await ctx.makeOrganization();
+    const user = await ctx.makeUser({ email: senderEmail });
+    const team = await ctx.makeTeam(org.id, user.id);
+    await ctx.makeTeamMember(team.id, user.id);
+    const agent = await ctx.makeInternalAgent({
+      organizationId: org.id,
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+    await ChatOpsChannelBindingModel.create({
+      organizationId: org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: agent.id,
+    });
+    return { senderEmail };
+  }
+
+  async function processChannelReply(params: {
+    message: IncomingChatMessage;
+    senderEmail: string;
+  }): Promise<ReturnType<typeof vi.fn>> {
+    mockA2AExecutor();
+    const sendReplySpy = vi.fn().mockResolvedValue("reply-id");
+    const provider = createMockProvider({
+      sendReply: sendReplySpy,
+      getUserEmail: async () => params.senderEmail,
+    });
+    const manager = new ChatOpsManager();
+    (
+      manager as unknown as { msTeamsProvider: ChatOpsProvider }
+    ).msTeamsProvider = provider;
+    await manager.processMessage({ message: params.message, provider });
+    return sendReplySpy;
+  }
+
+  test("rides the bot's first reply in a channel thread", async ({
+    makeOrganization,
+    makeUser,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const { senderEmail } = await bindAuthorizedChannel({
+      makeOrganization,
+      makeUser,
+      makeTeam,
+      makeTeamMember,
+      makeInternalAgent,
+    });
+    mockClaimThreadMuteHint.mockReset().mockResolvedValue(true);
+
+    const sendReplySpy = await processChannelReply({
+      senderEmail,
+      message: createMockMessage({
+        threadId: "thread-1",
+        senderEmail,
+        metadata: { conversationType: "channel", botMentioned: true },
+      }),
+    });
+
+    expect(mockClaimThreadMuteHint).toHaveBeenCalledWith({
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      threadId: "thread-1",
+    });
+    expect(sendReplySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ hint: THREAD_MUTE_HINT }),
+    );
+  });
+
+  test("omits the hint on later replies once the thread's slot is claimed", async ({
+    makeOrganization,
+    makeUser,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const { senderEmail } = await bindAuthorizedChannel({
+      makeOrganization,
+      makeUser,
+      makeTeam,
+      makeTeamMember,
+      makeInternalAgent,
+    });
+    // Slot already taken → claim returns false.
+    mockClaimThreadMuteHint.mockReset().mockResolvedValue(false);
+
+    const sendReplySpy = await processChannelReply({
+      senderEmail,
+      message: createMockMessage({
+        threadId: "thread-1",
+        senderEmail,
+        metadata: { conversationType: "channel", botMentioned: false },
+      }),
+    });
+
+    expect(mockClaimThreadMuteHint).toHaveBeenCalled();
+    expect(sendReplySpy.mock.calls[0][0].hint).toBeUndefined();
+  });
+
+  test("never hints outside a channel thread (DMs/group chats have no sticky auto-reply)", async ({
+    makeOrganization,
+    makeUser,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const { senderEmail } = await bindAuthorizedChannel({
+      makeOrganization,
+      makeUser,
+      makeTeam,
+      makeTeamMember,
+      makeInternalAgent,
+    });
+    mockClaimThreadMuteHint.mockReset().mockResolvedValue(true);
+
+    const sendReplySpy = await processChannelReply({
+      senderEmail,
+      message: createMockMessage({
+        threadId: "thread-1",
+        senderEmail,
+        metadata: { conversationType: "groupChat", botMentioned: true },
+      }),
+    });
+
+    // Gated out before the cache is even consulted.
+    expect(mockClaimThreadMuteHint).not.toHaveBeenCalled();
+    expect(sendReplySpy.mock.calls[0][0].hint).toBeUndefined();
   });
 
   test("suppresses the reply when the agent answers with the no-reply sentinel", async ({

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -43,12 +43,14 @@ import {
   ensureProvisionedUser,
   isSsoConfigured,
 } from "./auto-provision";
+import { claimThreadMuteHint } from "./channel-activation";
 import {
   CHATOPS_ATTACHMENT_LIMITS,
   CHATOPS_CHANNEL_DISCOVERY,
   CHATOPS_MESSAGE_RETENTION,
   CHATOPS_NO_REPLY_SENTINEL,
   SLACK_DEFAULT_CONNECTION_MODE,
+  THREAD_MUTE_HINT,
 } from "./constants";
 import MSTeamsProvider from "./ms-teams-provider";
 import SlackProvider from "./slack-provider";
@@ -1570,6 +1572,11 @@ export class ChatOpsManager {
         originalMessage: message,
         text: agentResponse,
         footer: `🤖 ${agent.name}`,
+        // Teach the off switch once per channel thread: sticky auto-reply only
+        // applies in channels, so the hint rides the bot's first reply there.
+        ...((await this.shouldHintThreadMute(provider, message)) && {
+          hint: THREAD_MUTE_HINT,
+        }),
         conversationReference: message.metadata?.conversationReference,
       });
     } else if (
@@ -1608,6 +1615,27 @@ export class ChatOpsManager {
       agentResponse,
       interactionId: resultMessage.messageId,
     };
+  }
+
+  /**
+   * Whether this reply should carry the one-time "you can mute me" hint.
+   *
+   * True only on the bot's FIRST reply in a channel thread — sticky auto-reply
+   * (and thus muting) exists only in channels, and claimThreadMuteHint ensures
+   * the hint rides a single reply per thread rather than every one.
+   */
+  private async shouldHintThreadMute(
+    provider: ChatOpsProvider,
+    message: IncomingChatMessage,
+  ): Promise<boolean> {
+    if (message.metadata?.conversationType !== "channel" || !message.threadId) {
+      return false;
+    }
+    return await claimThreadMuteHint({
+      provider: provider.providerId,
+      channelId: message.channelId,
+      threadId: message.threadId,
+    });
   }
 
   private async replyWithApprovalForm(params: {

--- a/platform/backend/src/agents/chatops/constants.ts
+++ b/platform/backend/src/agents/chatops/constants.ts
@@ -102,6 +102,16 @@ const THREAD_MUTED_LEAD_INS = [
 ] as const;
 
 /**
+ * A subtle one-time footer hint, appended to the bot's FIRST reply in a channel
+ * thread (see claimThreadMuteHint), teaching users the off switch for sticky
+ * auto-reply without the verbosity of the /help command. Plain text (no
+ * provider-specific markup) so it renders identically in Slack and MS Teams; the
+ * 🔇 glyph matches the mute reaction users can add to any bot reply.
+ */
+export const THREAD_MUTE_HINT =
+  'Reply "mute" or react 🔇 to stop auto-replies in this thread';
+
+/**
  * In group conversations the agent hears every message but should not answer
  * every one. When it decides no reply is needed it answers with exactly this
  * token, and the chatops layer posts nothing instead of a message.

--- a/platform/backend/src/agents/chatops/constants.ts
+++ b/platform/backend/src/agents/chatops/constants.ts
@@ -109,7 +109,7 @@ const THREAD_MUTED_LEAD_INS = [
  * 🔇 glyph matches the mute reaction users can add to any bot reply.
  */
 export const THREAD_MUTE_HINT =
-  'Reply "mute" or react 🔇 to stop auto-replies in this thread';
+  'Reply "mute" or react 🔇 to any of my messages to stop auto-replies in this thread';
 
 /**
  * In group conversations the agent hears every message but should not answer

--- a/platform/backend/src/agents/chatops/ms-teams-provider.test.ts
+++ b/platform/backend/src/agents/chatops/ms-teams-provider.test.ts
@@ -808,6 +808,69 @@ describe("MSTeamsProvider.convertToThreadMessages file metadata", () => {
   });
 });
 
+describe("MSTeamsProvider.sendReply", () => {
+  // Drives a reply through the conversationReference branch (no live
+  // turnContext) and returns the text handed to context.sendActivity.
+  async function captureReplyText(
+    options: Pick<
+      Parameters<MSTeamsProvider["sendReply"]>[0],
+      "footer" | "hint"
+    >,
+  ): Promise<string> {
+    const provider = createProvider();
+    const sendActivity = vi.fn().mockResolvedValue({ id: "reply-1" });
+    const continueConversationAsync = vi.fn(
+      async (
+        _appId: string,
+        _ref: unknown,
+        callback: (context: {
+          sendActivity: typeof sendActivity;
+        }) => Promise<void>,
+      ) => {
+        await callback({ sendActivity });
+      },
+    );
+    // biome-ignore lint/suspicious/noExplicitAny: test-only — mock adapter
+    (provider as any).adapter = { continueConversationAsync };
+
+    await provider.sendReply({
+      originalMessage: {
+        messageId: "msg-1",
+        channelId: "19:abc@thread.tacv2",
+        workspaceId: "team-uuid",
+        senderId: "user-1",
+        senderName: "Alice",
+        text: "hi",
+        rawText: "hi",
+        timestamp: new Date(),
+        isThreadReply: false,
+        metadata: { conversationReference: { foo: "bar" } },
+      },
+      text: "Here is your answer",
+      ...options,
+    });
+
+    return sendActivity.mock.calls[0][0] as string;
+  }
+
+  test("appends the mute hint on its own italic line below the footer", async () => {
+    const text = await captureReplyText({
+      footer: "🤖 Agent",
+      hint: 'Reply "mute" to stop',
+    });
+
+    expect(text).toBe(
+      'Here is your answer\n\n---\n\n🤖 Agent\n\n_Reply "mute" to stop_',
+    );
+  });
+
+  test("renders the hint under its own separator when there is no footer", async () => {
+    const text = await captureReplyText({ hint: 'Reply "mute" to stop' });
+
+    expect(text).toBe('Here is your answer\n\n---\n\n_Reply "mute" to stop_');
+  });
+});
+
 describe("MSTeamsProvider.addApprovalRequestForm", () => {
   // Drives the form through the conversationReference branch (no live
   // turnContext) and captures the Adaptive Card sent to the channel.

--- a/platform/backend/src/agents/chatops/ms-teams-provider.test.ts
+++ b/platform/backend/src/agents/chatops/ms-teams-provider.test.ts
@@ -853,14 +853,14 @@ describe("MSTeamsProvider.sendReply", () => {
     return sendActivity.mock.calls[0][0] as string;
   }
 
-  test("appends the mute hint on its own italic line below the footer", async () => {
+  test("puts the mute hint on its own italic line above the footer", async () => {
     const text = await captureReplyText({
       footer: "🤖 Agent",
       hint: 'Reply "mute" to stop',
     });
 
     expect(text).toBe(
-      'Here is your answer\n\n---\n\n🤖 Agent\n\n_Reply "mute" to stop_',
+      'Here is your answer\n\n---\n\n_Reply "mute" to stop_\n\n🤖 Agent',
     );
   });
 

--- a/platform/backend/src/agents/chatops/ms-teams-provider.ts
+++ b/platform/backend/src/agents/chatops/ms-teams-provider.ts
@@ -405,15 +405,16 @@ class MSTeamsProvider implements ChatOpsProvider {
     }
 
     let replyText = options.text;
-    if (options.footer) {
-      replyText += `\n\n---\n\n${options.footer}`;
-    }
     // An even-more-subtle hint (e.g. the one-time mute tip) on its own italic
-    // line below the footer. Italics keep it visually quieter than the footer.
+    // line ABOVE the footer, so the agent footer stays the last line. Italics
+    // keep it visually quieter than the footer.
     if (options.hint) {
-      replyText += options.footer
-        ? `\n\n_${options.hint}_`
-        : `\n\n---\n\n_${options.hint}_`;
+      replyText += `\n\n---\n\n_${options.hint}_`;
+    }
+    if (options.footer) {
+      replyText += options.hint
+        ? `\n\n${options.footer}`
+        : `\n\n---\n\n${options.footer}`;
     }
 
     // If a placeholder "Thinking..." message was sent (Teams channels),

--- a/platform/backend/src/agents/chatops/ms-teams-provider.ts
+++ b/platform/backend/src/agents/chatops/ms-teams-provider.ts
@@ -408,6 +408,13 @@ class MSTeamsProvider implements ChatOpsProvider {
     if (options.footer) {
       replyText += `\n\n---\n\n${options.footer}`;
     }
+    // An even-more-subtle hint (e.g. the one-time mute tip) on its own italic
+    // line below the footer. Italics keep it visually quieter than the footer.
+    if (options.hint) {
+      replyText += options.footer
+        ? `\n\n_${options.hint}_`
+        : `\n\n---\n\n_${options.hint}_`;
+    }
 
     // If a placeholder "Thinking..." message was sent (Teams channels),
     // update it with the actual response instead of sending a new message.

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -1037,7 +1037,7 @@ describe("SlackProvider.sendReply", () => {
     });
   });
 
-  test("renders the mute hint as its own subtle context block below the footer", async () => {
+  test("renders the mute hint as its own subtle context block above the footer", async () => {
     const provider = createProvider();
     const postMessage = vi.fn().mockResolvedValue({ ts: "2222222222.000000" });
     // biome-ignore lint/suspicious/noExplicitAny: test-only — mock Slack client
@@ -1062,18 +1062,18 @@ describe("SlackProvider.sendReply", () => {
     });
 
     const { blocks } = postMessage.mock.calls[0][0];
-    // markdown, then footer context, then the hint context as the final block.
+    // markdown, then the hint context, then the footer as the final block.
     expect(blocks).toEqual([
       { type: "markdown", text: "hi there" },
-      {
-        type: "context",
-        elements: [{ type: "plain_text", text: "🤖 Agent", emoji: true }],
-      },
       {
         type: "context",
         elements: [
           { type: "plain_text", text: 'Reply "mute" to stop', emoji: true },
         ],
+      },
+      {
+        type: "context",
+        elements: [{ type: "plain_text", text: "🤖 Agent", emoji: true }],
       },
     ]);
   });

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -1037,6 +1037,47 @@ describe("SlackProvider.sendReply", () => {
     });
   });
 
+  test("renders the mute hint as its own subtle context block below the footer", async () => {
+    const provider = createProvider();
+    const postMessage = vi.fn().mockResolvedValue({ ts: "2222222222.000000" });
+    // biome-ignore lint/suspicious/noExplicitAny: test-only — mock Slack client
+    (provider as any).client = { chat: { postMessage } };
+
+    await provider.sendReply({
+      originalMessage: {
+        messageId: "1234567890.123456",
+        channelId: "C12345",
+        workspaceId: "T12345",
+        threadId: "1111111111.000000",
+        senderId: "U_SENDER",
+        senderName: "Test User",
+        text: "hello",
+        rawText: "hello",
+        timestamp: new Date(),
+        isThreadReply: false,
+      },
+      text: "hi there",
+      footer: "🤖 Agent",
+      hint: 'Reply "mute" to stop',
+    });
+
+    const { blocks } = postMessage.mock.calls[0][0];
+    // markdown, then footer context, then the hint context as the final block.
+    expect(blocks).toEqual([
+      { type: "markdown", text: "hi there" },
+      {
+        type: "context",
+        elements: [{ type: "plain_text", text: "🤖 Agent", emoji: true }],
+      },
+      {
+        type: "context",
+        elements: [
+          { type: "plain_text", text: 'Reply "mute" to stop', emoji: true },
+        ],
+      },
+    ]);
+  });
+
   test("splits into thread follow-ups when markdown expansion would exceed Slack's 50-block cap", async () => {
     const provider = createProvider();
     const postMessage = vi

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -468,6 +468,15 @@ class SlackProvider implements ChatOpsProvider {
         });
       }
 
+      // An even-more-subtle hint (e.g. the one-time mute tip) rides the final
+      // message on its own context line, below the footer.
+      if (isFinal && options.hint) {
+        blocks.push({
+          type: "context",
+          elements: [{ type: "plain_text", text: options.hint, emoji: true }],
+        });
+      }
+
       const fallbackText = truncateFallbackText(
         isFinal && options.footer
           ? `${chunkText}\n\n${options.footer}`
@@ -1995,9 +2004,10 @@ function truncateFallbackText(text: string): string {
 }
 
 // Slack rejects chat.postMessage with more than 50 expanded blocks. Each
-// sendReply message reserves 1 slot for a context footer (continuation hint
-// or agent footer), so the markdown block's expansion is bounded to 45 — 4
-// under the 49 ceiling for safety against estimator drift.
+// sendReply message reserves slots for context footers (a continuation hint, or
+// the agent footer plus an optional one-time mute hint — at most 2), so the
+// markdown block's expansion is bounded to 45, keeping the worst case (45 + 2)
+// safely under the 50 ceiling against estimator drift.
 const MAX_ESTIMATED_RENDERED_BLOCKS = 45;
 
 /**

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -461,20 +461,24 @@ class SlackProvider implements ChatOpsProvider {
             },
           ],
         });
-      } else if (options.footer) {
-        blocks.push({
-          type: "context",
-          elements: [{ type: "plain_text", text: options.footer, emoji: true }],
-        });
-      }
-
-      // An even-more-subtle hint (e.g. the one-time mute tip) rides the final
-      // message on its own context line, below the footer.
-      if (isFinal && options.hint) {
-        blocks.push({
-          type: "context",
-          elements: [{ type: "plain_text", text: options.hint, emoji: true }],
-        });
+      } else {
+        // An even-more-subtle hint (e.g. the one-time mute tip) sits on its own
+        // context line ABOVE the agent footer, so the footer stays the last
+        // line of the reply.
+        if (options.hint) {
+          blocks.push({
+            type: "context",
+            elements: [{ type: "plain_text", text: options.hint, emoji: true }],
+          });
+        }
+        if (options.footer) {
+          blocks.push({
+            type: "context",
+            elements: [
+              { type: "plain_text", text: options.footer, emoji: true },
+            ],
+          });
+        }
       }
 
       const fallbackText = truncateFallbackText(

--- a/platform/backend/src/cache-manager.ts
+++ b/platform/backend/src/cache-manager.ts
@@ -52,6 +52,10 @@ export const CacheKey = {
   TeamsThreadActive: "teams-thread-active",
   /** Slack channel threads where the bot was @mentioned (sticky auto-reply) */
   SlackThreadActive: "slack-thread-active",
+  /** MS Teams channel threads that already got the one-time "you can mute me" hint */
+  TeamsThreadMuteHint: "teams-thread-mute-hint",
+  /** Slack channel threads that already got the one-time "you can mute me" hint */
+  SlackThreadMuteHint: "slack-thread-mute-hint",
 } as const;
 
 export type CacheKeyPrefix = (typeof CacheKey)[keyof typeof CacheKey];

--- a/platform/backend/src/types/chatops.ts
+++ b/platform/backend/src/types/chatops.ts
@@ -94,6 +94,11 @@ export interface ChatReplyOptions {
   replyInThread?: boolean;
   /** Optional: Footer text to append (e.g. agent name) */
   footer?: string;
+  /**
+   * Optional: an even-more-subtle hint rendered on its own line below the
+   * footer (e.g. the one-time "you can mute me" tip on a thread's first reply).
+   */
+  hint?: string;
   /** Provider-specific conversation reference for reply routing */
   conversationReference?: unknown;
 }


### PR DESCRIPTION
## What & why

Sticky channel auto-reply (#5490) keeps the bot replying to every message in a thread after the first @mention. We added an off switch — send `mute` (or `Archestra mute`, `stop replying`, etc.) or react to a bot reply with 🔇/🤫 — but users had no way to **discover** it short of the `/help` command.

This PR surfaces the off switch where it's most teachable: a subtle, **one-time footer hint on the bot's first reply in a channel thread**, using Slack's Block Kit "context" footer (and the Teams equivalent).

> Reply "mute" or react 🔇 to stop auto-replies in this thread

## How

- **`claimThreadMuteHint`** (`channel-activation.ts`) claims a one-time-per-thread slot in the distributed cache, sharing the 30-day sticky auto-reply TTL — so a thread that goes idle long enough to stop auto-replying is hinted again on revival. Cache failures are swallowed: a decorative hint must never break a reply.
- New optional **`hint`** on `ChatReplyOptions`, rendered as its own *even-more-subtle* line below the agent footer — a separate Slack `context` block, an italic line in Teams. Slack's block-budget comment is updated for the extra (≤2) context slots (worst case 45 + 2, safely under the 50 cap).
- The manager attaches the hint only on the agent-reply path, gated to **channel** threads (where sticky auto-reply applies) via `shouldHintThreadMute` — never in DMs or group chats.