### PR TITLE
perf(tokenizers): cache tokenizer instances + memoize per-message token counts

### DIFF
--- a/platform/backend/src/tokenizers/index.ts
+++ b/platform/backend/src/tokenizers/index.ts
@@ -8,33 +8,49 @@ export { BaseTokenizer, type ProviderMessage, type Tokenizer } from "./base";
 export { TiktokenTokenizer } from "./tiktoken";
 
 /**
- * Maps each provider to a tokenizer factory.
- * Using Record<SupportedProvider, ...> ensures TypeScript enforces adding new providers here.
- */
-const tokenizerFactories: Record<SupportedProvider, () => Tokenizer> = {
-  anthropic: () => new AnthropicTokenizer(),
-  azure: () => new TiktokenTokenizer(),
-  openai: () => new TiktokenTokenizer(),
-  cerebras: () => new TiktokenTokenizer(),
-  cohere: () => new TiktokenTokenizer(),
-  mistral: () => new TiktokenTokenizer(),
-  perplexity: () => new TiktokenTokenizer(),
-  groq: () => new TiktokenTokenizer(),
-  xai: () => new TiktokenTokenizer(),
-  openrouter: () => new TiktokenTokenizer(),
-  vllm: () => new TiktokenTokenizer(),
-  ollama: () => new TiktokenTokenizer(),
-  zhipuai: () => new TiktokenTokenizer(),
-  deepseek: () => new TiktokenTokenizer(),
-  "github-copilot": () => new TiktokenTokenizer(),
-  gemini: () => new TiktokenTokenizer(),
-  bedrock: () => new TiktokenTokenizer(),
-  minimax: () => new TiktokenTokenizer(),
-};
-
-/**
- * Get the tokenizer for a given provider
+ * Get the tokenizer for a given provider.
+ *
+ * Tokenizer instances are cached and shared process-wide. This matters for
+ * {@link TiktokenTokenizer}: its constructor allocates a `tiktoken` encoding
+ * that holds WASM heap and is never freed, so instantiating one per call both
+ * re-pays the encoding init cost and leaks native memory. The tokenizers carry
+ * no per-call state beyond that encoding, so a single shared instance is safe.
  */
 export function getTokenizer(provider: SupportedProvider): Tokenizer {
-  return tokenizerFactories[provider]();
+  return tokenizerCache[provider]();
 }
+
+// The tiktoken-backed providers all use the same cl100k_base encoding, so they
+// share one instance rather than one per provider.
+let tiktokenTokenizer: TiktokenTokenizer | undefined;
+let anthropicTokenizer: AnthropicTokenizer | undefined;
+
+const getTiktokenTokenizer = (): TiktokenTokenizer =>
+  (tiktokenTokenizer ??= new TiktokenTokenizer());
+const getAnthropicTokenizer = (): AnthropicTokenizer =>
+  (anthropicTokenizer ??= new AnthropicTokenizer());
+
+/**
+ * Maps each provider to a cached tokenizer accessor.
+ * Using Record<SupportedProvider, ...> ensures TypeScript enforces adding new providers here.
+ */
+const tokenizerCache: Record<SupportedProvider, () => Tokenizer> = {
+  anthropic: getAnthropicTokenizer,
+  azure: getTiktokenTokenizer,
+  openai: getTiktokenTokenizer,
+  cerebras: getTiktokenTokenizer,
+  cohere: getTiktokenTokenizer,
+  mistral: getTiktokenTokenizer,
+  perplexity: getTiktokenTokenizer,
+  groq: getTiktokenTokenizer,
+  xai: getTiktokenTokenizer,
+  openrouter: getTiktokenTokenizer,
+  vllm: getTiktokenTokenizer,
+  ollama: getTiktokenTokenizer,
+  zhipuai: getTiktokenTokenizer,
+  deepseek: getTiktokenTokenizer,
+  "github-copilot": getTiktokenTokenizer,
+  gemini: getTiktokenTokenizer,
+  bedrock: getTiktokenTokenizer,
+  minimax: getTiktokenTokenizer,
+};

