### PR TITLE
fix(bench): auto-answer MCP elicitation so runs don't hang

### DIFF
--- a/archestra-bench/envs/apps.toml
+++ b/archestra-bench/envs/apps.toml
@@ -16,12 +16,6 @@ fixture_mcp = true
 # assertion treats them as expected rather than a leak.
 tools = ["scaffold_app", "refine_app", "read_app", "edit_app", "validate_app", "list_apps", "render_app", "publish_app"]
 
-[agent]
-# A teammate handing off app work would rather keep moving than be pinged for every choice. This
-# nudge keeps the agent from stalling when a tool asks it to confirm details; the harness also
-# auto-answers any elicitation that still reaches it.
-system_prompt = "When a tool asks you to confirm details or fill in options, choose sensible defaults and keep going rather than waiting for someone to answer."
-
 # DeepWiki: a public, no-auth remote MCP the repo-docs-app wires into its app. Must list tools without
 # auth or env setup hard-fails naming it.
 [[mcps]]

--- a/archestra-bench/envs/apps.toml
+++ b/archestra-bench/envs/apps.toml
@@ -16,6 +16,12 @@ fixture_mcp = true
 # assertion treats them as expected rather than a leak.
 tools = ["scaffold_app", "refine_app", "read_app", "edit_app", "validate_app", "list_apps", "render_app", "publish_app"]
 
+[agent]
+# A teammate handing off app work would rather keep moving than be pinged for every choice. This
+# nudge keeps the agent from stalling when a tool asks it to confirm details; the harness also
+# auto-answers any elicitation that still reaches it.
+system_prompt = "When a tool asks you to confirm details or fill in options, choose sensible defaults and keep going rather than waiting for someone to answer."
+
 # DeepWiki: a public, no-auth remote MCP the repo-docs-app wires into its app. Must list tools without
 # auth or env setup hard-fails naming it.
 [[mcps]]

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -14,7 +14,7 @@ use tracing::info;
 
 use crate::chat_stream;
 use crate::config::types::ToolExposureMode;
-use crate::elicitation::{ElicitationAnswer, answer_for, parse_elicitation_request};
+use crate::elicitation::{ElicitationAnswer, ElicitationParse, answer_for, parse_elicitation_event};
 
 const DEFAULT_CHAT_TIMEOUT_S: f64 = 1800.0;
 
