### PR TITLE
feat(knowledge-base): per-connector toggle for crawling private networks

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -156974,6 +156974,9 @@
                                   "userAgent": {
                                     "type": "string",
                                     "minLength": 1
+                                  },
+                                  "allowPrivateNetwork": {
+                                    "type": "boolean"
                                   }
                                 },
                                 "required": [
@@ -158206,6 +158209,9 @@
                           "userAgent": {
                             "type": "string",
                             "minLength": 1
+                          },
+                          "allowPrivateNetwork": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -159090,6 +159096,9 @@
                             "userAgent": {
                               "type": "string",
                               "minLength": 1
+                            },
+                            "allowPrivateNetwork": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -160272,6 +160281,9 @@
                             "userAgent": {
                               "type": "string",
                               "minLength": 1
+                            },
+                            "allowPrivateNetwork": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -161336,6 +161348,9 @@
                           "userAgent": {
                             "type": "string",
                             "minLength": 1
+                          },
+                          "allowPrivateNetwork": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -162221,6 +162236,9 @@
                             "userAgent": {
                               "type": "string",
                               "minLength": 1
+                            },
+                            "allowPrivateNetwork": {
+                              "type": "boolean"
                             }
                           },
                           "required": [

--- a/platform/backend/src/knowledge-base/connectors/web-crawler/web-crawler-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/web-crawler/web-crawler-connector.test.ts
@@ -21,10 +21,14 @@ describe("WebCrawlerConnector", () => {
   });
 
   test("validates crawl scope and regular expression config", async () => {
-    const connector = new WebCrawlerConnector({ allowPrivateNetwork: true });
+    const connector = new WebCrawlerConnector();
+    // The crawl-scope assertions target an unresolvable test domain, so opt into
+    // private-network access to skip the DNS/SSRF gate and reach scope checks.
+    const base = { allowPrivateNetwork: true };
 
     await expect(
       connector.validateConfig({
+        ...base,
         startUrl: "https://docs.example.test/guide/",
         includePathPrefixes: ["/guide/"],
         excludePathPatterns: ["/search"],
@@ -32,6 +36,7 @@ describe("WebCrawlerConnector", () => {
     ).resolves.toEqual({ valid: true });
 
     const invalidPattern = await connector.validateConfig({
+      ...base,
       startUrl: "https://docs.example.test/guide/",
       excludePathPatterns: ["["],
     });
@@ -41,6 +46,7 @@ describe("WebCrawlerConnector", () => {
     });
 
     const unsafePattern = await connector.validateConfig({
+      ...base,
       startUrl: "https://docs.example.test/guide/",
       excludePathPatterns: ["(a+)+$"],
     });
@@ -51,12 +57,14 @@ describe("WebCrawlerConnector", () => {
 
     await expect(
       connector.validateConfig({
+        ...base,
         startUrl: "https://docs.example.test/guide/",
         includePathPrefixes: ["https://docs.example.test/guide/"],
       }),
     ).resolves.toEqual({ valid: true });
 
     const crossOriginPrefix = await connector.validateConfig({
+      ...base,
       startUrl: "https://docs.example.test/guide/",
       includePathPrefixes: ["https://other.example.test/guide/"],
     });
@@ -67,6 +75,7 @@ describe("WebCrawlerConnector", () => {
     });
 
     const invalidUrl = await connector.validateConfig({
+      ...base,
       startUrl: "not a url",
     });
     expect(invalidUrl).toEqual({
@@ -75,6 +84,7 @@ describe("WebCrawlerConnector", () => {
     });
 
     const excludedStartUrl = await connector.validateConfig({
+      ...base,
       startUrl: "https://docs.example.test/guide/",
       includePathPrefixes: ["/api/"],
     });
@@ -95,6 +105,17 @@ describe("WebCrawlerConnector", () => {
       valid: false,
       error: "Host 127.0.0.1 resolves to a private or internal network address",
     });
+  });
+
+  test("allows private network start URLs when the config opts in", async () => {
+    const connector = new WebCrawlerConnector();
+
+    const result = await connector.validateConfig({
+      startUrl: "http://127.0.0.1/docs/",
+      allowPrivateNetwork: true,
+    });
+
+    expect(result).toEqual({ valid: true });
   });
 
   test("crawls same-host HTML pages within include/exclude scope and extracts main content", async () => {
@@ -424,17 +445,17 @@ describe("WebCrawlerConnector", () => {
         res.end(JSON.stringify({ ok: true }));
       },
     });
-    const connector = new WebCrawlerConnector({ allowPrivateNetwork: true });
+    const connector = new WebCrawlerConnector();
 
     await expect(
       connector.testConnection({
-        config: { startUrl: `${site.url}/docs/` },
+        config: { startUrl: `${site.url}/docs/`, allowPrivateNetwork: true },
         credentials: { apiToken: "" },
       }),
     ).resolves.toEqual({ success: true });
 
     const notHtml = await connector.testConnection({
-      config: { startUrl: `${site.url}/not-html` },
+      config: { startUrl: `${site.url}/not-html`, allowPrivateNetwork: true },
       credentials: { apiToken: "" },
     });
     expect(notHtml.success).toBe(false);
@@ -442,7 +463,7 @@ describe("WebCrawlerConnector", () => {
   });
 
   test("testConnection reports invalid configuration", async () => {
-    const connector = new WebCrawlerConnector({ allowPrivateNetwork: true });
+    const connector = new WebCrawlerConnector();
 
     const result = await connector.testConnection({
       config: { startUrl: "not a url" },
@@ -470,7 +491,7 @@ describe("WebCrawlerConnector", () => {
   });
 
   test("sync throws on invalid configuration", async () => {
-    const connector = new WebCrawlerConnector({ allowPrivateNetwork: true });
+    const connector = new WebCrawlerConnector();
 
     await expect(
       firstSync(connector, { startUrl: "not a url" }),
@@ -705,11 +726,12 @@ function firstSync(
 async function collectBatches(
   config: Record<string, unknown>,
 ): Promise<ConnectorSyncBatch[]> {
-  const connector = new WebCrawlerConnector({ allowPrivateNetwork: true });
+  const connector = new WebCrawlerConnector();
   const batches: ConnectorSyncBatch[] = [];
 
   for await (const batch of connector.sync({
-    config,
+    // Tests crawl a loopback test server, so opt into private-network access.
+    config: { allowPrivateNetwork: true, ...config },
     credentials: { apiToken: "" },
     checkpoint: null,
   })) {

--- a/platform/backend/src/knowledge-base/connectors/web-crawler/web-crawler-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/web-crawler/web-crawler-connector.ts
@@ -54,18 +54,9 @@ type ExtractedPage = {
 };
 type CrawlerCheerioApi = CheerioCrawlingContext["$"];
 type CrawlerCheerioSelection = ReturnType<CrawlerCheerioApi>;
-type WebCrawlerConnectorOptions = {
-  allowPrivateNetwork?: boolean;
-};
 
 export class WebCrawlerConnector extends BaseConnector {
   type = "web_crawler" as const;
-  private readonly allowPrivateNetwork: boolean;
-
-  constructor(options: WebCrawlerConnectorOptions = {}) {
-    super();
-    this.allowPrivateNetwork = options.allowPrivateNetwork ?? false;
-  }
 
   async validateConfig(
     config: Record<string, unknown>,
@@ -80,7 +71,7 @@ export class WebCrawlerConnector extends BaseConnector {
 
     const error = await validateParsedConfig({
       config: parsed,
-      allowPrivateNetwork: this.allowPrivateNetwork,
+      allowPrivateNetwork: parsed.allowPrivateNetwork ?? false,
     });
     if (error) {
       return { valid: false, error };
@@ -99,7 +90,7 @@ export class WebCrawlerConnector extends BaseConnector {
     }
     const configError = await validateParsedConfig({
       config: parsed,
-      allowPrivateNetwork: this.allowPrivateNetwork,
+      allowPrivateNetwork: parsed.allowPrivateNetwork ?? false,
     });
     if (configError) {
       return { success: false, error: configError };
@@ -138,7 +129,7 @@ export class WebCrawlerConnector extends BaseConnector {
     }
     const configError = await validateParsedConfig({
       config: parsed,
-      allowPrivateNetwork: this.allowPrivateNetwork,
+      allowPrivateNetwork: parsed.allowPrivateNetwork ?? false,
     });
     if (configError) {
       throw new Error(configError);
@@ -206,7 +197,7 @@ export class WebCrawlerConnector extends BaseConnector {
             }
             await assertPublicCrawlUrl({
               url: _context.request.url,
-              allowPrivateNetwork: this.allowPrivateNetwork,
+              allowPrivateNetwork: params.config.allowPrivateNetwork ?? false,
             });
 
             gotOptions.headers = {
@@ -249,7 +240,8 @@ export class WebCrawlerConnector extends BaseConnector {
                   }
                   await assertPublicCrawlUrl({
                     url: target.href,
-                    allowPrivateNetwork: this.allowPrivateNetwork,
+                    allowPrivateNetwork:
+                      params.config.allowPrivateNetwork ?? false,
                   });
                 },
               ],

--- a/platform/backend/src/types/knowledge-connector.ts
+++ b/platform/backend/src/types/knowledge-connector.ts
@@ -362,6 +362,10 @@ export const WebCrawlerConfigSchema = z.object({
   batchSize: z.number().int().min(1).max(100).optional(),
   requestDelayMs: z.number().int().min(0).max(10_000).optional(),
   userAgent: z.string().min(1).optional(),
+  // Off by default: the crawler refuses hosts that resolve to private/internal
+  // addresses to guard against SSRF. Enable only for internal sites the
+  // Archestra workers are meant to reach.
+  allowPrivateNetwork: z.boolean().optional(),
 });
 export type WebCrawlerConfig = z.infer<typeof WebCrawlerConfigSchema>;
 

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -349,7 +349,13 @@ export function getDefaultConnectorConfig(
     onedrive: { type, userIds: "", recursive: true },
     outline: { type, outlineUrl: "https://app.getoutline.com" },
     salesforce: { type, loginUrl: "https://login.salesforce.com" },
-    web_crawler: { type, maxPages: 250, maxDepth: 3, batchSize: 25 },
+    web_crawler: {
+      type,
+      maxPages: 250,
+      maxDepth: 3,
+      batchSize: 25,
+      allowPrivateNetwork: false,
+    },
     perforce: { type },
   };
 
@@ -914,7 +920,30 @@ const INLINE_CONFIG_FIELDS: Record<
     </>
   ),
   outline: () => <></>,
-  web_crawler: () => <></>,
+  web_crawler: ({ form }) => (
+    <FormField
+      control={form.control}
+      name="config.allowPrivateNetwork"
+      render={({ field }) => (
+        <FormItem className="flex items-center justify-between rounded-lg border p-3">
+          <div className="space-y-0.5">
+            <FormLabel>Allow internal network addresses</FormLabel>
+            <FormDescription>
+              By default the crawler refuses hosts that resolve to private or
+              internal addresses. Enable to crawl an internal site reachable
+              from the workers.
+            </FormDescription>
+          </div>
+          <FormControl>
+            <Switch
+              checked={(field.value as boolean) ?? false}
+              onCheckedChange={field.onChange}
+            />
+          </FormControl>
+        </FormItem>
+      )}
+    />
+  ),
   salesforce: ({ form, mode }) => (
     <FormField
       control={form.control}

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -40980,6 +40980,7 @@ export type GetConnectorsResponses = {
                 batchSize?: number;
                 requestDelayMs?: number;
                 userAgent?: string;
+                allowPrivateNetwork?: boolean;
             } | {
                 type: 'perforce';
                 serverUrl: unknown;
@@ -41152,6 +41153,7 @@ export type CreateConnectorData = {
             batchSize?: number;
             requestDelayMs?: number;
             userAgent?: string;
+            allowPrivateNetwork?: boolean;
         } | {
             type: 'perforce';
             serverUrl: string;
@@ -41382,6 +41384,7 @@ export type CreateConnectorResponses = {
             batchSize?: number;
             requestDelayMs?: number;
             userAgent?: string;
+            allowPrivateNetwork?: boolean;
         } | {
             type: 'perforce';
             serverUrl: unknown;
@@ -41704,6 +41707,7 @@ export type GetConnectorResponses = {
             batchSize?: number;
             requestDelayMs?: number;
             userAgent?: string;
+            allowPrivateNetwork?: boolean;
         } | {
             type: 'perforce';
             serverUrl: unknown;
@@ -41862,6 +41866,7 @@ export type UpdateConnectorData = {
             batchSize?: number;
             requestDelayMs?: number;
             userAgent?: string;
+            allowPrivateNetwork?: boolean;
         } | {
             type: 'perforce';
             serverUrl: string;
@@ -42093,6 +42098,7 @@ export type UpdateConnectorResponses = {
             batchSize?: number;
             requestDelayMs?: number;
             userAgent?: string;
+            allowPrivateNetwork?: boolean;
         } | {
             type: 'perforce';
             serverUrl: unknown;


### PR DESCRIPTION
## Problem

The web crawler knowledge-base connector rejects any start URL whose host resolves to a **private or internal network address** with:

> Invalid connector configuration: Host `<host>` resolves to a private or internal network address

This is an SSRF safeguard (`allowPrivateNetwork`), but it was hardcoded on — there was no way to opt out.

That blocks a legitimate use case: teams running Archestra workers **inside their own network** who want to crawl internal-only web pages (e.g. an internal documentation site) that are reachable from the workers but resolve to private/internal addresses.

## Change

Make private-network access a **per-connector** setting rather than a deployment-wide one, so each web crawler source can individually opt in without loosening the SSRF guard platform-wide.

- **`allowPrivateNetwork`** added to `WebCrawlerConfigSchema` (optional, **default `false`**). The connector sources the flag from its own parsed config.
- **UI toggle** in the connector create/edit dialog, shown **inline directly under the Start URL field** (always visible, not buried in "Advanced"), off by default, with a short no-fluff explanation of what it does.
- Regenerated the API client + OpenAPI spec for the new field.

**Secure by default:** existing and new connectors keep the SSRF protection on unless a user explicitly flips the toggle for that specific source.