### PR TITLE
fix(dev): make worktree bootstrap async and stop duplicating the pnpm store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 platform/CLAUDE_LOCAL.md
 .pnpm-store/
 .dev-bin/
+.worktree-bootstrap.failed
 
 *.pyc
 __pycache__/

--- a/platform/scripts/worktree-bootstrap.sh
+++ b/platform/scripts/worktree-bootstrap.sh
@@ -56,8 +56,8 @@ ensure_dagger_cli() {
     echo "failed to download Dagger CLI v${version}" >&2
     return 1
   fi
-  chmod +x "$tmp"
-  mv -f "$tmp" "$bin"
+  chmod +x "$tmp" || { rm -f "$tmp"; echo "failed to prepare Dagger CLI v${version}" >&2; return 1; }
+  mv -f "$tmp" "$bin" || { rm -f "$tmp"; echo "failed to install Dagger CLI v${version}" >&2; return 1; }
 }
 bootstrap() {
   local root
@@ -99,10 +99,17 @@ worktree_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 bootstrap="$worktree_root/platform/scripts/worktree-bootstrap.sh"
 [ -x "$bootstrap" ] || exit 0
 log="$worktree_root/.worktree-bootstrap.log"
-# run detached with stdio redirected to the log so `git worktree add` returns
-# immediately instead of blocking on a full pnpm install.
-nohup "$bootstrap" bootstrap >"$log" 2>&1 &
-echo "Archestra worktree bootstrap started in background (log: $log; on failure: $worktree_root/.worktree-bootstrap.failed)" >&2
+# run detached (stdio redirected to the log, stdin from /dev/null) so
+# `git worktree add` returns immediately instead of blocking on a full pnpm
+# install. Fall back to a synchronous run if nohup is unavailable, so bootstrap
+# still happens rather than falsely reporting a background launch.
+if command -v nohup >/dev/null 2>&1; then
+  nohup "$bootstrap" bootstrap >"$log" 2>&1 </dev/null &
+  echo "Archestra worktree bootstrap started in background (log: $log; on failure: $worktree_root/.worktree-bootstrap.failed)" >&2
+else
+  "$bootstrap" bootstrap >"$log" 2>&1 </dev/null \
+    || echo "Archestra worktree bootstrap failed — see $log" >&2
+fi
 exit 0
 EOF
   chmod +x "$hook"

--- a/platform/scripts/worktree-bootstrap.sh
+++ b/platform/scripts/worktree-bootstrap.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+BOOTSTRAP_FAILED_MARKER=""
+
 repo_root() {
   local script_dir
   script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,19 +14,32 @@ main_repo_root() {
   common_git_dir="$(git -C "$root" rev-parse --path-format=absolute --git-common-dir)"
   dirname "$common_git_dir"
 }
+dagger_os() {
+  case "$(uname -s)" in
+    Darwin) echo darwin ;;
+    Linux) echo linux ;;
+    MINGW* | MSYS* | CYGWIN*) echo windows ;;
+    *) echo unsupported ;;
+  esac
+}
+# best-effort: never abort bootstrap on failure — deps are the critical output.
 ensure_dagger_cli() {
-  local bin root version os arch
+  local bin root version os arch tmp
+  os="$(dagger_os)"
+  if [ "$os" != darwin ] && [ "$os" != linux ]; then
+    echo "Skipping Dagger CLI bootstrap on $(uname -s); set ARCHESTRA_DAGGER_RUNTIME_CLI_BIN manually if the code runtime is needed" >&2
+    return 0
+  fi
   bin="$(main_repo_root)/.dev-bin/dagger"
   root="$(repo_root)"
   version="$(sed -n 's/^ARG DAGGER_VERSION=v\{0,1\}\([0-9][^[:space:]]*\)$/\1/p' "$root/platform/Dockerfile")"
   if [ -z "$version" ]; then
-    echo "ERROR: failed to read DAGGER_VERSION from platform/Dockerfile" >&2
-    exit 1
+    echo "could not read DAGGER_VERSION from platform/Dockerfile" >&2
+    return 1
   fi
   if [ -x "$bin" ] && "$bin" version 2>/dev/null | grep -q "v${version}"; then
     return 0
   fi
-  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   arch="$(uname -m)"
   case "$arch" in
     x86_64) arch=amd64 ;;
