### PR TITLE
fix(chat): guard model fetcher against a missing 'created' timestamp

### DIFF
--- a/platform/backend/src/routes/chat/model-fetchers/bearer-fetcher.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/bearer-fetcher.test.ts
@@ -68,6 +68,23 @@ describe("descriptor-table fetchers", () => {
     ]);
   });
 
+  test("tolerates a model missing created without crashing (createdAt undefined)", async () => {
+    // A provider response omitting `created` used to reach
+    // `new Date(NaN).toISOString()`, which throws and fails the whole fetch.
+    mockModelsResponse({ data: [{ id: "groq-a" }] });
+
+    const models = await modelFetchers.groq("k");
+
+    expect(models).toEqual([
+      {
+        id: "groq-a",
+        displayName: "groq-a",
+        provider: "groq",
+        createdAt: undefined,
+      },
+    ]);
+  });
+
   test("deepseek tolerates missing data and falls back createdAt to epoch", async () => {
     mockModelsResponse({ data: [{ id: "deepseek-chat" }] });
 

--- a/platform/backend/src/routes/chat/model-fetchers/bearer-fetcher.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/bearer-fetcher.ts
@@ -6,7 +6,9 @@ import { type ModelInfo, PLACEHOLDER_API_KEY, type StaticModel } from "./types";
 
 interface BearerRawModel {
   id: string;
-  created: number;
+  // Provider responses don't always include `created`, so treat it as optional
+  // untrusted input rather than trusting the OpenAI-compatible schema.
+  created?: number;
 }
 
 interface BearerFetcherDescriptor<
@@ -30,7 +32,9 @@ function defaultMapModel(
     id: model.id,
     displayName: model.id,
     provider,
-    createdAt: new Date(model.created * 1000).toISOString(),
+    createdAt: model.created
+      ? new Date(model.created * 1000).toISOString()
+      : undefined,
   };
 }
 


### PR DESCRIPTION
Prevents a model-list fetch from crashing when a provider omits the `created` timestamp.

- `platform/backend/src/routes/chat/model-fetchers/bearer-fetcher.ts` — `defaultMapModel` computed `new Date(model.created * 1000).toISOString()` treating `created` as always present. A provider `/models` response that omits `created` produces `new Date(NaN).toISOString()`, which throws `RangeError: Invalid time value` and fails the whole fetch. Now guards it exactly like the sibling `mapKeylessModel` (`createdAt` undefined when `created` is absent) and marks the field optional untrusted input.
- Regression test added in `bearer-fetcher.test.ts` — verified to throw `RangeError` before the fix and pass after.

Verification: Codex adversarial review — **UPHELD**. Independent review agrees.

https://claude.ai/code/session_01Fodt1NqqAtkqXQGaqKjKtm

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>