### PR TITLE
fix(analytics): keep dev/CI errors out of PostHog and harden LLM proxy error paths

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -446,6 +446,7 @@ jobs:
             -p 127.0.0.1:9000:9000 \
             -p 127.0.0.1:3000:3000 \
             -e ARCHESTRA_QUICKSTART=true \
+            -e ARCHESTRA_ANALYTICS=disabled \
             -e ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:latest \
             -e ARCHESTRA_OPENAI_BASE_URL=http://archestra-wiremock:8080/v1 \
             -e ARCHESTRA_ANTHROPIC_BASE_URL=http://archestra-wiremock:8080 \

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -446,8 +446,8 @@ jobs:
             -p 127.0.0.1:9000:9000 \
             -p 127.0.0.1:3000:3000 \
             -e ARCHESTRA_QUICKSTART=true \
-            -e ARCHESTRA_ANALYTICS=disabled \
             -e ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE=europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-base:latest \
+            -e ARCHESTRA_ANALYTICS=disabled \
             -e ARCHESTRA_OPENAI_BASE_URL=http://archestra-wiremock:8080/v1 \
             -e ARCHESTRA_ANTHROPIC_BASE_URL=http://archestra-wiremock:8080 \
             -e ARCHESTRA_GEMINI_BASE_URL=http://archestra-wiremock:8080 \

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1010,6 +1010,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -5306,6 +5307,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -6975,6 +6977,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -8132,6 +8135,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -9289,6 +9293,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -10463,6 +10468,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -11664,6 +11670,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -12835,6 +12842,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -14612,6 +14620,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -16953,6 +16962,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -18254,6 +18264,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -22742,6 +22753,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -24490,6 +24502,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -25700,6 +25713,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -26910,6 +26924,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -28137,6 +28152,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -29391,6 +29407,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -30616,6 +30633,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -32473,6 +32491,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -34924,6 +34943,7 @@
                       ]
                     },
                     "annotations": {
+                      "nullable": true,
                       "type": "array",
                       "items": {}
                     },
@@ -65717,6 +65737,7 @@
                                 ]
                               },
                               "annotations": {
+                                "nullable": true,
                                 "type": "array",
                                 "items": {}
                               },
@@ -67413,6 +67434,7 @@
                                 ]
                               },
                               "annotations": {
+                                "nullable": true,
                                 "type": "array",
                                 "items": {}
                               },
@@ -103465,6 +103487,7 @@
                                 ]
                               },
                               "annotations": {
+                                "nullable": true,
                                 "type": "array",
                                 "items": {}
                               },
@@ -104909,6 +104932,7 @@
                                 ]
                               },
                               "annotations": {
+                                "nullable": true,
                                 "type": "array",
                                 "items": {}
                               },
@@ -123780,6 +123804,7 @@
                                                   ]
                                                 },
                                                 "annotations": {
+                                                  "nullable": true,
                                                   "type": "array",
                                                   "items": {}
                                                 },
@@ -125060,6 +125085,7 @@
                                                   ]
                                                 },
                                                 "annotations": {
+                                                  "nullable": true,
                                                   "type": "array",
                                                   "items": {}
                                                 },
@@ -142237,6 +142263,7 @@
                                             ]
                                           },
                                           "annotations": {
+                                            "nullable": true,
                                             "type": "array",
                                             "items": {}
                                           },
