### PR TITLE
feat(mcp-gateway): default personal "My Gateway" to All-tools mode

### DIFF
--- a/platform/backend/src/models/agent.test.ts
+++ b/platform/backend/src/models/agent.test.ts
@@ -2557,6 +2557,10 @@ describe("AgentModel", () => {
       expect(gateway.isPersonalGateway).toBe(true);
       expect(gateway.authorId).toBe(user.id);
       expect(gateway.organizationId).toBe(org.id);
+      // Personal gateways default to "All" mode, which coerces toolExposureMode
+      // to the search_tools/run_tool dispatch surface.
+      expect(gateway.accessAllTools).toBe(true);
+      expect(gateway.toolExposureMode).toBe("search_and_run_only");
     });
 
     test("is idempotent within the same (user, org) - second call returns the same row", async ({
@@ -2610,6 +2614,12 @@ describe("AgentModel", () => {
       expect(gatewayA?.isPersonalGateway).toBe(true);
       expect(gatewayB?.isPersonalGateway).toBe(true);
       expect(gatewayA?.id).not.toBe(gatewayB?.id);
+      // The bulk-backfill path must produce the same "All" mode defaults as
+      // ensurePersonalMcpGateway, even though it bypasses AgentModel.create.
+      expect(gatewayA?.accessAllTools).toBe(true);
+      expect(gatewayA?.toolExposureMode).toBe("search_and_run_only");
+      expect(gatewayB?.accessAllTools).toBe(true);
+      expect(gatewayB?.toolExposureMode).toBe("search_and_run_only");
 
       const secondCount = await AgentModel.bulkBackfillPersonalMcpGateways();
       expect(secondCount).toBe(0);

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -2212,6 +2212,12 @@ class AgentModel {
           scope: "personal",
           description: PERSONAL_MCP_GATEWAY_DESCRIPTION,
           isPersonalGateway: true,
+          // The personal gateway defaults to "All" mode so it can reach every
+          // tool the user can access without per-tool assignment. Via the
+          // invariant in AgentModel.create, accessAllTools coerces
+          // toolExposureMode to "search_and_run_only" (the search_tools/run_tool
+          // dispatch surface).
+          accessAllTools: true,
         },
         userId,
       );
@@ -2287,6 +2293,11 @@ class AgentModel {
         agentType: "mcp_gateway" as const,
         scope: "personal" as const,
         isPersonalGateway: true,
+        // Personal gateways default to "All" mode (see ensurePersonalMcpGateway).
+        // This raw INSERT bypasses AgentModel.create, so set both fields here to
+        // preserve the accessAllTools => search_and_run_only invariant.
+        accessAllTools: true,
+        toolExposureMode: "search_and_run_only" as const,
         slug: `my-gateway-${userPart}-${crypto.randomUUID().slice(0, 6)}`,
       };
     });


### PR DESCRIPTION
## What

The per-user default MCP gateway (**"My Gateway"**) is created with `accessAllTools = false`, so it only exposes tools explicitly assigned to it (the MCP servers a user installs). This makes it default to **"All" mode** (`accessAllTools = true`) instead, so it can reach every tool the owning user can access — via the `search_tools`/`run_tool` dispatch surface — without per-tool assignment.

This matches the existing behavior of the personal chat agent (**"My Assistant"**), which already defaults to All-tools mode.

## Changes

Both personal-gateway creation paths in `backend/src/models/agent.ts` are updated:

- **`ensurePersonalMcpGateway`** (runtime: sign-in, org join, MCP install) — sets `accessAllTools: true`. `AgentModel.create`'s existing invariant coerces `toolExposureMode` to `"search_and_run_only"`.
- **`bulkBackfillPersonalMcpGateways`** (startup backfill) — a raw bulk `INSERT` that bypasses `AgentModel.create`, so it sets both `accessAllTools: true` and `toolExposureMode: "search_and_run_only"` explicitly to preserve the invariant.

## Behavioral note

Setting `accessAllTools: true` forces `toolExposureMode` to `search_and_run_only` (the dispatch surface), rather than exposing the full tool menu in `tools/list`. This is the same coupling the personal chat agent uses.