### PR TITLE
fix(chat): stop invalid mermaid diagrams from leaking an error graphic across pages

### DIFF
--- a/platform/frontend/src/components/mermaid-diagram.test.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MermaidDiagram } from "./mermaid-diagram";
+
+// jsdom has no SVG layout (getBBox), so mermaid never completes a *successful*
+// render here — every chart ends in the failure path. That is exactly the path
+// this bug lives on, so these tests exercise it directly. The success path is
+// verified against a real browser instead.
+const INVALID_CHART = "graph TD; A-->; --> this is not valid mermaid @@@";
+
+// Mermaid appends a temporary render scratch element (`<div id="d<renderId>">`)
+// to document.body while drawing. On a failed render it must still be removed;
+// the bug left it orphaned on document.body, outside React's tree.
+function leakedMermaidScratchNodes(): NodeListOf<Element> {
+  return document.body.querySelectorAll('div[id^="dmermaid"]');
+}
+
+afterEach(() => {
+  // Scratch nodes live on document.body (outside RTL's container), so RTL
+  // cleanup won't remove them — clear strays so a leak can't bleed between tests.
+  for (const el of Array.from(leakedMermaidScratchNodes())) {
+    el.remove();
+  }
+});
+
+describe("MermaidDiagram (invalid diagram handling)", () => {
+  it("does not leak mermaid's temp render node onto document.body", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<MermaidDiagram chart={INVALID_CHART} />);
+
+    // Settle: the render attempt has failed and been handled by the catch.
+    await waitFor(() =>
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Error rendering mermaid diagram:",
+        expect.anything(),
+      ),
+    );
+
+    expect(leakedMermaidScratchNodes()).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
+
+  it("shows a friendly error message instead of the raw diagram source", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<MermaidDiagram chart={INVALID_CHART} />);
+
+    expect(
+      await screen.findByText(/couldn't render the diagram/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/mermaid-diagram.tsx
+++ b/platform/frontend/src/components/mermaid-diagram.tsx
@@ -30,6 +30,11 @@ export function MermaidDiagram({
 
           mermaid.initialize({
             startOnLoad: false,
+            // On a parse/draw failure, mermaid otherwise appends an error
+            // "bomb" diagram to document.body and throws before removing it,
+            // orphaning that node outside React's tree. Suppressing it makes
+            // render() clean up its scratch element before throwing.
+            suppressErrorRendering: true,
             theme: isDark ? "dark" : "neutral",
             themeVariables: isDark
               ? {
@@ -72,10 +77,45 @@ export function MermaidDiagram({
           }
         } catch (error) {
           console.error("Error rendering mermaid diagram:", error);
-          if (ref.current) {
+          // Match the success path's guard: a stale rejected render (from an
+          // older chart/theme) must not overwrite a newer render's output.
+          if (ref.current && !isCancelled) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+
+            const box = document.createElement("div");
+            box.setAttribute("role", "alert");
+            box.className =
+              "w-full rounded-md border border-destructive/30 bg-destructive/10 p-3 text-left text-sm text-destructive";
+
+            const title = document.createElement("p");
+            title.className = "font-medium";
+            title.textContent = "Couldn't render the diagram";
+            box.appendChild(title);
+
+            // The catch also covers non-syntax failures (e.g. the dynamic
+            // mermaid import), so only claim invalid syntax on a parse error.
+            if (/parse error/i.test(message)) {
+              const hint = document.createElement("p");
+              hint.className = "mt-1 text-xs text-muted-foreground";
+              hint.textContent = "The mermaid syntax is invalid.";
+              box.appendChild(hint);
+            }
+
+            // Keep the parse error and the source available, but out of the way.
+            const details = document.createElement("details");
+            details.className = "mt-2";
+            const summary = document.createElement("summary");
+            summary.className = "cursor-pointer text-xs text-muted-foreground";
+            summary.textContent = "Show details";
+            details.appendChild(summary);
             const pre = document.createElement("pre");
-            pre.textContent = chart;
-            ref.current.replaceChildren(pre);
+            pre.className = "mt-1 overflow-x-auto whitespace-pre-wrap text-xs";
+            pre.textContent = `${message}\n\n${chart}`;
+            details.appendChild(pre);
+            box.appendChild(details);
+
+            ref.current.replaceChildren(box);
             setIsLoaded(true);
           }
         }


### PR DESCRIPTION
## Summary

An invalid ` ```mermaid ` block in a chat artifact or a project's `instructions.md` used to render Mermaid's "Syntax error in text" bomb graphic and — worse — leave that graphic on screen after navigating to other pages. Mermaid's `render()` draws an error diagram and re-throws before its own cleanup runs, so the temporary `<div>` it appends to `document.body` is orphaned outside React's tree; client-side navigation never removes it, so the error leaked across pages (issue #3511).

After this change, an invalid diagram shows an inline, accessible error box (`role="alert"`) reading "Couldn't render the diagram", with the parse error and the original source tucked into a collapsible `Show details` disclosure — and nothing is left behind on `document.body`, so navigating away is clean. Valid diagrams render unchanged.

Two mechanisms:
- `suppressErrorRendering: true` in `mermaid.initialize()` — Mermaid then removes its scratch element before throwing and never draws the bomb.
- The `catch` builds the friendly error box instead of dumping the raw source in a `<pre>`, and its DOM write is now guarded by `!isCancelled` (matching the success path) so a stale rejected render can't overwrite a newer valid diagram.

Closes #3511

<img width="1055" height="985" alt="image" src="https://github.com/user-attachments/assets/802eaf54-99bc-4f0f-a1ed-b584756e8bd0" />


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>