@@ -32,20 +47,33 @@ ensure_dagger_cli() {
   esac
   mkdir -p "$(dirname "$bin")"
   echo "Bootstrapping Dagger CLI v${version} for ${os}/${arch} into ${bin}" >&2
-  curl -fsSL "https://dl.dagger.io/dagger/releases/${version}/dagger_v${version}_${os}_${arch}.tar.gz" \
-    | tar -xz -C "$(dirname "$bin")" dagger
-  chmod +x "$bin"
+  # extract to a temp file and atomically rename so concurrent worktree adds
+  # can't interleave writes into the shared binary.
+  tmp="$(dirname "$bin")/.dagger.download.$$"
+  if ! curl -fsSL "https://dl.dagger.io/dagger/releases/${version}/dagger_v${version}_${os}_${arch}.tar.gz" \
+    | tar -xzO dagger >"$tmp"; then
+    rm -f "$tmp"
+    echo "failed to download Dagger CLI v${version}" >&2
+    return 1
+  fi
+  chmod +x "$tmp"
+  mv -f "$tmp" "$bin"
 }
 bootstrap() {
-  local root store_dir
+  local root
   root="$(repo_root)"
-  store_dir="$(main_repo_root)/.pnpm-store"
+  # the hook runs this detached, so any failure is otherwise only visible in the
+  # log. Drop a sentinel on failure (removed on success) that a session can detect
+  # instead of silently working against half-installed deps.
+  BOOTSTRAP_FAILED_MARKER="$root/.worktree-bootstrap.failed"
+  rm -f "$BOOTSTRAP_FAILED_MARKER"
+  trap 'rc=$?; if [ "$rc" -ne 0 ] && [ -n "$BOOTSTRAP_FAILED_MARKER" ]; then printf "%s\n" "worktree bootstrap failed (exit $rc) — see .worktree-bootstrap.log" >"$BOOTSTRAP_FAILED_MARKER"; fi' EXIT
   if [ ! -f "$root/platform/pnpm-lock.yaml" ]; then
     echo "ERROR: no platform/pnpm-lock.yaml under $root" >&2
     exit 1
   fi
-  CI=true pnpm --dir "$root/platform" install --frozen-lockfile --prefer-offline --store-dir "$store_dir"
-  ensure_dagger_cli
+  CI=true pnpm --dir "$root/platform" install --frozen-lockfile --prefer-offline
+  ensure_dagger_cli || echo "WARNING: Dagger CLI bootstrap failed; deps are installed. Re-run: pnpm worktree:bootstrap" >&2
 }
 install_hook() {
   local root common_git_dir hook_dir hook marker
@@ -70,10 +98,11 @@ esac
 worktree_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 bootstrap="$worktree_root/platform/scripts/worktree-bootstrap.sh"
 [ -x "$bootstrap" ] || exit 0
-"$bootstrap" bootstrap || {
-  status=$?
-  echo "WARNING: Archestra worktree bootstrap failed with exit $status. Run manually: $bootstrap bootstrap" >&2
-}
+log="$worktree_root/.worktree-bootstrap.log"
+# run detached with stdio redirected to the log so `git worktree add` returns
+# immediately instead of blocking on a full pnpm install.
+nohup "$bootstrap" bootstrap >"$log" 2>&1 &
+echo "Archestra worktree bootstrap started in background (log: $log; on failure: $worktree_root/.worktree-bootstrap.failed)" >&2
 exit 0
 EOF
   chmod +x "$hook"
@@ -82,5 +111,8 @@ EOF
 case "${1:-bootstrap}" in
   bootstrap) bootstrap ;;
   install-hook) install_hook ;;
-  *) echo "Usage: $0 [bootstrap|install-hook]" >&2; exit 1 ;;
+  *)
+    echo "Usage: $0 [bootstrap|install-hook]" >&2
+    exit 1
+    ;;
 esac


### PR DESCRIPTION
## Problem

The shared `post-checkout` hook installed by #6096 ran a synchronous `pnpm install` on every `git worktree add`, blocking worktree creation ~13s. It also forced a repo-local `--store-dir .pnpm-store` (a ~4.5GB duplicate of the global store on the same device) and the dagger download was macOS-only.

## Changes

- **Async**: the hook backgrounds bootstrap via `nohup … >log 2>&1 &`, so `git worktree add` returns immediately (~1.3s, git checkout only).
- **Failure sentinel**: a `.worktree-bootstrap.failed` marker (cleared on success) makes async install failures detectable instead of silent behind a "started" message.
- **Global store**: drop `--store-dir`; installs reuse the global pnpm store (same device → hardlinks), no duplication, no re-download.
- **Cross-platform dagger**: correct Linux mapping, Windows/Git Bash skips gracefully, download is non-fatal to the deps install and atomic (temp file + `mv`) so concurrent worktree adds can't corrupt the shared binary.

## Verification

- `git worktree add` returns ~1.3s; background install completes ~13.7s, worktree usable (`biome` runs).
- Main worktree `node_modules` untouched (inode unchanged); global store used (`downloaded 0`), no repo-local store created.
- Sentinel written on failure and cleared on success; atomic dagger re-download produces a working `v0.21.5` binary with no temp leftovers.
- `bash -n` clean.

> Note: after merge, re-run `pnpm worktree:install-hook` locally to pick up the async hook body.

https://claude.ai/code/session_013EsRt58jVZnLVAh2RcS7D8

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>