### PR TITLE
fix(apps): adds greeting when users open an app for the first time

### DIFF
--- a/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
@@ -85,6 +85,8 @@ describe("POST /api/apps/external/:mcpServerId/open-in-chat", () => {
     expect(conversationId).toBeTruthy();
 
     const messages = await MessageModel.findByConversation(conversationId);
+    // Exactly one message: external apps are read-only from chat, so they get no
+    // "ask me to change it" greeting (unlike owned apps).
     expect(messages).toHaveLength(1);
     const part = messages[0].content.parts[0] as {
       type: string;

--- a/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
@@ -85,8 +85,7 @@ describe("POST /api/apps/external/:mcpServerId/open-in-chat", () => {
     expect(conversationId).toBeTruthy();
 
     const messages = await MessageModel.findByConversation(conversationId);
-    // Exactly one message: external apps are read-only from chat, so they get no
-    // "ask me to change it" greeting (unlike owned apps).
+    // External apps are read-only from chat, so no greeting.
     expect(messages).toHaveLength(1);
     const part = messages[0].content.parts[0] as {
       type: string;

--- a/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
@@ -53,14 +53,28 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     await app.close();
   });
 
-  async function createApp(name: string): Promise<string> {
+  async function createApp(
+    name: string,
+    extra: Record<string, unknown> = {},
+  ): Promise<string> {
     const created = await app.inject({
       method: "POST",
       url: "/api/apps",
-      payload: { name },
+      payload: { name, ...extra },
     });
     expect(created.statusCode).toBe(200);
     return created.json().id;
+  }
+
+  // Editing the html forks a new version (latestVersion 1 → 2), taking the app past
+  // the scaffold so the open-in-chat greeting fires.
+  async function editApp(appId: string): Promise<void> {
+    const edited = await app.inject({
+      method: "PATCH",
+      url: `/api/apps/${appId}`,
+      payload: { html: "<h1>edited</h1>" },
+    });
+    expect(edited.statusCode).toBe(200);
   }
 
   // The seeded message is what makes the app render inline with no model turn —
@@ -82,8 +96,28 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     return part.output.structuredContent.id;
   }
 
-  test("seeds a conversation with the app rendered and returns its id", async () => {
+  // Owned apps are editable from chat, so a second assistant text message greets the
+  // user with what they can do — naming the app and repeating the app capabilities.
+  function expectSeededGreeting(
+    message: {
+      role: string;
+      content: { parts: Array<Record<string, unknown>> };
+    },
+    appName: string,
+  ): string {
+    expect(message.role).toBe("assistant");
+    const part = message.content.parts[0] as { type: string; text: string };
+    expect(part.type).toBe("text");
+    expect(part.text).toContain(appName);
+    expect(part.text).toContain("Your connected MCP tools & servers");
+    expect(part.text).toContain("A private + shared data store");
+    expect(part.text).toContain("Built-in AI to summarize & generate");
+    return part.text;
+  }
+
+  test("seeds a render plus a greeting for an app built past the scaffold", async () => {
     const appId = await createApp("Notes");
+    await editApp(appId);
 
     const res = await app.inject({
       method: "POST",
@@ -94,11 +128,28 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     expect(conversationId).toBeTruthy();
 
     const messages = await MessageModel.findByConversation(conversationId);
+    expect(messages).toHaveLength(2);
+    expect(expectSeededRender(messages[0])).toBe(appId);
+    expectSeededGreeting(messages[1], "Notes");
+  });
+
+  test("seeds only the render (no greeting) for a brand-new scaffold app", async () => {
+    // A fresh app still shows the default template, whose intro already lists the
+    // capabilities — so the greeting is suppressed to avoid repeating it.
+    const appId = await createApp("Fresh");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/apps/${appId}/open-in-chat`,
+    });
+    const { conversationId } = res.json();
+
+    const messages = await MessageModel.findByConversation(conversationId);
     expect(messages).toHaveLength(1);
     expect(expectSeededRender(messages[0])).toBe(appId);
   });
 
-  test("create with openInChat returns the seeded conversation id", async () => {
+  test("create with openInChat seeds only the render (still the scaffold)", async () => {
     const created = await app.inject({
       method: "POST",
       url: "/api/apps",
@@ -111,6 +162,22 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     const messages = await MessageModel.findByConversation(conversationId);
     expect(messages).toHaveLength(1);
     expect(expectSeededRender(messages[0])).toBe(id);
+  });
+
+  test("the seeded greeting includes the app description when set", async () => {
+    const id = await createApp("Tracker", { description: "Track team spend." });
+    await editApp(id);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/apps/${id}/open-in-chat`,
+    });
+    const { conversationId } = res.json();
+
+    const messages = await MessageModel.findByConversation(conversationId);
+    expect(messages).toHaveLength(2);
+    const greeting = expectSeededGreeting(messages[1], "Tracker");
+    expect(greeting).toContain("Track team spend.");
   });
 
   test("404s for an app the caller cannot view", async () => {

--- a/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
@@ -164,7 +164,7 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     expect(expectSeededRender(messages[0])).toBe(id);
   });
 
-  test("the seeded greeting includes the app description when set", async () => {
+  test("the seeded greeting omits the app description", async () => {
     const id = await createApp("Tracker", { description: "Track team spend." });
     await editApp(id);
 
@@ -177,7 +177,7 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     const messages = await MessageModel.findByConversation(conversationId);
     expect(messages).toHaveLength(2);
     const greeting = expectSeededGreeting(messages[1], "Tracker");
-    expect(greeting).toContain("Track team spend.");
+    expect(greeting).not.toContain("Track team spend.");
   });
 
   test("404s for an app the caller cannot view", async () => {

--- a/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
@@ -66,8 +66,7 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     return created.json().id;
   }
 
-  // Editing the html forks a new version (latestVersion 1 → 2), taking the app past
-  // the scaffold so the open-in-chat greeting fires.
+  // Forks a new version (latestVersion 1 → 2), so the open-in-chat greeting fires.
   async function editApp(appId: string): Promise<void> {
     const edited = await app.inject({
       method: "PATCH",
@@ -96,8 +95,6 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     return part.output.structuredContent.id;
   }
 
-  // Owned apps are editable from chat, so a second assistant text message greets the
-  // user with what they can do — naming the app and repeating the app capabilities.
   function expectSeededGreeting(
     message: {
       role: string;
@@ -134,8 +131,6 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
   });
 
   test("seeds only the render (no greeting) for a brand-new scaffold app", async () => {
-    // A fresh app still shows the default template, whose intro already lists the
-    // capabilities — so the greeting is suppressed to avoid repeating it.
     const appId = await createApp("Fresh");
 
     const res = await app.inject({

--- a/platform/backend/src/services/apps/app-chat-conversation.ts
+++ b/platform/backend/src/services/apps/app-chat-conversation.ts
@@ -66,11 +66,7 @@ export async function createSeededAppConversation(params: {
       input: { appId: app.id },
       output: buildAppRenderResult(app),
     },
-    // Owned apps are editable from chat, so greet the user with what they can do —
-    // but only once the app has been built past the scaffold. A brand-new app
-    // (latestVersion === 1) still shows the default template, whose intro screen
-    // already lists these capabilities, so the greeting would just repeat it.
-    // External apps (read-only) never greet — see createSeededExternalAppConversation.
+    // Skip for a brand-new app: its default template already lists these capabilities.
     greeting:
       app.latestVersion > 1 ? buildAppOpenedGreeting(app.name) : undefined,
   });
@@ -142,7 +138,6 @@ async function seedConversationWithRender(params: {
   agentId?: string;
   title: string;
   part: UIMessage["parts"][number];
-  /** When set, seed a trailing assistant text message after the render. */
   greeting?: string;
 }): Promise<{ conversationId: string }> {
   const { userId, organizationId, title, part, greeting } = params;
@@ -185,8 +180,7 @@ async function seedConversationWithRender(params: {
     content,
   });
 
-  // Kept a separate message so the render above stays byte-for-byte a model-driven
-  // render (a text part has no tool part, so deriveAppsFromMessages ignores it).
+  // Separate message so the render above stays a byte-for-byte model-driven render.
   if (greeting) {
     await MessageModel.create({
       conversationId: conversation.id,
@@ -220,11 +214,7 @@ async function resolveDefaultChatAgentId(params: {
   return created;
 }
 
-/**
- * The greeting seeded for an owned (editable) app: it names the app, restates the
- * platform capabilities, and tells the user they can both use it and ask for changes.
- * Markdown — the chat renders assistant text as Markdown.
- */
+/** Markdown greeting seeded when an owned app is opened in chat. */
 function buildAppOpenedGreeting(name: string): string {
   return (
     `Here's **${name}**, up and running.\n\n` +

--- a/platform/backend/src/services/apps/app-chat-conversation.ts
+++ b/platform/backend/src/services/apps/app-chat-conversation.ts
@@ -17,7 +17,7 @@ import {
   buildAppRenderResult,
   buildExternalAppRenderResult,
 } from "@/services/apps/app-render-result";
-import { ApiError, type App } from "@/types";
+import { ApiError } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
 
 const RENDER_APP_TOOL_NAME =
@@ -71,7 +71,8 @@ export async function createSeededAppConversation(params: {
     // (latestVersion === 1) still shows the default template, whose intro screen
     // already lists these capabilities, so the greeting would just repeat it.
     // External apps (read-only) never greet — see createSeededExternalAppConversation.
-    greeting: app.latestVersion > 1 ? buildAppOpenedGreeting(app) : undefined,
+    greeting:
+      app.latestVersion > 1 ? buildAppOpenedGreeting(app.name) : undefined,
   });
 }
 
@@ -224,13 +225,9 @@ async function resolveDefaultChatAgentId(params: {
  * platform capabilities, and tells the user they can both use it and ask for changes.
  * Markdown — the chat renders assistant text as Markdown.
  */
-function buildAppOpenedGreeting(
-  app: Pick<App, "name" | "description">,
-): string {
-  const lead = `Here's **${app.name}**, up and running.`;
-  const about = app.description?.trim() ? ` ${app.description.trim()}` : "";
+function buildAppOpenedGreeting(name: string): string {
   return (
-    `${lead}${about}\n\n` +
+    `Here's **${name}**, up and running.\n\n` +
     `It's an MCP app, so it can use:\n` +
     `- Your connected MCP tools & servers\n` +
     `- A private + shared data store\n` +

--- a/platform/backend/src/services/apps/app-chat-conversation.ts
+++ b/platform/backend/src/services/apps/app-chat-conversation.ts
@@ -17,7 +17,7 @@ import {
   buildAppRenderResult,
   buildExternalAppRenderResult,
 } from "@/services/apps/app-render-result";
-import { ApiError } from "@/types";
+import { ApiError, type App } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
 
 const RENDER_APP_TOOL_NAME =
@@ -66,6 +66,12 @@ export async function createSeededAppConversation(params: {
       input: { appId: app.id },
       output: buildAppRenderResult(app),
     },
+    // Owned apps are editable from chat, so greet the user with what they can do —
+    // but only once the app has been built past the scaffold. A brand-new app
+    // (latestVersion === 1) still shows the default template, whose intro screen
+    // already lists these capabilities, so the greeting would just repeat it.
+    // External apps (read-only) never greet — see createSeededExternalAppConversation.
+    greeting: app.latestVersion > 1 ? buildAppOpenedGreeting(app) : undefined,
   });
 }
 
@@ -135,8 +141,10 @@ async function seedConversationWithRender(params: {
   agentId?: string;
   title: string;
   part: UIMessage["parts"][number];
+  /** When set, seed a trailing assistant text message after the render. */
+  greeting?: string;
 }): Promise<{ conversationId: string }> {
-  const { userId, organizationId, title, part } = params;
+  const { userId, organizationId, title, part, greeting } = params;
 
   const agentId =
     params.agentId ??
@@ -176,6 +184,20 @@ async function seedConversationWithRender(params: {
     content,
   });
 
+  // Kept a separate message so the render above stays byte-for-byte a model-driven
+  // render (a text part has no tool part, so deriveAppsFromMessages ignores it).
+  if (greeting) {
+    await MessageModel.create({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: {
+        id: generateId(),
+        role: "assistant",
+        parts: [{ type: "text", text: greeting }],
+      } satisfies UIMessage,
+    });
+  }
+
   return { conversationId: conversation.id };
 }
 
@@ -195,4 +217,25 @@ async function resolveDefaultChatAgentId(params: {
     throw new ApiError(500, "Could not resolve a default chat agent.");
   }
   return created;
+}
+
+/**
+ * The greeting seeded for an owned (editable) app: it names the app, restates the
+ * platform capabilities, and tells the user they can both use it and ask for changes.
+ * Markdown — the chat renders assistant text as Markdown.
+ */
+function buildAppOpenedGreeting(
+  app: Pick<App, "name" | "description">,
+): string {
+  const lead = `Here's **${app.name}**, up and running.`;
+  const about = app.description?.trim() ? ` ${app.description.trim()}` : "";
+  return (
+    `${lead}${about}\n\n` +
+    `It's an MCP app, so it can use:\n` +
+    `- Your connected MCP tools & servers\n` +
+    `- A private + shared data store\n` +
+    `- Built-in AI to summarize & generate\n\n` +
+    `Use it as-is, or tell me what you'd like to change or add ` +
+    `— I'll update it live.`
+  );
 }


### PR DESCRIPTION
## Summary
- Greets users with an explanatory message: what they can do with the app
- This message is not added for the first draft -- html template contains same information

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>