### PR TITLE
feat(chat): clearer Files panel section copy and header

### DIFF
--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -19,7 +19,11 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
-import { collapseProjectChats } from "@/app/projects/[id]/project-chats.utils";
+import {
+  collapseProjectChats,
+  countRunsByTrigger,
+  formatScheduledRecentRow,
+} from "@/app/projects/[id]/project-chats.utils";
 import { ProjectSchedulesSection } from "@/app/projects/[id]/project-schedules-section";
 import { AgentIcon } from "@/components/agent-icon";
 import { FileDetailHeader } from "@/components/chat/file-detail-header";
@@ -288,6 +292,7 @@ function ChatsList({
   // A schedule's runs collapse to one row (its latest run); user chats are shown
   // as-is. Newest activity first.
   const chats = collapseProjectChats(conversations);
+  const runCounts = countRunsByTrigger(conversations);
   return (
     <section>
       <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-muted-foreground">
@@ -301,6 +306,15 @@ function ChatsList({
         <div className="space-y-2">
           {chats.map((conv) => {
             const isScheduled = conv.origin === "schedule_trigger";
+            const scheduled = isScheduled
+              ? formatScheduledRecentRow({
+                  scheduleName: conv.scheduleName,
+                  prompt: conv.title,
+                  runCount: conv.scheduleTriggerId
+                    ? (runCounts.get(conv.scheduleTriggerId) ?? 0)
+                    : 0,
+                })
+              : null;
             // A scheduled row opens its latest run's chat WITH the schedule
             // context, so the chat sidebar shows the runs navigator for the rest.
             const href = isScheduled
@@ -328,8 +342,8 @@ function ChatsList({
                 <span className="min-w-0 flex-1">
                   <span className="flex items-center gap-2">
                     <span className="truncate text-sm font-medium">
-                      {isScheduled
-                        ? (conv.scheduleName ?? "Scheduled task")
+                      {scheduled
+                        ? scheduled.title
                         : (conv.title ?? "Untitled chat")}
                     </span>
                     {conv.readOnly && (
@@ -340,8 +354,8 @@ function ChatsList({
                     )}
                   </span>
                   <span className="block truncate text-xs text-muted-foreground">
-                    {isScheduled
-                      ? (conv.title ?? "No prompt")
+                    {scheduled
+                      ? scheduled.meta
                       : conv.readOnly
                         ? `by ${conv.authorName ?? "someone else"}`
                         : "by you"}

--- a/platform/frontend/src/app/projects/[id]/project-chats.utils.test.ts
+++ b/platform/frontend/src/app/projects/[id]/project-chats.utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { collapseProjectChats } from "./project-chats.utils";
+import {
+  collapseProjectChats,
+  countRunsByTrigger,
+  formatScheduledRecentRow,
+} from "./project-chats.utils";
 
 type TestChat = {
   id: string;
@@ -100,5 +104,61 @@ describe("collapseProjectChats", () => {
       }),
     ]);
     expect(out.map((c) => c.id)).toEqual(["x2", "x1"]); // not collapsed together
+  });
+});
+
+describe("countRunsByTrigger", () => {
+  it("counts a schedule's runs and ignores user chats", () => {
+    const counts = countRunsByTrigger([
+      item({ id: "u1", origin: "user" }),
+      item({ id: "r1", origin: "schedule_trigger", scheduleTriggerId: "t1" }),
+      item({ id: "r2", origin: "schedule_trigger", scheduleTriggerId: "t1" }),
+      item({ id: "r3", origin: "schedule_trigger", scheduleTriggerId: "t2" }),
+    ]);
+    expect(counts.get("t1")).toBe(2);
+    expect(counts.get("t2")).toBe(1);
+    expect(counts.size).toBe(2); // user chat contributes no key
+  });
+
+  it("ignores scheduled chats with no schedule id", () => {
+    const counts = countRunsByTrigger([
+      item({ id: "x", origin: "schedule_trigger", scheduleTriggerId: null }),
+    ]);
+    expect(counts.size).toBe(0);
+  });
+});
+
+describe("formatScheduledRecentRow", () => {
+  it("prefixes the schedule name and pluralizes the run count", () => {
+    expect(
+      formatScheduledRecentRow({
+        scheduleName: "Weekly summary",
+        prompt: "Generate the report",
+        runCount: 12,
+      }),
+    ).toEqual({
+      title: "Scheduled task · Weekly summary",
+      meta: "12 runs · Generate the report",
+    });
+  });
+
+  it("uses the singular 'run' for a single run", () => {
+    expect(
+      formatScheduledRecentRow({
+        scheduleName: "Daily",
+        prompt: "do it",
+        runCount: 1,
+      }).meta,
+    ).toBe("1 run · do it");
+  });
+
+  it("falls back when the schedule name or prompt is missing", () => {
+    expect(
+      formatScheduledRecentRow({
+        scheduleName: null,
+        prompt: null,
+        runCount: 0,
+      }),
+    ).toEqual({ title: "Scheduled task", meta: "0 runs · No prompt" });
   });
 });

--- a/platform/frontend/src/app/projects/[id]/project-chats.utils.ts
+++ b/platform/frontend/src/app/projects/[id]/project-chats.utils.ts
@@ -37,3 +37,43 @@ export function collapseProjectChats<T extends CollapsibleChat>(
     return 0;
   });
 }
+
+/**
+ * Count each schedule's runs within a project's chat list, keyed by trigger id.
+ * A scheduled run is one `schedule_trigger` conversation, so the count is the
+ * number of runs that produced an openable chat — what the collapsed Recents row
+ * shows as "N runs".
+ */
+export function countRunsByTrigger<T extends CollapsibleChat>(
+  conversations: T[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const conversation of conversations) {
+    if (
+      conversation.origin === "schedule_trigger" &&
+      conversation.scheduleTriggerId
+    ) {
+      const id = conversation.scheduleTriggerId;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+/**
+ * Title + meta strings for a collapsed scheduled row in the Recents list. The
+ * title is prefixed with "Scheduled task" so the row reads as a schedule at a
+ * glance; the meta line leads with the run count, then the run's prompt.
+ */
+export function formatScheduledRecentRow(params: {
+  scheduleName: string | null;
+  prompt: string | null;
+  runCount: number;
+}): { title: string; meta: string } {
+  const { scheduleName, prompt, runCount } = params;
+  const runs = `${runCount} ${runCount === 1 ? "run" : "runs"}`;
+  return {
+    title: scheduleName ? `Scheduled task · ${scheduleName}` : "Scheduled task",
+    meta: `${runs} · ${prompt ?? "No prompt"}`,
+  };
+}

--- a/platform/frontend/src/app/projects/[id]/project-schedules-section.tsx
+++ b/platform/frontend/src/app/projects/[id]/project-schedules-section.tsx
@@ -2,14 +2,15 @@
 
 import {
   CalendarClock,
+  ExternalLink,
   MoreHorizontal,
-  Pencil,
+  Pause,
   Play,
   Plus,
   Power,
   Trash2,
 } from "lucide-react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { runChatHref } from "@/app/projects/[id]/schedules/[triggerId]/run-row.utils";
 import {
@@ -30,6 +31,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
@@ -117,6 +119,7 @@ export function ProjectSchedulesSection({
 // === internal components ===
 
 function ScheduleRow({ schedule }: { schedule: ScheduleTrigger }) {
+  const router = useRouter();
   const enableSchedule = useEnableScheduleTrigger();
   const disableSchedule = useDisableScheduleTrigger();
   const deleteSchedule = useDeleteScheduleTrigger();
@@ -124,84 +127,64 @@ function ScheduleRow({ schedule }: { schedule: ScheduleTrigger }) {
   const [editOpen, setEditOpen] = useState(false);
 
   const { resolve, isResolving } = useResolveRunChat();
-  // Clicking the schedule opens its LAST run's chat. Fetch just that run (no
-  // polling — the section already refreshes the trigger list).
+  // "Open recent run" (overflow menu) opens this schedule's LAST run's chat.
+  // Fetch just that run (no polling — the section already refreshes the trigger
+  // list).
   const { data: runsResponse } = useScheduleTriggerRuns(schedule.id, {
     limit: 1,
     refetchInterval: false,
   });
   const lastRun = runsResponse?.data?.[0];
-
-  const labelClassName = cn(
-    "min-w-0 flex-1 hover:opacity-80 transition-opacity",
-    !schedule.enabled && "opacity-60",
-  );
-  const scheduleLabel = (
-    <>
-      <span className="flex items-center gap-2">
-        <span className="truncate text-sm font-medium">{schedule.name}</span>
-        {!schedule.enabled && (
-          <Badge variant="outline" className="shrink-0">
-            Disabled
-          </Badge>
-        )}
-      </span>
-      <span className="block truncate text-xs text-muted-foreground">
-        {schedule.agent?.name ?? "Default agent"}
-      </span>
-    </>
-  );
-
   const lastRunChatHref = lastRun
     ? runChatHref({ triggerId: schedule.id, run: lastRun })
     : null;
-  // Last run has a chat → link straight to it. Last run without one (legacy) →
-  // create it on click, then open. No runs/chats yet → plain label that does
-  // nothing (the empty runs page has nothing to show); "Run manually" in the
-  // overflow menu is how you kick off the first run.
-  let nameNode: React.ReactNode;
-  if (lastRunChatHref) {
-    nameNode = (
-      <Link href={lastRunChatHref} className={labelClassName}>
-        {scheduleLabel}
-      </Link>
-    );
-  } else if (lastRun) {
-    nameNode = (
-      <button
-        type="button"
-        disabled={isResolving}
-        className={cn(labelClassName, "text-left")}
-        onClick={() => resolve(schedule.id, lastRun.id)}
-      >
-        {scheduleLabel}
-      </button>
-    );
-  } else {
-    nameNode = (
-      <div className={cn("min-w-0 flex-1", !schedule.enabled && "opacity-60")}>
-        {scheduleLabel}
-      </div>
-    );
-  }
+  // Last run has a chat → go straight to it. Last run without one (legacy) →
+  // create it, then open. No runs yet → the menu item is disabled.
+  const openRecentRun = () => {
+    if (lastRunChatHref) router.push(lastRunChatHref);
+    else if (lastRun) resolve(schedule.id, lastRun.id);
+  };
 
   return (
     <div className="flex items-center gap-3 rounded-lg border bg-card px-3 py-2.5">
-      <span
+      <button
+        type="button"
+        onClick={() => setEditOpen(true)}
         className={cn(
-          "flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10",
-          !schedule.enabled && "bg-muted",
+          "flex min-w-0 flex-1 items-center gap-3 text-left transition-opacity hover:opacity-80",
+          !schedule.enabled && "opacity-60",
         )}
       >
-        <CalendarClock
+        <span
           className={cn(
-            "h-4 w-4 text-primary",
-            !schedule.enabled && "text-muted-foreground",
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10",
+            !schedule.enabled && "bg-muted",
           )}
-          aria-hidden
-        />
-      </span>
-      {nameNode}
+        >
+          <CalendarClock
+            className={cn(
+              "h-4 w-4 text-primary",
+              !schedule.enabled && "text-muted-foreground",
+            )}
+            aria-hidden
+          />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium">
+              {schedule.name}
+            </span>
+            {!schedule.enabled && (
+              <Badge variant="outline" className="shrink-0">
+                Disabled
+              </Badge>
+            )}
+          </span>
+          <span className="block truncate text-xs text-muted-foreground">
+            {schedule.agent?.name ?? "Default agent"}
+          </span>
+        </span>
+      </button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon" aria-label="Schedule actions">
@@ -209,6 +192,14 @@ function ScheduleRow({ schedule }: { schedule: ScheduleTrigger }) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            disabled={!lastRun || isResolving}
+            onSelect={openRecentRun}
+          >
+            <ExternalLink className="h-4 w-4" />
+            Open recent run
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem
             disabled={runNow.isPending}
             onSelect={() => runNow.mutate(schedule.id)}
@@ -225,19 +216,15 @@ function ScheduleRow({ schedule }: { schedule: ScheduleTrigger }) {
           >
             {schedule.enabled ? (
               <>
-                <Power className="h-4 w-4" />
+                <Pause className="h-4 w-4" />
                 Disable
               </>
             ) : (
               <>
-                <Play className="h-4 w-4" />
+                <Power className="h-4 w-4" />
                 Enable
               </>
             )}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setEditOpen(true)}>
-            <Pencil className="h-4 w-4" />
-            Edit
           </DropdownMenuItem>
           <DropdownMenuItem
             variant="destructive"

--- a/platform/frontend/src/components/chat/file-list-section.tsx
+++ b/platform/frontend/src/components/chat/file-list-section.tsx
@@ -80,14 +80,12 @@ export function FileSection({
   return (
     <div className="mb-5">
       {title && (
-        // Two stacked lines — the group name reads as the header (larger, full
-        // color), with its persistence scope as a quieter line beneath it.
-        <div className="mb-2 px-1">
-          <div className="text-sm font-semibold text-foreground">{title}</div>
+        // One line — the group name, then its persistence scope after a middot,
+        // echoing the inline "name · description" of the instructions row below.
+        <div className="mb-1.5 flex items-baseline gap-1 px-1 text-[13px] leading-none">
+          <span className="font-medium text-muted-foreground">{title}</span>
           {description && (
-            <div className="mt-0.5 text-xs leading-snug text-muted-foreground">
-              {description}
-            </div>
+            <span className="text-muted-foreground/60">· {description}</span>
           )}
         </div>
       )}

--- a/platform/frontend/src/components/chat/file-list-section.tsx
+++ b/platform/frontend/src/components/chat/file-list-section.tsx
@@ -80,13 +80,14 @@ export function FileSection({
   return (
     <div className="mb-5">
       {title && (
-        // One quiet line — the group name, then its persistence scope after a
-        // middot — echoing the inline "name · description" of the pinned
-        // instructions row below it.
-        <div className="mb-1.5 flex items-baseline gap-1 px-1 text-[11px] leading-none">
-          <span className="font-medium text-muted-foreground">{title}</span>
+        // Two stacked lines — the group name reads as the header (larger, full
+        // color), with its persistence scope as a quieter line beneath it.
+        <div className="mb-2 px-1">
+          <div className="text-sm font-semibold text-foreground">{title}</div>
           {description && (
-            <span className="text-muted-foreground/60">· {description}</span>
+            <div className="mt-0.5 text-xs leading-snug text-muted-foreground">
+              {description}
+            </div>
           )}
         </div>
       )}

--- a/platform/frontend/src/lib/chat/conversation-files.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.test.ts
@@ -120,14 +120,14 @@ describe("persistentFilesSection", () => {
   it("labels a project chat's persistent files as shared with the project", () => {
     expect(persistentFilesSection("proj_1")).toEqual({
       title: "Project files",
-      description: "Shared with the whole project",
+      description: "shared with the whole project",
     });
   });
 
   it("labels a personal chat's persistent files as chat-scoped", () => {
     const chatScoped = {
       title: "Chat files",
-      description: "Saved to a project if you create one",
+      description: "saved to a project if you create one from this chat",
     };
     expect(persistentFilesSection(null)).toEqual(chatScoped);
     expect(persistentFilesSection(undefined)).toEqual(chatScoped);

--- a/platform/frontend/src/lib/chat/conversation-files.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.test.ts
@@ -120,15 +120,14 @@ describe("persistentFilesSection", () => {
   it("labels a project chat's persistent files as shared with the project", () => {
     expect(persistentFilesSection("proj_1")).toEqual({
       title: "Project files",
-      description: "Files shared across the project",
+      description: "Shared with the whole project",
     });
   });
 
   it("labels a personal chat's persistent files as chat-scoped", () => {
     const chatScoped = {
       title: "Chat files",
-      description:
-        "Files made here. They'll move to the project if you convert this chat into one.",
+      description: "Saved to a project if you create one",
     };
     expect(persistentFilesSection(null)).toEqual(chatScoped);
     expect(persistentFilesSection(undefined)).toEqual(chatScoped);

--- a/platform/frontend/src/lib/chat/conversation-files.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.test.ts
@@ -120,7 +120,7 @@ describe("persistentFilesSection", () => {
   it("labels a project chat's persistent files as shared with the project", () => {
     expect(persistentFilesSection("proj_1")).toEqual({
       title: "Project files",
-      description: "Shared with the project",
+      description: "Files shared across the project",
     });
   });
 

--- a/platform/frontend/src/lib/chat/conversation-files.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.test.ts
@@ -125,14 +125,13 @@ describe("persistentFilesSection", () => {
   });
 
   it("labels a personal chat's persistent files as chat-scoped", () => {
-    expect(persistentFilesSection(null)).toEqual({
+    const chatScoped = {
       title: "Chat files",
-      description: "Created in this chat",
-    });
-    expect(persistentFilesSection(undefined)).toEqual({
-      title: "Chat files",
-      description: "Created in this chat",
-    });
+      description:
+        "Files made here. They'll move to the project if you convert this chat into one.",
+    };
+    expect(persistentFilesSection(null)).toEqual(chatScoped);
+    expect(persistentFilesSection(undefined)).toEqual(chatScoped);
   });
 });
 

--- a/platform/frontend/src/lib/chat/conversation-files.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.ts
@@ -88,7 +88,7 @@ export function persistentFilesSection(projectId: string | null | undefined): {
   description: string;
 } {
   return projectId != null
-    ? { title: "Project files", description: "Shared with the project" }
+    ? { title: "Project files", description: "Files shared across the project" }
     : {
         title: "Chat files",
         description:

--- a/platform/frontend/src/lib/chat/conversation-files.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.ts
@@ -80,7 +80,8 @@ export function assembleFileSections(params: {
  * Header label + persistence-scope subtitle for the chat panel's group of
  * persistent files (this chat's saved outputs, plus the project's shared files
  * in a project chat). A project chat's files live with the project and are seen
- * by everyone with access; a personal chat's files stay with the conversation.
+ * by everyone with access; a personal chat's files carry into a project if you
+ * create one.
  * Attachments are labeled separately — see {@link ATTACHMENTS_SECTION}.
  */
 export function persistentFilesSection(projectId: string | null | undefined): {
@@ -88,19 +89,17 @@ export function persistentFilesSection(projectId: string | null | undefined): {
   description: string;
 } {
   return projectId != null
-    ? { title: "Project files", description: "Files shared across the project" }
+    ? { title: "Project files", description: "Shared with the whole project" }
     : {
         title: "Chat files",
-        description:
-          "Files made here. They'll move to the project if you convert this chat into one.",
+        description: "Saved to a project if you create one",
       };
 }
 
 /** Header label + subtitle for the user's uploaded inputs to a chat. */
 export const ATTACHMENTS_SECTION = {
   title: "Attachments",
-  description:
-    "Files you've added to this chat. They won't carry over to the project.",
+  description: "Stay in this chat",
 } as const;
 
 /**

--- a/platform/frontend/src/lib/chat/conversation-files.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.ts
@@ -89,17 +89,17 @@ export function persistentFilesSection(projectId: string | null | undefined): {
   description: string;
 } {
   return projectId != null
-    ? { title: "Project files", description: "Shared with the whole project" }
+    ? { title: "Project files", description: "shared with the whole project" }
     : {
         title: "Chat files",
-        description: "Saved to a project if you create one",
+        description: "saved to a project if you create one from this chat",
       };
 }
 
 /** Header label + subtitle for the user's uploaded inputs to a chat. */
 export const ATTACHMENTS_SECTION = {
   title: "Attachments",
-  description: "Stay in this chat",
+  description: "stay in this chat",
 } as const;
 
 /**

--- a/platform/frontend/src/lib/chat/conversation-files.ts
+++ b/platform/frontend/src/lib/chat/conversation-files.ts
@@ -89,13 +89,18 @@ export function persistentFilesSection(projectId: string | null | undefined): {
 } {
   return projectId != null
     ? { title: "Project files", description: "Shared with the project" }
-    : { title: "Chat files", description: "Created in this chat" };
+    : {
+        title: "Chat files",
+        description:
+          "Files made here. They'll move to the project if you convert this chat into one.",
+      };
 }
 
 /** Header label + subtitle for the user's uploaded inputs to a chat. */
 export const ATTACHMENTS_SECTION = {
   title: "Attachments",
-  description: "Your uploads",
+  description:
+    "Files you've added to this chat. They won't carry over to the project.",
 } as const;
 
 /**


### PR DESCRIPTION
## What

Refines the section-header copy (and bumps its size) in the chat **Files** panel so each file group says, in one short line, where its files live.

### Final copy

| Context | Group | Description |
|---|---|---|
| No-project chat | Chat files | Saved to a project if you create one |
| | Attachments | Stay in this chat |
| Project chat | Project files | Shared with the whole project |
| | Attachments | Stay in this chat |

### Why

The old descriptions (`Your uploads`, `Created in this chat`) didn't convey the one thing that distinguishes the groups: **chat files persist into a project, attachments don't.** The new copy makes that explicit while staying short, and drops mentions of "the project" only where they'd be confusing (e.g. in a chat that has no project yet).

`Attachments · Stay in this chat` reads the same in both chat types, so the attachments copy is a plain constant again — no project-dependent branch.

### Styling

The header stays a single muted `name · description` line; font bumped from `11px` → `13px` for legibility.

## Testing

- `conversation-files.test.ts` updated to pin the new copy — **8 passing**
- `biome`, `type-check` (tsgo), and `knip` all clean

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>