### PR TITLE
refactor(teams): share team authorization logic between REST routes and MCP tools

### DIFF
--- a/platform/backend/src/archestra-mcp-server/teams.ts
+++ b/platform/backend/src/archestra-mcp-server/teams.ts
@@ -1,5 +1,4 @@
 import {
-  ADMIN_ROLE_NAME,
   TOOL_ADD_TEAM_MEMBER_SHORT_NAME,
   TOOL_CREATE_TEAM_SHORT_NAME,
   TOOL_DELETE_TEAM_SHORT_NAME,
@@ -12,10 +11,16 @@ import {
 } from "@archestra/shared";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { hasAnyAgentTypeAdminPermission } from "@/auth/agent-type-permissions";
 import { userHasPermission } from "@/auth/utils";
 import logger from "@/logging";
-import { AgentToolModel, MemberModel, TeamModel } from "@/models";
+import { MemberModel, TeamModel } from "@/models";
+import {
+  canManageTeamMembers,
+  canReadTeam,
+  checkLastAdminInvariant,
+  cleanupCredentialSourcesAfterMemberRemoval,
+  getTeamForOrg,
+} from "@/services/team-authorization";
 import type { Team, TeamMember, TeamMemberListItem } from "@/types";
 import { TeamMemberRoleSchema, UuidIdSchema } from "@/types";
 import {
@@ -298,17 +303,17 @@ async function findTeamInOrg(
   teamId: string,
   organizationId: string | undefined,
 ): Promise<Team | null> {
-  const team = await TeamModel.findById(teamId);
-  if (!team || team.organizationId !== organizationId) {
+  if (!organizationId) {
     return null;
   }
-  return team;
+  return getTeamForOrg({ teamId, organizationId });
 }
 
 /**
  * Whether the caller can manage every team in the org. Mirrors the REST route:
  * the org-level `team:create` permission is the "team manager" signal (held by
- * admins and custom roles granted it).
+ * admins and custom roles granted it). MCP sessions carry no request headers,
+ * so this resolves from the user's role permissions.
  */
 async function isOrgTeamManager(context: ArchestraContext): Promise<boolean> {
   if (!context.userId || !context.organizationId) {
@@ -323,49 +328,46 @@ async function isOrgTeamManager(context: ArchestraContext): Promise<boolean> {
 }
 
 /**
- * Read access to a specific team: an org-level team manager sees every team; a
- * regular user only teams they belong to. Returns null when allowed, or a
- * not-found error (never disclosing the team's existence) when denied — the
- * same shape the REST route returns.
+ * Read access to a specific team, mapped to an MCP result: allowed → null;
+ * denied → a not-found error (never disclosing the team's existence, matching
+ * the REST route). Authorization itself lives in the shared service.
  */
 async function assertCanReadTeam(
   context: ArchestraContext,
   teamId: string,
 ): Promise<CallToolResult | null> {
-  if (await isOrgTeamManager(context)) {
-    return null;
+  if (!context.userId) {
+    return errorResult(`Team with ID ${teamId} not found.`);
   }
-  if (
-    context.userId &&
-    (await TeamModel.isUserInTeam(teamId, context.userId))
-  ) {
-    return null;
-  }
-  return errorResult(`Team with ID ${teamId} not found.`);
+  const allowed = await canReadTeam({
+    isOrgTeamManager: await isOrgTeamManager(context),
+    userId: context.userId,
+    teamId,
+  });
+  return allowed ? null : errorResult(`Team with ID ${teamId} not found.`);
 }
 
 /**
- * Membership-management access: an org-level team manager may manage any team's
- * members; otherwise the caller must be an admin of that specific team. Mirrors
- * the REST route's `assertCanManageTeam`. Returns null when allowed, or a
- * permission error when denied.
+ * Membership-management access, mapped to an MCP result: allowed → null;
+ * denied → a permission error. Authorization itself lives in the shared
+ * service (org-level team manager OR admin of that specific team).
  */
 async function assertCanManageTeamMembers(
   context: ArchestraContext,
   teamId: string,
 ): Promise<CallToolResult | null> {
-  if (await isOrgTeamManager(context)) {
-    return null;
-  }
-  if (
-    context.userId &&
-    (await TeamModel.isUserTeamAdmin(teamId, context.userId))
-  ) {
-    return null;
-  }
-  return errorResult(
-    "You must be a team admin or have organization-level team management permission to manage this team's members.",
-  );
+  const allowed =
+    !!context.userId &&
+    (await canManageTeamMembers({
+      isOrgTeamManager: await isOrgTeamManager(context),
+      userId: context.userId,
+      teamId,
+    }));
+  return allowed
+    ? null
+    : errorResult(
+        "You must be a team admin or have organization-level team management permission to manage this team's members.",
+      );
 }
 
 function serializeTeam(team: Team, memberCount: number) {
@@ -824,20 +826,17 @@ async function handleRemoveTeamMember(params: {
       return errorResult("Team member not found.");
     }
 
-    // Mirror the REST route: drop personal-credential assignments the removed
-    // user can no longer reach through any team. Best-effort — a cleanup
-    // failure must not fail the removal.
+    // Drop personal-credential assignments the removed user can no longer reach
+    // through any team. Best-effort — a cleanup failure must not fail the
+    // removal (same contract as the REST route).
     if (context.userId) {
       try {
-        const userIsAgentAdmin = await hasAnyAgentTypeAdminPermission({
-          userId: context.userId,
+        await cleanupCredentialSourcesAfterMemberRemoval({
+          actingUserId: context.userId,
+          removedUserId: args.user_id,
+          teamId: args.team_id,
           organizationId: context.organizationId,
         });
-        await AgentToolModel.cleanupInvalidCredentialSourcesForUser(
-          args.user_id,
-          args.team_id,
-          userIsAgentAdmin,
-        );
       } catch (cleanupError) {
         logger.error(
           { err: cleanupError, teamId: args.team_id, userId: args.user_id },
@@ -856,31 +855,21 @@ async function handleRemoveTeamMember(params: {
 }
 
 /**
- * Guard mirroring the REST route: refuse to demote or remove the sole admin of
- * a team. Returns an error result to surface, or null when the change is safe.
+ * Map the shared last-admin invariant onto an MCP result: allowed → null;
+ * denied → the corresponding error.
  */
 async function checkNotRemovingLastAdmin(params: {
   teamId: string;
   userId: string;
   nextRole: z.infer<typeof TeamMemberRoleSchema> | null;
 }): Promise<CallToolResult | null> {
-  const members = await TeamModel.getTeamMembers(params.teamId);
-  const target = members.find((member) => member.userId === params.userId);
-
-  if (!target) {
-    return errorResult("Team member not found.");
-  }
-
-  if (target.role !== ADMIN_ROLE_NAME || params.nextRole === ADMIN_ROLE_NAME) {
+  const check = await checkLastAdminInvariant(params);
+  if (check.ok) {
     return null;
   }
-
-  const adminCount = members.filter(
-    (member) => member.role === ADMIN_ROLE_NAME,
-  ).length;
-  if (adminCount <= 1) {
-    return errorResult("Cannot remove the last admin from a team.");
-  }
-
-  return null;
+  return errorResult(
+    check.reason === "last_admin"
+      ? "Cannot remove the last admin from a team."
+      : "Team member not found.",
+  );
 }

--- a/platform/backend/src/routes/team.ts
+++ b/platform/backend/src/routes/team.ts
@@ -7,9 +7,16 @@ import {
 } from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
-import { hasAnyAgentTypeAdminPermission, hasPermission } from "@/auth";
+import { hasPermission } from "@/auth";
 import { enterpriseTier } from "@/enterprise-tier";
-import { AgentToolModel, TeamLabelModel, TeamModel } from "@/models";
+import { TeamLabelModel, TeamModel } from "@/models";
+import {
+  canManageTeamMembers,
+  canReadTeam,
+  checkLastAdminInvariant,
+  cleanupCredentialSourcesAfterMemberRemoval,
+  getTeamForOrg,
+} from "@/services/team-authorization";
 import {
   AddTeamExternalGroupBodySchema,
   AddTeamMemberBodySchema,
@@ -129,26 +136,22 @@ const teamRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ params: { id }, organizationId, user, headers }, reply) => {
-      const team = await TeamModel.findById(id);
-
+      const team = await getTeamForOrg({ teamId: id, organizationId });
       if (!team) {
         throw new ApiError(404, "Team not found");
       }
 
-      // Verify the team belongs to the user's organization
-      if (team.organizationId !== organizationId) {
-        throw new ApiError(404, "Team not found");
-      }
-
-      const { success: canManageAllTeams } = await hasPermission(
+      const { success: isOrgTeamManager } = await hasPermission(
         { team: ["create"] },
         headers,
       );
-      if (!canManageAllTeams) {
-        const isMember = await TeamModel.isUserInTeam(id, user.id);
-        if (!isMember) {
-          throw new ApiError(404, "Team not found");
-        }
+      const canRead = await canReadTeam({
+        isOrgTeamManager,
+        userId: user.id,
+        teamId: id,
+      });
+      if (!canRead) {
+        throw new ApiError(404, "Team not found");
       }
 
       const labels = await TeamLabelModel.getLabelsForTeam(id);
@@ -251,21 +254,22 @@ const teamRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ params: { id }, organizationId, user, headers }, reply) => {
-      // Verify the team exists and belongs to the user's organization
-      const team = await TeamModel.findById(id);
-      if (!team || team.organizationId !== organizationId) {
+      const team = await getTeamForOrg({ teamId: id, organizationId });
+      if (!team) {
         throw new ApiError(404, "Team not found");
       }
 
-      const { success: canManageAllTeams } = await hasPermission(
+      const { success: isOrgTeamManager } = await hasPermission(
         { team: ["create"] },
         headers,
       );
-      if (!canManageAllTeams) {
-        const isMember = await TeamModel.isUserInTeam(id, user.id);
-        if (!isMember) {
-          throw new ApiError(404, "Team not found");
-        }
+      const canRead = await canReadTeam({
+        isOrgTeamManager,
+        userId: user.id,
+        teamId: id,
+      });
+      if (!canRead) {
+        throw new ApiError(404, "Team not found");
       }
 
       return reply.send(await TeamModel.getTeamMembersWithUsers(id));
@@ -290,9 +294,8 @@ const teamRoutes: FastifyPluginAsyncZod = async (fastify) => {
       { params: { id }, body: { userId, role }, organizationId, user, headers },
       reply,
     ) => {
-      // Verify the team exists and belongs to the user's organization
-      const team = await TeamModel.findById(id);
-      if (!team || team.organizationId !== organizationId) {
+      const team = await getTeamForOrg({ teamId: id, organizationId });
+      if (!team) {
         throw new ApiError(404, "Team not found");
       }
 
@@ -333,8 +336,8 @@ const teamRoutes: FastifyPluginAsyncZod = async (fastify) => {
       { params: { id, userId }, body: { role }, organizationId, user, headers },
       reply,
     ) => {
-      const team = await TeamModel.findById(id);
-      if (!team || team.organizationId !== organizationId) {
+      const team = await getTeamForOrg({ teamId: id, organizationId });
+      if (!team) {
         throw new ApiError(404, "Team not found");
       }
 
@@ -383,9 +386,8 @@ const teamRoutes: FastifyPluginAsyncZod = async (fastify) => {
       { params: { id, userId }, organizationId, user, headers },
       reply,
     ) => {
-      // Verify the team exists and belongs to the user's organization
-      const team = await TeamModel.findById(id);
-      if (!team || team.organizationId !== organizationId) {
+      const team = await getTeamForOrg({ teamId: id, organizationId });
+      if (!team) {
         throw new ApiError(404, "Team not found");
       }
 
@@ -408,20 +410,15 @@ const teamRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(404, "Team member not found");
       }
 
-      const userIsAgentAdmin = await hasAnyAgentTypeAdminPermission({
-        userId: user.id,
-        organizationId,
-      });
-
       // Clean up invalid credential sources (personal tokens) for this user
       // if they no longer have access to agents through other teams
       try {
-        const cleanedCount =
-          await AgentToolModel.cleanupInvalidCredentialSourcesForUser(
-            userId,
-            id,
-            userIsAgentAdmin,
-          );
+        const cleanedCount = await cleanupCredentialSourcesAfterMemberRemoval({
+          actingUserId: user.id,
+          removedUserId: userId,
+          teamId: id,
+          organizationId,
+        });
 
         if (cleanedCount > 0) {
           fastify.log.info(
@@ -650,21 +647,20 @@ async function assertCanManageTeam(params: {
   headers: Parameters<typeof hasPermission>[1];
   action: string;
 }) {
-  const { success: canManageAllTeams } = await hasPermission(
+  // Resolve the org-level "team manager" flag from the request session/API key
+  // (honoring API-key scoping), then defer the shared rule to the service.
+  const { success: isOrgTeamManager } = await hasPermission(
     { team: ["create"] },
     params.headers,
   );
 
-  if (canManageAllTeams) {
-    return;
-  }
+  const allowed = await canManageTeamMembers({
+    isOrgTeamManager,
+    userId: params.userId,
+    teamId: params.teamId,
+  });
 
-  const isTeamAdmin = await TeamModel.isUserTeamAdmin(
-    params.teamId,
-    params.userId,
-  );
-
-  if (!isTeamAdmin) {
+  if (!allowed) {
     throw new ApiError(403, `You must be a team admin to ${params.action}`);
   }
 }
@@ -674,21 +670,12 @@ async function assertNotRemovingLastTeamAdmin(params: {
   userId: string;
   nextRole: "admin" | "member" | null;
 }) {
-  const members = await TeamModel.getTeamMembers(params.teamId);
-  const targetMember = members.find(
-    (member) => member.userId === params.userId,
-  );
-
-  if (!targetMember) {
-    throw new ApiError(404, "Team member not found");
-  }
-
-  if (targetMember.role !== "admin" || params.nextRole === "admin") {
+  const check = await checkLastAdminInvariant(params);
+  if (check.ok) {
     return;
   }
-
-  const adminCount = members.filter((member) => member.role === "admin").length;
-  if (adminCount <= 1) {
-    throw new ApiError(400, "Cannot remove the last admin from a team");
+  if (check.reason === "member_not_found") {
+    throw new ApiError(404, "Team member not found");
   }
+  throw new ApiError(400, "Cannot remove the last admin from a team");
 }

--- a/platform/backend/src/services/team-authorization.test.ts
+++ b/platform/backend/src/services/team-authorization.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, test } from "@/test";
+import {
+  canManageTeamMembers,
+  canReadTeam,
+  checkLastAdminInvariant,
+  cleanupCredentialSourcesAfterMemberRemoval,
+  getTeamForOrg,
+} from "./team-authorization";
+
+describe("team-authorization service", () => {
+  let organizationId: string;
+  let creatorId: string;
+
+  beforeEach(async ({ makeOrganization, makeUser, makeMember }) => {
+    const org = await makeOrganization();
+    organizationId = org.id;
+    const creator = await makeUser();
+    creatorId = creator.id;
+    await makeMember(creator.id, org.id, { role: "admin" });
+  });
+
+  describe("getTeamForOrg", () => {
+    test("returns the team when it belongs to the org", async ({
+      makeTeam,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId, { name: "T" });
+      const result = await getTeamForOrg({ teamId: team.id, organizationId });
+      expect(result?.id).toBe(team.id);
+    });
+
+    test("returns null for a team in another org", async ({
+      makeTeam,
+      makeOrganization,
+      makeUser,
+    }) => {
+      const otherOrg = await makeOrganization();
+      const otherUser = await makeUser();
+      const team = await makeTeam(otherOrg.id, otherUser.id);
+      const result = await getTeamForOrg({ teamId: team.id, organizationId });
+      expect(result).toBeNull();
+    });
+
+    test("returns null for a missing team", async () => {
+      const result = await getTeamForOrg({
+        teamId: crypto.randomUUID(),
+        organizationId,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("canManageTeamMembers", () => {
+    test("an org team manager can manage any team", async ({ makeTeam }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const result = await canManageTeamMembers({
+        isOrgTeamManager: true,
+        userId: creatorId,
+        teamId: team.id,
+      });
+      expect(result).toBe(true);
+    });
+
+    test("a team admin can manage their team", async ({
+      makeTeam,
+      makeUser,
+      makeMember,
+      makeTeamMember,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const user = await makeUser();
+      await makeMember(user.id, organizationId, { role: "member" });
+      await makeTeamMember(team.id, user.id, { role: "admin" });
+      const result = await canManageTeamMembers({
+        isOrgTeamManager: false,
+        userId: user.id,
+        teamId: team.id,
+      });
+      expect(result).toBe(true);
+    });
+
+    test("a plain team member cannot manage the team", async ({
+      makeTeam,
+      makeUser,
+      makeMember,
+      makeTeamMember,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const user = await makeUser();
+      await makeMember(user.id, organizationId, { role: "member" });
+      await makeTeamMember(team.id, user.id, { role: "member" });
+      const result = await canManageTeamMembers({
+        isOrgTeamManager: false,
+        userId: user.id,
+        teamId: team.id,
+      });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("canReadTeam", () => {
+    test("an org team manager can read any team", async ({ makeTeam }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const result = await canReadTeam({
+        isOrgTeamManager: true,
+        userId: creatorId,
+        teamId: team.id,
+      });
+      expect(result).toBe(true);
+    });
+
+    test("a team member can read their team", async ({
+      makeTeam,
+      makeUser,
+      makeMember,
+      makeTeamMember,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const user = await makeUser();
+      await makeMember(user.id, organizationId, { role: "member" });
+      await makeTeamMember(team.id, user.id, { role: "member" });
+      const result = await canReadTeam({
+        isOrgTeamManager: false,
+        userId: user.id,
+        teamId: team.id,
+      });
+      expect(result).toBe(true);
+    });
+
+    test("a non-member cannot read the team", async ({
+      makeTeam,
+      makeUser,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const outsider = await makeUser();
+      const result = await canReadTeam({
+        isOrgTeamManager: false,
+        userId: outsider.id,
+        teamId: team.id,
+      });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("checkLastAdminInvariant", () => {
+    test("member_not_found when the target isn't on the team", async ({
+      makeTeam,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const result = await checkLastAdminInvariant({
+        teamId: team.id,
+        userId: crypto.randomUUID(),
+        nextRole: "member",
+      });
+      expect(result).toEqual({ ok: false, reason: "member_not_found" });
+    });
+
+    test("ok when demoting a non-admin member", async ({
+      makeTeam,
+      makeUser,
+      makeMember,
+      makeTeamMember,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const user = await makeUser();
+      await makeMember(user.id, organizationId, { role: "member" });
+      await makeTeamMember(team.id, user.id, { role: "member" });
+      const result = await checkLastAdminInvariant({
+        teamId: team.id,
+        userId: user.id,
+        nextRole: null,
+      });
+      expect(result).toEqual({ ok: true });
+    });
+
+    test("last_admin when the sole admin would be demoted", async ({
+      makeTeam,
+      makeUser,
+      makeMember,
+      makeTeamMember,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const admin = await makeUser();
+      await makeMember(admin.id, organizationId, { role: "member" });
+      await makeTeamMember(team.id, admin.id, { role: "admin" });
+      const result = await checkLastAdminInvariant({
+        teamId: team.id,
+        userId: admin.id,
+        nextRole: "member",
+      });
+      expect(result).toEqual({ ok: false, reason: "last_admin" });
+    });
+
+    test("ok when another admin remains", async ({
+      makeTeam,
+      makeUser,
+      makeMember,
+      makeTeamMember,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const adminA = await makeUser();
+      const adminB = await makeUser();
+      await makeMember(adminA.id, organizationId, { role: "member" });
+      await makeMember(adminB.id, organizationId, { role: "member" });
+      await makeTeamMember(team.id, adminA.id, { role: "admin" });
+      await makeTeamMember(team.id, adminB.id, { role: "admin" });
+      const result = await checkLastAdminInvariant({
+        teamId: team.id,
+        userId: adminA.id,
+        nextRole: null,
+      });
+      expect(result).toEqual({ ok: true });
+    });
+
+    test("ok when the sole admin keeps the admin role", async ({
+      makeTeam,
+      makeUser,
+      makeMember,
+      makeTeamMember,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const admin = await makeUser();
+      await makeMember(admin.id, organizationId, { role: "member" });
+      await makeTeamMember(team.id, admin.id, { role: "admin" });
+      const result = await checkLastAdminInvariant({
+        teamId: team.id,
+        userId: admin.id,
+        nextRole: "admin",
+      });
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe("cleanupCredentialSourcesAfterMemberRemoval", () => {
+    test("returns 0 when the team has no agents", async ({
+      makeTeam,
+      makeUser,
+      makeMember,
+    }) => {
+      const team = await makeTeam(organizationId, creatorId);
+      const removed = await makeUser();
+      await makeMember(removed.id, organizationId, { role: "member" });
+      const cleaned = await cleanupCredentialSourcesAfterMemberRemoval({
+        actingUserId: creatorId,
+        removedUserId: removed.id,
+        teamId: team.id,
+        organizationId,
+      });
+      expect(cleaned).toBe(0);
+    });
+  });
+});

--- a/platform/backend/src/services/team-authorization.ts
+++ b/platform/backend/src/services/team-authorization.ts
@@ -1,0 +1,128 @@
+import { ADMIN_ROLE_NAME } from "@archestra/shared";
+import { hasAnyAgentTypeAdminPermission } from "@/auth/agent-type-permissions";
+import { AgentToolModel, TeamModel } from "@/models";
+import type { Team } from "@/types";
+import type { TeamMemberRole } from "@/types/team-role";
+
+/**
+ * Shared team authorization + invariant logic, consumed by both the REST
+ * `/api/teams` routes and the Archestra MCP team tools so the two interfaces
+ * enforce identical rules.
+ *
+ * These functions are deliberately interface-agnostic: they take resolved
+ * primitives and return booleans / typed results rather than throwing
+ * `ApiError` or returning an MCP `CallToolResult`. Each caller maps a denial to
+ * its own error shape (REST → `ApiError`, MCP → `errorResult`).
+ *
+ * In particular, "is this caller an org-level team manager?" is NOT resolved
+ * here: the REST routes derive it from `hasPermission(headers)` (which honors
+ * API-key / service-account scoping), while the MCP tools derive it from
+ * `userHasPermission(userId, organizationId, …)`. Callers pass the resolved
+ * `isOrgTeamManager` flag in.
+ */
+
+/**
+ * Fetch a team scoped to an organization. Returns null when the team does not
+ * exist or belongs to a different org, so callers can never read or mutate
+ * teams outside the caller's organization.
+ */
+export async function getTeamForOrg(params: {
+  teamId: string;
+  organizationId: string;
+}): Promise<Team | null> {
+  const team = await TeamModel.findById(params.teamId);
+  if (!team || team.organizationId !== params.organizationId) {
+    return null;
+  }
+  return team;
+}
+
+/**
+ * Whether the caller may manage a team's membership: an org-level team manager
+ * may manage any team; otherwise the caller must be an admin of that specific
+ * team.
+ */
+export async function canManageTeamMembers(params: {
+  isOrgTeamManager: boolean;
+  userId: string;
+  teamId: string;
+}): Promise<boolean> {
+  if (params.isOrgTeamManager) {
+    return true;
+  }
+  return TeamModel.isUserTeamAdmin(params.teamId, params.userId);
+}
+
+/**
+ * Whether the caller may read a team: an org-level team manager sees every
+ * team; otherwise the caller must be a member of the team.
+ */
+export async function canReadTeam(params: {
+  isOrgTeamManager: boolean;
+  userId: string;
+  teamId: string;
+}): Promise<boolean> {
+  if (params.isOrgTeamManager) {
+    return true;
+  }
+  return TeamModel.isUserInTeam(params.teamId, params.userId);
+}
+
+type LastAdminCheck =
+  | { ok: true }
+  | { ok: false; reason: "member_not_found" | "last_admin" };
+
+/**
+ * Enforce that a role change or removal does not strip a team of its final
+ * admin. `nextRole` is the role the member would end up with (`null` when the
+ * member is being removed entirely).
+ */
+export async function checkLastAdminInvariant(params: {
+  teamId: string;
+  userId: string;
+  nextRole: TeamMemberRole | null;
+}): Promise<LastAdminCheck> {
+  const members = await TeamModel.getTeamMembers(params.teamId);
+  const target = members.find((member) => member.userId === params.userId);
+
+  if (!target) {
+    return { ok: false, reason: "member_not_found" };
+  }
+
+  // Only a demotion/removal of a current admin can reduce the admin count.
+  if (target.role !== ADMIN_ROLE_NAME || params.nextRole === ADMIN_ROLE_NAME) {
+    return { ok: true };
+  }
+
+  const adminCount = members.filter(
+    (member) => member.role === ADMIN_ROLE_NAME,
+  ).length;
+  if (adminCount <= 1) {
+    return { ok: false, reason: "last_admin" };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * After removing a user from a team, drop the personal-credential (static MCP
+ * server) assignments they can no longer reach through any team. Returns the
+ * number of assignments cleaned. Callers decide whether to treat a failure as
+ * fatal (both current callers run this best-effort).
+ */
+export async function cleanupCredentialSourcesAfterMemberRemoval(params: {
+  actingUserId: string;
+  removedUserId: string;
+  teamId: string;
+  organizationId: string;
+}): Promise<number> {
+  const actingUserIsAgentAdmin = await hasAnyAgentTypeAdminPermission({
+    userId: params.actingUserId,
+    organizationId: params.organizationId,
+  });
+  return AgentToolModel.cleanupInvalidCredentialSourcesForUser(
+    params.removedUserId,
+    params.teamId,
+    actingUserIsAgentAdmin,
+  );
+}


### PR DESCRIPTION
Stacked on #6116 (base = `feat/team-management-mcp-tools`).

## Why

#6116 added MCP team tools whose authorization rules deliberately mirror the REST `/api/teams` routes (org-scoping, manager-or-team-admin, last-admin protection, credential cleanup). That left the same rules implemented **twice** — once in `routes/team.ts`, once in `archestra-mcp-server/teams.ts` — which can drift. This extracts the shared logic into a service both interfaces call.

## What

New `backend/src/services/team-authorization.ts`:

| Function | Rule |
|----------|------|
| `getTeamForOrg` | org-scoped fetch — returns null for another org (no cross-org IDOR) |
| `canManageTeamMembers` | org-level team manager **or** admin of that specific team |
| `canReadTeam` | org-level team manager **or** member of that team |
| `checkLastAdminInvariant` | refuse to strip a team of its last admin (`{ ok } \| { ok:false, reason }`) |
| `cleanupCredentialSourcesAfterMemberRemoval` | drop now-unreachable personal-credential assignments |

## Design constraints that shaped the interface

1. **Different error models.** REST throws `ApiError`; the MCP path can't (its `catchError` collapses arbitrary throws to a generic "internal error"). So the service returns **booleans / typed results**, and each caller maps a denial to its own shape (`ApiError` vs `errorResult`).
2. **Different auth-context source.** REST resolves the org-level "team manager" flag from `hasPermission(headers)` (which honors **API-key / service-account scoping**); MCP from `userHasPermission(userId, org)`. Baking the manager check into the service would have silently changed REST behavior for scoped API keys — so each interface resolves that flag itself and **passes `isOrgTeamManager` in**.

## Behavior change

None. This is a pure refactor:
- REST `routes/team.ts` — `assertCanManageTeam`, `assertNotRemovingLastTeamAdmin`, the credential cleanup, the org-scoped fetch, and the GET read-scoping now delegate to the service.
- MCP `archestra-mcp-server/teams.ts` — its helper adapters now delegate to the service and only map results to `CallToolResult`.

## Tests

- New `team-authorization.test.ts` — unit tests for every service function (manager/admin/member matrices, last-admin invariant cases, org-scoping, cleanup).
- The existing REST route tests (`team-members.test.ts`, 39) and MCP tool tests (`teams.test.ts`, 34) both still pass unchanged — proving behavior preservation. 108 team-related tests green; `type-check`, `lint`, `knip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>