### PR TITLE
fix(chat): show underlying MCP server icon on run_tool circles

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1775,8 +1775,12 @@ const MessageTool = memo(
     }
 
     if (authToolBody) {
-      const shortName = parseFullToolName(toolName).toolName.replace(/_/g, " ");
-      const iconInfo = toolIconMap?.get(toolName);
+      // Unwrap run_tool so the circle carries the target tool's server icon.
+      const shortName = parseFullToolName(mcpAppToolName).toolName.replace(
+        /_/g,
+        " ",
+      );
+      const iconInfo = toolIconMap?.get(mcpAppToolName);
 
       return (
         <div className="mb-1">
@@ -1824,8 +1828,12 @@ const MessageTool = memo(
       !errorText
     ) {
       const compactState = getCompactToolState({ part, toolResultPart });
-      const shortName = parseFullToolName(toolName).toolName.replace(/_/g, " ");
-      const iconInfo = toolIconMap?.get(toolName);
+      // Unwrap run_tool so the circle carries the target tool's server icon.
+      const shortName = parseFullToolName(mcpAppToolName).toolName.replace(
+        /_/g,
+        " ",
+      );
+      const iconInfo = toolIconMap?.get(mcpAppToolName);
       // Fall back to the Archestra catalog icon for owned-app / archestra tools
       // whose icon isn't in the map yet (e.g. a still-pending management call).
       const catalogId =

--- a/platform/frontend/src/components/chat/compact-tool-call.test.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.test.tsx
@@ -1,3 +1,4 @@
+import { TOOL_RUN_TOOL_SHORT_NAME } from "@archestra/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -50,6 +51,85 @@ describe("CompactToolGroup", () => {
               toolCallId: "call-1",
               input: {},
               output: { ok: true },
+            },
+            toolResultPart: null,
+            errorText: undefined,
+          },
+        ]}
+        toolIconMap={new Map()}
+      />,
+    );
+
+    expect(screen.getByTestId("mcp-catalog-icon")).toHaveTextContent(
+      "00000000-0000-4000-8000-000000000001",
+    );
+  });
+
+  it("shows the target tool's server icon for a run_tool dispatch", () => {
+    mockIsToolName.mockImplementation((toolName: string) =>
+      toolName.startsWith("archestra__"),
+    );
+    mockGetToolShortName.mockImplementation((toolName: string) =>
+      toolName === "archestra__run_tool" ? TOOL_RUN_TOOL_SHORT_NAME : null,
+    );
+
+    render(
+      <CompactToolGroup
+        tools={[
+          {
+            kind: "tool",
+            key: "tool-1",
+            toolName: "archestra__run_tool",
+            part: {
+              type: "tool-archestra__run_tool",
+              state: "output-available",
+              toolCallId: "call-1",
+              input: {
+                tool_name: "context7__resolve-library-id",
+                tool_args: { libraryName: "react" },
+              },
+              output: { ok: true },
+            },
+            toolResultPart: null,
+            errorText: undefined,
+          },
+        ]}
+        toolIconMap={
+          new Map([
+            [
+              "context7__resolve-library-id",
+              { icon: "data:image/png;base64,x", catalogId: "catalog-ctx7" },
+            ],
+          ])
+        }
+      />,
+    );
+
+    expect(screen.getByTestId("mcp-catalog-icon")).toHaveTextContent(
+      "catalog-ctx7",
+    );
+  });
+
+  it("keeps the built-in icon for a run_tool call whose target is not known yet", () => {
+    mockIsToolName.mockImplementation((toolName: string) =>
+      toolName.startsWith("archestra__"),
+    );
+    mockGetToolShortName.mockImplementation((toolName: string) =>
+      toolName === "archestra__run_tool" ? TOOL_RUN_TOOL_SHORT_NAME : null,
+    );
+
+    render(
+      <CompactToolGroup
+        tools={[
+          {
+            kind: "tool",
+            key: "tool-1",
+            toolName: "archestra__run_tool",
+            part: {
+              type: "tool-archestra__run_tool",
+              state: "input-streaming",
+              toolCallId: "call-1",
+              input: {},
             },
             toolResultPart: null,
             errorText: undefined,

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/chat/chat-tools-display.utils";
 import { useArchestraMcpIdentity } from "@/lib/mcp/archestra-mcp-server";
 import { cn } from "@/lib/utils";
+import { resolveRunToolTargetName } from "./chat-messages.utils";
 import { HookRunChip, type HookRunChipData } from "./hook-run-chip";
 import { SkillPill } from "./skill-pill";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
@@ -304,14 +305,24 @@ export function CompactToolGroup({
               />
             );
           }
-          const iconInfo = toolIconMap?.get(entry.toolName);
+          // A run_tool dispatch belongs visually to its *target* tool: unwrap
+          // so the circle shows the underlying MCP server's icon (and tooltip
+          // name) instead of the generic Archestra built-in icon.
+          const displayToolName = resolveRunToolTargetName(
+            entry.part,
+            entry.toolName,
+            { getToolShortName },
+          );
+          const iconInfo = toolIconMap?.get(displayToolName);
           const fallbackCatalogId =
             iconInfo?.catalogId ??
-            (isToolName(entry.toolName) ? ARCHESTRA_MCP_CATALOG_ID : undefined);
+            (isToolName(displayToolName)
+              ? ARCHESTRA_MCP_CATALOG_ID
+              : undefined);
           return (
             <CompactCircle
               key={entry.key}
-              toolName={entry.toolName}
+              toolName={displayToolName}
               state={state}
               isExpanded={expandedKey === entry.key}
               isExpandable={canExpandToolCalls}


### PR DESCRIPTION
## Summary

On /chat, a `run_tool` dispatch rendered its tool circle with the raw wrapper name (`archestra__run_tool`), which missed the tool-icon map and fell back to the generic Archestra built-in icon.

This unwraps the dispatch to its target tool name (reusing the existing `resolveRunToolTargetName` helper, already used for MCP-app renders and approval prompts) **before** the icon lookup, so the circle — and its tooltip — carry the underlying MCP server's icon exactly like a direct call to that tool would.

Fixed in all three circle render sites:
- the compact tool-circle row (`CompactToolGroup`)
- the MCP-app circle in `MessageTool`
- the auth-error circle in `MessageTool`

Behavior notes:
- `run_tool` targeting an Archestra built-in still resolves to the Archestra icon (correct — the target owns the icon).
- While the wrapper's input is still streaming (no `tool_name` yet), the helper falls back to the wrapper name, so the circle shows the Archestra icon until the target is known.

## Tests

Added two component tests to `compact-tool-call.test.tsx`: one pinning that a `run_tool` call targeting a third-party tool shows that tool's catalog icon, and one pinning the streaming fallback to the built-in icon. `pnpm type-check`, biome, and the chat component test files all pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>