### PR TITLE
fix(llm): surface streaming LLM failures in session history + recover from OpenRouter-style context-length errors

### DIFF
--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -21,6 +21,7 @@ import { resolveAgentMaxOutputTokens } from "@/agents/agent-output-budget";
 import { MAX_AGENT_STEPS, runAgentStream } from "@/agents/agent-run-stream";
 import { buildAgentSystemPrompt } from "@/agents/agent-system-prompt";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
+import { guardStepMessages } from "@/agents/step-context-guard";
 import { subagentExecutionTracker } from "@/agents/subagent-execution-tracker";
 import { closeChatMcpClient, getChatMcpTools } from "@/clients/chat-mcp-client";
 import { createLLMModelForAgent } from "@/clients/llm-client";
@@ -379,6 +380,17 @@ export async function executeA2AMessage(
       maxOutputTokens: resolveAgentMaxOutputTokens({
         outputLength: modelRow?.outputLength ?? null,
         ceiling: config.chat.maxOutputTokensCeiling,
+      }),
+      // Per-step context guard: cap oversized tool results and keep the
+      // accumulated step history inside the model's context window. Overrides
+      // only what each step sends to the model — the loop's own state (and the
+      // persisted/streamed UIMessage) keeps the full tool outputs.
+      prepareStep: ({ messages }: { messages: ModelMessage[] }) => ({
+        messages: guardStepMessages({
+          messages,
+          contextLength: modelRow?.contextLength ?? null,
+          systemPrompt,
+        }),
       }),
     };
     const currentTurn: { role: "user"; content: UserContent } | null =

--- a/platform/backend/src/agents/agent-run-stream.ts
+++ b/platform/backend/src/agents/agent-run-stream.ts
@@ -16,7 +16,7 @@
 import { streamText } from "ai";
 import logger from "@/logging";
 import {
-  parseMaxInputTokens,
+  parseContextLengthError,
   trimMessagesToTokenLimit,
 } from "@/routes/chat/context-trimming";
 import { EmptyModelResponseError } from "@/routes/chat/errors";
@@ -132,23 +132,25 @@ export async function runAgentStream(params: {
     }
 
     if (probe.kind === "error") {
-      const maxTokens = parseMaxInputTokens(probe.error);
+      const contextError = parseContextLengthError(probe.error);
       if (
-        maxTokens !== null &&
+        contextError !== null &&
         Array.isArray(config.messages) &&
         contextTrimAttempts < MAX_CONTEXT_TRIM_ATTEMPTS
       ) {
         contextTrimAttempts++;
         const trimmed = trimMessagesToTokenLimit({
           messages: config.messages,
-          maxTokens,
+          maxTokens: contextError.maxInputTokens,
+          requestedTokens: contextError.requestedTokens,
           systemPrompt:
             typeof config.system === "string" ? config.system : undefined,
         });
         logger.info(
           {
             ...logContext,
-            maxTokens,
+            maxTokens: contextError.maxInputTokens,
+            requestedTokens: contextError.requestedTokens,
             originalMessages: config.messages.length,
             trimmedMessages: trimmed.length,
           },

--- a/platform/backend/src/agents/step-context-guard.test.ts
+++ b/platform/backend/src/agents/step-context-guard.test.ts
@@ -1,0 +1,65 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, test } from "vitest";
+import { guardStepMessages } from "./step-context-guard";
+
+const toolResultMessage = (value: string, toolCallId = "call_1") =>
+  ({
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId,
+        toolName: "list_workflow_runs",
+        output: { type: "text", value },
+      },
+    ],
+  }) as ModelMessage;
+
+describe("guardStepMessages", () => {
+  test("caps an oversized tool result and keeps its toolCallId pairing", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "list the workflow runs" },
+      toolResultMessage("x".repeat(400_000)),
+    ];
+    const result = guardStepMessages({ messages, contextLength: null });
+
+    const toolMessage = result[1];
+    expect(toolMessage.role).toBe("tool");
+    const part = (toolMessage.content as Array<Record<string, unknown>>)[0];
+    expect(part.toolCallId).toBe("call_1");
+    const output = part.output as { type: string; value: string };
+    expect(output.type).toBe("text");
+    expect(output.value.length).toBeLessThan(110_000);
+    expect(output.value).toContain("[tool result truncated");
+  });
+
+  test("returns the same array when nothing is oversized", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      toolResultMessage("small result"),
+    ];
+    expect(guardStepMessages({ messages, contextLength: null })).toBe(messages);
+  });
+
+  test("trims accumulated messages to the context-window budget", () => {
+    // budget: floor(100 * 0.8) tokens * 4 chars = 320 chars; three 200-char
+    // turns exceed it, so the oldest is dropped and a trim note is prepended.
+    const messages: ModelMessage[] = [
+      { role: "user", content: "a".repeat(200) },
+      { role: "assistant", content: "b".repeat(200) },
+      { role: "user", content: "c".repeat(200) },
+    ];
+    const result = guardStepMessages({ messages, contextLength: 100 });
+    expect(result.some((m) => m.content === "a".repeat(200))).toBe(false);
+    expect(result[result.length - 1].content).toBe("c".repeat(200));
+    expect(result[0].role).toBe("system");
+    expect(result[0].content).toContain("trimmed");
+  });
+
+  test("leaves messages within the context-window budget unchanged", () => {
+    const messages: ModelMessage[] = [{ role: "user", content: "hi" }];
+    expect(guardStepMessages({ messages, contextLength: 100_000 })).toBe(
+      messages,
+    );
+  });
+});

