### PR TITLE
ci: split Rust checks into a parallel job

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -282,31 +282,6 @@ jobs:
         with:
           working-directory: ./platform
 
-      - name: Setup Rust
-        run: |
-          rustup show
-          rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
-
-      - name: Install Rust musl toolchain dependencies
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-
-      - name: Verify Dagger version sync
-        run: ./scripts/check-dagger-version-sync.sh
-
-      - name: Rust musl checks
-        working-directory: ./platform/archestra-rs
-        env:
-          CC_x86_64_unknown_linux_musl: musl-gcc
-        run: |
-          cargo check --workspace --locked --target x86_64-unknown-linux-musl
-
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
-
-      - name: Rust dependency policy
-        working-directory: ./platform/archestra-rs
-        run: cargo deny check --config deny.toml advisories bans licenses sources
-
       # setup-env uses --frozen-lockfile, which skips minimum-release-age checks.
       # --fix-lockfile re-resolves and fails on immature deps (ERR_PNPM_NO_MATURE_MATCHING_VERSION).
       - name: Verify no immature dependencies
@@ -401,6 +376,51 @@ jobs:
           fi
 
           echo "✅ All validation checks passed"
+
+  # Rust toolchain checks, split out of the lint job so cargo work runs in
+  # parallel with the pnpm work instead of serializing ~1.5-2 min ahead of it.
+  # Needs no pnpm/setup-env: the Dagger sync script is pure shell and cargo
+  # operates on the committed lockfile.
+  platform-rust-checks:
+    name: Platform Rust Checks
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: ./platform
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Setup Rust
+        run: |
+          rustup show
+          rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+
+      - name: Install Rust musl toolchain dependencies
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Verify Dagger version sync
+        run: ./scripts/check-dagger-version-sync.sh
+
+      - name: Rust musl checks
+        working-directory: ./platform/archestra-rs
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+        run: |
+          cargo check --workspace --locked --target x86_64-unknown-linux-musl
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Rust dependency policy
+        working-directory: ./platform/archestra-rs
+        run: cargo deny check --config deny.toml advisories bans licenses sources
 
   # Backend unit tests, sharded across parallel runners. Vitest's --shard
   # slices the file list deterministically (SHA1 of each path), so the four

--- a/platform/backend/src/agents/a2a/stage-attachments.test.ts
+++ b/platform/backend/src/agents/a2a/stage-attachments.test.ts
@@ -7,7 +7,6 @@ import { SKILL_SANDBOX_HOME } from "@/skills-sandbox/runtime-image";
 import {
   afterAll,
   afterEach,
-  beforeAll,
   beforeEach,
   describe,
   expect,

--- a/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
@@ -9,14 +9,7 @@ import {
 import config from "@/config";
 import { KnowledgeBaseConnectorModel, ToolModel } from "@/models";
 import McpServerUserModel from "@/models/mcp-server-user";
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "@/test";
+import { afterAll, beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import {
   getUnassignedDiscoverableTools,

--- a/platform/backend/src/archestra-mcp-server/run-tool.test.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.test.ts
@@ -21,7 +21,6 @@ import { skillSandboxRuntimeService } from "@/skills-sandbox/skill-sandbox-runti
 import {
   afterAll,
   afterEach,
-  beforeAll,
   beforeEach,
   describe,
   expect,

--- a/platform/backend/src/archestra-mcp-server/sandbox.test.ts
+++ b/platform/backend/src/archestra-mcp-server/sandbox.test.ts
@@ -31,7 +31,6 @@ import { SkillSandboxError } from "@/skills-sandbox/types";
 import {
   afterAll,
   afterEach,
-  beforeAll,
   beforeEach,
   describe,
   expect,

--- a/platform/backend/src/models/agent-tool.test.ts
+++ b/platform/backend/src/models/agent-tool.test.ts
@@ -3,7 +3,7 @@ import {
   TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME,
   TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
 } from "@archestra/shared";
-import { afterAll, beforeAll } from "vitest";
+import { afterAll } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import config from "@/config";
 import { beforeEach, describe, expect, test } from "@/test";

--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -14,7 +14,7 @@ import {
   TOOL_TODO_WRITE_SHORT_NAME,
 } from "@archestra/shared";
 import { and, eq, sql } from "drizzle-orm";
-import { afterAll, beforeAll, beforeEach, vi } from "vitest";
+import { afterAll, beforeEach, vi } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { getArchestraMcpCatalogMetadata } from "@/archestra-mcp-server/metadata";
 import config from "@/config";

--- a/platform/backend/src/skills/skill-catalog-prompt.test.ts
+++ b/platform/backend/src/skills/skill-catalog-prompt.test.ts
@@ -1,14 +1,7 @@
 import { ADMIN_ROLE_NAME } from "@archestra/shared";
 import config from "@/config";
 import { SkillModel } from "@/models";
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "@/test";
+import { afterAll, beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { buildSkillCatalogPrompt } from "./skill-catalog-prompt";
 

--- a/platform/backend/src/skills/skill-version-resolution.test.ts
+++ b/platform/backend/src/skills/skill-version-resolution.test.ts
@@ -6,14 +6,7 @@ import {
   SkillVersionModel,
 } from "@/models";
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "@/test";
+import { afterAll, beforeEach, describe, expect, test } from "@/test";
 import type { Skill } from "@/types";
 import {
   resolveActivationVersion,


### PR DESCRIPTION
Stacked on #6145.

## What

The Rust steps in \`Platform Lint and Unit Tests\` (toolchain setup, musl deps, Dagger version sync, \`cargo check\`, cargo-deny install ~50s + policy check) serialized ~1.5–2 min ahead of the pnpm work while sharing nothing with it. They now run as a sibling **\`Platform Rust Checks\`** job:

- 4vcpu runner — cargo and the shell-only Dagger sync script need no pnpm/\`setup-env\`, so the job is checkout + Rust only.
- The lint job's critical path drops to checkout + pnpm checks + build (~1–1.5 min less).

Also applies the safe subset of \`pnpm lint:fix:unsafe\`: dead \`beforeAll\` imports left behind by the beforeEach conversions in #6145. The unsafe non-null-assertion rewrites in \`mcp-backing.app.route.test.ts\` were **discarded** — biome itself flags the \`a?.b!\` hybrids it produced and they break type-checking. 358 tests across the touched files pass; tsgo/biome/zizmor/supply-chain checks clean.

## Required-check change (repo admin, after this merges)

Add **\`Platform Rust Checks\`** to the main-branch ruleset's required status checks (alongside the \`Backend Unit Tests\` addition from #6145). Without it, Rust breakage would no longer block merges — the checks used to ride inside the already-required \`Platform Lint and Unit Tests\`. Same ordering rule as before: add it only after this lands on main.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>