### PR TITLE
ci: cache-optimize platform image build

### DIFF
--- a/.github/actions/blacksmith-build-push/action.yml
+++ b/.github/actions/blacksmith-build-push/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Optional Dockerfile target stage.
     required: false
     default: ""
+  provenance:
+    description: SLSA provenance attestation. Empty preserves buildx defaults; set 'false' to skip.
+    required: false
+    default: ""
   network:
     description: Network mode for the build.
     required: false
@@ -69,6 +73,7 @@ runs:
         tags: ${{ inputs.tags }}
         outputs: ${{ inputs.outputs }}
         target: ${{ inputs.target }}
+        provenance: ${{ inputs.provenance }}
         network: ${{ inputs.network }}
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.secrets }}

--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "Optional Dockerfile target stage"
     required: false
     default: ""
+  provenance:
+    description: "SLSA provenance attestation. Empty preserves buildx defaults (on for pushes); set 'false' to skip for images that are not published."
+    required: false
+    default: ""
   version:
     description: "Version to pass as VERSION build arg"
     required: false
@@ -139,6 +143,7 @@ runs:
         tags: ${{ inputs.tags }}
         outputs: ${{ inputs.outputs }}
         target: ${{ inputs.target }}
+        provenance: ${{ inputs.provenance }}
         network: host
         build-args: ${{ inputs.version != '' && format('VERSION={0}', inputs.version) || '' }}
         secrets: ${{ steps.prepare-secrets.outputs.value }}

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -85,11 +85,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup environment
-        if: ${{ matrix.use-build-action }}
-        uses: ./.github/actions/setup-env
-        with:
-          working-directory: ./platform
+      # NOTE: the Platform image build is fully self-contained inside Docker, so it does
+      # not need a host-side `pnpm install` / node toolchain. (The MCP Server Base leg
+      # sets use-build-action: false and never ran this step.)
 
       - name: Build Platform image
         if: ${{ matrix.use-build-action && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) }}
@@ -98,6 +96,10 @@ jobs:
           context: ${{ matrix.context }}
           load: "true"
           tags: ${{ matrix.local-tag-prefix }}:${{ github.sha }}
+          # E2E image consumed only by CI shards — skip SLSA provenance attestation to
+          # trim export time and keep a plain single-manifest image. (Published release
+          # images keep provenance via build-native-multi-arch-image.yml's default.)
+          provenance: "false"
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
 
@@ -115,6 +117,10 @@ jobs:
           context: ${{ matrix.context }}
           push: "true"
           tags: ${{ env.PLATFORM_IMAGE_REGISTRY }}/${{ env.PLATFORM_IMAGE_NAME }}:${{ github.sha }}
+          # E2E image consumed only by CI shards — skip SLSA provenance attestation to
+          # trim export time and keep a plain single-manifest image. (Published release
+          # images keep provenance via build-native-multi-arch-image.yml's default.)
+          provenance: "false"
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
 

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -177,6 +177,13 @@ RUN set -eux; \
 FROM base AS builder-base
 WORKDIR /app
 
+# Install the Rust toolchain used to compile the N-API addons during `pnpm build`.
+# Kept ABOVE the node_modules/source COPYs so this layer depends only on `base` and
+# stays cache-stable across ordinary source changes. When it lived below the COPYs
+# the ~12s apk install re-ran on every source-changing build because the preceding
+# COPY layers were invalidated.
+RUN apk add --no-cache build-base cargo rust
+
 # Version arg for Sentry release tracking
 ARG VERSION=dev
 
@@ -202,9 +209,6 @@ COPY archestra-rs/app-runtime-core ./archestra-rs/app-runtime-core
 COPY archestra-rs/app-runtime-rs ./archestra-rs/app-runtime-rs
 COPY archestra-rs/image-core ./archestra-rs/image-core
 COPY archestra-rs/image-rs ./archestra-rs/image-rs
