### PR TITLE
fix(mcp): close the client when tool discovery fails in connectAndGetTools

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -371,6 +371,25 @@ describe("McpClient", () => {
     expect(mockListResources).toHaveBeenCalledTimes(1);
   });
 
+  test("connectAndGetTools closes the client when tool discovery fails", async () => {
+    // Non-method-not-found error: discovery rethrows instead of falling back
+    mockListTools.mockRejectedValueOnce(new Error("tools/list exploded"));
+
+    const catalogItem = await InternalMcpCatalogModel.findById(catalogId);
+    if (!catalogItem) throw new Error("expected catalog item");
+
+    await expect(
+      mcpClient.connectAndGetTools({
+        catalogItem,
+        mcpServerId,
+        secrets: { access_token: "resource-token" },
+      }),
+    ).rejects.toThrow("Failed to connect to MCP server");
+
+    // The failed attempt must not leak its client/transport
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
   describe("executeToolCallForOwner (app owner)", () => {
     test("executes an app-assigned tool and persists an app-owned audit row", async ({
       makeApp,

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -2942,6 +2942,7 @@ class McpClient {
     let lastError: Error | undefined;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      let client: Client | undefined;
       try {
         // Get the appropriate transport using the existing helper
         const transport = await this.getTransport(
@@ -2957,7 +2958,7 @@ class McpClient {
         };
 
         // Create client with transport
-        const client = new Client(buildMcpClientInfo("archestra-platform"), {
+        client = new Client(buildMcpClientInfo("archestra-platform"), {
           capabilities,
         });
 
@@ -2986,6 +2987,19 @@ class McpClient {
         }));
       } catch (error) {
         lastError = error instanceof Error ? error : new Error("Unknown error");
+
+        // Only the success path closed the client; a failure after connect
+        // (e.g. tool discovery threw) would otherwise leak its transport.
+        if (client) {
+          try {
+            await client.close();
+          } catch (closeError) {
+            logger.warn(
+              { closeError, server: catalogItem.name },
+              "Error closing MCP client after failed tool discovery (non-fatal)",
+            );
+          }
+        }
 
         // If this is not the last attempt, log and retry
         if (attempt < maxRetries) {


### PR DESCRIPTION
- `backend/src/clients/mcp-client.ts:2987` → only the success path closed the one-shot discovery client; a failure after connect (tools/list threw, resource fallback failed) leaked the client and its HTTP transport per attempt — up to 6 per failed local-server sync, repeated every sync → the catch now closes the attempt's client (errors logged, non-fatal) before retrying/throwing.
- Regression test: remote catalog, connect succeeds, discovery rejects → expects rejection and exactly one close; proven to fail against the unfixed code.
- Scope note: the K8s-attach pending-start race (a close during a pending `attach()` cannot reach the late websocket, `k8s-attach-transport.ts:90-125`) was surfaced during review and is deliberately NOT claimed fixed here — it needs a transport-level change.
- Verified by an independent adversarial Codex review at plan (scope narrowed once) and diff stage (verdict: SHIP).

https://claude.ai/code/session_0111LPRAPTkArzWMSFzCjP5a

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>