### PR TITLE
fix(chatops): don't send a broken welcome DM to an existing user on the auto-provision race

### DIFF
--- a/platform/backend/src/agents/chatops/auto-provision.test.ts
+++ b/platform/backend/src/agents/chatops/auto-provision.test.ts
@@ -75,7 +75,7 @@ describe("ensureProvisionedUser", () => {
     );
   });
 
-  test('concurrent race resolves to the existing user with invitationId ""', async ({
+  test("concurrent race resolves to the existing user with no invitation (suppresses the welcome)", async ({
     makeOrganization,
   }) => {
     await makeOrganization();
@@ -106,6 +106,9 @@ describe("ensureProvisionedUser", () => {
 
     expect(result).not.toBeNull();
     expect(result?.user.id).toBe(racingUserId);
-    expect(result?.invitationId).toBe("");
+    // The already-existing user must come back with a null invitation so the
+    // caller's `invitationId !== null` gate skips the welcome DM (an empty
+    // string would pass that gate and send a broken signup link).
+    expect(result?.invitationId).toBeNull();
   });
 });

--- a/platform/backend/src/agents/chatops/auto-provision.ts
+++ b/platform/backend/src/agents/chatops/auto-provision.ts
@@ -25,13 +25,14 @@ const INVITATION_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
  *
  * Handles the race condition where two messages arrive simultaneously for the
  * same unregistered user: catches the unique constraint violation on user.email
- * and falls back to a findByEmail lookup.
+ * and falls back to a findByEmail lookup, returning `invitationId: null` for
+ * that already-existing user so callers suppress the welcome message.
  */
 export async function autoProvisionUser(params: {
   email: string;
   name: string;
   provider: ChatOpsProviderType;
-}): Promise<{ userId: string; invitationId: string }> {
+}): Promise<{ userId: string; invitationId: string | null }> {
   const { email, name, provider } = params;
   const normalizedEmail = email.toLowerCase();
 
@@ -108,7 +109,7 @@ export async function autoProvisionUser(params: {
       );
       const existingUser = await UserModel.findByEmail(normalizedEmail);
       if (existingUser) {
-        return { userId: existingUser.id, invitationId: "" };
+        return { userId: existingUser.id, invitationId: null };
       }
     }
     throw error;


### PR DESCRIPTION
Fixes a chatops auto-provision race that sent an already-registered user a welcome DM with a broken signup link.

- `platform/backend/src/agents/chatops/auto-provision.ts` — `autoProvisionUser`'s unique-constraint race fallback (user already exists) returned `invitationId: ""`. All three call sites (`slack-provider.ts:1112`, `chatops-manager.ts:395`, `chatops-manager.ts:1270`) gate the welcome DM on `invitationId !== null`, and `"" !== null` is true, so the existing user got a welcome DM whose link is `?invitationId=&email=…` (empty id). Now returns `null` (return type widened to `string | null`), so the gate suppresses the message — matching the non-race existing-user path.
- Regression test in `auto-provision.test.ts` updated to assert the corrected `null` contract (verified failing before the fix, passing after).
- The only other caller, `routes/chatops.ts:1920`, ignores the return value, so the type change stays entirely within `agents/chatops/`.

Verification: Codex adversarial review — **UPHELD**. Independent review agrees the fix is correct and in-scope.

https://claude.ai/code/session_01Fodt1NqqAtkqXQGaqKjKtm

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>