### PR TITLE
fix(skills): match `..` path segments not substrings in marketplace layout

### DIFF
--- a/platform/backend/src/skills/marketplace/layout.test.ts
+++ b/platform/backend/src/skills/marketplace/layout.test.ts
@@ -56,4 +56,41 @@ describe("computeLayout", () => {
     const lowered = files.map((f) => f.path.toLowerCase());
     expect(new Set(lowered).size).toBe(lowered.length);
   });
+
+  test("keeps files whose names merely contain dots but are not `..` segments", () => {
+    const files = computeLayout({
+      linkId: "aaaaaaaa-1111-2222-3333-444444444444",
+      marketplaceName: "org-abcd1234-skills",
+      ownerName: "Acme Corp",
+      displayName: "Acme Skills",
+      skills: [
+        makeSkill([
+          makeResourceFile("notes../file.md"),
+          makeResourceFile("..foo/bar.md"),
+        ]),
+      ],
+    });
+
+    // a "notes.." / "..foo" folder is a legitimate segment, not a traversal
+    expect(files.some((f) => /\/notes\.\.\/file\.md$/.test(f.path))).toBe(true);
+    expect(files.some((f) => /\/\.\.foo\/bar\.md$/.test(f.path))).toBe(true);
+  });
+
+  test("drops resource files that traverse out of the skill root", () => {
+    const files = computeLayout({
+      linkId: "aaaaaaaa-1111-2222-3333-444444444444",
+      marketplaceName: "org-abcd1234-skills",
+      ownerName: "Acme Corp",
+      displayName: "Acme Skills",
+      skills: [
+        makeSkill([
+          makeResourceFile("../evil.md"),
+          makeResourceFile("a/../../etc.md"),
+        ]),
+      ],
+    });
+
+    expect(files.some((f) => /evil\.md$/.test(f.path))).toBe(false);
+    expect(files.some((f) => /etc\.md$/.test(f.path))).toBe(false);
+  });
 });

--- a/platform/backend/src/skills/marketplace/layout.test.ts
+++ b/platform/backend/src/skills/marketplace/layout.test.ts
@@ -93,4 +93,18 @@ describe("computeLayout", () => {
     expect(files.some((f) => /evil\.md$/.test(f.path))).toBe(false);
     expect(files.some((f) => /etc\.md$/.test(f.path))).toBe(false);
   });
+
+  test("drops Windows-style backslash traversal segments", () => {
+    const files = computeLayout({
+      linkId: "aaaaaaaa-1111-2222-3333-444444444444",
+      marketplaceName: "org-abcd1234-skills",
+      ownerName: "Acme Corp",
+      displayName: "Acme Skills",
+      skills: [makeSkill([makeResourceFile("..\\evil.md")])],
+    });
+
+    // materialize.ts re-splits stored paths, so a backslash ".." segment must
+    // be rejected too, not just POSIX "../".
+    expect(files.some((f) => /evil\.md$/.test(f.path))).toBe(false);
+  });
 });

--- a/platform/backend/src/skills/marketplace/layout.ts
+++ b/platform/backend/src/skills/marketplace/layout.ts
@@ -198,11 +198,12 @@ function resolveResourceFile(params: {
   // Reject absolute paths and any `..` traversal *segment*. A substring test
   // (startsWith("..") / includes("../")) also drops legitimate names that merely
   // begin with or contain dots, e.g. a "notes.." folder, silently losing the
-  // file — so match whole segments, mirroring SkillFileInputSchema in
-  // ../validation.ts.
+  // file — so match whole segments. Split on both separators so a Windows-style
+  // "..\\evil.md" (which materialize.ts later re-splits) is still rejected, not
+  // just POSIX "../"; mirrors the intent of SkillFileInputSchema in ../validation.ts.
   if (
     path.posix.isAbsolute(relPath) ||
-    relPath.split("/").some((segment) => segment === "..")
+    relPath.split(/[/\\]/).some((segment) => segment === "..")
   ) {
     logger.warn(
       { path: file.path },

--- a/platform/backend/src/skills/marketplace/layout.ts
+++ b/platform/backend/src/skills/marketplace/layout.ts
@@ -195,7 +195,15 @@ function resolveResourceFile(params: {
     return null;
   }
   const relPath = path.posix.normalize(file.path.replace(/^\.?\//, ""));
-  if (relPath.startsWith("..") || relPath === "..") {
+  // Reject absolute paths and any `..` traversal *segment*. A substring test
+  // (startsWith("..") / includes("../")) also drops legitimate names that merely
+  // begin with or contain dots, e.g. a "notes.." folder, silently losing the
+  // file — so match whole segments, mirroring SkillFileInputSchema in
+  // ../validation.ts.
+  if (
+    path.posix.isAbsolute(relPath) ||
+    relPath.split("/").some((segment) => segment === "..")
+  ) {
     logger.warn(
       { path: file.path },
       "materialize: skipping file with traversal path",
@@ -209,14 +217,6 @@ function resolveResourceFile(params: {
     logger.warn(
       { path: file.path },
       "materialize: skipping reserved resource path SKILL.md",
-    );
-    return null;
-  }
-  // additional safety: reject any absolute or root-escape after normalization
-  if (path.posix.isAbsolute(relPath) || relPath.includes("../")) {
-    logger.warn(
-      { path: file.path },
-      "materialize: skipping file outside skill root",
     );
     return null;
   }


### PR DESCRIPTION
Ranger overnight sweep — area: skills & sandbox. Draft; verified by Codex on plan and diff (diff re-reviewed after an initial refutation, see below).

### What was wrong
- `backend/src/skills/marketplace/layout.ts` (`resolveResourceFile`): traversal was guarded with substring tests — `relPath.startsWith("..")` / `relPath.includes("../")`. These also dropped **legitimate** resource files whose segment merely begins with or contains dots (a `..foo/` or `notes../` folder), silently losing the file with a warn. The codebase already had the correct segment-wise check in `skills/validation.ts`.

### What changed
- Reject absolute paths and any whole `..` segment: `relPath.split(/[/\\]/).some(seg => seg === "..")`. Split on both `/` and `\` so a Windows-style `..\evil.md` (which `materialize.ts` re-splits on write) is still rejected. Null-byte and reserved-`SKILL.md` guards unchanged.
- Tests: legit `notes../`/`..foo/` files now survive; POSIX `../evil.md` / `a/../../etc.md` and backslash `..\evil.md` are still dropped.

Codex review history: the first diff (split on `/` only) was **refuted** for letting `..\evil.md` through; reworked to split on both separators. Re-review verdict: APPROVE (exhaustive escape analysis incl. mixed separators, unicode dot lookalikes, Windows absolute/UNC, drive+dot combos against the actual `materialize.ts` writer — no escape).

https://claude.ai/code/session_01SHh2gvihRHyYW7qC66vsWK

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>