### PR TITLE
feat(chat): !-prefixed messages run directly in the sandbox

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -25,6 +25,8 @@ Type `/` in the prompt input to open available chat commands.
 
 - [`/compact`](#context-compaction) summarizes older conversation history to reduce context usage and help prevent hitting the selected model's context limit. The full chat history remains visible in the conversation.
 
+When the agent has the code sandbox available, a message starting with `!` (for example `! ls attachments/`) runs the rest of the message as a shell command in the conversation's sandbox instead of asking the model. The command and its output appear in the conversation as a regular `run_command` tool call, so the agent sees the result in later turns. Output appears when the command finishes. Requires the `sandbox: execute` permission; without a sandbox, the message is sent as normal text. User-typed commands do not trigger PreToolUse/PostToolUse hooks — the user, not the model, initiated the call.
+
 ### MCP Elicitation
 
 Some MCP tools can ask for additional information while they run. Chat shows these requests as a modal form, validates required fields, and resumes the tool call after you continue. If the request points to an external URL, Chat only opens HTTP or HTTPS links.

--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -20,8 +20,9 @@ class MessageModel {
    */
   private static async touchConversation(
     conversationId: string,
+    executor: DbExecutor = db,
   ): Promise<void> {
-    await db
+    await executor
       .update(schema.conversationsTable)
       .set({
         updatedAt: new Date(),
@@ -57,12 +58,16 @@ class MessageModel {
       .insert(schema.messagesTable)
       .values(messages.map((m) => ({ id: uuidv7(), ...m })));
 
-    // Update conversation's updatedAt for all affected conversations
+    // Update conversation's updatedAt for all affected conversations. Must run
+    // on the same executor: with a transaction executor, a separate `db` query
+    // would escape the transaction (and deadlock single-connection PGlite).
     const uniqueConversationIds = [
       ...new Set(messages.map((m) => m.conversationId)),
     ];
     await Promise.all(
-      uniqueConversationIds.map((id) => MessageModel.touchConversation(id)),
+      uniqueConversationIds.map((id) =>
+        MessageModel.touchConversation(id, executor),
+      ),
     );
   }
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -161,8 +161,13 @@ import {
   normalizeChatMessagesForPersistence,
 } from "./normalization/normalize-chat-messages";
 import { buildModelMessages } from "./prepare-model-messages";
+import {
+  detectSandboxCommand,
+  runSandboxCommandTurn,
+} from "./sandbox-command-turn";
 import { repairHarmonyToolName } from "./tool-call-repair";
 import { createToolUiStartTransform } from "./tool-ui-stream";
+import { sendGatedUiMessageStreamResponse } from "./ui-stream-response";
 
 // The chat route always builds a `messages` (not `prompt`) config, so the
 // `runAgentStream` config is narrowed to require it.
@@ -249,13 +254,6 @@ function buildStreamErrorPayload(params: {
 
   return serialized;
 }
-
-// Upper bound on how long the response body's close waits for the active-run row
-// to be marked terminal. Terminalization is normally tens of milliseconds; this
-// cap keeps a wedged DB or notifier after stream-end from hanging the client EOF
-// indefinitely. Past it we release EOF and fall back to the pre-existing 409
-// window (which the stale reaper still cleans up).
-const TERMINAL_CLOSE_GATE_TIMEOUT_MS = 10_000;
 
 const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
   fastify.post(
@@ -501,6 +499,43 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
       try {
         const { agentId, agent } = conversation;
+
+        // A `!`-prefixed sandbox command turn: execute run_command directly
+        // and stream/persist the result as a normal tool part — no LLM call,
+        // so none of the context/tool building below runs.
+        const sandboxCommand = detectSandboxCommand(messages as ChatMessage[]);
+        if (sandboxCommand) {
+          return await runSandboxCommandTurn({
+            command: sandboxCommand.command,
+            messages: messages as ChatMessage[],
+            conversationId,
+            agent: { id: agentId, name: agent.name },
+            userId: user.id,
+            organizationId,
+            activeRunId: activeRun.id,
+            abortController: chatAbortController,
+            reply,
+            persistTurn: async (finalMessages) => {
+              if (trigger === "regenerate-message") {
+                await persistRegeneratedTurn({
+                  conversationId,
+                  requestMessages: messages,
+                  finalMessages,
+                });
+              } else {
+                await persistNewMessages(
+                  conversationId,
+                  finalMessages,
+                  "onFinish",
+                );
+              }
+            },
+            onStreamSettled: () => {
+              removeAbortListeners();
+              stopActiveRunPolling();
+            },
+          });
+        }
 
         // Extract and ingest documents to agent's knowledge base (fire and forget)
         // This runs asynchronously to avoid blocking the chat response
@@ -1343,11 +1378,11 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
               },
             });
 
-            const [responseStream, persistenceStream] = uiMessageStream.tee();
-            const { terminalReady } = activeChatRunService.drainStreamToEvents({
+            return await sendGatedUiMessageStreamResponse({
+              reply,
+              stream: uiMessageStream as ReadableStream<UIMessageChunk>,
               runId: activeRun.id,
               conversationId,
-              stream: persistenceStream as ReadableStream<UIMessageChunk>,
               abortController: chatAbortController,
               getTerminalStatus: async () => {
                 const latestRun = await ActiveChatRunModel.findById(
@@ -1365,65 +1400,6 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 return { status: "completed" };
               },
             });
-
-            const response = createUIMessageStreamResponse({
-              headers: {
-                // Prevent compression middleware from buffering the stream
-                // See: https://ai-sdk.dev/docs/troubleshooting/streaming-not-working-when-proxied
-                "Content-Encoding": "none",
-              },
-              stream: responseStream as ReadableStream<UIMessageChunk>,
-            });
-
-            // Log response headers for debugging
-            logger.info(
-              {
-                conversationId,
-                headers: Object.fromEntries(response.headers.entries()),
-                hasBody: !!response.body,
-              },
-              "Streaming chat response",
-            );
-
-            // Copy headers from Response to Fastify reply
-            for (const [key, value] of response.headers.entries()) {
-              reply.header(key, value);
-            }
-
-            // Send the Response body stream directly, but hold its CLOSE (not
-            // its bytes — they stream through unchanged) until the active-run row
-            // is marked terminal. Without this, a client that fires its next
-            // message the instant this response ends races the async drain and
-            // 409s against a row still flagged running.
-            if (!response.body) {
-              throw new ApiError(400, "No response body");
-            }
-            const gatedBody = (
-              response.body as ReadableStream<Uint8Array>
-            ).pipeThrough(
-              new TransformStream<Uint8Array, Uint8Array>({
-                async flush() {
-                  let timer: ReturnType<typeof setTimeout> | undefined;
-                  try {
-                    await Promise.race([
-                      terminalReady,
-                      new Promise<void>((resolve) => {
-                        timer = setTimeout(
-                          resolve,
-                          TERMINAL_CLOSE_GATE_TIMEOUT_MS,
-                        );
-                      }),
-                    ]);
-                  } finally {
-                    if (timer) {
-                      clearTimeout(timer);
-                    }
-                  }
-                },
-              }),
-            );
-            // biome-ignore lint/suspicious/noExplicitAny: Fastify reply.send accepts ReadableStream but TypeScript requires explicit cast
-            return reply.send(gatedBody as any);
           },
         });
       } catch (error) {

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -519,6 +519,8 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
               "Failed to persist user messages early (will retry in onFinish)",
             );
           }
+          const sandboxSlimChatErrorUi =
+            await OrganizationModel.getSlimChatErrorUi(organizationId);
           return await runSandboxCommandTurn({
             command: sandboxCommand.command,
             messages: messages as ChatMessage[],
@@ -555,6 +557,14 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
               removeAbortListeners();
               stopActiveRunPolling();
             },
+            buildErrorPayload: ({ error, mappedError }) =>
+              buildStreamErrorPayload({
+                error,
+                mappedError,
+                conversationId,
+                slimChatErrorUi: sandboxSlimChatErrorUi,
+                stage: "via stream",
+              }),
           });
         }
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -502,9 +502,23 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
         // A `!`-prefixed sandbox command turn: execute run_command directly
         // and stream/persist the result as a normal tool part — no LLM call,
-        // so none of the context/tool building below runs.
+        // so none of the context/tool building below runs. Re-sending a
+        // transcript that ends at a stored `!` message re-executes it — the
+        // same "sending a turn runs it" semantics regenerate relies on.
         const sandboxCommand = detectSandboxCommand(messages as ChatMessage[]);
         if (sandboxCommand) {
+          // Persist the user message before execution (mirrors the LLM path's
+          // early persist): the command lands in the sandbox replay log the
+          // moment it runs, so the transcript must already show it even if
+          // final persistence fails or the process dies mid-turn.
+          try {
+            await persistNewMessages(conversationId, messages, "earlyUserMsg");
+          } catch (error) {
+            logger.warn(
+              { error, conversationId },
+              "Failed to persist user messages early (will retry in onFinish)",
+            );
+          }
           return await runSandboxCommandTurn({
             command: sandboxCommand.command,
             messages: messages as ChatMessage[],
@@ -516,16 +530,23 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
             abortController: chatAbortController,
             reply,
             persistTurn: async (finalMessages) => {
+              // SessionStart hook runs (fired above on the first turn) are
+              // spliced into the assistant message exactly like the LLM path,
+              // so hook activity stays visible on a `!` first turn.
+              const messagesToPersist = applyHookRunsToMessages(
+                finalMessages,
+                hookRunCollector,
+              );
               if (trigger === "regenerate-message") {
                 await persistRegeneratedTurn({
                   conversationId,
                   requestMessages: messages,
-                  finalMessages,
+                  finalMessages: messagesToPersist,
                 });
               } else {
                 await persistNewMessages(
                   conversationId,
-                  finalMessages,
+                  messagesToPersist,
                   "onFinish",
                 );
               }

--- a/platform/backend/src/routes/chat/sandbox-command-turn.test.ts
+++ b/platform/backend/src/routes/chat/sandbox-command-turn.test.ts
@@ -250,6 +250,60 @@ describe("POST /api/chat sandbox command turn", () => {
     const rows = await MessageModel.findByConversation(conversationId);
     expect(rows).toHaveLength(1);
     expect((rows[0].content as ChatMessage).role).toBe("user");
+
+    // The active run was terminalized: a follow-up send is not 409-blocked.
+    const retry = await postChat({
+      id: conversationId,
+      messages: [markedUserMessage("! echo hi")],
+    });
+    expect(retry.statusCode).toBe(403);
+  });
+
+  test("a runtime failure surfaces as tool output through the real error mapping", async () => {
+    mockRunSandboxCommand.mockRejectedValue(new Error("engine unreachable"));
+
+    const response = await postChat({
+      id: conversationId,
+      messages: [markedUserMessage("! echo hi")],
+    });
+
+    expect(response.statusCode).toBe(200);
+    await vi.waitFor(async () => {
+      const rows = await MessageModel.findByConversation(conversationId);
+      expect(rows).toHaveLength(2);
+    });
+    const assistant = (await MessageModel.findByConversation(conversationId))
+      .map((row) => row.content as ChatMessage)
+      .at(-1);
+    // The runtime error travels the same path as a model-initiated failure:
+    // an isError tool result persisted as readable tool output, not a crash.
+    const toolParts = toolPartsOf(assistant as ChatMessage);
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0].state).toBe("output-available");
+    expect(typeof toolParts[0].output).toBe("string");
+  });
+
+  test("a marked message with multiple text parts is not executed", async () => {
+    const response = await postChat({
+      id: conversationId,
+      messages: [
+        {
+          id: "msg-user-1",
+          role: "user",
+          parts: [
+            { type: "text", text: "! echo hi" },
+            { type: "text", text: "&& rm -rf /" },
+          ],
+          metadata: { sandboxCommand: true },
+        },
+      ],
+    });
+
+    // Falls through to the normal LLM path — the composer never produces
+    // multi-text-part messages, so this shape is not a command.
+    expect(response.statusCode).toBe(200);
+    expect(mockRunSandboxCommand).not.toHaveBeenCalled();
+    expect(mockGetChatMcpTools).toHaveBeenCalledTimes(1);
   });
 
   test("a !-prefixed message without the marker goes to the normal LLM path", async () => {
@@ -338,6 +392,7 @@ describe("POST /api/chat sandbox command turn", () => {
         persisted.push(finalMessages);
       },
       onStreamSettled: () => {},
+      buildErrorPayload: ({ mappedError }) => JSON.stringify(mappedError),
     })) as unknown as ReadableStream<Uint8Array>;
 
     const reader = body.getReader();
@@ -382,6 +437,7 @@ describe("POST /api/chat sandbox command turn", () => {
         throw new Error("simulated persistence failure");
       },
       onStreamSettled: () => {},
+      buildErrorPayload: ({ mappedError }) => JSON.stringify(mappedError),
     })) as unknown as ReadableStream<Uint8Array>;
 
     // The command ran and the stream drains to completion — the persistence

--- a/platform/backend/src/routes/chat/sandbox-command-turn.test.ts
+++ b/platform/backend/src/routes/chat/sandbox-command-turn.test.ts
@@ -244,8 +244,12 @@ describe("POST /api/chat sandbox command turn", () => {
 
     expect(response.statusCode).toBe(403);
     expect(mockGetChatMcpTools).not.toHaveBeenCalled();
+    expect(mockRunSandboxCommand).not.toHaveBeenCalled();
+    // The user message persists (early persist runs before the availability
+    // check), but no command ran and no assistant turn exists.
     const rows = await MessageModel.findByConversation(conversationId);
-    expect(rows).toHaveLength(0);
+    expect(rows).toHaveLength(1);
+    expect((rows[0].content as ChatMessage).role).toBe("user");
   });
 
   test("a !-prefixed message without the marker goes to the normal LLM path", async () => {
@@ -347,6 +351,51 @@ describe("POST /api/chat sandbox command turn", () => {
     const toolParts = toolPartsOf(assistant as ChatMessage);
     expect(toolParts).toHaveLength(1);
     expect(toolParts[0].state).toBe("output-error");
+  });
+
+  test("a persistence failure after execution is contained: the stream still completes", async () => {
+    const activeRun = await activeChatRunService.createRun({
+      conversationId,
+      userId: user.id,
+      organizationId,
+    });
+    expect(activeRun).not.toBeNull();
+    if (!activeRun) throw new Error("unreachable");
+
+    const replyStub = {
+      header: () => {},
+      send: (body: ReadableStream<Uint8Array>) => body,
+    };
+
+    const body = (await runSandboxCommandTurn({
+      command: "echo hi",
+      messages: [markedUserMessage("! echo hi") as ChatMessage],
+      conversationId,
+      agent: { id: agentId, name: "Sandbox Agent" },
+      userId: user.id,
+      organizationId,
+      activeRunId: activeRun.id,
+      abortController: new AbortController(),
+      // biome-ignore lint/suspicious/noExplicitAny: minimal reply stub — only header/send are used by the turn
+      reply: replyStub as any,
+      persistTurn: async () => {
+        throw new Error("simulated persistence failure");
+      },
+      onStreamSettled: () => {},
+    })) as unknown as ReadableStream<Uint8Array>;
+
+    // The command ran and the stream drains to completion — the persistence
+    // error is logged, not propagated into the response stream.
+    const chunks: string[] = [];
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+    expect(mockRunSandboxCommand).toHaveBeenCalledTimes(1);
+    expect(chunks.join("")).not.toContain('"type":"error"');
   });
 });
 

--- a/platform/backend/src/routes/chat/sandbox-command-turn.test.ts
+++ b/platform/backend/src/routes/chat/sandbox-command-turn.test.ts
@@ -1,0 +1,399 @@
+import {
+  type ChatMessagePart,
+  TOOL_RUN_COMMAND_SHORT_NAME,
+} from "@archestra/shared";
+import { convertToModelMessages, type UIMessage } from "ai";
+import { vi } from "vitest";
+import { archestraMcpBranding } from "@/archestra-mcp-server";
+import config from "@/config";
+import { MessageModel } from "@/models";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { activeChatRunService } from "@/services/active-chat-run";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { ChatMessage, User } from "@/types";
+import { normalizeChatMessages } from "./normalization/normalize-chat-messages";
+import { runSandboxCommandTurn } from "./sandbox-command-turn";
+
+const mockCreateLLMModelForAgent = vi.hoisted(() => vi.fn());
+const mockGetChatMcpTools = vi.hoisted(() => vi.fn());
+const mockGetChatMcpToolUiResourceUris = vi.hoisted(() => vi.fn());
+const mockExtractAndIngestDocuments = vi.hoisted(() => vi.fn());
+const mockStartActiveChatSpan = vi.hoisted(() => vi.fn());
+const mockRunSandboxCommand = vi.hoisted(() => vi.fn());
+
+// The Dagger engine is the process boundary: without this mock an enabled
+// sandbox genuinely tries to reach an engine and hangs the suite. Everything
+// above it (tool dispatch, RBAC, replay-log persistence) stays real.
+vi.mock("@/sandbox-runtime/sandbox-runtime-service", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/sandbox-runtime/sandbox-runtime-service")
+    >();
+  return {
+    ...actual,
+    sandboxRuntimeService: {
+      isEnabled: true,
+      isReady: true,
+      bootStatus: "ready",
+      runCommand: mockRunSandboxCommand,
+    },
+  };
+});
+
+vi.mock("@/clients/llm-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/clients/llm-client")>();
+  return {
+    ...actual,
+    createLLMModelForAgent: mockCreateLLMModelForAgent,
+  };
+});
+
+vi.mock("@/clients/chat-mcp-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/clients/chat-mcp-client")>();
+  return {
+    ...actual,
+    getChatMcpTools: mockGetChatMcpTools,
+    getChatMcpToolUiResourceUris: mockGetChatMcpToolUiResourceUris,
+  };
+});
+
+vi.mock("@/knowledge-base", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/knowledge-base")>();
+  return {
+    ...actual,
+    extractAndIngestDocuments: mockExtractAndIngestDocuments,
+  };
+});
+
+vi.mock("@/observability/tracing", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/observability/tracing")>();
+  return {
+    ...actual,
+    startActiveChatSpan: mockStartActiveChatSpan,
+  };
+});
+
+const runCommandToolName = () =>
+  archestraMcpBranding.getToolName(TOOL_RUN_COMMAND_SHORT_NAME);
+
+const toolPartsOf = (message: ChatMessage): ChatMessagePart[] =>
+  (message.parts ?? []).filter(
+    (part) => part.type === `tool-${runCommandToolName()}`,
+  );
+
+describe("POST /api/chat sandbox command turn", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+  let agentId: string;
+  let conversationId: string;
+
+  beforeEach(
+    async ({
+      makeAgent,
+      makeConversation,
+      makeCustomRole,
+      makeMember,
+      makeOrganization,
+      makeUser,
+      seedAndAssignArchestraTools,
+    }) => {
+      // Must be on BEFORE seeding: the sandbox tools are only seeded (and thus
+      // assignable) while the feature is enabled. The per-test config restore
+      // runs before this hook, so the flag holds for the whole test; the
+      // fail-closed test flips it off explicitly.
+      config.skillsSandbox.enabled = true;
+
+      user = await makeUser();
+      const organization = await makeOrganization({ name: "Test Org" });
+      organizationId = organization.id;
+
+      const role = await makeCustomRole(organizationId, {
+        permission: { sandbox: ["execute"], chat: ["read", "create"] },
+      });
+      await makeMember(user.id, organizationId, { role: role.role });
+
+      const agent = await makeAgent({
+        organizationId,
+        name: "Sandbox Agent",
+        systemPrompt: "",
+      });
+      agentId = agent.id;
+      await seedAndAssignArchestraTools(agentId);
+
+      const conversation = await makeConversation(agentId, {
+        userId: user.id,
+        organizationId,
+      });
+      conversationId = conversation.id;
+
+      mockCreateLLMModelForAgent.mockResolvedValue({ model: "mock-model" });
+      mockGetChatMcpTools.mockResolvedValue({});
+      mockGetChatMcpToolUiResourceUris.mockResolvedValue({});
+      mockExtractAndIngestDocuments.mockResolvedValue(undefined);
+      mockRunSandboxCommand.mockResolvedValue({
+        stdout: "hi\n",
+        stderr: "",
+        exitCode: 0,
+        durationMs: 12,
+        timedOut: false,
+        truncated: false,
+      });
+      mockStartActiveChatSpan.mockImplementation(
+        async ({ callback }: { callback: () => Promise<Response> }) =>
+          callback(),
+      );
+
+      app = createFastifyInstance();
+      app.addHook("onRequest", async (request) => {
+        (request as typeof request & { user: User }).user = user;
+        (
+          request as typeof request & { organizationId: string }
+        ).organizationId = organizationId;
+      });
+      const { default: chatRoutes } = await import("./routes");
+      await app.register(chatRoutes);
+    },
+  );
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const markedUserMessage = (text: string, id = "msg-user-1") => ({
+    id,
+    role: "user",
+    parts: [{ type: "text", text }],
+    metadata: { sandboxCommand: true },
+  });
+
+  const postChat = (payload: Record<string, unknown>) =>
+    app.inject({ method: "POST", url: "/api/chat", payload });
+
+  test("executes the command without an LLM call and persists the turn as a run_command tool part", async () => {
+    const response = await postChat({
+      id: conversationId,
+      messages: [markedUserMessage("! echo hi")],
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mockGetChatMcpTools).not.toHaveBeenCalled();
+    expect(mockCreateLLMModelForAgent).not.toHaveBeenCalled();
+
+    await vi.waitFor(async () => {
+      const rows = await MessageModel.findByConversation(conversationId);
+      expect(rows).toHaveLength(2);
+    });
+    const rows = await MessageModel.findByConversation(conversationId);
+    const [userRow, assistantRow] = rows.map(
+      (row) => row.content as ChatMessage,
+    );
+
+    expect(userRow.role).toBe("user");
+    expect(
+      (userRow.metadata as { sandboxCommand?: boolean }).sandboxCommand,
+    ).toBe(true);
+
+    expect(assistantRow.role).toBe("assistant");
+    const toolParts = toolPartsOf(assistantRow);
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0].state).toBe("output-available");
+    expect(toolParts[0].input).toEqual({ command: "echo hi" });
+    expect(typeof toolParts[0].output).toBe("string");
+    expect(mockRunSandboxCommand).toHaveBeenCalledTimes(1);
+    expect(mockRunSandboxCommand.mock.calls[0][0].command).toBe("echo hi");
+  });
+
+  test("a non-zero exit code is normal tool output, not a turn error", async () => {
+    mockRunSandboxCommand.mockResolvedValue({
+      stdout: "",
+      stderr: "boom",
+      exitCode: 1,
+      durationMs: 5,
+      timedOut: false,
+      truncated: false,
+    });
+
+    const response = await postChat({
+      id: conversationId,
+      messages: [markedUserMessage("! false")],
+    });
+
+    expect(response.statusCode).toBe(200);
+    await vi.waitFor(async () => {
+      const rows = await MessageModel.findByConversation(conversationId);
+      expect(rows).toHaveLength(2);
+    });
+    const assistant = (await MessageModel.findByConversation(conversationId))
+      .map((row) => row.content as ChatMessage)
+      .at(-1);
+    const toolParts = toolPartsOf(assistant as ChatMessage);
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0].state).toBe("output-available");
+  });
+
+  test("fails closed when the marker is present but the sandbox is unavailable", async () => {
+    config.skillsSandbox.enabled = false;
+    const response = await postChat({
+      id: conversationId,
+      messages: [markedUserMessage("! echo hi")],
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(mockGetChatMcpTools).not.toHaveBeenCalled();
+    const rows = await MessageModel.findByConversation(conversationId);
+    expect(rows).toHaveLength(0);
+  });
+
+  test("a !-prefixed message without the marker goes to the normal LLM path", async () => {
+    const response = await postChat({
+      id: conversationId,
+      messages: [
+        {
+          id: "msg-user-1",
+          role: "user",
+          parts: [{ type: "text", text: "! echo hi" }],
+        },
+      ],
+    });
+
+    // The LLM context build ran (the turn itself fails later on the mock
+    // model, which is irrelevant here — the point is the branch was not taken).
+    expect(response.statusCode).toBe(200);
+    expect(mockGetChatMcpTools).toHaveBeenCalledTimes(1);
+  });
+
+  test("regenerate re-runs the command and replaces the trailing turn instead of appending", async () => {
+    const first = await postChat({
+      id: conversationId,
+      messages: [markedUserMessage("! echo hi")],
+    });
+    expect(first.statusCode).toBe(200);
+    await vi.waitFor(async () => {
+      expect(
+        await MessageModel.findByConversation(conversationId),
+      ).toHaveLength(2);
+    });
+    const staleAssistantId = (
+      (await MessageModel.findByConversation(conversationId))[1]
+        .content as ChatMessage
+    ).id;
+
+    const regen = await postChat({
+      id: conversationId,
+      trigger: "regenerate-message",
+      messages: [markedUserMessage("! echo hi")],
+    });
+    expect(regen.statusCode).toBe(200);
+
+    await vi.waitFor(async () => {
+      const rows = await MessageModel.findByConversation(conversationId);
+      expect(rows).toHaveLength(2);
+      const assistant = rows[1].content as ChatMessage;
+      expect(assistant.id).not.toBe(staleAssistantId);
+      expect(toolPartsOf(assistant)).toHaveLength(1);
+    });
+  });
+
+  test("a stop requested before execution persists an output-error part and runs nothing", async () => {
+    const activeRun = await activeChatRunService.createRun({
+      conversationId,
+      userId: user.id,
+      organizationId,
+    });
+    expect(activeRun).not.toBeNull();
+    if (!activeRun) throw new Error("unreachable");
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const persisted: ChatMessage[][] = [];
+    const headers: Record<string, string> = {};
+    const replyStub = {
+      header: (key: string, value: string) => {
+        headers[key] = value;
+      },
+      send: (body: ReadableStream<Uint8Array>) => body,
+    };
+
+    const body = (await runSandboxCommandTurn({
+      command: "echo hi",
+      messages: [markedUserMessage("! echo hi") as ChatMessage],
+      conversationId,
+      agent: { id: agentId, name: "Sandbox Agent" },
+      userId: user.id,
+      organizationId,
+      activeRunId: activeRun.id,
+      abortController,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal reply stub — only header/send are used by the turn
+      reply: replyStub as any,
+      persistTurn: async (finalMessages) => {
+        persisted.push(finalMessages);
+      },
+      onStreamSettled: () => {},
+    })) as unknown as ReadableStream<Uint8Array>;
+
+    const reader = body.getReader();
+    while (!(await reader.read()).done) {
+      // drain the SSE stream so the turn settles
+    }
+
+    await vi.waitFor(() => expect(persisted).toHaveLength(1));
+    const assistant = persisted[0].at(-1);
+    expect(assistant?.role).toBe("assistant");
+    const toolParts = toolPartsOf(assistant as ChatMessage);
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0].state).toBe("output-error");
+  });
+});
+
+describe("sandbox command tool part model visibility", () => {
+  test("the persisted tool part survives normalization and reaches the model messages", async () => {
+    const toolName = runCommandToolName();
+    const messages: ChatMessage[] = [
+      {
+        id: "u1",
+        role: "user",
+        parts: [{ type: "text", text: "! echo hi" }],
+        metadata: { sandboxCommand: true },
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: `tool-${toolName}`,
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { command: "echo hi" },
+            output: "Exit code 0\nstdout:\nhi",
+          },
+        ],
+      },
+    ];
+
+    const normalized = normalizeChatMessages(messages);
+    const modelMessages = await convertToModelMessages(
+      normalized as unknown as Omit<UIMessage, "id">[],
+    );
+
+    const assistantMessage = modelMessages.find((m) => m.role === "assistant");
+    expect(assistantMessage).toBeDefined();
+    expect(
+      (assistantMessage?.content as Array<{ type: string; toolName?: string }>)
+        .filter((part) => part.type === "tool-call")
+        .map((part) => part.toolName),
+    ).toEqual([toolName]);
+
+    const toolMessage = modelMessages.find((m) => m.role === "tool");
+    expect(toolMessage).toBeDefined();
+    expect(
+      (toolMessage?.content as Array<{ type: string; toolCallId?: string }>)
+        .filter((part) => part.type === "tool-result")
+        .map((part) => part.toolCallId),
+    ).toEqual(["call-1"]);
+  });
+});