-
-# Build the Rust N-API skill sandbox addon during the JS workspace build.
-RUN apk add --no-cache build-base cargo rust
 
 # Build all workspace
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Summary

Speeds up the **Build Platform Image** job in `platform-e2e-tests.yml` (runs on merge queue / `run-e2e` / schedule) with three low-risk changes. No changes to what the image contains.

## Measured phase breakdown

The specified example job log had expired, so I profiled the most recent equivalent warm merge-queue build (`Build Platform Image`, job `84643488518`, ~306s job / **237s** in the build+push step). On a warm build the expensive from-source Go compiles (`go-builder`: kind, docker-cli, dagger, kubectl) are **fully layer-cached (0s)** — the Dockerfile is already well cached (pnpm store, cargo registry/git/target, turbo remote cache + secrets, and `.next/cache` are all `--mount=type=cache`). What actually ran:

| Phase | Time | Notes |
|---|---|---|
| export + push to Artifact Registry | ~72s | inherent to `push: true`; includes provenance/attestation manifest |
| `pnpm install` (deps) / prod install | ~38s / ~32s | parallel; only re-runs when the lockfile changes |
| inter-stage `COPY node_modules` | ~18s+ | only when deps change |
| `pnpm build` | ~39s | turbo remote-cache hit |
| **`apk add build-base cargo rust`** | **~12s** | re-ran on **every** source-changing build (see below) |
| host-side `Setup environment` (pnpm install) | ~15s | separate job step, before Docker |

## Changes

1. **Dockerfile — reorder the Rust toolchain install.** `apk add build-base cargo rust` sat *below* the `COPY backend/frontend/archestra-rs` source steps in `builder-base`, so every PR that touches source invalidated the preceding COPY layers and re-ran the ~12s install. Moved it *above* the COPYs so it depends only on the `base` image and stays cache-stable. Saves ~12s on the common source-only build.

2. **Workflow — drop the dead `Setup environment` step.** The Platform image build is fully self-contained inside Docker (`build-docker-image` only shells out to `docker`; nothing consumes host `node_modules` or the `.env` copy). Removing it saves ~15-18s (step + its post-step) every run. The MCP Server Base leg already skipped it (`use-build-action: false`).

3. **Skip SLSA provenance for the E2E image.** The push build currently emits a provenance attestation manifest (visible as `exporting attestation manifest` / `exporting manifest list` in the log), turning the image into an attested manifest list. This image is consumed only by CI E2E shards, so I disable provenance to trim export time and keep a plain single-manifest image. Wired via a new **pass-through `provenance` input** on the `build-docker-image` and `blacksmith-build-push` composite actions, defaulting to empty (= buildx default). Only `platform-e2e-tests.yml`'s two Platform build calls set `provenance: "false"`; **published release images via `build-native-multi-arch-image.yml` keep provenance unchanged.**

**Expected effect:** ~30s+ off the common warm build (12s apk + ~15-18s setup-env + a few seconds of provenance export), i.e. roughly 10-14% faster, with larger relative savings on source-only PRs where deps are cached.

## Trade-offs / considered-but-skipped

- **One-time cache miss:** reordering the `apk` layer invalidates `builder-base` once; the next build re-runs from that layer down, then re-stabilizes.
- **Go module/build cache mounts on `go-builder`:** deliberately **not** added. In steady state those stages are already 0s layer-cache hits, so mounts give no benefit there; they'd only help the infrequent CVE-pin-bump builds while forcing an immediate full cold recompile of all four Go tools (several minutes) on merge. Net-negative for the steady-state goal.
- `docker-image-scanning.yml` has a similar dead `Setup environment` step; left out to keep this PR scoped to the E2E build path.

## Validation

- `docker build --check` on the Dockerfile: clean, no warnings.
- YAML loads for all three changed files.
- `python3 .github/scripts/check-supply-chain-policy.py`: passed.
- `zizmor .github/workflows/platform-e2e-tests.yml`: no findings.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>