### PR TITLE
chore(sandbox-core): remove a stale duplicate doc comment and redundant `let _`

### DIFF
--- a/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
+++ b/platform/archestra-rs/sandbox-core/src/backends/dagger.rs
@@ -259,7 +259,7 @@ impl SandboxBackend for DaggerBackend {
     async fn check_session(&self, traceparent: Option<String>) -> Result<()> {
         attach_trace(traceparent.as_deref());
         // ensure_warm covers the engine-reachable + base-image-buildable invariant.
-        let _ = self.ensure_warm().await?;
+        self.ensure_warm().await?;
         self.client.version().await.map_err(from_sdk)?;
         Ok(())
     }
@@ -1032,10 +1032,6 @@ fn any_exit_opts<'a>() -> ContainerWithExecOpts<'a> {
     }
 }
 
-/// categorise an error returned by the dagger SDK during exec evaluation. SDK
-/// errors with an embedded `exit code: N` come from a container exec that
-/// returned non-zero (kill-by-signal counts here too); everything else is a
-/// real transport/engine failure.
 /// categorise an error returned by the dagger SDK during exec evaluation. an
 /// exec that returned non-zero (kill-by-signal counts here too) becomes a
 /// `CommandFailed`; everything else is a real transport/engine failure, tagged


### PR DESCRIPTION
Ranger overnight sweep — area: skills & sandbox. Draft; net-negative cleanup only, verified by Codex on plan and diff.

### What changed (`archestra-rs/sandbox-core/src/backends/dagger.rs`)
- `from_sdk` carried two stacked doc-comment blocks; the first was a superseded copy left behind when the second (more precise) one was written. Removed the stale block.
- `let _ = self.ensure_warm().await?;` → `self.ensure_warm().await?;` — the `?` already propagates; the binding only discarded a non-`#[must_use]` `Container`.

No behavior change. `cargo clippy --all-targets -- -D warnings` passes and the 50 existing sandbox-core tests stay green. Net: 1 insertion, 5 deletions.

Codex diff-gate verdict: APPROVE (removed comment is superseded; drop is behavior-identical; scoped; no regression test needed for non-behavioral cleanup).

https://claude.ai/code/session_01SHh2gvihRHyYW7qC66vsWK

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>