### PR TITLE
fix(mcp-oauth): editable Additional scopes field (unbreak Google offline_access)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -144182,6 +144182,12 @@
                           "supports_resource_metadata": {
                             "type": "boolean"
                           },
+                          "additional_scopes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
                           "generic_oauth": {
                             "type": "boolean"
                           },
@@ -145077,6 +145083,12 @@
                       "supports_resource_metadata": {
                         "type": "boolean"
                       },
+                      "additional_scopes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
                       "generic_oauth": {
                         "type": "boolean"
                       },
@@ -145642,6 +145654,12 @@
                         },
                         "supports_resource_metadata": {
                           "type": "boolean"
+                        },
+                        "additional_scopes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
                         },
                         "generic_oauth": {
                           "type": "boolean"
@@ -146544,6 +146562,12 @@
                         "supports_resource_metadata": {
                           "type": "boolean"
                         },
+                        "additional_scopes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
                         "generic_oauth": {
                           "type": "boolean"
                         },
@@ -147413,6 +147437,12 @@
                       "supports_resource_metadata": {
                         "type": "boolean"
                       },
+                      "additional_scopes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
                       "generic_oauth": {
                         "type": "boolean"
                       },
@@ -147980,6 +148010,12 @@
                         },
                         "supports_resource_metadata": {
                           "type": "boolean"
+                        },
+                        "additional_scopes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
                         },
                         "generic_oauth": {
                           "type": "boolean"
@@ -150020,6 +150056,12 @@
                           "supports_resource_metadata": {
                             "type": "boolean"
                           },
+                          "additional_scopes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
                           "generic_oauth": {
                             "type": "boolean"
                           },
@@ -150921,6 +150963,12 @@
                         },
                         "supports_resource_metadata": {
                           "type": "boolean"
+                        },
+                        "additional_scopes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
                         },
                         "generic_oauth": {
                           "type": "boolean"
@@ -176757,6 +176805,12 @@
                                   "supports_resource_metadata": {
                                     "type": "boolean"
                                   },
+                                  "additional_scopes": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
                                   "generic_oauth": {
                                     "type": "boolean"
                                   },
@@ -177439,6 +177493,12 @@
                               "supports_resource_metadata": {
                                 "type": "boolean"
                               },
+                              "additional_scopes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
                               "generic_oauth": {
                                 "type": "boolean"
                               },
@@ -177821,6 +177881,12 @@
                                 },
                                 "supports_resource_metadata": {
                                   "type": "boolean"
+                                },
+                                "additional_scopes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "generic_oauth": {
                                   "type": "boolean"
@@ -178534,6 +178600,12 @@
                                 "supports_resource_metadata": {
                                   "type": "boolean"
                                 },
+                                "additional_scopes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
                                 "generic_oauth": {
                                   "type": "boolean"
                                 },
@@ -179219,6 +179291,12 @@
                               "supports_resource_metadata": {
                                 "type": "boolean"
                               },
+                              "additional_scopes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
                               "generic_oauth": {
                                 "type": "boolean"
                               },
@@ -179652,6 +179730,12 @@
                                 },
                                 "supports_resource_metadata": {
                                   "type": "boolean"
+                                },
+                                "additional_scopes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "generic_oauth": {
                                   "type": "boolean"
@@ -180654,6 +180738,12 @@
                                 "supports_resource_metadata": {
                                   "type": "boolean"
                                 },
+                                "additional_scopes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
                                 "generic_oauth": {
                                   "type": "boolean"
                                 },
@@ -181380,6 +181470,12 @@
                                 },
                                 "supports_resource_metadata": {
                                   "type": "boolean"
+                                },
+                                "additional_scopes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "generic_oauth": {
                                   "type": "boolean"
@@ -182111,6 +182207,12 @@
                                 },
                                 "supports_resource_metadata": {
                                   "type": "boolean"
+                                },
+                                "additional_scopes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "generic_oauth": {
                                   "type": "boolean"

--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -285,7 +285,7 @@ For upstream servers that use OAuth, Archestra handles the token lifecycle autom
 
 #### Troubleshooting refresh failures
 
