### PR TITLE
fix(chat): collapse prompt input toolbar when controls don't fit

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -39,7 +39,6 @@ import {
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import type { ModelSource } from "@/lib/chat/use-chat-preferences";
 import { useModelSelectorDisplay } from "@/lib/chat/use-model-selector-display.hook";
-import { useIsMobile } from "@/lib/hooks/use-mobile";
 
 export interface ChatPromptInputToolsProps {
   selectedModel: string;
@@ -100,6 +99,17 @@ export interface ChatPromptInputToolsProps {
    */
   agentModelDisplayName?: string;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  /**
+   * Whether the toolbar should collapse its inline controls into a three-dots
+   * menu. Decided by the parent based on whether they actually fit (measured on
+   * the footer), so it also triggers when a side panel squeezes the input.
+   */
+  isNarrow: boolean;
+  /**
+   * Ref attached to the inline tools row so the parent can measure its natural
+   * width and decide whether the controls still fit.
+   */
+  toolbarRef: React.RefObject<HTMLDivElement | null>;
 }
 
 const ChatPromptInputTools = memo(function ChatPromptInputTools({
@@ -129,9 +139,10 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   agentRequiresPerUserConnect = false,
   agentModelDisplayName,
   textareaRef,
+  isNarrow,
+  toolbarRef,
 }: ChatPromptInputToolsProps) {
   const attachments = usePromptInputAttachments();
-  const isMobile = useIsMobile();
 
   // Collapsed/expanded state for the model selector (defaults to collapsed = provider icon only)
   const { isCollapsed: showDefaultLogo, expand: expandModelSelector } =
@@ -190,9 +201,9 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   );
 
   return (
-    <PromptInputTools className="gap-0.5">
-      {/* Mobile: vertical three-dots menu for collapsed toolbar items */}
-      {isMobile &&
+    <PromptInputTools ref={toolbarRef} className="gap-0.5">
+      {/* Narrow: vertical three-dots menu for collapsed toolbar items */}
+      {isNarrow &&
         (showDefaultLogo &&
         logoProvider &&
         (modelSource === "agent" || modelSource === "organization") ? (
@@ -383,8 +394,8 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
         </Tooltip>
       )}
 
-      {/* Desktop: inline toolbar items */}
-      {!isMobile && (
+      {/* Wide: inline toolbar items */}
+      {!isNarrow && (
         <>
           {canSeeAgentPicker &&
             selectorAgentId !== undefined &&

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -19,12 +19,15 @@ const {
   mockFeatureState: { chatSecretScanEnabled: false },
 }));
 
-// Mock ResizeObserver which is used by Radix UI components
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
+// Mock ResizeObserver (used by Radix UI components and the prompt input's
+// toolbar-collapse hook). Must be a real constructor so `new ResizeObserver()`
+// works. jsdom reports 0 widths, so the hook measures nothing and leaves the
+// toolbar in its full (expanded) layout — which is what these tests exercise.
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
 
 // Mock window.matchMedia for useIsMobile hook
 Object.defineProperty(window, "matchMedia", {

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -44,6 +44,7 @@ import {
   migrateLegacyNewChatDraft,
 } from "@/lib/chat/chat-utils";
 import { useFeature } from "@/lib/config/config.query";
+import { useToolbarCollapse } from "@/lib/hooks/use-toolbar-collapse";
 import { useOrganization } from "@/lib/organization.query";
 import { scanText } from "@/lib/sensitive-data";
 import { useSkillsPaginated } from "@/lib/skills/skill.query";
@@ -73,7 +74,10 @@ function formatBytes(bytes: number): string {
 }
 
 export interface ArchestraPromptInputProps
-  extends Omit<ChatPromptInputToolsProps, "textareaRef"> {
+  extends Omit<
+    ChatPromptInputToolsProps,
+    "textareaRef" | "isNarrow" | "toolbarRef"
+  > {
   /**
    * Handle a submit. The textarea and the saved draft are cleared only when
    * this resolves/returns without throwing. Throw (or reject) to reject the
@@ -172,6 +176,20 @@ const PromptInputContent = ({
   const internalTextareaRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = externalTextareaRef ?? internalTextareaRef;
   const controller = usePromptInputController();
+
+  // Collapse the toolbar based on whether its inline controls actually fit —
+  // measured on the footer, not the viewport — so it reacts when the right-side
+  // panel squeezes the input while the window stays wide, and only collapses
+  // when the controls genuinely no longer fit.
+  const footerRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const trailingRef = useRef<HTMLDivElement>(null);
+  const isNarrow = useToolbarCollapse({
+    availableRef: footerRef,
+    contentRef: toolbarRef,
+    trailingRef,
+  });
+
   const commandItemRefs = useRef<Array<HTMLDivElement | null>>([]);
   const [activeCommandIndex, setActiveCommandIndex] = useState(0);
   const [dismissedSlashCommandValue, setDismissedSlashCommandValue] = useState<
@@ -683,8 +701,10 @@ const PromptInputContent = ({
             />
           )}
         </PromptInputBody>
-        <PromptInputFooter>
+        <PromptInputFooter ref={footerRef}>
           <ChatPromptInputTools
+            isNarrow={isNarrow}
+            toolbarRef={toolbarRef}
             selectedModel={selectedModel}
             onModelChange={onModelChange}
             conversationId={conversationId}
@@ -712,7 +732,7 @@ const PromptInputContent = ({
             contextWindow={contextWindow}
             lastCompaction={lastCompaction}
           />
-          <div className="flex items-center gap-2">
+          <div ref={trailingRef} className="flex items-center gap-2">
             <PromptInputSpeechButton
               textareaRef={textareaRef}
               onTranscriptionChange={handleTranscriptionChange}

--- a/platform/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/platform/frontend/src/components/ai-elements/prompt-input.tsx
@@ -1139,7 +1139,7 @@ export const PromptInputFooter = ({
   />
 );
 
-export type PromptInputToolsProps = HTMLAttributes<HTMLDivElement>;
+export type PromptInputToolsProps = ComponentProps<"div">;
 
 export const PromptInputTools = ({
   className,

--- a/platform/frontend/src/lib/hooks/use-toolbar-collapse.test.ts
+++ b/platform/frontend/src/lib/hooks/use-toolbar-collapse.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useToolbarCollapse } from "./use-toolbar-collapse";
+
+// Capture the observer callback so tests can drive resize events.
+let observerCallback: ResizeObserverCallback | null = null;
+
+beforeEach(() => {
+  observerCallback = null;
+  global.ResizeObserver = class {
+    constructor(callback: ResizeObserverCallback) {
+      observerCallback = callback;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Inline controls need 400px, trailing controls 72px → required total 472px.
+const TOOLS_WIDTH = 400;
+const TRAILING_WIDTH = 72;
+
+function setup(availableWidth: number) {
+  const available = { clientWidth: availableWidth };
+  const content = { scrollWidth: TOOLS_WIDTH };
+  const trailing = { offsetWidth: TRAILING_WIDTH };
+  const refs = {
+    availableRef: { current: available as unknown as HTMLElement },
+    contentRef: { current: content as unknown as HTMLElement },
+    trailingRef: { current: trailing as unknown as HTMLElement },
+  };
+  const { result } = renderHook(() => useToolbarCollapse(refs));
+  const resize = (width: number) => {
+    available.clientWidth = width;
+    act(() => {
+      observerCallback?.(
+        [] as unknown as ResizeObserverEntry[],
+        {} as ResizeObserver,
+      );
+    });
+  };
+  return { result, resize };
+}
+
+describe("useToolbarCollapse", () => {
+  it("stays expanded when the inline controls fit", () => {
+    const { result } = setup(900);
+    expect(result.current).toBe(false);
+  });
+
+  it("collapses when the inline controls do not fit", () => {
+    const { result } = setup(460); // 472 needed > 460
+    expect(result.current).toBe(true);
+  });
+
+  it("collapses when the container shrinks below what the controls need", () => {
+    const { result, resize } = setup(900);
+    expect(result.current).toBe(false);
+
+    resize(460);
+    expect(result.current).toBe(true);
+  });
+
+  it("does not re-expand until there is clearly enough room (hysteresis)", () => {
+    const { result, resize } = setup(460);
+    expect(result.current).toBe(true);
+
+    // Just past the raw requirement (472) but within the hysteresis band.
+    resize(500);
+    expect(result.current).toBe(true);
+
+    // Comfortably past requirement + hysteresis (472 + 40 = 512).
+    resize(520);
+    expect(result.current).toBe(false);
+  });
+
+  it("stays expanded when there is no container to measure", () => {
+    const refs = {
+      availableRef: { current: null },
+      contentRef: { current: null },
+      trailingRef: { current: null },
+    };
+    const { result } = renderHook(() => useToolbarCollapse(refs));
+    expect(result.current).toBe(false);
+  });
+});

--- a/platform/frontend/src/lib/hooks/use-toolbar-collapse.ts
+++ b/platform/frontend/src/lib/hooks/use-toolbar-collapse.ts
@@ -1,0 +1,90 @@
+import * as React from "react";
+
+// Breathing room (px) kept between the inline controls and the available space
+// before collapsing, so they don't collapse the instant they'd touch.
+const COLLAPSE_MARGIN = 8;
+// Extra width (px) required to expand again beyond what's needed to collapse.
+// This hysteresis prevents flip-flopping when the container hovers on the edge.
+const EXPAND_HYSTERESIS = 40;
+
+/**
+ * Decides whether a prompt-input-style toolbar should collapse its inline
+ * controls into a compact menu, based on whether they actually fit — not on a
+ * fixed viewport/container breakpoint.
+ *
+ * It measures the inline controls' natural width (`contentRef`) plus the
+ * always-present trailing controls (`trailingRef`) and compares that to the
+ * available width (`availableRef`, e.g. the footer row). Because the container
+ * can be squeezed by a side panel while the window stays wide, this reacts to
+ * the toolbar's own box via ResizeObserver.
+ *
+ * The inline width is cached while expanded, so once collapsed (inline controls
+ * unmounted) the decision to expand again uses the last-known requirement plus
+ * a hysteresis margin, avoiding oscillation at the threshold.
+ */
+export function useToolbarCollapse({
+  availableRef,
+  contentRef,
+  trailingRef,
+}: {
+  /** Element whose width is the space the toolbar has to work with. */
+  availableRef: React.RefObject<HTMLElement | null>;
+  /** Inline controls; their natural (scroll) width is what must fit. */
+  contentRef: React.RefObject<HTMLElement | null>;
+  /** Trailing controls (e.g. send button) always shown; width is reserved. */
+  trailingRef: React.RefObject<HTMLElement | null>;
+}): boolean {
+  const [collapsed, setCollapsed] = React.useState(false);
+  const collapsedRef = React.useRef(false);
+  // Last measured natural width of the inline controls (cached while expanded).
+  const requiredWidthRef = React.useRef(0);
+
+  React.useLayoutEffect(() => {
+    const available = availableRef.current;
+    if (!available) {
+      return;
+    }
+
+    const evaluate = () => {
+      // Only the inline controls carry variable width; cache it while they are
+      // mounted (expanded) so we can still decide once they're gone.
+      const content = contentRef.current;
+      if (content && !collapsedRef.current) {
+        requiredWidthRef.current = content.scrollWidth;
+      }
+
+      const required = requiredWidthRef.current;
+      if (required === 0) {
+        return; // Nothing measured yet.
+      }
+
+      const trailing = trailingRef.current?.offsetWidth ?? 0;
+      const needed = required + trailing;
+      const availableWidth = available.clientWidth;
+
+      const next = collapsedRef.current
+        ? needed + EXPAND_HYSTERESIS > availableWidth // stay collapsed until clearly roomy
+        : needed + COLLAPSE_MARGIN > availableWidth; // collapse as soon as it won't fit
+
+      if (next !== collapsedRef.current) {
+        collapsedRef.current = next;
+        setCollapsed(next);
+      }
+    };
+
+    evaluate();
+
+    const observer = new ResizeObserver(evaluate);
+    observer.observe(available);
+    if (contentRef.current) {
+      observer.observe(contentRef.current);
+    }
+    if (trailingRef.current) {
+      observer.observe(trailingRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [availableRef, contentRef, trailingRef]);
+
+  return collapsed;
+}


### PR DESCRIPTION
The prompt input toolbar collapsed to its compact three-dots menu based on viewport width, so it stayed wide when the right-side panel squeezed the input, and (once switched to container width) collapsed far too early.

Now it collapses only when the inline controls genuinely don't fit: measures the inline tools' natural width plus the trailing controls against the footer's available width, via ResizeObserver, with hysteresis to avoid flip-flop.

T-484

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>