### PR TITLE
fix: clear raced timeout timers once the winning promise settles

### DIFF
--- a/platform/backend/src/agents/subagents/policy-configuration.test.ts
+++ b/platform/backend/src/agents/subagents/policy-configuration.test.ts
@@ -374,6 +374,34 @@ describe("PolicyConfigurationService", () => {
     });
   });
 
+  describe("configurePoliciesForToolWithTimeout", () => {
+    test("clears the timeout timer when auto-configure finishes first", async ({
+      makeOrganization,
+      makeTool,
+    }) => {
+      vi.useFakeTimers();
+      try {
+        const org = await makeOrganization();
+        const tool = await makeTool();
+        vi.spyOn(service, "configurePoliciesForTool").mockResolvedValue({
+          success: true,
+        });
+
+        const before = vi.getTimerCount();
+        const result = await service.configurePoliciesForToolWithTimeout({
+          toolId: tool.id,
+          organizationId: org.id,
+        });
+
+        expect(result.success).toBe(true);
+        // The 20s timeout must not stay pending after the race settles
+        expect(vi.getTimerCount()).toBe(before);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("configurePoliciesForTools", () => {
     test("returns error for all tools when service not available", async ({
       makeOrganization,

--- a/platform/backend/src/agents/subagents/policy-configuration.ts
+++ b/platform/backend/src/agents/subagents/policy-configuration.ts
@@ -224,12 +224,13 @@ export class PolicyConfigurationService {
       await ToolModel.setAutoConfiguringState(toolId);
 
       // Create a 20-second timeout promise
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       const timeoutPromise = new Promise<{
         success: false;
         timedOut: true;
         error: string;
       }>((resolve) => {
-        setTimeout(() => {
+        timeoutId = setTimeout(() => {
           resolve({
             success: false,
             timedOut: true,
@@ -245,7 +246,7 @@ export class PolicyConfigurationService {
           timedOut: false,
         })),
         timeoutPromise,
-      ]);
+      ]).finally(() => clearTimeout(timeoutId));
 
       // Handle the result and clear loading timestamp
       if (result.timedOut) {

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -428,6 +428,19 @@ describe("chat-mcp-client health check", () => {
     await chatClient.__test.clearToolCache(cacheKey);
   });
 
+  test("clears the ping timeout timer once ping settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const before = vi.getTimerCount();
+      await chatClient.__test.pingClientWithTimeout({
+        ping: () => Promise.resolve({}),
+      });
+      expect(vi.getTimerCount()).toBe(before);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("discards cached client when ping hangs past timeout", async ({
     makeAgent,
     makeUser,

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -214,6 +214,7 @@ export const __test = {
   getCacheKey,
   isBrowserMcpTool,
   filterToolsByEnabledIds,
+  pingClientWithTimeout,
 };
 
 /**
@@ -696,15 +697,20 @@ async function pingClientWithTimeout(
   client: Pick<Client, "ping">,
   timeoutMs = CLIENT_PING_TIMEOUT_MS,
 ): Promise<void> {
-  await Promise.race([
-    client.ping(),
-    new Promise<never>((_, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error(`Ping timeout after ${timeoutMs}ms`));
-      }, timeoutMs);
-      timeout.unref?.();
-    }),
-  ]);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      client.ping(),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`Ping timeout after ${timeoutMs}ms`));
+        }, timeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 function shouldValidateCachedClient(cacheKey: string): boolean {


### PR DESCRIPTION
- `backend/src/clients/chat-mcp-client.ts:695` → `pingClientWithTimeout` left its (unref'd) reject-timer pending after a successful ping, holding the closure up to the 5s ping timeout; the connect path in the same file already cleared its timer in `finally` → same pattern applied.
- `backend/src/agents/subagents/policy-configuration.ts:227` → the 20s auto-configure timeout timer had no stored handle, was not unref'd, and was never cleared, keeping the event loop alive up to 20s after every completed auto-configure → handle captured and cleared via `.finally()` on the race.
- Regression tests in both suites assert the timer count returns to baseline after the raced operation resolves; both were proven to fail against the unfixed code.
- Verified by an independent adversarial Codex review at plan and diff stage (verdict: SHIP).

https://claude.ai/code/session_0111LPRAPTkArzWMSFzCjP5a

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>