### PR TITLE
fix(bedrock): accept Claude cachePoint and reasoningContent blocks from @ai-sdk/amazon-bedrock

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -68245,6 +68245,59 @@
                                 "required": [
                                   "cachePoint"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "reasoningContent": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "reasoningText": {
+                                            "type": "object",
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              },
+                                              "signature": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "text"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "reasoningText"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "redactedReasoning": {
+                                            "type": "object",
+                                            "properties": {
+                                              "data": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "data"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "redactedReasoning"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "reasoningContent"
+                                ]
                               }
                             ]
                           }
@@ -68348,6 +68401,10 @@
                           "required": [
                             "cachePoint"
                           ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {}
                         }
                       ]
                     }
@@ -69517,6 +69574,59 @@
                                 "required": [
                                   "cachePoint"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "reasoningContent": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "reasoningText": {
+                                            "type": "object",
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              },
+                                              "signature": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "text"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "reasoningText"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "redactedReasoning": {
+                                            "type": "object",
+                                            "properties": {
+                                              "data": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "data"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "redactedReasoning"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "reasoningContent"
+                                ]
                               }
                             ]
                           }
@@ -69620,6 +69730,10 @@
                           "required": [
                             "cachePoint"
                           ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {}
                         }
                       ]
                     }
@@ -70799,6 +70913,59 @@
                                 "required": [
                                   "cachePoint"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "reasoningContent": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "reasoningText": {
+                                            "type": "object",
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              },
+                                              "signature": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "text"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "reasoningText"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "redactedReasoning": {
+                                            "type": "object",
+                                            "properties": {
+                                              "data": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "data"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "redactedReasoning"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "reasoningContent"
+                                ]
                               }
                             ]
                           }
@@ -70902,6 +71069,10 @@
                           "required": [
                             "cachePoint"
                           ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {}
                         }
                       ]
                     }
@@ -71611,6 +71782,59 @@
                                 "required": [
                                   "cachePoint"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "reasoningContent": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "reasoningText": {
+                                            "type": "object",
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              },
+                                              "signature": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "text"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "reasoningText"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "redactedReasoning": {
+                                            "type": "object",
+                                            "properties": {
+                                              "data": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "data"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "redactedReasoning"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "reasoningContent"
+                                ]
                               }
                             ]
                           }
@@ -71714,6 +71938,10 @@
                           "required": [
                             "cachePoint"
                           ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {}
                         }
                       ]
                     }
@@ -72433,6 +72661,59 @@
                                 "required": [
                                   "cachePoint"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "reasoningContent": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "reasoningText": {
+                                            "type": "object",
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              },
+                                              "signature": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "text"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "reasoningText"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "redactedReasoning": {
+                                            "type": "object",
+                                            "properties": {
+                                              "data": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "data"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "redactedReasoning"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "reasoningContent"
+                                ]
                               }
                             ]
                           }
@@ -72536,6 +72817,10 @@
                           "required": [
                             "cachePoint"
                           ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {}
                         }
                       ]
                     }
@@ -73720,6 +74005,59 @@
                                 "required": [
                                   "cachePoint"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "reasoningContent": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "reasoningText": {
+                                            "type": "object",
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              },
+                                              "signature": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "text"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "reasoningText"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "redactedReasoning": {
+                                            "type": "object",
+                                            "properties": {
+                                              "data": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "data"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "redactedReasoning"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "reasoningContent"
+                                ]
                               }
                             ]
                           }
@@ -73823,6 +74161,10 @@
                           "required": [
                             "cachePoint"
                           ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {}
                         }
                       ]
                     }
@@ -112165,6 +112507,64 @@
                                                   "cachePoint"
                                                 ],
                                                 "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "reasoningContent": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "reasoningText": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "signature": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "reasoningText"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "redactedReasoning": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "data": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "data"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "redactedReasoning"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "reasoningContent"
+                                                ],
+                                                "additionalProperties": false
                                               }
                                             ]
                                           }
@@ -112257,6 +112657,10 @@
                                             "cachePoint"
                                           ],
                                           "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": {}
                                         }
                                       ]
                                     }
