### PR TITLE
ci: drop the Platform E2E Tests (Readonly Vault) job

### DIFF
--- a/.github/values-ci.yaml
+++ b/.github/values-ci.yaml
@@ -106,9 +106,8 @@ archestra:
     # Add Keycloak as trusted origin for SSO e2e tests (OIDC discovery URL validation)
     # Includes both the internal K8s service name and the NodePort URL that appears in OIDC discovery
     ARCHESTRA_AUTH_ADDITIONAL_TRUSTED_ORIGINS: "http://e2e-tests-keycloak:8080,http://localhost:30081"
-    # Shared CI secrets-manager configuration.
-    # Keep the generic suite on the standard DB-backed secrets manager. The
-    # readonly-vault coverage runs in its own dedicated job via a Helm override.
+    # Shared CI secrets-manager configuration. Keep the generic suite on the
+    # standard DB-backed secrets manager.
     ARCHESTRA_SECRETS_MANAGER: "DB"
     ARCHESTRA_HASHICORP_VAULT_ADDR: "http://vault:8200"
     ARCHESTRA_HASHICORP_VAULT_AUTH_METHOD: "K8S"

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -356,154 +356,6 @@ jobs:
           fi
           echo "All non-quickstart E2E shards passed."
 
-  platform-readonly-vault-e2e-tests-placeholder:
-    name: Platform E2E Tests (Readonly Vault)
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-e2e') }}
-    steps:
-      - name: Skip readonly-vault E2E on ordinary PR updates
-        run: echo "Readonly-vault E2E runs on merge queue or when the run-e2e label is added."
-
-  # Dedicated readonly-vault coverage. These tests need BYOS/readonly-vault runtime
-  # behavior, which conflicts with the generic suite's manual secret entry flows.
-  platform-readonly-vault-e2e-tests:
-    name: Platform E2E Tests (Readonly Vault)
-    needs: [platform-e2e-build]
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 30
-    permissions:
-      contents: read # Required to checkout the repository and read test assets.
-      id-token: write # Required for Workload Identity Federation in setup actions.
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 1
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
-        with:
-          working-directory: ./platform
-
-      - name: Load platform image
-        id: load-platform-image
-        uses: ./.github/actions/load-platform-image
-        with:
-          source: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'artifact' || 'registry' }}
-          image-tag: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('archestra-platform:{0}', github.sha) || format('{0}/{1}:{2}', env.PLATFORM_IMAGE_REGISTRY, env.PLATFORM_IMAGE_NAME, github.sha) }}
-
-      - name: Load MCP server base image
-        id: load-mcp-server-base-image
-        uses: ./.github/actions/load-mcp-server-base-image
-        with:
-          source: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'artifact' || 'registry' }}
-          image-tag: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('mcp-server-base:{0}', github.sha) || format('{0}/{1}:{2}', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME, github.sha) }}
-
-      - name: Setup Archestra Platform
-        id: setup-platform
-        uses: ./.github/actions/setup-archestra-platform
-        with:
-          kind-config-path: .github/kind.yaml
-          kind-cluster-name: archestra-ci-cluster
-          helm-values-path: .github/values-ci.yaml
-          deploy-e2e-dependencies: "true"
-          e2e-dependencies-install-mode: "foreground"
-          e2e-dependencies-extra-helm-set: "vault.k8sAuth.enabled=true,vault.k8sAuth.boundServiceAccountName=archestra-platform,vault.k8sAuth.boundServiceAccountNamespace=default,vault.secrets[0].path=secret/data/archestra/config,vault.secrets[0].data.dburl=postgresql://archestra:vault_e2e_custom_pw@archestra-platform-postgresql:5432/archestra_dev,vault.secrets[0].data.dummy_var=hello-from-vault"
-          e2e-dependencies-wait-for-vault: "true"
-          build-platform-image: "false"
-          platform-image-tag: ${{ steps.load-platform-image.outputs.image-tag }}
-          platform-context: ./platform
-          mcp-server-base-image-tag: ${{ steps.load-mcp-server-base-image.outputs.image-tag }}
-          extra-helm-set: "archestra.env.ARCHESTRA_SECRETS_MANAGER=READONLY_VAULT,archestra.env.ARCHESTRA_HASHICORP_VAULT_KV_VERSION=2,archestra.initContainers.vaultSecrets.secrets[0].path=secret/data/archestra/config,archestra.initContainers.vaultSecrets.secrets[1].path=secret/data/archestra/config"
-
-      - name: Run readonly-vault E2E tests
-        id: e2e
-        continue-on-error: true
-        uses: ./.github/actions/run-e2e-tests
-        with:
-          projects: credentials-with-vault
-          timeout: "20"
-
-      - name: Upload blob report
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/github-upload-artifact
-        with:
-          name: blob-report-readonly-vault
-          path: platform/e2e-tests/blob-report/
-          retention-days: 1
-
-      - name: Show logs on failure or flaky tests
-        if: steps.setup-platform.outcome == 'failure' || steps.e2e.outcome == 'failure' || steps.e2e.outputs.has_flaky_tests == 'true'
-        run: |
-          echo "=== Kubernetes Pods ==="
-          kubectl get pods -o wide || true
-
-          echo "=== Kubernetes Services ==="
-          kubectl get services || true
-
-          echo "=== Archestra Platform Logs (main container) ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform -c archestra-platform --tail=200 2>/dev/null || true
-
-          # The external-IdP validation logs (validateExternalIdpToken /
-          # "JWKS JWT validation failed") fire mid-run, well before this dump,
-          # so the --tail=200 above misses them. Grep the full backend log so a
-          # flaky JWKS-gateway 401 can be traced to the branch that rejected
-          # the token. --tail=-1 is required: with a label selector, kubectl
-          # logs otherwise caps output at the last 10 lines.
-          echo "=== External IdP validation (full-log grep) ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform \
-            -c archestra-platform --tail=-1 2>/dev/null \
-            | grep -iE 'validateExternalIdpToken|JWKS JWT validation failed|Invalid token for this profile' \
-            || echo "(no external-IdP validation log found)"
-
-          echo "=== Platform Init Container: vault-secrets ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform -c vault-secrets --tail=200 2>/dev/null || true
-
-          echo "=== Platform Init Container: setup-postgres-extensions ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform -c setup-postgres-extensions --tail=200 2>/dev/null || true
-
-          echo "=== Platform Init Container: wait-for-postgres ==="
-          kubectl logs -l app.kubernetes.io/name=archestra-platform -c wait-for-postgres --tail=200 2>/dev/null || true
-
-          echo "=== PostgreSQL Logs ==="
-          kubectl logs -l app.kubernetes.io/name=postgresql --tail=200 || true
-
-          echo "=== WireMock Logs ==="
-          kubectl logs -l app=e2e-tests-wiremock --tail=200 2>/dev/null || true
-
-          echo "=== Keycloak Logs ==="
-          kubectl logs -l app.kubernetes.io/name=keycloak --tail=200 2>/dev/null || true
-
-          echo "=== Vault Logs ==="
-          kubectl logs -l app.kubernetes.io/name=vault --tail=200 2>/dev/null || true
-
-          echo "=== MCP Example OAuth Server Logs ==="
-          kubectl logs -l app.kubernetes.io/name=mcp-example-oauth --tail=200 2>/dev/null || true
-
-          echo "=== Describe Platform Pod ==="
-          kubectl describe pod -l app.kubernetes.io/name=archestra-platform || true
-
-          echo "=== Describe PostgreSQL Pod ==="
-          kubectl describe pod -l app.kubernetes.io/name=postgresql || true
-
-          echo "=== PostgreSQL StatefulSet & PVCs ==="
-          kubectl get statefulset,pvc -l app.kubernetes.io/name=postgresql -o wide || true
-
-          echo "=== Recent Cluster Events ==="
-          kubectl get events --sort-by=.lastTimestamp -A 2>/dev/null | tail -60 || true
-
-      - name: Cleanup Kind cluster
-        if: always()
-        run: kind delete cluster --name archestra-ci-cluster || true
-
-      - name: Fail if readonly-vault E2E tests failed
-        if: ${{ always() && steps.e2e.outcome == 'failure' }}
-        run: |
-          echo "The readonly-vault E2E run failed."
-          exit 1
-
   # Quickstart E2E tests - validates docker run quickstart instructions work correctly
   # Runs the mcp-install.spec.ts test against the platform started via docker run
   platform-quickstart-e2e-tests-placeholder:
