### PR TITLE
feat(bench-dashboard): avg columns, reduce-report rendering, UI refresh

### DIFF
--- a/archestra-bench/dashboard/src/load.rs
+++ b/archestra-bench/dashboard/src/load.rs
@@ -142,6 +142,35 @@ impl RubricKey {
     }
 }
 
+/// Which pipeline produced a rendered reduce-phase report. The Rust analyzer writes
+/// `trajectory_analysis_<ts>.md`; the Claude skill writes `trajectory_analysis_claude_<ts>.md`.
+/// Discriminant order (analyzer, then Claude) is relied on for both slot indexing and render order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReduceSource {
+    Analyzer,
+    Claude,
+}
+
+impl ReduceSource {
+    pub const ALL: [ReduceSource; 2] = [ReduceSource::Analyzer, ReduceSource::Claude];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ReduceSource::Analyzer => "Analyzer report",
+            ReduceSource::Claude => "Claude report",
+        }
+    }
+}
+
+/// A discovered reduce-phase markdown report. Its content quotes untrusted agent/tool output, so the
+/// view renders it through the same neutralizing markdown path as trajectories.
+#[derive(Debug, Clone)]
+pub struct ReduceReport {
+    pub source: ReduceSource,
+    pub filename: String,
+    pub markdown: String,
+}
+
 /// Mean of a triage record's four grades.
 pub fn mean_grade(rubrics: &Rubrics) -> f64 {
     let sum: u32 = RubricKey::ALL
@@ -174,6 +203,9 @@ pub struct Run {
     /// Rubric records keyed by their `rollout` field (same key space as `rollouts`).
     pub rubrics: BTreeMap<String, TriageRecord>,
     pub rubric_status: RubricStatus,
+    /// Latest rendered reduce-phase report per source (analyzer, Claude), in that order. Empty when
+    /// no reduce report has been written for the run yet.
+    pub reports: Vec<ReduceReport>,
     /// Non-fatal problems (malformed rollout dirs, malformed rubric files) surfaced in the UI.
     pub warnings: Vec<String>,
 }
@@ -238,10 +270,20 @@ impl Run {
 
     /// Per-lane average of one rubric over the records present. `None` when a lane has no records.
     pub fn lane_rubric_avg(&self, lane: &str, key: RubricKey) -> Option<f64> {
+        self.rubric_avg_where(key, |r| r.id.lane == lane)
+    }
+
+    /// Overall average of one rubric across every rollout that has a record — the aggregate the
+    /// by-lane table's "avg" column shows. `None` when the run has no rubric records at all.
+    pub fn rubric_avg(&self, key: RubricKey) -> Option<f64> {
+        self.rubric_avg_where(key, |_| true)
+    }
+
+    fn rubric_avg_where(&self, key: RubricKey, pred: impl Fn(&Rollout) -> bool) -> Option<f64> {
         let grades: Vec<f64> = self
             .rollouts
             .values()
-            .filter(|r| r.id.lane == lane)
+            .filter(|r| pred(r))
             .filter_map(|r| self.rubrics.get(&r.id.to_string()))
             .map(|rec| f64::from(rec.rubrics.grade_of(key)))
             .collect();
@@ -273,6 +315,8 @@ pub struct RunListEntry {
     pub counts: OutcomeCounts,
     pub pass_rate: Option<f64>,
     pub rubric_status: RubricStatus,
+    /// Which reduce-phase reports exist for the run, in [`ReduceSource::ALL`] order.
+    pub report_sources: Vec<ReduceSource>,
 }
 
 /// True when the directory looks like a run root (the harness always writes `config.json` first
@@ -305,6 +349,7 @@ pub fn list_runs(experiments_dir: &Path) -> Result<Vec<RunListEntry>> {
             counts: run.counts(),
             pass_rate: run.pass_rate(),
             rubric_status: run.rubric_status,
+            report_sources: run.reports.iter().map(|r| r.source).collect(),
         });
     }
     runs.sort_by(|a, b| b.mtime.cmp(&a.mtime).then_with(|| b.id.cmp(&a.id)));
@@ -343,6 +388,7 @@ fn load_run_dir(dir: &Path, id: &str) -> Result<Run> {
     let aggregate = read_json_lenient::<Aggregate>(&dir.join(AGGREGATE_JSON), &mut warnings);
     let rollouts = discover_rollouts(dir, &mut warnings)?;
     let (rubrics, rubric_file_found) = load_rubrics(dir, &mut warnings)?;
+    let reports = load_reports(dir, &mut warnings)?;
 
     let matched = rollouts.keys().filter(|k| rubrics.contains_key(*k)).count();
     for key in rubrics.keys().filter(|k| !rollouts.contains_key(*k)) {
@@ -368,8 +414,55 @@ fn load_run_dir(dir: &Path, id: &str) -> Result<Run> {
         rollouts,
         rubrics,
         rubric_status,
+        reports,
         warnings,
     })
+}
+
+/// Discover the latest reduce-phase report of each source. "Latest" by the `<ts>` embedded in the
+/// file name (lexical, same convention as [`load_rubrics`], never mtime). Reports are returned in
+/// [`ReduceSource::ALL`] order. An unreadable report is skipped with a warning, not a hard failure.
+fn load_reports(run_dir: &Path, warnings: &mut Vec<String>) -> Result<Vec<ReduceReport>> {
+    let pattern = run_dir.join("trajectory_analysis_*.md");
+    let pattern = pattern.to_string_lossy();
+    // One slot per source, indexed by discriminant; each holds the newest `(ts, path)` seen.
+    let mut latest: [Option<(String, PathBuf)>; ReduceSource::ALL.len()] = [None, None];
+    for entry in glob::glob(&pattern).wrap_err("invalid report glob pattern")? {
+        let path = entry.wrap_err("reading report glob entry")?;
+        let stem = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let source = match stem.contains("_claude_") {
+            true => ReduceSource::Claude,
+            false => ReduceSource::Analyzer,
+        };
+        let ts = stem.rsplit('_').next().unwrap_or_default().to_string();
+        let slot = &mut latest[source as usize];
+        let newer = match slot {
+            Some((best, _)) => ts > *best,
+            None => true,
+        };
+        if newer {
+            *slot = Some((ts, path));
+        }
+    }
+    let mut reports = Vec::new();
+    for (source, slot) in ReduceSource::ALL.into_iter().zip(latest) {
+        let Some((_, path)) = slot else { continue };
+        match std::fs::read_to_string(&path) {
+            Ok(markdown) => reports.push(ReduceReport {
+                source,
+                filename: path
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+                markdown,
+            }),
+            Err(err) => warnings.push(format!("unreadable report file {}: {err}", path.display())),
+        }
+    }
+    Ok(reports)
 }
 
 /// Parse an optional JSON artifact; a malformed file degrades to `None` plus a warning instead of

--- a/archestra-bench/dashboard/src/views.rs
+++ b/archestra-bench/dashboard/src/views.rs
@@ -12,7 +12,9 @@ use serde::Deserialize;
 
 use archestra_bench_core::{Outcome, RolloutId, TriageRecord};
 
-use crate::load::{Rollout, RubricKey, RubricStatus, Run, RunListEntry, mean_grade};
+use crate::load::{
+    ReduceSource, Rollout, RubricKey, RubricStatus, Run, RunListEntry, mean_grade,
+};
 
 /// Everything outside `[A-Za-z0-9._-]` is percent-encoded, including `/` — rollout ids travel as a
 /// single opaque path segment.
@@ -84,6 +86,25 @@ impl RubricBadge {
 // GET /
 // ---------------------------------------------------------------------------
 
+/// A short abbreviation chip for a reduce report present on a run (A = analyzer, C = Claude).
+pub struct ReportChip {
+    pub abbr: &'static str,
+    pub title: String,
+}
+
+impl ReportChip {
+    fn of(source: ReduceSource) -> Self {
+        let abbr = match source {
+            ReduceSource::Analyzer => "A",
+            ReduceSource::Claude => "C",
+        };
+        ReportChip {
+            abbr,
+            title: source.label().to_string(),
+        }
+    }
+}
+
 pub struct RunRow {
     pub id: String,
     pub href: String,
@@ -92,7 +113,10 @@ pub struct RunRow {
     pub lanes: String,
     pub outcomes: String,
     pub pass_rate: String,
+    /// Integer percent (`"0".."100"`) for the pass-rate bar width; empty when the rate is unknown.
+    pub pass_pct: String,
     pub rubric_badge: RubricBadge,
+    pub reports: Vec<ReportChip>,
 }
 
 #[derive(Template)]
@@ -123,7 +147,12 @@ pub fn build_index(experiments_dir: &Path, entries: Vec<RunListEntry>) -> IndexT
                 lanes: e.lanes.join(", "),
                 outcomes,
                 pass_rate: fmt_rate(e.pass_rate),
+                pass_pct: e
+                    .pass_rate
+                    .map(|r| format!("{:.0}", r * 100.0))
+                    .unwrap_or_default(),
                 rubric_badge: RubricBadge::from_status(e.rubric_status),
+                reports: e.report_sources.iter().copied().map(ReportChip::of).collect(),
                 id: e.id,
             }
         })