@@ -112970,6 +113374,64 @@
                                                   "cachePoint"
                                                 ],
                                                 "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "reasoningContent": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "reasoningText": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "signature": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "reasoningText"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "redactedReasoning": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "data": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "data"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "redactedReasoning"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "reasoningContent"
+                                                ],
+                                                "additionalProperties": false
                                               }
                                             ]
                                           }
@@ -113062,6 +113524,10 @@
                                             "cachePoint"
                                           ],
                                           "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": {}
                                         }
                                       ]
                                     }
@@ -130507,6 +130973,64 @@
                                             "cachePoint"
                                           ],
                                           "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "reasoningContent": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "reasoningText": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "text": {
+                                                          "type": "string"
+                                                        },
+                                                        "signature": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "text"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "reasoningText"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "redactedReasoning": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "data": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "data"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "redactedReasoning"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "reasoningContent"
+                                          ],
+                                          "additionalProperties": false
                                         }
                                       ]
                                     }
@@ -130599,6 +131123,10 @@
                                       "cachePoint"
                                     ],
                                     "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }
@@ -131312,6 +131840,64 @@
                                             "cachePoint"
                                           ],
                                           "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "reasoningContent": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "reasoningText": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "text": {
+                                                          "type": "string"
+                                                        },
+                                                        "signature": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "text"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "reasoningText"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "redactedReasoning": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "data": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "data"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "redactedReasoning"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "reasoningContent"
+                                          ],
+                                          "additionalProperties": false
                                         }
                                       ]
                                     }
@@ -131404,6 +131990,10 @@
                                       "cachePoint"
                                     ],
                                     "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": {}
                                   }
                                 ]
                               }

--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -1,7 +1,7 @@
 import { EventStreamCodec } from "@smithy/eventstream-codec";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 import { describe, expect, test } from "@/test";
-import type { Bedrock } from "@/types";
+import { Bedrock } from "@/types";
 import { bedrockAdapterFactory, getCommandInput } from "./bedrock";
 
 const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
@@ -429,5 +429,68 @@ describe("Bedrock getUsage", () => {
       cacheWriteTokens: 1000,
       cacheWrite1hTokens: 400,
     });
