### PR TITLE
ci(e2e): remove placeholder jobs so a failing e2e run actually gates the merge queue

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -32,13 +32,32 @@ env:
   MCP_SERVER_BASE_IMAGE_NAME: mcp-server-base
 
 jobs:
-  # NOTE: there are deliberately NO same-named "placeholder" jobs for ordinary
-  # PR updates. GitHub treats a SKIPPED check run as satisfying a required
-  # status check, so on plain PR pushes the real jobs below (whose `if` is
-  # false) report skipped and the ruleset is satisfied without running e2e.
-  # Placeholder twins would ALSO report skipped on merge_group runs — and that
-  # skipped twin satisfies the required check even when the real job FAILS,
-  # which let the merge queue merge past days of red e2e. Do not re-add them.
+  # NOTE: there are deliberately NO same-named "placeholder" jobs for the
+  # NON-MATRIX checks below. GitHub treats a SKIPPED check run as satisfying a
+  # required status check, so on plain PR pushes the real jobs (whose `if` is
+  # false) report skipped under their own names and the ruleset is satisfied
+  # without running e2e. Placeholder twins would ALSO report skipped on
+  # merge_group runs — and that skipped twin satisfies the required check even
+  # when the real job FAILS, which let the merge queue merge past days of red
+  # e2e. Do not re-add them.
+  #
+  # The MATRIX build job is the one exception: a skipped matrix job never
+  # expands, so it reports as the literal "Build ${{ matrix.name }} Image" —
+  # the required "Build Platform Image" / "Build MCP Server Base Image"
+  # contexts would wait forever on ordinary PR pushes. Its placeholder is safe
+  # precisely for the same reason: skipped on merge_group, it reports under
+  # the unexpanded name, which cannot mask a real matrix job's failure.
+  platform-e2e-build-placeholder:
+    name: Build ${{ matrix.name }} Image
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-e2e') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [Platform, MCP Server Base]
+    steps:
+      - name: Skip full image build on ordinary PR updates
+        run: echo "Full E2E image builds run on merge queue or when the run-e2e label is added."
 
   # Build Docker images for e2e tests (platform and MCP server base).
   # Trusted PRs and merge queue runs push the platform image to Artifact Registry so

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -32,20 +32,13 @@ env:
   MCP_SERVER_BASE_IMAGE_NAME: mcp-server-base
 
 jobs:
-  # Required-check placeholders for ordinary PR updates. These let a single
-  # ruleset require merge-queue-only checks without forcing the full E2E suite
-  # to run on every PR push.
-  platform-e2e-build-placeholder:
-    name: Build ${{ matrix.name }} Image
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-e2e') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [Platform, MCP Server Base]
-    steps:
-      - name: Skip full image build on ordinary PR updates
-        run: echo "Full E2E image builds run on merge queue or when the run-e2e label is added."
+  # NOTE: there are deliberately NO same-named "placeholder" jobs for ordinary
+  # PR updates. GitHub treats a SKIPPED check run as satisfying a required
+  # status check, so on plain PR pushes the real jobs below (whose `if` is
+  # false) report skipped and the ruleset is satisfied without running e2e.
+  # Placeholder twins would ALSO report skipped on merge_group runs — and that
+  # skipped twin satisfies the required check even when the real job FAILS,
+  # which let the merge queue merge past days of red e2e. Do not re-add them.
 
   # Build Docker images for e2e tests (platform and MCP server base).
   # Trusted PRs and merge queue runs push the platform image to Artifact Registry so
@@ -165,14 +158,6 @@ jobs:
           path: /tmp/${{ matrix.tarball-name }}
           retention-days: 1
           compression-level: 0 # Already gzipped
-
-  platform-e2e-tests-placeholder:
-    name: Platform E2E Tests
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-e2e') }}
-    steps:
-      - name: Skip full non-quickstart E2E job on ordinary PR updates
-        run: echo "Full non-quickstart E2E runs on merge queue or when the run-e2e label is added."
 
   # E2E tests - runs the generic non-quickstart suites plus the Vault K8s startup
   # coverage against one shared CI deployment in the standard DB secrets mode.
@@ -356,15 +341,6 @@ jobs:
           fi
           echo "All non-quickstart E2E shards passed."
 
-  # Quickstart E2E tests - validates docker run quickstart instructions work correctly
-  # Runs the mcp-install.spec.ts test against the platform started via docker run
-  platform-quickstart-e2e-tests-placeholder:
-    name: Platform E2E Tests (Quickstart)
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-e2e') }}
-    steps:
-      - name: Skip quickstart E2E on ordinary PR updates
-        run: echo "Quickstart E2E runs on merge queue or when the run-e2e label is added."
 
   platform-quickstart-e2e-tests:
     name: Platform E2E Tests (Quickstart)
@@ -595,15 +571,6 @@ jobs:
           docker network rm archestra-quickstart-net 2>/dev/null || true
           docker volume rm archestra-ci-postgres-data 2>/dev/null || true
           docker volume rm archestra-ci-app-data 2>/dev/null || true
-
-  # Merge all Playwright reports into a single HTML report
-  platform-e2e-merge-reports-placeholder:
-    name: Merge E2E Test Reports
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-e2e') }}
-    steps:
-      - name: Skip report merge on ordinary PR updates
-        run: echo "Merged E2E reports are generated on merge queue or when the run-e2e label is added."
 
   platform-e2e-merge-reports:
     name: Merge E2E Test Reports


### PR DESCRIPTION
## Why the queue merged past 2.5 days of red e2e

The e2e workflow kept same-named **placeholder** twins of every required check (`Merge E2E Test Reports`, `Platform E2E Tests (Quickstart)`, …) so ordinary PR pushes could satisfy the ruleset without running the suite. But GitHub treats a **skipped check run as satisfying a required status check** — and that cuts both ways: on `merge_group` runs the placeholder's `if` is false → it reports **skipped** → the required check is satisfied **even while the real job fails**. Proof: main commit `310d76b85` carries `Merge E2E Test Reports: failure` AND `skipped` side by side — and merged. ~120 consecutive red merge-queue e2e runs sailed through this hole (the underlying e2e breakage itself is fixed by #6181 + #6189, both merged; the suite is green again).

## The fix

Delete the **non-matrix** placeholder jobs. Skipped-satisfies also holds for the real jobs: on ordinary PR events their `if`s are false, they report skipped under their own names, and the ruleset passes exactly as before. With the twins gone, a merge-group failure is the only check run carrying the required name — so it finally gates.

**One deliberate exception — the matrix build placeholder stays.** A *skipped matrix job never expands*: it reports a single check run under the literal `Build ${{ matrix.name }} Image`, so on plain PR pushes the required `Build Platform Image` / `Build MCP Server Base Image` contexts would wait forever ("waiting for status to be reported" — as this PR itself demonstrated before the second commit). The matrix placeholder is safe for the same reason the others were dangerous: when skipped on merge_group it reports under the *unexpanded* name, which cannot collide with (and therefore cannot mask) the real matrix jobs' failures.

- **No ruleset/admin changes needed** — required-check names are unchanged.
- A comment in the workflow explains both sides of the trap for future editors.

## Suggested validation once merged

Watch the next genuine e2e failure in the queue: the entry should now be ejected instead of merging.