### PR TITLE
test(backend): replace @/models mocks with real PGlite fixtures

### DIFF
--- a/platform/backend/src/auth/fastify-plugin/plugin.test.ts
+++ b/platform/backend/src/auth/fastify-plugin/plugin.test.ts
@@ -1,28 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { vi } from "vitest";
-import {
-  beforeEach,
-  describe,
-  expect,
-  type MockedFunction,
-  test,
-} from "@/test";
-import { ApiError } from "@/types";
 
-// Mock modules with factory functions to avoid hoisting issues
+// @/auth (better-auth + hasPermission) is the external auth boundary; the
+// access-control map and @/auth/utils are configuration/logic seams. The
+// database (UserModel / ServiceAccountModel) is NOT mocked — it's real PGlite.
 vi.mock("@/auth");
-
 vi.mock("@/auth/utils");
-
-vi.mock("@/models", () => ({
-  ServiceAccountModel: {
-    verifyToken: vi.fn(),
-  },
-  UserModel: {
-    getById: vi.fn(),
-  },
-}));
-
 vi.mock("@archestra/shared/access-control", () => ({
   requiredEndpointPermissionsMap: {
     createAgent: { agent: ["create"] },
@@ -34,9 +17,18 @@ vi.mock("@archestra/shared/access-control", () => ({
 }));
 
 import { betterAuth, hasPermission } from "@/auth";
-import { ServiceAccountModel, UserModel } from "@/models";
+import { UserModel } from "@/models";
+import {
+  beforeEach,
+  describe,
+  expect,
+  type MockedFunction,
+  test,
+} from "@/test";
+import { ApiError } from "@/types";
+import { Authnz } from "./middleware";
+import { authPlugin } from "./plugin";
 
-// Type the mocked functions
 const mockBetterAuth = betterAuth as unknown as {
   api: {
     getSession: MockedFunction<typeof betterAuth.api.getSession>;
@@ -46,19 +38,7 @@ const mockBetterAuth = betterAuth as unknown as {
 
 const mockHasPermission = hasPermission as MockedFunction<typeof hasPermission>;
 
-const mockUserModel = UserModel as unknown as {
-  getById: MockedFunction<typeof UserModel.getById>;
-};
-
-const mockServiceAccountModel = ServiceAccountModel as unknown as {
-  verifyToken: MockedFunction<typeof ServiceAccountModel.verifyToken>;
-};
-
-import { Authnz } from "./middleware";
-import { authPlugin } from "./plugin";
-
 type Session = Awaited<ReturnType<typeof betterAuth.api.getSession>>;
-type User = Awaited<ReturnType<typeof UserModel.getById>>;
 
 // The middleware calls getSession with `returnHeaders: true`, so the resolved
 // value is `{ response, headers }`. Wrap the bare session shape the tests build
@@ -67,147 +47,135 @@ const sessionResult = (session: unknown): Session =>
   ({ response: session, headers: new Headers() }) as unknown as Session;
 type ApiKey = Awaited<ReturnType<typeof betterAuth.api.verifyApiKey>>["key"];
 
+const mockReply = () =>
+  ({
+    status: vi.fn().mockReturnThis(),
+    send: vi.fn(),
+    header: vi.fn().mockReturnThis(),
+  }) as unknown as FastifyReply;
+
 describe("authPlugin integration", () => {
   const authnz = new Authnz();
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockServiceAccountModel.verifyToken.mockResolvedValue(null);
+    // Restore any vi.spyOn fault-injection (e.g. a rejecting getById) so it
+    // doesn't leak into later tests.
+    vi.restoreAllMocks();
   });
 
   describe("authentication", () => {
-    test("should allow authenticated session users", async () => {
+    test("should allow authenticated session users", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
       mockBetterAuth.api.getSession.mockResolvedValue(
         sessionResult({
-          user: { id: "user1" },
-          session: { activeOrganizationId: "org1" },
+          user: { id: user.id },
+          session: { activeOrganizationId: org.id },
         }),
       );
-      mockHasPermission.mockResolvedValue({
-        success: true,
-        error: null,
-      });
-      mockUserModel.getById.mockResolvedValue({
-        id: "user1",
-        name: "Test User",
-        organizationId: "org1",
-      } as User);
+      mockHasPermission.mockResolvedValue({ success: true, error: null });
 
-      const mockRequest = {
+      const request = {
         url: "/api/agents",
         method: "GET",
         headers: {},
-        routeOptions: {
-          schema: { operationId: "getAgents" },
-        },
+        routeOptions: { schema: { operationId: "getAgents" } },
       } as unknown as FastifyRequest;
+      const reply = mockReply();
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
+      await authnz.handle(request, reply);
 
-      await authnz.handle(mockRequest, mockReply);
-
-      expect(mockReply.status).not.toHaveBeenCalled();
-      expect(mockReply.send).not.toHaveBeenCalled();
+      expect(reply.status).not.toHaveBeenCalled();
+      expect(reply.send).not.toHaveBeenCalled();
     });
 
-    test("forwards better-auth's refreshed cookie-cache Set-Cookie to the reply", async () => {
+    test("forwards better-auth's refreshed cookie-cache Set-Cookie to the reply", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
       const refreshedCookie =
         "archestra.session_data=cached; Max-Age=60; Path=/";
       const authHeaders = new Headers();
       authHeaders.append("set-cookie", refreshedCookie);
       mockBetterAuth.api.getSession.mockResolvedValue({
         response: {
-          user: { id: "user1" },
-          session: { activeOrganizationId: "org1" },
+          user: { id: user.id },
+          session: { activeOrganizationId: org.id },
         },
         headers: authHeaders,
       } as unknown as Session);
       mockHasPermission.mockResolvedValue({ success: true, error: null });
-      mockUserModel.getById.mockResolvedValue({
-        id: "user1",
-        name: "Test User",
-        organizationId: "org1",
-      } as User);
 
-      const mockRequest = {
+      const request = {
+        url: "/api/agents",
+        method: "GET",
+        headers: {},
+        routeOptions: { schema: { operationId: "getAgents" } },
+      } as unknown as FastifyRequest;
+      const reply = mockReply();
+
+      await authnz.handle(request, reply);
+
+      expect(reply.header).toHaveBeenCalledWith("set-cookie", [
+        refreshedCookie,
+      ]);
+    });
+
+    test("should allow valid API key authentication", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
+      mockBetterAuth.api.getSession.mockRejectedValue(new Error("No session"));
+      mockBetterAuth.api.verifyApiKey.mockResolvedValue({
+        valid: true,
+        error: null,
+        key: makeApiKey({ referenceId: user.id }),
+      });
+      mockHasPermission.mockResolvedValue({ success: true, error: null });
+
+      const request = {
+        url: "/api/agents",
+        method: "GET",
+        headers: { authorization: "Bearer api-key-123" },
+        routeOptions: { schema: { operationId: "getAgents" } },
+      } as unknown as FastifyRequest;
+      const reply = mockReply();
+
+      await authnz.handle(request, reply);
+
+      expect(mockBetterAuth.api.verifyApiKey).toHaveBeenCalledWith({
+        body: { key: "Bearer api-key-123" },
+      });
+      expect(reply.status).not.toHaveBeenCalled();
+    });
+
+    test("should return 401 for invalid session", async () => {
+      mockBetterAuth.api.getSession.mockResolvedValue(sessionResult(null));
+
+      const request = {
         url: "/api/agents",
         method: "GET",
         headers: {},
         routeOptions: { schema: { operationId: "getAgents" } },
       } as unknown as FastifyRequest;
 
-      const headerSpy = vi.fn().mockReturnThis();
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-        header: headerSpy,
-      } as unknown as FastifyReply;
-
-      await authnz.handle(mockRequest, mockReply);
-
-      expect(headerSpy).toHaveBeenCalledWith("set-cookie", [refreshedCookie]);
-    });
-
-    test("should allow valid API key authentication", async () => {
-      mockBetterAuth.api.getSession.mockRejectedValue(new Error("No session"));
-      mockBetterAuth.api.verifyApiKey.mockResolvedValue({
-        valid: true,
-        error: null,
-        key: makeApiKey({ referenceId: "user1" }),
-      });
-      mockHasPermission.mockResolvedValue({
-        success: true,
-        error: null,
-      });
-      mockUserModel.getById.mockResolvedValue({
-        id: "user1",
-        name: "Test User",
-        organizationId: "org1",
-      } as User);
-
-      const mockRequest = {
-        url: "/api/agents",
-        method: "GET",
-        headers: { authorization: "Bearer api-key-123" },
-        routeOptions: {
-          schema: { operationId: "getAgents" },
-        },
-      } as unknown as FastifyRequest;
-
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
-
-      await authnz.handle(mockRequest, mockReply);
-
-      expect(mockBetterAuth.api.verifyApiKey).toHaveBeenCalledWith({
-        body: { key: "Bearer api-key-123" },
-      });
-      expect(mockReply.status).not.toHaveBeenCalled();
-    });
-
-    test("should return 401 for invalid session", async () => {
-      mockBetterAuth.api.getSession.mockResolvedValue(sessionResult(null));
-
-      const mockRequest = {
-        url: "/api/agents",
-        method: "GET",
-        headers: {},
-        routeOptions: {
-          schema: { operationId: "getAgents" },
-        },
-      } as unknown as FastifyRequest;
-
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
-
-      await expect(authnz.handle(mockRequest, mockReply)).rejects.toThrow(
+      await expect(authnz.handle(request, mockReply())).rejects.toThrow(
         "Unauthenticated",
       );
     });
@@ -220,127 +188,102 @@ describe("authPlugin integration", () => {
         key: null,
       });
 
-      const mockRequest = {
+      const request = {
         url: "/api/agents",
         method: "GET",
         headers: { authorization: "Bearer invalid-key" },
-        routeOptions: {
-          schema: { operationId: "getAgents" },
-        },
+        routeOptions: { schema: { operationId: "getAgents" } },
       } as unknown as FastifyRequest;
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
-
-      await expect(authnz.handle(mockRequest, mockReply)).rejects.toThrow(
+      await expect(authnz.handle(request, mockReply())).rejects.toThrow(
         "Unauthenticated",
       );
     });
   });
 
   describe("authorization", () => {
-    test("should return 403 for insufficient permissions", async () => {
+    test("should return 403 for insufficient permissions", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
       mockBetterAuth.api.getSession.mockResolvedValue(
         sessionResult({
-          user: { id: "user1" },
-          session: { activeOrganizationId: "org1" },
+          user: { id: user.id },
+          session: { activeOrganizationId: org.id },
         }),
       );
-      mockUserModel.getById.mockResolvedValue({
-        id: "user1",
-        name: "Test User",
-        organizationId: "org1",
-      } as User);
-      mockHasPermission.mockResolvedValue({
-        success: false,
-        error: null,
-      });
+      mockHasPermission.mockResolvedValue({ success: false, error: null });
 
-      const mockRequest = {
+      const request = {
         url: "/api/agents",
         method: "POST",
         headers: {},
-        routeOptions: {
-          schema: { operationId: "createAgent" },
-        },
+        routeOptions: { schema: { operationId: "createAgent" } },
       } as unknown as FastifyRequest;
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
-
-      await expect(authnz.handle(mockRequest, mockReply)).rejects.toThrow(
+      await expect(authnz.handle(request, mockReply())).rejects.toThrow(
         "Forbidden",
       );
     });
 
-    test("should return 403 for routes without operationId", async () => {
+    test("should return 403 for routes without operationId", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
       mockBetterAuth.api.getSession.mockResolvedValue(
         sessionResult({
-          user: { id: "user1" },
-          session: { activeOrganizationId: "org1" },
+          user: { id: user.id },
+          session: { activeOrganizationId: org.id },
         }),
       );
-      mockUserModel.getById.mockResolvedValue({
-        id: "user1",
-        name: "Test User",
-        organizationId: "org1",
-      } as User);
 
-      const mockRequest = {
+      const request = {
         url: "/api/unknown",
         method: "GET",
         headers: {},
-        routeOptions: {
-          schema: {}, // No operationId
-        },
+        routeOptions: { schema: {} }, // No operationId
       } as unknown as FastifyRequest;
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
-
-      await expect(authnz.handle(mockRequest, mockReply)).rejects.toThrow(
+      await expect(authnz.handle(request, mockReply())).rejects.toThrow(
         "Forbidden",
       );
     });
 
-    test("should check specific permissions for configured routes", async () => {
+    test("should check specific permissions for configured routes", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
       mockBetterAuth.api.getSession.mockResolvedValue(
         sessionResult({
-          user: { id: "user1" },
-          session: { activeOrganizationId: "org1" },
+          user: { id: user.id },
+          session: { activeOrganizationId: org.id },
         }),
       );
-      mockHasPermission.mockResolvedValue({
-        success: true,
-        error: null,
-      });
-      mockUserModel.getById.mockResolvedValue({
-        id: "user1",
-        name: "Test User",
-        organizationId: "org1",
-      } as User);
+      mockHasPermission.mockResolvedValue({ success: true, error: null });
 
-      const mockRequest = {
+      const request = {
         url: "/api/agents",
         method: "POST",
         headers: {},
-        routeOptions: {
-          schema: { operationId: "createAgent" },
-        },
+        routeOptions: { schema: { operationId: "createAgent" } },
       } as unknown as FastifyRequest;
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
-
-      await authnz.handle(mockRequest, mockReply);
+      await authnz.handle(request, mockReply());
 
       expect(mockHasPermission).toHaveBeenCalledWith(
         { agent: ["create"] },
@@ -351,80 +294,74 @@ describe("authPlugin integration", () => {
   });
 
   describe("user info population", () => {
-    test("should populate user and organizationId from session", async () => {
+    test("should populate user and organizationId from session", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
       mockBetterAuth.api.getSession.mockResolvedValue(
         sessionResult({
-          user: { id: "user1" },
-          session: { activeOrganizationId: "org1" },
+          user: { id: user.id },
+          session: { activeOrganizationId: org.id },
         }),
       );
-      mockHasPermission.mockResolvedValue({
-        success: true,
-        error: null,
-      });
-      mockUserModel.getById.mockResolvedValue({
-        id: "user1",
-        name: "Test User",
-        organizationId: "org1",
-      } as User);
+      mockHasPermission.mockResolvedValue({ success: true, error: null });
 
-      const mockRequest = {
+      const request = {
         url: "/api/agents",
         method: "GET",
         headers: {},
-        routeOptions: {
-          schema: { operationId: "getAgents" },
-        },
+        routeOptions: { schema: { operationId: "getAgents" } },
       } as unknown as FastifyRequest;
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
+      await authnz.handle(request, mockReply());
 
-      await authnz.handle(mockRequest, mockReply);
-
-      expect(mockRequest.user).toEqual({ id: "user1", name: "Test User" });
-      expect(mockRequest.organizationId).toBe("org1");
+      expect(request.user).toEqual(
+        expect.objectContaining({ id: user.id, name: user.name }),
+      );
+      // organizationId is not carried on request.user
+      expect(
+        (request.user as unknown as { organizationId?: string }).organizationId,
+      ).toBeUndefined();
+      expect(request.organizationId).toBe(org.id);
     });
 
-    test("should populate organizationId from UserModel when not in session", async () => {
-      const mockUser = {
-        id: "user1",
-        name: "Test User",
-        organizationId: "org2",
-      } as User;
+    test("should populate organizationId from the member record (not the session)", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      // The middleware always derives organizationId from UserModel.getById
+      // (the member join), never from session.activeOrganizationId.
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
       mockBetterAuth.api.getSession.mockResolvedValue(
         sessionResult({
-          user: { id: "user1" },
+          user: { id: user.id },
           session: {}, // No activeOrganizationId
         }),
       );
-      mockHasPermission.mockResolvedValue({
-        success: true,
-        error: null,
-      });
-      mockUserModel.getById.mockResolvedValue(mockUser);
+      mockHasPermission.mockResolvedValue({ success: true, error: null });
 
-      const mockRequest = {
+      const request = {
         url: "/api/agents",
         method: "GET",
         headers: {},
-        routeOptions: {
-          schema: { operationId: "getAgents" },
-        },
+        routeOptions: { schema: { operationId: "getAgents" } },
       } as unknown as FastifyRequest;
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
+      await authnz.handle(request, mockReply());
 
-      await authnz.handle(mockRequest, mockReply);
-
-      expect(mockUserModel.getById).toHaveBeenCalledWith("user1");
-      expect(mockRequest.user).toEqual({ id: "user1", name: "Test User" });
-      expect(mockRequest.organizationId).toBe("org2");
+      expect(request.user).toEqual(
+        expect.objectContaining({ id: user.id, name: user.name }),
+      );
+      expect(request.organizationId).toBe(org.id);
     });
   });
 
@@ -437,54 +374,46 @@ describe("authPlugin integration", () => {
         new Error("API key service down"),
       );
 
-      const mockRequest = {
+      const request = {
         url: "/api/agents",
         method: "GET",
         headers: { authorization: "Bearer some-key" },
-        routeOptions: {
-          schema: { operationId: "getAgents" },
-        },
+        routeOptions: { schema: { operationId: "getAgents" } },
       } as unknown as FastifyRequest;
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
-
-      await expect(authnz.handle(mockRequest, mockReply)).rejects.toThrow(
+      await expect(authnz.handle(request, mockReply())).rejects.toThrow(
         "Unauthenticated",
       );
     });
 
-    test("should reject with 401 when user population fails", async () => {
+    test("should reject with 401 when user population fails", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id);
+
       mockBetterAuth.api.getSession.mockResolvedValue(
         sessionResult({
-          user: { id: "user1" },
-          session: { activeOrganizationId: "org1" },
+          user: { id: user.id },
+          session: { activeOrganizationId: org.id },
         }),
       );
-      mockHasPermission.mockResolvedValue({
-        success: true,
-        error: null,
-      });
-      mockUserModel.getById.mockRejectedValue(new Error("DB error"));
+      mockHasPermission.mockResolvedValue({ success: true, error: null });
+      // Simulate the user lookup blowing up during population.
+      vi.spyOn(UserModel, "getById").mockRejectedValue(new Error("DB error"));
 
-      const mockRequest = {
+      const request = {
         url: "/api/agents",
         method: "GET",
         headers: {},
-        routeOptions: {
-          schema: { operationId: "getAgents" },
-        },
+        routeOptions: { schema: { operationId: "getAgents" } },
       } as unknown as FastifyRequest;
 
-      const mockReply = {
-        status: vi.fn().mockReturnThis(),
-        send: vi.fn(),
-      } as unknown as FastifyReply;
-
       // Should throw 401 when user info cannot be populated
-      await expect(authnz.handle(mockRequest, mockReply)).rejects.toThrow(
+      await expect(authnz.handle(request, mockReply())).rejects.toThrow(
         ApiError,
       );
     });

--- a/platform/backend/src/auth/utils.test.ts
+++ b/platform/backend/src/auth/utils.test.ts
@@ -1,29 +1,8 @@
 import type { IncomingHttpHeaders } from "node:http";
 import type { Permissions } from "@archestra/shared";
 import { vi } from "vitest";
-import { ServiceAccountModel, UserModel } from "@/models";
-import {
-  beforeEach,
-  describe,
-  expect,
-  type MockedFunction,
-  test,
-} from "@/test";
-import { hasPermission } from "./utils";
 
-vi.mock("@/models", () => ({
-  ServiceAccountModel: {
-    verifyToken: vi.fn(),
-    getPermissions: vi.fn(),
-    findById: vi.fn(),
-  },
-  UserModel: {
-    getById: vi.fn(),
-    getUserPermissions: vi.fn(),
-  },
-}));
-
-// Mock the better-auth module
+// better-auth is the real external auth boundary — mock it, not the DB.
 vi.mock("./better-auth", () => ({
   auth: {
     api: {
@@ -33,19 +12,15 @@ vi.mock("./better-auth", () => ({
   },
 }));
 
+import {
+  beforeEach,
+  describe,
+  expect,
+  type MockedFunction,
+  test,
+} from "@/test";
 import { auth as betterAuth } from "./better-auth";
-
-// Type the mocked functions
-const mockUserModel = UserModel as unknown as {
-  getById: MockedFunction<typeof UserModel.getById>;
-  getUserPermissions: MockedFunction<typeof UserModel.getUserPermissions>;
-};
-
-const mockServiceAccountModel = ServiceAccountModel as unknown as {
-  verifyToken: MockedFunction<typeof ServiceAccountModel.verifyToken>;
-  getPermissions: MockedFunction<typeof ServiceAccountModel.getPermissions>;
-  findById: MockedFunction<typeof ServiceAccountModel.findById>;
-};
+import { hasPermission } from "./utils";
 
 const mockBetterAuth = betterAuth as unknown as {
   api: {
@@ -59,23 +34,12 @@ type ApiKey = Awaited<ReturnType<typeof betterAuth.api.verifyApiKey>>["key"];
 describe("hasPermission", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUserModel.getById.mockResolvedValue(makeUserWithOrganization());
-    mockUserModel.getUserPermissions.mockResolvedValue({
-      agent: ["read", "create", "update", "delete", "admin"],
-      mcpServerInstallation: ["admin"],
-      team: ["read"],
-    });
-    mockServiceAccountModel.verifyToken.mockResolvedValue(null);
-    mockServiceAccountModel.getPermissions.mockResolvedValue({});
-    mockServiceAccountModel.findById.mockResolvedValue(null);
   });
 
   describe("session-based authentication", () => {
     test("should return success when user has required permissions", async () => {
       const permissions: Permissions = { agent: ["read"] };
-      const headers: IncomingHttpHeaders = {
-        cookie: "session-cookie",
-      };
+      const headers: IncomingHttpHeaders = { cookie: "session-cookie" };
 
       mockBetterAuth.api.hasPermission.mockResolvedValue({
         success: true,
@@ -93,9 +57,7 @@ describe("hasPermission", () => {
 
     test("should return failure when user lacks required permissions", async () => {
       const permissions: Permissions = { agent: ["admin"] };
-      const headers: IncomingHttpHeaders = {
-        cookie: "session-cookie",
-      };
+      const headers: IncomingHttpHeaders = { cookie: "session-cookie" };
 
       mockBetterAuth.api.hasPermission.mockResolvedValue({
         success: false,
@@ -104,10 +66,7 @@ describe("hasPermission", () => {
 
       const result = await hasPermission(permissions, headers);
 
-      expect(result).toEqual({
-        success: false,
-        error: null,
-      });
+      expect(result).toEqual({ success: false, error: null });
       expect(mockBetterAuth.api.hasPermission).toHaveBeenCalledWith({
         headers: expect.any(Headers),
         body: { permissions },
@@ -116,41 +75,55 @@ describe("hasPermission", () => {
   });
 
   describe("API key authentication", () => {
-    test("should allow valid API key when session check fails", async () => {
+    test("should allow valid API key when session check fails", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, {
+        permission: { agent: ["read"] },
+      });
+      await makeMember(user.id, org.id, { role: role.role });
+
       const permissions: Permissions = { agent: ["read"] };
       const headers: IncomingHttpHeaders = {
         authorization: "Bearer api-key-123",
       };
 
-      // Mock hasPermission to throw (simulating no active session/organization)
+      // No active session/organization → session check throws, API key fallback runs.
       mockBetterAuth.api.hasPermission.mockRejectedValue(
         new Error("No active organization"),
       );
-
-      // Mock API key verification to succeed
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
-        key: makeApiKey({
-          referenceId: "user1",
-          metadata: null,
-        }),
+        key: makeApiKey({ referenceId: user.id, metadata: null }),
       });
 
       const result = await hasPermission(permissions, headers);
 
       expect(result).toEqual({ success: true, error: null });
-      expect(mockUserModel.getById).toHaveBeenCalledWith("user1");
-      expect(mockUserModel.getUserPermissions).toHaveBeenCalledWith(
-        "user1",
-        "org-1",
-      );
       expect(mockBetterAuth.api.verifyApiKey).toHaveBeenCalledWith({
         body: { key: "Bearer api-key-123" },
       });
     });
 
-    test("should reject when API key owner lacks required permissions", async () => {
+    test("should reject when API key owner lacks required permissions", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, {
+        permission: { agent: ["read"] },
+      });
+      await makeMember(user.id, org.id, { role: role.role });
+
       const permissions: Permissions = { agent: ["admin"] };
       const headers: IncomingHttpHeaders = {
         authorization: "Bearer limited-user-key",
@@ -162,19 +135,7 @@ describe("hasPermission", () => {
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
-        key: makeApiKey({
-          referenceId: "user-limited",
-          metadata: null,
-        }),
-      });
-      mockUserModel.getById.mockResolvedValue(
-        makeUserWithOrganization({
-          id: "user-limited",
-          email: "user-limited@test.com",
-        }),
-      );
-      mockUserModel.getUserPermissions.mockResolvedValue({
-        agent: ["read"],
+        key: makeApiKey({ referenceId: user.id, metadata: null }),
       });
 
       const result = await hasPermission(permissions, headers);
@@ -191,12 +152,9 @@ describe("hasPermission", () => {
         authorization: "Bearer invalid-key",
       };
 
-      // Mock hasPermission to throw
       mockBetterAuth.api.hasPermission.mockRejectedValue(
         new Error("No active organization"),
       );
-
-      // Mock API key verification to fail
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: false,
         error: null,
@@ -207,9 +165,7 @@ describe("hasPermission", () => {
 
       expect(result).toEqual({
         success: false,
-        error: expect.objectContaining({
-          message: "Invalid API key",
-        }),
+        error: expect.objectContaining({ message: "Invalid API key" }),
       });
     });
 
@@ -225,21 +181,15 @@ describe("hasPermission", () => {
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
-        key: makeApiKey({
-          referenceId: undefined as unknown as string,
-        }),
+        key: makeApiKey({ referenceId: undefined as unknown as string }),
       });
 
       const result = await hasPermission(permissions, headers);
 
       expect(result).toEqual({
         success: false,
-        error: expect.objectContaining({
-          message: "Invalid API key",
-        }),
+        error: expect.objectContaining({ message: "Invalid API key" }),
       });
-      expect(mockUserModel.getById).not.toHaveBeenCalled();
-      expect(mockUserModel.getUserPermissions).not.toHaveBeenCalled();
     });
 
     test("should handle API key verification errors", async () => {
@@ -248,12 +198,9 @@ describe("hasPermission", () => {
         authorization: "Bearer some-key",
       };
 
-      // Mock hasPermission to throw
       mockBetterAuth.api.hasPermission.mockRejectedValue(
         new Error("No active organization"),
       );
-
-      // Mock API key verification to throw
       mockBetterAuth.api.verifyApiKey.mockRejectedValue(
         new Error("API key service error"),
       );
@@ -262,9 +209,7 @@ describe("hasPermission", () => {
 
       expect(result).toEqual({
         success: false,
-        error: expect.objectContaining({
-          message: "Invalid API key",
-        }),
+        error: expect.objectContaining({ message: "Invalid API key" }),
       });
     });
 
@@ -272,7 +217,6 @@ describe("hasPermission", () => {
       const permissions: Permissions = { agent: ["read"] };
       const headers: IncomingHttpHeaders = {};
 
-      // Mock hasPermission to throw
       mockBetterAuth.api.hasPermission.mockRejectedValue(
         new Error("No active organization"),
       );
@@ -281,9 +225,7 @@ describe("hasPermission", () => {
 
       expect(result).toEqual({
         success: false,
-        error: expect.objectContaining({
-          message: "No API key provided",
-        }),
+        error: expect.objectContaining({ message: "No API key provided" }),
       });
       expect(mockBetterAuth.api.verifyApiKey).not.toHaveBeenCalled();
     });
@@ -292,9 +234,7 @@ describe("hasPermission", () => {
   describe("edge cases", () => {
     test("should handle empty permissions object", async () => {
       const permissions: Permissions = {};
-      const headers: IncomingHttpHeaders = {
-        cookie: "session-cookie",
-      };
+      const headers: IncomingHttpHeaders = { cookie: "session-cookie" };
 
       mockBetterAuth.api.hasPermission.mockResolvedValue({
         success: true,
@@ -310,43 +250,57 @@ describe("hasPermission", () => {
       });
     });
 
-    test("should handle complex permissions object", async () => {
+    test("should handle complex permissions object", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
       const permissions: Permissions = {
         agent: ["read", "create", "update", "delete"],
         mcpServerInstallation: ["admin"],
         team: ["read"],
       };
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, { permission: permissions });
+      await makeMember(user.id, org.id, { role: role.role });
+
       const headers: IncomingHttpHeaders = {
         authorization: "Bearer api-key-complex",
       };
 
-      // Mock hasPermission to throw (API key fallback)
       mockBetterAuth.api.hasPermission.mockRejectedValue(
         new Error("No session"),
       );
-
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
-        key: makeApiKey({
-          referenceId: "user1",
-          metadata: null,
-        }),
+        key: makeApiKey({ referenceId: user.id, metadata: null }),
       });
 
       const result = await hasPermission(permissions, headers);
 
       expect(result).toEqual({ success: true, error: null });
-      expect(mockUserModel.getUserPermissions).toHaveBeenCalledTimes(1);
       expect(mockBetterAuth.api.verifyApiKey).toHaveBeenCalledWith({
         body: { key: "Bearer api-key-complex" },
       });
     });
 
-    test("should pass through different authorization header formats", async () => {
-      const permissions: Permissions = { agent: ["read"] };
+    test("should pass through different authorization header formats", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, {
+        permission: { agent: ["read"] },
+      });
+      await makeMember(user.id, org.id, { role: role.role });
 
-      // Test different header formats
+      const permissions: Permissions = { agent: ["read"] };
       const testCases = [
         "Bearer token123",
         "token456",
@@ -354,21 +308,15 @@ describe("hasPermission", () => {
       ];
 
       for (const authHeader of testCases) {
-        const headers: IncomingHttpHeaders = {
-          authorization: authHeader,
-        };
+        const headers: IncomingHttpHeaders = { authorization: authHeader };
 
         mockBetterAuth.api.hasPermission.mockRejectedValue(
           new Error("No session"),
         );
-
         mockBetterAuth.api.verifyApiKey.mockResolvedValue({
           valid: true,
           error: null,
-          key: makeApiKey({
-            referenceId: "user1",
-            metadata: null,
-          }),
+          key: makeApiKey({ referenceId: user.id, metadata: null }),
         });
 
         const result = await hasPermission(permissions, headers);
@@ -409,27 +357,6 @@ function makeApiKey(
     updatedAt: new Date(),
     metadata: null,
     permissions: null,
-    ...overrides,
-  };
-}
-
-function makeUserWithOrganization(
-  overrides: Partial<Awaited<ReturnType<typeof UserModel.getById>>> = {},
-): Awaited<ReturnType<typeof UserModel.getById>> {
-  return {
-    id: "user1",
-    name: "Test User",
-    email: "user1@test.com",
-    emailVerified: true,
-    image: null,
-    role: null,
-    banned: null,
-    banReason: null,
-    banExpires: null,
-    twoFactorEnabled: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    organizationId: "org-1",
     ...overrides,
   };
 }

--- a/platform/backend/src/knowledge-base/kb-interaction.test.ts
+++ b/platform/backend/src/knowledge-base/kb-interaction.test.ts
@@ -1,5 +1,8 @@
-import type { SupportedProvider } from "@archestra/shared";
+import type { InteractionSource, SupportedProvider } from "@archestra/shared";
+import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import db, { schema } from "@/database";
+import { InteractionModel, ModelModel } from "@/models";
 import { metrics } from "@/observability";
 import {
   getProviderChatInteractionType,
@@ -22,38 +25,6 @@ vi.mock("@/observability/tracing/llm", () => ({
   ),
 }));
 
-const mockCreate = vi.fn((_data: unknown) =>
-  Promise.resolve({ id: "test-interaction-id" }),
-);
-const mockFindByProviderAndModelId = vi.fn(
-  (_provider: unknown, _model: unknown) =>
-    Promise.resolve({
-      id: "model-1",
-      modelId: "text-embedding-3-small",
-      provider: "openai",
-      customPricePerMillionInput: null,
-      customPricePerMillionOutput: null,
-      promptPricePerToken: null,
-      completionPricePerToken: null,
-    }),
-);
-const mockGetEffectivePricing = vi.fn(() => ({
-  pricePerMillionInput: "0.02",
-  pricePerMillionOutput: "0.02",
-  source: "default",
-}));
-vi.mock("@/models", () => ({
-  InteractionModel: {
-    create: (data: unknown) => mockCreate(data),
-  },
-  ModelModel: {
-    findByProviderAndModelId: (_provider: unknown, _model: unknown) =>
-      mockFindByProviderAndModelId(_provider, _model),
-    getEffectivePricing: (_model: unknown, _modelId?: unknown) =>
-      mockGetEffectivePricing(),
-  },
-}));
-
 vi.mock("@/observability");
 
 vi.mock("@/config", async () =>
@@ -61,6 +32,13 @@ vi.mock("@/config", async () =>
     observability: { otel: { captureContent: false, contentMaxLength: 10000 } },
   }),
 );
+
+async function kbInteractions(source: InteractionSource) {
+  return db
+    .select()
+    .from(schema.interactionsTable)
+    .where(eq(schema.interactionsTable.source, source));
+}
 
 // ===== Tests =====
 
@@ -156,21 +134,20 @@ describe("withKbObservability", () => {
       }),
     });
 
-    // Give the fire-and-forget promise time to execute
-    await vi.waitFor(() => {
-      expect(mockCreate).toHaveBeenCalledOnce();
+    // The interaction is persisted fire-and-forget.
+    await vi.waitFor(async () => {
+      expect(await kbInteractions("knowledge:embedding")).toHaveLength(1);
     });
 
-    expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        profileId: null,
-        source: "knowledge:embedding",
-        type: "openai:embeddings",
-        model: "text-embedding-3-small",
-        inputTokens: 5,
-        outputTokens: 0,
-      }),
-    );
+    const [row] = await kbInteractions("knowledge:embedding");
+    expect(row).toMatchObject({
+      profileId: null,
+      source: "knowledge:embedding",
+      type: "openai:embeddings",
+      model: "text-embedding-3-small",
+      inputTokens: 5,
+      outputTokens: 0,
+    });
   });
 
   it("sets span attributes for source and token usage", async () => {
@@ -223,11 +200,13 @@ describe("withKbObservability", () => {
       }),
     ).rejects.toThrow("API failed");
 
-    expect(mockCreate).not.toHaveBeenCalled();
+    expect(await kbInteractions("knowledge:embedding")).toHaveLength(0);
   });
 
   it("still returns result when InteractionModel.create fails", async () => {
-    mockCreate.mockRejectedValueOnce(new Error("DB error"));
+    vi.spyOn(InteractionModel, "create").mockRejectedValueOnce(
+      new Error("DB error"),
+    );
 
     const result = await withKbObservability({
       ...baseParams,
@@ -245,10 +224,15 @@ describe("withKbObservability", () => {
   });
 
   it("calculates cost from model pricing and stores it", async () => {
-    mockGetEffectivePricing.mockReturnValueOnce({
-      pricePerMillionInput: "3.00",
-      pricePerMillionOutput: "15.00",
-      source: "custom",
+    // Admin-set custom pricing on the real model row drives the cost.
+    await ModelModel.create({
+      externalId: "openai/text-embedding-3-small",
+      provider: "openai",
+      modelId: "text-embedding-3-small",
+      inputModalities: null,
+      outputModalities: null,
+      customPricePerMillionInput: "3.00",
+      customPricePerMillionOutput: "15.00",
     });
 
     await withKbObservability({
@@ -263,22 +247,21 @@ describe("withKbObservability", () => {
       }),
     });
 
-    await vi.waitFor(() => {
-      expect(mockCreate).toHaveBeenCalledOnce();
+    await vi.waitFor(async () => {
+      expect(await kbInteractions("knowledge:embedding")).toHaveLength(1);
     });
 
     // Cost = (1M / 1M) * 3.00 + (0 / 1M) * 15.00 = 3.00
-    expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        cost: "3.0000000000",
-      }),
-    );
-
+    const [row] = await kbInteractions("knowledge:embedding");
+    expect(row.cost).toBe("3.0000000000");
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("archestra.cost", 3);
   });
 
   it("stores null cost when pricing lookup fails", async () => {
-    mockFindByProviderAndModelId.mockRejectedValueOnce(new Error("DB down"));
+    // Simulate the pricing lookup throwing (calculateKbCost swallows → cost null).
+    vi.spyOn(ModelModel, "findByProviderAndModelId").mockRejectedValueOnce(
+      new Error("DB down"),
+    );
 
     await withKbObservability({
       ...baseParams,
@@ -292,24 +275,15 @@ describe("withKbObservability", () => {
       }),
     });
 
-    await vi.waitFor(() => {
-      expect(mockCreate).toHaveBeenCalledOnce();
+    await vi.waitFor(async () => {
+      expect(await kbInteractions("knowledge:embedding")).toHaveLength(1);
     });
 
-    expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        cost: null,
-      }),
-    );
+    const [row] = await kbInteractions("knowledge:embedding");
+    expect(row.cost).toBeNull();
   });
 
   it("emits Prometheus metrics via reportKbLlmCall", async () => {
-    mockGetEffectivePricing.mockReturnValueOnce({
-      pricePerMillionInput: "2.00",
-      pricePerMillionOutput: "10.00",
-      source: "default",
-    });
-
     await withKbObservability({
       ...baseParams,
       callback: async () => "result",
@@ -333,7 +307,7 @@ describe("withKbObservability", () => {
         source: "knowledge:embedding",
       }),
     );
-    // Should include durationSeconds (number >= 0) and cost
+    // Should include durationSeconds (number >= 0)
     const call = reportKbLlmCall.mock.calls[0][0];
     expect(typeof call.durationSeconds).toBe("number");
     expect(call.durationSeconds).toBeGreaterThanOrEqual(0);
@@ -356,18 +330,17 @@ describe("withKbObservability", () => {
       }),
     });
 
-    await vi.waitFor(() => {
-      expect(mockCreate).toHaveBeenCalledOnce();
+    await vi.waitFor(async () => {
+      expect(await kbInteractions("knowledge:reranker")).toHaveLength(1);
     });
 
-    expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        source: "knowledge:reranker",
-        type: "anthropic:messages",
-        model: "claude-haiku-4-5-20251001",
-        inputTokens: 100,
-        outputTokens: 20,
-      }),
-    );
+    const [row] = await kbInteractions("knowledge:reranker");
+    expect(row).toMatchObject({
+      source: "knowledge:reranker",
+      type: "anthropic:messages",
+      model: "claude-haiku-4-5-20251001",
+      inputTokens: 100,
+      outputTokens: 20,
+    });
   });
 });

--- a/platform/backend/src/services/mcp-reinstall.test.ts
+++ b/platform/backend/src/services/mcp-reinstall.test.ts
@@ -9,27 +9,6 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
   },
 }));
 
-vi.mock("@/models", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/models")>();
-  return {
-    InternalMcpCatalogModel: {
-      update: vi.fn(),
-    },
-    McpServerModel: {
-      constructServerName: original.McpServerModel.constructServerName,
-      findByCatalogId: vi.fn(),
-      getToolsFromServer: vi.fn(),
-      update: vi.fn(),
-    },
-    ToolModel: {
-      slugifyName: vi.fn(
-        (prefix: string, name: string) => `${prefix}__${name}`,
-      ),
-      syncToolsForCatalog: vi.fn(),
-    },
-  };
-});
-
 vi.mock("@/websocket", () => ({
   broadcastMcpInstallationStatus: vi.fn(),
 }));
@@ -39,10 +18,30 @@ import {
   CATALOG_SHAPES,
   isMetadataOnlyEdit,
 } from "@archestra/shared";
+import { eq } from "drizzle-orm";
+import db, { schema } from "@/database";
 import { McpServerRuntimeManager } from "@/k8s/mcp-server-runtime";
-import { InternalMcpCatalogModel, McpServerModel, ToolModel } from "@/models";
+import { McpServerModel, ToolModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { InternalMcpCatalog, McpServer } from "@/types";
+
+// Re-fetch a server row after the code under test mutated it.
+async function getServer(id: string): Promise<McpServer> {
+  const [row] = await db
+    .select()
+    .from(schema.mcpServersTable)
+    .where(eq(schema.mcpServersTable.id, id));
+  return row as McpServer;
+}
+
+// Tools reconciled for a catalog (real ToolModel.syncToolsForCatalog writes).
+async function getCatalogTools(catalogId: string) {
+  return db
+    .select()
+    .from(schema.toolsTable)
+    .where(eq(schema.toolsTable.catalogId, catalogId));
+}
+
 import {
   autoReinstallServer,
   onlyForwardCompatibleEnvDiff,
@@ -1048,43 +1047,70 @@ describe("mcp-reinstall", () => {
   });
 
   describe("autoReinstallServer", () => {
-    const createServer = (overrides: Partial<McpServer> = {}): McpServer =>
-      ({
-        id: "server-123",
-        name: "Test Server",
-        ownerId: "user-123",
-        catalogId: "catalog-123",
-        serverType: "local",
-        scope: "personal",
-        ...overrides,
-      }) as McpServer;
-
-    // Helper to create a minimal catalog item
-    const createCatalog = (
-      overrides: Partial<InternalMcpCatalog> = {},
-    ): InternalMcpCatalog =>
-      ({
-        id: "catalog-123",
-        name: "Test Catalog",
-        serverType: "local",
-        localConfig: {
-          command: "npm",
-          arguments: ["start"],
-        },
-        ...overrides,
-      }) as InternalMcpCatalog;
-
     beforeEach(() => {
-      vi.clearAllMocks();
+      // Restore boundary spies (getToolsFromServer, syncToolsForCatalog) between tests.
+      vi.restoreAllMocks();
     });
 
-    test("throws error when restartServer fails for local server", async () => {
-      // Use name that already matches expected format so no name update happens before restart
-      const server = createServer({
-        serverType: "local",
-        name: "Test Catalog-user-123",
+    // Seeds a real local catalog + a real server row. serverType/reinstallRequired
+    // are set via a follow-up update since the fixture doesn't expose them.
+    const seed = async (
+      fixtures: {
+        makeInternalMcpCatalog: (
+          o?: Record<string, unknown>,
+        ) => Promise<InternalMcpCatalog>;
+        makeMcpServer: (o?: Record<string, unknown>) => Promise<McpServer>;
+      },
+      opts: {
+        catalogName: string;
+        catalogServerType: "local" | "remote";
+        serverName: string;
+        serverType: "local" | "remote";
+        scope?: "personal" | "team" | "org";
+        ownerId?: string | null;
+        teamId?: string | null;
+      },
+    ) => {
+      const catalog = await fixtures.makeInternalMcpCatalog({
+        name: opts.catalogName,
+        serverType: opts.catalogServerType,
+        ...(opts.catalogServerType === "local"
+          ? { localConfig: { command: "npm", arguments: ["start"] } }
+          : {}),
       });
-      const catalog = createCatalog({ serverType: "local" });
+      const created = await fixtures.makeMcpServer({
+        catalogId: catalog.id,
+        name: opts.serverName,
+        scope: opts.scope ?? "personal",
+        ownerId: opts.ownerId ?? null,
+        teamId: opts.teamId ?? null,
+      });
+      await db
+        .update(schema.mcpServersTable)
+        .set({ serverType: opts.serverType, reinstallRequired: true })
+        .where(eq(schema.mcpServersTable.id, created.id));
+      const server = await getServer(created.id);
+      return { catalog, server };
+    };
+
+    test("throws error when restartServer fails for local server", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeUser,
+    }) => {
+      const user = await makeUser();
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "Test Catalog",
+          catalogServerType: "local",
+          // Name already matches the reconstructed form, so no rename happens.
+          serverName: `Test Catalog-${user.id}`,
+          serverType: "local",
+          scope: "personal",
+          ownerId: user.id,
+        },
+      );
 
       vi.mocked(McpServerRuntimeManager.restartServer).mockRejectedValue(
         new Error("K8s deployment failed"),
@@ -1094,26 +1120,28 @@ describe("mcp-reinstall", () => {
         "K8s deployment failed",
       );
 
-      // Verify restartServer was called
       expect(McpServerRuntimeManager.restartServer).toHaveBeenCalledWith(
         server.id,
       );
-
-      // Verify reinstall flag update was NOT called since we threw before getting there
-      expect(McpServerModel.update).not.toHaveBeenCalledWith(server.id, {
-        reinstallRequired: false,
-      });
+      // Threw before clearing the flag → still required.
+      expect((await getServer(server.id)).reinstallRequired).toBe(true);
     });
 
-    test("throws error when getToolsFromServer fails", async () => {
-      // Use matching name so no name update happens
-      const server = createServer({
-        serverType: "remote",
-        name: "Test Catalog",
-      });
-      const catalog = createCatalog({ serverType: "remote" });
+    test("throws error when getToolsFromServer fails", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "Test Catalog",
+          catalogServerType: "remote",
+          serverName: "Test Catalog",
+          serverType: "remote",
+        },
+      );
 
-      vi.mocked(McpServerModel.getToolsFromServer).mockRejectedValue(
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockRejectedValue(
         new Error("Failed to fetch tools from MCP server"),
       );
 
@@ -1121,22 +1149,28 @@ describe("mcp-reinstall", () => {
         "Failed to fetch tools from MCP server",
       );
 
-      // Verify reinstall flag update was NOT called since we threw before completing
-      expect(McpServerModel.update).not.toHaveBeenCalled();
+      // Threw before completing → flag not cleared.
+      expect((await getServer(server.id)).reinstallRequired).toBe(true);
     });
 
-    test("throws error when syncToolsForCatalog fails", async () => {
-      // Use matching name so no name update happens
-      const server = createServer({
-        serverType: "remote",
-        name: "Test Catalog",
-      });
-      const catalog = createCatalog({ serverType: "remote" });
+    test("throws error when syncToolsForCatalog fails", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "Test Catalog",
+          catalogServerType: "remote",
+          serverName: "Test Catalog",
+          serverType: "remote",
+        },
+      );
 
-      vi.mocked(McpServerModel.getToolsFromServer).mockResolvedValue([
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([
         { name: "test-tool", description: "A test tool", inputSchema: {} },
       ]);
-      vi.mocked(ToolModel.syncToolsForCatalog).mockRejectedValue(
+      vi.spyOn(ToolModel, "syncToolsForCatalog").mockRejectedValue(
         new Error("Database constraint violation"),
       );
 
@@ -1144,17 +1178,26 @@ describe("mcp-reinstall", () => {
         "Database constraint violation",
       );
 
-      // Verify reinstall flag update was NOT called since we threw before completing
-      expect(McpServerModel.update).not.toHaveBeenCalled();
+      expect((await getServer(server.id)).reinstallRequired).toBe(true);
     });
 
-    test("throws error when deployment waitForDeploymentReady times out", async () => {
-      // Use name that already matches expected format so no name update happens before restart
-      const server = createServer({
-        serverType: "local",
-        name: "Test Catalog-user-123",
-      });
-      const catalog = createCatalog({ serverType: "local" });
+    test("throws error when deployment waitForDeploymentReady times out", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeUser,
+    }) => {
+      const user = await makeUser();
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "Test Catalog",
+          catalogServerType: "local",
+          serverName: `Test Catalog-${user.id}`,
+          serverType: "local",
+          scope: "personal",
+          ownerId: user.id,
+        },
+      );
 
       vi.mocked(McpServerRuntimeManager.restartServer).mockResolvedValue(
         undefined,
@@ -1169,54 +1212,52 @@ describe("mcp-reinstall", () => {
         "Deployment timeout",
       );
 
-      // Verify reinstall flag update was NOT called since we threw before completing
-      expect(McpServerModel.update).not.toHaveBeenCalledWith(server.id, {
-        reinstallRequired: false,
-      });
+      expect((await getServer(server.id)).reinstallRequired).toBe(true);
     });
 
-    test("succeeds for remote server - updates name and clears reinstall flag", async () => {
-      const server = createServer({
-        serverType: "remote",
-        name: "Old Catalog Name",
-      });
-      const catalog = createCatalog({
-        serverType: "remote",
-        name: "New Catalog Name",
-      });
+    test("succeeds for remote server - updates name and clears reinstall flag", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "New Catalog Name",
+          catalogServerType: "remote",
+          serverName: "Old Catalog Name",
+          serverType: "remote",
+        },
+      );
 
-      vi.mocked(McpServerModel.getToolsFromServer).mockResolvedValue([
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([
         { name: "test-tool", description: "A test tool", inputSchema: {} },
       ]);
-      vi.mocked(ToolModel.syncToolsForCatalog).mockResolvedValue({
-        created: [],
-        updated: [],
-        unchanged: [],
-        deleted: [],
-      });
-      vi.mocked(McpServerModel.update).mockResolvedValue({} as McpServer);
 
       await autoReinstallServer(server, catalog);
 
-      // Remote servers get the catalog name directly (no suffix)
-      expect(McpServerModel.update).toHaveBeenCalledWith(server.id, {
-        name: "New Catalog Name",
-      });
-      expect(McpServerModel.update).toHaveBeenCalledWith(server.id, {
-        reinstallRequired: false,
-      });
+      // Remote servers get the catalog name directly (no suffix), and the flag clears.
+      const updated = await getServer(server.id);
+      expect(updated.name).toBe("New Catalog Name");
+      expect(updated.reinstallRequired).toBe(false);
     });
 
-    test("reconstructs name with userId suffix when name already correct", async () => {
-      const server = createServer({
-        serverType: "local",
-        name: "microsoft__playwright-mcp-user-123",
-        ownerId: "user-123",
-      });
-      const catalog = createCatalog({
-        serverType: "local",
-        name: "microsoft__playwright-mcp",
-      });
+    test("reconstructs name with userId suffix when name already correct", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeUser,
+    }) => {
+      const user = await makeUser();
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "microsoft__playwright-mcp",
+          catalogServerType: "local",
+          serverName: `microsoft__playwright-mcp-${user.id}`,
+          serverType: "local",
+          scope: "personal",
+          ownerId: user.id,
+        },
+      );
 
       vi.mocked(McpServerRuntimeManager.restartServer).mockResolvedValue(
         undefined,
@@ -1224,36 +1265,35 @@ describe("mcp-reinstall", () => {
       vi.mocked(McpServerRuntimeManager.getOrLoadDeployment).mockResolvedValue({
         waitForDeploymentReady: vi.fn().mockResolvedValue(undefined),
       } as never);
-      vi.mocked(McpServerModel.getToolsFromServer).mockResolvedValue([
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([
         { name: "tool1", description: "A tool", inputSchema: {} },
       ]);
-      vi.mocked(ToolModel.syncToolsForCatalog).mockResolvedValue({
-        created: [],
-        updated: [],
-        unchanged: [],
-        deleted: [],
-      } as never);
-      vi.mocked(McpServerModel.update).mockResolvedValue({} as McpServer);
 
       await autoReinstallServer(server, catalog);
 
-      // Name already matches, so no name update call — only reinstall flag cleared
-      expect(McpServerModel.update).toHaveBeenCalledTimes(1);
-      expect(McpServerModel.update).toHaveBeenCalledWith(server.id, {
-        reinstallRequired: false,
-      });
+      // Name already matches → not renamed; only the reinstall flag clears.
+      const updated = await getServer(server.id);
+      expect(updated.name).toBe(`microsoft__playwright-mcp-${user.id}`);
+      expect(updated.reinstallRequired).toBe(false);
     });
 
-    test("updates name with userId suffix when catalog is renamed", async () => {
-      const server = createServer({
-        serverType: "local",
-        name: "old-catalog-name-user-123",
-        ownerId: "user-123",
-      });
-      const catalog = createCatalog({
-        serverType: "local",
-        name: "new-catalog-name",
-      });
+    test("updates name with userId suffix when catalog is renamed", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeUser,
+    }) => {
+      const user = await makeUser();
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "new-catalog-name",
+          catalogServerType: "local",
+          serverName: "old-catalog-name",
+          serverType: "local",
+          scope: "personal",
+          ownerId: user.id,
+        },
+      );
 
       vi.mocked(McpServerRuntimeManager.restartServer).mockResolvedValue(
         undefined,
@@ -1261,41 +1301,40 @@ describe("mcp-reinstall", () => {
       vi.mocked(McpServerRuntimeManager.getOrLoadDeployment).mockResolvedValue({
         waitForDeploymentReady: vi.fn().mockResolvedValue(undefined),
       } as never);
-      vi.mocked(McpServerModel.getToolsFromServer).mockResolvedValue([
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([
         { name: "tool1", description: "A tool", inputSchema: {} },
       ]);
-      vi.mocked(ToolModel.syncToolsForCatalog).mockResolvedValue({
-        created: [],
-        updated: [],
-        unchanged: [],
-        deleted: [],
-      } as never);
-      vi.mocked(McpServerModel.update).mockResolvedValue({} as McpServer);
 
       await autoReinstallServer(server, catalog);
 
-      // Name updated with new catalog name + userId suffix BEFORE restart
-      expect(McpServerModel.update).toHaveBeenCalledWith(server.id, {
-        name: "new-catalog-name-user-123",
-      });
-      // Then reinstall flag cleared after restart
-      expect(McpServerModel.update).toHaveBeenCalledWith(server.id, {
-        reinstallRequired: false,
-      });
+      // Name reconstructed as `<catalog>-<ownerId>`, then flag cleared.
+      const updated = await getServer(server.id);
+      expect(updated.name).toBe(`new-catalog-name-${user.id}`);
+      expect(updated.reinstallRequired).toBe(false);
     });
 
-    test("updates name with teamId suffix for team servers on catalog rename", async () => {
-      const server = createServer({
-        serverType: "local",
-        name: "old-name-team-456",
-        ownerId: "user-123",
-        teamId: "team-456",
-        scope: "team",
-      });
-      const catalog = createCatalog({
-        serverType: "local",
-        name: "new-name",
-      });
+    test("updates name with teamId suffix for team servers on catalog rename", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeUser,
+      makeOrganization,
+      makeTeam,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const team = await makeTeam(org.id, user.id);
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "new-name",
+          catalogServerType: "local",
+          serverName: "old-name",
+          serverType: "local",
+          scope: "team",
+          ownerId: user.id,
+          teamId: team.id,
+        },
+      );
 
       vi.mocked(McpServerRuntimeManager.restartServer).mockResolvedValue(
         undefined,
@@ -1303,34 +1342,32 @@ describe("mcp-reinstall", () => {
       vi.mocked(McpServerRuntimeManager.getOrLoadDeployment).mockResolvedValue({
         waitForDeploymentReady: vi.fn().mockResolvedValue(undefined),
       } as never);
-      vi.mocked(McpServerModel.getToolsFromServer).mockResolvedValue([]);
-      vi.mocked(ToolModel.syncToolsForCatalog).mockResolvedValue({
-        created: [],
-        updated: [],
-        unchanged: [],
-        deleted: [],
-      } as never);
-      vi.mocked(McpServerModel.update).mockResolvedValue({} as McpServer);
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([]);
 
       await autoReinstallServer(server, catalog);
 
-      // teamId takes precedence over ownerId for the suffix
-      expect(McpServerModel.update).toHaveBeenCalledWith(server.id, {
-        name: "new-name-team-456",
-      });
+      // teamId takes precedence over ownerId for the suffix.
+      expect((await getServer(server.id)).name).toBe(`new-name-${team.id}`);
     });
 
-    test("fixes legacy server missing userId suffix", async () => {
-      // Legacy server created before suffix logic was deployed
-      const server = createServer({
-        serverType: "local",
-        name: "microsoft__playwright-mcp",
-        ownerId: "user-123",
-      });
-      const catalog = createCatalog({
-        serverType: "local",
-        name: "microsoft__playwright-mcp",
-      });
+    test("fixes legacy server missing userId suffix", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeUser,
+    }) => {
+      const user = await makeUser();
+      // Legacy server created before suffix logic was deployed (no suffix).
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "microsoft__playwright-mcp",
+          catalogServerType: "local",
+          serverName: "microsoft__playwright-mcp",
+          serverType: "local",
+          scope: "personal",
+          ownerId: user.id,
+        },
+      );
 
       vi.mocked(McpServerRuntimeManager.restartServer).mockResolvedValue(
         undefined,
@@ -1338,31 +1375,33 @@ describe("mcp-reinstall", () => {
       vi.mocked(McpServerRuntimeManager.getOrLoadDeployment).mockResolvedValue({
         waitForDeploymentReady: vi.fn().mockResolvedValue(undefined),
       } as never);
-      vi.mocked(McpServerModel.getToolsFromServer).mockResolvedValue([]);
-      vi.mocked(ToolModel.syncToolsForCatalog).mockResolvedValue({
-        created: [],
-        updated: [],
-        unchanged: [],
-        deleted: [],
-      } as never);
-      vi.mocked(McpServerModel.update).mockResolvedValue({} as McpServer);
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([]);
 
       await autoReinstallServer(server, catalog);
 
-      // Name updated to add the missing userId suffix
-      expect(McpServerModel.update).toHaveBeenCalledWith(server.id, {
-        name: "microsoft__playwright-mcp-user-123",
-      });
+      expect((await getServer(server.id)).name).toBe(
+        `microsoft__playwright-mcp-${user.id}`,
+      );
     });
 
-    test("passes _meta and annotations as meta when syncing tools", async () => {
-      const server = createServer({ serverType: "remote" });
-      const catalog = createCatalog({ serverType: "remote" });
+    test("passes _meta and annotations as meta when syncing tools", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "Test Catalog",
+          catalogServerType: "remote",
+          serverName: "Test Catalog",
+          serverType: "remote",
+        },
+      );
 
       const toolMeta = { ui: { resourceUri: "mcp://app/view" } };
       const toolAnnotations = { readOnlyHint: true };
 
-      vi.mocked(McpServerModel.getToolsFromServer).mockResolvedValue([
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([
         {
           name: "ui-tool",
           description: "Tool with UI",
@@ -1371,29 +1410,34 @@ describe("mcp-reinstall", () => {
           annotations: toolAnnotations,
         },
       ]);
-      vi.mocked(ToolModel.syncToolsForCatalog).mockResolvedValue({
-        created: [],
-        updated: [],
-        unchanged: [],
-        deleted: [],
-      });
-      vi.mocked(McpServerModel.update).mockResolvedValue({} as McpServer);
 
       await autoReinstallServer(server, catalog);
 
-      expect(ToolModel.syncToolsForCatalog).toHaveBeenCalledWith([
-        expect.objectContaining({
-          meta: { _meta: toolMeta, annotations: toolAnnotations },
-        }),
-      ]);
+      // The reconciled tool row carries the combined meta payload.
+      const [tool] = await getCatalogTools(catalog.id);
+      expect(tool.meta).toEqual({
+        _meta: toolMeta,
+        annotations: toolAnnotations,
+      });
     });
 
-    test("succeeds for local server with full flow", async () => {
-      const server = createServer({
-        serverType: "local",
-        name: "Test Catalog-user-123",
-      });
-      const catalog = createCatalog({ serverType: "local" });
+    test("succeeds for local server with full flow", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeUser,
+    }) => {
+      const user = await makeUser();
+      const { catalog, server } = await seed(
+        { makeInternalMcpCatalog, makeMcpServer },
+        {
+          catalogName: "Test Catalog",
+          catalogServerType: "local",
+          serverName: `Test Catalog-${user.id}`,
+          serverType: "local",
+          scope: "personal",
+          ownerId: user.id,
+        },
+      );
 
       vi.mocked(McpServerRuntimeManager.restartServer).mockResolvedValue(
         undefined,
@@ -1401,87 +1445,65 @@ describe("mcp-reinstall", () => {
       vi.mocked(McpServerRuntimeManager.getOrLoadDeployment).mockResolvedValue({
         waitForDeploymentReady: vi.fn().mockResolvedValue(undefined),
       } as never);
-      vi.mocked(McpServerModel.getToolsFromServer).mockResolvedValue([
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([
         { name: "tool1", description: "First tool", inputSchema: {} },
         { name: "tool2", description: "Second tool", inputSchema: {} },
       ]);
-      vi.mocked(ToolModel.syncToolsForCatalog).mockResolvedValue({
-        created: [{ id: "new-tool" }],
-        updated: [{ id: "existing-tool" }],
-        unchanged: [],
-        deleted: [],
-      } as never);
-      vi.mocked(McpServerModel.update).mockResolvedValue({} as McpServer);
 
       await autoReinstallServer(server, catalog);
 
-      // Verify restart was called
       expect(McpServerRuntimeManager.restartServer).toHaveBeenCalledWith(
         server.id,
       );
 
-      // Verify tools were synced with correct data
-      expect(ToolModel.syncToolsForCatalog).toHaveBeenCalledWith([
-        expect.objectContaining({
-          name: "Test Catalog__tool1",
-          catalogId: catalog.id,
-          rawToolName: "tool1",
-        }),
-        expect.objectContaining({
-          name: "Test Catalog__tool2",
-          catalogId: catalog.id,
-          rawToolName: "tool2",
-        }),
-      ]);
+      // Both tools were reconciled into the tools table under the catalog.
+      const tools = await getCatalogTools(catalog.id);
+      const toolNames = tools.map((t) => t.name).sort();
+      expect(toolNames).toEqual(
+        [
+          ToolModel.slugifyName("Test Catalog", "tool1"),
+          ToolModel.slugifyName("Test Catalog", "tool2"),
+        ].sort(),
+      );
 
-      // Verify reinstall flag was cleared (name already correct, no name update)
-      expect(McpServerModel.update).toHaveBeenCalledTimes(1);
-      expect(McpServerModel.update).toHaveBeenCalledWith(server.id, {
-        reinstallRequired: false,
-      });
+      // Name already correct → not renamed; the reinstall flag cleared.
+      const updated = await getServer(server.id);
+      expect(updated.name).toBe(`Test Catalog-${user.id}`);
+      expect(updated.reinstallRequired).toBe(false);
     });
   });
 
   describe("reinstallMultitenantCatalog", () => {
-    const catalog = {
-      id: "catalog-mt",
-      name: "shared",
-      serverType: "local",
-      multitenant: true,
-      localConfig: { command: "npm", arguments: ["start"] },
-    } as InternalMcpCatalog;
-
     beforeEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
 
-    test("Phase 2 tool-sync failure flags the install for retry", async () => {
+    test("Phase 2 tool-sync failure flags the install for retry", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+    }) => {
       // Two tenants share the catalog. Pod recreate succeeds (Phase 1).
       // Tool fetch fails for tenantB only (Phase 2). We expect tenantB to
       // be flagged `reinstallRequired: true` so the per-install Reinstall
       // button surfaces; otherwise the tenant is stuck with only the red
       // error banner and no retry path.
-      const tenantA = {
-        id: "tenant-a",
-        name: "tenant-a",
-        catalogId: catalog.id,
+      const catalog = await makeInternalMcpCatalog({
+        name: "shared",
         serverType: "local",
-      } as McpServer;
-      const tenantB = {
-        id: "tenant-b",
-        name: "tenant-b",
-        catalogId: catalog.id,
-        serverType: "local",
-      } as McpServer;
+        localConfig: { command: "npm", arguments: ["start"] },
+      });
+      await db
+        .update(schema.internalMcpCatalogTable)
+        .set({ catalogReinstallRequired: true })
+        .where(eq(schema.internalMcpCatalogTable.id, catalog.id));
 
-      vi.mocked(McpServerModel.findByCatalogId).mockResolvedValue([
-        tenantA,
-        tenantB,
-      ]);
+      const tenantA = await makeMcpServer({ catalogId: catalog.id });
+      const tenantB = await makeMcpServer({ catalogId: catalog.id });
+
       vi.mocked(
         McpServerRuntimeManager.reinstallSharedDeployment,
       ).mockResolvedValue(undefined);
-      vi.mocked(McpServerModel.getToolsFromServer).mockImplementation(
+      vi.spyOn(McpServerModel, "getToolsFromServer").mockImplementation(
         async (server: McpServer) => {
           if (server.id === tenantB.id) {
             throw new Error("tool fetch boom");
@@ -1489,40 +1511,26 @@ describe("mcp-reinstall", () => {
           return [];
         },
       );
-      vi.mocked(ToolModel.syncToolsForCatalog).mockResolvedValue({
-        created: [],
-        updated: [],
-        unchanged: [],
-        deleted: [],
-      } as never);
-      vi.mocked(McpServerModel.update).mockResolvedValue({} as McpServer);
-      vi.mocked(InternalMcpCatalogModel.update).mockResolvedValue(
-        {} as InternalMcpCatalog,
-      );
 
       await reinstallMultitenantCatalog(catalog);
 
-      // The failing tenant must be marked for retry — this is the assertion
-      // the current code fails. Without `reinstallRequired: true`, the
-      // per-install Reinstall button stays hidden (mcp-server-card.tsx
-      // gates on this flag) and the tenant is stuck.
-      expect(McpServerModel.update).toHaveBeenCalledWith(
-        tenantB.id,
-        expect.objectContaining({
-          reinstallRequired: true,
-          localInstallationStatus: "error",
-        }),
-      );
+      // The failing tenant is flagged for retry so its per-install Reinstall
+      // button surfaces (mcp-server-card.tsx gates on this flag).
+      const failed = await getServer(tenantB.id);
+      expect(failed.reinstallRequired).toBe(true);
+      expect(failed.localInstallationStatus).toBe("error");
 
-      // Sanity: the successful tenant is NOT flagged for retry.
-      const tenantACalls = vi
-        .mocked(McpServerModel.update)
-        .mock.calls.filter(([id]) => id === tenantA.id);
-      const tenantAFlaggedForRetry = tenantACalls.some(
-        ([, patch]) =>
-          (patch as { reinstallRequired?: boolean }).reinstallRequired === true,
-      );
-      expect(tenantAFlaggedForRetry).toBe(false);
+      // The successful tenant finished cleanly and is NOT flagged for retry.
+      const ok = await getServer(tenantA.id);
+      expect(ok.reinstallRequired).toBe(false);
+      expect(ok.localInstallationStatus).toBe("success");
+
+      // Phase 1 succeeded → the catalog-level flag is cleared.
+      const [catalogRow] = await db
+        .select()
+        .from(schema.internalMcpCatalogTable)
+        .where(eq(schema.internalMcpCatalogTable.id, catalog.id));
+      expect(catalogRow.catalogReinstallRequired).toBe(false);
     });
   });
 });

--- a/platform/backend/src/task-queue/handlers/audit-log-cleanup-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/audit-log-cleanup-handler.test.ts
@@ -1,68 +1,96 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
-
-const mockDeleteAllOlderThan = vi.hoisted(() => vi.fn().mockResolvedValue(0));
-
-vi.mock("@/models", () => ({
-  AuditLogModel: { deleteAllOlderThan: mockDeleteAllOlderThan },
-}));
-
-const mockConfig = vi.hoisted(() => ({
-  auditLog: { retentionDays: 180 },
-}));
-vi.mock("@/config", () => ({ default: mockConfig }));
+import { vi } from "vitest";
 
 vi.mock("@/logging");
 
+import { count } from "drizzle-orm";
+import config from "@/config";
+import db, { schema } from "@/database";
 import logger from "@/logging";
+import { AuditLogModel } from "@/models";
+import { beforeEach, describe, expect, test } from "@/test";
 import { handleAuditLogCleanup } from "./audit-log-cleanup-handler";
+
+async function seedAuditLog(organizationId: string, createdAt: Date) {
+  await db.insert(schema.auditLogsTable).values({
+    organizationId,
+    occurredAt: createdAt,
+    createdAt,
+    actorType: "user",
+    action: "agent.created",
+    outcome: "success",
+  });
+}
+
+async function countAuditLogs(): Promise<number> {
+  const [{ total }] = await db
+    .select({ total: count() })
+    .from(schema.auditLogsTable);
+  return Number(total);
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 describe("handleAuditLogCleanup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockConfig.auditLog.retentionDays = 180;
+    config.auditLog.retentionDays = 180;
   });
 
-  test("logs and returns early when retentionDays is 0", async () => {
-    mockConfig.auditLog.retentionDays = 0;
+  test("logs and returns early when retentionDays is 0", async ({
+    makeOrganization,
+  }) => {
+    config.auditLog.retentionDays = 0;
+    const org = await makeOrganization();
+    await seedAuditLog(org.id, new Date(Date.now() - 365 * DAY_MS));
 
     await handleAuditLogCleanup();
 
-    expect(mockDeleteAllOlderThan).not.toHaveBeenCalled();
+    // Nothing is deleted when retention is disabled.
+    expect(await countAuditLogs()).toBe(1);
     expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
       expect.objectContaining({ retentionDays: 0 }),
       expect.stringContaining("disabled"),
     );
   });
 
-  test("runs a single DELETE across all orgs with the correct cutoff date", async () => {
-    mockDeleteAllOlderThan.mockResolvedValue(15);
+  test("deletes rows older than the cutoff across all orgs, keeps newer ones", async ({
+    makeOrganization,
+  }) => {
+    const orgA = await makeOrganization();
+    const orgB = await makeOrganization();
 
-    const before = Date.now();
+    // Older than the 180-day window → should be deleted (both orgs).
+    await seedAuditLog(orgA.id, new Date(Date.now() - 181 * DAY_MS));
+    await seedAuditLog(orgB.id, new Date(Date.now() - 200 * DAY_MS));
+    // Newer than the window → should survive.
+    await seedAuditLog(orgA.id, new Date(Date.now() - 179 * DAY_MS));
+    await seedAuditLog(orgB.id, new Date(Date.now() - 10 * DAY_MS));
+
     await handleAuditLogCleanup();
-    const after = Date.now();
 
-    expect(mockDeleteAllOlderThan).toHaveBeenCalledTimes(1);
-
-    const cutoff = (mockDeleteAllOlderThan.mock.calls[0][0] as Date).getTime();
-    const expectedMin = before - 180 * 24 * 60 * 60 * 1000;
-    const expectedMax = after - 180 * 24 * 60 * 60 * 1000;
-    expect(cutoff).toBeGreaterThanOrEqual(expectedMin);
-    expect(cutoff).toBeLessThanOrEqual(expectedMax);
+    expect(await countAuditLogs()).toBe(2);
   });
 
-  test("logs the deleted count and retention window on completion", async () => {
-    mockDeleteAllOlderThan.mockResolvedValue(42);
+  test("logs the deleted count and retention window on completion", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    await seedAuditLog(org.id, new Date(Date.now() - 200 * DAY_MS));
+    await seedAuditLog(org.id, new Date(Date.now() - 190 * DAY_MS));
+    await seedAuditLog(org.id, new Date(Date.now() - 185 * DAY_MS));
 
     await handleAuditLogCleanup();
 
     expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
-      expect.objectContaining({ deleted: 42, retentionDays: 180 }),
+      expect.objectContaining({ deleted: 3, retentionDays: 180 }),
       "audit-log retention sweep: complete",
     );
   });
 
   test("logs an error when the DELETE fails and does not throw", async () => {
-    mockDeleteAllOlderThan.mockRejectedValueOnce(new Error("DB error"));
+    vi.spyOn(AuditLogModel, "deleteAllOlderThan").mockRejectedValueOnce(
+      new Error("DB error"),
+    );
 
     await expect(handleAuditLogCleanup()).resolves.toBeUndefined();
 
@@ -72,18 +100,18 @@ describe("handleAuditLogCleanup", () => {
     );
   });
 
-  test("uses the configured retentionDays to compute the cutoff", async () => {
-    mockConfig.auditLog.retentionDays = 30;
-    mockDeleteAllOlderThan.mockResolvedValue(2);
+  test("uses the configured retentionDays to compute the cutoff", async ({
+    makeOrganization,
+  }) => {
+    config.auditLog.retentionDays = 30;
+    const org = await makeOrganization();
+    // Older than 30 days → deleted.
+    await seedAuditLog(org.id, new Date(Date.now() - 31 * DAY_MS));
+    // Newer than 30 days → kept.
+    await seedAuditLog(org.id, new Date(Date.now() - 29 * DAY_MS));
 
-    const before = Date.now();
     await handleAuditLogCleanup();
-    const after = Date.now();
 
-    const cutoff = (mockDeleteAllOlderThan.mock.calls[0][0] as Date).getTime();
-    const expectedMin = before - 30 * 24 * 60 * 60 * 1000;
-    const expectedMax = after - 30 * 24 * 60 * 60 * 1000;
-    expect(cutoff).toBeGreaterThanOrEqual(expectedMin);
-    expect(cutoff).toBeLessThanOrEqual(expectedMax);
+    expect(await countAuditLogs()).toBe(1);
   });
 });

--- a/platform/backend/src/task-queue/handlers/batch-embedding-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/batch-embedding-handler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { vi } from "vitest";
 
 const mockProcessDocuments = vi.hoisted(() =>
   vi.fn().mockResolvedValue(undefined),
@@ -7,17 +7,8 @@ vi.mock("@/knowledge-base", () => ({
   embeddingService: { processDocuments: mockProcessDocuments },
 }));
 
-const mockCompleteBatch = vi.hoisted(() => vi.fn());
-const mockUpdateConnector = vi.hoisted(() => vi.fn());
-const mockFindByIdConnector = vi.hoisted(() => vi.fn());
-vi.mock("@/models", () => ({
-  ConnectorRunModel: { completeBatch: mockCompleteBatch },
-  KnowledgeBaseConnectorModel: {
-    update: mockUpdateConnector,
-    findById: mockFindByIdConnector,
-  },
-}));
-
+import { ConnectorRunModel, KnowledgeBaseConnectorModel } from "@/models";
+import { beforeEach, describe, expect, test } from "@/test";
 import { handleBatchEmbedding } from "./batch-embedding-handler";
 
 describe("handleBatchEmbedding", () => {
@@ -27,67 +18,110 @@ describe("handleBatchEmbedding", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProcessDocuments.mockResolvedValue(undefined);
-    // Default: connector's lastSyncAt is old → no newer run → update proceeds
-    mockFindByIdConnector.mockResolvedValue({ lastSyncAt: OLD_DATE });
   });
 
-  test("processes documents and completes batch", async () => {
-    mockCompleteBatch.mockResolvedValue({
-      connectorId: "conn-1",
-      completedBatches: 1,
+  test("processes documents and completes a non-final batch", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncAt: OLD_DATE,
+    });
+    const run = await ConnectorRunModel.create({
+      connectorId: connector.id,
+      status: "running",
+      startedAt: RUN_STARTED_AT,
       totalBatches: 3,
+      completedBatches: 0,
     });
 
     await handleBatchEmbedding({
       documentIds: ["doc-1", "doc-2"],
-      connectorRunId: "run-1",
+      connectorRunId: run.id,
     });
 
     expect(mockProcessDocuments).toHaveBeenCalledWith(
       ["doc-1", "doc-2"],
-      "run-1",
+      run.id,
     );
-    expect(mockCompleteBatch).toHaveBeenCalledWith("run-1");
-    expect(mockUpdateConnector).not.toHaveBeenCalled();
+    // Batch advanced but the run is not finished, so the connector is untouched.
+    const updatedRun = await ConnectorRunModel.findById(run.id);
+    expect(updatedRun?.completedBatches).toBe(1);
+    expect(updatedRun?.status).toBe("running");
+    const updatedConnector = await KnowledgeBaseConnectorModel.findById(
+      connector.id,
+    );
+    expect(updatedConnector?.lastSyncStatus).toBeNull();
   });
 
-  test("finalizes connector when all batches are done", async () => {
-    mockCompleteBatch.mockResolvedValue({
-      connectorId: "conn-1",
-      completedBatches: 3,
-      totalBatches: 3,
-      status: "success",
+  test("finalizes connector when all batches are done", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncAt: OLD_DATE,
+    });
+    const run = await ConnectorRunModel.create({
+      connectorId: connector.id,
+      status: "running",
       startedAt: RUN_STARTED_AT,
+      totalBatches: 3,
+      completedBatches: 2,
     });
 
     await handleBatchEmbedding({
       documentIds: ["doc-1"],
-      connectorRunId: "run-1",
+      connectorRunId: run.id,
     });
 
-    expect(mockUpdateConnector).toHaveBeenCalledWith("conn-1", {
-      lastSyncStatus: "success",
-      lastSyncAt: expect.any(Date),
-    });
+    const updatedConnector = await KnowledgeBaseConnectorModel.findById(
+      connector.id,
+    );
+    expect(updatedConnector?.lastSyncStatus).toBe("success");
+    expect(updatedConnector?.lastSyncAt?.getTime()).toBeGreaterThan(
+      OLD_DATE.getTime(),
+    );
   });
 
-  test("skips connector update when a newer run has started", async () => {
+  test("skips connector update when a newer run has started", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
     const newerDate = new Date(RUN_STARTED_AT.getTime() + 60_000);
-    mockFindByIdConnector.mockResolvedValue({ lastSyncAt: newerDate });
-    mockCompleteBatch.mockResolvedValue({
-      connectorId: "conn-1",
-      completedBatches: 3,
-      totalBatches: 3,
-      status: "success",
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncAt: newerDate,
+    });
+    const run = await ConnectorRunModel.create({
+      connectorId: connector.id,
+      status: "running",
       startedAt: RUN_STARTED_AT,
+      totalBatches: 3,
+      completedBatches: 2,
     });
 
     await handleBatchEmbedding({
       documentIds: ["doc-1"],
-      connectorRunId: "run-1",
+      connectorRunId: run.id,
     });
 
-    expect(mockUpdateConnector).not.toHaveBeenCalled();
+    // A newer run owns the connector status now, so this run must not touch it.
+    const updatedConnector = await KnowledgeBaseConnectorModel.findById(
+      connector.id,
+    );
+    expect(updatedConnector?.lastSyncStatus).toBeNull();
+    expect(updatedConnector?.lastSyncAt?.getTime()).toBe(newerDate.getTime());
   });
 
   test("throws when documentIds is missing", async () => {
@@ -96,42 +130,72 @@ describe("handleBatchEmbedding", () => {
     ).rejects.toThrow("Missing documentIds in batch_embedding payload");
   });
 
-  // connectorRunId is optional — some embedding paths embed documents
+  // connectorRunId is optional — some embedding paths embed documents directly
   test("processes documents without connectorRunId", async () => {
+    const completeBatchSpy = vi.spyOn(ConnectorRunModel, "completeBatch");
+
     await handleBatchEmbedding({ documentIds: ["doc-1"] });
 
     expect(mockProcessDocuments).toHaveBeenCalledWith(["doc-1"], undefined);
-    expect(mockCompleteBatch).not.toHaveBeenCalled();
-    expect(mockUpdateConnector).not.toHaveBeenCalled();
+    expect(completeBatchSpy).not.toHaveBeenCalled();
   });
 
-  test("does not update connector status when run was superseded", async () => {
-    mockCompleteBatch.mockResolvedValue({
-      connectorId: "conn-1",
-      completedBatches: 3,
-      totalBatches: 3,
+  test("does not update connector status when run was superseded/failed", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncAt: OLD_DATE,
+    });
+    // A run already marked failed stays failed through completeBatch.
+    const run = await ConnectorRunModel.create({
+      connectorId: connector.id,
       status: "failed",
       startedAt: RUN_STARTED_AT,
+      totalBatches: 3,
+      completedBatches: 2,
     });
 
     await handleBatchEmbedding({
       documentIds: ["doc-1"],
-      connectorRunId: "run-1",
+      connectorRunId: run.id,
     });
 
-    expect(mockUpdateConnector).not.toHaveBeenCalled();
+    const updatedConnector = await KnowledgeBaseConnectorModel.findById(
+      connector.id,
+    );
+    expect(updatedConnector?.lastSyncStatus).toBeNull();
   });
 
-  test("propagates embedding errors", async () => {
+  test("propagates embedding errors and does not complete the batch", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
     mockProcessDocuments.mockRejectedValue(new Error("Embedding failed"));
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
+    const run = await ConnectorRunModel.create({
+      connectorId: connector.id,
+      status: "running",
+      startedAt: RUN_STARTED_AT,
+      totalBatches: 3,
+      completedBatches: 0,
+    });
 
     await expect(
       handleBatchEmbedding({
         documentIds: ["doc-1"],
-        connectorRunId: "run-1",
+        connectorRunId: run.id,
       }),
     ).rejects.toThrow("Embedding failed");
 
-    expect(mockCompleteBatch).not.toHaveBeenCalled();
+    const updatedRun = await ConnectorRunModel.findById(run.id);
+    expect(updatedRun?.completedBatches).toBe(0);
   });
 });

--- a/platform/backend/src/task-queue/handlers/check-due-connectors-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/check-due-connectors-handler.test.ts
@@ -1,28 +1,19 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
-
-const mockFindAllEnabled = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-const mockFindAllWithStatus = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-const mockConnectorUpdate = vi.hoisted(() => vi.fn().mockResolvedValue(null));
-const mockHasPendingOrProcessing = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(false),
-);
-const mockHasActiveRun = vi.hoisted(() => vi.fn().mockResolvedValue(false));
-vi.mock("@/models", () => ({
-  KnowledgeBaseConnectorModel: {
-    findAllEnabled: mockFindAllEnabled,
-    findAllWithStatus: mockFindAllWithStatus,
-    update: mockConnectorUpdate,
-  },
-  TaskModel: { hasPendingOrProcessing: mockHasPendingOrProcessing },
-  ConnectorRunModel: { hasActiveRun: mockHasActiveRun },
-}));
+import { vi } from "vitest";
 
 const mockEnqueue = vi.hoisted(() => vi.fn().mockResolvedValue("task-id"));
 vi.mock("@/task-queue", () => ({
   taskQueueService: { enqueue: mockEnqueue },
 }));
 
+import {
+  ConnectorRunModel,
+  KnowledgeBaseConnectorModel,
+  TaskModel,
+} from "@/models";
+import { beforeEach, describe, expect, test } from "@/test";
 import { handleCheckDueConnectors } from "./check-due-connectors-handler";
+
+const PAST = () => new Date(Date.now() - 120_000);
 
 describe("handleCheckDueConnectors", () => {
   beforeEach(() => {
@@ -30,112 +21,173 @@ describe("handleCheckDueConnectors", () => {
   });
 
   test("does nothing when no connectors are enabled", async () => {
-    mockFindAllEnabled.mockResolvedValue([]);
+    await handleCheckDueConnectors();
+
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  test("skips connectors without a schedule", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    // Empty schedule means "no cron" — the column is NOT NULL, so "" is the
+    // real-world representation of an unscheduled connector.
+    await makeKnowledgeBaseConnector(kb.id, org.id, {
+      schedule: "",
+      enabled: true,
+    });
 
     await handleCheckDueConnectors();
 
     expect(mockEnqueue).not.toHaveBeenCalled();
   });
 
-  test("skips connectors without a schedule", async () => {
-    mockFindAllEnabled.mockResolvedValue([
-      { id: "conn-1", schedule: null, lastSyncAt: null },
-    ]);
-
-    await handleCheckDueConnectors();
-
-    expect(mockEnqueue).not.toHaveBeenCalled();
-  });
-
-  test("enqueues connector sync when cron is due", async () => {
-    const pastDate = new Date(Date.now() - 120_000);
-    mockFindAllEnabled.mockResolvedValue([
-      {
-        id: "conn-1",
-        schedule: "* * * * *", // every minute
-        lastSyncAt: pastDate,
-      },
-    ]);
-    mockHasPendingOrProcessing.mockResolvedValue(false);
+  test("enqueues connector sync when cron is due", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id, {
+      schedule: "* * * * *",
+      enabled: true,
+    });
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncAt: PAST(),
+    });
 
     await handleCheckDueConnectors();
 
     expect(mockEnqueue).toHaveBeenCalledWith({
       taskType: "connector_sync",
-      payload: { connectorId: "conn-1" },
+      payload: { connectorId: connector.id },
     });
   });
 
-  test("does not enqueue when a pending/processing task already exists", async () => {
-    const pastDate = new Date(Date.now() - 120_000);
-    mockFindAllEnabled.mockResolvedValue([
-      {
-        id: "conn-1",
-        schedule: "* * * * *",
-        lastSyncAt: pastDate,
-      },
-    ]);
-    mockHasPendingOrProcessing.mockResolvedValue(true);
+  test("does not enqueue when a pending/processing task already exists", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id, {
+      schedule: "* * * * *",
+      enabled: true,
+    });
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncAt: PAST(),
+    });
+    await TaskModel.create({
+      taskType: "connector_sync",
+      payload: { connectorId: connector.id },
+      status: "pending",
+    });
 
     await handleCheckDueConnectors();
 
     expect(mockEnqueue).not.toHaveBeenCalled();
   });
 
-  test("continues processing other connectors when one fails", async () => {
-    const pastDate = new Date(Date.now() - 120_000);
-    mockFindAllEnabled.mockResolvedValue([
-      {
-        id: "conn-bad",
-        schedule: "INVALID_CRON",
-        lastSyncAt: pastDate,
-      },
-      {
-        id: "conn-good",
-        schedule: "* * * * *",
-        lastSyncAt: pastDate,
-      },
-    ]);
-    mockHasPendingOrProcessing.mockResolvedValue(false);
+  test("continues processing other connectors when one fails", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const bad = await makeKnowledgeBaseConnector(kb.id, org.id, {
+      schedule: "INVALID_CRON",
+      enabled: true,
+    });
+    await KnowledgeBaseConnectorModel.update(bad.id, { lastSyncAt: PAST() });
+    const good = await makeKnowledgeBaseConnector(kb.id, org.id, {
+      schedule: "* * * * *",
+      enabled: true,
+    });
+    await KnowledgeBaseConnectorModel.update(good.id, { lastSyncAt: PAST() });
 
     await handleCheckDueConnectors();
 
-    // The good connector should still be enqueued despite the bad one failing
+    // The good connector is still enqueued despite the bad one throwing.
     expect(mockEnqueue).toHaveBeenCalledWith({
       taskType: "connector_sync",
-      payload: { connectorId: "conn-good" },
+      payload: { connectorId: good.id },
     });
   });
 
-  test("resets orphaned running status to failed when no task or run exists", async () => {
-    mockFindAllWithStatus.mockResolvedValue([{ id: "conn-orphan" }]);
-    mockHasPendingOrProcessing.mockResolvedValue(false);
-    mockHasActiveRun.mockResolvedValue(false);
-
-    await handleCheckDueConnectors();
-
-    expect(mockConnectorUpdate).toHaveBeenCalledWith("conn-orphan", {
-      lastSyncStatus: "failed",
-      lastSyncError: "Sync task was lost",
+  test("resets orphaned running status to failed when no task or run exists", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id, {
+      enabled: false,
     });
-  });
-
-  test("does not reset running status when a pending task exists", async () => {
-    mockFindAllWithStatus.mockResolvedValue([{ id: "conn-pending" }]);
-    mockHasPendingOrProcessing.mockResolvedValue(true);
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncStatus: "running",
+    });
 
     await handleCheckDueConnectors();
 
-    expect(mockConnectorUpdate).not.toHaveBeenCalled();
+    const updated = await KnowledgeBaseConnectorModel.findById(connector.id);
+    expect(updated?.lastSyncStatus).toBe("failed");
+    expect(updated?.lastSyncError).toBe("Sync task was lost");
   });
 
-  test("does not reset running status when an active run exists", async () => {
-    mockFindAllWithStatus.mockResolvedValue([{ id: "conn-active" }]);
-    mockHasPendingOrProcessing.mockResolvedValue(false);
-    mockHasActiveRun.mockResolvedValue(true);
+  test("does not reset running status when a pending task exists", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id, {
+      enabled: false,
+    });
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncStatus: "running",
+    });
+    await TaskModel.create({
+      taskType: "connector_sync",
+      payload: { connectorId: connector.id },
+      status: "pending",
+    });
 
     await handleCheckDueConnectors();
 
-    expect(mockConnectorUpdate).not.toHaveBeenCalled();
+    const updated = await KnowledgeBaseConnectorModel.findById(connector.id);
+    expect(updated?.lastSyncStatus).toBe("running");
+  });
+
+  test("does not reset running status when an active run exists", async ({
+    makeOrganization,
+    makeKnowledgeBase,
+    makeKnowledgeBaseConnector,
+  }) => {
+    const org = await makeOrganization();
+    const kb = await makeKnowledgeBase(org.id);
+    const connector = await makeKnowledgeBaseConnector(kb.id, org.id, {
+      enabled: false,
+    });
+    await KnowledgeBaseConnectorModel.update(connector.id, {
+      lastSyncStatus: "running",
+    });
+    await ConnectorRunModel.create({
+      connectorId: connector.id,
+      status: "running",
+      startedAt: new Date(),
+    });
+
+    await handleCheckDueConnectors();
+
+    const updated = await KnowledgeBaseConnectorModel.findById(connector.id);
+    expect(updated?.lastSyncStatus).toBe("running");
   });
 });

--- a/platform/backend/src/task-queue/handlers/check-due-schedule-triggers-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/check-due-schedule-triggers-handler.test.ts
@@ -1,123 +1,124 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
-
-const mockFindDueTriggers = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-const mockMarkExecuted = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const mockHasPendingOrProcessingForTrigger = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(false),
-);
-const mockRunCreate = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({ id: "run-1" }),
-);
-const mockRunMarkCompleted = vi.hoisted(() => vi.fn().mockResolvedValue(null));
-
-vi.mock("@/models", () => ({
-  ScheduleTriggerModel: {
-    findDueTriggers: mockFindDueTriggers,
-    markExecuted: mockMarkExecuted,
-  },
-  TaskModel: {
-    hasPendingOrProcessingForTrigger: mockHasPendingOrProcessingForTrigger,
-  },
-  ScheduleTriggerRunModel: {
-    create: mockRunCreate,
-    markCompleted: mockRunMarkCompleted,
-  },
-}));
+import { vi } from "vitest";
 
 const mockEnqueue = vi.hoisted(() => vi.fn().mockResolvedValue("task-id"));
 vi.mock("@/task-queue", () => ({
   taskQueueService: { enqueue: mockEnqueue },
 }));
 
+import {
+  ScheduleTriggerModel,
+  ScheduleTriggerRunModel,
+  TaskModel,
+} from "@/models";
+import { beforeEach, describe, expect, test } from "@/test";
 import { handleCheckDueScheduleTriggers } from "./check-due-schedule-triggers-handler";
 
-const makeTrigger = (id: string) => ({
-  id,
-  organizationId: "org-1",
-  name: `Trigger ${id}`,
-  agentId: "agent-1",
-  messageTemplate: "Run task",
-  cronExpression: "* * * * *",
-  timezone: "UTC",
-  enabled: true,
-  actorUserId: "user-1",
-  lastExecutedAt: null,
-  createdAt: new Date(),
-});
+// A trigger whose last execution is in the past is due on the next minute tick.
+const TWO_MIN_AGO = () => new Date(Date.now() - 120_000);
 
 describe("handleCheckDueScheduleTriggers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  test("does nothing when no triggers are due", async () => {
-    mockFindDueTriggers.mockResolvedValue([]);
+  test("does nothing when no triggers are due", async ({
+    makeScheduleTrigger,
+  }) => {
+    // lastExecutedAt = now → next run is a minute out → not due yet.
+    const trigger = await makeScheduleTrigger({ lastExecutedAt: new Date() });
 
     await handleCheckDueScheduleTriggers();
 
     expect(mockEnqueue).not.toHaveBeenCalled();
-    expect(mockRunCreate).not.toHaveBeenCalled();
+    expect(
+      await ScheduleTriggerRunModel.countByTrigger({
+        organizationId: trigger.organizationId,
+        triggerId: trigger.id,
+      }),
+    ).toBe(0);
   });
 
-  test("creates run, marks executed, and enqueues task for due trigger", async () => {
-    const trigger = makeTrigger("t-1");
-    mockFindDueTriggers.mockResolvedValue([trigger]);
-    mockHasPendingOrProcessingForTrigger.mockResolvedValue(false);
-    mockRunCreate.mockResolvedValue({ id: "run-1" });
+  test("creates run, marks executed, and enqueues task for due trigger", async ({
+    makeScheduleTrigger,
+  }) => {
+    const trigger = await makeScheduleTrigger({
+      lastExecutedAt: TWO_MIN_AGO(),
+    });
 
     await handleCheckDueScheduleTriggers();
 
-    expect(mockRunCreate).toHaveBeenCalledWith({
-      organizationId: "org-1",
-      triggerId: "t-1",
-      runKind: "due",
+    const runs = await ScheduleTriggerRunModel.listByTrigger({
+      organizationId: trigger.organizationId,
+      triggerId: trigger.id,
     });
-    expect(mockMarkExecuted).toHaveBeenCalledWith("t-1", expect.any(Date));
+    expect(runs).toHaveLength(1);
+    expect(runs[0].runKind).toBe("due");
+
     expect(mockEnqueue).toHaveBeenCalledWith({
       taskType: "schedule_trigger_run_execute",
-      payload: { runId: "run-1", triggerId: "t-1" },
+      payload: { runId: runs[0].id, triggerId: trigger.id },
     });
+
+    const reloaded = await ScheduleTriggerModel.findById(trigger.id);
+    expect(reloaded?.lastExecutedAt?.getTime()).toBeGreaterThan(
+      TWO_MIN_AGO().getTime(),
+    );
   });
 
-  test("creates failed run and skips enqueue when task already in flight", async () => {
-    const trigger = makeTrigger("t-1");
-    mockFindDueTriggers.mockResolvedValue([trigger]);
-    mockHasPendingOrProcessingForTrigger.mockResolvedValue(true);
-    mockRunCreate.mockResolvedValue({ id: "skipped-run" });
+  test("creates failed run and skips enqueue when task already in flight", async ({
+    makeScheduleTrigger,
+  }) => {
+    const trigger = await makeScheduleTrigger({
+      lastExecutedAt: TWO_MIN_AGO(),
+    });
+    await TaskModel.create({
+      taskType: "schedule_trigger_run_execute",
+      payload: { triggerId: trigger.id },
+      status: "pending",
+    });
 
     await handleCheckDueScheduleTriggers();
 
-    expect(mockRunCreate).toHaveBeenCalledWith({
-      organizationId: "org-1",
-      triggerId: "t-1",
-      runKind: "due",
+    const runs = await ScheduleTriggerRunModel.listByTrigger({
+      organizationId: trigger.organizationId,
+      triggerId: trigger.id,
     });
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "skipped-run",
-      status: "failed",
-      error: "Skipped: previous run was still in progress",
-    });
-    expect(mockMarkExecuted).toHaveBeenCalledWith("t-1", expect.any(Date));
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe("failed");
+    expect(runs[0].error).toBe("Skipped: previous run was still in progress");
+
     expect(mockEnqueue).not.toHaveBeenCalled();
+
+    const reloaded = await ScheduleTriggerModel.findById(trigger.id);
+    expect(reloaded?.lastExecutedAt?.getTime()).toBeGreaterThan(
+      TWO_MIN_AGO().getTime(),
+    );
   });
 
-  test("continues processing when one trigger fails", async () => {
-    const badTrigger = makeTrigger("t-bad");
-    const goodTrigger = makeTrigger("t-good");
-    mockFindDueTriggers.mockResolvedValue([badTrigger, goodTrigger]);
-    mockHasPendingOrProcessingForTrigger.mockResolvedValue(false);
+  test("continues processing when one trigger fails", async ({
+    makeOrganization,
+    makeScheduleTrigger,
+  }) => {
+    const org = await makeOrganization();
+    await makeScheduleTrigger({
+      organizationId: org.id,
+      lastExecutedAt: TWO_MIN_AGO(),
+    });
+    await makeScheduleTrigger({
+      organizationId: org.id,
+      lastExecutedAt: TWO_MIN_AGO(),
+    });
 
-    // First create call throws, second succeeds
-    mockRunCreate
-      .mockRejectedValueOnce(new Error("DB error"))
-      .mockResolvedValueOnce({ id: "run-good" });
+    // First run-creation throws; the spy falls back to the real impl afterward.
+    const createSpy = vi.spyOn(ScheduleTriggerRunModel, "create");
+    createSpy.mockRejectedValueOnce(new Error("DB error"));
 
     await handleCheckDueScheduleTriggers();
 
+    // One trigger failed, the other still produced an enqueued run.
     expect(mockEnqueue).toHaveBeenCalledTimes(1);
-    expect(mockEnqueue).toHaveBeenCalledWith({
-      taskType: "schedule_trigger_run_execute",
-      payload: { runId: "run-good", triggerId: "t-good" },
-    });
+    const enqueuedRunId = mockEnqueue.mock.calls[0][0].payload.runId;
+    const run = await ScheduleTriggerRunModel.findById(enqueuedRunId);
+    expect(run).not.toBeNull();
   });
 });

--- a/platform/backend/src/task-queue/handlers/schedule-trigger-run-handler.test.ts
+++ b/platform/backend/src/task-queue/handlers/schedule-trigger-run-handler.test.ts
@@ -1,63 +1,27 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
-
-const mockRunFindById = vi.hoisted(() => vi.fn().mockResolvedValue(null));
-const mockRunMarkCompleted = vi.hoisted(() => vi.fn().mockResolvedValue(null));
-const mockTriggerFindById = vi.hoisted(() => vi.fn().mockResolvedValue(null));
-const mockUserGetById = vi.hoisted(() => vi.fn().mockResolvedValue(null));
-const mockAgentFindById = vi.hoisted(() => vi.fn().mockResolvedValue(null));
-const mockUserHasAgentAccess = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(true),
-);
-
-vi.mock("@/models", () => ({
-  ScheduleTriggerRunModel: {
-    findById: mockRunFindById,
-    markCompleted: mockRunMarkCompleted,
-  },
-  ScheduleTriggerModel: {
-    findById: mockTriggerFindById,
-  },
-  UserModel: {
-    getById: mockUserGetById,
-  },
-  AgentModel: {
-    findById: mockAgentFindById,
-  },
-  AgentTeamModel: {
-    userHasAgentAccess: mockUserHasAgentAccess,
-  },
-}));
+import { vi } from "vitest";
 
 vi.mock("@/auth");
 
-import { hasAnyAgentTypeAdminPermission } from "@/auth";
+const A2A_RESULT = {
+  messageId: "msg-1",
+  text: "done",
+  finishReason: "stop",
+  responseUiMessage: {
+    id: "asst-1",
+    role: "assistant",
+    parts: [{ type: "text", text: "done" }],
+  },
+};
 
-const mockExecuteA2AMessage = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({
-    messageId: "msg-1",
-    text: "done",
-    finishReason: "stop",
-    responseUiMessage: {
-      id: "asst-1",
-      role: "assistant",
-      parts: [{ type: "text", text: "done" }],
-    },
-  }),
-);
+const mockExecuteA2AMessage = vi.hoisted(() => vi.fn());
 vi.mock("@/agents/a2a-executor", () => ({
   executeA2AMessage: mockExecuteA2AMessage,
 }));
 
 const mockCreateAndLinkRunConversation = vi.hoisted(() => vi.fn());
-const mockPersistRunConversationMessages = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(undefined),
-);
-const mockRecordRunConversationError = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(undefined),
-);
-const mockPersistRunUserMessage = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(undefined),
-);
+const mockPersistRunConversationMessages = vi.hoisted(() => vi.fn());
+const mockRecordRunConversationError = vi.hoisted(() => vi.fn());
+const mockPersistRunUserMessage = vi.hoisted(() => vi.fn());
 vi.mock("@/services/scheduled-run-conversation", () => ({
   createAndLinkRunConversation: mockCreateAndLinkRunConversation,
   persistRunConversationMessages: mockPersistRunConversationMessages,
@@ -65,194 +29,232 @@ vi.mock("@/services/scheduled-run-conversation", () => ({
   recordRunConversationError: mockRecordRunConversationError,
 }));
 
+import { hasAnyAgentTypeAdminPermission } from "@/auth";
+import {
+  ProjectModel,
+  ScheduleTriggerModel,
+  ScheduleTriggerRunModel,
+  UserModel,
+} from "@/models";
+import { beforeEach, describe, expect, test } from "@/test";
 import { handleScheduleTriggerRunExecution } from "./schedule-trigger-run-handler";
-
-const makeRun = (overrides = {}) => ({
-  id: "run-1",
-  organizationId: "org-1",
-  triggerId: "trigger-1",
-  runKind: "due" as const,
-  status: "running" as const,
-  initiatedByUserId: null,
-  chatConversationId: null,
-  startedAt: new Date(),
-  completedAt: null,
-  error: null,
-  createdAt: new Date(),
-  ...overrides,
-});
-
-const makeTrigger = (overrides = {}) => ({
-  id: "trigger-1",
-  organizationId: "org-1",
-  name: "Test Trigger",
-  agentId: "agent-1",
-  messageTemplate: "Run the task",
-  cronExpression: "* * * * *",
-  timezone: "UTC",
-  enabled: true,
-  actorUserId: "user-1",
-  lastExecutedAt: null,
-  createdAt: new Date(),
-  ...overrides,
-});
-
-const makeUser = () => ({
-  id: "user-1",
-  name: "Test User",
-  email: "test@test.com",
-});
-
-const makeAgent = (overrides = {}) => ({
-  id: "agent-1",
-  organizationId: "org-1",
-  agentType: "agent",
-  name: "Test Agent",
-  ...overrides,
-});
 
 describe("handleScheduleTriggerRunExecution", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockRunFindById.mockResolvedValue(null);
-    mockRunMarkCompleted.mockResolvedValue(null);
-    mockTriggerFindById.mockResolvedValue(null);
-    mockUserGetById.mockResolvedValue(null);
-    mockAgentFindById.mockResolvedValue(null);
-    mockUserHasAgentAccess.mockResolvedValue(true);
     vi.mocked(hasAnyAgentTypeAdminPermission).mockResolvedValue(false);
+    mockExecuteA2AMessage.mockReset().mockResolvedValue(A2A_RESULT);
     mockCreateAndLinkRunConversation.mockReset();
-    mockPersistRunConversationMessages.mockReset();
-    mockPersistRunConversationMessages.mockResolvedValue(undefined);
-    mockRecordRunConversationError.mockReset();
-    mockRecordRunConversationError.mockResolvedValue(undefined);
-    mockPersistRunUserMessage.mockReset();
-    mockPersistRunUserMessage.mockResolvedValue(undefined);
-    mockExecuteA2AMessage.mockResolvedValue({
-      messageId: "msg-1",
-      text: "done",
-      finishReason: "stop",
-      responseUiMessage: {
-        id: "asst-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "done" }],
-      },
-    });
+    mockPersistRunConversationMessages.mockReset().mockResolvedValue(undefined);
+    mockRecordRunConversationError.mockReset().mockResolvedValue(undefined);
+    mockPersistRunUserMessage.mockReset().mockResolvedValue(undefined);
   });
 
-  test("executes A2A message and marks run as success", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(makeTrigger());
-    mockUserGetById.mockResolvedValue(makeUser());
-    mockAgentFindById.mockResolvedValue(makeAgent());
-    mockUserHasAgentAccess.mockResolvedValue(true);
+  test("executes A2A message and marks run as success", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
     expect(mockExecuteA2AMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        agentId: "agent-1",
-        message: "Run the task",
-        organizationId: "org-1",
-        userId: "user-1",
-        sessionId: "scheduled-run-1",
+        agentId: agent.id,
+        message: trigger.messageTemplate,
+        organizationId: org.id,
+        userId: actor.id,
+        sessionId: `scheduled-${run.id}`,
         source: "schedule-trigger",
       }),
     );
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "run-1",
-      status: "success",
-      error: null,
-    });
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("success");
+    expect(updated?.error).toBeNull();
   });
 
-  test("marks run as failed when trigger no longer exists", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(null);
+  test("marks run as failed when trigger no longer exists", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
+    // Simulate the trigger being deleted between run pickup and lookup.
+    vi.spyOn(ScheduleTriggerModel, "findById").mockResolvedValue(null);
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
     expect(mockExecuteA2AMessage).not.toHaveBeenCalled();
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "run-1",
-      status: "failed",
-      error: "Trigger no longer exists",
-    });
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("failed");
+    expect(updated?.error).toBe("Trigger no longer exists");
   });
 
-  test("marks run as failed when actor user no longer exists", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(makeTrigger());
-    mockUserGetById.mockResolvedValue(null);
+  test("marks run as failed when actor user no longer exists", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
+    // Simulate the actor being deleted between scheduling and execution.
+    vi.spyOn(UserModel, "getById").mockResolvedValue(null as never);
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
     expect(mockExecuteA2AMessage).not.toHaveBeenCalled();
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "run-1",
-      status: "failed",
-      error: "Scheduled trigger actor no longer exists",
-    });
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("failed");
+    expect(updated?.error).toBe("Scheduled trigger actor no longer exists");
   });
 
-  test("marks run as failed when actor lost agent access", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(makeTrigger());
-    mockUserGetById.mockResolvedValue(makeUser());
-    mockUserHasAgentAccess.mockResolvedValue(false);
+  test("marks run as failed when actor lost agent access", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const otherUser = await makeUser();
+    // A personal agent owned by someone else — the actor has no access to it.
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      systemPrompt: "You are a test agent",
+      scope: "personal",
+      authorId: otherUser.id,
+    });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
     expect(mockExecuteA2AMessage).not.toHaveBeenCalled();
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "run-1",
-      status: "failed",
-      error: "Scheduled trigger actor no longer has access to the target agent",
-    });
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("failed");
+    expect(updated?.error).toBe(
+      "Scheduled trigger actor no longer has access to the target agent",
+    );
   });
 
-  test("marks run as failed when executeA2AMessage throws", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(makeTrigger());
-    mockUserGetById.mockResolvedValue(makeUser());
-    mockAgentFindById.mockResolvedValue(makeAgent());
-    mockUserHasAgentAccess.mockResolvedValue(true);
+  test("marks run as failed when executeA2AMessage throws", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
     mockExecuteA2AMessage.mockRejectedValue(new Error("LLM provider down"));
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "run-1",
-      status: "failed",
-      error: "LLM provider down",
-    });
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("failed");
+    expect(updated?.error).toBe("LLM provider down");
   });
 
-  test("skips execution when run is not in running state", async () => {
-    mockRunFindById.mockResolvedValue(makeRun({ status: "success" }));
+  test("skips execution when run is not in running state", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
+    // Move the run out of the running state before the handler picks it up.
+    await ScheduleTriggerRunModel.markCompleted({
+      runId: run.id,
+      status: "success",
+    });
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
     expect(mockExecuteA2AMessage).not.toHaveBeenCalled();
-    expect(mockRunMarkCompleted).not.toHaveBeenCalled();
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("success");
   });
 
   test("throws when payload is missing runId", async () => {
@@ -261,38 +263,51 @@ describe("handleScheduleTriggerRunExecution", () => {
     ).rejects.toThrow("Missing runId");
   });
 
-  test("persists the run transcript from the executor result on a successful project-scoped run", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(
-      makeTrigger({ projectId: "project-1" }),
-    );
-    mockUserGetById.mockResolvedValue(makeUser());
-    mockAgentFindById.mockResolvedValue(makeAgent());
-    mockUserHasAgentAccess.mockResolvedValue(true);
+  test("persists the run transcript from the executor result on a successful project-scoped run", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const project = await ProjectModel.create({
+      organizationId: org.id,
+      userId: actor.id,
+      name: `Project ${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+      projectId: project.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
     mockCreateAndLinkRunConversation.mockResolvedValue({
       id: "conv-1",
-      userId: "user-1",
+      userId: actor.id,
     });
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
     expect(mockExecuteA2AMessage).toHaveBeenCalledWith(
       expect.objectContaining({ conversationId: "conv-1" }),
     );
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "run-1",
-      status: "success",
-      error: null,
-    });
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("success");
     // Transcript comes from the executor's in-memory result — the user prompt and
     // the complete assistant turn — not reconstructed from interactions.
     expect(mockPersistRunConversationMessages).toHaveBeenCalledWith(
       expect.objectContaining({
         conversation: expect.objectContaining({ id: "conv-1" }),
-        userText: "Run the task",
+        userText: trigger.messageTemplate,
         assistantMessage: expect.objectContaining({
           role: "assistant",
           parts: [{ type: "text", text: "done" }],
@@ -301,53 +316,79 @@ describe("handleScheduleTriggerRunExecution", () => {
     );
   });
 
-  test("does not persist messages for an unscoped run", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(makeTrigger());
-    mockUserGetById.mockResolvedValue(makeUser());
-    mockAgentFindById.mockResolvedValue(makeAgent());
-    mockUserHasAgentAccess.mockResolvedValue(true);
+  test("does not persist messages for an unscoped run", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
     expect(mockCreateAndLinkRunConversation).not.toHaveBeenCalled();
     expect(mockPersistRunConversationMessages).not.toHaveBeenCalled();
   });
 
-  test("does not persist messages when a project-scoped run fails", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(
-      makeTrigger({ projectId: "project-1" }),
-    );
-    mockUserGetById.mockResolvedValue(makeUser());
-    mockAgentFindById.mockResolvedValue(makeAgent());
-    mockUserHasAgentAccess.mockResolvedValue(true);
+  test("does not persist messages when a project-scoped run fails", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const project = await ProjectModel.create({
+      organizationId: org.id,
+      userId: actor.id,
+      name: `Project ${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+      projectId: project.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
     mockCreateAndLinkRunConversation.mockResolvedValue({
       id: "conv-1",
-      userId: "user-1",
+      userId: actor.id,
     });
     mockExecuteA2AMessage.mockRejectedValue(new Error("LLM provider down"));
 
     await handleScheduleTriggerRunExecution({
-      runId: "run-1",
-      triggerId: "trigger-1",
+      runId: run.id,
+      triggerId: trigger.id,
     });
 
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "run-1",
-      status: "failed",
-      error: "LLM provider down",
-    });
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("failed");
+    expect(updated?.error).toBe("LLM provider down");
     expect(mockPersistRunConversationMessages).not.toHaveBeenCalled();
     // The failed run keeps its conversation: the scheduled prompt is persisted as
     // the user message (so the chat carries it and "Try again" can resend it)...
     expect(mockPersistRunUserMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         conversation: expect.objectContaining({ id: "conv-1" }),
-        userText: "Run the task",
+        userText: trigger.messageTemplate,
       }),
     );
     // ...and the error is recorded as a chat error so the run's chat shows an
@@ -361,17 +402,33 @@ describe("handleScheduleTriggerRunExecution", () => {
     );
   });
 
-  test("a persist failure does not fail the run", async () => {
-    mockRunFindById.mockResolvedValue(makeRun());
-    mockTriggerFindById.mockResolvedValue(
-      makeTrigger({ projectId: "project-1" }),
-    );
-    mockUserGetById.mockResolvedValue(makeUser());
-    mockAgentFindById.mockResolvedValue(makeAgent());
-    mockUserHasAgentAccess.mockResolvedValue(true);
+  test("a persist failure does not fail the run", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInternalAgent,
+    makeScheduleTrigger,
+    makeScheduleTriggerRun,
+  }) => {
+    const org = await makeOrganization();
+    const actor = await makeUser();
+    await makeMember(actor.id, org.id);
+    const project = await ProjectModel.create({
+      organizationId: org.id,
+      userId: actor.id,
+      name: `Project ${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const trigger = await makeScheduleTrigger({
+      organizationId: org.id,
+      agentId: agent.id,
+      actorUserId: actor.id,
+      projectId: project.id,
+    });
+    const run = await makeScheduleTriggerRun(trigger.id);
     mockCreateAndLinkRunConversation.mockResolvedValue({
       id: "conv-1",
-      userId: "user-1",
+      userId: actor.id,
     });
     mockPersistRunConversationMessages.mockRejectedValue(
       new Error("persist blew up"),
@@ -379,15 +436,12 @@ describe("handleScheduleTriggerRunExecution", () => {
 
     await expect(
       handleScheduleTriggerRunExecution({
-        runId: "run-1",
-        triggerId: "trigger-1",
+        runId: run.id,
+        triggerId: trigger.id,
       }),
     ).resolves.toBeUndefined();
 
-    expect(mockRunMarkCompleted).toHaveBeenCalledWith({
-      runId: "run-1",
-      status: "success",
-      error: null,
-    });
+    const updated = await ScheduleTriggerRunModel.findById(run.id);
+    expect(updated?.status).toBe("success");
   });
 });

--- a/platform/backend/src/task-queue/task-queue.test.ts
+++ b/platform/backend/src/task-queue/task-queue.test.ts
@@ -1,28 +1,8 @@
 import { vi } from "vitest";
 
-// Mock TaskModel
-const mockCreate = vi.hoisted(() => vi.fn());
-const mockDequeue = vi.hoisted(() => vi.fn());
-const mockComplete = vi.hoisted(() => vi.fn());
-const mockFail = vi.hoisted(() => vi.fn());
-const mockResetStuckTasks = vi.hoisted(() => vi.fn().mockResolvedValue(0));
-const mockHasPendingOrProcessingByType = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(false),
-);
-const mockReleaseToQueue = vi.hoisted(() => vi.fn().mockResolvedValue(0));
-vi.mock("@/models", () => ({
-  TaskModel: {
-    create: mockCreate,
-    dequeue: mockDequeue,
-    complete: mockComplete,
-    fail: mockFail,
-    resetStuckTasks: mockResetStuckTasks,
-    hasPendingOrProcessingByType: mockHasPendingOrProcessingByType,
-    releaseToQueue: mockReleaseToQueue,
-  },
-}));
-
-// Mock config
+// Mock config (poll interval / concurrency / shutdown timeout are read at
+// startWorker/stopWorker time; the canonical factory keeps the rest of config
+// real). Config is a process-boundary concern, not a database interface.
 vi.mock("@/config", async () =>
   (await import("@/test/mocks/config")).configModuleMock({
     kb: {
@@ -45,30 +25,42 @@ vi.mock("@/observability/metrics", () => ({
   },
 }));
 
-// Suppress logger output during tests
-
 // Import after mocks are set up
+import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import type { Task } from "@/types";
+import db, { schema } from "@/database";
+import { TaskModel } from "@/models";
+import type { InsertTask, Task } from "@/types";
 import { taskQueueService } from "./task-queue";
 
-// Helper to create a fake task
-function fakeTask(overrides: Partial<Task> = {}): Task {
-  return {
-    id: "task-1",
+// Seeds a real task row. scheduledFor defaults to the past so the worker's
+// `scheduled_for <= NOW()` dequeue picks it up immediately.
+async function seedTask(overrides: Partial<InsertTask> = {}): Promise<Task> {
+  return await TaskModel.create({
     taskType: "connector_sync",
-    status: "processing",
     payload: { connectorId: "conn-1" },
-    attempt: 1,
-    maxAttempts: 5,
-    lastError: null,
-    periodic: false,
-    scheduledFor: new Date(),
-    startedAt: new Date(),
-    completedAt: null,
-    createdAt: new Date(),
+    scheduledFor: new Date(Date.now() - 60_000),
     ...overrides,
-  };
+  });
+}
+
+async function getTask(id: string): Promise<Task | undefined> {
+  const [row] = await db
+    .select()
+    .from(schema.tasksTable)
+    .where(eq(schema.tasksTable.id, id));
+  return row;
+}
+
+async function countTasks(
+  where: Partial<Pick<Task, "taskType" | "status">>,
+): Promise<number> {
+  const rows = await db.select().from(schema.tasksTable);
+  return rows.filter(
+    (r) =>
+      (where.taskType === undefined || r.taskType === where.taskType) &&
+      (where.status === undefined || r.status === where.status),
+  ).length;
 }
 
 describe("TaskQueueService", () => {
@@ -80,93 +72,81 @@ describe("TaskQueueService", () => {
   afterEach(async () => {
     await taskQueueService.stopWorker();
     vi.useRealTimers();
+    // Restore any vi.spyOn(TaskModel, ...) fault-injection so a rejecting
+    // create() doesn't leak into later (shuffled-order) tests.
+    vi.restoreAllMocks();
   });
 
   describe("enqueue", () => {
-    test("calls TaskModel.create with correct params and returns task id", async () => {
-      mockCreate.mockResolvedValue({ id: "task-123" });
-
+    test("persists a task with the given params and returns its id", async () => {
       const id = await taskQueueService.enqueue({
         taskType: "connector_sync",
         payload: { connectorId: "conn-1" },
       });
 
-      expect(id).toBe("task-123");
-      expect(mockCreate).toHaveBeenCalledWith({
-        taskType: "connector_sync",
-        payload: { connectorId: "conn-1" },
-        maxAttempts: 5,
-      });
+      const task = await getTask(id);
+      expect(task?.taskType).toBe("connector_sync");
+      expect(task?.payload).toEqual({ connectorId: "conn-1" });
+      expect(task?.maxAttempts).toBe(5);
     });
 
-    test("passes custom maxAttempts when provided", async () => {
-      mockCreate.mockResolvedValue({ id: "task-456" });
-
-      await taskQueueService.enqueue({
+    test("persists custom maxAttempts when provided", async () => {
+      const id = await taskQueueService.enqueue({
         taskType: "batch_embedding",
         payload: { documentIds: ["d1"] },
         maxAttempts: 3,
       });
 
-      expect(mockCreate).toHaveBeenCalledWith({
-        taskType: "batch_embedding",
-        payload: { documentIds: ["d1"] },
-        maxAttempts: 3,
-      });
+      const task = await getTask(id);
+      expect(task?.maxAttempts).toBe(3);
+      expect(task?.payload).toEqual({ documentIds: ["d1"] });
     });
   });
 
   describe("handler registration and dispatch", () => {
-    test("registered handler is called with task payload", async () => {
+    test("registered handler is called with task payload and task completes", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      const task = fakeTask({
+      const task = await seedTask({
         taskType: "connector_sync",
         payload: { connectorId: "conn-99" },
       });
-      mockDequeue.mockResolvedValueOnce(task);
-      mockComplete.mockResolvedValue(undefined);
 
       taskQueueService.registerHandler("connector_sync", handler);
       taskQueueService.startWorker();
 
-      // Advance timer to trigger poll
       await vi.advanceTimersByTimeAsync(1000);
 
       expect(handler).toHaveBeenCalledWith({ connectorId: "conn-99" });
+      expect((await getTask(task.id))?.status).toBe("completed");
     });
 
     test("fails task when no handler is registered for task type", async () => {
-      const task = fakeTask({ taskType: "batch_embedding" });
-      mockDequeue.mockResolvedValueOnce(task);
-      mockFail.mockResolvedValue(undefined);
+      const task = await seedTask({ taskType: "batch_embedding" });
 
       // Do not register a handler for "batch_embedding"
       taskQueueService.startWorker();
 
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockFail).toHaveBeenCalledWith({
-        id: task.id,
-        error: "No handler registered for task type: batch_embedding",
-        attempt: task.attempt,
-        maxAttempts: task.maxAttempts,
-      });
+      const updated = await getTask(task.id);
+      expect(updated?.lastError).toBe(
+        "No handler registered for task type: batch_embedding",
+      );
+      expect(updated?.status).not.toBe("completed");
     });
   });
 
   describe("task completion", () => {
     test("completes task when handler succeeds", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      const task = fakeTask();
-      mockDequeue.mockResolvedValueOnce(task);
-      mockComplete.mockResolvedValue(undefined);
+      const task = await seedTask();
 
       taskQueueService.registerHandler("connector_sync", handler);
       taskQueueService.startWorker();
 
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockComplete).toHaveBeenCalledWith(task.id);
+      expect((await getTask(task.id))?.status).toBe("completed");
     });
   });
 
@@ -175,53 +155,52 @@ describe("TaskQueueService", () => {
       const handler = vi
         .fn()
         .mockRejectedValue(new Error("something went wrong"));
-      const task = fakeTask({ attempt: 2, maxAttempts: 5 });
-      mockDequeue.mockResolvedValueOnce(task);
-      mockFail.mockResolvedValue(undefined);
+      const task = await seedTask({ attempt: 2, maxAttempts: 5 });
 
       taskQueueService.registerHandler("connector_sync", handler);
       taskQueueService.startWorker();
 
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockFail).toHaveBeenCalledWith({
-        id: task.id,
-        error: "something went wrong",
-        attempt: 2,
-        maxAttempts: 5,
-      });
-      expect(mockComplete).not.toHaveBeenCalled();
+      const updated = await getTask(task.id);
+      expect(updated?.lastError).toBe("something went wrong");
+      // attempt (2) < maxAttempts (5) → retried, not completed
+      expect(updated?.status).toBe("pending");
     });
   });
 
   describe("worker lifecycle", () => {
-    test("startWorker sets up polling interval", async () => {
-      mockDequeue.mockResolvedValue(null);
+    test("startWorker polls repeatedly", async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      taskQueueService.registerHandler("connector_sync", handler);
 
+      const first = await seedTask();
       taskQueueService.startWorker();
-
-      // First poll after interval
       await vi.advanceTimersByTimeAsync(1000);
-      expect(mockDequeue).toHaveBeenCalledTimes(1);
+      expect((await getTask(first.id))?.status).toBe("completed");
 
-      // Second poll
+      // A second task enqueued later is picked up on a subsequent poll,
+      // proving the interval keeps firing.
+      const second = await seedTask();
       await vi.advanceTimersByTimeAsync(1000);
-      expect(mockDequeue).toHaveBeenCalledTimes(2);
+      expect((await getTask(second.id))?.status).toBe("completed");
     });
 
-    test("stopWorker clears intervals and stops polling", async () => {
-      mockDequeue.mockResolvedValue(null);
+    test("stopWorker stops polling", async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      taskQueueService.registerHandler("connector_sync", handler);
 
+      const first = await seedTask();
       taskQueueService.startWorker();
-
       await vi.advanceTimersByTimeAsync(1000);
-      expect(mockDequeue).toHaveBeenCalledTimes(1);
+      expect((await getTask(first.id))?.status).toBe("completed");
 
       await taskQueueService.stopWorker();
 
-      // Further time advances should not trigger more polls
+      // A task enqueued after stop is never processed.
+      const second = await seedTask();
       await vi.advanceTimersByTimeAsync(5000);
-      expect(mockDequeue).toHaveBeenCalledTimes(1);
+      expect((await getTask(second.id))?.status).toBe("pending");
     });
 
     test("stopWorker is safe to call when worker is not started", async () => {
@@ -229,14 +208,10 @@ describe("TaskQueueService", () => {
     });
 
     test("stopWorker resolves immediately when no in-flight tasks", async () => {
-      mockDequeue.mockResolvedValue(null);
       taskQueueService.startWorker();
-
       await vi.advanceTimersByTimeAsync(1000);
 
-      await taskQueueService.stopWorker();
-
-      expect(mockReleaseToQueue).not.toHaveBeenCalled();
+      await expect(taskQueueService.stopWorker()).resolves.toBeUndefined();
     });
 
     test("stopWorker waits for in-flight tasks to drain", async () => {
@@ -245,10 +220,7 @@ describe("TaskQueueService", () => {
         resolveHandler = resolve;
       });
       const handler = vi.fn().mockReturnValue(handlerPromise);
-
-      const task = fakeTask({ id: "drain-task-1" });
-      mockDequeue.mockResolvedValueOnce(task);
-      mockComplete.mockResolvedValue(undefined);
+      const task = await seedTask();
 
       taskQueueService.registerHandler("connector_sync", handler);
       taskQueueService.startWorker();
@@ -257,21 +229,18 @@ describe("TaskQueueService", () => {
       await vi.advanceTimersByTimeAsync(1000);
       expect(handler).toHaveBeenCalled();
 
-      // Start stopping — should not resolve yet
+      // Start stopping — should not resolve until the handler finishes
       const stopPromise = taskQueueService.stopWorker();
-
-      // Complete the handler — should allow drain to finish
       resolveHandler();
       await stopPromise;
 
-      expect(mockReleaseToQueue).not.toHaveBeenCalled();
+      // Drained normally → task completed, not released back to pending.
+      expect((await getTask(task.id))?.status).toBe("completed");
     });
 
-    test("stopWorker releases tasks when drain times out", async () => {
+    test("stopWorker releases tasks back to pending when drain times out", async () => {
       const handler = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
-
-      const task = fakeTask({ id: "timeout-task-1" });
-      mockDequeue.mockResolvedValueOnce(task);
+      const task = await seedTask();
 
       taskQueueService.registerHandler("connector_sync", handler);
       taskQueueService.startWorker();
@@ -285,69 +254,69 @@ describe("TaskQueueService", () => {
       await vi.advanceTimersByTimeAsync(5000);
       await stopPromise;
 
-      expect(mockReleaseToQueue).toHaveBeenCalledWith(["timeout-task-1"]);
+      // The in-flight task was released back to the queue.
+      expect((await getTask(task.id))?.status).toBe("pending");
     });
   });
 
   describe("poll", () => {
     test("resets stuck tasks before dequeuing", async () => {
-      mockDequeue.mockResolvedValue(null);
-      mockResetStuckTasks.mockResolvedValue(0);
+      // A task stuck in processing for over an hour.
+      const stuck = await seedTask({
+        status: "processing",
+        startedAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      });
 
       taskQueueService.startWorker();
-
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockResetStuckTasks).toHaveBeenCalledWith(60 * 60 * 1000);
+      // resetStuckTasks (1h threshold) recovered it back to pending.
+      expect((await getTask(stuck.id))?.status).toBe("pending");
     });
 
     test("does nothing when no tasks are available", async () => {
-      mockDequeue.mockResolvedValue(null);
-
       taskQueueService.startWorker();
 
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockDequeue).toHaveBeenCalled();
-      expect(mockComplete).not.toHaveBeenCalled();
-      expect(mockFail).not.toHaveBeenCalled();
+      expect(await countTasks({ status: "completed" })).toBe(0);
     });
   });
 
   describe("seedPeriodicTasks", () => {
     test("seeds periodic tasks when none exist", async () => {
-      mockHasPendingOrProcessingByType.mockResolvedValue(false);
-      mockCreate.mockResolvedValue({ id: "periodic-1" });
-
       await taskQueueService.seedPeriodicTasks();
 
-      expect(mockHasPendingOrProcessingByType).toHaveBeenCalledWith(
-        "check_due_connectors",
-      );
-      expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          taskType: "check_due_connectors",
-          payload: {},
-          maxAttempts: 1,
-          periodic: true,
-        }),
-      );
+      const rows = await db
+        .select()
+        .from(schema.tasksTable)
+        .where(eq(schema.tasksTable.taskType, "check_due_connectors"));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].periodic).toBe(true);
+      expect(rows[0].maxAttempts).toBe(1);
+      expect(rows[0].payload).toEqual({});
     });
 
     test("skips seeding when periodic task already exists", async () => {
-      mockHasPendingOrProcessingByType.mockResolvedValue(true);
+      await seedTask({
+        taskType: "check_due_connectors",
+        payload: {},
+        periodic: true,
+        maxAttempts: 1,
+        status: "pending",
+      });
 
       await taskQueueService.seedPeriodicTasks();
 
-      expect(mockCreate).not.toHaveBeenCalled();
+      // Not duplicated for the already-present type.
+      expect(await countTasks({ taskType: "check_due_connectors" })).toBe(1);
     });
 
     test("catches unique constraint violation during seeding", async () => {
-      mockHasPendingOrProcessingByType.mockResolvedValue(false);
       const uniqueError = Object.assign(new Error("unique violation"), {
         code: "23505",
       });
-      mockCreate.mockRejectedValue(uniqueError);
+      vi.spyOn(TaskModel, "create").mockRejectedValue(uniqueError);
 
       // Should not throw
       await expect(
@@ -359,104 +328,93 @@ describe("TaskQueueService", () => {
   describe("rescheduleIfPeriodic", () => {
     test("reschedules periodic task after completion", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      const task = fakeTask({
+      const task = await seedTask({
         taskType: "check_due_connectors",
         periodic: true,
         maxAttempts: 1,
         payload: {},
       });
-      mockDequeue.mockResolvedValueOnce(task);
-      mockComplete.mockResolvedValue(undefined);
-      // First call for reschedule
-      mockCreate.mockResolvedValue({ id: "rescheduled-1" });
 
       taskQueueService.registerHandler("check_due_connectors", handler);
       taskQueueService.startWorker();
 
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockComplete).toHaveBeenCalledWith(task.id);
-      // Verify reschedule was called with periodic: true and a future scheduledFor
-      expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          taskType: "check_due_connectors",
-          payload: {},
-          maxAttempts: 1,
-          periodic: true,
-          scheduledFor: expect.any(Date),
-        }),
-      );
+      expect((await getTask(task.id))?.status).toBe("completed");
+      // A fresh periodic task was enqueued for the next interval.
+      const pending = await countTasks({
+        taskType: "check_due_connectors",
+        status: "pending",
+      });
+      expect(pending).toBe(1);
     });
 
     test("reschedules periodic task after terminal failure (dead)", async () => {
       const handler = vi
         .fn()
         .mockRejectedValue(new Error("periodic task failed"));
-      const task = fakeTask({
+      const task = await seedTask({
         taskType: "check_due_connectors",
         periodic: true,
         attempt: 1,
         maxAttempts: 1,
         payload: {},
       });
-      mockDequeue.mockResolvedValueOnce(task);
-      mockFail.mockResolvedValue({ ...task, status: "dead" });
-      mockCreate.mockResolvedValue({ id: "rescheduled-2" });
 
       taskQueueService.registerHandler("check_due_connectors", handler);
       taskQueueService.startWorker();
 
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockFail).toHaveBeenCalled();
-      expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
+      // attempt (1) >= maxAttempts (1) → dead, and a replacement was scheduled.
+      expect((await getTask(task.id))?.status).toBe("dead");
+      expect(
+        await countTasks({
           taskType: "check_due_connectors",
-          periodic: true,
+          status: "pending",
         }),
-      );
+      ).toBe(1);
     });
 
     test("does not reschedule non-periodic tasks", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      const task = fakeTask({
+      const task = await seedTask({
         taskType: "connector_sync",
         payload: { connectorId: "conn-1" },
       });
-      mockDequeue.mockResolvedValueOnce(task);
-      mockComplete.mockResolvedValue(undefined);
 
       taskQueueService.registerHandler("connector_sync", handler);
       taskQueueService.startWorker();
 
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockComplete).toHaveBeenCalledWith(task.id);
-      // mockCreate should not have been called for rescheduling
-      expect(mockCreate).not.toHaveBeenCalled();
+      expect((await getTask(task.id))?.status).toBe("completed");
+      // No new task was created.
+      expect(await countTasks({ status: "pending" })).toBe(0);
     });
 
     test("catches unique constraint violation during rescheduling", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      const task = fakeTask({
+      const task = await seedTask({
         taskType: "check_due_connectors",
         periodic: true,
         payload: {},
       });
-      mockDequeue.mockResolvedValueOnce(task);
-      mockComplete.mockResolvedValue(undefined);
+
+      taskQueueService.registerHandler("check_due_connectors", handler);
+      // Force the reschedule enqueue (TaskModel.create) to hit a unique
+      // violation; complete() uses a different method so the task still finishes.
       const uniqueError = Object.assign(new Error("unique violation"), {
         code: "23505",
       });
-      mockCreate.mockRejectedValue(uniqueError);
+      vi.spyOn(TaskModel, "create").mockRejectedValue(uniqueError);
 
-      taskQueueService.registerHandler("check_due_connectors", handler);
       taskQueueService.startWorker();
 
       // Should not throw
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(mockComplete).toHaveBeenCalledWith(task.id);
+      expect((await getTask(task.id))?.status).toBe("completed");
     });
   });
 });


### PR DESCRIPTION
Re-lands the models→PGlite portion of #6158, which #6165 reverted wholesale along with its unrelated table migration (the migration is being re-done migration-free in #6172; the three concerns are now separate PRs).

Auth, task-queue, knowledge-base, and mcp-reinstall tests seed state through real model methods against the per-file PGlite database instead of `vi.mock`-ing `@/models` modules — they exercise actual queries and constraints. Files whose last `vi.mock` disappears also move to the fast non-isolated vitest project.

No product code changes. All 10 files verified green on this branch alone.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>