### PR TITLE
refactor(skills): dedupe isSkillRuntimeTool into @archestra/shared

### DIFF
--- a/platform/backend/src/skills/agent-migration.ts
+++ b/platform/backend/src/skills/agent-migration.ts
@@ -1,20 +1,6 @@
-import {
-  parseFullToolName,
-  SKILL_ARCHESTRA_TOOL_SHORT_NAMES,
-} from "@archestra/shared";
+import { isSkillRuntimeTool } from "@archestra/shared";
 import { promptNeedsRendering } from "@/templating";
 import type { ResourceVisibilityScope } from "@/types/visibility";
-
-/**
- * Short names of the Archestra skill-runtime/plumbing tools (list, load,
- * create, update). Every skill-enabled agent carries the whole set once
- * its org opts in, so recommending them inside a generated skill is circular
- * noise — the activating agent already has them. Matched by short name (prefix
- * stripped) so white-labeled tool prefixes are caught too.
- */
-const SKILL_RUNTIME_TOOL_SHORT_NAMES: ReadonlySet<string> = new Set(
-  SKILL_ARCHESTRA_TOOL_SHORT_NAMES,
-);
 
 /**
  * The subset of an agent the migration actually reads. Declaring it explicitly
@@ -331,12 +317,6 @@ function buildAllowedTools(
     detail: `${tools.length} tool(s) carried into allowed-tools`,
   });
   return tools.map((tool) => tool.name).join(" ");
-}
-
-/** True for an Archestra skill-runtime tool, regardless of its server prefix. */
-function isSkillRuntimeTool(toolName: string): boolean {
-  const { toolName: shortName } = parseFullToolName(toolName);
-  return SKILL_RUNTIME_TOOL_SHORT_NAMES.has(shortName);
 }
 
 /**

--- a/platform/backend/src/skills/skill-description.ts
+++ b/platform/backend/src/skills/skill-description.ts
@@ -1,7 +1,4 @@
-import {
-  parseFullToolName,
-  SKILL_ARCHESTRA_TOOL_SHORT_NAMES,
-} from "@archestra/shared";
+import { isSkillRuntimeTool } from "@archestra/shared";
 import { createLLMModel } from "@/clients/llm-client";
 import logger from "@/logging";
 import { generateTaggedText } from "@/utils/generate-tagged-text";
@@ -144,15 +141,6 @@ Rules:
 - Base it only on the provided agent details; do not invent capabilities.`;
 
 const MAX_PROMPT_CHARS = 4000;
-
-const SKILL_RUNTIME_TOOL_SHORT_NAMES: ReadonlySet<string> = new Set(
-  SKILL_ARCHESTRA_TOOL_SHORT_NAMES,
-);
-
-function isSkillRuntimeTool(toolName: string): boolean {
-  const { toolName: shortName } = parseFullToolName(toolName);
-  return SKILL_RUNTIME_TOOL_SHORT_NAMES.has(shortName);
-}
 
 function truncate(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max)}…` : value;

--- a/platform/shared/archestra-mcp-server.ts
+++ b/platform/shared/archestra-mcp-server.ts
@@ -1,6 +1,6 @@
 // This file contains Enterprise regions licensed under LICENSE_ENTERPRISE.
 import { DEFAULT_APP_NAME, MCP_SERVER_TOOL_NAME_SEPARATOR } from "./consts";
-import { slugify } from "./utils";
+import { parseFullToolName, slugify } from "./utils";
 
 export const ARCHESTRA_MCP_SERVER_NAME = "archestra";
 
@@ -427,6 +427,22 @@ export const SKILL_ARCHESTRA_TOOL_SHORT_NAMES = [
   TOOL_CREATE_SKILL_SHORT_NAME,
   TOOL_UPDATE_SKILL_SHORT_NAME,
 ] as const satisfies readonly ArchestraToolShortName[];
+
+const SKILL_RUNTIME_TOOL_SHORT_NAMES: ReadonlySet<string> = new Set(
+  SKILL_ARCHESTRA_TOOL_SHORT_NAMES,
+);
+
+/**
+ * True for an Archestra skill-runtime/plumbing tool (list, load, create,
+ * update), regardless of its server prefix. Every skill-enabled agent carries
+ * the whole set once its org opts in, so recommending them inside a generated
+ * skill is circular noise. Matched by short name (prefix stripped) so
+ * white-labeled tool prefixes are caught too.
+ */
+export function isSkillRuntimeTool(toolName: string): boolean {
+  const { toolName: shortName } = parseFullToolName(toolName);
+  return SKILL_RUNTIME_TOOL_SHORT_NAMES.has(shortName);
+}
 
 /**
  * MCP App management tools — assigned to new agents by default when the apps


### PR DESCRIPTION
## What

`skill-description.ts` and `agent-migration.ts` each defined a byte-identical `SKILL_RUNTIME_TOOL_SHORT_NAMES` set + `isSkillRuntimeTool()` helper. This hosts the single detection function next to its taxonomy (`SKILL_ARCHESTRA_TOOL_SHORT_NAMES`, `parseFullToolName`) in `@archestra/shared` and imports it in both call sites.

## Why

One source of truth for "is this a skill-runtime tool". Behavior-preserving; net **-16 lines**.

## Verification

- `shared` + `backend` type-check ✓
- `skill-description.test.ts`, `agent-migration.test.ts`, `shared/archestra-mcp-server.test.ts` ✓
- biome lint ✓

https://claude.ai/code/session_01J3nFRcA2FxomtLKDL39zKz

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>