### PR TITLE
fix(apps): mcp rendering in sidebar, rendering of multiple instances in chat

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -2184,6 +2184,7 @@ export function ChatPageContent({
 
   return (
     <AppsProvider
+      key={conversationId ?? "new"}
       apps={mcpApps}
       onShowInPanel={() => openRightPanelTab("apps" as RightPanelTab)}
       onClosePanel={closeRightPanel}

--- a/platform/frontend/src/components/chat/apps-context.tsx
+++ b/platform/frontend/src/components/chat/apps-context.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { buildAppGroups } from "./apps-context.utils";
 import type { McpToolOutput } from "./mcp-app-container";
 
 export interface PanelApp {
@@ -113,86 +114,58 @@ export function AppsProvider({
   onClosePanel?: () => void;
   children: ReactNode;
 }) {
-  // Apps the user explicitly collapsed, keyed per app (see `openKeyByToolCallId`).
+  // Apps the user explicitly collapsed, keyed per app (an `AppGroup.key`).
   // Everything expands by default, so a new app auto-opens by being absent here.
   const [closedKeys, setClosedKeys] = useState<ReadonlySet<string>>(EMPTY_SET);
-  // Which render of an owned app is the visible one (appId → toolCallId); absent
-  // → the latest. Clicking an older owned pill points it here.
-  const [activeOwnedRender, setActiveOwnedRender] =
+  // Which render of an owned app the user picked as visible (appId → toolCallId);
+  // absent → the latest. Clicking an older owned pill points it here.
+  const [pickedOwnedRender, setPickedOwnedRender] =
     useState<ReadonlyMap<string, string>>(EMPTY_MAP);
   // Explicit right-panel pick; null falls back to the latest still-open app.
   const [explicitPanelId, setExplicitPanelId] = useState<string | null>(null);
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  // Per render: its canonical (visible) render — the user-picked owned render
-  // while present, else the latest — and its open-state key (appId for owned so
-  // renders share one open state, else toolCallId).
-  const { canonicalByToolCallId, openKeyByToolCallId } = useMemo(() => {
-    const latestOwned = new Map<string, PanelApp>();
-    for (const a of apps) {
-      if (!a.appId) continue;
-      const cur = latestOwned.get(a.appId);
-      if (!cur || a.createdAt >= cur.createdAt) latestOwned.set(a.appId, a);
-    }
-    const canonicalForApp = new Map<string, string>();
-    for (const [appId, latest] of latestOwned) {
-      const picked = activeOwnedRender.get(appId);
-      const pickedPresent = apps.some(
-        (a) => a.toolCallId === picked && a.appId === appId,
-      );
-      canonicalForApp.set(
-        appId,
-        pickedPresent && picked ? picked : latest.toolCallId,
-      );
-    }
-    const canonical = new Map<string, string>();
-    const openKey = new Map<string, string>();
-    for (const a of apps) {
-      canonical.set(
-        a.toolCallId,
-        a.appId ? (canonicalForApp.get(a.appId) ?? a.toolCallId) : a.toolCallId,
-      );
-      openKey.set(a.toolCallId, a.appId ?? a.toolCallId);
-    }
-    return { canonicalByToolCallId: canonical, openKeyByToolCallId: openKey };
-  }, [apps, activeOwnedRender]);
+  // One group per app: owned renders fold into a shared group with a single
+  // visible `activeRender` (the user's pick while present, else the latest);
+  // external renders are singleton groups. `groupByToolCallId` maps any render to
+  // its group so every callback below is an O(1) lookup instead of a scan.
+  const { groupByToolCallId } = useMemo(
+    () => buildAppGroups(apps, pickedOwnedRender),
+    [apps, pickedOwnedRender],
+  );
 
+  // The visible (canonical) render for an app: its group's active render. An
+  // unknown id (e.g. a render not yet in `apps`) is its own canonical render.
   const canonicalToolCallId = useCallback(
-    (id: string) => canonicalByToolCallId.get(id) ?? id,
-    [canonicalByToolCallId],
+    (id: string) => groupByToolCallId.get(id)?.activeRender.toolCallId ?? id,
+    [groupByToolCallId],
   );
 
-  const latestToolCallId = useMemo(
-    () =>
-      apps.reduce<PanelApp | null>(
-        (latest, a) =>
-          !latest || a.createdAt >= latest.createdAt ? a : latest,
-        null,
-      )?.toolCallId ?? null,
-    [apps],
-  );
-
-  // Open when this is the canonical render and its app isn't collapsed.
+  // Open when this is the group's active render and the group isn't collapsed.
+  // An unknown id is treated as its own default-open singleton.
   const isAppOpen = useCallback(
-    (id: string) =>
-      canonicalToolCallId(id) === id &&
-      !closedKeys.has(openKeyByToolCallId.get(id) ?? id),
-    [canonicalToolCallId, closedKeys, openKeyByToolCallId],
+    (id: string) => {
+      const group = groupByToolCallId.get(id);
+      if (!group) return !closedKeys.has(id);
+      return group.activeRender.toolCallId === id && !closedKeys.has(group.key);
+    },
+    [groupByToolCallId, closedKeys],
   );
 
   // Collapse when this render is the visible, open one; otherwise make it the
   // visible render (moving an owned dup here) and open the app.
   const toggleAppOpen = useCallback(
     (id: string) => {
-      const key = openKeyByToolCallId.get(id) ?? id;
-      const visibleHere = canonicalToolCallId(id) === id;
-      const appId = apps.find((a) => a.toolCallId === id)?.appId ?? null;
+      const group = groupByToolCallId.get(id);
+      const key = group?.key ?? id;
+      const appId = group?.appId ?? null;
+      const visibleHere = (group?.activeRender.toolCallId ?? id) === id;
       if (visibleHere && !closedKeys.has(key)) {
         setClosedKeys((prev) => new Set(prev).add(key));
       } else {
         if (appId) {
-          setActiveOwnedRender((prev) => new Map(prev).set(appId, id));
+          setPickedOwnedRender((prev) => new Map(prev).set(appId, id));
         }
         setClosedKeys((prev) => {
           if (!prev.has(key)) return prev;
@@ -203,7 +176,7 @@ export function AppsProvider({
       }
       setSettingsOpen(false);
     },
-    [apps, canonicalToolCallId, closedKeys, openKeyByToolCallId],
+    [groupByToolCallId, closedKeys],
   );
 
   // Switching the panel app drops the previous app's settings form.
@@ -215,33 +188,32 @@ export function AppsProvider({
     [canonicalToolCallId],
   );
 
-  // One hosted app, never blank: explicit pick, else latest still-open, else latest.
+  // One hosted app, never blank: explicit pick, else latest still-open active
+  // render, else the latest active render overall.
   const panelToolCallId = useMemo(() => {
-    if (explicitPanelId && apps.some((a) => a.toolCallId === explicitPanelId)) {
+    if (explicitPanelId && groupByToolCallId.has(explicitPanelId)) {
       return explicitPanelId;
     }
-    const latestOpen = apps
-      .filter(
-        (a) =>
-          canonicalByToolCallId.get(a.toolCallId) === a.toolCallId &&
-          !closedKeys.has(
-            openKeyByToolCallId.get(a.toolCallId) ?? a.toolCallId,
-          ),
-      )
-      .reduce<PanelApp | null>(
-        (latest, a) =>
-          !latest || a.createdAt >= latest.createdAt ? a : latest,
-        null,
-      )?.toolCallId;
-    return latestOpen ?? latestToolCallId;
-  }, [
-    explicitPanelId,
-    apps,
-    closedKeys,
-    canonicalByToolCallId,
-    openKeyByToolCallId,
-    latestToolCallId,
-  ]);
+    const isActive = (a: PanelApp) =>
+      groupByToolCallId.get(a.toolCallId)?.activeRender.toolCallId ===
+      a.toolCallId;
+    const latestBy = (predicate: (a: PanelApp) => boolean) =>
+      apps
+        .filter(predicate)
+        .reduce<PanelApp | null>(
+          (latest, a) =>
+            !latest || a.createdAt >= latest.createdAt ? a : latest,
+          null,
+        )?.toolCallId ?? null;
+    const latestOpen = latestBy(
+      (a) =>
+        isActive(a) &&
+        !closedKeys.has(
+          groupByToolCallId.get(a.toolCallId)?.key ?? a.toolCallId,
+        ),
+    );
+    return latestOpen ?? latestBy(isActive);
+  }, [explicitPanelId, apps, closedKeys, groupByToolCallId]);
 
   const openRightPanel = useCallback(() => {
     onShowInPanel?.();

--- a/platform/frontend/src/components/chat/apps-context.tsx
+++ b/platform/frontend/src/components/chat/apps-context.tsx
@@ -53,21 +53,17 @@ export interface PanelApp {
 interface AppsContextValue {
   /** All apps currently mounted in the conversation, in the order they appeared. */
   apps: PanelApp[];
-  /**
-   * toolCallId of the single open app — the one shown either inline in the chat
-   * stream or in the right panel. Every section derives its pressed / inline /
-   * panel state from this one value; opening any app collapses the previous one
-   * to a pill. Defaults to the latest app.
-   */
-  openToolCallId: string | null;
-  /**
-   * Set the single open app, or `null` to collapse (nothing open). Pills pass
-   * their toolCallId to open, or `null` when they're already open to toggle
-   * closed. Where the app then shows — inline or the right panel — is derived
-   * from `portalTarget` (whether the Apps tab is hosting), not stored here.
-   */
-  setOpenToolCallId: (toolCallId: string | null) => void;
-  /** Open the right panel on the Apps tab. Call alongside `setOpenToolCallId` to send an app there ("Open in right panel"). */
+  /** Whether this render is expanded inline. Apps expand by default; only the canonical (latest) owned render can. */
+  isAppOpen: (toolCallId: string) => boolean;
+  /** Toggle one app's inline expansion (canonicalized), leaving other open apps alone. */
+  toggleAppOpen: (toolCallId: string) => void;
+  /** The single app the right panel hosts: the explicit pick, else the latest still-open app, else the latest — never blank. */
+  panelToolCallId: string | null;
+  /** Point the right panel at an app (pill selector / "Open in right panel"). */
+  setPanelApp: (toolCallId: string) => void;
+  /** Map any render to the canonical render for its app (latest owned render, or itself). */
+  canonicalToolCallId: (toolCallId: string) => string;
+  /** Open the right panel on the Apps tab. */
   openRightPanel: () => void;
   /** DOM node where the open app should portal its content; null when the panel is not on the Apps tab. */
   portalTarget: HTMLElement | null;
@@ -85,10 +81,16 @@ interface AppsContextValue {
 
 const AppsContext = createContext<AppsContextValue | null>(null);
 
+const EMPTY_SET: ReadonlySet<string> = new Set();
+const EMPTY_MAP: ReadonlyMap<string, string> = new Map();
+
 const NOOP_VALUE: AppsContextValue = {
   apps: [],
-  openToolCallId: null,
-  setOpenToolCallId: () => {},
+  isAppOpen: () => false,
+  toggleAppOpen: () => {},
+  panelToolCallId: null,
+  setPanelApp: () => {},
+  canonicalToolCallId: (id) => id,
   openRightPanel: () => {},
   portalTarget: null,
   setPortalTarget: () => {},
@@ -111,42 +113,135 @@ export function AppsProvider({
   onClosePanel?: () => void;
   children: ReactNode;
 }) {
-  // `undefined` = untouched, so the open app defaults to the latest; a string is
-  // an explicit choice; `null` is an explicit collapse (nothing open).
-  const [explicitOpen, setExplicitOpen] = useState<string | null | undefined>(
-    undefined,
-  );
+  // Apps the user explicitly collapsed, keyed per app (see `openKeyByToolCallId`).
+  // Everything expands by default, so a new app auto-opens by being absent here.
+  const [closedKeys, setClosedKeys] = useState<ReadonlySet<string>>(EMPTY_SET);
+  // Which render of an owned app is the visible one (appId → toolCallId); absent
+  // → the latest. Clicking an older owned pill points it here.
+  const [activeOwnedRender, setActiveOwnedRender] =
+    useState<ReadonlyMap<string, string>>(EMPTY_MAP);
+  // Explicit right-panel pick; null falls back to the latest still-open app.
+  const [explicitPanelId, setExplicitPanelId] = useState<string | null>(null);
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  // Resolve the open app: untouched → the latest (most recently registered) app;
-  // an explicit collapse (`null`) → nothing; an explicit choice → that app while
-  // it's still present. A stale choice (a superseded owned-app render, or an id
-  // from a previous conversation) isn't found and falls through to the latest,
-  // so a new render of an owned app takes focus and no reset is needed on switch.
-  const openToolCallId = useMemo(() => {
-    const latestToolCallId =
+  // Per render: its canonical (visible) render — the user-picked owned render
+  // while present, else the latest — and its open-state key (appId for owned so
+  // renders share one open state, else toolCallId).
+  const { canonicalByToolCallId, openKeyByToolCallId } = useMemo(() => {
+    const latestOwned = new Map<string, PanelApp>();
+    for (const a of apps) {
+      if (!a.appId) continue;
+      const cur = latestOwned.get(a.appId);
+      if (!cur || a.createdAt >= cur.createdAt) latestOwned.set(a.appId, a);
+    }
+    const canonicalForApp = new Map<string, string>();
+    for (const [appId, latest] of latestOwned) {
+      const picked = activeOwnedRender.get(appId);
+      const pickedPresent = apps.some(
+        (a) => a.toolCallId === picked && a.appId === appId,
+      );
+      canonicalForApp.set(
+        appId,
+        pickedPresent && picked ? picked : latest.toolCallId,
+      );
+    }
+    const canonical = new Map<string, string>();
+    const openKey = new Map<string, string>();
+    for (const a of apps) {
+      canonical.set(
+        a.toolCallId,
+        a.appId ? (canonicalForApp.get(a.appId) ?? a.toolCallId) : a.toolCallId,
+      );
+      openKey.set(a.toolCallId, a.appId ?? a.toolCallId);
+    }
+    return { canonicalByToolCallId: canonical, openKeyByToolCallId: openKey };
+  }, [apps, activeOwnedRender]);
+
+  const canonicalToolCallId = useCallback(
+    (id: string) => canonicalByToolCallId.get(id) ?? id,
+    [canonicalByToolCallId],
+  );
+
+  const latestToolCallId = useMemo(
+    () =>
       apps.reduce<PanelApp | null>(
         (latest, a) =>
           !latest || a.createdAt >= latest.createdAt ? a : latest,
         null,
-      )?.toolCallId ?? null;
-    // An explicit collapse (null) empties the inline stream, but the panel
-    // always hosts one app when the conversation has any — fall back to the
-    // latest there so the Apps tab never renders blank.
-    if (explicitOpen === null) return portalTarget ? latestToolCallId : null;
-    if (explicitOpen && apps.some((a) => a.toolCallId === explicitOpen)) {
-      return explicitOpen;
-    }
-    return latestToolCallId;
-  }, [explicitOpen, apps, portalTarget]);
+      )?.toolCallId ?? null,
+    [apps],
+  );
 
-  // Setting the open app always returns to the live app — the settings form
-  // belongs to the app that was open, not the one switched to.
-  const setOpenToolCallId = useCallback((toolCallId: string | null) => {
-    setExplicitOpen(toolCallId);
-    setSettingsOpen(false);
-  }, []);
+  // Open when this is the canonical render and its app isn't collapsed.
+  const isAppOpen = useCallback(
+    (id: string) =>
+      canonicalToolCallId(id) === id &&
+      !closedKeys.has(openKeyByToolCallId.get(id) ?? id),
+    [canonicalToolCallId, closedKeys, openKeyByToolCallId],
+  );
+
+  // Collapse when this render is the visible, open one; otherwise make it the
+  // visible render (moving an owned dup here) and open the app.
+  const toggleAppOpen = useCallback(
+    (id: string) => {
+      const key = openKeyByToolCallId.get(id) ?? id;
+      const visibleHere = canonicalToolCallId(id) === id;
+      const appId = apps.find((a) => a.toolCallId === id)?.appId ?? null;
+      if (visibleHere && !closedKeys.has(key)) {
+        setClosedKeys((prev) => new Set(prev).add(key));
+      } else {
+        if (appId) {
+          setActiveOwnedRender((prev) => new Map(prev).set(appId, id));
+        }
+        setClosedKeys((prev) => {
+          if (!prev.has(key)) return prev;
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      }
+      setSettingsOpen(false);
+    },
+    [apps, canonicalToolCallId, closedKeys, openKeyByToolCallId],
+  );
+
+  // Switching the panel app drops the previous app's settings form.
+  const setPanelApp = useCallback(
+    (id: string) => {
+      setExplicitPanelId(canonicalToolCallId(id));
+      setSettingsOpen(false);
+    },
+    [canonicalToolCallId],
+  );
+
+  // One hosted app, never blank: explicit pick, else latest still-open, else latest.
+  const panelToolCallId = useMemo(() => {
+    if (explicitPanelId && apps.some((a) => a.toolCallId === explicitPanelId)) {
+      return explicitPanelId;
+    }
+    const latestOpen = apps
+      .filter(
+        (a) =>
+          canonicalByToolCallId.get(a.toolCallId) === a.toolCallId &&
+          !closedKeys.has(
+            openKeyByToolCallId.get(a.toolCallId) ?? a.toolCallId,
+          ),
+      )
+      .reduce<PanelApp | null>(
+        (latest, a) =>
+          !latest || a.createdAt >= latest.createdAt ? a : latest,
+        null,
+      )?.toolCallId;
+    return latestOpen ?? latestToolCallId;
+  }, [
+    explicitPanelId,
+    apps,
+    closedKeys,
+    canonicalByToolCallId,
+    openKeyByToolCallId,
+    latestToolCallId,
+  ]);
 
   const openRightPanel = useCallback(() => {
     onShowInPanel?.();
@@ -160,8 +255,11 @@ export function AppsProvider({
   const value = useMemo<AppsContextValue>(
     () => ({
       apps,
-      openToolCallId,
-      setOpenToolCallId,
+      isAppOpen,
+      toggleAppOpen,
+      panelToolCallId,
+      setPanelApp,
+      canonicalToolCallId,
       openRightPanel,
       portalTarget,
       setPortalTarget,
@@ -171,8 +269,11 @@ export function AppsProvider({
     }),
     [
       apps,
-      openToolCallId,
-      setOpenToolCallId,
+      isAppOpen,
+      toggleAppOpen,
+      panelToolCallId,
+      setPanelApp,
+      canonicalToolCallId,
       openRightPanel,
       portalTarget,
       closePanel,

--- a/platform/frontend/src/components/chat/apps-context.tsx
+++ b/platform/frontend/src/components/chat/apps-context.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import type { McpToolOutput } from "./mcp-app-container";
 
 export interface PanelApp {
   toolCallId: string;
@@ -37,6 +38,14 @@ export interface PanelApp {
   mcpServerId?: string | null;
   /** Latest owned-app version this entry shows. */
   version?: number | null;
+  /**
+   * External MCP-UI tool result, so a panel-hosted render can seed its iframe
+   * (`sendToolResult`) exactly like the inline render instead of re-calling the
+   * source tool. Owned apps have none (their management result is not app data).
+   */
+  rawOutput?: McpToolOutput | null;
+  /** Tool input for the iframe; best-effort — only present on same-part results. */
+  toolInput?: Record<string, unknown> | null;
   /** Timestamp (ms) when the app first registered — used to order entries and default to the latest. */
   createdAt: number;
 }

--- a/platform/frontend/src/components/chat/apps-context.utils.test.ts
+++ b/platform/frontend/src/components/chat/apps-context.utils.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { PanelApp } from "./apps-context";
+import { buildAppGroups } from "./apps-context.utils";
+
+const app = (
+  toolCallId: string,
+  appId: string | null,
+  createdAt: number,
+): PanelApp => ({
+  toolCallId,
+  label: appId ? "Dashboard" : "Excalidraw",
+  uiResourceUri: appId ? `ui://archestra-app/${appId}` : "ui://excalidraw",
+  appId,
+  createdAt,
+});
+
+const NO_PICK = new Map<string, string>();
+
+describe("buildAppGroups", () => {
+  it("folds owned renders into one group per appId, external renders stand alone", () => {
+    const apps = [
+      app("tc1", "app-1", 0),
+      app("tc2", "app-1", 10),
+      app("tc3", null, 5),
+    ];
+    const { groups } = buildAppGroups(apps, NO_PICK);
+    expect(groups.map((g) => g.key)).toEqual(["app-1", "tc3"]);
+    expect(groups[0].renders.map((r) => r.toolCallId)).toEqual(["tc1", "tc2"]);
+    expect(groups[1].renders.map((r) => r.toolCallId)).toEqual(["tc3"]);
+  });
+
+  it("defaults the active render to the latest by createdAt", () => {
+    const { groupByToolCallId } = buildAppGroups(
+      [app("tc1", "app-1", 0), app("tc2", "app-1", 10)],
+      NO_PICK,
+    );
+    expect(groupByToolCallId.get("tc1")?.activeRender.toolCallId).toBe("tc2");
+  });
+
+  it("breaks a createdAt tie toward the later render in appearance order", () => {
+    // Streaming leaves createdAt at 0, so ties are common.
+    const { groupByToolCallId } = buildAppGroups(
+      [app("tc1", "app-1", 0), app("tc2", "app-1", 0)],
+      NO_PICK,
+    );
+    expect(groupByToolCallId.get("tc1")?.activeRender.toolCallId).toBe("tc2");
+  });
+
+  it("uses the user's picked render when it is still present", () => {
+    const { groupByToolCallId } = buildAppGroups(
+      [app("tc1", "app-1", 0), app("tc2", "app-1", 10)],
+      new Map([["app-1", "tc1"]]),
+    );
+    expect(groupByToolCallId.get("tc2")?.activeRender.toolCallId).toBe("tc1");
+  });
+
+  it("falls back to the latest when the picked render is gone", () => {
+    const { groupByToolCallId } = buildAppGroups(
+      [app("tc1", "app-1", 0), app("tc2", "app-1", 10)],
+      new Map([["app-1", "tc-removed"]]),
+    );
+    expect(groupByToolCallId.get("tc1")?.activeRender.toolCallId).toBe("tc2");
+  });
+
+  it("ignores a pick that names a render belonging to another app", () => {
+    const { groupByToolCallId } = buildAppGroups(
+      [app("tc1", "app-1", 0), app("tc2", "app-1", 10), app("tc3", "app-2", 5)],
+      new Map([["app-1", "tc3"]]),
+    );
+    expect(groupByToolCallId.get("tc1")?.activeRender.toolCallId).toBe("tc2");
+  });
+
+  it("maps every render — older owned dups included — to its group", () => {
+    const apps = [app("tc1", "app-1", 0), app("tc2", "app-1", 10)];
+    const { groupByToolCallId } = buildAppGroups(apps, NO_PICK);
+    expect(groupByToolCallId.get("tc1")).toBe(groupByToolCallId.get("tc2"));
+    expect(groupByToolCallId.size).toBe(2);
+  });
+});

--- a/platform/frontend/src/components/chat/apps-context.utils.ts
+++ b/platform/frontend/src/components/chat/apps-context.utils.ts
@@ -1,0 +1,72 @@
+import type { PanelApp } from "./apps-context";
+
+export interface AppGroup {
+  /** `appId ?? toolCallId` — the shared open-state key for this app's renders. */
+  key: string;
+  /** Owned-app id, or null for an external MCP-UI render. */
+  appId: string | null;
+  /** Every render of this app, in appearance order. */
+  renders: PanelApp[];
+  /**
+   * The visible render: the user's picked render when it's still present, else
+   * the latest by `createdAt`. External apps always have a single render.
+   */
+  activeRender: PanelApp;
+}
+
+/**
+ * Group a flat, per-render app list into one {@link AppGroup} per app. Owned
+ * apps (shared `appId`) fold their many renders into one group that shares open
+ * state and exposes a single visible `activeRender`; external MCP-UI renders are
+ * singleton groups keyed by their `toolCallId`. Returns the groups in
+ * first-appearance order plus a lookup from any render's `toolCallId` to its
+ * group, so callers translate a render id to its app in O(1).
+ */
+export function buildAppGroups(
+  apps: PanelApp[],
+  pickedOwnedRender: ReadonlyMap<string, string>,
+): { groups: AppGroup[]; groupByToolCallId: Map<string, AppGroup> } {
+  const rendersByKey = new Map<string, PanelApp[]>();
+  const keyOrder: string[] = [];
+  for (const app of apps) {
+    const key = app.appId ?? app.toolCallId;
+    const existing = rendersByKey.get(key);
+    if (existing) {
+      existing.push(app);
+    } else {
+      rendersByKey.set(key, [app]);
+      keyOrder.push(key);
+    }
+  }
+
+  const groups: AppGroup[] = [];
+  const groupByToolCallId = new Map<string, AppGroup>();
+  for (const key of keyOrder) {
+    const renders = rendersByKey.get(key) as PanelApp[];
+    const appId = renders[0].appId ?? null;
+    const picked = appId ? pickedOwnedRender.get(appId) : undefined;
+    const pickedRender = picked
+      ? renders.find((r) => r.toolCallId === picked)
+      : undefined;
+    const group: AppGroup = {
+      key,
+      appId,
+      renders,
+      activeRender: pickedRender ?? latestByCreatedAt(renders),
+    };
+    groups.push(group);
+    for (const render of renders) {
+      groupByToolCallId.set(render.toolCallId, group);
+    }
+  }
+
+  return { groups, groupByToolCallId };
+}
+
+// Latest render by `createdAt`; ties resolve to the later render in appearance
+// order (streaming leaves `createdAt` at 0, so ties are common).
+function latestByCreatedAt(renders: PanelApp[]): PanelApp {
+  return renders.reduce((latest, r) =>
+    r.createdAt >= latest.createdAt ? r : latest,
+  );
+}

--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -4,12 +4,10 @@ import {
   SUBAGENT_TOOL_CALL_PART_TYPE,
 } from "@archestra/shared";
 import { describe, expect, it } from "vitest";
-import type { PanelApp } from "./apps-context";
 import {
   collectBrowserToolCallIds,
   collectSubagentToolCalls,
   deriveAppsFromMessages,
-  distinctPanelApps,
   extractFileAttachments,
   extractOwnedAppRender,
   filterOptimisticToolCalls,
@@ -967,41 +965,6 @@ describe("identifyCompactToolGroups", () => {
     expect(groupMap.get(0)?.entries).toHaveLength(3);
     expect(consumedIndices.has(2)).toBe(true);
     expect(consumedIndices.has(3)).toBe(true);
-  });
-});
-
-describe("distinctPanelApps", () => {
-  const app = (
-    toolCallId: string,
-    appId: string | null,
-    createdAt: number,
-  ): PanelApp => ({
-    toolCallId,
-    label: appId ? "Dashboard" : "Excalidraw",
-    uiResourceUri: appId ? `ui://archestra-app/${appId}` : "ui://excalidraw",
-    appId,
-    version: 1,
-    createdAt,
-  });
-
-  it("collapses owned renders by appId, keeping the latest by createdAt", () => {
-    const apps = [
-      app("tc1", "app-1", 0),
-      app("tc2", "app-1", 10),
-      app("tc3", "app-2", 5),
-    ];
-    expect(distinctPanelApps(apps).map((a) => a.toolCallId)).toEqual([
-      "tc2",
-      "tc3",
-    ]);
-  });
-
-  it("keeps every external render (no appId) as its own entry", () => {
-    const apps = [app("tc1", null, 0), app("tc2", null, 10)];
-    expect(distinctPanelApps(apps).map((a) => a.toolCallId)).toEqual([
-      "tc1",
-      "tc2",
-    ]);
   });
 });
 

--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -292,6 +292,8 @@ describe("deriveAppsFromMessages", () => {
         appId: null,
         mcpServerId: null,
         toolName: "pm__show_board",
+        rawOutput: { _meta: { ui: { resourceUri: "ui://pm/board" } } },
+        toolInput: null,
         version: null,
         createdAt: Date.parse("2026-05-29T18:13:52.000Z"),
       },
@@ -328,10 +330,64 @@ describe("deriveAppsFromMessages", () => {
         appId: null,
         mcpServerId: "srv-1",
         toolName: "pm__show_board",
+        rawOutput: {
+          _meta: { ui: { resourceUri: "ui://pm/board", mcpServerId: "srv-1" } },
+        },
+        toolInput: null,
         version: null,
         createdAt: Date.parse("2026-05-29T18:13:52.000Z"),
       },
     ]);
+  });
+
+  it("carries the tool result as rawOutput so a panel render can seed its iframe", () => {
+    const output = {
+      _meta: { ui: { resourceUri: "ui://pm/board" } },
+      structuredContent: { applicants: [{ id: 24 }] },
+    };
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "pm__show_board",
+            toolCallId: "call_1",
+            state: "output-available",
+            input: { limit: 5 },
+            output,
+          },
+        ],
+      },
+    ] as never;
+
+    const apps = deriveAppsFromMessages(messages, {}, getToolShortName);
+    expect(apps[0].rawOutput).toEqual(output);
+    expect(apps[0].toolInput).toEqual({ limit: 5 });
+  });
+
+  it("stores the run_tool-unwrapped target name so the server prefix matches inline", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-archestra__run_tool",
+            toolCallId: "call_1",
+            state: "output-available",
+            input: { tool_name: "pm__show_board", tool_args: { limit: 5 } },
+            output: { _meta: { ui: { resourceUri: "ui://pm/board" } } },
+          },
+        ],
+      },
+    ] as never;
+
+    const apps = deriveAppsFromMessages(messages, {}, getToolShortName);
+    expect(apps[0].toolName).toBe("pm__show_board");
+    // toolInput seeds the target tool's args, not the run_tool wrapper.
+    expect(apps[0].toolInput).toEqual({ limit: 5 });
   });
 
   it("returns an app from early UI-start data before the result arrives", () => {
@@ -370,6 +426,8 @@ describe("deriveAppsFromMessages", () => {
         appId: null,
         mcpServerId: null,
         toolName: "pm__show_board",
+        // No result yet (early UI-start), so no seed; the pending input is kept.
+        toolInput: {},
         version: null,
         createdAt: 0,
       },
@@ -595,6 +653,8 @@ describe("deriveAppsFromMessages", () => {
         appId: null,
         mcpServerId: null,
         toolName: "pm__show_board",
+        rawOutput: { _meta: { ui: { resourceUri: "ui://pm/board" } } },
+        toolInput: null,
         version: null,
         createdAt: Date.parse("2026-05-29T18:00:00.000Z"),
       },
@@ -605,6 +665,8 @@ describe("deriveAppsFromMessages", () => {
         appId: null,
         mcpServerId: null,
         toolName: "pm__show_board",
+        rawOutput: { _meta: { ui: { resourceUri: "ui://pm/board" } } },
+        toolInput: null,
         version: null,
         createdAt: Date.parse("2026-05-29T18:05:00.000Z"),
       },

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -18,6 +18,7 @@ import {
 import type { PanelApp } from "./apps-context";
 import type { FileAttachment } from "./editable-user-message";
 import type { HookRunChipData } from "./hook-run-chip";
+import type { McpToolOutput } from "./mcp-app-container";
 
 export type OptimisticToolCall = {
   toolCallId: string;
@@ -245,7 +246,22 @@ export function deriveAppsFromMessages(
           uiResourceUri: outputUri,
           appId: null,
           mcpServerId,
-          toolName: fullToolName,
+          // Unwrap run_tool so the server prefix matches the inline render.
+          toolName: resolveRunToolTargetName(part, fullToolName, {
+            getToolShortName,
+          }),
+          // Seed the panel-hosted iframe with the tool result exactly like the
+          // inline render, so it doesn't re-call its source tool on mount.
+          rawOutput: part.output as McpToolOutput,
+          // Unwrap run_tool's tool_args so the seeded input matches inline.
+          toolInput:
+            getToolShortName(fullToolName) === TOOL_RUN_TOOL_SHORT_NAME
+              ? ((
+                  part.input as
+                    | { tool_args?: Record<string, unknown> }
+                    | undefined
+                )?.tool_args ?? null)
+              : ((part.input as Record<string, unknown> | undefined) ?? null),
           version: null,
           createdAt: createdAt ?? 0,
         });

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -151,35 +151,6 @@ export function extractOwnedAppRender(params: {
 }
 
 /**
- * Collapse the render registry to one entry per distinct app, for display
- * surfaces that must not repeat an app (the right-panel app switcher). Owned
- * apps collapse by `appId` keeping the latest render (max `createdAt`); external
- * MCP-UI renders each stand alone (no `appId`), so they are kept per tool call.
- * The full registry keeps every render so each inline pill stays independently
- * openable — only display consumers dedup.
- */
-export function distinctPanelApps(apps: PanelApp[]): PanelApp[] {
-  const result: PanelApp[] = [];
-  const ownedIndex = new Map<string, number>();
-
-  for (const app of apps) {
-    if (!app.appId) {
-      result.push(app);
-      continue;
-    }
-    const existing = ownedIndex.get(app.appId);
-    if (existing === undefined) {
-      ownedIndex.set(app.appId, result.length);
-      result.push(app);
-    } else if (app.createdAt >= result[existing].createdAt) {
-      result[existing] = app;
-    }
-  }
-
-  return result;
-}
-
-/**
  * Derive the list of MCP Apps for a conversation directly from its messages
  * (plus any early UI-start data from the active stream).
  *
@@ -197,8 +168,8 @@ export function distinctPanelApps(apps: PanelApp[]): PanelApp[] {
  * openable and expands its app under itself. Owned apps always resolve to the
  * latest version at render time (their runtime endpoint is keyed by `appId`), so
  * a stale render still shows current content. Display surfaces that must not
- * repeat an app (the right-panel switcher) collapse the registry via
- * {@link distinctPanelApps} instead of the registry deduping here.
+ * repeat an app fold the registry into per-app groups (see `buildAppGroups`)
+ * instead of the registry deduping here.
  */
 
 /**

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -533,20 +533,25 @@ describe("McpAppSection panel hosting", () => {
     expect(screen.queryByText(/runtime error/i)).not.toBeInTheDocument();
   });
 
-  it("resolves the open app to the latest while the panel hosts, even after an inline collapse", async () => {
-    // Repro: collapsing every inline app sets the open app to null (correct for
-    // the chat stream). Opening the panel afterwards must still host an app —
-    // the Apps tab has no "nothing open" state — so a null collapse falls back
-    // to the latest app while the panel is hosting (portalTarget set).
+  it("keeps the panel resolved to a single app even after every inline app is collapsed", async () => {
+    // The Apps tab has no "nothing open" state: the panel must always host one
+    // app. Collapsing every inline app must not blank it — it falls back to the
+    // latest app.
     const user = userEvent.setup();
 
     function Probe() {
-      const { openToolCallId, setOpenToolCallId, setPortalTarget } = useApps();
+      const { panelToolCallId, toggleAppOpen, setPortalTarget } = useApps();
       return (
         <div>
-          <div data-testid="open">{openToolCallId ?? "none"}</div>
-          <button type="button" onClick={() => setOpenToolCallId(null)}>
-            collapse
+          <div data-testid="panel">{panelToolCallId ?? "none"}</div>
+          <button
+            type="button"
+            onClick={() => {
+              toggleAppOpen("tc1");
+              toggleAppOpen("tc2");
+            }}
+          >
+            collapse all
           </button>
           <button
             type="button"
@@ -581,30 +586,29 @@ describe("McpAppSection panel hosting", () => {
       );
     });
 
-    // Untouched → the latest app (tc2) is open.
-    expect(screen.getByTestId("open")).toHaveTextContent("tc2");
+    // Untouched → the latest app (tc2) is the panel's app.
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc2");
 
-    // Collapse all inline apps → nothing open (no panel hosting yet).
+    // Collapsing every inline app must not blank the panel — it stays on tc2.
     await act(async () => {
-      await user.click(screen.getByRole("button", { name: "collapse" }));
+      await user.click(screen.getByRole("button", { name: "collapse all" }));
     });
-    expect(screen.getByTestId("open")).toHaveTextContent("none");
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc2");
 
-    // Opening the panel (portalTarget set) must resolve back to the latest app
-    // rather than leaving the tab blank.
+    // Hosting the panel keeps it on that single app.
     await act(async () => {
       await user.click(screen.getByRole("button", { name: "host panel" }));
     });
-    expect(screen.getByTestId("open")).toHaveTextContent("tc2");
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc2");
   });
 
-  it("collapses a non-open app to a pill while another app is open", async () => {
+  it("expands each app inline by default and toggles just that app with its pill", async () => {
     const user = userEvent.setup();
 
     await act(async () => {
       render(
-        // tc1 is the latest (greatest createdAt), so it's the default open app;
-        // the rendered tc2 section is not open and collapses to a pill.
+        // Every app expands inline by default, so the rendered tc2 section shows
+        // its live app immediately rather than only when it is the latest.
         <AppsProvider
           apps={[
             {
@@ -631,11 +635,17 @@ describe("McpAppSection panel hosting", () => {
       );
     });
 
-    // One app open at a time: tc2 shows only its pill, no live iframe.
-    expect(document.querySelector("iframe")).not.toBeInTheDocument();
+    // Open by default: the live iframe is mounted.
+    expect(document.querySelector("iframe")).toBeInTheDocument();
     const pill = screen.getByRole("button", { name: /get-data/i });
 
-    // Clicking the pill opens tc2 inline.
+    // Clicking the pill collapses just this app.
+    await act(async () => {
+      await user.click(pill);
+    });
+    expect(document.querySelector("iframe")).not.toBeInTheDocument();
+
+    // Clicking again reopens it.
     await act(async () => {
       await user.click(pill);
     });
@@ -654,7 +664,7 @@ describe("McpAppSection older renders (no suppression)", () => {
     >);
   });
 
-  it("hides the diagnostics panel while the app is closed, shows it once opened", async () => {
+  it("shows the diagnostics panel while the app is open and hides it once collapsed", async () => {
     const user = userEvent.setup();
     reportAppDiagnostic(APP_ID, 1, {
       type: "csp-violation",
@@ -663,16 +673,8 @@ describe("McpAppSection older renders (no suppression)", () => {
 
     await act(async () => {
       render(
-        // Another app (tc-other) is newest, so it's the default open one and the
-        // rendered APP_ID section (tc1) starts closed.
         <AppsProvider
           apps={[
-            {
-              toolCallId: "tc-other",
-              label: "Other App",
-              uiResourceUri: "resource://test-server/ui-other",
-              createdAt: 1,
-            },
             {
               toolCallId: "tc1",
               label: "Dashboard",
@@ -693,16 +695,16 @@ describe("McpAppSection older renders (no suppression)", () => {
       );
     });
 
-    // Closed: the error is hidden along with the iframe.
-    expect(document.querySelector("iframe")).not.toBeInTheDocument();
-    expect(screen.queryByText(/runtime error/i)).not.toBeInTheDocument();
+    // Open by default: both the app and its diagnostics are visible.
+    expect(document.querySelector("iframe")).toBeInTheDocument();
+    expect(screen.getByText(/runtime error/i)).toBeInTheDocument();
 
-    // Opening the pill reveals both the app and its diagnostics.
+    // Collapsing the app hides the error along with the iframe.
     await act(async () => {
       await user.click(screen.getByRole("button", { name: "Dashboard" }));
     });
-    expect(document.querySelector("iframe")).toBeInTheDocument();
-    expect(screen.getByText(/runtime error/i)).toBeInTheDocument();
+    expect(document.querySelector("iframe")).not.toBeInTheDocument();
+    expect(screen.queryByText(/runtime error/i)).not.toBeInTheDocument();
   });
 
   it("shows an older owned render as a plain pill (app name only) that opens inline on click", async () => {
@@ -786,6 +788,88 @@ describe("McpAppSection older renders (no suppression)", () => {
 
     expect(document.querySelector("iframe")).toBeInTheDocument();
     expect(screen.queryByText(/· Updated/)).not.toBeInTheDocument();
+  });
+});
+
+describe("McpAppSection multi-open", () => {
+  const APP_ID = "947051c7-ea8e-48ed-8077-a3cc904d9d61";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearAllAppDiagnostics();
+    mockUseApp.mockReturnValue({ data: undefined } as ReturnType<
+      typeof useApp
+    >);
+  });
+
+  it("shows one instance of a repeated owned app and moves it to the clicked render", async () => {
+    const user = userEvent.setup();
+    const apps = [
+      {
+        toolCallId: "tc1",
+        label: "Dashboard",
+        uiResourceUri: defaultProps.uiResourceUri,
+        appId: APP_ID,
+        createdAt: 0,
+      },
+      {
+        toolCallId: "tc2",
+        label: "Dashboard",
+        uiResourceUri: defaultProps.uiResourceUri,
+        appId: APP_ID,
+        createdAt: 1,
+      },
+    ];
+
+    await act(async () => {
+      render(
+        <AppsProvider apps={apps}>
+          <div data-testid="sec-tc1">
+            <McpAppSection
+              {...defaultProps}
+              appId={APP_ID}
+              appName="Dashboard"
+              toolName="archestra__edit_app"
+              toolCallId="tc1"
+              preloadedResource={preloadedResource}
+            />
+          </div>
+          <div data-testid="sec-tc2">
+            <McpAppSection
+              {...defaultProps}
+              appId={APP_ID}
+              appName="Dashboard"
+              toolName="archestra__edit_app"
+              toolCallId="tc2"
+              preloadedResource={preloadedResource}
+            />
+          </div>
+        </AppsProvider>,
+      );
+    });
+
+    // The latest render (tc2) shows the single live instance; the older is a pill.
+    expect(document.querySelectorAll("iframe")).toHaveLength(1);
+    expect(
+      screen.getByTestId("sec-tc2").querySelector("iframe"),
+    ).toBeInTheDocument();
+
+    // Clicking the older render's pill moves the single instance under it and
+    // collapses the newer one — still exactly one open.
+    await act(async () => {
+      await user.click(
+        within(screen.getByTestId("sec-tc1")).getByRole("button", {
+          name: "Dashboard",
+        }),
+      );
+    });
+    expect(document.querySelectorAll("iframe")).toHaveLength(1);
+    expect(
+      screen.getByTestId("sec-tc1").querySelector("iframe"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("sec-tc2").querySelector("iframe"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -602,6 +602,65 @@ describe("McpAppSection panel hosting", () => {
     expect(screen.getByTestId("panel")).toHaveTextContent("tc2");
   });
 
+  it("hosts the picked render in the panel after collapsing every app", async () => {
+    // With no explicit panel pick and every app collapsed, the panel falls back
+    // to the group's active render — honoring an older-render pick — rather than
+    // the raw latest render.
+    const user = userEvent.setup();
+
+    function Probe() {
+      const { panelToolCallId, toggleAppOpen } = useApps();
+      return (
+        <div>
+          <div data-testid="panel">{panelToolCallId ?? "none"}</div>
+          <button type="button" onClick={() => toggleAppOpen("tc1")}>
+            toggle tc1
+          </button>
+        </div>
+      );
+    }
+
+    await act(async () => {
+      render(
+        <AppsProvider
+          apps={[
+            {
+              toolCallId: "tc1",
+              label: "Dashboard",
+              uiResourceUri: defaultProps.uiResourceUri,
+              appId: APP_ID,
+              createdAt: 0,
+            },
+            {
+              toolCallId: "tc2",
+              label: "Dashboard",
+              uiResourceUri: defaultProps.uiResourceUri,
+              appId: APP_ID,
+              createdAt: 1,
+            },
+          ]}
+        >
+          <Probe />
+        </AppsProvider>,
+      );
+    });
+
+    // Untouched → the latest render (tc2) is active and hosted.
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc2");
+
+    // Picking the older render tc1 makes it active and hosted.
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "toggle tc1" }));
+    });
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc1");
+
+    // Collapsing the app (second toggle) keeps the panel on the picked render.
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "toggle tc1" }));
+    });
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc1");
+  });
+
   it("expands each app inline by default and toggles just that app with its pill", async () => {
     const user = userEvent.setup();
 

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -462,6 +462,22 @@ describe("McpAppContainer inline height (via McpAppSection)", () => {
     const bridge = await renderReadyApp(2000, { panel: true });
     expect(lastGuestContainerDimensions(bridge)).toEqual({});
   });
+
+  it("seeds the panel-hosted guest with the tool result (parity with inline)", async () => {
+    // Regression from #6163 (portal removal): the fresh panel iframe must be
+    // seeded with the tool result — otherwise an app that renders from the
+    // pushed result re-calls its source tool live, which 404s for tools that
+    // aren't directly listed on the gateway.
+    const bridge = await renderReadyApp(2000, { panel: true });
+    await act(async () => {
+      bridge.oninitialized();
+    });
+    expect(bridge.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [{ type: "text", text: "some result" }],
+      }),
+    );
+  });
 });
 
 describe("McpAppSection panel hosting", () => {

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -193,8 +193,11 @@ export function McpAppSection({
     resourceState.key === resourceKey ? resourceState.state : "unknown";
 
   const {
-    openToolCallId,
-    setOpenToolCallId,
+    isAppOpen,
+    toggleAppOpen,
+    panelToolCallId,
+    setPanelApp,
+    canonicalToolCallId,
     openRightPanel,
     closePanel,
     portalTarget,
@@ -214,15 +217,20 @@ export function McpAppSection({
 
   const headerName = ownedApp?.name || appName || mcpToolLabel(toolName);
   const isPanelSurface = surface === "panel";
-  // This render is the single open app (`openToolCallId`). An app without a
-  // toolCallId isn't in the registry (can't be selected), so it stands alone and
-  // is always "open". The panel surface only ever renders the open app.
-  const isOpen = isPanelSurface || !toolCallId || openToolCallId === toolCallId;
-  // The open app is hosted in the right-panel sidebar when the Apps tab is open
-  // (`portalTarget` set): a separate `surface="panel"` instance renders it there,
-  // so the inline stream shows just a marker. On the panel surface itself this is
-  // effectively "this is that render".
-  const shownInSidebar = isOpen && !!portalTarget;
+  const standalone = !toolCallId;
+  const canonicalId = toolCallId ? canonicalToolCallId(toolCallId) : undefined;
+  // Expanded inline when the panel isn't hosting and this render is standalone or
+  // the open canonical one. Multiple apps can be expanded at once.
+  const expandedInline =
+    !isPanelSurface &&
+    !portalTarget &&
+    (standalone || (!!toolCallId && isAppOpen(toolCallId)));
+  // This render is the one hosted in the right panel; inline collapses to a marker.
+  const isPanelFocused =
+    !isPanelSurface &&
+    !!portalTarget &&
+    !!canonicalId &&
+    panelToolCallId === canonicalId;
 
   // Reconstruct McpCallToolResult for AppFrame. Owned apps get none — the
   // management tool's result is not app data.
@@ -238,17 +246,10 @@ export function McpAppSection({
     };
   }, [rawOutput, appId]);
 
-  // A pill opens its app inline: set it open and always close the right panel so
-  // the app lands inline rather than in the panel.
-  const openInline = (id: string) => {
-    setOpenToolCallId(id);
-    closePanel();
-  };
-
   const handleShowInPanel = () => {
     if (!toolCallId) return;
     setDisplayMode("inline"); // panel is the app's frame — never fullscreen there
-    setOpenToolCallId(toolCallId);
+    setPanelApp(toolCallId);
     openRightPanel();
   };
 
@@ -409,12 +410,9 @@ export function McpAppSection({
   // inside the height-constrained panel (item 3).
   const diagnostics = appId ? <AppDiagnosticsPanel appId={appId} /> : null;
 
-  // The app marker is always a top-level flex item, so it sits on the same row
-  // as the host tool-call circle. Pressed = this app is the open one and shown
-  // inline; it reads unpressed while the app lives in the right panel or while
-  // another app is open. A red dot flags a runtime error. Clicking toggles: open
-  // this app, or collapse it when it's already open inline (pressed).
-  const pressed = isOpen && !shownInSidebar;
+  // The marker sits on the host tool-call circle's row. Pressed = expanded inline;
+  // a red dot flags a runtime error. Clicking toggles this app's inline render.
+  const pressed = expandedInline;
   const marker = (
     <McpAppMarkerCircle
       label={headerName}
@@ -422,31 +420,24 @@ export function McpAppSection({
       hasError={hasRuntimeError}
       onClick={() => {
         if (!toolCallId) return;
-        // With the panel open, pills are the app selector: clicking another
-        // app's pill retargets the panel to it, and clicking the app already in
-        // the panel closes it. With no panel open, toggle the inline render.
+        // With the panel open, pills select the hosted app; otherwise they toggle
+        // this app's inline render, leaving other open apps alone.
         if (portalTarget) {
-          if (shownInSidebar) closePanel();
-          else setOpenToolCallId(toolCallId);
-        } else if (pressed) {
-          setOpenToolCallId(null);
+          if (isPanelFocused) closePanel();
+          else setPanelApp(toolCallId);
         } else {
-          openInline(toolCallId);
+          toggleAppOpen(toolCallId);
         }
       }}
     />
   );
 
-  // Everything under the circle+marker row stacks in one full-width column:
-  // tool-call details (above the app), then the inline app card + its
-  // "Open in right panel" button, then the diagnostics summary. The inline app
-  // and its diagnostics render only for the open app while it isn't hosted in
-  // the sidebar; other (closed) apps show just their pill — the error stays
-  // hidden with the iframe (one app open at a time; the pill's red dot remains).
+  // Under the marker row: tool-call details, then (only while expanded inline) the
+  // app card, its "Open in right panel" button, and the diagnostics summary.
   const belowColumn = (
     <div className="flex w-full flex-col items-start gap-2">
       {toolDetails ? <div className="w-full">{toolDetails}</div> : null}
-      {isOpen && !shownInSidebar ? (
+      {expandedInline ? (
         <div className="flex w-full flex-col items-start gap-2">
           {liveSurface}
           {toolCallId && displayMode !== "fullscreen" ? (

--- a/platform/frontend/src/components/chat/right-side-panel.tsx
+++ b/platform/frontend/src/components/chat/right-side-panel.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import {
   AppWindow,
@@ -6,19 +6,19 @@ import {
   FileText,
   Globe,
   PanelRightClose,
-} from 'lucide-react';
-import { useEffect, useLayoutEffect, useRef } from 'react';
-import { useApps } from '@/components/chat/apps-context';
-import { BrowserPanel } from '@/components/chat/browser-panel';
-import { ConversationFilesPanel } from '@/components/chat/conversation-files-panel';
-import { McpAppSection } from '@/components/chat/mcp-app-container';
-import { ResizableRightPanel } from '@/components/chat/resizable-right-panel';
-import { ScheduleRunsList } from '@/components/scheduled-tasks/schedule-runs-list';
-import { Button } from '@/components/ui/button';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useScheduleTrigger } from '@/lib/schedule-trigger.query';
+} from "lucide-react";
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { useApps } from "@/components/chat/apps-context";
+import { BrowserPanel } from "@/components/chat/browser-panel";
+import { ConversationFilesPanel } from "@/components/chat/conversation-files-panel";
+import { McpAppSection } from "@/components/chat/mcp-app-container";
+import { ResizableRightPanel } from "@/components/chat/resizable-right-panel";
+import { ScheduleRunsList } from "@/components/scheduled-tasks/schedule-runs-list";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useScheduleTrigger } from "@/lib/schedule-trigger.query";
 
-export type RightPanelTab = 'runs' | 'files' | 'browser' | 'apps';
+export type RightPanelTab = "runs" | "files" | "browser" | "apps";
 
 interface RightSidePanelProps {
   isOpen: boolean;
@@ -73,15 +73,15 @@ export function RightSidePanel({
   const portalDivRef = useRef<HTMLDivElement | null>(null);
 
   let resolvedTab: RightPanelTab = activeTab;
-  if (resolvedTab === 'browser' && !canShowBrowser) resolvedTab = 'files';
+  if (resolvedTab === "browser" && !canShowBrowser) resolvedTab = "files";
   // The Runs tab only exists for scheduled-run chats; fall back otherwise.
-  if (resolvedTab === 'runs' && !scheduledRun) resolvedTab = 'files';
+  if (resolvedTab === "runs" && !scheduledRun) resolvedTab = "files";
 
   // Activate the portal target only while the Apps tab is showing — when the
   // user switches to artifact/browser or closes the panel, the app falls back
   // to inline rendering in the chat.
   useEffect(() => {
-    const shouldHostApp = isOpen && resolvedTab === 'apps';
+    const shouldHostApp = isOpen && resolvedTab === "apps";
     setPortalTarget(shouldHostApp ? portalDivRef.current : null);
     return () => {
       setPortalTarget(null);
@@ -147,23 +147,23 @@ export function RightSidePanel({
         </div>
 
         <div className="flex-1 min-h-0 overflow-hidden relative">
-          {resolvedTab === 'runs' && scheduledRun && (
+          {resolvedTab === "runs" && scheduledRun && (
             <RunsPanel
               triggerId={scheduledRun.triggerId}
               currentRunId={scheduledRun.runId}
               projectId={projectId ?? null}
             />
           )}
-          {resolvedTab === 'files' && (
+          {resolvedTab === "files" && (
             <ConversationFilesPanel
-              key={conversationId ?? 'none'}
+              key={conversationId ?? "none"}
               conversationId={conversationId}
               artifact={artifact}
               projectId={projectId}
               onClose={onClose}
             />
           )}
-          {resolvedTab === 'browser' && canShowBrowser && (
+          {resolvedTab === "browser" && canShowBrowser && (
             <BrowserPanel
               isOpen
               onClose={onClose}
@@ -178,7 +178,7 @@ export function RightSidePanel({
           )}
           {/* Apps tab content: renders the open app directly (no portal). The
               app-switcher lives in the hosted card's header (see McpAppCard). */}
-          {resolvedTab === 'apps' && (
+          {resolvedTab === "apps" && (
             <div className="flex flex-col h-full">
               <div ref={portalDivRef} className="flex-1 min-h-0 relative">
                 {apps.length === 0 ? (
@@ -203,15 +203,13 @@ export function RightSidePanel({
 }
 
 /**
- * Renders the single open app (`openToolCallId`) directly in the panel — no
- * portal. Mounts a `surface="panel"` app section from the shared apps list;
- * switching the open app remounts via the key. The app-endpoint is rebuilt from
- * the list entry, so owned apps need no extra data and external apps use the
- * conversation's agent (or their pinned install).
+ * Renders the single hosted app (`panelToolCallId`) directly in the panel.
+ * Switching the hosted app remounts via the key; the app-endpoint is rebuilt from
+ * the list entry (owned apps need no extra data, external apps use the agent).
  */
 function PanelAppHost({ agentId }: { agentId?: string }) {
-  const { apps, openToolCallId } = useApps();
-  const app = apps.find((a) => a.toolCallId === openToolCallId);
+  const { apps, panelToolCallId } = useApps();
+  const app = apps.find((a) => a.toolCallId === panelToolCallId);
   if (!app) {
     return null;
   }
@@ -227,12 +225,12 @@ function PanelAppHost({ agentId }: { agentId?: string }) {
       key={app.toolCallId}
       surface="panel"
       uiResourceUri={app.uiResourceUri}
-      agentId={agentId ?? ''}
+      agentId={agentId ?? ""}
       appId={app.appId ?? undefined}
       mcpServerId={app.mcpServerId}
       appName={app.label}
       appVersion={app.version}
-      toolName={app.toolName ?? ''}
+      toolName={app.toolName ?? ""}
       toolCallId={app.toolCallId}
       rawOutput={app.rawOutput ?? undefined}
       toolInput={app.toolInput ?? undefined}
@@ -297,7 +295,7 @@ function RunsPanel({
       className="flex h-full flex-col overflow-y-auto p-3"
     >
       <div className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Runs · {trigger?.name ?? 'Schedule'}
+        Runs · {trigger?.name ?? "Schedule"}
       </div>
       <ScheduleRunsList triggerId={triggerId} currentRunId={currentRunId} />
     </div>

--- a/platform/frontend/src/components/chat/right-side-panel.tsx
+++ b/platform/frontend/src/components/chat/right-side-panel.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import {
   AppWindow,
@@ -6,19 +6,19 @@ import {
   FileText,
   Globe,
   PanelRightClose,
-} from "lucide-react";
-import { useEffect, useLayoutEffect, useRef } from "react";
-import { useApps } from "@/components/chat/apps-context";
-import { BrowserPanel } from "@/components/chat/browser-panel";
-import { ConversationFilesPanel } from "@/components/chat/conversation-files-panel";
-import { McpAppSection } from "@/components/chat/mcp-app-container";
-import { ResizableRightPanel } from "@/components/chat/resizable-right-panel";
-import { ScheduleRunsList } from "@/components/scheduled-tasks/schedule-runs-list";
-import { Button } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useScheduleTrigger } from "@/lib/schedule-trigger.query";
+} from 'lucide-react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useApps } from '@/components/chat/apps-context';
+import { BrowserPanel } from '@/components/chat/browser-panel';
+import { ConversationFilesPanel } from '@/components/chat/conversation-files-panel';
+import { McpAppSection } from '@/components/chat/mcp-app-container';
+import { ResizableRightPanel } from '@/components/chat/resizable-right-panel';
+import { ScheduleRunsList } from '@/components/scheduled-tasks/schedule-runs-list';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useScheduleTrigger } from '@/lib/schedule-trigger.query';
 
-export type RightPanelTab = "runs" | "files" | "browser" | "apps";
+export type RightPanelTab = 'runs' | 'files' | 'browser' | 'apps';
 
 interface RightSidePanelProps {
   isOpen: boolean;
@@ -73,15 +73,15 @@ export function RightSidePanel({
   const portalDivRef = useRef<HTMLDivElement | null>(null);
 
   let resolvedTab: RightPanelTab = activeTab;
-  if (resolvedTab === "browser" && !canShowBrowser) resolvedTab = "files";
+  if (resolvedTab === 'browser' && !canShowBrowser) resolvedTab = 'files';
   // The Runs tab only exists for scheduled-run chats; fall back otherwise.
-  if (resolvedTab === "runs" && !scheduledRun) resolvedTab = "files";
+  if (resolvedTab === 'runs' && !scheduledRun) resolvedTab = 'files';
 
   // Activate the portal target only while the Apps tab is showing — when the
   // user switches to artifact/browser or closes the panel, the app falls back
   // to inline rendering in the chat.
   useEffect(() => {
-    const shouldHostApp = isOpen && resolvedTab === "apps";
+    const shouldHostApp = isOpen && resolvedTab === 'apps';
     setPortalTarget(shouldHostApp ? portalDivRef.current : null);
     return () => {
       setPortalTarget(null);
@@ -147,23 +147,23 @@ export function RightSidePanel({
         </div>
 
         <div className="flex-1 min-h-0 overflow-hidden relative">
-          {resolvedTab === "runs" && scheduledRun && (
+          {resolvedTab === 'runs' && scheduledRun && (
             <RunsPanel
               triggerId={scheduledRun.triggerId}
               currentRunId={scheduledRun.runId}
               projectId={projectId ?? null}
             />
           )}
-          {resolvedTab === "files" && (
+          {resolvedTab === 'files' && (
             <ConversationFilesPanel
-              key={conversationId ?? "none"}
+              key={conversationId ?? 'none'}
               conversationId={conversationId}
               artifact={artifact}
               projectId={projectId}
               onClose={onClose}
             />
           )}
-          {resolvedTab === "browser" && canShowBrowser && (
+          {resolvedTab === 'browser' && canShowBrowser && (
             <BrowserPanel
               isOpen
               onClose={onClose}
@@ -178,7 +178,7 @@ export function RightSidePanel({
           )}
           {/* Apps tab content: renders the open app directly (no portal). The
               app-switcher lives in the hosted card's header (see McpAppCard). */}
-          {resolvedTab === "apps" && (
+          {resolvedTab === 'apps' && (
             <div className="flex flex-col h-full">
               <div ref={portalDivRef} className="flex-1 min-h-0 relative">
                 {apps.length === 0 ? (
@@ -215,18 +215,27 @@ function PanelAppHost({ agentId }: { agentId?: string }) {
   if (!app) {
     return null;
   }
+
+  // An external app drives the agent gateway; mounting a fresh iframe against an
+  // empty agent (`/api/mcp/`) would 404, so bail like the inline render's guard.
+  if (!app.appId && !app.mcpServerId && !agentId) {
+    return null;
+  }
+
   return (
     <McpAppSection
       key={app.toolCallId}
       surface="panel"
       uiResourceUri={app.uiResourceUri}
-      agentId={agentId ?? ""}
+      agentId={agentId ?? ''}
       appId={app.appId ?? undefined}
       mcpServerId={app.mcpServerId}
       appName={app.label}
       appVersion={app.version}
-      toolName={app.toolName ?? ""}
+      toolName={app.toolName ?? ''}
       toolCallId={app.toolCallId}
+      rawOutput={app.rawOutput ?? undefined}
+      toolInput={app.toolInput ?? undefined}
     />
   );
 }
@@ -288,7 +297,7 @@ function RunsPanel({
       className="flex h-full flex-col overflow-y-auto p-3"
     >
       <div className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Runs · {trigger?.name ?? "Schedule"}
+        Runs · {trigger?.name ?? 'Schedule'}
       </div>
       <ScheduleRunsList triggerId={triggerId} currentRunId={currentRunId} />
     </div>


### PR DESCRIPTION
## Summary
- External MCP Apps in chat now expand independently: opening one no longer collapses the others. All apps are expanded by default
- A newly opened app auto-expands even after you've manually opened/closed earlier ones (fixes the reported bug where a second app stayed collapsed).
- A repeated owned app still shows only one instance at a time; clicking an older duplicate's pill moves that single
instance to where you clicked and collapses the newer one.
- The right panel still hosts exactly one app; its pills act as the selector, and it never renders blank.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>