### PR TITLE
feat(agents): file-handling guidance in the agent system prompt (+ bench task)

### DIFF
--- a/archestra-bench/README.md
+++ b/archestra-bench/README.md
@@ -111,6 +111,7 @@ Which Archestra capability each task is built to exercise. A task usually leans 
 | `review-file-upload-persistence` | basic | ✓ | ✓ | | | | | red-herring | |
 | `solidarity-tax-usd` | basic | ✓ | | | | | ✓ | | |
 | `ib-deck-qc` | basic | ✓ | ✓ | | | | | red-herring | persist |
+| `expense-report-continue` | basic | ✓ | ✓ | ✓ | | | | | persist |
 | `author-skill` | archestra-api | ✓ | | | author | | | | state |
 | `letter-count` | archestra-api | | | | | | | | state |
 | `author-aec-normalizer-skill` | archestra-api | ✓ | ✓ | | author | | | | state |
@@ -136,7 +137,8 @@ Which Archestra capability each task is built to exercise. A task usually leans 
 - **State/persist** — marked only where introspecting/mutating Archestra's own state is the task's
   *headline* point. `state`: the answer itself comes from what the agent *did* to Archestra, graded via
   the `[state].rest` backend snapshot (`author-skill`, `letter-count`); `persist`: a file carried across
-  a `new_conversation` boundary via persistent storage (`purchase-ledger`, `ib-deck-qc`).
+  a `new_conversation` boundary via persistent storage (`purchase-ledger`, `ib-deck-qc`,
+  `expense-report-continue`).
   (`decode-cipher`/`xlsx-live-formulas` also
   snapshot `[state].rest`, but only to enforce skill use — counted under Skills, not here.)
 

--- a/archestra-bench/envs/basic.toml
+++ b/archestra-bench/envs/basic.toml
@@ -1,6 +1,6 @@
 id = "basic"
 name = "Basic"
-tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "github-stars", "lena-png-size", "sqlite-orders", "cv-shortlist", "invoice-approval", "ai-sre-fk-drain", "ai-sre-cache-treadmill", "decode-cipher", "xlsx-live-formulas", "purchase-ledger", "aec-material-json-takeoff", "renewal-churn-risk", "pcap-soc-triage", "xlsx-comment-injection", "it-license-rollup", "it-audit-resist-injection", "access-request-intake", "review-run-command-persistence", "review-file-upload-persistence", "solidarity-tax-usd", "ib-deck-qc"]
+tasks = ["pi-gif-zip", "crypto-price", "median-salary", "nitpicker-version", "github-stars", "lena-png-size", "sqlite-orders", "cv-shortlist", "invoice-approval", "ai-sre-fk-drain", "ai-sre-cache-treadmill", "decode-cipher", "xlsx-live-formulas", "purchase-ledger", "aec-material-json-takeoff", "renewal-churn-risk", "pcap-soc-triage", "xlsx-comment-injection", "it-license-rollup", "it-audit-resist-injection", "access-request-intake", "review-run-command-persistence", "review-file-upload-persistence", "solidarity-tax-usd", "ib-deck-qc", "expense-report-continue"]
 
 # Starts the harness-owned `acme_it` synthetic MCP (fixed, controlled content) and registers it to every
 # lane's agent. It serves stateless data, so one shared instance is safe across concurrent lanes -- the

