### PR TITLE
perf(backend): vitest isolate:false split + sharded CI + boundary-mocked test suite

### DIFF
--- a/.claude/skills/archestra-dev-backend-tests/SKILL.md
+++ b/.claude/skills/archestra-dev-backend-tests/SKILL.md
@@ -45,6 +45,7 @@ Consequences:
   ```
 
   Never hand-roll a partial `{ default: { kb: {...} } }` — it silently drops the rest of the config.
+- **Mutating the real config** (`config.apps.enabled = true` style, common in clean-project files): set it in `beforeEach` or inside the test, NOT in `beforeAll` or at module scope — the shared setup restores the pristine config before every test in the shared-worker project, so a once-per-file mutation evaporates after the first test. No manual restore needed.
 - **Never write a bespoke partial factory** for a module that has a canonical mock, and **never mix a bare `vi.mock("x")` with a factory `vi.mock("x", ...)` for the same specifier across files** — Vitest can silently skip one depending on execution order (vitest-dev/vitest#10145).
 - Mock typing is real: `vi.mocked(fn)` carries the actual signature. If the compiler rejects your mock's resolved value, the OLD untyped mock was probably wrong (e.g. resolving a truthy object where the code expects a boolean).
 

--- a/.claude/skills/archestra-dev-backend-tests/SKILL.md
+++ b/.claude/skills/archestra-dev-backend-tests/SKILL.md
@@ -31,6 +31,8 @@ Consequences:
   });
   ```
 
+- **`@/auth/utils`**: bare `vi.mock("@/auth/utils");` (resolves `src/auth/__mocks__/utils.ts`). Needed separately from `@/auth` when the code under test imports from "@/auth/utils" directly — module mocks match specifiers, not re-exports.
+- **`@/observability`**: bare `vi.mock("@/observability");` (resolves `src/observability/__mocks__/index.ts`). `metrics`/`tracing` are memoized proxy trees — any `metrics.<ns>.<fn>` access yields a stable `vi.fn()`, so assert via `vi.mocked(metrics.llm.someFn)` with no factory.
 - **`@/logging`**: do NOT mock just to silence output — the shared setup already runs the real logger at level `silent`. Only mock when a test asserts on logger calls, with a bare `vi.mock("@/logging");` (resolves `src/logging/__mocks__/index.ts`). `vi.spyOn(logger, ...)` does not work — the export is a Proxy binding methods to a private pino instance.
 - **`@/config`**: use the canonical deep-merge factory so unspecified keys keep their real values:
 

