### PR TITLE
fix(apps): reject self-overlapping old_str in edit_app instead of editing the first match

### DIFF
--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -602,6 +602,21 @@ describe("read_app / edit_app", () => {
     expect((await AppModel.findById(appId))?.latestVersion).toBe(version);
   });
 
+  test("a self-overlapping old_str is rejected as ambiguous, not silently replaced", async () => {
+    // "aa" matches at indices 5 and 6 in "aaa" (overlapping). The uniqueness
+    // guard must see both and reject, never collapse to one and edit the first.
+    const { appId, version } = await scaffoldWithHtml("<pre>aaa</pre>");
+    const result = await editApp(appId, version, [
+      { old_str: "aa", new_str: "bb" },
+    ]);
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain("matched 2 times");
+    expect((await AppModel.findById(appId))?.latestVersion).toBe(version);
+    expect(
+      (await AppVersionModel.findByAppAndVersion(appId, version))?.html,
+    ).toBe("<pre>aaa</pre>");
+  });
+
   test("a no-op edit (old_str === new_str) is rejected", async () => {
     const { appId, version } = await scaffoldWithHtml("<h1>same</h1>");
     const result = await editApp(appId, version, [

--- a/platform/backend/src/archestra-mcp-server/apps.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.ts
@@ -1623,12 +1623,16 @@ function truncateUtf8(
   return { text: buf.subarray(0, end).toString("utf8"), truncated: true };
 }
 
+// Count every start position where `needle` matches, including overlapping ones
+// (e.g. "\n\n" twice in "\n\n\n"). The edit path uses this to enforce a unique
+// match, so a self-overlapping old_str must read as ambiguous — not collapse to
+// one and silently replace the first occurrence. Advance by one position.
 function countOccurrences(haystack: string, needle: string): number {
   let count = 0;
   let pos = haystack.indexOf(needle);
   while (pos !== -1) {
     count++;
-    pos = haystack.indexOf(needle, pos + needle.length);
+    pos = haystack.indexOf(needle, pos + 1);
   }
   return count;
 }


### PR DESCRIPTION
## Bug

`edit_app`'s uniqueness guard ("`old_str` must occur exactly once") counted matches with `countOccurrences`, which advanced by `needle.length` and so counted only **non-overlapping** matches. A self-overlapping `old_str` therefore read as a single unique match and the edit silently replaced the **first** occurrence:

- `old_str = "\n\n"` against `"\n\n\n"` (consecutive blank lines — common in real HTML) → counted 1, real positions 0 and 1
- `old_str = "aa"` against `"aaa"` → counted 1, real positions 0 and 1

The model believes there was one match and gets a silent, possibly-wrong edit, violating the documented "exactly once" contract.

## Fix

Count every start position where `old_str` matches, including overlapping ones (advance by 1). Such an `old_str` is now correctly rejected as ambiguous with the existing `matched N times` error, exactly like non-overlapping duplicates.

## Validation

- `pnpm type-check` + `biome` clean
- Added a regression test; full `apps.test.ts` (78 tests) passes
- One-line behavior fix toward the contract; the only newly-rejected inputs are self-overlapping `old_str`s that were previously edited silently and wrongly

Built on top of #5855.

https://claude.ai/code/session_01KgqWNJa6EHsLnbLgCtTJgq

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>