### PR TITLE
fix(auth): evaluate RBAC from the database, not the session cookie cache

### DIFF
--- a/platform/backend/src/auth/fastify-plugin/middleware.ts
+++ b/platform/backend/src/auth/fastify-plugin/middleware.ts
@@ -321,10 +321,15 @@ export class Authnz {
       },
       "[Authnz] Checking required permissions",
     );
+    // Pass the DB-fresh identity populateUserInfo already resolved so the
+    // permission check never consults the (possibly stale) session cookie.
     const result = await hasPermission(
       requiredPermissions,
       request.headers,
       request.serviceAccount,
+      request.user && request.organizationId
+        ? { userId: request.user.id, organizationId: request.organizationId }
+        : undefined,
     );
     logger.trace({ routeId, result }, "[Authnz] hasPermission result");
     return result;

--- a/platform/backend/src/auth/fastify-plugin/plugin.test.ts
+++ b/platform/backend/src/auth/fastify-plugin/plugin.test.ts
@@ -289,6 +289,9 @@ describe("authPlugin integration", () => {
         { agent: ["create"] },
         expect.objectContaining({}),
         undefined,
+        // DB-fresh identity from populateUserInfo, so the permission check
+        // never re-reads the (possibly stale) session cookie.
+        { userId: user.id, organizationId: org.id },
       );
     });
   });

