### PR TITLE
Support pasting JSON arrays in the MCP server Arguments field

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useCreateMcpServerInstallationRequest } from "@/lib/mcp/mcp-server-installation-request.query";
+import { parseArgumentsInput } from "./mcp-catalog-form.utils";
 
 const customServerRequestSchema = z
   .object({
@@ -119,10 +120,7 @@ export function CustomServerRequestDialog({
             serverType: "local" as const,
             localConfig: {
               command: values.command,
-              arguments: values.arguments
-                .split("\n")
-                .map((arg) => arg.trim())
-                .filter((arg) => arg.length > 0),
+              arguments: parseArgumentsInput(values.arguments),
               environment:
                 values.environment.length > 0 ? values.environment : undefined,
             },
@@ -276,7 +274,9 @@ export function CustomServerRequestDialog({
                     name="arguments"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Arguments (one per line)</FormLabel>
+                        <FormLabel>
+                          Arguments (one per line, or paste a JSON array)
+                        </FormLabel>
                         <FormControl>
                           <Textarea
                             placeholder={`/path/to/server.js\n--verbose`}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1297,7 +1297,7 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments (one per line, or paste a JSON array)
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -1,10 +1,43 @@
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 import {
   buildCloneFormValues,
+  parseArgumentsInput,
   transformCatalogItemToFormValues,
   transformExternalCatalogToFormValues,
   transformFormToApiData,
 } from "./mcp-catalog-form.utils";
+
+describe("parseArgumentsInput", () => {
+  it("returns an empty array for empty input", () => {
+    expect(parseArgumentsInput()).toEqual([]);
+    expect(parseArgumentsInput("")).toEqual([]);
+    expect(parseArgumentsInput("   ")).toEqual([]);
+  });
+
+  it("splits one-arg-per-line input, trimming and dropping blank lines", () => {
+    expect(parseArgumentsInput("-y\n  pulumi-mcp  \n\n--verbose")).toEqual([
+      "-y",
+      "pulumi-mcp",
+      "--verbose",
+    ]);
+  });
+
+  it("parses a pasted JSON array of strings", () => {
+    expect(parseArgumentsInput('["-y", "pulumi-mcp", "--verbose"]')).toEqual([
+      "-y",
+      "pulumi-mcp",
+      "--verbose",
+    ]);
+  });
+
+  it("falls back to line parsing when the JSON array contains non-strings", () => {
+    expect(parseArgumentsInput('["-y", 42]')).toEqual(['["-y", 42]']);
+  });
+
+  it("falls back to line parsing for malformed JSON-looking input", () => {
+    expect(parseArgumentsInput("[not valid json")).toEqual(["[not valid json"]);
+  });
+});
 
 describe("transformFormToApiData", () => {
   it("maps custom auth and additional headers into userConfig", () => {

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -12,6 +12,34 @@ import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 type McpCatalogApiData =
   archestraApiTypes.CreateInternalMcpCatalogItemData["body"];
 
+// Parses the Arguments textarea input into a string array. Supports the
+// original one-arg-per-line format as well as a pasted JSON array (the
+// format most MCP server catalogs show their args in), so users can
+// copy-paste configs without reformatting them by hand.
+export function parseArgumentsInput(input?: string): string[] {
+  const trimmed = input?.trim() ?? "";
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (
+        Array.isArray(parsed) &&
+        parsed.every((arg) => typeof arg === "string")
+      ) {
+        return parsed.map((arg) => arg.trim()).filter((arg) => arg.length > 0);
+      }
+    } catch {
+      // Not valid JSON - fall through to newline parsing below.
+    }
+  }
+
+  return trimmed
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
 // Transform function to convert form values to API format
 export function transformFormToApiData(
   values: McpCatalogFormValues,
@@ -35,12 +63,7 @@ export function transformFormToApiData(
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
     // Parse arguments string into array
-    const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
-      : [];
+    const argumentsArray = parseArgumentsInput(values.localConfig.arguments);
 
     data.localConfig = {
       command: values.localConfig.command || undefined,


### PR DESCRIPTION
## Summary
Most MCP server catalogs show their args as a JSON array (e.g. `["-y", "pulumi-mcp"]`), 
but the Arguments field only accepted one arg per line, so pasting a JSON array in 
directly produced a single malformed argument.

- `parseArgumentsInput()` now detects a pasted JSON array of strings and uses it 
  directly, falling back to the existing one-arg-per-line parsing for everything else 
  (fully backward compatible).
- Applied in both places the Arguments textarea exists: the main MCP catalog form and 
  the custom server request dialog.
- Updated both field labels to mention JSON is accepted.

Closes #3859

## Test plan
- [x] Added 5 unit tests covering: empty input, one-per-line, valid JSON array, JSON 
  array with non-string values (falls back), malformed JSON-looking input (falls back)
- [x] `pnpm test` — 63/63 passing
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm type-check` (tsgo) — clean