### PR TITLE
ci(docker): assemble the production image with pnpm deploy

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -256,6 +256,31 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     SENTRY_URL=https://de.sentry.io/ \
     pnpm build
 
+# Assemble the production backend with `pnpm deploy` — pnpm's recommended
+# monorepo packaging step (https://pnpm.io/cli/deploy). It produces a
+# self-contained /prod/backend whose node_modules includes every workspace
+# dependency (the three NAPI crates, @archestra/napi-loader, @archestra/shared)
+# alongside their transitive production deps, with each crate able to resolve
+# @archestra/napi-loader from a nested store. This replaces the old hand-rolled
+# COPY of each crate's *.node / index.cjs into a workspace-shaped, root-hoisted
+# node_modules (the layout that dropped @archestra/napi-loader and crashed the
+# image with MODULE_NOT_FOUND).
+#
+# Ordering matters: this runs AFTER `pnpm build`, so the compiled *.node addons
+# already exist in each crate dir. deploy copies them via the crates' `files`
+# globs — it never rebuilds (install scripts are disabled repo-wide).
+#
+# --legacy keeps pnpm's original deploy implementation, which does not require
+# inject-workspace-packages=true. We deliberately avoid enabling that setting:
+# injecting would copy workspace packages into node_modules instead of
+# symlinking them, changing the dev/Tilt layout and breaking the NAPI crates'
+# watch-mode rebuilds. --legacy scopes the deploy semantics to this build step
+# only, leaving local development untouched. The frontend is intentionally not
+# deployed here: `next build` already emits a self-contained standalone server
+# (frontend/.next/standalone), which we copy directly below.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm deploy --filter=@backend --prod --legacy /prod/backend
+
 # <----- Final unified stage ----->
 FROM base AS unified
 WORKDIR /app
@@ -353,15 +378,10 @@ RUN mkdir -p /var/lib/postgresql/data /run/postgresql && \
 # Mark PostgreSQL data directory as a volume for data persistence
 VOLUME /var/lib/postgresql/data /app/data
 
-# Copy package files
-# pnpm-workspace.yaml contains pnpm v11 project settings.
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY backend/package.json backend/
-COPY frontend/package.json frontend/
-COPY archestra-rs/napi-loader/package.json archestra-rs/napi-loader/
-COPY archestra-rs/sandbox-rs/package.json archestra-rs/sandbox-rs/
-COPY archestra-rs/app-runtime-rs/package.json archestra-rs/app-runtime-rs/
-COPY archestra-rs/image-rs/package.json archestra-rs/image-rs/
+# Runtime files. The backend and its full node_modules arrive as a single
+# self-contained tree from the builder's `pnpm deploy` output (copied below),
+# and the frontend ships as Next's standalone server, so no package manifests
+# or `pnpm install` are needed in this stage.
 COPY docker/scripts/docker-banner.sh /app/docker-banner.sh
 COPY docker/scripts/docker-entrypoint.sh /docker-entrypoint.sh
 # slim Dagger Engine manifest (rendered in the dagger-manifest stage above)
@@ -373,51 +393,22 @@ COPY --from=dagger-engine-image /dagger-engine.tar /app/dagger-engine.tar
 COPY docker/supervisord/supervisord.conf /etc/supervisord.conf
 COPY docker/supervisord/postgres.conf /etc/supervisord.postgres.conf
 