--- a/platform/backend/src/auth/utils.test.ts
+++ b/platform/backend/src/auth/utils.test.ts
@@ -6,7 +6,7 @@ import { vi } from "vitest";
 vi.mock("./better-auth", () => ({
   auth: {
     api: {
-      hasPermission: vi.fn(),
+      getSession: vi.fn(),
       verifyApiKey: vi.fn(),
     },
   },
@@ -24,7 +24,7 @@ import { hasPermission } from "./utils";
 
 const mockBetterAuth = betterAuth as unknown as {
   api: {
-    hasPermission: MockedFunction<typeof betterAuth.api.hasPermission>;
+    getSession: MockedFunction<() => Promise<unknown>>;
     verifyApiKey: MockedFunction<typeof betterAuth.api.verifyApiKey>;
   };
 };
@@ -37,40 +37,112 @@ describe("hasPermission", () => {
   });
 
   describe("session-based authentication", () => {
-    test("should return success when user has required permissions", async () => {
+    test("should return success when user has required permissions", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, {
+        permission: { agent: ["read"] },
+      });
+      await makeMember(user.id, org.id, { role: role.role });
+
       const permissions: Permissions = { agent: ["read"] };
       const headers: IncomingHttpHeaders = { cookie: "session-cookie" };
 
-      mockBetterAuth.api.hasPermission.mockResolvedValue({
-        success: true,
-        error: null,
+      // The session is only consulted for the caller's IDENTITY; the
+      // permissions themselves are evaluated from the DB member role.
+      mockBetterAuth.api.getSession.mockResolvedValue({
+        user: { id: user.id },
       });
 
       const result = await hasPermission(permissions, headers);
 
       expect(result).toEqual({ success: true, error: null });
-      expect(mockBetterAuth.api.hasPermission).toHaveBeenCalledWith({
-        headers: expect.any(Headers),
-        body: { permissions },
-      });
     });
 
-    test("should return failure when user lacks required permissions", async () => {
+    test("should return failure when user lacks required permissions", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, {
+        permission: { agent: ["read"] },
+      });
+      await makeMember(user.id, org.id, { role: role.role });
+
       const permissions: Permissions = { agent: ["admin"] };
       const headers: IncomingHttpHeaders = { cookie: "session-cookie" };
 
-      mockBetterAuth.api.hasPermission.mockResolvedValue({
-        success: false,
-        error: null,
+      mockBetterAuth.api.getSession.mockResolvedValue({
+        user: { id: user.id },
       });
 
       const result = await hasPermission(permissions, headers);
 
-      expect(result).toEqual({ success: false, error: null });
-      expect(mockBetterAuth.api.hasPermission).toHaveBeenCalledWith({
-        headers: expect.any(Headers),
-        body: { permissions },
+      expect(result).toEqual({
+        success: false,
+        error: expect.objectContaining({ message: "Forbidden" }),
       });
+    });
+
+    test("evaluates the DB role even when the session cookie carries a stale activeOrganizationId", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
+      // Regression for the merge-queue e2e outage: the session cookie cache
+      // snapshots activeOrganizationId at session creation, and a session
+      // created by sign-up-with-invitation caches `null` (the membership is
+      // accepted afterwards). Authorization must follow the DB membership,
+      // not the cookie snapshot.
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, {
+        permission: { mcpServerInstallation: ["create"] },
+      });
+      await makeMember(user.id, org.id, { role: role.role });
+
+      mockBetterAuth.api.getSession.mockResolvedValue({
+        user: { id: user.id },
+        session: { activeOrganizationId: null },
+      });
+
+      const result = await hasPermission(
+        { mcpServerInstallation: ["create"] },
+        { cookie: "session-cookie" },
+      );
+
+      expect(result).toEqual({ success: true, error: null });
+    });
+
+    test("skips session resolution when the caller provides a DB-fresh user context", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, {
+        permission: { agent: ["read"] },
+      });
+      await makeMember(user.id, org.id, { role: role.role });
+
+      const result = await hasPermission({ agent: ["read"] }, {}, undefined, {
+        userId: user.id,
+        organizationId: org.id,
+      });
+
+      expect(result).toEqual({ success: true, error: null });
+      expect(mockBetterAuth.api.getSession).not.toHaveBeenCalled();
     });
   });
 
@@ -93,10 +165,8 @@ describe("hasPermission", () => {
         authorization: "Bearer api-key-123",
       };
 
-      // No active session/organization → session check throws, API key fallback runs.
-      mockBetterAuth.api.hasPermission.mockRejectedValue(
-        new Error("No active organization"),
-      );
+      // No session → the session path throws and the API key fallback runs.
+      mockBetterAuth.api.getSession.mockResolvedValue(null);
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
@@ -129,9 +199,7 @@ describe("hasPermission", () => {
         authorization: "Bearer limited-user-key",
       };
 
-      mockBetterAuth.api.hasPermission.mockRejectedValue(
-        new Error("No session"),
-      );
+      mockBetterAuth.api.getSession.mockResolvedValue(null);
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
@@ -152,9 +220,7 @@ describe("hasPermission", () => {
         authorization: "Bearer invalid-key",
       };
 
-      mockBetterAuth.api.hasPermission.mockRejectedValue(
-        new Error("No active organization"),
-      );
+      mockBetterAuth.api.getSession.mockResolvedValue(null);
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: false,
         error: null,
@@ -175,9 +241,7 @@ describe("hasPermission", () => {
         authorization: "Bearer ownerless-key",
       };
 
-      mockBetterAuth.api.hasPermission.mockRejectedValue(
-        new Error("No active organization"),
-      );
+      mockBetterAuth.api.getSession.mockResolvedValue(null);
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
@@ -198,9 +262,7 @@ describe("hasPermission", () => {
         authorization: "Bearer some-key",
       };
 
-      mockBetterAuth.api.hasPermission.mockRejectedValue(
-        new Error("No active organization"),
-      );
+      mockBetterAuth.api.getSession.mockResolvedValue(null);
       mockBetterAuth.api.verifyApiKey.mockRejectedValue(
         new Error("API key service error"),
       );
@@ -217,9 +279,7 @@ describe("hasPermission", () => {
       const permissions: Permissions = { agent: ["read"] };
       const headers: IncomingHttpHeaders = {};
 
-      mockBetterAuth.api.hasPermission.mockRejectedValue(
-        new Error("No active organization"),
-      );
+      mockBetterAuth.api.getSession.mockResolvedValue(null);
 
       const result = await hasPermission(permissions, headers);
 
@@ -232,22 +292,29 @@ describe("hasPermission", () => {
   });
 
   describe("edge cases", () => {
-    test("should handle empty permissions object", async () => {
+    test("should handle empty permissions object", async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeCustomRole,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      const role = await makeCustomRole(org.id, {
+        permission: { agent: ["read"] },
+      });
+      await makeMember(user.id, org.id, { role: role.role });
+
       const permissions: Permissions = {};
       const headers: IncomingHttpHeaders = { cookie: "session-cookie" };
 
-      mockBetterAuth.api.hasPermission.mockResolvedValue({
-        success: true,
-        error: null,
+      mockBetterAuth.api.getSession.mockResolvedValue({
+        user: { id: user.id },
       });
 
       const result = await hasPermission(permissions, headers);
 
       expect(result).toEqual({ success: true, error: null });
-      expect(mockBetterAuth.api.hasPermission).toHaveBeenCalledWith({
-        headers: expect.any(Headers),
-        body: { permissions: {} },
-      });
     });
 
     test("should handle complex permissions object", async ({
@@ -270,9 +337,7 @@ describe("hasPermission", () => {
         authorization: "Bearer api-key-complex",
       };
 
-      mockBetterAuth.api.hasPermission.mockRejectedValue(
-        new Error("No session"),
-      );
+      mockBetterAuth.api.getSession.mockResolvedValue(null);
       mockBetterAuth.api.verifyApiKey.mockResolvedValue({
         valid: true,
         error: null,
@@ -310,9 +375,7 @@ describe("hasPermission", () => {
       for (const authHeader of testCases) {
         const headers: IncomingHttpHeaders = { authorization: authHeader };
 
-        mockBetterAuth.api.hasPermission.mockRejectedValue(
-          new Error("No session"),
-        );
+        mockBetterAuth.api.getSession.mockResolvedValue(null);
         mockBetterAuth.api.verifyApiKey.mockResolvedValue({
           valid: true,
           error: null,

--- a/platform/backend/src/auth/utils.ts
+++ b/platform/backend/src/auth/utils.ts
@@ -9,6 +9,12 @@ export const hasPermission = async (
   permissions: Permissions,
   requestHeaders: IncomingHttpHeaders,
   serviceAccount?: SelectServiceAccount,
+  /**
+   * DB-fresh caller identity (request.user.id / request.organizationId) when
+   * the auth middleware already resolved it — skips re-deriving the identity
+   * from the session.
+   */
+  userContext?: { userId: string; organizationId: string },
 ): Promise<{ success: boolean; error: Error | null }> => {
   const headers = new Headers(requestHeaders as HeadersInit);
   logger.trace(
@@ -24,11 +30,31 @@ export const hasPermission = async (
       });
     }
 
-    const result = await betterAuth.api.hasPermission({
-      headers,
-      body: {
-        permissions,
-      },
+    // Authorization is evaluated against the database (member role + custom
+    // roles), NOT via better-auth's session-resolved hasPermission: the
+    // session cookie cache (see session.cookieCache in better-auth config)
+    // can carry a stale activeOrganizationId snapshot — e.g. a session
+    // created by sign-up-with-invitation caches `null` until the TTL lapses,
+    // denying every org-scoped request for that window. The cookie is only
+    // trusted for IDENTITY (user id, which sign-in/sign-up always rewrite);
+    // role and organization come from the DB on every check, matching the
+    // request.organizationId the route handler will execute under.
+    if (userContext) {
+      return await checkUserPermissions({ ...userContext, permissions });
+    }
+
+    const session = await betterAuth.api.getSession({ headers });
+    if (!session?.user?.id) {
+      throw new Error("No session");
+    }
+    const { organizationId } = await UserModel.getById(session.user.id);
+    if (!organizationId) {
+      return { success: false, error: new Error("Forbidden") };
+    }
+    const result = await checkUserPermissions({
+      userId: session.user.id,
+      organizationId,
+      permissions,
     });
     logger.trace(
       { success: result.success },
@@ -140,9 +166,21 @@ async function checkApiKeyPermissions(params: {
     return { success: false, error: new Error("Forbidden") };
   }
 
-  const userPermissions = await UserModel.getUserPermissions(
-    apiKeyUserId,
+  return checkUserPermissions({
+    userId: apiKeyUserId,
     organizationId,
+    permissions: params.permissions,
+  });
+}
+
+async function checkUserPermissions(params: {
+  userId: string;
+  organizationId: string;
+  permissions: Permissions;
+}): Promise<{ success: boolean; error: Error | null }> {
+  const userPermissions = await UserModel.getUserPermissions(
+    params.userId,
+    params.organizationId,
   );
   const hasAllPermissions = hasRequiredPermissions(
     userPermissions,


### PR DESCRIPTION
## TL;DR — this is the "e2e flakiness"

Merge-queue e2e has not been flaky — it has been **100% red since #6002 merged on June 29 at 15:32 UTC** (123 consecutive queue failures; the first red run starts the same minute #6002 hit main). It looked like flakiness because PR-branch "Platform E2E Tests" runs are placeholder skips — real e2e only executes on `merge_group` / dispatch / the `run-e2e` label.

## Root cause

#6002 enabled better-auth's **session cookie cache (60s)**. Authorization (`betterAuth.api.hasPermission`) resolves the caller's `activeOrganizationId` from that cached cookie snapshot. A session created by **sign-up-with-invitation** snapshots `activeOrganizationId: null` — the membership is accepted *after* the session is created — so every org-scoped request from that user 403s until the TTL lapses.

CI hits this deterministically: each run builds a fresh cluster, invites its e2e users (editor / basic-user / member), and runs the specs within the 60s window → `mcp-catalog-promote-to-team.spec.ts` fails on all retries with 403 (confirmed via the playwright trace artifact: `POST /api/internal_mcp_catalog → 403`). Dev machines never reproduce it: long-lived users sign **in**, which caches a correct snapshot. #6161's faster e2e spin-up (merged today) pulled *more* specs inside the stale window, which is when `apps.spec.ts` / `chat.spec.ts` joined the failures.

## Fix

`hasPermission` now trusts the session **only for identity** (user id — sign-in/up always rewrite the cookie itself) and evaluates permissions from the **DB member role**, in the same organization the request executes under (`request.organizationId`):

- the auth middleware passes its already-resolved DB-fresh `{userId, organizationId}` so the hot path gains no extra queries
- direct route callers (mcp-server, organization-role, websocket, …) resolve identity from the session, then evaluate from the DB — same pattern the API-key path always used
- this also removes a latent inconsistency: authorization previously used the cookie's `activeOrganizationId` while route handlers used the DB-derived `request.organizationId`

The #6002 perf win is preserved — the per-request *session table* lookup stays cookie-cached; only role/org facts are read fresh (they were already being read fresh for `request.user`).