### PR TITLE
fix(llm): highlight only one row in API key selector when keys share a name

### DIFF
--- a/platform/frontend/src/components/llm-provider-api-key-dropdown.test.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-dropdown.test.tsx
@@ -41,6 +41,79 @@ describe("LlmProviderApiKeyDropdown", () => {
     expect(screen.getByText("OpenAI key")).toBeInTheDocument();
   });
 
+  it("highlights only one row when keys share the same name", async () => {
+    const user = userEvent.setup();
+
+    renderDropdown({
+      availableKeys: [
+        {
+          id: "key-1",
+          name: "Anthropic",
+          provider: "anthropic",
+          scope: "personal",
+          teamName: null,
+        },
+        {
+          id: "key-2",
+          name: "Anthropic",
+          provider: "anthropic",
+          scope: "personal",
+          teamName: null,
+        },
+      ] as LlmProviderApiKey[],
+      selectedApiKeyId: "key-2",
+      onSelectKey: () => {},
+      triggerVariant: "button",
+    });
+
+    await user.click(screen.getByRole("button", { name: /anthropic/i }));
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(
+      options.filter(
+        (option) => option.getAttribute("aria-selected") === "true",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("filters keys by name via search", async () => {
+    const user = userEvent.setup();
+
+    renderDropdown({
+      availableKeys: [
+        {
+          id: "key-1",
+          name: "Prod key",
+          provider: "anthropic",
+          scope: "personal",
+          teamName: null,
+        },
+        {
+          id: "key-2",
+          name: "Staging key",
+          provider: "openai",
+          scope: "personal",
+          teamName: null,
+        },
+      ] as LlmProviderApiKey[],
+      selectedApiKeyId: null,
+      onSelectKey: () => {},
+      triggerVariant: "button",
+      showChatTestIds: true,
+    });
+
+    await user.click(screen.getByRole("button", { name: /select api key/i }));
+    await user.type(
+      screen.getByTestId(E2eTestId.ChatApiKeySelectorSearchInput),
+      "Staging",
+    );
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("Staging key");
+  });
+
   it("supports selecting organization default", async () => {
     const user = userEvent.setup();
     const onSelectOrganizationDefault = vi.fn();

--- a/platform/frontend/src/components/llm-provider-api-key-dropdown.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-dropdown.tsx
@@ -232,7 +232,8 @@ export function LlmProviderApiKeyDropdown({
                         ? getChatApiKeySelectorOptionTestId(key.id)
                         : undefined
                     }
-                    value={`${provider} ${key.name} ${key.teamName || ""}`}
+                    value={key.id}
+                    keywords={[provider, key.name, key.teamName ?? ""]}
                     onSelect={() => onSelectKey(key.id)}
                     className="cursor-pointer"
                   >


### PR DESCRIPTION
## Problem

In the LLM provider API key selector, multiple rows can render as highlighted at the same time when two API keys share the same display name (e.g. two keys both named "Anthropic"):

cmdk tracks the active item by its `value` string. The `CommandItem` value was built from `provider + name + teamName`, so identically-named keys under the same provider collided and cmdk marked every matching row as selected.

## Fix

Use the API key id (unique) as the cmdk `value`, and move the provider/name/team text into cmdk's `keywords` prop so search filtering behaves exactly as before.

## Tests

- New regression test: two keys with the same name → exactly one row has `aria-selected="true"` (fails on `main`, passes with the fix)
- New test pinning search-by-name filtering still works via `keywords`

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>