@@ -143517,6 +143544,7 @@
                                             ]
                                           },
                                           "annotations": {
+                                            "nullable": true,
                                             "type": "array",
                                             "items": {}
                                           },

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -892,8 +892,8 @@ My Files is the persistent byte-storage layer used by Projects and the `search_f
   - Example: `archestra-prod/`
 
 - **`ARCHESTRA_ANALYTICS`** - Controls PostHog analytics for product improvements.
-  - Default: `enabled`
-  - Set to `disabled` to opt-out of analytics
+  - Default: `enabled` in production builds (`NODE_ENV=production`, which includes the released Docker images); disabled in development/test environments
+  - Set to `disabled` to opt-out of analytics, or `enabled` to force it on regardless of environment
 
 - **`ARCHESTRA_ANALYTICS_POSTHOG_KEY`** - PostHog project key used when analytics is enabled.
   - Default: Archestra's hosted PostHog project key

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -132,7 +132,9 @@ ARCHESTRA_AUTH_COOKIE_DOMAIN=""
 # Analytics configuration for PostHog. Governs frontend product analytics +
 # session replay, backend instance heartbeats, and backend error tracking
 # (5xx exceptions + preceding logs sent to PostHog Error Tracking).
-# Set to "disabled" to turn all of it off. Enabled by default.
+# Set to "disabled" to turn all of it off, or "enabled" to force it on.
+# Unset, it is enabled only when NODE_ENV is "production" (the released Docker
+# images), so local dev/test runs never report analytics or errors.
 ARCHESTRA_ANALYTICS=
 # Optional: override the PostHog project key / host (defaults target Archestra's
 # own PostHog instance). Point these at your own instance to self-host analytics.

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -64,7 +64,9 @@ describe("getAnalyticsConfig", () => {
     process.env = originalEnv;
   });
 
-  test("uses the default PostHog analytics config", () => {
+  test("uses the default PostHog analytics config, enabled in production", () => {
+    process.env.NODE_ENV = "production";
+
     expect(getAnalyticsConfig()).toEqual({
       enabled: true,
       posthog: {
@@ -72,6 +74,26 @@ describe("getAnalyticsConfig", () => {
         host: "https://eu.i.posthog.com",
       },
     });
+  });
+
+  test("defaults to disabled outside production", () => {
+    process.env.NODE_ENV = "development";
+
+    expect(getAnalyticsConfig().enabled).toBe(false);
+  });
+
+  test("explicit ARCHESTRA_ANALYTICS=enabled wins outside production", () => {
+    process.env.NODE_ENV = "development";
+    process.env.ARCHESTRA_ANALYTICS = "enabled";
+
+    expect(getAnalyticsConfig().enabled).toBe(true);
+  });
+
+  test("explicit ARCHESTRA_ANALYTICS=disabled wins in production", () => {
+    process.env.NODE_ENV = "production";
+    process.env.ARCHESTRA_ANALYTICS = "disabled";
+
+    expect(getAnalyticsConfig().enabled).toBe(false);
   });
 
   test("uses custom PostHog analytics env vars", () => {

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -881,17 +881,30 @@ export function parseCommaSeparatedList(value: string): string[] {
 }
 
 /** @public — exported for testability */
-export const getAnalyticsConfig = () => ({
-  enabled: process.env.ARCHESTRA_ANALYTICS !== "disabled",
-  posthog: {
-    key:
-      process.env.ARCHESTRA_ANALYTICS_POSTHOG_KEY?.trim() ||
-      DEFAULT_POSTHOG_KEY,
-    host:
-      process.env.ARCHESTRA_ANALYTICS_POSTHOG_HOST?.trim() ||
-      DEFAULT_POSTHOG_HOST,
-  },
-});
+export const getAnalyticsConfig = () => {
+  const analyticsEnv = process.env.ARCHESTRA_ANALYTICS?.trim();
+  // Evaluated at call time (not the module-level `isProduction`) so tests can
+  // exercise both environments.
+  const isProductionEnv = ["production", "prod"].includes(
+    process.env.NODE_ENV?.toLowerCase() ?? "",
+  );
+  return {
+    // Analytics (PostHog product analytics, instance heartbeats, and backend
+    // error tracking) defaults to on only in production builds. Local dev and
+    // test runs (bare `pnpm dev`, vitest — where NODE_ENV isn't "production")
+    // stay silent unless ARCHESTRA_ANALYTICS is explicitly set, which always
+    // wins in both directions ("disabled" → off, any other value → on).
+    enabled: analyticsEnv ? analyticsEnv !== "disabled" : isProductionEnv,
+    posthog: {
+      key:
+        process.env.ARCHESTRA_ANALYTICS_POSTHOG_KEY?.trim() ||
+        DEFAULT_POSTHOG_KEY,
+      host:
+        process.env.ARCHESTRA_ANALYTICS_POSTHOG_HOST?.trim() ||
+        DEFAULT_POSTHOG_HOST,
+    },
+  };
+};
 
 const mcpServerBaseImage =
   process.env.ARCHESTRA_ORCHESTRATOR_MCP_SERVER_BASE_IMAGE ||

--- a/platform/backend/src/routes/proxy/adapters/openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.test.ts
@@ -237,13 +237,58 @@ describe("OpenAIResponseAdapter", () => {
       expect(adapter.getFinishReasons()).toEqual(["stop"]);
     });
 
-    test("returns empty array when choices is missing (e.g. upstream error body)", () => {
+    test("returns empty array when choices is empty", () => {
       const response = {
-        error: { message: "upstream failure" },
-      } as unknown as OpenAi.Types.ChatCompletionsResponse;
+        ...createMockResponse({ role: "assistant", content: "x" }),
+        choices: [],
+      };
 
       const adapter = openaiAdapterFactory.createResponseAdapter(response);
       expect(adapter.getFinishReasons()).toEqual([]);
+      expect(adapter.getText()).toBe("");
+      expect(adapter.getToolCalls()).toEqual([]);
+      expect(adapter.hasToolCalls()).toBe(false);
+    });
+  });
+
+  describe("responses without choices (upstream error bodies)", () => {
+    test("surfaces the embedded upstream error message and status", () => {
+      const response = {
+        error: { message: "Rate limit exceeded", code: 429 },
+      } as unknown as OpenAi.Types.ChatCompletionsResponse;
+
+      expect(() =>
+        openaiAdapterFactory.createResponseAdapter(response),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 429,
+          message: "Rate limit exceeded",
+        }),
+      );
+    });
+
+    test("defaults to 502 with a generic message when no error details exist", () => {
+      const response = {} as unknown as OpenAi.Types.ChatCompletionsResponse;
+
+      expect(() =>
+        openaiAdapterFactory.createResponseAdapter(response),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 502,
+          message:
+            "Upstream openai provider returned a response without choices",
+        }),
+      );
+    });
+
+    test("ignores non-HTTP error codes when picking the status", () => {
+      const response = {
+        error: { message: "boom", code: "model_not_found" },
+      } as unknown as OpenAi.Types.ChatCompletionsResponse;
+
+      expect(() =>
+        openaiAdapterFactory.createResponseAdapter(response),
+      ).toThrow(expect.objectContaining({ statusCode: 502 }));
     });
   });
 

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -1,4 +1,5 @@
 import {
+  ApiError,
   ArchestraInternalErrorCode,
   type SupportedProvider,
 } from "@archestra/shared";
@@ -869,6 +870,7 @@ export class OpenAIResponseAdapter
     response: OpenAiResponse,
     provider: SupportedProvider = "openai",
   ) {
+    assertResponseHasChoices(response, provider);
     this.response = response;
     this.provider = provider;
   }
@@ -1681,3 +1683,41 @@ export const openAiEmbeddingsAdapterFactory: OpenAiEmbeddingsProvider =
     "openai",
     () => config.llm.openai.baseUrl,
   );
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/**
+ * Some OpenAI-compatible upstreams (LiteLLM, OpenRouter, misconfigured
+ * gateways) return HTTP 200 with an error-shaped body — no `choices` array,
+ * usually an `error` object instead. Downstream code (getText, tool-call
+ * policy evaluation, response serialization) assumes `choices` exists, so
+ * surface the upstream failure as a typed error here instead of crashing with
+ * an opaque TypeError.
+ */
+function assertResponseHasChoices(
+  response: OpenAiResponse,
+  provider: SupportedProvider,
+): void {
+  if (Array.isArray(response?.choices)) return;
+
+  const embeddedError = (
+    response as unknown as {
+      error?: { message?: unknown; code?: unknown; status?: unknown };
+    }
+  )?.error;
+
+  const rawStatus = embeddedError?.status ?? embeddedError?.code;
+  const statusCode =
+    typeof rawStatus === "number" && rawStatus >= 400 && rawStatus <= 599
+      ? rawStatus
+      : 502;
+
+  const upstreamMessage =
+    typeof embeddedError?.message === "string" && embeddedError.message
+      ? embeddedError.message
+      : `Upstream ${provider} provider returned a response without choices`;
+
+  throw new ApiError(statusCode, upstreamMessage);
+}

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -383,6 +383,9 @@ function captureServerException(
       method: request.method,
       url: request.url,
       route: request.routeOptions?.url,
+      // The requested host (from the Host header) — identifies which
+      // deployment hit the error, used by the PostHog Slack alert template.
+      hostname: request.host,
       reqId: request.id,
       ...extraProperties,
     },

--- a/platform/backend/src/services/error-tracking.test.ts
+++ b/platform/backend/src/services/error-tracking.test.ts
@@ -20,6 +20,7 @@ describe("PostHogErrorTrackingService", () => {
     const service = new PostHogErrorTrackingService({
       analyticsConfig: enabledAnalyticsConfig,
       appVersion: "1.2.3",
+      environment: "production",
       createClient: () => client,
       loadInstanceId: async () => "instance-1",
       getRecentLogs: () => [],
@@ -43,6 +44,7 @@ describe("PostHogErrorTrackingService", () => {
     expect(properties).toMatchObject({
       source: "backend",
       app_version: "1.2.3",
+      environment: "production",
       instance_id: "instance-1",
       $groups: { instance: "instance-1" },
       $session_id: "session-abc",

--- a/platform/backend/src/services/error-tracking.ts
+++ b/platform/backend/src/services/error-tracking.ts
@@ -69,6 +69,7 @@ class PostHogErrorTrackingService {
     private readonly options: {
       analyticsConfig?: AnalyticsConfig;
       appVersion?: string;
+      environment?: string;
       createClient?: (params: {
         key: string;
         host: string;
@@ -135,6 +136,7 @@ class PostHogErrorTrackingService {
       this.client.captureException(error, resolvedDistinctId, {
         source: "backend",
         app_version: this.getAppVersion(),
+        environment: this.getEnvironment(),
         ...(this.instanceId && {
           instance_id: this.instanceId,
           $groups: { instance: this.instanceId },
@@ -176,6 +178,10 @@ class PostHogErrorTrackingService {
 
   private getAppVersion(): string {
     return this.options.appVersion ?? config.api.version;
+  }
+
+  private getEnvironment(): string {
+    return this.options.environment ?? (config.environment || "development");
   }
 
   private createClient(params: {

--- a/platform/backend/src/types/llm-providers/cerebras/api.ts
+++ b/platform/backend/src/types/llm-providers/cerebras/api.ts
@@ -38,7 +38,9 @@ const CerebrasChoiceSchema = z
         content: z.string().nullable().optional(),
         refusal: z.string().nullable().optional(),
         role: z.enum(["assistant"]),
-        annotations: z.array(z.any()).optional(),
+        // Some OpenAI-compatible upstreams return `annotations: null` instead of
+        // omitting it; without nullable() the response fails serialization (500).
+        annotations: z.array(z.any()).nullable().optional(),
         audio: z.any().nullable().optional(),
         function_call: z
           .object({

--- a/platform/backend/src/types/llm-providers/ollama/api.ts
+++ b/platform/backend/src/types/llm-providers/ollama/api.ts
@@ -37,7 +37,9 @@ const ChoiceSchema = z
         content: z.string().nullable(),
         refusal: z.string().nullable().optional(),
         role: z.enum(["assistant"]),
-        annotations: z.array(z.any()).optional(),
+        // Some OpenAI-compatible upstreams return `annotations: null` instead of
+        // omitting it; without nullable() the response fails serialization (500).
+        annotations: z.array(z.any()).nullable().optional(),
         audio: z.any().nullable().optional(),
         function_call: z
           .object({

--- a/platform/backend/src/types/llm-providers/openai/api.ts
+++ b/platform/backend/src/types/llm-providers/openai/api.ts
@@ -42,7 +42,9 @@ const ChoiceSchema = z
         content: z.string().nullable(),
         refusal: z.string().nullable().optional(),
         role: z.enum(["assistant"]),
-        annotations: z.array(z.any()).optional(),
+        // Some OpenAI-compatible upstreams return `annotations: null` instead of
+        // omitting it; without nullable() the response fails serialization (500).
+        annotations: z.array(z.any()).nullable().optional(),
         audio: z.any().nullable().optional(),
         function_call: z
           .object({

--- a/platform/backend/src/types/llm-providers/vllm/api.ts
+++ b/platform/backend/src/types/llm-providers/vllm/api.ts
@@ -37,7 +37,9 @@ const ChoiceSchema = z
         content: z.string().nullable(),
         refusal: z.string().nullable().optional(),
         role: z.enum(["assistant"]),
-        annotations: z.array(z.any()).optional(),
+        // Some OpenAI-compatible upstreams return `annotations: null` instead of
+        // omitting it; without nullable() the response fails serialization (500).
+        annotations: z.array(z.any()).nullable().optional(),
         audio: z.any().nullable().optional(),
         function_call: z
           .object({

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -309,7 +309,7 @@ export type OpenAiChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -1811,7 +1811,7 @@ export type CerebrasChatCompletionResponseInput = {
             content?: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             function_call?: {
                 arguments: string;
@@ -2276,7 +2276,7 @@ export type MistralChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -2633,7 +2633,7 @@ export type PerplexityChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -2990,7 +2990,7 @@ export type GroqChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -3351,7 +3351,7 @@ export type OpenrouterChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -3689,7 +3689,7 @@ export type VllmChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             function_call?: {
                 arguments: string;
@@ -4014,7 +4014,7 @@ export type OllamaChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             function_call?: {
                 arguments: string;
@@ -4532,7 +4532,7 @@ export type DeepSeekChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -5245,7 +5245,7 @@ export type XaiChatCompletionResponseInput = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -5623,7 +5623,7 @@ export type OpenAiChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -7125,7 +7125,7 @@ export type CerebrasChatCompletionResponse = {
             content?: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             function_call?: {
                 arguments: string;
@@ -7590,7 +7590,7 @@ export type MistralChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -7947,7 +7947,7 @@ export type PerplexityChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -8304,7 +8304,7 @@ export type GroqChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -8665,7 +8665,7 @@ export type OpenrouterChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -9003,7 +9003,7 @@ export type VllmChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             function_call?: {
                 arguments: string;
@@ -9328,7 +9328,7 @@ export type OllamaChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             function_call?: {
                 arguments: string;
@@ -9846,7 +9846,7 @@ export type DeepSeekChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -10559,7 +10559,7 @@ export type XaiChatCompletionResponse = {
             content: string | null;
             refusal?: string | null;
             role: 'assistant';
-            annotations?: Array<unknown>;
+            annotations?: Array<unknown> | null;
             audio?: unknown;
             /**
              * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -18946,7 +18946,7 @@ export type AzureChatCompletionsWithDefaultAgentResponses = {
                 content: string | null;
                 refusal?: string | null;
                 role: 'assistant';
-                annotations?: Array<unknown>;
+                annotations?: Array<unknown> | null;
                 audio?: unknown;
                 /**
                  * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -19446,7 +19446,7 @@ export type AzureChatCompletionsWithAgentResponses = {
                 content: string | null;
                 refusal?: string | null;
                 role: 'assistant';
-                annotations?: Array<unknown>;
+                annotations?: Array<unknown> | null;
                 audio?: unknown;
                 /**
                  * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -29220,7 +29220,7 @@ export type GithubCopilotChatCompletionsWithDefaultAgentResponses = {
                 content: string | null;
                 refusal?: string | null;
                 role: 'assistant';
-                annotations?: Array<unknown>;
+                annotations?: Array<unknown> | null;
                 audio?: unknown;
                 /**
                  * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -29667,7 +29667,7 @@ export type GithubCopilotChatCompletionsWithAgentResponses = {
                 content: string | null;
                 refusal?: string | null;
                 role: 'assistant';
-                annotations?: Array<unknown>;
+                annotations?: Array<unknown> | null;
                 audio?: unknown;
                 /**
                  * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -33787,7 +33787,7 @@ export type GetInteractionsResponses = {
                         content: string | null;
                         refusal?: string | null;
                         role: 'assistant';
-                        annotations?: Array<unknown>;
+                        annotations?: Array<unknown> | null;
                         audio?: unknown;
                         /**
                          * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -34020,7 +34020,7 @@ export type GetInteractionsResponses = {
                         content: string | null;
                         refusal?: string | null;
                         role: 'assistant';
-                        annotations?: Array<unknown>;
+                        annotations?: Array<unknown> | null;
                         audio?: unknown;
                         /**
                          * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -37424,7 +37424,7 @@ export type GetInteractionResponses = {
                     content: string | null;
                     refusal?: string | null;
                     role: 'assistant';
-                    annotations?: Array<unknown>;
+                    annotations?: Array<unknown> | null;
                     audio?: unknown;
                     /**
                      * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431
@@ -37657,7 +37657,7 @@ export type GetInteractionResponses = {
                     content: string | null;
                     refusal?: string | null;
                     role: 'assistant';
-                    annotations?: Array<unknown>;
+                    annotations?: Array<unknown> | null;
                     audio?: unknown;
                     /**
                      * https://github.com/openai/openai-node/blob/v6.0.0/src/resources/chat/completions/completions.ts#L431

--- a/platform/shared/hey-api/clients/archestra-catalog/types.gen.ts
+++ b/platform/shared/hey-api/clients/archestra-catalog/types.gen.ts
@@ -57,7 +57,7 @@ export type ArchestraMcpServerManifest = {
     display_name: string;
     instructions?: string;
     readme: string | null;
-    category: 'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General' | null;
+    category: 'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General' | 'MCP Apps Demo' | null;
     quality_score: number | null;
     archestra_config?: {
         client_config_permutations: {
@@ -177,7 +177,7 @@ export type SearchMcpServerCatalogData = {
         /**
          * Filter by category
          */
-        category?: 'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General';
+        category?: 'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General' | 'MCP Apps Demo';
         /**
          * Filter by programming language
          */
@@ -297,7 +297,7 @@ export type GetMcpServerCategoriesResponses = {
      * Successful response
      */
     200: {
-        categories: Array<'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General'>;
+        categories: Array<'Aggregators' | 'Art & Culture' | 'Healthcare' | 'Browser Automation' | 'Cloud' | 'Development' | 'CLI Tools' | 'Communication' | 'Data' | 'Logistics' | 'Data Science' | 'IoT' | 'File Management' | 'Finance' | 'Gaming' | 'Knowledge' | 'Location' | 'Marketing' | 'Monitoring' | 'Media' | 'AI Tools' | 'Search' | 'Security' | 'Social Media' | 'Sports' | 'Support' | 'Translation' | 'Audio' | 'Travel' | 'Messengers' | 'Email' | 'CRM' | 'Enterprise' | 'Job Search' | 'Local files' | 'General' | 'MCP Apps Demo'>;
     };
 };
 


### PR DESCRIPTION
## Why

We recently started sending backend exceptions to PostHog Error Tracking. Auditing the first week of data showed two problems:

1. **Dev/CI environments leak errors.** Tilt disables analytics, but bare `pnpm dev` did not, and the quickstart e2e CI job runs the Docker image, which bakes in `ARCHESTRA_ANALYTICS=enabled` and `VERSION=dev`. The top issue in PostHog (345 occurrences across ~115 short-lived "instances", all `app_version=dev`, exactly 3 events each) was entirely CI quickstart runs hitting WireMock-mocked LLM endpoints.
2. **Two real product bugs surfaced by the data** (details below).

## What changed

### Stop dev/CI noise
- `getAnalyticsConfig()`: analytics now defaults to enabled **only when `NODE_ENV` is production**. An explicit `ARCHESTRA_ANALYTICS` value always wins (`disabled` → off anywhere, anything else → on anywhere). Released Docker images set both `NODE_ENV=production` and `ARCHESTRA_ANALYTICS=enabled`, so production behavior is unchanged.
- The quickstart e2e job now passes `-e ARCHESTRA_ANALYTICS=disabled` to its `docker run` (the helm-based e2e path already disabled it via `values-ci.yaml`).
- Captured exceptions now carry `environment` and request `hostname` properties, so anything that still slips through is filterable in PostHog, and the Slack alert can name the deployment that hit the error.

### Fix the top real errors
- **`TypeError: Cannot read properties of undefined (reading '0')` in `OpenAIResponseAdapter.getText`** — some OpenAI-compatible upstreams return HTTP 200 with an error-shaped body and no `choices` array. The adapter (shared by all OpenAI-compatible providers via delegation) now rejects such responses with a typed upstream error: the embedded error message and status when present (e.g. a 429), otherwise 502. Clients get a meaningful error instead of an opaque 500, and 4xx upstream failures are no longer captured as internal errors.
- **`Response doesn't match the schema` 500s in `handleNonStreaming`** — some OpenAI-compatible upstreams return `choices[0].message.annotations: null` instead of omitting the field; the response schema rejected it during serialization, turning a successful completion into a 500. `annotations` is now nullable in the OpenAI/Cerebras/Ollama/vLLM response schemas.

Not addressed (environmental, not code bugs): DB `connect EPERM` failures from one deployment's network policy, and an upstream Azure 404 for a nonexistent deployment name.

## Testing
- New unit tests: analytics gating (production vs dev vs explicit override), adapter behavior for choices-less bodies (embedded status honored, 502 fallback, non-HTTP codes ignored) and empty-`choices` arrays, `environment` property on captured exceptions.
- `pnpm lint`, `pnpm type-check`, `pnpm knip` clean; full `src/routes/proxy` suite + config/analytics/error-tracking tests pass (849 tests).

## Docs
- `.env.example` and `docs/pages/platform-deployment.md` updated for the new `ARCHESTRA_ANALYTICS` default semantics.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>