### PR TITLE
fix(chat): refresh project chat list after deleting or forking a project chat

### DIFF
--- a/platform/frontend/src/lib/chat/chat-share.query.test.tsx
+++ b/platform/frontend/src/lib/chat/chat-share.query.test.tsx
@@ -4,7 +4,11 @@ import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleApiError } from "@/lib/utils";
-import { useConversationShare } from "./chat-share.query";
+import {
+  useConversationShare,
+  useForkConversation,
+  useForkSharedConversation,
+} from "./chat-share.query";
 
 vi.mock("@archestra/shared", () => ({
   archestraApiSdk: {
@@ -79,5 +83,59 @@ describe("useConversationShare", () => {
 
     await waitFor(() => expect(result.current.data).toBeNull());
     expect(mockedHandleApiError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fork project-list invalidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderWithClient = <T,>(hook: () => T) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { invalidateSpy, ...renderHook(hook, { wrapper }) };
+  };
+
+  it("useForkConversation invalidates the project's conversation list when the fork lands in a project", async () => {
+    vi.mocked(archestraApiSdk.forkChatConversation).mockResolvedValue({
+      data: { id: "forked", projectId: "p1" },
+      error: undefined,
+    } as Awaited<ReturnType<typeof archestraApiSdk.forkChatConversation>>);
+
+    const { invalidateSpy, result } = renderWithClient(() =>
+      useForkConversation(),
+    );
+
+    await result.current.mutateAsync({ conversationId: "c1", agentId: "a1" });
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["projects", "p1", "conversations"],
+      }),
+    );
+  });
+
+  it("useForkSharedConversation leaves project queries untouched for a non-project fork", async () => {
+    vi.mocked(archestraApiSdk.forkSharedConversation).mockResolvedValue({
+      data: { id: "forked", projectId: null },
+      error: undefined,
+    } as Awaited<ReturnType<typeof archestraApiSdk.forkSharedConversation>>);
+
+    const { invalidateSpy, result } = renderWithClient(() =>
+      useForkSharedConversation(),
+    );
+
+    await result.current.mutateAsync({ shareId: "s1", agentId: "a1" });
+
+    const touchedProjects = invalidateSpy.mock.calls.some(
+      ([arg]) => Array.isArray(arg?.queryKey) && arg.queryKey[0] === "projects",
+    );
+    expect(touchedProjects).toBe(false);
   });
 });

--- a/platform/frontend/src/lib/chat/chat-share.query.ts
+++ b/platform/frontend/src/lib/chat/chat-share.query.ts
@@ -104,6 +104,11 @@ export function useForkSharedConversation() {
     onSuccess: (data) => {
       if (!data) return;
       queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      if (data.projectId) {
+        queryClient.invalidateQueries({
+          queryKey: ["projects", data.projectId, "conversations"],
+        });
+      }
     },
   });
 }
@@ -130,6 +135,11 @@ export function useForkConversation() {
     onSuccess: (data) => {
       if (!data) return;
       queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      if (data.projectId) {
+        queryClient.invalidateQueries({
+          queryKey: ["projects", data.projectId, "conversations"],
+        });
+      }
     },
   });
 }

