### PR TITLE
fix(docker): install workspace deps' runtime deps in the production image

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -370,7 +370,12 @@ COPY docker/supervisord/supervisord.conf /etc/supervisord.conf
 COPY docker/supervisord/postgres.conf /etc/supervisord.postgres.conf
 
 # Install production dependencies for both workspaces
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod --filter=@backend --filter=@frontend
+# The "..." suffix includes each package's workspace dependencies in the
+# install. Without it pnpm only creates node_modules for @backend/@frontend
+# themselves, and workspace deps' own runtime deps are never linked — the
+# three NAPI crates' index.cjs require @archestra/napi-loader and crash the
+# image with MODULE_NOT_FOUND (first surfaced as 500s on POST /api/apps).
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod --filter=@backend... --filter=@frontend...
 
 # CVE-2026-33671: replace Next's bundled picomatch 4.0.3 with 4.0.4 (same as deps stage).
 # Production install refetches next so the patched copy from the builder is not inherited.


### PR DESCRIPTION
**Urgent: every platform image built since #6138-era merges today has apps, skill-sandbox, and image tooling broken** (500 `Cannot find module '@archestra/napi-loader'`).

## Root cause

\`0d2884644\` extracted the NAPI crates' shared loader into a new workspace package \`@archestra/napi-loader\`. The Dockerfile/lockfile/deps were all updated correctly — but the runner stage installs with:

```
pnpm install --frozen-lockfile --prod --filter=@backend --filter=@frontend
```

Without the \`...\` suffix, pnpm installs only those two packages' **own** node_modules; workspace dependencies' runtime deps are never linked. \`archestra-rs/app-runtime-rs/node_modules\` is never created, so \`index.cjs\`'s \`require("@archestra/napi-loader")\` crashes. Before the refactor the NAPI crates had **zero runtime dependencies**, so the missing \`...\` was latent.

Reproduced in a scratch pnpm workspace: without \`...\` → dependency package's node_modules missing; with \`...\` → linked. Fix is the two \`...\` suffixes.

## Why CI didn't stop it

The merge-queue e2e gate (**Merge E2E Test Reports**) merges Playwright blob reports but never inspects shard results — a failing shard doesn't fail the gate. \`apps.spec.ts › create an app from a template\` has failed all retries in **every** merge-queue run since ~20:51 today (checked pr-6125, pr-6135, pr-6145 queue runs) while everything merged normally. A separate PR will make the gate honest; this fix must land first so the gate fix doesn't freeze the queue.

## Verification

- Scratch-workspace reproduction of both filter behaviors (see commit message).
- \`docker build --check\` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>