### PR TITLE
feat(llm): Anthropic Workload Identity Federation (keyless auth)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -93758,6 +93758,9 @@
                         "azureOpenAiEntraIdEnabled": {
                           "type": "boolean"
                         },
+                        "anthropicWifEnabled": {
+                          "type": "boolean"
+                        },
                         "bedrockIamAuthEnabled": {
                           "type": "boolean"
                         },
@@ -93843,6 +93846,7 @@
                         "byosEnabled",
                         "byosVaultKvVersion",
                         "azureOpenAiEntraIdEnabled",
+                        "anthropicWifEnabled",
                         "bedrockIamAuthEnabled",
                         "geminiVertexAiEnabled",
                         "globalToolPolicy",

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1007,6 +1007,20 @@ These environment variables set the default base URL for each LLM provider. Per-
   - Uses Azure Identity `DefaultAzureCredential` with token scope `https://ai.azure.com/.default`
   - Claude deployments must already exist in the Azure resource. Microsoft lists additional Claude prerequisites: paid eligible subscription, supported region, Azure Marketplace access for partner models, permission to subscribe to model offerings, and Contributor or Owner role on the resource group. Azure also requires Anthropic deployment metadata: `industry`, `organizationName`, and `countryCode`.
 
+- **`ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID`**, **`ARCHESTRA_ANTHROPIC_ORGANIZATION_ID`**, **`ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID`** - Enable keyless Anthropic authentication via [Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation).
+  - All three are required, plus one identity token source (below). A partial configuration logs a warning at startup and disables WIF.
+  - Values come from the federation rule (`fdrl_...`), organization ID, and service account (`svac_...`) created in the Claude Console under **Settings → Workload identity**.
+
+- **`ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE`** - Path to the OIDC identity token file issued by your identity provider (e.g. a Kubernetes projected service-account token).
+  - Example: `/var/run/secrets/anthropic.com/token`
+  - Re-read on every token exchange, so rotated tokens are picked up automatically. Prefer this over the inline variant in production.
+
+- **`ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN`** - Inline OIDC identity token; alternative to `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE`.
+  - Identity tokens are short-lived, so this is mainly useful for testing. The file variant takes precedence when both are set.
+
+- **`ARCHESTRA_ANTHROPIC_WORKSPACE_ID`** - Anthropic workspace ID (`wrkspc_...`) for Workload Identity Federation.
+  - Optional; required only when the federation rule covers more than one workspace.
+
 - **`ARCHESTRA_GEMINI_BASE_URL`** - Override the Google Gemini API base URL.
   - Default: `https://generativelanguage.googleapis.com`
   - Use this to point to your own proxy or other custom endpoints