--- a/platform/frontend/src/lib/chat/chat.query.test.tsx
+++ b/platform/frontend/src/lib/chat/chat.query.test.tsx
@@ -12,6 +12,7 @@ import {
   useConversationFiles,
   useConversations,
   useConversationUpdatedCacheSync,
+  useDeleteConversation,
   useKeepViewedConversationRead,
   useMarkConversationRead,
   useMemberDefaultModel,
@@ -25,6 +26,7 @@ vi.mock("@archestra/shared", () => ({
     getMemberDefaultModel: vi.fn(),
     getConversationEnabledTools: vi.fn(),
     markChatConversationRead: vi.fn(),
+    deleteChatConversation: vi.fn(),
   },
   PLAYWRIGHT_MCP_CATALOG_ID: "playwright-catalog-id",
   PLAYWRIGHT_MCP_SERVER_NAME: "playwright-mcp",
@@ -493,5 +495,67 @@ describe("conversation read-state hooks", () => {
     });
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+  });
+});
+
+describe("useDeleteConversation project-list invalidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(archestraApiSdk.deleteChatConversation).mockResolvedValue({
+      data: { success: true },
+      error: undefined,
+    } as Awaited<ReturnType<typeof archestraApiSdk.deleteChatConversation>>);
+  });
+
+  const renderDelete = (conversation: {
+    id: string;
+    projectId: string | null;
+  }) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      ["conversations", undefined],
+      [{ ...makeConversation(), ...conversation }],
+    );
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return {
+      invalidateSpy,
+      ...renderHook(() => useDeleteConversation(), { wrapper }),
+    };
+  };
+
+  it("invalidates the project's conversation list when a project chat is deleted", async () => {
+    const { invalidateSpy, result } = renderDelete({
+      id: "c1",
+      projectId: "p1",
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("c1");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["projects", "p1", "conversations"],
+    });
+  });
+
+  it("does not invalidate any project query for a non-project chat", async () => {
+    const { invalidateSpy, result } = renderDelete({
+      id: "c1",
+      projectId: null,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("c1");
+    });
+
+    const touchedProjects = invalidateSpy.mock.calls.some(
+      ([arg]) => Array.isArray(arg?.queryKey) && arg.queryKey[0] === "projects",
+    );
+    expect(touchedProjects).toBe(false);
   });
 });

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -570,6 +570,12 @@ export function useDeleteConversation() {
         queryKey: ["conversations"],
       });
 
+      // Capture the deleted conversation's project (if any) so onSettled can
+      // also refresh the project page's own conversation list.
+      const projectId = previousQueries
+        .flatMap(([, data]) => data ?? [])
+        .find((c) => c.id === deletedId)?.projectId;
+
       // Optimistically remove the conversation from every cached list
       queryClient.setQueriesData<
         archestraApiTypes.GetChatConversationsResponses["200"]
@@ -577,7 +583,7 @@ export function useDeleteConversation() {
         old ? old.filter((c) => c.id !== deletedId) : old,
       );
 
-      return { previousQueries };
+      return { previousQueries, projectId };
     },
     onError: (_error, _deletedId, context) => {
       // Roll back optimistic removal on failure
@@ -600,9 +606,16 @@ export function useDeleteConversation() {
 
       toast.success("Conversation deleted");
     },
-    onSettled: () => {
+    onSettled: (_data, _error, _deletedId, context) => {
       // Always refetch to ensure server state is in sync
       queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      // A project chat is also listed on its project page under a separate
+      // query key, which the sidebar invalidation above does not cover.
+      if (context?.projectId) {
+        queryClient.invalidateQueries({
+          queryKey: ["projects", context.projectId, "conversations"],
+        });
+      }
     },
   });
 }


### PR DESCRIPTION
Refreshes a project's chat list after a chat is removed or forked, closing a stale-cache gap where the project page kept showing chats until a hard refresh.

- `platform/frontend/src/lib/chat/chat.query.ts` — `useDeleteConversation` only invalidated the sidebar `["conversations"]` cache, never the project page's `["projects", projectId, "conversations"]` list (read at `lib/projects/projects.query.ts:97`). Now captures the deleted chat's `projectId` from the optimistic snapshot in `onMutate` and invalidates the project list in `onSettled`. Fixes #5910.
- `platform/frontend/src/lib/chat/chat-share.query.ts` — `useForkConversation` and `useForkSharedConversation` had the same gap; a fork inherits the source chat's project server-side but stayed invisible on the project page. Both now invalidate `["projects", data.projectId, "conversations"]` when the fork response carries a `projectId`.
- Regression tests added in `chat.query.test.tsx` and `chat-share.query.test.tsx` (verified failing before the fix, passing after); negative tests assert no project invalidation for non-project chats.

Verification: Codex adversarial review — **UPHELD** (probed projectId recovery, undefined-skip, response-type presence, exact key match, and fail-before test behavior; no defect found). Independent review agrees.

https://claude.ai/code/session_01Fodt1NqqAtkqXQGaqKjKtm

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>