### PR TITLE
fix(skills): check reset visibility before revealing skill type

### DIFF
--- a/platform/backend/src/routes/skill/reset.skill.route.test.ts
+++ b/platform/backend/src/routes/skill/reset.skill.route.test.ts
@@ -6,8 +6,16 @@ import {
   BUILT_IN_SKILLS,
   builtInSkillSourceRef,
 } from "@/skills/built-in-skills";
-import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  useRouteTestApp,
+} from "@/test";
 import type { User } from "@/types";
+import skillRoutes from "./skill.routes";
 
 const [BASE_SKILL] = BUILT_IN_SKILLS;
 
@@ -92,5 +100,38 @@ describe("POST /api/skills/:id/reset", () => {
     });
 
     expect(response.statusCode).toBe(400);
+  });
+});
+
+describe("POST /api/skills/:id/reset — scope visibility", () => {
+  const ctx = useRouteTestApp(skillRoutes);
+
+  test("a skill the caller cannot see returns 404, not a 400 that leaks its type", async ({
+    makeUser,
+  }) => {
+    const author = await makeUser();
+    const skill = await SkillModel.createWithFiles({
+      skill: {
+        organizationId: ctx.organizationId,
+        authorId: author.id,
+        name: "someone-elses-skill",
+        description: "private",
+        content: "# private",
+        metadata: {},
+        sourceType: "manual",
+        scope: "personal",
+      },
+      files: [],
+    });
+    if (!skill) throw new Error("seed failed");
+
+    // request user is neither the author nor an admin, so the skill is not
+    // visible to them: reset must 404 before the sourceType 400 fires.
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: `/api/skills/${skill.id}/reset`,
+    });
+
+    expect(response.statusCode).toBe(404);
   });
 });

--- a/platform/backend/src/routes/skill/skill.routes.ts
+++ b/platform/backend/src/routes/skill/skill.routes.ts
@@ -679,6 +679,10 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async ({ params: { id }, organizationId, user }, reply) => {
       const skill = await findSkillOrThrow(id, organizationId);
+      // Check scope-visibility first (404 if the caller can't see the skill),
+      // before revealing its sourceType via a 400, matching the update/delete
+      // routes and the authorizeSkillModify contract (no scope leak).
+      await authorizeSkillModify({ skill, userId: user.id, organizationId });
 
       if (skill.sourceType !== "built_in") {
         throw new ApiError(400, "Only built-in skills can be reset to default");
@@ -689,8 +693,6 @@ const skillRoutes: FastifyPluginAsyncZod = async (fastify) => {
       if (!definition) {
         throw new ApiError(404, "No shipped default exists for this skill");
       }
-
-      await authorizeSkillModify({ skill, userId: user.id, organizationId });
 
       // brand the shipped default under this org's white-label identity before
       // writing it, matching syncBuiltInSkills (no-op unless full white-labeling


### PR DESCRIPTION
Ranger overnight sweep — area: skills & sandbox. Draft; each PR is a single independently-reviewable fix, cut from the pinned run base and verified by an independent model (Codex) on both plan and diff.

### What was wrong
- `backend/src/routes/skill/skill.routes.ts` (reset handler): `POST /api/skills/:id/reset` ran the `sourceType` (400) and shipped-default (404) checks **before** `authorizeSkillModify`, which is where the scope-visibility check (`userHasSkillAccess` → 404) lives. A caller who cannot see a skill therefore learned it exists and is non-`built_in` via the 400 — the `update` and `delete` routes, and the `authorizeSkillModify` contract, deliberately run the visibility check first to avoid exactly this scope leak.

### What changed
- Moved `authorizeSkillModify` to immediately after `findSkillOrThrow`, before the type checks, so an unseeable skill returns 404. Behavior is identical for authorized, visible callers.
- Added a regression test: a personal skill the caller cannot see now returns 404, not 400 (fails on the old ordering, passes now).

Codex diff-gate verdict: APPROVE (behavior-preserving for authorized callers; matches sibling routes and the documented contract).

https://claude.ai/code/session_01SHh2gvihRHyYW7qC66vsWK

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>