@@ -603,8 +603,17 @@ impl EvalClient {
         &self,
         event: &HashMap<String, JsonValue>,
     ) -> Result<(), ClientError> {
-        let Some(req) = parse_elicitation_request(event) else {
-            return Ok(());
+        let req = match parse_elicitation_event(event) {
+            ElicitationParse::NotElicitation => return Ok(()),
+            // A `data-mcp-elicitation` event we can't answer would otherwise leave the tool blocked
+            // for 10 minutes; surface it instead of silently ignoring it.
+            ElicitationParse::Malformed => {
+                return Err(ContractError(
+                    "unanswerable data-mcp-elicitation event: missing id/conversationId".to_string(),
+                )
+                .into());
+            }
+            ElicitationParse::Request(req) => req,
         };
         let answer = answer_for(&req);
         self.resolve_elicitation(&req.id, &req.conversation_id, &answer)

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -10,10 +10,11 @@ use serde::Serialize;
 use serde_json::Value as JsonValue;
 use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep, timeout};
+use tracing::info;
 
 use crate::chat_stream;
 use crate::config::types::ToolExposureMode;
-use crate::elicitation::ElicitationAnswer;
+use crate::elicitation::{ElicitationAnswer, answer_for, parse_elicitation_request};
 
 const DEFAULT_CHAT_TIMEOUT_S: f64 = 1800.0;
 
@@ -594,9 +595,32 @@ impl EvalClient {
             .map_err(ClientError::Api)
     }
 
-    /// Answer a pending MCP elicitation so the blocked tool call unblocks. The backend caches the
-    /// response for its 10-minute poll window, so a very early POST is still consumed.
-    pub async fn resolve_elicitation(
+    /// Auto-answer an MCP elicitation carried by a chat stream event, if the event is one. A tool
+    /// that elicits mid-call blocks server-side until this POST answers it, and no human watches a
+    /// benchmark stream. A non-elicitation event is a no-op; an answer POST that fails returns `Err`
+    /// so the caller can fail the stage rather than wait out the backend's 10-minute timeout.
+    pub async fn answer_if_elicitation(
+        &self,
+        event: &HashMap<String, JsonValue>,
+    ) -> Result<(), ClientError> {
+        let Some(req) = parse_elicitation_request(event) else {
+            return Ok(());
+        };
+        let answer = answer_for(&req);
+        self.resolve_elicitation(&req.id, &req.conversation_id, &answer)
+            .await?;
+        info!(
+            "auto-answered MCP elicitation {} ({:?}) with {}",
+            req.id,
+            req.mode,
+            answer.action.as_wire()
+        );
+        Ok(())
+    }
+
+    /// POST the answer to `/api/chat/elicitation/:id`. The backend caches the response for its
+    /// 10-minute poll window, so a very early POST is still consumed.
+    pub(crate) async fn resolve_elicitation(
         &self,
         id: &str,
         conversation_id: &str,
@@ -604,7 +628,7 @@ impl EvalClient {
     ) -> Result<(), ClientError> {
         let mut body = serde_json::json!({
             "conversationId": conversation_id,
-            "action": answer.action,
+            "action": answer.action.as_wire(),
         });
         if let Some(content) = &answer.content {
             body["content"] = JsonValue::Object(content.clone());

--- a/archestra-bench/runner/src/client.rs
+++ b/archestra-bench/runner/src/client.rs
@@ -13,6 +13,7 @@ use tokio::time::{Duration, sleep, timeout};
 
 use crate::chat_stream;
 use crate::config::types::ToolExposureMode;
+use crate::elicitation::ElicitationAnswer;
 
 const DEFAULT_CHAT_TIMEOUT_S: f64 = 1800.0;
 
@@ -591,6 +592,31 @@ impl EvalClient {
         self.request(Method::GET, path, None, None)
             .await
             .map_err(ClientError::Api)
+    }
+
+    /// Answer a pending MCP elicitation so the blocked tool call unblocks. The backend caches the
+    /// response for its 10-minute poll window, so a very early POST is still consumed.
+    pub async fn resolve_elicitation(
+        &self,
+        id: &str,
+        conversation_id: &str,
+        answer: &ElicitationAnswer,
+    ) -> Result<(), ClientError> {
+        let mut body = serde_json::json!({
+            "conversationId": conversation_id,
+            "action": answer.action,
+        });
+        if let Some(content) = &answer.content {
+            body["content"] = JsonValue::Object(content.clone());
+        }
+        self.request(
+            Method::POST,
+            &format!("/api/chat/elicitation/{id}"),
+            None,
+            Some(&body),
+        )
+        .await?;
+        Ok(())
     }
 
     pub async fn create_conversation(

--- a/archestra-bench/runner/src/elicitation.rs
+++ b/archestra-bench/runner/src/elicitation.rs
@@ -52,31 +52,48 @@ pub(crate) struct ElicitationAnswer {
     pub content: Option<Map<String, JsonValue>>,
 }
 
-/// Parse a chat SSE event into an elicitation request, or `None` when it is not one. Fields live
-/// under the nested `data` object, matching the backend writer and frontend reader.
-pub(crate) fn parse_elicitation_request(
-    event: &HashMap<String, JsonValue>,
-) -> Option<ElicitationRequest> {
+/// Outcome of inspecting a chat SSE event for an elicitation request.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ElicitationParse {
+    /// Not an elicitation event — ignore it.
+    NotElicitation,
+    /// An elicitation event missing the `data.id`/`data.conversationId` needed to answer it. It
+    /// cannot be answered, so the caller must fail loudly rather than leave the tool blocked.
+    Malformed,
+    /// A well-formed elicitation request.
+    Request(ElicitationRequest),
+}
+
+/// Inspect a chat SSE event. Fields live under the nested `data` object, matching the backend writer
+/// and frontend reader. A `data-mcp-elicitation` event we cannot answer is `Malformed`, never
+/// silently ignored.
+pub(crate) fn parse_elicitation_event(event: &HashMap<String, JsonValue>) -> ElicitationParse {
     if event.get("type").and_then(|v| v.as_str()) != Some(ELICITATION_EVENT_TYPE) {
-        return None;
+        return ElicitationParse::NotElicitation;
     }
-    let data = event.get("data").and_then(|v| v.as_object())?;
-    let id = data.get("id").and_then(|v| v.as_str())?.to_string();
-    let conversation_id = data
-        .get("conversationId")
-        .and_then(|v| v.as_str())?
-        .to_string();
-    let mode = match data.get("mode").and_then(|v| v.as_str()) {
-        // The backend defaults an absent mode to "form" (chat-mcp-elicitation.ts), so mirror that.
-        Some("url") => ElicitationMode::Url,
-        _ => ElicitationMode::Form,
-    };
-    Some(ElicitationRequest {
-        id,
-        conversation_id,
-        mode,
-        requested_schema: data.get("requestedSchema").cloned(),
-    })
+    let parsed = (|| {
+        let data = event.get("data").and_then(|v| v.as_object())?;
+        let id = data.get("id").and_then(|v| v.as_str())?.to_string();
+        let conversation_id = data
+            .get("conversationId")
+            .and_then(|v| v.as_str())?
+            .to_string();
+        let mode = match data.get("mode").and_then(|v| v.as_str()) {
+            // The backend defaults an absent mode to "form" (chat-mcp-elicitation.ts), so mirror it.
+            Some("url") => ElicitationMode::Url,
+            _ => ElicitationMode::Form,
+        };
+        Some(ElicitationRequest {
+            id,
+            conversation_id,
+            mode,
+            requested_schema: data.get("requestedSchema").cloned(),
+        })
+    })();
+    match parsed {
+        Some(req) => ElicitationParse::Request(req),
+        None => ElicitationParse::Malformed,
+    }
 }
 
 /// The auto-answer: accept a form with recommended defaults; decline a URL flow (it cannot be
@@ -169,7 +186,9 @@ mod tests {
                 "requestedSchema": { "type": "object", "properties": {} }
             }
         }));
-        let req = parse_elicitation_request(&event).expect("parsed");
+        let ElicitationParse::Request(req) = parse_elicitation_event(&event) else {
+            panic!("expected a well-formed request");
+        };
         assert_eq!(req.id, "elicit-1");
         assert_eq!(req.conversation_id, "conv-1");
         assert_eq!(req.mode, ElicitationMode::Form);
@@ -182,25 +201,29 @@ mod tests {
             "type": "data-mcp-elicitation",
             "data": { "id": "a", "conversationId": "b" }
         }));
+        let ElicitationParse::Request(req) = parse_elicitation_event(&event) else {
+            panic!("expected a well-formed request");
+        };
+        assert_eq!(req.mode, ElicitationMode::Form);
+    }
+
+    #[test]
+    fn non_elicitation_event_is_ignored() {
+        let event = event_from(json!({ "type": "text-delta", "delta": "hi" }));
         assert_eq!(
-            parse_elicitation_request(&event).unwrap().mode,
-            ElicitationMode::Form
+            parse_elicitation_event(&event),
+            ElicitationParse::NotElicitation
         );
     }
 
     #[test]