@@ -755,7 +607,7 @@ jobs:
 
   platform-e2e-merge-reports:
     name: Merge E2E Test Reports
-    needs: [platform-e2e-tests-shards, platform-readonly-vault-e2e-tests, platform-quickstart-e2e-tests]
+    needs: [platform-e2e-tests-shards, platform-quickstart-e2e-tests]
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
@@ -819,11 +671,10 @@ jobs:
       - name: Fail if any e2e job failed
         env:
           SHARDS_RESULT: ${{ needs.platform-e2e-tests-shards.result }}
-          VAULT_RESULT: ${{ needs.platform-readonly-vault-e2e-tests.result }}
           QUICKSTART_RESULT: ${{ needs.platform-quickstart-e2e-tests.result }}
         run: |
           failed=0
-          for pair in "shards:$SHARDS_RESULT" "readonly-vault:$VAULT_RESULT" "quickstart:$QUICKSTART_RESULT"; do
+          for pair in "shards:$SHARDS_RESULT" "quickstart:$QUICKSTART_RESULT"; do
             name="${pair%%:*}"; result="${pair##*:}"
             echo "$name: $result"
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then


### PR DESCRIPTION
## Summary

Removes the dedicated **Platform E2E Tests (Readonly Vault)** E2E job from `platform-e2e-tests.yml` — both the real merge-queue/`run-e2e` job and its ordinary-PR placeholder — and drops its wiring from the **Merge E2E Test Reports** gate (`needs` and the result-check loop). The stale readonly-vault note in `values-ci.yaml` is removed; the shared Vault/secrets config it referenced is used by the generic suite and stays.

The `credentials-with-vault` Playwright project still exists and runs locally; only its dedicated CI job is dropped. The `Platform E2E Tests (Readonly Vault)` context has been removed from the `main` ruleset's required checks, so the removed job no longer gates merges.
