### PR TITLE
fix(chat): suppress whitespace-only assistant text bubbles

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -105,6 +105,7 @@ import {
   filterOptimisticToolCalls,
   hasTextPart,
   identifyCompactToolGroups,
+  isBlankAssistantTextPart,
   resolveRunToolTargetName,
 } from "./chat-messages.utils";
 import { CompactToolGroup, type ToolIconMap } from "./compact-tool-call";
@@ -629,10 +630,12 @@ export function ChatMessages({
 
                     switch (part.type) {
                       case "text": {
-                        // Skip empty text parts from assistant messages.
-                        // OpenAI-compatible providers (Ollama, vLLM, etc.) may send empty content
-                        // alongside tool calls, which the AI SDK converts into an empty text part.
-                        if (!part.text && message.role === "assistant") {
+                        // Skip blank text parts from assistant messages. Models
+                        // routinely stream a whitespace-only chunk (" ", "\n\n")
+                        // right before a tool call, which the AI SDK turns into a
+                        // text part; rendered, it shows as an empty message bubble.
+                        // Trims so whitespace-only — not just "" — is suppressed.
+                        if (isBlankAssistantTextPart(part, message.role)) {
                           return null;
                         }
 

--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -11,6 +11,7 @@ import {
   getAppRenderVerb,
   hasTextPart,
   identifyCompactToolGroups,
+  isBlankAssistantTextPart,
   isSupersededRender,
   mcpToolLabel,
 } from "./chat-messages.utils";
@@ -877,5 +878,45 @@ describe("getAppRenderVerb", () => {
 
   it("returns null for non-app tools", () => {
     expect(getAppRenderVerb("google__search")).toBeNull();
+  });
+});
+
+describe("isBlankAssistantTextPart", () => {
+  const textPart = (text: string): UIMessage["parts"][number] => ({
+    type: "text",
+    text,
+  });
+
+  it.each([
+    " ",
+    "   ",
+    "\n\n",
+    "\t",
+    "\n  \t ",
+  ])("suppresses whitespace-only assistant text %j", (text) => {
+    expect(isBlankAssistantTextPart(textPart(text), "assistant")).toBe(true);
+  });
+
+  it("suppresses an empty-string assistant text part", () => {
+    expect(isBlankAssistantTextPart(textPart(""), "assistant")).toBe(true);
+  });
+
+  it("keeps assistant text that has real content", () => {
+    expect(isBlankAssistantTextPart(textPart("  hello  "), "assistant")).toBe(
+      false,
+    );
+  });
+
+  it("never suppresses non-assistant (user) text, even when blank", () => {
+    expect(isBlankAssistantTextPart(textPart("\n\n"), "user")).toBe(false);
+  });
+
+  it("ignores non-text parts", () => {
+    expect(
+      isBlankAssistantTextPart(
+        { type: "step-start" } as UIMessage["parts"][number],
+        "assistant",
+      ),
+    ).toBe(false);
   });
 });

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -79,6 +79,21 @@ export function hasTextPart(parts: UIMessage["parts"] | undefined): boolean {
   return parts?.some((p) => p.type === "text") ?? false;
 }
 
+/**
+ * Assistant turns routinely contain throwaway whitespace-only `text` parts that
+ * the model streams right before a tool call (e.g. `" "`, `"   "`, `"\n\n"`).
+ * They carry no content and must not render as empty message bubbles. The check
+ * trims before testing for emptiness, matching the `text.trim().length > 0`
+ * guards used elsewhere in the message stream; a bare `!part.text` only catches
+ * the strictly-empty string and lets whitespace through.
+ */
+export function isBlankAssistantTextPart(
+  part: UIMessage["parts"][number],
+  role: UIMessage["role"],
+): boolean {
+  return role === "assistant" && part.type === "text" && !part.text.trim();
+}
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 


### PR DESCRIPTION
## Problem

Assistant turns render **empty message bubbles** ("empty pills") before tool calls — see T-436 / #6053.

## Root cause

Models routinely stream a whitespace-only text chunk right before invoking a tool (observed `" "` / `"   "` via Kimi on staging, `"\n\n"` via a local model). The AI SDK turns each chunk into its own `text` part, e.g.:

```
[1] text  "\n\n"            ← empty bubble
[2] tool  search_tools
[4] text  "\n\n"            ← empty bubble
[5] tool  run_tool
[7] text  "…real answer…"
```

The render guard in `chat-messages.tsx` only skipped the **strictly-empty** string:

```ts
if (!part.text && message.role === "assistant") return null;
```

`"\n\n"` (and `" "`) is truthy, so it slipped through and rendered as a visually empty bubble — even though the sibling "meaningful text" guards in the same message stream already use `text.trim().length > 0`. This is a renderer gap (the guard has never trimmed), not model-specific.

## Fix

- Extract `isBlankAssistantTextPart(part, role)` into `chat-messages.utils.ts` — trims before the emptiness check, so `""`, `" "`, `"   "`, `"\n\n"` are all treated as blank.
- Use it in the render guard so blank assistant text parts `return null` and never render a bubble.

## Testing

- New unit tests in `chat-messages.utils.test.ts` (9 cases): whitespace variants suppressed, empty string suppressed, real content kept, user-role text never suppressed, non-text parts ignored.
- `pnpm type-check` clean, `biome check` clean.

Closes #6053

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>