### PR TITLE
fix(mcp): render MCP App UI resources reached via all-tools dynamic access

### DIFF
--- a/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
+++ b/platform/backend/src/archestra-mcp-server/dynamic-tools.test.ts
@@ -22,6 +22,7 @@ import {
   getUnassignedDiscoverableTools,
   isDynamicallyAvailableArchestraTool,
   resolveDynamicTool,
+  resolveDynamicToolByUiResource,
 } from "./dynamic-tools";
 
 const QUERY_KNOWLEDGE_SOURCES_FULL_NAME = getArchestraToolFullName(
@@ -247,6 +248,151 @@ describe("resolveDynamicTool", () => {
 
     const assigned = await ToolModel.getAssignedToolNames(agent.id);
     expect(assigned.has("github__search_repositories")).toBe(false);
+  });
+});
+
+describe("resolveDynamicToolByUiResource", () => {
+  const RESOURCE_URI = "ui://excalidraw/mcp-app.html";
+  let agent: Agent;
+  let organizationId: string;
+  let userId: string;
+
+  beforeEach(async ({ makeAgent, makeMember, makeOrganization, makeUser }) => {
+    const org = await makeOrganization();
+    organizationId = org.id;
+    const user = await makeUser();
+    userId = user.id;
+    await makeMember(user.id, org.id, { role: "admin" });
+    agent = await makeAgent({
+      name: "Dynamic Agent",
+      organizationId: org.id,
+      accessAllTools: true,
+    });
+  });
+
+  test("resolves each ui:// resource to its own tool, keyed on the exact resourceUri", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({ organizationId });
+    // Two UI tools in the same catalog: resolving each URI must return that
+    // tool, not the other. Asserting BOTH directions discriminates the exact
+    // resourceUri match regardless of row ordering — if the filter ignored the
+    // URI, both resolutions would return the same first-ordered row and one of
+    // these assertions would fail.
+    await makeTool({
+      name: "excalidraw__other_view",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: "ui://excalidraw/other.html" } } },
+    });
+    await makeTool({
+      name: "excalidraw__create_view",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+    });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+
+    const target = await resolveDynamicToolByUiResource({
+      resourceUri: RESOURCE_URI,
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+    expect(target?.name).toBe("excalidraw__create_view");
+    expect(target?.catalogId).toBe(catalog.id);
+
+    const other = await resolveDynamicToolByUiResource({
+      resourceUri: "ui://excalidraw/other.html",
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+    expect(other?.name).toBe("excalidraw__other_view");
+  });
+
+  test("null when the agent's access-all-tools setting is off", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const strictAgent = await makeAgent({
+      name: "Strict Agent",
+      organizationId,
+    });
+    const catalog = await makeInternalMcpCatalog({ organizationId });
+    await makeTool({
+      name: "excalidraw__create_view",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+    });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+
+    const tool = await resolveDynamicToolByUiResource({
+      resourceUri: RESOURCE_URI,
+      agentId: strictAgent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tool).toBeNull();
+  });
+
+  test("null when the backing tool is not accessible to the user", async ({
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({ organizationId });
+    await makeTool({
+      name: "excalidraw__create_view",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+    });
+    // No install (makeMcpServer) → the catalog is not reachable for the user.
+
+    const tool = await resolveDynamicToolByUiResource({
+      resourceUri: RESOURCE_URI,
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tool).toBeNull();
+  });
+
+  test("null (fail closed) when the same ui:// resource is claimed by two accessible catalogs", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    // Two reachable catalogs both advertise the SAME ui:// URI. A resource read
+    // carries only the URI, so the resolver cannot know which server ran the
+    // tool — it must refuse rather than serve HTML from the wrong backend.
+    const catalogA = await makeInternalMcpCatalog({ organizationId });
+    await makeTool({
+      name: "excalidraw__create_view",
+      catalogId: catalogA.id,
+      meta: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+    });
+    await makeMcpServer({ catalogId: catalogA.id, scope: "org" });
+
+    const catalogB = await makeInternalMcpCatalog({ organizationId });
+    await makeTool({
+      name: "impostor__create_view",
+      catalogId: catalogB.id,
+      meta: { _meta: { ui: { resourceUri: RESOURCE_URI } } },
+    });
+    await makeMcpServer({ catalogId: catalogB.id, scope: "org" });
+
+    const tool = await resolveDynamicToolByUiResource({
+      resourceUri: RESOURCE_URI,
+      agentId: agent.id,
+      userId,
+      organizationId,
+    });
+
+    expect(tool).toBeNull();
   });
 });
 

--- a/platform/backend/src/archestra-mcp-server/dynamic-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/dynamic-tools.ts
@@ -94,6 +94,53 @@ export async function resolveDynamicTool(params: {
 }
 
 /**
+ * Resolve the tool that backs an MCP App `ui://` resource when the tool is
+ * reachable only through dynamic access ("all tools" mode) and has no
+ * `agent_tools` assignment — so a resource read can find its catalog/server
+ * without an assignment. Applies the same gates as `resolveDynamicTool` (agent
+ * setting, catalog visibility, per-tool RBAC). Returns null when the strict
+ * assigned-only behavior applies or the resource is not accessible.
+ */
+export async function resolveDynamicToolByUiResource(params: {
+  resourceUri: string;
+  agentId: string;
+  userId?: string;
+  organizationId?: string;
+}): Promise<Tool | null> {
+  const ctx = await dynamicAccessContext(params);
+  if (!ctx) {
+    return null;
+  }
+
+  const accessible = await ToolModel.getMcpToolsAccessibleToUser({
+    userId: ctx.userId,
+    organizationId: ctx.organizationId,
+    environmentId: ctx.agentEnvironmentId,
+    isAdmin: await userIsCatalogAdmin(ctx.userId, ctx.organizationId),
+    uiResourceUri: params.resourceUri,
+  });
+  // A ui:// URI is not globally unique. If it matches tools across more than one
+  // catalog the user can reach, a colliding catalog could serve app HTML in
+  // place of the tool that actually ran — and a resource read carries only the
+  // URI, so it cannot disambiguate. Fail closed rather than guess.
+  const matchedCatalogIds = new Set(accessible.map((t) => t.catalogId));
+  if (matchedCatalogIds.size > 1) {
+    return null;
+  }
+  const tool = accessible[0];
+  if (!tool) {
+    return null;
+  }
+
+  const permitted = await filterToolNamesByPermission(
+    [tool.name],
+    ctx.userId,
+    ctx.organizationId,
+  );
+  return permitted.has(tool.name) ? tool : null;
+}
+
+/**
  * Whether an unassigned Archestra built-in may execute for this agent/user
  * anyway: the sandbox runtime tools when the sandbox runtime is on, the
  * persistent-files (Projects) tools when the Projects feature is on (see

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -2148,8 +2148,10 @@ describe("buildArchestraToolOutput", () => {
     });
     await makeAgentTool(owner.id, targetTool.id);
 
-    // A different agent without the tool assigned must not resolve it: the
-    // target lookup is scoped to the caller's agent, so no UI resource attaches.
+    // A different agent without the tool assigned and without dynamic access
+    // (accessAllTools defaults off) cannot reach the tool, so no UI resource
+    // attaches — the assignment-scoped lookup misses and the dynamic fallback
+    // is gated off.
     const otherAgent = await makeAgent();
     const result = await buildArchestraToolOutput({
       response: archestraResponse,
@@ -2159,6 +2161,92 @@ describe("buildArchestraToolOutput", () => {
         tool_args: { elements: "[]" },
       },
       agentId: otherAgent.id,
+    });
+
+    expect(result).toBe("Diagram displayed!");
+  });
+
+  test("attaches the target tool's UI resource for an unassigned tool reached via dynamic access", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeMember,
+    makeOrganization,
+    makeTool,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    // "All tools" mode: run_tool dispatches to any tool the user can access
+    // without an agent_tools assignment. The UI resource must still attach so
+    // the MCP App renders as an iframe instead of a plain tool-call card.
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: true,
+    });
+    const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+    await makeTool({
+      name: "excalidraw__create_view",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: "ui://excalidraw/mcp-app.html" } } },
+    });
+    // The org-scoped install that makes the catalog reachable for the user.
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+
+    const result = await buildArchestraToolOutput({
+      response: archestraResponse,
+      toolName: "archestra__run_tool",
+      toolArguments: {
+        tool_name: "excalidraw__create_view",
+        tool_args: { elements: "[]" },
+      },
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
+    });
+
+    expect(result).toMatchObject({
+      content: "Diagram displayed!",
+      _meta: { ui: { resourceUri: "ui://excalidraw/mcp-app.html" } },
+    });
+  });
+
+  test("does not attach the UI resource for an all-tools agent when the target tool is not accessible", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMember,
+    makeOrganization,
+    makeTool,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: true,
+    });
+    const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+    await makeTool({
+      name: "excalidraw__create_view",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: "ui://excalidraw/mcp-app.html" } } },
+    });
+    // No install (makeMcpServer) for this catalog: the tool is not reachable, so
+    // the dynamic fallback must not attach its UI resource — the boundary the
+    // widening must respect.
+
+    const result = await buildArchestraToolOutput({
+      response: archestraResponse,
+      toolName: "archestra__run_tool",
+      toolArguments: {
+        tool_name: "excalidraw__create_view",
+        tool_args: { elements: "[]" },
+      },
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
     });
 
     expect(result).toBe("Diagram displayed!");

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -27,6 +27,7 @@ import {
   archestraMcpBranding,
   executeArchestraTool,
 } from "@/archestra-mcp-server";
+import { resolveDynamicTool } from "@/archestra-mcp-server/dynamic-tools";
 import { resolveRunToolTarget } from "@/archestra-mcp-server/run-tool-target";
 import type { ChatMcpElicitationBridge } from "@/clients/chat-mcp-elicitation";
 import mcpClient, { type TokenAuthContext } from "@/clients/mcp-client";
@@ -259,6 +260,8 @@ export function buildMcpGatewayTool(params: {
               toolName: mcpTool.name,
               toolArguments,
               agentId: ctx.agentId,
+              userId: ctx.userId,
+              organizationId: ctx.organizationId,
             });
           } else {
             // Execute non-Archestra tools via shared helper with browser sync
@@ -479,7 +482,8 @@ function extractModelOutputImages(
  * for the common case; when run_tool dispatched to an interactive tool, returns
  * the rich shape (with `_meta.ui.resourceUri` from the target tool's definition)
  * so the frontend renders the MCP App — mirroring how `executeMcpTool` enriches
- * directly-called tools.
+ * directly-called tools. The target's UI resource is resolved from its
+ * assignment, or (for an "all tools" agent) from the user's dynamic-access set.
  * @public — exported for testability
  */
 export async function buildArchestraToolOutput(params: {
@@ -487,6 +491,14 @@ export async function buildArchestraToolOutput(params: {
   toolName: string;
   toolArguments: unknown;
   agentId: string;
+  /**
+   * Caller identity used to resolve the dispatched target tool's UI resource
+   * when the tool is reachable only through dynamic access ("all tools" mode)
+   * and has no `agent_tools` assignment. Omit for callers that never dispatch
+   * unassigned tools; the resolution then stays assignment-scoped.
+   */
+  userId?: string;
+  organizationId?: string;
 }): Promise<
   | string
   | {
@@ -496,7 +508,8 @@ export async function buildArchestraToolOutput(params: {
       rawContent?: ContentBlock[];
     }
 > {
-  const { response, toolName, toolArguments, agentId } = params;
+  const { response, toolName, toolArguments, agentId, userId, organizationId } =
+    params;
   // Never stringify an image block into the text summary — its base64 would
   // bloat context and evade the history image-stripper. Images ride rawContent
   // and reach the model as bounded media parts via toModelOutput instead.
@@ -550,7 +563,21 @@ export async function buildArchestraToolOutput(params: {
 
   let resourceUri: string | undefined;
   try {
-    const toolDef = await ToolModel.findByNameForAgent(targetToolName, agentId);
+    // Assigned tools resolve directly. A tool the agent reaches only through
+    // dynamic access ("all tools" mode) has no `agent_tools` row, so fall back
+    // to the same user-scoped resolution run_tool used to dispatch it —
+    // otherwise its MCP App UI resource is dropped and the app renders as a
+    // plain tool-call card instead of an iframe.
+    const toolDef =
+      (await ToolModel.findByNameForAgent(targetToolName, agentId)) ??
+      (userId && organizationId
+        ? await resolveDynamicTool({
+            toolName: targetToolName,
+            agentId,
+            userId,
+            organizationId,
+          })
+        : null);
     resourceUri = (
       toolDef?.meta as { _meta?: { ui?: McpUiToolMeta } } | undefined
     )?._meta?.ui?.resourceUri;

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -26,7 +26,7 @@ import * as oauthRoutes from "@/routes/oauth";
 import { secretManager } from "@/secrets-manager";
 import { beforeEach, describe, expect, test } from "@/test";
 import { agentOwner, appOwner } from "@/types";
-import mcpClient from "./mcp-client";
+import mcpClient, { type TokenAuthContext } from "./mcp-client";
 
 // Mock the MCP SDK
 const mockCallTool = vi.fn();
@@ -7179,5 +7179,151 @@ describe("connectAndGetTools network egress enforcement", () => {
     expect(result.isError).toBe(true);
     expect(result.error).toContain('not permitted by the "locked" environment');
     expect(mockConnect).not.toHaveBeenCalled();
+  });
+});
+
+describe("pickInstallForCaller (caller-scoped install selection)", () => {
+  // Pins the credential boundary readResource relies on: when a shared catalog
+  // has several installs, connect only to one the caller can actually reach
+  // (own personal → team → org). Never an arbitrary servers[0], which could be
+  // another user's personal install and would read with that user's secrets.
+  const pickInstallForCaller = (
+    servers: unknown[],
+    tokenAuth: TokenAuthContext | undefined,
+  ): Promise<{ id: string } | undefined> =>
+    (
+      mcpClient as unknown as {
+        pickInstallForCaller: (
+          allServers: unknown[],
+          tokenAuth: TokenAuthContext | undefined,
+        ) => Promise<{ id: string } | undefined>;
+      }
+    ).pickInstallForCaller(servers, tokenAuth);
+
+  const userToken = (
+    userId: string,
+    organizationId: string,
+  ): TokenAuthContext => ({
+    tokenId: randomUUID(),
+    teamId: null,
+    isOrganizationToken: false,
+    isUserToken: true,
+    userId,
+    organizationId,
+  });
+
+  test("prefers the caller's own personal install over another user's", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    const other = await makeUser();
+    const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+
+    // Another user's install FIRST: the pre-fix servers[0] returned this one.
+    const otherInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      ownerId: other.id,
+      scope: "personal",
+    });
+    const ownInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      ownerId: caller.id,
+      scope: "personal",
+    });
+
+    const picked = await pickInstallForCaller(
+      [otherInstall, ownInstall],
+      userToken(caller.id, org.id),
+    );
+
+    expect(picked?.id).toBe(ownInstall.id);
+  });
+
+  test("fails closed when only another user's personal install exists", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    const other = await makeUser();
+    const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+
+    const otherInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      ownerId: other.id,
+      scope: "personal",
+    });
+
+    const picked = await pickInstallForCaller(
+      [otherInstall],
+      userToken(caller.id, org.id),
+    );
+
+    expect(picked).toBeUndefined();
+  });
+
+  test("selects a team install when the caller belongs to that team", async ({
+    makeOrganization,
+    makeUser,
+    makeTeam,
+    makeTeamMember,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    const other = await makeUser();
+    const team = await makeTeam(org.id, caller.id);
+    await makeTeamMember(team.id, caller.id);
+    const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+
+    // Decoy first, so a naive servers[0] would miss the team install.
+    const otherInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      ownerId: other.id,
+      scope: "personal",
+    });
+    const teamInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      teamId: team.id,
+      scope: "team",
+    });
+
+    const picked = await pickInstallForCaller(
+      [otherInstall, teamInstall],
+      userToken(caller.id, org.id),
+    );
+
+    expect(picked?.id).toBe(teamInstall.id);
+  });
+
+  test("falls back to an org-scoped install when the caller has no personal or team install", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+
+    const orgInstall = await makeMcpServer({
+      catalogId: catalog.id,
+      ownerId: null,
+      scope: "org",
+    });
+
+    const picked = await pickInstallForCaller(
+      [orgInstall],
+      userToken(caller.id, org.id),
+    );
+
+    expect(picked?.id).toBe(orgInstall.id);
   });
 });

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -3284,7 +3284,11 @@ class McpClient {
       "readResource: Starting resource read",
     );
 