--- a/docs/pages/platform-supported-llm-providers.md
+++ b/docs/pages/platform-supported-llm-providers.md
@@ -88,6 +88,14 @@ Azure requires Anthropic deployment metadata when creating Claude deployments: `
 
 See Microsoft's [Claude on Foundry guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-claude) for the Azure endpoint and authentication details.
 
+### Workload Identity Federation (keyless)
+
+Archestra can authenticate to the Anthropic API without a static API key using [Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation): it exchanges a short-lived OIDC identity token from your identity provider (Kubernetes, AWS, GCP, Entra ID, GitHub Actions, and others) for an Anthropic access token and sends it as `Authorization: Bearer` upstream. Tokens are cached and refreshed automatically before expiry.
+
+Configure a federation issuer, service account, and federation rule in the Claude Console (**Settings → Workload identity**), then set the `ARCHESTRA_ANTHROPIC_*` WIF environment variables — see [Environment Variables](/docs/platform-deployment#environment-variables) in the deployment docs. When configured, Archestra creates an "Anthropic Workload Identity Federation" system key automatically and syncs the available Claude models; users can also create Anthropic provider keys without entering an API key.
+
+Note: the SDK-standard `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` environment variables take precedence over federation if present in the backend environment, matching Anthropic's documented credential precedence.
+
 ## Google Gemini
 
 Archestra supports both the [Google AI Studio](https://ai.google.dev/) (Gemini Developer API) and [Vertex AI](https://cloud.google.com/vertex-ai) implementations of the Gemini API.

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -7,6 +7,13 @@ SUBDOMAIN=n8n
 # LLM Provider Base URLs
 ARCHESTRA_OPENAI_BASE_URL=https://api.openai.com/v1
 ARCHESTRA_ANTHROPIC_BASE_URL=https://api.anthropic.com
+# Anthropic Workload Identity Federation (keyless auth; all of rule/org/service-account plus one token source required)
+# ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID=fdrl_...
+# ARCHESTRA_ANTHROPIC_ORGANIZATION_ID=00000000-0000-0000-0000-000000000000
+# ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
+# ARCHESTRA_ANTHROPIC_WORKSPACE_ID=wrkspc_...
+# ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/secrets/anthropic.com/token
+# ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN=
 ARCHESTRA_GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # Cohere Base URL (uses https://api.cohere.ai by default)
 ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai

--- a/platform/backend/src/clients/anthropic-workload-identity.test.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.test.ts
@@ -189,7 +189,9 @@ describe("anthropicWorkloadIdentity", () => {
       };
       const fetchMock = vi
         .spyOn(globalThis, "fetch")
-        .mockImplementation(async () => tokenResponse("sk-ant-oat01-file", 3600));
+        .mockImplementation(async () =>
+          tokenResponse("sk-ant-oat01-file", 3600),
+        );
 
       await anthropicWorkloadIdentity.getAccessToken();
       await writeFile(tokenFile, "jwt-generation-2\n", "utf8");

--- a/platform/backend/src/clients/anthropic-workload-identity.test.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.test.ts
@@ -2,20 +2,12 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import type { AnthropicWifConfig } from "@/config";
-
-const mockConfig = vi.hoisted(() => ({
-  llm: {
-    anthropic: {
-      baseUrl: "https://api.anthropic.com",
-      wif: null as AnthropicWifConfig | null,
-    },
-  },
-}));
-
-vi.mock("@/config", () => ({ default: mockConfig }));
-
+import config, { type AnthropicWifConfig } from "@/config";
 import { anthropicWorkloadIdentity } from "./anthropic-workload-identity";
+
+// No module mocks: the WIF client reads config and hits the network at runtime,
+// so we mutate the real config and stub the fetch/env boundary — which keeps
+// this file in the fast (shared-worker) vitest project.
 
 const WIF_CONFIG: AnthropicWifConfig = {
   federationRuleId: "fdrl_test",
@@ -24,6 +16,9 @@ const WIF_CONFIG: AnthropicWifConfig = {
   workspaceId: "wrkspc_test",
   identityToken: "jwt-inline",
 };
+
+const originalWif = config.llm.anthropic.wif;
+const originalBaseUrl = config.llm.anthropic.baseUrl;
 
 function tokenResponse(accessToken: string, expiresIn = 3600): Response {
   return new Response(
@@ -37,30 +32,30 @@ function tokenResponse(accessToken: string, expiresIn = 3600): Response {
   );
 }
 
-describe("anthropicWorkloadIdentity", () => {
-  const originalStaticEnv = {
-    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
-    ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
-  };
+/** Stub global fetch and return the mock for assertions. */
+function stubFetch(
+  impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+) {
+  const fetchMock = vi.fn(impl);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
 
+describe("anthropicWorkloadIdentity", () => {
   beforeEach(() => {
     anthropicWorkloadIdentity.resetForTests();
-    mockConfig.llm.anthropic.baseUrl = "https://api.anthropic.com";
-    mockConfig.llm.anthropic.wif = { ...WIF_CONFIG };
-    delete process.env.ANTHROPIC_API_KEY;
-    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    config.llm.anthropic.baseUrl = "https://api.anthropic.com";
+    config.llm.anthropic.wif = { ...WIF_CONFIG };
+    // Static SDK env credentials shadow WIF; ensure they're absent by default
+    // (a real ANTHROPIC_API_KEY may be present in the dev .env).
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "");
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    vi.useRealTimers();
-    for (const [key, value] of Object.entries(originalStaticEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
+    anthropicWorkloadIdentity.resetForTests();
+    config.llm.anthropic.wif = originalWif;
+    config.llm.anthropic.baseUrl = originalBaseUrl;
   });
 
   describe("isEnabled", () => {
@@ -69,21 +64,24 @@ describe("anthropicWorkloadIdentity", () => {
     });
 
     test("disabled when WIF is not configured", () => {
-      mockConfig.llm.anthropic.wif = null;
+      config.llm.anthropic.wif = null;
       expect(anthropicWorkloadIdentity.isEnabled()).toBe(false);
     });
 
-    test("shadowed by static SDK env credentials (documented precedence)", () => {
-      process.env.ANTHROPIC_API_KEY = "sk-ant-static";
+    test.each([
+      ["ANTHROPIC_API_KEY", "sk-ant-static"],
+      ["ANTHROPIC_AUTH_TOKEN", "auth-token"],
+    ])("shadowed by static SDK credential %s (documented precedence)", (envVar, value) => {
+      vi.stubEnv(envVar, value);
       expect(anthropicWorkloadIdentity.isEnabled()).toBe(false);
     });
   });
 
   describe("getAccessToken", () => {
     test("exchanges the identity token via the RFC 7523 jwt-bearer grant", async () => {
-      const fetchMock = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(tokenResponse("sk-ant-oat01-test"));
+      const fetchMock = stubFetch(async () =>
+        tokenResponse("sk-ant-oat01-test"),
+      );
 
       await expect(anthropicWorkloadIdentity.getAccessToken()).resolves.toBe(
         "sk-ant-oat01-test",
@@ -107,10 +105,10 @@ describe("anthropicWorkloadIdentity", () => {
     });
 
     test("omits workspace_id when not configured", async () => {
-      mockConfig.llm.anthropic.wif = { ...WIF_CONFIG, workspaceId: undefined };
-      const fetchMock = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(tokenResponse("sk-ant-oat01-test"));
+      config.llm.anthropic.wif = { ...WIF_CONFIG, workspaceId: undefined };
+      const fetchMock = stubFetch(async () =>
+        tokenResponse("sk-ant-oat01-test"),
+      );
 
       await anthropicWorkloadIdentity.getAccessToken();
 
@@ -119,9 +117,9 @@ describe("anthropicWorkloadIdentity", () => {
     });
 
     test("caches the token until the advisory refresh window", async () => {
-      const fetchMock = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(tokenResponse("sk-ant-oat01-cached"));
+      const fetchMock = stubFetch(async () =>
+        tokenResponse("sk-ant-oat01-cached"),
+      );
 
       await anthropicWorkloadIdentity.getAccessToken();
       await anthropicWorkloadIdentity.getAccessToken();
@@ -130,9 +128,9 @@ describe("anthropicWorkloadIdentity", () => {
     });
 
     test("deduplicates concurrent exchanges", async () => {
-      const fetchMock = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(tokenResponse("sk-ant-oat01-dedup"));
+      const fetchMock = stubFetch(async () =>
+        tokenResponse("sk-ant-oat01-dedup"),
+      );
 
       await Promise.all([
         anthropicWorkloadIdentity.getAccessToken(),
@@ -145,16 +143,18 @@ describe("anthropicWorkloadIdentity", () => {
 
     test("re-exchanges inside the advisory window and serves the cached token if the exchange fails", async () => {
       vi.useFakeTimers();
-      const fetchMock = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(tokenResponse("sk-ant-oat01-first", 3600));
+      let fail = false;
+      stubFetch(async () => {
+        if (fail) throw new Error("token endpoint unreachable");
+        return tokenResponse("sk-ant-oat01-first", 3600);
+      });
 
       await anthropicWorkloadIdentity.getAccessToken();
 
       // Inside the advisory window (120s before expiry) but outside the
       // mandatory window (30s): a failed refresh falls back to the cache.
       vi.setSystemTime(Date.now() + (3600 - 60) * 1000);
-      fetchMock.mockRejectedValue(new Error("token endpoint unreachable"));
+      fail = true;
 
       await expect(anthropicWorkloadIdentity.getAccessToken()).resolves.toBe(
         "sk-ant-oat01-first",
@@ -163,14 +163,16 @@ describe("anthropicWorkloadIdentity", () => {
 
     test("fails hard inside the mandatory refresh window", async () => {
       vi.useFakeTimers();
-      const fetchMock = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(tokenResponse("sk-ant-oat01-first", 3600));
+      let fail = false;
+      stubFetch(async () => {
+        if (fail) throw new Error("token endpoint unreachable");
+        return tokenResponse("sk-ant-oat01-first", 3600);
+      });
 
       await anthropicWorkloadIdentity.getAccessToken();
 
       vi.setSystemTime(Date.now() + (3600 - 10) * 1000);
-      fetchMock.mockRejectedValue(new Error("token endpoint unreachable"));
+      fail = true;
 
       await expect(anthropicWorkloadIdentity.getAccessToken()).rejects.toThrow(
         "token endpoint unreachable",
@@ -182,16 +184,14 @@ describe("anthropicWorkloadIdentity", () => {
       const dir = await mkdtemp(join(tmpdir(), "anthropic-wif-"));
       const tokenFile = join(dir, "token.jwt");
       await writeFile(tokenFile, "jwt-generation-1\n", "utf8");
-      mockConfig.llm.anthropic.wif = {
+      config.llm.anthropic.wif = {
         ...WIF_CONFIG,
         identityToken: undefined,
         identityTokenFile: tokenFile,
       };
-      const fetchMock = vi
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async () =>
-          tokenResponse("sk-ant-oat01-file", 3600),
-        );
+      const fetchMock = stubFetch(async () =>
+        tokenResponse("sk-ant-oat01-file", 3600),
+      );
 
       await anthropicWorkloadIdentity.getAccessToken();
       await writeFile(tokenFile, "jwt-generation-2\n", "utf8");
@@ -207,11 +207,12 @@ describe("anthropicWorkloadIdentity", () => {
     });
 
     test("surfaces non-OK exchange responses with the request id", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response("{}", {
-          status: 403,
-          headers: { "request-id": "req_123" },
-        }),
+      stubFetch(
+        async () =>
+          new Response("{}", {
+            status: 403,
+            headers: { "request-id": "req_123" },
+          }),
       );
 
       await expect(anthropicWorkloadIdentity.getAccessToken()).rejects.toThrow(
@@ -220,10 +221,11 @@ describe("anthropicWorkloadIdentity", () => {
     });
 
     test("rejects token responses without a usable access token", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({ access_token: "", expires_in: 3600 }), {
-          status: 200,
-        }),
+      stubFetch(
+        async () =>
+          new Response(JSON.stringify({ access_token: "", expires_in: 3600 }), {
+            status: 200,
+          }),
       );
 
       await expect(anthropicWorkloadIdentity.getAccessToken()).rejects.toThrow(
@@ -234,9 +236,7 @@ describe("anthropicWorkloadIdentity", () => {
 
   describe("createFetch", () => {
     test("injects the federated bearer token and strips x-api-key", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        tokenResponse("sk-ant-oat01-wrapped"),
-      );
+      stubFetch(async () => tokenResponse("sk-ant-oat01-wrapped"));
       const providerFetch = vi.fn().mockResolvedValue(new Response("{}"));
       const wrappedFetch = anthropicWorkloadIdentity.createFetch(
         providerFetch as typeof fetch,

--- a/platform/backend/src/clients/anthropic-workload-identity.test.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.test.ts
@@ -1,0 +1,256 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { AnthropicWifConfig } from "@/config";
+
+const mockConfig = vi.hoisted(() => ({
+  llm: {
+    anthropic: {
+      baseUrl: "https://api.anthropic.com",
+      wif: null as AnthropicWifConfig | null,
+    },
+  },
+}));
+
+vi.mock("@/config", () => ({ default: mockConfig }));
+
+import { anthropicWorkloadIdentity } from "./anthropic-workload-identity";
+
+const WIF_CONFIG: AnthropicWifConfig = {
+  federationRuleId: "fdrl_test",
+  organizationId: "00000000-0000-0000-0000-000000000000",
+  serviceAccountId: "svac_test",
+  workspaceId: "wrkspc_test",
+  identityToken: "jwt-inline",
+};
+
+function tokenResponse(accessToken: string, expiresIn = 3600): Response {
+  return new Response(
+    JSON.stringify({
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: expiresIn,
+      scope: "workspace:developer",
+    }),
+    { status: 200 },
+  );
+}
+
+describe("anthropicWorkloadIdentity", () => {
+  const originalStaticEnv = {
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+  };
+
+  beforeEach(() => {
+    anthropicWorkloadIdentity.resetForTests();
+    mockConfig.llm.anthropic.baseUrl = "https://api.anthropic.com";
+    mockConfig.llm.anthropic.wif = { ...WIF_CONFIG };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    for (const [key, value] of Object.entries(originalStaticEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  describe("isEnabled", () => {
+    test("enabled with complete config", () => {
+      expect(anthropicWorkloadIdentity.isEnabled()).toBe(true);
+    });
+
+    test("disabled when WIF is not configured", () => {
+      mockConfig.llm.anthropic.wif = null;
+      expect(anthropicWorkloadIdentity.isEnabled()).toBe(false);
+    });
+
+    test("shadowed by static SDK env credentials (documented precedence)", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-static";
+      expect(anthropicWorkloadIdentity.isEnabled()).toBe(false);
+    });
+  });
+
+  describe("getAccessToken", () => {
+    test("exchanges the identity token via the RFC 7523 jwt-bearer grant", async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(tokenResponse("sk-ant-oat01-test"));
+
+      await expect(anthropicWorkloadIdentity.getAccessToken()).resolves.toBe(
+        "sk-ant-oat01-test",
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.anthropic.com/v1/oauth/token",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            assertion: "jwt-inline",
+            federation_rule_id: "fdrl_test",
+            organization_id: "00000000-0000-0000-0000-000000000000",
+            service_account_id: "svac_test",
+            workspace_id: "wrkspc_test",
+          }),
+        },
+      );
+    });
+
+    test("omits workspace_id when not configured", async () => {
+      mockConfig.llm.anthropic.wif = { ...WIF_CONFIG, workspaceId: undefined };
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(tokenResponse("sk-ant-oat01-test"));
+
+      await anthropicWorkloadIdentity.getAccessToken();
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+      expect(body).not.toHaveProperty("workspace_id");
+    });
+
+    test("caches the token until the advisory refresh window", async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(tokenResponse("sk-ant-oat01-cached"));
+
+      await anthropicWorkloadIdentity.getAccessToken();
+      await anthropicWorkloadIdentity.getAccessToken();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("deduplicates concurrent exchanges", async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(tokenResponse("sk-ant-oat01-dedup"));
+
+      await Promise.all([
+        anthropicWorkloadIdentity.getAccessToken(),
+        anthropicWorkloadIdentity.getAccessToken(),
+        anthropicWorkloadIdentity.getAccessToken(),
+      ]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("re-exchanges inside the advisory window and serves the cached token if the exchange fails", async () => {
+      vi.useFakeTimers();
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(tokenResponse("sk-ant-oat01-first", 3600));
+
+      await anthropicWorkloadIdentity.getAccessToken();
+
+      // Inside the advisory window (120s before expiry) but outside the
+      // mandatory window (30s): a failed refresh falls back to the cache.
+      vi.setSystemTime(Date.now() + (3600 - 60) * 1000);
+      fetchMock.mockRejectedValue(new Error("token endpoint unreachable"));
+
+      await expect(anthropicWorkloadIdentity.getAccessToken()).resolves.toBe(
+        "sk-ant-oat01-first",
+      );
+    });
+
+    test("fails hard inside the mandatory refresh window", async () => {
+      vi.useFakeTimers();
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(tokenResponse("sk-ant-oat01-first", 3600));
+
+      await anthropicWorkloadIdentity.getAccessToken();
+
+      vi.setSystemTime(Date.now() + (3600 - 10) * 1000);
+      fetchMock.mockRejectedValue(new Error("token endpoint unreachable"));
+
+      await expect(anthropicWorkloadIdentity.getAccessToken()).rejects.toThrow(
+        "token endpoint unreachable",
+      );
+    });
+
+    test("re-reads the identity token file on every exchange (rotated projected tokens)", async () => {
+      vi.useFakeTimers();
+      const dir = await mkdtemp(join(tmpdir(), "anthropic-wif-"));
+      const tokenFile = join(dir, "token.jwt");
+      await writeFile(tokenFile, "jwt-generation-1\n", "utf8");
+      mockConfig.llm.anthropic.wif = {
+        ...WIF_CONFIG,
+        identityToken: undefined,
+        identityTokenFile: tokenFile,
+      };
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async () => tokenResponse("sk-ant-oat01-file", 3600));
+
+      await anthropicWorkloadIdentity.getAccessToken();
+      await writeFile(tokenFile, "jwt-generation-2\n", "utf8");
+      vi.setSystemTime(Date.now() + 3600 * 1000);
+      await anthropicWorkloadIdentity.getAccessToken();
+
+      const assertions = fetchMock.mock.calls.map(
+        (call) => JSON.parse(call[1]?.body as string).assertion,
+      );
+      expect(assertions).toEqual(["jwt-generation-1", "jwt-generation-2"]);
+
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    test("surfaces non-OK exchange responses with the request id", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("{}", {
+          status: 403,
+          headers: { "request-id": "req_123" },
+        }),
+      );
+
+      await expect(anthropicWorkloadIdentity.getAccessToken()).rejects.toThrow(
+        "token exchange failed with status 403 (request-id: req_123)",
+      );
+    });
+
+    test("rejects token responses without a usable access token", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ access_token: "", expires_in: 3600 }), {
+          status: 200,
+        }),
+      );
+
+      await expect(anthropicWorkloadIdentity.getAccessToken()).rejects.toThrow(
+        "invalid token response",
+      );
+    });
+  });
+
+  describe("createFetch", () => {
+    test("injects the federated bearer token and strips x-api-key", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        tokenResponse("sk-ant-oat01-wrapped"),
+      );
+      const providerFetch = vi.fn().mockResolvedValue(new Response("{}"));
+      const wrappedFetch = anthropicWorkloadIdentity.createFetch(
+        providerFetch as typeof fetch,
+      );
+
+      await wrappedFetch("https://api.anthropic.com/v1/messages", {
+        headers: {
+          "x-api-key": "placeholder",
+          "anthropic-version": "2023-06-01",
+        },
+      });
+
+      const headers = providerFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.get("authorization")).toBe("Bearer sk-ant-oat01-wrapped");
+      expect(headers.has("x-api-key")).toBe(false);
+      expect(headers.get("anthropic-version")).toBe("2023-06-01");
+    });
+  });
+});

--- a/platform/backend/src/clients/anthropic-workload-identity.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.ts
@@ -1,0 +1,208 @@
+import { readFile } from "node:fs/promises";
+import config from "@/config";
+import logger from "@/logging";
+
+/**
+ * Anthropic Workload Identity Federation (WIF) client.
+ *
+ * Exchanges an IdP-issued OIDC identity token for a short-lived Anthropic
+ * access token via the RFC 7523 `jwt-bearer` grant and injects it as an
+ * `Authorization: Bearer` header on upstream Anthropic requests. Configured
+ * exclusively through backend env vars (see `config.llm.anthropic.wif`) —
+ * WIF is admin-controlled infrastructure auth, never per-request input.
+ *
+ * Token caching mirrors the official SDKs' two-tier refresh schedule: an
+ * advisory refresh 120s before expiry (serve the cached token if the exchange
+ * fails) and a mandatory refresh 30s before expiry (fail hard).
+ *
+ * @see https://platform.claude.com/docs/en/manage-claude/workload-identity-federation
+ */
+class AnthropicWorkloadIdentityClient {
+  private cachedToken: TokenCacheEntry | null = null;
+  private inFlightExchange: Promise<TokenCacheEntry> | null = null;
+
+  /**
+   * Whether keyless Anthropic auth via WIF should be used. Requires complete
+   * WIF env configuration, and — matching the official SDKs' credential
+   * precedence — is shadowed by static SDK env credentials
+   * (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) when those are set.
+   */
+  isEnabled(): boolean {
+    return config.llm.anthropic.wif !== null && !hasStaticSdkEnvCredentials();
+  }
+
+  /**
+   * Wrap a fetch implementation so every request carries a fresh federated
+   * bearer token. Replaces any `x-api-key` header the SDK may have set.
+   */
+  createFetch(baseFetch?: typeof fetch): typeof fetch {
+    const fetchFn = baseFetch ?? fetch;
+
+    return (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const token = await this.getAccessToken();
+      const headers = mergeHeaders(input, init);
+      headers.delete("x-api-key");
+      headers.set("authorization", `Bearer ${token}`);
+      return fetchFn(input, { ...init, headers });
+    }) as typeof fetch;
+  }
+
+  async getAccessToken(): Promise<string> {
+    const now = Date.now();
+    const cached = this.cachedToken;
+    if (cached && now < cached.expiresAtMs - ADVISORY_REFRESH_MS) {
+      return cached.accessToken;
+    }
+
+    try {
+      return (await this.refreshToken()).accessToken;
+    } catch (error) {
+      // Advisory window: the cached token is still comfortably valid, so keep
+      // serving it when the token endpoint is unreachable. Inside the
+      // mandatory window the token is too close to expiry — surface the error.
+      if (cached && now < cached.expiresAtMs - MANDATORY_REFRESH_MS) {
+        logger.warn(
+          {
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
+          },
+          "Anthropic WIF token refresh failed; serving cached token",
+        );
+        return cached.accessToken;
+      }
+      throw error;
+    }
+  }
+
+  resetForTests(): void {
+    this.cachedToken = null;
+    this.inFlightExchange = null;
+  }
+
+  /** Deduplicates concurrent exchanges into a single in-flight request. */
+  private refreshToken(): Promise<TokenCacheEntry> {
+    this.inFlightExchange ??= this.exchangeToken()
+      .then((entry) => {
+        this.cachedToken = entry;
+        return entry;
+      })
+      .finally(() => {
+        this.inFlightExchange = null;
+      });
+    return this.inFlightExchange;
+  }
+
+  private async exchangeToken(): Promise<TokenCacheEntry> {
+    const wif = config.llm.anthropic.wif;
+    if (!wif) {
+      throw new Error(
+        "Anthropic Workload Identity Federation is not configured",
+      );
+    }
+
+    const assertion = await readIdentityToken(wif);
+    const response = await fetch(
+      `${normalizeBaseUrl(config.llm.anthropic.baseUrl)}/v1/oauth/token`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          grant_type: JWT_BEARER_GRANT_TYPE,
+          assertion,
+          federation_rule_id: wif.federationRuleId,
+          organization_id: wif.organizationId,
+          service_account_id: wif.serviceAccountId,
+          ...(wif.workspaceId ? { workspace_id: wif.workspaceId } : {}),
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const requestId = response.headers.get("request-id");
+      throw new Error(
+        `Anthropic Workload Identity Federation token exchange failed with status ${response.status}${requestId ? ` (request-id: ${requestId})` : ""}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      access_token?: unknown;
+      expires_in?: unknown;
+    };
+    if (
+      typeof data.access_token !== "string" ||
+      data.access_token.length === 0 ||
+      typeof data.expires_in !== "number" ||
+      !Number.isFinite(data.expires_in) ||
+      data.expires_in <= 0
+    ) {
+      throw new Error(
+        "Anthropic Workload Identity Federation token exchange returned an invalid token response",
+      );
+    }
+
+    return {
+      accessToken: data.access_token,
+      expiresAtMs: Date.now() + data.expires_in * 1000,
+    };
+  }
+}
+
+export const anthropicWorkloadIdentity = new AnthropicWorkloadIdentityClient();
+
+// === Internal helpers ===
+
+const JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const ADVISORY_REFRESH_MS = 120_000;
+const MANDATORY_REFRESH_MS = 30_000;
+
+interface TokenCacheEntry {
+  accessToken: string;
+  expiresAtMs: number;
+}
+
+/**
+ * The Anthropic SDKs place static env credentials above federation in their
+ * credential precedence; these are the SDK's own ambient env vars, not
+ * ARCHESTRA_-prefixed config.
+ */
+function hasStaticSdkEnvCredentials(): boolean {
+  return Boolean(
+    process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN,
+  );
+}
+
+/**
+ * The identity token file is re-read on every exchange so rotated projected
+ * tokens (e.g. Kubernetes service-account tokens) are picked up transparently.
+ */
+async function readIdentityToken(wif: {
+  identityTokenFile?: string;
+  identityToken?: string;
+}): Promise<string> {
+  if (wif.identityTokenFile) {
+    return (await readFile(wif.identityTokenFile, "utf8")).trim();
+  }
+  if (wif.identityToken) {
+    return wif.identityToken;
+  }
+  throw new Error(
+    "Anthropic Workload Identity Federation has no identity token source configured",
+  );
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function mergeHeaders(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+): Headers {
+  const headers = new Headers(
+    input instanceof Request ? input.headers : undefined,
+  );
+  for (const [key, value] of new Headers(init?.headers).entries()) {
+    headers.set(key, value);
+  }
+  return headers;
+}

--- a/platform/backend/src/clients/anthropic-workload-identity.ts
+++ b/platform/backend/src/clients/anthropic-workload-identity.ts
@@ -101,6 +101,10 @@ class AnthropicWorkloadIdentityClient {
     }
 
     const assertion = await readIdentityToken(wif);
+    // The exchange targets the configured Anthropic base URL (matching the
+    // official SDK's oidcFederationProvider({ baseURL }) behavior) so it can be
+    // routed through a proxy. WIF and the Azure Foundry base URL never collide:
+    // the Foundry Entra ID path is checked before WIF in every call site.
     const response = await fetch(
       `${normalizeBaseUrl(config.llm.anthropic.baseUrl)}/v1/oauth/token`,
       {

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -24,6 +24,7 @@ import {
 import { context, propagation } from "@opentelemetry/api";
 import type { streamText } from "ai";
 import { isAnthropicNativeEndpoint } from "@/clients/anthropic-endpoint";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import {
   createAzureFetchWithApiVersion,
@@ -262,6 +263,8 @@ export async function createLLMModelForAgent(params: {
   const isOllama = provider === "ollama";
   const isAzureWithEntra =
     provider === "azure" && isAzureOpenAiEntraIdEnabled();
+  const isAnthropicWithWif =
+    provider === "anthropic" && anthropicWorkloadIdentity.isEnabled();
 
   logger.info(
     {
@@ -272,6 +275,7 @@ export async function createLLMModelForAgent(params: {
       isVllm,
       isOllama,
       isAzureWithEntra,
+      isAnthropicWithWif,
     },
     "Using LLM provider API key",
   );
@@ -282,7 +286,8 @@ export async function createLLMModelForAgent(params: {
     !isBedrockWithIamAuth &&
     !isVllm &&
     !isOllama &&
-    !isAzureWithEntra
+    !isAzureWithEntra &&
+    !isAnthropicWithWif
   ) {
     // Per-user providers (GitHub Copilot) need the acting user's own linked
     // account; surface a typed error so callers can prompt them to connect

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -18,6 +18,7 @@ import config, {
   getOtlpAuthHeaders,
   getTrustedOrigins,
   parseActiveChatRunPollIntervalMs,
+  parseAnthropicWifConfig,
   parseAuditLogRetentionDays,
   parseBodyLimit,
   parseCodeRuntimeDaggerRunnerHost,
@@ -1861,5 +1862,58 @@ describe("parseLogFormat", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Invalid ARCHESTRA_LOGGING_FORMAT value "xml"'),
     );
+  });
+});
+
+describe("parseAnthropicWifConfig", () => {
+  const completeEnv = {
+    federationRuleId: "fdrl_test",
+    organizationId: "00000000-0000-0000-0000-000000000000",
+    serviceAccountId: "svac_test",
+    identityTokenFile: "/var/run/secrets/anthropic.com/token",
+  };
+
+  test("returns null when nothing is set", () => {
+    expect(parseAnthropicWifConfig({})).toBeNull();
+  });
+
+  test("parses a complete configuration with a token file", () => {
+    expect(parseAnthropicWifConfig(completeEnv)).toEqual({
+      federationRuleId: "fdrl_test",
+      organizationId: "00000000-0000-0000-0000-000000000000",
+      serviceAccountId: "svac_test",
+      identityTokenFile: "/var/run/secrets/anthropic.com/token",
+    });
+  });
+
+  test("accepts an inline identity token as the token source", () => {
+    expect(
+      parseAnthropicWifConfig({
+        ...completeEnv,
+        identityTokenFile: undefined,
+        identityToken: "jwt-inline",
+      }),
+    ).toMatchObject({ identityToken: "jwt-inline" });
+  });
+
+  test("includes the optional workspace ID when set", () => {
+    expect(
+      parseAnthropicWifConfig({ ...completeEnv, workspaceId: "wrkspc_test" }),
+    ).toMatchObject({ workspaceId: "wrkspc_test" });
+  });
+
+  test.each([
+    ["federationRuleId", { ...completeEnv, federationRuleId: undefined }],
+    ["organizationId", { ...completeEnv, organizationId: undefined }],
+    ["serviceAccountId", { ...completeEnv, serviceAccountId: undefined }],
+    ["token source", { ...completeEnv, identityTokenFile: undefined }],
+  ])("disables WIF when %s is missing", (_label, env) => {
+    expect(parseAnthropicWifConfig(env)).toBeNull();
+  });
+
+  test("treats whitespace-only values as unset", () => {
+    expect(
+      parseAnthropicWifConfig({ ...completeEnv, federationRuleId: "  " }),
+    ).toBeNull();
   });
 });

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -459,6 +459,11 @@ export interface AnthropicWifConfig {
   serviceAccountId: string;
   workspaceId?: string;
   identityTokenFile?: string;
+  /**
+   * Inline identity token (a JWT). Held in the config singleton, so prefer
+   * `identityTokenFile` in production — only the path is stored, not the secret,
+   * and the file is re-read on every exchange to pick up rotation.
+   */
   identityToken?: string;
 }
 

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -452,6 +452,72 @@ export const parseDatabaseStatementTimeoutMillis = (
   return parsed;
 };
 
+export interface AnthropicWifConfig {
+  federationRuleId: string;
+  organizationId: string;
+  serviceAccountId: string;
+  workspaceId?: string;
+  identityTokenFile?: string;
+  identityToken?: string;
+}
+
+/**
+ * Parse Anthropic Workload Identity Federation (keyless auth) configuration.
+ * Enabled only when the federation rule ID, organization ID, service account
+ * ID, and an identity token source are all present; a partial configuration
+ * logs a warning and disables WIF rather than failing at request time.
+ *
+ * @public — exported for testability
+ */
+export const parseAnthropicWifConfig = (env: {
+  federationRuleId?: string | undefined;
+  organizationId?: string | undefined;
+  serviceAccountId?: string | undefined;
+  workspaceId?: string | undefined;
+  identityTokenFile?: string | undefined;
+  identityToken?: string | undefined;
+}): AnthropicWifConfig | null => {
+  const federationRuleId = env.federationRuleId?.trim();
+  const organizationId = env.organizationId?.trim();
+  const serviceAccountId = env.serviceAccountId?.trim();
+  const workspaceId = env.workspaceId?.trim();
+  const identityTokenFile = env.identityTokenFile?.trim();
+  const identityToken = env.identityToken?.trim();
+
+  const anySet = Boolean(
+    federationRuleId ||
+      organizationId ||
+      serviceAccountId ||
+      workspaceId ||
+      identityTokenFile ||
+      identityToken,
+  );
+  if (!anySet) {
+    return null;
+  }
+
+  if (
+    !federationRuleId ||
+    !organizationId ||
+    !serviceAccountId ||
+    !(identityTokenFile || identityToken)
+  ) {
+    logger.warn(
+      "Anthropic Workload Identity Federation is partially configured and will be disabled. Set ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID, ARCHESTRA_ANTHROPIC_ORGANIZATION_ID, ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID, and one of ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE or ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN.",
+    );
+    return null;
+  }
+
+  return {
+    federationRuleId,
+    organizationId,
+    serviceAccountId,
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(identityTokenFile ? { identityTokenFile } : {}),
+    ...(identityToken ? { identityToken } : {}),
+  };
+};
+
 /** @public — exported for testability */
 export const parseMetricsPort = (envValue?: string | undefined): number => {
   const value = envValue?.trim();
@@ -1061,6 +1127,15 @@ const config = {
       azureFoundryEntraIdEnabled:
         process.env.ARCHESTRA_ANTHROPIC_AZURE_FOUNDRY_ENTRA_ID_ENABLED ===
         "true",
+      // Workload Identity Federation (keyless upstream auth); null when not configured.
+      wif: parseAnthropicWifConfig({
+        federationRuleId: process.env.ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID,
+        organizationId: process.env.ARCHESTRA_ANTHROPIC_ORGANIZATION_ID,
+        serviceAccountId: process.env.ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID,
+        workspaceId: process.env.ARCHESTRA_ANTHROPIC_WORKSPACE_ID,
+        identityTokenFile: process.env.ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE,
+        identityToken: process.env.ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN,
+      }),
     },
     gemini: {
       baseUrl:

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -452,6 +452,7 @@ export const parseDatabaseStatementTimeoutMillis = (
   return parsed;
 };
 
+/** @public — exported for testability */
 export interface AnthropicWifConfig {
   federationRuleId: string;
   organizationId: string;

--- a/platform/backend/src/models/llm-provider-api-key.ts
+++ b/platform/backend/src/models/llm-provider-api-key.ts
@@ -6,6 +6,7 @@ import {
   type SupportedProvider,
 } from "@archestra/shared";
 import { and, asc, desc, eq, ilike, inArray, or, sql } from "drizzle-orm";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import db, { schema } from "@/database";
 import { computeSecretStorageType } from "@/secrets-manager/utils";
@@ -275,6 +276,7 @@ class LlmProviderApiKeyModel {
         schema.llmProviderApiKeysTable.provider,
         getProvidersWithOptionalApiKey({
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
         }),
       ),
     );
@@ -444,6 +446,7 @@ class LlmProviderApiKeyModel {
         schema.llmProviderApiKeysTable.provider,
         getProvidersWithOptionalApiKey({
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
         }),
       ),
     );
@@ -524,6 +527,7 @@ class LlmProviderApiKeyModel {
         schema.llmProviderApiKeysTable.provider,
         getProvidersWithOptionalApiKey({
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
         }),
       ),
     );
@@ -823,6 +827,7 @@ function canUseProviderApiKey(
 
   return getProvidersWithOptionalApiKey({
     azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+    anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
   }).includes(apiKey.provider);
 }
 

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
@@ -1,110 +1,127 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
-
-vi.mock("@/clients/anthropic-workload-identity", () => ({
-  anthropicWorkloadIdentity: {
-    isEnabled: vi.fn(() => false),
-    getAccessToken: vi.fn(async () => "sk-ant-oat01-test"),
-  },
-}));
-
-vi.mock("@/clients/azure-openai-credentials", () => ({
-  getAzureAiFoundryBearerTokenProvider: vi.fn(),
-  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
-}));
-
-vi.mock("@/config", () => ({
-  default: {
-    llm: {
-      anthropic: {
-        baseUrl: "https://api.anthropic.com",
-      },
-    },
-  },
-}));
-
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import config, { type AnthropicWifConfig } from "@/config";
 import { fetchAnthropicModels } from "./anthropic";
 
-const mockWifIsEnabled = vi.mocked(anthropicWorkloadIdentity.isEnabled);
+// No module mocks: drive the real WIF client + fetcher through the fetch
+// boundary and real config, keeping this file in the fast vitest project.
 
-const MODELS_RESPONSE = new Response(
-  JSON.stringify({
-    data: [
-      {
-        id: "claude-sonnet-4-5",
-        display_name: "Claude Sonnet 4.5",
-        created_at: "2026-01-01T00:00:00Z",
-      },
-    ],
-  }),
-  { status: 200 },
-);
+const WIF_CONFIG: AnthropicWifConfig = {
+  federationRuleId: "fdrl_test",
+  organizationId: "00000000-0000-0000-0000-000000000000",
+  serviceAccountId: "svac_test",
+  identityToken: "jwt-inline",
+};
+
+const originalWif = config.llm.anthropic.wif;
+
+function stubAnthropicFetch() {
+  const fetchMock = vi.fn(
+    async (
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ): Promise<Response> => {
+      const url = String(input);
+      if (url.endsWith("/v1/oauth/token")) {
+        return new Response(
+          JSON.stringify({
+            access_token: "sk-ant-oat01-test",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/v1/models")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "claude-sonnet-4-6",
+                display_name: "Claude Sonnet 4.6",
+                created_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected request: ${url}`);
+    },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+/** The headers the fetcher sent on the `/v1/models` request. */
+function modelsRequestHeaders(
+  fetchMock: ReturnType<typeof stubAnthropicFetch>,
+): Record<string, string> {
+  const call = fetchMock.mock.calls.find((c) =>
+    String(c[0]).includes("/v1/models"),
+  );
+  return (call?.[1]?.headers ?? {}) as Record<string, string>;
+}
 
 describe("fetchAnthropicModels", () => {
+  beforeEach(() => {
+    anthropicWorkloadIdentity.resetForTests();
+    config.llm.anthropic.wif = null;
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "");
+  });
+
   afterEach(() => {
-    vi.restoreAllMocks();
-    mockWifIsEnabled.mockReturnValue(false);
+    anthropicWorkloadIdentity.resetForTests();
+    config.llm.anthropic.wif = originalWif;
   });
 
   test("uses a federated bearer token for keyless fetches when WIF is enabled", async () => {
-    mockWifIsEnabled.mockReturnValue(true);
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(MODELS_RESPONSE.clone());
+    config.llm.anthropic.wif = { ...WIF_CONFIG };
+    const fetchMock = stubAnthropicFetch();
 
-    await expect(fetchAnthropicModels("")).resolves.toMatchObject([
+    await expect(
+      fetchAnthropicModels("", "https://api.anthropic.com"),
+    ).resolves.toMatchObject([
       {
-        id: "claude-sonnet-4-5",
-        displayName: "Claude Sonnet 4.5",
+        id: "claude-sonnet-4-6",
+        displayName: "Claude Sonnet 4.6",
         provider: "anthropic",
       },
     ]);
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.anthropic.com/v1/models?limit=100",
-      {
-        headers: {
-          Authorization: "Bearer sk-ant-oat01-test",
-          "anthropic-version": "2023-06-01",
-        },
-      },
-    );
+    expect(modelsRequestHeaders(fetchMock)).toEqual({
+      Authorization: "Bearer sk-ant-oat01-test",
+      "anthropic-version": "2023-06-01",
+    });
   });
 
   test("an explicit API key takes precedence over WIF", async () => {
-    mockWifIsEnabled.mockReturnValue(true);
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(MODELS_RESPONSE.clone());
+    config.llm.anthropic.wif = { ...WIF_CONFIG };
+    const fetchMock = stubAnthropicFetch();
 
-    await fetchAnthropicModels("sk-ant-explicit");
+    await fetchAnthropicModels("sk-ant-explicit", "https://api.anthropic.com");
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.anthropic.com/v1/models?limit=100",
-      {
-        headers: {
-          "x-api-key": "sk-ant-explicit",
-          "anthropic-version": "2023-06-01",
-        },
-      },
-    );
+    expect(modelsRequestHeaders(fetchMock)).toEqual({
+      "x-api-key": "sk-ant-explicit",
+      "anthropic-version": "2023-06-01",
+    });
+    // No token exchange should have happened.
+    expect(
+      fetchMock.mock.calls.some((c) =>
+        String(c[0]).endsWith("/v1/oauth/token"),
+      ),
+    ).toBe(false);
   });
 
   test("falls back to an empty x-api-key when no auth method is available", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(MODELS_RESPONSE.clone());
+    const fetchMock = stubAnthropicFetch();
 
-    await fetchAnthropicModels("");
+    await fetchAnthropicModels("", "https://api.anthropic.com");
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.anthropic.com/v1/models?limit=100",
-      {
-        headers: {
-          "x-api-key": "",
-          "anthropic-version": "2023-06-01",
-        },
-      },
-    );
+    expect(modelsRequestHeaders(fetchMock)).toEqual({
+      "x-api-key": "",
+      "anthropic-version": "2023-06-01",
+    });
   });
 });

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/clients/anthropic-workload-identity", () => ({
+  anthropicWorkloadIdentity: {
+    isEnabled: vi.fn(() => false),
+    getAccessToken: vi.fn(async () => "sk-ant-oat01-test"),
+  },
+}));
+
+vi.mock("@/clients/azure-openai-credentials", () => ({
+  getAzureAiFoundryBearerTokenProvider: vi.fn(),
+  isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
+}));
+
+vi.mock("@/config", () => ({
+  default: {
+    llm: {
+      anthropic: {
+        baseUrl: "https://api.anthropic.com",
+      },
+    },
+  },
+}));
+
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
+import { fetchAnthropicModels } from "./anthropic";
+
+const mockWifIsEnabled = vi.mocked(anthropicWorkloadIdentity.isEnabled);
+
+const MODELS_RESPONSE = new Response(
+  JSON.stringify({
+    data: [
+      {
+        id: "claude-sonnet-4-5",
+        display_name: "Claude Sonnet 4.5",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+  }),
+  { status: 200 },
+);
+
+describe("fetchAnthropicModels", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockWifIsEnabled.mockReturnValue(false);
+  });
+
+  test("uses a federated bearer token for keyless fetches when WIF is enabled", async () => {
+    mockWifIsEnabled.mockReturnValue(true);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(MODELS_RESPONSE.clone());
+
+    await expect(fetchAnthropicModels("")).resolves.toMatchObject([
+      {
+        id: "claude-sonnet-4-5",
+        displayName: "Claude Sonnet 4.5",
+        provider: "anthropic",
+      },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/models?limit=100",
+      {
+        headers: {
+          Authorization: "Bearer sk-ant-oat01-test",
+          "anthropic-version": "2023-06-01",
+        },
+      },
+    );
+  });
+
+  test("an explicit API key takes precedence over WIF", async () => {
+    mockWifIsEnabled.mockReturnValue(true);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(MODELS_RESPONSE.clone());
+
+    await fetchAnthropicModels("sk-ant-explicit");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/models?limit=100",
+      {
+        headers: {
+          "x-api-key": "sk-ant-explicit",
+          "anthropic-version": "2023-06-01",
+        },
+      },
+    );
+  });
+
+  test("falls back to an empty x-api-key when no auth method is available", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(MODELS_RESPONSE.clone());
+
+    await fetchAnthropicModels("");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/models?limit=100",
+      {
+        headers: {
+          "x-api-key": "",
+          "anthropic-version": "2023-06-01",
+        },
+      },
+    );
+  });
+});

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -1,3 +1,4 @@
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
@@ -52,10 +53,16 @@ async function getAnthropicAuthHeaders(
     return { "x-api-key": apiKey };
   }
 
-  if (!isAnthropicAzureFoundryEntraIdEnabled()) {
-    return { "x-api-key": "" };
+  if (isAnthropicAzureFoundryEntraIdEnabled()) {
+    const tokenProvider = getAzureAiFoundryBearerTokenProvider();
+    return { Authorization: `Bearer ${await tokenProvider()}` };
   }
 
-  const tokenProvider = getAzureAiFoundryBearerTokenProvider();
-  return { Authorization: `Bearer ${await tokenProvider()}` };
+  if (anthropicWorkloadIdentity.isEnabled()) {
+    return {
+      Authorization: `Bearer ${await anthropicWorkloadIdentity.getAccessToken()}`,
+    };
+  }
+
+  return { "x-api-key": "" };
 }

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -2,6 +2,7 @@ import { RouteId, SupportedProvidersSchema } from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { getEmailProviderInfo } from "@/agents/incoming-email";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
@@ -73,6 +74,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               byosEnabled: z.boolean(),
               byosVaultKvVersion: z.enum(["1", "2"]).nullable(),
               azureOpenAiEntraIdEnabled: z.boolean(),
+              anthropicWifEnabled: z.boolean(),
               bedrockIamAuthEnabled: z.boolean(),
               geminiVertexAiEnabled: z.boolean(),
               globalToolPolicy: z.enum(["permissive", "restrictive"]),
@@ -134,6 +136,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           byosEnabled: isByosEnabled(),
           byosVaultKvVersion: getByosVaultKvVersion(),
           azureOpenAiEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
           bedrockIamAuthEnabled: isBedrockIamAuthEnabled(),
           geminiVertexAiEnabled: isVertexAiEnabled(),
           globalToolPolicy,

--- a/platform/backend/src/routes/llm-provider-api-keys.test.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.test.ts
@@ -12,6 +12,12 @@ vi.mock("@/clients/gemini-client", () => ({
   isVertexAiEnabled: vi.fn(),
 }));
 
+vi.mock("@/clients/anthropic-workload-identity", () => ({
+  anthropicWorkloadIdentity: {
+    isEnabled: vi.fn(() => false),
+  },
+}));
+
 vi.mock("@/clients/azure-openai-credentials", () => ({
   isAnthropicAzureFoundryEntraIdEnabled: vi.fn(() => false),
   isAzureOpenAiEntraIdEnabled: vi.fn(),
@@ -59,11 +65,13 @@ vi.mock("@/services/model-sync", () => ({
 }));
 
 import { hasPermission, userHasPermission } from "@/auth";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
 import { testProviderApiKey } from "@/routes/chat/model-fetchers/registry";
 import { validateProviderAllowed } from "./llm-provider-api-keys";
 
+const mockAnthropicWifIsEnabled = vi.mocked(anthropicWorkloadIdentity.isEnabled);
 const mockIsAzureOpenAiEntraIdEnabled = vi.mocked(isAzureOpenAiEntraIdEnabled);
 const mockIsVertexAiEnabled = vi.mocked(isVertexAiEnabled);
 const mockHasPermission = vi.mocked(hasPermission);
@@ -214,6 +222,7 @@ describe("LLM Provider API Keys CRUD", () => {
     vi.clearAllMocks();
     setupAdminApp();
     mockIsAzureOpenAiEntraIdEnabled.mockReturnValue(false);
+    mockAnthropicWifIsEnabled.mockReturnValue(false);
 
     const organization = await makeOrganization();
     organizationId = organization.id;
@@ -780,6 +789,81 @@ describe("LLM Provider API Keys CRUD", () => {
       "azure",
       "",
       "https://runtime.example.com/openai/v1",
+      null,
+    );
+  });
+
+  test("creates a keyless Anthropic key when Workload Identity Federation is configured", async () => {
+    mockAnthropicWifIsEnabled.mockReturnValue(true);
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Anthropic WIF",
+        provider: "anthropic",
+        scope: "personal",
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(200);
+    expect(createResponse.json()).toMatchObject({
+      name: "Anthropic WIF",
+      provider: "anthropic",
+      secretId: null,
+    });
+    // Keyless create must still exercise the WIF token exchange + model listing.
+    expect(mockTestProviderApiKey).toHaveBeenCalledWith(
+      "anthropic",
+      "",
+      undefined,
+      undefined,
+    );
+  });
+
+  test("rejects keyless Anthropic keys when Workload Identity Federation is not configured", async () => {
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Anthropic Keyless",
+        provider: "anthropic",
+        scope: "personal",
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(400);
+  });
+
+  test("re-tests keyless Anthropic WIF key when runtime settings change", async () => {
+    mockAnthropicWifIsEnabled.mockReturnValue(true);
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Anthropic WIF",
+        provider: "anthropic",
+        scope: "personal",
+      },
+    });
+    expect(createResponse.statusCode).toBe(200);
+    const createdKey = createResponse.json();
+    mockTestProviderApiKey.mockClear();
+
+    const updateResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/llm-provider-api-keys/${createdKey.id}`,
+      payload: {
+        baseUrl: "https://api.anthropic.com",
+      },
+    });
+
+    expect(updateResponse.statusCode).toBe(200);
+    expect(mockTestProviderApiKey).toHaveBeenCalledWith(
+      "anthropic",
+      "",
+      "https://api.anthropic.com",
       null,
     );
   });

--- a/platform/backend/src/routes/llm-provider-api-keys.test.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.test.ts
@@ -71,7 +71,9 @@ import { isVertexAiEnabled } from "@/clients/gemini-client";
 import { testProviderApiKey } from "@/routes/chat/model-fetchers/registry";
 import { validateProviderAllowed } from "./llm-provider-api-keys";
 
-const mockAnthropicWifIsEnabled = vi.mocked(anthropicWorkloadIdentity.isEnabled);
+const mockAnthropicWifIsEnabled = vi.mocked(
+  anthropicWorkloadIdentity.isEnabled,
+);
 const mockIsAzureOpenAiEntraIdEnabled = vi.mocked(isAzureOpenAiEntraIdEnabled);
 const mockIsVertexAiEnabled = vi.mocked(isVertexAiEnabled);
 const mockHasPermission = vi.mocked(hasPermission);

--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -10,6 +10,7 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { capitalize } from "lodash-es";
 import { z } from "zod";
 import { hasPermission, userHasPermission } from "@/auth";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import {
   type BedrockSigV4Credentials,
@@ -301,6 +302,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 isProviderApiKeyOptional({
                   provider: data.provider,
                   azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+                  anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
                 }) || data.apiKey
               );
             },
@@ -454,6 +456,19 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
           );
         }
       } else if (
+        body.provider === "anthropic" &&
+        !actualApiKeyValue &&
+        anthropicWorkloadIdentity.isEnabled()
+      ) {
+        // Keyless Anthropic key backed by Workload Identity Federation —
+        // exercises the token exchange and model listing end to end.
+        await testApiKeyOrThrow(
+          body.provider,
+          "",
+          runtimeTestBaseUrl,
+          body.extraHeaders,
+        );
+      } else if (
         !actualApiKeyValue &&
         isProviderApiKeyOptional({
           provider: body.provider,
@@ -477,6 +492,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         !isProviderApiKeyOptional({
           provider: body.provider,
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
         })
       ) {
         throw new ApiError(
@@ -508,6 +524,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         isProviderApiKeyOptional({
           provider: body.provider,
           azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+          anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
         });
       if (canSync) {
         try {
@@ -830,6 +847,17 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ) {
           await testKeylessAzureEntraOrThrow(
             "runtime",
+            testBaseUrl,
+            testExtraHeaders,
+          );
+        } else if (
+          apiKeyFromDB.provider === "anthropic" &&
+          anthropicWorkloadIdentity.isEnabled()
+        ) {
+          // Keyless Anthropic WIF key — re-test with the updated runtime settings.
+          await testApiKeyOrThrow(
+            apiKeyFromDB.provider,
+            "",
             testBaseUrl,
             testExtraHeaders,
           );

--- a/platform/backend/src/routes/llm-provider-models.ts
+++ b/platform/backend/src/routes/llm-provider-models.ts
@@ -14,6 +14,7 @@ import {
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { LRUCacheManager } from "@/cache-manager";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isBedrockIamAuthEnabled } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
@@ -466,6 +467,7 @@ async function syncVisibleApiKeyModels(params: {
     !isProviderApiKeyOptional({
       provider: apiKey.provider,
       azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+      anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
     })
   ) {
     if (apiKey.secretId) {

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -2,6 +2,7 @@ import AnthropicProvider from "@anthropic-ai/sdk";
 import type { ArchestraInternalErrorCode } from "@archestra/shared";
 import { encode as toonEncode } from "@toon-format/toon";
 import { get } from "lodash-es";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import {
   getAzureAiFoundryBearerTokenProvider,
   isAnthropicAzureFoundryEntraIdEnabled,
@@ -1205,6 +1206,21 @@ export const anthropicAdapterFactory: LLMProvider<
           ...options.defaultHeaders,
           // The fetch wrapper replaces this sentinel with a fresh Entra ID token on every request.
           Authorization: "Bearer <entra-id-managed>",
+        },
+      });
+    }
+
+    if (!apiKey && anthropicWorkloadIdentity.isEnabled()) {
+      return new AnthropicProvider({
+        apiKey: null,
+        authToken: null,
+        baseURL: options.baseUrl,
+        fetch: anthropicWorkloadIdentity.createFetch(customFetch),
+        timeout: ANTHROPIC_CLIENT_TIMEOUT_MS,
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          // The fetch wrapper replaces this sentinel with a fresh WIF access token on every request.
+          Authorization: "Bearer <workload-identity-managed>",
         },
       });
     }

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -24,6 +24,7 @@ import {
 } from "@opentelemetry/api";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { LRUCacheManager } from "@/cache-manager";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import config from "@/config";
 import logger from "@/logging";
@@ -1911,6 +1912,7 @@ function shouldUseKeylessProviderApiKey(params: {
   return isProviderApiKeyOptional({
     provider: row.provider,
     azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+    anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
   });
 }
 

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -72,9 +72,13 @@ class SystemKeyManager {
       // Entra ID and Workload Identity Federation): system keys are looked up
       // per provider, so two "anthropic" entries would delete each other's key.
       provider: "anthropic",
-      name: anthropicWorkloadIdentity.isEnabled()
-        ? "Anthropic Workload Identity Federation"
-        : "Anthropic Azure Foundry Entra ID",
+      // Lazy so the created key's name reflects whichever method is actually
+      // active at sync time, not the value captured at class construction.
+      get name() {
+        return anthropicWorkloadIdentity.isEnabled()
+          ? "Anthropic Workload Identity Federation"
+          : "Anthropic Azure Foundry Entra ID";
+      },
       isEnabled: () =>
         (isAnthropicAzureFoundryEntraIdEnabled() &&
           isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl)) ||

--- a/platform/backend/src/services/system-key-manager.ts
+++ b/platform/backend/src/services/system-key-manager.ts
@@ -1,4 +1,5 @@
 import type { SupportedProvider } from "@archestra/shared";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import {
   isAnthropicAzureFoundryEntraIdEnabled,
   isAzureOpenAiEntraIdEnabled,
@@ -67,11 +68,17 @@ class SystemKeyManager {
       },
     },
     {
+      // One entry covers both keyless Anthropic auth methods (Azure Foundry
+      // Entra ID and Workload Identity Federation): system keys are looked up
+      // per provider, so two "anthropic" entries would delete each other's key.
       provider: "anthropic",
-      name: "Anthropic Azure Foundry Entra ID",
+      name: anthropicWorkloadIdentity.isEnabled()
+        ? "Anthropic Workload Identity Federation"
+        : "Anthropic Azure Foundry Entra ID",
       isEnabled: () =>
-        isAnthropicAzureFoundryEntraIdEnabled() &&
-        isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl),
+        (isAnthropicAzureFoundryEntraIdEnabled() &&
+          isAzureAiFoundryBaseUrl(config.llm.anthropic.baseUrl)) ||
+        anthropicWorkloadIdentity.isEnabled(),
       customFetch: async () => {
         const models = await fetchAnthropicModels(
           "",

--- a/platform/backend/src/utils/llm-api-key-resolution.ts
+++ b/platform/backend/src/utils/llm-api-key-resolution.ts
@@ -3,6 +3,7 @@ import {
   providerRequiresPerUserCredential,
   type SupportedProvider,
 } from "@archestra/shared";
+import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { getProviderEnvApiKey } from "@/config";
 import { LlmProviderApiKeyModel, TeamModel } from "@/models";
@@ -79,6 +80,7 @@ export async function resolveProviderApiKey(params: {
       isProviderApiKeyOptional({
         provider,
         azureEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),
+        anthropicWifEnabled: anthropicWorkloadIdentity.isEnabled(),
       })
     ) {
       return {

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -122,6 +122,7 @@ export default function ApiKeysPage() {
   const deleteMutation = useDeleteLlmProviderApiKey();
   const byosEnabled = useFeature("byosEnabled");
   const azureOpenAiEntraIdEnabled = useFeature("azureOpenAiEntraIdEnabled");
+  const anthropicWifEnabled = useFeature("anthropicWifEnabled");
 
   // Dialog states
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -411,6 +412,7 @@ export default function ApiKeysPage() {
             isProviderApiKeyOptional({
               provider: row.original.provider,
               azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
+              anthropicWifEnabled: anthropicWifEnabled === true,
             }) ? (
               <>
                 <CheckCircle2 className="h-4 w-4 text-green-500" />
@@ -473,6 +475,7 @@ export default function ApiKeysPage() {
       openDeleteDialog,
       getKeyUsage,
       azureOpenAiEntraIdEnabled,
+      anthropicWifEnabled,
     ],
   );
 

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -123,6 +123,7 @@ function AddApiKeyDialog({
   const createMutation = useCreateLlmProviderApiKey();
   const byosEnabled = useFeature("byosEnabled");
   const azureOpenAiEntraIdEnabled = useFeature("azureOpenAiEntraIdEnabled");
+  const anthropicWifEnabled = useFeature("anthropicWifEnabled");
   const bedrockIamAuthEnabled = useFeature("bedrockIamAuthEnabled");
   const geminiVertexAiEnabled = useFeature("geminiVertexAiEnabled");
 
@@ -150,6 +151,7 @@ function AddApiKeyDialog({
       : isProviderApiKeyOptional({
           provider: formValues.provider,
           azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
+          anthropicWifEnabled: anthropicWifEnabled === true,
         }) || formValues.apiKey);
 
   const handleCreate = form.handleSubmit(async (values) => {

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
@@ -196,8 +196,12 @@ function getIsCreateFormValid(params: {
   byosEnabled: boolean;
   values: LlmProviderApiKeyFormValues;
 }) {
-  const { azureOpenAiEntraIdEnabled, anthropicWifEnabled, byosEnabled, values } =
-    params;
+  const {
+    azureOpenAiEntraIdEnabled,
+    anthropicWifEnabled,
+    byosEnabled,
+    values,
+  } = params;
 
   if (values.provider === "bedrock" && values.bedrockAuthMethod === "sigv4") {
     return Boolean(

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
@@ -53,6 +53,7 @@ export function CreateLlmProviderApiKeyDialog({
   const { data: existingKeys = [] } = useLlmProviderApiKeys({ enabled: open });
   const byosEnabled = useFeature("byosEnabled");
   const azureOpenAiEntraIdEnabled = useFeature("azureOpenAiEntraIdEnabled");
+  const anthropicWifEnabled = useFeature("anthropicWifEnabled");
   const bedrockIamAuthEnabled = useFeature("bedrockIamAuthEnabled");
   const geminiVertexAiEnabled = useFeature("geminiVertexAiEnabled");
   const { data: canCreateOrgScopedKey } = useHasPermissions({
@@ -79,6 +80,7 @@ export function CreateLlmProviderApiKeyDialog({
   const formValues = form.watch();
   const isValid = getIsCreateFormValid({
     azureOpenAiEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
+    anthropicWifEnabled: anthropicWifEnabled === true,
     byosEnabled: Boolean(byosEnabled),
     values: formValues,
   });
@@ -190,10 +192,12 @@ function getDefaultFormValues(params: {
 
 function getIsCreateFormValid(params: {
   azureOpenAiEntraIdEnabled: boolean;
+  anthropicWifEnabled: boolean;
   byosEnabled: boolean;
   values: LlmProviderApiKeyFormValues;
 }) {
-  const { azureOpenAiEntraIdEnabled, byosEnabled, values } = params;
+  const { azureOpenAiEntraIdEnabled, anthropicWifEnabled, byosEnabled, values } =
+    params;
 
   if (values.provider === "bedrock" && values.bedrockAuthMethod === "sigv4") {
     return Boolean(
@@ -211,6 +215,7 @@ function getIsCreateFormValid(params: {
         : isProviderApiKeyOptional({
             provider: values.provider,
             azureEntraIdEnabled: azureOpenAiEntraIdEnabled,
+            anthropicWifEnabled,
           }) || values.apiKey),
   );
 }

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_PROVIDER_BASE_URLS,
   E2eTestId,
   isProviderApiKeyOptional,
+  isSelfHostedProvider,
   providerRequiresPerUserCredential,
 } from "@archestra/shared";
 import { Building2, CheckCircle2, Trash2, User, Users } from "lucide-react";
@@ -934,21 +935,14 @@ export function LlmProviderApiKeyForm({
             Override the default API endpoint. Useful for self-hosted or proxy
             setups.
           </p>
-          {isProviderApiKeyOptional({
-            provider,
-            azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
-          }) &&
-            // Docker-localhost hint applies to self-hosted providers only, not
-            // cloud keyless auth (Azure Entra ID, Anthropic WIF).
-            provider !== "azure" &&
-            provider !== "anthropic" && (
-              <p className="text-xs text-muted-foreground">
-                If this app runs in Docker, <code>localhost</code> points at the
-                container, not your host machine. Use{" "}
-                <code>host.docker.internal</code> instead (e.g.{" "}
-                <code>http://host.docker.internal:11434/v1</code>).
-              </p>
-            )}
+          {isSelfHostedProvider(provider) && (
+            <p className="text-xs text-muted-foreground">
+              If this app runs in Docker, <code>localhost</code> points at the
+              container, not your host machine. Use{" "}
+              <code>host.docker.internal</code> instead (e.g.{" "}
+              <code>http://host.docker.internal:11434/v1</code>).
+            </p>
+          )}
           <Input
             id="llm-provider-api-key-base-url"
             type="url"

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -318,6 +318,7 @@ export function LlmProviderApiKeyForm({
   const authDocsUrl = getFrontendDocsUrl("platform-llm-proxy-authentication");
   const byosEnabled = useFeature("byosEnabled");
   const azureOpenAiEntraIdEnabled = useFeature("azureOpenAiEntraIdEnabled");
+  const anthropicWifEnabled = useFeature("anthropicWifEnabled");
   const { data: providerBaseUrls } = useProviderBaseUrls();
   const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
   const { data: isLlmProviderApiKeyAdmin } = useHasPermissions({
@@ -727,6 +728,7 @@ export function LlmProviderApiKeyForm({
                     {isProviderApiKeyOptional({
                       provider,
                       azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
+                      anthropicWifEnabled: anthropicWifEnabled === true,
                     }) ? (
                       <span className="font-normal text-muted-foreground">
                         (optional)
@@ -936,7 +938,10 @@ export function LlmProviderApiKeyForm({
             provider,
             azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
           }) &&
-            provider !== "azure" && (
+            // Docker-localhost hint applies to self-hosted providers only, not
+            // cloud keyless auth (Azure Entra ID, Anthropic WIF).
+            provider !== "azure" &&
+            provider !== "anthropic" && (
               <p className="text-xs text-muted-foreground">
                 If this app runs in Docker, <code>localhost</code> points at the
                 container, not your host machine. Use{" "}

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -37,6 +37,7 @@ export function makeConfig(
       byosEnabled: false,
       byosVaultKvVersion: "1",
       azureOpenAiEntraIdEnabled: false,
+      anthropicWifEnabled: false,
       bedrockIamAuthEnabled: false,
       geminiVertexAiEnabled: false,
       globalToolPolicy: "permissive",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -26324,6 +26324,7 @@ export type GetConfigResponses = {
             byosEnabled: boolean;
             byosVaultKvVersion: '1' | '2';
             azureOpenAiEntraIdEnabled: boolean;
+            anthropicWifEnabled: boolean;
             bedrockIamAuthEnabled: boolean;
             geminiVertexAiEnabled: boolean;
             globalToolPolicy: 'permissive' | 'restrictive';

--- a/platform/shared/model-constants.test.ts
+++ b/platform/shared/model-constants.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   getProvidersWithOptionalApiKey,
   isProviderApiKeyOptional,
+  isSelfHostedProvider,
   requiresOpenAiResponsesApi,
 } from "./model-constants";
 
@@ -41,10 +42,38 @@ describe("provider API key optional helpers", () => {
     ).toBe(true);
   });
 
+  test("treats Anthropic as optional only when Workload Identity Federation is enabled", () => {
+    expect(isProviderApiKeyOptional({ provider: "anthropic" })).toBe(false);
+    expect(
+      isProviderApiKeyOptional({
+        provider: "anthropic",
+        anthropicWifEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
   test("lists providers with optional API keys", () => {
     expect(getProvidersWithOptionalApiKey()).toEqual(["ollama", "vllm"]);
     expect(
       getProvidersWithOptionalApiKey({ azureEntraIdEnabled: true }),
     ).toEqual(["ollama", "vllm", "azure"]);
+    expect(
+      getProvidersWithOptionalApiKey({ anthropicWifEnabled: true }),
+    ).toEqual(["ollama", "vllm", "anthropic"]);
+  });
+});
+
+describe("isSelfHostedProvider", () => {
+  test("matches only the self-hosted providers", () => {
+    expect(isSelfHostedProvider("ollama")).toBe(true);
+    expect(isSelfHostedProvider("vllm")).toBe(true);
+  });
+
+  test("excludes cloud keyless providers (no per-provider denylist needed)", () => {
+    // These are optional-key via runtime flags but are NOT self-hosted, so the
+    // Docker-localhost hint must not apply to them.
+    expect(isSelfHostedProvider("azure")).toBe(false);
+    expect(isSelfHostedProvider("anthropic")).toBe(false);
+    expect(isSelfHostedProvider("openai")).toBe(false);
   });
 });

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -132,19 +132,25 @@ export function providerRequiresPerUserCredential(
 export function isProviderApiKeyOptional(params: {
   provider: SupportedProvider;
   azureEntraIdEnabled?: boolean;
+  anthropicWifEnabled?: boolean;
 }): boolean {
   return (
     PROVIDERS_WITH_OPTIONAL_API_KEY.has(params.provider) ||
-    (params.provider === "azure" && params.azureEntraIdEnabled === true)
+    (params.provider === "azure" && params.azureEntraIdEnabled === true) ||
+    (params.provider === "anthropic" && params.anthropicWifEnabled === true)
   );
 }
 
 export function getProvidersWithOptionalApiKey(params?: {
   azureEntraIdEnabled?: boolean;
+  anthropicWifEnabled?: boolean;
 }): SupportedProvider[] {
   const providers = [...PROVIDERS_WITH_OPTIONAL_API_KEY];
   if (params?.azureEntraIdEnabled === true) {
     providers.push("azure");
+  }
+  if (params?.anthropicWifEnabled === true) {
+    providers.push("anthropic");
   }
   return providers;
 }

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -141,6 +141,17 @@ export function isProviderApiKeyOptional(params: {
   );
 }
 
+/**
+ * Self-hosted providers whose endpoint typically points at a localhost / in-cluster
+ * URL — the only ones the Docker-localhost connection hint applies to. This is the
+ * *unconditional* optional-key set (Ollama, vLLM): cloud keyless providers (Azure
+ * Entra ID, Anthropic WIF) are optional only via runtime flags, so they are excluded
+ * automatically without a per-provider denylist.
+ */
+export function isSelfHostedProvider(provider: SupportedProvider): boolean {
+  return PROVIDERS_WITH_OPTIONAL_API_KEY.has(provider);
+}
+
 export function getProvidersWithOptionalApiKey(params?: {
   azureEntraIdEnabled?: boolean;
   anthropicWifEnabled?: boolean;


### PR DESCRIPTION
## What

Adds **Anthropic Workload Identity Federation (WIF)** keyless authentication, configured entirely through backend environment variables. When configured, Archestra exchanges an IdP-issued OIDC identity token for a short-lived Anthropic access token and sends `Authorization: Bearer <token>` upstream — no static `sk-ant-...` API key required.

Closes #4468.

> Reimplementation of community PR #4800 (closed). That attempt's per-key `identityTokenFile` field let any authenticated user make the backend read an arbitrary file and POST its contents to a user-supplied host via the token exchange. This version is env-only and admin-controlled, mirroring the existing Azure Entra ID / Vertex AI / Bedrock IAM keyless patterns.

## Configuration

| Env var | Required | Notes |
| --- | --- | --- |
| `ARCHESTRA_ANTHROPIC_FEDERATION_RULE_ID` | yes | `fdrl_...` |
| `ARCHESTRA_ANTHROPIC_ORGANIZATION_ID` | yes | org UUID |
| `ARCHESTRA_ANTHROPIC_SERVICE_ACCOUNT_ID` | yes | `svac_...` |
| `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN_FILE` | one of | path to the projected OIDC token (preferred) |
| `ARCHESTRA_ANTHROPIC_IDENTITY_TOKEN` | one of | inline token (testing) |
| `ARCHESTRA_ANTHROPIC_WORKSPACE_ID` | optional | `wrkspc_...`, only when the rule spans multiple workspaces |

A partial configuration logs a warning at startup and disables WIF rather than failing at request time.

## How it works

- **`config.ts`** parses the env vars into `config.llm.anthropic.wif` (`parseAnthropicWifConfig`, unit-tested).
- **`anthropicWorkloadIdentity` client** exchanges the token via the RFC 7523 `jwt-bearer` grant at `/v1/oauth/token`, caches the access token with the SDK-documented **advisory (−120s) / mandatory (−30s)** refresh windows, dedups concurrent exchanges, and re-reads the token file on every exchange so rotated projected tokens (e.g. Kubernetes SA tokens) are picked up transparently.
- Static SDK env credentials (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) **shadow** WIF, matching Anthropic's documented credential precedence.
- Keyless Anthropic rides the existing rails: a system key auto-creates via `system-key-manager` (single Anthropic entry, so it can't collide with the Azure Foundry entry), `isProviderApiKeyOptional` gains an `anthropicWifEnabled` flag threaded through every consumer, and the **proxy adapter + model fetcher** inject the federated bearer token when no API key is present.
- **Frontend**: `anthropicWifEnabled` exposed via `/api/config`; the Anthropic API key renders as optional wherever Azure Entra keyless already does. No per-key form.

Validated against the official docs: https://platform.claude.com/docs/en/manage-claude/workload-identity-federation