### PR TITLE
fix(skills): accept a leading UTF-8 BOM in SKILL.md frontmatter

### DIFF
--- a/platform/backend/src/skills/parser.test.ts
+++ b/platform/backend/src/skills/parser.test.ts
@@ -29,6 +29,23 @@ describe("parseSkillManifest", () => {
     expect(parsed.metadata).toEqual({});
   });
 
+  test("parses a manifest that starts with a UTF-8 BOM", () => {
+    const raw = `﻿${[
+      "---",
+      "name: bom-skill",
+      "description: Has a byte order mark.",
+      "---",
+      "",
+      "# Body",
+    ].join("\n")}`;
+
+    const parsed = parseSkillManifest(raw);
+
+    expect(parsed.name).toBe("bom-skill");
+    expect(parsed.description).toBe("Has a byte order mark.");
+    expect(parsed.content).toBe("# Body");
+  });
+
   test("normalizes allowed-tools from a string or a YAML sequence", () => {
     const fromString = parseSkillManifest(
       [

--- a/platform/backend/src/skills/parser.ts
+++ b/platform/backend/src/skills/parser.ts
@@ -42,7 +42,11 @@ export const SKILL_MANIFEST_FILENAME = "SKILL.md";
  * the required `name`/`description` fields.
  */
 export function parseSkillManifest(raw: string): ParsedSkill {
-  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/);
+  // A SKILL.md authored on Windows can carry a leading UTF-8 BOM, which
+  // github-import preserves (it decodes with ignoreBOM). Strip it so the
+  // frontmatter block, anchored at the start of the string, still matches.
+  const text = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/);
   if (!match) {
     throw new SkillParseError(
       "SKILL.md must start with a YAML frontmatter block delimited by ---",
@@ -78,7 +82,7 @@ export function parseSkillManifest(raw: string): ParsedSkill {
   return {
     name,
     description,
-    content: raw.slice(match[0].length).trim(),
+    content: text.slice(match[0].length).trim(),
     license: readString(fields.license) || null,
     compatibility: readString(fields.compatibility) || null,
     allowedTools: readAllowedTools(fields["allowed-tools"]),


### PR DESCRIPTION
Ranger overnight sweep — area: skills & sandbox. Draft; verified by Codex on plan and diff.

### What was wrong
- `backend/src/skills/parser.ts` (`parseSkillManifest`): the frontmatter regex is anchored at the start of the string, so a `SKILL.md` carrying a leading UTF-8 BOM failed to match and was rejected as "must start with a YAML frontmatter block". `github-import` decodes with `ignoreBOM`, deliberately preserving a leading BOM, so a BOM-prefixed manifest from a real repo was silently classified "unparseable" and dropped during discovery/import.

### What changed
- Strip a single leading `U+FEFF` before matching (and slice the body from the stripped text). Non-BOM manifests are byte-for-byte unchanged.
- Added a regression test: a BOM-prefixed manifest now parses its name/description/body (throws before the fix).

Codex diff-gate verdict: APPROVE (`text` used for both match and body slice; non-BOM path unchanged; no downstream depends on raw BOM bytes — stored content comes from parsed `content`, and `SKILL.md` is excluded from imported resources).

https://claude.ai/code/session_01SHh2gvihRHyYW7qC66vsWK

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>