### PR TITLE
ci: sync Rust toolchain in backend test shards only when the build misses cache

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -467,21 +467,24 @@ jobs:
         with:
           working-directory: ./platform
 
-      # Fork PRs run without turbo remote caching (secrets are withheld), so
-      # the NAPI crate builds below actually invoke cargo. Sync the pinned
-      # toolchain (rust-toolchain.toml) serially first — otherwise turbo's
-      # parallel crate builds each trigger a concurrent rustup download of
-      # the same components, which races and fails with "could not rename
-      # downloaded file".
-      - name: Setup Rust
-        run: rustup show
-
       # Tests load the Rust NAPI bindings (@archestra/app-runtime-rs etc.),
       # which `turbo check:ci` builds implicitly via the task graph. Running
       # vitest directly skips that, so build backend's workspace deps here —
-      # turbo remote caching makes this seconds on a cache hit.
+      # turbo remote caching makes this seconds on a cache hit, and on a hit
+      # no cargo runs, so the pinned Rust toolchain isn't needed at all
+      # (an unconditional `rustup show` cost ~10s per shard). On a miss
+      # (fork PRs run without cache secrets, so cargo really builds), turbo's
+      # parallel crate builds each trigger a concurrent rustup download of
+      # the same toolchain, which races and fails with "could not rename
+      # downloaded file" — so on failure, sync the toolchain serially and
+      # retry once.
       - name: Build backend workspace dependencies
-        run: pnpm exec turbo build --filter="@backend^..."
+        run: |
+          pnpm exec turbo build --filter="@backend^..." || {
+            echo "Build failed — syncing pinned Rust toolchain and retrying once..."
+            rustup show
+            pnpm exec turbo build --filter="@backend^..."
+          }
 
       - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
         working-directory: ./platform/backend


### PR DESCRIPTION
The backend unit test shards each spent ~10s on an unconditional `rustup show` while their actual `turbo build --filter="@backend^..."` is a 1–2s remote-cache hit that never invokes cargo. Drop the standing step; on a genuine miss (fork PRs run without turbo cache secrets, so cargo really builds) the failure-retry syncs the pinned toolchain serially and re-runs the build once — preserving the protection against turbo's parallel crate builds racing concurrent rustup downloads ("could not rename downloaded file").

Audit of the other two `Setup Rust` sites, left unchanged deliberately:
- **platform-lint-and-unit-tests** — `turbo check:ci` + `pnpm build` genuinely compile the NAPI crates on any cache miss (including same-repo PRs touching Rust), and a failure-retry wrapper there would re-run the entire check suite on any ordinary lint/type failure. 10s on a multi-minute serial job isn't worth that trade.
- **platform-rust-checks** — the whole job is cargo; obviously needs the toolchain (plus musl targets).

Net effect: −10s wall-clock per shard on every PR push (4 shards), zero behavior change on the cold path.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>