### PR TITLE
fix(cache): LRU has() no longer promotes recency; drop dead wrap option

### DIFF
--- a/platform/backend/src/cache-manager.test.ts
+++ b/platform/backend/src/cache-manager.test.ts
@@ -452,4 +452,21 @@ describe("LRUCacheManager", () => {
       vi.useRealTimers();
     }
   });
+
+  test("has() does not promote an entry's LRU recency", () => {
+    const cache = new LRUCacheManager<string>({ maxSize: 2 });
+
+    cache.set("A", "a");
+    cache.set("B", "b");
+    // A pure existence check — must not count as a use of A.
+    expect(cache.has("A")).toBe(true);
+    cache.set("C", "c");
+    cache.set("D", "d");
+
+    // With get-based has(), A would have been promoted and survived both
+    // rotations; with peek it ages out like any untouched entry.
+    expect(cache.has("A")).toBe(false);
+    expect(cache.has("C")).toBe(true);
+    expect(cache.has("D")).toBe(true);
+  });
 });

--- a/platform/backend/src/cache-manager.ts
+++ b/platform/backend/src/cache-manager.ts
@@ -307,7 +307,7 @@ class CacheManager {
   async wrap<T>(
     key: AllowedCacheKey,
     fnc: () => Promise<T>,
-    { ttl }: { ttl?: number; refreshThreshold?: number } = {},
+    { ttl }: { ttl?: number } = {},
   ): Promise<T> {
     const cached = await this.get<T>(key);
     if (cached !== undefined) {
@@ -437,7 +437,9 @@ export class LRUCacheManager<T = unknown> {
    * Check if a key exists in the cache (and is not expired).
    */
   has(key: string): boolean {
-    const entry = this.lruStore.get(key);
+    // peek, not get: a pure existence check must not promote the entry's
+    // recency, or has()-only keys outlive keys that are actually read.
+    const entry = this.lruStore.peek(key);
     if (!entry) {
       return false;
     }


### PR DESCRIPTION
- `backend/src/cache-manager.ts:439` → `LRUCacheManager.has()` called QuickLRU's `get`, so pure existence checks bumped the entry to most-recently-used and distorted eviction order (has()-only keys outlived keys actually read) → `peek`, with the expiry-eviction branch unchanged. The only production `has()` caller (auth/cimd.ts) does not rely on promotion.
- `backend/src/cache-manager.ts:310` → `wrap()` accepted a `refreshThreshold` option that was never implemented and never passed by any caller → removed from the type.
- New regression test pins that `has()` leaves LRU order untouched (sequence validated against installed quick-lru 7.3.0's generational eviction); proven to fail on the get-based implementation.
- Verified by an independent adversarial Codex review at plan (test scenario corrected once for QuickLRU's dual-cache design) and diff stage (verdict: SHIP).

https://claude.ai/code/session_0111LPRAPTkArzWMSFzCjP5a

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>