-    fn non_elicitation_event_is_none() {
-        let event = event_from(json!({ "type": "text-delta", "delta": "hi" }));
-        assert!(parse_elicitation_request(&event).is_none());
-    }
-
-    #[test]
-    fn missing_ids_is_none() {
+    fn elicitation_missing_ids_is_malformed() {
+        // Typed as an elicitation but unanswerable (no id) — must surface, not be silently skipped.
         let event = event_from(json!({
             "type": "data-mcp-elicitation",
             "data": { "conversationId": "b" }
         }));
-        assert!(parse_elicitation_request(&event).is_none());
+        assert_eq!(parse_elicitation_event(&event), ElicitationParse::Malformed);
     }
 
     #[test]

--- a/archestra-bench/runner/src/elicitation.rs
+++ b/archestra-bench/runner/src/elicitation.rs
@@ -15,30 +15,48 @@ use serde_json::{Map, Value as JsonValue};
 const ELICITATION_EVENT_TYPE: &str = "data-mcp-elicitation";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ElicitationMode {
+pub(crate) enum ElicitationMode {
     Form,
     Url,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ElicitationRequest {
+pub(crate) struct ElicitationRequest {
     pub id: String,
     pub conversation_id: String,
     pub mode: ElicitationMode,
     pub requested_schema: Option<JsonValue>,
 }
 
-/// A response ready to POST to `/api/chat/elicitation/:id`. `action` is a wire literal ("accept" /
-/// "decline"); `content` is present only for an accepted form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ElicitationAction {
+    Accept,
+    Decline,
+}
+
+impl ElicitationAction {
+    /// The wire literal the backend's `ChatMcpElicitationResponseSchema` expects.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            ElicitationAction::Accept => "accept",
+            ElicitationAction::Decline => "decline",
+        }
+    }
+}
+
+/// A response ready to POST to `/api/chat/elicitation/:id`. `content` is present only for an
+/// accepted form.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ElicitationAnswer {
-    pub action: &'static str,
+pub(crate) struct ElicitationAnswer {
+    pub action: ElicitationAction,
     pub content: Option<Map<String, JsonValue>>,
 }
 
 /// Parse a chat SSE event into an elicitation request, or `None` when it is not one. Fields live
 /// under the nested `data` object, matching the backend writer and frontend reader.
-pub fn parse_elicitation_request(event: &HashMap<String, JsonValue>) -> Option<ElicitationRequest> {
+pub(crate) fn parse_elicitation_request(
+    event: &HashMap<String, JsonValue>,
+) -> Option<ElicitationRequest> {
     if event.get("type").and_then(|v| v.as_str()) != Some(ELICITATION_EVENT_TYPE) {
         return None;
     }
@@ -63,14 +81,14 @@ pub fn parse_elicitation_request(event: &HashMap<String, JsonValue>) -> Option<E
 
 /// The auto-answer: accept a form with recommended defaults; decline a URL flow (it cannot be
 /// completed headlessly, and declining unblocks the tool).
-pub fn answer_for(req: &ElicitationRequest) -> ElicitationAnswer {
+pub(crate) fn answer_for(req: &ElicitationRequest) -> ElicitationAnswer {
     match req.mode {
         ElicitationMode::Form => ElicitationAnswer {
-            action: "accept",
+            action: ElicitationAction::Accept,
             content: Some(default_content_from_schema(req.requested_schema.as_ref())),
         },
         ElicitationMode::Url => ElicitationAnswer {
-            action: "decline",
+            action: ElicitationAction::Decline,
             content: None,
         },
     }
@@ -79,7 +97,7 @@ pub fn answer_for(req: &ElicitationRequest) -> ElicitationAnswer {
 /// Build form content from a requested schema, recommended default first: the property's declared
 /// `default`, else its first `enum` value, else a typed zero-value. Every value is coerced into the
 /// backend-allowed union; a property that cannot yield an allowed value is omitted.
-pub fn default_content_from_schema(schema: Option<&JsonValue>) -> Map<String, JsonValue> {
+pub(crate) fn default_content_from_schema(schema: Option<&JsonValue>) -> Map<String, JsonValue> {
     let mut content = Map::new();
     let Some(properties) = schema
         .and_then(|s| s.get("properties"))
@@ -262,7 +280,7 @@ mod tests {
             })),
         };
         let answer = answer_for(&req);
-        assert_eq!(answer.action, "accept");
+        assert_eq!(answer.action, ElicitationAction::Accept);
         assert_eq!(answer.content.unwrap().get("name"), Some(&json!("")));
     }
 
@@ -275,7 +293,7 @@ mod tests {
             requested_schema: None,
         };
         let answer = answer_for(&req);
-        assert_eq!(answer.action, "decline");
+        assert_eq!(answer.action, ElicitationAction::Decline);
         assert!(answer.content.is_none());
     }
 }

--- a/archestra-bench/runner/src/elicitation.rs
+++ b/archestra-bench/runner/src/elicitation.rs
@@ -1,0 +1,281 @@
+//! Elicitation concern: turn a backend `data-mcp-elicitation` chat event into an auto-answer the
+//! headless benchmark can POST back, so a tool that elicits mid-call unblocks instead of stalling
+//! until the backend's 10-minute elicitation timeout.
+//!
+//! The backend writes `{ type: "data-mcp-elicitation", data: { id, conversationId, mode,
+//! requestedSchema, ... } }` and then polls a cache for a `POST /api/chat/elicitation/:id`
+//! (`platform/backend/src/clients/chat-mcp-elicitation.ts`). The answer content is validated only
+//! against the primitive union `string | number | boolean | string[]`, not the original
+//! `requestedSchema`, so this module coerces every value into that union.
+
+use std::collections::HashMap;
+
+use serde_json::{Map, Value as JsonValue};
+
+const ELICITATION_EVENT_TYPE: &str = "data-mcp-elicitation";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElicitationMode {
+    Form,
+    Url,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ElicitationRequest {
+    pub id: String,
+    pub conversation_id: String,
+    pub mode: ElicitationMode,
+    pub requested_schema: Option<JsonValue>,
+}
+
+/// A response ready to POST to `/api/chat/elicitation/:id`. `action` is a wire literal ("accept" /
+/// "decline"); `content` is present only for an accepted form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ElicitationAnswer {
+    pub action: &'static str,
+    pub content: Option<Map<String, JsonValue>>,
+}
+
+/// Parse a chat SSE event into an elicitation request, or `None` when it is not one. Fields live
+/// under the nested `data` object, matching the backend writer and frontend reader.
+pub fn parse_elicitation_request(event: &HashMap<String, JsonValue>) -> Option<ElicitationRequest> {
+    if event.get("type").and_then(|v| v.as_str()) != Some(ELICITATION_EVENT_TYPE) {
+        return None;
+    }
+    let data = event.get("data").and_then(|v| v.as_object())?;
+    let id = data.get("id").and_then(|v| v.as_str())?.to_string();
+    let conversation_id = data
+        .get("conversationId")
+        .and_then(|v| v.as_str())?
+        .to_string();
+    let mode = match data.get("mode").and_then(|v| v.as_str()) {
+        // The backend defaults an absent mode to "form" (chat-mcp-elicitation.ts), so mirror that.
+        Some("url") => ElicitationMode::Url,
+        _ => ElicitationMode::Form,
+    };
+    Some(ElicitationRequest {
+        id,
+        conversation_id,
+        mode,
+        requested_schema: data.get("requestedSchema").cloned(),
+    })
+}
+
+/// The auto-answer: accept a form with recommended defaults; decline a URL flow (it cannot be
+/// completed headlessly, and declining unblocks the tool).
+pub fn answer_for(req: &ElicitationRequest) -> ElicitationAnswer {
+    match req.mode {
+        ElicitationMode::Form => ElicitationAnswer {
+            action: "accept",
+            content: Some(default_content_from_schema(req.requested_schema.as_ref())),
+        },
+        ElicitationMode::Url => ElicitationAnswer {
+            action: "decline",
+            content: None,
+        },
+    }
+}
+
+/// Build form content from a requested schema, recommended default first: the property's declared
+/// `default`, else its first `enum` value, else a typed zero-value. Every value is coerced into the
+/// backend-allowed union; a property that cannot yield an allowed value is omitted.
+pub fn default_content_from_schema(schema: Option<&JsonValue>) -> Map<String, JsonValue> {
+    let mut content = Map::new();
+    let Some(properties) = schema
+        .and_then(|s| s.get("properties"))
+        .and_then(|p| p.as_object())
+    else {
+        return content;
+    };
+    for (key, prop) in properties {
+        if let Some(value) = default_for_property(prop) {
+            content.insert(key.clone(), value);
+        }
+    }
+    content
+}
+
+fn default_for_property(prop: &JsonValue) -> Option<JsonValue> {
+    if let Some(value) = prop.get("default").and_then(coerce_allowed) {
+        return Some(value);
+    }
+    if let Some(value) = prop
+        .get("enum")
+        .and_then(|v| v.as_array())
+        .and_then(|values| values.iter().find_map(coerce_allowed))
+    {
+        return Some(value);
+    }
+    match prop.get("type").and_then(|v| v.as_str()) {
+        Some("string") => Some(JsonValue::String(String::new())),
+        Some("number") | Some("integer") => Some(JsonValue::from(0)),
+        Some("boolean") => Some(JsonValue::Bool(false)),
+        Some("array") => Some(JsonValue::Array(Vec::new())),
+        _ => None,
+    }
+}
+
+/// Keep a value only if it fits the backend's `string | number | boolean | string[]` union.
+fn coerce_allowed(value: &JsonValue) -> Option<JsonValue> {
+    match value {
+        JsonValue::String(_) | JsonValue::Number(_) | JsonValue::Bool(_) => Some(value.clone()),
+        JsonValue::Array(items) if items.iter().all(JsonValue::is_string) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event_from(value: JsonValue) -> HashMap<String, JsonValue> {
+        value
+            .as_object()
+            .expect("object")
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn parses_fields_from_nested_data() {
+        // The exact wire shape a benchmark run receives.
+        let event = event_from(json!({
+            "type": "data-mcp-elicitation",
+            "data": {
+                "id": "elicit-1",
+                "conversationId": "conv-1",
+                "toolName": "refine_app",
+                "mode": "form",
+                "requestedSchema": { "type": "object", "properties": {} }
+            }
+        }));
+        let req = parse_elicitation_request(&event).expect("parsed");
+        assert_eq!(req.id, "elicit-1");
+        assert_eq!(req.conversation_id, "conv-1");
+        assert_eq!(req.mode, ElicitationMode::Form);
+        assert!(req.requested_schema.is_some());
+    }
+
+    #[test]
+    fn absent_mode_defaults_to_form() {
+        let event = event_from(json!({
+            "type": "data-mcp-elicitation",
+            "data": { "id": "a", "conversationId": "b" }
+        }));
+        assert_eq!(
+            parse_elicitation_request(&event).unwrap().mode,
+            ElicitationMode::Form
+        );
+    }
+
+    #[test]
+    fn non_elicitation_event_is_none() {
+        let event = event_from(json!({ "type": "text-delta", "delta": "hi" }));
+        assert!(parse_elicitation_request(&event).is_none());
+    }
+
+    #[test]
+    fn missing_ids_is_none() {
+        let event = event_from(json!({
+            "type": "data-mcp-elicitation",
+            "data": { "conversationId": "b" }
+        }));
+        assert!(parse_elicitation_request(&event).is_none());
+    }
+
+    #[test]
+    fn recommended_default_wins_over_enum_and_type() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "level": { "type": "string", "enum": ["read", "admin"], "default": "read" }
+            }
+        });
+        let content = default_content_from_schema(Some(&schema));
+        assert_eq!(content.get("level"), Some(&json!("read")));
+    }
+
+    #[test]
+    fn enum_used_when_no_default() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "level": { "type": "string", "enum": ["read", "admin"] } }
+        });
+        let content = default_content_from_schema(Some(&schema));
+        assert_eq!(content.get("level"), Some(&json!("read")));
+    }
+
+    #[test]
+    fn typed_zero_values_when_no_default_or_enum() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "count": { "type": "integer" },
+                "ratio": { "type": "number" },
+                "flag": { "type": "boolean" },
+                "tags": { "type": "array" }
+            }
+        });
+        let content = default_content_from_schema(Some(&schema));
+        assert_eq!(content.get("name"), Some(&json!("")));
+        assert_eq!(content.get("count"), Some(&json!(0)));
+        assert_eq!(content.get("ratio"), Some(&json!(0)));
+        assert_eq!(content.get("flag"), Some(&json!(false)));
+        assert_eq!(content.get("tags"), Some(&json!([])));
+    }
+
+    #[test]
+    fn disallowed_default_falls_through_to_typed_zero() {
+        // An object-valued default cannot cross the backend's primitive union, so it is dropped and
+        // the typed zero-value is used instead.
+        let schema = json!({
+            "type": "object",
+            "properties": { "opts": { "type": "string", "default": { "nested": true } } }
+        });
+        let content = default_content_from_schema(Some(&schema));
+        assert_eq!(content.get("opts"), Some(&json!("")));
+    }
+
+    #[test]
+    fn untyped_property_without_default_is_omitted() {
+        let schema = json!({ "type": "object", "properties": { "mystery": {} } });
+        assert!(default_content_from_schema(Some(&schema)).is_empty());
+    }
+
+    #[test]
+    fn absent_schema_yields_empty_content() {
+        assert!(default_content_from_schema(None).is_empty());
+    }
+
+    #[test]
+    fn form_answer_accepts_with_defaults() {
+        let req = ElicitationRequest {
+            id: "a".into(),
+            conversation_id: "b".into(),
+            mode: ElicitationMode::Form,
+            requested_schema: Some(json!({
+                "type": "object",
+                "properties": { "name": { "type": "string" } }
+            })),
+        };
+        let answer = answer_for(&req);
+        assert_eq!(answer.action, "accept");
+        assert_eq!(answer.content.unwrap().get("name"), Some(&json!("")));
+    }
+
+    #[test]
+    fn url_answer_declines() {
+        let req = ElicitationRequest {
+            id: "a".into(),
+            conversation_id: "b".into(),
+            mode: ElicitationMode::Url,
+            requested_schema: None,
+        };
+        let answer = answer_for(&req);
+        assert_eq!(answer.action, "decline");
+        assert!(answer.content.is_none());
+    }
+}

