### PR TITLE
chore(dev): bootstrap deps for worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 platform/CLAUDE_LOCAL.md
 .pnpm-store/
+.dev-bin/
 
 *.pyc
 __pycache__/

--- a/platform/dev/run-backend-dev.sh
+++ b/platform/dev/run-backend-dev.sh
@@ -33,12 +33,16 @@ if [ "${ARCHESTRA_CODE_RUNTIME_ENABLED:-}" = "true" ]; then
     export ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST="tcp://127.0.0.1:1234"
   fi
 
-  # the Dagger Node SDK shells out to the `dagger` CLI to open engine sessions
+  # the Dagger SDK shells out to the `dagger` CLI to open engine sessions
   # even when the runner host is set. prod bakes the binary into the image
-  # (see ../Dockerfile), so for local dev we mirror that by bootstrapping a
-  # project-local copy here. version must match helm/dagger-runtime/Chart.yaml.
-  DAGGER_VERSION="0.21.5"
-  DAGGER_BIN="$(pwd)/dev/bin/dagger"
+  # (see ../Dockerfile), so for local dev we mirror that by bootstrapping one
+  # copy shared by all git worktrees for this clone.
+  DAGGER_VERSION="$(sed -n 's/^ARG DAGGER_VERSION=v\{0,1\}\([0-9][^[:space:]]*\)$/\1/p' Dockerfile)"
+  DAGGER_BIN="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.dev-bin/dagger"
+  if [ -z "$DAGGER_VERSION" ]; then
+    echo "failed to read DAGGER_VERSION from Dockerfile" >&2
+    exit 1
+  fi
   if [ ! -x "$DAGGER_BIN" ] || ! "$DAGGER_BIN" version 2>/dev/null | grep -q "v${DAGGER_VERSION}"; then
     OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
     ARCH="$(uname -m)"
@@ -52,7 +56,8 @@ if [ "${ARCHESTRA_CODE_RUNTIME_ENABLED:-}" = "true" ]; then
       | tar -xz -C "$(dirname "$DAGGER_BIN")" dagger
     chmod +x "$DAGGER_BIN"
   fi
-  if [ -z "${ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN:-}" ]; then
+  if [ -z "${ARCHESTRA_DAGGER_RUNTIME_CLI_BIN:-}" ] && [ -z "${ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN:-}" ]; then
+    export ARCHESTRA_DAGGER_RUNTIME_CLI_BIN="$DAGGER_BIN"
     export ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN="$DAGGER_BIN"
   fi
 

--- a/platform/package.json
+++ b/platform/package.json
@@ -27,6 +27,8 @@
     "license-check": "tsx standalone-scripts/license-check.ts",
     "codegen": "CODEGEN=true turbo codegen && python3 dev/grafana/generate-pg-dashboard-variants.py",
     "cleanup:dev:caches": "tsx standalone-scripts/cleanup-dev-caches.ts",
+    "worktree:bootstrap": "scripts/worktree-bootstrap.sh bootstrap",
+    "worktree:install-hook": "scripts/worktree-bootstrap.sh install-hook",
     "skills:index": "tsx standalone-scripts/generate-skill-index.ts",
     "db:generate": "turbo db:generate --ui=tui",
     "db:migrate": "turbo db:migrate",

--- a/platform/scripts/worktree-bootstrap.sh
+++ b/platform/scripts/worktree-bootstrap.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root() {
+  local script_dir
+  script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  git -C "$script_dir/../.." rev-parse --show-toplevel
+}
+main_repo_root() {
+  local root common_git_dir
+  root="$(repo_root)"
+  common_git_dir="$(git -C "$root" rev-parse --path-format=absolute --git-common-dir)"
+  dirname "$common_git_dir"
+}
+ensure_dagger_cli() {
+  local bin root version os arch
+  bin="$(main_repo_root)/.dev-bin/dagger"
+  root="$(repo_root)"
+  version="$(sed -n 's/^ARG DAGGER_VERSION=v\{0,1\}\([0-9][^[:space:]]*\)$/\1/p' "$root/platform/Dockerfile")"
+  if [ -z "$version" ]; then
+    echo "ERROR: failed to read DAGGER_VERSION from platform/Dockerfile" >&2
+    exit 1
+  fi
+  if [ -x "$bin" ] && "$bin" version 2>/dev/null | grep -q "v${version}"; then
+    return 0
+  fi
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64) arch=amd64 ;;
+    aarch64) arch=arm64 ;;
+  esac
+  mkdir -p "$(dirname "$bin")"
+  echo "Bootstrapping Dagger CLI v${version} for ${os}/${arch} into ${bin}" >&2
+  curl -fsSL "https://dl.dagger.io/dagger/releases/${version}/dagger_v${version}_${os}_${arch}.tar.gz" \
+    | tar -xz -C "$(dirname "$bin")" dagger
+  chmod +x "$bin"
+}
+bootstrap() {
+  local root store_dir
+  root="$(repo_root)"
+  store_dir="$(main_repo_root)/.pnpm-store"
+  if [ ! -f "$root/platform/pnpm-lock.yaml" ]; then
+    echo "ERROR: no platform/pnpm-lock.yaml under $root" >&2
+    exit 1
+  fi
+  CI=true pnpm --dir "$root/platform" install --frozen-lockfile --prefer-offline --store-dir "$store_dir"
+  ensure_dagger_cli
+}
+install_hook() {
+  local root common_git_dir hook_dir hook marker
+  root="$(repo_root)"
+  common_git_dir="$(git -C "$root" rev-parse --path-format=absolute --git-common-dir)"
+  hook_dir="$common_git_dir/hooks"
+  hook="$hook_dir/post-checkout"
+  marker="archestra-worktree-bootstrap"
+  if [ -e "$hook" ] && ! grep -q "$marker" "$hook"; then
+    echo "ERROR: refusing to overwrite existing unmanaged hook: $hook" >&2
+    exit 1
+  fi
+  mkdir -p "$hook_dir"
+  cat >"$hook" <<'EOF'
+#!/bin/sh
+# archestra-worktree-bootstrap
+set -u
+case "${1:-}" in
+  0000000000000000000000000000000000000000) ;;
+  *) exit 0 ;;
+esac
+worktree_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+bootstrap="$worktree_root/platform/scripts/worktree-bootstrap.sh"
+[ -x "$bootstrap" ] || exit 0
+"$bootstrap" bootstrap || {
+  status=$?
+  echo "WARNING: Archestra worktree bootstrap failed with exit $status. Run manually: $bootstrap bootstrap" >&2
+}
+exit 0
+EOF
+  chmod +x "$hook"
+  echo "Installed Archestra worktree bootstrap hook: $hook" >&2
+}
+case "${1:-bootstrap}" in
+  bootstrap) bootstrap ;;
+  install-hook) install_hook ;;
+  *) echo "Usage: $0 [bootstrap|install-hook]" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- Add a worktree bootstrap script that installs platform deps through the shared repo .pnpm-store and ensures a shared .dev-bin/dagger binary.
- Add package scripts for manual bootstrap and installing the local post-checkout hook.
- Make backend dev runtime reuse the shared Dagger CLI across worktrees.

## Verification
- bash -n scripts/worktree-bootstrap.sh && sh -n dev/run-backend-dev.sh
- git diff --cached --check
- pnpm worktree:bootstrap
- pnpm worktree:install-hook && ../.git/hooks/post-checkout 0000000000000000000000000000000000000000 HEAD 1
- ../.dev-bin/dagger version

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>