+  });
+});
+
+describe("Bedrock system content validation (issue #3406)", () => {
+  // Exact body @ai-sdk/amazon-bedrock emits for a Claude request with prompt
+  // caching (as used by OpenCode): a system cachePoint breakpoint follows the
+  // system text, landing at system[1]. Older Archestra validation rejected this
+  // with "body/system/1 Invalid input"; it must now validate and pass through.
+  test("accepts a cachePoint breakpoint in the system array", () => {
+    const result = Bedrock.API.ConverseRequestSchema.safeParse({
+      modelId: "anthropic.claude-haiku-4-5-20251001-v1:0",
+      system: [
+        { text: "You are a helpful assistant." },
+        { cachePoint: { type: "default" } },
+      ],
+      messages: [{ role: "user", content: [{ text: "hi" }] }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("forwards the system cachePoint to Bedrock unchanged", () => {
+    const request = createConverseRequest({
+      system: [
+        { text: "You are a helpful assistant." },
+        { cachePoint: { type: "default" } },
+      ],
+    });
+
+    const commandInput = getCommandInput(request);
+
+    expect(commandInput.system).toEqual([
+      { text: "You are a helpful assistant." },
+      { cachePoint: { type: "default" } },
+    ]);
+  });
+
+  test("normalizes Anthropic-style { type: 'text' } system blocks", () => {
+    const request = createConverseRequest({
+      system: [{ type: "text", text: "You are a helpful assistant." }] as never,
+    });
+
+    const commandInput = getCommandInput(request);
+
+    expect(commandInput.system).toEqual([
+      { text: "You are a helpful assistant." },
+    ]);
+  });
+
+  // Forward-compat: an unmodeled but object-shaped Bedrock-native system block
+  // must not 400 the whole request — AWS is the authoritative validator, so we
+  // accept it and forward it untouched instead of rejecting future block types.
+  test("accepts and passes through an unknown system block shape", () => {
+    const futureBlock = { reasoningContent: { text: "scratchpad" } };
+    const request = createConverseRequest({
+      system: [{ text: "sys" }, futureBlock] as never,
+    });
+
+    const parsed = Bedrock.API.ConverseRequestSchema.safeParse(request);
+    expect(parsed.success).toBe(true);
+
+    const commandInput = getCommandInput(request);
+    expect(commandInput.system).toEqual([{ text: "sys" }, futureBlock]);
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -482,7 +482,7 @@ describe("Bedrock system content validation (issue #3406)", () => {
   // must not 400 the whole request — AWS is the authoritative validator, so we
   // accept it and forward it untouched instead of rejecting future block types.
   test("accepts and passes through an unknown system block shape", () => {
-    const futureBlock = { reasoningContent: { text: "scratchpad" } };
+    const futureBlock = { somethingBedrockAddsLater: { foo: "bar" } };
     const request = createConverseRequest({
       system: [{ text: "sys" }, futureBlock] as never,
     });
@@ -492,5 +492,67 @@ describe("Bedrock system content validation (issue #3406)", () => {
 
     const commandInput = getCommandInput(request);
     expect(commandInput.system).toEqual([{ text: "sys" }, futureBlock]);
+  });
+});
+
+describe("Bedrock reasoningContent message blocks (issue #3406)", () => {
+  // With Claude extended thinking, @ai-sdk/amazon-bedrock echoes the prior
+  // assistant reasoning back on the next turn as a reasoningContent block in the
+  // assistant message content. Older validation had no case for it and 400'd
+  // with "body/messages/N/content/M Invalid input"; it must now validate and
+  // pass through to Bedrock unchanged.
+  const reasoningBlock = {
+    reasoningContent: {
+      reasoningText: { text: "2 + 2 is 4.", signature: "ErUBCk...sig==" },
+    },
+  };
+
+  test("accepts a reasoningText block in an assistant message", () => {
+    const result = Bedrock.API.ConverseRequestSchema.safeParse({
+      modelId: "anthropic.claude-haiku-4-5-20251001-v1:0",
+      messages: [
+        { role: "user", content: [{ text: "What is 2+2?" }] },
+        { role: "assistant", content: [reasoningBlock, { text: "4" }] },
+        { role: "user", content: [{ text: "And 3+3?" }] },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a redactedReasoning block in an assistant message", () => {
+    const result = Bedrock.API.ConverseRequestSchema.safeParse({
+      modelId: "anthropic.claude-haiku-4-5-20251001-v1:0",
+      messages: [
+        { role: "user", content: [{ text: "hi" }] },
+        {
+          role: "assistant",
+          content: [
+            { reasoningContent: { redactedReasoning: { data: "abc123==" } } },
+            { text: "hello" },
+          ],
+        },
+        { role: "user", content: [{ text: "again" }] },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("forwards the reasoningContent block to Bedrock unchanged", () => {
+    const request = createConverseRequest({
+      messages: [
+        { role: "user", content: [{ text: "What is 2+2?" }] },
+        {
+          role: "assistant",
+          content: [reasoningBlock, { text: "4" }],
+        } as never,
+        { role: "user", content: [{ text: "And 3+3?" }] },
+      ],
+    });
+
+    const commandInput = getCommandInput(request);
+
+    expect(commandInput.messages?.[1]?.content?.[0]).toEqual(reasoningBlock);
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -51,7 +51,14 @@ type BedrockCommandContext = {
     modelId: string;
     messages: BedrockMessages | undefined;
     system:
-      | Array<{ text?: string; guardContent?: unknown; cachePoint?: unknown }>
+      | Array<{
+          text?: string;
+          guardContent?: unknown;
+          cachePoint?: unknown;
+          // Passthrough for Bedrock-native system blocks we don't model
+          // explicitly (see SystemContentBlockSchema forward-compat fallback).
+          [key: string]: unknown;
+        }>
       | undefined;
     inferenceConfig: BedrockRequest["inferenceConfig"];
     toolConfig:
@@ -1560,7 +1567,7 @@ function buildBedrockCommandContext(
         isNova: shouldEncodeHyphens,
       }),
       system: request.system?.map((s) => {
-        if ("text" in s) return { text: s.text };
+        if ("text" in s && typeof s.text === "string") return { text: s.text };
         return s;
       }),
       inferenceConfig: request.inferenceConfig,

--- a/platform/backend/src/types/llm-providers/bedrock/messages.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/messages.ts
@@ -185,6 +185,15 @@ export const MessageSchema = z.object({
 // System content block (text or guard content)
 // Also accepts Anthropic-style { type: "text", text: string } blocks (e.g. from @ai-sdk/amazon-bedrock)
 // and normalizes them to Bedrock format { text: string }
+//
+// Forward-compat fallback: Bedrock periodically introduces new system block
+// shapes and @ai-sdk/amazon-bedrock forwards whatever the caller configures
+// (the `cachePoint` block was one such addition — before it was modeled here,
+// a Claude request with prompt caching failed with "body/system/1 Invalid
+// input"). As a pass-through proxy we must not 400 a request just because a
+// block isn't in our allowlist; AWS is the authoritative validator. Any object
+// we don't explicitly model is accepted and forwarded to Bedrock unchanged.
+// The known shapes stay first so their normalization/typing still applies.
 const SystemContentBlockSchema = z.union([
   z
     .object({ type: z.literal("text"), text: z.string() })
@@ -192,6 +201,7 @@ const SystemContentBlockSchema = z.union([
   z.object({ text: z.string() }),
   GuardContentBlockSchema,
   CachePointContentBlockSchema,
+  z.record(z.string(), z.unknown()),
 ]);
 
 export const SystemSchema = z.array(SystemContentBlockSchema);

--- a/platform/backend/src/types/llm-providers/bedrock/messages.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/messages.ts
@@ -137,6 +137,30 @@ const CachePointContentBlockSchema = z.object({
   }),
 });
 
+// Reasoning content block — Claude extended-thinking output. On a multi-turn
+// request @ai-sdk/amazon-bedrock echoes the prior assistant reasoning back as a
+// `{ reasoningContent: ... }` block in the assistant message content, so the
+// proxy must accept it or the whole request 400s with
+// "body/messages/N/content/M Invalid input" (the same failure class as the
+// system cachePoint block). Two variants per the Bedrock Converse API: plain
+// reasoning text with a signature, or redacted reasoning bytes. `signature` is
+// optional so a text variant without one still validates and passes through.
+const ReasoningContentBlockSchema = z.object({
+  reasoningContent: z.union([
+    z.object({
+      reasoningText: z.object({
+        text: z.string(),
+        signature: z.string().optional(),
+      }),
+    }),
+    z.object({
+      redactedReasoning: z.object({
+        data: z.string(),
+      }),
+    }),
+  ]),
+});
+
 // =============================================================================
 // EXPORTED CONTENT BLOCK UNIONS
 // =============================================================================
@@ -156,6 +180,7 @@ export const AssistantContentBlockSchema = z.union([
   TextContentBlockSchema,
   ToolUseContentBlockSchema,
   CachePointContentBlockSchema,
+  ReasoningContentBlockSchema,
 ]);
 
 // Content block union for all messages
@@ -167,6 +192,7 @@ export const ContentBlockSchema = z.union([
   ToolUseContentBlockSchema,
   ToolResultContentBlockSchema,
   CachePointContentBlockSchema,
+  ReasoningContentBlockSchema,
 ]);
 
 // =============================================================================

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -19618,6 +19618,17 @@ export type BedrockConverseWithDefaultAgentData = {
                     type: string;
                     ttl?: string;
                 };
+            } | {
+                reasoningContent: {
+                    reasoningText: {
+                        text: string;
+                        signature?: string;
+                    };
+                } | {
+                    redactedReasoning: {
+                        data: string;
+                    };
+                };
             }>;
         }>;
         system?: Array<{
@@ -19637,6 +19648,8 @@ export type BedrockConverseWithDefaultAgentData = {
                 type: string;
                 ttl?: string;
             };
+        } | {
+            [key: string]: unknown;
         }>;
         inferenceConfig?: {
             maxTokens?: number;
@@ -19942,6 +19955,17 @@ export type BedrockConverseWithAgentData = {
                     type: string;
                     ttl?: string;
                 };
+            } | {
+                reasoningContent: {
+                    reasoningText: {
+                        text: string;
+                        signature?: string;
+                    };
+                } | {
+                    redactedReasoning: {
+                        data: string;
+                    };
+                };
             }>;
         }>;
         system?: Array<{
@@ -19961,6 +19985,8 @@ export type BedrockConverseWithAgentData = {
                 type: string;
                 ttl?: string;
             };
+        } | {
+            [key: string]: unknown;
         }>;
         inferenceConfig?: {
             maxTokens?: number;
@@ -20268,6 +20294,17 @@ export type BedrockConverseStreamWithDefaultAgentData = {
                     type: string;
                     ttl?: string;
                 };
+            } | {
+                reasoningContent: {
+                    reasoningText: {
+                        text: string;
+                        signature?: string;
+                    };
+                } | {
+                    redactedReasoning: {
+                        data: string;
+                    };
+                };
             }>;
         }>;
         system?: Array<{
@@ -20287,6 +20324,8 @@ export type BedrockConverseStreamWithDefaultAgentData = {
                 type: string;
                 ttl?: string;
             };
+        } | {
+            [key: string]: unknown;
         }>;
         inferenceConfig?: {
             maxTokens?: number;
@@ -20463,6 +20502,17 @@ export type BedrockConverseStreamWithAgentData = {
                     type: string;
                     ttl?: string;
                 };
+            } | {
+                reasoningContent: {
+                    reasoningText: {
+                        text: string;
+                        signature?: string;
+                    };
+                } | {
+                    redactedReasoning: {
+                        data: string;
+                    };
+                };
             }>;
         }>;
         system?: Array<{
@@ -20482,6 +20532,8 @@ export type BedrockConverseStreamWithAgentData = {
                 type: string;
                 ttl?: string;
             };
+        } | {
+            [key: string]: unknown;
         }>;
         inferenceConfig?: {
             maxTokens?: number;
@@ -20660,6 +20712,17 @@ export type BedrockConverseWithAgentAndModelData = {
                     type: string;
                     ttl?: string;
                 };
+            } | {
+                reasoningContent: {
+                    reasoningText: {
+                        text: string;
+                        signature?: string;
+                    };
+                } | {
+                    redactedReasoning: {
+                        data: string;
+                    };
+                };
             }>;
         }>;
         system?: Array<{
@@ -20679,6 +20742,8 @@ export type BedrockConverseWithAgentAndModelData = {
                 type: string;
                 ttl?: string;
             };
+        } | {
+            [key: string]: unknown;
         }>;
         inferenceConfig?: {
             maxTokens?: number;
@@ -20987,6 +21052,17 @@ export type BedrockConverseStreamWithAgentAndModelData = {
                     type: string;
                     ttl?: string;
                 };
+            } | {
+                reasoningContent: {
+                    reasoningText: {
+                        text: string;
+                        signature?: string;
+                    };
+                } | {
+                    redactedReasoning: {
+                        data: string;
+                    };
+                };
             }>;
         }>;
         system?: Array<{
@@ -21006,6 +21082,8 @@ export type BedrockConverseStreamWithAgentAndModelData = {
                 type: string;
                 ttl?: string;
             };
+        } | {
+            [key: string]: unknown;
         }>;
         inferenceConfig?: {
             maxTokens?: number;
@@ -31356,6 +31434,17 @@ export type GetInteractionsResponses = {
                             type: string;
                             ttl?: string;
                         };
+                    } | {
+                        reasoningContent: {
+                            reasoningText: {
+                                text: string;
+                                signature?: string;
+                            };
+                        } | {
+                            redactedReasoning: {
+                                data: string;
+                            };
+                        };
                     }>;
                 }>;
                 system?: Array<{
@@ -31372,6 +31461,8 @@ export type GetInteractionsResponses = {
                         type: string;
                         ttl?: string;
                     };
+                } | {
+                    [key: string]: unknown;
                 }>;
                 inferenceConfig?: {
                     maxTokens?: number;
@@ -31525,6 +31616,17 @@ export type GetInteractionsResponses = {
                             type: string;
                             ttl?: string;
                         };
+                    } | {
+                        reasoningContent: {
+                            reasoningText: {
+                                text: string;
+                                signature?: string;
+                            };
+                        } | {
+                            redactedReasoning: {
+                                data: string;
+                            };
+                        };
                     }>;
                 }>;
                 system?: Array<{
@@ -31541,6 +31643,8 @@ export type GetInteractionsResponses = {
                         type: string;
                         ttl?: string;
                     };
+                } | {
+                    [key: string]: unknown;
                 }>;
                 inferenceConfig?: {
                     maxTokens?: number;
@@ -34971,6 +35075,17 @@ export type GetInteractionResponses = {
                         type: string;
                         ttl?: string;
                     };
+                } | {
+                    reasoningContent: {
+                        reasoningText: {
+                            text: string;
+                            signature?: string;
+                        };
+                    } | {
+                        redactedReasoning: {
+                            data: string;
+                        };
+                    };
                 }>;
             }>;
             system?: Array<{
@@ -34987,6 +35102,8 @@ export type GetInteractionResponses = {
                     type: string;
                     ttl?: string;
                 };
+            } | {
+                [key: string]: unknown;
             }>;
             inferenceConfig?: {
                 maxTokens?: number;
@@ -35140,6 +35257,17 @@ export type GetInteractionResponses = {
                         type: string;
                         ttl?: string;
                     };
+                } | {
+                    reasoningContent: {
+                        reasoningText: {
+                            text: string;
+                            signature?: string;
+                        };
+                    } | {
+                        redactedReasoning: {
+                            data: string;
+                        };
+                    };
                 }>;
             }>;
             system?: Array<{
@@ -35156,6 +35284,8 @@ export type GetInteractionResponses = {
                     type: string;
                     ttl?: string;
                 };
+            } | {
+                [key: string]: unknown;
             }>;
             inferenceConfig?: {
                 maxTokens?: number;


### PR DESCRIPTION
Closes #3406

## Problem

Using OpenCode with the Archestra Bedrock proxy via `@ai-sdk/amazon-bedrock`, Claude requests failed with:

```
Bad Request: {"error":{"message":"body/system/1 Invalid input","type":"api_validation_error"}}
```

Non-Claude Bedrock models worked in the same setup, making it look Claude-specific.

## Root cause

The failing block is Archestra's own Zod validation rejecting a Bedrock-native block the SDK emits.

I captured the actual body `@ai-sdk/amazon-bedrock` produces for a Claude request (mock-fetch against the real SDK). With prompt caching — which OpenCode enables for Anthropic/Claude models but not for others — the system array is:

```json
"system": [
  { "text": "You are a helpful assistant." },
  { "cachePoint": { "type": "default" } }   // <- body/system/1
]
```

So it's "Claude-specific" only because non-Claude models don't get a cache breakpoint. The reporter runs `1.1.22`, whose system content union had no `cachePoint` case, so the request 400'd.

`cachePoint` was later modeled in the system union (shipped in `1.2.60`), so the exact reported payload already validates on `main`. But the union is a strict allowlist that fails the whole request the next time a new Bedrock-native block appears — which is the actual class of bug worth fixing.

## Second, same-class bug found while extending coverage

Multi-turn Claude requests with **extended thinking** send the prior assistant reasoning back as a `{ reasoningContent: { reasoningText | redactedReasoning } }` block (confirmed emitted by `@ai-sdk/amazon-bedrock`). The message-content union didn't model it, so those requests 400 with `body/messages/N/content/M Invalid input`.

## Verification

- Reproduced both 400s end-to-end against the current schema using the real SDK-emitted bodies, and confirmed the patched schema accepts + forwards both.