### PR TITLE
refactor(frontend): dedupe test mocks into Jest-style __mocks__ canonical mocks

### DIFF
--- a/.claude/skills/archestra-dev-frontend/SKILL.md
+++ b/.claude/skills/archestra-dev-frontend/SKILL.md
@@ -67,3 +67,9 @@ pnpm knip   # flags unused exports; part of frontend check:ci
 - Use `const appName = useAppName();` and interpolate the app name so white-labeled deployments render correctly.
 - Always use `getDocsUrl(DocsPage.PageName, "optional-anchor")` from `@archestra/shared` for documentation links.
 - Never hardcode documentation URLs.
+
+## Test mocking
+
+- Frequently-mocked modules have Jest-style `__mocks__` canonical mocks — activate with a bare `vi.mock("<specifier>");` and configure per test via `vi.mocked(...)`. Covered: `@/lib/auth/auth.query`, `@/lib/organization.query`, `@/lib/config/config.query`, `@/lib/teams/team.query`, `@/lib/hooks/use-app-name`, `@/lib/clients/auth/auth-client` (a memoized proxy — every path like `authClient.signIn.email` is a stable `vi.fn()`), plus root-level `__mocks__/` for `next/navigation` and `sonner`.
+- Do not write a bespoke partial factory for those specifiers. Exception: a file that partially mocks `@/lib/config/config` may keep factories for the query mocks — the canonical mocks' `importActual` chain eagerly loads `auth-client` → `config/config` and breaks under a partial config mock.
+- The `@` alias must stay declared in `vitest.config.ts` `resolve.alias` with an absolute path — tsconfig-paths-only aliasing silently breaks `__mocks__` resolution (vitest-dev/vitest#8343).

--- a/platform/frontend/__mocks__/next/navigation.ts
+++ b/platform/frontend/__mocks__/next/navigation.ts
@@ -1,0 +1,17 @@
+/**
+ * Jest-style mock for `next/navigation` (root-level `__mocks__` — the
+ * node_modules convention), activated per test file by a bare
+ * `vi.mock("next/navigation");`. All hooks are bare `vi.fn()`s — configure
+ * via `vi.mocked(useRouter).mockReturnValue(...)`.
+ */
+import { vi } from "vitest";
+
+export const useRouter = vi.fn();
+export const usePathname = vi.fn();
+export const useSearchParams = vi.fn();
+export const useParams = vi.fn();
+export const useSelectedLayoutSegment = vi.fn();
+export const useSelectedLayoutSegments = vi.fn();
+export const redirect = vi.fn();
+export const permanentRedirect = vi.fn();
+export const notFound = vi.fn();

--- a/platform/frontend/__mocks__/sonner.ts
+++ b/platform/frontend/__mocks__/sonner.ts
@@ -1,0 +1,20 @@
+/**
+ * Jest-style mock for `sonner` (root-level `__mocks__`), activated per test
+ * file by a bare `vi.mock("sonner");`. Assert via
+ * `vi.mocked(toast.success)` etc.; `Toaster` renders nothing.
+ */
+import { vi } from "vitest";
+
+const toastFn = vi.fn() as ReturnType<typeof vi.fn> & Record<string, unknown>;
+toastFn.success = vi.fn();
+toastFn.error = vi.fn();
+toastFn.info = vi.fn();
+toastFn.warning = vi.fn();
+toastFn.message = vi.fn();
+toastFn.loading = vi.fn();
+toastFn.promise = vi.fn();
+toastFn.dismiss = vi.fn();
+toastFn.custom = vi.fn();
+
+export const toast = toastFn;
+export const Toaster = vi.fn(() => null);

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
@@ -25,21 +25,13 @@ const mockChatState: {
   sessionStatusById: {},
 };
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockRouterPush }),
-  usePathname: () => mockChatState.pathname,
-  useSearchParams: () => ({
-    get: () => null,
-  }),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/auth/auth.hook", () => ({
   useIsAuthenticated: () => true,
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: true }),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/chat/chat-utils", () => ({
   getConversationDisplayTitle: (title: string | null) =>
@@ -95,9 +87,7 @@ vi.mock("@/lib/chat/chat.query", () => ({
   usePinConversation: () => ({ mutate: vi.fn() }),
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => true,
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@/lib/projects/projects.query", () => ({
   useProjects: () => ({ data: mockProjects }),
@@ -230,8 +220,25 @@ vi.mock("lucide-react", async (importOriginal) => {
   };
 });
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 // Import after mocks
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
 import { ChatSidebarSection } from "./chat-sidebar-section";
+
+beforeEach(() => {
+  vi.mocked(useRouter).mockReturnValue({
+    push: mockRouterPush,
+  } as unknown as ReturnType<typeof useRouter>);
+  vi.mocked(usePathname).mockImplementation(() => mockChatState.pathname);
+  vi.mocked(useSearchParams).mockReturnValue({
+    get: () => null,
+  } as unknown as ReturnType<typeof useSearchParams>);
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: true,
+  } as ReturnType<typeof useHasPermissions>);
+  vi.mocked(useFeature).mockReturnValue(true);
+});
 
 function makeConv(
   id: string,

--- a/platform/frontend/src/app/_parts/posthog-provider.test.tsx
+++ b/platform/frontend/src/app/_parts/posthog-provider.test.tsx
@@ -34,13 +34,9 @@ vi.mock("posthog-js/react", () => ({
   }) => <>{children}</>,
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/config/config.query", () => ({
-  usePublicConfig: vi.fn(),
-}));
+vi.mock("@/lib/config/config.query");
 
 describe("PostHogProviderWrapper", () => {
   beforeEach(() => {

--- a/platform/frontend/src/app/_parts/sidebar-user-menu.test.tsx
+++ b/platform/frontend/src/app/_parts/sidebar-user-menu.test.tsx
@@ -5,11 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    getSession: vi.fn(),
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 function renderMenu() {
   const queryClient = new QueryClient({

--- a/platform/frontend/src/app/_parts/with-auth-check.test.tsx
+++ b/platform/frontend/src/app/_parts/with-auth-check.test.tsx
@@ -11,16 +11,10 @@ vi.mock("@sentry/nextjs", () => ({
 }));
 
 // Mock Next.js router and navigation
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-  usePathname: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 // Mock auth query
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: vi.fn(),
-  useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 // Mock shared module
 vi.mock("@archestra/shared", () => ({

--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -1,7 +1,9 @@
 import type { archestraApiTypes } from "@archestra/shared";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { AppCard } from "./app-card";
 
 type AppListItem = archestraApiTypes.GetAppsResponses["200"]["data"][number];
@@ -17,18 +19,14 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: pushMock }),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/app.query", () => ({
   useOpenAppInChat: () => ({ mutateAsync: vi.fn() }),
   useOpenExternalAppInChat: () => ({ mutateAsync: openExternalMutate }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: true }),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 // Stub the delete dialog so the card test asserts it opens, not its internals.
 vi.mock("./app-delete-dialog", () => ({
@@ -72,6 +70,15 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     </div>
   ),
 }));
+
+beforeEach(() => {
+  vi.mocked(useRouter).mockReturnValue({
+    push: pushMock,
+  } as unknown as ReturnType<typeof useRouter>);
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: true,
+  } as ReturnType<typeof useHasPermissions>);
+});
 
 const ownedApp: Extract<AppListItem, { source: "owned" }> = {
   source: "owned",

--- a/platform/frontend/src/app/apps/_parts/app-create-dialog.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-create-dialog.test.tsx
@@ -8,19 +8,21 @@ const { pushMock, createMutateMock, useCreateAppMock } = vi.hoisted(() => ({
   useCreateAppMock: vi.fn(),
 }));
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: pushMock }),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/app.query", () => ({
   useCreateApp: useCreateAppMock,
 }));
 