--- a/platform/backend/src/routes/chat/sandbox-command-turn.ts
+++ b/platform/backend/src/routes/chat/sandbox-command-turn.ts
@@ -55,10 +55,12 @@ export function detectSandboxCommand(
  * is available, but availability is re-checked here — a forged or stale marker
  * gets an error, never a silent fallback to the LLM.
  *
- * Deliberately skipped relative to a model turn: chat lifecycle hooks
- * (Pre/PostToolUse — the user, not the model, initiated this call) and the
- * LLM-facing context build. The active-run lifecycle, stop semantics, stream
- * replay, and persistence shape all match a normal turn.
+ * Deliberately skipped relative to a model turn: Pre/PostToolUse hooks (the
+ * user, not the model, initiated this call) and the LLM-facing context build.
+ * SessionStart hooks still fire at the route level on a first turn — the
+ * session genuinely starts — and their runs are spliced into the persisted
+ * turn by the caller. The active-run lifecycle, stop semantics, stream replay,
+ * and persistence shape all match a normal turn.
  */
 export async function runSandboxCommandTurn(params: {
   command: string;

--- a/platform/backend/src/routes/chat/sandbox-command-turn.ts
+++ b/platform/backend/src/routes/chat/sandbox-command-turn.ts
@@ -37,11 +37,15 @@ export function detectSandboxCommand(
   if (!metadata.success || metadata.data.sandboxCommand !== true) {
     return null;
   }
-  const text = (last.parts ?? [])
-    .filter((part) => part.type === "text")
-    .map((part) => part.text ?? "")
-    .join("\n");
-  return parseSandboxCommand(text);
+  // Exactly one text part — the only shape the composer produces (file parts
+  // may accompany it). A multi-text-part message with the marker came from a
+  // non-composer client; treat it as a normal message rather than guessing
+  // how to join the parts into a command.
+  const textParts = (last.parts ?? []).filter((part) => part.type === "text");
+  if (textParts.length !== 1) {
+    return null;
+  }
+  return parseSandboxCommand(textParts[0].text ?? "");
 }
 
 /**
@@ -76,6 +80,14 @@ export async function runSandboxCommandTurn(params: {
   persistTurn: (finalMessages: ChatMessage[]) => Promise<void>;
   /** Detach stop-polling and abort listeners once the stream settles. */
   onStreamSettled: () => void;
+  /**
+   * Serialize a stream error through the route's chat-error pipeline
+   * (persistence, trace correlation, slim-mode sanitization).
+   */
+  buildErrorPayload: (params: {
+    error: unknown;
+    mappedError: ChatErrorResponse;
+  }) => string;
 }): Promise<FastifyReply> {
   const {
     command,
@@ -89,6 +101,7 @@ export async function runSandboxCommandTurn(params: {
     reply,
     persistTurn,
     onStreamSettled,
+    buildErrorPayload,
   } = params;
 
   const available = await isSkillSandboxAvailableForAgent({
@@ -139,31 +152,51 @@ export async function runSandboxCommandTurn(params: {
         return;
       }
 
-      // RBAC and assignment are enforced inside executeArchestraTool; errors
-      // (denials, validation, sandbox runtime failures) come back as isError
-      // results whose text the same output shaping turns into tool output —
-      // exactly what a model-initiated call would persist.
-      const response = await executeArchestraTool(
-        toolName,
-        { command },
-        {
-          agent,
-          conversationId,
-          isolationKey: conversationId,
-          userId,
+      // Heartbeat while the command runs (container materialization + replay
+      // + the command itself can take minutes) so proxies with idle timeouts
+      // don't cut the SSE — same cadence as the LLM path's tool executions.
+      const heartbeatInterval = setInterval(() => {
+        try {
+          writer.write({
+            type: "data-heartbeat",
+            data: { timestamp: Date.now() },
+          });
+        } catch {
+          clearInterval(heartbeatInterval);
+        }
+      }, 5000);
+
+      let response: Awaited<ReturnType<typeof executeArchestraTool>>;
+      let output: Awaited<ReturnType<typeof buildArchestraToolOutput>>;
+      try {
+        // RBAC and assignment are enforced inside executeArchestraTool; errors
+        // (denials, validation, sandbox runtime failures) come back as isError
+        // results whose text the same output shaping turns into tool output —
+        // exactly what a model-initiated call would persist.
+        response = await executeArchestraTool(
+          toolName,
+          { command },
+          {
+            agent,
+            conversationId,
+            isolationKey: conversationId,
+            userId,
+            agentId: agent.id,
+            organizationId,
+            abortSignal: abortController.signal,
+          },
+        );
+        output = await buildArchestraToolOutput({
+          response,
+          toolName,
+          toolArguments: { command },
           agentId: agent.id,
+          userId,
           organizationId,
-          abortSignal: abortController.signal,
-        },
-      );
-      const output = await buildArchestraToolOutput({
-        response,
-        toolName,
-        toolArguments: { command },
-        agentId: agent.id,
-        userId,
-        organizationId,
-      });
+        });
+      } finally {
+        clearInterval(heartbeatInterval);
+      }
 
       logger.info(
         { conversationId, command, isError: response.isError ?? false },
@@ -184,17 +217,26 @@ export async function runSandboxCommandTurn(params: {
         { error, conversationId, command },
         "[Chat] Sandbox command turn failed",
       );
-      return JSON.stringify({
-        code: ChatErrorCode.ServerError,
-        message: `Sandbox command failed: ${activeRunError}`,
-        isRetryable: true,
-      } satisfies ChatErrorResponse);
+      return buildErrorPayload({
+        error,
+        mappedError: {
+          code: ChatErrorCode.Unknown,
+          message: `Sandbox command failed: ${activeRunError}`,
+          isRetryable: true,
+        },
+      });
     },
     onFinish: async ({ messages: finalMessages }) => {
       onStreamSettled();
       try {
         await persistTurn(finalMessages as unknown as ChatMessage[]);
       } catch (error) {
+        // The command already ran and sits in the sandbox replay log; fail the
+        // run so the desync from the visible transcript is at least surfaced
+        // (the user message itself was persisted before execution).
+        activeRunError = `Failed to persist the command result: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
         logger.error(
           { error, conversationId },
           "Failed to persist sandbox command turn",

--- a/platform/backend/src/routes/chat/sandbox-command-turn.ts
+++ b/platform/backend/src/routes/chat/sandbox-command-turn.ts
@@ -1,0 +1,224 @@
+import {
+  ApiError,
+  ChatErrorCode,
+  type ChatErrorResponse,
+  ChatMessageMetadataSchema,
+  parseSandboxCommand,
+  TOOL_RUN_COMMAND_SHORT_NAME,
+} from "@archestra/shared";
+import { createUIMessageStream, generateId, type UIMessage } from "ai";
+import type { FastifyReply } from "fastify";
+import {
+  archestraMcpBranding,
+  executeArchestraTool,
+} from "@/archestra-mcp-server";
+import { buildArchestraToolOutput } from "@/clients/chat-tool-builder";
+import logger from "@/logging";
+import { ActiveChatRunModel } from "@/models";
+import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
+import type { ChatMessage } from "@/types";
+import { sendGatedUiMessageStreamResponse } from "./ui-stream-response";
+
+/**
+ * A `!`-prefixed composer message the user asked to run directly in the
+ * conversation's sandbox (Claude Code's `!` convention). Detected only when
+ * the composer attached the `sandboxCommand` metadata marker AND the text
+ * still parses as a command — the marker alone never executes anything, and
+ * the command is always re-derived from the visible message text.
+ */
+export function detectSandboxCommand(
+  messages: ChatMessage[],
+): { command: string } | null {
+  const last = messages.at(-1);
+  if (!last || last.role !== "user") {
+    return null;
+  }
+  const metadata = ChatMessageMetadataSchema.safeParse(last.metadata);
+  if (!metadata.success || metadata.data.sandboxCommand !== true) {
+    return null;
+  }
+  const text = (last.parts ?? [])
+    .filter((part) => part.type === "text")
+    .map((part) => part.text ?? "")
+    .join("\n");
+  return parseSandboxCommand(text);
+}
+
+/**
+ * Run a `!`-prefixed user message as a `run_command` execution instead of an
+ * LLM turn. The result streams to the client and persists as the same
+ * `tool-<run_command>` part a model-initiated call produces, so the transcript
+ * renders it with the normal tool UI and later LLM turns see the command and
+ * its output in history.
+ *
+ * Fail-closed: the composer only attaches the marker when the agent's sandbox
+ * is available, but availability is re-checked here — a forged or stale marker
+ * gets an error, never a silent fallback to the LLM.
+ *
+ * Deliberately skipped relative to a model turn: chat lifecycle hooks
+ * (Pre/PostToolUse — the user, not the model, initiated this call) and the
+ * LLM-facing context build. The active-run lifecycle, stop semantics, stream
+ * replay, and persistence shape all match a normal turn.
+ */
+export async function runSandboxCommandTurn(params: {
+  command: string;
+  messages: ChatMessage[];
+  conversationId: string;
+  agent: { id: string; name: string };
+  userId: string;
+  organizationId: string;
+  activeRunId: string;
+  abortController: AbortController;
+  reply: FastifyReply;
+  /** Persist the finished turn (regenerate-aware; owned by the route). */
+  persistTurn: (finalMessages: ChatMessage[]) => Promise<void>;
+  /** Detach stop-polling and abort listeners once the stream settles. */
+  onStreamSettled: () => void;
+}): Promise<FastifyReply> {
+  const {
+    command,
+    messages,
+    conversationId,
+    agent,
+    userId,
+    organizationId,
+    activeRunId,
+    abortController,
+    reply,
+    persistTurn,
+    onStreamSettled,
+  } = params;
+
+  const available = await isSkillSandboxAvailableForAgent({
+    userId,
+    organizationId,
+    agentId: agent.id,
+  });
+  if (!available) {
+    throw new ApiError(
+      403,
+      "Sandbox commands are not available for this agent. The sandbox feature, your sandbox permission, or the agent's sandbox tools may have been disabled.",
+    );
+  }
+
+  const toolName = archestraMcpBranding.getToolName(
+    TOOL_RUN_COMMAND_SHORT_NAME,
+  );
+
+  let activeRunError: string | null = null;
+
+  const stream = createUIMessageStream({
+    originalMessages: messages as unknown as UIMessage[],
+    execute: async ({ writer }) => {
+      const toolCallId = generateId();
+      writer.write({ type: "start" });
+      writer.write({ type: "start-step" });
+      writer.write({
+        type: "tool-input-available",
+        toolCallId,
+        toolName,
+        input: { command },
+      });
+
+      // Stop requested before execution began: end the turn without running.
+      // Once execution starts it runs to completion (the Dagger exec is not
+      // abortable mid-flight — parity with a model-initiated run_command) and
+      // its output IS persisted even if a stop lands meanwhile: the command
+      // was appended to the sandbox replay log, so dropping the visible part
+      // would desync the transcript from the sandbox's real state.
+      if (abortController.signal.aborted) {
+        writer.write({
+          type: "tool-output-error",
+          toolCallId,
+          errorText: "Stopped before the command ran.",
+        });
+        writer.write({ type: "finish-step" });
+        writer.write({ type: "finish" });
+        return;
+      }
+
+      // RBAC and assignment are enforced inside executeArchestraTool; errors
+      // (denials, validation, sandbox runtime failures) come back as isError
+      // results whose text the same output shaping turns into tool output —
+      // exactly what a model-initiated call would persist.
+      const response = await executeArchestraTool(
+        toolName,
+        { command },
+        {
+          agent,
+          conversationId,
+          isolationKey: conversationId,
+          userId,
+          agentId: agent.id,
+          organizationId,
+          abortSignal: abortController.signal,
+        },
+      );
+      const output = await buildArchestraToolOutput({
+        response,
+        toolName,
+        toolArguments: { command },
+        agentId: agent.id,
+        userId,
+        organizationId,
+      });
+
+      logger.info(
+        { conversationId, command, isError: response.isError ?? false },
+        "[Chat] Executed user-initiated sandbox command",
+      );
+
+      writer.write({
+        type: "tool-output-available",
+        toolCallId,
+        output,
+      });
+      writer.write({ type: "finish-step" });
+      writer.write({ type: "finish" });
+    },
+    onError: (error) => {
+      activeRunError = error instanceof Error ? error.message : String(error);
+      logger.error(
+        { error, conversationId, command },
+        "[Chat] Sandbox command turn failed",
+      );
+      return JSON.stringify({
+        code: ChatErrorCode.ServerError,
+        message: `Sandbox command failed: ${activeRunError}`,
+        isRetryable: true,
+      } satisfies ChatErrorResponse);
+    },
+    onFinish: async ({ messages: finalMessages }) => {
+      onStreamSettled();
+      try {
+        await persistTurn(finalMessages as unknown as ChatMessage[]);
+      } catch (error) {
+        logger.error(
+          { error, conversationId },
+          "Failed to persist sandbox command turn",
+        );
+      }
+    },
+  });
+
+  return sendGatedUiMessageStreamResponse({
+    reply,
+    stream,
+    runId: activeRunId,
+    conversationId,
+    abortController,
+    getTerminalStatus: async () => {
+      const latestRun = await ActiveChatRunModel.findById(activeRunId);
+      if (latestRun?.stopRequestedAt) {
+        return { status: "cancelled" };
+      }
+      if (activeRunError) {
+        return { status: "failed", error: activeRunError };
+      }
+      if (abortController.signal.aborted) {
+        return { status: "cancelled" };
+      }
+      return { status: "completed" };
+    },
+  });
+}

--- a/platform/backend/src/routes/chat/ui-stream-response.ts
+++ b/platform/backend/src/routes/chat/ui-stream-response.ts
@@ -1,0 +1,92 @@
+import { ApiError } from "@archestra/shared";
+import { createUIMessageStreamResponse, type UIMessageChunk } from "ai";
+import type { FastifyReply } from "fastify";
+import logger from "@/logging";
+import { activeChatRunService } from "@/services/active-chat-run";
+
+/**
+ * Send a UI-message stream as the chat response while draining a copy into the
+ * active-run event log. The response body's CLOSE (not its bytes — they stream
+ * through unchanged) is held until the active-run row is marked terminal.
+ * Without this, a client that fires its next message the instant this response
+ * ends races the async drain and 409s against a row still flagged running.
+ */
+export async function sendGatedUiMessageStreamResponse(params: {
+  reply: FastifyReply;
+  stream: ReadableStream<UIMessageChunk>;
+  runId: string;
+  conversationId: string;
+  abortController: AbortController;
+  getTerminalStatus: () => Promise<{
+    status: "completed" | "failed" | "cancelled";
+    error?: string | null;
+  }>;
+}): Promise<FastifyReply> {
+  const { reply, runId, conversationId, abortController, getTerminalStatus } =
+    params;
+
+  const [responseStream, persistenceStream] = params.stream.tee();
+  const { terminalReady } = activeChatRunService.drainStreamToEvents({
+    runId,
+    conversationId,
+    stream: persistenceStream,
+    abortController,
+    getTerminalStatus,
+  });
+
+  const response = createUIMessageStreamResponse({
+    headers: {
+      // Prevent compression middleware from buffering the stream
+      // See: https://ai-sdk.dev/docs/troubleshooting/streaming-not-working-when-proxied
+      "Content-Encoding": "none",
+    },
+    stream: responseStream,
+  });
+
+  // Log response headers for debugging
+  logger.info(
+    {
+      conversationId,
+      headers: Object.fromEntries(response.headers.entries()),
+      hasBody: !!response.body,
+    },
+    "Streaming chat response",
+  );
+
+  // Copy headers from Response to Fastify reply
+  for (const [key, value] of response.headers.entries()) {
+    reply.header(key, value);
+  }
+
+  if (!response.body) {
+    throw new ApiError(400, "No response body");
+  }
+  const gatedBody = (response.body as ReadableStream<Uint8Array>).pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      async flush() {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            terminalReady,
+            new Promise<void>((resolve) => {
+              timer = setTimeout(resolve, TERMINAL_CLOSE_GATE_TIMEOUT_MS);
+            }),
+          ]);
+        } finally {
+          if (timer) {
+            clearTimeout(timer);
+          }
+        }
+      },
+    }),
+  );
+  // biome-ignore lint/suspicious/noExplicitAny: Fastify reply.send accepts ReadableStream but TypeScript requires explicit cast
+  return reply.send(gatedBody as any);
+}
+
+// Upper bound on how long the response body's close waits for the active-run row
+// to be marked terminal. Terminalization is normally tens of milliseconds; this
+// cap keeps a wedged DB or notifier after stream-end from hanging the client EOF
+// indefinitely. Past it we release EOF and fall back to the pre-existing 409
+// window (which the stale reaper still cleans up).
+const TERMINAL_CLOSE_GATE_TIMEOUT_MS = 10_000;

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -162,6 +162,7 @@ import {
 } from "./chat-initial-state";
 import ArchestraPromptInput, {
   type ArchestraPromptInputProps,
+  type ChatSubmitOptions,
 } from "./prompt-input";
 import { resolveSharedConversationForkState } from "./shared-conversation-fork";
 import { buildSkillCommands, resolveUrlSkillAction } from "./skill-commands";
@@ -235,6 +236,9 @@ export function ChatPageContent({
   // Skill invoked via slash command on the first message of a new chat,
   // held until the conversation exists and the message can be sent.
   const pendingSkillRef = useRef<ChatSkillMetadata | undefined>(undefined);
+  // Sandbox-command marker (`!` prefix) on the first message of a new chat,
+  // held the same way so the deferred send stamps metadata.sandboxCommand.
+  const pendingSandboxCommandRef = useRef<true | undefined>(undefined);
   // Composer prefill from a `?skillId=` deep link; handed to the composer
   // once and cleared via onPrefillApplied.
   const [composerPrefill, setComposerPrefill] = useState<string | null>(null);
@@ -1370,9 +1374,11 @@ export function ChatPageContent({
     const promptToSend = pendingPromptRef.current;
     const filesToSend = pendingFilesRef.current;
     const skillToSend = pendingSkillRef.current;
+    const sandboxCommandToSend = pendingSandboxCommandRef.current;
     pendingPromptRef.current = undefined;
     pendingFilesRef.current = [];
     pendingSkillRef.current = undefined;
+    pendingSandboxCommandRef.current = undefined;
 
     const parts: ChatMessagePart[] = [];
 
@@ -1396,6 +1402,7 @@ export function ChatPageContent({
       metadata: {
         createdAt: new Date().toISOString(),
         ...(skillToSend ? { skill: skillToSend } : {}),
+        ...(sandboxCommandToSend ? { sandboxCommand: true as const } : {}),
         ...(initialAppDiagnostics.length > 0
           ? { appDiagnostics: initialAppDiagnostics }
           : {}),
@@ -1568,6 +1575,7 @@ export function ChatPageContent({
       metadata: {
         createdAt: new Date().toISOString(),
         ...(skillToAttach ? { skill: skillToAttach } : {}),
+        ...(options?.sandboxCommand ? { sandboxCommand: true as const } : {}),
         ...(appDiagnostics.length > 0 ? { appDiagnostics } : {}),
       },
     });
@@ -1822,23 +1830,25 @@ export function ChatPageContent({
 
   // Core logic for starting a new conversation with a message
   const submitInitialMessage = useCallback(
-    (message: Partial<PromptInputMessage>, skill?: ChatSkillMetadata) => {
+    (message: Partial<PromptInputMessage>, options?: ChatSubmitOptions) => {
       if (isPlaywrightSetupVisible) return;
       const hasText = message.text?.trim();
       const hasFiles = message.files && message.files.length > 0;
 
       if (
-        (!hasText && !hasFiles && !skill) ||
+        (!hasText && !hasFiles && !options?.skill) ||
         !initialAgentId ||
         createConversationMutation.isPending
       ) {
         return;
       }
 
-      // Store the message (text, files, skill) to send after conversation is created
+      // Store the message (text, files, submit options) to send after the
+      // conversation is created
       pendingPromptRef.current = message.text || "";
       pendingFilesRef.current = message.files || [];
-      pendingSkillRef.current = skill;
+      pendingSkillRef.current = options?.skill;
+      pendingSandboxCommandRef.current = options?.sandboxCommand;
 
       // Check if there are pending tool actions to apply
       const pendingActions = getPendingActions(initialAgentId);
@@ -1912,7 +1922,7 @@ export function ChatPageContent({
           // Throw to keep the textarea and draft intact (onSubmit contract).
           throw new Error("offline-not-submit");
         }
-        submitInitialMessage(message, options?.skill);
+        submitInitialMessage(message, options);
       },
       [submitInitialMessage, connectivity.state],
     );

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -10,6 +10,7 @@ const {
   mockTextInputClear,
   mockControllerState,
   mockFeatureState,
+  mockProfileState,
 } = vi.hoisted(() => ({
   mockUseChatPlaceholder: vi.fn(),
   mockUseSkillsPaginated: vi.fn(),
@@ -17,6 +18,9 @@ const {
   mockTextInputClear: vi.fn(),
   mockControllerState: { value: "", files: [] as { url: string }[] },
   mockFeatureState: { chatSecretScanEnabled: false },
+  mockProfileState: {
+    agent: null as { sandboxAvailable: boolean } | null,
+  },
 }));
 
 // Mock ResizeObserver which is used by Radix UI components
@@ -213,10 +217,10 @@ vi.mock("@/components/ui/tooltip", () => ({
   ),
 }));
 
-// Mock agent query hooks
+// Mock agent query hooks; mockProfileState.agent controls sandboxAvailable
 vi.mock("@/lib/agent.query", () => ({
   useProfile: () => ({
-    data: null,
+    data: mockProfileState.agent,
     isLoading: false,
     error: null,
   }),
@@ -298,6 +302,7 @@ describe("ArchestraPromptInput", () => {
     mockControllerState.value = "";
     mockControllerState.files = [];
     mockFeatureState.chatSecretScanEnabled = false;
+    mockProfileState.agent = null;
     localStorage.clear();
   });
 
@@ -801,6 +806,84 @@ describe("ArchestraPromptInput", () => {
       const [message, , options] = onSubmit.mock.calls[0];
       expect(message.text).toBe("summarize the repo");
       expect(options).toEqual({ skill: { id: skill.id, name: skill.name } });
+    });
+
+    it("keeps skill command handling with the sandbox available", () => {
+      const onSubmit = vi.fn();
+      mockProfileState.agent = { sandboxAvailable: true };
+      mockControllerState.value = "/my-skill summarize the repo";
+
+      render(<ArchestraPromptInput {...defaultProps} onSubmit={onSubmit} />);
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const [message, , options] = onSubmit.mock.calls[0];
+      expect(message.text).toBe("summarize the repo");
+      expect(options).toEqual({ skill: { id: skill.id, name: skill.name } });
+    });
+  });
+
+  describe("sandbox commands", () => {
+    it("sandbox available: a `!` message dispatches with the sandboxCommand option and unchanged text", () => {
+      const onSubmit = vi.fn();
+      mockProfileState.agent = { sandboxAvailable: true };
+      mockControllerState.value = "! echo hi";
+
+      render(<ArchestraPromptInput {...defaultProps} onSubmit={onSubmit} />);
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const [message, , options] = onSubmit.mock.calls[0];
+      expect(message.text).toBe("! echo hi");
+      expect(options).toEqual({ sandboxCommand: true });
+    });
+
+    it("sandbox unavailable: the same `!` message submits as a plain message", () => {
+      const onSubmit = vi.fn();
+      mockProfileState.agent = { sandboxAvailable: false };
+      mockControllerState.value = "! echo hi";
+
+      render(<ArchestraPromptInput {...defaultProps} onSubmit={onSubmit} />);
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const [message, , options] = onSubmit.mock.calls[0];
+      expect(message.text).toBe("! echo hi");
+      expect(options).toBeUndefined();
+    });
+
+    it("a bare `!` submits as a plain message even with the sandbox available", () => {
+      const onSubmit = vi.fn();
+      mockProfileState.agent = { sandboxAvailable: true };
+      mockControllerState.value = "!";
+
+      render(<ArchestraPromptInput {...defaultProps} onSubmit={onSubmit} />);
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const [message, , options] = onSubmit.mock.calls[0];
+      expect(message.text).toBe("!");
+      expect(options).toBeUndefined();
+    });
+
+    it("keeps /compact interception with the sandbox available", () => {
+      const onSubmit = vi.fn();
+      const onCompactConversation = vi.fn();
+      mockProfileState.agent = { sandboxAvailable: true };
+      mockControllerState.value = "/compact";
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          conversationId="conversation-1"
+          onCompactConversation={onCompactConversation}
+          onSubmit={onSubmit}
+        />,
+      );
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+
+      expect(onCompactConversation).toHaveBeenCalledTimes(1);
+      expect(onSubmit).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -9,6 +9,7 @@ import {
   getMediaType,
   getModelReadableMimeTypes,
   INLINE_TEXT_MAX_BYTES,
+  parseSandboxCommand,
   supportsFileUploads,
 } from "@archestra/shared";
 import type { ChatStatus } from "ai";
@@ -72,6 +73,16 @@ function formatBytes(bytes: number): string {
     : `${Math.round(bytes / 1024)} KB`;
 }
 
+/**
+ * Options riding alongside a submitted message. At most one is set: a `/`
+ * slash command activates a skill, a `!` prefix marks the message for direct
+ * sandbox execution (the marker lands in `metadata.sandboxCommand`).
+ */
+export type ChatSubmitOptions = {
+  skill?: ChatSkillMetadata;
+  sandboxCommand?: true;
+};
+
 export interface ArchestraPromptInputProps
   extends Omit<ChatPromptInputToolsProps, "textareaRef"> {
   /**
@@ -82,7 +93,7 @@ export interface ArchestraPromptInputProps
   onSubmit: (
     message: PromptInputMessage,
     e: FormEvent<HTMLFormElement>,
-    options?: { skill?: ChatSkillMetadata },
+    options?: ChatSubmitOptions,
   ) => void | Promise<void>;
   status: ChatStatus;
   // Tools integration props
@@ -311,6 +322,12 @@ const PromptInputContent = ({
     [controller.textInput],
   );
 
+  // Subtle affordance for the `!` convention: shown while the typed text
+  // starts with `!` on a sandbox-equipped agent, i.e. whenever submitting
+  // could run it as a sandbox command instead of sending it to the model.
+  const isSandboxCommandHintVisible =
+    sandboxAvailable && controller.textInput.value.trimStart().startsWith("!");
+
   // The picker stays open while the user is still typing the command token;
   // once a space is entered they have moved on to the prompt body.
   const isSlashCommandOpen =
@@ -456,7 +473,7 @@ const PromptInputContent = ({
   const pendingSubmissionRef = useRef<{
     outgoing: PromptInputMessage;
     e: FormEvent<HTMLFormElement>;
-    options?: { skill: ChatSkillMetadata };
+    options?: ChatSubmitOptions;
     resolve: () => void;
     reject: (reason?: unknown) => void;
   } | null>(null);
@@ -470,7 +487,7 @@ const PromptInputContent = ({
     (
       outgoing: PromptInputMessage,
       e: FormEvent<HTMLFormElement>,
-      options?: { skill: ChatSkillMetadata },
+      options?: ChatSubmitOptions,
     ): void | Promise<void> => {
       const result = onSubmit(outgoing, e, options);
       if (result instanceof Promise) {
@@ -499,6 +516,13 @@ const PromptInputContent = ({
         return;
       }
 
+      // a `!`-prefixed message runs directly in the conversation's sandbox —
+      // disjoint from the `/`-commands above and the skill commands below,
+      // since those require a `/` prefix. The text is sent exactly as typed;
+      // only a metadata marker rides along.
+      const isSandboxCommand =
+        sandboxAvailable && parseSandboxCommand(trimmed) !== null;
+
       // a skill command activates the skill; any text after the token is an
       // optional prompt — a bare skill command sends with an empty prompt
       let outgoing = message;
@@ -509,7 +533,11 @@ const PromptInputContent = ({
         outgoing = { ...message, text: parsed.remaining };
       }
 
-      const options = skill ? { skill } : undefined;
+      const options: ChatSubmitOptions | undefined = skill
+        ? { skill }
+        : isSandboxCommand
+          ? { sandboxCommand: true }
+          : undefined;
 
       if (sensitiveDataDetectionEnabled && outgoing.text.length > 0) {
         const findings = scanText(outgoing.text);
@@ -537,6 +565,7 @@ const PromptInputContent = ({
       onCompactConversation,
       runCompactCommand,
       runDebugCommand,
+      sandboxAvailable,
       sensitiveDataDetectionEnabled,
       skillCommands,
     ],
@@ -596,6 +625,13 @@ const PromptInputContent = ({
 
   return (
     <div className="relative">
+      {isSandboxCommandHintVisible && (
+        <div className="absolute inset-x-0 bottom-full mb-2 px-3 text-xs text-muted-foreground">
+          Messages starting with{" "}
+          <span className="font-mono font-medium">!</span> run as commands in
+          the sandbox
+        </div>
+      )}
       {isSlashCommandOpen && (
         <div className="absolute inset-x-0 bottom-full z-50 mb-2 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg">
           <PromptInputCommand className="h-auto rounded-none bg-transparent">

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -14,6 +14,7 @@ import {
   INPUT_MODALITY_OPTIONS,
   isInlineableTextMimeType,
   OUTPUT_MODALITY_OPTIONS,
+  parseSandboxCommand,
   supportsFileUploads,
 } from "./chat";
 
@@ -458,5 +459,33 @@ describe("hasRenderableAssistantContent", () => {
   test("returns false for no parts", () => {
     expect(hasRenderableAssistantContent({ parts: [] })).toBe(false);
     expect(hasRenderableAssistantContent({})).toBe(false);
+  });
+});
+
+describe("parseSandboxCommand", () => {
+  test("extracts the command after the bang", () => {
+    expect(parseSandboxCommand("! npx foo mcp add")).toEqual({
+      command: "npx foo mcp add",
+    });
+  });
+
+  test("accepts the bang glued to the command", () => {
+    expect(parseSandboxCommand("!echo hi")).toEqual({ command: "echo hi" });
+  });
+
+  test("ignores surrounding whitespace", () => {
+    expect(parseSandboxCommand("  ! ls -la  ")).toEqual({ command: "ls -la" });
+  });
+
+  test("rejects a bare bang", () => {
+    expect(parseSandboxCommand("!")).toBeNull();
+    expect(parseSandboxCommand("!   ")).toBeNull();
+  });
+
+  test("rejects ordinary messages", () => {
+    expect(parseSandboxCommand("hello world")).toBeNull();
+    expect(parseSandboxCommand("")).toBeNull();
+    expect(parseSandboxCommand("/compact")).toBeNull();
+    expect(parseSandboxCommand("what does ! mean in bash?")).toBeNull();
   });
 });

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -415,8 +415,32 @@ export const ChatMessageMetadataSchema = z
   .object({
     skill: ChatSkillMetadataSchema.optional(),
     appDiagnostics: ChatAppDiagnosticsMetadataSchema.optional(),
+    /**
+     * Marks a `!`-prefixed user message the composer submitted for direct
+     * sandbox execution (no LLM turn). A marker only — the command is always
+     * re-derived server-side from the message text via `parseSandboxCommand`,
+     * so a forged marker can never execute anything other than what the
+     * transcript shows.
+     */
+    sandboxCommand: z.literal(true).optional(),
   })
   .passthrough();
+
+/**
+ * Parse a `!`-prefixed chat message into the shell command it requests
+ * (Claude Code's `!` convention). Returns null for anything else, including a
+ * bare `!` — those submit as ordinary messages. Used by the composer to decide
+ * whether to mark a message and by the chat route to derive the command to
+ * execute; both sides must agree, which is why it lives in shared.
+ */
+export function parseSandboxCommand(text: string): { command: string } | null {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("!")) {
+    return null;
+  }
+  const command = trimmed.slice(1).trim();
+  return command.length > 0 ? { command } : null;
+}
 
 // ============================================================================
 // Zod Schemas for Model Modalities


### PR DESCRIPTION
Typing `! <command>` in chat executes it in the conversation's sandbox via `run_command` when the agent is sandbox-equipped, instead of sending it to the LLM. The command and its output persist as a regular `run_command` tool part, so the transcript renders it with the normal tool UI and the model sees the result in later turns. Without a sandbox, `!` messages behave as plain text.

- Frontend: the composer attaches a `sandboxCommand` metadata marker when `sandboxAvailable` and the text parses as a command (live-chat and deferred new-chat paths); a hint shows while typing a command.
- Backend: a branch in `POST /api/chat` re-checks availability fail-closed (feature flag + `sandbox:execute` RBAC + tool assignment), executes via `executeArchestraTool`, streams `tool-input-available`/`tool-output-available` chunks with heartbeats, and persists the turn (regenerate replaces the trailing turn atomically). The command is always re-derived from the visible message text, never from the marker. Pre/PostToolUse hooks don't fire for user-typed commands; SessionStart still does and its runs are spliced into the persisted turn.
- Extracted the gated stream-response scaffolding (`ui-stream-response.ts`) and shared it with the LLM path, behavior-identical.
- Fixed `MessageModel.bulkCreate` letting the conversation-touch update escape the caller's transaction.

Notes:
- Output appears when the command finishes (the Dagger backend buffers stdout/stderr; no incremental streaming).
- The exec path is covered by route-level integration tests (CI has no Dagger engine for e2e).

https://claude.ai/code/session_01K3j653UNQ7vEbfgktqRoLk

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>