### PR TITLE
fix(chat): show a working retry for retryable errors mid-flight

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -845,10 +845,12 @@ export function ChatPageContent({
   const stop = chatSession?.stop;
 
   // Re-send the most recent user message by regenerating its turn. Shared by the
-  // provider-connect auto-rerun and the scheduled-run "Try again". Returns whether
-  // a resend was actually started (false while a turn is in flight or there's no
-  // user message), so callers can skip side effects when nothing is resent.
-  const resendLastUserMessage = useCallback((): boolean => {
+  // provider-connect auto-rerun and the "Try again" affordance. Resolves to whether
+  // a resend was actually issued (false while a turn is in flight or there's no user
+  // message); awaiting regenerateUserMessage means it only resolves true once the
+  // turn is genuinely being re-run, so callers can safely gate side effects (e.g.
+  // clearing the persisted error) on the result.
+  const resendLastUserMessage = useCallback(async (): Promise<boolean> => {
     if (status === "submitted" || status === "streaming") return false;
     if (!regenerateUserMessage) return false;
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -858,7 +860,7 @@ export function ChatPageContent({
       if (partIndex < 0) return false;
       const part = message.parts[partIndex];
       const text = "text" in part ? part.text : "";
-      void regenerateUserMessage({ messageId: message.id, partIndex, text });
+      await regenerateUserMessage({ messageId: message.id, partIndex, text });
       return true;
     }
     return false;
@@ -866,18 +868,29 @@ export function ChatPageContent({
 
   // After the user connects a per-user provider (e.g. GitHub Copilot) via the
   // inline auth card, re-run their original prompt automatically. The connect
-  // mutation already invalidated the model/key caches.
-  const handleProviderConnected = resendLastUserMessage;
+  // mutation already invalidated the model/key caches. Fire-and-forget: the
+  // provider-auth card owns its own feedback.
+  const handleProviderConnected = useCallback(() => {
+    void resendLastUserMessage();
+  }, [resendLastUserMessage]);
 
-  // Scheduled-run "Try again": resend the scheduled prompt, and only once that's
-  // underway clear the persisted error so the card disappears. Ordering matters —
-  // clearing first would wipe the error card even if the resend couldn't start.
-  // Only wired for scheduled-run chats (and the chat is owner-editable here, since
-  // read-only viewers render MessageThread instead of this).
+  // "Try again" on a retryable chat error: resend the last user turn, and only
+  // once the resend is genuinely issued clear the persisted error so the card
+  // disappears. Ordering matters — clearing first would wipe the error card even
+  // if the resend never started. If the resend itself fails, keep the card so the
+  // user still sees the error. Owner-editable chats only (read-only viewers render
+  // MessageThread instead of this).
   const clearChatErrors = useClearChatErrors();
-  const handleScheduledRunRetry = useCallback(async () => {
+  const handleChatErrorRetry = useCallback(async () => {
     if (!conversationId) return;
-    if (!resendLastUserMessage()) return;
+    let resent: boolean;
+    try {
+      resent = await resendLastUserMessage();
+    } catch (error) {
+      console.error("[Chat] Retry failed to resend the last message", error);
+      return;
+    }
+    if (!resent) return;
     await clearChatErrors.mutateAsync({ id: conversationId });
   }, [conversationId, clearChatErrors, resendLastUserMessage]);
   // Hide the error while the session is auto-recovering (retry scheduled or
@@ -2102,9 +2115,7 @@ export function ChatPageContent({
                       compactions={conversation?.compactions ?? []}
                       onRegenerateUserMessage={regenerateUserMessage}
                       onProviderConnected={handleProviderConnected}
-                      onChatErrorRetry={
-                        scheduledRun ? handleScheduledRunRetry : undefined
-                      }
+                      onChatErrorRetry={handleChatErrorRetry}
                       error={error}
                       onToolApprovalResponse={
                         addToolApprovalResponse

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -871,7 +871,9 @@ export function ChatPageContent({
   // mutation already invalidated the model/key caches. Fire-and-forget: the
   // provider-auth card owns its own feedback.
   const handleProviderConnected = useCallback(() => {
-    void resendLastUserMessage();
+    void resendLastUserMessage().catch((error) => {
+      console.error("[Chat] Failed to re-run after provider connect", error);
+    });
   }, [resendLastUserMessage]);
 
   // "Try again" on a retryable chat error: resend the last user turn, and only

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -72,8 +72,19 @@ vi.mock("@/components/chat/editable-user-message", () => ({
 }));
 
 vi.mock("@/components/chat/inline-chat-error", () => ({
-  InlineChatError: ({ error }: { error: Error }) => (
-    <div data-testid="inline-chat-error">{error.message}</div>
+  InlineChatError: ({
+    error,
+    onRetry,
+  }: {
+    error: Error;
+    onRetry?: () => void;
+  }) => (
+    <div
+      data-testid="inline-chat-error"
+      data-has-retry={onRetry ? "true" : "false"}
+    >
+      {error.message}
+    </div>
   ),
 }));
 
@@ -417,6 +428,67 @@ describe("ChatMessages", () => {
     expect(error.compareDocumentPosition(retry)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+    // A retry resends the last user turn, but this error precedes a later
+    // message — offering retry here would rerun the wrong turn.
+    expect(error.getAttribute("data-has-retry")).toBe("false");
+  });
+
+  it("offers retry only on the trailing persisted error, not an older one", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        metadata: { createdAt: "2026-04-22T12:00:00.000Z" },
+        parts: [{ type: "text", text: "first try" }],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        metadata: { createdAt: "2026-04-22T12:02:00.000Z" },
+        parts: [{ type: "text", text: "second try" }],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+        onChatErrorRetry={vi.fn()}
+        chatErrors={[
+          {
+            id: "error-old",
+            conversationId: "conv-1",
+            createdAt: "2026-04-22T12:01:00.000Z",
+            error: {
+              code: "network_error",
+              message: "Older failure",
+              isRetryable: true,
+            },
+          },
+          {
+            id: "error-latest",
+            conversationId: "conv-1",
+            createdAt: "2026-04-22T12:05:00.000Z",
+            error: {
+              code: "network_error",
+              message: "Latest failure",
+              isRetryable: true,
+            },
+          },
+        ]}
+      />,
+    );
+
+    const errors = screen.getAllByTestId("inline-chat-error");
+    const older = errors.find((el) =>
+      el.textContent?.includes("Older failure"),
+    );
+    const latest = errors.find((el) =>
+      el.textContent?.includes("Latest failure"),
+    );
+    expect(older?.getAttribute("data-has-retry")).toBe("false");
+    expect(latest?.getAttribute("data-has-retry")).toBe("true");
   });
 
   it("renders unavailable tool failures as tool rows without global chat errors", () => {

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -467,6 +467,13 @@ export function ChatMessages({
     chatErrors.some(
       (chatError) => chatError.error.message === liveErrorMessage,
     );
+  // Retrying resends the *last* user turn, so only a persisted error with no
+  // message after it (the failed latest turn) may offer a retry — an older error
+  // card between messages would otherwise rerun the wrong turn.
+  const lastMessageTimelineIndex = timelineItems.reduce(
+    (last, item, index) => (item.kind === "message" ? index : last),
+    -1,
+  );
 
   let unsafeContextDividerEmitted = false;
   const claimUnsafeContextDivider = (): boolean => {
@@ -495,7 +502,7 @@ export function ChatMessages({
           {unsafeContextBoundary?.kind === "preexisting_untrusted" && (
             <PreexistingUnsafeContextDivider dividerRef={unsafeBoundaryRef} />
           )}
-          {timelineItems.map((item) => {
+          {timelineItems.map((item, index) => {
             if (item.kind === "chat-error") {
               return (
                 <InlineChatError
@@ -508,7 +515,11 @@ export function ChatMessages({
                   selectedModel={selectedModel}
                   modelSource={modelSource}
                   onProviderConnected={onProviderConnected}
-                  onRetry={onChatErrorRetry}
+                  onRetry={
+                    index > lastMessageTimelineIndex
+                      ? onChatErrorRetry
+                      : undefined
+                  }
                 />
               );
             }

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1331,6 +1331,7 @@ export function ChatMessages({
               selectedModel={selectedModel}
               modelSource={modelSource}
               onProviderConnected={onProviderConnected}
+              onRetry={onChatErrorRetry}
             />
           )}
           {pendingToolCalls.map((toolCall) => (

--- a/platform/frontend/src/components/chat/inline-chat-error.test.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.test.tsx
@@ -287,4 +287,71 @@ describe("InlineChatError", () => {
 
     await waitFor(() => expect(onProviderConnected).toHaveBeenCalledTimes(1));
   });
+
+  const retryableError = () =>
+    new Error(
+      JSON.stringify({
+        code: "network_error",
+        message: "Connection error. Please check your network and try again.",
+        isRetryable: true,
+      }),
+    );
+
+  const nonRetryableError = () =>
+    new Error(
+      JSON.stringify({
+        code: "authentication",
+        message: "Authentication failed.",
+        isRetryable: false,
+      }),
+    );
+
+  it("shows a Try again button for a retryable error and calls onRetry", async () => {
+    const onRetry = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<InlineChatError error={retryableError()} onRetry={onRetry} />);
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Try again for a non-retryable error even when onRetry is provided", () => {
+    render(<InlineChatError error={nonRetryableError()} onRetry={vi.fn()} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Try again" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Try again for a retryable error when no onRetry is provided", () => {
+    render(<InlineChatError error={retryableError()} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Try again" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables Try again while a retry is in flight so it cannot double-fire", async () => {
+    let resolveRetry: (() => void) | undefined;
+    const onRetry = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    render(<InlineChatError error={retryableError()} onRetry={onRetry} />);
+
+    const button = screen.getByRole("button", { name: "Try again" });
+    await user.click(button);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(button).toBeDisabled());
+
+    await user.click(button);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    resolveRetry?.();
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
 });

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -39,9 +39,8 @@ interface InlineChatErrorProps {
   /** Re-run the original prompt after the user connects a per-user provider. */
   onProviderConnected?: () => void;
   /**
-   * When set, render a "Try again" button that clears this error and resends the
-   * prompt. Wired only for scheduled-run chats — other chats omit it and keep
-   * their existing edit-the-message retry flow.
+   * When set and the error is retryable, render a "Try again" button that resends
+   * the last user turn and clears this error. Read-only viewers omit it.
    */
   onRetry?: () => void | Promise<void>;
 }
@@ -58,6 +57,7 @@ export function InlineChatError({
   onRetry,
 }: InlineChatErrorProps) {
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+  const [isRetrying, setIsRetrying] = useState(false);
   const { data: isAdmin } = useHasPermissions({
     organizationSettings: ["read"],
   });
@@ -136,19 +136,32 @@ export function InlineChatError({
     );
   };
 
-  const retryButton = onRetry ? (
-    <Button
-      variant="outline"
-      size="sm"
-      className="h-7 gap-1.5"
-      onClick={() => {
-        void onRetry();
-      }}
-    >
-      <RefreshCw className="h-3.5 w-3.5" />
-      Try again
-    </Button>
-  ) : null;
+  const retryButton =
+    chatError.isRetryable && onRetry ? (
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 gap-1.5"
+        disabled={isRetrying}
+        onClick={() => {
+          setIsRetrying(true);
+          void (async () => {
+            try {
+              await onRetry();
+            } catch (error) {
+              console.error("[InlineChatError] Retry failed", error);
+            } finally {
+              setIsRetrying(false);
+            }
+          })();
+        }}
+      >
+        <RefreshCw
+          className={`h-3.5 w-3.5 ${isRetrying ? "animate-spin" : ""}`}
+        />
+        Try again
+      </Button>
+    ) : null;
 
   if (slimChatErrorUi) {
     return (

--- a/platform/frontend/src/lib/chat/chat-retry.utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-retry.utils.test.ts
@@ -1,0 +1,52 @@
+import { ChatErrorCode } from "@archestra/shared";
+import { describe, expect, it } from "vitest";
+import { isRetryableError, parseStructuredChatError } from "./chat-retry.utils";
+
+function structuredError(code: ChatErrorCode, isRetryable: boolean): Error {
+  return new Error(JSON.stringify({ code, message: "boom", isRetryable }));
+}
+
+describe("isRetryableError", () => {
+  it("auto-retries a structured network_error", () => {
+    expect(
+      isRetryableError(structuredError(ChatErrorCode.NetworkError, true)),
+    ).toBe(true);
+  });
+
+  it("does not auto-retry a network_error flagged non-retryable", () => {
+    expect(
+      isRetryableError(structuredError(ChatErrorCode.NetworkError, false)),
+    ).toBe(false);
+  });
+
+  it("does not auto-retry other structured retryable codes (e.g. rate_limit)", () => {
+    expect(
+      isRetryableError(structuredError(ChatErrorCode.RateLimit, true)),
+    ).toBe(false);
+  });
+
+  it("auto-retries unstructured client network failures", () => {
+    expect(isRetryableError(new Error("Failed to fetch"))).toBe(true);
+  });
+
+  it("does not auto-retry an arbitrary unstructured error", () => {
+    expect(isRetryableError(new Error("something unexpected"))).toBe(false);
+  });
+});
+
+describe("parseStructuredChatError", () => {
+  it("parses a structured chat error payload", () => {
+    const parsed = parseStructuredChatError(
+      JSON.stringify({
+        code: ChatErrorCode.NetworkError,
+        message: "boom",
+        isRetryable: true,
+      }),
+    );
+    expect(parsed?.code).toBe(ChatErrorCode.NetworkError);
+  });
+
+  it("returns null for a plain (non-JSON) message", () => {
+    expect(parseStructuredChatError("Failed to fetch")).toBeNull();
+  });
+});

--- a/platform/frontend/src/lib/chat/chat-retry.utils.ts
+++ b/platform/frontend/src/lib/chat/chat-retry.utils.ts
@@ -1,0 +1,43 @@
+import {
+  ChatErrorCode,
+  type ChatErrorResponse,
+  isChatErrorResponse,
+} from "@archestra/shared";
+
+/** Network-level errors that never reach the backend (no structured payload). */
+const RETRYABLE_CLIENT_ERRORS = [
+  "Failed to fetch",
+  "NetworkError",
+  "No output generated",
+  "network",
+];
+
+/** Parse a chat error's message into a structured backend error, if it is one. */
+export function parseStructuredChatError(
+  message: string,
+): ChatErrorResponse | null {
+  try {
+    const parsed: unknown = JSON.parse(message);
+    return isChatErrorResponse(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether the client may silently auto-retry this streaming error. */
+export function isRetryableError(error: Error): boolean {
+  const msg = error.message;
+  // Structured backend chat errors already reached the server. Most should render
+  // once — auto-retrying duplicates the LLM request and changes trace IDs. The one
+  // exception is a dropped connection (network_error): the stream died, so a retry
+  // is a fresh attempt (a still-live run instead yields a 409 and reattaches), and
+  // it mirrors how the unstructured client network failures below already retry.
+  const structured = parseStructuredChatError(msg);
+  if (structured) {
+    return (
+      structured.code === ChatErrorCode.NetworkError && structured.isRetryable
+    );
+  }
+
+  return RETRYABLE_CLIENT_ERRORS.some((p) => msg.includes(p));
+}

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -63,6 +63,9 @@ vi.mock("@/lib/chat/chat.query", () => ({
     isPending: false,
     mutateAsync: mocks.mutateAsync,
   }),
+  useClearChatErrors: () => ({
+    mutateAsync: mocks.mutateAsync,
+  }),
   useConversation: () => ({ data: conversationMock.data }),
   useConversationUpdatedCacheSync: () => {},
 }));

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -11,6 +11,7 @@ type ChatSessionSnapshot = ReturnType<
 const mocks = vi.hoisted(() => ({
   addToolApprovalResponse: vi.fn(),
   addToolResult: vi.fn(),
+  clearChatErrors: vi.fn(),
   clearError: vi.fn(),
   getQueryData: vi.fn(),
   invalidateQueries: vi.fn(),
@@ -64,7 +65,7 @@ vi.mock("@/lib/chat/chat.query", () => ({
     mutateAsync: mocks.mutateAsync,
   }),
   useClearChatErrors: () => ({
-    mutateAsync: mocks.mutateAsync,
+    mutateAsync: mocks.clearChatErrors,
   }),
   useConversation: () => ({ data: conversationMock.data }),
   useConversationUpdatedCacheSync: () => {},
@@ -157,6 +158,150 @@ describe("ChatProvider retries", () => {
     });
 
     expect(mocks.regenerate).toHaveBeenCalledTimes(1);
+  });
+
+  const networkError = () =>
+    new Error(
+      JSON.stringify({
+        code: "network_error",
+        isRetryable: true,
+        message: "Connection error. Please check your network and try again.",
+      }),
+    );
+
+  it("auto-retries a structured network_error", async () => {
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(mocks.useChat).toHaveBeenCalled());
+
+    vi.useFakeTimers();
+    act(() => {
+      chatOptions?.onError?.(networkError());
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(mocks.regenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the stale persisted error card after a network_error retry succeeds", async () => {
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(mocks.useChat).toHaveBeenCalled());
+
+    vi.useFakeTimers();
+    act(() => {
+      chatOptions?.onError?.(networkError());
+      vi.advanceTimersByTime(1500);
+    });
+    expect(mocks.regenerate).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+    await act(async () => {
+      await chatOptions?.onFinish?.({ message: { parts: [] }, isAbort: false });
+    });
+
+    expect(mocks.clearChatErrors).toHaveBeenCalledWith({
+      id: "conversation-1",
+    });
+  });
+
+  it("does not clear persisted errors when a run succeeds after a non-retried error", async () => {
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(mocks.useChat).toHaveBeenCalled());
+
+    // server_error is not silently auto-retried, so it stays terminal and leaves
+    // no pending "clear on retry" intent for the next successful turn.
+    act(() => {
+      chatOptions?.onError?.(
+        new Error(
+          JSON.stringify({
+            code: "server_error",
+            isRetryable: true,
+            message: "The AI provider is experiencing issues.",
+          }),
+        ),
+      );
+    });
+    await act(async () => {
+      await chatOptions?.onFinish?.({ message: { parts: [] }, isAbort: false });
+    });
+
+    expect(mocks.clearChatErrors).not.toHaveBeenCalled();
+  });
+
+  it("does not clear persisted errors on a later success after the retry reattaches with a 204", async () => {
+    let resolveResume: (() => void) | undefined;
+    mocks.resumeStream.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveResume = resolve;
+        }),
+    );
+
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(mocks.useChat).toHaveBeenCalled());
+
+    // network_error auto-retries; its regenerate re-POSTs into the still-live run
+    // and lands the duplicate-run 409, so the session reattaches via resumeStream.
+    vi.useFakeTimers();
+    act(() => {
+      chatOptions?.onError?.(networkError());
+      chatOptions?.onFinish?.({
+        message: { parts: [] },
+        isAbort: false,
+        isError: true,
+        isDisconnect: true,
+      });
+      vi.advanceTimersByTime(1500);
+    });
+    expect(mocks.regenerate).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      chatOptions?.onError?.(
+        new Error("This conversation already has an active response."),
+      );
+      chatOptions?.onFinish?.({
+        message: { parts: [] },
+        isAbort: false,
+        isError: true,
+        isDisconnect: false,
+      });
+    });
+    expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
+
+    // The run had already finished: resumeStream resolves 204 with no
+    // onFinish/onError, concluding recovery.
+    vi.useRealTimers();
+    await act(async () => {
+      resolveResume?.();
+    });
+
+    // A later unrelated turn succeeds — it must NOT clear the persisted error,
+    // since the reattach already concluded the recovery.
+    mocks.clearChatErrors.mockClear();
+    await act(async () => {
+      await chatOptions?.onFinish?.({ message: { parts: [] }, isAbort: false });
+    });
+
+    expect(mocks.clearChatErrors).not.toHaveBeenCalled();
   });
 
   it("updates live context token estimate from usage and compaction data", async () => {

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -42,11 +42,16 @@ import {
   McpElicitationDialog,
 } from "@/components/chat/mcp-elicitation-dialog";
 import {
+  useClearChatErrors,
   useConversationUpdatedCacheSync,
   useGenerateConversationTitle,
   useResolveChatMcpElicitation,
 } from "@/lib/chat/chat.query";
 import { useUpdateChatMessage } from "@/lib/chat/chat-message.query";
+import {
+  isRetryableError,
+  parseStructuredChatError,
+} from "@/lib/chat/chat-retry.utils";
 import {
   pruneEmptyTrailingAssistantMessage,
   restoreRenderableAssistantParts,
@@ -70,13 +75,6 @@ import { useAppName } from "@/lib/hooks/use-app-name";
 const SESSION_CLEANUP_TIMEOUT = 10 * 60 * 1000; // 10 min
 const MAX_AUTO_RETRIES = 2;
 const AUTO_RETRY_DELAY_MS = 1500;
-/** Network-level errors that never reach the backend */
-const RETRYABLE_CLIENT_ERRORS = [
-  "Failed to fetch",
-  "NetworkError",
-  "No output generated",
-  "network",
-];
 
 export type ContextCompactionState = {
   isCompacting: boolean;
@@ -94,20 +92,6 @@ type ContextCompactionRecord = NonNullable<
 > & {
   updateContextTokens?: boolean;
 };
-
-function isRetryableError(error: Error): boolean {
-  const msg = error.message;
-  // Structured backend chat errors already reached the server and should render
-  // once. Retrying here creates duplicate LLM requests and changes trace IDs.
-  try {
-    JSON.parse(msg);
-    return false;
-  } catch {
-    // not JSON
-  }
-
-  return RETRYABLE_CLIENT_ERRORS.some((p) => msg.includes(p));
-}
 
 function isDuplicateActiveRunError(error: Error): boolean {
   // Match the backend's exact duplicate-run message rather than a bare "409",
@@ -479,6 +463,11 @@ function ChatSessionHook({
   // Auto-retry state for transient errors
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
+  // Set while auto-retrying a *structured* (backend-persisted) error, so a
+  // successful retry can wipe the now-stale persisted error card the backend
+  // never clears on its own.
+  const recoveredPersistedErrorRef = useRef(false);
+  const clearChatErrors = useClearChatErrors();
   // Monotonically counts onError invocations. The duplicate-run reattach uses
   // it to detect that nothing happened between calling resumeStream() and its
   // promise resolving — the "run already finished" case, where the reconnect
@@ -582,6 +571,20 @@ function ChatSessionHook({
       // errors.
       if (!isError) {
         setIsRecovering(false);
+        // A structured error we silently auto-retried just succeeded — clear the
+        // stale persisted error card the backend leaves behind (it never clears it
+        // on a new run). Reset the flag first so a re-entrant finish can't double-fire.
+        if (recoveredPersistedErrorRef.current) {
+          recoveredPersistedErrorRef.current = false;
+          try {
+            await clearChatErrors.mutateAsync({ id: conversationId });
+          } catch (error) {
+            console.error(
+              "[ChatSession] Failed to clear stale chat error after retry",
+              error,
+            );
+          }
+        }
       }
 
       // When the user stops mid-tool-call, the assistant message is left with a
@@ -763,6 +766,10 @@ function ChatSessionHook({
         retryCountRef.current < MAX_AUTO_RETRIES
       ) {
         retryCountRef.current++;
+        // A structured error was persisted by the backend; a successful retry must
+        // clear that stale card (onFinish). Unstructured client errors leave no row.
+        recoveredPersistedErrorRef.current =
+          parseStructuredChatError(chatError.message) !== null;
         console.info(
           `[ChatSession] Auto-retrying (${retryCountRef.current}/${MAX_AUTO_RETRIES})...`,
         );
@@ -783,7 +790,9 @@ function ChatSessionHook({
         return;
       }
 
-      // Terminal: no recovery in flight — surface the error.
+      // Terminal: no recovery in flight — surface the error (and keep its
+      // persisted card, so drop any pending "clear on successful retry" intent).
+      recoveredPersistedErrorRef.current = false;
       setPendingMcpElicitation(null);
       setIsRecovering(false);
     },

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -750,6 +750,10 @@ function ChatSessionHook({
             errorSeqRef.current === reattachErrorSeq
           ) {
             setIsRecovering(false);
+            // This reattach ends the recovery without an onFinish/onError, so
+            // drop any pending "clear the persisted error on success" intent —
+            // otherwise it leaks into a later unrelated success.
+            recoveredPersistedErrorRef.current = false;
             // Drop the stale duplicate-run error so the SDK returns to
             // "ready" instead of idling in the suppressed error state.
             clearErrorRef.current?.();
@@ -1007,6 +1011,9 @@ function ChatSessionHook({
   ) {
     lastUserMessageIdRef.current = lastStableUserMessage.id;
     retryCountRef.current = 0;
+    // A new turn: any pending "clear the prior turn's persisted error on a
+    // successful retry" intent no longer applies to this turn.
+    recoveredPersistedErrorRef.current = false;
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

A retryable error surfacing mid agentic flight (live streaming chat) — e.g. `network_error` "Connection error. Please check your network and try again." — showed the error card with **no retry button**, leaving the user stuck. The affordance existed but was gated on an `onRetry` prop wired only for scheduled runs, never rendered for live errors, and never consulted the error's `isRetryable` flag. Structured backend `network_error`s were also excluded from client-side auto-retry.

## Changes

- **`inline-chat-error.tsx`** — gate the "Try again" button on `chatError.isRetryable && onRetry`; add an in-flight guard (disabled + spinner) so it can't double-fire.
- **`page.tsx`** — `resendLastUserMessage` awaits the regenerate so it reports success only once the turn is genuinely re-run; the retry handler clears the persisted error **only after a confirmed resend** (fixes a pre-existing clear-before-resend data-loss race), catches resend failure, and is wired for all owner-editable chats.
- **`chat-messages.tsx`** — pass `onRetry` to the live error; scope persisted-error retry to the **trailing** error (no message after it) so a resend always targets the failed turn rather than a newer one.
- **`chat-retry.utils.ts` (new)** — extracted `isRetryableError`; structured `network_error` now auto-retries (narrowly — not rate-limit/empty-response). `global-chat.context.tsx` clears the stale persisted error card on a successful silent auto-retry, with the recovery flag reset across all exit paths (terminal error, 204-reattach, new turn).

## Behavior notes

- Scheduled runs previously showed "Try again" for any error; they now show it only for retryable ones (retrying a non-retryable error can't help).
- Read-only viewers (MessageThread) still show no retry button.

## Tests

New/extended behavior tests: button gating + in-flight guard (`inline-chat-error`), retry classification (`chat-retry.utils`), the recovery/clear lifecycle including the 409→204 no-leak case (`global-chat.context`), and trailing-vs-older retry scoping (`chat-messages`).

`type-check`, `biome`, and the full frontend test suite pass.

https://claude.ai/code/session_01BkdDrN42LPvMSyCo9R7mSX

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>