### PR TITLE
refactor(skills): reuse shared formatBytes in skill editor dialog

### DIFF
--- a/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
@@ -30,6 +30,7 @@ import {
   useSkill,
   useUpdateSkill,
 } from "@/lib/skills/skill.query";
+import { formatBytes } from "@/lib/skills-sandbox/sandbox-file-preview";
 import { cn } from "@/lib/utils";
 import { composeManifest, parseManifestFields } from "./manifest-compose";
 import { SkillScopeSelector } from "./skill-scope-selector";
@@ -869,12 +870,6 @@ function Marker({ ok }: { ok: boolean }) {
 function approxBase64Bytes(content: string): number {
   // Each 4 chars of base64 encodes 3 bytes; ignore padding for a rough estimate.
   return Math.floor((content.length * 3) / 4);
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function buildTree(


### PR DESCRIPTION
## What

`skill-editor-dialog.tsx` re-implemented `formatBytes` byte-for-byte. The same function is already exported and unit-tested in `lib/skills-sandbox/sandbox-file-preview.ts`. This imports the shared one and deletes the local copy.

## Why

One tested implementation of the B/KB/MB formatter. Net **-5 lines**, behavior-preserving.

## Verification

- frontend type-check ✓
- `sandbox-file-preview.test.ts` (3) ✓
- biome lint ✓

https://claude.ai/code/session_01J3nFRcA2FxomtLKDL39zKz

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>