### PR TITLE
fix(bench): write trajectory records atomically to prevent interleaving

### DIFF
--- a/archestra-bench/runner/src/run.rs
+++ b/archestra-bench/runner/src/run.rs
@@ -2394,13 +2394,19 @@ impl RunArtifacts {
         } else {
             record.insert("data".to_string(), data);
         }
-        let line = match serde_json::to_string(&serde_json::Value::Object(record)) {
+        let mut line = match serde_json::to_string(&serde_json::Value::Object(record)) {
             Ok(l) => l,
             Err(e) => {
                 error!("failed to serialize trajectory record: {e}");
                 return;
             }
         };
+        // Emit the record and its terminator as one buffer: a `tokio::fs::File`'s writes are
+        // backgrounded and its `write_all` does not guarantee the bytes reached the kernel before
+        // the next append runs, so a record and a separate newline write could interleave with the
+        // following record under `O_APPEND`. One atomic write plus an explicit flush (both still
+        // under the `sequence` lock) keeps every record on its own line.
+        line.push('\n');
         if let Err(e) = async {
             let mut f: tokio::fs::File = fs::OpenOptions::new()
                 .create(true)
@@ -2408,7 +2414,7 @@ impl RunArtifacts {
                 .open(self.path.join("trajectory.jsonl"))
                 .await?;
             f.write_all(line.as_bytes()).await?;
-            f.write_all(b"\n").await?;
+            f.flush().await?;
             Ok::<(), std::io::Error>(())
         }
         .await


### PR DESCRIPTION
## Problem

The analyzer aborts on `malformed trajectory record: trailing characters` when a `trajectory.jsonl` contains two JSON records concatenated on one physical line (with a trailing blank line). Sequence numbers are unique and contiguous, so a single writer produced it — a write race, not two colliding writers.

## Root cause

`RunArtifacts::append` wrote each record as **two** separate `write_all` calls (record body, then `\n`) to a freshly-opened `tokio::fs::File`, with no flush. tokio file writes are backgrounded: `write_all().await` does not guarantee the bytes reached the kernel before the next append runs, and the `sequence` mutex serializes scheduling but not completion. Under `O_APPEND`, a record's newline write could lose the race with the next record's body write, gluing two records together.

## Fix

Append the record and its newline as one buffer in a single `write_all`, then `flush()` before releasing the lock. Each record is now one atomic `O_APPEND` write, so records can never split or concatenate.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>