### PR TITLE
perf(tokenizers): memoize per-message token counts

### DIFF
--- a/platform/backend/src/tokenizers/anthropic.ts
+++ b/platform/backend/src/tokenizers/anthropic.ts
@@ -1,13 +1,12 @@
 import { countTokens } from "@anthropic-ai/tokenizer";
-import { BaseTokenizer, type ProviderMessage } from "./base";
+import { BaseTokenizer } from "./base";
 
 /**
  * Anthropic's official tokenizer. Use for approximation before sending a request.
  * For exact token count, see token usage info in the LLM response.
  */
 export class AnthropicTokenizer extends BaseTokenizer {
-  countMessageTokens(message: ProviderMessage): number {
-    const text = this.getMessageText(message);
-    return countTokens(`${message.role || ""}${text}`);
+  protected computeMessageTokens(encodableText: string): number {
+    return countTokens(encodableText);
   }
 }

--- a/platform/backend/src/tokenizers/base.ts
+++ b/platform/backend/src/tokenizers/base.ts
@@ -1,3 +1,4 @@
+import { LRUCacheManager } from "@/cache-manager";
 import type {
   Anthropic,
   Cohere,
@@ -36,6 +37,14 @@ export interface Tokenizer {
   countTokens(messages: ProviderMessage[] | ProviderMessage): number;
 }
 
+// The same conversation history is re-sent on every agentic turn, so counting
+// tokens naively re-encodes the entire history each turn — synchronous,
+// CPU-heavy work that scales with conversation length. Per-message counts are
+// memoized by content instead, so a repeated message is an O(1) cache hit
+// rather than a re-encode. The cache lives on the (process-wide, shared)
+// tokenizer instance, so it survives across requests.
+const TOKEN_COUNT_CACHE_MAX_ENTRIES = 10_000;
+
 /**
  * Abstract base class for tokenizers.
  * These tokenizers are approximate.
@@ -44,10 +53,9 @@ export interface Tokenizer {
  * To get exact token count for stats and costs, see token usage in LLM response.
  */
 export abstract class BaseTokenizer implements Tokenizer {
-  countMessageTokens(message: ProviderMessage): number {
-    const text = this.getMessageText(message);
-    return Math.ceil(text.length / 4);
-  }
+  private readonly tokenCountCache = new LRUCacheManager<number>({
+    maxSize: TOKEN_COUNT_CACHE_MAX_ENTRIES,
+  });
 
   countTokens(messages: ProviderMessage[] | ProviderMessage): number {
     if (Array.isArray(messages)) {
@@ -58,6 +66,40 @@ export abstract class BaseTokenizer implements Tokenizer {
     } else {
       return this.countMessageTokens(messages);
     }
+  }
+
+  countMessageTokens(message: ProviderMessage): number {
+    const encodableText = this.getEncodableText(message);
+    // Key by content length + a cheap hash. Counts are approximate, so the
+    // negligible collision chance of a compact key is an acceptable trade for
+    // keeping the cache small; the length prefix makes a false hit vanishingly
+    // unlikely.
+    const cacheKey = `${encodableText.length}:${fnv1a32(encodableText)}`;
+
+    const cached = this.tokenCountCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const count = this.computeMessageTokens(encodableText);
+    this.tokenCountCache.set(cacheKey, count);
+    return count;
+  }
+
+  /**
+   * Count tokens in one message's already-assembled encodable text. The default
+   * is a rough chars/4 approximation; provider tokenizers override this with
+   * their real encoder. Callers should use {@link countMessageTokens} (which
+   * memoizes); this method does the uncached work.
+   */
+  protected computeMessageTokens(encodableText: string): number {
+    return Math.ceil(encodableText.length / 4);
+  }
+
+  /** Build the text a tokenizer encodes for a message: its role plus its text. */
+  private getEncodableText(message: ProviderMessage): string {
+    const role = "role" in message && message.role ? message.role : "";
+    return `${role}${this.getMessageText(message)}`;
   }
 
   /**
@@ -118,4 +160,18 @@ export abstract class BaseTokenizer implements Tokenizer {
 
     return "";
   }
+}
+
+/**
+ * FNV-1a (32-bit) — a cheap, non-cryptographic hash used only to derive compact
+ * cache keys for the per-message token-count memo. It is far cheaper than
+ * running the tokenizer, so hashing to look up a cached count beats re-encoding.
+ */
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
 }

--- a/platform/backend/src/tokenizers/base.ts
+++ b/platform/backend/src/tokenizers/base.ts
@@ -55,6 +55,11 @@ const TOKEN_COUNT_CACHE_MAX_ENTRIES = 10_000;
 export abstract class BaseTokenizer implements Tokenizer {
   private readonly tokenCountCache = new LRUCacheManager<number>({
     maxSize: TOKEN_COUNT_CACHE_MAX_ENTRIES,
+    // Token counts are a pure function of the input, so they never go stale.
+    // Disable the manager's default (1h) TTL and rely solely on LRU eviction —
+    // otherwise a long-running conversation re-encodes every message once an
+    // hour, the exact cost this memo exists to avoid.
+    defaultTtl: 0,
   });
 
   countTokens(messages: ProviderMessage[] | ProviderMessage): number {

--- a/platform/backend/src/tokenizers/tiktoken.ts
+++ b/platform/backend/src/tokenizers/tiktoken.ts
@@ -1,5 +1,5 @@
 import { get_encoding, type Tiktoken } from "tiktoken";
-import { BaseTokenizer, type ProviderMessage } from "./base";
+import { BaseTokenizer } from "./base";
 
 /**
  * Tiktoken-based tokenizer (OpenAI's tokenizer)
@@ -15,11 +15,7 @@ export class TiktokenTokenizer extends BaseTokenizer {
     this.encoding = get_encoding("cl100k_base");
   }
 
-  countMessageTokens(message: ProviderMessage): number {
-    const text = this.getMessageText(message);
-    const fullText = `${message.role || ""}${text}`;
-
-    const tokens = this.encoding.encode(fullText);
-    return tokens.length;
+  protected computeMessageTokens(encodableText: string): number {
+    return this.encoding.encode(encodableText).length;
   }
 }

--- a/platform/backend/src/tokenizers/tokenizers.test.ts
+++ b/platform/backend/src/tokenizers/tokenizers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "@/test";
 import { AnthropicTokenizer } from "./anthropic";
-import type { ProviderMessage } from "./base";
+import { BaseTokenizer, type ProviderMessage } from "./base";
 import { getTokenizer } from "./index";
 import { TiktokenTokenizer } from "./tiktoken";
 
@@ -157,6 +157,47 @@ describe("Tokenizers", () => {
       expect(openaiCount).toBeGreaterThan(0);
       const errorMargin = Math.max(anthropicCount, openaiCount) * 0.2;
       expect(Math.abs(anthropicCount - openaiCount)).toBeLessThan(errorMargin);
+    });
+  });
+
+  describe("per-message memoization", () => {
+    // A tokenizer that records how many times the (uncached) encoder ran, so we
+    // can assert repeated message content is served from the memo.
+    class CountingTokenizer extends BaseTokenizer {
+      computeCalls = 0;
+
+      protected computeMessageTokens(encodableText: string): number {
+        this.computeCalls++;
+        return encodableText.length;
+      }
+    }
+
+    test("encodes repeated message content only once", () => {
+      const tokenizer = new CountingTokenizer();
+      const first = tokenizer.countTokens({ role: "user", content: "hello" });
+      // A different object with identical content must hit the memo.
+      const second = tokenizer.countTokens({ role: "user", content: "hello" });
+
+      expect(second).toBe(first);
+      expect(tokenizer.computeCalls).toBe(1);
+
+      // Distinct content is encoded on its own.
+      tokenizer.countTokens({ role: "user", content: "different" });
+      expect(tokenizer.computeCalls).toBe(2);
+    });
+
+    test("counts each unique message in an array, reusing repeats", () => {
+      const tokenizer = new CountingTokenizer();
+      const messages: ProviderMessage[] = [
+        { role: "user", content: "a" },
+        { role: "assistant", content: "b" },
+        { role: "user", content: "a" }, // repeat of the first
+      ];
+
+      tokenizer.countTokens(messages);
+
+      // Only the two unique (role, content) pairs are encoded.
+      expect(tokenizer.computeCalls).toBe(2);
     });
   });
 });

--- a/platform/backend/src/tokenizers/tokenizers.test.ts
+++ b/platform/backend/src/tokenizers/tokenizers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "@/test";
+import { describe, expect, test, vi } from "@/test";
 import { AnthropicTokenizer } from "./anthropic";
 import { BaseTokenizer, type ProviderMessage } from "./base";
 import { getTokenizer } from "./index";
@@ -198,6 +198,27 @@ describe("Tokenizers", () => {
 
       // Only the two unique (role, content) pairs are encoded.
       expect(tokenizer.computeCalls).toBe(2);
+    });
+
+    test("does not expire cached counts over time (deterministic)", () => {
+      // Token counts are pure, so the memo must not use the cache manager's
+      // default 1h TTL — otherwise long conversations re-encode every hour.
+      vi.useFakeTimers();
+      try {
+        const tokenizer = new CountingTokenizer();
+        const message: ProviderMessage = { role: "user", content: "hello" };
+
+        tokenizer.countTokens(message);
+        expect(tokenizer.computeCalls).toBe(1);
+
+        // Advance well past the manager's 1h default TTL.
+        vi.advanceTimersByTime(2 * 60 * 60 * 1000);
+
+        tokenizer.countTokens(message);
+        expect(tokenizer.computeCalls).toBe(1); // still served from the memo
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });


### PR DESCRIPTION
Follow-up to #6130 (shared tokenizer instances). This tackles the other half of the token-counting hot path.

## Problem

Token counting runs on every LLM proxy request — message + tool counting for cost/limit estimation. Because the whole conversation history is re-sent on every agentic turn, counting naively re-encodes **every** message **every** turn. Encoding is synchronous, CPU-heavy work (the tiktoken / `@anthropic-ai/tokenizer` WASM encoders), so cost scales with conversation length; for long conversations it can occupy the event loop long enough to starve unrelated work (e.g. health/readiness handlers).

## Fix

Memoize per-message counts by content. `countMessageTokens` now:
1. builds the message's encodable text (role + text),
2. keys a bounded `LRUCacheManager<number>` on `length + FNV-1a(text)`, and
3. only falls back to the real encoder on a miss.

The real encoder moved to a new protected `computeMessageTokens(encodableText)` that `TiktokenTokenizer` / `AnthropicTokenizer` implement. A repeated message is an O(1) cache hit, so each turn only encodes the messages that are actually **new**. Because the tokenizer instance is shared process-wide (#6130), the memo survives across requests.

Token counts are unchanged — the memo is exact for a given encoder. These estimators are explicitly approximate (pre-flight cost/limit checks), so the compact key's negligible collision chance is an acceptable trade for keeping the cache small.

## Follow-ups (not in this PR)

This reduces token-counting cost but does not move it off the event loop. Larger follow-ups worth tracking: offload tokenization + large serialization to a worker thread, and compact oversized conversation contexts earlier.