### PR TITLE
refactor(skills): remove superseded SkillModel.findByName

### DIFF
--- a/platform/backend/src/archestra-mcp-server/skills.test.ts
+++ b/platform/backend/src/archestra-mcp-server/skills.test.ts
@@ -373,7 +373,7 @@ describe("skill tool execution", () => {
     expect(result.isError).toBe(false);
     expect(textOf(result)).toContain('Created skill "research"');
 
-    const skill = await SkillModel.findByName(organizationId, "research");
+    const [skill] = await SkillModel.findAllByName(organizationId, "research");
     expect(skill?.content).toBe("Run the research playbook.");
     expect(skill?.scope).toBe("personal");
     expect(skill?.authorId).toBe(userId);
@@ -393,7 +393,7 @@ describe("skill tool execution", () => {
     );
     expect(result.isError).toBe(false);
 
-    const skill = await SkillModel.findByName(organizationId, "multi");
+    const [skill] = await SkillModel.findAllByName(organizationId, "multi");
     const files = await SkillFileModel.findBySkillId(skill?.id ?? "");
     expect(files.map((f) => `${f.path}:${f.kind}`).sort()).toEqual([
       "references/api.md:reference",
@@ -466,7 +466,10 @@ describe("skill tool execution", () => {
     );
 
     expect(result.isError).toBe(false);
-    const skill = await SkillModel.findByName(organizationId, "pdf-processing");
+    const [skill] = await SkillModel.findAllByName(
+      organizationId,
+      "pdf-processing",
+    );
     expect(skill?.content).toBe("Updated instructions.");
   });
 
@@ -487,7 +490,10 @@ describe("skill tool execution", () => {
     );
     expect(result.isError).toBe(false);
 
-    const skill = await SkillModel.findByName(organizationId, "pdf-processing");
+    const [skill] = await SkillModel.findAllByName(
+      organizationId,
+      "pdf-processing",
+    );
     const files = await SkillFileModel.findBySkillId(skill?.id ?? "");
     expect(files.map((f) => f.path)).toEqual(["references/NEW.md"]);
   });
@@ -508,7 +514,10 @@ describe("skill tool execution", () => {
     );
     expect(result.isError).toBe(false);
 
-    const skill = await SkillModel.findByName(organizationId, "pdf-processing");
+    const [skill] = await SkillModel.findAllByName(
+      organizationId,
+      "pdf-processing",
+    );
     const files = await SkillFileModel.findBySkillId(skill?.id ?? "");
     expect(files.map((f) => f.path)).toEqual(["references/KEEP.md"]);
   });
@@ -572,7 +581,7 @@ describe("skill tool execution", () => {
     );
 
     expect(result.isError).toBe(false);
-    const skill = await SkillModel.findByName(organizationId, "my-skill");
+    const [skill] = await SkillModel.findAllByName(organizationId, "my-skill");
     expect(skill?.content).toBe("Second draft.");
   });
 

--- a/platform/backend/src/models/skill.ts
+++ b/platform/backend/src/models/skill.ts
@@ -123,23 +123,6 @@ class SkillModel {
     return result ?? null;
   }
 
-  static async findByName(
-    organizationId: string,
-    name: string,
-  ): Promise<Skill | null> {
-    const [result] = await db
-      .select()
-      .from(schema.skillsTable)
-      .where(
-        and(
-          eq(schema.skillsTable.organizationId, organizationId),
-          eq(schema.skillsTable.name, name),
-        ),
-      );
-
-    return result ?? null;
-  }
-
   /**
    * All skills sharing a name within an org. Since name uniqueness is now
    * per-scope (personal names per author, shared names per org), a single

--- a/platform/backend/src/routes/skill/convert.skill.route.test.ts
+++ b/platform/backend/src/routes/skill/convert.skill.route.test.ts
@@ -95,7 +95,7 @@ describe("POST /api/agents/:id/convert-to-skill", () => {
     ).toBe("personal");
 
     // by default non-destructive: the skill persisted, the agent is untouched.
-    const stored = await SkillModel.findByName(
+    const [stored] = await SkillModel.findAllByName(
       organizationId,
       "support-helper",
     );

--- a/platform/backend/src/routes/skill/create.skill.route.test.ts
+++ b/platform/backend/src/routes/skill/create.skill.route.test.ts
@@ -238,8 +238,8 @@ describe("POST /api/skills", () => {
       expect(response.statusCode).toBe(400);
       // the skill row must not have been committed
       expect(
-        await SkillModel.findByName(ctx.organizationId, "orphan-check"),
-      ).toBeNull();
+        await SkillModel.findAllByName(ctx.organizationId, "orphan-check"),
+      ).toHaveLength(0);
     });
 
     test("persists team assignments atomically with the skill", async ({
@@ -291,8 +291,8 @@ describe("POST /api/skills", () => {
 
       expect(response.statusCode).toBe(400);
       expect(
-        await SkillModel.findByName(ctx.organizationId, "teamless-skill"),
-      ).toBeNull();
+        await SkillModel.findAllByName(ctx.organizationId, "teamless-skill"),
+      ).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## What

`SkillModel.findByName(org, name)` returns an arbitrary row for an `(org, name)` pair. It was superseded by `findAllByName` in #5127 when skills moved to per-scope name uniqueness, and has had **no production callers since** (verified across full git history). Its sibling's doc comment explicitly warns that `findByName` "must not be used for access-scoped lookup" — a footgun kept alive only by test call sites.

This removes the method and repoints the remaining test usages at `findAllByName` (the `.toBeNull()` orphan checks become clearer `.toHaveLength(0)` assertions).

## Why

Completes the per-scope-uniqueness migration and removes a dangerous lookup from the production model surface. Internal method (not externally reachable), so no behavior change. Net **-8 lines**.

## Verification

- backend type-check ✓
- `skills.test.ts`, `create`/`convert` skill route tests, `skill.test.ts` (75) ✓
- biome lint ✓

https://claude.ai/code/session_01J3nFRcA2FxomtLKDL39zKz

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>