### PR TITLE
fix(skills): keep marketplace name frozen when rotating a share link

### DIFF
--- a/platform/backend/src/routes/skill-share/rotate.skill-share.route.test.ts
+++ b/platform/backend/src/routes/skill-share/rotate.skill-share.route.test.ts
@@ -49,6 +49,37 @@ describe("POST /api/skill-share-links/:id/rotate", () => {
     ).not.toBeNull();
   });
 
+  test("keeps the marketplace name frozen at create time", async ({
+    makeMember,
+  }) => {
+    await makeMember(ctx.user.id, ctx.organizationId, {
+      role: ADMIN_ROLE_NAME,
+    });
+    const skill = await seedSkill({
+      organizationId: ctx.organizationId,
+      name: "frozen-name",
+    });
+    // a name that does NOT match what deriveMarketplaceName would produce for
+    // this org (e.g. the link was created under earlier branding)
+    const frozenName = "legacy-brand-marketplace-skills";
+    const { link } = await SkillShareLinkModel.create({
+      organizationId: ctx.organizationId,
+      createdByUserId: ctx.user.id,
+      skillIds: [skill.id],
+      marketplaceName: frozenName,
+    });
+
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: `/api/skill-share-links/${link.id}/rotate`,
+      payload: { skillIds: [skill.id] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const rotated = await SkillShareLinkModel.findById(response.json().link.id);
+    expect(rotated?.marketplaceName).toBe(frozenName);
+  });
+
   test("forwards expiresAt to the replacement link", async ({ makeMember }) => {
     await makeMember(ctx.user.id, ctx.organizationId, {
       role: ADMIN_ROLE_NAME,

--- a/platform/backend/src/routes/skill-share/skill-share.routes.ts
+++ b/platform/backend/src/routes/skill-share/skill-share.routes.ts
@@ -176,7 +176,11 @@ const skillShareRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(404, "Skill share link not found");
       }
 
-      const marketplaceName = await deriveMarketplaceName(organizationId);
+      // The marketplace name is frozen at create time (clients register the
+      // marketplace under it locally), so a rotation must keep the existing
+      // link's name — re-deriving it would silently rename the marketplace if
+      // the org's branding changed since the link was created.
+      const marketplaceName = existing.marketplaceName;
       if (isReservedMarketplaceName(marketplaceName)) {
         throw new ApiError(
           400,


### PR DESCRIPTION
Ranger overnight sweep — area: skills & sandbox. Draft; single fix, cut from the pinned run base, verified by Codex on plan and diff.

### What was wrong
- `backend/src/routes/skill-share/skill-share.routes.ts` (rotate handler): rotation re-derived the marketplace name from the org's **current** branding (`deriveMarketplaceName`) instead of reusing the link's stored name. Clients register the marketplace under that exact name locally, so a rotation after any branding change (org rename, white-label change) would silently rename it and break every installed marketplace — the precise failure the "frozen at create time" invariant (documented on both the route and the `marketplace_name` column) exists to prevent.

### What changed
- Reuse `existing.marketplaceName` in rotate (still runs the reserved-name check on it).
- Added a regression test: a link seeded with a name that differs from what `deriveMarketplaceName` currently produces keeps that name across rotation (fails on the old re-derive, passes now).

Codex diff-gate verdict: APPROVE (field always populated; no unique-name obstacle; no evidence rotate was meant to rename; other rotate tests unaffected).

https://claude.ai/code/session_01SHh2gvihRHyYW7qC66vsWK

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>