### PR TITLE
fix(mcp): stop offering a dead-end install link when the caller can't access the catalog

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -1090,6 +1090,64 @@ describe("McpClient", () => {
         );
       });
 
+      test("still offers the install link for a team-token caller (fail-open: no user identity to check accessibility against)", async ({
+        makeMember,
+        makeOrganization,
+        makeTeam,
+        makeUser,
+      }) => {
+        const org = await makeOrganization();
+        const owner = await makeUser();
+        await makeMember(owner.id, org.id, { role: "member" });
+        const team = await makeTeam(org.id, owner.id);
+
+        // A personal-scope catalog item owned by `owner`. A team token has no
+        // user identity, so accessibility cannot be evaluated for it; the
+        // fail-open MUST keep offering the install link (the caller behind the
+        // token may still be able to act on it). If accessibility were ever
+        // computed for team tokens, this personal item would be inaccessible
+        // and the link would be dropped — so this pin guards the fail-open.
+        const catalogItem = await InternalMcpCatalogModel.create(
+          {
+            name: `personal-${randomUUID().slice(0, 8)}`,
+            serverType: "remote",
+            serverUrl: "https://example.com/mcp",
+            scope: "personal",
+          },
+          { organizationId: org.id, authorId: owner.id },
+        );
+        const tool = await ToolModel.createToolIfNotExists({
+          name: `${catalogItem.name}__do_thing`,
+          description: "Personal-server tool",
+          parameters: {},
+          catalogId: catalogItem.id,
+        });
+        await AgentToolModel.create(agentId, tool.id, {
+          credentialResolutionMode: "dynamic",
+        });
+
+        const result = await mcpClient.executeToolCallForOwner(
+          { id: "call_teamtoken", name: tool.name, arguments: {} },
+          agentOwner(agentId),
+          {
+            tokenId: "tok-team",
+            teamId: team.id,
+            isOrganizationToken: false,
+            organizationId: org.id,
+          },
+        );
+
+        expect(result.isError).toBe(true);
+        const archestraError = result?._meta?.archestraError as
+          | { type?: string; action?: string; actionUrl?: string }
+          | undefined;
+        expect(archestraError?.type).toBe("auth_required");
+        expect(archestraError?.action).toBe("install_mcp_credentials");
+        expect(archestraError?.actionUrl).toContain(
+          `/mcp/registry?install=${catalogItem.id}`,
+        );
+      });
+
       test("All-tools mode ignores a static assignment pin and uses the server's connection policy", async ({
         makeAgent,
         makeMember,

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -990,6 +990,106 @@ describe("McpClient", () => {
         expect(mockCallTool).toHaveBeenCalledTimes(1);
       });
 
+      test("no self-service install link when the tool's catalog item is another user's personal server", async ({
+        makeMember,
+        makeOrganization,
+        makeUser,
+      }) => {
+        const org = await makeOrganization();
+        const owner = await makeUser();
+        await makeMember(owner.id, org.id, { role: "member" });
+        const caller = await makeUser();
+        await makeMember(caller.id, org.id, { role: "member" });
+
+        // A personal-scope catalog item owned by `owner`, invisible to `caller`.
+        const catalogItem = await InternalMcpCatalogModel.create(
+          {
+            name: `personal-${randomUUID().slice(0, 8)}`,
+            serverType: "remote",
+            serverUrl: "https://example.com/mcp",
+            scope: "personal",
+          },
+          { organizationId: org.id, authorId: owner.id },
+        );
+        const tool = await ToolModel.createToolIfNotExists({
+          name: `${catalogItem.name}__do_thing`,
+          description: "Personal-server tool",
+          parameters: {},
+          catalogId: catalogItem.id,
+        });
+        await AgentToolModel.create(agentId, tool.id, {
+          credentialResolutionMode: "dynamic",
+        });
+
+        const result = await mcpClient.executeToolCallForOwner(
+          { id: "call_deadend", name: tool.name, arguments: {} },
+          agentOwner(agentId),
+          userToken(caller.id, org.id),
+        );
+
+        expect(result.isError).toBe(true);
+        const archestraError = result?._meta?.archestraError as
+          | { type?: string; action?: string; actionUrl?: string }
+          | undefined;
+        expect(archestraError?.type).toBe("auth_required");
+        // The caller cannot install another user's personal item, so no
+        // self-service install link is offered.
+        expect(archestraError?.actionUrl).toBeUndefined();
+        expect(archestraError?.action).toBeUndefined();
+        expect(result?.error).not.toContain("/mcp/registry?install=");
+        expect(result?.error).not.toMatch(/visit[^.]*https?:\/\//i);
+        // ...and it names a remediation the caller can actually pursue.
+        expect(result?.error).toMatch(/owner|administrator|share/i);
+      });
+
+      test("still offers the install link when the caller can access the catalog (org-scoped, no install yet)", async ({
+        makeMember,
+        makeOrganization,
+        makeUser,
+      }) => {
+        const org = await makeOrganization();
+        const caller = await makeUser();
+        await makeMember(caller.id, org.id, { role: "member" });
+
+        // An org-scoped catalog item the caller CAN see and install; with no
+        // install yet, the self-service install link is legitimate and MUST be
+        // preserved even though the caller-access check runs (orgId present).
+        const catalogItem = await InternalMcpCatalogModel.create(
+          {
+            name: `org-${randomUUID().slice(0, 8)}`,
+            serverType: "remote",
+            serverUrl: "https://example.com/mcp",
+            scope: "org",
+          },
+          { organizationId: org.id },
+        );
+        const tool = await ToolModel.createToolIfNotExists({
+          name: `${catalogItem.name}__do_thing`,
+          description: "Org-server tool",
+          parameters: {},
+          catalogId: catalogItem.id,
+        });
+        await AgentToolModel.create(agentId, tool.id, {
+          credentialResolutionMode: "dynamic",
+        });
+
+        const result = await mcpClient.executeToolCallForOwner(
+          { id: "call_install", name: tool.name, arguments: {} },
+          agentOwner(agentId),
+          userToken(caller.id, org.id),
+        );
+
+        expect(result.isError).toBe(true);
+        const archestraError = result?._meta?.archestraError as
+          | { type?: string; action?: string; actionUrl?: string }
+          | undefined;
+        expect(archestraError?.type).toBe("auth_required");
+        expect(archestraError?.action).toBe("install_mcp_credentials");
+        expect(archestraError?.actionUrl).toContain(
+          `/mcp/registry?install=${catalogItem.id}`,
+        );
+      });
+
       test("All-tools mode ignores a static assignment pin and uses the server's connection policy", async ({
         makeAgent,
         makeMember,

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1707,7 +1707,6 @@ class McpClient {
       : this.buildConnectionUnavailableMessage(
           catalogDisplayName,
           tool.catalogId,
-          tokenAuth,
         );
     return {
       error: await this.createErrorResult(
@@ -2564,13 +2563,11 @@ class McpClient {
   private buildConnectionUnavailableMessage(
     catalogDisplayName: string,
     catalogId: string,
-    tokenAuth?: TokenAuthContext,
   ): AuthRequiredMcpToolError {
-    const context = this.formatAuthContext(tokenAuth);
     return {
       type: "auth_required",
       message:
-        `The tool's MCP server "${catalogDisplayName}" is not shared with your account (${context}), ` +
+        `The tool's MCP server "${catalogDisplayName}" is not shared with your account, ` +
         "so it cannot run for you and you cannot set up your own connection to it. " +
         "Ask the server's owner or an administrator to share it with your team or organization, " +
         "to designate a shared connection for it, or to run this tool on your behalf.",

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -2567,7 +2567,7 @@ class McpClient {
     return {
       type: "auth_required",
       message:
-        `The tool's MCP server "${catalogDisplayName}" is not shared with your account, ` +
+        `The tool's MCP server "${catalogDisplayName}" is not shared with you, ` +
         "so it cannot run for you and you cannot set up your own connection to it. " +
         "Ask the server's owner or an administrator to share it with your team or organization, " +
         "to designate a shared connection for it, or to run this tool on your behalf.",

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -30,6 +30,7 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import QuickLRU from "quick-lru";
 import { unavailableThirdPartyToolMessage } from "@/archestra-mcp-server/tool-recovery-messages";
+import { getMcpCatalogPermissionChecker } from "@/auth/mcp-catalog-permissions";
 import { LRUCacheManager } from "@/cache-manager";
 import config from "@/config";
 import { McpServerRuntimeManager } from "@/k8s/mcp-server-runtime";
@@ -44,6 +45,7 @@ import {
   TeamModel,
   ToolModel,
 } from "@/models";
+import McpCatalogTeamModel from "@/models/mcp-catalog-team";
 import {
   classifyThrownRefreshError,
   discoverOAuthEndpoints,
@@ -1689,13 +1691,24 @@ class McpClient {
       };
     }
 
-    // No server found - return an actionable error with install link
+    // No server found. Offer a self-service install link only when the caller
+    // can actually reach it; otherwise the catalog item is not shared with them
+    // (e.g. another user's personal-scope server) and the link is a dead end.
     const catalogDisplayName = tool.catalogName || catalogItem.name;
-    const authError = this.buildAuthRequiredMessage(
-      catalogDisplayName,
+    const authError = (await this.callerCanConnectCatalog(
       tool.catalogId,
       tokenAuth,
-    );
+    ))
+      ? this.buildAuthRequiredMessage(
+          catalogDisplayName,
+          tool.catalogId,
+          tokenAuth,
+        )
+      : this.buildConnectionUnavailableMessage(
+          catalogDisplayName,
+          tool.catalogId,
+          tokenAuth,
+        );
     return {
       error: await this.createErrorResult(
         toolCall,
@@ -2506,6 +2519,64 @@ class McpClient {
 
     this.oauthRefreshLocks.set(secretId, refreshPromise);
     return refreshPromise;
+  }
+
+  /**
+   * Whether the calling identity could set up its own connection for a catalog
+   * item — i.e. the item is visible and installable to it. A user token that
+   * cannot (another user's personal-scope item, or a team item for a team it is
+   * not in) must not be handed a self-service install link it cannot act on.
+   * Team/org-token callers, callers whose organization is unknown, and any
+   * lookup error fall back to the install-link guidance rather than being
+   * suppressed.
+   */
+  private async callerCanConnectCatalog(
+    catalogId: string,
+    tokenAuth?: TokenAuthContext,
+  ): Promise<boolean> {
+    if (!tokenAuth?.userId || !tokenAuth.organizationId) {
+      return true;
+    }
+    try {
+      const checker = await getMcpCatalogPermissionChecker({
+        userId: tokenAuth.userId,
+        organizationId: tokenAuth.organizationId,
+      });
+      const accessibleIds =
+        await McpCatalogTeamModel.getUserAccessibleCatalogIds(
+          tokenAuth.userId,
+          checker.isAdmin,
+          tokenAuth.organizationId,
+        );
+      return accessibleIds.includes(catalogId);
+    } catch {
+      return true;
+    }
+  }
+
+  /**
+   * Auth-required error for a caller who cannot set up their own connection to
+   * the catalog item because it is not shared with them. Carries no install
+   * `actionUrl` or `action`, so no client (chat card, non-UI client, or the
+   * model relaying the text) presents a self-service link the caller cannot use;
+   * the message names the remediations open to them.
+   */
+  private buildConnectionUnavailableMessage(
+    catalogDisplayName: string,
+    catalogId: string,
+    tokenAuth?: TokenAuthContext,
+  ): AuthRequiredMcpToolError {
+    const context = this.formatAuthContext(tokenAuth);
+    return {
+      type: "auth_required",
+      message:
+        `The tool's MCP server "${catalogDisplayName}" is not shared with your account (${context}), ` +
+        "so it cannot run for you and you cannot set up your own connection to it. " +
+        "Ask the server's owner or an administrator to share it with your team or organization, " +
+        "to designate a shared connection for it, or to run this tool on your behalf.",
+      catalogId,
+      catalogName: catalogDisplayName,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

An agent in **Custom** tool mode can have a tool attached whose backing MCP server is another user's **personal** registry item. When a different member triggers that tool, per-caller credential resolution finds no install they can use, and the MCP gateway returned an `auth_required` error whose `actionUrl` and message pointed the member at `/mcp/registry?install=<catalogId>`.

That catalog item is invisible to the member (they get `403`), so the chat card's **"Set up credentials"** button opened the registry page to a silent no-op — a prompt that leads nowhere. And because the error text instructs the model to display the URL verbatim, the model relayed the dead link too.

After this change, the gateway offers a self-service install link **only when the caller can actually access/install the catalog item**. When they can't, it returns a non-actionable `auth_required` — no `actionUrl`/`action` — whose message names the real remedies: the server's owner or an administrator sharing it with the caller's team or organization, re-scoping it, designating a shared (service-account) connection, or running the tool on the caller's behalf. The chat card renders no button for a link-less `auth_required`, and the model has no URL to echo.

Callers who *can* self-serve (organization/team catalogs, or their own personal item) still get the install link, and the owner's own calls are unaffected. The visibility check fails open — team/org tokens, an unknown organization, or a lookup error keep the existing install-link guidance.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>