-`no_refresh_token` means the provider issued no refresh token, so the connection breaks once the access token expires. Refresh tokens require the `offline_access` scope; Archestra requests it automatically (Microsoft Entra omits it from its metadata and returns none otherwise). Reconnect to re-authorize — if it persists, grant `offline_access` for the app, which some tenants gate behind admin consent.
+`no_refresh_token` means the provider issued no refresh token, so the connection breaks once its access token expires. The server's **Additional scopes** field (pre-filled with `offline_access`) is appended to every authorization request to ask for one — keep it for Microsoft Entra and other standard OIDC providers, and clear it for providers that reject the scope (e.g. Google, which uses `access_type=offline`). Reconnect after changing it; if it persists, confirm the provider grants offline access to the app, which some tenants gate behind admin consent.
 
 ### Enterprise Identity Credential Resolution
 

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -476,30 +476,50 @@ describe("OAuth helper functions", () => {
       globalThis.fetch = originalFetch;
     });
 
-    test("requests offline_access so the provider issues a refresh token", async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          authorization_endpoint: "https://example.com/authorize",
-          token_endpoint: "https://example.com/token",
-          scopes_supported: ["api://server/access_as_user"],
-        }),
-      }) as Mock;
+    test("omits offline_access when additional_scopes is empty", async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error("Network error"));
+      globalThis.fetch = fetchMock;
+
+      const result = await resolveOAuthScopesForAuthorization({
+        oauthConfig: {
+          server_url: "https://accounts.google.com",
+          supports_resource_metadata: false,
+          scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+          additional_scopes: [],
+        },
+      });
+
+      expect(result.scopesToUse).toEqual([
+        "https://www.googleapis.com/auth/gmail.readonly",
+      ]);
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      globalThis.fetch = originalFetch;
+    });
+
+    test("appends configured additional_scopes verbatim", async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error("Network error"));
+      globalThis.fetch = fetchMock;
 
       const result = await resolveOAuthScopesForAuthorization({
         oauthConfig: {
           server_url: "https://example.com",
           supports_resource_metadata: false,
-          scopes: [],
+          scopes: ["read"],
+          additional_scopes: ["offline_access", "custom:scope"],
         },
       });
 
-      expect(result.scopesToUse).toContain("offline_access");
+      expect(result.scopesToUse).toEqual([
+        "read",
+        "offline_access",
+        "custom:scope",
+      ]);
 
       globalThis.fetch = originalFetch;
     });
 
