### PR TITLE
feat(skills): explain GitHub import is a one-time snapshot

### DIFF
--- a/platform/frontend/src/app/skills/_parts/import-skills-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/import-skills-dialog.tsx
@@ -38,6 +38,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useGithubAppConfigs } from "@/lib/github-app-config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import {
   useDiscoverGithubSkills,
   useImportGithubSkills,
@@ -93,6 +94,7 @@ export function ImportSkillsDialog({
   const discover = useDiscoverGithubSkills();
   const importSkills = useImportGithubSkills();
   const { data: githubAppConfigs = [] } = useGithubAppConfigs();
+  const appName = useAppName();
 
   const [repoUrl, setRepoUrl] = useState(initialRepoUrl);
   const [path, setPath] = useState("");
@@ -614,6 +616,15 @@ export function ImportSkillsDialog({
         </div>
       ) : (
         <div className="space-y-6">
+          <div className="flex gap-2.5 rounded-md border bg-muted/40 px-3 py-2.5 text-sm text-muted-foreground">
+            <Info className="mt-0.5 size-4 shrink-0" />
+            <p>
+              Importing copies the selected skills into your organization once.{" "}
+              {appName} doesn’t pull from the repo afterward — later changes
+              there won’t appear here, your edits here won’t go back to GitHub,
+              and re-importing skips skills you’ve already imported.
+            </p>
+          </div>
           <div className="space-y-2">
             <Label htmlFor="skill-repo-url">Repository URL</Label>
             <Input

--- a/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   Folder,
   FolderOpen,
+  Github,
   Plus,
   RotateCcw,
   Trash2,
@@ -25,6 +26,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import {
   useCreateSkill,
   useSkill,
@@ -107,6 +109,15 @@ export function SkillEditorDialog({
   );
   const createSkill = useCreateSkill();
   const updateSkill = useUpdateSkill();
+  const appName = useAppName();
+
+  // GitHub-imported skills are a one-time snapshot, not a live link: editing
+  // here never touches the repo, and the repo is never re-pulled. Surface that
+  // in edit mode so the disconnect isn't a surprise.
+  const isGithubSkill = isEdit && skill?.sourceType === "github";
+  const githubSourceRepo = isGithubSkill
+    ? (skill?.sourceRef?.split("@")[0] ?? null)
+    : null;
 
   const [manifest, setManifest] = useState("");
   const [files, setFiles] = useState<ResourceFile[]>([]);
@@ -367,6 +378,23 @@ export function SkillEditorDialog({
         </div>
       ) : (
         <div className="flex h-full min-h-0 flex-col gap-4">
+          {isGithubSkill && (
+            <div className="flex gap-2.5 rounded-md border bg-muted/40 px-3 py-2.5 text-sm text-muted-foreground">
+              <Github className="mt-0.5 size-4 shrink-0" />
+              <p>
+                Imported from{" "}
+                {githubSourceRepo ? (
+                  <code className="font-mono text-foreground">
+                    {githubSourceRepo}
+                  </code>
+                ) : (
+                  "GitHub"
+                )}{" "}
+                as a one-time copy. Saving changes here won’t update the repo,
+                and {appName} won’t pull later changes from it.
+              </p>
+            </div>
+          )}
           <div className="grid min-h-0 flex-1 grid-cols-[240px_1fr] gap-3">
             <div className="flex min-h-0 flex-col rounded-md border">
               <div className="flex-1 overflow-y-auto p-2">


### PR DESCRIPTION
Closes #5995

Skills imported from a GitHub repo are copied once into Postgres. There is no scheduled job that re-pulls the repo, and edits made in Archestra never go back to GitHub — the two copies are fully decoupled after import. Re-importing a skill that already exists is skipped, not refreshed. None of this was communicated, and because each skill row shows its `owner/repo` provenance, users reasonably assumed a live, two-way sync existed.

Two informational banners close that gap:

- **Import dialog** — states up front that importing copies the selected skills once, that Archestra won't pull later repo changes, that edits here won't return to GitHub, and that re-importing skips skills already in the org.
- **Edit skill dialog** — for skills whose `sourceType` is `github`, a banner naming the source repo makes clear that saving edits won't touch the repo and the repo is never re-pulled. It renders only when editing a GitHub-sourced skill (not for preview, new, built-in, or manually-created skills), and uses the configured app name so white-label deployments stay branded correctly.