-# Install production dependencies for both workspaces
-# The "..." suffix includes each package's workspace dependencies in the
-# install. Without it pnpm only creates node_modules for @backend/@frontend
-# themselves, and workspace deps' own runtime deps are never linked — the
-# three NAPI crates' index.cjs require @archestra/napi-loader and crash the
-# image with MODULE_NOT_FOUND (first surfaced as 500s on POST /api/apps).
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod --filter=@backend... --filter=@frontend...
-
-# CVE-2026-33671: replace Next's bundled picomatch 4.0.3 with 4.0.4 (same as deps stage).
-# Production install refetches next so the patched copy from the builder is not inherited.
-RUN set -eux; \
-    cd /tmp; \
-    wget -q -O picomatch-4.0.4.tgz https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz; \
-    echo "515b5ab666558ed9a117483a310892aede54a68dd78f2d8db6604513e578571c  picomatch-4.0.4.tgz" | sha256sum -c -; \
-    target=/app/frontend/node_modules/next/dist/compiled/picomatch; \
-    rm -rf "$target"/*; \
-    tar -xzf picomatch-4.0.4.tgz --strip-components=1 -C "$target"; \
-    rm -f picomatch-4.0.4.tgz; \
-    grep -q '"version": "4.0.4"' "$target/package.json"
-
 # CVE-2026-12151: corepack's cached pnpm bundles undici 6.26.0 (<6.27.0) at
 # /root/.cache/node/corepack/.../dist/node_modules/undici — pnpm overrides cannot
-# reach it. pnpm is only needed at build time (the prod install above); runtime DB
-# migrations call drizzle-kit directly (see docker/supervisord/supervisord.conf),
-# so drop corepack/pnpm from the final image entirely.
+# reach it. pnpm is only needed in the builder stage (the `pnpm build` +
+# `pnpm deploy` there); this runtime stage runs no pnpm at all — DB migrations
+# call drizzle-kit directly (see docker/supervisord/supervisord.conf) — so drop
+# corepack/pnpm from the final image entirely.
 RUN rm -rf /root/.cache/node/corepack /usr/local/bin/pnpm /usr/local/bin/pnpx
 
-# Copy built backend
-COPY --from=builder /app/backend/dist ./backend/dist
-COPY --from=builder /app/backend/scripts ./backend/scripts
-COPY --from=builder /app/backend/drizzle.config.ts ./backend/
-COPY --from=builder /app/backend/src/database/migrations ./backend/src/database/migrations
-COPY --from=builder /app/archestra-rs/sandbox-rs/index.cjs ./archestra-rs/sandbox-rs/
-COPY --from=builder /app/archestra-rs/sandbox-rs/index.d.ts ./archestra-rs/sandbox-rs/
-COPY --from=builder /app/archestra-rs/sandbox-rs/*.node ./archestra-rs/sandbox-rs/
-COPY --from=builder /app/archestra-rs/app-runtime-rs/index.cjs ./archestra-rs/app-runtime-rs/
-COPY --from=builder /app/archestra-rs/app-runtime-rs/index.d.ts ./archestra-rs/app-runtime-rs/
-COPY --from=builder /app/archestra-rs/app-runtime-rs/*.node ./archestra-rs/app-runtime-rs/
-COPY --from=builder /app/archestra-rs/image-rs/index.cjs ./archestra-rs/image-rs/
-COPY --from=builder /app/archestra-rs/image-rs/index.d.ts ./archestra-rs/image-rs/
-COPY --from=builder /app/archestra-rs/image-rs/*.node ./archestra-rs/image-rs/
-# Shared JS loader required at runtime by the three NAPI crates' index.cjs
-# (pure JS, no .node); the prod install links it into each crate's node_modules.
-COPY --from=builder /app/archestra-rs/napi-loader/index.cjs ./archestra-rs/napi-loader/
-COPY --from=builder /app/archestra-rs/napi-loader/index.d.ts ./archestra-rs/napi-loader/
+# Copy the fully-assembled backend from the builder's `pnpm deploy` output.
+# /prod/backend contains backend/dist, scripts, drizzle.config.ts and the
+# migrations (scoped by the backend package's `files` field) plus a
+# self-contained node_modules — including the three NAPI crates with their
+# compiled *.node addons and a resolvable @archestra/napi-loader. This single
+# tree replaces the previous per-crate .node/index.cjs copy choreography and
+# the runtime `pnpm install`.
+COPY --from=builder /prod/backend ./backend
 RUN chmod +x /app/backend/scripts/start-production.sh
 
 # Copy built frontend

--- a/platform/backend/package.json
+++ b/platform/backend/package.json
@@ -6,6 +6,13 @@
   "private": true,
   "license": "UNLICENSED",
   "type": "module",
+  "//files": "Scopes what `pnpm deploy` copies into the production image (platform/Dockerfile). Without this, legacy deploy copies the whole package dir (src, test/config files) into the image. @backend is private and never published, so this only affects the deploy/pack file set.",
+  "files": [
+    "dist",
+    "scripts",
+    "drizzle.config.ts",
+    "src/database/migrations"
+  ],
   "scripts": {
     "build": "tsdown && pnpm run sentry:sourcemaps",
     "start": "NODE_ENV=production ./scripts/start-production.sh",


### PR DESCRIPTION
## What

Assemble the production platform image's **backend** with pnpm's recommended monorepo packaging step, [`pnpm deploy`](https://pnpm.io/cli/deploy), instead of a runtime filtered `pnpm install --prod` plus hand-rolled COPY choreography of each NAPI crate's `.node`/`index.cjs` files.

This supersedes the install line from #6152 (the `--filter=@backend... --filter=@frontend...` hotfix): that fix worked, but the underlying assembly was fragile — a workspace-shaped, root-hoisted `node_modules` where each `@archestra/*` crate was copied in by hand and `@archestra/napi-loader` was copied in as a separate step. Getting that layout slightly wrong is exactly what dropped napi-loader and crashed the image with `MODULE_NOT_FOUND` in the first place.

`pnpm deploy` produces a single self-contained `/prod/backend` whose `node_modules` nests every workspace dependency (the three NAPI crates, `@archestra/napi-loader`, `@archestra/shared`) alongside their transitive production deps, with each crate resolving napi-loader from a nested store. The runner stage becomes one `COPY --from=builder /prod/backend ./backend`.

## How / rationale (per the pnpm docs)

- **Runs in the builder stage, after `pnpm build`.** deploy copies each crate's compiled `*.node` addon via the crate `files` globs — it never rebuilds (install scripts are disabled repo-wide via `ignoreScripts`), so the addons must already exist when it runs.
- **`--legacy` mode.** pnpm 10+ requires either `inject-workspace-packages=true` or legacy mode for `deploy`. **Trade-off:** enabling `inject-workspace-packages` would *copy* workspace packages into `node_modules` instead of symlinking them, which changes the local dev / Tilt `node_modules` layout and breaks the NAPI crates' watch-mode rebuilds. `--legacy` is passed only on the Docker build command, so local development is completely untouched (no `pnpm-workspace.yaml` change).
- **`files` field on `backend/package.json`.** In legacy mode deploy copies the *whole* package directory, so without this the image would carry `backend/src` and all the config files. `@backend` is private/never-published, so a `files` field only affects the deploy/pack set. Scoped to `dist`, `scripts`, `drizzle.config.ts`, `src/database/migrations`.
- **Frontend is unchanged.** `next build` already emits a self-contained standalone server, so the frontend is *not* deployed — it ships via `.next/standalone` exactly as before. Dropping the runner's frontend prod install also let us delete the frontend picomatch re-patch: that patch only existed because the prod install refetched an unpatched `next`; the standalone server inherits the picomatch **4.0.4** already patched in the deps stage (verified below).

## Path changes (old → new)

| Concern | Old (main) | New |
|---|---|---|
| Backend prod deps | `pnpm install --prod --filter=@backend...` in **runner** → hoisted `/app/node_modules` + `/app/backend/node_modules` | `pnpm deploy --filter=@backend --prod --legacy /prod/backend` in **builder** → self-contained `/app/backend/node_modules` |
| Backend `dist`, `scripts`, `drizzle.config.ts`, migrations | four separate `COPY --from=builder` lines | included in `/prod/backend` via the new `files` field |
| NAPI crates (`sandbox-rs`, `app-runtime-rs`, `image-rs`) | per-crate COPY of `index.cjs`/`index.d.ts`/`*.node` into `/app/archestra-rs/*/` | nested at `/app/backend/node_modules/@archestra/*/` (with `*.node`) by deploy |
| `@archestra/napi-loader` | copied into `/app/archestra-rs/napi-loader/` | nested in `/app/backend/node_modules/.pnpm/…`, resolvable from each crate |
| Runtime crate location | `/app/archestra-rs/*` | `/app/backend/node_modules/@archestra/*` |
| Frontend | frontend prod install + standalone copy | standalone copy only (install dropped) |
| Frontend picomatch CVE re-patch | re-patch `/app/frontend/node_modules/next/…` after prod install | removed — standalone inherits patched `next` from deps stage |
| Runtime `pnpm`/corepack | removed after prod install | removed (unchanged; runner now runs no pnpm at all) |

Path consumers audited and confirmed still correct: `docker/supervisord/supervisord.conf` (backend `directory=/app/backend`, `./node_modules/.bin/drizzle-kit migrate`, `./scripts/start-production.sh`; frontend `node server.js`), `backend/scripts/start-production.sh` (`node dist/server.mjs`), `drizzle.config.ts`. No script references the old `/app/archestra-rs/*` paths.

## Validation

Docker daemon **is** available; a full local build + run was performed (linux/arm64, `--target unified`).

- ✅ **Full image build** succeeded (`BUILD_EXIT=0`). The `pnpm deploy` step passed the supply-chain lockfile policy (2050 entries) and reported *"Shared workspace lockfile detected but configuration forces legacy deploy implementation"* — legacy mode active as intended.
- ✅ **NAPI resolution under musl (the napi-loader bug class) — provably dead.** Inside the image:
  ```
  LOADED @archestra/app-runtime-rs -> prepareAppEnvelope,scanAppHtml,escapeAngleBrackets
  LOADED @archestra/sandbox-rs     -> checkSession,runSandbox,readArtifact
  LOADED @archestra/image-rs       -> shrinkImageToFit
  ALL NAPI CRATES + @archestra/napi-loader RESOLVED under musl
  ```
- ✅ **Boot smoke (internal DB).** Migrations applied via the deployed `drizzle-kit` (`[✓] migrations applied successfully!`), backend/frontend/postgres all reached supervisord `RUNNING`, backend seeded built-in agents. `GET /health` → `200 {"name":"Archestra","status":"ok","version":"dev"}`; frontend `:3000` → `307` (expected). Log scan for `MODULE_NOT_FOUND`/napi/uncaught errors: **empty**.
- ✅ **Self-contained backend**: `drizzle-kit` bin, `dist/server.mjs`, migrations, `drizzle.config.ts` all present under `/app/backend`; `backend/src` contains only `database/migrations` (no source bloat).
- ✅ **Hygiene**: no `pnpm`/corepack cache in the final image (CVE-2026-12151 cleanup intact).
- ✅ `docker build --check` clean; `check-supply-chain-policy.py` passed. No workflows/YAML touched.

### Pre-existing note (not a regression)
The frontend `next@16.3.0-canary.56` compiled picomatch is **4.0.4** (patched) in the image. There is also a `next@16.2.6` in the backend closure — it is an **optional peer of `better-auth`** (unused Next.js integration in a Fastify backend, i.e. dead code) and its *vendored* picomatch has no version field. This copy is pinned by the (unchanged) lockfile and main's old picomatch patch only ever touched the frontend's canary `next`, so main's image already shipped this same unpatched vendored copy. This PR only relocates it (`/app/node_modules/.pnpm` → `/app/backend/node_modules/.pnpm`); patching it would be out of scope.

## Notes for reviewers
- Local build was **arm64 only**. A CI multi-arch build (amd64 + arm64) should run before merge to confirm the amd64 leg; the logic is arch-independent (napi-loader resolves the musl triple per arch).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>