### PR TITLE
perf(bench): hoist per-call regex compilation to LazyLock

### DIFF
--- a/archestra-bench/runner/src/config/tasks.rs
+++ b/archestra-bench/runner/src/config/tasks.rs
@@ -1,9 +1,13 @@
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use regex::Regex;
 
 use super::toml_util::{self, TomlTable};
 use super::types::{Stage, StagedFile, Task, Verifier};
 
-const FILE_PLACEHOLDER_RE: &str = r"\{\{file:([^}]+)\}\}";
+static FILE_PLACEHOLDER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\{\{file:([^}]+)\}\}").expect("valid regex"));
 const DEFAULT_MAX_FORMAT_ATTEMPTS: i64 = 3;
 
 #[derive(Debug, thiserror::Error)]
@@ -101,9 +105,8 @@ fn load_stage(row: &TomlTable, ctx: &str, task_dir: &Path) -> Result<Stage, Task
 
 fn expand_files(text: &str, task_dir: &Path, ctx: &str) -> Result<String, TaskConfigError> {
     let base = task_dir;
-    let re = regex::Regex::new(FILE_PLACEHOLDER_RE).expect("valid regex");
     let mut errors = Vec::new();
-    let result = re.replace_all(text, |caps: &regex::Captures| {
+    let result = FILE_PLACEHOLDER.replace_all(text, |caps: &regex::Captures| {
         let rel = caps[1].trim();
         let target = match resolve_under(base, rel) {
             Ok(t) => t,

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use archestra_bench_core::slug;
 use chrono::Utc;
@@ -2716,12 +2716,15 @@ fn text_block_id(event: &HashMap<String, serde_json::Value>) -> String {
         .to_string()
 }
 
+static RUNTIME_PLACEHOLDER: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"\{\{(cell|agent_id)\}\}").expect("valid regex"));
+
 fn expand_runtime(text: &str, mapping: &HashMap<String, String>) -> String {
-    let re = regex::Regex::new(r"\{\{(cell|agent_id)\}\}").expect("valid regex");
-    re.replace_all(text, |caps: &regex::Captures| {
-        mapping.get(caps[1].trim()).cloned().unwrap_or_default()
-    })
-    .to_string()
+    RUNTIME_PLACEHOLDER
+        .replace_all(text, |caps: &regex::Captures| {
+            mapping.get(caps[1].trim()).cloned().unwrap_or_default()
+        })
+        .to_string()
 }
 
 fn rollout_token(rollout_key: &str, model_name: &str) -> String {


### PR DESCRIPTION
## What

Two hot-path regexes in the benchmark runner were recompiled on every call:

- `expand_runtime` (`run.rs`) recompiles `{{cell|agent_id}}` **once per stage per rollout** — the hottest config path in a run.
- `expand_files` (`config/tasks.rs`) recompiles `{{file:…}}` on every task-config load.

Both are now compiled once via `std::sync::LazyLock` (no new dependency; std-only, available on the edition-2024 toolchain).

## Why

Found during a `unify` survey of `archestra-bench`. Regex compilation is non-trivial work repeated needlessly in a per-rollout loop.

## Behavior

Preserved — identical patterns and identical replace closures. Existing `test_expand_runtime` and the task-config tests pass unchanged.

https://claude.ai/code/session_01WzkWfL9N1hbkmvzZko5XUx

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>