### PR TITLE
feat(chat): show which credential scope (personal/team/org) expired on the re-auth card

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -2188,6 +2188,65 @@ describe("buildArchestraToolOutput", () => {
 
     expect(result).toBe("Diagram displayed!");
   });
+
+  test("preserves a structured auth error (with credential scope) for a run_tool dispatch so chat renders the rich card", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    const archestraError = {
+      type: "auth_expired" as const,
+      message: 'Expired or invalid authentication for "GitHub"',
+      catalogId: "cat_1",
+      catalogName: "GitHub",
+      serverId: "srv_1",
+      reauthUrl: "http://localhost:3000/mcp/registry?reauth=cat_1&server=srv_1",
+      credentialScope: "team" as const,
+      credentialTeamName: "Platform Team",
+    };
+
+    const result = await buildArchestraToolOutput({
+      response: {
+        content: [{ type: "text" as const, text: archestraError.message }],
+        isError: true,
+        _meta: { archestraError },
+        structuredContent: { archestraError },
+      },
+      toolName: "archestra__run_tool",
+      toolArguments: { tool_name: "github__whoami", tool_args: {} },
+      agentId: agent.id,
+    });
+
+    // Rich shape (not a bare string) so extractMcpToolError finds the structured
+    // error and the frontend renders the scoped re-auth card.
+    expect(result).toMatchObject({
+      content: archestraError.message,
+      _meta: {
+        archestraError: {
+          type: "auth_expired",
+          credentialScope: "team",
+          credentialTeamName: "Platform Team",
+        },
+      },
+      structuredContent: { archestraError: { type: "auth_expired" } },
+    });
+  });
+
+  test("still returns plain text for a run_tool dispatch error without a structured Archestra error", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    const result = await buildArchestraToolOutput({
+      response: {
+        content: [{ type: "text" as const, text: "Error: rate limited." }],
+        isError: true,
+      },
+      toolName: "archestra__run_tool",
+      toolArguments: { tool_name: "github__whoami", tool_args: {} },
+      agentId: agent.id,
+    });
+
+    expect(result).toBe("Error: rate limited.");
+  });
 });
 
 describe("throwIfApprovalRequired", () => {

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -4,6 +4,7 @@
 // execution). Must not import chat-mcp-client.ts (cycle).
 import { randomUUID } from "node:crypto";
 import {
+  extractMcpToolError,
   isAppRenderingArchestraToolShortName,
   isBrowserMcpTool,
   parseFullToolName,
@@ -561,6 +562,23 @@ export async function buildArchestraToolOutput(params: {
     );
   }
   if (!resourceUri) {
+    // A dispatched third-party tool with no MCP-App UI. If it returned a
+    // structured Archestra error (e.g. the expired-auth re-auth payload),
+    // preserve `_meta`/`structuredContent` so chat renders the same rich card
+    // as a direct call. The bare-text fallback below strips
+    // `_meta.archestraError`/`structuredContent.archestraError`, degrading the
+    // card to a text-parsed one (which loses e.g. the credential scope). Mirrors
+    // the direct path (executeMcpTool), which keeps these fields on error.
+    if (response.isError && extractMcpToolError(response)) {
+      return {
+        content: text,
+        _meta: response._meta as Record<string, unknown> | undefined,
+        structuredContent: response.structuredContent as
+          | Record<string, unknown>
+          | undefined,
+        rawContent: response.content as ContentBlock[],
+      };
+    }
     return text;
   }
 

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4247,6 +4247,89 @@ describe("McpClient", () => {
         });
       });
 
+      test("does not label a personal install as the caller's own when the caller is not the owner", async ({
+        makeUser,
+      }) => {
+        const connectionOwner = await makeUser({
+          email: "personal-owner@example.com",
+        });
+        const invokingUser = await makeUser({
+          email: "personal-invoker@example.com",
+        });
+
+        // Non-OAuth (PAT) catalog so no token refresh intercepts the auth-error
+        // tool result before the expired-auth message is built.
+        const catalog = await InternalMcpCatalogModel.create({
+          name: "github-shared-personal",
+          serverType: "remote",
+          serverUrl: "https://api.githubcopilot.com/mcp/",
+        });
+
+        const secret = await secretManager().createSecret(
+          { access_token: "expired-pat" },
+          "shared-personal-secret",
+        );
+
+        // Personal install owned by connectionOwner, statically assigned to the
+        // agent so a different caller routes through it — the retained-assignment
+        // shape the scope helper must not misattribute as the caller's own.
+        const mcpServer = await McpServerModel.create({
+          name: "github-shared-personal",
+          catalogId: catalog.id,
+          secretId: secret.id,
+          serverType: "remote",
+          ownerId: connectionOwner.id,
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-shared-personal__list_repos",
+          description: "List repos",
+          parameters: {},
+          catalogId: catalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: mcpServer.id,
+        });
+
+        // Tool RESULT (not a thrown error) carrying an auth failure — this path
+        // builds the expired-auth message without the assigned-credential owner
+        // guard that the thrown path has, so the scope helper is what protects
+        // against misattribution here.
+        mockCallTool.mockResolvedValueOnce({
+          isError: true,
+          content: [{ type: "text", text: "401 unauthorized: token expired" }],
+        });
+        mockConnect.mockResolvedValue(undefined);
+
+        const result = await mcpClient.executeToolCallForOwner(
+          {
+            id: "call_shared_personal",
+            name: "github-shared-personal__list_repos",
+            arguments: {},
+          },
+          agentOwner(agentId),
+          {
+            tokenId: "invoker-token",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: invokingUser.id,
+          },
+        );
+
+        expect(result).toMatchObject({ isError: true });
+        const archestraError = (
+          result?._meta as { archestraError?: Record<string, unknown> }
+        )?.archestraError;
+        expect(archestraError).toMatchObject({
+          type: "auth_expired",
+          serverId: mcpServer.id,
+        });
+        // Not the caller's own credential → no "Your personal credentials …".
+        expect(archestraError?.credentialScope).toBeUndefined();
+        expect(archestraError?.credentialTeamName).toBeUndefined();
+      });
+
       test("records a no_refresh_token state when an OAuth tool call throws UnauthorizedError and no refresh token is stored", async ({
         makeUser,
       }) => {

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -4155,6 +4155,94 @@ describe("McpClient", () => {
             catalogName: "github-oauth-server",
             serverId: mcpServer.id,
             reauthUrl: `${config.frontendBaseUrl}${MCP_CATALOG_INSTALL_PATH}?${MCP_CATALOG_REAUTH_QUERY_PARAM}=${oauthCatalog.id}&${MCP_CATALOG_SERVER_QUERY_PARAM}=${mcpServer.id}`,
+            // Owner-invoked personal connection → personal credential, no team.
+            credentialScope: "personal",
+            credentialTeamName: null,
+          },
+        });
+      });
+
+      test("labels the expired-auth error with the owning team for a team-scoped credential", async ({
+        makeUser,
+        makeTeam,
+        makeOrganization,
+      }) => {
+        const org = await makeOrganization();
+        const teamMember = await makeUser({
+          email: "team-expired-member@example.com",
+        });
+        const team = await makeTeam(org.id, teamMember.id, {
+          name: "Platform Team",
+        });
+
+        const oauthCatalog = await InternalMcpCatalogModel.create({
+          name: "github-team-server",
+          serverType: "remote",
+          serverUrl: "https://api.githubcopilot.com/mcp/",
+          oauthConfig: {
+            name: "GitHub",
+            server_url: "https://api.githubcopilot.com/mcp/",
+            client_id: "test-client-id",
+            redirect_uris: ["http://localhost:3000/callback"],
+            scopes: ["repo"],
+            default_scopes: ["repo"],
+            supports_resource_metadata: false,
+          },
+        });
+
+        const secret = await secretManager().createSecret(
+          { access_token: "expired-token" },
+          "team-expired-oauth-secret",
+        );
+
+        const mcpServer = await McpServerModel.create({
+          name: "github-team-server",
+          catalogId: oauthCatalog.id,
+          secretId: secret.id,
+          serverType: "remote",
+          teamId: team.id,
+          scope: "team",
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-team-server__list_repos",
+          description: "List repos",
+          parameters: {},
+          catalogId: oauthCatalog.id,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          mcpServerId: mcpServer.id,
+        });
+
+        const { UnauthorizedError } = await import(
+          "@modelcontextprotocol/sdk/client/auth.js"
+        );
+        mockCallTool.mockRejectedValueOnce(new UnauthorizedError());
+        mockConnect.mockResolvedValue(undefined);
+
+        const result = await mcpClient.executeToolCallForOwner(
+          {
+            id: "call_team_expired",
+            name: "github-team-server__list_repos",
+            arguments: {},
+          },
+          agentOwner(agentId),
+          {
+            tokenId: "team-token",
+            teamId: team.id,
+            isOrganizationToken: false,
+            userId: teamMember.id,
+          },
+        );
+
+        expect(result).toMatchObject({ isError: true });
+        expect(result?._meta).toMatchObject({
+          archestraError: {
+            type: "auth_expired",
+            serverId: mcpServer.id,
+            credentialScope: "team",
+            credentialTeamName: "Platform Team",
           },
         });
       });

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -68,6 +68,7 @@ import type {
   MCPGatewayAuthMethod,
   McpServer,
   McpToolAssignment,
+  ResourceVisibilityScope,
   ToolOwner,
 } from "@/types";
 import { agentOwner } from "@/types";
