### PR TITLE
fix(ci): await and paginate cache deletion in the clear-cache workflow

### DIFF
--- a/.github/workflows/clear-github-actions-cache.yml
+++ b/.github/workflows/clear-github-actions-cache.yml
@@ -29,13 +29,13 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             console.log("About to clear")
-            const caches = await github.rest.actions.getActionsCacheList({
+            const caches = await github.paginate(github.rest.actions.getActionsCacheList, {
               owner: context.repo.owner,
               repo: context.repo.repo,
             })
-            for (const cache of caches.data.actions_caches) {
+            for (const cache of caches) {
               console.log(cache)
-              github.rest.actions.deleteActionsCacheById({
+              await github.rest.actions.deleteActionsCacheById({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 cache_id: cache.id,


### PR DESCRIPTION
- `.github/workflows/clear-github-actions-cache.yml:38` → `deleteActionsCacheById` was called without `await` inside the loop: deletions were fire-and-forget, rejections were unhandled, and "Clear completed" could print before any delete settled → each call is now awaited, so a failed delete fails the step.
- `.github/workflows/clear-github-actions-cache.yml:32` → `getActionsCacheList` fetched only the first page (default 30), silently leaving the rest of the caches in place → `github.paginate(...)` walks all pages (returns the flattened array; loop adjusted).
- Codex diff gate: PASS (verified the paginate return-shape normalization against the installed @octokit/plugin-paginate-rest).

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>