### PR TITLE
ci(e2e): make the merge-queue gate fail when e2e jobs fail

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -803,3 +803,30 @@ jobs:
         with:
           report-file: platform/e2e-tests/results.json
           job-summary: true
+
+      # This job is the merge queue's only e2e gate ("Merge E2E Test Reports"
+      # is the required check; the per-shard jobs are not). Without this step
+      # the job succeeds whenever report-merging succeeds, so red shards ride
+      # through the queue unnoticed — which is exactly how a broken production
+      # image (MODULE_NOT_FOUND on @archestra/napi-loader) shipped while
+      # apps.spec.ts failed every queue run.
+      - name: Fail if any e2e job failed
+        env:
+          SHARDS_RESULT: ${{ needs.platform-e2e-tests-shards.result }}
+          VAULT_RESULT: ${{ needs.platform-readonly-vault-e2e-tests.result }}
+          QUICKSTART_RESULT: ${{ needs.platform-quickstart-e2e-tests.result }}
+        run: |
+          failed=0
+          for pair in "shards:$SHARDS_RESULT" "readonly-vault:$VAULT_RESULT" "quickstart:$QUICKSTART_RESULT"; do
+            name="${pair%%:*}"; result="${pair##*:}"
+            echo "$name: $result"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              failed=1
+            fi
+          done
+          if [ "$failed" = "1" ]; then
+            echo "::error::One or more e2e jobs failed - failing the merge-queue gate."
+            exit 1
+          fi
+          echo "All e2e jobs green."
+


### PR DESCRIPTION
**Merge AFTER #6152** — with the gate honest, the queue will (correctly) reject entries while e2e is red, and e2e is red on main until the image fix lands.

## What

\`Merge E2E Test Reports\` is the merge queue's required e2e check, but the job only merged Playwright blob reports — it never looked at \`needs.*.result\`. A failing shard produced a red job in the run *and a green required check*, so the queue merged anyway. Verified on the queue runs for pr-6125, pr-6135, and pr-6145: \`Platform E2E Tests Shard (1/2)\` failed in each, every entry merged. This is how the napi-loader image breakage (#6152) shipped silently.

The job now ends with a step that fails unless every needed e2e job concluded \`success\` (or \`skipped\`, for event-gated jobs).

## Required-checks review (from the ruleset screenshot)

- **\`Merge E2E Test Reports\`** — correct required check; this PR is what makes it meaningful.
- **\`Platform E2E Tests (Quickstart)\` / \`(Readonly Vault)\`** — correct; their jobs report honestly.
- **\`Platform E2E Tests\`** — vacuous: that name is only the ordinary-PR placeholder job (real coverage runs as shards + this gate on \`merge_group\`). Harmless, but removable to avoid confusion.
- Everything else in the list is fine.

## Sequencing

1. Merge #6152 (image fix) and let a queue run confirm \`apps.spec.ts\` is green again.
2. Then merge this. If \`mcp-catalog-promote-to-team.spec.ts\` (the other repeat offender) still fails after #6152, quarantine or fix it before merging this, or the queue will hard-block.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>