### PR TITLE
fix(email): retry incoming email on transient agent-run failure

### DIFF
--- a/platform/backend/src/agents/incoming-email/index.test.ts
+++ b/platform/backend/src/agents/incoming-email/index.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/auth", () => ({
 import { executeA2AMessage } from "@/agents/a2a-executor";
 import { userHasPermission } from "@/auth";
 import db, { schema } from "@/database";
+import ProcessedEmailModel from "@/models/processed-email";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { IncomingEmail } from "@/types";
 import { MAX_EMAIL_BODY_SIZE } from "./constants";
@@ -557,6 +558,111 @@ describe("processIncomingEmail", () => {
     // Second call with same messageId should be skipped (deduplication)
     await processIncomingEmail(email, mockProvider);
     expect(vi.mocked(executeA2AMessage)).not.toHaveBeenCalled();
+  });
+
+  test("releases the processed marker when the agent run fails so a redelivery retries", async ({
+    makeUser,
+    makeOrganization,
+    makeTeam,
+  }) => {
+    const user = await makeUser();
+    const org = await makeOrganization();
+    const team = await makeTeam(org.id, user.id);
+
+    const internalAgent = await createTestInternalAgent(org.id, {
+      incomingEmailEnabled: true,
+      incomingEmailSecurityMode: "public",
+    });
+    const agentId = internalAgent.id;
+
+    await db
+      .insert(schema.agentTeamsTable)
+      .values({ agentId, teamId: team.id });
+
+    const mockProvider = {
+      providerId: "outlook",
+      displayName: "Outlook",
+      isConfigured: () => true,
+      initialize: vi.fn(),
+      generateEmailAddress: vi.fn(),
+      getEmailDomain: () => "test.com",
+      parseWebhookNotification: vi.fn(),
+      validateWebhookRequest: vi.fn(),
+      handleValidationChallenge: vi.fn(),
+      cleanup: vi.fn(),
+      extractPromptIdFromEmail: () => agentId,
+    } as unknown as OutlookEmailProvider;
+
+    const email: IncomingEmail = {
+      messageId: "test-transient-failure-msg-1",
+      toAddress: `agents+agent-${agentId}@test.com`,
+      fromAddress: "sender@example.com",
+      subject: "Test Subject",
+      body: "Hello, agent!",
+      receivedAt: new Date(),
+    };
+
+    // First delivery: the agent run fails transiently (e.g. provider 429/5xx).
+    vi.mocked(executeA2AMessage).mockRejectedValueOnce(
+      new Error("transient provider failure"),
+    );
+
+    await expect(processIncomingEmail(email, mockProvider)).rejects.toThrow(
+      "transient provider failure",
+    );
+
+    // The claim must have been released so the email is not stuck as processed.
+    expect(await ProcessedEmailModel.isProcessed(email.messageId)).toBe(false);
+
+    // Redelivery of the same email should be reprocessed, not deduplicated away.
+    vi.mocked(executeA2AMessage).mockClear();
+    await processIncomingEmail(email, mockProvider);
+    expect(vi.mocked(executeA2AMessage)).toHaveBeenCalledTimes(1);
+    expect(await ProcessedEmailModel.isProcessed(email.messageId)).toBe(true);
+  });
+
+  test("keeps the email marked when validation fails (agent disabled), since retrying won't help", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+
+    const internalAgent = await createTestInternalAgent(org.id, {
+      incomingEmailEnabled: false,
+    });
+    const agentId = internalAgent.id;
+
+    const mockProvider = {
+      providerId: "outlook",
+      displayName: "Outlook",
+      isConfigured: () => true,
+      initialize: vi.fn(),
+      generateEmailAddress: vi.fn(),
+      getEmailDomain: () => "test.com",
+      parseWebhookNotification: vi.fn(),
+      validateWebhookRequest: vi.fn(),
+      handleValidationChallenge: vi.fn(),
+      cleanup: vi.fn(),
+      extractPromptIdFromEmail: () => agentId,
+    } as unknown as OutlookEmailProvider;
+
+    const email: IncomingEmail = {
+      messageId: "test-validation-failure-msg-1",
+      toAddress: `agents+agent-${agentId}@test.com`,
+      fromAddress: "sender@example.com",
+      subject: "Test Subject",
+      body: "Hello, agent!",
+      receivedAt: new Date(),
+    };
+
+    vi.mocked(executeA2AMessage).mockClear();
+
+    await expect(processIncomingEmail(email, mockProvider)).rejects.toThrow(
+      /not enabled/,
+    );
+
+    // Agent never ran, and the marker stays so redelivery is deduplicated away.
+    expect(vi.mocked(executeA2AMessage)).not.toHaveBeenCalled();
+    expect(await ProcessedEmailModel.isProcessed(email.messageId)).toBe(true);
   });
 });
 

