### PR TITLE
perf: run independent queries concurrently on hot paths

### DIFF
--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -98,12 +98,12 @@ export class A2AManager {
     try {
       const { actor, agentId, request, systemParams } = params;
 
-      const a2aUser =
+      const [a2aUser, agent] = await Promise.all([
         actor.kind === "user" && actor.id !== "system"
-          ? await UserModel.getById(actor.id)
-          : null;
-
-      const agent = await AgentModel.findById(agentId);
+          ? UserModel.getById(actor.id)
+          : null,
+        AgentModel.findById(agentId),
+      ]);
       if (!agent) {
         throw new A2AError(A2AErrorKind.AgentNotFound);
       }
@@ -240,18 +240,22 @@ export class A2AManager {
       }
 
       const sessionId = systemParams?.sessionId ?? context?.id;
+      const [teams, userTeams] = await Promise.all([
+        AgentTeamModel.getTeamLabelInfoForAgent(agentId),
+        a2aUser
+          ? TeamModel.getTeamLabelInfoForUser({
+              userId: a2aUser.id,
+              organizationId: agent.organizationId,
+            })
+          : [],
+      ]);
       const result = await startActiveChatSpan({
         agentName: agent.name,
         agentId,
         agentType: agent.agentType ?? undefined,
         sessionId,
-        teams: await AgentTeamModel.getTeamLabelInfoForAgent(agentId),
-        userTeams: a2aUser
-          ? await TeamModel.getTeamLabelInfoForUser({
-              userId: a2aUser.id,
-              organizationId: agent.organizationId,
-            })
-          : [],
+        teams,
+        userTeams,
         routeCategory: systemParams?.routeCategory ?? RouteCategory.A2A,
         user: a2aUser
           ? { id: a2aUser.id, email: a2aUser.email, name: a2aUser.name }

--- a/platform/backend/src/agents/a2a/a2a-model-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-model-manager.ts
@@ -145,14 +145,17 @@ export class A2ATaskManager {
     if (context.id !== task.contextId) {
       throw new A2AError(A2AErrorKind.TaskContextMismatch);
     }
-    const approvalRequests = z.array(A2AArchestraApprovalRequestSchema).parse(
-      await A2ATaskApprovalRequestModel.findByTaskId(task.id)
+    const [approvalRequestRows, history] = await Promise.all([
+      A2ATaskApprovalRequestModel.findByTaskId(task.id)
         // Sort for deterministic persistence
         .then((reqs) =>
           reqs.sort((a, b) => a.approvalId.localeCompare(b.approvalId)),
         ),
-    );
-    const history = await A2AMessageModel.findByTaskId(task.id);
+      A2AMessageModel.findByTaskId(task.id),
+    ]);
+    const approvalRequests = z
+      .array(A2AArchestraApprovalRequestSchema)
+      .parse(approvalRequestRows);
 
     const statusMessage = history.length
       ? history[history.length - 1]

--- a/platform/backend/src/services/agent-export.ts
+++ b/platform/backend/src/services/agent-export.ts
@@ -101,35 +101,37 @@ async function resolveToolReferences(
     ),
   ];
 
-  const catalogNameMap = new Map<string, string>();
-  if (catalogIds.length > 0) {
-    const catalogRows = await db
-      .select({
-        id: schema.internalMcpCatalogTable.id,
-        name: schema.internalMcpCatalogTable.name,
-      })
-      .from(schema.internalMcpCatalogTable)
-      .where(inArray(schema.internalMcpCatalogTable.id, catalogIds));
-
-    for (const row of catalogRows) {
-      catalogNameMap.set(row.id, row.name);
-    }
-  }
-
   // Batch-fetch credential resolution modes from agent_tools junction table
   const toolIds = nonDelegationTools.map((t) => t.id);
-  const junctionRows = await db
-    .select({
-      toolId: schema.agentToolsTable.toolId,
-      credentialResolutionMode: schema.agentToolsTable.credentialResolutionMode,
-    })
-    .from(schema.agentToolsTable)
-    .where(
-      and(
-        eq(schema.agentToolsTable.agentId, agent.id),
-        inArray(schema.agentToolsTable.toolId, toolIds),
+  const [catalogRows, junctionRows] = await Promise.all([
+    catalogIds.length > 0
+      ? db
+          .select({
+            id: schema.internalMcpCatalogTable.id,
+            name: schema.internalMcpCatalogTable.name,
+          })
+          .from(schema.internalMcpCatalogTable)
+          .where(inArray(schema.internalMcpCatalogTable.id, catalogIds))
+      : [],
+    db
+      .select({
+        toolId: schema.agentToolsTable.toolId,
+        credentialResolutionMode:
+          schema.agentToolsTable.credentialResolutionMode,
+      })
+      .from(schema.agentToolsTable)
+      .where(
+        and(
+          eq(schema.agentToolsTable.agentId, agent.id),
+          inArray(schema.agentToolsTable.toolId, toolIds),
+        ),
       ),
-    );
+  ]);
+
+  const catalogNameMap = new Map<string, string>();
+  for (const row of catalogRows) {
+    catalogNameMap.set(row.id, row.name);
+  }
 
   const credentialModeMap = new Map<string, string>();
   for (const row of junctionRows) {

--- a/platform/backend/src/utils/llm-resolution.ts
+++ b/platform/backend/src/utils/llm-resolution.ts
@@ -88,8 +88,10 @@ export async function resolveConversationLlmSelectionForAgent(params: {
     }
   }
 
-  const member = await MemberModel.getByUserId(userId, organizationId);
-  const organization = await OrganizationModel.getById(organizationId);
+  const [member, organization] = await Promise.all([
+    MemberModel.getByUserId(userId, organizationId),
+    OrganizationModel.getById(organizationId),
+  ]);
 
   const configuredLevels: ModelSelection[] = [
     { modelId: params.explicitModelId, apiKeyId: params.explicitApiKeyId },


### PR DESCRIPTION
Five sites awaited pairs of independent reads sequentially, adding a full DB round-trip of latency each. Each pair now runs under `Promise.all` with all conditional skips preserved.

- `backend/src/agents/a2a/a2a-manager.ts:101` → user + agent lookups serialized on every A2A sendMessage → concurrent (user lookup stays conditional on a real user actor).
- `backend/src/agents/a2a/a2a-manager.ts:248` → agent-team and user-team label lookups serialized inside the chat-span args → resolved concurrently before the span starts.
- `backend/src/agents/a2a/a2a-model-manager.ts:148` → approval-requests and task history serialized per task hydration → concurrent; sort/parse semantics unchanged.
- `backend/src/services/agent-export.ts:106` → catalog-name and junction selects serialized → concurrent; catalog query still skipped when no tool has a catalogId.
- `backend/src/utils/llm-resolution.ts:91` → member + organization lookups serialized → concurrent, matching the Promise.all already used later in the same function.
- Latency-only change (pure reads); existing suites pin semantics and stay green.
- Verified by an independent adversarial Codex review at plan and diff stage (verdict: SHIP).

https://claude.ai/code/session_0111LPRAPTkArzWMSFzCjP5a

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>