### PR TITLE
docs(environments): simplify trusted image registries section

### DIFF
--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -42,7 +42,7 @@ An environment can list the image registries it trusts. If an MCP server's image
 
 ### Use case
 
-Acme wants engineers to install MCP servers only from its own image registry. An admin adds that registry to the environment. Servers from it deploy automatically; anything from another registry waits for admin approval.
+Acme wants engineers to install MCP servers only from its own image registry. An admin sets the environment's trusted list to `registry.acme.com`. Servers built from `registry.acme.com/slack-mcp` or `registry.acme.com/jira-mcp` deploy automatically, but one from `ghcr.io/community/notion-mcp` waits for admin approval.
 
 ![Trusted image registries editor in Settings > Environments](/docs/automated_screenshots/platform-environments_trusted-image-registries.webp)
 

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -36,19 +36,15 @@ An environment can be marked **restricted**. Only members with the `environment:
 
 ## Trusted image registries
 
-To govern where a self-hosted MCP server's code comes from, an environment can list the image registries it trusts. If a server's image comes from a registry that isn't on the list, the server is not deployed — it waits for an admin to review and approve it first. With no list set, any image is allowed.
+An environment can list the image registries it trusts. If an MCP server's image is not from a trusted registry, it is not deployed until an admin approves it. With no list set, any image is allowed.
 
 ![MCP server held pending admin approval of its image](/docs/automated_screenshots/platform-environments_image-pending-approval.webp)
 
 ### Use case
 
-Acme Inc wants engineers to install MCP servers only from its own image registry, which holds only verified images and the images engineers push when deploying their own servers. An admin adds that registry to the environment. Servers built from those images install and deploy on their own; anything from another registry is held until an admin approves it.
+Acme wants engineers to install MCP servers only from its own image registry. An admin adds that registry to the environment. Servers from it deploy automatically; anything from another registry waits for admin approval.
 
 ![Trusted image registries editor in Settings > Environments](/docs/automated_screenshots/platform-environments_trusted-image-registries.webp)
-
-### What gets held
-
-A server is held only when it is self-hosted, uses its own custom image, is installed by a non-admin, and runs in an environment whose list its image doesn't match. Admins are never held — they own the list and do the approving. Remote servers, built-in servers, [Apps](/docs/platform-apps), the platform's default image, and an image already on the list all deploy normally. The check runs every time the image would start: install, reinstall, image refresh, and re-authenticate.
 
 ## Tool and knowledge isolation
 


### PR DESCRIPTION
## What

Simplifies the **Trusted image registries** section of the Environments docs.

- Tightened the opening paragraph (dropped "self-hosted" / "server's code" phrasing).
- Rewrote the **Use case** with a concrete example: trusted list set to `registry.acme.com`, servers from `registry.acme.com/slack-mcp` and `registry.acme.com/jira-mcp` deploy automatically, while `ghcr.io/community/notion-mcp` waits for admin approval.
- Removed the **What gets held** subsection.

## Scope

Docs-only — single file: `docs/pages/platform-environments.md`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>