### PR TITLE
perf(db): stop fetching rows that are only counted or discarded

### DIFF
--- a/platform/backend/src/database/soft-delete.ts
+++ b/platform/backend/src/database/soft-delete.ts
@@ -1,4 +1,4 @@
-import { and, isNull, not, type SQL } from "drizzle-orm";
+import { and, isNull, not, type SQL, sql } from "drizzle-orm";
 import type { PgTable, PgUpdateSetSource } from "drizzle-orm/pg-core";
 import type db from "@/database";
 import type { Transaction } from "@/database";
@@ -60,6 +60,11 @@ export async function hardDelete<T extends PgTable>(
 ): Promise<number> {
   if (!where) throw new Error("hardDelete requires a where clause");
 
-  const rows = await executor.delete(table).where(where).returning();
+  // Constant projection: the rows are only counted, so don't ship every
+  // column of every deleted row back over the wire.
+  const rows = await executor
+    .delete(table)
+    .where(where)
+    .returning({ _: sql`1` });
   return rows.length;
 }

--- a/platform/backend/src/models/message.test.ts
+++ b/platform/backend/src/models/message.test.ts
@@ -49,6 +49,43 @@ describe("MessageModel", () => {
     });
   });
 
+  describe("existsForConversation", () => {
+    test("reports emptiness without loading rows", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ name: "Exists Test Agent", teams: [] });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Exists Test",
+      });
+
+      expect(await MessageModel.existsForConversation(conversation.id)).toBe(
+        false,
+      );
+
+      await MessageModel.create({
+        conversationId: conversation.id,
+        role: "user",
+        content: {
+          id: "temp-id",
+          role: "user",
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      });
+
+      expect(await MessageModel.existsForConversation(conversation.id)).toBe(
+        true,
+      );
+    });
+  });
+
   describe("bulkCreate", () => {
     test("updates conversation updatedAt when messages are bulk created", async ({
       makeUser,

--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -81,6 +81,17 @@ class MessageModel {
     return messages;
   }
 
+  /** Cheap emptiness probe — avoids loading full rows just to count them. */
+  static async existsForConversation(conversationId: string): Promise<boolean> {
+    const [row] = await db
+      .select({ id: schema.messagesTable.id })
+      .from(schema.messagesTable)
+      .where(eq(schema.messagesTable.conversationId, conversationId))
+      .limit(1);
+
+    return row !== undefined;
+  }
+
   static async delete(id: string): Promise<void> {
     await db
       .delete(schema.messagesTable)

--- a/platform/backend/src/services/scheduled-run-conversation.ts
+++ b/platform/backend/src/services/scheduled-run-conversation.ts
@@ -134,8 +134,7 @@ export async function persistRunConversationMessages(params: {
 }): Promise<void> {
   const { conversation, userText, assistantMessage } = params;
 
-  const existing = await MessageModel.findByConversation(conversation.id);
-  if (existing.length > 0) {
+  if (await MessageModel.existsForConversation(conversation.id)) {
     return;
   }
 
@@ -173,8 +172,7 @@ export async function persistRunUserMessage(params: {
 }): Promise<void> {
   const { conversation, userText } = params;
 
-  const existing = await MessageModel.findByConversation(conversation.id);
-  if (existing.length > 0) {
+  if (await MessageModel.existsForConversation(conversation.id)) {
     return;
   }
 
@@ -228,11 +226,11 @@ export async function ensureFailedRunErrorVisible(params: {
     return;
   }
 
-  const [messages, errors] = await Promise.all([
-    MessageModel.findByConversation(conversation.id),
+  const [hasMessages, errors] = await Promise.all([
+    MessageModel.existsForConversation(conversation.id),
     ConversationChatErrorModel.findByConversation(conversation.id),
   ]);
-  if (messages.length > 0 || errors.length > 0) {
+  if (hasMessages || errors.length > 0) {
     return;
   }
 
@@ -269,8 +267,10 @@ export async function backfillRunConversationMessages(params: {
     return;
   }
 
+  // Only interactions[0] is consumed below — the newest interaction carries the
+  // full history in its request and the final reply in its response.
   const interactionResult = await InteractionModel.findAllPaginated(
-    { limit: 50, offset: 0 },
+    { limit: 1, offset: 0 },
     { sortBy: "createdAt", sortDirection: "desc" },
     ownerUserId,
     true,


### PR DESCRIPTION
- `backend/src/database/soft-delete.ts:63` → `hardDelete` used bare `.returning()` (every column of every deleted row) solely to compute `rows.length` → constant `returning({ _: sql\`1\` })` projection; counting stays driver-agnostic (works under PGlite where `rowCount` does not).
- `backend/src/services/scheduled-run-conversation.ts:272` → backfill fetched 50 full interaction rows (request/response LLM transcripts) while consuming only the newest one → `limit: 1`.
- `backend/src/services/scheduled-run-conversation.ts:137,176,231` → idempotency checks loaded a conversation's entire message history just to test emptiness → new `MessageModel.existsForConversation` (`SELECT id … LIMIT 1`), `findByConversation` untouched for callers that consume rows.
- New model test covers the exists probe false→true; existing soft-delete count assertions and scheduled-run suites stay green.
- Verified by an independent adversarial Codex review at plan (reshaped once after a PGlite `rowCount` refutation) and diff stage (verdict: SHIP).

https://claude.ai/code/session_0111LPRAPTkArzWMSFzCjP5a

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>