### PR TITLE
feat(apps): publish_app accepts team names, not just uuids

### DIFF
--- a/docs/pages/platform-archestra-mcp-server.md
+++ b/docs/pages/platform-archestra-mcp-server.md
@@ -2142,7 +2142,7 @@ Required RBAC permission: `app:update`
 |-----------|------|----------|-------------|
 | `appId` | `string` | Yes | The app id to publish. |
 | `scope` | `"team" \| "org"` | Yes | Publish to specific teams or to the whole organization. Promotes the app out of personal scope. |
-| `teamIds` | `string[]` | No | Target team ids — required when scope is team. |
+| `teams` | `string[]` | No | Target teams, each a team name or team id — required when scope is team. Pass the team name the user gave (e.g. ["Platform"]); no need to look up ids first. |
 
 ##### Output
 

--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -2314,7 +2314,7 @@ describe("publish_app", () => {
     expect((await AppModel.findById(app.id))?.scope).toBe("personal");
   });
 
-  test("publishing to a team requires teamIds", async ({
+  test("publishing to a team requires teams", async ({
     makeAgent,
     makeUser,
     makeMember,
@@ -2336,7 +2336,7 @@ describe("publish_app", () => {
 
     const result = await publish({ appId: app.id, scope: "team" }, context);
     expect(result.isError).toBe(true);
-    expect((result.content[0] as any).text).toContain("team id");
+    expect((result.content[0] as any).text).toContain("at least one team");
   });
 
   test("an admin publishes to a team and assigns it", async ({
@@ -2364,12 +2364,172 @@ describe("publish_app", () => {
     };
 
     const result = await publish(
-      { appId: app.id, scope: "team", teamIds: [team.id] },
+      { appId: app.id, scope: "team", teams: [team.id] },
       context,
     );
     expect(result.isError).toBe(false);
     expect(structured(result).scope).toBe("team");
     expect(await AppAccessModel.getTeamsForApp(app.id)).toEqual([team.id]);
+  });
+
+  test("an admin publishes to a team by its name instead of its id", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+    makeApp,
+    makeTeam,
+  }) => {
+    const agent = await makeAgent({ name: "Publish TeamName" });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId, { role: ADMIN_ROLE_NAME });
+    const team = await makeTeam(agent.organizationId, user.id, {
+      name: "Growth Team",
+    });
+    const app = await makeApp({
+      organizationId: agent.organizationId,
+      scope: "personal",
+      authorId: user.id,
+    });
+    const context: ArchestraContext = {
+      agent: { id: agent.id, name: agent.name },
+      organizationId: agent.organizationId,
+      userId: user.id,
+    };
+
+    const result = await publish(
+      { appId: app.id, scope: "team", teams: ["Growth Team"] },
+      context,
+    );
+    expect(result.isError).toBe(false);
+    expect(structured(result).scope).toBe("team");
+    expect(await AppAccessModel.getTeamsForApp(app.id)).toEqual([team.id]);
+  });
+
+  test("team names match case-insensitively when unambiguous", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+    makeApp,
+    makeTeam,
+  }) => {
+    const agent = await makeAgent({ name: "Publish TeamNameCI" });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId, { role: ADMIN_ROLE_NAME });
+    const team = await makeTeam(agent.organizationId, user.id, {
+      name: "Platform",
+    });
+    const app = await makeApp({
+      organizationId: agent.organizationId,
+      scope: "personal",
+      authorId: user.id,
+    });
+    const context: ArchestraContext = {
+      agent: { id: agent.id, name: agent.name },
+      organizationId: agent.organizationId,
+      userId: user.id,
+    };
+
+    const result = await publish(
+      { appId: app.id, scope: "team", teams: ["platform"] },
+      context,
+    );
+    expect(result.isError).toBe(false);
+    expect(await AppAccessModel.getTeamsForApp(app.id)).toEqual([team.id]);
+  });
+
+  test("a name and the id of the same team dedupe to one assignment", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+    makeApp,
+    makeTeam,
+  }) => {
+    const agent = await makeAgent({ name: "Publish TeamDedupe" });
+    const user = await makeUser();
+    await makeMember(user.id, agent.organizationId, { role: ADMIN_ROLE_NAME });
+    const team = await makeTeam(agent.organizationId, user.id, {
+      name: "Dedupe Team",
+    });
+    const app = await makeApp({
+      organizationId: agent.organizationId,
+      scope: "personal",
+      authorId: user.id,
+    });
+    const context: ArchestraContext = {
+      agent: { id: agent.id, name: agent.name },
+      organizationId: agent.organizationId,
+      userId: user.id,
+    };
+
+    const result = await publish(
+      { appId: app.id, scope: "team", teams: ["Dedupe Team", team.id] },
+      context,
+    );
+    expect(result.isError).toBe(false);
+    expect(await AppAccessModel.getTeamsForApp(app.id)).toEqual([team.id]);
+  });
+
+  test("an ambiguous case-insensitive team name is rejected", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+    makeApp,
+    makeTeam,
+  }) => {
+    const agent = await makeAgent({ name: "Publish TeamAmbiguous" });
+    const orgId = agent.organizationId;
+    const user = await makeUser();
+    await makeMember(user.id, orgId, { role: ADMIN_ROLE_NAME });
+    await makeTeam(orgId, user.id, { name: "Design" });
+    await makeTeam(orgId, user.id, { name: "design" });
+    const app = await makeApp({
+      organizationId: orgId,
+      scope: "personal",
+      authorId: user.id,
+    });
+    const context: ArchestraContext = {
+      agent: { id: agent.id, name: agent.name },
+      organizationId: orgId,
+      userId: user.id,
+    };
+
+    const result = await publish(
+      { appId: app.id, scope: "team", teams: ["DESIGN"] },
+      context,
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain("ambiguous");
+    expect((await AppModel.findById(app.id))?.scope).toBe("personal");
+  });
+
+  test("rejects a team name that does not exist in the org", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+    makeApp,
+  }) => {
+    const agent = await makeAgent({ name: "Publish UnknownName" });
+    const orgId = agent.organizationId;
+    const user = await makeUser();
+    await makeMember(user.id, orgId, { role: ADMIN_ROLE_NAME });
+    const app = await makeApp({
+      organizationId: orgId,
+      scope: "personal",
+      authorId: user.id,
+    });
+    const context: ArchestraContext = {
+      agent: { id: agent.id, name: agent.name },
+      organizationId: orgId,
+      userId: user.id,
+    };
+
+    const result = await publish(
+      { appId: app.id, scope: "team", teams: ["No Such Team"] },
+      context,
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain("Unknown team");
+    expect((await AppModel.findById(app.id))?.scope).toBe("personal");
   });
 
   // The source-scope gate: a team admin (editor) can see every org app but must