--- a/archestra-bench/runner/src/lib.rs
+++ b/archestra-bench/runner/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod chat_stream;
 pub mod client;
 pub mod config;
+pub mod elicitation;
 pub mod fixture_mcp;
 pub mod interactions;
 pub mod lifecycle;

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -17,6 +17,7 @@ use crate::chat_stream::{ChatRecordKind, ChatRunResult, ChatStreamRecord, apply_
 use crate::client::{AgentCreate, ContractError, EvalClient, FilePart};
 use crate::config::types::{EnvConfig, Stage, Task, ToolExposureMode};
 use crate::config::{Lane, load_envs, load_lanes};
+use crate::elicitation::{answer_for, parse_elicitation_request};
 use crate::fixture_mcp::{FIXTURE_MCP_NAME, FixtureMcp};
 use crate::interactions::{RunUsage, extract_effective_prompts, sum_usage};
 use crate::lifecycle::Instance;
@@ -2000,7 +2001,30 @@ async fn drive_stage(
         coalescer.feed(&record).await;
         match record.kind {
             ChatRecordKind::Event if record.event.is_some() => {
-                apply_chat_event(run, &record.event.unwrap());
+                let event = record.event.unwrap();
+                // A tool that elicits mid-call blocks server-side until this POST answers it. No
+                // human is watching a benchmark stream, so auto-answer and let the agent continue.
+                if let Some(req) = parse_elicitation_request(&event) {
+                    let answer = answer_for(&req);
+                    if let Err(e) = client
+                        .resolve_elicitation(&req.id, &req.conversation_id, &answer)
+                        .await
+                    {
+                        // Backend heartbeats keep the stream from going idle, so a failed answer
+                        // would otherwise hang until the backend's 10-minute elicitation timeout.
+                        // Fail the stage now instead.
+                        if stream_parse_error.is_none() {
+                            stream_parse_error =
+                                Some(format!("failed to answer MCP elicitation {}: {e}", req.id));
+                        }
+                        break;
+                    }
+                    info!(
+                        "auto-answered MCP elicitation {} ({:?}) with {}",
+                        req.id, req.mode, answer.action
+                    );
+                }
+                apply_chat_event(run, &event);
             }
             ChatRecordKind::ParseError if stream_parse_error.is_none() => {
                 stream_parse_error = Some(record.reason.unwrap_or_else(|| {

--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -17,7 +17,6 @@ use crate::chat_stream::{ChatRecordKind, ChatRunResult, ChatStreamRecord, apply_
 use crate::client::{AgentCreate, ContractError, EvalClient, FilePart};
 use crate::config::types::{EnvConfig, Stage, Task, ToolExposureMode};
 use crate::config::{Lane, load_envs, load_lanes};
-use crate::elicitation::{answer_for, parse_elicitation_request};
 use crate::fixture_mcp::{FIXTURE_MCP_NAME, FixtureMcp};
 use crate::interactions::{RunUsage, extract_effective_prompts, sum_usage};
 use crate::lifecycle::Instance;
@@ -2002,27 +2001,14 @@ async fn drive_stage(
         match record.kind {
             ChatRecordKind::Event if record.event.is_some() => {
                 let event = record.event.unwrap();
-                // A tool that elicits mid-call blocks server-side until this POST answers it. No
-                // human is watching a benchmark stream, so auto-answer and let the agent continue.
-                if let Some(req) = parse_elicitation_request(&event) {
-                    let answer = answer_for(&req);
-                    if let Err(e) = client
-                        .resolve_elicitation(&req.id, &req.conversation_id, &answer)
-                        .await
-                    {
-                        // Backend heartbeats keep the stream from going idle, so a failed answer
-                        // would otherwise hang until the backend's 10-minute elicitation timeout.
-                        // Fail the stage now instead.
-                        if stream_parse_error.is_none() {
-                            stream_parse_error =
-                                Some(format!("failed to answer MCP elicitation {}: {e}", req.id));
-                        }
-                        break;
+                // Auto-answer any elicitation this event carries before folding it. Backend
+                // heartbeats keep the stream from going idle, so a failed answer would otherwise
+                // hang until the backend's 10-minute elicitation timeout; fail the stage instead.
+                if let Err(e) = client.answer_if_elicitation(&event).await {
+                    if stream_parse_error.is_none() {
+                        stream_parse_error = Some(format!("failed to answer MCP elicitation: {e}"));
                     }
-                    info!(
-                        "auto-answered MCP elicitation {} ({:?}) with {}",
-                        req.id, req.mode, answer.action
-                    );
+                    break;
                 }
                 apply_chat_event(run, &event);
             }

--- a/archestra-bench/runner/tests/elicitation_flow.rs
+++ b/archestra-bench/runner/tests/elicitation_flow.rs
@@ -1,17 +1,18 @@
-//! End-to-end: a chat stream emits an MCP elicitation event, the harness answers it, and the tool
-//! unblocks. A local HTTP server plays the backend (real network I/O over a TCP boundary, no mocking
-//! of the runner's own code): it streams an elicitation event, then withholds the `finish` event
-//! until the runner has POSTed an answer — so a passing test proves the auto-answer is what lets the
-//! run continue.
+//! End-to-end: a chat stream emits an MCP elicitation event, the harness answers it via the same
+//! `EvalClient::answer_if_elicitation` that `drive_stage` calls, and the tool unblocks. A local HTTP
+//! server plays the backend (real network I/O over a TCP boundary, no mocking of the runner's own
+//! code): it streams an elicitation event, then withholds the `finish` event until the runner has
+//! POSTed an answer — so a passing test proves the auto-answer is what lets the run continue.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use archestra_bench::client::EvalClient;
-use archestra_bench::elicitation::{answer_for, parse_elicitation_request};
 use axum::{
     Json, Router,
     body::Body,
     extract::{Path, State},
+    http::StatusCode,
     response::Response,
     routing::post,
 };
@@ -56,10 +57,7 @@ async fn chat_handler(State(state): State<Arc<BackendState>>) -> Response {
             }
         })
     );
-    let finish_line = format!(
-        "data: {}\n",
-        json!({ "type": "finish", "finishReason": "stop" })
-    );
+    let finish_line = format!("data: {}\n", json!({ "type": "finish", "finishReason": "stop" }));
 
     let stream = futures::stream::unfold(
         (StreamStep::Elicit, state, elicit_line, finish_line),
@@ -99,23 +97,30 @@ async fn elicitation_handler(
     Json(json!({ "success": true }))
 }
 
+async fn serve(app: Router) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
 #[tokio::test]
 async fn auto_answers_form_elicitation_and_unblocks_stream() {
     let state = Arc::new(BackendState {
         posted_body: Mutex::new(None),
         answered: Notify::new(),
     });
-    let app = Router::new()
-        .route("/api/chat", post(chat_handler))
-        .route("/api/chat/elicitation/{id}", post(elicitation_handler))
-        .with_state(state.clone());
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
+    let base_url = serve(
+        Router::new()
+            .route("/api/chat", post(chat_handler))
+            .route("/api/chat/elicitation/{id}", post(elicitation_handler))
+            .with_state(state.clone()),
+    )
+    .await;
 
-    let client = EvalClient::new(format!("http://{addr}"), None);
+    let client = EvalClient::new(base_url, None);
 
     let saw_finish = timeout(Duration::from_secs(10), async {
         let mut stream = client
@@ -123,17 +128,15 @@ async fn auto_answers_form_elicitation_and_unblocks_stream() {
             .await
             .expect("chat stream opens");
 
-        // Mirror drive_stage's per-event handling: answer any elicitation, note the finish.
+        // Exercise the exact per-event path drive_stage uses.
         let mut saw_finish = false;
         while let Some(record) = stream.next().await {
             let Some(event) = &record.event else { continue };
-            if let Some(req) = parse_elicitation_request(event) {
-                let answer = answer_for(&req);
-                client
-                    .resolve_elicitation(&req.id, &req.conversation_id, &answer)
-                    .await
-                    .expect("elicitation answer posts");
-            } else if event.get("type").and_then(|v| v.as_str()) == Some("finish") {
+            client
+                .answer_if_elicitation(event)
+                .await
+                .expect("elicitation answer posts");
+            if event.get("type").and_then(|v| v.as_str()) == Some("finish") {
                 saw_finish = true;
             }
         }
@@ -142,10 +145,7 @@ async fn auto_answers_form_elicitation_and_unblocks_stream() {
     .await
     .expect("stream completes within the timeout");
 
-    assert!(
-        saw_finish,
-        "finish only arrives after the elicitation is answered"
-    );
+    assert!(saw_finish, "finish only arrives after the elicitation is answered");
 
     let posted = state
         .posted_body
@@ -160,5 +160,33 @@ async fn auto_answers_form_elicitation_and_unblocks_stream() {
             "action": "accept",
             "content": { "access_level": "read-only" }
         })
+    );
+}
+
+#[tokio::test]
+async fn failed_answer_post_surfaces_error() {
+    // A 5xx from the elicitation endpoint must surface as Err so drive_stage fails the stage rather
+    // than waiting out the backend's 10-minute elicitation timeout.
+    let base_url = serve(Router::new().route(
+        "/api/chat/elicitation/{id}",
+        post(|| async { (StatusCode::INTERNAL_SERVER_ERROR, "boom") }),
+    ))
+    .await;
+    let client = EvalClient::new(base_url, None);
+
+    let event: HashMap<String, Value> = serde_json::from_value(json!({
+        "type": "data-mcp-elicitation",
+        "data": {
+            "id": "e1",
+            "conversationId": "c1",
+            "mode": "form",
+            "requestedSchema": { "type": "object", "properties": {} }
+        }
+    }))
+    .unwrap();
+
+    assert!(
+        client.answer_if_elicitation(&event).await.is_err(),
+        "a failed answer POST must surface as an error"
     );
 }

--- a/archestra-bench/runner/tests/elicitation_flow.rs
+++ b/archestra-bench/runner/tests/elicitation_flow.rs
@@ -1,0 +1,164 @@
+//! End-to-end: a chat stream emits an MCP elicitation event, the harness answers it, and the tool
+//! unblocks. A local HTTP server plays the backend (real network I/O over a TCP boundary, no mocking
+//! of the runner's own code): it streams an elicitation event, then withholds the `finish` event
+//! until the runner has POSTed an answer — so a passing test proves the auto-answer is what lets the
+//! run continue.
+
+use std::sync::Arc;
+
+use archestra_bench::client::EvalClient;
+use archestra_bench::elicitation::{answer_for, parse_elicitation_request};
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::{Path, State},
+    response::Response,
+    routing::post,
+};
+use bytes::Bytes;
+use futures::StreamExt;
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::sync::{Mutex, Notify};
+use tokio::time::{Duration, timeout};
+
+struct BackendState {
+    posted_body: Mutex<Option<Value>>,
+    answered: Notify,
+}
+
+enum StreamStep {
+    Elicit,
+    AwaitAnswer,
+    Done,
+}
+
+async fn chat_handler(State(state): State<Arc<BackendState>>) -> Response {
+    let elicit_line = format!(
+        "data: {}\n",
+        json!({
+            "type": "data-mcp-elicitation",
+            "data": {
+                "id": "elicit-xyz",
+                "conversationId": "conv-abc",
+                "toolName": "refine_app",
+                "mode": "form",
+                "requestedSchema": {
+                    "type": "object",
+                    "properties": {
+                        "access_level": {
+                            "type": "string",
+                            "enum": ["read-only", "admin"],
+                            "default": "read-only"
+                        }
+                    }
+                }
+            }
+        })
+    );
+    let finish_line = format!(
+        "data: {}\n",
+        json!({ "type": "finish", "finishReason": "stop" })
+    );
+
+    let stream = futures::stream::unfold(
+        (StreamStep::Elicit, state, elicit_line, finish_line),
+        |(step, state, elicit_line, finish_line)| async move {
+            match step {
+                StreamStep::Elicit => Some((
+                    Ok::<Bytes, std::io::Error>(Bytes::from(elicit_line.clone())),
+                    (StreamStep::AwaitAnswer, state, elicit_line, finish_line),
+                )),
+                StreamStep::AwaitAnswer => {
+                    // Gate the finish event on the runner's answer, so the assertion below proves
+                    // the POST is what unblocks the stream.
+                    state.answered.notified().await;
+                    Some((
+                        Ok(Bytes::from(finish_line.clone())),
+                        (StreamStep::Done, state, elicit_line, finish_line),
+                    ))
+                }
+                StreamStep::Done => None,
+            }
+        },
+    );
+
+    Response::builder()
+        .header("content-type", "text/event-stream")
+        .body(Body::from_stream(stream))
+        .unwrap()
+}
+
+async fn elicitation_handler(
+    Path(_id): Path<String>,
+    State(state): State<Arc<BackendState>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    *state.posted_body.lock().await = Some(body);
+    state.answered.notify_one();
+    Json(json!({ "success": true }))
+}
+
+#[tokio::test]
+async fn auto_answers_form_elicitation_and_unblocks_stream() {
+    let state = Arc::new(BackendState {
+        posted_body: Mutex::new(None),
+        answered: Notify::new(),
+    });
+    let app = Router::new()
+        .route("/api/chat", post(chat_handler))
+        .route("/api/chat/elicitation/{id}", post(elicitation_handler))
+        .with_state(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = EvalClient::new(format!("http://{addr}"), None);
+
+    let saw_finish = timeout(Duration::from_secs(10), async {
+        let mut stream = client
+            .stream_chat_records("conv-abc", &[], "hi", &[], "turn-1")
+            .await
+            .expect("chat stream opens");
+
+        // Mirror drive_stage's per-event handling: answer any elicitation, note the finish.
+        let mut saw_finish = false;
+        while let Some(record) = stream.next().await {
+            let Some(event) = &record.event else { continue };
+            if let Some(req) = parse_elicitation_request(event) {
+                let answer = answer_for(&req);
+                client
+                    .resolve_elicitation(&req.id, &req.conversation_id, &answer)
+                    .await
+                    .expect("elicitation answer posts");
+            } else if event.get("type").and_then(|v| v.as_str()) == Some("finish") {
+                saw_finish = true;
+            }
+        }
+        saw_finish
+    })
+    .await
+    .expect("stream completes within the timeout");
+
+    assert!(
+        saw_finish,
+        "finish only arrives after the elicitation is answered"
+    );
+
+    let posted = state
+        .posted_body
+        .lock()
+        .await
+        .clone()
+        .expect("elicitation POST was received");
+    assert_eq!(
+        posted,
+        json!({
+            "conversationId": "conv-abc",
+            "action": "accept",
+            "content": { "access_level": "read-only" }
+        })
+    );
+}

--- a/archestra-bench/runner/tests/elicitation_flow.rs
+++ b/archestra-bench/runner/tests/elicitation_flow.rs
@@ -190,3 +190,21 @@ async fn failed_answer_post_surfaces_error() {
         "a failed answer POST must surface as an error"
     );
 }
+
+#[tokio::test]
+async fn malformed_elicitation_event_surfaces_error() {
+    // Typed as an elicitation but missing the id needed to answer it. It must fail loudly rather
+    // than be silently skipped (which would leave the tool blocked). No POST is attempted, so the
+    // base URL is never contacted.
+    let client = EvalClient::new("http://127.0.0.1:1", None);
+    let event: HashMap<String, Value> = serde_json::from_value(json!({
+        "type": "data-mcp-elicitation",
+        "data": { "conversationId": "c1" }
+    }))
+    .unwrap();
+
+    assert!(
+        client.answer_if_elicitation(&event).await.is_err(),
+        "an unanswerable elicitation event must surface as an error"
+    );
+}


### PR DESCRIPTION
## Problem

Benchmark runs hang when an MCP tool elicits mid-call. The backend writes a `data-mcp-elicitation` SSE event and then blocks the tool for up to 10 minutes waiting for `POST /api/chat/elicitation/:id`. In a headless benchmark there is no viewer to answer, and backend heartbeats keep the stream from ever going idle, so the runner's idle timeout never fires — the run stalls (repro: `apps` env, `access-request-app`, whose `refine_app` step elicits).

## Fix

The runner watches the chat stream and auto-answers any elicitation so the tool unblocks and the agent continues:

- **Form** → `accept` with the schema's **recommended default first** (declared `default`, else first `enum` value, else a typed zero-value), every value coerced into the backend-allowed `string | number | boolean | string[]` union.
- **URL** → `decline` (can't be completed headlessly; declining unblocks the tool).
- A failed answer **fails the stage promptly** instead of waiting out the backend's 10-min timeout.

This is harness-only — no backend/frontend changes; the real elicitation endpoint and bridge are exercised as-is.

## Changes

- `runner/src/elicitation.rs` — new module: parse the event, build the answer (accept/decline action enum, recommended-default content generation). Unit-tested.
- `runner/src/client.rs` — `answer_if_elicitation` (the shared reaction `drive_stage` and the test both call) + `resolve_elicitation` POST.
- `runner/src/run.rs` — wire into the `drive_stage` stream loop.
- `runner/tests/elicitation_flow.rs` — integration test over a local HTTP server (finish is withheld until the answer POST arrives) plus a POST-failure case.

## Validation

`cargo clippy --all-targets -- -D warnings` and `cargo test` pass (148 lib + integration tests). Live end-to-end against `apps`/`access-request-app` (needs API keys + Dagger) is the remaining manual check.

https://claude.ai/code/session_011g3xnMhsB2uDAuK6jifeH7