--- a/platform/backend/src/agents/incoming-email/index.ts
+++ b/platform/backend/src/agents/incoming-email/index.ts
@@ -796,33 +796,53 @@ ${formattedHistory}
   // userId is determined by security mode:
   // - private: actual user ID from email lookup
   // - internal/public: "system" (anonymous)
-  const result = await startActiveChatSpan({
-    agentName: agent.name,
-    agentId,
-    teams: await AgentTeamModel.getTeamLabelInfoForAgent(agentId),
-    userTeams: emailUser
-      ? await TeamModel.getTeamLabelInfoForUser({
-          userId: emailUser.id,
+  // The email was optimistically marked as processed above for cross-pod
+  // dedup. If the agent run fails for a transient reason (provider 429/5xx,
+  // timeout), release that claim so a provider redelivery is reprocessed
+  // instead of being deduplicated away and lost forever. Validation failures
+  // (missing/disabled agent, etc.) throw earlier and stay marked, since
+  // retrying them won't help.
+  let result: Awaited<ReturnType<typeof executeA2AMessage>>;
+  try {
+    result = await startActiveChatSpan({
+      agentName: agent.name,
+      agentId,
+      teams: await AgentTeamModel.getTeamLabelInfoForAgent(agentId),
+      userTeams: emailUser
+        ? await TeamModel.getTeamLabelInfoForUser({
+            userId: emailUser.id,
+            organizationId: organization,
+          })
+        : [],
+      routeCategory: RouteCategory.EMAIL,
+      triggerSource: "email",
+      user: emailUser
+        ? { id: emailUser.id, email: emailUser.email, name: emailUser.name }
+        : null,
+      callback: async () => {
+        return executeA2AMessage({
+          agentId,
+          message,
           organizationId: organization,
-        })
-      : [],
-    routeCategory: RouteCategory.EMAIL,
-    triggerSource: "email",
-    user: emailUser
-      ? { id: emailUser.id, email: emailUser.email, name: emailUser.name }
-      : null,
-    callback: async () => {
-      return executeA2AMessage({
+          userId,
+          sessionId: buildEmailSessionId(email.conversationId),
+          source: "email",
+          attachments: a2aAttachments.length > 0 ? a2aAttachments : undefined,
+        });
+      },
+    });
+  } catch (error) {
+    await ProcessedEmailModel.deleteByMessageId(email.messageId);
+    logger.warn(
+      {
+        messageId: email.messageId,
         agentId,
-        message,
-        organizationId: organization,
-        userId,
-        sessionId: buildEmailSessionId(email.conversationId),
-        source: "email",
-        attachments: a2aAttachments.length > 0 ? a2aAttachments : undefined,
-      });
-    },
-  });
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "[IncomingEmail] Agent execution failed; released processed marker so a redelivery can retry",
+    );
+    throw error;
+  }
 
   logger.info(
     {

--- a/platform/backend/src/models/processed-email.ts
+++ b/platform/backend/src/models/processed-email.ts
@@ -55,6 +55,24 @@ class ProcessedEmailModel {
   }
 
   /**
+   * Release the processed-email claim for a messageId.
+   *
+   * Used to undo an optimistic tryMarkAsProcessed() when the agent run fails
+   * transiently, so a provider redelivery can be reprocessed instead of being
+   * deduplicated away and lost forever.
+   *
+   * @param messageId - The email provider's message ID
+   * @returns true if a record was deleted, false if none existed
+   */
+  static async deleteByMessageId(messageId: string): Promise<boolean> {
+    const result = await db
+      .delete(schema.processedEmailsTable)
+      .where(eq(schema.processedEmailsTable.messageId, messageId));
+
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
    * Delete old processed email records.
    * Should be called periodically to prevent unbounded table growth.
    *


### PR DESCRIPTION
Fixes #5580.

`processIncomingEmail` optimistically marks an email as processed (for cross-pod dedup) **before** running the agent. If `executeA2AMessage` then failed for a transient reason (provider 429/5xx, timeout), the throw was only logged and the webhook returned 200 — but the processed marker was never cleared. When the provider redelivered the email it was deduplicated away, so **the email was answered never**.