@@ -185,6 +214,9 @@ pub struct GridCell {
 pub struct GridRow {
     pub label: String,
     pub cells: Vec<Option<GridCell>>,
+    /// Mean of this task's graded cells across the shown lanes; empty when none carry a grade.
+    pub avg_text: String,
+    pub avg_class: String,
 }
 
 pub struct GridView {
@@ -220,6 +252,7 @@ pub fn build_grid(run: &Run, filters: &GridFilters) -> GridView {
     let mut rows = Vec::new();
     for (env, task) in row_keys {
         let mut cells = Vec::with_capacity(lanes.len());
+        let mut grades: Vec<f64> = Vec::new();
         for lane in &lanes {
             let key = RolloutId {
                 env: env.clone(),
@@ -227,20 +260,31 @@ pub fn build_grid(run: &Run, filters: &GridFilters) -> GridView {
                 lane: lane.clone(),
             }
             .to_string();
-            let cell = run
+            let rollout = run
                 .rollouts
                 .get(&key)
-                .filter(|r| cell_matches(r, run.rubrics.get(&key), filters))
-                .map(|r| make_cell(run, r));
-            if cell.is_some() {
+                .filter(|r| cell_matches(r, run.rubrics.get(&key), filters));
+            if rollout.is_some() {
                 shown += 1;
+                if let Some(rec) = run.rubrics.get(&key) {
+                    grades.push(mean_grade(&rec.rubrics));
+                }
             }
-            cells.push(cell);
+            cells.push(rollout.map(|r| make_cell(run, r)));
         }
         if cells.iter().any(Option::is_some) {
+            let (avg_text, avg_class) = match grades.len() {
+                0 => (String::new(), String::new()),
+                n => {
+                    let avg = grades.iter().sum::<f64>() / n as f64;
+                    (format!("{avg:.1}"), grade_class(avg))
+                }
+            };
             rows.push(GridRow {
                 label: format!("{env}/{task}"),
                 cells,
+                avg_text,
+                avg_class,
             });
         }
     }
@@ -310,15 +354,30 @@ pub struct SummaryRow {
     pub value: String,
 }
 
+/// One outcome tally rendered as a colored pill on the run page.
+pub struct OutcomePill {
+    pub label: &'static str,
+    pub count: u64,
+    pub class: String,
+}
+
 pub struct RubricAvgRow {
     pub label: String,
     pub values: Vec<String>,
+    /// Average of this rubric across all lanes (over every rollout with a record).
+    pub avg: String,
 }
 
 pub struct HackRow {
     pub id: String,
     pub href: String,
     pub evidence: String,
+}
+
+pub struct ReportView {
+    pub label: String,
+    pub filename: String,
+    pub html: String,
 }
 
 #[derive(Template)]
@@ -328,10 +387,12 @@ pub struct RunTemplate {
     pub date: String,
     pub warnings: Vec<String>,
     pub summary: Vec<SummaryRow>,
+    pub outcome_pills: Vec<OutcomePill>,
     pub rubric_badge: RubricBadge,
     pub lanes: Vec<String>,
     pub has_rubrics: bool,
     pub rubric_rows: Vec<RubricAvgRow>,
+    pub reports: Vec<ReportView>,
     pub hacking: Vec<HackRow>,
     pub outcome_options: Vec<&'static str>,
     pub grid_url: String,
@@ -349,18 +410,22 @@ pub fn build_run(run: &Run, grid_html: String) -> RunTemplate {
             label: "pass rate".to_string(),
             value: fmt_rate(run.pass_rate()),
         },
-        SummaryRow {
-            label: "outcomes".to_string(),
-            value: format!(
-                "passed {} · failed {} · format_failed {} · no_submission {} · agent_error {}",
-                counts.passed,
-                counts.failed,
-                counts.format_failed,
-                counts.no_submission,
-                counts.agent_error
-            ),
-        },
     ];
+    let outcome_pills = [
+        ("passed", counts.passed),
+        ("failed", counts.failed),
+        ("format_failed", counts.format_failed),
+        ("no_submission", counts.no_submission),
+        ("agent_error", counts.agent_error),
+    ]
+    .into_iter()
+    .filter(|(_, count)| *count > 0)
+    .map(|(label, count)| OutcomePill {
+        label,
+        count,
+        class: format!("outcome-{label}"),
+    })
+    .collect();
     if let Some(agg) = &run.aggregate {
         if let Some(turns) = agg.avg_turns {
             summary.push(SummaryRow {
@@ -384,17 +449,29 @@ pub fn build_run(run: &Run, grid_html: String) -> RunTemplate {
 
     let lanes = run.lane_names();
     let has_rubrics = !matches!(run.rubric_status, RubricStatus::None);
+    let fmt_avg = |v: Option<f64>| match v {
+        Some(avg) => format!("{avg:.1}"),
+        None => "—".to_string(),
+    };
     let rubric_rows = RubricKey::ALL
         .iter()
         .map(|key| RubricAvgRow {
             label: key.label().to_string(),
             values: lanes
                 .iter()
-                .map(|lane| match run.lane_rubric_avg(lane, *key) {
-                    Some(avg) => format!("{avg:.1}"),
-                    None => "—".to_string(),
-                })
+                .map(|lane| fmt_avg(run.lane_rubric_avg(lane, *key)))
                 .collect(),
+            avg: fmt_avg(run.rubric_avg(*key)),
+        })
+        .collect();
+
+    let reports = run
+        .reports
+        .iter()
+        .map(|r| ReportView {
+            label: r.source.label().to_string(),
+            filename: r.filename.clone(),
+            html: render_markdown(&r.markdown),
         })
         .collect();
 
@@ -405,10 +482,12 @@ pub fn build_run(run: &Run, grid_html: String) -> RunTemplate {
         date: fmt_time(run.mtime),
         warnings: run.warnings.clone(),
         summary,
+        outcome_pills,
         rubric_badge: RubricBadge::from_status(run.rubric_status),
         lanes,
         has_rubrics,
         rubric_rows,
+        reports,
         hacking,
         outcome_options: ALL_OUTCOMES.iter().map(|o| o.value()).collect(),
         grid_url: format!("/runs/{}/grid", encode_segment(&run.id)),

--- a/archestra-bench/dashboard/static/styles.css
+++ b/archestra-bench/dashboard/static/styles.css
@@ -1,4 +1,4 @@
-/* dashboard overrides on top of classless PicoCSS */
+/* dashboard styling on top of classless PicoCSS */
 
 :root {
     --grade-1: #dc2626;
@@ -6,12 +6,50 @@
     --grade-3: #f59e0b;
     --grade-4: #84cc16;
     --grade-5: #10b981;
+    --accent: #6366f1;
+    --pico-spacing: 1rem;
+    --radius: 0.6rem;
 }
 
-.muted {
-    color: var(--pico-muted-color);
-    font-size: 0.9rem;
+body { background: var(--pico-background-color); }
+
+body > main {
+    max-width: 74rem;
+    padding-top: 1.5rem;
 }
+
+/* ---- top bar ---- */
+.topbar {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding: 0.7rem clamp(1rem, 4vw, 2rem);
+    border-bottom: 1px solid var(--pico-muted-border-color);
+    background: var(--pico-card-background-color);
+    position: sticky;
+    top: 0;
+    z-index: 20;
+}
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--pico-color);
+}
+.brand-mark { color: var(--accent); font-size: 1.1rem; }
+.brand-sub { color: var(--pico-muted-color); font-size: 0.85rem; }
+
+h1 { margin-bottom: 0.25rem; }
+h2 { margin-bottom: 0.7rem; font-size: 1.25rem; }
+section { margin-bottom: 2.25rem; }
+.crumb { margin-bottom: 0.5rem; font-size: 0.9rem; }
+.crumb a { text-decoration: none; }
+.path { font-family: var(--pico-font-family-monospace); word-break: break-all; }
+
+.muted { color: var(--pico-muted-color); font-size: 0.9rem; font-weight: 400; }
+.nowrap { white-space: nowrap; }
 
 .warning {
     color: #b45309;
@@ -21,12 +59,62 @@
     border-radius: 0.25rem;
 }
 
-/* badges (run list + run header) */
+/* ---- cards ---- */
+.card {
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--radius);
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+}
+.card.danger { border-color: color-mix(in srgb, var(--grade-1) 45%, transparent); padding: 0.5rem 1.2rem; }
+.card.danger h2 { color: var(--grade-1); }
+.empty { padding: 1.2rem; color: var(--pico-muted-color); }
+
+/* table cards: table sits flush inside the rounded card, no double border */
+.table-card { overflow: hidden; }
+.table-card table { margin: 0; }
+.table-card table :is(th, td):first-child { padding-left: 1rem; }
+.table-card table :is(th, td):last-child { padding-right: 1rem; }
+
+/* ---- stat tiles ---- */
+.stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+    gap: 0.75rem;
+}
+.stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.75rem 0.9rem;
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--radius);
+}
+.stat-label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--pico-muted-color); }
+.stat-value { font-size: 1.35rem; font-weight: 700; line-height: 1.1; }
+
+/* ---- outcome pills ---- */
+.pills { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.9rem; }
+.pill {
+    font-size: 0.8rem;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    border: 1px solid var(--pico-muted-border-color);
+}
+.pill b { font-weight: 700; }
+.pill.outcome-passed { color: var(--grade-5); border-color: color-mix(in srgb, var(--grade-5) 45%, transparent); background: color-mix(in srgb, var(--grade-5) 12%, transparent); }
+.pill.outcome-failed { color: var(--grade-1); border-color: color-mix(in srgb, var(--grade-1) 45%, transparent); background: color-mix(in srgb, var(--grade-1) 12%, transparent); }
+.pill.outcome-format_failed,
+.pill.outcome-no_submission,
+.pill.outcome-agent_error { color: var(--grade-3); border-color: color-mix(in srgb, var(--grade-3) 45%, transparent); background: color-mix(in srgb, var(--grade-3) 12%, transparent); }
+
+/* ---- badges ---- */
 .badge {
     display: inline-block;
     font-size: 0.75rem;
     font-weight: 600;
-    padding: 0.1rem 0.5rem;
+    padding: 0.1rem 0.55rem;
     border-radius: 999px;
     vertical-align: middle;
     white-space: nowrap;
@@ -35,10 +123,11 @@
 .badge-partial { background: var(--grade-3); color: #111; }
 .badge-none { background: var(--pico-muted-border-color); color: var(--pico-color); }
 
-/* grade chips: fixed hex backgrounds, so text color is chosen per background luminance
-   and stays readable in both PicoCSS light and dark modes */
+/* ---- grade chips: fixed hex backgrounds, text color chosen per luminance ---- */
 .chip {
     display: inline-block;
+    min-width: 1.6rem;
+    text-align: center;
     font-size: 0.75rem;
     font-weight: 700;
     padding: 0.05rem 0.4rem;
@@ -52,7 +141,22 @@
 .grade-5 { background: var(--grade-5); color: #fff; }
 .chip-hack { background: var(--grade-1); color: #fff; }
 
-/* outcome badges/cells */
+/* ---- report chips (run list A/C) ---- */
+.report-chip {
+    display: inline-block;
+    min-width: 1.4rem;
+    text-align: center;
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 0.05rem 0.3rem;
+    margin-right: 0.2rem;
+    border-radius: 0.25rem;
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+/* ---- outcome text colors (grid + header badges) ---- */
 .outcome-passed { color: var(--grade-5); }
 .outcome-failed { color: var(--grade-1); }
 .outcome-format_failed,
@@ -66,31 +170,65 @@
 .badge.outcome-agent_error,
 .badge.outcome-unknown { background: var(--grade-3); color: #111; }
 
-/* filters */
-.filters {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    align-items: end;
+/* ---- run list ---- */
+table.runs { font-size: 0.9rem; }
+.run-link { font-weight: 600; text-decoration: none; }
+.rate { display: flex; align-items: center; gap: 0.5rem; }
+.rate-bar { flex: 1; min-width: 3.5rem; height: 0.4rem; border-radius: 999px; background: var(--pico-muted-border-color); overflow: hidden; }
+.rate-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--grade-4), var(--grade-5)); }
+.rate-val { font-variant-numeric: tabular-nums; font-size: 0.85rem; white-space: nowrap; }
+
+/* ---- tables (generic) ---- */
+table { font-size: 0.9rem; }
+tbody tr:hover { background: var(--pico-table-row-stripped-background-color); }
+th.avg-col, td.avg-col {
+    border-left: 2px solid var(--pico-muted-border-color);
+    font-weight: 600;
+    text-align: center;
 }
+
+/* ---- filters ---- */
+.filters { display: flex; flex-wrap: wrap; gap: 1rem; align-items: end; margin-bottom: 1rem; }
 .filters label { margin: 0; font-size: 0.85rem; }
 .filters select { margin: 0; width: auto; }
 .filters .check { display: flex; align-items: center; gap: 0.4rem; padding-bottom: 0.4rem; }
 
-/* rollout grid */
-.grid-scroll { overflow-x: auto; }
-table.grid { font-size: 0.85rem; }
+/* ---- rollout grid ---- */
+.grid-scroll { overflow-x: auto; border: 1px solid var(--pico-muted-border-color); border-radius: var(--radius); }
+table.grid { font-size: 0.85rem; margin: 0; }
+table.grid thead th { position: sticky; top: 0; background: var(--pico-card-background-color); z-index: 2; }
+table.grid tbody th {
+    position: sticky;
+    left: 0;
+    background: var(--pico-card-background-color);
+    white-space: nowrap;
+    z-index: 1;
+}
 table.grid td.cell { white-space: nowrap; }
-table.grid td.cell a { text-decoration: none; }
-table.grid td.cell-empty { color: var(--pico-muted-color); }
+table.grid td.cell a { text-decoration: none; display: inline-flex; align-items: center; gap: 0.35rem; }
+table.grid td.cell a:hover .outcome { text-decoration: underline; }
+table.grid td.cell-empty, table.grid .cell-empty { color: var(--pico-muted-color); }
 
-/* key/value tables */
+/* ---- key/value tables ---- */
 table.kv th { width: 14rem; font-weight: 600; }
 
-/* rendered trajectory */
-.trajectory {
-    max-height: 70vh;
-    overflow-y: auto;
-    padding: 1rem;
+/* ---- reward-hacking list ---- */
+.hack-list { margin: 0.3rem 0 0.6rem; }
+
+/* ---- collapsible reports + trajectory ---- */
+details.report {
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--radius);
+    padding: 0 1.1rem;
+    margin-bottom: 0.9rem;
 }
+details.report > summary { padding: 0.8rem 0; cursor: pointer; font-size: 1rem; }
+details.report > summary:hover { color: var(--accent); }
+details.report > summary h2 { display: inline-block; margin: 0; font-size: 1.2rem; }
+details.report[open] > summary { border-bottom: 1px solid var(--pico-muted-border-color); margin-bottom: 0.5rem; }
+
+/* rendered trajectory / report bodies: full render, page scrolls (no inner scrollbar) */
+.trajectory { padding: 0.5rem 0 1rem; }
 .trajectory pre { white-space: pre-wrap; word-break: break-word; }
+.trajectory img { max-width: 100%; height: auto; }

--- a/archestra-bench/dashboard/templates/base.html
+++ b/archestra-bench/dashboard/templates/base.html
@@ -9,8 +9,12 @@
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
-    <header>
-        <nav><a href="/"><strong>archestra-bench</strong></a></nav>
+    <header class="topbar">
+        <a class="brand" href="/">
+            <span class="brand-mark">⬡</span>
+            <span>archestra-bench</span>
+        </a>
+        <span class="brand-sub">trajectory dashboard</span>
     </header>
     <main>
         {% block content %}{% endblock %}

--- a/archestra-bench/dashboard/templates/grid.html
+++ b/archestra-bench/dashboard/templates/grid.html
@@ -6,7 +6,7 @@
     <div class="grid-scroll">
         <table class="grid">
             <thead>
-                <tr><th>task</th>{% for lane in grid.lanes %}<th>{{ lane }}</th>{% endfor %}</tr>
+                <tr><th>task</th>{% for lane in grid.lanes %}<th>{{ lane }}</th>{% endfor %}<th class="avg-col">avg</th></tr>
             </thead>
             <tbody>
             {% for row in grid.rows %}
@@ -26,6 +26,7 @@
                     <td class="cell cell-empty">—</td>
                     {% endmatch %}
                     {% endfor %}
+                    <td class="cell avg-col">{% if row.avg_text.is_empty() %}<span class="cell-empty">—</span>{% else %}<span class="chip {{ row.avg_class }}">{{ row.avg_text }}</span>{% endif %}</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/archestra-bench/dashboard/templates/index.html
+++ b/archestra-bench/dashboard/templates/index.html
@@ -2,27 +2,41 @@
 {% block title %}runs — bench dashboard{% endblock %}
 {% block content %}
 <h1>Runs</h1>
-<p class="muted">{{ experiments_dir }}</p>
+<p class="muted path">{{ experiments_dir }}</p>
 {% if runs.is_empty() %}
-<p>No runs found.</p>
+<article class="empty">No runs found in this experiments directory.</article>
 {% else %}
-<table>
+<div class="card table-card">
+<table class="runs">
     <thead>
-        <tr><th>run</th><th>date</th><th>envs</th><th>lanes</th><th>outcomes</th><th>pass rate</th><th>rubrics</th></tr>
+        <tr><th>run</th><th>date</th><th>envs</th><th>lanes</th><th>outcomes</th><th>pass rate</th><th>rubrics</th><th>reports</th></tr>
     </thead>
     <tbody>
     {% for run in runs %}
         <tr>
-            <td><a href="{{ run.href }}">{{ run.id }}</a></td>
-            <td>{{ run.date }}</td>
+            <td><a class="run-link" href="{{ run.href }}">{{ run.id }}</a></td>
+            <td class="muted nowrap">{{ run.date }}</td>
             <td>{{ run.envs }}</td>
             <td>{{ run.lanes }}</td>
-            <td>{{ run.outcomes }}</td>
-            <td>{{ run.pass_rate }}</td>
+            <td class="nowrap">{{ run.outcomes }}</td>
+            <td>
+                {% if run.pass_pct.is_empty() %}<span class="muted">—</span>
+                {% else %}
+                <div class="rate" title="{{ run.pass_rate }}">
+                    <div class="rate-bar"><div class="rate-fill" style="width:{{ run.pass_pct }}%"></div></div>
+                    <span class="rate-val">{{ run.pass_rate }}</span>
+                </div>
+                {% endif %}
+            </td>
             <td><span class="badge {{ run.rubric_badge.class }}">{{ run.rubric_badge.label }}</span></td>
+            <td class="nowrap">
+                {% if run.reports.is_empty() %}<span class="muted">—</span>
+                {% else %}{% for r in run.reports %}<span class="report-chip" title="{{ r.title }}">{{ r.abbr }}</span>{% endfor %}{% endif %}
+            </td>
         </tr>
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endif %}
 {% endblock %}

--- a/archestra-bench/dashboard/templates/rollout.html
+++ b/archestra-bench/dashboard/templates/rollout.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
 {% block title %}{{ id }} — bench dashboard{% endblock %}
 {% block content %}
-<p><a href="{{ run_href }}">← {{ run_id }}</a></p>
+<p class="crumb"><a href="{{ run_href }}">← {{ run_id }}</a></p>
 <h1>{{ id }} <span class="badge {{ outcome_class }}">{{ outcome_label }}</span></h1>
 
 <section>
     <h2>Metadata</h2>
+    <div class="card table-card">
     <table class="kv">
         <tbody>
         {% for row in meta_rows %}
@@ -13,6 +14,7 @@
         {% endfor %}
         </tbody>
     </table>
+    </div>
 </section>
 
 {% match rubric %}
@@ -23,6 +25,7 @@
     <p class="warning">⚠ reward hacking suspected{% if !r.hacking_evidence.is_empty() %}: <em>{{ r.hacking_evidence }}</em>{% endif %}</p>
     {% endif %}
     <p><strong>Verdict:</strong> {{ r.verdict }}</p>
+    <div class="card table-card">
     <table>
         <thead>
             <tr><th>rubric</th><th>grade</th><th>comment</th></tr>
@@ -33,6 +36,7 @@
         {% endfor %}
         </tbody>
     </table>
+    </div>
     {% if !r.observations.is_empty() %}
     <h3>Observations</h3>
     <ul>
@@ -47,10 +51,13 @@
 {% endmatch %}
 
 <section>
-    <h2>Trajectory</h2>
     {% if trajectory_note.is_empty() %}
-    <article class="trajectory">{{ trajectory_html|safe }}</article>
+    <details class="report">
+        <summary><h2>Trajectory</h2></summary>
+        <article class="trajectory">{{ trajectory_html|safe }}</article>
+    </details>
     {% else %}
+    <h2>Trajectory</h2>
     <p class="muted">{{ trajectory_note }}</p>
     {% endif %}
 </section>

--- a/archestra-bench/dashboard/templates/run.html
+++ b/archestra-bench/dashboard/templates/run.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ id }} — bench dashboard{% endblock %}
 {% block content %}
+<p class="crumb"><a href="/">← runs</a></p>
 <h1>{{ id }} <span class="badge {{ rubric_badge.class }}">{{ rubric_badge.label }}</span></h1>
 <p class="muted">{{ date }}</p>
 
@@ -9,20 +10,24 @@
 {% endfor %}
 
 <section>
-    <h2>Metrics</h2>
-    <table class="kv">
-        <tbody>
-        {% for row in summary %}
-            <tr><th>{{ row.label }}</th><td>{{ row.value }}</td></tr>
-        {% endfor %}
-        </tbody>
-    </table>
+    <div class="stats">
+    {% for row in summary %}
+        <div class="stat"><span class="stat-label">{{ row.label }}</span><span class="stat-value">{{ row.value }}</span></div>
+    {% endfor %}
+    </div>
+    {% if !outcome_pills.is_empty() %}
+    <div class="pills">
+    {% for o in outcome_pills %}
+        <span class="pill {{ o.class }}">{{ o.label }} <b>{{ o.count }}</b></span>
+    {% endfor %}
+    </div>
+    {% endif %}
 </section>
 
 {% if !hacking.is_empty() %}
-<section class="hacking">
-    <h2>Reward hacking suspected</h2>
-    <ul>
+<section class="card danger">
+    <h2>⚠ Reward hacking suspected</h2>
+    <ul class="hack-list">
     {% for h in hacking %}
         <li><a href="{{ h.href }}">{{ h.id }}</a>{% if !h.evidence.is_empty() %} — <em>{{ h.evidence }}</em>{% endif %}</li>
     {% endfor %}
@@ -33,16 +38,30 @@
 {% if has_rubrics %}
 <section>
     <h2>Rubric averages by lane</h2>
+    <div class="card table-card">
     <table>
         <thead>
-            <tr><th>rubric</th>{% for lane in lanes %}<th>{{ lane }}</th>{% endfor %}</tr>
+            <tr><th>rubric</th>{% for lane in lanes %}<th>{{ lane }}</th>{% endfor %}<th class="avg-col">avg</th></tr>
         </thead>
         <tbody>
         {% for row in rubric_rows %}
-            <tr><th>{{ row.label }}</th>{% for v in row.values %}<td>{{ v }}</td>{% endfor %}</tr>
+            <tr><th>{{ row.label }}</th>{% for v in row.values %}<td>{{ v }}</td>{% endfor %}<td class="avg-col">{{ row.avg }}</td></tr>
         {% endfor %}
         </tbody>
     </table>
+    </div>
+</section>
+{% endif %}
+
+{% if !reports.is_empty() %}
+<section>
+    <h2>Analysis reports</h2>
+    {% for report in reports %}
+    <details class="report">
+        <summary><strong>{{ report.label }}</strong> <span class="muted">{{ report.filename }}</span></summary>
+        <article class="trajectory">{{ report.html|safe }}</article>
+    </details>
+    {% endfor %}
 </section>
 {% endif %}
 

--- a/archestra-bench/dashboard/tests/dashboard.rs
+++ b/archestra-bench/dashboard/tests/dashboard.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
-use bench_dashboard::load::{RubricKey, RubricStatus, list_runs, load_run};
+use bench_dashboard::load::{ReduceSource, RubricKey, RubricStatus, list_runs, load_run};
 
 fn fixtures() -> PathBuf {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/experiments");
@@ -115,6 +115,39 @@ fn partial_rubrics_average_only_over_present_records() {
 }
 
 #[test]
+fn rubric_avg_averages_over_all_records_across_lanes() {
+    let run = load_run(&fixtures(), "run_a").unwrap().unwrap();
+    // Two records (both kimi): knowledge 4/2, reasoning 3/4, if 5/3, ergonomics 2/5.
+    assert_eq!(run.rubric_avg(RubricKey::Knowledge), Some(3.0));
+    assert_eq!(run.rubric_avg(RubricKey::Reasoning), Some(3.5));
+    assert_eq!(run.rubric_avg(RubricKey::InstructionFollowing), Some(4.0));
+    assert_eq!(run.rubric_avg(RubricKey::EnvErgonomics), Some(3.5));
+
+    // A run with no rubric records has no averages, not zeros.
+    let run_b = load_run(&fixtures(), "run_b").unwrap().unwrap();
+    assert_eq!(run_b.rubric_avg(RubricKey::Knowledge), None);
+}
+
+#[test]
+fn reduce_reports_load_latest_per_source_in_order() {
+    let run = load_run(&fixtures(), "run_a").unwrap().unwrap();
+    let sources: Vec<ReduceSource> = run.reports.iter().map(|r| r.source).collect();
+    assert_eq!(sources, [ReduceSource::Analyzer, ReduceSource::Claude]);
+    assert_eq!(
+        run.reports[0].filename,
+        "trajectory_analysis_20260701-120000.md"
+    );
+    assert_eq!(
+        run.reports[1].filename,
+        "trajectory_analysis_claude_20260701-120000.md"
+    );
+
+    // A run with no reduce report has no reports.
+    let run_b = load_run(&fixtures(), "run_b").unwrap().unwrap();
+    assert!(run_b.reports.is_empty());
+}
+
+#[test]
 fn malformed_rubric_file_degrades_to_rubric_less_with_warning() {
     let run = load_run(&fixtures(), "run_b").unwrap().unwrap();
     assert_eq!(run.rubric_status, RubricStatus::None);
@@ -163,6 +196,10 @@ async fn index_renders() {
     assert_eq!(status, StatusCode::OK);
     assert!(body.contains("href=\"/runs/run_a\""));
     assert!(body.contains("href=\"/runs/run_b\""));
+    // run_a has both reduce reports, so its row carries the report chips.
+    assert!(body.contains("report-chip"), "report chips on run list");
+    // A pass rate present -> a rendered rate bar.
+    assert!(body.contains("rate-fill"), "pass-rate bar on run list");
 }
 
 #[tokio::test]
@@ -171,6 +208,26 @@ async fn run_page_renders_with_opaque_rollout_links() {
     assert_eq!(status, StatusCode::OK);
     // Grid cells link to the percent-encoded opaque rollout id, `__` in the task and all.
     assert!(body.contains("/runs/run_a/rollouts/basic%2Ftricky__part__kimi"));
+}
+
+#[tokio::test]
+async fn run_page_renders_reduce_reports_and_avg_columns() {
+    let (status, body) = get("/runs/run_a").await;
+    assert_eq!(status, StatusCode::OK);
+    // Both reduce reports render as collapsible sections labelled by source.
+    assert!(body.contains("class=\"report\""), "report section present");
+    assert!(body.contains("Analyzer report"), "analyzer report labelled");
+    assert!(body.contains("Claude report"), "claude report labelled");
+    // Aggregate "avg" columns exist on the grid and the rubric-by-lane table.
+    assert!(body.contains("class=\"avg-col\""), "avg column rendered");
+}
+
+#[tokio::test]
+async fn grid_shows_per_task_average() {
+    // basic/alpha's only graded rollout (kimi) has mean grade 3.5, so the row avg is 3.5.
+    let (status, body) = get("/runs/run_a/grid?lane=kimi").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains(">3.5</span>"), "per-task avg chip: {body}");
 }
 
 #[tokio::test]

--- a/archestra-bench/dashboard/tests/fixtures/experiments/run_a/trajectory_analysis_20260701-120000.md
+++ b/archestra-bench/dashboard/tests/fixtures/experiments/run_a/trajectory_analysis_20260701-120000.md
@@ -1,0 +1,5 @@
+# Analyzer reduce report
+
+## Summary
+
+Two rollouts triaged; kimi lane carried the run.

--- a/archestra-bench/dashboard/tests/fixtures/experiments/run_a/trajectory_analysis_claude_20260701-120000.md
+++ b/archestra-bench/dashboard/tests/fixtures/experiments/run_a/trajectory_analysis_claude_20260701-120000.md
@@ -1,0 +1,5 @@
+# Claude reduce report
+
+## Summary
+
+Same run, second-opinion pass.


### PR DESCRIPTION
## What

- **Avg columns.** The task × lane grid gets a per-task **avg** column (mean of the row's graded cells, filter-aware) and the rubric-by-lane table gets a per-rubric **avg** column (overall mean across lanes).
- **Reduce-report rendering.** When a run has a rendered reduce-phase report, the run page shows the latest per source — the analyzer's `trajectory_analysis_<ts>.md` and the Claude skill's `trajectory_analysis_claude_<ts>.md` — in collapsible sections. Content goes through the existing untrusted-markdown path (raw HTML neutralized, active-scheme links stripped, remote images blocked). The run list shows an `A`/`C` chip per run.
- **Trajectory.** Rollout trajectories render in full with no inner scrollbar, collapsed by default.
- **UI refresh.** Stat tiles + outcome pills on the run page, a pass-rate bar and report chips on the run list, card surfaces, and a sticky top bar — all driven off Pico's light/dark variables.

## Validation

- `cargo test -p bench-dashboard` (23 tests) and `cargo clippy -p bench-dashboard --all-targets -- -D warnings` clean.
- Verified all pages against a live server on the test fixtures.

https://claude.ai/code/session_01PZYrm66es4aNzHQKQKcmf4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>