### PR TITLE
fix(chat/proxy): give untyped MCP tool schema nodes an explicit type for Gemini/Vertex

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -252,6 +252,58 @@ describe("normalizeJsonSchema", () => {
     expect(normalizeJsonSchema(schema)).toEqual({ type: "string" });
   });
 
+  test("gives untyped nodes an explicit type (Gemini/Vertex rejects untyped schema nodes)", () => {
+    // posthog__cohorts-partial-update shape: `query` is zod.unknown().nullable(),
+    // which serializes to a bare {} branch that Vertex 400s on — even behind
+    // OpenRouter when it routes the model to a Google-hosted deployment.
+    const schema = {
+      type: "object",
+      properties: {
+        query: { anyOf: [{}, { type: "null" }] },
+        payload: {},
+        config: { properties: { a: { type: "string" } } },
+        tags: { items: { type: "string" } },
+        mode: { enum: ["fast", "slow"] },
+        count: { enum: [1, 2] },
+        linked: { $ref: "#/$defs/Thing" },
+      },
+      $defs: { Thing: { type: "string" } },
+    };
+    expect(normalizeJsonSchema(schema)).toEqual({
+      type: "object",
+      properties: {
+        query: {
+          anyOf: [
+            { type: "object", additionalProperties: true },
+            { type: "null" },
+          ],
+        },
+        payload: { type: "object", additionalProperties: true },
+        config: {
+          type: "object",
+          properties: { a: { type: "string" } },
+          additionalProperties: false,
+        },
+        tags: { type: "array", items: { type: "string" } },
+        mode: { type: "string", enum: ["fast", "slow"] },
+        count: { type: "integer", enum: [1, 2] },
+        linked: { $ref: "#/$defs/Thing" },
+      },
+      $defs: { Thing: { type: "string" } },
+      additionalProperties: false,
+    });
+  });
+
+  test("keeps a bare any-node open instead of clamping it with additionalProperties: false", () => {
+    const result = normalizeJsonSchema({
+      type: "object",
+      properties: { anything: {} },
+    });
+    expect(
+      (result.properties as Record<string, Record<string, unknown>>).anything,
+    ).toEqual({ type: "object", additionalProperties: true });
+  });
+
   test("does not mutate the original schema", () => {
     const schema = {
       type: "object",

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -1527,12 +1527,144 @@ function normalizeJsonSchema(schema: unknown): JSONSchema7 {
     return fallbackSchema;
   }
 
+  // Give every subschema an explicit `type`. MCP servers may emit untyped
+  // nodes (e.g. zod `z.unknown()` becomes a bare `{}`), which are valid JSON
+  // Schema but rejected by providers with strict function-call validation —
+  // Gemini/Vertex 400s with "schema didn't specify the schema type field",
+  // and that can surface even behind OpenRouter when it routes a model to a
+  // Google-hosted deployment.
+  const typed = ensureExplicitSchemaTypes(schema);
+
   // Add additionalProperties: false to all object-type schemas recursively.
   // This is required for OpenAI-compatible providers (Ollama, vLLM) to properly
   // emit streaming tool calls instead of outputting tool calls as text content.
   // Without it, models hallucinate extra properties and providers may fail to
   // recognize the output as a tool call in streaming mode.
-  return addAdditionalPropertiesFalse(schema) as JSONSchema7;
+  return addAdditionalPropertiesFalse(typed) as JSONSchema7;
+}
+
+// JSON-schema keywords whose value is a map of named subschemas
+const SUBSCHEMA_MAP_KEYS = [
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+] as const;
+
+// JSON-schema keywords whose value is an array of subschemas
+const SUBSCHEMA_ARRAY_KEYS = [
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "prefixItems",
+] as const;
+
+// JSON-schema keywords whose value is a single subschema
+const SINGLE_SUBSCHEMA_KEYS = [
+  "additionalProperties",
+  "items",
+  "contains",
+  "not",
+] as const;
+
+/**
+ * Recursively ensures every schema node carries an explicit `type` (or is a
+ * `$ref` / an `anyOf`/`oneOf`/`allOf` composite whose branches are typed).
+ * The type is inferred from structural keywords when possible; a completely
+ * bare "accept anything" node (`{}`) becomes an open object — the same
+ * fallback Google's own SDKs and LiteLLM apply for Vertex compatibility.
+ */
+function ensureExplicitSchemaTypes(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = { ...schema };
+
+  for (const key of SUBSCHEMA_MAP_KEYS) {
+    const map = result[key];
+    if (isRecord(map)) {
+      const newMap: Record<string, unknown> = {};
+      for (const [name, sub] of Object.entries(map)) {
+        newMap[name] = isRecord(sub) ? ensureExplicitSchemaTypes(sub) : sub;
+      }
+      result[key] = newMap;
+    }
+  }
+
+  for (const key of SUBSCHEMA_ARRAY_KEYS) {
+    const arr = result[key];
+    if (Array.isArray(arr)) {
+      result[key] = arr.map((sub) =>
+        isRecord(sub) ? ensureExplicitSchemaTypes(sub) : sub,
+      );
+    }
+  }
+
+  for (const key of SINGLE_SUBSCHEMA_KEYS) {
+    const sub = result[key];
+    if (isRecord(sub)) {
+      result[key] = ensureExplicitSchemaTypes(sub);
+    }
+  }
+
+  // `items` may also be the (deprecated) tuple form
+  if (Array.isArray(result.items)) {
+    result.items = result.items.map((sub) =>
+      isRecord(sub) ? ensureExplicitSchemaTypes(sub) : sub,
+    );
+  }
+
+  if (result.type !== undefined || typeof result.$ref === "string") {
+    return result;
+  }
+  // Composite nodes are typed via their branches
+  if (
+    Array.isArray(result.anyOf) ||
+    Array.isArray(result.oneOf) ||
+    Array.isArray(result.allOf)
+  ) {
+    return result;
+  }
+
+  const inferred = inferSchemaType(result);
+  if (inferred) {
+    result.type = inferred;
+    return result;
+  }
+
+  // Bare "any" node: default to an open object. `additionalProperties: true`
+  // is set explicitly so addAdditionalPropertiesFalse doesn't clamp it shut.
+  result.type = "object";
+  result.additionalProperties = true;
+  return result;
+}
+
+/** Infers a JSON-schema `type` from structural keywords, or null for a bare node. */
+function inferSchemaType(node: Record<string, unknown>): string | null {
+  if (
+    isRecord(node.properties) ||
+    isRecord(node.patternProperties) ||
+    Array.isArray(node.required) ||
+    "additionalProperties" in node
+  ) {
+    return "object";
+  }
+  if ("items" in node || "prefixItems" in node || "contains" in node) {
+    return "array";
+  }
+  const literals = Array.isArray(node.enum)
+    ? node.enum
+    : "const" in node
+      ? [node.const]
+      : [];
+  const nonNull = literals.filter((v) => v !== null);
+  if (nonNull.length > 0) {
+    if (nonNull.every((v) => typeof v === "string")) return "string";
+    if (nonNull.every((v) => typeof v === "boolean")) return "boolean";
+    if (nonNull.every((v) => typeof v === "number")) {
+      return nonNull.every((v) => Number.isInteger(v)) ? "integer" : "number";
+    }
+  }
+  return null;
 }
 
 /**

--- a/platform/backend/src/routes/proxy/adapters/gemini-schema.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-schema.test.ts
@@ -166,6 +166,76 @@ describe("sanitizeGeminiToolSchema", () => {
     expect(sanitizeGeminiToolSchema([1, 2])).toEqual([1, 2]);
   });
 
+  it("defaults a bare untyped node to object (zod z.unknown() shape)", () => {
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "object",
+        properties: { payload: {} },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: { payload: { type: "object" } },
+    });
+  });
+
+  it("types untyped anyOf branches but leaves the composite node untyped (the reported Vertex failure shape)", () => {
+    // posthog__cohorts-partial-update `query`: zod.unknown().nullable()
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "object",
+        properties: {
+          query: { anyOf: [{}, { type: "null" }] },
+        },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        query: { anyOf: [{ type: "object" }, { type: "null" }] },
+      },
+    });
+  });
+
+  it("infers object/array types from structural keywords", () => {
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "object",
+        properties: {
+          config: { properties: { a: { type: "string" } } },
+          tags: { items: { type: "string" } },
+          strict: { additionalProperties: false },
+        },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        config: { type: "object", properties: { a: { type: "string" } } },
+        tags: { type: "array", items: { type: "string" } },
+        strict: { type: "object", additionalProperties: false },
+      },
+    });
+  });
+
+  it("types an untyped string enum as string", () => {
+    expect(sanitizeGeminiToolSchema({ enum: ["a", "b"] })).toEqual({
+      type: "string",
+      enum: ["a", "b"],
+    });
+  });
+
+  it("leaves $ref nodes untyped", () => {
+    expect(
+      sanitizeGeminiToolSchema({
+        type: "object",
+        properties: { linked: { $ref: "#/$defs/Thing" } },
+        $defs: { Thing: { type: "string" } },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: { linked: { $ref: "#/$defs/Thing" } },
+      $defs: { Thing: { type: "string" } },
+    });
+  });
+
   it("does not mutate the input", () => {
     const schema = {
       type: "object",

--- a/platform/backend/src/routes/proxy/adapters/gemini-schema.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-schema.ts
@@ -4,6 +4,12 @@
 // rejects with 400 INVALID_ARGUMENT. This sanitizer walks a tool parameter schema
 // and removes non-string enums while preserving the value type, folding the dropped
 // literal(s) into the field description so the model keeps the hint.
+//
+// Gemini/Vertex also rejects schema nodes that carry no `type` at all ("schema
+// didn't specify the schema type field"). MCP servers routinely emit such nodes —
+// zod `z.unknown()` serializes to a bare `{}` — so the sanitizer infers a type
+// from structural keywords and defaults a bare "any" node to `object`, matching
+// the fallback in Google's own SDKs.
 
 type SchemaObject = Record<string, unknown>;
 
@@ -51,7 +57,48 @@ export function sanitizeGeminiToolSchema(schema: unknown): unknown {
   const result: SchemaObject = { ...(schema as SchemaObject) };
   normalizeEnum(result);
   recurseSubschemas(result);
+  ensureNodeType(result);
   return result;
+}
+
+// Gemini requires every schema node to declare a `type` (composites expressed
+// via anyOf/oneOf/allOf are typed through their branches, and $ref nodes through
+// their target). Infer one from structural keywords; a completely bare node —
+// JSON Schema's "accept anything" — falls back to `object`, the same default
+// Google's own generative-ai SDKs apply.
+function ensureNodeType(node: SchemaObject): void {
+  if (node.type !== undefined || typeof node.$ref === "string") return;
+  if (
+    Array.isArray(node.anyOf) ||
+    Array.isArray(node.oneOf) ||
+    Array.isArray(node.allOf)
+  ) {
+    return;
+  }
+
+  if (
+    node.properties !== undefined ||
+    node.patternProperties !== undefined ||
+    node.required !== undefined ||
+    node.additionalProperties !== undefined
+  ) {
+    node.type = "object";
+    return;
+  }
+  if (
+    node.items !== undefined ||
+    node.prefixItems !== undefined ||
+    node.contains !== undefined
+  ) {
+    node.type = "array";
+    return;
+  }
+  if (Array.isArray(node.enum) && node.enum.length > 0) {
+    // normalizeEnum already ran: a surviving enum is all-string
+    node.type = "string";
+    return;
+  }
+  node.type = "object";
 }
 
 function normalizeEnum(node: SchemaObject): void {


### PR DESCRIPTION
## Problem

A Slack chatops session failed with:

> Unable to submit request because `posthog__cohorts-partial-update` functionDeclaration `parameters.query` schema didn't specify the schema type field.

Root cause chain:

1. PostHog's remote MCP (`mcp-eu.posthog.com`) auto-generates tools from its API; the cohort `query` field is `zod.unknown().optional()`, which serializes to a bare `{}` subschema (`anyOf: [{}, {"type": "null"}]`). That is **valid JSON Schema and valid MCP** — it works on OpenAI/Anthropic.
2. Google Gemini/Vertex rejects function declarations containing any schema node without an explicit `type` (400 INVALID_ARGUMENT).
3. The agent's model was `openrouter/~moonshotai/kimi-latest`; OpenRouter routes Kimi K2 to several upstream hosts **including Google Vertex**, so the Google 400 surfaced even though no Gemini model was configured. The request died before a response was logged, which is why the LLM logs show nothing for the failure.

This is a well-known ecosystem gap — LibreChat, LiteLLM, Google ADK, and gemini-cli all ship sanitizers for exactly this class of schema.

## Fix

Two layers, following the untyped-node → `object` fallback used by Google's own generative-ai SDKs and LiteLLM's OpenAI→Vertex converter:

- **`chat-tool-builder.ts` `normalizeJsonSchema`** (chat/chatops path, applies to every provider since the downstream host is opaque behind OpenRouter): recursively give every schema node an explicit `type`, inferred from structural keywords (`properties`/`items`/`enum`/`const`); `$ref` nodes and `anyOf`/`oneOf`/`allOf` composites stay untyped but their branches are typed; a bare "any" node becomes an open object with `additionalProperties: true` so the existing OpenAI `additionalProperties: false` clamp doesn't seal it shut.
- **`gemini-schema.ts` `sanitizeGeminiToolSchema`** (direct Gemini/Vertex proxy path): same inference, so proxy users bringing their own clients don't hit the 400 either.

## Tests

- `gemini-schema.test.ts`: bare `{}` node, the exact reported `anyOf [{}, null]` shape, structural inference (object/array/additionalProperties), untyped string enums, `$ref` passthrough.
- `chat-mcp-client.test.ts` (`normalizeJsonSchema`): the PostHog-shaped schema end-to-end, plus a guard that synthesized any-nodes stay open instead of being clamped by `additionalProperties: false`.

All existing gemini adapter / translator / provider-matrix tests pass unchanged; backend `type-check`, `lint`, and `knip` are green.

No docs changes: internal robustness fix, no user-facing behavior/config surface.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>