### PR TITLE
fix(chat): don't claim copy success when the clipboard write fails

### DIFF
--- a/platform/frontend/src/components/chat/inline-chat-error.test.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -257,6 +259,42 @@ describe("InlineChatError", () => {
     expect(
       screen.getByRole("button", { name: /Sign in with GitHub/i }),
     ).toBeInTheDocument();
+  });
+
+  it("does not claim success when the clipboard write fails", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    render(
+      <InlineChatError error={new Error("Failed to fetch")} slimChatErrorUi />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Copy error details" }),
+    );
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("toasts success once the clipboard write resolves", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    render(
+      <InlineChatError error={new Error("Failed to fetch")} slimChatErrorUi />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Copy error details" }),
+    );
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1));
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("auto-resends the original prompt after connecting the provider", async () => {

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -107,7 +107,7 @@ export function InlineChatError({
   if (chatError.spanId)
     refEntries.push({ label: "Span", value: chatError.spanId });
 
-  const copyDebugInfo = () => {
+  const copyDebugInfo = async () => {
     const lines: string[] = [];
 
     lines.push(supportMessage?.trim() || chatError.message);
@@ -130,10 +130,14 @@ export function InlineChatError({
       lines.push(`${entry.label}: ${entry.value}`);
     }
 
-    navigator.clipboard.writeText(lines.join("\n"));
-    toast.success(
-      slimChatErrorUi ? "Error details copied" : "Debug info copied",
-    );
+    try {
+      await navigator.clipboard.writeText(lines.join("\n"));
+      toast.success(
+        slimChatErrorUi ? "Error details copied" : "Debug info copied",
+      );
+    } catch {
+      toast.error("Couldn't copy to clipboard");
+    }
   };
 
   const retryButton = onRetry ? (


### PR DESCRIPTION
Stops the inline chat-error "copy" control from claiming success when the clipboard write actually failed.

- `platform/frontend/src/components/chat/inline-chat-error.tsx:133` — `copyDebugInfo` called `navigator.clipboard.writeText(...)` **without awaiting it**, then showed `toast.success(...)` unconditionally. A rejected write (insecure context, no clipboard permission, unfocused document) left an unhandled promise rejection and still told the user "Debug info copied". Now awaits the write in try/catch, toasts success only on resolution, and shows an error toast on failure — mirroring the sibling copy handlers (`conversation-artifact`, `conversation-files-panel`, `model-selector`).
- Regression tests in `inline-chat-error.test.tsx`: a rejecting write now yields an error toast and no success toast (verified failing before the fix); a resolving write still toasts success (happy-path guard).

Verification: Codex plan gate + diff gate — plan **PROCEED**, diff **UPHELD**. Independent review agrees.

https://claude.ai/code/session_01Fodt1NqqAtkqXQGaqKjKtm

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>