--- a/platform/backend/src/agents/step-context-guard.ts
+++ b/platform/backend/src/agents/step-context-guard.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-step context guard for the agentic loop (wired via the AI SDK's
+ * `prepareStep` hook, which lets each step override the messages sent to the
+ * model without touching the loop's own accumulated state).
+ *
+ * Tool results enter the loop's history uncapped — a single oversized result
+ * (e.g. a raw workflow-runs listing) can blow past the model's context window
+ * mid-turn. Before each step, cap oversized tool-result outputs and, when the
+ * model's context window is known, proactively trim the step's messages to fit
+ * instead of waiting for the provider to reject the request.
+ */
+import type { ModelMessage } from "ai";
+import { trimMessagesToTokenLimit } from "@/routes/chat/context-trimming";
+
+export function guardStepMessages(params: {
+  messages: ModelMessage[];
+  contextLength: number | null;
+  systemPrompt?: string;
+}): ModelMessage[] {
+  const { messages, contextLength, systemPrompt } = params;
+  const capped = capOversizedToolResults(messages);
+  if (!contextLength) return capped;
+  return trimMessagesToTokenLimit({
+    messages: capped,
+    maxTokens: Math.floor(contextLength * CONTEXT_WINDOW_BUDGET_RATIO),
+    systemPrompt,
+  });
+}
+
+// =============================================================================
+// INTERNAL
+// =============================================================================
+
+/**
+ * Replace tool-result outputs whose serialized size exceeds the cap with a
+ * truncated text rendering plus a notice. The replacement happens in place on
+ * the tool message (same toolCallId), so tool-call/tool-result pairing stays
+ * intact for provider validation.
+ */
+function capOversizedToolResults(messages: ModelMessage[]): ModelMessage[] {
+  let changed = false;
+  const result = messages.map((message) => {
+    if (message.role !== "tool" || !Array.isArray(message.content)) {
+      return message;
+    }
+    let messageChanged = false;
+    const content = message.content.map((part) => {
+      if (part.type !== "tool-result") return part;
+      const serialized = JSON.stringify(part.output);
+      if (serialized.length <= MAX_TOOL_RESULT_CONTEXT_CHARS) return part;
+      messageChanged = true;
+      return {
+        ...part,
+        output: {
+          type: "text" as const,
+          value: `${serialized.slice(0, MAX_TOOL_RESULT_CONTEXT_CHARS)}\n[tool result truncated: ${serialized.length} chars exceeded the ${MAX_TOOL_RESULT_CONTEXT_CHARS}-char limit for model context]`,
+        },
+      };
+    });
+    if (!messageChanged) return message;
+    changed = true;
+    return { ...message, content } as ModelMessage;
+  });
+  return changed ? result : messages;
+}
+
+// ~25k tokens at typical densities — generous enough for legitimate large
+// outputs (file reads, API listings) while keeping a single result from
+// consuming a meaningful fraction of the context window.
+const MAX_TOOL_RESULT_CONTEXT_CHARS = 100_000;
+
+// Mirrors the /chat auto-compaction threshold (CONTEXT_COMPACTION_AUTO_THRESHOLD):
+// leave 20% of the window for the system prompt estimate error and the response.
+const CONTEXT_WINDOW_BUDGET_RATIO = 0.8;

--- a/platform/backend/src/routes/chat/context-trimming.test.ts
+++ b/platform/backend/src/routes/chat/context-trimming.test.ts
@@ -219,6 +219,56 @@ describe("trimMessagesToTokenLimit", () => {
     expect(trimmed[trimmed.length - 1].content).toBe("c".repeat(100));
   });
 
+  test("drops tool results orphaned by trimming their assistant tool call", () => {
+    // The oldest (assistant tool-call) message gets dropped by the budget;
+    // its tool-result message must go with it or providers reject the payload.
+    const assistantToolCall = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "x".repeat(300) },
+        {
+          type: "tool-call",
+          toolCallId: "call_1",
+          toolName: "search",
+          input: {},
+        },
+      ],
+    } as ModelMessage;
+    const toolResult = {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call_1",
+          toolName: "search",
+          output: { type: "text", value: "result" },
+        },
+      ],
+    } as ModelMessage;
+    const messages = [
+      assistantToolCall,
+      toolResult,
+      msg("user", "z".repeat(100)),
+    ];
+    // 300-char budget: dropping the ~410-char assistant message brings the
+    // total under budget while the small tool result itself survives — only
+    // the orphan cleanup removes it.
+    const result = trimMessagesToTokenLimit({ messages, maxTokens: 75 });
+    expect(result.some((m) => m === assistantToolCall)).toBe(false);
+    expect(
+      result.some(
+        (m) =>
+          m.role === "tool" &&
+          Array.isArray(m.content) &&
+          m.content.some(
+            (part) =>
+              part.type === "tool-result" && part.toolCallId === "call_1",
+          ),
+      ),
+    ).toBe(false);
+    expect(result[result.length - 1].content).toBe("z".repeat(100));
+  });
+
   test("never returns undefined entries when only system messages exist", () => {
     const messages = [
       msg("system", "x".repeat(200)),

--- a/platform/backend/src/routes/chat/context-trimming.test.ts
+++ b/platform/backend/src/routes/chat/context-trimming.test.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, test } from "vitest";
 import {
-  parseMaxInputTokens,
+  parseContextLengthError,
   shouldProbeTextStreamForContextTrimRetry,
   trimMessagesToTokenLimit,
 } from "./context-trimming";
@@ -9,22 +9,47 @@ import {
 const msg = (role: ModelMessage["role"], content: string): ModelMessage =>
   ({ role, content }) as ModelMessage;
 
-describe("parseMaxInputTokens", () => {
-  test("parses limit from LiteLLM error message", () => {
+describe("parseContextLengthError", () => {
+  test("parses limit and requested tokens from LiteLLM error message", () => {
     const error = new Error(
       'litellm.BadRequestError: Hosted_vllmException - {"error":{"message":"You passed 8193 input tokens and requested 0 output tokens. However, the model\'s context length is only 8192 tokens, resulting in a maximum input length of 8192 tokens.","type":"BadRequestError","param":"input_tokens","code":400}}',
     );
-    expect(parseMaxInputTokens(error)).toBe(8192);
+    expect(parseContextLengthError(error)).toEqual({
+      maxInputTokens: 8192,
+      requestedTokens: 8193,
+    });
+  });
+
+  test("parses limit and requested tokens from OpenRouter-style error message", () => {
+    const error = new Error(
+      "This endpoint's maximum context length is 262144 tokens. However, you requested about 285869 tokens (279144 of text input, 6725 of tool input). Please reduce the length of either one.",
+    );
+    expect(parseContextLengthError(error)).toEqual({
+      maxInputTokens: 262144,
+      requestedTokens: 285869,
+    });
+  });
+
+  test("parses limit alone when the requested count is absent", () => {
+    const error = new Error(
+      "the model supports a maximum context length is 128000 tokens",
+    );
+    expect(parseContextLengthError(error)).toEqual({
+      maxInputTokens: 128000,
+      requestedTokens: undefined,
+    });
   });
 
   test("returns null for unrelated errors", () => {
-    expect(parseMaxInputTokens(new Error("rate limit exceeded"))).toBeNull();
+    expect(
+      parseContextLengthError(new Error("rate limit exceeded")),
+    ).toBeNull();
   });
 
   test("returns null for non-error values", () => {
-    expect(parseMaxInputTokens(null)).toBeNull();
-    expect(parseMaxInputTokens(undefined)).toBeNull();
-    expect(parseMaxInputTokens(42)).toBeNull();
+    expect(parseContextLengthError(null)).toBeNull();
+    expect(parseContextLengthError(undefined)).toBeNull();
+    expect(parseContextLengthError(42)).toBeNull();
   });
 });
 
@@ -168,6 +193,30 @@ describe("trimMessagesToTokenLimit", () => {
     // the text request survives as string content; no oversized image part.
     const surviving = result.find((m) => m.role === "user");
     expect(surviving?.content).toBe("summarize this screenshot");
+  });
+
+  test("trims token-dense payloads when the provider reported the request's token count", () => {
+    // A payload at ~2 chars/token: the 4-chars/token default budget
+    // (maxTokens * 4 = 400 chars) exceeds the 300-char payload, so without the
+    // provider-reported count nothing would be trimmed and the retry would
+    // fail identically.
+    const messages = [
+      msg("user", "a".repeat(100)),
+      msg("tool" as ModelMessage["role"], "b".repeat(100)),
+      msg("user", "c".repeat(100)),
+    ];
+    const untrimmed = trimMessagesToTokenLimit({ messages, maxTokens: 100 });
+    expect(untrimmed).toBe(messages);
+
+    // Provider says the 300-char payload was 150 tokens (2 chars/token) against
+    // a 100-token limit — the derived budget forces a real trim.
+    const trimmed = trimMessagesToTokenLimit({
+      messages,
+      maxTokens: 100,
+      requestedTokens: 150,
+    });
+    expect(trimmed.some((m) => m.content === "a".repeat(100))).toBe(false);
+    expect(trimmed[trimmed.length - 1].content).toBe("c".repeat(100));
   });
 
   test("never returns undefined entries when only system messages exist", () => {

--- a/platform/backend/src/routes/chat/context-trimming.ts
+++ b/platform/backend/src/routes/chat/context-trimming.ts
@@ -157,11 +157,11 @@ export function trimMessagesToTokenLimit(params: {
         : ({ role: last.role, content: text.slice(0, keep) } as ModelMessage);
   }
 
-  const result: ModelMessage[] = [
+  const result: ModelMessage[] = dropOrphanedToolResults([
     ...system,
     ...middle,
     ...(trimmedLast ? [trimmedLast] : []),
-  ];
+  ]);
 
   if (result.length < messages.length || trimmedLast !== last) {
     result.unshift({
@@ -171,5 +171,45 @@ export function trimMessagesToTokenLimit(params: {
     });
   }
 
+  return result;
+}
+
+// =============================================================================
+// INTERNAL
+// =============================================================================
+
+/**
+ * Dropping a middle assistant message can orphan the tool message carrying its
+ * tool results; providers reject a tool result without the matching tool call,
+ * which would make the trimmed retry fail on a validation error instead of the
+ * context limit. Drop orphaned tool-result parts (and tool messages left
+ * empty) so the trimmed payload stays valid.
+ */
+function dropOrphanedToolResults(messages: ModelMessage[]): ModelMessage[] {
+  const toolCallIds = new Set<string>();
+  const result: ModelMessage[] = [];
+  for (const message of messages) {
+    if (message.role === "assistant" && Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (part.type === "tool-call") toolCallIds.add(part.toolCallId);
+      }
+      result.push(message);
+      continue;
+    }
+    if (message.role === "tool" && Array.isArray(message.content)) {
+      const content = message.content.filter(
+        (part) =>
+          part.type !== "tool-result" || toolCallIds.has(part.toolCallId),
+      );
+      if (content.length === 0) continue;
+      result.push(
+        content.length === message.content.length
+          ? message
+          : ({ ...message, content } as ModelMessage),
+      );
+      continue;
+    }
+    result.push(message);
+  }
   return result;
 }

--- a/platform/backend/src/routes/chat/context-trimming.ts
+++ b/platform/backend/src/routes/chat/context-trimming.ts
@@ -1,13 +1,19 @@
 /**
- * Workaround for LiteLLM/vLLM context length errors.
- * When these proxies return a 400 with "maximum input length of N tokens",
- * we parse the limit, trim messages, and retry the request.
+ * Workaround for provider context length errors.
+ * When a provider/gateway returns a 400 describing the context limit
+ * (vLLM/LiteLLM "maximum input length of N tokens", OpenRouter-style
+ * "maximum context length is N tokens"), we parse the limit, trim
+ * messages, and retry the request.
  */
 import type { SupportedProvider } from "@archestra/shared";
 import { APICallError, type ModelMessage } from "ai";
 import { TOKEN_ESTIMATE } from "./normalization/estimate-message-tokens";
 
 const CHARS_PER_TOKEN = TOKEN_ESTIMATE.charsPerToken;
+
+// Trim below the reported limit so the retried request clears it even with
+// estimation error; see the charsPerToken derivation in trimMessagesToTokenLimit.
+const CONTEXT_TRIM_HEADROOM_RATIO = 0.9;
 
 /**
  * Gemini can emit tool-call chunks before any text. Probing textStream to detect
@@ -20,11 +26,26 @@ export function shouldProbeTextStreamForContextTrimRetry(
   return provider !== "gemini";
 }
 
+export interface ContextLengthError {
+  maxInputTokens: number;
+  /**
+   * Token count the provider says the rejected request carried. Used to derive
+   * the payload's real chars-per-token ratio when trimming (token-dense JSON
+   * payloads run well under the 4-chars-per-token default).
+   */
+  requestedTokens?: number;
+}
+
 /**
- * Parse max input token limit from vLLM/LiteLLM error responses.
- * Matches: "maximum input length of 8192 tokens"
+ * Parse the token limit (and, when reported, the rejected request's token
+ * count) from provider context-length error responses. Matches:
+ * - vLLM/LiteLLM: "You passed 8193 input tokens ... maximum input length of 8192 tokens"
+ * - OpenRouter-style gateways: "maximum context length is 262144 tokens.
+ *   However, you requested about 285869 tokens"
  */
-export function parseMaxInputTokens(error: unknown): number | null {
+export function parseContextLengthError(
+  error: unknown,
+): ContextLengthError | null {
   let body: string | undefined;
 
   if (APICallError.isInstance(error)) {
@@ -35,8 +56,29 @@ export function parseMaxInputTokens(error: unknown): number | null {
   }
   if (!body) return null;
 
-  const match = body.match(/maximum input length of (\d+)/);
-  return match ? Number.parseInt(match[1], 10) : null;
+  const vllmMatch = body.match(/maximum input length of (\d+)/);
+  if (vllmMatch) {
+    const requested = body.match(/[Yy]ou passed (\d+) input tokens/);
+    return {
+      maxInputTokens: Number.parseInt(vllmMatch[1], 10),
+      requestedTokens: requested
+        ? Number.parseInt(requested[1], 10)
+        : undefined,
+    };
+  }
+
+  const gatewayMatch = body.match(/maximum context length is (\d+)/);
+  if (gatewayMatch) {
+    const requested = body.match(/[Yy]ou requested (?:about )?(\d+) tokens/);
+    return {
+      maxInputTokens: Number.parseInt(gatewayMatch[1], 10),
+      requestedTokens: requested
+        ? Number.parseInt(requested[1], 10)
+        : undefined,
+    };
+  }
+
+  return null;
 }
 
 /**
@@ -50,15 +92,26 @@ export function trimMessagesToTokenLimit(params: {
   messages: ModelMessage[];
   maxTokens: number;
   systemPrompt?: string;
+  /** Provider-reported token count of the rejected request (see ContextLengthError). */
+  requestedTokens?: number;
 }): ModelMessage[] {
-  const { messages, maxTokens, systemPrompt } = params;
+  const { messages, maxTokens, systemPrompt, requestedTokens } = params;
   const systemPromptChars = systemPrompt?.length ?? 0;
-  const charBudget = Math.max(
-    maxTokens * CHARS_PER_TOKEN - systemPromptChars,
-    0,
-  );
   const chars = (m: ModelMessage) => JSON.stringify(m.content).length;
   let total = messages.reduce((s, m) => s + chars(m), 0);
+
+  // Token-dense payloads (large JSON tool results) can run near 2 chars/token,
+  // so a budget built on the 4-chars/token default can exceed the payload and
+  // trim nothing. When the provider reported the rejected request's token
+  // count, derive the payload's real ratio instead, with headroom because the
+  // retry only gets one attempt (and non-message tokens like tool definitions
+  // count against the limit but not against this char total).
+  const charsPerToken =
+    requestedTokens && requestedTokens > 0
+      ? ((total + systemPromptChars) / requestedTokens) *
+        CONTEXT_TRIM_HEADROOM_RATIO
+      : CHARS_PER_TOKEN;
+  const charBudget = Math.max(maxTokens * charsPerToken - systemPromptChars, 0);
   if (total <= charBudget || messages.length === 0) return messages;
 
   const system = messages.filter((m) => m.role === "system");

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1415,7 +1415,7 @@ async function readAll(stream: ReadableStream<unknown>): Promise<unknown[]> {
 }
 
 // streamText result whose fullStream throws a context-length error on first read,
-// matching parseMaxInputTokens. Used to exercise the bounded context-trim retry.
+// matching parseContextLengthError. Used to exercise the bounded context-trim retry.
 function fakeContextLengthErrorResult() {
   return {
     fullStream: {

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -30,6 +30,7 @@ import {
   createAnthropicTestClient,
   createGeminiTestClient,
   createOpenAiTestClient,
+  type OpenAiStubOptions,
 } from "@/test/llm-provider-stubs";
 import type { Agent } from "@/types";
 import { ApiError } from "@/types";
@@ -110,7 +111,7 @@ import openAiProxyRoutes from "./routes/openai";
 describe("LLM Proxy Handler Prometheus Metrics", () => {
   let app: FastifyInstance;
   let testAgent: Agent;
-  let openAiStubOptions: { interruptAtChunk?: number };
+  let openAiStubOptions: OpenAiStubOptions;
   let anthropicStubOptions: {
     includeToolUse?: boolean;
     interruptAtChunk?: number;
@@ -369,6 +370,40 @@ describe("LLM Proxy Handler Prometheus Metrics", () => {
         }),
       );
     });
+
+    test("streaming failure before any usage persists an error interaction", async () => {
+      // A provider 400 (e.g. context length exceeded) rejects the stream before
+      // any chunk — the failure must still land in the interactions log so it
+      // shows up in LLM logs / session history.
+      openAiStubOptions.failStreamWithError =
+        "This endpoint's maximum context length is 262144 tokens. However, you requested about 285869 tokens";
+
+      await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+          "user-agent": "test-client",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "Hello!" }],
+          stream: true,
+        },
+      });
+
+      const rows = await db
+        .select()
+        .from(schema.interactionsTable)
+        .where(eq(schema.interactionsTable.profileId, testAgent.id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].response).toMatchObject({
+        error: expect.stringContaining("maximum context length"),
+      });
+      expect(rows[0].inputTokens).toBe(0);
+      expect(rows[0].outputTokens).toBe(0);
+    });
   });
 
   describe("Anthropic", () => {
@@ -623,7 +658,7 @@ describe("LLM Proxy Handler Prometheus Metrics", () => {
 describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
   let app: FastifyInstance;
   let testAgent: Agent;
-  let openAiStubOptions: { interruptAtChunk?: number };
+  let openAiStubOptions: OpenAiStubOptions;
   let anthropicStubOptions: {
     includeToolUse?: boolean;
     interruptAtChunk?: number;

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -1411,6 +1411,46 @@ async function handleStreaming<
     streamCompleted = true;
     return reply;
   } catch (error) {
+    // The finally-block persist below is gated on usage, so a stream that
+    // fails before any usage arrives (e.g. a provider 400 rejecting the
+    // request) would otherwise leave no trace in LLM logs / session history.
+    if (!streamAdapter.state.usage) {
+      try {
+        const errorMessage = provider.extractErrorMessage(error);
+        logger.info(
+          { profileId: agent.id, errorMessage },
+          "Persisting error interaction record for failed stream",
+        );
+        await InteractionModel.create({
+          profileId: agent.id,
+          externalAgentId,
+          executionId,
+          userId,
+          virtualKeyId,
+          passthroughVirtualKeyId,
+          sessionId,
+          sessionSource,
+          source,
+          authMethod,
+          authenticatedAppId: authenticatedApp?.id,
+          authenticatedAppName: authenticatedApp?.name,
+          type: provider.interactionType,
+          request: originalRequest as InteractionRequest,
+          processedRequest: request as InteractionRequest,
+          response: { error: errorMessage },
+          model: actualModel,
+          baselineModel,
+          inputTokens: 0,
+          outputTokens: 0,
+        });
+      } catch (interactionError) {
+        logger.error(
+          { err: interactionError, profileId: agent.id },
+          "Failed to create error interaction record for failed stream",
+        );
+      }
+    }
+
     return handleError(
       error,
       reply,

--- a/platform/backend/src/test/llm-provider-stubs.ts
+++ b/platform/backend/src/test/llm-provider-stubs.ts
@@ -4,6 +4,8 @@ import type OpenAI from "openai";
 
 export interface OpenAiStubOptions {
   interruptAtChunk?: number;
+  /** Reject streaming requests with this error message before any chunk arrives (e.g. a provider 400). */
+  failStreamWithError?: string;
 }
 
 export interface AnthropicStubOptions {
@@ -29,6 +31,9 @@ export function createOpenAiTestClient(options: OpenAiStubOptions = {}) {
           params: OpenAI.Chat.Completions.ChatCompletionCreateParams,
         ) => {
           if (params.stream) {
+            if (options.failStreamWithError) {
+              throw new Error(options.failStreamWithError);
+            }
             return createOpenAiStream(options);
           }
 

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
@@ -370,12 +370,19 @@ export default function SessionDetailPage({
                       </Badge>
                     </TableCell>
                     <TableCell className="overflow-hidden">
-                      <Badge
-                        variant="secondary"
-                        className="text-xs max-w-full inline-flex truncate"
-                      >
-                        {dynamicInteraction.modelName}
-                      </Badge>
+                      <div className="flex flex-wrap gap-1">
+                        <Badge
+                          variant="secondary"
+                          className="text-xs max-w-full inline-flex truncate"
+                        >
+                          {dynamicInteraction.modelName}
+                        </Badge>
+                        {dynamicInteraction.hasErrorResponse() && (
+                          <Badge variant="destructive" className="text-xs">
+                            Error
+                          </Badge>
+                        )}
+                      </div>
                     </TableCell>
                     <TableCell className="font-mono text-xs">
                       <TooltipProvider>

--- a/platform/shared/interactions/interaction.utils.test.ts
+++ b/platform/shared/interactions/interaction.utils.test.ts
@@ -24,6 +24,12 @@ describe("DynamicInteraction with a failed-interaction error response", () => {
     );
   });
 
+  it("reports the failure via hasErrorResponse", () => {
+    expect(new DynamicInteraction(errorInteraction).hasErrorResponse()).toBe(
+      true,
+    );
+  });
+
   it("renders the error as an assistant message instead of throwing", () => {
     const interaction = new DynamicInteraction(errorInteraction);
     const messages = interaction.mapToUiMessages();

--- a/platform/shared/interactions/interaction.utils.ts
+++ b/platform/shared/interactions/interaction.utils.ts
@@ -207,6 +207,11 @@ export class DynamicInteraction implements InteractionUtils {
     return null;
   }
 
+  /** True when the interaction is a persisted failure (`{ error }` response). */
+  hasErrorResponse(): boolean {
+    return this.getErrorResponseText() !== null;
+  }
+
   isLastMessageToolCall(): boolean {
     return this.interactionClass.isLastMessageToolCall();
   }


### PR DESCRIPTION
## Context

A ChatOps (Slack) session hit a provider 400 — *"This endpoint's maximum context length is 262144 tokens. However, you requested about 285869 tokens"* — and the turn hard-failed to Slack with "Sorry, I encountered an error processing your request." Root cause: a single 440KB tool result (a raw GitHub `workflow_runs` listing) entered the agentic loop's step history uncapped, pushing one turn from 24k to 263k input tokens. Three product gaps made this worse than it needed to be:

1. **The failure was invisible in `/llm/logs/session/:id`.** The failed call left no `interactions` row at all: `handleStreaming` catches stream errors internally (so the outer catch that persists error interactions never fires), and its `finally`-block persist is gated on `usage`, which never arrives when the provider rejects the request before the first chunk. `conversation_chat_errors` doesn't cover this either — it's keyed to chat-conversation UUIDs, and ChatOps sessions (`chatops:slack:…`) have no conversation row.
2. **The reactive context-trim retry never fired.** `parseMaxInputTokens` only matched the vLLM/LiteLLM phrasing (`maximum input length of N`), not the OpenRouter-style `maximum context length is N tokens`. And even matched, the 4-chars/token default budget can exceed a token-dense payload entirely (this one ran ~2 chars/token), so the trim would have been a no-op and the single retry would fail identically.
3. **The A2A agentic loop had no proactive context management.** Nothing capped tool results entering step history, and nothing consulted the model's `contextLength` before dispatch — for ChatOps, scheduled runs, incoming email, delegation, and both a2a routes.

## Changes

- **`llm-proxy-handler.ts`** — when a stream fails before any usage is captured, persist an error interaction (`response: { error }`), mirroring the existing non-streaming behavior. Failed calls now show up in LLM logs and session history for every source, including ChatOps and raw API clients.
- **`context-trimming.ts` / `agent-run-stream.ts`** — `parseMaxInputTokens` → `parseContextLengthError`: recognizes both error phrasings and also extracts the provider-reported request token count. `trimMessagesToTokenLimit` uses that count to derive the payload's real chars-per-token ratio (with 0.9 headroom) instead of assuming 4 chars/token, so token-dense payloads actually get trimmed. It also now drops tool results orphaned by trimming their assistant tool-call message — providers reject unpaired tool results, which would turn the trimmed retry into a validation error.
- **`step-context-guard.ts` + `a2a-executor.ts`** — proactive per-step context guard wired via the AI SDK `prepareStep` hook on the shared A2A executor: before each step, tool-result outputs above 100k chars are capped in place with a truncation notice (toolCallId pairing preserved), and when the model row has a `contextLength`, the step's messages are trimmed to 80% of the window (the same threshold `/chat` auto-compaction uses). `prepareStep` overrides only what each step sends to the model — the loop's accumulated state and the persisted/streamed UIMessage keep the full tool outputs.
- **`interaction.utils.ts` / session detail page** — failed interactions are now flagged with a destructive **Error** badge in the session history table (`DynamicInteraction.hasErrorResponse()`; the error text already rendered as the assistant turn via the existing `{ error }` handling).

## Why prepareStep and not A2A contextId statefulness

The A2A protocol's native answer to conversation state is `contextId`/stateful tasks — the client sends only the new message and the server owns history. Our `A2AManager` already implements this (non-stateless mode persists full turns in `a2a_message` and replays them; `routes/a2a-v2.ts` uses it), but ChatOps opts out with `stateless: true` and replays the Slack thread as text. Switching ChatOps to stateful `contextId` would *not* have prevented this incident — the blowup happened inside a single turn, and persisting tool results across turns would have made it worse without a guard. It's also a product-semantics change (Slack threads are multi-user; the replay captures other people's messages between bot invocations), so it stays a follow-up. The per-step guard is the layer that actually bounds context growth, and it protects the stateful a2a-v2 path's replayed histories too (`prepareStep` runs on the first step as well).

## Testing

- New integration test: a streaming provider rejection through the real proxy handler persists an error interaction row.
- New unit tests: both context-length error phrasings parse (limit + requested tokens); token-dense payloads trim under the derived ratio where the default budget would trim nothing; oversized tool results are capped with pairing preserved; step messages trim to the context-window budget; orphaned tool results are dropped after trimming.
- The `prepareStep` wiring in `a2a-executor.ts` is a one-line hook into the tested pure guard, left without a dedicated test per the no-wiring-tests convention.
- Existing stream-route trim-retry, proxy handler, a2a-executor (64), and shared interaction tests pass; backend/frontend/shared type-check, biome on touched files, and backend knip clean.

## Follow-up (not in this PR)

- Move ChatOps from stateless full-thread replay to A2A `contextId` continuation (send only the new message + Slack-thread delta), which would carry tool results across turns and cut per-turn replay cost — needs a design pass for multi-user thread semantics.
- LLM-summarization compaction (the `/chat` `compactMessagesForChat`) for the A2A path: it's currently coupled to chat tables (`conversation_compactions` FK, `messages`, attachments), so reusing it requires extracting the summary-generation core.