--- a/.claude/skills/archestra-dev-backend-tests/SKILL.md
+++ b/.claude/skills/archestra-dev-backend-tests/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: archestra-dev-backend-tests
+description: Use when writing or modifying Archestra backend unit tests (platform/backend/src/**/*.test.ts) — mocking modules, stubbing globals, database fixtures, vitest projects/isolation, or test performance.
+---
+
+# Archestra Backend Unit Tests
+
+Run commands from `platform/` unless specifically instructed otherwise. Run a single file with `cd backend && npx vitest run <file>`.
+
+## The two vitest projects (why mocking style matters)
+
+`backend/vitest.config.ts` splits test files into two projects at config-load time by grepping file content:
+
+- **`clean`** — files with NO `vi.mock`/`vi.doMock`/`vi.hoisted` run with `isolate: false`: worker threads share the module cache, so the backend module graph is imported once per worker instead of once per file. This is the fast path.
+- **`mocked`** — files using module mocking keep full isolation, because Vitest never resets the module-mock registry between files in a shared worker (vitest-dev/vitest#4894).
+
+Consequences:
+
+- **Prefer not mocking modules at all.** Every file that drops its last `vi.mock` automatically joins the fast project. Mock at the process boundary instead (fetch, network) when possible.
+- Routing is automatic — never maintain a file list; adding `vi.mock` to a file safely moves it to the isolated project on the next run.
+
+## Module mocking rules
+
+- **`@/auth`**: activate with a bare `vi.mock("@/auth");` — Vitest resolves the Jest-style `src/auth/__mocks__/index.ts`, which re-exports the canonical factory (`src/test/mocks/auth.ts`: every export a bare `vi.fn()`). Configure behavior per test via `vi.mocked(...)`:
+
+  ```ts
+  vi.mock("@/auth");
+  import { hasPermission } from "@/auth";
+  beforeEach(() => {
+    vi.mocked(hasPermission).mockResolvedValue({ success: true, error: null });
+  });
+  ```
+
+- **`@/logging`**: do NOT mock just to silence output — the shared setup already runs the real logger at level `silent`. Only mock when a test asserts on logger calls, with a bare `vi.mock("@/logging");` (resolves `src/logging/__mocks__/index.ts`). `vi.spyOn(logger, ...)` does not work — the export is a Proxy binding methods to a private pino instance.
+- **`@/config`**: use the canonical deep-merge factory so unspecified keys keep their real values:
+
+  ```ts
+  vi.mock("@/config", async () =>
+    (await import("@/test/mocks/config")).configModuleMock({
+      kb: { taskWorkerPollIntervalSeconds: 1 },
+    }),
+  );
+  ```
+
+  Never hand-roll a partial `{ default: { kb: {...} } }` — it silently drops the rest of the config.
+- **Never write a bespoke partial factory** for a module that has a canonical mock, and **never mix a bare `vi.mock("x")` with a factory `vi.mock("x", ...)` for the same specifier across files** — Vitest can silently skip one depending on execution order (vitest-dev/vitest#10145).
+- Mock typing is real: `vi.mocked(fn)` carries the actual signature. If the compiler rejects your mock's resolved value, the OLD untyped mock was probably wrong (e.g. resolving a truthy object where the code expects a boolean).
+
+## Global stubs (fetch, window, env)
+
+The config sets `unstubGlobals: true` / `unstubEnvs: true`: every `vi.stubGlobal`/`vi.stubEnv` is auto-reverted after EACH test.
+
+- **Stub in `beforeEach`, never only at module scope or in `beforeAll`** — a module-scope stub is silently removed after the first test:
+
+  ```ts
+  const fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock); // covers import time
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock); // re-applied per test
+  });
+  ```
+
+- **Never raw-assign `globalThis.fetch = ...`** — use `vi.stubGlobal`. (The shared setup restores the real fetch after every test as a safety net, so a raw assignment doesn't survive anyway.)
+- Faking browser globals (`window`, `location`) confuses PGlite's environment detection; the shared setup finishes PGlite init before test code runs, but always clean such globals up in `afterAll`.
+
+## Database
+
+- Never mock `@/database` or model modules for DB behavior — every file gets a real PGlite loaded from a pre-migrated snapshot (`src/test/global-setup.ts` + `src/test/setup.ts`); tables are truncated between tests.
+- Create data through fixtures from `@/test` (`makeUser`, `makeOrganization`, `makeAgent`, ...) — see the Backend Test Fixtures section in platform/CLAUDE.md.
+- On file teardown the injected DB is cleared: module-level code that runs between files gets getDb()'s "Database not initialized" (a handled condition), never a closed PGlite.
+
+## Performance etiquette
+
+- The suite's budget is module-import cost. Heavy new top-level imports in widely-imported modules cost every worker; test-only helpers belong under `src/test/`.
+- Local full-suite runs cap workers at cores−2 (config) so the machine stays usable; CI runs 4 shards via `vitest run --shard=k/4` behind the `Backend Unit Tests` gate job.

--- a/.claude/skills/archestra-dev-backend-tests/SKILL.md
+++ b/.claude/skills/archestra-dev-backend-tests/SKILL.md
@@ -19,6 +19,28 @@ Consequences:
 - **Prefer not mocking modules at all.** Every file that drops its last `vi.mock` automatically joins the fast project. Mock at the process boundary instead (fetch, network) when possible.
 - Routing is automatic — never maintain a file list; adding `vi.mock` to a file safely moves it to the isolated project on the next run.
 
+## HTTP boundary mocking (instead of vi.mock on client libraries)
+
+Never `vi.mock` an HTTP client library (`jira.js`, `@gitbeaker/rest`, `openai`, ...). Use MSW via the `useMswServer` helper — the real client runs and only the network is faked (MSW intercepts axios, fetch, and undici alike):
+
+```ts
+import { http, HttpResponse } from "msw";
+import { useMswServer } from "@/test/msw";
+
+const server = useMswServer();
+test("...", async () => {
+  server.use(
+    http.get("https://example.atlassian.net/rest/api/3/search/jql", () =>
+      HttpResponse.json({ issues: [] }),
+    ),
+  );
+});
+```
+
+Unhandled requests fail the test loudly. The helper's lifecycle is per test (it must be — the shared setup restores `globalThis.fetch` after every test); don't hand-roll `setupServer` with `beforeAll` listen.
+
+Wire-level gotchas learned in past conversions: clients retry — gitbeaker retries 429/502 up to 10× with backoff and openai retries 429/5xx (serve a non-retried status like 500, or account for the retries); MSW 2.x route paths use path-to-regexp 8, which rejects RegExp paths and bare `*` — use `:param` segments (URL-encoded slashes like `%2F` stay one segment and decode in the param).
+
 ## Module mocking rules
 
 - **`@/auth`**: activate with a bare `vi.mock("@/auth");` — Vitest resolves the Jest-style `src/auth/__mocks__/index.ts`, which re-exports the canonical factory (`src/test/mocks/auth.ts`: every export a bare `vi.fn()`). Configure behavior per test via `vi.mocked(...)`:
@@ -33,6 +55,7 @@ Consequences:
 
 - **`@/auth/utils`**: bare `vi.mock("@/auth/utils");` (resolves `src/auth/__mocks__/utils.ts`). Needed separately from `@/auth` when the code under test imports from "@/auth/utils" directly — module mocks match specifiers, not re-exports.
 - **`@/observability`**: bare `vi.mock("@/observability");` (resolves `src/observability/__mocks__/index.ts`). `metrics`/`tracing` are memoized proxy trees — any `metrics.<ns>.<fn>` access yields a stable `vi.fn()`, so assert via `vi.mocked(metrics.llm.someFn)` with no factory.
+- **`@/cache-manager`**: bare `vi.mock("@/cache-manager");` (resolves `src/__mocks__/cache-manager.ts`) — a Map-backed `cacheManager` fake with real cache semantics that needs no `start()`, auto-reset before every test; `CacheKey` and `LRUCacheManager` stay real. Tests needing a cache MISS mid-test call `await cacheManager.delete(key)`.
 - **`@/logging`**: do NOT mock just to silence output — the shared setup already runs the real logger at level `silent`. Only mock when a test asserts on logger calls, with a bare `vi.mock("@/logging");` (resolves `src/logging/__mocks__/index.ts`). `vi.spyOn(logger, ...)` does not work — the export is a Proxy binding methods to a private pino instance.
 - **`@/config`**: use the canonical deep-merge factory so unspecified keys keep their real values:
 
@@ -44,7 +67,7 @@ Consequences:
   );
   ```
 
-  Never hand-roll a partial `{ default: { kb: {...} } }` — it silently drops the rest of the config.
+  Never hand-roll a partial `{ default: { kb: {...} } }` — it silently drops the rest of the config. And prefer no config mock at all: direct mutation (next bullet) keeps the file in the fast project; the factory is only NEEDED when the code under test reads config at module-import time (module-level `const` captures), which a runtime mutation can't reach.
 - **Mutating the real config** (`config.apps.enabled = true` style, common in clean-project files): set it in `beforeEach` or inside the test, NOT in `beforeAll` or at module scope — the shared setup restores the pristine config before every test in the shared-worker project, so a once-per-file mutation evaporates after the first test. No manual restore needed.
 - **Never write a bespoke partial factory** for a module that has a canonical mock, and **never mix a bare `vi.mock("x")` with a factory `vi.mock("x", ...)` for the same specifier across files** — Vitest can silently skip one depending on execution order (vitest-dev/vitest#10145).
 - Mock typing is real: `vi.mocked(fn)` carries the actual signature. If the compiler rejects your mock's resolved value, the OLD untyped mock was probably wrong (e.g. resolving a truthy object where the code expects a boolean).

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -417,6 +417,9 @@ jobs:
     defaults:
       run:
         working-directory: ./platform
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
     strategy:
       # A failing shard must not cancel its siblings; we want the full
       # failure picture in one pass.
@@ -434,6 +437,13 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           working-directory: ./platform
+
+      # Tests load the Rust NAPI bindings (@archestra/app-runtime-rs etc.),
+      # which `turbo check:ci` builds implicitly via the task graph. Running
+      # vitest directly skips that, so build backend's workspace deps here —
+      # turbo remote caching makes this seconds on a cache hit.
+      - name: Build backend workspace dependencies
+        run: pnpm exec turbo build --filter="@backend^..."
 
       - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
         working-directory: ./platform/backend

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -447,7 +447,9 @@ jobs:
 
       - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
         working-directory: ./platform/backend
-        run: pnpm exec vitest run --shard=${{ matrix.shard }}/4
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: pnpm exec vitest run --shard="${SHARD}/4"
 
   # Stable-named gate over the shard matrix so branch protection / merge queue
   # can require a single check ("Backend Unit Tests") regardless of shard count.

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -312,8 +312,13 @@ jobs:
       - name: Verify no immature dependencies
         run: pnpm install --fix-lockfile --lockfile-only --ignore-scripts
 
+      # Backend unit tests run in the parallel sharded "Backend Unit Tests"
+      # jobs below; here the backend runs check:commit (same checks minus
+      # vitest) so this job stops being serialized behind the largest suite.
       - name: Type checking, linting, formatting, unit tests
-        run: pnpm check:ci
+        run: |
+          pnpm exec turbo check:ci --filter=!@backend
+          pnpm exec turbo check:commit --filter=@backend
 
       # Validates the production build (turbo build: next build + backend build +
       # Rust NAPI) compiles on every push. This replaces the per-push Docker image
@@ -396,6 +401,62 @@ jobs:
           fi
 
           echo "✅ All validation checks passed"
+
+  # Backend unit tests, sharded across parallel runners. Vitest's --shard
+  # slices the file list deterministically (SHA1 of each path), so the four
+  # jobs partition the suite exactly once. Splitting this out of the lint job
+  # takes the suite off the workflow's critical path.
+  backend-unit-tests:
+    name: Backend Unit Tests (shard ${{ matrix.shard }}/4)
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    # A full local suite run is ~4 min on comparable hardware; a shard is a
+    # quarter of that plus setup. 15 minutes means something is hung.
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: ./platform
+    strategy:
+      # A failing shard must not cancel its siblings; we want the full
+      # failure picture in one pass.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          working-directory: ./platform
+
+      - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
+        working-directory: ./platform/backend
+        run: pnpm exec vitest run --shard=${{ matrix.shard }}/4
+
+  # Stable-named gate over the shard matrix so branch protection / merge queue
+  # can require a single check ("Backend Unit Tests") regardless of shard count.
+  backend-unit-tests-gate:
+    name: Backend Unit Tests
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    if: always()
+    needs: [backend-unit-tests]
+    permissions: {}
+    steps:
+      - name: Check shard results
+        env:
+          SHARDS_RESULT: ${{ needs.backend-unit-tests.result }}
+        run: |
+          if [ "$SHARDS_RESULT" != "success" ]; then
+            echo "::error::One or more backend unit test shards failed (result: $SHARDS_RESULT)."
+            exit 1
+          fi
+          echo "✅ All backend unit test shards passed."
 
   frontend-integration-tests:
     name: Frontend Integration Tests (MSW)

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -30,6 +30,7 @@ Load these project skills when the task matches their domain:
 
 - `archestra-dev-frontend` - use for frontend Next.js/React work, UI components, forms, TanStack Query hooks, generated API clients, white-label copy, and docs links.
 - `archestra-dev-migrations` - use for Drizzle schema changes, generated migrations, data migrations, custom migrations, `drizzle-kit check` failures, or migration conflict resolution via its `resolve-conflicts.md` subpage.
+- `archestra-dev-backend-tests` - use for backend unit tests (`backend/src/**/*.test.ts`): module mocking rules, global stubs, DB fixtures, vitest projects/isolation, test performance.
 - `archestra-dev-e2e` - use for Playwright e2e tests, API/UI fixtures, WireMock setup, local/CI e2e behavior, and locator guidance.
 - `archestra-dev-observability` - use for tracing, metrics, OpenTelemetry, Tempo, Grafana, Prometheus, LLM/MCP spans, or observability label changes.
 - `archestra-dev-rust-napi` - use for Rust core code, NAPI bindings, generated TypeScript bindings, Rust telemetry, and Rust checks.
@@ -275,7 +276,7 @@ pnpm rebuild <package-name>  # Enable scripts for specific package
 - **knip --production (IMPORTANT)**: Backend `check:ci` runs `pnpm knip` = `knip:dev && knip:production`. The `--production` pass ignores `*.test.ts` and cross-workspace consumers (e.g. the `standalone-scripts/` index generator), so an export used only by tests or those scripts fails CI even though plain `knip` passes. Before pushing backend export changes, run `cd backend && pnpm knip` (the full dev+production combo). Tag intentionally-public exports consumed only outside knip's view with a JSDoc `/** @public — reason */` tag (see `config.ts`, `middleware.ts`).
 - **Module Code Order (CRITICAL)**: Always place exports at TOP of file, internal helpers at BOTTOM. Use section comments (`// ===`) to separate. Function declarations are hoisted, so helpers can be called before defined.
 - Use the `logger` instance from `@/logging` for all logging (replaces console.log/error/warn/info)
-- **Backend Testing Best Practices**: Never mock database interfaces in backend tests - use the existing `backend/src/test/setup.ts` PGlite setup for real database testing, and use model methods to create/manipulate test data for integration-focused testing
+- **Backend Testing Best Practices**: Never mock database interfaces in backend tests - use the existing `backend/src/test/setup.ts` PGlite setup for real database testing, and use model methods to create/manipulate test data for integration-focused testing. For module mocking and global stubs, load the `archestra-dev-backend-tests` skill: mock-free files run in a shared-worker fast path, `@/auth`/`@/logging` mocks go through their `__mocks__` dirs (bare `vi.mock("@/auth")`), `@/config` through `configModuleMock(overrides)`, and `vi.stubGlobal` must be (re-)applied in `beforeEach` because stubs auto-revert after every test
 - **API Response Standardization**: Use `constructResponseSchema` helper for all routes to ensure consistent error responses (400, 401, 403, 404, 500)
 - **Error Handling**: Always use `throw new ApiError(statusCode, message)` for error responses - never use manual `reply.status().send({ error: ... })`. The centralized Fastify error handler formats all errors consistently as `{ error: { message, type } }` and logs appropriately.
 - **Protected Routes & Authentication**: Routes under `/api/` are protected by the auth middleware which guarantees `request.user` and `request.organizationId` exist. Never add redundant null checks like `if (!request.organizationId) throw new ApiError(401, "Unauthorized")` - just use `request.organizationId` directly. The middleware handles authentication; routes handle authorization and business logic.
@@ -412,7 +413,7 @@ pnpm rebuild <package-name>  # Enable scripts for specific package
 
 **Testing**:
 
-- **Backend**: Vitest with PGLite for in-memory PostgreSQL testing - never mock database interfaces, use real database operations via models for comprehensive integration testing
+- **Backend**: Vitest with PGLite for in-memory PostgreSQL testing - never mock database interfaces, use real database operations via models for comprehensive integration testing. Load the `archestra-dev-backend-tests` skill for mocking/stub/isolation rules — files without `vi.mock` run in a faster shared-worker vitest project, so prefer boundary mocks over module mocks
 - **Test What Matters**: Prefer behavior-focused tests over implementation-detail tests. Do not add tests that only assert class names, prop plumbing, or incidental markup unless that detail is itself the contract.
 - **E2E Tests**: Load the `archestra-dev-e2e` skill for Playwright tests, fixtures, WireMock setup, local/CI behavior, and locator guidance.
 - **Backend Test Fixtures**: Import from `@/test` to access Vitest context with fixture functions. Available fixtures: `makeUser`, `makeAdmin`, `makeOrganization`, `makeTeam`, `makeAgent`, `makeTool`, `makeAgentTool`, `makeToolPolicy`, `makeTrustedDataPolicy`, `makeCustomRole`, `makeMember`, `makeMcpServer`, `makeInternalMcpCatalog`, `makeInvitation`, `seedAndAssignArchestraTools`

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -166,6 +166,7 @@
     "@typescript/native-preview": "catalog:",
     "esbuild": "^0.28.1",
     "knip": "^5.85.0",
+    "msw": "^2.14.6",
     "tsdown": "^0.21.0",
     "tsx": "^4.21.0",
     "typescript": "catalog:",

--- a/platform/backend/src/__mocks__/cache-manager.ts
+++ b/platform/backend/src/__mocks__/cache-manager.ts
@@ -1,0 +1,72 @@
+/**
+ * Jest-style mock for `@/cache-manager`, activated per test file by a bare
+ * `vi.mock("@/cache-manager");`.
+ *
+ * `cacheManager` is replaced by a Map-backed fake with real cache semantics
+ * (values persist within a test, TTLs ignored) that needs no `start()` — it
+ * satisfies both historical mock intents: tests that only needed to silence
+ * "CacheManager: Not started" warnings, and tests that assert cached
+ * behavior. The store resets before every test, so nothing leaks between
+ * tests or files. Tests that need a cache MISS mid-test should
+ * `await cacheManager.delete(key)` explicitly.
+ *
+ * `CacheKey` and `LRUCacheManager` are the real implementations —
+ * LRUCacheManager is pure in-memory and safe in tests as-is.
+ */
+import { beforeEach, vi } from "vitest";
+
+const actual =
+  await vi.importActual<typeof import("@/cache-manager")>("@/cache-manager");
+
+export const CacheKey = actual.CacheKey;
+export const LRUCacheManager = actual.LRUCacheManager;
+
+class FakeCacheManager {
+  private store = new Map<string, unknown>();
+
+  start(): void {}
+  shutdown(): void {}
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.store.get(key) as T | undefined;
+  }
+
+  async set<T>(key: string, value: T, _ttl?: number): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.store.delete(key);
+  }
+
+  async getAndDelete<T>(key: string): Promise<T | undefined> {
+    const value = this.store.get(key) as T | undefined;
+    this.store.delete(key);
+    return value;
+  }
+
+  async deleteByPrefix(prefix: string): Promise<number> {
+    let deleted = 0;
+    for (const key of [...this.store.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
+
+  /** Test-only: wipe the store (also done automatically before each test). */
+  reset(): void {
+    this.store.clear();
+  }
+}
+
+export const cacheManager = new FakeCacheManager();
+
+// This module is only evaluated inside a test file's context (via vi.mock),
+// so registering a hook here is safe and gives every consumer a clean cache
+// per test without any per-file boilerplate.
+beforeEach(() => {
+  cacheManager.reset();
+});

--- a/platform/backend/src/agents/a2a/stage-attachments.test.ts
+++ b/platform/backend/src/agents/a2a/stage-attachments.test.ts
@@ -4,7 +4,15 @@ import config from "@/config";
 import { SkillSandboxModel, SkillSandboxReplayEventModel } from "@/models";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
 import { SKILL_SANDBOX_HOME } from "@/skills-sandbox/runtime-image";
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "@/test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@/test";
 import { stageAttachmentsIntoSandbox } from "./stage-attachments";
 
 // Exercises the real staging path against the test DB: per-execution sandbox
@@ -15,7 +23,7 @@ describe("stageAttachmentsIntoSandbox (integration)", () => {
   const originalDagger = config.daggerRuntime.enabled;
   const isolationKeys: string[] = [];
 
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
     (config.daggerRuntime as { enabled: boolean }).enabled = true;
   });

--- a/platform/backend/src/agents/chatops/channel-activation.test.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.test.ts
@@ -1,24 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { cacheManager } from "@/cache-manager";
 
-// Mock the distributed cache with an in-memory Map (preserve CacheKey etc.).
-// The `mock`-prefixed names are referenced lazily inside the fn bodies so they
-// survive vi.mock hoisting.
-const mockCache = new Map<string, unknown>();
-const mockSetCalls: Array<[string, unknown, number | undefined]> = [];
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...actual,
-    cacheManager: {
-      get: vi.fn(async (key: string) => mockCache.get(key)),
-      set: vi.fn(async (key: string, value: unknown, ttl?: number) => {
-        mockCache.set(key, value);
-        mockSetCalls.push([key, value, ttl]);
-      }),
-      delete: vi.fn(async (key: string) => mockCache.delete(key)),
-    },
-  };
-});
+// The canonical Map-backed fake from src/__mocks__/cache-manager.ts stands in
+// for the distributed cache (preserves CacheKey etc.); the store resets before
+// every test. A spy over the fake's real set() lets tests assert the TTLs.
+vi.mock("@/cache-manager");
+
+const setSpy = vi.spyOn(cacheManager, "set");
 
 import {
   claimThreadMuteHint,
@@ -45,8 +33,6 @@ const TEAMS = {
 
 describe("channel-activation (sticky channel auto-reply)", () => {
   beforeEach(() => {
-    mockCache.clear();
-    mockSetCalls.length = 0;
     vi.clearAllMocks();
   });
 
@@ -91,8 +77,8 @@ describe("channel-activation (sticky channel auto-reply)", () => {
   test("marking active writes with the configured TTL", async () => {
     await markChannelThreadActive(TEAMS);
 
-    expect(mockSetCalls).toHaveLength(1);
-    const [key, value, ttl] = mockSetCalls[0];
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const [key, value, ttl] = setSpy.mock.calls[0];
     expect(key).toContain(CHANNEL);
     expect(value).toBe(true);
     expect(ttl).toBe(CHATOPS_CHANNEL_AUTO_REPLY.ACTIVE_TTL_MS);
@@ -126,8 +112,6 @@ describe("channel-activation (sticky channel auto-reply)", () => {
 
 describe("claimThreadMuteHint", () => {
   beforeEach(() => {
-    mockCache.clear();
-    mockSetCalls.length = 0;
     vi.clearAllMocks();
   });
 
@@ -140,8 +124,8 @@ describe("claimThreadMuteHint", () => {
   test("records the claim with the sticky auto-reply TTL", async () => {
     await claimThreadMuteHint(TEAMS);
 
-    expect(mockSetCalls).toHaveLength(1);
-    const [key, value, ttl] = mockSetCalls[0];
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const [key, value, ttl] = setSpy.mock.calls[0];
     expect(key).toContain(CHANNEL);
     expect(value).toBe(true);
     expect(ttl).toBe(CHATOPS_CHANNEL_AUTO_REPLY.ACTIVE_TTL_MS);

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -5,30 +5,12 @@ import {
 } from "@archestra/shared";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-// In-memory stand-in for the distributed cache so the sticky-thread activation
-// gate (channel-activation.ts) works without starting the real cache manager.
-// The `mock`-prefixed name is referenced lazily inside the factory so it
-// survives vi.mock hoisting. Tests that need specific cache behavior still
-// vi.spyOn(cacheManager, ...) and restore afterwards.
-const mockCacheStore = new Map<string, unknown>();
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...actual,
-    cacheManager: {
-      async get(key: string) {
-        return mockCacheStore.get(key);
-      },
-      async set(key: string, value: unknown) {
-        mockCacheStore.set(key, value);
-        return true;
-      },
-      async delete(key: string) {
-        return mockCacheStore.delete(key);
-      },
-    },
-  };
-});
+// The canonical Map-backed fake from src/__mocks__/cache-manager.ts stands in
+// for the distributed cache so the sticky-thread activation gate
+// (channel-activation.ts) works without starting the real cache manager; the
+// store resets before every test. Tests that need specific cache behavior still
+// vi.spyOn(cacheManager, ...).
+vi.mock("@/cache-manager");
 
 import { CacheKey, cacheManager } from "@/cache-manager";
 import { markChannelThreadActive } from "./channel-activation";
@@ -845,8 +827,8 @@ describe("SlackProvider.parseWebhookNotification — mute reaction", () => {
   const ROOT = "7777777777.000001";
   const BOT_REPLY_TS = "7777777777.000002";
 
-  // These tests reuse one channel/thread, so reset the shared cache each time.
-  beforeEach(() => mockCacheStore.clear());
+  // These tests reuse one channel/thread; the fake cache resets before each
+  // test automatically, so no manual clearing is needed here.
 
   // Client with a postMessage spy and a conversations.replies that resolves the
   // thread root (messages[0].ts) for the reacted message.

--- a/platform/backend/src/agents/incoming-email/index.test.ts
+++ b/platform/backend/src/agents/incoming-email/index.test.ts
@@ -7,9 +7,9 @@ vi.mock("@/agents/a2a-executor", () => ({
 }));
 
 // Mock the auth utils for permission checks
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { executeA2AMessage } from "@/agents/a2a-executor";
 import { userHasPermission } from "@/auth";

--- a/platform/backend/src/agents/incoming-email/index.test.ts
+++ b/platform/backend/src/agents/incoming-email/index.test.ts
@@ -7,9 +7,7 @@ vi.mock("@/agents/a2a-executor", () => ({
 }));
 
 // Mock the auth utils for permission checks
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { executeA2AMessage } from "@/agents/a2a-executor";
 import { userHasPermission } from "@/auth";

--- a/platform/backend/src/agents/utils.test.ts
+++ b/platform/backend/src/agents/utils.test.ts
@@ -1,22 +1,11 @@
 import { vi } from "vitest";
-import { type AllowedCacheKey, CacheKey } from "@/cache-manager";
+import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
 import { beforeEach, describe, expect, test } from "@/test";
 import { isRateLimited, type RateLimitEntry } from "./utils";
 
-// Mock cacheManager while preserving other exports (like LRUCacheManager, CacheKey)
-const mockCache = new Map<string, RateLimitEntry>();
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...actual,
-    cacheManager: {
-      get: vi.fn(async (key: string) => mockCache.get(key)),
-      set: vi.fn(async (key: string, value: RateLimitEntry) => {
-        mockCache.set(key, value);
-      }),
-    },
-  };
-});
+// The canonical Map-backed fake from src/__mocks__/cache-manager.ts; reads
+// and seeds below go through the fake's own get/set.
+vi.mock("@/cache-manager");
 
 describe("isRateLimited", () => {
   const testConfig = { windowMs: 60_000, maxRequests: 3 };
@@ -24,7 +13,6 @@ describe("isRateLimited", () => {
     `${CacheKey.WebhookRateLimit}-test-127.0.0.1` as AllowedCacheKey;
 
   beforeEach(() => {
-    mockCache.clear();
     vi.clearAllMocks();
   });
 
@@ -32,7 +20,7 @@ describe("isRateLimited", () => {
     const result = await isRateLimited(testCacheKey, testConfig);
 
     expect(result).toBe(false);
-    expect(mockCache.get(testCacheKey)).toMatchObject({
+    expect(await cacheManager.get(testCacheKey)).toMatchObject({
       count: 1,
     });
   });
@@ -45,7 +33,9 @@ describe("isRateLimited", () => {
     // Third request (at limit)
     expect(await isRateLimited(testCacheKey, testConfig)).toBe(false);
 
-    expect(mockCache.get(testCacheKey)?.count).toBe(3);
+    expect((await cacheManager.get<RateLimitEntry>(testCacheKey))?.count).toBe(
+      3,
+    );
   });
 
   test("blocks requests at the limit", async () => {
@@ -65,13 +55,13 @@ describe("isRateLimited", () => {
       count: testConfig.maxRequests,
       windowStart: Date.now() - testConfig.windowMs - 1000, // 1 second past expiry
     };
-    mockCache.set(testCacheKey, expiredEntry);
+    await cacheManager.set(testCacheKey, expiredEntry);
 
     // Should allow the request and reset counter
     const result = await isRateLimited(testCacheKey, testConfig);
 
     expect(result).toBe(false);
-    expect(mockCache.get(testCacheKey)).toMatchObject({
+    expect(await cacheManager.get(testCacheKey)).toMatchObject({
       count: 1,
     });
   });
@@ -117,12 +107,12 @@ describe("isRateLimited", () => {
   test("preserves windowStart when incrementing count", async () => {
     // First request sets windowStart
     await isRateLimited(testCacheKey, testConfig);
-    const initialEntry = mockCache.get(testCacheKey);
+    const initialEntry = await cacheManager.get<RateLimitEntry>(testCacheKey);
     const initialWindowStart = initialEntry?.windowStart;
 
     // Second request should preserve windowStart
     await isRateLimited(testCacheKey, testConfig);
-    const updatedEntry = mockCache.get(testCacheKey);
+    const updatedEntry = await cacheManager.get<RateLimitEntry>(testCacheKey);
 
     expect(updatedEntry?.windowStart).toBe(initialWindowStart);
     expect(updatedEntry?.count).toBe(2);

--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -54,24 +54,9 @@ import { type ArchestraContext, executeArchestraTool } from ".";
 
 // The elicitation bridge polls cacheManager for the user's answer; cacheManager
 // is the Postgres-backed singleton (not started in PGlite tests), so back it
-// with an in-memory map. The bridge and refine_app (the SUT) are real.
-const elicitationStore = vi.hoisted(() => new Map<string, unknown>());
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...actual,
-    cacheManager: {
-      set: async (key: string, value: unknown) => {
-        elicitationStore.set(key, value);
-      },
-      getAndDelete: async (key: string) => {
-        const value = elicitationStore.get(key);
-        elicitationStore.delete(key);
-        return value;
-      },
-    },
-  };
-});
+// with the canonical Map-backed fake from src/__mocks__/cache-manager.ts. The
+// bridge and refine_app (the SUT) are real.
+vi.mock("@/cache-manager");
 
 // App tools are only dispatchable when the feature is enabled.
 const originalAppsEnabled = config.apps.enabled;

--- a/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
@@ -270,7 +270,7 @@ describe("isDynamicallyAvailableArchestraTool", () => {
 
   describe("sandbox built-ins", () => {
     const originalSandboxEnabled = config.skillsSandbox.enabled;
-    beforeAll(() => {
+    beforeEach(() => {
       (config.skillsSandbox as { enabled: boolean }).enabled = true;
     });
     afterAll(() => {

--- a/platform/backend/src/archestra-mcp-server/run-tool.test.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.test.ts
@@ -808,7 +808,7 @@ describe("run_tool", () => {
     let dynamicAgent: Agent;
     let dynamicContext: ArchestraContext;
 
-    beforeAll(() => {
+    beforeEach(() => {
       (config.skillsSandbox as { enabled: boolean }).enabled = true;
     });
 

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -109,7 +109,7 @@ describe("sandbox tools (runtime enabled)", () => {
   let context: ArchestraContext;
   const originalEnabled = config.skillsSandbox.enabled;
 
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
   });
 
@@ -1067,7 +1067,7 @@ describe("sandbox tools (runtime enabled)", () => {
     // exercise the real persistence + validation path against PGlite.
     describe("with the runtime engine available", () => {
       const originalDagger = config.daggerRuntime.enabled;
-      beforeAll(() => {
+      beforeEach(() => {
         (config.daggerRuntime as { enabled: boolean }).enabled = true;
       });
       afterAll(() => {
@@ -1186,7 +1186,7 @@ describe("sandbox tools (runtime enabled)", () => {
     // gate runs; a deleted skill must fail the call before any container build.
     describe("revocation gate", () => {
       const originalDagger = config.daggerRuntime.enabled;
-      beforeAll(() => {
+      beforeEach(() => {
         (config.daggerRuntime as { enabled: boolean }).enabled = true;
       });
       afterAll(() => {
@@ -1251,7 +1251,7 @@ describe("PFS tools (search_files, my_file source, download_file project)", () =
   let context: ArchestraContext;
   const originalEnabled = config.skillsSandbox.enabled;
 
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
   });
   afterAll(() => {
@@ -1532,7 +1532,7 @@ describe("project file scope (save_file, scoped search/my_file)", () => {
   let context: ArchestraContext;
   const originalEnabled = config.skillsSandbox.enabled;
 
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
   });
   afterAll(() => {
@@ -1940,7 +1940,7 @@ describe("read_file", () => {
   let context: ArchestraContext;
   const originalEnabled = config.skillsSandbox.enabled;
 
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
   });
   afterAll(() => {
@@ -2414,7 +2414,7 @@ describe("edit_file / delete_file", () => {
   let context: ArchestraContext;
   const originalEnabled = config.skillsSandbox.enabled;
 
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
   });
   afterAll(() => {
@@ -2656,7 +2656,7 @@ describe("projects feature gating (search_files / save_file / my_file)", () => {
   const originalSandbox = config.skillsSandbox.enabled;
   const originalProjects = config.projects.enabled;
 
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
   });
   afterAll(() => {

--- a/platform/backend/src/auth/__mocks__/index.ts
+++ b/platform/backend/src/auth/__mocks__/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Jest-style mock for `@/auth`, activated per test file by a bare
+ * `vi.mock("@/auth");` — Vitest resolves this `__mocks__` sibling instead of
+ * the real module. Delegates to the canonical factory so the mock surface
+ * lives in one place; configure behavior via `vi.mocked(...)` in the test.
+ *
+ * NOTE: this resolution works because the `@` alias is defined with an
+ * absolute path in vitest.config.ts `resolve.alias`. If the file here is ever
+ * renamed/moved, bare `vi.mock("@/auth")` silently degrades to an automock of
+ * the real module and dependent tests fail loudly.
+ */
+import { authModuleMock } from "@/test/mocks/auth";
+
+const mock = authModuleMock();
+export const {
+  getAgentTypePermissionChecker,
+  hasAnyAgentTypeAdminPermission,
+  hasAnyAgentTypeReadPermission,
+  isAgentTypeAdmin,
+  requireAgentModifyPermission,
+  requireAgentTypePermission,
+  betterAuth,
+  fastifyAuthPlugin,
+  hasPermission,
+  userHasPermission,
+} = mock;

--- a/platform/backend/src/auth/__mocks__/utils.ts
+++ b/platform/backend/src/auth/__mocks__/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Jest-style mock for `@/auth/utils`, activated per test file by a bare
+ * `vi.mock("@/auth/utils");`. Needed separately from the `@/auth` mock when
+ * the code under test imports from "@/auth/utils" directly — module mocks
+ * match specifiers, not re-exports.
+ */
+import { vi } from "vitest";
+
+export const hasPermission = vi.fn();
+export const userHasPermission = vi.fn();
+export const getPermissionsForUserContext = vi.fn();

--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -5,21 +5,11 @@ import { cacheManager } from "@/cache-manager";
 import type * as originalConfigModule from "@/config";
 import { enterpriseTier } from "@/enterprise-tier";
 
-// The logger is a Proxy at runtime — vi.spyOn can't intercept its properties.
-// Replace the module with a plain mock object so individual tests can assert on it.
-const logErrorFn = vi.hoisted(() => vi.fn());
-vi.mock("@/logging", () => ({
-  default: {
-    error: logErrorFn,
-    info: vi.fn(),
-    warn: vi.fn(),
-    debug: vi.fn(),
-    trace: vi.fn(),
-    fatal: vi.fn(),
-    child: vi.fn().mockReturnThis(),
-  },
-}));
+vi.mock("@/logging", async () =>
+  (await import("@/test/mocks/logging")).loggingModuleMock(),
+);
 
+import logger from "@/logging";
 import {
   AccountModel,
   MemberModel,
@@ -2478,8 +2468,8 @@ describe("auth event audit logging", () => {
     await expect(handleAfterHook(ctx)).resolves.not.toThrow();
 
     await waitForAuditWrite();
-    // logErrorFn is the module-level mock for logger.error — verify it was called.
-    expect(logErrorFn).toHaveBeenCalled();
+    // Verify logger.error was called.
+    expect(vi.mocked(logger.error)).toHaveBeenCalled();
     createSpy.mockRestore();
   });
 

--- a/platform/backend/src/auth/better-auth.test.ts
+++ b/platform/backend/src/auth/better-auth.test.ts
@@ -5,9 +5,7 @@ import { cacheManager } from "@/cache-manager";
 import type * as originalConfigModule from "@/config";
 import { enterpriseTier } from "@/enterprise-tier";
 
-vi.mock("@/logging", async () =>
-  (await import("@/test/mocks/logging")).loggingModuleMock(),
-);
+vi.mock("@/logging");
 
 import logger from "@/logging";
 import {

--- a/platform/backend/src/auth/fastify-plugin/plugin.test.ts
+++ b/platform/backend/src/auth/fastify-plugin/plugin.test.ts
@@ -10,9 +10,7 @@ import {
 import { ApiError } from "@/types";
 
 // Mock modules with factory functions to avoid hoisting issues
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 vi.mock("@/auth/utils", () => ({
   hasPermission: vi.fn(),

--- a/platform/backend/src/auth/fastify-plugin/plugin.test.ts
+++ b/platform/backend/src/auth/fastify-plugin/plugin.test.ts
@@ -10,15 +10,9 @@ import {
 import { ApiError } from "@/types";
 
 // Mock modules with factory functions to avoid hoisting issues
-vi.mock("@/auth", () => ({
-  betterAuth: {
-    api: {
-      getSession: vi.fn(),
-      verifyApiKey: vi.fn(),
-    },
-  },
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 vi.mock("@/auth/utils", () => ({
   hasPermission: vi.fn(),

--- a/platform/backend/src/auth/fastify-plugin/plugin.test.ts
+++ b/platform/backend/src/auth/fastify-plugin/plugin.test.ts
@@ -12,9 +12,7 @@ import { ApiError } from "@/types";
 // Mock modules with factory functions to avoid hoisting issues
 vi.mock("@/auth");
 
-vi.mock("@/auth/utils", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth/utils");
 
 vi.mock("@/models", () => ({
   ServiceAccountModel: {

--- a/platform/backend/src/clients/azure-openai-credentials.test.ts
+++ b/platform/backend/src/clients/azure-openai-credentials.test.ts
@@ -7,18 +7,14 @@ vi.mock("@azure/identity", () => ({
   getBearerTokenProvider: vi.fn(() => async () => "token"),
 }));
 
-vi.mock("@/config", () => ({
-  default: {
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
     llm: {
-      azure: {
-        entraIdEnabled: true,
-      },
-      anthropic: {
-        azureFoundryEntraIdEnabled: true,
-      },
+      azure: { entraIdEnabled: true },
+      anthropic: { azureFoundryEntraIdEnabled: true },
     },
-  },
-}));
+  }),
+);
 
 import { getBearerTokenProvider } from "@azure/identity";
 import {

--- a/platform/backend/src/clients/chat-mcp-elicitation.test.ts
+++ b/platform/backend/src/clients/chat-mcp-elicitation.test.ts
@@ -1,19 +1,18 @@
 import type { ElicitRequest } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { cacheManager } from "@/cache-manager";
 import {
   createChatMcpElicitationBridge,
   resolveChatMcpElicitation,
 } from "@/clients/chat-mcp-elicitation";
 
-const cacheManagerMocks = vi.hoisted(() => ({
-  getAndDelete: vi.fn(),
-  set: vi.fn(),
-}));
+// The canonical Map-backed fake from src/__mocks__/cache-manager.ts. These
+// tests drive the polling loop by stubbing getAndDelete per call and assert on
+// set(), so they spy over the fake's real methods.
+vi.mock("@/cache-manager");
 
-vi.mock("@/cache-manager", () => ({
-  CacheKey: { ChatMcpElicitation: "chat-mcp-elicitation" },
-  cacheManager: cacheManagerMocks,
-}));
+const getAndDeleteSpy = vi.spyOn(cacheManager, "getAndDelete");
+const setSpy = vi.spyOn(cacheManager, "set");
 
 describe("chat MCP elicitation", () => {
   afterEach(() => {
@@ -29,13 +28,11 @@ describe("chat MCP elicitation", () => {
     });
     bridge.setWriter(writer);
 
-    cacheManagerMocks.getAndDelete
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce({
-        conversationId: "00000000-0000-4000-8000-000000000001",
-        action: "accept",
-        content: { project: "alpha", priority: 2 },
-      });
+    getAndDeleteSpy.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+      conversationId: "00000000-0000-4000-8000-000000000001",
+      action: "accept",
+      content: { project: "alpha", priority: 2 },
+    });
 
     const handler = bridge.createHandler({ toolName: "example__create_issue" });
     const resultPromise = handler(
@@ -79,7 +76,7 @@ describe("chat MCP elicitation", () => {
     });
     bridge.setWriter(writer);
 
-    cacheManagerMocks.getAndDelete
+    getAndDeleteSpy
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
@@ -105,19 +102,19 @@ describe("chat MCP elicitation", () => {
       {} as never,
     );
 
-    expect(cacheManagerMocks.getAndDelete).toHaveBeenCalledTimes(1);
+    expect(getAndDeleteSpy).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(249);
-    expect(cacheManagerMocks.getAndDelete).toHaveBeenCalledTimes(1);
+    expect(getAndDeleteSpy).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(1);
-    expect(cacheManagerMocks.getAndDelete).toHaveBeenCalledTimes(2);
+    expect(getAndDeleteSpy).toHaveBeenCalledTimes(2);
 
     await vi.advanceTimersByTimeAsync(499);
-    expect(cacheManagerMocks.getAndDelete).toHaveBeenCalledTimes(2);
+    expect(getAndDeleteSpy).toHaveBeenCalledTimes(2);
     await vi.advanceTimersByTimeAsync(1);
-    expect(cacheManagerMocks.getAndDelete).toHaveBeenCalledTimes(3);
+    expect(getAndDeleteSpy).toHaveBeenCalledTimes(3);
 
     await vi.advanceTimersByTimeAsync(999);
-    expect(cacheManagerMocks.getAndDelete).toHaveBeenCalledTimes(3);
+    expect(getAndDeleteSpy).toHaveBeenCalledTimes(3);
     await vi.advanceTimersByTimeAsync(1);
 
     await expect(resultPromise).resolves.toEqual({
@@ -136,7 +133,7 @@ describe("chat MCP elicitation", () => {
     });
     bridge.setWriter(writer);
 
-    cacheManagerMocks.getAndDelete.mockResolvedValue(undefined);
+    getAndDeleteSpy.mockResolvedValue(undefined);
 
     const handler = bridge.createHandler({ toolName: "example__create_issue" });
     const resultPromise = handler(
@@ -154,9 +151,7 @@ describe("chat MCP elicitation", () => {
       {} as never,
     );
 
-    await vi.waitFor(() =>
-      expect(cacheManagerMocks.getAndDelete).toHaveBeenCalled(),
-    );
+    await vi.waitFor(() => expect(getAndDeleteSpy).toHaveBeenCalled());
 
     abortController.abort();
 
@@ -173,13 +168,11 @@ describe("chat MCP elicitation", () => {
     });
     bridge.setWriter(writer);
 
-    cacheManagerMocks.getAndDelete
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce({
-        conversationId: "00000000-0000-4000-8000-000000000001",
-        action: "accept",
-        content: { features: ["search"] },
-      });
+    getAndDeleteSpy.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+      conversationId: "00000000-0000-4000-8000-000000000001",
+      action: "accept",
+      content: { features: ["search"] },
+    });
 
     const outcomePromise = bridge.elicit({
       toolName: "archestra__refine_app",
@@ -216,11 +209,11 @@ describe("chat MCP elicitation", () => {
     await expect(
       bridge.elicit({ toolName: "archestra__refine_app", message: "Hi?" }),
     ).resolves.toEqual({ status: "no_viewer" });
-    expect(cacheManagerMocks.getAndDelete).not.toHaveBeenCalled();
+    expect(getAndDeleteSpy).not.toHaveBeenCalled();
   });
 
   test("stores user responses for the pending elicitation id", async () => {
-    cacheManagerMocks.set.mockResolvedValue(undefined);
+    setSpy.mockResolvedValue(undefined);
 
     await resolveChatMcpElicitation({
       id: "00000000-0000-4000-8000-000000000002",
@@ -230,7 +223,7 @@ describe("chat MCP elicitation", () => {
       },
     });
 
-    expect(cacheManagerMocks.set).toHaveBeenCalledWith(
+    expect(setSpy).toHaveBeenCalledWith(
       "chat-mcp-elicitation-00000000-0000-4000-8000-000000000002",
       {
         conversationId: "00000000-0000-4000-8000-000000000001",

--- a/platform/backend/src/clients/models-dev-client.test.ts
+++ b/platform/backend/src/clients/models-dev-client.test.ts
@@ -11,8 +11,12 @@ const { mockFetch } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
 }));
 
-// Mock global fetch
+// Mock global fetch. The config's `unstubGlobals` removes stubs after every
+// test, so re-apply before each one; the top-level stub covers import time.
 vi.stubGlobal("fetch", mockFetch);
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
 
 // Import after mock is defined
 import { modelsDevClient } from "./models-dev-client";

--- a/platform/backend/src/clients/models-dev-client.test.ts
+++ b/platform/backend/src/clients/models-dev-client.test.ts
@@ -21,31 +21,9 @@ beforeEach(() => {
 // Import after mock is defined
 import { modelsDevClient } from "./models-dev-client";
 
-// Mock the cache manager to avoid "CacheManager: Not started" errors
-vi.mock("@/cache-manager", () => {
-  class MockLRUCacheManager {
-    get() {
-      return undefined;
-    }
-    set() {}
-    delete() {
-      return true;
-    }
-    has() {
-      return false;
-    }
-    clear() {}
-  }
-
-  return {
-    CacheKey: { ModelsDevSync: "models-dev-sync" },
-    cacheManager: {
-      get: vi.fn().mockResolvedValue(undefined),
-      set: vi.fn().mockResolvedValue(undefined),
-    },
-    LRUCacheManager: MockLRUCacheManager,
-  };
-});
+// The canonical Map-backed fake from src/__mocks__/cache-manager.ts avoids
+// "CacheManager: Not started" errors; the store resets before every test.
+vi.mock("@/cache-manager");
 
 /**
  * Helper to create a mock models.dev model object

--- a/platform/backend/src/database/index.ts
+++ b/platform/backend/src/database/index.ts
@@ -156,10 +156,15 @@ export { schema };
 /**
  * Set the database instance directly (for testing purposes only).
  * This bypasses the normal initialization flow.
+ *
+ * Pass `null` on test-file teardown: between files in a shared worker,
+ * accesses through the proxy then fail with getDb()'s "Database not
+ * initialized" — a condition import-time consumers already tolerate —
+ * instead of "PGlite is closed" from a torn-down instance.
  * @public — consumed via dynamic import in src/test/setup.ts
  */
 export function __setTestDb(
-  testDb: ReturnType<typeof drizzle<typeof schema>>,
+  testDb: ReturnType<typeof drizzle<typeof schema>> | null,
 ): void {
   db = testDb;
 }

--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -9,16 +9,6 @@ import {
   wrapPoolWithRetry,
 } from "./retry";
 
-// Suppress logger output during tests
-vi.mock("@/logging", () => ({
-  default: {
-    warn: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    fatal: vi.fn(),
-  },
-}));
-
 describe("isTransientDbError", () => {
   test("returns false for non-Error values", () => {
     expect(isTransientDbError("string")).toBe(false);

--- a/platform/backend/src/features/browser-stream/routes/browser-stream.routes.test.ts
+++ b/platform/backend/src/features/browser-stream/routes/browser-stream.routes.test.ts
@@ -5,20 +5,14 @@ import {
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
 import { vi } from "vitest";
-import type * as originalConfigModule from "@/config";
 import { BrowserStreamService } from "@/features/browser-stream/services/browser-stream.service";
 import AgentModel from "@/models/agent";
 import { beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock(),
+);
 
 // Import routes AFTER mocking config (dynamic import needed because of the mock)
 const { default: browserStreamRoutes } = await import(

--- a/platform/backend/src/features/browser-stream/routes/browser-stream.routes.test.ts
+++ b/platform/backend/src/features/browser-stream/routes/browser-stream.routes.test.ts
@@ -7,18 +7,10 @@ import {
 import { vi } from "vitest";
 import { BrowserStreamService } from "@/features/browser-stream/services/browser-stream.service";
 import AgentModel from "@/models/agent";
+import chatRoutes from "@/routes/chat/routes";
 import { beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
-
-vi.mock("@/config", async () =>
-  (await import("@/test/mocks/config")).configModuleMock(),
-);
-
-// Import routes AFTER mocking config (dynamic import needed because of the mock)
-const { default: browserStreamRoutes } = await import(
-  "./browser-stream.routes"
-);
-const { default: chatRoutes } = await import("@/routes/chat/routes");
+import browserStreamRoutes from "./browser-stream.routes";
 
 const buildAppWithUser = async (user: User, organizationId: string) => {
   const app = Fastify({ logger: false })

--- a/platform/backend/src/features/browser-stream/websocket/browser-stream.websocket.test.ts
+++ b/platform/backend/src/features/browser-stream/websocket/browser-stream.websocket.test.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import type { ClientWebSocketMessage } from "@archestra/shared";
 import { vi } from "vitest";
 import { WebSocket as WS } from "ws";
+import { browserStreamFeature } from "@/features/browser-stream/services/browser-stream.feature";
 import AgentModel from "@/models/agent";
 import {
   afterAll,
@@ -11,15 +12,7 @@ import {
   expect,
   test,
 } from "@/test";
-
-vi.mock("@/config", async () =>
-  (await import("@/test/mocks/config")).configModuleMock(),
-);
-
-const { browserStreamFeature } = await import(
-  "@/features/browser-stream/services/browser-stream.feature"
-);
-const { default: websocketService } = await import("@/websocket");
+import websocketService from "@/websocket";
 
 const httpServer = createServer();
 

--- a/platform/backend/src/features/browser-stream/websocket/browser-stream.websocket.test.ts
+++ b/platform/backend/src/features/browser-stream/websocket/browser-stream.websocket.test.ts
@@ -2,7 +2,6 @@ import { createServer } from "node:http";
 import type { ClientWebSocketMessage } from "@archestra/shared";
 import { vi } from "vitest";
 import { WebSocket as WS } from "ws";
-import type * as originalConfigModule from "@/config";
 import AgentModel from "@/models/agent";
 import {
   afterAll,
@@ -13,14 +12,9 @@ import {
   test,
 } from "@/test";
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock(),
+);
 
 const { browserStreamFeature } = await import(
   "@/features/browser-stream/services/browser-stream.feature"

--- a/platform/backend/src/k8s/dagger-environment-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/manager.test.ts
@@ -22,16 +22,11 @@ vi.mock("@/k8s/cluster-dns", async (importOriginal) => ({
 
 // reconcileEnvironment short-circuits unless the sandbox feature is on; flip the
 // flag, leaving the rest of config real so the StatefulSet builder tests stand.
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/config")>();
-  return {
-    ...actual,
-    default: {
-      ...actual.default,
-      skillsSandbox: { ...actual.default.skillsSandbox, enabled: true },
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    skillsSandbox: { enabled: true },
+  }),
+);
 
 // Mock the leaf module (not the @/models barrel) so the override propagates
 // through the index's `export { default as OrganizationModel }` re-export to the

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import { PassThrough } from "node:stream";
 import * as k8s from "@kubernetes/client-node";
 import { vi } from "vitest";
-import type * as originalConfigModule from "@/config";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { McpServer, NetworkPolicy } from "@/types";
 
@@ -56,21 +55,17 @@ vi.mock("@kubernetes/client-node", () => {
 });
 
 // Mock the dependencies before importing the manager
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-      orchestrator: {
-        kubernetes: {
-          namespace: "test-namespace",
-          kubeconfig: undefined,
-          loadKubeconfigFromCurrentCluster: false,
-        },
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    orchestrator: {
+      kubernetes: {
+        namespace: "test-namespace",
+        kubeconfig: undefined,
+        loadKubeconfigFromCurrentCluster: false,
       },
     },
-  };
-});
+  }),
+);
 
 // Track K8sDeployment constructor calls and method invocations
 const mockCreateK8sSecret = vi.fn().mockResolvedValue(undefined);

--- a/platform/backend/src/k8s/shared.test.ts
+++ b/platform/backend/src/k8s/shared.test.ts
@@ -1,5 +1,4 @@
 import { vi } from "vitest";
-import type * as originalConfigModule from "@/config";
 import { describe, expect, test } from "@/test";
 
 vi.mock("@kubernetes/client-node", () => {
@@ -28,21 +27,17 @@ vi.mock("@kubernetes/client-node", () => {
   };
 });
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-      orchestrator: {
-        kubernetes: {
-          namespace: "",
-          kubeconfig: undefined,
-          loadKubeconfigFromCurrentCluster: false,
-        },
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    orchestrator: {
+      kubernetes: {
+        namespace: "",
+        kubeconfig: undefined,
+        loadKubeconfigFromCurrentCluster: false,
       },
     },
-  };
-});
+  }),
+);
 
 describe("shared K8s utilities", () => {
   describe("sanitizeLabelValue", () => {
@@ -172,7 +167,7 @@ describe("shared K8s utilities", () => {
     test("returns false when no K8s env vars are set", async () => {
       vi.resetModules();
       vi.doMock("@/config", async (importOriginal) => {
-        const actual = await importOriginal<typeof originalConfigModule>();
+        const actual = await importOriginal<typeof import("@/config")>();
         return {
           default: {
             ...actual.default,
@@ -193,7 +188,7 @@ describe("shared K8s utilities", () => {
     test("returns true when kubeconfig is set", async () => {
       vi.resetModules();
       vi.doMock("@/config", async (importOriginal) => {
-        const actual = await importOriginal<typeof originalConfigModule>();
+        const actual = await importOriginal<typeof import("@/config")>();
         return {
           default: {
             ...actual.default,
@@ -214,7 +209,7 @@ describe("shared K8s utilities", () => {
     test("returns true when loadKubeconfigFromCurrentCluster is true", async () => {
       vi.resetModules();
       vi.doMock("@/config", async (importOriginal) => {
-        const actual = await importOriginal<typeof originalConfigModule>();
+        const actual = await importOriginal<typeof import("@/config")>();
         return {
           default: {
             ...actual.default,
@@ -235,7 +230,7 @@ describe("shared K8s utilities", () => {
     test("returns false when kubeconfig is empty string", async () => {
       vi.resetModules();
       vi.doMock("@/config", async (importOriginal) => {
-        const actual = await importOriginal<typeof originalConfigModule>();
+        const actual = await importOriginal<typeof import("@/config")>();
         return {
           default: {
             ...actual.default,
@@ -258,7 +253,7 @@ describe("shared K8s utilities", () => {
     test("returns configured namespace when set", async () => {
       vi.resetModules();
       vi.doMock("@/config", async (importOriginal) => {
-        const actual = await importOriginal<typeof originalConfigModule>();
+        const actual = await importOriginal<typeof import("@/config")>();
         return {
           default: {
             ...actual.default,
@@ -279,7 +274,7 @@ describe("shared K8s utilities", () => {
     test("returns 'default' when namespace is not set", async () => {
       vi.resetModules();
       vi.doMock("@/config", async (importOriginal) => {
-        const actual = await importOriginal<typeof originalConfigModule>();
+        const actual = await importOriginal<typeof import("@/config")>();
         return {
           default: {
             ...actual.default,

--- a/platform/backend/src/knowledge-base/connectors/gitlab/gitlab-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/gitlab/gitlab-connector.test.ts
@@ -1,36 +1,173 @@
-import { vi } from "vitest";
-import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
 import type { ConnectorSyncBatch } from "@/types";
 import { GitlabConnector } from "./gitlab-connector";
 
-// Mock @gitbeaker/rest SDK
-const mockShowCurrentUser = vi.fn();
-const mockProjectsAll = vi.fn();
-const mockProjectsShow = vi.fn();
-const mockGroupsAllProjects = vi.fn();
-const mockIssuesAll = vi.fn();
-const mockIssueNotesAll = vi.fn();
-const mockMergeRequestsAll = vi.fn();
-const mockMergeRequestNotesAll = vi.fn();
-const mockAllRepositoryTrees = vi.fn();
-const mockRepositoryFilesShow = vi.fn();
+// Wire-level (MSW) mocking: the real @gitbeaker/rest client runs and only the
+// HTTP boundary is faked. gitbeaker uses global fetch, which MSW intercepts.
+// The client is created with `camelize` disabled (the default), so wire
+// responses stay snake_case exactly as the GitLab REST API returns them.
+const GL = "https://gitlab.com";
 
-vi.mock("@gitbeaker/rest", () => ({
-  Gitlab: class MockGitlab {
-    Users = { showCurrentUser: mockShowCurrentUser };
-    Projects = { all: mockProjectsAll, show: mockProjectsShow };
-    Groups = { allProjects: mockGroupsAllProjects };
-    Issues = { all: mockIssuesAll };
-    IssueNotes = { all: mockIssueNotesAll };
-    MergeRequests = { all: mockMergeRequestsAll };
-    MergeRequestNotes = { all: mockMergeRequestNotesAll };
-    Repositories = { allRepositoryTrees: mockAllRepositoryTrees };
-    RepositoryFiles = { show: mockRepositoryFilesShow };
-  },
-}));
+const mockProject = {
+  id: 42,
+  name: "my-project",
+  path_with_namespace: "my-group/my-project",
+  web_url: "https://gitlab.com/my-group/my-project",
+};
 
 describe("GitlabConnector", () => {
+  const server = useMswServer();
   let connector: GitlabConnector;
+
+  // Captured wire traffic, reset per test.
+  const userRequests: URL[] = [];
+  const issuesRequests: URL[] = [];
+  const mrRequests: URL[] = [];
+  const projectsAllRequests: URL[] = [];
+  const groupProjectsRequests: URL[] = [];
+  const treeRequests: URL[] = [];
+  const fileRequests: string[] = [];
+
+  function userHandler(status?: number) {
+    return http.get(`${GL}/api/v4/user`, ({ request }) => {
+      userRequests.push(new URL(request.url));
+      if (status) {
+        return HttpResponse.json({ message: "401 Unauthorized" }, { status });
+      }
+      return HttpResponse.json({ id: 1, username: "test-user" });
+    });
+  }
+
+  function projectShowHandler(project: unknown = mockProject) {
+    return http.get(`${GL}/api/v4/projects/42`, () =>
+      HttpResponse.json(project as Record<string, unknown>),
+    );
+  }
+
+  function projectsAllHandler(projects: unknown[]) {
+    return http.get(`${GL}/api/v4/projects`, ({ request }) => {
+      projectsAllRequests.push(new URL(request.url));
+      return HttpResponse.json(projects);
+    });
+  }
+
+  function groupProjectsHandler(projects: unknown[], groupId = "my-group") {
+    return http.get(
+      `${GL}/api/v4/groups/${groupId}/projects`,
+      ({ request }) => {
+        groupProjectsRequests.push(new URL(request.url));
+        return HttpResponse.json(projects);
+      },
+    );
+  }
+
+  function issuesHandler(pages: unknown[][]) {
+    let call = 0;
+    return http.get(`${GL}/api/v4/projects/42/issues`, ({ request }) => {
+      issuesRequests.push(new URL(request.url));
+      const page = pages[Math.min(call, pages.length - 1)];
+      call += 1;
+      return HttpResponse.json(page);
+    });
+  }
+
+  function issuesErrorHandler(status: number) {
+    return http.get(`${GL}/api/v4/projects/42/issues`, () =>
+      HttpResponse.json({ message: "Request failed" }, { status }),
+    );
+  }
+
+  function mergeRequestsHandler(pages: unknown[][]) {
+    let call = 0;
+    return http.get(
+      `${GL}/api/v4/projects/42/merge_requests`,
+      ({ request }) => {
+        mrRequests.push(new URL(request.url));
+        const page = pages[Math.min(call, pages.length - 1)];
+        call += 1;
+        return HttpResponse.json(page);
+      },
+    );
+  }
+
+  function issueNotesHandler(config?: {
+    notes?: Record<number, unknown[]>;
+    errors?: Record<number, { status: number; message: string }>;
+  }) {
+    return http.get(
+      `${GL}/api/v4/projects/42/issues/:iid/notes`,
+      ({ params }) => {
+        const iid = Number(params.iid);
+        const err = config?.errors?.[iid];
+        if (err) {
+          return HttpResponse.json(
+            { message: err.message },
+            { status: err.status },
+          );
+        }
+        return HttpResponse.json(config?.notes?.[iid] ?? []);
+      },
+    );
+  }
+
+  function mrNotesHandler(config?: {
+    notes?: Record<number, unknown[]>;
+    errors?: Record<number, { status: number; message: string }>;
+  }) {
+    return http.get(
+      `${GL}/api/v4/projects/42/merge_requests/:iid/notes`,
+      ({ params }) => {
+        const iid = Number(params.iid);
+        const err = config?.errors?.[iid];
+        if (err) {
+          return HttpResponse.json(
+            { message: err.message },
+            { status: err.status },
+          );
+        }
+        return HttpResponse.json(config?.notes?.[iid] ?? []);
+      },
+    );
+  }
+
+  function treeHandler(items: unknown[]) {
+    return http.get(
+      `${GL}/api/v4/projects/42/repository/tree`,
+      ({ request }) => {
+        treeRequests.push(new URL(request.url));
+        return HttpResponse.json(items);
+      },
+    );
+  }
+
+  function fileHandler(config: {
+    contents?: Record<string, string>;
+    errors?: Record<string, number>;
+  }) {
+    return http.get(
+      // The client URL-encodes the file path (slashes become %2F), so it is a
+      // single path segment here; MSW decodes the captured param.
+      `${GL}/api/v4/projects/42/repository/files/:filePath`,
+      ({ params }) => {
+        const filePath = String(params.filePath);
+        fileRequests.push(filePath);
+        const errStatus = config.errors?.[filePath];
+        if (errStatus) {
+          return HttpResponse.json(
+            { message: "file error" },
+            { status: errStatus },
+          );
+        }
+        return HttpResponse.json({
+          content: Buffer.from(config.contents?.[filePath] ?? "").toString(
+            "base64",
+          ),
+        });
+      },
+    );
+  }
 
   const validConfig = {
     gitlabUrl: "https://gitlab.com",
@@ -42,12 +179,14 @@ describe("GitlabConnector", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    userRequests.length = 0;
+    issuesRequests.length = 0;
+    mrRequests.length = 0;
+    projectsAllRequests.length = 0;
+    groupProjectsRequests.length = 0;
+    treeRequests.length = 0;
+    fileRequests.length = 0;
     connector = new GitlabConnector();
-  });
-
-  afterEach(() => {
-    vi.resetAllMocks();
   });
 
   describe("validateConfig", () => {
@@ -112,10 +251,7 @@ describe("GitlabConnector", () => {
 
   describe("testConnection", () => {
     test("returns success when API responds OK", async () => {
-      mockShowCurrentUser.mockResolvedValueOnce({
-        id: 1,
-        username: "test-user",
-      });
+      server.use(userHandler());
 
       const result = await connector.testConnection({
         config: validConfig,
@@ -123,11 +259,11 @@ describe("GitlabConnector", () => {
       });
 
       expect(result).toEqual({ success: true });
-      expect(mockShowCurrentUser).toHaveBeenCalled();
+      expect(userRequests).toHaveLength(1);
     });
 
     test("returns error when API throws", async () => {
-      mockShowCurrentUser.mockRejectedValueOnce(new Error("401 Unauthorized"));
+      server.use(userHandler(401));
 
       const result = await connector.testConnection({
         config: validConfig,
@@ -150,13 +286,6 @@ describe("GitlabConnector", () => {
   });
 
   describe("sync", () => {
-    const mockProject = {
-      id: 42,
-      name: "my-project",
-      path_with_namespace: "my-group/my-project",
-      web_url: "https://gitlab.com/my-group/my-project",
-    };
-
     function makeIssue(
       iid: number,
       title: string,
@@ -192,7 +321,7 @@ describe("GitlabConnector", () => {
     }
 
     beforeEach(() => {
-      mockProjectsShow.mockResolvedValue(mockProject);
+      server.use(projectShowHandler());
     });
 
     test("yields batch of documents from issues", async () => {
@@ -201,11 +330,11 @@ describe("GitlabConnector", () => {
         makeIssue(2, "Second issue"),
       ];
 
-      mockIssuesAll.mockResolvedValueOnce(issues);
-      mockIssueNotesAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
-
-      // MR pass
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([issues]),
+        issueNotesHandler(),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -224,17 +353,16 @@ describe("GitlabConnector", () => {
     });
 
     test("yields merge request documents", async () => {
-      // Issues pass
-      mockIssuesAll.mockResolvedValueOnce([]);
-
       const mrs = [
         makeMergeRequest(10, "Feature branch"),
         makeMergeRequest(11, "Bug fix"),
       ];
-      mockMergeRequestsAll.mockResolvedValueOnce(mrs);
-      mockMergeRequestNotesAll
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
+
+      server.use(
+        issuesHandler([[]]),
+        mergeRequestsHandler([mrs]),
+        mrNotesHandler(),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -256,24 +384,28 @@ describe("GitlabConnector", () => {
     });
 
     test("includes notes in document content", async () => {
-      mockIssuesAll.mockResolvedValueOnce([makeIssue(1, "Issue with notes")]);
-      mockIssueNotesAll.mockResolvedValueOnce([
-        {
-          body: "This is a comment",
-          author: { username: "reviewer", name: "Reviewer" },
-          created_at: "2024-01-16T12:00:00.000Z",
-          system: false,
-        },
-        {
-          body: "assigned to @reviewer",
-          author: { username: "system", name: "System" },
-          created_at: "2024-01-16T11:00:00.000Z",
-          system: true,
-        },
-      ]);
-
-      // MR pass
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([[makeIssue(1, "Issue with notes")]]),
+        issueNotesHandler({
+          notes: {
+            1: [
+              {
+                body: "This is a comment",
+                author: { username: "reviewer", name: "Reviewer" },
+                created_at: "2024-01-16T12:00:00.000Z",
+                system: false,
+              },
+              {
+                body: "assigned to @reviewer",
+                author: { username: "system", name: "System" },
+                created_at: "2024-01-16T11:00:00.000Z",
+                system: true,
+              },
+            ],
+          },
+        }),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -298,17 +430,11 @@ describe("GitlabConnector", () => {
       );
       const page2Issues = [makeIssue(51, "Issue 51")];
 
-      mockIssuesAll
-        .mockResolvedValueOnce(page1Issues)
-        .mockResolvedValueOnce(page2Issues);
-
-      // Notes for each issue
-      for (let i = 0; i < 51; i++) {
-        mockIssueNotesAll.mockResolvedValueOnce([]);
-      }
-
-      // MR pass
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([page1Issues, page2Issues]),
+        issueNotesHandler(),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -328,8 +454,7 @@ describe("GitlabConnector", () => {
     });
 
     test("incremental sync uses checkpoint timestamp", async () => {
-      mockIssuesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(issuesHandler([[]]), mergeRequestsHandler([[]]));
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -340,10 +465,8 @@ describe("GitlabConnector", () => {
         batches.push(batch);
       }
 
-      expect(mockIssuesAll).toHaveBeenCalledWith(
-        expect.objectContaining({
-          updatedAfter: "2024-01-10T00:00:00.000Z",
-        }),
+      expect(issuesRequests[0].searchParams.get("updated_after")).toBe(
+        "2024-01-10T00:00:00.000Z",
       );
     });
 
@@ -353,11 +476,11 @@ describe("GitlabConnector", () => {
         makeIssue(2, "Skip this", { labels: ["wontfix"] }),
       ];
 
-      mockIssuesAll.mockResolvedValueOnce(issues);
-      mockIssueNotesAll.mockResolvedValueOnce([]);
-
-      // MR pass
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([issues]),
+        issueNotesHandler(),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -377,8 +500,10 @@ describe("GitlabConnector", () => {
 
     test("respects includeIssues=false", async () => {
       // Only MR pass should run
-      mockMergeRequestsAll.mockResolvedValueOnce([makeMergeRequest(1, "A MR")]);
-      mockMergeRequestNotesAll.mockResolvedValueOnce([]);
+      server.use(
+        mergeRequestsHandler([[makeMergeRequest(1, "A MR")]]),
+        mrNotesHandler(),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -393,12 +518,14 @@ describe("GitlabConnector", () => {
       expect(allDocs.every((d) => d.metadata.kind === "merge_request")).toBe(
         true,
       );
-      expect(mockIssuesAll).not.toHaveBeenCalled();
+      expect(issuesRequests).toHaveLength(0);
     });
 
     test("respects includeMergeRequests=false", async () => {
-      mockIssuesAll.mockResolvedValueOnce([makeIssue(1, "An issue")]);
-      mockIssueNotesAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([[makeIssue(1, "An issue")]]),
+        issueNotesHandler(),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -411,13 +538,15 @@ describe("GitlabConnector", () => {
 
       const allDocs = batches.flatMap((b) => b.documents);
       expect(allDocs.every((d) => d.metadata.kind === "issue")).toBe(true);
-      expect(mockMergeRequestsAll).not.toHaveBeenCalled();
+      expect(mrRequests).toHaveLength(0);
     });
 
     test("builds source URL correctly for issues", async () => {
-      mockIssuesAll.mockResolvedValueOnce([makeIssue(5, "Test issue")]);
-      mockIssueNotesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([[makeIssue(5, "Test issue")]]),
+        issueNotesHandler(),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -434,11 +563,13 @@ describe("GitlabConnector", () => {
     });
 
     test("includes metadata in documents", async () => {
-      mockIssuesAll.mockResolvedValueOnce([
-        makeIssue(1, "Test issue", { labels: ["bug", "urgent"] }),
-      ]);
-      mockIssueNotesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([
+          [makeIssue(1, "Test issue", { labels: ["bug", "urgent"] })],
+        ]),
+        issueNotesHandler(),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -465,14 +596,16 @@ describe("GitlabConnector", () => {
         makeIssue(3, "Third issue"),
       ];
 
-      mockIssuesAll.mockResolvedValueOnce(issues);
-      mockIssueNotesAll
-        .mockResolvedValueOnce([])
-        .mockRejectedValueOnce(new Error("502 Bad Gateway"))
-        .mockResolvedValueOnce([]);
-
-      // MR pass
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([issues]),
+        issueNotesHandler({
+          // 502 is a gitbeaker retry status; serve the message via a
+          // non-retry status so the failure surfaces immediately with the
+          // expected error string.
+          errors: { 2: { status: 500, message: "502 Bad Gateway" } },
+        }),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -497,17 +630,18 @@ describe("GitlabConnector", () => {
     });
 
     test("continues sync when MR note fetch fails", async () => {
-      // Issues pass - empty
-      mockIssuesAll.mockResolvedValueOnce([]);
-
       const mrs = [
         makeMergeRequest(10, "Feature branch"),
         makeMergeRequest(11, "Bug fix"),
       ];
-      mockMergeRequestsAll.mockResolvedValueOnce(mrs);
-      mockMergeRequestNotesAll
-        .mockRejectedValueOnce(new Error("500 Internal Server Error"))
-        .mockResolvedValueOnce([]);
+
+      server.use(
+        issuesHandler([[]]),
+        mergeRequestsHandler([mrs]),
+        mrNotesHandler({
+          errors: { 10: { status: 500, message: "500 Internal Server Error" } },
+        }),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -534,9 +668,7 @@ describe("GitlabConnector", () => {
     });
 
     test("throws on API error", async () => {
-      mockIssuesAll.mockRejectedValueOnce(
-        new Error("Request failed with status code 403"),
-      );
+      server.use(issuesErrorHandler(403));
 
       const generator = connector.sync({
         config: validConfig,
@@ -553,9 +685,11 @@ describe("GitlabConnector", () => {
         groupId: "my-group",
       };
 
-      mockGroupsAllProjects.mockResolvedValueOnce([mockProject]);
-      mockIssuesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        groupProjectsHandler([mockProject]),
+        issuesHandler([[]]),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -566,9 +700,11 @@ describe("GitlabConnector", () => {
         batches.push(batch);
       }
 
-      expect(mockGroupsAllProjects).toHaveBeenCalledWith("my-group", {
-        perPage: 100,
-      });
+      expect(groupProjectsRequests).toHaveLength(1);
+      expect(groupProjectsRequests[0].pathname).toBe(
+        "/api/v4/groups/my-group/projects",
+      );
+      expect(groupProjectsRequests[0].searchParams.get("per_page")).toBe("100");
     });
 
     test("fetches member projects when no filter specified", async () => {
@@ -576,9 +712,11 @@ describe("GitlabConnector", () => {
         gitlabUrl: "https://gitlab.com",
       };
 
-      mockProjectsAll.mockResolvedValueOnce([mockProject]);
-      mockIssuesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        projectsAllHandler([mockProject]),
+        issuesHandler([[]]),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -589,8 +727,9 @@ describe("GitlabConnector", () => {
         batches.push(batch);
       }
 
-      expect(mockProjectsAll).toHaveBeenCalledWith(
-        expect.objectContaining({ membership: true }),
+      expect(projectsAllRequests).toHaveLength(1);
+      expect(projectsAllRequests[0].searchParams.get("membership")).toBe(
+        "true",
       );
     });
 
@@ -603,9 +742,11 @@ describe("GitlabConnector", () => {
         },
       ];
 
-      mockIssuesAll.mockResolvedValueOnce(issues);
-      mockIssueNotesAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([issues]),
+        issueNotesHandler(),
+        mergeRequestsHandler([[]]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -625,8 +766,7 @@ describe("GitlabConnector", () => {
     });
 
     test("checkpoint preserves previous value when batch has no items", async () => {
-      mockIssuesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(issuesHandler([[]]), mergeRequestsHandler([[]]));
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -648,41 +788,27 @@ describe("GitlabConnector", () => {
   });
 
   describe("markdown file sync", () => {
-    const mockProject = {
-      id: 42,
-      name: "my-project",
-      path_with_namespace: "my-group/my-project",
-      web_url: "https://gitlab.com/my-group/my-project",
-    };
-
     beforeEach(() => {
-      mockProjectsShow.mockResolvedValue(mockProject);
+      server.use(projectShowHandler());
     });
 
     test("fetches and indexes markdown files when includeMarkdownFiles is true", async () => {
-      // Issues pass - empty
-      mockIssuesAll.mockResolvedValueOnce([]);
-      // MR pass - empty
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
-
-      // Markdown: get repo tree
-      mockAllRepositoryTrees.mockResolvedValueOnce([
-        { type: "blob", path: "README.md" },
-        { type: "blob", path: "docs/guide.mdx" },
-        { type: "blob", path: "src/index.ts" },
-        { type: "tree", path: "docs" },
-      ]);
-
-      // Markdown: get file contents
-      mockRepositoryFilesShow
-        .mockResolvedValueOnce({
-          content: Buffer.from("# README\nHello world").toString("base64"),
-        })
-        .mockResolvedValueOnce({
-          content: Buffer.from("# Guide\nSome guide content").toString(
-            "base64",
-          ),
-        });
+      server.use(
+        issuesHandler([[]]),
+        mergeRequestsHandler([[]]),
+        treeHandler([
+          { type: "blob", path: "README.md" },
+          { type: "blob", path: "docs/guide.mdx" },
+          { type: "blob", path: "src/index.ts" },
+          { type: "tree", path: "docs" },
+        ]),
+        fileHandler({
+          contents: {
+            "README.md": "# README\nHello world",
+            "docs/guide.mdx": "# Guide\nSome guide content",
+          },
+        }),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -709,8 +835,7 @@ describe("GitlabConnector", () => {
     });
 
     test("does not fetch markdown files when includeMarkdownFiles is not set", async () => {
-      mockIssuesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
+      server.use(issuesHandler([[]]), mergeRequestsHandler([[]]));
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -721,24 +846,23 @@ describe("GitlabConnector", () => {
         batches.push(batch);
       }
 
-      expect(mockAllRepositoryTrees).not.toHaveBeenCalled();
-      expect(mockRepositoryFilesShow).not.toHaveBeenCalled();
+      expect(treeRequests).toHaveLength(0);
+      expect(fileRequests).toHaveLength(0);
     });
 
     test("continues when file content fetch fails", async () => {
-      mockIssuesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
-
-      mockAllRepositoryTrees.mockResolvedValueOnce([
-        { type: "blob", path: "a.md" },
-        { type: "blob", path: "b.md" },
-      ]);
-
-      mockRepositoryFilesShow
-        .mockRejectedValueOnce(new Error("403 Forbidden"))
-        .mockResolvedValueOnce({
-          content: Buffer.from("# B file").toString("base64"),
-        });
+      server.use(
+        issuesHandler([[]]),
+        mergeRequestsHandler([[]]),
+        treeHandler([
+          { type: "blob", path: "a.md" },
+          { type: "blob", path: "b.md" },
+        ]),
+        fileHandler({
+          contents: { "b.md": "# B file" },
+          errors: { "a.md": 403 },
+        }),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -760,10 +884,11 @@ describe("GitlabConnector", () => {
     });
 
     test("handles empty repo tree gracefully", async () => {
-      mockIssuesAll.mockResolvedValueOnce([]);
-      mockMergeRequestsAll.mockResolvedValueOnce([]);
-
-      mockAllRepositoryTrees.mockResolvedValueOnce([]);
+      server.use(
+        issuesHandler([[]]),
+        mergeRequestsHandler([[]]),
+        treeHandler([]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({

--- a/platform/backend/src/knowledge-base/connectors/jira/jira-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/jira/jira-connector.test.ts
@@ -1,5 +1,6 @@
-import { vi } from "vitest";
-import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
 import type { ConnectorSyncBatch } from "@/types";
 import {
   extractTextFromAdf,
@@ -7,31 +8,68 @@ import {
   JiraConnector,
 } from "./jira-connector";
 
-// Mock jira.js SDK
-const mockGetCurrentUser = vi.fn();
-const mockEnhancedSearchPost = vi.fn();
-const mockSearchForIssuesUsingJql = vi.fn();
-const mockSearchForIssuesUsingJqlPost = vi.fn();
-const capturedConfigs: { type: string; config: Record<string, unknown> }[] = [];
-
-vi.mock("jira.js", () => ({
-  ClientType: { Version2: "Version2", Version3: "Version3" },
-  // biome-ignore lint/suspicious/noExplicitAny: mock factory
-  createClient: (type: any, config: any) => {
-    capturedConfigs.push({ type, config });
-    return {
-      myself: { getCurrentUser: mockGetCurrentUser },
-      issueSearch: {
-        searchForIssuesUsingJqlEnhancedSearchPost: mockEnhancedSearchPost,
-        searchForIssuesUsingJql: mockSearchForIssuesUsingJql,
-        searchForIssuesUsingJqlPost: mockSearchForIssuesUsingJqlPost,
-      },
-    };
-  },
-}));
+// Wire-level (MSW) mocking: the real jira.js client runs and only the HTTP
+// boundary is faked. jira.js uses axios under the hood, which MSW intercepts.
+const CLOUD_HOST = "https://mysite.atlassian.net";
+const SERVER_HOST = "https://jira.mycompany.com";
+const COMPANY_HOST = "https://mycompany.atlassian.net";
 
 describe("JiraConnector", () => {
+  const server = useMswServer();
   let connector: JiraConnector;
+
+  // Captured wire traffic, reset per test.
+  const myselfHeaders: Headers[] = [];
+  const enhancedSearchBodies: Array<Record<string, unknown>> = [];
+  const v2SearchBodies: Array<Record<string, unknown>> = [];
+
+  function myselfHandler(opts: {
+    version: 2 | 3;
+    host: string;
+    status?: number;
+  }) {
+    return http.get(
+      `${opts.host}/rest/api/${opts.version}/myself`,
+      ({ request }) => {
+        myselfHeaders.push(request.headers);
+        if (opts.status) {
+          return HttpResponse.json(
+            { errorMessages: ["Unauthorized"] },
+            { status: opts.status },
+          );
+        }
+        return HttpResponse.json({ displayName: "Test User", active: true });
+      },
+    );
+  }
+
+  function enhancedSearchHandler(pages: unknown[], host = CLOUD_HOST) {
+    let call = 0;
+    return http.post(`${host}/rest/api/3/search/jql`, async ({ request }) => {
+      enhancedSearchBodies.push(
+        (await request.json()) as Record<string, unknown>,
+      );
+      const page = pages[Math.min(call, pages.length - 1)];
+      call += 1;
+      return HttpResponse.json(page as Record<string, unknown>);
+    });
+  }
+
+  function enhancedSearchErrorHandler(status: number, host = CLOUD_HOST) {
+    return http.post(`${host}/rest/api/3/search/jql`, () =>
+      HttpResponse.json({ errorMessages: ["Bad Request"] }, { status }),
+    );
+  }
+
+  function v2SearchHandler(pages: unknown[], host = SERVER_HOST) {
+    let call = 0;
+    return http.post(`${host}/rest/api/2/search`, async ({ request }) => {
+      v2SearchBodies.push((await request.json()) as Record<string, unknown>);
+      const page = pages[Math.min(call, pages.length - 1)];
+      call += 1;
+      return HttpResponse.json(page as Record<string, unknown>);
+    });
+  }
 
   const validConfig = {
     jiraBaseUrl: "https://mysite.atlassian.net",
@@ -45,13 +83,10 @@ describe("JiraConnector", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    capturedConfigs.length = 0;
+    myselfHeaders.length = 0;
+    enhancedSearchBodies.length = 0;
+    v2SearchBodies.length = 0;
     connector = new JiraConnector();
-  });
-
-  afterEach(() => {
-    vi.resetAllMocks();
   });
 
   describe("validateConfig", () => {
@@ -102,10 +137,7 @@ describe("JiraConnector", () => {
 
   describe("testConnection", () => {
     test("returns success when API responds OK", async () => {
-      mockGetCurrentUser.mockResolvedValueOnce({
-        displayName: "Test User",
-        active: true,
-      });
+      server.use(myselfHandler({ version: 3, host: CLOUD_HOST }));
 
       const result = await connector.testConnection({
         config: validConfig,
@@ -113,25 +145,23 @@ describe("JiraConnector", () => {
       });
 
       expect(result).toEqual({ success: true });
-      expect(mockGetCurrentUser).toHaveBeenCalled();
+      expect(myselfHeaders).toHaveLength(1);
     });
 
     test("returns success for server instances", async () => {
-      mockGetCurrentUser.mockResolvedValueOnce({
-        displayName: "Test User",
-      });
+      server.use(myselfHandler({ version: 2, host: SERVER_HOST }));
 
       const result = await connector.testConnection({
-        config: { ...validConfig, isCloud: false },
+        config: { ...validConfig, jiraBaseUrl: SERVER_HOST, isCloud: false },
         credentials,
       });
 
       expect(result).toEqual({ success: true });
-      expect(mockGetCurrentUser).toHaveBeenCalled();
+      expect(myselfHeaders).toHaveLength(1);
     });
 
     test("returns error when API throws", async () => {
-      mockGetCurrentUser.mockRejectedValueOnce(new Error("401 Unauthorized"));
+      server.use(myselfHandler({ version: 3, host: CLOUD_HOST, status: 401 }));
 
       const result = await connector.testConnection({
         config: validConfig,
@@ -153,65 +183,51 @@ describe("JiraConnector", () => {
     });
 
     test("uses basic auth for server when email is provided", async () => {
-      mockGetCurrentUser.mockResolvedValueOnce({ displayName: "User" });
+      server.use(myselfHandler({ version: 2, host: SERVER_HOST }));
 
       await connector.testConnection({
-        config: { ...validConfig, isCloud: false },
+        config: { ...validConfig, jiraBaseUrl: SERVER_HOST, isCloud: false },
         credentials: { email: "admin", apiToken: "password123" },
       });
 
-      const serverConfig = capturedConfigs.find(
-        (c) => c.type === "Version2",
-      )?.config;
-      expect(serverConfig?.authentication).toEqual({
-        basic: { email: "admin", apiToken: "password123" },
-      });
+      const expected = `Basic ${Buffer.from("admin:password123").toString("base64")}`;
+      expect(myselfHeaders[0].get("authorization")).toBe(expected);
     });
 
     test("uses oauth2 (PAT) auth for server when email is not provided", async () => {
-      mockGetCurrentUser.mockResolvedValueOnce({ displayName: "User" });
+      server.use(myselfHandler({ version: 2, host: SERVER_HOST }));
 
       await connector.testConnection({
-        config: { ...validConfig, isCloud: false },
+        config: { ...validConfig, jiraBaseUrl: SERVER_HOST, isCloud: false },
         credentials: { apiToken: "pat-token-value" },
       });
 
-      const serverConfig = capturedConfigs.find(
-        (c) => c.type === "Version2",
-      )?.config;
-      expect(serverConfig?.authentication).toEqual({
-        oauth2: { accessToken: "pat-token-value" },
-      });
+      expect(myselfHeaders[0].get("authorization")).toBe(
+        "Bearer pat-token-value",
+      );
     });
 
     test("sets noCheckAtlassianToken for server instances", async () => {
-      mockGetCurrentUser.mockResolvedValueOnce({ displayName: "User" });
+      server.use(myselfHandler({ version: 2, host: SERVER_HOST }));
 
       await connector.testConnection({
-        config: { ...validConfig, isCloud: false },
+        config: { ...validConfig, jiraBaseUrl: SERVER_HOST, isCloud: false },
         credentials: { apiToken: "pat-token" },
       });
 
-      const serverConfig = capturedConfigs.find(
-        (c) => c.type === "Version2",
-      )?.config;
-      expect(serverConfig?.noCheckAtlassianToken).toBe(true);
+      expect(myselfHeaders[0].get("x-atlassian-token")).toBe("no-check");
     });
 
     test("uses basic auth for cloud instances", async () => {
-      mockGetCurrentUser.mockResolvedValueOnce({ displayName: "User" });
+      server.use(myselfHandler({ version: 3, host: CLOUD_HOST }));
 
       await connector.testConnection({
         config: validConfig,
         credentials,
       });
 
-      const cloudConfig = capturedConfigs.find(
-        (c) => c.type === "Version3",
-      )?.config;
-      expect(cloudConfig?.authentication).toEqual({
-        basic: { email: "user@example.com", apiToken: "test-api-token" },
-      });
+      const expected = `Basic ${Buffer.from("user@example.com:test-api-token").toString("base64")}`;
+      expect(myselfHeaders[0].get("authorization")).toBe(expected);
     });
   });
 
@@ -256,10 +272,7 @@ describe("JiraConnector", () => {
         makeIssue("PROJ-2", "Second issue"),
       ];
 
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues,
-        nextPageToken: null,
-      });
+      server.use(enhancedSearchHandler([{ issues, nextPageToken: null }]));
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -279,10 +292,7 @@ describe("JiraConnector", () => {
     });
 
     test("passes JQL and fields to search", async () => {
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [],
-        nextPageToken: null,
-      });
+      server.use(enhancedSearchHandler([{ issues: [], nextPageToken: null }]));
 
       const batches = [];
       for await (const batch of connector.sync({
@@ -293,7 +303,7 @@ describe("JiraConnector", () => {
         batches.push(batch);
       }
 
-      expect(mockEnhancedSearchPost).toHaveBeenCalledWith(
+      expect(enhancedSearchBodies[0]).toEqual(
         expect.objectContaining({
           jql: expect.stringContaining('project = "PROJ"'),
           fields: expect.arrayContaining(["summary", "description"]),
@@ -303,10 +313,7 @@ describe("JiraConnector", () => {
     });
 
     test("builds project IN JQL for multiple project keys", async () => {
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [],
-        nextPageToken: null,
-      });
+      server.use(enhancedSearchHandler([{ issues: [], nextPageToken: null }]));
 
       const batches = [];
       for await (const batch of connector.sync({
@@ -320,7 +327,7 @@ describe("JiraConnector", () => {
         batches.push(batch);
       }
 
-      expect(mockEnhancedSearchPost).toHaveBeenCalledWith(
+      expect(enhancedSearchBodies[0]).toEqual(
         expect.objectContaining({
           jql: expect.stringContaining('project IN ("ENG", "OPS")'),
         }),
@@ -333,15 +340,12 @@ describe("JiraConnector", () => {
       );
       const page2Issues = [makeIssue("PROJ-51", "Issue 51")];
 
-      mockEnhancedSearchPost
-        .mockResolvedValueOnce({
-          issues: page1Issues,
-          nextPageToken: "next-page-token",
-        })
-        .mockResolvedValueOnce({
-          issues: page2Issues,
-          nextPageToken: null,
-        });
+      server.use(
+        enhancedSearchHandler([
+          { issues: page1Issues, nextPageToken: "next-page-token" },
+          { issues: page2Issues, nextPageToken: null },
+        ]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -359,17 +363,14 @@ describe("JiraConnector", () => {
       expect(batches[1].hasMore).toBe(false);
 
       // Second call should include the nextPageToken
-      expect(mockEnhancedSearchPost).toHaveBeenCalledTimes(2);
-      expect(mockEnhancedSearchPost.mock.calls[1][0]).toEqual(
+      expect(enhancedSearchBodies).toHaveLength(2);
+      expect(enhancedSearchBodies[1]).toEqual(
         expect.objectContaining({ nextPageToken: "next-page-token" }),
       );
     });
 
     test("incremental sync with old checkpoint (no lastRawUpdatedAt) applies 14-hour safety buffer", async () => {
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [],
-        nextPageToken: null,
-      });
+      server.use(enhancedSearchHandler([{ issues: [], nextPageToken: null }]));
 
       const batches = [];
       for await (const batch of connector.sync({
@@ -381,15 +382,13 @@ describe("JiraConnector", () => {
       }
 
       // 2024-01-10T00:00Z minus 14 hours = 2024-01-09T10:00Z
-      const callArgs = mockEnhancedSearchPost.mock.calls[0][0];
-      expect(callArgs.jql).toContain('updated >= "2024/01/09 10:00"');
+      expect(enhancedSearchBodies[0].jql).toContain(
+        'updated >= "2024/01/09 10:00"',
+      );
     });
 
     test("incremental sync with lastRawUpdatedAt uses local date extraction", async () => {
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [],
-        nextPageToken: null,
-      });
+      server.use(enhancedSearchHandler([{ issues: [], nextPageToken: null }]));
 
       const batches = [];
       for await (const batch of connector.sync({
@@ -405,8 +404,9 @@ describe("JiraConnector", () => {
       }
 
       // Should extract local components from raw timestamp (11:30 EDT), NOT convert from UTC
-      const callArgs = mockEnhancedSearchPost.mock.calls[0][0];
-      expect(callArgs.jql).toContain('updated >= "2024/06/20 11:30"');
+      expect(enhancedSearchBodies[0].jql).toContain(
+        'updated >= "2024/06/20 11:30"',
+      );
     });
 
     test("skips issues with labels in labelsToSkip", async () => {
@@ -421,10 +421,7 @@ describe("JiraConnector", () => {
         },
       ];
 
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues,
-        nextPageToken: null,
-      });
+      server.use(enhancedSearchHandler([{ issues, nextPageToken: null }]));
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -462,10 +459,9 @@ describe("JiraConnector", () => {
         ],
       };
 
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [issue],
-        nextPageToken: null,
-      });
+      server.use(
+        enhancedSearchHandler([{ issues: [issue], nextPageToken: null }]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -485,10 +481,11 @@ describe("JiraConnector", () => {
     });
 
     test("builds source URL correctly", async () => {
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [makeIssue("PROJ-1", "Test issue")],
-        nextPageToken: null,
-      });
+      server.use(
+        enhancedSearchHandler([
+          { issues: [makeIssue("PROJ-1", "Test issue")], nextPageToken: null },
+        ]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -505,10 +502,11 @@ describe("JiraConnector", () => {
     });
 
     test("includes metadata in documents", async () => {
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [makeIssue("PROJ-1", "Test issue")],
-        nextPageToken: null,
-      });
+      server.use(
+        enhancedSearchHandler([
+          { issues: [makeIssue("PROJ-1", "Test issue")], nextPageToken: null },
+        ]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -550,10 +548,7 @@ describe("JiraConnector", () => {
         },
       ];
 
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues,
-        nextPageToken: null,
-      });
+      server.use(enhancedSearchHandler([{ issues, nextPageToken: null }]));
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -577,10 +572,7 @@ describe("JiraConnector", () => {
     });
 
     test("checkpoint preserves previous value when batch has no issues", async () => {
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [],
-        nextPageToken: null,
-      });
+      server.use(enhancedSearchHandler([{ issues: [], nextPageToken: null }]));
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -622,10 +614,21 @@ describe("JiraConnector", () => {
         },
       ];
 
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: firstSyncIssues,
-        nextPageToken: null,
-      });
+      // Second sync: an issue was updated at 12:05 (after last issue's 12:00 timestamp)
+      const updatedIssue = {
+        ...makeIssue("PROJ-1", "Issue 1 - updated"),
+        fields: {
+          ...makeIssue("PROJ-1", "Issue 1 - updated").fields,
+          updated: "2024-06-20T12:05:00.000Z",
+        },
+      };
+
+      server.use(
+        enhancedSearchHandler([
+          { issues: firstSyncIssues, nextPageToken: null },
+          { issues: [updatedIssue], nextPageToken: null },
+        ]),
+      );
 
       const firstBatches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -638,20 +641,6 @@ describe("JiraConnector", () => {
 
       const savedCheckpoint = firstBatches[0].checkpoint;
 
-      // Second sync: an issue was updated at 12:05 (after last issue's 12:00 timestamp)
-      const updatedIssue = {
-        ...makeIssue("PROJ-1", "Issue 1 - updated"),
-        fields: {
-          ...makeIssue("PROJ-1", "Issue 1 - updated").fields,
-          updated: "2024-06-20T12:05:00.000Z",
-        },
-      };
-
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [updatedIssue],
-        nextPageToken: null,
-      });
-
       const secondBatches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
         config: validConfig,
@@ -662,8 +651,9 @@ describe("JiraConnector", () => {
       }
 
       // The JQL should use the last issue's updated timestamp
-      const jql = mockEnhancedSearchPost.mock.calls[1][0].jql;
-      expect(jql).toContain('updated >= "2024/06/20 12:00"');
+      expect(enhancedSearchBodies[1].jql).toContain(
+        'updated >= "2024/06/20 12:00"',
+      );
 
       // Should find the updated issue
       expect(secondBatches[0].documents).toHaveLength(1);
@@ -671,9 +661,7 @@ describe("JiraConnector", () => {
     });
 
     test("throws on search API error", async () => {
-      mockEnhancedSearchPost.mockRejectedValueOnce(
-        new Error("Request failed with status code 400"),
-      );
+      server.use(enhancedSearchErrorHandler(400));
 
       const generator = connector.sync({
         config: validConfig,
@@ -715,12 +703,16 @@ describe("JiraConnector", () => {
     }
 
     test("uses searchForIssuesUsingJqlPost instead of enhanced search", async () => {
-      mockSearchForIssuesUsingJqlPost.mockResolvedValueOnce({
-        issues: [makeIssue("SRV-1", "Server issue")],
-        startAt: 0,
-        maxResults: 50,
-        total: 1,
-      });
+      server.use(
+        v2SearchHandler([
+          {
+            issues: [makeIssue("SRV-1", "Server issue")],
+            startAt: 0,
+            maxResults: 50,
+            total: 1,
+          },
+        ]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -731,8 +723,8 @@ describe("JiraConnector", () => {
         batches.push(batch);
       }
 
-      expect(mockSearchForIssuesUsingJqlPost).toHaveBeenCalledTimes(1);
-      expect(mockEnhancedSearchPost).not.toHaveBeenCalled();
+      expect(v2SearchBodies).toHaveLength(1);
+      expect(enhancedSearchBodies).toHaveLength(0);
       expect(batches).toHaveLength(1);
       expect(batches[0].documents).toHaveLength(1);
       expect(batches[0].documents[0].id).toBe("SRV-1");
@@ -744,19 +736,22 @@ describe("JiraConnector", () => {
       );
       const page2Issues = [makeIssue("SRV-51", "Issue 51")];
 
-      mockSearchForIssuesUsingJqlPost
-        .mockResolvedValueOnce({
-          issues: page1Issues,
-          startAt: 0,
-          maxResults: 50,
-          total: 51,
-        })
-        .mockResolvedValueOnce({
-          issues: page2Issues,
-          startAt: 50,
-          maxResults: 50,
-          total: 51,
-        });
+      server.use(
+        v2SearchHandler([
+          {
+            issues: page1Issues,
+            startAt: 0,
+            maxResults: 50,
+            total: 51,
+          },
+          {
+            issues: page2Issues,
+            startAt: 50,
+            maxResults: 50,
+            total: 51,
+          },
+        ]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -774,19 +769,23 @@ describe("JiraConnector", () => {
       expect(batches[1].hasMore).toBe(false);
 
       // Second call should use startAt=50
-      expect(mockSearchForIssuesUsingJqlPost).toHaveBeenCalledTimes(2);
-      expect(mockSearchForIssuesUsingJqlPost.mock.calls[1][0]).toEqual(
+      expect(v2SearchBodies).toHaveLength(2);
+      expect(v2SearchBodies[1]).toEqual(
         expect.objectContaining({ startAt: 50, maxResults: 50 }),
       );
     });
 
     test("stops when fewer results than BATCH_SIZE returned", async () => {
-      mockSearchForIssuesUsingJqlPost.mockResolvedValueOnce({
-        issues: [makeIssue("SRV-1", "Only issue")],
-        startAt: 0,
-        maxResults: 50,
-        total: 1,
-      });
+      server.use(
+        v2SearchHandler([
+          {
+            issues: [makeIssue("SRV-1", "Only issue")],
+            startAt: 0,
+            maxResults: 50,
+            total: 1,
+          },
+        ]),
+      );
 
       const batches: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -799,7 +798,7 @@ describe("JiraConnector", () => {
 
       expect(batches).toHaveLength(1);
       expect(batches[0].hasMore).toBe(false);
-      expect(mockSearchForIssuesUsingJqlPost).toHaveBeenCalledTimes(1);
+      expect(v2SearchBodies).toHaveLength(1);
     });
   });
 
@@ -839,11 +838,17 @@ describe("JiraConnector", () => {
         };
       }
 
-      // Test with trailing slash
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [makeIssue("PROJ-1")],
-        nextPageToken: null,
-      });
+      // Both configs normalize to the same host, so one handler serves both
+      // syncs (each consumes one queued response).
+      server.use(
+        enhancedSearchHandler(
+          [
+            { issues: [makeIssue("PROJ-1")], nextPageToken: null },
+            { issues: [makeIssue("PROJ-1")], nextPageToken: null },
+          ],
+          COMPANY_HOST,
+        ),
+      );
 
       const batchesWithSlash: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({
@@ -857,12 +862,6 @@ describe("JiraConnector", () => {
       })) {
         batchesWithSlash.push(batch);
       }
-
-      // Test without trailing slash
-      mockEnhancedSearchPost.mockResolvedValueOnce({
-        issues: [makeIssue("PROJ-1")],
-        nextPageToken: null,
-      });
 
       const batchesWithoutSlash: ConnectorSyncBatch[] = [];
       for await (const batch of connector.sync({

--- a/platform/backend/src/knowledge-base/connectors/perforce/p4-rest-client.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/perforce/p4-rest-client.test.ts
@@ -19,17 +19,21 @@ const fetchState: {
   calls: Array<{ url: URL; init: RequestInit }>;
 } = { handler: undefined, calls: [] };
 
-vi.stubGlobal(
-  "fetch",
-  vi.fn(async (input: string | URL, init: RequestInit = {}) => {
-    const url = input instanceof URL ? input : new URL(String(input));
-    fetchState.calls.push({ url, init });
-    if (!fetchState.handler) {
-      throw new Error("fetchState.handler not configured in test");
-    }
-    return fetchState.handler(url, init);
-  }),
-);
+const fetchMock = vi.fn(async (input: string | URL, init: RequestInit = {}) => {
+  const url = input instanceof URL ? input : new URL(String(input));
+  fetchState.calls.push({ url, init });
+  if (!fetchState.handler) {
+    throw new Error("fetchState.handler not configured in test");
+  }
+  return fetchState.handler(url, init);
+});
+
+// The config's `unstubGlobals` removes stubs after every test, so re-apply
+// before each one; the top-level stub covers import time.
+vi.stubGlobal("fetch", fetchMock);
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
 
 function jsonl(records: Array<Record<string, unknown>>): string {
   return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;

--- a/platform/backend/src/knowledge-base/connectors/perforce/perforce-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/perforce/perforce-connector.test.ts
@@ -12,17 +12,21 @@ const fetchState: {
   calls: Array<{ url: URL }>;
 } = { handler: undefined, calls: [] };
 
-vi.stubGlobal(
-  "fetch",
-  vi.fn(async (input: string | URL) => {
-    const url = input instanceof URL ? input : new URL(String(input));
-    fetchState.calls.push({ url });
-    if (!fetchState.handler) {
-      throw new Error("fetchState.handler not configured in test");
-    }
-    return fetchState.handler(url);
-  }),
-);
+const fetchMock = vi.fn(async (input: string | URL) => {
+  const url = input instanceof URL ? input : new URL(String(input));
+  fetchState.calls.push({ url });
+  if (!fetchState.handler) {
+    throw new Error("fetchState.handler not configured in test");
+  }
+  return fetchState.handler(url);
+});
+
+// The config's `unstubGlobals` removes stubs after every test, so re-apply
+// before each one; the top-level stub covers import time.
+vi.stubGlobal("fetch", fetchMock);
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
 
 function jsonl(records: Array<Record<string, unknown>>): string {
   return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;

--- a/platform/backend/src/knowledge-base/connectors/perforce/perforce-sync.integration.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/perforce/perforce-sync.integration.test.ts
@@ -11,16 +11,20 @@ const fetchState: {
   handler: undefined | ((url: URL) => Response);
 } = { handler: undefined };
 
-vi.stubGlobal(
-  "fetch",
-  vi.fn(async (input: string | URL) => {
-    const url = input instanceof URL ? input : new URL(String(input));
-    if (!fetchState.handler) {
-      throw new Error("fetchState.handler not configured in test");
-    }
-    return fetchState.handler(url);
-  }),
-);
+const fetchMock = vi.fn(async (input: string | URL) => {
+  const url = input instanceof URL ? input : new URL(String(input));
+  if (!fetchState.handler) {
+    throw new Error("fetchState.handler not configured in test");
+  }
+  return fetchState.handler(url);
+});
+
+// The config's `unstubGlobals` removes stubs after every test, so re-apply
+// before each one; the top-level stub covers import time.
+vi.stubGlobal("fetch", fetchMock);
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
 
 const mockEmbeddingsCreate = vi.hoisted(() => vi.fn());
 vi.mock("openai", () => {

--- a/platform/backend/src/knowledge-base/connectors/perforce/perforce-sync.integration.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/perforce/perforce-sync.integration.test.ts
@@ -1,45 +1,58 @@
+import { HttpResponse, http } from "msw";
 import { vi } from "vitest";
+import { useMswServer } from "@/test/msw";
 
 // End-to-end pipeline test for the Perforce connector: the REAL
 // PerforceConnector, sync service, chunker, embedding service, task records,
-// and database run together. Mocked: the HTTP boundary to the P4 REST API
-// (global fetch) and the embedding provider (the openai client plus the
-// org-level embedding-config lookup — the latter is internal but resolves
-// external provider credentials; mocking it follows embedder.test.ts).
+// and database run together. Mocked at the network boundary (MSW): the P4 REST
+// API and the OpenAI embeddings endpoint. The org-level embedding-config lookup
+// stays module-mocked (internal, but resolves external provider credentials;
+// mirrors embedder.test.ts).
 
 const fetchState: {
   handler: undefined | ((url: URL) => Response);
 } = { handler: undefined };
 
-const fetchMock = vi.fn(async (input: string | URL) => {
-  const url = input instanceof URL ? input : new URL(String(input));
+// openai@6 requests base64 embeddings by default and decodes them client-side,
+// so the wire payload must carry Float32Array bytes, not a JSON number array.
+function encodeEmbedding(values: number[]): string {
+  const floats = new Float32Array(values);
+  return Buffer.from(
+    floats.buffer,
+    floats.byteOffset,
+    floats.byteLength,
+  ).toString("base64");
+}
+
+function p4Handler({ request }: { request: Request }): Response {
   if (!fetchState.handler) {
     throw new Error("fetchState.handler not configured in test");
   }
-  return fetchState.handler(url);
-});
+  return fetchState.handler(new URL(request.url));
+}
 
-// The config's `unstubGlobals` removes stubs after every test, so re-apply
-// before each one; the top-level stub covers import time.
-vi.stubGlobal("fetch", fetchMock);
-beforeEach(() => {
-  vi.stubGlobal("fetch", fetchMock);
-});
-
-const mockEmbeddingsCreate = vi.hoisted(() => vi.fn());
-vi.mock("openai", () => {
-  class MockOpenAI {
-    static APIError = class APIError extends Error {
-      status: number;
-      constructor(status: number, message: string) {
-        super(message);
-        this.status = status;
-      }
-    };
-    embeddings = { create: mockEmbeddingsCreate };
-  }
-  return { default: MockOpenAI };
-});
+const mswHandlers = [
+  http.get(
+    "https://perforce.example.com:8080/api/v0/file/revisions",
+    p4Handler,
+  ),
+  http.get("https://perforce.example.com:8080/api/v0/file/contents", p4Handler),
+  http.post("https://api.openai.com/v1/embeddings", async ({ request }) => {
+    const body = (await request.json()) as { input: string[]; model: string };
+    return HttpResponse.json({
+      object: "list",
+      data: body.input.map((_, index) => ({
+        object: "embedding",
+        embedding: encodeEmbedding(
+          Array.from({ length: 1536 }, (_, i) => (index + i) * 1e-4),
+        ),
+        index,
+      })),
+      model: body.model,
+      usage: { prompt_tokens: 0, total_tokens: 0 },
+    });
+  }),
+];
 
 const mockGetDefaultOrgEmbeddingConfig = vi.hoisted(() => vi.fn());
 vi.mock("@/knowledge-base/kb-llm-client", () => ({
@@ -215,6 +228,8 @@ async function drainEmbeddingTasks(): Promise<number> {
 }
 
 describe("Perforce connector end-to-end sync", () => {
+  useMswServer(...mswHandlers);
+
   beforeEach(() => {
     fetchState.handler = undefined;
     vi.clearAllMocks();
@@ -230,18 +245,6 @@ describe("Perforce connector end-to-end sync", () => {
         inputModalities: null,
       },
     });
-    mockEmbeddingsCreate.mockImplementation(
-      async ({ input }: { input: string[] }) => ({
-        object: "list",
-        data: input.map((_, index) => ({
-          object: "embedding",
-          embedding: Array.from({ length: 1536 }, (_, i) => (index + i) * 1e-4),
-          index,
-        })),
-        model: "text-embedding-3-small",
-        usage: { prompt_tokens: 0, total_tokens: 0 },
-      }),
-    );
   });
 
   test("ingests and embeds depot files, then syncs only incremental changes", async ({

--- a/platform/backend/src/knowledge-base/connectors/servicenow/servicenow-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/servicenow/servicenow-connector.test.ts
@@ -3,9 +3,13 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { ConnectorSyncBatch } from "@/types";
 import { ServiceNowConnector } from "./servicenow-connector";
 
-// Mock global fetch
+// Mock global fetch. The config's `unstubGlobals` removes stubs after every
+// test, so re-apply before each one; the top-level stub covers import time.
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
 
 describe("ServiceNowConnector", () => {
   let connector: ServiceNowConnector;

--- a/platform/backend/src/knowledge-base/embedder.test.ts
+++ b/platform/backend/src/knowledge-base/embedder.test.ts
@@ -1,27 +1,68 @@
-import { vi } from "vitest";
+import { HttpResponse, http } from "msw";
+import { beforeEach, vi } from "vitest";
+import { useMswServer } from "@/test/msw";
 
-const mockEmbeddingsCreate = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({
-    object: "list",
-    data: [],
-    model: "text-embedding-3-small",
-    usage: { prompt_tokens: 0, total_tokens: 0 },
-  }),
-);
+// Per-call scripting for the OpenAI embeddings wire endpoint. Each `run_command`
+// dequeues the next response; an `error` entry serves a wire-level OpenAI error
+// with `x-should-retry: false` so the SDK surfaces it without its own internal
+// retries (the embedder does its own app-level retry loop).
+type EmbeddingResponseSpec =
+  | { kind: "ok"; embeddings: number[][] }
+  | { kind: "error"; status: number };
 
-vi.mock("openai", () => {
-  class MockOpenAI {
-    static APIError = class APIError extends Error {
-      status: number;
-      constructor(status: number, message: string) {
-        super(message);
-        this.status = status;
-      }
+const embeddingRequests: Array<{
+  model: string;
+  input: string[];
+  dimensions?: number;
+}> = [];
+const responseQueue: EmbeddingResponseSpec[] = [];
+
+// openai@6 requests base64 embeddings by default and decodes them client-side,
+// so the wire payload must carry Float32Array bytes, not a JSON number array.
+function encodeEmbedding(values: number[]): string {
+  const floats = new Float32Array(values);
+  return Buffer.from(
+    floats.buffer,
+    floats.byteOffset,
+    floats.byteLength,
+  ).toString("base64");
+}
+
+const embeddingHandler = http.post(
+  "https://api.openai.com/v1/embeddings",
+  async ({ request }) => {
+    const body = (await request.json()) as {
+      model: string;
+      input: string[];
+      dimensions?: number;
     };
-    embeddings = { create: mockEmbeddingsCreate };
-  }
-  return { default: MockOpenAI };
-});
+    embeddingRequests.push({
+      model: body.model,
+      input: body.input,
+      dimensions: body.dimensions,
+    });
+
+    const next = responseQueue.shift();
+    if (next?.kind === "error") {
+      return HttpResponse.json(
+        { error: { message: "embedding failure", type: "server_error" } },
+        { status: next.status, headers: { "x-should-retry": "false" } },
+      );
+    }
+
+    const embeddings = next?.embeddings ?? body.input.map(() => []);
+    return HttpResponse.json({
+      object: "list",
+      data: embeddings.map((embedding, index) => ({
+        object: "embedding",
+        embedding: encodeEmbedding(embedding),
+        index,
+      })),
+      model: body.model,
+      usage: { prompt_tokens: 10, total_tokens: 10 },
+    });
+  },
+);
 
 const mockGetDefaultOrgEmbeddingConfig = vi.hoisted(() => vi.fn());
 vi.mock("./kb-llm-client", () => ({
@@ -50,6 +91,13 @@ function makeEmbeddingContext() {
 }
 
 describe("EmbeddingService", () => {
+  useMswServer(embeddingHandler);
+
+  beforeEach(() => {
+    embeddingRequests.length = 0;
+    responseQueue.length = 0;
+  });
+
   test("processes pending document — chunks get embeddings, status completed", async ({
     makeOrganization,
     makeKnowledgeBase,
@@ -83,15 +131,7 @@ describe("EmbeddingService", () => {
 
     const emb0 = makeFakeEmbedding(1);
     const emb1 = makeFakeEmbedding(2);
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [
-        { object: "embedding", embedding: emb0, index: 0 },
-        { object: "embedding", embedding: emb1, index: 1 },
-      ],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 10, total_tokens: 10 },
-    });
+    responseQueue.push({ kind: "ok", embeddings: [emb0, emb1] });
 
     await embeddingService.processDocument(doc.id, makeEmbeddingContext());
 
@@ -106,11 +146,13 @@ describe("EmbeddingService", () => {
     expect(chunks[0].embedding?.[0]).toBeCloseTo(emb0[0], 4);
     expect(chunks[1].embedding?.[0]).toBeCloseTo(emb1[0], 4);
 
-    expect(mockEmbeddingsCreate).toHaveBeenCalledWith({
-      model: "text-embedding-3-small",
-      input: ["Chunk one content", "Chunk two content"],
-      dimensions: 1536,
-    });
+    expect(embeddingRequests).toEqual([
+      {
+        model: "text-embedding-3-small",
+        input: ["Chunk one content", "Chunk two content"],
+        dimensions: 1536,
+      },
+    ]);
   });
 
   test("OpenAI failure marks document as failed", async ({
@@ -139,7 +181,8 @@ describe("EmbeddingService", () => {
       },
     ]);
 
-    mockEmbeddingsCreate.mockRejectedValueOnce(new Error("API rate limited"));
+    // 400 is non-retryable, so the embedder fails the document after one call.
+    responseQueue.push({ kind: "error", status: 400 });
 
     await embeddingService.processDocument(doc.id, makeEmbeddingContext());
 
@@ -170,7 +213,7 @@ describe("EmbeddingService", () => {
     const updated = await KbDocumentModel.findById(doc.id);
     expect(updated?.embeddingStatus).toBe("completed");
     expect(updated?.chunkCount).toBe(0);
-    expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+    expect(embeddingRequests).toHaveLength(0);
   });
 
   test("already-completed document is skipped", async ({
@@ -194,7 +237,7 @@ describe("EmbeddingService", () => {
 
     await embeddingService.processDocument(doc.id, makeEmbeddingContext());
 
-    expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+    expect(embeddingRequests).toHaveLength(0);
   });
 
   test("retries on 429 rate limit and succeeds", async ({
@@ -225,29 +268,17 @@ describe("EmbeddingService", () => {
 
     const emb = makeFakeEmbedding(10);
 
-    // Create a retryable error that matches the isRetryableError check
-    const rateLimitError = Object.assign(new Error("Rate limited"), {
-      status: 429,
-    });
-    // Make it pass the instanceof check in the actual OpenAI module
-    const OpenAIMod = (await import("openai")).default;
-    Object.setPrototypeOf(rateLimitError, OpenAIMod.APIError.prototype);
-
-    // First call fails with 429, second succeeds
-    mockEmbeddingsCreate
-      .mockRejectedValueOnce(rateLimitError)
-      .mockResolvedValueOnce({
-        object: "list",
-        data: [{ object: "embedding", embedding: emb, index: 0 }],
-        model: "text-embedding-3-small",
-        usage: { prompt_tokens: 5, total_tokens: 5 },
-      });
+    // First call fails with a retryable 429, second succeeds.
+    responseQueue.push(
+      { kind: "error", status: 429 },
+      { kind: "ok", embeddings: [emb] },
+    );
 
     await embeddingService.processDocument(doc.id, makeEmbeddingContext());
 
     const updated = await KbDocumentModel.findById(doc.id);
     expect(updated?.embeddingStatus).toBe("completed");
-    expect(mockEmbeddingsCreate).toHaveBeenCalledTimes(2);
+    expect(embeddingRequests).toHaveLength(2);
   });
 
   test("fails after exhausting retries", async ({
@@ -276,24 +307,18 @@ describe("EmbeddingService", () => {
       },
     ]);
 
-    const OpenAIMod2 = (await import("openai")).default;
-    const makeServerError = () => {
-      const err = Object.assign(new Error("Server error"), { status: 500 });
-      Object.setPrototypeOf(err, OpenAIMod2.APIError.prototype);
-      return err;
-    };
-
-    // Fail all 3 attempts
-    mockEmbeddingsCreate
-      .mockRejectedValueOnce(makeServerError())
-      .mockRejectedValueOnce(makeServerError())
-      .mockRejectedValueOnce(makeServerError());
+    // Fail all 3 attempts with retryable 500s.
+    responseQueue.push(
+      { kind: "error", status: 500 },
+      { kind: "error", status: 500 },
+      { kind: "error", status: 500 },
+    );
 
     await embeddingService.processDocument(doc.id, makeEmbeddingContext());
 
     const updated = await KbDocumentModel.findById(doc.id);
     expect(updated?.embeddingStatus).toBe("failed");
-    expect(mockEmbeddingsCreate).toHaveBeenCalledTimes(3);
+    expect(embeddingRequests).toHaveLength(3);
   });
 
   test("processDocuments batches chunks from multiple documents into single API call", async ({
@@ -339,22 +364,13 @@ describe("EmbeddingService", () => {
     const emb2 = makeFakeEmbedding(3);
 
     // All 3 chunks should arrive in a single API call
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [
-        { object: "embedding", embedding: emb0, index: 0 },
-        { object: "embedding", embedding: emb1, index: 1 },
-        { object: "embedding", embedding: emb2, index: 2 },
-      ],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 15, total_tokens: 15 },
-    });
+    responseQueue.push({ kind: "ok", embeddings: [emb0, emb1, emb2] });
 
     await embeddingService.processDocuments([doc1.id, doc2.id]);
 
     // Only 1 OpenAI API call for all 3 chunks
-    expect(mockEmbeddingsCreate).toHaveBeenCalledTimes(1);
-    expect(mockEmbeddingsCreate).toHaveBeenCalledWith({
+    expect(embeddingRequests).toHaveLength(1);
+    expect(embeddingRequests[0]).toEqual({
       model: "text-embedding-3-small",
       input: ["Doc1 Chunk A", "Doc1 Chunk B", "Doc2 Chunk A"],
       dimensions: 1536,
@@ -408,7 +424,7 @@ describe("EmbeddingService", () => {
     expect(updated?.embeddingStatus).toBe("pending");
 
     // No OpenAI API call should have been made
-    expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+    expect(embeddingRequests).toHaveLength(0);
   });
 
   test("processDocuments marks only affected documents as failed on partial API failure", async ({
@@ -448,7 +464,7 @@ describe("EmbeddingService", () => {
     ]);
     // doc2 has no chunks → should complete with chunkCount 0
 
-    mockEmbeddingsCreate.mockRejectedValueOnce(new Error("API down"));
+    responseQueue.push({ kind: "error", status: 400 });
 
     await embeddingService.processDocuments([doc1.id, doc2.id]);
 

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
@@ -1,34 +1,75 @@
+import { HttpResponse, http } from "msw";
 import { beforeEach, vi } from "vitest";
 import { describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
 
-const mockEmbeddingsCreate = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({
+interface CapturedRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: { model: string; input: string[]; dimensions?: number };
+}
+
+const capturedRequests: CapturedRequest[] = [];
+
+// openai@6 requests base64 embeddings by default and decodes them client-side,
+// so the wire payload must carry Float32Array bytes, not a JSON number array.
+function encodeEmbedding(values: number[]): string {
+  const floats = new Float32Array(values);
+  return Buffer.from(
+    floats.buffer,
+    floats.byteOffset,
+    floats.byteLength,
+  ).toString("base64");
+}
+
+// Deployment-scoped embeddings endpoints the tests exercise. Exact URLs (not a
+// wildcard) — path-to-regexp@8 chokes on MSW's `*` param under this msw build.
+const EMBEDDINGS_URL = {
+  small:
+    "https://resource.openai.azure.com/openai/deployments/text-embedding-3-small/embeddings",
+  large:
+    "https://resource.openai.azure.com/openai/deployments/text-embedding-3-large/embeddings",
+  v1: "https://resource.services.ai.azure.com/openai/v1/embeddings",
+} as const;
+
+const embeddingResolver = async ({
+  request,
+}: {
+  request: Request;
+}): Promise<Response> => {
+  const body = (await request.json()) as {
+    model: string;
+    input: string[];
+    dimensions?: number;
+  };
+  capturedRequests.push({
+    url: request.url,
+    headers: Object.fromEntries(request.headers),
+    body: {
+      model: body.model,
+      input: body.input,
+      dimensions: body.dimensions,
+    },
+  });
+  return HttpResponse.json({
     object: "list",
-    data: [{ object: "embedding", embedding: [0.1, 0.2], index: 0 }],
+    data: [
+      {
+        object: "embedding",
+        embedding: encodeEmbedding([0.1, 0.2]),
+        index: 0,
+      },
+    ],
     model: "text-embedding-3-small",
     usage: { prompt_tokens: 4, total_tokens: 4 },
-  }),
-);
-const mockOpenAIConstructor = vi.hoisted(() => vi.fn());
+  });
+};
 
-vi.mock("openai", () => {
-  class MockOpenAI {
-    static APIError = class APIError extends Error {
-      status: number;
-      constructor(status: number, message: string) {
-        super(message);
-        this.status = status;
-      }
-    };
-
-    embeddings = { create: mockEmbeddingsCreate };
-
-    constructor(options: unknown) {
-      mockOpenAIConstructor(options);
-    }
-  }
-  return { default: MockOpenAI };
-});
+const defaultHandlers = [
+  http.post(EMBEDDINGS_URL.small, embeddingResolver),
+  http.post(EMBEDDINGS_URL.large, embeddingResolver),
+  http.post(EMBEDDINGS_URL.v1, embeddingResolver),
+];
 
 const mockIsAzureOpenAiEntraIdEnabled = vi.hoisted(() => vi.fn());
 const mockGetAzureOpenAiBearerTokenProvider = vi.hoisted(() => vi.fn());
@@ -52,18 +93,16 @@ vi.mock("@/config", async () =>
 import { type AzureEmbeddingError, callAzureEmbedding } from "./azure";
 
 describe("callAzureEmbedding", () => {
+  const server = useMswServer(...defaultHandlers);
+
   beforeEach(() => {
-    vi.unstubAllGlobals();
-    mockEmbeddingsCreate.mockClear();
-    mockOpenAIConstructor.mockClear();
+    capturedRequests.length = 0;
     mockIsAzureOpenAiEntraIdEnabled.mockReset();
     mockGetAzureOpenAiBearerTokenProvider.mockReset();
   });
 
   test("uses Azure deployment-scoped embeddings endpoint with api-key auth", async () => {
     mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
-    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
-    vi.stubGlobal("fetch", fetchMock);
 
     const response = await callAzureEmbedding({
       inputs: ["hello"],
@@ -73,30 +112,25 @@ describe("callAzureEmbedding", () => {
       dimensions: 1536,
     });
 
-    expect(response.data[0].embedding).toEqual([0.1, 0.2]);
-    expect(mockOpenAIConstructor).toHaveBeenCalledWith({
-      apiKey: "azure-key",
-      baseURL:
-        "https://resource.openai.azure.com/openai/deployments/text-embedding-3-small",
-      defaultHeaders: { "api-key": "azure-key" },
-      fetch: expect.any(Function),
-    });
-    expect(mockEmbeddingsCreate).toHaveBeenCalledWith({
+    // Float32 wire encoding is lossy, so assert closeness rather than equality.
+    expect(response.data[0].embedding).toEqual([
+      expect.closeTo(0.1),
+      expect.closeTo(0.2),
+    ]);
+
+    expect(capturedRequests).toHaveLength(1);
+    const [req] = capturedRequests;
+    const url = new URL(req.url);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://resource.openai.azure.com/openai/deployments/text-embedding-3-small/embeddings",
+    );
+    expect(url.searchParams.get("api-version")).toBe("2024-02-01");
+    expect(req.headers["api-key"]).toBe("azure-key");
+    expect(req.body).toEqual({
       model: "text-embedding-3-small",
       input: ["hello"],
       dimensions: 1536,
     });
-
-    const [{ fetch }] = mockOpenAIConstructor.mock.calls[0] as [
-      { fetch: typeof globalThis.fetch },
-    ];
-    await fetch("https://resource.openai.azure.com/openai/test?existing=1");
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://resource.openai.azure.com/openai/test?existing=1&api-version=2024-02-01",
-      undefined,
-    );
-
-    vi.unstubAllGlobals();
   });
 
   test("uses Azure Entra bearer auth for keyless embedding config", async () => {
@@ -114,14 +148,14 @@ describe("callAzureEmbedding", () => {
     expect(mockGetAzureOpenAiBearerTokenProvider).toHaveBeenCalledWith(
       "https://resource.openai.azure.com/openai",
     );
-    expect(mockOpenAIConstructor).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiKey: "unused",
-        baseURL:
-          "https://resource.openai.azure.com/openai/deployments/text-embedding-3-large",
-        defaultHeaders: { Authorization: "Bearer entra-token" },
-      }),
+
+    const [req] = capturedRequests;
+    const url = new URL(req.url);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://resource.openai.azure.com/openai/deployments/text-embedding-3-large/embeddings",
     );
+    // defaultHeaders (Entra bearer) override the SDK's default api-key auth header.
+    expect(req.headers.authorization).toBe("Bearer entra-token");
   });
 
   test("preserves Azure OpenAI v1 base URLs without api-version injection", async () => {
@@ -134,12 +168,13 @@ describe("callAzureEmbedding", () => {
       baseUrl: "https://resource.services.ai.azure.com/openai/v1",
     });
 
-    expect(mockOpenAIConstructor).toHaveBeenCalledWith({
-      apiKey: "azure-key",
-      baseURL: "https://resource.services.ai.azure.com/openai/v1",
-      defaultHeaders: { "api-key": "azure-key" },
-      fetch: undefined,
-    });
+    const [req] = capturedRequests;
+    const url = new URL(req.url);
+    expect(url.href).toBe(
+      "https://resource.services.ai.azure.com/openai/v1/embeddings",
+    );
+    expect(url.searchParams.has("api-version")).toBe(false);
+    expect(req.headers["api-key"]).toBe("azure-key");
   });
 
   test("throws on invalid Azure base URL", async () => {
@@ -160,18 +195,24 @@ describe("callAzureEmbedding", () => {
 
   test("preserves Azure retry-after from rate-limit errors", async () => {
     mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
-    const OpenAI = (await import("openai")).default;
-    const MockApiError = OpenAI.APIError as unknown as new (
-      status: number,
-      message: string,
-    ) => Error & { status: number };
-    const error = Object.assign(
-      new MockApiError(429, "Please retry after 60 seconds."),
-      {
-        headers: { "retry-after": "45" },
-      },
+    // x-should-retry: false disables the SDK's own 429 retry loop so the
+    // rate-limit error surfaces immediately with its retry-after header intact.
+    server.use(
+      http.post(EMBEDDINGS_URL.small, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Please retry after 60 seconds.",
+              type: "rate_limit_exceeded",
+            },
+          },
+          {
+            status: 429,
+            headers: { "retry-after": "45", "x-should-retry": "false" },
+          },
+        ),
+      ),
     );
-    mockEmbeddingsCreate.mockRejectedValueOnce(error);
 
     await expect(
       callAzureEmbedding({
@@ -188,13 +229,18 @@ describe("callAzureEmbedding", () => {
 
   test("falls back to Azure retry-after message when header is missing", async () => {
     mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
-    const OpenAI = (await import("openai")).default;
-    const MockApiError = OpenAI.APIError as unknown as new (
-      status: number,
-      message: string,
-    ) => Error & { status: number };
-    mockEmbeddingsCreate.mockRejectedValueOnce(
-      new MockApiError(429, "Please retry after 60 seconds."),
+    server.use(
+      http.post(EMBEDDINGS_URL.small, () =>
+        HttpResponse.json(
+          {
+            error: {
+              message: "Please retry after 60 seconds.",
+              type: "rate_limit_exceeded",
+            },
+          },
+          { status: 429, headers: { "x-should-retry": "false" } },
+        ),
+      ),
     );
 
     await expect(

--- a/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/azure.test.ts
@@ -38,23 +38,16 @@ vi.mock("@/clients/azure-openai-credentials", () => ({
   isAzureOpenAiEntraIdEnabled: mockIsAzureOpenAiEntraIdEnabled,
 }));
 
-vi.mock("@/config", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/config")>();
-  return {
-    ...original,
-    default: {
-      ...original.default,
-      llm: {
-        ...original.default.llm,
-        azure: {
-          ...original.default.llm.azure,
-          apiVersion: "2024-02-01",
-          baseUrl: "https://fallback-resource.openai.azure.com/openai",
-        },
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    llm: {
+      azure: {
+        apiVersion: "2024-02-01",
+        baseUrl: "https://fallback-resource.openai.azure.com/openai",
       },
     },
-  };
-});
+  }),
+);
 
 import { type AzureEmbeddingError, callAzureEmbedding } from "./azure";
 

--- a/platform/backend/src/knowledge-base/kb-interaction.test.ts
+++ b/platform/backend/src/knowledge-base/kb-interaction.test.ts
@@ -1,5 +1,6 @@
 import type { SupportedProvider } from "@archestra/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { metrics } from "@/observability";
 import {
   getProviderChatInteractionType,
   withKbObservability,
@@ -53,14 +54,7 @@ vi.mock("@/models", () => ({
   },
 }));
 
-const mockReportKbLlmCall = vi.fn();
-vi.mock("@/observability", () => ({
-  metrics: {
-    llm: {
-      reportKbLlmCall: (params: unknown) => mockReportKbLlmCall(params),
-    },
-  },
-}));
+vi.mock("@/observability");
 
 vi.mock("@/config", async () =>
   (await import("@/test/mocks/config")).configModuleMock({
@@ -328,8 +322,9 @@ describe("withKbObservability", () => {
       }),
     });
 
-    expect(mockReportKbLlmCall).toHaveBeenCalledOnce();
-    expect(mockReportKbLlmCall).toHaveBeenCalledWith(
+    const reportKbLlmCall = vi.mocked(metrics.llm.reportKbLlmCall);
+    expect(reportKbLlmCall).toHaveBeenCalledOnce();
+    expect(reportKbLlmCall).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "openai",
         model: "text-embedding-3-small",
@@ -339,7 +334,7 @@ describe("withKbObservability", () => {
       }),
     );
     // Should include durationSeconds (number >= 0) and cost
-    const call = mockReportKbLlmCall.mock.calls[0][0];
+    const call = reportKbLlmCall.mock.calls[0][0];
     expect(typeof call.durationSeconds).toBe("number");
     expect(call.durationSeconds).toBeGreaterThanOrEqual(0);
   });

--- a/platform/backend/src/knowledge-base/kb-interaction.test.ts
+++ b/platform/backend/src/knowledge-base/kb-interaction.test.ts
@@ -62,20 +62,11 @@ vi.mock("@/observability", () => ({
   },
 }));
 
-vi.mock("@/logging", () => ({
-  default: {
-    warn: vi.fn(),
-    debug: vi.fn(),
-    info: vi.fn(),
-    error: vi.fn(),
-  },
-}));
-
-vi.mock("@/config", () => ({
-  default: {
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
     observability: { otel: { captureContent: false, contentMaxLength: 10000 } },
-  },
-}));
+  }),
+);
 
 // ===== Tests =====
 

--- a/platform/backend/src/knowledge-base/kb-llm-client.test.ts
+++ b/platform/backend/src/knowledge-base/kb-llm-client.test.ts
@@ -12,18 +12,6 @@ vi.mock("@/clients/llm-client", () => ({
   createDirectLLMModel: mockCreateDirectLLMModel,
 }));
 
-vi.mock("openai", () => {
-  class MockOpenAI {
-    apiKey: string;
-    baseURL?: string;
-    constructor(opts: { apiKey: string; baseURL?: string }) {
-      this.apiKey = opts.apiKey;
-      this.baseURL = opts.baseURL;
-    }
-  }
-  return { default: MockOpenAI };
-});
-
 import db, { schema } from "@/database";
 import { LlmProviderApiKeyModel, OrganizationModel } from "@/models";
 import { describe, expect, test } from "@/test";

--- a/platform/backend/src/knowledge-base/query.test.ts
+++ b/platform/backend/src/knowledge-base/query.test.ts
@@ -1,20 +1,57 @@
-import { vi } from "vitest";
+import { HttpResponse, http } from "msw";
+import { beforeEach, vi } from "vitest";
+import { useMswServer } from "@/test/msw";
 
-const mockEmbeddingsCreate = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({
-    object: "list",
-    data: [{ object: "embedding", embedding: [], index: 0 }],
-    model: "text-embedding-3-small",
-    usage: { prompt_tokens: 5, total_tokens: 5 },
-  }),
+// Query embeddings are scripted per test: each embedding call dequeues the next
+// vector. Tests that mock the DB search layer don't care about the vector, so an
+// empty queue falls back to a valid non-zero embedding.
+const embeddingRequests: Array<{
+  model: string;
+  input: string[];
+  dimensions?: number;
+}> = [];
+const embeddingQueue: number[][] = [];
+
+// openai@6 requests base64 embeddings by default and decodes them client-side,
+// so the wire payload must carry Float32Array bytes, not a JSON number array.
+function encodeEmbedding(values: number[]): string {
+  const floats = new Float32Array(values);
+  return Buffer.from(
+    floats.buffer,
+    floats.byteOffset,
+    floats.byteLength,
+  ).toString("base64");
+}
+
+const embeddingHandler = http.post(
+  "https://api.openai.com/v1/embeddings",
+  async ({ request }) => {
+    const body = (await request.json()) as {
+      model: string;
+      input: string[];
+      dimensions?: number;
+    };
+    embeddingRequests.push({
+      model: body.model,
+      input: body.input,
+      dimensions: body.dimensions,
+    });
+
+    const embedding = embeddingQueue.shift() ?? new Array(1536).fill(0.001);
+    return HttpResponse.json({
+      object: "list",
+      data: [
+        {
+          object: "embedding",
+          embedding: encodeEmbedding(embedding),
+          index: 0,
+        },
+      ],
+      model: body.model,
+      usage: { prompt_tokens: 5, total_tokens: 5 },
+    });
+  },
 );
-
-vi.mock("openai", () => {
-  class MockOpenAI {
-    embeddings = { create: mockEmbeddingsCreate };
-  }
-  return { default: MockOpenAI };
-});
 
 const mockRerank = vi.hoisted(() =>
   vi.fn().mockImplementation(({ chunks }: { chunks: unknown[] }) => chunks),
@@ -42,7 +79,6 @@ vi.mock("@/config", async () =>
   }),
 );
 
-import OpenAI from "openai";
 import { KbChunkModel, KbDocumentModel } from "@/models";
 import type { VectorSearchResult } from "@/models/kb-chunk";
 import { describe, expect, test } from "@/test";
@@ -54,11 +90,13 @@ function makeFakeEmbedding(seed: number): number[] {
 }
 
 function setupEmbeddingConfig() {
-  const client = new OpenAI({ apiKey: "test-key" });
   mockResolveEmbeddingConfig.mockResolvedValue({
-    client,
+    apiKey: "test-key",
+    baseUrl: null,
     model: "text-embedding-3-small",
     dimensions: 1536,
+    provider: "openai",
+    inputModalities: null,
   });
 }
 
@@ -69,6 +107,13 @@ function setupSingleQueryExpansion() {
 }
 
 describe("QueryService", () => {
+  useMswServer(embeddingHandler);
+
+  beforeEach(() => {
+    embeddingRequests.length = 0;
+    embeddingQueue.length = 0;
+  });
+
   test("returns ranked results with citations", async ({
     makeOrganization,
     makeKnowledgeBase,
@@ -118,14 +163,9 @@ describe("QueryService", () => {
       1536,
     );
 
-    // Mock query embedding - similar to emb0
+    // Query embedding - similar to emb0
     const queryEmb = makeFakeEmbedding(1.1);
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [{ object: "embedding", embedding: queryEmb, index: 0 }],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 5, total_tokens: 5 },
-    });
+    embeddingQueue.push(queryEmb);
 
     const results = await queryService.query({
       connectorIds: [connector.id],
@@ -148,7 +188,7 @@ describe("QueryService", () => {
     // First result should have higher score (closer embedding)
     expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
 
-    expect(mockEmbeddingsCreate).toHaveBeenCalledWith({
+    expect(embeddingRequests[0]).toEqual({
       model: "text-embedding-3-small",
       input: ["TypeScript"],
       dimensions: 1536,
@@ -166,13 +206,7 @@ describe("QueryService", () => {
     setupEmbeddingConfig();
     setupSingleQueryExpansion();
 
-    const queryEmb = makeFakeEmbedding(1);
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [{ object: "embedding", embedding: queryEmb, index: 0 }],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 5, total_tokens: 5 },
-    });
+    embeddingQueue.push(makeFakeEmbedding(1));
 
     const results = await queryService.query({
       connectorIds: [connector.id],
@@ -227,13 +261,7 @@ describe("QueryService", () => {
       },
     ]);
 
-    const queryEmb = makeFakeEmbedding(1);
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [{ object: "embedding", embedding: queryEmb, index: 0 }],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 5, total_tokens: 5 },
-    });
+    embeddingQueue.push(makeFakeEmbedding(1));
 
     const results = await queryService.query({
       connectorIds: [connector.id],
@@ -277,13 +305,7 @@ describe("QueryService", () => {
       },
     ]);
 
-    const queryEmb = makeFakeEmbedding(1);
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [{ object: "embedding", embedding: queryEmb, index: 0 }],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 5, total_tokens: 5 },
-    });
+    embeddingQueue.push(makeFakeEmbedding(1));
 
     const results = await queryService.query({
       connectorIds: [connector.id],
@@ -331,13 +353,7 @@ describe("QueryService", () => {
     }));
     await KbChunkModel.updateEmbeddings(updates, 1536);
 
-    const queryEmb = makeFakeEmbedding(0);
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [{ object: "embedding", embedding: queryEmb, index: 0 }],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 5, total_tokens: 5 },
-    });
+    embeddingQueue.push(makeFakeEmbedding(0));
 
     const results = await queryService.query({
       connectorIds: [connector.id],
@@ -405,14 +421,7 @@ describe("QueryService", () => {
       .spyOn(KbChunkModel, "fullTextSearch")
       .mockResolvedValueOnce([fullTextOnly, { ...sharedResult, score: 3.0 }]);
 
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [
-        { object: "embedding", embedding: makeFakeEmbedding(1), index: 0 },
-      ],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 5, total_tokens: 5 },
-    });
+    embeddingQueue.push(makeFakeEmbedding(1));
 
     const results = await queryService.query({
       connectorIds: [connector.id],
@@ -463,14 +472,7 @@ describe("QueryService", () => {
       .spyOn(KbChunkModel, "fullTextSearch")
       .mockResolvedValueOnce([]);
 
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [
-        { object: "embedding", embedding: makeFakeEmbedding(1), index: 0 },
-      ],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 5, total_tokens: 5 },
-    });
+    embeddingQueue.push(makeFakeEmbedding(1));
 
     const results = await queryService.query({
       connectorIds: [connector.id],
@@ -529,14 +531,7 @@ describe("QueryService", () => {
       .spyOn(KbChunkModel, "fullTextSearch")
       .mockResolvedValueOnce([chunk2, chunk1]);
 
-    mockEmbeddingsCreate.mockResolvedValueOnce({
-      object: "list",
-      data: [
-        { object: "embedding", embedding: makeFakeEmbedding(1), index: 0 },
-      ],
-      model: "text-embedding-3-small",
-      usage: { prompt_tokens: 5, total_tokens: 5 },
-    });
+    embeddingQueue.push(makeFakeEmbedding(1));
 
     // Reranker reverses the order
     mockRerank.mockResolvedValueOnce([chunk2, chunk1]);
@@ -582,7 +577,7 @@ describe("QueryService", () => {
 
     expect(results).toEqual([]);
     // Should not attempt to create embeddings
-    expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+    expect(embeddingRequests).toHaveLength(0);
   });
 
   test("multi-query expansion searches each query independently and merges", async ({
@@ -652,31 +647,11 @@ describe("QueryService", () => {
       .spyOn(KbChunkModel, "fullTextSearch")
       .mockResolvedValue([]);
 
-    mockEmbeddingsCreate
-      .mockResolvedValueOnce({
-        object: "list",
-        data: [
-          { object: "embedding", embedding: makeFakeEmbedding(1), index: 0 },
-        ],
-        model: "text-embedding-3-small",
-        usage: { prompt_tokens: 5, total_tokens: 5 },
-      })
-      .mockResolvedValueOnce({
-        object: "list",
-        data: [
-          { object: "embedding", embedding: makeFakeEmbedding(2), index: 0 },
-        ],
-        model: "text-embedding-3-small",
-        usage: { prompt_tokens: 5, total_tokens: 5 },
-      })
-      .mockResolvedValueOnce({
-        object: "list",
-        data: [
-          { object: "embedding", embedding: makeFakeEmbedding(3), index: 0 },
-        ],
-        model: "text-embedding-3-small",
-        usage: { prompt_tokens: 5, total_tokens: 5 },
-      });
+    embeddingQueue.push(
+      makeFakeEmbedding(1),
+      makeFakeEmbedding(2),
+      makeFakeEmbedding(3),
+    );
 
     const results = await queryService.query({
       connectorIds: [connector.id],
@@ -696,7 +671,7 @@ describe("QueryService", () => {
     ).toBe(true);
 
     // Verify multiple embedding calls were made (one per expanded query)
-    expect(mockEmbeddingsCreate).toHaveBeenCalledTimes(3);
+    expect(embeddingRequests).toHaveLength(3);
 
     // Verify reranker uses original query text
     expect(mockRerank).toHaveBeenCalledWith(

--- a/platform/backend/src/knowledge-base/query.test.ts
+++ b/platform/backend/src/knowledge-base/query.test.ts
@@ -36,18 +36,11 @@ vi.mock("./query-expansion", () => ({
   KEYWORD_QUERY_HYBRID_ALPHA_WEIGHT: 4.0,
 }));
 
-vi.mock("@/config", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/config")>();
-  return {
-    ...original,
-    default: {
-      ...original.default,
-      kb: {
-        hybridSearchEnabled: true,
-      },
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    kb: { hybridSearchEnabled: true },
+  }),
+);
 
 import OpenAI from "openai";
 import { KbChunkModel, KbDocumentModel } from "@/models";

--- a/platform/backend/src/logging/__mocks__/index.ts
+++ b/platform/backend/src/logging/__mocks__/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Jest-style mock for `@/logging`, activated per test file by a bare
+ * `vi.mock("@/logging");`. Delegates to the canonical factory so the mock
+ * surface lives in one place.
+ */
+import { loggingModuleMock } from "@/test/mocks/logging";
+
+const mock = loggingModuleMock();
+export default mock.default;

--- a/platform/backend/src/middleware/audit-log-hook.test.ts
+++ b/platform/backend/src/middleware/audit-log-hook.test.ts
@@ -18,9 +18,7 @@ const KNOWN_RESOURCE_ID = vi.hoisted(
   () => "00000000-0000-0000-0000-000000000001",
 );
 
-vi.mock("@/logging", async () =>
-  (await import("@/test/mocks/logging")).loggingModuleMock(),
-);
+vi.mock("@/logging");
 
 vi.mock("./audit-log-registry", async () => {
   const { AuditEventNameSchema } =

--- a/platform/backend/src/middleware/audit-log-hook.test.ts
+++ b/platform/backend/src/middleware/audit-log-hook.test.ts
@@ -18,20 +18,9 @@ const KNOWN_RESOURCE_ID = vi.hoisted(
   () => "00000000-0000-0000-0000-000000000001",
 );
 
-const logErrorFn = vi.hoisted(() => vi.fn());
-const logWarnFn = vi.hoisted(() => vi.fn());
-
-vi.mock("@/logging", () => ({
-  default: {
-    error: logErrorFn,
-    warn: logWarnFn,
-    info: vi.fn(),
-    debug: vi.fn(),
-    trace: vi.fn(),
-    fatal: vi.fn(),
-    child: vi.fn().mockReturnThis(),
-  },
-}));
+vi.mock("@/logging", async () =>
+  (await import("@/test/mocks/logging")).loggingModuleMock(),
+);
 
 vi.mock("./audit-log-registry", async () => {
   const { AuditEventNameSchema } =
@@ -149,6 +138,7 @@ vi.mock("./audit-log-registry", async () => {
   };
 });
 
+import logger from "@/logging";
 import AuditLogModel from "@/models/audit-log";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
@@ -581,8 +571,10 @@ describe("registerAuditLogHook", () => {
       expect(rows[0].action).toBe("unknown.created");
       expect(rows[0].resourceType).toBeNull();
 
-      expect(logWarnFn).toHaveBeenCalledTimes(1);
-      expect(logWarnFn.mock.calls[0][1]).toMatch(/no action resolved/);
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(logger.warn).mock.calls[0][1]).toMatch(
+        /no action resolved/,
+      );
     });
   });
 
@@ -883,11 +875,13 @@ describe("registerAuditLogHook", () => {
       expect(rows[0].after).toBeNull();
 
       expect(
-        logErrorFn.mock.calls.some(
-          (call: readonly unknown[]) =>
-            typeof call[1] === "string" &&
-            (call[1] as string).includes("fetchById"),
-        ),
+        vi
+          .mocked(logger.error)
+          .mock.calls.some(
+            (call: readonly unknown[]) =>
+              typeof call[1] === "string" &&
+              (call[1] as string).includes("fetchById"),
+          ),
       ).toBe(true);
 
       throwing.mockRestore();
@@ -905,11 +899,13 @@ describe("registerAuditLogHook", () => {
       await settle();
 
       expect(
-        logErrorFn.mock.calls.some(
-          (call: readonly unknown[]) =>
-            typeof call[1] === "string" &&
-            (call[1] as string).includes("failed to write audit log row"),
-        ),
+        vi
+          .mocked(logger.error)
+          .mock.calls.some(
+            (call: readonly unknown[]) =>
+              typeof call[1] === "string" &&
+              (call[1] as string).includes("failed to write audit log row"),
+          ),
       ).toBe(true);
 
       createSpy.mockRestore();

--- a/platform/backend/src/models/agent-tool.test.ts
+++ b/platform/backend/src/models/agent-tool.test.ts
@@ -15,7 +15,7 @@ import AgentToolModel from "./agent-tool";
 // auto-assigned app tools into them (app-tool assignment is covered in
 // tool-archestra-assignment.test.ts)
 const originalAppsEnabled = config.apps.enabled;
-beforeAll(() => {
+beforeEach(() => {
   (config.apps as { enabled: boolean }).enabled = false;
 });
 afterAll(() => {

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -15,31 +15,10 @@ import IdentityProviderModel, {
   type IdpGetRoleData,
 } from "./identity-provider.ee";
 
-// Mock cacheManager for SSO groups caching tests (preserves LRUCacheManager, CacheKey exports)
-const mockCacheStore = new Map<string, unknown>();
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...actual,
-    cacheManager: {
-      get: vi.fn(async (key: string) => mockCacheStore.get(key)),
-      set: vi.fn(async (key: string, value: unknown, _ttl?: number) => {
-        mockCacheStore.set(key, value);
-        return value;
-      }),
-      delete: vi.fn(async (key: string) => {
-        const existed = mockCacheStore.has(key);
-        mockCacheStore.delete(key);
-        return existed;
-      }),
-      getAndDelete: vi.fn(async (key: string) => {
-        const value = mockCacheStore.get(key);
-        mockCacheStore.delete(key);
-        return value;
-      }),
-    },
-  };
-});
+// The canonical Map-backed fake from src/__mocks__/cache-manager.ts backs the
+// SSO groups caching tests (preserves LRUCacheManager, CacheKey exports); the
+// store resets before every test.
+vi.mock("@/cache-manager");
 
 const mockProvider = {
   id: "test-provider-id",

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -15,16 +15,6 @@ import IdentityProviderModel, {
   type IdpGetRoleData,
 } from "./identity-provider.ee";
 
-// Mock the logger to avoid console output during tests
-vi.mock("@/logging", () => ({
-  default: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-}));
-
 // Mock cacheManager for SSO groups caching tests (preserves LRUCacheManager, CacheKey exports)
 const mockCacheStore = new Map<string, unknown>();
 vi.mock("@/cache-manager", async (importOriginal) => {

--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -14,7 +14,7 @@ import {
   TOOL_TODO_WRITE_SHORT_NAME,
 } from "@archestra/shared";
 import { and, eq, sql } from "drizzle-orm";
-import { afterAll, beforeAll, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, vi } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { getArchestraMcpCatalogMetadata } from "@/archestra-mcp-server/metadata";
 import config from "@/config";
@@ -32,7 +32,7 @@ import TrustedDataPolicyModel from "./trusted-data-policy";
 // auto-assigned app tools into them (app-tool assignment is covered in
 // tool-archestra-assignment.test.ts)
 const originalAppsEnabled = config.apps.enabled;
-beforeAll(() => {
+beforeEach(() => {
   (config.apps as { enabled: boolean }).enabled = false;
 });
 afterAll(() => {

--- a/platform/backend/src/observability/__mocks__/index.ts
+++ b/platform/backend/src/observability/__mocks__/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Jest-style mock for `@/observability`, activated per test file by a bare
+ * `vi.mock("@/observability");`.
+ *
+ * The real module exposes eight `export * as ...` metric namespaces whose
+ * function lists grow over time. Instead of hand-mirroring that surface (and
+ * silently drifting), `metrics` and `tracing` are memoized proxies: the first
+ * access to any `metrics.<ns>.<fn>` creates a stable `vi.fn()` and returns
+ * the same instance afterwards, so both the code under test and
+ * `vi.mocked(metrics.llm.someFn)` assertions in tests see one shared spy.
+ * `vi.clearAllMocks()` covers these like any other mock.
+ */
+import { vi } from "vitest";
+
+export const initializeObservabilityMetrics = vi.fn();
+export const metrics = inertNamespace(2);
+export const tracing = inertNamespace(1);
+
+/** Proxy tree of the given depth: leaves are memoized vi.fn()s. */
+function inertNamespace(depth: number): Record<string, never> {
+  const children = new Map<string | symbol, unknown>();
+  return new Proxy(Object.create(null), {
+    get(_target, prop) {
+      // Play nice with promise-resolution and module interop probes.
+      if (prop === "then" || prop === Symbol.toStringTag) return undefined;
+      if (!children.has(prop)) {
+        children.set(prop, depth > 1 ? inertNamespace(depth - 1) : vi.fn());
+      }
+      return children.get(prop);
+    },
+  });
+}

--- a/platform/backend/src/routes/agent-export-import.test.ts
+++ b/platform/backend/src/routes/agent-export-import.test.ts
@@ -14,14 +14,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/observability", () => ({
-  initializeObservabilityMetrics: vi.fn(),
-  metrics: {
-    llm: { initializeMetrics: vi.fn() },
-    mcp: { initializeMcpMetrics: vi.fn() },
-    agentExecution: { initializeAgentExecutionMetrics: vi.fn() },
-  },
-}));
+vi.mock("@/observability");
 
 describe("Agent export/import routes", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/agent-type-permissions.test.ts
+++ b/platform/backend/src/routes/agent-type-permissions.test.ts
@@ -5,14 +5,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/observability", () => ({
-  initializeObservabilityMetrics: vi.fn(),
-  metrics: {
-    llm: { initializeMetrics: vi.fn() },
-    mcp: { initializeMcpMetrics: vi.fn() },
-    agentExecution: { initializeAgentExecutionMetrics: vi.fn() },
-  },
-}));
+vi.mock("@/observability");
 
 /**
  * Route-level integration tests for agent-type permission isolation.

--- a/platform/backend/src/routes/agent.clone.test.ts
+++ b/platform/backend/src/routes/agent.clone.test.ts
@@ -15,9 +15,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { type Agent, ApiError, type User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const mockGetAgentTypePermissionChecker = getAgentTypePermissionChecker as Mock;
 const mockRequireAgentModifyPermission = requireAgentModifyPermission as Mock;

--- a/platform/backend/src/routes/agent.clone.test.ts
+++ b/platform/backend/src/routes/agent.clone.test.ts
@@ -3,6 +3,9 @@ import { eq } from "drizzle-orm";
 import { type Mock, vi } from "vitest";
 import {
   getAgentTypePermissionChecker,
+  hasAnyAgentTypeAdminPermission,
+  hasAnyAgentTypeReadPermission,
+  isAgentTypeAdmin,
   requireAgentModifyPermission,
 } from "@/auth";
 import db, { schema } from "@/database";
@@ -12,14 +15,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { type Agent, ApiError, type User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  getAgentTypePermissionChecker: vi.fn(),
-  hasAnyAgentTypeReadPermission: vi.fn().mockResolvedValue(true),
-  requireAgentModifyPermission: vi.fn(),
-  requireAgentTypePermission: vi.fn(),
-  isAgentTypeAdmin: vi.fn().mockResolvedValue(true),
-  hasAnyAgentTypeAdminPermission: vi.fn().mockResolvedValue(true),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 const mockGetAgentTypePermissionChecker = getAgentTypePermissionChecker as Mock;
 const mockRequireAgentModifyPermission = requireAgentModifyPermission as Mock;
@@ -31,6 +29,10 @@ describe("clone agent route", () => {
 
   beforeEach(async ({ makeOrganization, makeUser, makeMember }) => {
     vi.clearAllMocks();
+
+    vi.mocked(hasAnyAgentTypeReadPermission).mockResolvedValue(true);
+    vi.mocked(isAgentTypeAdmin).mockResolvedValue(true);
+    vi.mocked(hasAnyAgentTypeAdminPermission).mockResolvedValue(true);
 
     user = await makeUser();
     const organization = await makeOrganization();

--- a/platform/backend/src/routes/agent.restricted-environment.test.ts
+++ b/platform/backend/src/routes/agent.restricted-environment.test.ts
@@ -17,9 +17,7 @@ import type { User } from "@/types";
  * `userHasPermission` varies per test; the route ORs the admin + deploy probes
  * into `canDeployToRestricted` and feeds `assertCanAssignEnvironment`.
  */
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import {
   getAgentTypePermissionChecker,

--- a/platform/backend/src/routes/agent.restricted-environment.test.ts
+++ b/platform/backend/src/routes/agent.restricted-environment.test.ts
@@ -17,23 +17,16 @@ import type { User } from "@/types";
  * `userHasPermission` varies per test; the route ORs the admin + deploy probes
  * into `canDeployToRestricted` and feeds `assertCanAssignEnvironment`.
  */
-vi.mock("@/auth", () => ({
-  getAgentTypePermissionChecker: vi.fn(async () => ({
-    require: vi.fn(),
-    isAdmin: vi.fn(() => true),
-    isTeamAdmin: vi.fn(() => true),
-    getAgentTypesWithPermission: vi.fn(() => [
-      "agent",
-      "mcp_gateway",
-      "llm_proxy",
-    ]),
-  })),
-  hasAnyAgentTypeReadPermission: vi.fn(async () => true),
-  requireAgentModifyPermission: vi.fn(() => {}),
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
-import { userHasPermission } from "@/auth";
+import {
+  getAgentTypePermissionChecker,
+  hasAnyAgentTypeReadPermission,
+  requireAgentModifyPermission,
+  userHasPermission,
+} from "@/auth";
 import { createEnvironment } from "@/services/environments/environment";
 
 const mockUserHasPermission = userHasPermission as Mock;
@@ -45,6 +38,19 @@ describe("Agent routes - restricted environment assignment guard", () => {
   let canDeployToRestricted: boolean;
 
   beforeEach(async ({ makeOrganization, makeUser }) => {
+    (getAgentTypePermissionChecker as Mock).mockImplementation(async () => ({
+      require: vi.fn(),
+      isAdmin: vi.fn(() => true),
+      isTeamAdmin: vi.fn(() => true),
+      getAgentTypesWithPermission: vi.fn(() => [
+        "agent",
+        "mcp_gateway",
+        "llm_proxy",
+      ]),
+    }));
+    (hasAnyAgentTypeReadPermission as Mock).mockResolvedValue(true);
+    (requireAgentModifyPermission as Mock).mockImplementation(() => {});
+
     canDeployToRestricted = false;
     mockUserHasPermission.mockImplementation(
       async (_userId: string, _orgId: string, resource: string) =>

--- a/platform/backend/src/routes/agent.test.ts
+++ b/platform/backend/src/routes/agent.test.ts
@@ -14,14 +14,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/observability", () => ({
-  initializeObservabilityMetrics: vi.fn(),
-  metrics: {
-    llm: { initializeMetrics: vi.fn() },
-    mcp: { initializeMcpMetrics: vi.fn() },
-    agentExecution: { initializeAgentExecutionMetrics: vi.fn() },
-  },
-}));
+vi.mock("@/observability");
 
 describe("agent routes", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/audit-log.test.ts
+++ b/platform/backend/src/routes/audit-log.test.ts
@@ -19,9 +19,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type AuditLog, type User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const hasPermissionMock = vi.mocked(hasPermission);
 

--- a/platform/backend/src/routes/audit-log.test.ts
+++ b/platform/backend/src/routes/audit-log.test.ts
@@ -23,14 +23,7 @@ vi.mock("@/auth");
 
 const hasPermissionMock = vi.mocked(hasPermission);
 
-vi.mock("@/observability", () => ({
-  initializeObservabilityMetrics: vi.fn(),
-  metrics: {
-    llm: { initializeMetrics: vi.fn() },
-    mcp: { initializeMcpMetrics: vi.fn() },
-    agentExecution: { initializeAgentExecutionMetrics: vi.fn() },
-  },
-}));
+vi.mock("@/observability");
 
 function seedRow(
   organizationId: string,

--- a/platform/backend/src/routes/audit-log.test.ts
+++ b/platform/backend/src/routes/audit-log.test.ts
@@ -12,19 +12,18 @@
  */
 
 import { vi } from "vitest";
+import { hasPermission } from "@/auth";
 import AuditLogModel from "@/models/audit-log";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type AuditLog, type User } from "@/types";
 
-const { hasPermissionMock } = vi.hoisted(() => ({
-  hasPermissionMock: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
-vi.mock("@/auth", () => ({
-  hasPermission: hasPermissionMock,
-}));
+const hasPermissionMock = vi.mocked(hasPermission);
 
 vi.mock("@/observability", () => ({
   initializeObservabilityMetrics: vi.fn(),
@@ -87,8 +86,10 @@ describe("GET /api/audit-logs", () => {
     });
 
     // Simulate the permission gate that fastifyAuthPlugin normally provides.
+    // The mock's configured resolution decides the outcome; the permissions
+    // argument is unused, but the real signature requires an object.
     app.addHook("preHandler", async (request) => {
-      const result = await hasPermissionMock(undefined, request.headers);
+      const result = await hasPermissionMock({}, request.headers);
       if (!result?.success) {
         throw new ApiError(403, "Forbidden");
       }

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -22,9 +22,7 @@ import {
 } from "@/services/apps/app-connector-resource";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 describe("auth routes", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/auth.test.ts
+++ b/platform/backend/src/routes/auth.test.ts
@@ -22,16 +22,16 @@ import {
 } from "@/services/apps/app-connector-resource";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 
-vi.mock("@/auth", () => ({
-  betterAuth: {
-    handler: vi.fn(),
-  },
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 describe("auth routes", () => {
   let app: FastifyInstanceWithZod;
 
   beforeEach(async () => {
+    // `handler` is not part of the canonical @/auth mock surface, so add it here.
+    betterAuth.handler = vi.fn();
     app = createFastifyInstance();
     const { default: authRoutes } = await import("./auth");
     await app.register(authRoutes);

--- a/platform/backend/src/routes/built-in-agents.test.ts
+++ b/platform/backend/src/routes/built-in-agents.test.ts
@@ -11,9 +11,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 describe("built-in agents routes", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/built-in-agents.test.ts
+++ b/platform/backend/src/routes/built-in-agents.test.ts
@@ -1,24 +1,19 @@
 import { BUILT_IN_AGENT_IDS, BUILT_IN_AGENT_NAMES } from "@archestra/shared";
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
+import {
+  getAgentTypePermissionChecker,
+  hasAnyAgentTypeReadPermission,
+  isAgentTypeAdmin,
+} from "@/auth";
 import { AgentModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  getAgentTypePermissionChecker: vi.fn().mockResolvedValue({
-    require: vi.fn(),
-    isAdmin: vi.fn().mockReturnValue(true),
-    isTeamAdmin: vi.fn().mockReturnValue(true),
-    hasAnyReadPermission: vi.fn().mockReturnValue(true),
-    hasAnyAdminPermission: vi.fn().mockReturnValue(true),
-  }),
-  hasAnyAgentTypeReadPermission: vi.fn().mockResolvedValue(true),
-  requireAgentModifyPermission: vi.fn(),
-  requireAgentTypePermission: vi.fn(),
-  isAgentTypeAdmin: vi.fn().mockResolvedValue(true),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 describe("built-in agents routes", () => {
   let app: FastifyInstanceWithZod;
@@ -26,6 +21,16 @@ describe("built-in agents routes", () => {
   let organizationId: string;
 
   beforeEach(async ({ makeOrganization, makeUser }) => {
+    (getAgentTypePermissionChecker as Mock).mockResolvedValue({
+      require: vi.fn(),
+      isAdmin: vi.fn().mockReturnValue(true),
+      isTeamAdmin: vi.fn().mockReturnValue(true),
+      hasAnyReadPermission: vi.fn().mockReturnValue(true),
+      hasAnyAdminPermission: vi.fn().mockReturnValue(true),
+    });
+    vi.mocked(hasAnyAgentTypeReadPermission).mockResolvedValue(true);
+    vi.mocked(isAgentTypeAdmin).mockResolvedValue(true);
+
     user = await makeUser();
     const organization = await makeOrganization();
     organizationId = organization.id;

--- a/platform/backend/src/routes/chat/conversation-routes.test.ts
+++ b/platform/backend/src/routes/chat/conversation-routes.test.ts
@@ -733,6 +733,10 @@ describe("chat conversation and message routes", () => {
         parts: [{ type: "text", text: "Original text" }],
       },
     });
+    // "Subsequent" is a strict createdAt comparison; back-to-back creates can
+    // land on the same timestamp and make the follow-up invisible to the
+    // delete. Force a measurable gap so the test pins intent, not timing.
+    await new Promise((resolve) => setTimeout(resolve, 5));
     await MessageModel.create({
       conversationId: conversation.id,
       role: "assistant",

--- a/platform/backend/src/routes/chat/model-fetchers/azure.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/azure.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
 import { fetchAzureModels } from "./azure";
 
-vi.mock("@/config", () => ({
-  default: {
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
     llm: {
       azure: {
         baseUrl:
@@ -10,12 +10,8 @@ vi.mock("@/config", () => ({
         apiVersion: "2024-02-01",
       },
     },
-  },
-}));
-
-vi.mock("@/logging", () => ({
-  default: { warn: vi.fn(), error: vi.fn() },
-}));
+  }),
+);
 
 vi.mock("@/clients/azure-openai-credentials", () => ({
   getAzureManagementBearerTokenProvider: vi.fn(() => async () => "mgmt-token"),

--- a/platform/backend/src/routes/chat/model-fetchers/bearer-fetcher.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/bearer-fetcher.test.ts
@@ -4,7 +4,12 @@ import { beforeEach, describe, expect, test } from "@/test";
 import { modelFetchers } from "./index";
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// The shared test setup restores the real fetch after every test, so
+// re-apply the mock before each one.
+vi.stubGlobal("fetch", mockFetch);
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
 
 function mockModelsResponse(json: unknown) {
   mockFetch.mockResolvedValueOnce({

--- a/platform/backend/src/routes/chat/model-fetchers/bedrock.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/bedrock.test.ts
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { fetchBedrockModels } from "./bedrock";
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// The shared test setup restores the real fetch after every test, so
+// re-apply the mock before each one.
+vi.stubGlobal("fetch", mockFetch);
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
 
 describe("fetchBedrockModels", () => {
   const originalBaseUrl = config.llm.bedrock.baseUrl;

--- a/platform/backend/src/routes/chat/model-fetchers/gemini.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/gemini.test.ts
@@ -4,7 +4,12 @@ import { beforeEach, describe, expect, test } from "@/test";
 import { fetchGeminiModels, fetchGeminiModelsViaVertexAi } from "./gemini";
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// The shared test setup restores the real fetch after every test, so
+// re-apply the mock before each one.
+vi.stubGlobal("fetch", mockFetch);
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
 
 vi.mock("@/clients/gemini-client", () => ({
   createGoogleGenAIClient: vi.fn(),

--- a/platform/backend/src/routes/chat/model-fetchers/openai-compatible.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openai-compatible.test.ts
@@ -4,7 +4,12 @@ import { beforeEach, describe, expect, test } from "@/test";
 import { fetchModelsWithBearerAuth } from "./openai-compatible";
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// The shared test setup restores the real fetch after every test, so
+// re-apply the mock before each one.
+vi.stubGlobal("fetch", mockFetch);
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
 
 describe("fetchModelsWithBearerAuth", () => {
   beforeEach(() => {

--- a/platform/backend/src/routes/chat/model-fetchers/openrouter.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openrouter.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, test } from "@/test";
 import { fetchOpenrouterModels } from "./openrouter";
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// The shared test setup restores the real fetch after every test, so
+// re-apply the mock before each one.
+vi.stubGlobal("fetch", mockFetch);
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
 
 describe("fetchOpenrouterModels", () => {
   beforeEach(() => {

--- a/platform/backend/src/routes/chat/model-fetchers/registry.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/registry.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, test } from "@/test";
 import { testProviderApiKey } from "./registry";
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// The shared test setup restores the real fetch after every test, so
+// re-apply the mock before each one.
+vi.stubGlobal("fetch", mockFetch);
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
 
 describe("provider fetcher registry", () => {
   beforeEach(() => {

--- a/platform/backend/src/routes/connection-setup/create.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/create.connection-setup.route.test.ts
@@ -5,9 +5,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 // cacheManager needs a live PostgreSQL connection that PGlite tests don't
 // have; back it with a Map (same convention as src/agents/utils.test.ts).

--- a/platform/backend/src/routes/connection-setup/create.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/create.connection-setup.route.test.ts
@@ -5,9 +5,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 // cacheManager needs a live PostgreSQL connection that PGlite tests don't
 // have; back it with a Map (same convention as src/agents/utils.test.ts).

--- a/platform/backend/src/routes/connection-setup/create.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/create.connection-setup.route.test.ts
@@ -8,22 +8,9 @@ import type { User } from "@/types";
 vi.mock("@/auth");
 
 // cacheManager needs a live PostgreSQL connection that PGlite tests don't
-// have; back it with a Map (same convention as src/agents/utils.test.ts).
-const mockCache = new Map<string, unknown>();
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...original,
-    cacheManager: {
-      get: vi.fn(async (key: string) => mockCache.get(key)),
-      set: vi.fn(async (key: string, value: unknown) => {
-        mockCache.set(key, value);
-        return true;
-      }),
-      delete: vi.fn(async (key: string) => mockCache.delete(key)),
-    },
-  };
-});
+// have; back it with the canonical Map-backed fake from
+// src/__mocks__/cache-manager.ts (reset before every test).
+vi.mock("@/cache-manager");
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/connection-setup/passthrough-key.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/passthrough-key.connection-setup.route.test.ts
@@ -4,9 +4,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/connection-setup/passthrough-key.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/passthrough-key.connection-setup.route.test.ts
@@ -4,9 +4,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/connection-setup/script.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/script.connection-setup.route.test.ts
@@ -18,23 +18,10 @@ import type { User } from "@/types";
 vi.mock("@/auth");
 
 // cacheManager needs a live PostgreSQL connection that PGlite tests don't
-// have; back it with a Map (same convention as src/agents/utils.test.ts) so
-// the rate limiter runs for real against an in-memory store.
-const mockCache = new Map<string, unknown>();
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...original,
-    cacheManager: {
-      get: vi.fn(async (key: string) => mockCache.get(key)),
-      set: vi.fn(async (key: string, value: unknown) => {
-        mockCache.set(key, value);
-        return true;
-      }),
-      delete: vi.fn(async (key: string) => mockCache.delete(key)),
-    },
-  };
-});
+// have; back it with the canonical Map-backed fake from
+// src/__mocks__/cache-manager.ts so the rate limiter runs for real against an
+// in-memory store (reset before every test).
+vi.mock("@/cache-manager");
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/connection-setup/script.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/script.connection-setup.route.test.ts
@@ -15,9 +15,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 // cacheManager needs a live PostgreSQL connection that PGlite tests don't
 // have; back it with a Map (same convention as src/agents/utils.test.ts) so

--- a/platform/backend/src/routes/connection-setup/script.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/script.connection-setup.route.test.ts
@@ -15,9 +15,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 // cacheManager needs a live PostgreSQL connection that PGlite tests don't
 // have; back it with a Map (same convention as src/agents/utils.test.ts) so

--- a/platform/backend/src/routes/connection-setup/virtual-key.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/virtual-key.connection-setup.route.test.ts
@@ -4,9 +4,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/connection-setup/virtual-key.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/virtual-key.connection-setup.route.test.ts
@@ -4,9 +4,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/custom-role.ee.test.ts
+++ b/platform/backend/src/routes/custom-role.ee.test.ts
@@ -16,9 +16,7 @@ const { createOrgRoleMock, updateOrgRoleMock, deleteOrgRoleMock } = vi.hoisted(
   }),
 );
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const hasPermissionMock = vi.mocked(hasPermission);
 

--- a/platform/backend/src/routes/custom-role.ee.test.ts
+++ b/platform/backend/src/routes/custom-role.ee.test.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { vi } from "vitest";
+import { betterAuth, hasPermission } from "@/auth";
 import db, { schema } from "@/database";
 import OrganizationRoleModel from "@/models/organization-role";
 import type { FastifyInstanceWithZod } from "@/server";
@@ -7,28 +8,19 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-const {
-  createOrgRoleMock,
-  updateOrgRoleMock,
-  deleteOrgRoleMock,
-  hasPermissionMock,
-} = vi.hoisted(() => ({
-  createOrgRoleMock: vi.fn(),
-  updateOrgRoleMock: vi.fn(),
-  deleteOrgRoleMock: vi.fn(),
-  hasPermissionMock: vi.fn(),
-}));
+const { createOrgRoleMock, updateOrgRoleMock, deleteOrgRoleMock } = vi.hoisted(
+  () => ({
+    createOrgRoleMock: vi.fn(),
+    updateOrgRoleMock: vi.fn(),
+    deleteOrgRoleMock: vi.fn(),
+  }),
+);
 
-vi.mock("@/auth", () => ({
-  betterAuth: {
-    api: {
-      createOrgRole: createOrgRoleMock,
-      updateOrgRole: updateOrgRoleMock,
-      deleteOrgRole: deleteOrgRoleMock,
-    },
-  },
-  hasPermission: hasPermissionMock,
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
+
+const hasPermissionMock = vi.mocked(hasPermission);
 
 describe("custom role routes", () => {
   let app: FastifyInstanceWithZod;
@@ -38,6 +30,16 @@ describe("custom role routes", () => {
 
   beforeEach(async ({ makeAdmin, makeMember, makeOrganization }) => {
     vi.clearAllMocks();
+
+    // These better-auth org-role API methods are not part of the canonical
+    // @/auth mock surface, so wire them onto betterAuth.api here. The casts
+    // are needed because the mocks don't carry better-auth's strict endpoint
+    // types; the routes only ever call them as plain functions.
+    const api = betterAuth.api as unknown as Record<string, unknown>;
+    api.createOrgRole = createOrgRoleMock;
+    api.updateOrgRole = updateOrgRoleMock;
+    api.deleteOrgRole = deleteOrgRoleMock;
+
     user = await makeAdmin();
     authenticatedUser = user;
     const organization = await makeOrganization();
@@ -61,7 +63,7 @@ describe("custom role routes", () => {
     });
 
     // Default: hasPermission grants admin access
-    hasPermissionMock.mockResolvedValue({ success: true });
+    hasPermissionMock.mockResolvedValue({ success: true, error: null });
 
     const { default: organizationRoleRoutes } = await import(
       "./organization-role"
@@ -223,7 +225,7 @@ describe("custom role routes", () => {
       permission: { ac: ["read", "update"] },
     });
 
-    deleteOrgRoleMock.mockResolvedValue({ success: true });
+    deleteOrgRoleMock.mockResolvedValue({ success: true, error: null });
 
     const deleteResponse = await app.inject({
       method: "DELETE",
@@ -700,7 +702,7 @@ describe("custom role routes", () => {
       permission: { agent: ["read"] },
     });
 
-    deleteOrgRoleMock.mockResolvedValue({ success: true });
+    deleteOrgRoleMock.mockResolvedValue({ success: true, error: null });
 
     const deleteResponse = await app.inject({
       method: "DELETE",

--- a/platform/backend/src/routes/default-user-limit.test.ts
+++ b/platform/backend/src/routes/default-user-limit.test.ts
@@ -5,14 +5,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/observability", () => ({
-  initializeObservabilityMetrics: vi.fn(),
-  metrics: {
-    llm: { initializeMetrics: vi.fn() },
-    mcp: { initializeMcpMetrics: vi.fn() },
-    agentExecution: { initializeAgentExecutionMetrics: vi.fn() },
-  },
-}));
+vi.mock("@/observability");
 
 describe("default-user-limit routes", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/environment.kubernetes-namespace.test.ts
+++ b/platform/backend/src/routes/environment.kubernetes-namespace.test.ts
@@ -4,9 +4,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 vi.mock("@/k8s/mcp-server-runtime/manager", () => ({
   default: {

--- a/platform/backend/src/routes/environment.kubernetes-namespace.test.ts
+++ b/platform/backend/src/routes/environment.kubernetes-namespace.test.ts
@@ -4,9 +4,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 vi.mock("@/k8s/mcp-server-runtime/manager", () => ({
   default: {

--- a/platform/backend/src/routes/environment.test.ts
+++ b/platform/backend/src/routes/environment.test.ts
@@ -14,9 +14,7 @@ import { ApiError, type User } from "@/types";
 // permission map wiring (and a genuine 403 for a non-permitted member), the hook
 // replicates the middleware's authorization gate using the actual
 // requiredEndpointPermissionsMap.
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 // Keep the K8s runtime ENABLED but stub the actual cluster calls, so the route
 // exercises its real namespace-validation branch without depending on whether

--- a/platform/backend/src/routes/environment.test.ts
+++ b/platform/backend/src/routes/environment.test.ts
@@ -14,9 +14,9 @@ import { ApiError, type User } from "@/types";
 // permission map wiring (and a genuine 403 for a non-permitted member), the hook
 // replicates the middleware's authorization gate using the actual
 // requiredEndpointPermissionsMap.
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 // Keep the K8s runtime ENABLED but stub the actual cluster calls, so the route
 // exercises its real namespace-validation branch without depending on whether

--- a/platform/backend/src/routes/github-copilot-auth/poll.github-copilot-auth.route.test.ts
+++ b/platform/backend/src/routes/github-copilot-auth/poll.github-copilot-auth.route.test.ts
@@ -5,23 +5,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
 // cacheManager (used by the rate limiter) needs a live PostgreSQL connection
-// that PGlite tests don't have; back it with a Map (same convention as
-// script.connection-setup.route.test.ts).
-const mockCache = new Map<string, unknown>();
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...original,
-    cacheManager: {
-      get: vi.fn(async (key: string) => mockCache.get(key)),
-      set: vi.fn(async (key: string, value: unknown) => {
-        mockCache.set(key, value);
-        return true;
-      }),
-      delete: vi.fn(async (key: string) => mockCache.delete(key)),
-    },
-  };
-});
+// that PGlite tests don't have; back it with the canonical Map-backed fake from
+// src/__mocks__/cache-manager.ts (reset before every test).
+vi.mock("@/cache-manager");
 
 describe("POST /api/github-copilot-auth/device/poll", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/github-copilot-auth/start.github-copilot-auth.route.test.ts
+++ b/platform/backend/src/routes/github-copilot-auth/start.github-copilot-auth.route.test.ts
@@ -5,23 +5,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
 // cacheManager (used by the rate limiter) needs a live PostgreSQL connection
-// that PGlite tests don't have; back it with a Map (same convention as
-// script.connection-setup.route.test.ts).
-const mockCache = new Map<string, unknown>();
-vi.mock("@/cache-manager", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/cache-manager")>();
-  return {
-    ...original,
-    cacheManager: {
-      get: vi.fn(async (key: string) => mockCache.get(key)),
-      set: vi.fn(async (key: string, value: unknown) => {
-        mockCache.set(key, value);
-        return true;
-      }),
-      delete: vi.fn(async (key: string) => mockCache.delete(key)),
-    },
-  };
-});
+// that PGlite tests don't have; back it with the canonical Map-backed fake from
+// src/__mocks__/cache-manager.ts (reset before every test).
+vi.mock("@/cache-manager");
 
 describe("POST /api/github-copilot-auth/device/start", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/internal-mcp-catalog.delete-parent-with-installed-child.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.delete-parent-with-installed-child.test.ts
@@ -6,9 +6,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.delete-parent-with-installed-child.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.delete-parent-with-installed-child.test.ts
@@ -6,9 +6,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.deployment-yaml.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.deployment-yaml.test.ts
@@ -12,9 +12,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.deployment-yaml.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.deployment-yaml.test.ts
@@ -12,9 +12,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.environment-relocation.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.environment-relocation.test.ts
@@ -5,9 +5,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 // Force the K8s runtime ON so the route's relocation branch is exercised, and
 // stub the cluster calls. The teardown/recreate primitives are no-ops here; we

--- a/platform/backend/src/routes/internal-mcp-catalog.environment-relocation.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.environment-relocation.test.ts
@@ -5,9 +5,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 // Force the K8s runtime ON so the route's relocation branch is exercised, and
 // stub the cluster calls. The teardown/recreate primitives are no-ops here; we

--- a/platform/backend/src/routes/internal-mcp-catalog.headers.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.headers.test.ts
@@ -6,9 +6,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.headers.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.headers.test.ts
@@ -6,9 +6,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.image-approval.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.image-approval.test.ts
@@ -12,9 +12,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 // Keep the real diff helpers; stub the pod-recreating reinstall so the
 // approval-triggered cascade is observable without touching Kubernetes.

--- a/platform/backend/src/routes/internal-mcp-catalog.image-approval.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.image-approval.test.ts
@@ -6,19 +6,15 @@ import {
 } from "fastify-type-provider-zod";
 import { type Mock, vi } from "vitest";
 import { hasPermission } from "@/auth";
-import {
-  InternalMcpCatalogModel,
-  McpServerModel,
-  OrganizationModel,
-} from "@/models";
+import { InternalMcpCatalogModel } from "@/models";
 import { autoReinstallServer } from "@/services/mcp-reinstall";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 // Keep the real diff helpers; stub the pod-recreating reinstall so the
 // approval-triggered cascade is observable without touching Kubernetes.

--- a/platform/backend/src/routes/internal-mcp-catalog.image-pull-secrets.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.image-pull-secrets.test.ts
@@ -11,9 +11,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.image-pull-secrets.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.image-pull-secrets.test.ts
@@ -11,9 +11,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.labels.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.labels.test.ts
@@ -11,9 +11,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.labels.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.labels.test.ts
@@ -11,9 +11,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.list.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.list.test.ts
@@ -11,9 +11,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.list.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.list.test.ts
@@ -11,9 +11,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.member-update.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.member-update.test.ts
@@ -15,9 +15,7 @@ import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 // scope gate uses getPermissionsForUserContext (the REAL member role), so this
 // verifies the handler restricts a member to their own personal items even with
 // the route-level `mcpRegistry:update` grant.
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 const mockHasPermission = hasPermission as Mock;
 
 describe("member catalog update is limited to own personal items", () => {

--- a/platform/backend/src/routes/internal-mcp-catalog.member-update.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.member-update.test.ts
@@ -15,7 +15,9 @@ import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 // scope gate uses getPermissionsForUserContext (the REAL member role), so this
 // verifies the handler restricts a member to their own personal items even with
 // the route-level `mcpRegistry:update` grant.
-vi.mock("@/auth", () => ({ hasPermission: vi.fn() }));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 const mockHasPermission = hasPermission as Mock;
 
 describe("member catalog update is limited to own personal items", () => {

--- a/platform/backend/src/routes/internal-mcp-catalog.metadata-only-edit.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.metadata-only-edit.test.ts
@@ -21,9 +21,7 @@ async function assertCascadeDidNotFire(spy: MockInstance): Promise<void> {
   expect(spy).not.toHaveBeenCalled();
 }
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.metadata-only-edit.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.metadata-only-edit.test.ts
@@ -21,9 +21,9 @@ async function assertCascadeDidNotFire(spy: MockInstance): Promise<void> {
   expect(spy).not.toHaveBeenCalled();
 }
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.permissions.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.permissions.test.ts
@@ -12,9 +12,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.permissions.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.permissions.test.ts
@@ -12,9 +12,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.refresh-image.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.refresh-image.test.ts
@@ -15,9 +15,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 vi.mock("@/services/mcp-reinstall", async (importOriginal) => {
   const original =

--- a/platform/backend/src/routes/internal-mcp-catalog.refresh-image.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.refresh-image.test.ts
@@ -15,9 +15,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 vi.mock("@/services/mcp-reinstall", async (importOriginal) => {
   const original =

--- a/platform/backend/src/routes/internal-mcp-catalog.reinstall.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.reinstall.test.ts
@@ -12,9 +12,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 vi.mock("@/services/mcp-reinstall", async (importOriginal) => {
   const original =

--- a/platform/backend/src/routes/internal-mcp-catalog.reinstall.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.reinstall.test.ts
@@ -12,9 +12,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 vi.mock("@/services/mcp-reinstall", async (importOriginal) => {
   const original =

--- a/platform/backend/src/routes/internal-mcp-catalog.restricted-environment.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.restricted-environment.test.ts
@@ -6,9 +6,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 import { createEnvironment } from "@/services/environments/environment";

--- a/platform/backend/src/routes/internal-mcp-catalog.restricted-environment.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.restricted-environment.test.ts
@@ -6,9 +6,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 import { createEnvironment } from "@/services/environments/environment";

--- a/platform/backend/src/routes/internal-mcp-catalog.secrets-preservation.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.secrets-preservation.test.ts
@@ -6,9 +6,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.secrets-preservation.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.secrets-preservation.test.ts
@@ -6,9 +6,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.storage-routing.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.storage-routing.test.ts
@@ -6,9 +6,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.storage-routing.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.storage-routing.test.ts
@@ -6,9 +6,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.team-scope.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.team-scope.test.ts
@@ -10,9 +10,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.team-scope.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.team-scope.test.ts
@@ -10,9 +10,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.test.ts
@@ -18,9 +18,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/internal-mcp-catalog.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.test.ts
@@ -18,9 +18,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 import internalMcpCatalogRoutes from "./internal-mcp-catalog";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 const mockHasPermission = hasPermission as Mock;
 

--- a/platform/backend/src/routes/k8s-capabilities.test.ts
+++ b/platform/backend/src/routes/k8s-capabilities.test.ts
@@ -6,9 +6,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 vi.mock("@/k8s/capabilities", () => ({
   getK8sCapabilities: vi.fn(),

--- a/platform/backend/src/routes/k8s-capabilities.test.ts
+++ b/platform/backend/src/routes/k8s-capabilities.test.ts
@@ -6,9 +6,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, describe, expect, test } from "@/test";
 import { ApiError, type User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 vi.mock("@/k8s/capabilities", () => ({
   getK8sCapabilities: vi.fn(),

--- a/platform/backend/src/routes/knowledge-base.restricted-environment.test.ts
+++ b/platform/backend/src/routes/knowledge-base.restricted-environment.test.ts
@@ -1,4 +1,4 @@
-import { type Mock, vi } from "vitest";
+import { vi } from "vitest";
 import { KnowledgeBaseConnectorModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
@@ -10,15 +10,12 @@ import type { User } from "@/types";
 // environment:deploy-to-restricted (or environment:admin). The gate computes
 // canDeployToRestricted from `userHasPermission`, so we override only that
 // export (resource-aware) and leave the rest of @/auth/utils intact.
-vi.mock("@/auth/utils", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/auth/utils")>();
-  return { ...actual, userHasPermission: vi.fn() };
-});
+vi.mock("@/auth/utils");
 
 import { userHasPermission } from "@/auth/utils";
 import { createEnvironment } from "@/services/environments/environment";
 
-const mockUserHasPermission = userHasPermission as Mock;
+const mockUserHasPermission = vi.mocked(userHasPermission);
 
 describe("Knowledge connector - restricted environment assignment guard", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/limits.test.ts
+++ b/platform/backend/src/routes/limits.test.ts
@@ -6,14 +6,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/observability", () => ({
-  initializeObservabilityMetrics: vi.fn(),
-  metrics: {
-    llm: { initializeMetrics: vi.fn() },
-    mcp: { initializeMcpMetrics: vi.fn() },
-    agentExecution: { initializeAgentExecutionMetrics: vi.fn() },
-  },
-}));
+vi.mock("@/observability");
 
 describe("limits routes", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/llm-provider-api-keys.test.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.test.ts
@@ -20,9 +20,7 @@ vi.mock("@/clients/azure-openai-credentials", () => ({
 }));
 
 // Mock auth for permission checks
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 // Mock testProviderApiKey to avoid external calls
 vi.mock("@/routes/chat/model-fetchers/registry", () => ({

--- a/platform/backend/src/routes/llm-provider-api-keys.test.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.test.ts
@@ -20,10 +20,9 @@ vi.mock("@/clients/azure-openai-credentials", () => ({
 }));
 
 // Mock auth for permission checks
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 // Mock testProviderApiKey to avoid external calls
 vi.mock("@/routes/chat/model-fetchers/registry", () => ({

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -19,7 +19,6 @@ import type { ListToolsResult } from "@modelcontextprotocol/sdk/types.js";
 import { vi } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import mcpClient from "@/clients/mcp-client";
-import type * as originalConfigModule from "@/config";
 import {
   AgentTeamModel,
   McpCatalogLabelModel,
@@ -35,15 +34,11 @@ import { MCP_RESOURCE_REFERENCE_PREFIX } from "@/services/identity-providers/ent
 import type { JwksValidationResult } from "@/services/jwks-validator";
 import { describe, expect, test } from "@/test";
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-      enterpriseFeatures: { ...actual.default.enterpriseFeatures, core: true },
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    enterpriseFeatures: { core: true },
+  }),
+);
 
 const mockValidateJwt = vi.fn<() => Promise<JwksValidationResult | null>>();
 

--- a/platform/backend/src/routes/mcp-server-installation-requests.test.ts
+++ b/platform/backend/src/routes/mcp-server-installation-requests.test.ts
@@ -6,9 +6,9 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
 // Mock hasPermission - admin by default
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/mcp-server-installation-requests.test.ts
+++ b/platform/backend/src/routes/mcp-server-installation-requests.test.ts
@@ -6,9 +6,7 @@ import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
 // Mock hasPermission - admin by default
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/mcp-server.image-gate.test.ts
+++ b/platform/backend/src/routes/mcp-server.image-gate.test.ts
@@ -1,5 +1,10 @@
 import { eq } from "drizzle-orm";
 import { vi } from "vitest";
+import {
+  getPermissionsForUserContext,
+  hasPermission,
+  userHasPermission,
+} from "@/auth/utils";
 import db, { schema } from "@/database";
 import { InternalMcpCatalogModel, OrganizationModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
@@ -10,16 +15,12 @@ import type { User } from "@/types";
 
 const {
   connectAndGetToolsMock,
-  hasPermissionMock,
-  userHasPermissionMock,
   k8sStartServerMock,
   k8sRestartServerMock,
   k8sStopServerMock,
   k8sGetOrLoadDeploymentMock,
 } = vi.hoisted(() => ({
   connectAndGetToolsMock: vi.fn(),
-  hasPermissionMock: vi.fn(),
-  userHasPermissionMock: vi.fn(),
   k8sStartServerMock: vi.fn(),
   k8sRestartServerMock: vi.fn(),
   k8sStopServerMock: vi.fn(),
@@ -36,13 +37,7 @@ vi.mock("@/clients/mcp-client", () => ({
   },
 }));
 
-vi.mock("@/auth/utils", () => ({
-  hasPermission: hasPermissionMock,
-  userHasPermission: userHasPermissionMock,
-  // The image gate resolves the catalog author's privilege; empty permissions
-  // make the author a non-privileged member, so these image-based cases gate.
-  getPermissionsForUserContext: () => Promise.resolve({}),
-}));
+vi.mock("@/auth/utils");
 
 vi.mock("@/k8s/mcp-server-runtime", () => ({
   McpServerRuntimeManager: {
@@ -53,6 +48,12 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
     getOrLoadDeployment: k8sGetOrLoadDeploymentMock,
   },
 }));
+
+const hasPermissionMock = vi.mocked(hasPermission);
+const userHasPermissionMock = vi.mocked(userHasPermission);
+const getPermissionsForUserContextMock = vi.mocked(
+  getPermissionsForUserContext,
+);
 
 /**
  * Install-time trusted-image-registry gate: a personal local catalog item whose
@@ -70,8 +71,11 @@ describe("MCP Server Install - trusted-image-registry gate", () => {
     organizationId = organization.id;
     await makeMember(user.id, organization.id);
 
-    hasPermissionMock.mockResolvedValue({ success: true });
+    hasPermissionMock.mockResolvedValue({ success: true, error: null });
     userHasPermissionMock.mockResolvedValue(true);
+    // The image gate resolves the catalog author's privilege; empty permissions
+    // make the author a non-privileged member, so these image-based cases gate.
+    getPermissionsForUserContextMock.mockResolvedValue({});
     k8sStartServerMock.mockResolvedValue(undefined);
     k8sRestartServerMock.mockResolvedValue(undefined);
     k8sStopServerMock.mockResolvedValue(undefined);
@@ -95,6 +99,7 @@ describe("MCP Server Install - trusted-image-registry gate", () => {
     connectAndGetToolsMock.mockReset();
     hasPermissionMock.mockReset();
     userHasPermissionMock.mockReset();
+    getPermissionsForUserContextMock.mockReset();
     k8sStartServerMock.mockReset();
     k8sRestartServerMock.mockReset();
     k8sStopServerMock.mockReset();

--- a/platform/backend/src/routes/mcp-server.install-secret-routing.test.ts
+++ b/platform/backend/src/routes/mcp-server.install-secret-routing.test.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import { vi } from "vitest";
+import { hasPermission, userHasPermission } from "@/auth/utils";
 import db, { schema } from "@/database";
 import { secretManager } from "@/secrets-manager";
 import type { FastifyInstanceWithZod } from "@/server";
@@ -9,16 +10,12 @@ import type { User } from "@/types";
 
 const {
   connectAndGetToolsMock,
-  hasPermissionMock,
-  userHasPermissionMock,
   k8sStartServerMock,
   k8sRestartServerMock,
   k8sStopServerMock,
   k8sGetOrLoadDeploymentMock,
 } = vi.hoisted(() => ({
   connectAndGetToolsMock: vi.fn(),
-  hasPermissionMock: vi.fn(),
-  userHasPermissionMock: vi.fn(),
   k8sStartServerMock: vi.fn(),
   k8sRestartServerMock: vi.fn(),
   k8sStopServerMock: vi.fn(),
@@ -35,10 +32,7 @@ vi.mock("@/clients/mcp-client", () => ({
   },
 }));
 
-vi.mock("@/auth/utils", () => ({
-  hasPermission: hasPermissionMock,
-  userHasPermission: userHasPermissionMock,
-}));
+vi.mock("@/auth/utils");
 
 vi.mock("@/k8s/mcp-server-runtime", () => ({
   McpServerRuntimeManager: {
@@ -49,6 +43,9 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
     getOrLoadDeployment: k8sGetOrLoadDeploymentMock,
   },
 }));
+
+const hasPermissionMock = vi.mocked(hasPermission);
+const userHasPermissionMock = vi.mocked(userHasPermission);
 
 /**
 THESE TESTS ARE COVERING EXISING BEHAVIOUR AND EXISTS TO MAKE SURE WE DON'T BREAK IT ACCIDENTALLY.
@@ -73,7 +70,7 @@ describe("MCP Server Install - Per-User Value Routing", () => {
     organizationId = organization.id;
     await makeMember(user.id, organization.id);
 
-    hasPermissionMock.mockResolvedValue({ success: true });
+    hasPermissionMock.mockResolvedValue({ success: true, error: null });
     userHasPermissionMock.mockResolvedValue(true);
     k8sStartServerMock.mockResolvedValue(undefined);
     k8sRestartServerMock.mockResolvedValue(undefined);

--- a/platform/backend/src/routes/mcp-server.reauthenticate.route.test.ts
+++ b/platform/backend/src/routes/mcp-server.reauthenticate.route.test.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import { hasPermission, userHasPermission } from "@/auth/utils";
 import { OrganizationModel } from "@/models";
 import McpServerModel from "@/models/mcp-server";
 import { secretManager } from "@/secrets-manager";
@@ -7,17 +8,12 @@ import { createFastifyInstance } from "@/server";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-const {
-  invalidateConnectionsForServerMock,
-  hasPermissionMock,
-  userHasPermissionMock,
-  k8sRestartServerMock,
-} = vi.hoisted(() => ({
-  invalidateConnectionsForServerMock: vi.fn(),
-  hasPermissionMock: vi.fn(),
-  userHasPermissionMock: vi.fn(),
-  k8sRestartServerMock: vi.fn(),
-}));
+const { invalidateConnectionsForServerMock, k8sRestartServerMock } = vi.hoisted(
+  () => ({
+    invalidateConnectionsForServerMock: vi.fn(),
+    k8sRestartServerMock: vi.fn(),
+  }),
+);
 
 vi.mock("@/clients/mcp-client", () => ({
   McpServerNotReadyError: class extends Error {},
@@ -27,10 +23,7 @@ vi.mock("@/clients/mcp-client", () => ({
   },
 }));
 
-vi.mock("@/auth/utils", () => ({
-  hasPermission: hasPermissionMock,
-  userHasPermission: userHasPermissionMock,
-}));
+vi.mock("@/auth/utils");
 
 vi.mock("@/k8s/mcp-server-runtime", () => ({
   McpServerRuntimeManager: {
@@ -38,6 +31,9 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
     restartServer: k8sRestartServerMock,
   },
 }));
+
+const hasPermissionMock = vi.mocked(hasPermission);
+const userHasPermissionMock = vi.mocked(userHasPermission);
 
 describe("PATCH /api/mcp_server/:id/reauthenticate", () => {
   let app: FastifyInstanceWithZod;
@@ -50,7 +46,7 @@ describe("PATCH /api/mcp_server/:id/reauthenticate", () => {
     organizationId = organization.id;
     await makeMember(user.id, organization.id);
 
-    hasPermissionMock.mockResolvedValue({ success: true });
+    hasPermissionMock.mockResolvedValue({ success: true, error: null });
     userHasPermissionMock.mockResolvedValue(true);
     invalidateConnectionsForServerMock.mockResolvedValue(undefined);
     k8sRestartServerMock.mockResolvedValue(undefined);

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -1,6 +1,7 @@
 import { OAUTH_TOKEN_TYPE } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
 import { vi } from "vitest";
+import { hasPermission, userHasPermission } from "@/auth/utils";
 import db, { schema } from "@/database";
 import { McpServerModel } from "@/models";
 import McpServerUserModel from "@/models/mcp-server-user";
@@ -13,27 +14,23 @@ import type { User } from "@/types";
 const {
   connectAndGetToolsMock,
   exchangeEnterpriseManagedCredentialMock,
-  hasPermissionMock,
   invalidateConnectionsForServerMock,
   inspectServerMock,
   k8sGetOrLoadDeploymentMock,
   k8sRestartServerMock,
   k8sStartServerMock,
   k8sStopServerMock,
-  userHasPermissionMock,
   MockMcpServerConnectionTimeoutError,
   MockMcpServerNotReadyError,
 } = vi.hoisted(() => ({
   connectAndGetToolsMock: vi.fn(),
   exchangeEnterpriseManagedCredentialMock: vi.fn(),
-  hasPermissionMock: vi.fn(),
   invalidateConnectionsForServerMock: vi.fn(),
   inspectServerMock: vi.fn(),
   k8sGetOrLoadDeploymentMock: vi.fn(),
   k8sRestartServerMock: vi.fn(),
   k8sStartServerMock: vi.fn(),
   k8sStopServerMock: vi.fn(),
-  userHasPermissionMock: vi.fn(),
   MockMcpServerNotReadyError: class MockMcpServerNotReadyError extends Error {},
   MockMcpServerConnectionTimeoutError: class MockMcpServerConnectionTimeoutError extends Error {},
 }));
@@ -52,10 +49,7 @@ vi.mock("@/services/identity-providers/enterprise-managed/exchange", () => ({
   exchangeEnterpriseManagedCredential: exchangeEnterpriseManagedCredentialMock,
 }));
 
-vi.mock("@/auth/utils", () => ({
-  hasPermission: hasPermissionMock,
-  userHasPermission: userHasPermissionMock,
-}));
+vi.mock("@/auth/utils");
 
 vi.mock("@/k8s/mcp-server-runtime", () => ({
   McpServerRuntimeManager: {
@@ -66,6 +60,9 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
     getOrLoadDeployment: k8sGetOrLoadDeploymentMock,
   },
 }));
+
+const hasPermissionMock = vi.mocked(hasPermission);
+const userHasPermissionMock = vi.mocked(userHasPermission);
 
 // Wait for the reinstall route's `setImmediate`-scheduled background work
 // to flip the install row off "pending". Fails the test if it doesn't —
@@ -105,7 +102,7 @@ describe("mcp server inspect route", () => {
     const organization = await makeOrganization();
     organizationId = organization.id;
     await makeMember(user.id, organization.id);
-    hasPermissionMock.mockResolvedValue({ success: true });
+    hasPermissionMock.mockResolvedValue({ success: true, error: null });
     userHasPermissionMock.mockResolvedValue(true);
     k8sStartServerMock.mockResolvedValue(undefined);
     k8sRestartServerMock.mockResolvedValue(undefined);
@@ -171,7 +168,7 @@ describe("mcp server inspect route", () => {
       catalogId: catalog.id,
     });
 
-    hasPermissionMock.mockResolvedValueOnce({ success: false });
+    hasPermissionMock.mockResolvedValueOnce({ success: false, error: null });
 
     const response = await app.inject({
       method: params.method,
@@ -237,7 +234,7 @@ describe("mcp server inspect route", () => {
     makeTeam,
     makeTeamMember,
   }) => {
-    hasPermissionMock.mockResolvedValueOnce({ success: false });
+    hasPermissionMock.mockResolvedValueOnce({ success: false, error: null });
 
     const selectedTeam = await makeTeam(organizationId, user.id, {
       name: "Selected Team",
@@ -282,7 +279,7 @@ describe("mcp server inspect route", () => {
     makeTeamMember,
     makeUser,
   }) => {
-    hasPermissionMock.mockResolvedValueOnce({ success: true });
+    hasPermissionMock.mockResolvedValueOnce({ success: true, error: null });
 
     const otherUser = await makeUser({ email: "other-owner@example.com" });
     const selectedTeam = await makeTeam(organizationId, user.id, {
@@ -320,7 +317,7 @@ describe("mcp server inspect route", () => {
     makeOrganization,
     makeUser,
   }) => {
-    hasPermissionMock.mockResolvedValueOnce({ success: true });
+    hasPermissionMock.mockResolvedValueOnce({ success: true, error: null });
 
     const organization = await makeOrganization();
     organizationId = organization.id;
@@ -363,7 +360,7 @@ describe("mcp server inspect route", () => {
     makeTeamMember,
     makeUser,
   }) => {
-    hasPermissionMock.mockResolvedValueOnce({ success: true });
+    hasPermissionMock.mockResolvedValueOnce({ success: true, error: null });
 
     const organization = await makeOrganization();
     organizationId = organization.id;
@@ -3576,12 +3573,12 @@ describe("mcp server inspect route", () => {
     hasPermissionMock.mockImplementation(
       async (permission: Record<string, string[]>) => {
         if (permission.team?.includes("create")) {
-          return { success: opts.canManageAllTeams };
+          return { success: opts.canManageAllTeams, error: null };
         }
         if (permission.mcpServerInstallation?.includes("update")) {
-          return { success: opts.isEditor };
+          return { success: opts.isEditor, error: null };
         }
-        return { success: false };
+        return { success: false, error: null };
       },
     );
   }
@@ -3784,7 +3781,7 @@ describe("mcp server core route coverage", () => {
     const organization = await makeOrganization();
     organizationId = organization.id;
     await makeMember(user.id, organization.id);
-    hasPermissionMock.mockResolvedValue({ success: true });
+    hasPermissionMock.mockResolvedValue({ success: true, error: null });
     userHasPermissionMock.mockResolvedValue(true);
     k8sStopServerMock.mockResolvedValue(undefined);
 

--- a/platform/backend/src/routes/metrics.test.ts
+++ b/platform/backend/src/routes/metrics.test.ts
@@ -17,22 +17,11 @@ vi.mock("fastify-metrics", () => ({
   },
 }));
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/config")>();
-  return {
-    ...actual,
-    default: {
-      ...actual.default,
-      observability: {
-        ...actual.default.observability,
-        metrics: {
-          ...actual.default.observability.metrics,
-          secret: "foo-bar",
-        },
-      },
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    observability: { metrics: { secret: "foo-bar" } },
+  }),
+);
 
 import {
   createFastifyInstance,

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -25,6 +25,15 @@ import oauthRoutes, {
   sanitizeOAuthErrorCode,
 } from "./oauth";
 
+// Several tests below swap `globalThis.fetch` for a mock and restore it inline
+// after their assertions. If an assertion throws, the inline restore is skipped
+// and the mocked fetch leaks into whatever test file runs next in the worker.
+// This top-level hook guarantees the real fetch is back after every test.
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
 describe("OAuth helper functions", () => {
   describe("generateCodeVerifier", () => {
     test("returns a base64url-encoded string", () => {

--- a/platform/backend/src/routes/organization-connection-settings.test.ts
+++ b/platform/backend/src/routes/organization-connection-settings.test.ts
@@ -1,34 +1,20 @@
 import { vi } from "vitest";
-import type * as originalConfigModule from "@/config";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-const { hasPermissionMock } = vi.hoisted(() => ({
-  hasPermissionMock: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
-vi.mock("@/auth", async () => {
-  const actual = await vi.importActual<typeof import("@/auth")>("@/auth");
-  return {
-    ...actual,
-    hasPermission: hasPermissionMock,
-  };
-});
+import { hasPermission } from "@/auth";
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-      enterpriseFeatures: {
-        ...actual.default.enterpriseFeatures,
-        core: true,
-      },
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    enterpriseFeatures: { core: true },
+  }),
+);
 
 describe("PATCH /api/organization/connection-settings", () => {
   let app: FastifyInstanceWithZod;
@@ -37,7 +23,7 @@ describe("PATCH /api/organization/connection-settings", () => {
 
   beforeEach(async ({ makeAdmin, makeMember, makeOrganization }) => {
     vi.clearAllMocks();
-    hasPermissionMock.mockResolvedValue({ success: true });
+    vi.mocked(hasPermission).mockResolvedValue({ success: true, error: null });
 
     adminUser = await makeAdmin();
     const organization = await makeOrganization();

--- a/platform/backend/src/routes/organization-connection-settings.test.ts
+++ b/platform/backend/src/routes/organization-connection-settings.test.ts
@@ -4,9 +4,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/organization.default-environment.test.ts
+++ b/platform/backend/src/routes/organization.default-environment.test.ts
@@ -12,9 +12,7 @@ import { ApiError, type User } from "@/types";
 // `hasPermission` mocked. To exercise the real route -> permission map wiring
 // (and a genuine 403 for a non-permitted member), the hook replicates the
 // middleware's authorization gate using the actual requiredEndpointPermissionsMap.
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 vi.mock("@/k8s/mcp-server-runtime/manager", () => ({
   default: {

--- a/platform/backend/src/routes/organization.default-environment.test.ts
+++ b/platform/backend/src/routes/organization.default-environment.test.ts
@@ -12,9 +12,9 @@ import { ApiError, type User } from "@/types";
 // `hasPermission` mocked. To exercise the real route -> permission map wiring
 // (and a genuine 403 for a non-permitted member), the hook replicates the
 // middleware's authorization gate using the actual requiredEndpointPermissionsMap.
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 vi.mock("@/k8s/mcp-server-runtime/manager", () => ({
   default: {

--- a/platform/backend/src/routes/organization.test.ts
+++ b/platform/backend/src/routes/organization.test.ts
@@ -14,12 +14,6 @@ import type { User } from "@/types";
 const VALID_PNG_BASE64 =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg==";
 
-vi.mock("@/config", async () =>
-  (await import("@/test/mocks/config")).configModuleMock({
-    enterpriseFeatures: { fullWhiteLabeling: true },
-  }),
-);
-
 describe("organization routes", () => {
   let app: FastifyInstanceWithZod;
   let user: User;

--- a/platform/backend/src/routes/organization.test.ts
+++ b/platform/backend/src/routes/organization.test.ts
@@ -1,6 +1,5 @@
 import { vi } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
-import type * as originalConfigModule from "@/config";
 import * as embeddingClients from "@/knowledge-base/embedding-clients";
 import LlmProviderApiKeyModel from "@/models/llm-provider-api-key";
 import LlmProviderApiKeyModelLinkModel from "@/models/llm-provider-api-key-model";
@@ -15,18 +14,11 @@ import type { User } from "@/types";
 const VALID_PNG_BASE64 =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg==";
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-      enterpriseFeatures: {
-        ...actual.default.enterpriseFeatures,
-        fullWhiteLabeling: true,
-      },
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    enterpriseFeatures: { fullWhiteLabeling: true },
+  }),
+);
 
 describe("organization routes", () => {
   let app: FastifyInstanceWithZod;

--- a/platform/backend/src/routes/proxy/adapters/anthropic-azure-foundry.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-azure-foundry.test.ts
@@ -1,9 +1,7 @@
 import type AnthropicProvider from "@anthropic-ai/sdk";
 import { describe, expect, test, vi } from "vitest";
 
-vi.mock("@/observability", () => ({
-  metrics: { llm: { getObservableFetch: vi.fn() } },
-}));
+vi.mock("@/observability");
 
 vi.mock("@/clients/azure-openai-credentials", () => ({
   getAzureAiFoundryBearerTokenProvider: vi.fn(

--- a/platform/backend/src/routes/proxy/adapters/azure.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.test.ts
@@ -2,9 +2,7 @@ import type OpenAIProvider from "openai";
 import { vi } from "vitest";
 import { describe, expect, test } from "@/test";
 
-vi.mock("@/observability", () => ({
-  metrics: { llm: { getObservableFetch: vi.fn() } },
-}));
+vi.mock("@/observability");
 
 vi.mock("@/clients/azure-openai-credentials", () => ({
   getAzureOpenAiBearerTokenProvider: vi.fn(() => async () => "entra-token"),

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -72,23 +72,10 @@ vi.mock("@/observability/tracing", async (importOriginal) => {
 });
 
 // Mock metrics
-const mockReportBlockedTools = vi.fn();
-vi.mock("@/observability", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/observability")>();
-  return {
-    ...original,
-    metrics: {
-      ...original.metrics,
-      llm: {
-        ...original.metrics.llm,
-        reportBlockedTools: (...args: unknown[]) =>
-          mockReportBlockedTools(...args),
-      },
-    },
-  };
-});
+vi.mock("@/observability");
 
 // Import after mocks
+import { metrics } from "@/observability";
 import {
   buildInteractionRecord,
   calculateInteractionCosts,
@@ -433,7 +420,7 @@ describe("recordBlockedToolCallMetrics", () => {
       externalAgentId: "ext-2",
     });
 
-    expect(mockReportBlockedTools).toHaveBeenCalledWith(
+    expect(vi.mocked(metrics.llm.reportBlockedTools)).toHaveBeenCalledWith(
       "anthropic",
       agent,
       1,

--- a/platform/backend/src/routes/proxy/routes/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/routes/anthropic.test.ts
@@ -32,9 +32,7 @@ import { createAnthropicTestClient } from "@/test/llm-provider-stubs";
 import { anthropicAdapterFactory } from "../adapters";
 import anthropicProxyRoutes from "./anthropic";
 
-vi.mock("@/logging", async () =>
-  (await import("@/test/mocks/logging")).loggingModuleMock(),
-);
+vi.mock("@/logging");
 
 function findAnthropicRequestLog(message: string) {
   return vi

--- a/platform/backend/src/routes/proxy/routes/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/routes/anthropic.test.ts
@@ -32,15 +32,9 @@ import { createAnthropicTestClient } from "@/test/llm-provider-stubs";
 import { anthropicAdapterFactory } from "../adapters";
 import anthropicProxyRoutes from "./anthropic";
 
-vi.mock("@/logging", () => ({
-  default: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    trace: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
+vi.mock("@/logging", async () =>
+  (await import("@/test/mocks/logging")).loggingModuleMock(),
+);
 
 function findAnthropicRequestLog(message: string) {
   return vi

--- a/platform/backend/src/routes/schedule-trigger.test.ts
+++ b/platform/backend/src/routes/schedule-trigger.test.ts
@@ -8,9 +8,7 @@ import { projectService } from "@/services/project";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasAnyAgentTypeAdminPermission, hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/schedule-trigger.test.ts
+++ b/platform/backend/src/routes/schedule-trigger.test.ts
@@ -8,12 +8,11 @@ import { projectService } from "@/services/project";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  hasAnyAgentTypeAdminPermission: vi.fn().mockResolvedValue(false),
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
-import { hasPermission } from "@/auth";
+import { hasAnyAgentTypeAdminPermission, hasPermission } from "@/auth";
 
 const mockHasPermission = hasPermission as Mock;
 
@@ -24,6 +23,7 @@ describe("schedule trigger routes", () => {
 
   beforeEach(async ({ makeMember, makeOrganization, makeUser }) => {
     mockHasPermission.mockResolvedValue({ success: true, error: null });
+    vi.mocked(hasAnyAgentTypeAdminPermission).mockResolvedValue(false);
 
     adminUser = await makeUser();
     const organization = await makeOrganization();

--- a/platform/backend/src/routes/team-labels.test.ts
+++ b/platform/backend/src/routes/team-labels.test.ts
@@ -1,34 +1,20 @@
 import { vi } from "vitest";
-import type * as originalConfigModule from "@/config";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-const { hasPermissionMock } = vi.hoisted(() => ({
-  hasPermissionMock: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
-vi.mock("@/auth", async () => {
-  const actual = await vi.importActual<typeof import("@/auth")>("@/auth");
-  return {
-    ...actual,
-    hasPermission: hasPermissionMock,
-  };
-});
+import { hasPermission } from "@/auth";
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-      enterpriseFeatures: {
-        ...actual.default.enterpriseFeatures,
-        core: true,
-      },
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    enterpriseFeatures: { core: true },
+  }),
+);
 
 type LabelInput = { key: string; value: string };
 
@@ -55,7 +41,7 @@ describe("team label routes", () => {
 
   beforeEach(async ({ makeAdmin, makeMember, makeOrganization }) => {
     vi.clearAllMocks();
-    hasPermissionMock.mockResolvedValue({ success: true });
+    vi.mocked(hasPermission).mockResolvedValue({ success: true, error: null });
 
     adminUser = await makeAdmin();
     const organization = await makeOrganization();
@@ -229,7 +215,10 @@ describe("team label routes", () => {
       const { default: teamRoutes } = await import("./team");
       await memberApp.register(teamRoutes);
       // Member lacks organization-level team-management permission.
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await memberApp.inject({
         method: "GET",

--- a/platform/backend/src/routes/team-labels.test.ts
+++ b/platform/backend/src/routes/team-labels.test.ts
@@ -4,9 +4,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/team-members.test.ts
+++ b/platform/backend/src/routes/team-members.test.ts
@@ -1,35 +1,21 @@
 import { vi } from "vitest";
-import type * as originalConfigModule from "@/config";
 import { TeamModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-const { hasPermissionMock } = vi.hoisted(() => ({
-  hasPermissionMock: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
-vi.mock("@/auth", async () => {
-  const actual = await vi.importActual<typeof import("@/auth")>("@/auth");
-  return {
-    ...actual,
-    hasPermission: hasPermissionMock,
-  };
-});
+import { hasPermission } from "@/auth";
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-      enterpriseFeatures: {
-        ...actual.default.enterpriseFeatures,
-        core: true,
-      },
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
+    enterpriseFeatures: { core: true },
+  }),
+);
 
 describe("team routes", () => {
   let app: FastifyInstanceWithZod;
@@ -38,7 +24,7 @@ describe("team routes", () => {
 
   beforeEach(async ({ makeAdmin, makeMember, makeOrganization }) => {
     vi.clearAllMocks();
-    hasPermissionMock.mockResolvedValue({ success: true });
+    vi.mocked(hasPermission).mockResolvedValue({ success: true, error: null });
 
     adminUser = await makeAdmin();
     const organization = await makeOrganization();
@@ -130,7 +116,10 @@ describe("team routes", () => {
       await memberApp.register(teamRoutes);
 
       // Member does not have organization-level team management permission
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await memberApp.inject({
         method: "GET",
@@ -173,7 +162,10 @@ describe("team routes", () => {
       const { default: teamRoutes } = await import("./team");
       await memberApp.register(teamRoutes);
 
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await memberApp.inject({
         method: "GET",
@@ -372,7 +364,10 @@ describe("team routes", () => {
       const { default: teamRoutes } = await import("./team");
       await memberApp.register(teamRoutes);
 
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await memberApp.inject({
         method: "PUT",
@@ -420,7 +415,10 @@ describe("team routes", () => {
       const { default: teamRoutes } = await import("./team");
       await memberApp.register(teamRoutes);
 
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await memberApp.inject({
         method: "PUT",
@@ -531,7 +529,10 @@ describe("team routes", () => {
       });
       const { default: teamRoutes } = await import("./team");
       await teamAdminApp.register(teamRoutes);
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await teamAdminApp.inject({
         method: "POST",
@@ -575,7 +576,10 @@ describe("team routes", () => {
       });
       const { default: teamRoutes } = await import("./team");
       await memberApp.register(teamRoutes);
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await memberApp.inject({
         method: "POST",
@@ -617,7 +621,10 @@ describe("team routes", () => {
       });
       const { default: teamRoutes } = await import("./team");
       await teamAdminApp.register(teamRoutes);
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await teamAdminApp.inject({
         method: "PUT",
@@ -747,7 +754,10 @@ describe("team routes", () => {
       const { default: teamRoutes } = await import("./team");
       await memberApp.register(teamRoutes);
 
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await memberApp.inject({
         method: "GET",
@@ -879,7 +889,10 @@ describe("team routes", () => {
       });
       const { default: teamRoutes } = await import("./team");
       await teamAdminApp.register(teamRoutes);
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const response = await teamAdminApp.inject({
         method: "POST",
@@ -927,7 +940,10 @@ describe("team routes", () => {
       });
       const { default: teamRoutes } = await import("./team");
       await teamAdminApp.register(teamRoutes);
-      hasPermissionMock.mockResolvedValue({ success: false });
+      vi.mocked(hasPermission).mockResolvedValue({
+        success: false,
+        error: null,
+      });
 
       const deleteResponse = await teamAdminApp.inject({
         method: "DELETE",
@@ -968,8 +984,9 @@ describe("team routes", () => {
       });
       const { default: teamRoutes } = await import("./team");
       await legacyRoleApp.register(teamRoutes);
-      hasPermissionMock.mockImplementation(async (permissions) => ({
+      vi.mocked(hasPermission).mockImplementation(async (permissions) => ({
         success: permissions?.team?.includes("admin") ?? false,
+        error: null,
       }));
 
       const response = await legacyRoleApp.inject({
@@ -980,11 +997,11 @@ describe("team routes", () => {
 
       expect(response.statusCode).toBe(403);
       expect(response.json().error.message).toContain("team admin");
-      expect(hasPermissionMock).toHaveBeenCalledWith(
+      expect(vi.mocked(hasPermission)).toHaveBeenCalledWith(
         { team: ["create"] },
         expect.any(Object),
       );
-      expect(hasPermissionMock).not.toHaveBeenCalledWith(
+      expect(vi.mocked(hasPermission)).not.toHaveBeenCalledWith(
         { team: ["admin"] },
         expect.any(Object),
       );

--- a/platform/backend/src/routes/team-members.test.ts
+++ b/platform/backend/src/routes/team-members.test.ts
@@ -5,9 +5,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/token.test.ts
+++ b/platform/backend/src/routes/token.test.ts
@@ -5,9 +5,9 @@ import { TeamModel, TeamTokenModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 
 // Mock the hasPermission function
-vi.mock("@/auth", () => ({
-  hasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/token.test.ts
+++ b/platform/backend/src/routes/token.test.ts
@@ -5,9 +5,7 @@ import { TeamModel, TeamTokenModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 
 // Mock the hasPermission function
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/virtual-api-key/create.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/create.virtual-api-key.route.test.ts
@@ -6,9 +6,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/virtual-api-key/create.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/create.virtual-api-key.route.test.ts
@@ -6,9 +6,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/virtual-api-key/delete.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/delete.virtual-api-key.route.test.ts
@@ -4,9 +4,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/virtual-api-key/delete.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/delete.virtual-api-key.route.test.ts
@@ -4,9 +4,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/virtual-api-key/get.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/get.virtual-api-key.route.test.ts
@@ -5,9 +5,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/virtual-api-key/get.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/get.virtual-api-key.route.test.ts
@@ -5,9 +5,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/virtual-api-key/update.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/update.virtual-api-key.route.test.ts
@@ -4,9 +4,9 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", () => ({
-  userHasPermission: vi.fn(),
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/routes/virtual-api-key/update.virtual-api-key.route.test.ts
+++ b/platform/backend/src/routes/virtual-api-key/update.virtual-api-key.route.test.ts
@@ -4,9 +4,7 @@ import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import type { User } from "@/types";
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { userHasPermission } from "@/auth";
 

--- a/platform/backend/src/skills/skill-catalog-prompt.test.ts
+++ b/platform/backend/src/skills/skill-catalog-prompt.test.ts
@@ -73,7 +73,7 @@ describe("buildSkillCatalogPrompt (sandbox available)", () => {
   let userId: string;
   const originalEnabled = config.skillsSandbox.enabled;
 
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
   });
 

--- a/platform/backend/src/skills/skill-version-resolution.test.ts
+++ b/platform/backend/src/skills/skill-version-resolution.test.ts
@@ -6,7 +6,14 @@ import {
   SkillVersionModel,
 } from "@/models";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
-import { afterAll, beforeAll, describe, expect, test } from "@/test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@/test";
 import type { Skill } from "@/types";
 import {
   resolveActivationVersion,
@@ -138,7 +145,7 @@ describe("resolveEffectiveSkillVersion", () => {
 describe("resolveActivationVersion (sandbox runtime enabled)", () => {
   const originalSkills = config.skillsSandbox.enabled;
   const originalDagger = config.daggerRuntime.enabled;
-  beforeAll(() => {
+  beforeEach(() => {
     (config.skillsSandbox as { enabled: boolean }).enabled = true;
     (config.daggerRuntime as { enabled: boolean }).enabled = true;
   });

--- a/platform/backend/src/task-queue/handlers/audit-log-cleanup-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/audit-log-cleanup-handler.test.ts
@@ -11,9 +11,7 @@ const mockConfig = vi.hoisted(() => ({
 }));
 vi.mock("@/config", () => ({ default: mockConfig }));
 
-vi.mock("@/logging", async () =>
-  (await import("@/test/mocks/logging")).loggingModuleMock(),
-);
+vi.mock("@/logging");
 
 import logger from "@/logging";
 import { handleAuditLogCleanup } from "./audit-log-cleanup-handler";

--- a/platform/backend/src/task-queue/handlers/audit-log-cleanup-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/audit-log-cleanup-handler.test.ts
@@ -11,14 +11,11 @@ const mockConfig = vi.hoisted(() => ({
 }));
 vi.mock("@/config", () => ({ default: mockConfig }));
 
-const mockLogger = vi.hoisted(() => ({
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-  debug: vi.fn(),
-}));
-vi.mock("@/logging", () => ({ default: mockLogger }));
+vi.mock("@/logging", async () =>
+  (await import("@/test/mocks/logging")).loggingModuleMock(),
+);
 
+import logger from "@/logging";
 import { handleAuditLogCleanup } from "./audit-log-cleanup-handler";
 
 describe("handleAuditLogCleanup", () => {
@@ -33,7 +30,7 @@ describe("handleAuditLogCleanup", () => {
     await handleAuditLogCleanup();
 
     expect(mockDeleteAllOlderThan).not.toHaveBeenCalled();
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
       expect.objectContaining({ retentionDays: 0 }),
       expect.stringContaining("disabled"),
     );
@@ -60,7 +57,7 @@ describe("handleAuditLogCleanup", () => {
 
     await handleAuditLogCleanup();
 
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
       expect.objectContaining({ deleted: 42, retentionDays: 180 }),
       "audit-log retention sweep: complete",
     );
@@ -71,7 +68,7 @@ describe("handleAuditLogCleanup", () => {
 
     await expect(handleAuditLogCleanup()).resolves.toBeUndefined();
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
       expect.objectContaining({ error: "DB error", retentionDays: 180 }),
       "audit-log retention sweep: failed",
     );

--- a/platform/backend/src/task-queue/handlers/batch-embedding-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/batch-embedding-handler.test.ts
@@ -18,15 +18,6 @@ vi.mock("@/models", () => ({
   },
 }));
 
-vi.mock("@/logging", () => ({
-  default: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
-
 import { handleBatchEmbedding } from "./batch-embedding-handler";
 
 describe("handleBatchEmbedding", () => {

--- a/platform/backend/src/task-queue/handlers/check-due-connectors-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/check-due-connectors-handler.test.ts
@@ -22,15 +22,6 @@ vi.mock("@/task-queue", () => ({
   taskQueueService: { enqueue: mockEnqueue },
 }));
 
-vi.mock("@/logging", () => ({
-  default: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
-
 import { handleCheckDueConnectors } from "./check-due-connectors-handler";
 
 describe("handleCheckDueConnectors", () => {

--- a/platform/backend/src/task-queue/handlers/check-due-schedule-triggers-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/check-due-schedule-triggers-handler.test.ts
@@ -29,15 +29,6 @@ vi.mock("@/task-queue", () => ({
   taskQueueService: { enqueue: mockEnqueue },
 }));
 
-vi.mock("@/logging", () => ({
-  default: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
-
 import { handleCheckDueScheduleTriggers } from "./check-due-schedule-triggers-handler";
 
 const makeTrigger = (id: string) => ({

--- a/platform/backend/src/task-queue/handlers/schedule-trigger-run-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/schedule-trigger-run-handler.test.ts
@@ -8,9 +8,6 @@ const mockAgentFindById = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 const mockUserHasAgentAccess = vi.hoisted(() =>
   vi.fn().mockResolvedValue(true),
 );
-const mockHasAnyAgentTypeAdminPermission = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({ success: false }),
-);
 
 vi.mock("@/models", () => ({
   ScheduleTriggerRunModel: {
@@ -31,9 +28,11 @@ vi.mock("@/models", () => ({
   },
 }));
 
-vi.mock("@/auth", () => ({
-  hasAnyAgentTypeAdminPermission: mockHasAnyAgentTypeAdminPermission,
-}));
+vi.mock("@/auth", async () =>
+  (await import("@/test/mocks/auth")).authModuleMock(),
+);
+
+import { hasAnyAgentTypeAdminPermission } from "@/auth";
 
 const mockExecuteA2AMessage = vi.hoisted(() =>
   vi.fn().mockResolvedValue({
@@ -66,15 +65,6 @@ vi.mock("@/services/scheduled-run-conversation", () => ({
   persistRunConversationMessages: mockPersistRunConversationMessages,
   persistRunUserMessage: mockPersistRunUserMessage,
   recordRunConversationError: mockRecordRunConversationError,
-}));
-
-vi.mock("@/logging", () => ({
-  default: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
 }));
 
 import { handleScheduleTriggerRunExecution } from "./schedule-trigger-run-handler";
@@ -132,7 +122,7 @@ describe("handleScheduleTriggerRunExecution", () => {
     mockUserGetById.mockResolvedValue(null);
     mockAgentFindById.mockResolvedValue(null);
     mockUserHasAgentAccess.mockResolvedValue(true);
-    mockHasAnyAgentTypeAdminPermission.mockResolvedValue({ success: false });
+    vi.mocked(hasAnyAgentTypeAdminPermission).mockResolvedValue(false);
     mockCreateAndLinkRunConversation.mockReset();
     mockPersistRunConversationMessages.mockReset();
     mockPersistRunConversationMessages.mockResolvedValue(undefined);

--- a/platform/backend/src/task-queue/handlers/schedule-trigger-run-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/schedule-trigger-run-handler.test.ts
@@ -28,9 +28,7 @@ vi.mock("@/models", () => ({
   },
 }));
 
-vi.mock("@/auth", async () =>
-  (await import("@/test/mocks/auth")).authModuleMock(),
-);
+vi.mock("@/auth");
 
 import { hasAnyAgentTypeAdminPermission } from "@/auth";
 

--- a/platform/backend/src/task-queue/task-queue.test.ts
+++ b/platform/backend/src/task-queue/task-queue.test.ts
@@ -23,15 +23,15 @@ vi.mock("@/models", () => ({
 }));
 
 // Mock config
-vi.mock("@/config", () => ({
-  default: {
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock({
     kb: {
       taskWorkerPollIntervalSeconds: 1,
       taskWorkerMaxConcurrent: 2,
       taskWorkerShutdownTimeoutSeconds: 5,
     },
-  },
-}));
+  }),
+);
 
 // Mock observability metrics (avoid importing tracing which requires config.observability.otel)
 vi.mock("@/observability/metrics", () => ({
@@ -46,14 +46,6 @@ vi.mock("@/observability/metrics", () => ({
 }));
 
 // Suppress logger output during tests
-vi.mock("@/logging", () => ({
-  default: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-}));
 
 // Import after mocks are set up
 import { afterEach, beforeEach, describe, expect, test } from "vitest";

--- a/platform/backend/src/test/mocks/auth.ts
+++ b/platform/backend/src/test/mocks/auth.ts
@@ -3,18 +3,17 @@ import { vi } from "vitest";
 /**
  * Canonical module mock for `@/auth`.
  *
- * Usage (the async-factory form is required so the hoisted `vi.mock` call can
- * reach this helper):
+ * Test files activate it with a bare `vi.mock("@/auth");` — Vitest resolves
+ * the Jest-style `src/auth/__mocks__/index.ts`, which re-exports this
+ * factory's surface:
  *
  * ```ts
- * vi.mock("@/auth", async () =>
- *   (await import("@/test/mocks/auth")).authModuleMock(),
- * );
+ * vi.mock("@/auth");
  *
  * import { hasPermission } from "@/auth";
  *
  * beforeEach(() => {
- *   vi.mocked(hasPermission).mockResolvedValue(true);
+ *   vi.mocked(hasPermission).mockResolvedValue({ success: true, error: null });
  * });
  * ```
  *

--- a/platform/backend/src/test/mocks/auth.ts
+++ b/platform/backend/src/test/mocks/auth.ts
@@ -1,0 +1,51 @@
+import { vi } from "vitest";
+
+/**
+ * Canonical module mock for `@/auth`.
+ *
+ * Usage (the async-factory form is required so the hoisted `vi.mock` call can
+ * reach this helper):
+ *
+ * ```ts
+ * vi.mock("@/auth", async () =>
+ *   (await import("@/test/mocks/auth")).authModuleMock(),
+ * );
+ *
+ * import { hasPermission } from "@/auth";
+ *
+ * beforeEach(() => {
+ *   vi.mocked(hasPermission).mockResolvedValue(true);
+ * });
+ * ```
+ *
+ * Every export of `@/auth` is a bare `vi.fn()` — configure behavior per test
+ * via `vi.mocked(...)` instead of writing a bespoke factory. Keeping one
+ * canonical shape avoids the drift of 40+ hand-rolled partial factories and
+ * the vitest pitfall of mixing automocks and factory mocks for the same
+ * specifier (vitest-dev/vitest#10145).
+ */
+export function authModuleMock() {
+  return {
+    // ./agent-type-permissions
+    getAgentTypePermissionChecker: vi.fn(),
+    hasAnyAgentTypeAdminPermission: vi.fn(),
+    hasAnyAgentTypeReadPermission: vi.fn(),
+    isAgentTypeAdmin: vi.fn(),
+    requireAgentModifyPermission: vi.fn(),
+    requireAgentTypePermission: vi.fn(),
+    // ./better-auth — only the API surface tests actually exercise
+    betterAuth: {
+      api: {
+        getSession: vi.fn(),
+        verifyApiKey: vi.fn(),
+        hasPermission: vi.fn(),
+      },
+      $context: Promise.resolve({}),
+    },
+    // ./fastify-plugin
+    fastifyAuthPlugin: vi.fn(),
+    // ./utils
+    hasPermission: vi.fn(),
+    userHasPermission: vi.fn(),
+  };
+}

--- a/platform/backend/src/test/mocks/config.ts
+++ b/platform/backend/src/test/mocks/config.ts
@@ -1,0 +1,49 @@
+import { vi } from "vitest";
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+/**
+ * Canonical module mock for `@/config`: the REAL config deep-merged with the
+ * test's overrides.
+ *
+ * ```ts
+ * vi.mock("@/config", async () =>
+ *   (await import("@/test/mocks/config")).configModuleMock({
+ *     kb: { taskWorkerPollIntervalSeconds: 1 },
+ *   }),
+ * );
+ * ```
+ *
+ * Starting from the actual config keeps every field the module under test
+ * incidentally reads populated — bespoke `{ default: { kb: {...} } }`
+ * factories silently drop the rest of the config and break the first time
+ * the code under test touches another key.
+ */
+export async function configModuleMock(
+  overrides: DeepPartial<typeof import("@/config").default> = {},
+) {
+  const actual = await vi.importActual<typeof import("@/config")>("@/config");
+  return {
+    default: deepMerge(structuredClone(actual.default), overrides),
+  };
+}
+
+function deepMerge<T>(base: T, overrides: DeepPartial<T>): T {
+  for (const key of Object.keys(overrides) as Array<keyof T>) {
+    const value = overrides[key];
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      typeof base[key] === "object" &&
+      base[key] !== null
+    ) {
+      deepMerge(base[key], value as DeepPartial<T[keyof T]>);
+    } else {
+      base[key] = value as T[keyof T];
+    }
+  }
+  return base;
+}

--- a/platform/backend/src/test/mocks/logging.ts
+++ b/platform/backend/src/test/mocks/logging.ts
@@ -1,0 +1,39 @@
+import { vi } from "vitest";
+
+/**
+ * Canonical module mock for `@/logging`, for tests that ASSERT on logger
+ * calls:
+ *
+ * ```ts
+ * vi.mock("@/logging", async () =>
+ *   (await import("@/test/mocks/logging")).loggingModuleMock(),
+ * );
+ *
+ * import logger from "@/logging";
+ * expect(vi.mocked(logger.error)).toHaveBeenCalledWith(...);
+ * ```
+ *
+ * Tests that mock `@/logging` merely to SILENCE it should drop the mock
+ * instead: the shared test setup already runs the real logger at level
+ * "silent", and dropping the last `vi.mock` moves the file into the
+ * non-isolated (fast) vitest project.
+ *
+ * A module mock is required for assertions because the real export is a
+ * Proxy whose `get` returns methods bound to a private pino instance —
+ * `vi.spyOn(logger, "error")` cannot intercept it.
+ */
+export function loggingModuleMock() {
+  const logger = {
+    fatal: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    silent: vi.fn(),
+    level: "silent",
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return { default: logger };
+}

--- a/platform/backend/src/test/mocks/logging.ts
+++ b/platform/backend/src/test/mocks/logging.ts
@@ -2,12 +2,11 @@ import { vi } from "vitest";
 
 /**
  * Canonical module mock for `@/logging`, for tests that ASSERT on logger
- * calls:
+ * calls. Activated with a bare `vi.mock("@/logging");` — Vitest resolves the
+ * Jest-style `src/logging/__mocks__/index.ts`, which re-exports this factory:
  *
  * ```ts
- * vi.mock("@/logging", async () =>
- *   (await import("@/test/mocks/logging")).loggingModuleMock(),
- * );
+ * vi.mock("@/logging");
  *
  * import logger from "@/logging";
  * expect(vi.mocked(logger.error)).toHaveBeenCalledWith(...);

--- a/platform/backend/src/test/msw.ts
+++ b/platform/backend/src/test/msw.ts
@@ -1,0 +1,53 @@
+import type { RequestHandler } from "msw";
+import { setupServer } from "msw/node";
+import { afterEach, beforeEach } from "vitest";
+
+/**
+ * Boundary-mock HTTP for a test file with MSW. Intercepts axios, global
+ * fetch, and undici alike — use this instead of `vi.mock`-ing an HTTP client
+ * module (jira.js, @gitbeaker/rest, openai, ...): the real client runs and
+ * only the network is faked, and a file whose last `vi.mock` disappears
+ * automatically joins the fast (shared-worker) vitest project.
+ *
+ * ```ts
+ * import { http, HttpResponse } from "msw";
+ * import { useMswServer } from "@/test/msw";
+ *
+ * const server = useMswServer(); // or with default handlers
+ * test("...", async () => {
+ *   server.use(
+ *     http.get("https://example.atlassian.net/rest/api/3/search/jql", () =>
+ *       HttpResponse.json({ issues: [] }),
+ *     ),
+ *   );
+ *   // exercise the real client
+ * });
+ * ```
+ *
+ * Lifecycle is per TEST, not per file: the shared setup restores the real
+ * `globalThis.fetch` after every test (leak protection), which would strip a
+ * beforeAll-installed fetch interceptor for the rest of the file. Listening
+ * in beforeEach re-patches after that restore; closing in afterEach runs
+ * before the setup's restore (file hooks run first), so teardown never
+ * leaves a half-patched state — in shared workers a leaked interceptor
+ * would poison every later file.
+ *
+ * Unhandled requests fail the test (`onUnhandledRequest: "error"`), so a
+ * missing handler is a loud failure instead of a live network call.
+ */
+export function useMswServer(
+  ...defaultHandlers: RequestHandler[]
+): ReturnType<typeof setupServer> {
+  const server = setupServer(...defaultHandlers);
+
+  beforeEach(() => {
+    server.listen({ onUnhandledRequest: "error" });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    server.close();
+  });
+
+  return server;
+}

--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -35,6 +35,12 @@ process.env.ARCHESTRA_CHAT_ACTIVE_RUN_POLLING_COMPATIBILITY_ENABLED = "true";
 // branch's project / My-Files / PFS-tool tests run. The gating ("OFF") tests
 // flip config.projects.enabled to false locally.
 process.env.ARCHESTRA_PROJECTS_ENABLED = "true";
+// Same for Apps: app route/tool tests exercise the enabled paths, and the
+// gating ("OFF") tests flip config.apps.enabled to false in their own
+// beforeEach. Before the per-test config restore existed, these tests rode a
+// cross-file config.apps.enabled leak (or the developer's .env) — make the
+// default explicit so CI and local agree.
+process.env.ARCHESTRA_APPS_ENABLED = "true";
 // Pin "My Files" byte storage to the inline (db) provider for hermetic tests,
 // independent of the dev .env. The filesystem-specific suites opt in by
 // overriding config.fileStorage at runtime against a temp root.

--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -96,6 +96,12 @@ beforeAll(async () => {
     }
   }
 
+  // Finish PGlite's async WASM init (incl. its browser-vs-node environment
+  // detection) before any test code runs: tests that fake browser globals
+  // (e.g. a `window` for the app SDK) would otherwise race the detection and
+  // send PGlite down the browser path mid-init.
+  await pgliteClient.waitReady;
+
   // Set the test database via the internal setter (for getDb() and proxy)
   const dbModule = await import("../database/index.js");
   dbModule.__setTestDb(

--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -102,18 +102,18 @@ beforeAll(async () => {
   // send PGlite down the browser path mid-init.
   await pgliteClient.waitReady;
 
-  // Set the test database via the internal setter (for getDb() and proxy)
+  // Set the test database via the internal setter. The module's default
+  // export is a forwarding Proxy over getDb(), so consumers — including
+  // singletons constructed at import time, like better-auth's drizzle
+  // adapter — always reach the CURRENT file's database. Do not replace the
+  // default export with the concrete instance: in a shared worker
+  // (isolate: false) that would pin import-time consumers to whichever
+  // file's PGlite happened to be live, which is closed by the time later
+  // files run ("PGlite is closed").
   const dbModule = await import("../database/index.js");
   dbModule.__setTestDb(
     testDb as unknown as Parameters<typeof dbModule.__setTestDb>[0],
   );
-
-  // Also replace the default export for compatibility
-  Object.defineProperty(dbModule, "default", {
-    value: testDb,
-    writable: true,
-    configurable: true,
-  });
 });
 
 /**
@@ -147,9 +147,17 @@ beforeEach(async () => {
 });
 
 /**
- * Clear mocks after each test
+ * Clear mocks after each test, and restore the real fetch.
+ *
+ * Several tests replace `globalThis.fetch` directly (not via vi.stubGlobal,
+ * which `unstubGlobals` already handles). A mock left behind — e.g. when an
+ * assertion throws before an inline restore — poisons every later file in
+ * the worker. This hook is registered before any test-file hooks, so Vitest
+ * runs it LAST in the afterEach sequence: it always gets the final word.
  */
+const realFetch = globalThis.fetch;
 afterEach(() => {
+  globalThis.fetch = realFetch;
   vi.clearAllMocks();
 });
 

--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -50,6 +50,9 @@ process.setMaxListeners(20);
 
 // Module-level variables to persist across tests within a file
 let pgliteClient: PGlite | null = null;
+// Pristine config snapshot for the per-test restore (see beforeAll/beforeEach).
+let liveConfig: Record<string, unknown> | null = null;
+let pristineConfig: Record<string, unknown> | null = null;
 let testDb: ReturnType<typeof drizzle> | null = null;
 const originalConsoleWarn = console.warn;
 
@@ -114,6 +117,22 @@ beforeAll(async () => {
   dbModule.__setTestDb(
     testDb as unknown as Parameters<typeof dbModule.__setTestDb>[0],
   );
+
+  // Snapshot the pristine config once per worker (first file's beforeAll).
+  // Tests mutate the real config object directly (config.apps.enabled = ...),
+  // and in a shared worker (isolate: false) an unrestored mutation leaks into
+  // every later file. beforeEach below restores this snapshot before each
+  // test, so per-test/beforeEach mutations keep working while nothing leaks.
+  // Only the shared-worker ("clean") vitest project needs this — isolated
+  // files can't leak across files, and their bespoke config mocks may carry
+  // getter-only properties the restore could not assign to.
+  if (process.env.ARCHESTRA_TEST_SHARED_WORKERS === "true") {
+    liveConfig ??= (await import("../config.js")).default as unknown as Record<
+      string,
+      unknown
+    >;
+    pristineConfig ??= structuredClone(liveConfig);
+  }
 });
 
 /**
@@ -123,6 +142,14 @@ beforeAll(async () => {
 beforeEach(async () => {
   if (!pgliteClient) {
     throw new Error("Database not initialized. Did beforeAll run?");
+  }
+
+  // Restore the pristine config before every test. This hook is registered
+  // before any test-file hooks, so a file's own beforeEach still applies its
+  // config tweaks on top — but nothing a test mutated can leak into the next
+  // test or, in shared workers, the next file.
+  if (liveConfig && pristineConfig) {
+    restoreConfig(liveConfig, structuredClone(pristineConfig));
   }
 
   // Get all user tables from the database (excluding system tables)
@@ -183,3 +210,41 @@ afterAll(async () => {
   }
   testDb = null;
 });
+
+/**
+ * Overwrite `live`'s contents with `snapshot`'s, in place (the config module
+ * object is referenced everywhere, so identity must be preserved). Keys added
+ * by a test are deleted; nested objects are restored recursively.
+ */
+function restoreConfig(
+  live: Record<string, unknown>,
+  snapshot: Record<string, unknown>,
+): void {
+  for (const key of Object.keys(live)) {
+    if (!(key in snapshot)) {
+      delete live[key];
+    }
+  }
+  for (const [key, snapValue] of Object.entries(snapshot)) {
+    const liveValue = live[key];
+    if (
+      snapValue !== null &&
+      typeof snapValue === "object" &&
+      !Array.isArray(snapValue) &&
+      liveValue !== null &&
+      typeof liveValue === "object" &&
+      !Array.isArray(liveValue)
+    ) {
+      restoreConfig(
+        liveValue as Record<string, unknown>,
+        snapValue as Record<string, unknown>,
+      );
+    } else {
+      // Skip accessor properties (getter-only config fields cannot be
+      // assigned, and getter-based test doubles manage their own state).
+      const descriptor = Object.getOwnPropertyDescriptor(live, key);
+      if (descriptor && !("value" in descriptor)) continue;
+      live[key] = snapValue;
+    }
+  }
+}

--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -162,10 +162,20 @@ afterEach(() => {
 });
 
 /**
- * Clean up the PGlite client after all tests in the file complete
+ * Clean up the PGlite client after all tests in the file complete.
+ *
+ * Clearing the injected test DB matters in shared workers (isolate: false):
+ * module-level consumers evaluated while the NEXT file loads — e.g.
+ * better-auth's eager context init querying trusted IdP providers — would
+ * otherwise reach this file's closed PGlite and surface as unhandled
+ * "PGlite is closed" rejections. With the DB cleared they get getDb()'s
+ * "Database not initialized", which those import-time paths already handle.
  */
 afterAll(async () => {
   console.warn = originalConsoleWarn;
+
+  const dbModule = await import("../database/index.js");
+  dbModule.__setTestDb(null);
 
   if (pgliteClient) {
     await pgliteClient.close();

--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -8,19 +8,13 @@ import { eq } from "drizzle-orm";
 import { vi } from "vitest";
 import { WebSocket as WS } from "ws";
 import { betterAuth } from "@/auth";
-import type * as originalConfigModule from "@/config";
 import db, { schema } from "@/database";
 import AgentModel from "@/models/agent";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 
-vi.mock("@/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof originalConfigModule>();
-  return {
-    default: {
-      ...actual.default,
-    },
-  };
-});
+vi.mock("@/config", async () =>
+  (await import("@/test/mocks/config")).configModuleMock(),
+);
 
 const { browserStreamFeature } = await import(
   "@/features/browser-stream/services/browser-stream.feature"

--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -9,20 +9,11 @@ import { vi } from "vitest";
 import { WebSocket as WS } from "ws";
 import { betterAuth } from "@/auth";
 import db, { schema } from "@/database";
+import { browserStreamFeature } from "@/features/browser-stream/services/browser-stream.feature";
+import McpServerRuntimeManager from "@/k8s/mcp-server-runtime/manager";
 import AgentModel from "@/models/agent";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
-
-vi.mock("@/config", async () =>
-  (await import("@/test/mocks/config")).configModuleMock(),
-);
-
-const { browserStreamFeature } = await import(
-  "@/features/browser-stream/services/browser-stream.feature"
-);
-const { default: websocketService } = await import("@/websocket");
-const { default: McpServerRuntimeManager } = await import(
-  "@/k8s/mcp-server-runtime/manager"
-);
+import websocketService from "@/websocket";
 
 interface WebSocketClientContext {
   userId: string;
@@ -72,7 +63,7 @@ const service = websocketService as unknown as {
   wss: { clients: Set<WS> } | null;
 };
 
-// Initialize browser stream context once for all tests (config mock is already applied)
+// Initialize browser stream context once for all tests
 service.initBrowserStreamContextForTesting();
 
 describe("websocket authentication", () => {

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -127,6 +127,11 @@ export default defineConfig({
           name: "clean",
           include: testFiles.clean,
           isolate: false,
+          // Workers are shared in this project, so the test setup restores
+          // shared mutable state (the config object) between tests. The
+          // isolated project skips that — its per-file registries can't leak,
+          // and exotic config mocks (getter-only properties) would break it.
+          env: { ARCHESTRA_TEST_SHARED_WORKERS: "true" },
           // Inherit everything else from root, but globalSetup must not be
           // re-run per project — the snapshot is built once at the root.
           globalSetup: [],

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -1,8 +1,56 @@
+import { readdirSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 const isCI = process.env.CI === "true";
+
+/**
+ * Partition test files by whether they use Vitest module mocking.
+ *
+ * `vi.mock`/`vi.doMock` registrations live in the worker's shared module/mock
+ * registry, which Vitest does NOT reset between files when `isolate: false`
+ * (see https://vitest.dev/guide/improving-performance and
+ * vitest-dev/vitest#4894, #10145) — so mock-using files must keep isolation,
+ * while everything else can share each worker's module cache and skip
+ * re-importing the whole backend graph per file (~6s/file saved).
+ *
+ * Routing is computed from file CONTENT at config-load time, so a new test
+ * that adds `vi.mock` is automatically placed in the isolated project — no
+ * manual list to maintain.
+ */
+function partitionTestFiles(): { mocked: string[]; clean: string[] } {
+  const root = path.resolve(__dirname, "./src");
+  const usesModuleMocks = /\bvi\.(mock|doMock|unmock|doUnmock|hoisted)\(/;
+  const mocked: string[] = [];
+  const clean: string[] = [];
+
+  for (const entry of readdirSync(root, {
+    recursive: true,
+    withFileTypes: true,
+  })) {
+    if (!entry.isFile() || !entry.name.endsWith(".test.ts")) continue;
+    const absolute = path.join(entry.parentPath, entry.name);
+    const relative = `./${path.relative(__dirname, absolute)}`;
+    if (usesModuleMocks.test(readFileSync(absolute, "utf-8"))) {
+      mocked.push(relative);
+    } else {
+      clean.push(relative);
+    }
+  }
+
+  if (mocked.length === 0 || clean.length === 0) {
+    throw new Error(
+      `Test partition looks wrong (mocked=${mocked.length}, clean=${clean.length}); ` +
+        "check partitionTestFiles() in vitest.config.ts",
+    );
+  }
+
+  return { mocked, clean };
+}
+
+const testFiles = partitionTestFiles();
 
 export default defineConfig({
   plugins: [rawPythonPlugin()],
@@ -18,10 +66,10 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    include: ["./src/**/*.test.ts"],
     environment: "node",
     // Build the migrated schema once and snapshot it (see global-setup.ts); each test
     // file's beforeAll then loads the snapshot instead of replaying all migrations.
+    // Root-level only: it must run ONCE per run, not once per project below.
     globalSetup: ["./src/test/global-setup.ts"],
     setupFiles: ["./src/test/setup.ts"],
 
@@ -32,15 +80,30 @@ export default defineConfig({
      * - https://vitest.dev/guide/improving-performance
      * - https://vitest.dev/guide/profiling-test-performance
      *
-     * Note: We keep isolation enabled (default) because our database tests
-     * use module-level state that needs to be reset between test files.
-     * The main performance win comes from the setup.ts optimization:
-     * - beforeAll: creates PGlite + runs migrations ONCE per file
+     * Isolation is per-project (see `projects` below): files that never touch
+     * the module-mock registry run with `isolate: false`, sharing each
+     * worker's module cache instead of re-importing the whole backend graph
+     * per file — the dominant cost of the suite. Files using vi.mock keep
+     * isolation because Vitest's mock registry is not reset between files in
+     * a shared worker (vitest-dev/vitest#4894).
+     *
+     * DB state stays per-file either way (setup.ts):
+     * - beforeAll: creates PGlite from the migrated snapshot ONCE per file
      * - beforeEach: truncates tables (fast) instead of recreating DB
      */
 
     // Use threads pool - faster than forks for Node.js tests
     pool: "threads",
+
+    // Auto-restore vi.stubGlobal/vi.stubEnv after every test. Without this, a
+    // stub left behind by one test file poisons later files sharing the worker.
+    unstubGlobals: true,
+    unstubEnvs: true,
+
+    // Vitest defaults to one worker per core, which pins the whole machine
+    // during a full-suite run. Locally, leave a couple of cores free for the
+    // human; CI runners keep the default (all cores).
+    ...(isCI ? {} : { maxWorkers: Math.max(4, os.availableParallelism() - 2) }),
 
     // Increase concurrency on CI for faster test execution
     maxConcurrency: isCI ? 12 : 6,
@@ -56,6 +119,29 @@ export default defineConfig({
 
     // Hook timeout for beforeAll/afterAll (migrations can take time)
     hookTimeout: 60000,
+
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "clean",
+          include: testFiles.clean,
+          isolate: false,
+          // Inherit everything else from root, but globalSetup must not be
+          // re-run per project — the snapshot is built once at the root.
+          globalSetup: [],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "mocked",
+          include: testFiles.mocked,
+          isolate: true,
+          globalSetup: [],
+        },
+      },
+    ],
   },
 });
 

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -506,6 +506,9 @@ importers:
       knip:
         specifier: ^5.85.0
         version: 5.86.0(@types/node@25.5.0)(typescript@6.0.2)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.5.0)(typescript@6.0.2)
       tsdown:
         specifier: ^0.21.0
         version: 0.21.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1)(typescript@6.0.2)


### PR DESCRIPTION
## Why

The **Type checking, linting, formatting, unit tests** step took ~8.5 min of the ~11.5 min \`Platform Lint and Unit Tests\` job — all of it backend vitest. Profiling showed the dominant cost was not the tests themselves but **per-file isolation re-importing the entire backend module graph 588 times** (~3000s aggregate import cost; ~6.3s/file).

## What

### 1. Two-project Vitest split (\`backend/vitest.config.ts\`)

\`vi.mock\` registrations live in the worker's shared module/mock registry, which Vitest does not reset between files when \`isolate: false\` ([vitest-dev/vitest#4894](https://github.com/vitest-dev/vitest/issues/4894), [#10145](https://github.com/vitest-dev/vitest/issues/10145)) — measured here as 127 of 156 \`vi.mock\` files failing without isolation, while 428 of 432 mock-free files passed. So:

- **\`clean\` project** (~438 files, no module mocking) runs \`isolate: false\` — each worker imports the module graph once and reuses it.
- **\`mocked\` project** (~150 files using \`vi.mock\`/\`vi.hoisted\`) keeps full isolation.
- Routing is computed **from file content at config-load time** — a new test that adds \`vi.mock\` self-sorts into the isolated project; no manual list.

### 2. Cross-file leak guards (each killed a class of order-dependent flake)

Shared workers turn "forgot to restore" into cross-file poison, so the shared setup now guarantees restoration of every leakable global:

- **fetch**: \`unstubGlobals\`/\`unstubEnvs\` in config + an always-runs-last \`afterEach\` restore of \`globalThis.fetch\`; eleven module-scope fetch stubs re-apply per test.
- **the DB**: PGlite init awaited before test code (browser-global fakes raced its environment detection); \`@/database\`'s forwarding proxy no longer replaced by a concrete instance (better-auth's adapter was pinned to a closed DB); injected DB cleared on file teardown (unhandled "PGlite is closed" rejections became the handled "Database not initialized" path).
- **config**: tests mutate the real config object; the setup snapshots pristine config per worker and restores it before every test (shared-worker project only). This flushed out that the app suites' CI pass depended on a cross-file \`config.apps.enabled\` leak — \`ARCHESTRA_APPS_ENABLED\` is now forced in test env like \`ARCHESTRA_PROJECTS_ENABLED\`.
- Local full-suite runs cap \`maxWorkers\` at cores−2 so they don't pin the developer's machine (CI keeps all cores).

### 3. Mock architecture: canonical \`__mocks__\` + boundary mocking

320 \`vi.mock\` call sites hand-rolled factories for the same few modules. Now:

- **Jest-style \`__mocks__\` dirs** (bare \`vi.mock("@/auth");\`) for \`@/auth\` (was ×46), \`@/auth/utils\` (×6), \`@/logging\` (×13, silence-only mocks deleted), \`@/observability\` (×10, memoized proxy trees so the metric surface can't drift), and \`@/cache-manager\` (×11, Map-backed stateful fake with real cache semantics, auto-reset per test). Verified the \`__mocks__\` sibling resolution works through our absolute-path \`resolve.alias\`.
- **\`@/config\`** keeps a parameterized factory (\`configModuleMock(overrides)\` deep-merges onto the real config) — needed only when code reads config at import time; otherwise tests now mutate the real config in \`beforeEach\` (the restore guard covers them) and drop the mock entirely.
- **HTTP boundary mocking with MSW** (\`src/test/msw.ts\`, per-test lifecycle): jira.js and @gitbeaker/rest connector tests run the REAL clients against wire-level handlers — both files fully mock-free now — and four knowledge-base suites serve real OpenAI wire responses (incl. base64 Float32Array embeddings for openai@6) instead of mocking the \`openai\` module.
- The typed shared mocks surfaced latent bugs the untyped bespoke ones hid (a "deny" permission mock resolving a truthy object; a delete-subsequent-messages test racing same-millisecond \`createdAt\` ties).

### 4. Sharded CI (4× \`vitest run --shard=k/4\`)

Backend unit tests move out of the lint job into a 4-shard matrix running in parallel with it (the lint job's backend swaps \`check:ci\` → \`check:commit\`, identical minus vitest). Shards build backend's workspace deps first (Rust NAPI bindings; seconds on a turbo remote-cache hit). A stable-named **\`Backend Unit Tests\`** gate job aggregates the matrix for branch protection / merge queue.

### 5. Guidance for future test authors

- New skill \`.claude/skills/archestra-dev-backend-tests/SKILL.md\` — isolation model, canonical mocks, MSW boundary mocking (incl. client-retry and path-to-regexp gotchas), stub/config hygiene, DB fixtures.
- \`platform/CLAUDE.md\` (\`AGENTS.md\` symlinks to it): skill registered, backend-testing bullets updated.

## Measured results (local, 18-core; multiple shuffle seeds)

| | main | this PR |
|---|---|---|
| Full-suite wall | 314s | **~195–210s** |
| Aggregate import cost | 3005s | ~1200–1300s |
| Failing files | 2 (env-dependent on dev machines; green on CI) | same 2, no new failures |
| Unhandled rejections | occasional (better-auth init race) | 0 |

CI: lint job ~2.5–3 min, each test shard ~2–2.5 min, all parallel — the lint+test critical path drops from ~11.5 min to **~3 min**.

## Required-check follow-up (repo admin, after merge)

Add **\`Backend Unit Tests\`** (the gate job, not the per-shard names) to the main-branch ruleset's required status checks. The workflow already runs on \`merge_group\`, and the gate uses \`if: always()\` so it always reports. Do this **after** this PR merges — adding it before would block other open PRs that don't have the job yet.

## Follow-ups (separate PRs)

- \`ai\` SDK mocks (9 chat/agent files): converting to the boundary means emulating provider SSE stream wire formats in the suite's most complex tests — deliberately excluded from this PR.
- \`@/models\` mocks (11 files) should become real-PGlite tests.
- Product edge surfaced here: message "delete subsequent" ordering uses a strict \`createdAt\` comparison — two messages created in the same millisecond tie and the later one survives.