### PR TITLE
fix(chat): don't auto-select unconnected per-user model over keyed model

### DIFF
--- a/platform/frontend/src/components/chat/model-selector.test.tsx
+++ b/platform/frontend/src/components/chat/model-selector.test.tsx
@@ -119,6 +119,33 @@ describe("ModelSelector coverage matrix", () => {
     await waitFor(() => expect(onModelChange).toHaveBeenCalledWith("m1"));
   });
 
+  // The org-wide GitHub Copilot catalog is flagged "best" but requires a
+  // per-user connection the viewer lacks; auto-select must prefer their own
+  // keyed model rather than silently defaulting to the unconnected provider.
+  it("auto-selects a keyed model over an unconnected per-user 'best' model", async () => {
+    setQuery({
+      modelsByProvider: {
+        "github-copilot": [
+          model({
+            dbId: "copilot-1",
+            provider: "github-copilot",
+            isBest: true,
+            requiresUserConnection: true,
+            isConnected: false,
+          }),
+        ],
+        anthropic: [
+          model({ dbId: "kimi-1", provider: "anthropic", isBest: false }),
+        ],
+      },
+    });
+    const { onModelChange } = renderSelector({
+      selectedModel: "stale-id",
+      variant: "default",
+    });
+    await waitFor(() => expect(onModelChange).toHaveBeenCalledWith("kimi-1"));
+  });
+
   it("renders the empty-selection placeholder and does not auto-select", () => {
     setQuery({ modelsByProvider: { openai: [model()] } });
     const { onModelChange } = renderSelector({

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -694,6 +694,8 @@ export const ModelSelector = memo(function ModelSelector({
       availableModels: allAvailableModels.map((m) => ({
         id: m.dbId,
         isBest: m.isBest,
+        requiresUserConnection: m.requiresUserConnection,
+        isConnected: m.isConnected,
       })),
       isLoading,
     });

--- a/platform/frontend/src/lib/chat/use-chat-preferences.test.ts
+++ b/platform/frontend/src/lib/chat/use-chat-preferences.test.ts
@@ -236,6 +236,59 @@ describe("resolveAutoSelectedModel", () => {
       }),
     ).toBe("uuid-a");
   });
+
+  test("prefers a keyed model over an unconnected per-user 'best' model", () => {
+    expect(
+      resolveAutoSelectedModel({
+        selectedModel: "uuid-deleted",
+        availableModels: [
+          {
+            id: "uuid-copilot",
+            isBest: true,
+            requiresUserConnection: true,
+            isConnected: false,
+          },
+          { id: "uuid-kimi" },
+        ],
+        isLoading: false,
+      }),
+    ).toBe("uuid-kimi");
+  });
+
+  test("falls back to an unconnected per-user model when nothing else is available", () => {
+    expect(
+      resolveAutoSelectedModel({
+        selectedModel: "uuid-deleted",
+        availableModels: [
+          {
+            id: "uuid-copilot",
+            isBest: true,
+            requiresUserConnection: true,
+            isConnected: false,
+          },
+        ],
+        isLoading: false,
+      }),
+    ).toBe("uuid-copilot");
+  });
+
+  test("a connected per-user 'best' model stays eligible", () => {
+    expect(
+      resolveAutoSelectedModel({
+        selectedModel: "uuid-deleted",
+        availableModels: [
+          {
+            id: "uuid-copilot",
+            isBest: true,
+            requiresUserConnection: true,
+            isConnected: true,
+          },
+          { id: "uuid-kimi" },
+        ],
+        isLoading: false,
+      }),
+    ).toBe("uuid-copilot");
+  });
 });
 
 describe("agentRequiresPerUserConnect", () => {

--- a/platform/frontend/src/lib/chat/use-chat-preferences.ts
+++ b/platform/frontend/src/lib/chat/use-chat-preferences.ts
@@ -47,6 +47,10 @@ interface AutoSelectableModel {
   /** The models.id UUID. */
   id: string;
   isBest?: boolean;
+  /** A per-user provider (e.g. GitHub Copilot) catalogued for all members. */
+  requiresUserConnection?: boolean;
+  /** Whether the viewer has connected the per-user provider. */
+  isConnected?: boolean;
 }
 
 /**
@@ -55,6 +59,12 @@ interface AutoSelectableModel {
  *
  * Auto-selection only triggers when the selected model is genuinely
  * unavailable (e.g. the API key changed and the model is no longer offered).
+ *
+ * Prefers a ready-to-use model over a per-user-provider model the viewer hasn't
+ * connected: the latter is catalogued org-wide and flagged "best", so without
+ * this it would win the fallback over the viewer's own keyed models (mirrors the
+ * ready-to-use fallback in `resolveInitialModel`). Falls back to the full list
+ * when nothing is ready, so a connect-only org still gets a selection.
  */
 export function resolveAutoSelectedModel(params: {
   selectedModel: string;
@@ -65,7 +75,10 @@ export function resolveAutoSelectedModel(params: {
   if (isLoading || availableModels.length === 0) return null;
   if (!selectedModel) return null;
   if (availableModels.some((m) => m.id === selectedModel)) return null;
-  const fallback = pickBestModel(availableModels);
+  const ready = availableModels.filter(
+    (m) => !(m.requiresUserConnection && !m.isConnected),
+  );
+  const fallback = pickBestModel(ready.length > 0 ? ready : availableModels);
   return fallback && fallback.id !== selectedModel ? fallback.id : null;
 }
 


### PR DESCRIPTION
## Problem

The chat model selector's auto-select fed every available model — including the org-wide GitHub Copilot catalog, whose models are flagged `isBest` but require a per-user connection — into `pickBestModel` (`find(m => m.isBest) ?? models[0]`). A user's own keyed provider (e.g. a custom Anthropic-compatible Kimi key) whose model ids match no "best" marker pattern has no `isBest` model, so the unconnected Copilot model won the fallback regardless of array order.

## Fix

`resolveAutoSelectedModel` now prefers the ready-to-use subset of candidates (`!(requiresUserConnection && !isConnected)`), falling back to the full list only when none are ready (so a connect-only org still gets a selection). The single caller forwards `requiresUserConnection`/`isConnected` from `LlmModel`. This mirrors the two-tier fallback already in `resolveInitialModel`.

Frontend only — the backend send-time resolver already ranks solely over keys the user can access, so an unconnected per-user key never enters its fallback.

## Tests
- `resolveAutoSelectedModel`: prefers keyed model over unconnected per-user `isBest`; falls back to unconnected per-user when nothing else; connected per-user stays eligible.
- `ModelSelector`: regression guard that the caller forwards the connection flags.

https://claude.ai/code/session_01Qb2WWWPNEPYQvf6HE2josX

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>