### PR TITLE
fix(backend): capture pristine test config at setup-module scope

### DIFF
--- a/platform/backend/src/models/agent-tool.test.ts
+++ b/platform/backend/src/models/agent-tool.test.ts
@@ -17,6 +17,7 @@ import AgentToolModel from "./agent-tool";
 const originalAppsEnabled = config.apps.enabled;
 beforeEach(() => {
   (config.apps as { enabled: boolean }).enabled = false;
+  (config.skillsSandbox as { enabled: boolean }).enabled = false;
 });
 afterAll(() => {
   (config.apps as { enabled: boolean }).enabled = originalAppsEnabled;

--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -34,6 +34,10 @@ import TrustedDataPolicyModel from "./trusted-data-policy";
 const originalAppsEnabled = config.apps.enabled;
 beforeEach(() => {
   (config.apps as { enabled: boolean }).enabled = false;
+  // Pin every tool-gating flag this suite's expected tool sets assume —
+  // relying on the worker-pristine baseline for these let a rare cross-file
+  // ordering surface sandbox/app tools in the default-assignment counts.
+  (config.skillsSandbox as { enabled: boolean }).enabled = false;
 });
 afterAll(() => {
   (config.apps as { enabled: boolean }).enabled = originalAppsEnabled;

--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -56,9 +56,20 @@ process.setMaxListeners(20);
 
 // Module-level variables to persist across tests within a file
 let pgliteClient: PGlite | null = null;
-// Pristine config snapshot for the per-test restore (see beforeAll/beforeEach).
+// Pristine config snapshot for the per-test restore (see beforeEach).
+// Captured HERE at setup-module scope — setup files evaluate before any test
+// file's module code in the worker, so a test file that mutates config (or
+// installs accessors) during its own module evaluation can no longer poison
+// the baseline the way a first-file beforeAll capture could.
 let liveConfig: Record<string, unknown> | null = null;
 let pristineConfig: Record<string, unknown> | null = null;
+if (process.env.ARCHESTRA_TEST_SHARED_WORKERS === "true") {
+  liveConfig = (await import("../config.js")).default as unknown as Record<
+    string,
+    unknown
+  >;
+  pristineConfig = structuredClone(liveConfig);
+}
 let testDb: ReturnType<typeof drizzle> | null = null;
 const originalConsoleWarn = console.warn;
 
@@ -123,22 +134,6 @@ beforeAll(async () => {
   dbModule.__setTestDb(
     testDb as unknown as Parameters<typeof dbModule.__setTestDb>[0],
   );
-
-  // Snapshot the pristine config once per worker (first file's beforeAll).
-  // Tests mutate the real config object directly (config.apps.enabled = ...),
-  // and in a shared worker (isolate: false) an unrestored mutation leaks into
-  // every later file. beforeEach below restores this snapshot before each
-  // test, so per-test/beforeEach mutations keep working while nothing leaks.
-  // Only the shared-worker ("clean") vitest project needs this — isolated
-  // files can't leak across files, and their bespoke config mocks may carry
-  // getter-only properties the restore could not assign to.
-  if (process.env.ARCHESTRA_TEST_SHARED_WORKERS === "true") {
-    liveConfig ??= (await import("../config.js")).default as unknown as Record<
-      string,
-      unknown
-    >;
-    pristineConfig ??= structuredClone(liveConfig);
-  }
 });
 
 /**


### PR DESCRIPTION
Fixes the ordering flake that (correctly) kicked #6153 out of the merge queue — \`tool.test.ts\` intermittently saw sandbox/app tools in default-assignment counts.

## Mechanism

The per-test config restore (from #6145) snapshotted its pristine baseline in the **first test file's \`beforeAll\`** — which runs *after* that file's module scope. Anything that touches config during module evaluation of whichever file happens to load first in a worker poisons the baseline for every later file in that worker. Rare (needs a specific file-to-worker pairing), unreproducible with a fixed seed (worker assignment is timing-dependent), and exactly the kind of thing the sharded gate exists to catch.

## Fix

- Snapshot moves to **setup-module scope**: setup files evaluate before any test file's module code in the worker, so the poisoning window is structurally gone. Still gated to the shared-worker project via \`ARCHESTRA_TEST_SHARED_WORKERS\`.
- Defense-in-depth: \`tool.test.ts\`/\`agent-tool.test.ts\` now pin \`skillsSandbox\` alongside \`apps\` in their own \`beforeEach\` — suites asserting exact tool sets own every flag those sets depend on.

## Verification

Full backend suite: **590 files / 10137 tests, zero failures, zero unhandled errors** (first fully-clean run including the newly-ported e2e specs from #6155).

After this merges: **re-queue #6153** — its previous queue entry was evicted by this flake, not by anything wrong with the gate change itself.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>