-    const mcpServer = await this.findMcpServerForResource(uri, agentId);
+    const mcpServer = await this.findMcpServerForResource(
+      uri,
+      agentId,
+      tokenAuth,
+    );
 
     if (!mcpServer) {
       logger.error(
@@ -3332,6 +3336,7 @@ class McpClient {
   private async findMcpServerForResource(
     uri: string,
     agentId: string,
+    tokenAuth?: TokenAuthContext,
   ): Promise<{
     server: NonNullable<Awaited<ReturnType<typeof McpServerModel.findById>>>;
     catalogItem: NonNullable<
@@ -3342,13 +3347,37 @@ class McpClient {
       agentId,
       uri,
     );
+    let catalogId = matchingTools[0]?.catalogId ?? null;
 
-    if (matchingTools.length > 0 && matchingTools[0].catalogId) {
-      const catalogId = matchingTools[0].catalogId;
+    // Assignment miss: a tool the agent reaches only through dynamic access
+    // ("all tools" mode) has no agent_tools row, so its resource is invisible to
+    // the assignment-scoped lookup above. Fall back to the same user-scoped
+    // resolution run_tool uses — otherwise the MCP App fails to load its HTML
+    // even though the tool ran. Dynamic import avoids a static cycle with
+    // archestra-mcp-server (which reaches this client through run_tool).
+    if (!catalogId && tokenAuth?.userId && tokenAuth.organizationId) {
+      const { resolveDynamicToolByUiResource } = await import(
+        "@/archestra-mcp-server/dynamic-tools"
+      );
+      const dynamicTool = await resolveDynamicToolByUiResource({
+        resourceUri: uri,
+        agentId,
+        userId: tokenAuth.userId,
+        organizationId: tokenAuth.organizationId,
+      });
+      catalogId = dynamicTool?.catalogId ?? null;
+    }
+
+    if (catalogId) {
       const catalogItem = await InternalMcpCatalogModel.findById(catalogId);
       if (catalogItem) {
         const servers = await McpServerModel.findByCatalogId(catalogId);
-        const server = servers[0];
+        // Select the install the caller can actually reach (own → team → org),
+        // the same connection policy tool execution uses — never another user's
+        // personal install of a shared catalog, whose secrets this read would
+        // otherwise connect with. Fail closed when the caller has no accessible
+        // install rather than falling back to an arbitrary one.
+        const server = await this.pickInstallForCaller(servers, tokenAuth);
         if (server) {
           logger.info(
             { uri, agentId, serverId: server.id, serverName: catalogItem.name },
@@ -3418,7 +3447,11 @@ class McpClient {
     _currentResult: ResourceContents,
   ): Promise<void> {
     try {
-      const mcpServer = await this.findMcpServerForResource(uri, agentId);
+      const mcpServer = await this.findMcpServerForResource(
+        uri,
+        agentId,
+        _tokenAuth,
+      );
       if (!mcpServer) {
         logger.debug(
           { uri, agentId },

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -630,6 +630,12 @@ class ToolModel {
     environmentId: string | null;
     /** Exact-name filter for single-tool resolution (avoids loading the whole corpus). */
     name?: string;
+    /**
+     * Exact MCP App `ui://` resource filter, for resolving which accessible tool
+     * backs a resource read without loading the whole corpus. Matches the same
+     * canonical/legacy meta keys as the external-apps listing.
+     */
+    uiResourceUri?: string;
   }): Promise<Tool[]> {
     const catalogIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
       params.userId,
@@ -668,6 +674,9 @@ class ToolModel {
           toolInEnvironmentPredicate(params.environmentId),
           params.name !== undefined
             ? eq(schema.toolsTable.name, params.name)
+            : undefined,
+          params.uiResourceUri !== undefined
+            ? eq(toolUiResourceUriSql(), params.uiResourceUri)
             : undefined,
         ),
       )


### PR DESCRIPTION
## Summary

Agents in "all tools" mode can call a tool that was never explicitly assigned in `agent_tools`. Two places that attach a tool's UI resource to a `run_tool` result — output enrichment and the follow-up `resources/read` — only looked the tool up through the assignment table, so an unassigned MCP App tool call succeeded but rendered as a plain text result in chat instead of its interactive iframe.

Both lookups now fall back to the same caller-scoped dynamic-access resolution `run_tool` already uses for unassigned tools, so the UI resource resolves the same way for a dynamically-reached tool as it does for an assigned one. This applies to both an unassigned tool on an installed external MCP server and an unassigned owned "App".

The `resources/read` path also now selects the caller's own install (own → team → org) on a shared catalog instead of an arbitrary one, and fails closed if a `ui://` resource URI resolves to tools across more than one catalog.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>