### PR TITLE
test(bench): drop thin server-boot smoke tests

### DIFF
--- a/archestra-bench/runner/src/fixture_mcp.rs
+++ b/archestra-bench/runner/src/fixture_mcp.rs
@@ -374,13 +374,6 @@ fn object_schema(properties: &[(&str, JsonValue)], required: &[&str]) -> Map<Str
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn test_fixture_mcp_starts() {
-        let mcp = FixtureMcp::start("acme_it-test").await.unwrap();
-        assert!(mcp.base_url().starts_with("http://127.0.0.1:"));
-        mcp.stop().await;
-    }
-
     #[test]
     fn test_dataset_parses_and_is_nonempty() {
         let rows = seats();

--- a/archestra-bench/runner/src/mcp_server.rs
+++ b/archestra-bench/runner/src/mcp_server.rs
@@ -455,13 +455,6 @@ fn sort_json_value(value: JsonValue) -> JsonValue {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn test_mcp_server_starts() {
-        let mcp = BenchmarkMcp::start("benchmark-test").await.unwrap();
-        assert!(mcp.base_url().starts_with("http://127.0.0.1:"));
-        mcp.stop().await;
-    }
-
     #[test]
     fn test_schema_errors_type_mismatch() {
         let schema = serde_json::json!({


### PR DESCRIPTION
## What

Removes two thin smoke tests:

- `test_mcp_server_starts` (`mcp_server.rs`)
- `test_fixture_mcp_starts` (`fixture_mcp.rs`)

Each only asserted that the in-process server boots and its `base_url()` starts with `http://127.0.0.1:`, then stopped it.

## Why

Found during a `unify` test census of `archestra-bench`. The meaningful behavior each file owns — schema validation and submission handling (`mcp_server`), the embedded dataset and access-request validation (`fixture_mcp`) — is covered by the tests that remain, and the boot path runs on every real benchmark invocation. The boot assertions added little signal for the maintenance surface they pinned.

Each module retains real coverage (5 and 3 tests respectively); 129 lib tests pass.

https://claude.ai/code/session_01WzkWfL9N1hbkmvzZko5XUx

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>