-    test("does not duplicate offline_access when it is already configured", async () => {
+    test("does not duplicate a scope already present", async () => {
       const fetchMock = vi.fn().mockRejectedValue(new Error("Network error"));
       globalThis.fetch = fetchMock;
 
@@ -512,7 +532,6 @@ describe("OAuth helper functions", () => {
       });
 
       expect(result.scopesToUse).toEqual(["read", "offline_access"]);
-      expect(fetchMock).not.toHaveBeenCalled();
 
       globalThis.fetch = originalFetch;
     });

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -42,6 +42,7 @@ interface OAuthScopeConfig {
   auth_server_url?: string;
   resource_metadata_url?: string;
   well_known_url?: string;
+  additional_scopes?: string[];
 }
 
 /**
@@ -143,12 +144,30 @@ export async function resolveOAuthScopesForAuthorization(params: {
   discoveredScopes: string[];
   scopesToUse: string[];
 }> {
+  // Append the catalog item's additional scopes on top of the configured or
+  // discovered scopes, deduped. Defaults to `["offline_access"]` when unset so
+  // the provider issues a refresh token (`offline_access` is a behavioral scope
+  // that providers like Microsoft Entra omit from metadata and require to be
+  // requested). Clear it for providers that reject it (e.g. Google).
+  const additionalScopes = params.oauthConfig.additional_scopes ?? [
+    OFFLINE_ACCESS_OAUTH_SCOPE,
+  ];
+  const withAdditionalScopes = (scopes: string[]): string[] => {
+    const merged = [...scopes];
+    for (const scope of additionalScopes) {
+      if (!merged.includes(scope)) {
+        merged.push(scope);
+      }
+    }
+    return merged;
+  };
+
   const configuredScopes = params.oauthConfig.scopes ?? [];
   if (configuredScopes.length > 0) {
     return {
       configuredScopes,
       discoveredScopes: [],
-      scopesToUse: withOfflineAccess(configuredScopes),
+      scopesToUse: withAdditionalScopes(configuredScopes),
     };
   }
 
@@ -168,25 +187,8 @@ export async function resolveOAuthScopesForAuthorization(params: {
   return {
     configuredScopes,
     discoveredScopes,
-    scopesToUse: withOfflineAccess(discoveredScopes),
+    scopesToUse: withAdditionalScopes(discoveredScopes),
   };
-}
-
-/**
- * Ensure `offline_access` is in the requested scopes so the token endpoint
- * issues a refresh token. It's a behavioral OIDC scope rather than a resource
- * scope, so providers like Microsoft Entra omit it from `scopes_supported` and
- * only return a refresh token when it's explicitly requested. Without it, a
- * server's access token silently expires with no way to refresh, surfacing
- * later as a `no_refresh_token` error. Requested for every authorization_code
- * flow, mirroring the inbound OAuth provider side (see `mcp-oauth-client.ts`).
- * The configured/discovered scopes are reported unchanged; only the set we
- * actually request is augmented.
- */
-function withOfflineAccess(scopes: string[]): string[] {
-  return scopes.includes(OFFLINE_ACCESS_OAUTH_SCOPE)
-    ? scopes
-    : [...scopes, OFFLINE_ACCESS_OAUTH_SCOPE];
 }
 
 /**

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -285,6 +285,7 @@ export function McpCatalogForm({
                 ? `${window.location.origin}/oauth-callback`
                 : "",
             scopes: "read, write",
+            additional_scopes: "offline_access",
             supports_resource_metadata: true,
             grantType: "authorization_code",
             authServerUrl: "",
@@ -2042,6 +2043,31 @@ export function McpCatalogForm({
                                       </FormControl>
                                       <FormDescription>
                                         Comma-separated list of OAuth scopes.
+                                      </FormDescription>
+                                      <FormMessage />
+                                    </FormItem>
+                                  )}
+                                />
+
+                                <FormField
+                                  control={form.control}
+                                  name="oauthConfig.additional_scopes"
+                                  render={({ field }) => (
+                                    <FormItem>
+                                      <FormLabel>Additional scopes</FormLabel>
+                                      <FormControl>
+                                        <Input
+                                          placeholder="offline_access"
+                                          className="font-mono"
+                                          {...field}
+                                        />
+                                      </FormControl>
+                                      <FormDescription>
+                                        Always appended on top of the requested
+                                        scopes. offline_access is added by
+                                        default so the provider returns a
+                                        refresh token; clear it for providers
+                                        that reject it (e.g. Google).
                                       </FormDescription>
                                       <FormMessage />
                                     </FormItem>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.types.ts
@@ -34,6 +34,7 @@ export const oauthConfigSchema = z
     resource: z.string().optional().or(z.literal("")),
     redirect_uris: z.string().optional().or(z.literal("")),
     scopes: z.string().optional().or(z.literal("")),
+    additional_scopes: z.string().optional().or(z.literal("")),
     supports_resource_metadata: z.boolean(),
     authServerUrl: z
       .string()

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -223,6 +223,52 @@ describe("transformFormToApiData", () => {
     });
   });
 
+  it("parses the additional scopes field into an array", () => {
+    const values: McpCatalogFormValues = {
+      name: "Additional Scopes OAuth MCP",
+      description: "",
+      icon: null,
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com",
+      authMethod: "oauth",
+      includeBearerPrefix: true,
+      authHeaderName: "",
+      additionalHeaders: [],
+      oauthConfig: {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        audience: "",
+        redirect_uris: "https://app.example.com/oauth-callback",
+        scopes: "read",
+        additional_scopes: "offline_access, custom:scope",
+        supports_resource_metadata: false,
+        grantType: "authorization_code",
+        oauthServerUrl: "",
+        authServerUrl: "",
+        authorizationEndpoint: "",
+        wellKnownUrl: "",
+        resourceMetadataUrl: "",
+        tokenEndpoint: "",
+      },
+      enterpriseManagedConfig: null,
+      localConfig: undefined,
+      deploymentSpecYaml: "",
+      originalDeploymentSpecYaml: "",
+      oauthClientSecretVaultPath: "",
+      oauthClientSecretVaultKey: "",
+      localConfigVaultPath: "",
+      localConfigVaultKey: "",
+      labels: [],
+      scope: "personal",
+      teams: [],
+    };
+
+    expect(transformFormToApiData(values).oauthConfig).toMatchObject({
+      scopes: ["read"],
+      additional_scopes: ["offline_access", "custom:scope"],
+    });
+  });
+
   it("treats comma-only scopes input as blank (persists empty scopes with read/write fallback)", () => {
     const values: McpCatalogFormValues = {
       name: "Comma Scope OAuth MCP",

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -91,6 +91,10 @@ export function transformFormToApiData(
       .map((scope) => scope.trim())
       .filter((scope) => scope.length > 0);
     const scopesList = parsedScopes;
+    const additionalScopesList = (values.oauthConfig.additional_scopes ?? "")
+      .split(",")
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0);
 
     // For local servers, use oauthServerUrl; for remote servers, use serverUrl
     const oauthServerUrl =
@@ -141,6 +145,7 @@ export function transformFormToApiData(
             ? []
             : ["read", "write"],
       supports_resource_metadata: values.oauthConfig.supports_resource_metadata,
+      additional_scopes: isClientCredentials ? undefined : additionalScopesList,
     };
 
     // BYOS: Include OAuth client secret vault path and key if set
@@ -320,6 +325,7 @@ export function transformCatalogItemToFormValues(
         resource: string;
         redirect_uris: string;
         scopes: string;
+        additional_scopes: string;
         supports_resource_metadata: boolean;
         grantType: "authorization_code" | "client_credentials";
         authServerUrl?: string;
@@ -344,6 +350,12 @@ export function transformCatalogItemToFormValues(
       resource: item.oauthConfig.resource || "",
       redirect_uris: item.oauthConfig.redirect_uris?.join(", ") || "",
       scopes: item.oauthConfig.scopes?.join(", ") || "",
+      // Undefined means the item predates this field, so show the default
+      // offline_access; an explicit empty array means the user cleared it.
+      additional_scopes:
+        item.oauthConfig.additional_scopes !== undefined
+          ? item.oauthConfig.additional_scopes.join(", ")
+          : "offline_access",
       supports_resource_metadata:
         item.oauthConfig.supports_resource_metadata ?? true,
       grantType: item.oauthConfig.grant_type ?? "authorization_code",
@@ -585,6 +597,9 @@ export function transformExternalCatalogToFormValues(
           ? `${window.location.origin}/oauth-callback`
           : ""),
       scopes: server.oauth_config.scopes?.join(", ") ?? "",
+      // The external catalog manifest does not carry additional_scopes, so
+      // start from the default that requests a refresh token.
+      additional_scopes: "offline_access",
       supports_resource_metadata:
         server.oauth_config.supports_resource_metadata ?? true,
       grantType:
@@ -762,6 +777,7 @@ export function transformExternalCatalogToFormValues(
           ? `${window.location.origin}/oauth-callback`
           : "",
       scopes: "read, write",
+      additional_scopes: "offline_access",
       supports_resource_metadata: true,
       grantType: "authorization_code",
       authServerUrl: "",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -37704,6 +37704,7 @@ export type GetInternalMcpCatalogResponses = {
             well_known_url?: string;
             default_scopes: Array<string>;
             supports_resource_metadata: boolean;
+            additional_scopes?: Array<string>;
             generic_oauth?: boolean;
             token_endpoint?: string;
             access_token_env_var?: string;
@@ -37844,6 +37845,7 @@ export type CreateInternalMcpCatalogItemData = {
             well_known_url?: string;
             default_scopes: Array<string>;
             supports_resource_metadata: boolean;
+            additional_scopes?: Array<string>;
             generic_oauth?: boolean;
             token_endpoint?: string;
             access_token_env_var?: string;
@@ -38041,6 +38043,7 @@ export type CreateInternalMcpCatalogItemResponses = {
             well_known_url?: string;
             default_scopes: Array<string>;
             supports_resource_metadata: boolean;
+            additional_scopes?: Array<string>;
             generic_oauth?: boolean;
             token_endpoint?: string;
             access_token_env_var?: string;
@@ -38339,6 +38342,7 @@ export type GetInternalMcpCatalogItemResponses = {
             well_known_url?: string;
             default_scopes: Array<string>;
             supports_resource_metadata: boolean;
+            additional_scopes?: Array<string>;
             generic_oauth?: boolean;
             token_endpoint?: string;
             access_token_env_var?: string;
@@ -38473,6 +38477,7 @@ export type UpdateInternalMcpCatalogItemData = {
             well_known_url?: string;
             default_scopes: Array<string>;
             supports_resource_metadata: boolean;
+            additional_scopes?: Array<string>;
             generic_oauth?: boolean;
             token_endpoint?: string;
             access_token_env_var?: string;
@@ -38671,6 +38676,7 @@ export type UpdateInternalMcpCatalogItemResponses = {
             well_known_url?: string;
             default_scopes: Array<string>;
             supports_resource_metadata: boolean;
+            additional_scopes?: Array<string>;
             generic_oauth?: boolean;
             token_endpoint?: string;
             access_token_env_var?: string;
@@ -39148,6 +39154,7 @@ export type ListPendingImageApprovalCatalogItemsResponses = {
             well_known_url?: string;
             default_scopes: Array<string>;
             supports_resource_metadata: boolean;
+            additional_scopes?: Array<string>;
             generic_oauth?: boolean;
             token_endpoint?: string;
             access_token_env_var?: string;
@@ -39361,6 +39368,7 @@ export type ApproveCatalogItemImageResponses = {
             well_known_url?: string;
             default_scopes: Array<string>;
             supports_resource_metadata: boolean;
+            additional_scopes?: Array<string>;
             generic_oauth?: boolean;
             token_endpoint?: string;
             access_token_env_var?: string;
@@ -45904,6 +45912,7 @@ export type GetMcpServerInstallationRequestsResponses = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;
@@ -46004,6 +46013,7 @@ export type CreateMcpServerInstallationRequestData = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;
@@ -46164,6 +46174,7 @@ export type CreateMcpServerInstallationRequestResponses = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;
@@ -46429,6 +46440,7 @@ export type GetMcpServerInstallationRequestResponses = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;
@@ -46529,6 +46541,7 @@ export type UpdateMcpServerInstallationRequestData = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;
@@ -46701,6 +46714,7 @@ export type UpdateMcpServerInstallationRequestResponses = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;
@@ -46883,6 +46897,7 @@ export type ApproveMcpServerInstallationRequestResponses = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;
@@ -47065,6 +47080,7 @@ export type DeclineMcpServerInstallationRequestResponses = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;
@@ -47247,6 +47263,7 @@ export type AddMcpServerInstallationRequestNoteResponses = {
                 well_known_url?: string;
                 default_scopes: Array<string>;
                 supports_resource_metadata: boolean;
+                additional_scopes?: Array<string>;
                 generic_oauth?: boolean;
                 token_endpoint?: string;
                 access_token_env_var?: string;

--- a/platform/shared/mcp-server-config.ts
+++ b/platform/shared/mcp-server-config.ts
@@ -18,6 +18,11 @@ export const OAuthConfigSchema = z
     well_known_url: z.string().optional(),
     default_scopes: z.array(z.string()),
     supports_resource_metadata: z.boolean(),
+    // Extra scopes always appended to the requested scopes on the
+    // authorization_code flow, on top of configured/discovered scopes. Defaults
+    // to `["offline_access"]` when unset so the provider returns a refresh
+    // token; clear it for providers that reject `offline_access` (e.g. Google).
+    additional_scopes: z.array(z.string()).optional(),
     generic_oauth: z.boolean().optional(),
     token_endpoint: z.string().optional(),
     access_token_env_var: z


### PR DESCRIPTION
## Why

PR #6066 was squash-merged early, landing only the first version of that change: the outbound MCP OAuth flow **unconditionally** appended `offline_access` to every authorization request. Google rejects `offline_access` with `Error 400: invalid_scope`, so this breaks every Google-backed server (Gmail, Drive, Calendar) on `main` right now. The follow-up commits that fixed this never made it into #6066 (pushed after the merge).

This PR lands the corrected design on top of current `main`.

## What

Replace the unconditional append with an explicit **Additional scopes** field on the catalog item. These scopes are appended (deduped) on top of the configured or discovered scopes at authorization time. The field defaults to `[offline_access]` when unset, so standard OIDC providers (e.g. Microsoft Entra) still receive a refresh token, while admins **clear it** for providers that reject the scope (e.g. Google, which grants refresh tokens via `access_type=offline` instead).

`offline_access` is just a scope, so this keeps the mechanism generic — no provider host-detection in the backend, and it stays separate from the main **Scopes** field so discovery still works.

- **shared**: `OAuthConfigSchema.additional_scopes` (optional `string[]`)
- **backend**: `resolveOAuthScopesForAuthorization` appends `additional_scopes` (default `[offline_access]`), deduped
- **frontend**: "Additional scopes" text field in the catalog OAuth form, pre-filled with `offline_access`, parsed to an array
- **docs**: `no_refresh_token` troubleshooting points at the field
- regenerated `docs/openapi.json` + the generated API client

## Existing servers

Legacy catalog items have no `additional_scopes`, so the backend defaults to `[offline_access]` — reconnecting a broken Entra server fixes it with no edit. For Google servers, clear the field and reconnect.

## Tests

- backend `oauth.test.ts`: append / empty / custom / dedup cases (68 pass)
- frontend `mcp-catalog-form.utils.test.ts`: field parses to array (28 pass)
- type-check, lint, knip green on backend + frontend; generated diffs are additions-only

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>