+import { useRouter } from "next/navigation";
 import { AppCreateDialog } from "./app-create-dialog";
 
 describe("AppCreateDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({
+      push: pushMock,
+    } as unknown as ReturnType<typeof useRouter>);
     createMutateMock.mockResolvedValue({
       id: "app-123",
       conversationId: "conv-456",

--- a/platform/frontend/src/app/apps/_parts/app-tools-editor.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-editor.test.tsx
@@ -20,7 +20,6 @@ const {
   unassignMutate,
   useAppMock,
   useAppToolsMock,
-  useHasPermissionsMock,
   useInternalMcpCatalogMock,
   fetchCatalogToolsMock,
 } = vi.hoisted(() => ({
@@ -28,7 +27,6 @@ const {
   unassignMutate: vi.fn(),
   useAppMock: vi.fn(),
   useAppToolsMock: vi.fn(),
-  useHasPermissionsMock: vi.fn(),
   useInternalMcpCatalogMock: vi.fn(),
   fetchCatalogToolsMock: vi.fn(),
 }));
@@ -40,9 +38,7 @@ vi.mock("@/lib/app.query", () => ({
   useUnassignToolFromApp: () => ({ mutate: unassignMutate }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: useHasPermissionsMock,
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
   useInternalMcpCatalog: useInternalMcpCatalogMock,
@@ -54,6 +50,7 @@ vi.mock("@/components/mcp-catalog-icon", () => ({
   McpCatalogIcon: () => null,
 }));
 
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { AppToolsEditor } from "./app-tools-editor";
 
 const APP_ID = "app-1";
@@ -91,7 +88,9 @@ describe("AppToolsEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useAppMock.mockReturnValue({ data: { environmentId: null } });
-    useHasPermissionsMock.mockReturnValue({ data: true });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
     useInternalMcpCatalogMock.mockReturnValue({ data: [makeCatalog()] });
     // create_issue is already assigned; delete_issue is available but not.
     useAppToolsMock.mockReturnValue({
@@ -165,7 +164,9 @@ describe("AppToolsEditor", () => {
   });
 
   it("shows a read-only assigned list without edit affordances for viewers", async () => {
-    useHasPermissionsMock.mockReturnValue({ data: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
     renderTab();
 
     // Assigned tool is listed, but no checkbox (no editing) is rendered.

--- a/platform/frontend/src/app/apps/catalog/[catalogId]/run/page.client.test.tsx
+++ b/platform/frontend/src/app/apps/catalog/[catalogId]/run/page.client.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import { useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CatalogAppRunPage from "./page.client";
 
 const resolution = {
@@ -34,10 +35,7 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(searchString),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/app.query", () => ({
   useExternalApp: () => ({ data: resolution, isPending: false }),
@@ -48,6 +46,19 @@ vi.mock("@/components/mcp-app/app-frame", () => ({
     <div data-testid="app-frame" data-resource={resourceUri} />
   ),
 }));
+
+beforeEach(() => {
+  vi.mocked(useRouter).mockReturnValue({
+    replace: vi.fn(),
+    push: vi.fn(),
+  } as unknown as ReturnType<typeof useRouter>);
+  vi.mocked(useSearchParams).mockImplementation(
+    () =>
+      new URLSearchParams(searchString) as unknown as ReturnType<
+        typeof useSearchParams
+      >,
+  );
+});
 
 afterEach(() => {
   searchString = "";

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.test.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.test.tsx
@@ -26,11 +26,7 @@ Element.prototype.releasePointerCapture = vi.fn();
 const mockUseAuditLogs = vi.fn();
 const mockUseMembersPaginated = vi.fn();
 
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-  usePathname: vi.fn(),
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/audit-log/audit-log.query", async () => {
   const actual = await vi.importActual<

--- a/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
+++ b/platform/frontend/src/app/auth/[path]/auth-page-with-invitation-check.test.tsx
@@ -4,13 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInvitationCheck } from "@/lib/auth/invitation.query";
 import { useBackendConnectivity } from "@/lib/config/backend-connectivity";
 import { usePublicConfig } from "@/lib/config/config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { AuthPageWithInvitationCheck } from "./auth-page-with-invitation-check";
 
 // Mock Next.js navigation
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 // Mock invitation query
 vi.mock("@/lib/auth/invitation.query", () => ({
@@ -22,13 +20,9 @@ vi.mock("@/lib/config/backend-connectivity", () => ({
   useBackendConnectivity: vi.fn(),
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  usePublicConfig: vi.fn(),
-}));
+vi.mock("@/lib/config/config.query");
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Sparky",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 // Mock AuthViewWithErrorHandling
 vi.mock("@/app/auth/_components/auth-view-with-error-handling", () => ({
@@ -70,6 +64,7 @@ const mockRetry = vi.fn();
 describe("AuthPageWithInvitationCheck", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useAppName).mockReturnValue("Sparky");
     vi.mocked(useRouter).mockReturnValue({
       push: mockRouterPush,
       replace: mockRouterReplace,

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.test.tsx
@@ -7,7 +7,11 @@ import {
   hasSsoSignInAttempt,
   recordSsoSignInAttempt,
 } from "@/lib/auth/sso-sign-in-attempt";
-import { usePublicConfig } from "@/lib/config/config.query";
+import {
+  usePublicConfig,
+  usePublicEnterpriseCoreActive,
+} from "@/lib/config/config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { AuthViewWithErrorHandling } from "./auth-view-with-error-handling";
 
 vi.mock("./two-factor-view", () => ({
@@ -27,9 +31,7 @@ vi.mock("@/lib/auth/account.query", () => ({
   }),
 }));
 
-vi.mock("next/navigation", () => ({
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/config/config", () => ({
   default: {
@@ -37,18 +39,13 @@ vi.mock("@/lib/config/config", () => ({
   },
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  usePublicConfig: vi.fn(),
-  usePublicEnterpriseCoreActive: () => false,
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@/lib/auth/identity-provider-read.query", () => ({
   usePublicIdentityProviders: () => ({ data: [] }),
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Test App",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("./sign-out-with-idp-logout", () => ({
   SignOutWithIdpLogout: () => <div data-testid="sign-out" />,
@@ -61,6 +58,8 @@ describe("AuthViewWithErrorHandling", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useAppName).mockReturnValue("Test App");
+    vi.mocked(usePublicEnterpriseCoreActive).mockReturnValue(false);
     mockSignInMutateAsync.mockResolvedValue({
       redirectUrl: "/",
     });

--- a/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
+++ b/platform/frontend/src/app/auth/_components/backend-connectivity-status.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BackendConnectivityStatus } from "./backend-connectivity-status";
 
 // Mock the hooks
@@ -7,19 +7,23 @@ vi.mock("@/lib/config/backend-connectivity", () => ({
   useBackendConnectivity: vi.fn(),
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Sparky",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
-vi.mock("next/navigation", () => ({
-  useSearchParams: vi.fn(() => new URLSearchParams()),
-}));
+vi.mock("next/navigation");
 
 import { useSearchParams } from "next/navigation";
 import { useBackendConnectivity } from "@/lib/config/backend-connectivity";
+import { useAppName } from "@/lib/hooks/use-app-name";
 
 describe("BackendConnectivityStatus", () => {
   const mockRetry = vi.fn();
+
+  beforeEach(() => {
+    vi.mocked(useAppName).mockReturnValue("Sparky");
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+    );
+  });
 
   it("should render nothing when status is initializing", () => {
     vi.mocked(useBackendConnectivity).mockReturnValue({

--- a/platform/frontend/src/app/auth/_components/two-factor-view.test.tsx
+++ b/platform/frontend/src/app/auth/_components/two-factor-view.test.tsx
@@ -13,17 +13,9 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
-vi.mock("next/navigation", () => ({
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    twoFactor: {
-      verifyTotp: vi.fn(),
-    },
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 function renderView() {
   const queryClient = new QueryClient({

--- a/platform/frontend/src/app/auth/sign-up-with-invitation/page.test.tsx
+++ b/platform/frontend/src/app/auth/sign-up-with-invitation/page.test.tsx
@@ -4,20 +4,12 @@ import userEvent from "@testing-library/user-event";
 import { useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authClient } from "@/lib/clients/auth/auth-client";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import SignUpWithInvitationPage from "./page";
 
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    signUp: {
-      email: vi.fn(),
-    },
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 vi.mock("@/lib/auth/invitation.query", () => ({
   useInvitationCheck: vi.fn(() => ({
@@ -31,9 +23,7 @@ vi.mock("@/lib/auth/invitation.query", () => ({
   })),
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Archestra",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("@/components/app-logo", () => ({
   AppLogo: () => <div data-testid="app-logo">App Logo</div>,
@@ -73,6 +63,7 @@ function renderPage() {
 describe("SignUpWithInvitationPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useAppName).mockReturnValue("Archestra");
     vi.mocked(useRouter).mockReturnValue({
       push: vi.fn(),
       replace: routerReplace,

--- a/platform/frontend/src/app/auth/sso/[providerId]/page.test.tsx
+++ b/platform/frontend/src/app/auth/sso/[providerId]/page.test.tsx
@@ -11,22 +11,13 @@ import {
 import { authClient } from "@/lib/clients/auth/auth-client";
 import IdpInitiatedSsoPage from "./page";
 
-vi.mock("next/navigation", () => ({
-  useParams: vi.fn(),
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/components/app-logo", () => ({
   AppLogo: () => <div data-testid="app-logo" />,
 }));
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    signIn: {
-      sso: vi.fn(),
-    },
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 vi.mock("@/lib/auth/linked-idp", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/auth/linked-idp")>();

--- a/platform/frontend/src/app/auth/sso/linked-callback/page.test.tsx
+++ b/platform/frontend/src/app/auth/sso/linked-callback/page.test.tsx
@@ -5,9 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { completeLinkedIdentityProviderIntent } from "@/lib/auth/linked-idp";
 import LinkedIdentityProviderCallbackPage from "./page";
 
-vi.mock("next/navigation", () => ({
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/components/app-logo", () => ({
   AppLogo: () => <div data-testid="app-logo" />,

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NEW_CHAT_DRAFT_STORAGE_KEY } from "@/lib/chat/chat-utils";
 
 const {
-  mockUseOrganization,
   mockUseChatPlaceholder,
   mockUseSkillsPaginated,
   mockTextInputSetInput,
@@ -12,7 +11,6 @@ const {
   mockControllerState,
   mockFeatureState,
 } = vi.hoisted(() => ({
-  mockUseOrganization: vi.fn(),
   mockUseChatPlaceholder: vi.fn(),
   mockUseSkillsPaginated: vi.fn(),
   mockTextInputSetInput: vi.fn(),
@@ -243,9 +241,7 @@ vi.mock("@/lib/chat/chat.query", () => ({
   useToggleHooksDebug: () => ({ mutate: vi.fn() }),
 }));
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => mockUseOrganization(),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/lib/chat/chat-placeholder.hook", () => ({
   useChatPlaceholder: (...args: unknown[]) => mockUseChatPlaceholder(...args),
@@ -255,25 +251,14 @@ vi.mock("@/lib/skills/skill.query", () => ({
   useSkillsPaginated: () => mockUseSkillsPaginated(),
 }));
 
-// Mock for useHasPermissions - default to non-admin
-const mockUseHasPermissions = vi.fn().mockReturnValue({
-  data: false,
-  isPending: false,
-  isLoading: false,
-});
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => mockUseHasPermissions(),
-}));
-
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: (flag: string) =>
-    flag === "chatSecretScanEnabled"
-      ? mockFeatureState.chatSecretScanEnabled
-      : undefined,
-}));
+vi.mock("@/lib/config/config.query");
 
 // Import the component after mocks are set up
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
+import { useOrganization } from "@/lib/organization.query";
 import ArchestraPromptInput from "./prompt-input";
 
 describe("ArchestraPromptInput", () => {
@@ -288,10 +273,20 @@ describe("ArchestraPromptInput", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseOrganization.mockReturnValue({
+    vi.mocked(useOrganization).mockReturnValue({
       data: null,
       isLoading: false,
-    });
+    } as unknown as ReturnType<typeof useOrganization>);
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+      isPending: false,
+      isLoading: false,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useFeature).mockImplementation((flag) =>
+      flag === "chatSecretScanEnabled"
+        ? mockFeatureState.chatSecretScanEnabled
+        : undefined,
+    );
     mockUseChatPlaceholder.mockReturnValue({
       placeholder: "Animated placeholder",
       isAnimating: true,
@@ -390,11 +385,11 @@ describe("ArchestraPromptInput", () => {
 
     it("should show settings link in tooltip for admins when file uploads disabled", () => {
       // Mock admin user with agentSettings update permission
-      mockUseHasPermissions.mockReturnValue({
+      vi.mocked(useHasPermissions).mockReturnValue({
         data: true,
         isPending: false,
         isLoading: false,
-      });
+      } as ReturnType<typeof useHasPermissions>);
 
       render(
         <ArchestraPromptInput
@@ -420,11 +415,11 @@ describe("ArchestraPromptInput", () => {
 
     it("should show admin message in tooltip for non-admins when file uploads disabled", () => {
       // Mock non-admin user without agentSettings update permission
-      mockUseHasPermissions.mockReturnValue({
+      vi.mocked(useHasPermissions).mockReturnValue({
         data: false,
         isPending: false,
         isLoading: false,
-      });
+      } as ReturnType<typeof useHasPermissions>);
 
       render(
         <ArchestraPromptInput
@@ -468,11 +463,11 @@ describe("ArchestraPromptInput", () => {
     });
 
     it("should render model selector when user has provider settings permission", () => {
-      mockUseHasPermissions.mockReturnValue({
+      vi.mocked(useHasPermissions).mockReturnValue({
         data: true,
         isPending: false,
         isLoading: false,
-      });
+      } as ReturnType<typeof useHasPermissions>);
 
       render(
         <ArchestraPromptInput {...defaultProps} allowFileUploads={true} />,
@@ -482,13 +477,13 @@ describe("ArchestraPromptInput", () => {
     });
 
     it("should keep a single organization placeholder static", () => {
-      mockUseOrganization.mockReturnValue({
+      vi.mocked(useOrganization).mockReturnValue({
         data: {
           chatPlaceholders: ["Ask the support agent"],
           animateChatPlaceholders: true,
         },
         isLoading: false,
-      });
+      } as unknown as ReturnType<typeof useOrganization>);
       mockUseChatPlaceholder.mockReturnValue({
         placeholder: "Ask the support agent",
         isAnimating: false,
@@ -511,13 +506,13 @@ describe("ArchestraPromptInput", () => {
     });
 
     it("should keep placeholders static when animation is disabled", () => {
-      mockUseOrganization.mockReturnValue({
+      vi.mocked(useOrganization).mockReturnValue({
         data: {
           chatPlaceholders: ["First placeholder", "Second placeholder"],
           animateChatPlaceholders: false,
         },
         isLoading: false,
-      });
+      } as unknown as ReturnType<typeof useOrganization>);
       mockUseChatPlaceholder.mockReturnValue({
         placeholder: "Second placeholder",
         isAnimating: false,
@@ -772,10 +767,10 @@ describe("ArchestraPromptInput", () => {
     };
 
     beforeEach(() => {
-      mockUseOrganization.mockReturnValue({
+      vi.mocked(useOrganization).mockReturnValue({
         data: { skillSlashCommandsEnabled: true },
         isLoading: false,
-      });
+      } as unknown as ReturnType<typeof useOrganization>);
       mockUseSkillsPaginated.mockReturnValue({
         data: { data: [skill] },
         isLoading: false,

--- a/platform/frontend/src/app/connection_beta/connect-command-panel.test.tsx
+++ b/platform/frontend/src/app/connection_beta/connect-command-panel.test.tsx
@@ -1,16 +1,15 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
 import { CONNECT_CLIENTS } from "./clients";
 import { ConnectCommandPanel } from "./connect-command-panel";
 
-const { createSetupMock, fetchSkillsMock, hasPermissionsMock } = vi.hoisted(
-  () => ({
-    createSetupMock: vi.fn(),
-    fetchSkillsMock: vi.fn(),
-    hasPermissionsMock: vi.fn(),
-  }),
-);
+const { createSetupMock, fetchSkillsMock } = vi.hoisted(() => ({
+  createSetupMock: vi.fn(),
+  fetchSkillsMock: vi.fn(),
+}));
 
 vi.mock("@/lib/connection-setup.query", () => ({
   useCreateConnectionSetup: () => ({
@@ -24,13 +23,9 @@ vi.mock("./skills-marketplace-step", () => ({
   useTotalSkillCount: () => ({ data: 2 }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => hasPermissionsMock(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => true,
-}));
+vi.mock("@/lib/config/config.query");
 
 const { availableKeysMock, createKeyMock } = vi.hoisted(() => ({
   availableKeysMock: vi.fn(),
@@ -94,7 +89,10 @@ function renderPanel(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  hasPermissionsMock.mockReturnValue({ data: true });
+  vi.mocked(useFeature).mockReturnValue(true);
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: true,
+  } as ReturnType<typeof useHasPermissions>);
   availableKeysMock.mockReturnValue({
     data: [{ provider: "anthropic" }, { provider: "bedrock" }],
   });
@@ -225,7 +223,9 @@ describe("ConnectCommandPanel", () => {
   });
 
   it("skips skills entirely for non-admin users", async () => {
-    hasPermissionsMock.mockReturnValue({ data: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
     renderPanel();
 
     await waitFor(() =>

--- a/platform/frontend/src/app/connection_beta/proxy-client-instructions.test.tsx
+++ b/platform/frontend/src/app/connection_beta/proxy-client-instructions.test.tsx
@@ -1,20 +1,17 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { CONNECT_CLIENTS } from "./clients";
 import { ProxyClientInstructions } from "./proxy-client-instructions";
 
-const {
-  provisionMock,
-  passthroughProvisionMock,
-  hasPermissionsMock,
-  availableKeysMock,
-} = vi.hoisted(() => ({
-  provisionMock: vi.fn(),
-  passthroughProvisionMock: vi.fn(),
-  hasPermissionsMock: vi.fn(),
-  availableKeysMock: vi.fn(),
-}));
+const { provisionMock, passthroughProvisionMock, availableKeysMock } =
+  vi.hoisted(() => ({
+    provisionMock: vi.fn(),
+    passthroughProvisionMock: vi.fn(),
+    availableKeysMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/connection-setup.query", () => ({
   useCreateConnectionVirtualKey: () => ({
@@ -27,9 +24,7 @@ vi.mock("@/lib/connection-setup.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => hasPermissionsMock(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/llm-provider-api-keys.query", () => ({
   useAvailableLlmProviderApiKeys: () => availableKeysMock(),
@@ -42,11 +37,19 @@ vi.mock("@/components/create-llm-provider-api-key-dialog", () => ({
 
 // The component reads the selected provider from the URL and writes selections
 // back; a static search param + no-op updater is enough for these assertions.
-vi.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams("providerId=anthropic"),
-  usePathname: () => "/connection_beta",
-  useRouter: () => ({ replace: vi.fn() }),
-}));
+vi.mock("next/navigation");
+
+beforeEach(() => {
+  vi.mocked(useSearchParams).mockReturnValue(
+    new URLSearchParams("providerId=anthropic") as unknown as ReturnType<
+      typeof useSearchParams
+    >,
+  );
+  vi.mocked(usePathname).mockReturnValue("/connection_beta");
+  vi.mocked(useRouter).mockReturnValue({
+    replace: vi.fn(),
+  } as unknown as ReturnType<typeof useRouter>);
+});
 
 function genericClient() {
   const client = CONNECT_CLIENTS.find((c) => c.id === "generic");
@@ -68,8 +71,10 @@ function renderInstructions() {
 describe("ProxyClientInstructions — Any Client step 4", () => {
   beforeEach(() => {
     provisionMock.mockReset();
-    hasPermissionsMock.mockReset();
-    hasPermissionsMock.mockReturnValue({ data: true });
+    vi.mocked(useHasPermissions).mockReset();
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
     availableKeysMock.mockReset();
     // the user has an anthropic provider key by default
     availableKeysMock.mockReturnValue({ data: [{ provider: "anthropic" }] });
@@ -114,7 +119,9 @@ describe("ProxyClientInstructions — Any Client step 4", () => {
   });
 
   it("disables the virtual-key option without llmVirtualKey:create", () => {
-    hasPermissionsMock.mockReturnValue({ data: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
     renderInstructions();
 
     expect(screen.getByRole("tab", { name: "Virtual key" })).toBeDisabled();
@@ -161,8 +168,10 @@ describe("ProxyClientInstructions — Claude Desktop attribution header", () => 
 
   beforeEach(() => {
     passthroughProvisionMock.mockReset();
-    hasPermissionsMock.mockReset();
-    hasPermissionsMock.mockReturnValue({ data: true });
+    vi.mocked(useHasPermissions).mockReset();
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
     availableKeysMock.mockReset();
     availableKeysMock.mockReturnValue({ data: [] });
   });
@@ -195,7 +204,9 @@ describe("ProxyClientInstructions — Claude Desktop attribution header", () => 
   });
 
   it("points to the Virtual API Keys page when the user can't mint a key", () => {
-    hasPermissionsMock.mockReturnValue({ data: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
     renderClaudeDesktop();
 
     expect(passthroughProvisionMock).not.toHaveBeenCalled();

--- a/platform/frontend/src/app/connection_beta/skills-marketplace-step.test.tsx
+++ b/platform/frontend/src/app/connection_beta/skills-marketplace-step.test.tsx
@@ -3,6 +3,9 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { CONNECT_CLIENTS } from "./clients";
 import { SkillsMarketplaceStep } from "./skills-marketplace-step";
 
@@ -21,14 +24,12 @@ const {
   revokeLinkMock,
   rotateLinkMock,
   getSkillsMock,
-  hasPermissionsMock,
 } = vi.hoisted(() => ({
   listLinksMock: vi.fn(),
   createLinkMock: vi.fn(),
   revokeLinkMock: vi.fn(),
   rotateLinkMock: vi.fn(),
   getSkillsMock: vi.fn(),
-  hasPermissionsMock: vi.fn(),
 }));
 
 vi.mock("@archestra/shared", async () => {
@@ -58,17 +59,11 @@ vi.mock("@/lib/skills/skill-share.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => hasPermissionsMock(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => true,
-}));
+vi.mock("@/lib/config/config.query");
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Archestra",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 function findClient(id: string) {
   const client = CONNECT_CLIENTS.find((c) => c.id === id);
@@ -110,7 +105,11 @@ const CREATE_RESPONSE = {
 describe("SkillsMarketplaceStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    hasPermissionsMock.mockReturnValue({ data: true });
+    vi.mocked(useFeature).mockReturnValue(true);
+    vi.mocked(useAppName).mockReturnValue("Archestra");
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
     getSkillsMock.mockResolvedValue({
       data: {
         data: [{ id: "skill-1" }, { id: "skill-2" }],
@@ -121,7 +120,9 @@ describe("SkillsMarketplaceStep", () => {
   });
 
   it("returns null for non-admin users", () => {
-    hasPermissionsMock.mockReturnValue({ data: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
     listLinksMock.mockReturnValue({
       data: { links: [] },
       isPending: false,

--- a/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.test.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.test.tsx
@@ -10,19 +10,15 @@ vi.mock("@/lib/knowledge/knowledge-base.query", () => ({
   useKnowledgeBaseConfigStatus: () => mockConfigStatus,
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: true, isPending: false }),
-  useMissingPermissions: () => [],
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-  }),
-  usePathname: () => "/knowledge/knowledge-bases",
-  useSearchParams: () => new URLSearchParams(),
-}));
+vi.mock("next/navigation");
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  useHasPermissions,
+  useMissingPermissions,
+} from "@/lib/auth/auth.query";
 import { KnowledgePageLayout } from "./knowledge-page-layout";
 
 function renderLayout(isPending = false) {
@@ -45,6 +41,18 @@ function renderLayout(isPending = false) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: true,
+    isPending: false,
+  } as ReturnType<typeof useHasPermissions>);
+  vi.mocked(useMissingPermissions).mockReturnValue({});
+  vi.mocked(useRouter).mockReturnValue({
+    push: vi.fn(),
+  } as unknown as ReturnType<typeof useRouter>);
+  vi.mocked(usePathname).mockReturnValue("/knowledge/knowledge-bases");
+  vi.mocked(useSearchParams).mockReturnValue(
+    new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+  );
   mockIsKnowledgeBaseConfigured = false;
   mockConfigStatus = { embedding: false, reranker: false };
 });

--- a/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/_parts/connector-documents-table.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectorDocumentsTable } from "./connector-documents-table";
 
@@ -8,11 +9,7 @@ const mockUpdateQueryParams = vi.fn();
 const mockDeleteMutateAsync = vi.fn();
 const mockPush = vi.fn();
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => new URLSearchParams(""),
-  usePathname: () => "/knowledge/connectors/connector-1",
-}));
+vi.mock("next/navigation");
 
 const mockDocument = {
   id: "doc-1",
@@ -84,6 +81,13 @@ vi.mock("@/lib/knowledge/kb-document.query", () => ({
 describe("ConnectorDocumentsTable", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockPush,
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("") as unknown as ReturnType<typeof useSearchParams>,
+    );
+    vi.mocked(usePathname).mockReturnValue("/knowledge/connectors/connector-1");
     mockDeleteMutateAsync.mockResolvedValue({ success: true });
   });
 

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.test.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateConnectorDialog } from "./create-connector-dialog";
 
@@ -50,11 +51,7 @@ Element.prototype.releasePointerCapture = vi.fn();
 
 const mockMutateAsync = vi.fn();
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
-  usePathname: () => "/knowledge/knowledge-bases",
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/knowledge/connector.query", () => ({
   useCreateConnector: () => ({
@@ -106,6 +103,13 @@ async function renderGithubConfigureStep() {
 describe("CreateConnectorDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+    );
+    vi.mocked(usePathname).mockReturnValue("/knowledge/knowledge-bases");
   });
 
   describe("rendering", () => {

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.test.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.test.tsx
@@ -54,9 +54,9 @@ vi.mock("@/lib/knowledge/connector.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/teams/team.query", () => ({
-  useTeams: () => ({ data: [] }),
-}));
+vi.mock("@/lib/teams/team.query");
+
+import { useTeams } from "@/lib/teams/team.query";
 
 type ConnectorFixture = Parameters<typeof EditConnectorDialog>[0]["connector"];
 
@@ -105,6 +105,9 @@ function renderDialog(connector: ConnectorFixture = makeAsanaConnector()) {
 describe("EditConnectorDialog - Asana", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeams>);
   });
 
   it("submits array fields as arrays when the user does not edit them", async () => {

--- a/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/costs/page.test.tsx
@@ -1,5 +1,6 @@
 import type { StatisticsTimeFrame } from "@archestra/shared";
 import { render, waitFor } from "@testing-library/react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import StatisticsPage from "./page";
 
@@ -12,10 +13,7 @@ const mockUseProfileStatistics = vi.fn();
 const mockUseModelStatistics = vi.fn();
 const mockUseCostSavingsStatistics = vi.fn();
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockRouterPush }),
-  useSearchParams: () => mockSearchParams,
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/app/llm/(costs)/layout", () => ({
   useSetCostsAction: () => mockSetCostsAction,
@@ -60,6 +58,12 @@ describe("StatisticsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockRouterPush,
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(useSearchParams).mockImplementation(
+      () => mockSearchParams as unknown as ReturnType<typeof useSearchParams>,
+    );
     mockSearchParams = new URLSearchParams();
     mockUseTeamStatistics.mockReturnValue({ data: [] });
     mockUseProfileStatistics.mockReturnValue({ data: [] });

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -5,7 +5,6 @@ import LimitsPage, { getLimitModels } from "./page";
 const mockSetCostsAction = vi.fn();
 const mockUseLimits = vi.fn();
 const mockUseAllVirtualApiKeys = vi.fn();
-const mockUseHasPermissions = vi.fn(() => ({ data: true, isPending: false }));
 
 vi.mock("next/link", () => ({
   default: ({
@@ -44,16 +43,9 @@ vi.mock("@/lib/environment.query", () => ({
   useEnvironments: () => ({ data: { environments: [] } }),
 }));
 
-vi.mock("@/lib/teams/team.query", () => ({
-  useTeams: () => ({ data: [] }),
-}));
+vi.mock("@/lib/teams/team.query");
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({
-    data: { id: "org-1", defaultUserLimitValue: 100 },
-  }),
-  useOrganizationMembers: () => ({ data: [] }),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/lib/virtual-api-keys.query", () => ({
   useAllVirtualApiKeys: (...args: unknown[]) =>
@@ -99,10 +91,17 @@ vi.mock("@/lib/hooks/use-data-table-query-params", () => ({
   }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => mockUseHasPermissions(),
-  useMissingPermissions: () => [],
-}));
+vi.mock("@/lib/auth/auth.query");
+
+import {
+  useHasPermissions,
+  useMissingPermissions,
+} from "@/lib/auth/auth.query";
+import {
+  useOrganization,
+  useOrganizationMembers,
+} from "@/lib/organization.query";
+import { useTeams } from "@/lib/teams/team.query";
 
 vi.mock("@/components/loading", () => ({
   LoadingSpinner: () => <div>Loading</div>,
@@ -320,7 +319,22 @@ vi.mock("@/components/searchable-multi-select", () => ({
 describe("LimitsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseHasPermissions.mockReturnValue({ data: true, isPending: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+      isPending: false,
+    } as unknown as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useMissingPermissions).mockReturnValue(
+      [] as unknown as ReturnType<typeof useMissingPermissions>,
+    );
+    vi.mocked(useTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeams>);
+    vi.mocked(useOrganization).mockReturnValue({
+      data: { id: "org-1", defaultUserLimitValue: 100 },
+    } as unknown as ReturnType<typeof useOrganization>);
+    vi.mocked(useOrganizationMembers).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useOrganizationMembers>);
     mockUseLimits.mockReturnValue({ data: [], isPending: false });
     mockUseAllVirtualApiKeys.mockReturnValue({
       data: { data: [], pagination: { total: 0 } },
@@ -348,7 +362,10 @@ describe("LimitsPage", () => {
   });
 
   it("hides the default user limit settings notice without settings permission", () => {
-    mockUseHasPermissions.mockReturnValue({ data: false, isPending: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+      isPending: false,
+    } as unknown as ReturnType<typeof useHasPermissions>);
 
     render(<LimitsPage />);
 

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/owner-select-field.test.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/owner-select-field.test.tsx
@@ -4,12 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const useMembersPaginated = vi.fn();
 
-vi.mock("@/lib/auth/auth.query", () => {
-  // Stable reference, like the real TanStack Query session, so the component's
-  // accumulator effect doesn't re-run every render.
-  const session = { data: { user: { id: "u-self" } } };
-  return { useSession: () => session };
-});
+// Stable reference, like the real TanStack Query session, so the component's
+// accumulator effect doesn't re-run every render.
+const mockSession = { data: { user: { id: "u-self" } } };
+
+vi.mock("@/lib/auth/auth.query");
+
+import { useSession } from "@/lib/auth/auth.query";
 
 vi.mock("@/lib/member.query", () => ({
   useMembersPaginated: (...args: unknown[]) => useMembersPaginated(...args),
@@ -38,6 +39,9 @@ describe("shouldShowOwnerField", () => {
 
 describe("OwnerSelectField", () => {
   beforeEach(() => {
+    vi.mocked(useSession).mockReturnValue(
+      mockSession as unknown as ReturnType<typeof useSession>,
+    );
     useMembersPaginated.mockReset();
     useMembersPaginated.mockReturnValue({
       data: { data: MEMBERS },

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.test.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.test.tsx
@@ -12,11 +12,7 @@ import {
 } from "@/lib/interactions/interaction.query";
 import SessionDetailPage from "./page.client";
 
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-  useSearchParams: vi.fn(),
-  usePathname: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/interactions/interaction.query", () => ({
   useInteractions: vi.fn(),

--- a/platform/frontend/src/app/llm/model-providers/page.test.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.test.tsx
@@ -3,7 +3,6 @@
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockUseHasPermissions = vi.fn();
 const mockUseLlmProviderApiKeys = vi.fn();
 
 vi.mock("next/image", () => ({
@@ -21,9 +20,7 @@ vi.mock("@/components/page-layout", () => ({
   ),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: (...args: unknown[]) => mockUseHasPermissions(...args),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/llm-provider-api-keys.query", () => ({
   useDeleteLlmProviderApiKey: () => ({
@@ -45,9 +42,7 @@ vi.mock("@/lib/llm-oauth-clients.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({ data: null }),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/lib/virtual-api-keys.query", () => ({
   useAllVirtualApiKeys: () => ({
@@ -59,9 +54,7 @@ vi.mock("@/lib/virtual-api-keys.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => false,
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@/lib/docs/docs", () => ({
   getFrontendDocsUrl: () => "https://example.com/docs",
@@ -164,11 +157,20 @@ vi.mock("@/components/ui/select", () => ({
   SelectValue: () => null,
 }));
 
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
+import { useOrganization } from "@/lib/organization.query";
 import ApiKeysPage from "./page";
 
 describe("ApiKeysPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useOrganization).mockReturnValue({
+      data: null,
+    } as unknown as ReturnType<typeof useOrganization>);
+    vi.mocked(useFeature).mockReturnValue(
+      false as unknown as ReturnType<typeof useFeature>,
+    );
     mockUseLlmProviderApiKeys.mockReturnValue({
       data: [],
       isPending: false,
@@ -176,10 +178,10 @@ describe("ApiKeysPage", () => {
   });
 
   it("does not query API keys while read permission is still loading", () => {
-    mockUseHasPermissions.mockReturnValue({
+    vi.mocked(useHasPermissions).mockReturnValue({
       data: false,
       isPending: true,
-    });
+    } as unknown as ReturnType<typeof useHasPermissions>);
 
     render(<ApiKeysPage />);
 
@@ -194,10 +196,10 @@ describe("ApiKeysPage", () => {
   });
 
   it("queries API keys after read permission resolves", () => {
-    mockUseHasPermissions.mockReturnValue({
+    vi.mocked(useHasPermissions).mockReturnValue({
       data: true,
       isPending: false,
-    });
+    } as unknown as ReturnType<typeof useHasPermissions>);
 
     render(<ApiKeysPage />);
 

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.enterprise.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.enterprise.test.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useEnterpriseFeature, useFeature } from "@/lib/config/config.query";
 import { useEnvironments } from "@/lib/environment.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
+import { useDefaultEnvironment } from "@/lib/organization.query";
+import {
+  useAssignableTeams,
+  useMyTeams,
+  useTeams,
+} from "@/lib/teams/team.query";
 import { McpCatalogForm } from "./mcp-catalog-form";
 
 const { useIdentityProvidersMock, useK8sImagePullSecretsMock } = vi.hoisted(
@@ -12,15 +20,7 @@ const { useIdentityProvidersMock, useK8sImagePullSecretsMock } = vi.hoisted(
   }),
 );
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: vi.fn((feature: string) => {
-    if (feature === "mcpServerBaseImage") return "";
-    if (feature === "orchestratorK8sRuntime") return true;
-    if (feature === "byosEnabled") return false;
-    return undefined;
-  }),
-  useEnterpriseFeature: vi.fn(() => false),
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@/lib/config/config", () => ({
   default: {
@@ -30,19 +30,9 @@ vi.mock("@/lib/config/config", () => ({
   },
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: vi.fn(() => ({ data: true })),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/organization.query", () => ({
-  useDefaultEnvironment: vi.fn(() => ({
-    name: "Default",
-    namespace: null,
-    description: null,
-    networkPolicy: null,
-    restricted: false,
-  })),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/lib/environment.query", () => ({
   useEnvironments: vi.fn(() => ({
@@ -54,11 +44,7 @@ vi.mock("@/lib/auth/identity-provider-read.query", () => ({
   useIdentityProviders: useIdentityProvidersMock,
 }));
 
-vi.mock("@/lib/teams/team.query", () => ({
-  useTeams: vi.fn(() => ({ data: [] })),
-  useMyTeams: vi.fn(() => ({ data: [] })),
-  useAssignableTeams: vi.fn(() => ({ data: [] })),
-}));
+vi.mock("@/lib/teams/team.query");
 
 vi.mock("@/lib/mcp/internal-mcp-catalog.query", () => ({
   useK8sImagePullSecrets: useK8sImagePullSecretsMock,
@@ -73,9 +59,7 @@ vi.mock("@/lib/docs/docs", () => ({
   getFrontendDocsUrl: vi.fn(() => "https://docs.example.com/mcp-auth"),
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: vi.fn(() => "Archestra"),
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("@/components/agent-icon-picker", () => ({
   AgentIconPicker: () => <div data-testid="agent-icon-picker" />,
@@ -104,6 +88,27 @@ describe("McpCatalogForm enterprise gating", () => {
       if (feature === "byosEnabled") return false;
       return undefined;
     });
+    vi.mocked(useEnterpriseFeature).mockReturnValue(false);
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useDefaultEnvironment).mockReturnValue({
+      name: "Default",
+      namespace: null,
+      description: null,
+      networkPolicy: null,
+      restricted: false,
+    } as ReturnType<typeof useDefaultEnvironment>);
+    vi.mocked(useTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeams>);
+    vi.mocked(useMyTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useMyTeams>);
+    vi.mocked(useAssignableTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useAssignableTeams>);
+    vi.mocked(useAppName).mockReturnValue("Archestra");
     useIdentityProvidersMock.mockReturnValue({ data: [] });
     useK8sImagePullSecretsMock.mockReturnValue({ data: [] });
     global.ResizeObserver = class ResizeObserver {

--- a/platform/frontend/src/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useAssignableTeams } from "@/lib/teams/team.query";
 import { SelectMcpServerCredentialTypeAndTeams } from "./select-mcp-server-credential-type-and-teams";
 
 const CATALOG_ID = "cat-1";
@@ -20,19 +22,24 @@ vi.mock("@/lib/mcp/mcp-server.query", () => ({
   useMcpServers: () => ({ data: installedServers }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useSession: () => ({ data: { user: { id: CURRENT_USER_ID } } }),
-  // Member role: no mcpServerInstallation:update and no :admin.
-  useHasPermissions: () => ({ data: false }),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/teams/team.query", () => ({
-  useAssignableTeams: () => ({ data: [], isLoading: false }),
-}));
+vi.mock("@/lib/teams/team.query");
 
 describe("SelectMcpServerCredentialTypeAndTeams", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: CURRENT_USER_ID } },
+    } as ReturnType<typeof useSession>);
+    // Member role: no mcpServerInstallation:update and no :admin.
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useAssignableTeams).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAssignableTeams>);
   });
 
   it("blocks a fresh install when every scope is already taken", async () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/use-can-reauthenticate.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/use-can-reauthenticate.test.tsx
@@ -2,20 +2,11 @@ import { ADMIN_ROLE_NAME } from "@archestra/shared";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockSession = vi.fn();
-const mockMyTeams = vi.fn();
-const mockHasPermissions = vi.fn();
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/teams/team.query");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useSession: () => mockSession(),
-  useHasPermissions: (perm: { mcpServerInstallation?: string[] }) =>
-    mockHasPermissions(perm),
-}));
-
-vi.mock("@/lib/teams/team.query", () => ({
-  useMyTeams: () => mockMyTeams(),
-}));
-
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useMyTeams } from "@/lib/teams/team.query";
 import { useCanReauthenticate } from "./use-can-reauthenticate";
 
 const CURRENT_USER = "user-self";
@@ -35,17 +26,21 @@ function setup({
     members?: Array<{ userId: string; role: string }>;
   }>;
 }) {
-  mockSession.mockReturnValue({ data: { user: { id: CURRENT_USER } } });
-  mockMyTeams.mockReturnValue({ data: teams ?? [] });
-  mockHasPermissions.mockImplementation(
-    (perm: { mcpServerInstallation?: string[] }) => {
-      const actions = perm.mcpServerInstallation ?? [];
-      if (actions.includes("create")) return { data: create };
-      if (actions.includes("update")) return { data: update };
-      if (actions.includes("admin")) return { data: admin };
-      return { data: false };
-    },
-  );
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { id: CURRENT_USER } },
+  } as ReturnType<typeof useSession>);
+  vi.mocked(useMyTeams).mockReturnValue({
+    data: teams ?? [],
+  } as unknown as ReturnType<typeof useMyTeams>);
+  vi.mocked(useHasPermissions).mockImplementation(((perm: {
+    mcpServerInstallation?: string[];
+  }) => {
+    const actions = perm.mcpServerInstallation ?? [];
+    if (actions.includes("create")) return { data: create };
+    if (actions.includes("update")) return { data: update };
+    if (actions.includes("admin")) return { data: admin };
+    return { data: false };
+  }) as unknown as typeof useHasPermissions);
   return renderHook(() => useCanReauthenticate()).result.current;
 }
 

--- a/platform/frontend/src/app/oauth/consent/consent-form.test.tsx
+++ b/platform/frontend/src/app/oauth/consent/consent-form.test.tsx
@@ -8,10 +8,7 @@ import {
 } from "@/lib/auth/oauth.query";
 import { ConsentForm } from "./consent-form";
 
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/auth/oauth.query", () => ({
   useOAuthClientInfo: vi.fn(),

--- a/platform/frontend/src/app/projects/page.client.test.tsx
+++ b/platform/frontend/src/app/projects/page.client.test.tsx
@@ -1,5 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useTeams } from "@/lib/teams/team.query";
 
 const mockRouterPush = vi.fn();
 const mockDeleteMutateAsync = vi.fn();
@@ -29,11 +32,7 @@ type ProjectFixture = {
   createdAt: string;
 };
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockRouterPush }),
-  useSearchParams: () => new URLSearchParams(),
-  usePathname: () => "/projects",
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/components/search-input", () => ({
   SearchInput: () => <input aria-label="Search projects" />,
@@ -195,9 +194,7 @@ vi.mock("@/components/api-key-load-error", () => ({
   ),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: false }),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/projects/projects.query", () => ({
   useProjects: () => ({ data: mockProjects, isPending: false }),
@@ -225,9 +222,7 @@ vi.mock("@/lib/projects/projects.query", () => ({
   useSetProjectShare: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
-vi.mock("@/lib/teams/team.query", () => ({
-  useTeams: () => ({ data: [] }),
-}));
+vi.mock("@/lib/teams/team.query");
 
 vi.mock("@/lib/schedule-trigger.query", () => ({
   useScheduleTriggers: () => ({ data: undefined }),
@@ -238,6 +233,19 @@ import ProjectsPageClient from "./page.client";
 describe("ProjectsPageClient", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockRouterPush,
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+    );
+    vi.mocked(usePathname).mockReturnValue("/projects");
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeams>);
     mockProjects = [];
     mockApiKeyState = {
       hasAnyApiKey: true,

--- a/platform/frontend/src/app/settings/account/_components/sessions-card.test.tsx
+++ b/platform/frontend/src/app/settings/account/_components/sessions-card.test.tsx
@@ -6,17 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { SessionsCard } from "./sessions-card";
 
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-}));
+vi.mock("next/navigation");
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    getSession: vi.fn(),
-    listSessions: vi.fn(),
-    revokeSession: vi.fn(),
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 const CHROME_MAC_UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";

--- a/platform/frontend/src/app/settings/account/_components/two-factor-card.test.tsx
+++ b/platform/frontend/src/app/settings/account/_components/two-factor-card.test.tsx
@@ -6,19 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { TwoFactorCard } from "./two-factor-card";
 
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-}));
+vi.mock("next/navigation");
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    getSession: vi.fn(),
-    twoFactor: {
-      enable: vi.fn(),
-      disable: vi.fn(),
-    },
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 const mockRouterPush = vi.fn();
 

--- a/platform/frontend/src/app/settings/agents/page.test.tsx
+++ b/platform/frontend/src/app/settings/agents/page.test.tsx
@@ -139,24 +139,14 @@ vi.mock("@/lib/llm-provider-api-keys.query", () => ({
 
 const mutateAsync = vi.fn();
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({
-    data: mockOrganization,
-  }),
-  useAppearanceSettings: () => ({
-    data: {
-      appName: "Spark",
-    },
-  }),
-  useUpdateAgentSettings: () => ({
-    mutateAsync,
-    isPending: false,
-  }),
-  useUpdateSecuritySettings: () => ({
-    mutateAsync,
-    isPending: false,
-  }),
-}));
+vi.mock("@/lib/organization.query");
+
+import {
+  useAppearanceSettings,
+  useOrganization,
+  useUpdateAgentSettings,
+  useUpdateSecuritySettings,
+} from "@/lib/organization.query";
 
 import AgentSettingsPage from "./page";
 
@@ -191,6 +181,21 @@ beforeEach(() => {
     },
   ];
   mockAgents = [];
+
+  vi.mocked(useOrganization).mockReturnValue({
+    data: mockOrganization,
+  } as unknown as ReturnType<typeof useOrganization>);
+  vi.mocked(useAppearanceSettings).mockReturnValue({
+    data: { appName: "Spark" },
+  } as unknown as ReturnType<typeof useAppearanceSettings>);
+  vi.mocked(useUpdateAgentSettings).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdateAgentSettings>);
+  vi.mocked(useUpdateSecuritySettings).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdateSecuritySettings>);
 });
 
 describe("AgentSettingsPage", () => {

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.test.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.test.tsx
@@ -7,9 +7,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { useForm } from "react-hook-form";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { OidcConfigForm } from "./oidc-config-form.ee";
 
 vi.mock("./role-mapping-form.ee", () => ({
@@ -20,15 +21,17 @@ vi.mock("./team-sync-config-form.ee", () => ({
   TeamSyncConfigForm: () => <div>Team Sync</div>,
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Archestra",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 global.ResizeObserver = class ResizeObserver {
   observe() {}
   unobserve() {}
   disconnect() {}
 } as unknown as typeof ResizeObserver;
+
+beforeEach(() => {
+  vi.mocked(useAppName).mockReturnValue("Archestra");
+});
 
 function TestWrapper({
   onSubmit,

--- a/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.test.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.test.tsx
@@ -7,7 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useForm } from "react-hook-form";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { RoleMappingForm } from "./role-mapping-form.ee";
@@ -34,13 +34,9 @@ vi.mock("@/lib/role.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/organization.query", () => ({
-  useAppearanceSettings: () => ({
-    data: {
-      appName: "Spark",
-    },
-  }),
-}));
+vi.mock("@/lib/organization.query");
+
+import { useAppearanceSettings } from "@/lib/organization.query";
 
 vi.mock("@/lib/auth/identity-provider.query.ee", () => ({
   useIdentityProviderLatestIdTokenClaims: () => ({
@@ -114,6 +110,12 @@ function getDeleteButtons() {
     .getAllByRole("button", { name: "" })
     .filter((btn) => btn.querySelector("svg.lucide-trash-2") !== null);
 }
+
+beforeEach(() => {
+  vi.mocked(useAppearanceSettings).mockReturnValue({
+    data: { appName: "Spark" },
+  } as unknown as ReturnType<typeof useAppearanceSettings>);
+});
 
 describe("RoleMappingForm", () => {
   it("shows the template debugger without token claims", async () => {

--- a/platform/frontend/src/app/settings/identity-providers/_parts/team-sync-config-form.ee.test.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/team-sync-config-form.ee.test.tsx
@@ -6,17 +6,12 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useForm } from "react-hook-form";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Form } from "@/components/ui/form";
+import { useAppearanceSettings } from "@/lib/organization.query";
 import { TeamSyncConfigForm } from "./team-sync-config-form.ee";
 
-vi.mock("@/lib/organization.query", () => ({
-  useAppearanceSettings: () => ({
-    data: {
-      appName: "Spark",
-    },
-  }),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/lib/auth/identity-provider.query.ee", () => ({
   useIdentityProviderLatestIdTokenClaims: () => ({
@@ -70,6 +65,12 @@ function TestWrapper({
     </Form>
   );
 }
+
+beforeEach(() => {
+  vi.mocked(useAppearanceSettings).mockReturnValue({
+    data: { appName: "Spark" },
+  } as unknown as ReturnType<typeof useAppearanceSettings>);
+});
 
 describe("TeamSyncConfigForm", () => {
   it("shows the template debugger without token claims", async () => {

--- a/platform/frontend/src/app/settings/knowledge/page.test.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.test.tsx
@@ -55,25 +55,14 @@ let mockOrganization: Record<string, unknown> | null = null;
 let mockOrgPending = false;
 let mockUpdateKnowledgeSettings = vi.fn();
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({
-    data: mockOrganization,
-    isPending: mockOrgPending,
-  }),
-  useUpdateKnowledgeSettings: () => ({
-    mutateAsync: mockUpdateKnowledgeSettings,
-    isPending: false,
-  }),
-  useTestEmbeddingConnection: () => ({
-    mutateAsync: vi.fn(),
-    mutate: vi.fn(),
-    isPending: false,
-  }),
-  useDropEmbeddingConfig: () => ({
-    mutateAsync: vi.fn(),
-    isPending: false,
-  }),
-}));
+vi.mock("@/lib/organization.query");
+
+import {
+  useDropEmbeddingConfig,
+  useOrganization,
+  useTestEmbeddingConnection,
+  useUpdateKnowledgeSettings,
+} from "@/lib/organization.query";
 
 let mockApiKeys: Array<{
   id: string;
@@ -128,14 +117,14 @@ vi.mock("@/lib/llm-models.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => false,
-  useEnterpriseFeature: () => false,
-  useSmallTeamTier: () => undefined,
-  useProviderBaseUrls: () => ({
-    data: {},
-  }),
-}));
+vi.mock("@/lib/config/config.query");
+
+import {
+  useEnterpriseFeature,
+  useFeature,
+  useProviderBaseUrls,
+  useSmallTeamTier,
+} from "@/lib/config/config.query";
 
 vi.mock("@/lib/team.query", () => ({
   useTeams: () => ({
@@ -144,21 +133,16 @@ vi.mock("@/lib/team.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: true, isPending: false }),
-  useMissingPermissions: () => [],
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    useSession: vi.fn().mockReturnValue({
-      data: {
-        user: { id: "test-user", email: "test@example.com" },
-        session: { id: "test-session" },
-      },
-    }),
-  },
-}));
+import {
+  useHasPermissions,
+  useMissingPermissions,
+} from "@/lib/auth/auth.query";
+
+vi.mock("@/lib/clients/auth/auth-client");
+
+import { authClient } from "@/lib/clients/auth/auth-client";
 
 // Need to import after mocks are set up
 import KnowledgeSettingsPage from "./page";
@@ -200,6 +184,54 @@ beforeEach(() => {
       embeddingDimensions: 1536,
     },
   ];
+
+  vi.mocked(useOrganization).mockImplementation(
+    () =>
+      ({
+        data: mockOrganization,
+        isPending: mockOrgPending,
+      }) as unknown as ReturnType<typeof useOrganization>,
+  );
+  vi.mocked(useUpdateKnowledgeSettings).mockImplementation(
+    () =>
+      ({
+        mutateAsync: mockUpdateKnowledgeSettings,
+        isPending: false,
+      }) as unknown as ReturnType<typeof useUpdateKnowledgeSettings>,
+  );
+  vi.mocked(useTestEmbeddingConnection).mockReturnValue({
+    mutateAsync: vi.fn(),
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useTestEmbeddingConnection>);
+  vi.mocked(useDropEmbeddingConfig).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useDropEmbeddingConfig>);
+
+  vi.mocked(useFeature).mockReturnValue(
+    false as unknown as ReturnType<typeof useFeature>,
+  );
+  vi.mocked(useEnterpriseFeature).mockReturnValue(false);
+  vi.mocked(useSmallTeamTier).mockReturnValue(undefined);
+  vi.mocked(useProviderBaseUrls).mockReturnValue({
+    data: {},
+  } as unknown as ReturnType<typeof useProviderBaseUrls>);
+
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: true,
+    isPending: false,
+  } as ReturnType<typeof useHasPermissions>);
+  vi.mocked(useMissingPermissions).mockReturnValue(
+    [] as unknown as ReturnType<typeof useMissingPermissions>,
+  );
+
+  vi.mocked(authClient.useSession).mockReturnValue({
+    data: {
+      user: { id: "test-user", email: "test@example.com" },
+      session: { id: "test-session" },
+    },
+  } as unknown as ReturnType<typeof authClient.useSession>);
 });
 
 describe("KnowledgeSettingsPage", () => {

--- a/platform/frontend/src/app/settings/llm/page.test.tsx
+++ b/platform/frontend/src/app/settings/llm/page.test.tsx
@@ -14,28 +14,47 @@ let mockTeams: Array<{
 }> = [];
 const mockUpdateLlmSettingsMutateAsync = vi.fn();
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({
-    data: mockOrganization,
+vi.mock("@/lib/organization.query");
+vi.mock("@/lib/teams/team.query");
+vi.mock("@/lib/auth/auth.query");
+
+import {
+  useHasPermissions,
+  useMissingPermissions,
+} from "@/lib/auth/auth.query";
+import {
+  useOrganization,
+  useUpdateLlmSettings,
+} from "@/lib/organization.query";
+import { useTeams } from "@/lib/teams/team.query";
+
+beforeEach(() => {
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: true,
     isPending: false,
-  }),
-  useUpdateLlmSettings: () => ({
+  } as ReturnType<typeof useHasPermissions>);
+  vi.mocked(useMissingPermissions).mockReturnValue(
+    [] as unknown as ReturnType<typeof useMissingPermissions>,
+  );
+  vi.mocked(useOrganization).mockImplementation(
+    () =>
+      ({
+        data: mockOrganization,
+        isPending: false,
+      }) as ReturnType<typeof useOrganization>,
+  );
+  vi.mocked(useUpdateLlmSettings).mockReturnValue({
     mutateAsync: mockUpdateLlmSettingsMutateAsync,
     isPending: false,
-  }),
-}));
-
-vi.mock("@/lib/teams/team.query", () => ({
-  useTeams: () => ({
-    data: mockTeams,
-    isPending: false,
-  }),
-}));
-
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: true, isPending: false }),
-  useMissingPermissions: () => [],
-}));
+  } as unknown as ReturnType<typeof useUpdateLlmSettings>);
+  vi.mocked(useTeams).mockImplementation(
+    () =>
+      ({
+        data: mockTeams,
+        isPending: false,
+      }) as ReturnType<typeof useTeams>,
+  );
+});
 
 import LlmSettingsPage from "./page";
 

--- a/platform/frontend/src/app/settings/organization/_components/oauth-token-lifetime-section.test.tsx
+++ b/platform/frontend/src/app/settings/organization/_components/oauth-token-lifetime-section.test.tsx
@@ -21,25 +21,18 @@ const mutateAsync = vi.fn();
 let mockOrganization: Record<string, unknown> | null = null;
 let mockOrganizationPending = false;
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({
-    data: mockOrganization,
-    isPending: mockOrganizationPending,
-  }),
-  useAppearanceSettings: () => ({
-    data: { appName: null },
-  }),
-  useUpdateAuthSettings: () => ({
-    mutateAsync,
-    isPending: false,
-  }),
-}));
+vi.mock("@/lib/organization.query");
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: true, isPending: false }),
-  useMissingPermissions: () => [],
-}));
-
+import {
+  useHasPermissions,
+  useMissingPermissions,
+} from "@/lib/auth/auth.query";
+import {
+  useAppearanceSettings,
+  useOrganization,
+  useUpdateAuthSettings,
+} from "@/lib/organization.query";
 import { OAuthTokenLifetimeSection } from "./oauth-token-lifetime-section";
 
 function renderPage() {
@@ -64,6 +57,28 @@ describe("OAuthTokenLifetimeSection", () => {
     mutateAsync.mockResolvedValue({
       oauthAccessTokenLifetimeSeconds: 604_800,
     });
+
+    vi.mocked(useOrganization).mockImplementation(
+      () =>
+        ({
+          data: mockOrganization,
+          isPending: mockOrganizationPending,
+        }) as ReturnType<typeof useOrganization>,
+    );
+    vi.mocked(useAppearanceSettings).mockReturnValue({
+      data: { appName: null },
+    } as unknown as ReturnType<typeof useAppearanceSettings>);
+    vi.mocked(useUpdateAuthSettings).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateAuthSettings>);
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+      isPending: false,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useMissingPermissions).mockReturnValue(
+      [] as unknown as ReturnType<typeof useMissingPermissions>,
+    );
   });
 
   it("submits a preset OAuth token lifetime", async () => {

--- a/platform/frontend/src/app/settings/roles/page.test.tsx
+++ b/platform/frontend/src/app/settings/roles/page.test.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useEnterpriseFeature,
+  useSmallTeamTier,
+} from "@/lib/config/config.query";
 
 const mockUserSearchableSelect = vi.fn(
   (_props: {
@@ -15,10 +19,7 @@ const mockUserSearchableSelect = vi.fn(
   }) => <div data-testid="user-searchable-select" />,
 );
 
-vi.mock("@/lib/config/config.query", () => ({
-  useEnterpriseFeature: () => false,
-  useSmallTeamTier: () => undefined,
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@/components/roles/roles-list.ee", () => ({
   RolesList: () => <div>roles list</div>,
@@ -54,6 +55,13 @@ vi.mock("@/lib/impersonation.query", () => ({
     isPending: false,
   }),
 }));
+
+beforeEach(() => {
+  vi.mocked(useEnterpriseFeature).mockReturnValue(false);
+  vi.mocked(useSmallTeamTier).mockReturnValue(
+    undefined as ReturnType<typeof useSmallTeamTier>,
+  );
+});
 
 describe("RolesSettingsPage", () => {
   it("uses the searchable user select for role debugging", async () => {

--- a/platform/frontend/src/app/settings/settings-tabs.test.tsx
+++ b/platform/frontend/src/app/settings/settings-tabs.test.tsx
@@ -5,11 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { useSettingsTabs } from "./settings-tabs";
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    getSession: vi.fn(),
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 let mockPermissions: Permissions = {};
 

--- a/platform/frontend/src/components/agent-dialog.test.tsx
+++ b/platform/frontend/src/components/agent-dialog.test.tsx
@@ -2,6 +2,13 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { forwardRef, useImperativeHandle } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import {
+  useEnterpriseFeature,
+  useFeature,
+  useSmallTeamTier,
+} from "@/lib/config/config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { AgentDialog } from "./agent-dialog";
 
 global.ResizeObserver = class ResizeObserver {
@@ -14,7 +21,6 @@ const {
   pendingSaveChanges,
   useAvailableLlmProviderApiKeysMock,
   useAgentDelegationsMock,
-  useHasPermissionsMock,
   useInternalAgentsMock,
   useLlmModelsByProviderMock,
   useProfileMock,
@@ -33,7 +39,6 @@ const {
   ),
   useAvailableLlmProviderApiKeysMock: vi.fn(() => ({ data: [] })),
   useLlmModelsByProviderMock: vi.fn(() => ({ modelsByProvider: {} })),
-  useHasPermissionsMock: vi.fn((..._args: unknown[]) => ({ data: true })),
   useUpdateProfileMock: vi.fn(() => ({
     mutateAsync: vi.fn(),
     isPending: false,
@@ -77,19 +82,13 @@ vi.mock("@/lib/agent-tools.query", () => ({
   useSyncAgentDelegations: useSyncAgentDelegationsMock,
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: useHasPermissionsMock,
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/chat/chat.query", () => ({
   useChatProfileMcpTools: () => ({ data: [], isLoading: false }),
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => false,
-  useEnterpriseFeature: () => false,
-  useSmallTeamTier: () => undefined,
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@/lib/knowledge/connector.query", () => ({
   useConnectors: () => ({ data: [] }),
@@ -108,9 +107,7 @@ vi.mock("@/lib/llm-provider-api-keys.query", () => ({
   useAvailableLlmProviderApiKeys: useAvailableLlmProviderApiKeysMock,
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Archestra",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("@/lib/docs/docs", () => ({
   getFrontendDocsUrl: () => "/docs",
@@ -338,6 +335,15 @@ vi.mock("@/components/ui/tooltip", () => ({
   ),
 }));
 
+beforeEach(() => {
+  vi.mocked(useFeature).mockReturnValue(
+    false as unknown as ReturnType<typeof useFeature>,
+  );
+  vi.mocked(useEnterpriseFeature).mockReturnValue(false);
+  vi.mocked(useSmallTeamTier).mockReturnValue(undefined);
+  vi.mocked(useAppName).mockReturnValue("Archestra");
+});
+
 const baseAgent = {
   id: "00000000-0000-4000-8000-000000000001",
   organizationId: "00000000-0000-4000-8000-000000000010",
@@ -387,7 +393,9 @@ const targetAgent = {
 describe("AgentDialog delegation state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useHasPermissionsMock.mockImplementation(() => ({ data: true }));
+    vi.mocked(useHasPermissions).mockImplementation(
+      () => ({ data: true }) as unknown as ReturnType<typeof useHasPermissions>,
+    );
     useProfileMock.mockReturnValue({ data: null, refetch: vi.fn() });
     useInternalAgentsMock.mockReturnValue({ data: [targetAgent] });
     useAgentDelegationsMock.mockReturnValue({
@@ -431,7 +439,9 @@ describe("AgentDialog delegation state", () => {
 describe.skip("AgentDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useHasPermissionsMock.mockImplementation(() => ({ data: true }));
+    vi.mocked(useHasPermissions).mockImplementation(
+      () => ({ data: true }) as unknown as ReturnType<typeof useHasPermissions>,
+    );
   });
 
   it("does not eagerly enable agent-only queries for a closed MCP gateway dialog", () => {
@@ -515,13 +525,13 @@ describe.skip("AgentDialog", () => {
   });
 
   it("does not enable LLM queries when the user lacks LLM read permissions", () => {
-    useHasPermissionsMock.mockImplementation((...args: unknown[]) => {
+    vi.mocked(useHasPermissions).mockImplementation(((...args: unknown[]) => {
       const permissions = (args[0] ?? {}) as Record<string, unknown>;
       if ("llmProviderApiKey" in permissions || "llmModel" in permissions) {
         return { data: false };
       }
       return { data: true };
-    });
+    }) as unknown as typeof useHasPermissions);
 
     render(
       <AgentDialog open={true} onOpenChange={vi.fn()} agentType="agent" />,
@@ -537,13 +547,13 @@ describe.skip("AgentDialog", () => {
   });
 
   it("shows org default model message when the user cannot read keys or models", () => {
-    useHasPermissionsMock.mockImplementation((...args: unknown[]) => {
+    vi.mocked(useHasPermissions).mockImplementation(((...args: unknown[]) => {
       const permissions = (args[0] ?? {}) as Record<string, unknown>;
       if ("llmProviderApiKey" in permissions || "llmModel" in permissions) {
         return { data: false };
       }
       return { data: true };
-    });
+    }) as unknown as typeof useHasPermissions);
 
     render(
       <AgentDialog open={true} onOpenChange={vi.fn()} agentType="agent" />,

--- a/platform/frontend/src/components/agent-scope-filter.test.tsx
+++ b/platform/frontend/src/components/agent-scope-filter.test.tsx
@@ -8,33 +8,18 @@ Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
 Element.prototype.setPointerCapture = vi.fn();
 Element.prototype.releasePointerCapture = vi.fn();
 
-const mockUseHasPermissions = vi.fn();
-const mockUseSession = vi.fn();
-const mockUseSearchParams = vi.fn();
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: (...args: unknown[]) => mockUseHasPermissions(...args),
-  useSession: (...args: unknown[]) => mockUseSession(...args),
-}));
-
-vi.mock("next/navigation", () => ({
-  useSearchParams: (...args: unknown[]) => mockUseSearchParams(...args),
-  useRouter: () => ({ push: vi.fn() }),
-  usePathname: () => "/agents",
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/lib/agent.query", () => ({
   useLabelKeys: () => ({ data: [] }),
   useLabelValues: () => ({ data: [] }),
 }));
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganizationMembers: () => ({ data: [] }),
-}));
+vi.mock("@/lib/organization.query");
 
-vi.mock("@/lib/teams/team.query", () => ({
-  useTeams: () => ({ data: [] }),
-}));
+vi.mock("@/lib/teams/team.query");
 
 // Stub the sibling controls so the only `combobox` roles in the tree are the
 // scope select and the (conditional) owner select under test.
@@ -53,21 +38,42 @@ vi.mock("@/components/permission-requirement-hint", () => ({
   PermissionRequirementHint: () => null,
 }));
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { useOrganizationMembers } from "@/lib/organization.query";
+import { useTeams } from "@/lib/teams/team.query";
 import { AgentScopeFilter } from "./agent-scope-filter";
 
 describe("AgentScopeFilter owner selector gating", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseSession.mockReturnValue({ data: { user: { id: "user-1" } } });
-    mockUseSearchParams.mockReturnValue(new URLSearchParams("scope=personal"));
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "user-1" } },
+    } as ReturnType<typeof useSession>);
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("scope=personal") as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(usePathname).mockReturnValue("/agents");
+    vi.mocked(useOrganizationMembers).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useOrganizationMembers>);
+    vi.mocked(useTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeams>);
   });
 
   it("hides the owner selector for a non-admin even if they have member:read", async () => {
-    mockUseHasPermissions.mockImplementation(
+    vi.mocked(useHasPermissions).mockImplementation(
       (permissions: Record<string, unknown>) => {
         // Has member:read and team:read, but NOT agent:admin.
-        if ("agent" in permissions) return { data: false };
-        return { data: true };
+        if ("agent" in permissions)
+          return { data: false } as ReturnType<typeof useHasPermissions>;
+        return { data: true } as ReturnType<typeof useHasPermissions>;
       },
     );
 
@@ -78,10 +84,11 @@ describe("AgentScopeFilter owner selector gating", () => {
   });
 
   it("shows the owner selector for a resource admin", async () => {
-    mockUseHasPermissions.mockImplementation(
+    vi.mocked(useHasPermissions).mockImplementation(
       (permissions: Record<string, unknown>) => {
-        if ("agent" in permissions) return { data: true };
-        return { data: true };
+        if ("agent" in permissions)
+          return { data: true } as ReturnType<typeof useHasPermissions>;
+        return { data: true } as ReturnType<typeof useHasPermissions>;
       },
     );
 

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -177,10 +177,7 @@ vi.mock("@/components/chat/knowledge-graph-citations", () => ({
   hasKnowledgeBaseToolCall: () => false,
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: true }),
-  useSession: () => ({ data: { user: { name: "Joey" } } }),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/chat/chat.query", () => ({
   useProfileToolsWithIds: () => ({ data: [] }),
@@ -204,13 +201,9 @@ vi.mock("@/lib/mcp/mcp-install-orchestrator.hook", () => ({
   }),
 }));
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({ data: null }),
-}));
+vi.mock("@/lib/organization.query");
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppIconLogo: () => "/custom-logo.png",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("@/lib/chat/global-chat.context", () => ({
   useGlobalChat: () => ({
@@ -227,12 +220,25 @@ vi.mock("@/lib/mcp/archestra-mcp-server", () => ({
   }),
 }));
 
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { PERSISTED_MESSAGE_ID_METADATA_KEY } from "@/lib/chat/chat-utils";
+import { useAppIconLogo } from "@/lib/hooks/use-app-name";
+import { useOrganization } from "@/lib/organization.query";
 import { ChatMessages } from "./chat-messages";
 
 describe("ChatMessages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { name: "Joey" } },
+    } as ReturnType<typeof useSession>);
+    vi.mocked(useOrganization).mockReturnValue({
+      data: null,
+    } as unknown as ReturnType<typeof useOrganization>);
+    vi.mocked(useAppIconLogo).mockReturnValue("/custom-logo.png");
   });
 
   it("renders the swap divider for branded built-in swap tools", () => {

--- a/platform/frontend/src/components/chat/context-window-panel.test.tsx
+++ b/platform/frontend/src/components/chat/context-window-panel.test.tsx
@@ -1,16 +1,19 @@
 import type { ContextWindowBreakdown } from "@archestra/shared";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import {
   ContextWindowDialog,
   ContextWindowPanel,
 } from "./context-window-panel";
 
 // useAppName is used inside ContextWindowDialog for the empty-state copy
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Archestra",
-}));
+vi.mock("@/lib/hooks/use-app-name");
+
+beforeEach(() => {
+  vi.mocked(useAppName).mockReturnValue("Archestra");
+});
 
 // ============================================================================
 // Fixtures

--- a/platform/frontend/src/components/chat/edit-policy-dialog.test.tsx
+++ b/platform/frontend/src/components/chat/edit-policy-dialog.test.tsx
@@ -1,22 +1,18 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useOrganization } from "@/lib/organization.query";
 import { EditPolicyDialog } from "./edit-policy-dialog";
 
 const mockUseAllProfileTools = vi.fn();
-const mockUseHasPermissions = vi.fn();
-const mockUseOrganization = vi.fn();
 
 vi.mock("@/lib/agent-tools.query", () => ({
   useAllProfileTools: (...args: unknown[]) => mockUseAllProfileTools(...args),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: (...args: unknown[]) => mockUseHasPermissions(...args),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: (...args: unknown[]) => mockUseOrganization(...args),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/app/mcp/tool-guardrails/_parts/tool-call-policies", () => ({
   ToolCallPolicies: () => <div>Tool call policies</div>,
@@ -28,13 +24,15 @@ vi.mock("@/app/mcp/tool-guardrails/_parts/tool-result-policies", () => ({
 
 describe("EditPolicyDialog", () => {
   it("shows the organization support message when the user cannot update tool policies", () => {
-    mockUseHasPermissions.mockReturnValue({ data: false });
-    mockUseOrganization.mockReturnValue({
+    vi.mocked(useHasPermissions).mockReturnValue({ data: false } as ReturnType<
+      typeof useHasPermissions
+    >);
+    vi.mocked(useOrganization).mockReturnValue({
       data: {
         chatErrorSupportMessage:
           "Contact support@company.com and include the blocked tool details.",
       },
-    });
+    } as unknown as ReturnType<typeof useOrganization>);
     mockUseAllProfileTools.mockReturnValue({ data: { data: [] } });
 
     render(
@@ -57,12 +55,14 @@ describe("EditPolicyDialog", () => {
   });
 
   it("shows a generic message when the user cannot update tool policies and no support message is configured", () => {
-    mockUseHasPermissions.mockReturnValue({ data: false });
-    mockUseOrganization.mockReturnValue({
+    vi.mocked(useHasPermissions).mockReturnValue({ data: false } as ReturnType<
+      typeof useHasPermissions
+    >);
+    vi.mocked(useOrganization).mockReturnValue({
       data: {
         chatErrorSupportMessage: null,
       },
-    });
+    } as unknown as ReturnType<typeof useOrganization>);
     mockUseAllProfileTools.mockReturnValue({ data: { data: [] } });
 
     render(
@@ -82,12 +82,15 @@ describe("EditPolicyDialog", () => {
   });
 
   it("shows a loading state while permission checks are still pending", () => {
-    mockUseHasPermissions.mockReturnValue({ data: false, isLoading: true });
-    mockUseOrganization.mockReturnValue({
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+      isLoading: true,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useOrganization).mockReturnValue({
       data: {
         chatErrorSupportMessage: "Contact support@company.com",
       },
-    });
+    } as unknown as ReturnType<typeof useOrganization>);
     mockUseAllProfileTools.mockReturnValue({ data: { data: [] } });
 
     render(

--- a/platform/frontend/src/components/chat/inline-chat-error.test.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.test.tsx
@@ -2,17 +2,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
-}));
+vi.mock("sonner");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({ data: true }),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/llm-provider-api-keys.query", () => ({
   useCreateLlmProviderApiKey: () => ({
@@ -35,6 +29,9 @@ import { InlineChatError } from "./inline-chat-error";
 describe("InlineChatError", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
   });
 
   it("shows only the support message and correlation IDs in slim mode", () => {

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -49,9 +49,7 @@ vi.mock("@/lib/config/config", () => ({
   }),
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => null,
-}));
+vi.mock("@/lib/config/config.query");
 
 // Avoid pulling the real auth client / app query (and their network deps) into
 // the test; the edit pencil is covered by app-frame.test.tsx.
@@ -83,6 +81,7 @@ import {
   clearAllAppDiagnostics,
   reportAppDiagnostic,
 } from "@/lib/chat/app-diagnostics-store";
+import { useFeature } from "@/lib/config/config.query";
 import { AppsProvider, useApps } from "./apps-context";
 import { McpAppSection } from "./mcp-app-container";
 
@@ -107,6 +106,9 @@ const preloadedResource = {
 describe("McpAppSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useFeature).mockReturnValue(
+      null as unknown as ReturnType<typeof useFeature>,
+    );
   });
 
   it("shows loading spinner when resource has not yet loaded", () => {

--- a/platform/frontend/src/components/chat/policy-denied-tool.test.tsx
+++ b/platform/frontend/src/components/chat/policy-denied-tool.test.tsx
@@ -1,17 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useOrganization } from "@/lib/organization.query";
 import { PolicyDeniedTool } from "./policy-denied-tool";
 
-const mockUseHasPermissions = vi.fn();
-const mockUseOrganization = vi.fn();
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: (...args: unknown[]) => mockUseHasPermissions(...args),
-}));
-
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: (...args: unknown[]) => mockUseOrganization(...args),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("./edit-policy-dialog", () => ({
   EditPolicyDialog: () => <div>Edit policy dialog</div>,
@@ -36,13 +31,15 @@ describe("PolicyDeniedTool", () => {
   });
 
   it("shows the inline support message and hides the edit action when the user cannot update policies", () => {
-    mockUseHasPermissions.mockReturnValue({ data: false });
-    mockUseOrganization.mockReturnValue({
+    vi.mocked(useHasPermissions).mockReturnValue({ data: false } as ReturnType<
+      typeof useHasPermissions
+    >);
+    vi.mocked(useOrganization).mockReturnValue({
       data: {
         chatErrorSupportMessage:
           "Contact support@company.com and include the blocked tool details.",
       },
-    });
+    } as unknown as ReturnType<typeof useOrganization>);
 
     render(<PolicyDeniedTool {...defaultProps} editable={true} />);
 
@@ -57,12 +54,14 @@ describe("PolicyDeniedTool", () => {
   });
 
   it("shows the edit action when the user can update policies", () => {
-    mockUseHasPermissions.mockReturnValue({ data: true });
-    mockUseOrganization.mockReturnValue({
+    vi.mocked(useHasPermissions).mockReturnValue({ data: true } as ReturnType<
+      typeof useHasPermissions
+    >);
+    vi.mocked(useOrganization).mockReturnValue({
       data: {
         chatErrorSupportMessage: "Contact support@company.com",
       },
-    });
+    } as unknown as ReturnType<typeof useOrganization>);
 
     render(<PolicyDeniedTool {...defaultProps} editable={true} />);
 

--- a/platform/frontend/src/components/chat/share-conversation-dialog.test.tsx
+++ b/platform/frontend/src/components/chat/share-conversation-dialog.test.tsx
@@ -1,14 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSession } from "@/lib/auth/auth.query";
+import { useOrganizationMembers } from "@/lib/organization.query";
+import { useTeams } from "@/lib/teams/team.query";
 import { ShareConversationDialog } from "./share-conversation-dialog";
 
 const mockShareMutateAsync = vi.fn();
 const mockUnshareMutateAsync = vi.fn();
-const { mockToastSuccess } = vi.hoisted(() => ({
-  mockToastSuccess: vi.fn(),
-}));
 const mockUseConversationShare = vi.fn<
   () => {
     data: {
@@ -36,33 +37,13 @@ vi.mock("@/lib/chat/chat-share.query", () => ({
   })),
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: mockToastSuccess,
-  },
-}));
+vi.mock("sonner");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useSession: vi.fn(() => ({
-    data: {
-      user: {
-        id: "current-user-id",
-      },
-    },
-  })),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/teams/team.query", () => ({
-  useTeams: vi.fn(() => ({
-    data: [{ id: "team-1", name: "Engineering" }],
-  })),
-}));
+vi.mock("@/lib/teams/team.query");
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganizationMembers: vi.fn(() => ({
-    data: [{ id: "user-1", name: "Taylor", email: "taylor@example.com" }],
-  })),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("@/components/ui/assignment-combobox", () => ({
   AssignmentCombobox: ({
@@ -125,6 +106,19 @@ vi.mock("@/components/visibility-selector", () => ({
 
 describe("ShareConversationDialog", () => {
   beforeEach(() => {
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: {
+          id: "current-user-id",
+        },
+      },
+    } as ReturnType<typeof useSession>);
+    vi.mocked(useTeams).mockReturnValue({
+      data: [{ id: "team-1", name: "Engineering" }],
+    } as unknown as ReturnType<typeof useTeams>);
+    vi.mocked(useOrganizationMembers).mockReturnValue({
+      data: [{ id: "user-1", name: "Taylor", email: "taylor@example.com" }],
+    } as unknown as ReturnType<typeof useOrganizationMembers>);
     mockUseConversationShare.mockReturnValue({
       data: null,
       isLoading: false,
@@ -137,7 +131,7 @@ describe("ShareConversationDialog", () => {
       userIds: [],
     });
     mockUnshareMutateAsync.mockReset();
-    mockToastSuccess.mockReset();
+    vi.mocked(toast.success).mockReset();
     Object.defineProperty(window, "location", {
       value: { origin: "http://localhost:3000" },
       configurable: true,
@@ -200,7 +194,7 @@ describe("ShareConversationDialog", () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
     expect(screen.getByText("http://localhost:3000/chat/conv-1")).toBeVisible();
     expect(writeText).toHaveBeenCalledWith("http://localhost:3000/chat/conv-1");
-    expect(mockToastSuccess).toHaveBeenCalledWith(
+    expect(toast.success).toHaveBeenCalledWith(
       "Chat visibility updated and share link copied",
     );
   });

--- a/platform/frontend/src/components/conversation-search-palette.test.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.test.tsx
@@ -8,24 +8,15 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }));
 
-const {
-  mockRouterPush,
-  mockUsePathname,
-  mockDeleteMutate,
-  mockUseConversations,
-  mockUseFeature,
-} = vi.hoisted(() => ({
-  mockRouterPush: vi.fn(),
-  mockUsePathname: vi.fn(),
-  mockDeleteMutate: vi.fn(),
-  mockUseConversations: vi.fn(),
-  mockUseFeature: vi.fn(),
-}));
+const { mockRouterPush, mockDeleteMutate, mockUseConversations } = vi.hoisted(
+  () => ({
+    mockRouterPush: vi.fn(),
+    mockDeleteMutate: vi.fn(),
+    mockUseConversations: vi.fn(),
+  }),
+);
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockRouterPush }),
-  usePathname: () => mockUsePathname(),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@uidotdev/usehooks", () => ({
   useDebounce: (value: string) => value,
@@ -39,17 +30,9 @@ vi.mock("@/lib/auth/auth.hook", () => ({
   useIsAuthenticated: () => true,
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => ({
-    data: true,
-    isPending: false,
-    isLoading: false,
-  }),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: (flag: string) => mockUseFeature(flag),
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@/lib/chat/chat-utils", () => ({
   getConversationDisplayTitle: (title: string | null) =>
@@ -139,8 +122,11 @@ vi.mock("@/components/ui/badge", () => ({
   ),
 }));
 
+import { usePathname, useRouter } from "next/navigation";
 // Import component after mocks
 import { act } from "react";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
 import { ConversationSearchPalette } from "./conversation-search-palette";
 
 describe("ConversationSearchPalette", () => {
@@ -151,8 +137,16 @@ describe("ConversationSearchPalette", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseFeature.mockReturnValue(false);
-    mockUsePathname.mockReturnValue("/chat");
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockRouterPush,
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+      isPending: false,
+      isLoading: false,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useFeature).mockReturnValue(false);
+    vi.mocked(usePathname).mockReturnValue("/chat");
     mockUseConversations.mockReturnValue({
       data: [
         {
@@ -204,7 +198,7 @@ describe("ConversationSearchPalette", () => {
       isLoading: false,
       isFetching: false,
     });
-    mockUseFeature.mockReturnValue(false);
+    vi.mocked(useFeature).mockReturnValue(false);
     render(<ConversationSearchPalette {...defaultProps} />);
 
     fireEvent.click(screen.getByText("Connect"));
@@ -218,7 +212,7 @@ describe("ConversationSearchPalette", () => {
       isLoading: false,
       isFetching: false,
     });
-    mockUseFeature.mockReturnValue(true);
+    vi.mocked(useFeature).mockReturnValue(true);
     render(<ConversationSearchPalette {...defaultProps} />);
 
     fireEvent.click(screen.getByText("Connect"));
@@ -232,7 +226,7 @@ describe("ConversationSearchPalette", () => {
       isLoading: false,
       isFetching: false,
     });
-    mockUseFeature.mockReturnValue(true);
+    vi.mocked(useFeature).mockReturnValue(true);
     render(<ConversationSearchPalette {...defaultProps} />);
 
     fireEvent.click(screen.getByText("MCP Registry"));
@@ -267,7 +261,7 @@ describe("ConversationSearchPalette", () => {
   });
 
   it("redirects to /chat when deleting the currently viewed conversation", () => {
-    mockUsePathname.mockReturnValue("/chat/conv-1");
+    vi.mocked(usePathname).mockReturnValue("/chat/conv-1");
 
     render(<ConversationSearchPalette {...defaultProps} />);
 
@@ -293,7 +287,7 @@ describe("ConversationSearchPalette", () => {
   });
 
   it("does not redirect when deleting a conversation that is not currently viewed", () => {
-    mockUsePathname.mockReturnValue("/chat/conv-2");
+    vi.mocked(usePathname).mockReturnValue("/chat/conv-2");
 
     render(<ConversationSearchPalette {...defaultProps} />);
 

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.test.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
 import { CreateLlmProviderApiKeyDialog } from "./create-llm-provider-api-key-dialog";
 
 const mutateAsync = vi.fn();
-const hasPermissions = vi.fn(() => ({ data: true }));
 
 vi.mock("@/components/llm-provider-api-key-form", () => ({
   LLM_PROVIDER_API_KEY_PLACEHOLDER: "••••••••••••••••",
@@ -32,20 +33,19 @@ vi.mock("@/lib/llm-provider-api-keys.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => false,
-}));
+vi.mock("@/lib/config/config.query");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => hasPermissions(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 describe("CreateLlmProviderApiKeyDialog", () => {
   beforeEach(() => {
     mutateAsync.mockReset();
     mutateAsync.mockResolvedValue({});
-    hasPermissions.mockReset();
-    hasPermissions.mockReturnValue({ data: false });
+    vi.mocked(useFeature).mockReturnValue(false);
+    vi.mocked(useHasPermissions).mockReset();
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
   });
 
   it("submits the shared create API key flow and closes on success", async () => {
@@ -104,7 +104,9 @@ describe("CreateLlmProviderApiKeyDialog", () => {
   });
 
   it("defaults the scope to org when the user has llmProviderApiKey:admin", async () => {
-    hasPermissions.mockReturnValue({ data: true });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
     const user = userEvent.setup();
 
     render(

--- a/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
+++ b/platform/frontend/src/components/identity-provider-selector.ee.test.tsx
@@ -9,18 +9,10 @@ import { usePublicEnterpriseCoreActive } from "@/lib/config/config.query";
 import { IdentityProviderSelector } from "./identity-provider-selector.ee";
 
 // Mock next/navigation
-vi.mock("next/navigation", () => ({
-  useSearchParams: vi.fn(),
-}));
+vi.mock("next/navigation");
 
 // Mock auth client
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    signIn: {
-      sso: vi.fn(),
-    },
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 // Mock identity providers query
 vi.mock("@/lib/auth/identity-provider.query.ee", () => ({
@@ -28,9 +20,7 @@ vi.mock("@/lib/auth/identity-provider.query.ee", () => ({
 }));
 
 // Mock the runtime public-config hook the selector now reads from.
-vi.mock("@/lib/config/config.query", () => ({
-  usePublicEnterpriseCoreActive: vi.fn(() => true),
-}));
+vi.mock("@/lib/config/config.query");
 
 // Mock identity provider icons to avoid Next.js Image issues
 vi.mock("./identity-provider-icons.ee", () => ({

--- a/platform/frontend/src/components/import-agent-dialog.test.tsx
+++ b/platform/frontend/src/components/import-agent-dialog.test.tsx
@@ -20,6 +20,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { ImportAgentDialog } from "./import-agent-dialog";
 
 // ---------------------------------------------------------------------------
@@ -43,9 +44,7 @@ vi.mock("@/lib/agent.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Archestra",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("@/components/editor", () => ({
   Editor: (props: {
@@ -136,6 +135,7 @@ async function simulateFileUpload(
 
 describe("ImportAgentDialog", () => {
   beforeEach(() => {
+    vi.mocked(useAppName).mockReturnValue("Archestra");
     mutate.mockClear();
     mutate.mockImplementation((payload, options) => {
       options?.onSuccess?.({

--- a/platform/frontend/src/components/json-code-block.test.tsx
+++ b/platform/frontend/src/components/json-code-block.test.tsx
@@ -37,12 +37,7 @@ vi.mock("react-syntax-highlighter/dist/esm/styles/prism", () => ({
   oneLight: {},
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
-}));
+vi.mock("sonner");
 
 import { JsonCodeBlock } from "./json-code-block";
 

--- a/platform/frontend/src/components/message-thread.test.tsx
+++ b/platform/frontend/src/components/message-thread.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOrganization } from "@/lib/organization.query";
 import MessageThread, { type PartialUIMessage } from "./message-thread";
 
 vi.mock("@/components/ai-elements/conversation", () => ({
@@ -87,9 +88,13 @@ vi.mock("@/components/divider", () => ({
   default: () => null,
 }));
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({ data: null }),
-}));
+vi.mock("@/lib/organization.query");
+
+beforeEach(() => {
+  vi.mocked(useOrganization).mockReturnValue({
+    data: null,
+  } as unknown as ReturnType<typeof useOrganization>);
+});
 
 describe("MessageThread", () => {
   it("renders the swap-agent divider instead of the raw swap tool box", () => {

--- a/platform/frontend/src/components/oauth-confirmation-dialog.test.tsx
+++ b/platform/frontend/src/components/oauth-confirmation-dialog.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFeature } from "@/lib/config/config.query";
 import { OAuthConfirmationDialog } from "./oauth-confirmation-dialog";
 
 // Simulate a catalog item that is already installed everywhere the caller can
@@ -25,13 +26,12 @@ vi.mock(
   }),
 );
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: () => false,
-}));
+vi.mock("@/lib/config/config.query");
 
 describe("OAuthConfirmationDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useFeature).mockReturnValue(false);
   });
 
   it("blocks installing a server that is already installed everywhere", () => {

--- a/platform/frontend/src/components/settings/role-permissions-card.test.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RolePermissionsCard } from "@/components/settings/role-permissions-card";
-import { useSession } from "@/lib/auth/auth.query";
+import { useAllPermissions, useSession } from "@/lib/auth/auth.query";
+import {
+  useActiveMemberRole,
+  useActiveOrganization,
+} from "@/lib/organization.query";
 
 const mockUpdateNameMutateAsync = vi.fn();
 
@@ -12,28 +16,25 @@ vi.mock("@/lib/auth/account.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useAllPermissions: () => ({
-    data: null,
-    isLoading: false,
-  }),
-  useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/organization.query", () => ({
-  useActiveOrganization: () => ({
-    data: { id: "org-1" },
-  }),
-  useActiveMemberRole: () => ({
-    data: "admin",
-    isLoading: false,
-  }),
-}));
+vi.mock("@/lib/organization.query");
 
 describe("RolePermissionsCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUpdateNameMutateAsync.mockResolvedValue(true);
+    vi.mocked(useAllPermissions).mockReturnValue({
+      data: null,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAllPermissions>);
+    vi.mocked(useActiveOrganization).mockReturnValue({
+      data: { id: "org-1" },
+    } as unknown as ReturnType<typeof useActiveOrganization>);
+    vi.mocked(useActiveMemberRole).mockReturnValue({
+      data: "admin",
+      isLoading: false,
+    } as unknown as ReturnType<typeof useActiveMemberRole>);
     vi.mocked(useSession).mockReturnValue({
       data: {
         user: {

--- a/platform/frontend/src/components/sidebar-warnings.test.tsx
+++ b/platform/frontend/src/components/sidebar-warnings.test.tsx
@@ -1,24 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Controllable mock return values
-const mockUseSession = vi.fn();
-const mockUseDefaultCredentialsEnabled = vi.fn();
-const mockUseHasPermissions = vi.fn();
-const mockUseFeature = vi.fn();
-const mockUseDisableBasicAuth = vi.fn();
+vi.mock("@/lib/auth/auth.query");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useDefaultCredentialsEnabled: (...args: unknown[]) =>
-    mockUseDefaultCredentialsEnabled(...args),
-  useHasPermissions: (...args: unknown[]) => mockUseHasPermissions(...args),
-  useSession: (...args: unknown[]) => mockUseSession(...args),
-}));
-
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: (...args: unknown[]) => mockUseFeature(...args),
-  useDisableBasicAuth: (...args: unknown[]) => mockUseDisableBasicAuth(...args),
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@archestra/shared", () => ({
   DEFAULT_ADMIN_EMAIL: "admin@example.com",
@@ -34,6 +19,12 @@ vi.mock("@/components/default-credentials-warning", () => ({
   ),
 }));
 
+import {
+  useDefaultCredentialsEnabled,
+  useHasPermissions,
+  useSession,
+} from "@/lib/auth/auth.query";
+import { useDisableBasicAuth, useFeature } from "@/lib/config/config.query";
 import { SidebarWarnings } from "./sidebar-warnings";
 
 describe("SidebarWarnings", () => {
@@ -41,21 +32,25 @@ describe("SidebarWarnings", () => {
     vi.clearAllMocks();
 
     // Default: no session, no warnings, has both org and agent settings update permission
-    mockUseSession.mockReturnValue({ data: null });
-    mockUseDefaultCredentialsEnabled.mockReturnValue({
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+    } as unknown as ReturnType<typeof useSession>);
+    vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
       data: false,
       isLoading: false,
-    });
-    mockUseFeature.mockReturnValue("strict");
-    mockUseDisableBasicAuth.mockReturnValue(false);
-    mockUseHasPermissions.mockImplementation((permissions) => {
+    } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
+    vi.mocked(useFeature).mockReturnValue(
+      "strict" as ReturnType<typeof useFeature>,
+    );
+    vi.mocked(useDisableBasicAuth).mockReturnValue(false);
+    vi.mocked(useHasPermissions).mockImplementation((permissions) => {
       if ("organization" in (permissions as Record<string, unknown>)) {
-        return { data: true };
+        return { data: true } as ReturnType<typeof useHasPermissions>;
       }
       if ("agentSettings" in (permissions as Record<string, unknown>)) {
-        return { data: true };
+        return { data: true } as ReturnType<typeof useHasPermissions>;
       }
-      return { data: false };
+      return { data: false } as ReturnType<typeof useHasPermissions>;
     });
   });
 
@@ -65,29 +60,31 @@ describe("SidebarWarnings", () => {
   });
 
   it("renders nothing while loading credentials", () => {
-    mockUseDefaultCredentialsEnabled.mockReturnValue({
+    vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
       data: undefined,
       isLoading: true,
-    });
+    } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
     const { container } = render(<SidebarWarnings />);
     expect(container.firstChild).toBeNull();
   });
 
   it("renders nothing while loading features", () => {
-    mockUseSession.mockReturnValue({
+    vi.mocked(useSession).mockReturnValue({
       data: { user: { email: "admin@example.com" } },
-    });
-    mockUseFeature.mockReturnValue(undefined);
+    } as unknown as ReturnType<typeof useSession>);
+    vi.mocked(useFeature).mockReturnValue(undefined);
     const { container } = render(<SidebarWarnings />);
     expect(container.firstChild).toBeNull();
   });
 
   describe("security engine warning", () => {
     it("shows slim inline warning inside alert box with Fix link", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "other@example.com" } },
-      });
-      mockUseFeature.mockReturnValue("permissive");
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useFeature).mockReturnValue(
+        "permissive" as ReturnType<typeof useFeature>,
+      );
 
       render(<SidebarWarnings />);
 
@@ -99,18 +96,24 @@ describe("SidebarWarnings", () => {
     });
 
     it("does not show when no session exists", () => {
-      mockUseSession.mockReturnValue({ data: null });
-      mockUseFeature.mockReturnValue("permissive");
+      vi.mocked(useSession).mockReturnValue({
+        data: null,
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useFeature).mockReturnValue(
+        "permissive" as ReturnType<typeof useFeature>,
+      );
 
       const { container } = render(<SidebarWarnings />);
       expect(container.firstChild).toBeNull();
     });
 
     it("does not show when policy is not permissive", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "user@example.com" } },
-      });
-      mockUseFeature.mockReturnValue("strict");
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useFeature).mockReturnValue(
+        "strict" as ReturnType<typeof useFeature>,
+      );
 
       const { container } = render(<SidebarWarnings />);
       expect(container.firstChild).toBeNull();
@@ -119,13 +122,13 @@ describe("SidebarWarnings", () => {
 
   describe("default credentials warning", () => {
     it("renders DefaultCredentialsWarning with slim prop", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "admin@example.com" } },
-      });
-      mockUseDefaultCredentialsEnabled.mockReturnValue({
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
         data: true,
         isLoading: false,
-      });
+      } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
 
       render(<SidebarWarnings />);
 
@@ -135,27 +138,27 @@ describe("SidebarWarnings", () => {
     });
 
     it("does not show for non-admin users", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "other@example.com" } },
-      });
-      mockUseDefaultCredentialsEnabled.mockReturnValue({
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
         data: true,
         isLoading: false,
-      });
+      } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
 
       const { container } = render(<SidebarWarnings />);
       expect(container.firstChild).toBeNull();
     });
 
     it("does not show when basic auth is disabled", () => {
-      mockUseDisableBasicAuth.mockReturnValue(true);
-      mockUseSession.mockReturnValue({
+      vi.mocked(useDisableBasicAuth).mockReturnValue(true);
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "admin@example.com" } },
-      });
-      mockUseDefaultCredentialsEnabled.mockReturnValue({
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
         data: true,
         isLoading: false,
-      });
+      } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
 
       render(<SidebarWarnings />);
       expect(
@@ -164,13 +167,13 @@ describe("SidebarWarnings", () => {
     });
 
     it("does not show when credentials are not default", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "admin@example.com" } },
-      });
-      mockUseDefaultCredentialsEnabled.mockReturnValue({
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
         data: false,
         isLoading: false,
-      });
+      } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
 
       const { container } = render(<SidebarWarnings />);
       expect(container.firstChild).toBeNull();
@@ -179,14 +182,16 @@ describe("SidebarWarnings", () => {
 
   describe("both warnings", () => {
     it("shows both warnings inside a single alert box without accordion", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "admin@example.com" } },
-      });
-      mockUseDefaultCredentialsEnabled.mockReturnValue({
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
         data: true,
         isLoading: false,
-      });
-      mockUseFeature.mockReturnValue("permissive");
+      } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
+      vi.mocked(useFeature).mockReturnValue(
+        "permissive" as ReturnType<typeof useFeature>,
+      );
 
       render(<SidebarWarnings />);
 
@@ -202,21 +207,21 @@ describe("SidebarWarnings", () => {
 
   describe("permission gating", () => {
     it("hides default credentials warning when user lacks organization:update permission", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "admin@example.com" } },
-      });
-      mockUseDefaultCredentialsEnabled.mockReturnValue({
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
         data: true,
         isLoading: false,
-      });
-      mockUseHasPermissions.mockImplementation((permissions) => {
+      } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
+      vi.mocked(useHasPermissions).mockImplementation((permissions) => {
         if ("organization" in (permissions as Record<string, unknown>)) {
-          return { data: false };
+          return { data: false } as ReturnType<typeof useHasPermissions>;
         }
         if ("agentSettings" in (permissions as Record<string, unknown>)) {
-          return { data: true };
+          return { data: true } as ReturnType<typeof useHasPermissions>;
         }
-        return { data: false };
+        return { data: false } as ReturnType<typeof useHasPermissions>;
       });
 
       const { container } = render(<SidebarWarnings />);
@@ -227,18 +232,20 @@ describe("SidebarWarnings", () => {
     });
 
     it("hides security engine warning when user lacks agentSettings:update permission", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "other@example.com" } },
-      });
-      mockUseFeature.mockReturnValue("permissive");
-      mockUseHasPermissions.mockImplementation((permissions) => {
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useFeature).mockReturnValue(
+        "permissive" as ReturnType<typeof useFeature>,
+      );
+      vi.mocked(useHasPermissions).mockImplementation((permissions) => {
         if ("organization" in (permissions as Record<string, unknown>)) {
-          return { data: true };
+          return { data: true } as ReturnType<typeof useHasPermissions>;
         }
         if ("agentSettings" in (permissions as Record<string, unknown>)) {
-          return { data: false };
+          return { data: false } as ReturnType<typeof useHasPermissions>;
         }
-        return { data: false };
+        return { data: false } as ReturnType<typeof useHasPermissions>;
       });
 
       const { container } = render(<SidebarWarnings />);
@@ -247,15 +254,19 @@ describe("SidebarWarnings", () => {
     });
 
     it("hides both warnings when user lacks agentSettings:update permission", () => {
-      mockUseSession.mockReturnValue({
+      vi.mocked(useSession).mockReturnValue({
         data: { user: { email: "admin@example.com" } },
-      });
-      mockUseDefaultCredentialsEnabled.mockReturnValue({
+      } as unknown as ReturnType<typeof useSession>);
+      vi.mocked(useDefaultCredentialsEnabled).mockReturnValue({
         data: true,
         isLoading: false,
-      });
-      mockUseFeature.mockReturnValue("permissive");
-      mockUseHasPermissions.mockImplementation(() => ({ data: false }));
+      } as unknown as ReturnType<typeof useDefaultCredentialsEnabled>);
+      vi.mocked(useFeature).mockReturnValue(
+        "permissive" as ReturnType<typeof useFeature>,
+      );
+      vi.mocked(useHasPermissions).mockImplementation(
+        () => ({ data: false }) as ReturnType<typeof useHasPermissions>,
+      );
 
       const { container } = render(<SidebarWarnings />);
       expect(container.firstChild).toBeNull();

--- a/platform/frontend/src/components/table-row-actions.test.tsx
+++ b/platform/frontend/src/components/table-row-actions.test.tsx
@@ -1,21 +1,24 @@
 import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  useHasPermissions,
+  useMissingPermissions,
+} from "@/lib/auth/auth.query";
 import { type TableRowAction, TableRowActions } from "./table-row-actions";
 
 // Mocking icons
 const MockIcon = () => <span data-testid="mock-icon">Icon</span>;
 
-// Mocking hooks
+// The PermissionButton mock below reads the same hook the component does, so a
+// single shared hoisted driver keeps both in lockstep; the bare auth.query mock
+// delegates the real hooks to it in `beforeEach`.
 const { useHasPermissionsMock, useMissingPermissionsMock } = vi.hoisted(() => ({
   useHasPermissionsMock: vi.fn(() => ({ data: true })),
   useMissingPermissionsMock: vi.fn(() => ({})),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: useHasPermissionsMock,
-  useMissingPermissions: useMissingPermissionsMock,
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/auth/auth.utils", () => ({
   formatMissingPermissions: vi.fn(() => "Missing permissions"),
@@ -167,6 +170,12 @@ describe("TableRowActions", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useHasPermissions).mockImplementation(
+      useHasPermissionsMock as unknown as typeof useHasPermissions,
+    );
+    vi.mocked(useMissingPermissions).mockImplementation(
+      useMissingPermissionsMock as unknown as typeof useMissingPermissions,
+    );
     useHasPermissionsMock.mockReturnValue({ data: true });
   });
 

--- a/platform/frontend/src/components/teams/team-management-dialog.test.tsx
+++ b/platform/frontend/src/components/teams/team-management-dialog.test.tsx
@@ -2,17 +2,15 @@ import type { archestraApiTypes } from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature } from "@/lib/config/config.query";
 import { TeamManagementDialog } from "./team-management-dialog";
 
 type Team = archestraApiTypes.GetTeamsResponses["200"]["data"][number];
 
-const { useFeatureMock, useHasPermissionsMock, useTokensMock } = vi.hoisted(
-  () => ({
-    useFeatureMock: vi.fn(),
-    useHasPermissionsMock: vi.fn(),
-    useTokensMock: vi.fn(),
-  }),
-);
+const { useTokensMock } = vi.hoisted(() => ({
+  useTokensMock: vi.fn(),
+}));
 
 vi.mock("@/components/tabbed-dialog-shell", () => ({
   TabbedDialogShell: ({
@@ -28,9 +26,7 @@ vi.mock("@/components/tabbed-dialog-shell", () => ({
   ),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: useHasPermissionsMock,
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/config/config", () => ({
   default: {
@@ -40,9 +36,7 @@ vi.mock("@/lib/config/config", () => ({
   },
 }));
 
-vi.mock("@/lib/config/config.query", () => ({
-  useFeature: useFeatureMock,
-}));
+vi.mock("@/lib/config/config.query");
 
 vi.mock("@/lib/teams/team-token.query", () => ({
   useTokens: useTokensMock,
@@ -51,8 +45,12 @@ vi.mock("@/lib/teams/team-token.query", () => ({
 describe("TeamManagementDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useFeatureMock.mockReturnValue(true);
-    useHasPermissionsMock.mockReturnValue({ data: false });
+    vi.mocked(useFeature).mockReturnValue(
+      true as ReturnType<typeof useFeature>,
+    );
+    vi.mocked(useHasPermissions).mockReturnValue({ data: false } as ReturnType<
+      typeof useHasPermissions
+    >);
     useTokensMock.mockReturnValue({ data: { tokens: [] } });
   });
 
@@ -66,7 +64,9 @@ describe("TeamManagementDialog", () => {
   });
 
   it("shows token and vault tabs to users with team:update when vault is enabled", () => {
-    useHasPermissionsMock.mockReturnValue({ data: true });
+    vi.mocked(useHasPermissions).mockReturnValue({ data: true } as ReturnType<
+      typeof useHasPermissions
+    >);
 
     renderDialog();
 
@@ -75,8 +75,12 @@ describe("TeamManagementDialog", () => {
   });
 
   it("hides the vault tab when vault is disabled", () => {
-    useHasPermissionsMock.mockReturnValue({ data: true });
-    useFeatureMock.mockReturnValue(false);
+    vi.mocked(useHasPermissions).mockReturnValue({ data: true } as ReturnType<
+      typeof useHasPermissions
+    >);
+    vi.mocked(useFeature).mockReturnValue(
+      false as ReturnType<typeof useFeature>,
+    );
 
     renderDialog();
 

--- a/platform/frontend/src/components/teams/team-management-external-sync.ee.test.tsx
+++ b/platform/frontend/src/components/teams/team-management-external-sync.ee.test.tsx
@@ -2,38 +2,39 @@ import type { archestraApiTypes } from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { TeamManagementExternalSyncSection } from "./team-management-external-sync.ee";
 
 type Team = archestraApiTypes.GetTeamsResponses["200"]["data"][number];
 
-const { useHasPermissionsMock, useIdentityProvidersMock } = vi.hoisted(() => ({
-  useHasPermissionsMock: vi.fn(),
+const { useIdentityProvidersMock } = vi.hoisted(() => ({
   useIdentityProvidersMock: vi.fn(),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: useHasPermissionsMock,
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/auth/identity-provider.query.ee", () => ({
   useIdentityProviderLatestIdTokenClaims: vi.fn(() => ({ data: null })),
   useIdentityProviders: useIdentityProvidersMock,
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Test App",
-}));
+vi.mock("@/lib/hooks/use-app-name");
 
 describe("TeamManagementExternalSyncSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useAppName).mockReturnValue("Test App");
     useIdentityProvidersMock.mockReturnValue({ data: [] });
   });
 
   it("links users with identityProvider:create to identity provider setup", () => {
-    useHasPermissionsMock.mockImplementation((permissions) => ({
-      data: permissions.identityProvider?.includes("create") ?? false,
-    }));
+    vi.mocked(useHasPermissions).mockImplementation(
+      (permissions) =>
+        ({
+          data: permissions.identityProvider?.includes("create") ?? false,
+        }) as ReturnType<typeof useHasPermissions>,
+    );
 
     renderSection();
 
@@ -46,7 +47,9 @@ describe("TeamManagementExternalSyncSection", () => {
   });
 
   it("asks users without identityProvider:create to contact an admin", () => {
-    useHasPermissionsMock.mockReturnValue({ data: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as ReturnType<typeof useHasPermissions>);
 
     renderSection();
 

--- a/platform/frontend/src/components/teams/teams-list.test.tsx
+++ b/platform/frontend/src/components/teams/teams-list.test.tsx
@@ -2,34 +2,24 @@ import type { archestraApiTypes } from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import {
+  useTeamLabelKeys,
+  useTeamLabelValues,
+  useTeams,
+} from "@/lib/teams/team.query";
 import { TeamsList } from "./teams-list";
 
 type Team = archestraApiTypes.GetTeamsResponses["200"]["data"][number];
 
-const {
-  mockSetSettingsAction,
-  useHasPermissionsMock,
-  useSessionMock,
-  useTeamsMock,
-  useTeamLabelKeysMock,
-  useTeamLabelValuesMock,
-  queryParamsHolder,
-} = vi.hoisted(() => ({
+const { mockSetSettingsAction, queryParamsHolder } = vi.hoisted(() => ({
   mockSetSettingsAction: vi.fn(),
-  useHasPermissionsMock: vi.fn(),
-  useSessionMock: vi.fn(),
-  useTeamsMock: vi.fn(),
-  useTeamLabelKeysMock: vi.fn(),
-  useTeamLabelValuesMock: vi.fn(),
   queryParamsHolder: { current: new URLSearchParams() },
 }));
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
-  usePathname: () => "/settings/teams",
-  useSearchParams: () => new URLSearchParams(),
-}));
+vi.mock("next/navigation");
 
 vi.mock("@/app/settings/layout", () => ({
   useSetSettingsAction: () => mockSetSettingsAction,
@@ -110,10 +100,7 @@ vi.mock("@/components/table-row-actions", () => ({
   ),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: useHasPermissionsMock,
-  useSession: useSessionMock,
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/hooks/use-data-table-query-params", () => ({
   useDataTableQueryParams: () => ({
@@ -122,11 +109,7 @@ vi.mock("@/lib/hooks/use-data-table-query-params", () => ({
   }),
 }));
 
-vi.mock("@/lib/teams/team.query", () => ({
-  useTeams: useTeamsMock,
-  useTeamLabelKeys: useTeamLabelKeysMock,
-  useTeamLabelValues: useTeamLabelValuesMock,
-}));
+vi.mock("@/lib/teams/team.query");
 
 vi.mock("./team-management-dialog", () => ({
   TeamManagementDialog: ({
@@ -141,18 +124,38 @@ vi.mock("./team-management-dialog", () => ({
 describe("TeamsList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useSessionMock.mockReturnValue({ data: { user: { id: "user-1" } } });
-    useHasPermissionsMock.mockImplementation((permissions) => ({
-      data: !permissions.team?.includes("update"),
-    }));
-    useTeamLabelKeysMock.mockReturnValue({ data: [] });
-    useTeamLabelValuesMock.mockReturnValue({ data: [] });
-    useTeamsMock.mockReturnValue({ data: [], isLoading: false });
+    vi.mocked(useRouter).mockReturnValue({
+      replace: vi.fn(),
+      push: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(usePathname).mockReturnValue("/settings/teams");
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+    );
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "user-1" } },
+    } as ReturnType<typeof useSession>);
+    vi.mocked(useHasPermissions).mockImplementation(
+      (permissions) =>
+        ({
+          data: !permissions.team?.includes("update"),
+        }) as ReturnType<typeof useHasPermissions>,
+    );
+    vi.mocked(useTeamLabelKeys).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeamLabelKeys>);
+    vi.mocked(useTeamLabelValues).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeamLabelValues>);
+    vi.mocked(useTeams).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useTeams>);
     queryParamsHolder.current = new URLSearchParams();
   });
 
   it("lets literal team admins edit their team without organization-level team update permission", () => {
-    useTeamsMock.mockReturnValue({
+    vi.mocked(useTeams).mockReturnValue({
       data: [
         makeTeam({
           members: [
@@ -164,7 +167,7 @@ describe("TeamsList", () => {
         }),
       ],
       isLoading: false,
-    });
+    } as unknown as ReturnType<typeof useTeams>);
 
     renderTeamsList();
 
@@ -177,7 +180,7 @@ describe("TeamsList", () => {
   });
 
   it("keeps edit disabled for regular team members without organization-level team update permission", () => {
-    useTeamsMock.mockReturnValue({
+    vi.mocked(useTeams).mockReturnValue({
       data: [
         makeTeam({
           members: [
@@ -189,7 +192,7 @@ describe("TeamsList", () => {
         }),
       ],
       isLoading: false,
-    });
+    } as unknown as ReturnType<typeof useTeams>);
 
     renderTeamsList();
 
@@ -203,7 +206,7 @@ describe("TeamsList", () => {
 
     renderTeamsList();
 
-    expect(useTeamsMock).toHaveBeenCalledWith(
+    expect(useTeams).toHaveBeenCalledWith(
       expect.objectContaining({ name: "platform", labels: "env:prod" }),
     );
   });

--- a/platform/frontend/src/lib/__mocks__/organization.query.ts
+++ b/platform/frontend/src/lib/__mocks__/organization.query.ts
@@ -1,0 +1,38 @@
+/**
+ * Jest-style mock for `@/lib/organization.query`, activated per test file by a bare
+ * `vi.mock("@/lib/organization.query");`. Every hook is a bare `vi.fn()` — configure per
+ * test via `vi.mocked(...)`. Query-key constants stay real (pure data).
+ */
+import { vi } from "vitest";
+
+const actual = await vi.importActual<typeof import("@/lib/organization.query")>(
+  "@/lib/organization.query",
+);
+
+export const appearanceKeys = actual.appearanceKeys;
+export const organizationKeys = actual.organizationKeys;
+
+export const useAppearanceSettings = vi.fn();
+export const useInvitation = vi.fn();
+export const useActiveOrganization = vi.fn();
+export const useActiveMemberRole = vi.fn();
+export const useAcceptInvitation = vi.fn();
+export const useInvitationsList = vi.fn();
+export const useCancelInvitation = vi.fn();
+export const useCreateInvitation = vi.fn();
+export const useOrganization = vi.fn();
+export const useOrganizationOnboardingStatus = vi.fn();
+export const useUpdateAppearanceSettings = vi.fn();
+export const useUpdateSecuritySettings = vi.fn();
+export const useUpdateLlmSettings = vi.fn();
+export const useUpdateAgentSettings = vi.fn();
+export const useUpdateConnectionSettings = vi.fn();
+export const useUpdateDefaultEnvironment = vi.fn();
+export const useDefaultEnvironment = vi.fn();
+export const useUpdateAuthSettings = vi.fn();
+export const useUpdateKnowledgeSettings = vi.fn();
+export const useDropEmbeddingConfig = vi.fn();
+export const useTestEmbeddingConnection = vi.fn();
+export const useOrganizationMembers = vi.fn();
+export const useMemberSignupStatus = vi.fn();
+export const useDeletePendingSignupMember = vi.fn();

--- a/platform/frontend/src/lib/auth/__mocks__/auth.query.ts
+++ b/platform/frontend/src/lib/auth/__mocks__/auth.query.ts
@@ -1,0 +1,20 @@
+/**
+ * Jest-style mock for `@/lib/auth/auth.query`, activated per test file by a
+ * bare `vi.mock("@/lib/auth/auth.query");`. Every hook is a bare `vi.fn()` —
+ * configure per test via `vi.mocked(useHasPermissions).mockReturnValue(...)`.
+ * The query-key helpers stay real (pure data, safe everywhere).
+ */
+import { vi } from "vitest";
+
+const actual = await vi.importActual<typeof import("@/lib/auth/auth.query")>(
+  "@/lib/auth/auth.query",
+);
+
+export const authQueryKeys = actual.authQueryKeys;
+export const useSession = vi.fn();
+export const useCurrentOrgMembers = vi.fn();
+export const useHasPermissions = vi.fn();
+export const useMissingPermissions = vi.fn();
+export const useAllPermissions = vi.fn();
+export const usePermissionMap = vi.fn();
+export const useDefaultCredentialsEnabled = vi.fn();

--- a/platform/frontend/src/lib/auth/account.query.test.ts
+++ b/platform/frontend/src/lib/auth/account.query.test.ts
@@ -5,13 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSignInWithEmailMutation } from "@/lib/auth/account.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    signIn: {
-      email: vi.fn(),
-    },
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 function createWrapper() {
   const queryClient = new QueryClient({

--- a/platform/frontend/src/lib/auth/account.query.test.tsx
+++ b/platform/frontend/src/lib/auth/account.query.test.tsx
@@ -6,18 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { useChangeAccountPasswordMutation } from "./account.query";
 
-vi.mock("sonner", () => ({
-  toast: {
-    error: vi.fn(),
-    success: vi.fn(),
-  },
-}));
+vi.mock("sonner");
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    changePassword: vi.fn(),
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 describe("useChangeAccountPasswordMutation", () => {
   beforeEach(() => {

--- a/platform/frontend/src/lib/auth/auth.hook.test.ts
+++ b/platform/frontend/src/lib/auth/auth.hook.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
 import { useSession } from "@/lib/auth/auth.query";
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 type Session = ReturnType<typeof useSession>;
 

--- a/platform/frontend/src/lib/auth/auth.query.test.tsx
+++ b/platform/frontend/src/lib/auth/auth.query.test.tsx
@@ -13,14 +13,7 @@ import * as authUtils from "@/lib/auth/auth.utils";
 import { authClient } from "@/lib/clients/auth/auth-client";
 
 // Mock the auth client and SDK
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    getSession: vi.fn(),
-    organization: {
-      listMembers: vi.fn(),
-    },
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 vi.mock("@archestra/shared", async () => {
   const actual = await vi.importActual("@archestra/shared");

--- a/platform/frontend/src/lib/chat/chat.query.test.tsx
+++ b/platform/frontend/src/lib/chat/chat.query.test.tsx
@@ -1,6 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, test, vi } from "vitest";
 import { handleApiError } from "@/lib/utils";
@@ -32,10 +33,7 @@ vi.mock("@archestra/shared", () => ({
   PLAYWRIGHT_MCP_SERVER_NAME: "playwright-mcp",
 }));
 
-const mockPathname = { value: "/chat" };
-vi.mock("next/navigation", () => ({
-  usePathname: () => mockPathname.value,
-}));
+vi.mock("next/navigation");
 
 const wsHandlers: Record<string, (msg: unknown) => void> = {};
 vi.mock("@/lib/websocket/websocket", () => ({
@@ -410,7 +408,7 @@ describe("conversation read-state hooks", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPathname.value = "/chat";
+    vi.mocked(usePathname).mockReturnValue("/chat");
     for (const key of Object.keys(wsHandlers)) delete wsHandlers[key];
     vi.mocked(archestraApiSdk.markChatConversationRead).mockResolvedValue({
       data: { success: true },
@@ -441,7 +439,7 @@ describe("conversation read-state hooks", () => {
   });
 
   it("useKeepViewedConversationRead marks the viewed unread conversation read", async () => {
-    mockPathname.value = "/chat/c1";
+    vi.mocked(usePathname).mockReturnValue("/chat/c1");
     renderWithSeed(
       () => useKeepViewedConversationRead(),
       seededList({ id: "c1", unread: true }),
@@ -455,7 +453,7 @@ describe("conversation read-state hooks", () => {
   });
 
   it("useKeepViewedConversationRead does not mark an already-read viewed conversation", async () => {
-    mockPathname.value = "/chat/c1";
+    vi.mocked(usePathname).mockReturnValue("/chat/c1");
     renderWithSeed(
       () => useKeepViewedConversationRead(),
       seededList({ id: "c1", unread: false }),
@@ -466,7 +464,7 @@ describe("conversation read-state hooks", () => {
   });
 
   it("useKeepViewedConversationRead does not mark read off a conversation route", async () => {
-    mockPathname.value = "/chat";
+    vi.mocked(usePathname).mockReturnValue("/chat");
     renderWithSeed(
       () => useKeepViewedConversationRead(),
       seededList({ id: "c1", unread: true }),

--- a/platform/frontend/src/lib/chat/conversation-search.hook.test.ts
+++ b/platform/frontend/src/lib/chat/conversation-search.hook.test.ts
@@ -1,19 +1,20 @@
 "use client";
 
 import { act, renderHook } from "@testing-library/react";
+import { useRouter } from "next/navigation";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useConversationSearch } from "@/lib/chat/conversation-search.hook";
 
-const mockPush = vi.fn();
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockPush }),
-}));
+vi.mock("next/navigation");
 
 describe("useConversationSearch", () => {
   let originalPlatform: string;
 
   beforeEach(() => {
     originalPlatform = navigator.platform;
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
   });
 
   afterEach(() => {

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1,7 +1,9 @@
 import type { UIMessage } from "@ai-sdk/react";
 import { act, render, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
+import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { ChatProvider, useGlobalChat } from "./global-chat.context";
 
 type ChatSessionSnapshot = ReturnType<
@@ -22,7 +24,6 @@ const mocks = vi.hoisted(() => ({
   sendMessage: vi.fn(),
   setMessages: vi.fn(),
   stop: vi.fn(),
-  toastError: vi.fn(),
   useChat: vi.fn(),
 }));
 
@@ -35,11 +36,7 @@ vi.mock("ai", () => ({
   lastAssistantMessageIsCompleteWithApprovalResponses: vi.fn(() => true),
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    error: mocks.toastError,
-  },
-}));
+vi.mock("sonner");
 
 vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({
@@ -71,9 +68,11 @@ vi.mock("@/lib/chat/chat.query", () => ({
   useConversationUpdatedCacheSync: () => {},
 }));
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Archestra",
-}));
+vi.mock("@/lib/hooks/use-app-name");
+
+beforeEach(() => {
+  vi.mocked(useAppName).mockReturnValue("Archestra");
+});
 
 vi.mock("@/lib/config/config", () => ({
   default: {
@@ -587,7 +586,7 @@ describe("ChatProvider retries", () => {
       );
     });
 
-    expect(mocks.toastError).toHaveBeenCalledWith(
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
       "This conversation already has a response in progress. Stop it before sending another message.",
     );
     expect(mocks.regenerate).not.toHaveBeenCalled();
@@ -643,7 +642,7 @@ describe("ChatProvider retries", () => {
     // run via the replay endpoint instead of telling the user to stop a
     // response they cannot see.
     expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
-    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
   });
 
   it("concludes recovery when the reattach finds the run already finished (204 no-op)", async () => {
@@ -720,7 +719,7 @@ describe("ChatProvider retries", () => {
       );
     });
     expect(mocks.resumeStream).toHaveBeenCalledTimes(1);
-    expect(mocks.toastError).toHaveBeenCalledWith(
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
       "This conversation already has a response in progress. Stop it before sending another message.",
     );
   });

--- a/platform/frontend/src/lib/chatops/chatops-config.query.test.tsx
+++ b/platform/frontend/src/lib/chatops/chatops-config.query.test.tsx
@@ -17,12 +17,7 @@ vi.mock("@archestra/shared", async () => {
   };
 });
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
-}));
+vi.mock("sonner");
 
 vi.mock("@/lib/utils", async () => {
   const actual = await vi.importActual("@/lib/utils");

--- a/platform/frontend/src/lib/clients/auth/__mocks__/auth-client.ts
+++ b/platform/frontend/src/lib/clients/auth/__mocks__/auth-client.ts
@@ -1,0 +1,30 @@
+/**
+ * Jest-style mock for `@/lib/clients/auth/auth-client`, activated per test
+ * file by a bare `vi.mock("@/lib/clients/auth/auth-client");`.
+ *
+ * better-auth's client is a deep tree (authClient.signIn.email,
+ * authClient.twoFactor.verifyTotp, ...) that tests mock in different
+ * shapes, so `authClient` is a memoized proxy: every property path yields a
+ * stable node that is BOTH callable (a `vi.fn()`) and traversable. Configure
+ * any leaf with `vi.mocked(authClient.listSessions).mockResolvedValue(...)`;
+ * `vi.clearAllMocks()` covers the nodes like any other mock.
+ */
+import { vi } from "vitest";
+
+// biome-ignore lint/suspicious/noExplicitAny: intentionally shapeless test double
+function mockNode(): any {
+  const fn = vi.fn();
+  const children = new Map<string | symbol, unknown>();
+  return new Proxy(fn, {
+    get(target, prop, receiver) {
+      // vi.fn internals (mock, mockReturnValue, ...) and Function.prototype
+      if (prop in target) return Reflect.get(target, prop, receiver);
+      // Play nice with promise-resolution probes.
+      if (prop === "then") return undefined;
+      if (!children.has(prop)) children.set(prop, mockNode());
+      return children.get(prop);
+    },
+  });
+}
+
+export const authClient = mockNode();

--- a/platform/frontend/src/lib/config/__mocks__/config.query.ts
+++ b/platform/frontend/src/lib/config/__mocks__/config.query.ts
@@ -1,0 +1,17 @@
+/**
+ * Jest-style mock for `@/lib/config/config.query`, activated per test file by a bare
+ * `vi.mock("@/lib/config/config.query");`. Every hook is a bare `vi.fn()` — configure per
+ * test via `vi.mocked(...)`. Query-key constants stay real (pure data).
+ */
+import { vi } from "vitest";
+
+export const useConfig = vi.fn();
+export const usePublicConfig = vi.fn();
+export const useDisableBasicAuth = vi.fn();
+export const useDisableInvitations = vi.fn();
+export const usePublicEnterpriseCoreActive = vi.fn();
+export const useProviderBaseUrls = vi.fn();
+export const useFeature = vi.fn();
+export const useEnterpriseFeature = vi.fn();
+export const useSmallTeamTier = vi.fn();
+export const usePublicBaseUrl = vi.fn();

--- a/platform/frontend/src/lib/config/connectivity.test.tsx
+++ b/platform/frontend/src/lib/config/connectivity.test.tsx
@@ -16,7 +16,7 @@ vi.mock("@archestra/shared", async (importOriginal) => {
   };
 });
 
-vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("sonner");
 
 import { ConnectivityProvider, useConnectivity } from "./connectivity";
 

--- a/platform/frontend/src/lib/hooks/__mocks__/use-app-name.ts
+++ b/platform/frontend/src/lib/hooks/__mocks__/use-app-name.ts
@@ -1,0 +1,15 @@
+/**
+ * Jest-style mock for `@/lib/hooks/use-app-name`, activated per test file by a bare
+ * `vi.mock("@/lib/hooks/use-app-name");`. Every hook is a bare `vi.fn()` — configure per
+ * test via `vi.mocked(...)`. Query-key constants stay real (pure data).
+ */
+import { vi } from "vitest";
+
+const actual = await vi.importActual<typeof import("@/lib/hooks/use-app-name")>(
+  "@/lib/hooks/use-app-name",
+);
+
+export const DEFAULT_APP_LOGO = actual.DEFAULT_APP_LOGO;
+
+export const useAppName = vi.fn();
+export const useAppIconLogo = vi.fn();

--- a/platform/frontend/src/lib/hooks/use-app-name.test.ts
+++ b/platform/frontend/src/lib/hooks/use-app-name.test.ts
@@ -1,31 +1,33 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppearanceSettings } from "@/lib/organization.query";
 
-const { mockUseAppearanceSettings, mockUseTheme } = vi.hoisted(() => ({
-  mockUseAppearanceSettings: vi.fn(),
+const { mockUseTheme } = vi.hoisted(() => ({
   mockUseTheme: vi.fn(),
 }));
 
-vi.mock("@/lib/organization.query", () => ({
-  useAppearanceSettings: () => mockUseAppearanceSettings(),
-}));
+vi.mock("@/lib/organization.query");
 
 vi.mock("next-themes", () => ({
   useTheme: () => mockUseTheme(),
 }));
+
+function mockAppearance(data: unknown) {
+  vi.mocked(useAppearanceSettings).mockReturnValue({
+    data,
+  } as unknown as ReturnType<typeof useAppearanceSettings>);
+}
 
 import { useAppIconLogo, useAppName } from "./use-app-name";
 
 describe("useAppName", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseAppearanceSettings.mockReturnValue({ data: null });
+    mockAppearance(null);
   });
 
   it("uses the public appearance app name when available", () => {
-    mockUseAppearanceSettings.mockReturnValue({
-      data: { appName: "Sparky" },
-    });
+    mockAppearance({ appName: "Sparky" });
 
     const { result } = renderHook(() => useAppName());
 
@@ -42,14 +44,12 @@ describe("useAppName", () => {
 describe("useAppIconLogo", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseAppearanceSettings.mockReturnValue({ data: null });
+    mockAppearance(null);
     mockUseTheme.mockReturnValue({ resolvedTheme: "light" });
   });
 
   it("uses the public appearance icon logo when available", () => {
-    mockUseAppearanceSettings.mockReturnValue({
-      data: { iconLogo: "data:image/png;base64,appearance" },
-    });
+    mockAppearance({ iconLogo: "data:image/png;base64,appearance" });
 
     const { result } = renderHook(() => useAppIconLogo());
 
@@ -64,11 +64,9 @@ describe("useAppIconLogo", () => {
 
   it("uses the dark icon logo in dark mode when available", () => {
     mockUseTheme.mockReturnValue({ resolvedTheme: "dark" });
-    mockUseAppearanceSettings.mockReturnValue({
-      data: {
-        iconLogo: "data:image/png;base64,light",
-        iconLogoDark: "data:image/svg+xml;base64,dark",
-      },
+    mockAppearance({
+      iconLogo: "data:image/png;base64,light",
+      iconLogoDark: "data:image/svg+xml;base64,dark",
     });
 
     const { result } = renderHook(() => useAppIconLogo());
@@ -78,8 +76,9 @@ describe("useAppIconLogo", () => {
 
   it("falls back to the light icon logo in dark mode when no dark variant is set", () => {
     mockUseTheme.mockReturnValue({ resolvedTheme: "dark" });
-    mockUseAppearanceSettings.mockReturnValue({
-      data: { iconLogo: "data:image/png;base64,light", iconLogoDark: null },
+    mockAppearance({
+      iconLogo: "data:image/png;base64,light",
+      iconLogoDark: null,
     });
 
     const { result } = renderHook(() => useAppIconLogo());

--- a/platform/frontend/src/lib/hooks/use-data-table-query-params.test.ts
+++ b/platform/frontend/src/lib/hooks/use-data-table-query-params.test.ts
@@ -1,23 +1,28 @@
 "use client";
 
 import { act, renderHook } from "@testing-library/react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDataTableQueryParams } from "./use-data-table-query-params";
 
 const mockPush = vi.fn();
-const mockUseSearchParams = vi.fn();
 
-vi.mock("next/navigation", () => ({
-  usePathname: () => "/agents",
-  useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => mockUseSearchParams(),
-}));
+vi.mock("next/navigation");
+
+function setSearchParams(params: URLSearchParams) {
+  vi.mocked(useSearchParams).mockReturnValue(
+    params as unknown as ReturnType<typeof useSearchParams>,
+  );
+}
 
 describe("useDataTableQueryParams", () => {
   beforeEach(() => {
-    mockPush.mockReset();
-    mockUseSearchParams.mockReset();
-    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+    vi.clearAllMocks();
+    vi.mocked(usePathname).mockReturnValue("/agents");
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockPush,
+    } as unknown as ReturnType<typeof useRouter>);
+    setSearchParams(new URLSearchParams());
   });
 
   it("returns default pagination values when query params are absent", () => {
@@ -29,9 +34,7 @@ describe("useDataTableQueryParams", () => {
   });
 
   it("parses page and pageSize from search params", () => {
-    mockUseSearchParams.mockReturnValue(
-      new URLSearchParams("page=3&pageSize=25&search=models"),
-    );
+    setSearchParams(new URLSearchParams("page=3&pageSize=25&search=models"));
 
     const { result } = renderHook(() => useDataTableQueryParams());
 
@@ -42,9 +45,7 @@ describe("useDataTableQueryParams", () => {
   });
 
   it("updates query params and removes empty values", () => {
-    mockUseSearchParams.mockReturnValue(
-      new URLSearchParams("page=2&pageSize=10&search=agents"),
-    );
+    setSearchParams(new URLSearchParams("page=2&pageSize=10&search=agents"));
 
     const { result } = renderHook(() => useDataTableQueryParams());
 
@@ -62,9 +63,7 @@ describe("useDataTableQueryParams", () => {
   });
 
   it("pushes the bare pathname when all query params are removed", () => {
-    mockUseSearchParams.mockReturnValue(
-      new URLSearchParams("page=1&pageSize=10"),
-    );
+    setSearchParams(new URLSearchParams("page=1&pageSize=10"));
 
     const { result } = renderHook(() => useDataTableQueryParams());
 

--- a/platform/frontend/src/lib/knowledge/connector-runs-not-found.test.tsx
+++ b/platform/frontend/src/lib/knowledge/connector-runs-not-found.test.tsx
@@ -1,11 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetConnectorRuns, mockToastError } = vi.hoisted(() => ({
+const { mockGetConnectorRuns } = vi.hoisted(() => ({
   mockGetConnectorRuns: vi.fn(),
-  mockToastError: vi.fn(),
 }));
 
 vi.mock("@archestra/shared", async (importOriginal) => {
@@ -19,9 +19,7 @@ vi.mock("@archestra/shared", async (importOriginal) => {
   };
 });
 
-vi.mock("sonner", () => ({
-  toast: { error: mockToastError, success: vi.fn() },
-}));
+vi.mock("sonner");
 
 import { useConnectorRuns } from "./connector.query";
 
@@ -54,7 +52,7 @@ describe("useConnectorRuns — missing parent (404)", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBeNull();
     expect(result.current.isError).toBe(false);
-    expect(mockToastError).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("still surfaces a non-404 failure as an error", async () => {

--- a/platform/frontend/src/lib/knowledge/kb-document.query.test.tsx
+++ b/platform/frontend/src/lib/knowledge/kb-document.query.test.tsx
@@ -1,12 +1,12 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetConnectorDocuments = vi.fn();
 const mockGetConnectorDocument = vi.fn();
 const mockDeleteConnectorDocument = vi.fn();
 const mockHandleApiError = vi.fn();
-const mockToastSuccess = vi.fn();
 
 vi.mock("@archestra/shared", () => ({
   archestraApiSdk: {
@@ -23,11 +23,7 @@ vi.mock("@/lib/utils", () => ({
   handleApiError: (...args: unknown[]) => mockHandleApiError(...args),
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: (...args: unknown[]) => mockToastSuccess(...args),
-  },
-}));
+vi.mock("sonner");
 
 import {
   useConnectorDocument,
@@ -185,8 +181,6 @@ describe("kb-document query hooks", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["connectors", "connector-1"],
     });
-    expect(mockToastSuccess).toHaveBeenCalledWith(
-      "Document deleted successfully",
-    );
+    expect(toast.success).toHaveBeenCalledWith("Document deleted successfully");
   });
 });

--- a/platform/frontend/src/lib/knowledge/knowledge-base.query.test.tsx
+++ b/platform/frontend/src/lib/knowledge/knowledge-base.query.test.tsx
@@ -1,26 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOrganization } from "@/lib/organization.query";
 
 let mockOrganization: Record<string, unknown> | null = null;
 
-vi.mock("@/lib/organization.query", () => ({
-  useOrganization: () => ({
-    data: mockOrganization,
-    isPending: false,
-  }),
-}));
+vi.mock("@/lib/organization.query");
 
-vi.mock("@/lib/clients/auth/auth-client", () => ({
-  authClient: {
-    useSession: vi.fn().mockReturnValue({
-      data: {
-        user: { id: "test-user", email: "test@example.com" },
-        session: { id: "test-session" },
-      },
-    }),
-  },
-}));
+vi.mock("@/lib/clients/auth/auth-client");
 
 import {
   useIsKnowledgeBaseConfigured,
@@ -39,6 +26,13 @@ const createWrapper = () => {
 beforeEach(() => {
   vi.clearAllMocks();
   mockOrganization = null;
+  vi.mocked(useOrganization).mockImplementation(
+    () =>
+      ({
+        data: mockOrganization,
+        isPending: false,
+      }) as unknown as ReturnType<typeof useOrganization>,
+  );
 });
 
 describe("useIsKnowledgeBaseConfigured", () => {

--- a/platform/frontend/src/lib/llm-models.query.test.tsx
+++ b/platform/frontend/src/lib/llm-models.query.test.tsx
@@ -19,12 +19,7 @@ vi.mock("@archestra/shared", () => ({
   LAZY_MODEL_SYNC_STATUS_PENDING: "pending",
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    error: vi.fn(),
-    success: vi.fn(),
-  },
-}));
+vi.mock("sonner");
 
 describe("useLlmModels", () => {
   beforeEach(() => {

--- a/platform/frontend/src/lib/llm-provider-api-keys.query.test.tsx
+++ b/platform/frontend/src/lib/llm-provider-api-keys.query.test.tsx
@@ -1,14 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 
-const { mockGetLlmProviderApiKeys, mockToastError, mockHasPermissions } =
-  vi.hoisted(() => ({
-    mockGetLlmProviderApiKeys: vi.fn(),
-    mockToastError: vi.fn(),
-    mockHasPermissions: vi.fn(),
-  }));
+const { mockGetLlmProviderApiKeys } = vi.hoisted(() => ({
+  mockGetLlmProviderApiKeys: vi.fn(),
+}));
 
 vi.mock("@archestra/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@archestra/shared")>();
@@ -22,13 +21,9 @@ vi.mock("@archestra/shared", async (importOriginal) => {
   };
 });
 
-vi.mock("sonner", () => ({
-  toast: { error: mockToastError, success: vi.fn() },
-}));
+vi.mock("sonner");
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useHasPermissions: () => mockHasPermissions(),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 import {
   useHasAnyApiKey,
@@ -63,7 +58,7 @@ describe("useLlmProviderApiKeys", () => {
     // branch on to show the load-error state.
     expect(result.current.isLoadingError).toBe(true);
     expect(result.current.data).toBeUndefined();
-    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it("does not toast on failure when toastOnError is false", async () => {
@@ -77,7 +72,7 @@ describe("useLlmProviderApiKeys", () => {
     );
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(mockToastError).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("returns the keys on success without an error", async () => {
@@ -96,7 +91,9 @@ describe("useLlmProviderApiKeys", () => {
 describe("useHasAnyApiKey", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockHasPermissions.mockReturnValue({ data: true });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as unknown as ReturnType<typeof useHasPermissions>);
   });
 
   it("reports a load error when the first keys fetch fails", async () => {
@@ -111,7 +108,9 @@ describe("useHasAnyApiKey", () => {
   });
 
   it("does not run the query or report a load error without read permission", async () => {
-    mockHasPermissions.mockReturnValue({ data: false });
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: false,
+    } as unknown as ReturnType<typeof useHasPermissions>);
 
     const { result } = renderHook(() => useHasAnyApiKey(), { wrapper });
 

--- a/platform/frontend/src/lib/mcp/archestra-mcp-server.test.tsx
+++ b/platform/frontend/src/lib/mcp/archestra-mcp-server.test.tsx
@@ -1,16 +1,16 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppName } from "@/lib/hooks/use-app-name";
 
-const mockUseAppName = vi.fn();
-const mockConfig = {
-  enterpriseFeatures: {
-    fullWhiteLabeling: false,
+const { mockConfig } = vi.hoisted(() => ({
+  mockConfig: {
+    enterpriseFeatures: {
+      fullWhiteLabeling: false,
+    },
   },
-};
-
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => mockUseAppName(),
 }));
+
+vi.mock("@/lib/hooks/use-app-name");
 
 vi.mock("@/lib/config/config", () => ({
   default: new Proxy(
@@ -33,7 +33,7 @@ describe("useArchestraMcpIdentity", () => {
   });
 
   it("returns default built-in MCP identity when full white-labeling is disabled", () => {
-    mockUseAppName.mockReturnValue("Sparky");
+    vi.mocked(useAppName).mockReturnValue("Sparky");
     mockConfig.enterpriseFeatures.fullWhiteLabeling = false;
 
     const { result } = renderHook(() => useArchestraMcpIdentity());
@@ -51,7 +51,7 @@ describe("useArchestraMcpIdentity", () => {
   });
 
   it("returns branded MCP identity when full white-labeling is enabled", () => {
-    mockUseAppName.mockReturnValue("Sparky");
+    vi.mocked(useAppName).mockReturnValue("Sparky");
     mockConfig.enterpriseFeatures.fullWhiteLabeling = true;
 
     const { result } = renderHook(() => useArchestraMcpIdentity());
@@ -69,7 +69,7 @@ describe("useArchestraMcpIdentity", () => {
   });
 
   it("returns stable references across rerenders when branding inputs are unchanged", () => {
-    mockUseAppName.mockReturnValue("Sparky");
+    vi.mocked(useAppName).mockReturnValue("Sparky");
     mockConfig.enterpriseFeatures.fullWhiteLabeling = true;
 
     const { result, rerender } = renderHook(() => useArchestraMcpIdentity());

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSession } from "@/lib/auth/auth.query";
 import { useMcpInstallOrchestrator } from "./mcp-install-orchestrator.hook";
 
 const {
@@ -44,9 +45,7 @@ vi.mock("@/lib/mcp/mcp-server.query", () => ({
   }),
 }));
 
-vi.mock("@/lib/auth/auth.query", () => ({
-  useSession: () => ({ data: { user: { id: "test-user" } } }),
-}));
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@/lib/auth/oauth.query", () => ({
   useInitiateOAuth: () => ({
@@ -85,6 +84,9 @@ vi.mock("@/lib/auth/oauth-session", () => ({
 describe("useMcpInstallOrchestrator", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "test-user" } },
+    } as unknown as ReturnType<typeof useSession>);
     mutateAsyncMock.mockResolvedValue({
       authorizationUrl: "https://posthog.example.com/oauth/authorize",
       state: "oauth-state-123",

--- a/platform/frontend/src/lib/policy.query.test.tsx
+++ b/platform/frontend/src/lib/policy.query.test.tsx
@@ -2,11 +2,10 @@ import { archestraApiSdk } from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import type React from "react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCallPolicyMutation, useResultPolicyMutation } from "./policy.query";
 import { handleApiError } from "./utils";
-
-const mockToastSuccess = vi.fn();
 
 vi.mock("@archestra/shared", async () => {
   const actual = await vi.importActual("@archestra/shared");
@@ -21,12 +20,7 @@ vi.mock("@archestra/shared", async () => {
   };
 });
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: (...args: unknown[]) => mockToastSuccess(...args),
-    error: vi.fn(),
-  },
-}));
+vi.mock("sonner");
 
 vi.mock("./utils", async () => {
   const actual = await vi.importActual("./utils");
@@ -78,7 +72,7 @@ describe("policy row update mutations", () => {
     });
 
     expect(mutationResult).toBe(true);
-    expect(mockToastSuccess).toHaveBeenCalledWith("Call policy updated");
+    expect(toast.success).toHaveBeenCalledWith("Call policy updated");
     expect(handleApiError).not.toHaveBeenCalled();
   });
 
@@ -97,7 +91,7 @@ describe("policy row update mutations", () => {
     });
 
     expect(mutationResult).toBe(true);
-    expect(mockToastSuccess).toHaveBeenCalledWith("Result policy updated");
+    expect(toast.success).toHaveBeenCalledWith("Result policy updated");
     expect(handleApiError).not.toHaveBeenCalled();
   });
 });

--- a/platform/frontend/src/lib/teams/__mocks__/team.query.ts
+++ b/platform/frontend/src/lib/teams/__mocks__/team.query.ts
@@ -1,0 +1,14 @@
+/**
+ * Jest-style mock for `@/lib/teams/team.query`, activated per test file by a bare
+ * `vi.mock("@/lib/teams/team.query");`. Every hook is a bare `vi.fn()` — configure per
+ * test via `vi.mocked(...)`. Query-key constants stay real (pure data).
+ */
+import { vi } from "vitest";
+
+export const useTeams = vi.fn();
+export const useTeamLabelKeys = vi.fn();
+export const useTeamLabelValues = vi.fn();
+export const useMyTeams = vi.fn();
+export const useAssignableTeams = vi.fn();
+export const useTeamsPaginated = vi.fn();
+export const useTeamsWithVaultFolders = vi.fn();

--- a/platform/frontend/src/lib/utils/api.test.ts
+++ b/platform/frontend/src/lib/utils/api.test.ts
@@ -1,10 +1,7 @@
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockToastError } = vi.hoisted(() => ({ mockToastError: vi.fn() }));
-
-vi.mock("sonner", () => ({
-  toast: { error: mockToastError, success: vi.fn() },
-}));
+vi.mock("sonner");
 
 import { throwOnApiError } from "./api";
 
@@ -16,19 +13,19 @@ describe("throwOnApiError", () => {
   it("does nothing when there is no error", () => {
     expect(() => throwOnApiError(null)).not.toThrow();
     expect(() => throwOnApiError(undefined)).not.toThrow();
-    expect(mockToastError).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("throws and toasts on a real error by default", () => {
     expect(() => throwOnApiError({ message: "boom" })).toThrow();
-    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it("throws without toasting when toastOnError is false", () => {
     expect(() =>
       throwOnApiError({ message: "boom" }, { toastOnError: false }),
     ).toThrow();
-    expect(mockToastError).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("treats a not-found as a non-error when allowNotFound is set", () => {
@@ -38,7 +35,7 @@ describe("throwOnApiError", () => {
         { allowNotFound: true },
       ),
     ).not.toThrow();
-    expect(mockToastError).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("still throws on a not-found when allowNotFound is not set", () => {

--- a/platform/frontend/vitest.config.ts
+++ b/platform/frontend/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   resolve: {
     alias: {
+      // Explicit absolute-path alias (tsconfigPaths also provides "@/", but
+      // Vitest's Jest-style __mocks__ sibling resolution only works reliably
+      // through resolve.alias — with tsconfig-paths-only aliasing it silently
+      // falls back to automocking (vitest-dev/vitest#8343).
+      "@": path.resolve(__dirname, "./src"),
       "@archestra/shared/access-control": path.resolve(
         __dirname,
         "../shared/access-control.ts",


### PR DESCRIPTION
Frontend follow-up to #6145's backend mock cleanup. (\`shared/\` was audited too: its 31 test files use no module mocks — nothing to do there. No perf/sharding changes — the frontend suite doesn't need them.)

## Why

121 of 262 frontend test files hand-rolled \`vi.mock\` factories for the same few modules: \`@/lib/auth/auth.query\` ×39, \`next/navigation\` ×30, \`@/lib/organization.query\` ×20, \`config.query\` ×19, \`use-app-name\` ×14, \`sonner\` ×13, \`auth-client\` ×13, \`team.query\` ×10 — every one a slightly different partial shape.

## What

- **Canonical \`__mocks__\` for eight specifiers**, activated by a bare \`vi.mock("<spec>");\`: query hooks are bare \`vi.fn()\`s (configure via \`vi.mocked\`), query-key constants stay real, better-auth's \`authClient\` is a memoized proxy (every path like \`authClient.signIn.email\` is a stable callable \`vi.fn\`), and \`next/navigation\` + \`sonner\` use the root-level \`__mocks__/\` convention for node_modules packages.
- **86 of 88 files converted**; two keep factories deliberately — their partial \`@/lib/config/config\` mocks break the canonical mocks' \`importActual\` chain (documented in the skill). Mixing is safe here: frontend tests are fully isolated per file, so the cross-file registry hazard (vitest#10145) can't occur.
- **\`vitest.config.ts\` now declares \`@\` as an absolute-path \`resolve.alias\`** — with tsconfig-paths-only aliasing, Vitest's \`__mocks__\` sibling resolution silently degrades to automocking (vitest-dev/vitest#8343). Verified empirically before converting.
- The typed shared mocks surfaced latent type mismatches the untyped factories hid (e.g. \`useMissingPermissions\` mocked to return \`[]\` where the signature says \`Permissions\`) — pinned with explicit casts preserving runtime behavior.
- \`archestra-dev-frontend\` skill updated with the conventions.

## Verification

Frontend \`check:ci\` fully green: **262 files / 2296 tests passed**, type-check, knip, biome.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>