@@ -2396,7 +2556,7 @@ describe("publish_app", () => {
     };
 
     const result = await publish(
-      { appId: app.id, scope: "team", teamIds: [team.id] },
+      { appId: app.id, scope: "team", teams: [team.id] },
       context,
     );
     expect(result.isError).toBe(true);
@@ -2405,7 +2565,7 @@ describe("publish_app", () => {
     expect(await AppAccessModel.getTeamsForApp(app.id)).toEqual([]);
   });
 
-  test("rejects teamIds when publishing to org scope", async ({
+  test("rejects teams when publishing to org scope", async ({
     makeAgent,
     makeUser,
     makeMember,
@@ -2429,7 +2589,7 @@ describe("publish_app", () => {
     };
 
     const result = await publish(
-      { appId: app.id, scope: "org", teamIds: [team.id] },
+      { appId: app.id, scope: "org", teams: [team.id] },
       context,
     );
     expect(result.isError).toBe(true);
@@ -2457,7 +2617,7 @@ describe("publish_app", () => {
     };
 
     const result = await publish(
-      { appId: app.id, scope: "team", teamIds: [crypto.randomUUID()] },
+      { appId: app.id, scope: "team", teams: [crypto.randomUUID()] },
       context,
     );
     expect(result.isError).toBe(true);

--- a/platform/backend/src/archestra-mcp-server/apps.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.ts
@@ -34,7 +34,7 @@ import {
 import {
   assertCallerMayModifyApp,
   callerIsAppAdmin,
-  resolveOrgTeamIds,
+  resolveOrgTeams,
 } from "@/services/apps/app-authorization";
 import { buildAppCapabilityContext } from "@/services/apps/app-capability-context";
 import {
@@ -228,10 +228,12 @@ const PublishAppSchema = z.strictObject({
     .describe(
       "Publish to specific teams or to the whole organization. Promotes the app out of personal scope.",
     ),
-  teamIds: z
-    .array(z.string().uuid())
+  teams: z
+    .array(z.string().min(1))
     .optional()
-    .describe("Target team ids — required when scope is team."),
+    .describe(
+      'Target teams, each a team name or team id — required when scope is team. Pass the team name the user gave (e.g. ["Platform"]); no need to look up ids first.',
+    ),
 });
 
 const PublishAppOutputSchema = z.object({
@@ -985,7 +987,7 @@ const registry = defineArchestraTools([
     shortName: TOOL_PUBLISH_APP_SHORT_NAME,
     title: "Publish App",
     description:
-      "Share an app with others: promote it out of personal scope so others can run it — this is how you distribute or make an app available to a team or the whole org — to specific teams (scope: team, with teamIds) or the whole organization (scope: org). Publishing is gated by the caller's role: org-wide needs an app admin, a team needs a team admin who belongs to that team. Publishing changes only the app's sharing scope: it does not modify the HTML or re-run validation, so confirm the current version is sound with validate_app (or get_app_diagnostics) beforehand if you need to. Returns the app's standalone run page.",
+      "Share an app with others: promote it out of personal scope so others can run it — this is how you distribute or make an app available to a team or the whole org — to specific teams (scope: team, with teams — team names or ids) or the whole organization (scope: org). Publishing is gated by the caller's role: org-wide needs an app admin, a team needs a team admin who belongs to that team. Publishing changes only the app's sharing scope: it does not modify the HTML or re-run validation, so confirm the current version is sound with validate_app (or get_app_diagnostics) beforehand if you need to. Returns the app's standalone run page.",
     schema: PublishAppSchema,
     outputSchema: PublishAppOutputSchema,
     async handler({ args, context }) {
@@ -993,14 +995,14 @@ const registry = defineArchestraTools([
         return errorResult("Authentication required to publish an app.");
       }
       const { userId, organizationId } = context;
-      if (args.scope === "team" && (args.teamIds?.length ?? 0) === 0) {
+      if (args.scope === "team" && (args.teams?.length ?? 0) === 0) {
         return errorResult(
-          "Publishing to a team requires at least one team id in teamIds.",
+          "Publishing to a team requires at least one team in teams — pass the team name (or id) the user wants to share with; use list_teams to discover teams if needed.",
         );
       }
-      if (args.scope === "org" && (args.teamIds?.length ?? 0) > 0) {
+      if (args.scope === "org" && (args.teams?.length ?? 0) > 0) {
         return errorResult(
-          "teamIds is only valid when publishing to a team; omit it for org scope.",
+          "teams is only valid when publishing to a team; omit it for org scope.",
         );
       }
       const loaded = await loadAppForCaller({
@@ -1014,11 +1016,11 @@ const registry = defineArchestraTools([
       let teamIds: string[];
       try {
         // Validate the requested teams exist in the caller's org before any auth
-        // or write, so a foreign-org or unknown team id can never be assigned to
+        // or write, so a foreign-org or unknown team can never be assigned to
         // the app's backing catalog.
         teamIds =
           args.scope === "team"
-            ? await resolveOrgTeamIds(args.teamIds, organizationId)
+            ? await resolveOrgTeams(args.teams, organizationId)
             : [];
         // Authorize BOTH the app's current scope and the destination, exactly as
         // the REST re-scope path does. The source check is what stops a team

--- a/platform/backend/src/routes/app/app.routes.ts
+++ b/platform/backend/src/routes/app/app.routes.ts
@@ -31,7 +31,7 @@ import {
 import {
   assertCallerMayModifyApp,
   callerIsAppAdmin,
-  resolveOrgTeamIds,
+  resolveOrgTeams,
 } from "@/services/apps/app-authorization";
 import {
   createSeededAppConversation,
@@ -243,7 +243,7 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async ({ body, user, organizationId }, reply) => {
       const scope = body.scope ?? "personal";
-      const teamIds = await resolveOrgTeamIds(body.teamIds, organizationId);
+      const teamIds = await resolveOrgTeams(body.teamIds, organizationId);
       if (scope === "team" && teamIds.length === 0) {
         throw new ApiError(
           400,
@@ -442,7 +442,7 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const resourceTeamIds = await AppAccessModel.getTeamsForApp(app.id);
       const nextTeamIds =
         body.teamIds !== undefined
-          ? await resolveOrgTeamIds(body.teamIds, organizationId)
+          ? await resolveOrgTeams(body.teamIds, organizationId)
           : undefined;
 
       await assertCallerMayModifyApp({

--- a/platform/backend/src/services/apps/app-authorization.ts
+++ b/platform/backend/src/services/apps/app-authorization.ts
@@ -5,29 +5,56 @@ import { ApiError } from "@/types";
 import type { AppScope } from "@/types/app";
 
 /**
- * Dedupe the requested team ids and assert every one belongs to the caller's
- * org, throwing `ApiError(400)` otherwise. Shared by the REST app routes and the
- * `publish_app` MCP tool so neither can assign an app to a foreign-org team or
- * a team id that does not exist.
+ * Resolve requested team references — team ids or team names — to a deduped
+ * list of team ids, asserting every one belongs to the caller's org and
+ * throwing `ApiError(400)` otherwise. Shared by the REST app routes (which
+ * pass ids) and the `publish_app` MCP tool (where the model passes whatever
+ * the user said, usually a team name) so neither can assign an app to a
+ * foreign-org team or a team that does not exist. Names match exactly first,
+ * then case-insensitively when that is unambiguous.
  */
-export async function resolveOrgTeamIds(
-  teamIds: string[] | undefined,
+export async function resolveOrgTeams(
+  teamRefs: string[] | undefined,
   organizationId: string,
 ): Promise<string[]> {
-  const unique = [...new Set(teamIds ?? [])];
+  const unique = [...new Set((teamRefs ?? []).map((ref) => ref.trim()))];
   if (unique.length === 0) return [];
-  const teams = await TeamModel.findByIds(unique);
-  const inOrg = new Set(
-    teams.filter((t) => t.organizationId === organizationId).map((t) => t.id),
-  );
-  const invalid = unique.filter((id) => !inOrg.has(id));
-  if (invalid.length > 0) {
+  const orgTeams = await TeamModel.findByOrganization(organizationId);
+  const teamsById = new Map(orgTeams.map((team) => [team.id, team]));
+  const resolved = new Set<string>();
+  const unknown: string[] = [];
+  for (const ref of unique) {
+    const byId = teamsById.get(ref);
+    if (byId) {
+      resolved.add(byId.id);
+      continue;
+    }
+    const exact = orgTeams.filter((team) => team.name === ref);
+    const matches =
+      exact.length > 0
+        ? exact
+        : orgTeams.filter(
+            (team) => team.name.toLowerCase() === ref.toLowerCase(),
+          );
+    if (matches.length > 1) {
+      throw new ApiError(
+        400,
+        `Team name "${ref}" is ambiguous in this organization; pass the team id instead.`,
+      );
+    }
+    if (matches.length === 1) {
+      resolved.add(matches[0].id);
+      continue;
+    }
+    unknown.push(ref);
+  }
+  if (unknown.length > 0) {
     throw new ApiError(
       400,
-      `Unknown team(s) for this organization: ${invalid.join(", ")}`,
+      `Unknown team(s) for this organization: ${unknown.join(", ")}`,
     );
   }
-  return unique;
+  return [...resolved];
 }
 
 /**


### PR DESCRIPTION
## Problem

From the /chat UI, sharing an app with a team goes through the `publish_app` MCP tool, whose `teamIds` param only accepted UUIDs. Users say *"share it with my team"* or *"share with team X"* — never a UUID — so the model had to first resolve the name via `list_teams` (an extra hop that fails outright when `list_teams` isn't assigned to the agent, since Archestra tools are explicitly assigned).

## Change

- `publish_app`'s `teamIds` param is renamed to `teams`; each entry may be a **team name or a team id**. The description tells the model to pass the name the user gave directly.
- Name resolution is org-scoped: exact match first, then case-insensitive when unambiguous (mirrors the `get_team` tool's existing name-lookup precedent). Ambiguous names get a targeted error asking for the id.
- The shared resolver `resolveOrgTeamIds` → `resolveOrgTeams` (`services/apps/app-authorization.ts`) still enforces the foreign-org/unknown-team guard and is still used by the REST app routes (which keep sending UUIDs — no REST/UI change).
- Guard errors are now self-recovering for the model: the empty-`teams` error says to pass the user's team name (or use `list_teams`); unknown/ambiguous names get specific messages. No team names are enumerated in errors, preserving `list_teams`' visibility rules.
- Regenerated `docs/pages/platform-archestra-mcp-server.md` (tool description change).

## Tests

- Updated existing `publish_app` tests for the renamed param.
- New tests: publish by exact name, case-insensitive name, name+id dedupe, ambiguous case-variant names rejected, unknown name rejected (app scope untouched in both failure cases).
- `pnpm type-check`, `pnpm knip` (dev+production), biome, and the app route + apps MCP test suites (191 tests) all pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>