### PR TITLE
ci: disable V8 PKU JIT-page tracking in backend unit test shards

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -483,11 +483,19 @@ jobs:
       - name: Build backend workspace dependencies
         run: pnpm exec turbo build --filter="@backend^..."
 
+      # --no-memory-protection-keys: V8's PKU-backed JIT-page tracking
+      # (ThreadIsolation) intermittently dies with a fatal
+      # "Check failed: jit_page.has_value()" when WASM (PGlite) runs across
+      # vitest worker threads. The hardware feature only exists on these
+      # Linux runners' CPUs — dev machines never hit it. PKU is a
+      # defense-in-depth hardening for JIT pages, not a correctness feature,
+      # so disabling it for the test run is safe. NODE_OPTIONS disallows the
+      # flag, hence invoking the vitest entry through node directly.
       - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
         working-directory: ./platform/backend
         env:
           SHARD: ${{ matrix.shard }}
-        run: pnpm exec vitest run --shard="${SHARD}/4"
+        run: node --no-memory-protection-keys node_modules/vitest/vitest.mjs run --shard="${SHARD}/4"
 
   # Stable-named gate over the shard matrix so branch protection / merge queue
   # can require a single check ("Backend Unit Tests") regardless of shard count.


### PR DESCRIPTION
## Problem

Backend unit test shards occasionally die with a fatal V8 crash (e.g. [this run on #6172](https://github.com/archestra-ai/archestra/actions/runs/28586541957/job/84759463969)):

```
# Fatal error in , line 0
# Check failed: jit_page.has_value().
 2: 0x2684403 V8_Fatal(char const*, ...) [node]
```

## Diagnosis

The failing check is [`CHECK(jit_page.has_value())` in V8's `code-memory-access.cc`](https://github.com/v8/v8/blob/main/src/common/code-memory-access.cc) (`ThreadIsolation::LookupJitPageLocked`) — the **ThreadIsolation** subsystem, which write-protects JIT/WASM code pages using hardware memory protection keys (AMD PKU / Intel MPK). PGlite's WASM code churn across vitest `worker_threads` races V8's process-global JIT-page map; when a lookup misses, the process aborts.

- **Why only CI:** the governing flag `--memory-protection-keys` defaults ON but only engages where PKU hardware exists (AMD EPYC / Intel Xeon — i.e. the Blacksmith runners). Dev machines lack PKU, so ThreadIsolation never activates and the crash can't reproduce locally.
- **Load-dependent:** more worker threads → more concurrent WASM code (de)allocation → higher hit rate.
- **No upgrade fix:** this code path ships in the V8 bundled with Node 18–24; no patch release closes this specific CHECK. Flag mitigation is the correct remedy, not a version bump.

## Fix

Run the shard step with `--no-memory-protection-keys`. PKU here is defense-in-depth hardening for JIT memory, not a correctness feature — tests lose nothing. Delivery matters, all verified on Node 24.11.1:

- ✅ real CLI arg on the process that runs vitest (what this PR does): ThreadIsolation is process-global, so the worker-thread isolates inherit it
- ❌ `NODE_OPTIONS` — Node hard-errors ("not allowed in NODE_OPTIONS")
- ❌ vitest `poolOptions.threads.execArgv` — worker_threads reject V8 flags with `ERR_WORKER_INVALID_EXEC_ARGV`

Hence `node --no-memory-protection-keys node_modules/vitest/vitest.mjs run …` in the workflow step. (The heavier alternative — switching to `pool: "forks"`, which accepts V8 flags in execArgv and avoids the WASM-in-threads class entirely — is available if this ever proves insufficient, at some startup cost per worker.)

## Worth watching

The recurring shard-2 "batch of tests in one file all time out at 30s" stalls (e.g. [this](https://github.com/archestra-ai/archestra/actions/runs/28586639448/job/84759790295)) are plausibly the same pathology wedging instead of crashing — same WASM-in-worker-threads setup, same PKU runners. If those disappear after this lands, that's confirmation; if not, they need their own investigation.