### PR TITLE
ci: only alert on real release failures, not release-PR-build flakes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -298,10 +298,17 @@ jobs:
 
   notify-release-failure:
     name: Notify release failure
-    # Pages #alerting whenever any job in the release pipeline fails, so a broken release
-    # (e.g. an image or chart that never published) is surfaced immediately instead of
-    # failing silently. Skipped jobs are not failures, so ordinary non-release pushes and
-    # dispatch-time opt-outs do not trigger an alert.
+    # Pages #alerting when a release that was ACTUALLY being published fails, so a broken
+    # release (e.g. an image or chart that never published) is surfaced immediately
+    # instead of failing silently.
+    #
+    # The release-please job runs in two contexts: on every push to main it just rebuilds
+    # the release PR (should_publish=false), and only when a release PR is merged does it
+    # actually cut a release (should_publish=true). We gate on platform_should_publish so
+    # transient flakes in the former context (e.g. release-please's "other side closed"
+    # API blips, which self-heal on the next commit) don't page anyone. Real publish
+    # failures set should_publish=true before any downstream step can fail, so they still
+    # alert.
     needs:
       - release-please
       - build-and-push-mcp-server-docker-image
@@ -309,7 +316,7 @@ jobs:
       - build-and-push-platform-docker-image-to-dockerhub
       - publish-platform-helm-chart
       - publish-github-release
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && needs.release-please.outputs.platform_should_publish == 'true' && contains(needs.*.result, 'failure') }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions: {}
     steps:


### PR DESCRIPTION
## Why

Right after #6132 merged, #alerting got a **false** failure alert:

> 🚨 Platform release failed — **unknown**
> • release-please: `failure` · everything else `skipped`

That run ([28538943731](https://github.com/archestra-ai/archestra/actions/runs/28538943731)) was **not** cutting a release — it was the merge commit of #6132, where release-please just rebuilds the release PR (`should_publish=false`, hence `version: unknown`). The release-please *action* died on a transient `release-please failed: other side closed` GitHub API blip, which self-healed on the very next commit.

The `release-please` workflow runs in **two contexts**:
- **Every push to main** → release-please rebuilds/updates the release PR. `should_publish=false`. No artifacts. Transient API flakes here are noise.
- **A release PR is merged** → release-please actually cuts the release. `should_publish=true`. Artifacts get built and pushed. Failures here are real.

`notify-release-failure` alerted on `contains(needs.*.result, 'failure')` alone, so it paged on the first (non-release) context too.

## Fix

Gate the alert on `needs.release-please.outputs.platform_should_publish == 'true'` so it only fires when a release was genuinely being published.

`resolve-release` sets `should_publish` **before** any downstream step (tag creation, image builds, chart publish, GitHub-release publish) can fail, so genuine publish failures still set it to `true` and still alert. Transient flakes in the release-PR-rebuild context leave it `false`/empty → no page. Those self-heal on the next commit.