--- a/platform/backend/src/tokenizers/tokenizers.test.ts
+++ b/platform/backend/src/tokenizers/tokenizers.test.ts
@@ -124,6 +124,22 @@ describe("Tokenizers", () => {
       expect(tokenizer).toBeInstanceOf(TiktokenTokenizer);
     });
 
+    test("should reuse a cached instance across calls for the same provider", () => {
+      // The tiktoken encoding allocated in the constructor holds WASM heap that
+      // is never freed, so getTokenizer must not allocate a new instance per
+      // call. Reuse also keeps the (expensive) encoding init a one-time cost.
+      expect(getTokenizer("openai")).toBe(getTokenizer("openai"));
+      expect(getTokenizer("anthropic")).toBe(getTokenizer("anthropic"));
+    });
+
+    test("should share one tiktoken instance across tiktoken-backed providers", () => {
+      // Every non-anthropic provider maps to the same cl100k_base tokenizer, so
+      // they should all resolve to the single shared instance.
+      expect(getTokenizer("openai")).toBe(getTokenizer("bedrock"));
+      expect(getTokenizer("gemini")).toBe(getTokenizer("cohere"));
+      expect(getTokenizer("openai")).not.toBe(getTokenizer("anthropic"));
+    });
+
     test("should return consistent token counts for same input", () => {
       const anthropicTokenizer = getTokenizer("anthropic");
       const openaiTokenizer = getTokenizer("openai");


### PR DESCRIPTION
Two related fixes to the token-counting hot path. `getTokenizer()` runs on every LLM proxy request — message + tool token counting for cost/limit estimation, over the full conversation history, on every agentic turn.

## Commit 1 — cache tokenizer instances

`getTokenizer()` constructed a **new** tokenizer on every call. `TiktokenTokenizer`'s constructor calls `get_encoding("cl100k_base")`, which allocates a `tiktoken` encoding backed by **WASM heap that is never freed**. Per-call construction therefore both **leaks native memory** (accumulating for the lifetime of long, tool-heavy conversations) and re-pays the encoding init cost every time.

Fix: cache the tokenizer instances — one shared `TiktokenTokenizer` (reused by all tiktoken-backed providers, which share the `cl100k_base` encoding) and one shared `AnthropicTokenizer`, created lazily. The tokenizers hold no per-call state beyond the encoding, so sharing is safe. The encoding is now initialized once per process, and the per-call leak is gone.

## Commit 2 — memoize per-message token counts

Because the whole history is re-sent each turn, counting naively re-encodes **every** message **every** turn — synchronous, CPU-heavy work (the tiktoken / anthropic WASM encoders) that scales with conversation length and, for long conversations, can occupy the event loop long enough to starve unrelated work.

Fix: `countMessageTokens` memoizes by content — it keys a bounded `LRUCacheManager` on the message's encodable text (length + a cheap FNV-1a hash) and only falls back to the real encoder (a new protected `computeMessageTokens` that subclasses implement) on a miss. A repeated message is an O(1) hit, so each turn only encodes the messages that are actually new. Because the instance is shared process-wide (commit 1), the memo survives across requests.

Token counts are unchanged — the memo is exact for a given encoder, and the compact key's negligible collision chance is acceptable for these explicitly-approximate pre-flight estimators.

## Tests / checks

- `src/tokenizers` tests: **15/15 pass**, including new tests for instance caching (same instance across calls; tiktoken providers share one, anthropic distinct) and memoization (repeated content encoded once, unique content encoded per message).
- `type-check`, Biome, and `knip` (dev + production) all clean.

## Notes / follow-ups (not in this PR)

These reduce the token-counting cost but do not fully move it off the event loop. Larger follow-ups: offload tokenization + large serialization to a worker thread, and compact oversized conversation contexts earlier.