--- a/archestra-bench/tasks/expense-report-continue/build_fixtures.py
+++ b/archestra-bench/tasks/expense-report-continue/build_fixtures.py
@@ -1,0 +1,151 @@
+"""Regenerate the two vendor-statement PDFs (staged to the agent) and the verifier-only
+`expected/report.json` from one data source, so the PDF contents and the ground truth can never drift.
+
+Not staged to the agent (only files named in a `[[stages.files]]` block are). Run with a Python that
+has reportlab installed:
+
+    python build_fixtures.py
+
+The line items are deliberately small and the amounts distinct so the verifier can match each row by
+(date, category, amount) without depending on how the model lays the workbook out.
+"""
+
+import json
+from pathlib import Path
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import LETTER
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+HERE = Path(__file__).resolve().parent
+INPUTS = HERE / "inputs"
+EXPECTED = HERE / "expected"
+
+# Reimbursable categories (used to derive the stage-2 ground truth).
+REIMBURSABLE_CATEGORIES = {"Travel", "Meals"}
+
+# Two corporate-card statements. Categories are mixed across both cards on purpose, so no vendor,
+# card, or category alignment lets a model shortcut the per-row reimbursable classification. Each line
+# item: (date, merchant, description, category, amount). All (date, category, amount) keys are unique.
+STATEMENTS = [
+    {
+        "cardholder": "Dana Rivera",
+        "card_last4": "4471",
+        "period": "March 2026",
+        "pdf": "card-statement-4471-march.pdf",
+        "items": [
+            ("2026-03-02", "Quill & Co", "Printer paper and toner", "Office Supplies", 62.10),
+            ("2026-03-05", "Redline Rail", "Train fare to client site", "Travel", 88.00),
+            ("2026-03-09", "The Copper Kettle", "Lunch with client", "Meals", 45.30),
+            ("2026-03-14", "Summit Software", "Design tool seat (monthly)", "Software", 120.00),
+        ],
+    },
+    {
+        "cardholder": "Miguel Santos",
+        "card_last4": "8820",
+        "period": "March 2026",
+        "pdf": "card-statement-8820-march.pdf",
+        "items": [
+            ("2026-03-06", "Metro Cab", "Taxi to airport", "Travel", 27.50),
+            ("2026-03-12", "Deskworks", "Ergonomic chair", "Office Supplies", 149.99),
+            ("2026-03-18", "Brightline Bistro", "Team dinner", "Meals", 76.40),
+            ("2026-03-27", "Cloudstore", "Cloud storage (monthly)", "Software", 30.00),
+        ],
+    },
+]
+
+
+def build_pdf(statement: dict) -> None:
+    styles = getSampleStyleSheet()
+    doc = SimpleDocTemplate(
+        str(INPUTS / statement["pdf"]),
+        pagesize=LETTER,
+        title=f"Corporate Card Statement — card ending {statement['card_last4']}",
+    )
+    flow = [
+        Paragraph("Corporate Card Statement", styles["Title"]),
+        Paragraph(
+            f"Card ending {statement['card_last4']} — {statement['cardholder']} — {statement['period']}",
+            styles["Heading2"],
+        ),
+        Spacer(1, 0.25 * inch),
+        Paragraph(
+            "Transactions posted this period are listed below. All amounts are in USD.",
+            styles["Normal"],
+        ),
+        Spacer(1, 0.2 * inch),
+    ]
+
+    rows = [["Date", "Merchant", "Description", "Category", "Amount (USD)"]]
+    for date, merchant, desc, category, amount in statement["items"]:
+        rows.append([date, merchant, desc, category, f"{amount:.2f}"])
+    total = sum(item[4] for item in statement["items"])
+    rows.append(["", "", "", "Total", f"{total:.2f}"])
+
+    table = Table(
+        rows,
+        colWidths=[0.9 * inch, 1.5 * inch, 2.0 * inch, 1.4 * inch, 1.1 * inch],
+    )
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1f3b57")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("ALIGN", (4, 0), (4, -1), "RIGHT"),
+                ("GRID", (0, 0), (-1, -2), 0.5, colors.grey),
+                ("LINEABOVE", (0, -1), (-1, -1), 1, colors.black),
+                ("FONTNAME", (3, -1), (4, -1), "Helvetica-Bold"),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -2), [colors.white, colors.HexColor("#eef2f6")]),
+            ]
+        )
+    )
+    flow.append(table)
+    doc.build(flow)
+
+
+def build_expected() -> dict:
+    line_items = []
+    category_totals: dict[str, float] = {}
+    for statement in STATEMENTS:
+        for date, merchant, desc, category, amount in statement["items"]:
+            reimbursable = category in REIMBURSABLE_CATEGORIES
+            line_items.append(
+                {
+                    "date": date,
+                    "vendor": merchant,
+                    "description": desc,
+                    "category": category,
+                    "amount": round(amount, 2),
+                    "reimbursable": reimbursable,
+                }
+            )
+            category_totals[category] = round(category_totals.get(category, 0.0) + amount, 2)
+
+    reimbursable_total = round(
+        sum(i["amount"] for i in line_items if i["reimbursable"]), 2
+    )
+    return {
+        "line_items": line_items,
+        "category_totals": category_totals,
+        "reimbursable_total": reimbursable_total,
+    }
+
+
+def main() -> None:
+    INPUTS.mkdir(parents=True, exist_ok=True)
+    EXPECTED.mkdir(parents=True, exist_ok=True)
+    for statement in STATEMENTS:
+        build_pdf(statement)
+    expected = build_expected()
+    (EXPECTED / "report.json").write_text(json.dumps(expected, indent=2) + "\n")
+    print("wrote", [s["pdf"] for s in STATEMENTS], "and expected/report.json")
+    print(json.dumps(expected, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/archestra-bench/tasks/expense-report-continue/expected/report.json
+++ b/archestra-bench/tasks/expense-report-continue/expected/report.json
@@ -1,0 +1,75 @@
+{
+  "line_items": [
+    {
+      "date": "2026-03-02",
+      "vendor": "Quill & Co",
+      "description": "Printer paper and toner",
+      "category": "Office Supplies",
+      "amount": 62.1,
+      "reimbursable": false
+    },
+    {
+      "date": "2026-03-05",
+      "vendor": "Redline Rail",
+      "description": "Train fare to client site",
+      "category": "Travel",
+      "amount": 88.0,
+      "reimbursable": true
+    },
+    {
+      "date": "2026-03-09",
+      "vendor": "The Copper Kettle",
+      "description": "Lunch with client",
+      "category": "Meals",
+      "amount": 45.3,
+      "reimbursable": true
+    },
+    {
+      "date": "2026-03-14",
+      "vendor": "Summit Software",
+      "description": "Design tool seat (monthly)",
+      "category": "Software",
+      "amount": 120.0,
+      "reimbursable": false
+    },
+    {
+      "date": "2026-03-06",
+      "vendor": "Metro Cab",
+      "description": "Taxi to airport",
+      "category": "Travel",
+      "amount": 27.5,
+      "reimbursable": true
+    },
+    {
+      "date": "2026-03-12",
+      "vendor": "Deskworks",
+      "description": "Ergonomic chair",
+      "category": "Office Supplies",
+      "amount": 149.99,
+      "reimbursable": false
+    },
+    {
+      "date": "2026-03-18",
+      "vendor": "Brightline Bistro",
+      "description": "Team dinner",
+      "category": "Meals",
+      "amount": 76.4,
+      "reimbursable": true
+    },
+    {
+      "date": "2026-03-27",
+      "vendor": "Cloudstore",
+      "description": "Cloud storage (monthly)",
+      "category": "Software",
+      "amount": 30.0,
+      "reimbursable": false
+    }
+  ],
+  "category_totals": {
+    "Office Supplies": 212.09,
+    "Travel": 115.5,
+    "Meals": 121.7,
+    "Software": 150.0
+  },
+  "reimbursable_total": 237.2
+}

--- a/archestra-bench/tasks/expense-report-continue/inputs/card-statement-4471-march.pdf
+++ b/archestra-bench/tasks/expense-report-continue/inputs/card-statement-4471-march.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260701155528+01'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260701155528+01'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Corporate Card Statement \204 card ending 4471) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1017
+>>
+stream
+Gat%!9lo#B&A@Zcp=(7RM(6V6[Z;lESS=:%"7@`W'a,rF%r.RfrV'UNZEX^Z><K^HlKr?DmZYV?ikqeRFTV%UK(klS0FlJGQllI)#P]-1ISH1sq>n[!,8bj9o&[IiL9WWM`[$q*!t/o\c>='2Ag@d1/k6kJcEmG1jf6fa=8<&$-(9Zcb8Z7D+M*9=*ZXp(_P^anr5T^D`?_ZF9WQE[\hWFZK^]jAF7-q4V$`ON<TgB*4K<eB#>VgGlFC)L(YB'I]j-TJ`Tt+>_mHGElHM0.<Ec>DBsP*r6WTFt"6JC4X`K\C5iinn;n7DC3'._^O(2!XG"g)R=u@c,==qU-]o3PK=n0^+hi)m"<D=<C1Dp8Q*qOaiLaO&2V<*in!#g@n,meNW!T:]H>>/TM#70R`FV9#o"!eR(jnL3W:YUgl+&=j0s-_5t_[.i9EsU*oa$t46,9`:p5goo%Z.$l+`2B!VTcQ)V7%I?47l!:g6Pm=9kN6/"Hl_ToIR_Y'qd#Nf^((l?,T`9?_"X*&i-C1]GeWEqF;8I82aSJF@8g=Nhbij&ne(F&qfFZn_07TZ`ooMRpY;R@cJbEmd@aC%GF%NAX;*AYgNIA`)HOnr+Z?nKk_KWQ%sSa43FVP@;M(]mWj<;;%_L5[fVBFOb/@e#*?7j2*lkBGQ=U89//uW.Qm"oKFO.4qH=2qkV1SsQTn=m"n$<Em=?:9*a1$&3YQOa%b;(+e\#/G"*f_\`.8Qhr4.]pr?-K'EnR(GBOCC\l6&&Y:(c!h_cs^"r,V^UHZ>Fm(l&>.R&U8-:0#]PW0bdgE;jLs.\W;77:>-Yec%_uT$0`&i[p[5?a?Zf44s\VCCJL,m`R4FPP@?,!XAjg=X:)4_*a[Bk>IV:O^>S`s6=uI9P/68[nhVo7WP)1BpWBpf%'/+>EF3s)#M:6'jhTWLEMM33n]GRYBJs20BGrOmN>HMs`f"HrQ(ls:[b;1Yc^PY^[S%ZWbB2m7!OHuhc(HuN;Z6U7?EpA-Dd)^24YZ[6[DY!l~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000582 00000 n 
+0000000895 00000 n 
+0000000954 00000 n 
+trailer
+<<
+/ID 
+[<f1f191f1749fbb6783b1e1f0d980b5a3><f1f191f1749fbb6783b1e1f0d980b5a3>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2062
+%%EOF

--- a/archestra-bench/tasks/expense-report-continue/inputs/card-statement-8820-march.pdf
+++ b/archestra-bench/tasks/expense-report-continue/inputs/card-statement-8820-march.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260701155528+01'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260701155528+01'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Corporate Card Statement \204 card ending 8820) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 995
+>>
+stream
+Gat%!;01GF%"@A@k`PSAT'Z[$H#.3(]A9u&8+tLM(C[*6@V3Kgrqjfo',!oX)a6M7I?O7pZH[pZ@b'os#ImFbdq8lD6a?_.Oq<dpn;p=m9peF?&k'qUN&k/,lumtuXGqls3C_uCUl3+#Mo"&)`)<6g=i5?!m+tiEC7$N`L1Q3NY)DiXOr$ZliMHk#r?$%PEtJA=6Wc(*/r+/KR4d')YluR:KdY.j=JX]Hc=!W/dN#nlg!pQljeBl\@Lds23Ljlq(s@liR:2(hQ!%+XBjt(^:oc?/`<#\p;!Kp&]+egn;mQ[>2.UEtIb'p4,B0,`TQ5*)b!T`7$i%9F-_pJm7`9SlZNt\0)A&Mu@@YS1%"nj:L]S\baB0]-O2<nR$"5B@`#_LcI5fapat4-[km';,"8;g/LG@oc-c1\J&L0I\E#/Fc^d&;5XQH!>Hn%8pWm`$jZ#C/@hW%"IC>"/+'LR5s6K=T7e(jYZ/<VCE]frN6\p#1/N".g3U$&raf%B`?d#c9n_"9eb[Mf6mRc4<0?$0D`'Bho'KJnjG$fskWL'BS9N0*edKeBLD"8k:$hI@5l-\^!!9&7<*W)m8U`l"h63ZI!1,iOoq8Om;\0-^W+g*=W4#VhCZ<kZ3bqg')(k-5G?CC69'/&4GAm2.SHnU7`8<uRCFrB<mI^`K0T#`i.2(<.V[LF@ni:Jm-Ko[l6pDKfZX()lW1>-V[uWqT)laoUtV6BBRek_3'j+M#(3*Z57s%^qFR4`3A#iT@E:bT,5idb'*Q>a+H)_4fC[it9F.;=:aahD+jldJGQ@VL2<0gGCHE31tp7&#k0i%HV/jT>J<^oPX8!=SL7.C@H3<dAmX."!Y@@k?a1PpjJRgTjt?8E;omt$_$"UI4fPi*BP.2fim91T4r!EfHMre^mCoqUY'8M3GGiK2HkJr)D-i+(12qgMdie'@C'Gq[2ZE-2\n'TVLZ'gHL\q(\bELD:lF10hp#7Res,Ge8KOo9PJ7]R/BR~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000582 00000 n 
+0000000895 00000 n 
+0000000954 00000 n 
+trailer
+<<
+/ID 
+[<fd9a9f5ccb8ef94b70a112f49f0fe5df><fd9a9f5ccb8ef94b70a112f49f0fe5df>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2039
+%%EOF

--- a/archestra-bench/tasks/expense-report-continue/notes.md
+++ b/archestra-bench/tasks/expense-report-continue/notes.md
@@ -1,0 +1,38 @@
+# expense-report-continue (cross-conversation "pull up my report")
+
+Tests whether an agent can find and keep working on a file the user produced in an **earlier chat** —
+the read-side "take my report" behavior, where the referenced file lives in the user's persistent
+files, not in the (empty) sandbox of the new conversation.
+
+## Shape
+
+- **Stage 1 (chat 1):** two March corporate-card statements are attached as PDFs. The user asks for a
+  single Excel expense report (one row per transaction) and to "save it so I can pick it back up
+  later." Persisting it to the user's files — not just leaving it in the sandbox — is left for the
+  agent to work out; the prompt never names `save_file`/`download_file`/`search_files`.
+- **Stage 2 (chat 2, `new_conversation = true`):** a fresh conversation with an empty sandbox and no
+  attachments. The user asks to pull the report back up and extend it (a `reimbursable` column for
+  Travel/Meals, plus a per-category totals sheet), then export it.
+
+## Why the oracle is genuine, not a proxy
+
+The eight March transactions exist **only** inside the report saved in stage 1 — the PDFs are gone in
+stage 2 and the new sandbox starts empty. So a final workbook that reproduces those transactions can
+only have come from discovering the saved report (via `search_files`) and reopening it. The
+verifier's line-item fidelity check is therefore the real gate on the cross-conversation behavior, and
+a model that regenerates from scratch or fails to find the report cannot pass it. The per-lane project
+is what persists the file across the two conversations (see `envs/basic.toml` / `runner/src/run.rs`).
+
+## Grading (`verifier.py`, openpyxl)
+
+Against the never-staged `expected/report.json`:
+1. **Line items recovered + extended** — all eight transactions present (matched on the unique
+   `(category, amount)` pair, so column order / date format don't matter), each with the correct
+   vendor and a correct `reimbursable` flag, and no extra rows (a leaked subtotal row fails).
+2. **Second sheet** with the per-category totals is present.
+3. **Submitted totals** — `category_totals` and `reimbursable_total` from `submit_result` match.
+
+`build_fixtures.py` (task root, never staged) regenerates the two PDFs and `expected/report.json` from
+one data source so they can't drift; run it with a Python that has `reportlab` installed. Categories
+are mixed across both cards on purpose so no vendor/card/category alignment lets a model shortcut the
+per-row reimbursable classification.

--- a/archestra-bench/tasks/expense-report-continue/task.toml
+++ b/archestra-bench/tasks/expense-report-continue/task.toml
@@ -1,0 +1,63 @@
+# The exported .xlsx from the FINAL stage is graded; `report` names it in submit_result.
+artifact_key = "report"
+
+# Stage 1 (chat 1): two PDF card statements are attached; the user asks for an Excel report and to
+# save it for later. Persisting it to the user's files (not just the sandbox) is left for the agent to
+# work out -- the next stage runs in a fresh conversation and can only reach it through persistent
+# storage.
+[[stages]]
+text = """Hey -- I've attached our two March corporate card statements (cards 4471 and 8820). Can you pull every transaction off them into a single Excel expense report for me? One row per transaction, with the date, the merchant, a short description, the category, and the amount. Save it as an .xlsx so I can pick it back up later -- no need to total anything yet."""
+
+  [[stages.files]]
+  src = "card-statement-4471-march.pdf"
+  dest = "/home/sandbox/attachments/card-statement-4471-march.pdf"
+  mime_type = "application/pdf"
+
+  [[stages.files]]
+  src = "card-statement-8820-march.pdf"
+  dest = "/home/sandbox/attachments/card-statement-8820-march.pdf"
+  mime_type = "application/pdf"
+
+# Stage 2 (chat 2): a brand-new conversation with an empty sandbox and no attachments. The March
+# transactions exist only inside the report the agent saved in stage 1, so the agent has to find that
+# report and keep working from it.
+[[stages]]
+new_conversation = true
+text = """Can you pull up my March expense report -- the Excel one you put together from the card statements -- and keep working on it for me? Two things I need:
+
+- add a column that flags whether each expense is reimbursable; treat Travel and Meals as reimbursable and everything else as not, and
+- add a second sheet that totals the amount for each category.
+
+When it's ready, export it with download_file and send it over with submit_result as result = {"report": "<the exported filename>", "category_totals": [{"category": "<name>", "total": <amount>}, ...], "reimbursable_total": <total of the reimbursable expenses>}."""
+
+[result_schema]
+type = "object"
+required = ["report", "category_totals", "reimbursable_total"]
+additionalProperties = false
+
+  [result_schema.properties.report]
+  type = "string"
+  minLength = 1
+
+  [result_schema.properties.reimbursable_total]
+  type = "number"
+  minimum = 0
+
+  [result_schema.properties.category_totals]
+  type = "array"
+  minItems = 1
+
+    [result_schema.properties.category_totals.items]
+    type = "object"
+    required = ["category", "total"]
+    additionalProperties = false
+
+      [result_schema.properties.category_totals.items.properties.category]
+      type = "string"
+      minLength = 1
+
+      [result_schema.properties.category_totals.items.properties.total]
+      type = "number"
+
+[verifier]
+deps = ["openpyxl==3.1.5"]

--- a/archestra-bench/tasks/expense-report-continue/verifier.py
+++ b/archestra-bench/tasks/expense-report-continue/verifier.py
@@ -1,0 +1,191 @@
+"""Grade the continued March expense report.
+
+The march transactions live only in the report the agent saved in the first chat; the second chat runs
+in a fresh conversation with an empty sandbox and no attachments. So a final workbook that reproduces
+those transactions can only have come from finding and reopening that saved report -- there is nowhere
+else the data exists. That makes the line-item fidelity check (below) the real gate on the
+cross-conversation "pull up my report" behavior, not a proxy for it.
+
+Reads BENCH_OUTPUT (the exported .xlsx), BENCH_RESULT (the submitted JSON), and the never-staged
+BENCH_FIXTURES/expected/report.json (the ground-truth line items and totals). Rows are matched on the
+category+amount pair (unique across the eight transactions), so the check does not depend on how the
+agent orders columns or formats dates.
+"""
+
+import io
+import re
+
+import openpyxl
+
+from bench_verifier import output, read_fixture_json, result
+
+MONEY_TOL = 0.01
+
+TRUTHY = {"yes", "y", "true", "t", "reimbursable", "1", "1.0", "✓", "x"}
+FALSY = {"no", "n", "false", "f", "not reimbursable", "non-reimbursable", "0", "0.0", "", "-", "none"}
+
+
+# === helpers ===
+
+def _expected() -> dict:
+    return read_fixture_json("expected", "report.json")
+
+
+def _cents(value) -> int | None:
+    """Amount -> integer cents, tolerant of currency symbols and thousands separators."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return round(float(value) * 100)
+    if isinstance(value, str):
+        cleaned = re.sub(r"[^0-9.\-]", "", value.replace(",", ""))
+        if cleaned in ("", "-", ".", "-."):
+            return None
+        try:
+            return round(float(cleaned) * 100)
+        except ValueError:
+            return None
+    return None
+
+
+def _norm(value) -> str:
+    return re.sub(r"\s+", " ", str(value if value is not None else "")).strip().lower()
+
+
+def _norm_vendor(value) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(value or "").lower().replace("&", "and")).strip()
+
+
+def _parse_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    token = _norm(value)
+    if token in TRUTHY:
+        return True
+    if token in FALSY:
+        return False
+    raise AssertionError(f"reimbursable cell is not a clear yes/no: {value!r}")
+
+
+def _workbook():
+    return openpyxl.load_workbook(io.BytesIO(output().read_bytes()), data_only=True)
+
+
+def _header_map(ws) -> dict[str, int] | None:
+    """Map logical column -> index from a sheet's first row, or None if it isn't the line-item sheet."""
+    header = [_norm(c.value) for c in ws[1]] if ws.max_row else []
+    cols: dict[str, int] = {}
+    for idx, name in enumerate(header):
+        if not name:
+            continue
+        if "date" in name and "date" not in cols:
+            cols["date"] = idx
+        elif ("vendor" in name or "merchant" in name) and "vendor" not in cols:
+            cols["vendor"] = idx
+        elif ("description" in name or "detail" in name or "memo" in name) and "description" not in cols:
+            cols["description"] = idx
+        elif "categ" in name and "category" not in cols:
+            cols["category"] = idx
+        elif ("amount" in name or "cost" in name or "total" in name) and "amount" not in cols:
+            cols["amount"] = idx
+        elif "reimburs" in name and "reimbursable" not in cols:
+            cols["reimbursable"] = idx
+    # The line-item sheet is the one carrying per-transaction detail: a date, an amount, and a
+    # description column. The category-totals sheet (category + total only) won't match.
+    if {"date", "amount", "description"} <= cols.keys():
+        return cols
+    return None
+
+
+def _line_item_sheet(wb):
+    for ws in wb.worksheets:
+        cols = _header_map(ws)
+        if cols is not None:
+            return ws, cols
+    raise AssertionError("no worksheet with date/description/amount headers (the line-item report)")
+
+
+def _data_rows(ws, cols: dict[str, int]) -> list[dict]:
+    rows = []
+    for r in range(2, ws.max_row + 1):
+        values = [c.value for c in ws[r]]
+        amount = _cents(values[cols["amount"]]) if cols["amount"] < len(values) else None
+        category = values[cols["category"]] if cols.get("category", 99) < len(values) else None
+        if amount is None or not _norm(category):
+            continue  # blank row or a subtotal/label row without a real category+amount
+        rows.append(
+            {
+                "category": _norm(category),
+                "cents": amount,
+                "vendor": values[cols["vendor"]] if cols.get("vendor", 99) < len(values) else None,
+                "reimbursable": values[cols["reimbursable"]] if cols.get("reimbursable", 99) < len(values) else None,
+                "row": r,
+            }
+        )
+    return rows
+
+
+# === checks ===
+
+def test_line_items_recovered_and_extended() -> None:
+    """Every March transaction is present (proving the saved report was found and reopened), with the
+    correct vendor and a correct reimbursable flag, and nothing extra."""
+    exp = _expected()["line_items"]
+    ws, cols = _line_item_sheet(_workbook())
+    assert "reimbursable" in cols, "the line-item sheet has no reimbursable column"
+
+    rows = _data_rows(ws, cols)
+    by_key: dict[tuple[str, int], dict] = {}
+    for row in rows:
+        key = (row["category"], row["cents"])
+        assert key not in by_key, f"duplicate transaction row for {key} at row {row['row']}"
+        by_key[key] = row
+
+    expected_keys = {(_norm(i["category"]), round(i["amount"] * 100)) for i in exp}
+    got_keys = set(by_key)
+    assert got_keys == expected_keys, (
+        f"line items {sorted(got_keys)} != expected {sorted(expected_keys)}; "
+        f"missing {sorted(expected_keys - got_keys)}; extra {sorted(got_keys - expected_keys)}"
+    )
+
+    for item in exp:
+        row = by_key[(_norm(item["category"]), round(item["amount"] * 100))]
+        assert _norm_vendor(row["vendor"]) == _norm_vendor(item["vendor"]), (
+            f"row {row['row']} vendor {row['vendor']!r} != expected {item['vendor']!r}"
+        )
+        assert _parse_bool(row["reimbursable"]) == item["reimbursable"], (
+            f"row {row['row']} ({item['category']} {item['amount']}) reimbursable "
+            f"{row['reimbursable']!r} != expected {item['reimbursable']}"
+        )
+
+
+def test_category_totals_sheet_present() -> None:
+    """A second sheet lists per-category totals (numeric correctness is graded via submit_result)."""
+    wb = _workbook()
+    line_ws, _ = _line_item_sheet(wb)
+    others = [ws for ws in wb.worksheets if ws.title != line_ws.title]
+    assert others, "expected a second worksheet with per-category totals"
+
+    expected_categories = {_norm(c) for c in _expected()["category_totals"]}
+    for ws in others:
+        seen = {_norm(cell.value) for row in ws.iter_rows() for cell in row if cell.value is not None}
+        if expected_categories <= seen:
+            return
+    raise AssertionError(
+        f"no second sheet lists all categories {sorted(expected_categories)}"
+    )
+
+
+def test_submitted_totals() -> None:
+    exp = _expected()
+    submitted = result()["category_totals"]
+    got = {_norm(item["category"]): float(item["total"]) for item in submitted}
+    want = {_norm(k): v for k, v in exp["category_totals"].items()}
+    assert set(got) == set(want), f"submitted categories {sorted(got)} != expected {sorted(want)}"
+    for cat, total in want.items():
+        assert abs(got[cat] - total) <= MONEY_TOL, f"category {cat} total {got[cat]} != expected {total}"
+
+    reimbursable = float(result()["reimbursable_total"])
+    assert abs(reimbursable - exp["reimbursable_total"]) <= MONEY_TOL, (
+        f"reimbursable_total {reimbursable} != expected {exp['reimbursable_total']}"
+    )

--- a/platform/backend/src/agents/agent-system-prompt.test.ts
+++ b/platform/backend/src/agents/agent-system-prompt.test.ts
@@ -1,4 +1,14 @@
-import { ADMIN_ROLE_NAME, TOOL_LOAD_SKILL_SHORT_NAME } from "@archestra/shared";
+import {
+  ADMIN_ROLE_NAME,
+  type ArchestraToolShortName,
+  TOOL_DOWNLOAD_FILE_SHORT_NAME,
+  TOOL_LOAD_SKILL_SHORT_NAME,
+  TOOL_READ_FILE_SHORT_NAME,
+  TOOL_RUN_COMMAND_SHORT_NAME,
+  TOOL_SAVE_FILE_SHORT_NAME,
+  TOOL_SEARCH_FILES_SHORT_NAME,
+  TOOL_UPLOAD_FILE_SHORT_NAME,
+} from "@archestra/shared";
 import type { Tool } from "ai";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { SkillModel } from "@/models";
@@ -16,6 +26,25 @@ const loadSkillToolName = archestraMcpBranding.getToolName(
 );
 const someTool: Record<string, Tool> = { some_tool: {} as Tool };
 const withLoadSkill: Record<string, Tool> = { [loadSkillToolName]: {} as Tool };
+
+const brand = (shortName: ArchestraToolShortName) =>
+  archestraMcpBranding.getToolName(shortName);
+const searchFilesToolName = brand(TOOL_SEARCH_FILES_SHORT_NAME);
+// Sandbox runtime + persistent-file tools: the "full" file surface.
+const withFileTools: Record<string, Tool> = {
+  [brand(TOOL_RUN_COMMAND_SHORT_NAME)]: {} as Tool,
+  [brand(TOOL_DOWNLOAD_FILE_SHORT_NAME)]: {} as Tool,
+  [brand(TOOL_UPLOAD_FILE_SHORT_NAME)]: {} as Tool,
+  [searchFilesToolName]: {} as Tool,
+  [brand(TOOL_READ_FILE_SHORT_NAME)]: {} as Tool,
+  [brand(TOOL_SAVE_FILE_SHORT_NAME)]: {} as Tool,
+};
+// Sandbox runtime only (Projects off): no persistent-file tools.
+const withSandboxOnly: Record<string, Tool> = {
+  [brand(TOOL_RUN_COMMAND_SHORT_NAME)]: {} as Tool,
+  [brand(TOOL_DOWNLOAD_FILE_SHORT_NAME)]: {} as Tool,
+  [brand(TOOL_UPLOAD_FILE_SHORT_NAME)]: {} as Tool,
+};
 
 async function seedSkill(organizationId: string) {
   return await SkillModel.createWithFiles({
@@ -119,55 +148,72 @@ describe("buildAgentSystemPrompt", () => {
     expect(withoutCatalog).not.toContain("<available_skills>");
   });
 
-  test("adds the sandbox fallback instruction only when the sandbox is usable", async ({
+  test("adds file-handling guidance only when the agent has file tools", async ({
     makeAgent,
     makeUser,
     makeMember,
-    makeCustomRole,
-    seedAndAssignArchestraTools,
   }) => {
-    const config = (await import("@/config")).default;
-    const originalEnabled = config.skillsSandbox.enabled;
-    (config.skillsSandbox as { enabled: boolean }).enabled = true;
+    const agent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId);
+    const common = {
+      agent,
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    };
 
-    try {
-      const agent = await makeAgent({
-        systemPrompt: "Base.",
-        toolExposureMode: "full",
-      });
-      const user = await makeUser();
-      const role = await makeCustomRole(agent.organizationId, {
-        permission: { sandbox: ["execute"] },
-      });
-      await makeMember(user.id, agent.organizationId, { role: role.role });
-      await seedAndAssignArchestraTools(agent.id);
+    const withFiles = await buildAgentSystemPrompt({
+      ...common,
+      mcpTools: withFileTools,
+    });
+    // sandbox surface
+    expect(withFiles).toContain("code execution environment");
+    expect(withFiles).toContain(SKILL_SANDBOX_ATTACHMENTS_DIR);
+    // persistent-files surface + the "find the file the user referred to" path
+    expect(withFiles).toContain("persistent files");
+    expect(withFiles).toContain("Files panel");
+    expect(withFiles).toContain(searchFilesToolName);
+    expect(withFiles).toContain("did not attach this turn");
 
-      const withSandbox = await buildAgentSystemPrompt({
-        agent,
-        mcpTools: {},
-        organizationId: agent.organizationId,
-        userId: user.id,
-        agentId: agent.id,
-      });
-      expect(withSandbox).toContain("code execution environment");
-      // attachment staging guidance rides on the same sandbox-available gate
-      expect(withSandbox).toContain(SKILL_SANDBOX_ATTACHMENTS_DIR);
+    // an agent with no file tools gets no file-handling guidance at all
+    const withoutFiles = await buildAgentSystemPrompt({
+      ...common,
+      mcpTools: someTool,
+    });
+    expect(withoutFiles).not.toContain("code execution environment");
+    expect(withoutFiles).not.toContain(SKILL_SANDBOX_ATTACHMENTS_DIR);
+    expect(withoutFiles).not.toContain("persistent files");
+  });
 
-      // the same agent gets no instruction once the sandbox is disabled on the
-      // deployment, even with the tools assigned and the permission granted
-      (config.skillsSandbox as { enabled: boolean }).enabled = false;
-      const withoutSandbox = await buildAgentSystemPrompt({
-        agent,
-        mcpTools: {},
-        organizationId: agent.organizationId,
-        userId: user.id,
-        agentId: agent.id,
-      });
-      expect(withoutSandbox).not.toContain("code execution environment");
-      expect(withoutSandbox).not.toContain(SKILL_SANDBOX_ATTACHMENTS_DIR);
-    } finally {
-      (config.skillsSandbox as { enabled: boolean }).enabled = originalEnabled;
-    }
+  test("words file guidance to the tools present: sandbox-only omits persistent-file discovery", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+  }) => {
+    const agent = await makeAgent({
+      systemPrompt: "Base.",
+      toolExposureMode: "full",
+    });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId);
+
+    const prompt = await buildAgentSystemPrompt({
+      agent,
+      mcpTools: withSandboxOnly,
+      organizationId: agent.organizationId,
+      userId: user.id,
+      agentId: agent.id,
+    });
+
+    // sandbox guidance is present, but the persistent-file search/discovery
+    // paragraph is not — those tools aren't available to this agent.
+    expect(prompt).toContain("code execution environment");
+    expect(prompt).not.toContain(searchFilesToolName);
+    expect(prompt).not.toContain("did not attach this turn");
   });
 
   test("adds the tool-result instruction only when tools are present", async ({

--- a/platform/backend/src/agents/agent-system-prompt.ts
+++ b/platform/backend/src/agents/agent-system-prompt.ts
@@ -1,16 +1,25 @@
 import {
+  type ArchestraToolShortName,
   buildUserSystemPromptContext,
+  PROJECTS_FILE_ARCHESTRA_TOOL_SHORT_NAMES,
+  TOOL_DOWNLOAD_FILE_SHORT_NAME,
   TOOL_LOAD_SKILL_SHORT_NAME,
+  TOOL_READ_FILE_SHORT_NAME,
   TOOL_RUN_COMMAND_SHORT_NAME,
   TOOL_RUN_TOOL_SHORT_NAME,
+  TOOL_SAVE_FILE_SHORT_NAME,
+  TOOL_SEARCH_FILES_SHORT_NAME,
   TOOL_SEARCH_TOOLS_SHORT_NAME,
+  TOOL_UPLOAD_FILE_SHORT_NAME,
 } from "@archestra/shared";
 import type { Tool } from "ai";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { TeamModel, UserModel } from "@/models";
 import { buildSkillCatalogPrompt } from "@/skills/skill-catalog-prompt";
-import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
-import { SKILL_SANDBOX_ATTACHMENTS_DIR } from "@/skills-sandbox/runtime-image";
+import {
+  SKILL_SANDBOX_ATTACHMENTS_DIR,
+  SKILL_SANDBOX_HOME,
+} from "@/skills-sandbox/runtime-image";
 import {
   promptNeedsRendering,
   renderSystemPrompt,
@@ -88,16 +97,16 @@ export async function buildAgentSystemPrompt(params: {
 
   // eagerly list the agent's skills in the prompt (like Claude Code /
   // opencode), but only when the agent can actually load them.
-  const [skillCatalogPrompt, sandboxAvailable] = await Promise.all([
+  const skillCatalogPrompt =
     archestraMcpBranding.getToolName(TOOL_LOAD_SKILL_SHORT_NAME) in mcpTools
-      ? buildSkillCatalogPrompt({ organizationId, userId, agentId })
-      : null,
-    isSkillSandboxAvailableForAgent({ userId, organizationId, agentId }),
-  ]);
+      ? await buildSkillCatalogPrompt({ organizationId, userId, agentId })
+      : null;
 
-  const sandboxFallbackInstruction = sandboxAvailable
-    ? buildSandboxFallbackInstruction()
-    : null;
+  // Scope file-handling guidance to what the agent can actually do: emit it only
+  // when the sandbox and/or persistent-file tools are in its tool set, and word
+  // it from the tools actually present. Keyed off mcpTools (already RBAC- and
+  // availability-filtered upstream), not a separate availability probe.
+  const fileHandlingInstruction = buildFileHandlingInstruction(mcpTools);
 
   const projectInstructionsPrompt = projectInstructions
     ? `${PROJECT_INSTRUCTIONS_PREFIX}\n\n${projectInstructions}`
@@ -109,7 +118,7 @@ export async function buildAgentSystemPrompt(params: {
       renderedPrompt,
       projectInstructionsPrompt,
       skillCatalogPrompt,
-      sandboxFallbackInstruction,
+      fileHandlingInstruction,
       TOOL_DENIAL_INSTRUCTION,
       toolResultInstructions,
       hookSessionContext,
@@ -146,11 +155,80 @@ async function renderAgentPrompt(params: {
   return renderSystemPrompt(systemPrompt, promptContext);
 }
 
-function buildSandboxFallbackInstruction(): string {
+/**
+ * File-handling guidance, assembled from the file tools the agent actually has.
+ * Returns null when it has none. Two surfaces drive the wording:
+ *  - the sandbox runtime (`run_command` + `download_file`/`upload_file`): a
+ *    scratch Linux workspace the user cannot see;
+ *  - the persistent files (`search_files`/`read_file`/`save_file`/…): the
+ *    conversation's Files panel, the only place the user sees a file.
+ * Every referenced tool is guarded by its presence, so the block never names a
+ * tool the agent can't call. Tool names are branded via `archestraMcpBranding`.
+ */
+function buildFileHandlingInstruction(
+  mcpTools: Record<string, Tool>,
+): string | null {
+  const has = (shortName: ArchestraToolShortName): boolean =>
+    archestraMcpBranding.getToolName(shortName) in mcpTools;
+
+  const hasSandbox = has(TOOL_RUN_COMMAND_SHORT_NAME);
+  const hasPersistentFiles = PROJECTS_FILE_ARCHESTRA_TOOL_SHORT_NAMES.some(has);
+  if (!hasSandbox && !hasPersistentFiles) {
+    return null;
+  }
+
   const runCommand = archestraMcpBranding.getToolName(
     TOOL_RUN_COMMAND_SHORT_NAME,
   );
-  return `You have a code execution environment: \`${runCommand}\` runs shell commands and Python in a persistent Linux workspace. When the available tools do not cover a task, you can fall back to it — for example to compute, transform files, or fetch data over the network. Files the user attaches to the conversation are staged for you under \`${SKILL_SANDBOX_ATTACHMENTS_DIR}/\`; read them from there. Write any files you produce to absolute paths in the workspace.`;
+  const downloadFile = archestraMcpBranding.getToolName(
+    TOOL_DOWNLOAD_FILE_SHORT_NAME,
+  );
+  const uploadFile = archestraMcpBranding.getToolName(
+    TOOL_UPLOAD_FILE_SHORT_NAME,
+  );
+  const searchFiles = archestraMcpBranding.getToolName(
+    TOOL_SEARCH_FILES_SHORT_NAME,
+  );
+  const readFile = archestraMcpBranding.getToolName(TOOL_READ_FILE_SHORT_NAME);
+  const saveFile = archestraMcpBranding.getToolName(TOOL_SAVE_FILE_SHORT_NAME);
+
+  const paragraphs: string[] = [];
+
+  if (hasSandbox) {
+    paragraphs.push(
+      `You have a code execution environment: \`${runCommand}\` runs shell commands and Python in a persistent Linux workspace at \`${SKILL_SANDBOX_HOME}\`. Use it to compute, transform files, run scripts, or fetch data when the other tools don't cover the task. Files there persist across commands within this conversation but the user cannot see them. Files the user attached are staged under \`${SKILL_SANDBOX_ATTACHMENTS_DIR}/\` — the on-disk name may be sanitized, so \`ls\` that directory to find them.`,
+    );
+  }
+
+  if (hasPersistentFiles) {
+    const deliver = hasSandbox
+      ? `To hand a file to the user it must land there: compose inline content with \`${saveFile}\`, or export something already on the sandbox disk (a script's output, an attachment) with \`${downloadFile}\` by its path. Never read a file's bytes back and paste them into your reply or \`${saveFile}\` — export by path so the bytes never pass through your context. Use \`${uploadFile}\` to pull a persistent or inline file into the sandbox to process it.`
+      : `To hand a file to the user, write it to the persistent files with \`${saveFile}\`; it then appears in their Files panel.`;
+    paragraphs.push(
+      `The files the user can see live in the conversation's persistent files (their Files panel), not in the sandbox workspace. ${deliver}`,
+    );
+  } else if (hasSandbox) {
+    // Sandbox runtime without the persistent-file tools (Projects off): the only
+    // way to surface a file to the user is to export it from the sandbox.
+    paragraphs.push(
+      `To hand a file to the user, export it from the sandbox with \`${downloadFile}\` by its path; its bytes are recorded for the user's Files panel without passing through your reply.`,
+    );
+  }
+
+  paragraphs.push(
+    `When a request implies a deliverable — "write/create/save a report, doc, script, dataset", or output longer than a short snippet — produce a file rather than only printing it in chat. A saved file appears in the user's Files panel automatically; reference it by name with a one-line summary rather than restating its contents. For a quick answer, just reply.`,
+  );
+
+  if (hasPersistentFiles) {
+    const readBinary = hasSandbox
+      ? ` For other binary types (PDF, docx, xlsx, archives), \`${uploadFile}\` it into the sandbox and inspect with \`${runCommand}\`.`
+      : "";
+    paragraphs.push(
+      `If the user points at a file they did not attach this turn — "my report", "the doc from earlier", "update the spreadsheet" — it is in the persistent files, not on the sandbox disk. Call \`${searchFiles}\` first (omit the query to list them; matching is on filename only, so list and scan when the description isn't a filename), then act on the \`ref\` it returns; don't \`ls ${SKILL_SANDBOX_HOME}\` for it, since files the user dropped into the Files panel never appear there. To read it, \`${readFile}\` returns text as numbered lines and PNG/JPEG/WebP/GIF inline, straight from the persistent store.${readBinary} If a text or image attachment is already visible to you inline, use it as-is rather than re-fetching it.`,
+    );
+  }
+
+  return paragraphs.join("\n\n");
 }
 
 function buildLoadToolsWhenNeededSystemPrompt(): string {


### PR DESCRIPTION
## What

Two related changes.

**1. File-handling guidance in the agent system prompt** (`feat(agents)`)

Adds a compact "Working with files" block to the assembled agent system prompt, emitted **only when the agent actually has the sandbox and/or persistent-file tools** (keyed off `mcpTools`, so it never names a tool the agent can't call, and it's branding-aware).

It supplies the mental model the per-tool descriptions don't give on their own:
- the ephemeral **sandbox** (`/home/sandbox`, which the user can't see) vs. the user-visible **persistent files** (the Files panel);
- how to deliver a file (`save_file` for inline content / `download_file` by path), keeping a file's bytes out of the model's context;
- the read side — a file the user refers to but *didn't attach this turn* lives in the persistent files and must be found via `search_files`, not an empty-sandbox `ls`.

Replaces the single sandbox-fallback sentence. The gate moves from a sandbox availability probe to actual tool presence in `mcpTools`, and the wording degrades to the tool groups present (full / sandbox-only).

**2. `expense-report-continue` benchmark task** (`test(bench)`)

A two-stage archestra-bench task that exercises the read-side behavior across conversations: chat 1 attaches two PDF card statements and asks for an Excel report saved for later; chat 2 (a fresh conversation with an empty sandbox and no attachments) asks to "pull up my report" and extend it (reimbursable column + per-category totals sheet). The March transactions exist only inside the report saved in chat 1, so a final workbook that reproduces them can only have come from finding and reopening that report via the persistent files — a non-gameable check on the discovery behavior. Graded with openpyxl against never-staged fixtures.

## Testing

- `pnpm type-check`, Biome, `knip` (dev + production) — all green.
- `agent-system-prompt.test.ts` — 11/11 pass (the gate test was rewritten into tool-presence variants: full / sandbox-only / no-file-tools).
- Bench task validated through the real `load_task` loader; the verifier passes a correct workbook and a reformatted-but-correct one, and fails six defect variants (missing item, wrong reimbursable flag, leaked subtotal row, wrong reported total, no second sheet, no reimbursable column).
- Live bench run (Claude Sonnet 4.5) passes end-to-end; the trajectory confirms chat 2 uses `search_files` to rediscover the saved report before extending it.

## Notes

- No docs change — internal system-prompt text, not a user-facing API/UI contract.
- Fixtures are regenerable via `build_fixtures.py` (one data source for the PDFs and `expected/report.json`, so they can't drift).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>