### PR TITLE
perf(task-queue): fold attempt decrement into releaseToQueue bulk update

### DIFF
--- a/platform/backend/src/models/task.test.ts
+++ b/platform/backend/src/models/task.test.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { describe, expect, test } from "@/test";
 import TaskModel from "./task";
@@ -217,6 +217,38 @@ describe("TaskModel", () => {
 
       const released = await TaskModel.releaseToQueue([task1.id, task2.id]);
       expect(released).toBe(2);
+
+      const rows = await db
+        .select()
+        .from(schema.tasksTable)
+        .where(inArray(schema.tasksTable.id, [task1.id, task2.id]));
+      for (const row of rows) {
+        expect(row.status).toBe("pending");
+        expect(row.attempt).toBe(0);
+      }
+    });
+
+    test("clamps attempt at 0 when releasing", async () => {
+      const task = await TaskModel.create({
+        taskType: "connector_sync",
+        payload: { connectorId: "conn-1" },
+      });
+      await TaskModel.dequeue();
+      // Force the edge: a processing task whose attempt is already 0
+      await db
+        .update(schema.tasksTable)
+        .set({ attempt: 0 })
+        .where(eq(schema.tasksTable.id, task.id));
+
+      const released = await TaskModel.releaseToQueue([task.id]);
+      expect(released).toBe(1);
+
+      const [updated] = await db
+        .select()
+        .from(schema.tasksTable)
+        .where(eq(schema.tasksTable.id, task.id));
+      expect(updated.attempt).toBe(0);
+      expect(updated.status).toBe("pending");
     });
   });
 

--- a/platform/backend/src/models/task.test.ts
+++ b/platform/backend/src/models/task.test.ts
@@ -228,6 +228,36 @@ describe("TaskModel", () => {
       }
     });
 
+    test("decrements each task's own attempt in a mixed batch", async () => {
+      const task1 = await TaskModel.create({
+        taskType: "connector_sync",
+        payload: { connectorId: "conn-1" },
+      });
+      const task2 = await TaskModel.create({
+        taskType: "batch_embedding",
+        payload: { documentIds: ["d1"] },
+      });
+
+      await TaskModel.dequeue();
+      await TaskModel.dequeue();
+      // Simulate a task on a later retry so batch rows carry different attempts
+      await db
+        .update(schema.tasksTable)
+        .set({ attempt: 3 })
+        .where(eq(schema.tasksTable.id, task2.id));
+
+      const released = await TaskModel.releaseToQueue([task1.id, task2.id]);
+      expect(released).toBe(2);
+
+      const rows = await db
+        .select()
+        .from(schema.tasksTable)
+        .where(inArray(schema.tasksTable.id, [task1.id, task2.id]));
+      const byId = new Map(rows.map((r) => [r.id, r]));
+      expect(byId.get(task1.id)?.attempt).toBe(0);
+      expect(byId.get(task2.id)?.attempt).toBe(2);
+    });
+
     test("clamps attempt at 0 when releasing", async () => {
       const task = await TaskModel.create({
         taskType: "connector_sync",

--- a/platform/backend/src/models/task.ts
+++ b/platform/backend/src/models/task.ts
@@ -122,17 +122,12 @@ class TaskModel {
         status: "pending",
         startedAt: null,
         scheduledFor: new Date(),
+        // Decrement attempt so the interrupted attempt doesn't count
+        // against max retries (ack-late semantics)
+        attempt: sql`GREATEST(${t.attempt} - 1, 0)`,
       })
       .where(and(inArray(t.id, ids), eq(t.status, "processing")))
       .returning({ id: t.id });
-
-    // Decrement attempt for each released task so the interrupted attempt
-    // doesn't count against max retries (ack-late semantics)
-    for (const row of result) {
-      await db.execute(
-        sql`UPDATE tasks SET attempt = GREATEST(attempt - 1, 0) WHERE id = ${row.id}`,
-      );
-    }
 
     return result.length;
   }


### PR DESCRIPTION
- `backend/src/models/task.ts:115` → `releaseToQueue` issued one raw `UPDATE tasks SET attempt = GREATEST(attempt-1,0)` per released row after the bulk status reset (N+1 writes; a crash between the statements could leave a released task with an undecremented attempt) → the decrement now rides the same bulk UPDATE's `SET` clause.
- Tests: multi-row release now asserts per-row status/attempt, plus new mixed-attempt-batch and attempt-0 clamp cases.
- Verified by an independent adversarial Codex review at plan and diff stage (verdict: SHIP).

https://claude.ai/code/session_0111LPRAPTkArzWMSFzCjP5a

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>