@@ -690,12 +691,12 @@ class McpClient {
 
         if (toolResultAuthError && tool.catalogId && targetMcpServerId) {
           const catalogDisplayName = tool.catalogName || catalogItem.name;
-          const authError = this.buildExpiredAuthMessage(
+          const authError = await this.buildExpiredAuthMessage({
             catalogDisplayName,
-            tool.catalogId,
-            targetMcpServerId,
+            catalogId: tool.catalogId,
+            mcpServerId: targetMcpServerId,
             tokenAuth,
-          );
+          });
           return await this.createErrorResult(
             toolCall,
             owner,
@@ -925,12 +926,13 @@ class McpClient {
                 assignmentError,
               );
             }
-            const authError = this.buildExpiredAuthMessage(
+            const authError = await this.buildExpiredAuthMessage({
               catalogDisplayName,
-              tool.catalogId,
-              targetMcpServerId,
+              catalogId: tool.catalogId,
+              mcpServerId: targetMcpServerId,
               tokenAuth,
-            );
+              resolvedServer: targetServer,
+            });
             return await this.createErrorResult(
               toolCall,
               owner,
@@ -2402,12 +2404,12 @@ class McpClient {
 
       if (isRetryAuthError && toolCatalogId) {
         const catalogDisplayName = toolCatalogName || catalogItem.name;
-        const authError = this.buildExpiredAuthMessage(
+        const authError = await this.buildExpiredAuthMessage({
           catalogDisplayName,
-          toolCatalogId,
-          targetMcpServerId,
+          catalogId: toolCatalogId,
+          mcpServerId: targetMcpServerId,
           tokenAuth,
-        );
+        });
         return await this.createErrorResult(
           toolCall,
           owner,
@@ -2568,15 +2570,30 @@ class McpClient {
    * Build an actionable error message for expired or invalid credentials,
    * with a deep link to the re-authentication dialog.
    */
-  private buildExpiredAuthMessage(
-    catalogDisplayName: string,
-    catalogId: string,
-    mcpServerId: string,
-    tokenAuth?: TokenAuthContext,
-    detailOverride?: string,
-  ): AuthExpiredMcpToolError {
+  private async buildExpiredAuthMessage(params: {
+    catalogDisplayName: string;
+    catalogId: string;
+    mcpServerId: string;
+    tokenAuth?: TokenAuthContext;
+    detailOverride?: string;
+    // Pass the already-loaded install to avoid a redundant lookup when the
+    // caller has resolved it (otherwise the scope is fetched by id).
+    resolvedServer?: Pick<McpServer, "scope" | "teamId" | "ownerId">;
+  }): Promise<AuthExpiredMcpToolError> {
+    const {
+      catalogDisplayName,
+      catalogId,
+      mcpServerId,
+      tokenAuth,
+      detailOverride,
+      resolvedServer,
+    } = params;
     const context = this.formatAuthContext(tokenAuth);
     const reauthUrl = `${config.frontendBaseUrl}${MCP_CATALOG_INSTALL_PATH}?${MCP_CATALOG_REAUTH_QUERY_PARAM}=${catalogId}&${MCP_CATALOG_SERVER_QUERY_PARAM}=${mcpServerId}`;
+    const scope = await this.describeResolvedCredentialScope(
+      mcpServerId,
+      resolvedServer,
+    );
     return {
       type: "auth_expired",
       message: formatActionableAuthError({
@@ -2592,7 +2609,46 @@ class McpClient {
       catalogName: catalogDisplayName,
       serverId: mcpServerId,
       reauthUrl,
+      credentialScope: scope?.credentialScope,
+      credentialTeamName: scope?.credentialTeamName,
     };
+  }
+
+  /**
+   * Describe which credential (personal / team / org) a resolved install
+   * represents, plus the owning team's display name for team credentials, so
+   * the re-authentication card can tell the user whose credential expired.
+   * Mirrors the runtime resolution priority in {@link pickInstallForCaller}:
+   * an org-scoped install is org-wide; anything bound to a team is a team
+   * credential; everything else is a personal credential.
+   */
+  private async describeResolvedCredentialScope(
+    mcpServerId: string,
+    preloadedServer?: Pick<McpServer, "scope" | "teamId" | "ownerId">,
+  ): Promise<{
+    credentialScope: ResourceVisibilityScope;
+    credentialTeamName: string | null;
+  } | null> {
+    let server = preloadedServer;
+    if (!server) {
+      const [loaded] = await McpServerModel.findByIdsBasic([mcpServerId]);
+      server = loaded;
+    }
+    if (!server) {
+      return null;
+    }
+
+    if (server.scope === "org") {
+      return { credentialScope: "org", credentialTeamName: null };
+    }
+    if (server.teamId) {
+      const [team] = await TeamModel.findByIds([server.teamId]);
+      return {
+        credentialScope: "team",
+        credentialTeamName: team?.name ?? null,
+      };
+    }
+    return { credentialScope: "personal", credentialTeamName: null };
   }
 
   private buildAssignedCredentialUnavailableMessage(

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -2592,6 +2592,7 @@ class McpClient {
     const reauthUrl = `${config.frontendBaseUrl}${MCP_CATALOG_INSTALL_PATH}?${MCP_CATALOG_REAUTH_QUERY_PARAM}=${catalogId}&${MCP_CATALOG_SERVER_QUERY_PARAM}=${mcpServerId}`;
     const scope = await this.describeResolvedCredentialScope(
       mcpServerId,
+      tokenAuth,
       resolvedServer,
     );
     return {
@@ -2620,10 +2621,15 @@ class McpClient {
    * the re-authentication card can tell the user whose credential expired.
    * Mirrors the runtime resolution priority in {@link pickInstallForCaller}:
    * an org-scoped install is org-wide; anything bound to a team is a team
-   * credential; everything else is a personal credential.
+   * credential; everything else is a personal credential — but a personal
+   * install is only reported as "personal" (the card says "Your personal
+   * credentials …") when the caller actually owns it. Returns null when the
+   * scope can't be attributed to the caller, so the card falls back to neutral
+   * generic copy.
    */
   private async describeResolvedCredentialScope(
     mcpServerId: string,
+    tokenAuth: TokenAuthContext | undefined,
     preloadedServer?: Pick<McpServer, "scope" | "teamId" | "ownerId">,
   ): Promise<{
     credentialScope: ResourceVisibilityScope;
@@ -2648,7 +2654,20 @@ class McpClient {
         credentialTeamName: team?.name ?? null,
       };
     }
-    return { credentialScope: "personal", credentialTeamName: null };
+    // Personal install. Only present it as the caller's own credential when the
+    // caller owns it. A personal install resolved on behalf of another caller —
+    // a catalog pinned to a service-account connection
+    // (dynamicConnectionMcpServerId) or a retained static assignment — must not
+    // be labeled "personal", or the card would falsely claim "Your personal
+    // credentials …" and point the caller at the wrong owner.
+    if (
+      tokenAuth?.userId &&
+      server.ownerId &&
+      tokenAuth.userId === server.ownerId
+    ) {
+      return { credentialScope: "personal", credentialTeamName: null };
+    }
+    return null;
   }
 
   private buildAssignedCredentialUnavailableMessage(

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -8,6 +8,7 @@ import {
   getArchestraToolFullName,
   HOOK_RUN_PART_TYPE,
   parseFullToolName,
+  type ResourceVisibilityScope,
   SWAP_AGENT_FAILED_POKE_TEXT,
   SWAP_AGENT_POKE_PREFIX,
   SWAP_AGENT_POKE_TEXT,
@@ -2653,6 +2654,50 @@ function isMessagePositionBefore(params: {
   return params.boundaryPartIndex < params.beforePartIndex;
 }
 
+// Names which credential expired on the re-authentication card. The returned
+// subject is grammatically the plural "credentials" so it reads naturally with
+// the "… have expired or are invalid" copy that follows. Falls back to the
+// scope-less "Your credentials" when the resolved scope is unknown (text-parsed
+// errors, or chat history predating the structured field).
+function expiredCredentialSubject(params: {
+  scope?: ResourceVisibilityScope;
+  teamName?: string | null;
+}): React.ReactNode {
+  const { scope, teamName } = params;
+
+  if (scope === "personal") {
+    return (
+      <>
+        Your <span className="font-medium">personal</span> credentials
+      </>
+    );
+  }
+
+  if (scope === "team") {
+    return teamName ? (
+      <>
+        The <span className="font-medium">{teamName}</span> team&rsquo;s
+        credentials
+      </>
+    ) : (
+      <>
+        Your <span className="font-medium">team&rsquo;s</span> credentials
+      </>
+    );
+  }
+
+  if (scope === "org") {
+    return (
+      <>
+        The <span className="font-medium">organization&rsquo;s</span>{" "}
+        credentials
+      </>
+    );
+  }
+
+  return <>Your credentials</>;
+}
+
 function authCardProps(params: {
   toolName: string;
   authState: ToolAuthState | null;
@@ -2683,8 +2728,12 @@ function authCardProps(params: {
         title: "Expired / Invalid Authentication",
         description: (
           <>
-            Your credentials for &ldquo;{displayName}&rdquo; have expired or are
-            invalid. Re-authenticate to continue using this tool.
+            {expiredCredentialSubject({
+              scope: authState.credentialScope,
+              teamName: authState.credentialTeamName,
+            })}{" "}
+            for &ldquo;{displayName}&rdquo; have expired or are invalid.
+            Re-authenticate to continue using this tool.
           </>
         ),
         buttonText: onReauth ? "Re-authenticate" : "Manage credentials",

--- a/platform/frontend/src/lib/chat/mcp-error-ui.test.ts
+++ b/platform/frontend/src/lib/chat/mcp-error-ui.test.ts
@@ -374,6 +374,70 @@ describe("resolveToolAuthState", () => {
     });
   });
 
+  it("propagates a personal credential scope for structured auth-expired errors", () => {
+    expect(
+      resolveToolAuthState({
+        rawOutput: {
+          archestraError: {
+            type: "auth_expired",
+            message: "Expired",
+            catalogName: "GitHub",
+            catalogId: "cat_1",
+            serverId: "s_1",
+            reauthUrl:
+              "http://localhost:3000/mcp/registry?reauth=cat_1&server=s_1",
+            credentialScope: "personal",
+          },
+        },
+      }),
+    ).toEqual({
+      kind: "auth-expired",
+      catalogName: "GitHub",
+      reauthUrl: "http://localhost:3000/mcp/registry?reauth=cat_1&server=s_1",
+      catalogId: "cat_1",
+      serverId: "s_1",
+      credentialScope: "personal",
+    });
+  });
+
+  it("carries the owning team name for team-scoped auth-expired errors", () => {
+    expect(
+      resolveToolAuthState({
+        rawOutput: {
+          archestraError: {
+            type: "auth_expired",
+            message: "Expired",
+            catalogName: "GitHub",
+            catalogId: "cat_1",
+            serverId: "s_1",
+            reauthUrl:
+              "http://localhost:3000/mcp/registry?reauth=cat_1&server=s_1",
+            credentialScope: "team",
+            credentialTeamName: "Platform Team",
+          },
+        },
+      }),
+    ).toMatchObject({
+      kind: "auth-expired",
+      credentialScope: "team",
+      credentialTeamName: "Platform Team",
+    });
+  });
+
+  it("leaves scope undefined for text-parsed expired-auth errors", () => {
+    const authState = resolveToolAuthState({
+      errorText: [
+        'Expired or invalid authentication for "GitHub".',
+        "To re-authenticate, please visit: http://localhost:3000/mcp/registry?reauth=cat_1&server=s_1",
+      ].join("\n"),
+    });
+
+    expect(authState?.kind).toBe("auth-expired");
+    expect(
+      (authState as { credentialScope?: string }).credentialScope,
+    ).toBeUndefined();
+  });
+
   it("parses policy-denied tool errors from errorText", () => {
     const authState = resolveToolAuthState({
       errorText:

--- a/platform/frontend/src/lib/chat/mcp-error-ui.ts
+++ b/platform/frontend/src/lib/chat/mcp-error-ui.ts
@@ -4,6 +4,7 @@ import {
   MCP_CATALOG_INSTALL_QUERY_PARAM,
   MCP_CATALOG_REAUTH_QUERY_PARAM,
   MCP_CATALOG_SERVER_QUERY_PARAM,
+  type ResourceVisibilityScope,
 } from "@archestra/shared";
 import type { PolicyDeniedPart } from "@/components/message-thread";
 
@@ -44,6 +45,12 @@ export type ToolAuthState =
       reauthUrl: string;
       catalogId: string | null;
       serverId: string | null;
+      // Which credential expired (personal / team / org) and, for team
+      // credentials, the owning team's name. Absent for text-parsed errors and
+      // for chat history predating the structured field, in which case the card
+      // falls back to generic "Your credentials …" copy.
+      credentialScope?: ResourceVisibilityScope;
+      credentialTeamName?: string | null;
     };
 
 export function parsePolicyDenied(text: string): PolicyDeniedPart | null {
@@ -155,6 +162,8 @@ export function resolveToolAuthState(params: {
       reauthUrl: structuredError.reauthUrl,
       catalogId: structuredError.catalogId,
       serverId: structuredError.serverId,
+      credentialScope: structuredError.credentialScope,
+      credentialTeamName: structuredError.credentialTeamName,
     };
   }
 

--- a/platform/shared/mcp-tool-error.test.ts
+++ b/platform/shared/mcp-tool-error.test.ts
@@ -70,6 +70,34 @@ describe("extractMcpToolError", () => {
     });
   });
 
+  it("preserves the resolved credential scope on an auth_expired error", () => {
+    expect(
+      extractMcpToolError({
+        archestraError: {
+          type: "auth_expired",
+          message: "Expired auth",
+          catalogId: "cat_123",
+          catalogName: "GitHub",
+          serverId: "srv_123",
+          reauthUrl:
+            "http://localhost:3000/mcp/registry?reauth=cat_123&server=srv_123",
+          credentialScope: "team",
+          credentialTeamName: "Platform Team",
+        },
+      }),
+    ).toEqual({
+      type: "auth_expired",
+      message: "Expired auth",
+      catalogId: "cat_123",
+      catalogName: "GitHub",
+      serverId: "srv_123",
+      reauthUrl:
+        "http://localhost:3000/mcp/registry?reauth=cat_123&server=srv_123",
+      credentialScope: "team",
+      credentialTeamName: "Platform Team",
+    });
+  });
+
   it("extracts an assigned-credential-unavailable error", () => {
     expect(
       extractMcpToolError({

--- a/platform/shared/mcp-tool-error.ts
+++ b/platform/shared/mcp-tool-error.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { isSensitiveContextPolicyDeniedReason } from "./tool-invocation-policy-reasons";
 import { parseArchestraToolRefusal } from "./tool-refusal";
+import { ResourceVisibilityScopeSchema } from "./visibility";
 
 export const McpToolErrorTypeSchema = z.enum([
   "auth_required",
@@ -44,6 +45,13 @@ export const AuthExpiredMcpToolErrorSchema = z
     catalogName: z.string(),
     serverId: z.string(),
     reauthUrl: z.string().url(),
+    // Which credential the runtime resolved for this call (personal / team /
+    // org) so the chat card can tell the user whose credential expired.
+    // Optional so errors persisted in chat history before this field existed
+    // still parse and render (they fall back to generic copy).
+    credentialScope: ResourceVisibilityScopeSchema.optional(),
+    // Owning team's display name, present only for team-scoped credentials.
+    credentialTeamName: z.string().nullable().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## What & why

When an MCP tool call fails because its credential expired, the chat "Expired / Invalid Authentication" card said only _"Your credentials for "X" have expired…"_. It never told the user **which** credential expired — their personal one, a team's, or the organization's — which matters when a catalog has connections at multiple scopes.

This PR names the scope inline in the card copy:

- **Personal** → "Your **personal** credentials for "GitHub" have expired…"
- **Team** → "The **{Team Name}** team's credentials for "GitHub" have expired…"
- **Org** → "The **organization's** credentials for "GitHub" have expired…"

When the scope isn't known (tool results persisted in chat history before this change, or text-parsed errors) it falls back to the original generic copy.

## How it works

1. **shared** (`mcp-tool-error.ts`): add optional `credentialScope` + `credentialTeamName` to the `auth_expired` MCP tool error. Optional on purpose so errors already persisted in chat history still parse and render.
2. **backend** (`mcp-client.ts`): a new `describeResolvedCredentialScope` helper reads the failed install's `scope`/`teamId` (mirroring the runtime resolution priority in `pickInstallForCaller`) and looks up the owning team's name; `buildExpiredAuthMessage` populates the two fields.
3. **frontend** (`mcp-error-ui.ts`, `chat-messages.tsx`): thread the fields through `ToolAuthState` and render the scoped subject inline via a small `expiredCredentialSubject` helper.

### Second commit — the `run_tool` path

Tools invoked via the built-in `run_tool` (dynamic access) go through `buildArchestraToolOutput`, which collapsed an error result to a **bare text string** — dropping `_meta.archestraError` / `structuredContent.archestraError`. That made every structured error card on the `run_tool` path degrade to the frontend's text-parsed fallback (generic copy, no scope), while directly-assigned tools kept the rich card.

The second commit preserves `_meta`/`structuredContent` whenever a dispatched error carries a structured Archestra error (gated on `extractMcpToolError`), mirroring the direct `executeMcpTool` path. Plain errors without a structured payload still return text unchanged. This also restores the other structured cards (assigned-credential-unavailable, auth-required, policy-denied) on the `run_tool` path.

## Testing

- **shared**: round-trip test that the new fields survive `extractMcpToolError`; the existing test already covers the backward-compat (missing-field) case.
- **frontend**: `resolveToolAuthState` propagates personal/team scope; text-parsed errors leave scope undefined.
- **backend**: integration tests for `buildExpiredAuthMessage` (owner-invoked personal → `personal`; team-scoped install → `team` + team name) and `buildArchestraToolOutput` (structured auth error with scope survives `run_tool`; plain error still returns text).
- `pnpm type-check`, Biome, and the touched suites pass locally.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>