### PR TITLE
ci: remove dead outputs and an unreachable step from composite actions

### DIFF
--- a/.github/actions/blacksmith-build-push/action.yml
+++ b/.github/actions/blacksmith-build-push/action.yml
@@ -49,15 +49,9 @@ inputs:
     required: false
     default: ""
 outputs:
-  imageid:
-    description: Built image ID.
-    value: ${{ steps.build.outputs.imageid }}
   digest:
     description: Built image digest.
     value: ${{ steps.build.outputs.digest }}
-  metadata:
-    description: Build metadata.
-    value: ${{ steps.build.outputs.metadata }}
 runs:
   using: composite
   steps:

--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -63,12 +63,6 @@ outputs:
   digest:
     description: "Image digest"
     value: ${{ steps.build.outputs.digest }}
-  imageid:
-    description: "Image ID"
-    value: ${{ steps.build.outputs.imageid }}
-  metadata:
-    description: "Build metadata"
-    value: ${{ steps.build.outputs.metadata }}
 
 runs:
   using: composite

--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -11,12 +11,6 @@ outputs:
   token:
     description: Generated GitHub App token.
     value: ${{ steps.create-token.outputs.token }}
-  installation-id:
-    description: Installation ID used to generate the token.
-    value: ${{ steps.create-token.outputs.installation-id }}
-  app-slug:
-    description: Slug of the GitHub App.
-    value: ${{ steps.create-token.outputs.app-slug }}
 runs:
   using: composite
   steps:

--- a/.github/actions/github-cache/action.yml
+++ b/.github/actions/github-cache/action.yml
@@ -19,12 +19,6 @@ outputs:
   cache-hit:
     description: A boolean value to indicate an exact match was found for the key.
     value: ${{ steps.cache.outputs.cache-hit }}
-  cache-primary-key:
-    description: The primary key provided by the action.
-    value: ${{ steps.cache.outputs.cache-primary-key }}
-  cache-matched-key:
-    description: The actual cache key that was restored.
-    value: ${{ steps.cache.outputs.cache-matched-key }}
 runs:
   using: composite
   steps:

--- a/.github/actions/github-download-artifact/action.yml
+++ b/.github/actions/github-download-artifact/action.yml
@@ -33,8 +33,3 @@ runs:
         path: ${{ inputs.path }}
         pattern: ${{ inputs.pattern }}
         merge-multiple: ${{ inputs.merge-multiple }}
-    - name: Download all artifacts
-      if: ${{ inputs.name == '' && inputs.pattern == '' }}
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        path: ${{ inputs.path }}

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -36,9 +36,6 @@ outputs:
   has_flaky_tests:
     description: "Whether flaky tests were detected"
     value: ${{ steps.check-flaky.outputs.has_flaky_tests }}
-  blob_report_path:
-    description: "Path to the blob report directory"
-    value: ${{ steps.paths.outputs.blob_report_path }}
 
 runs:
   using: composite
@@ -57,16 +54,6 @@ runs:
           echo "EOF"
         } >> "$GITHUB_ENV"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-    - name: Set output paths
-      id: paths
-      shell: bash
-      env:
-        WORKING_DIRECTORY: ${{ inputs.working_directory }}
-        E2E_TESTS_PATH: ${{ inputs.e2e_tests_path }}
-      run: |
-        echo "blob_report_path=${WORKING_DIRECTORY}/${E2E_TESTS_PATH}/blob-report/" >> $GITHUB_OUTPUT
-        echo "output_file=${WORKING_DIRECTORY}/playwright-output.txt" >> $GITHUB_OUTPUT
 
     - name: Run E2E tests
       id: e2e

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -3,7 +3,7 @@ description: Setup node/pnpm + install dependencies
 inputs:
   working-directory:
     description: The working directory to install dependencies in
-    required: true
+    required: false
     default: platform
 runs:
   using: composite


### PR DESCRIPTION
All items verified dead by repo-wide grep, independently re-verified by the Codex plan and diff gates (both PASS). Deletion-only except one metadata correction; net -43/+1 lines.

- `.github/actions/github-cache/action.yml:22-27` → outputs `cache-primary-key`/`cache-matched-key` had zero consumers (all 8 callers read only `cache-hit`) → deleted.
- `.github/actions/github-app-token/action.yml:14-19` → outputs `installation-id`/`app-slug` unused (callers read only `token`) → deleted.
- `.github/actions/blacksmith-build-push/action.yml`, `.github/actions/build-docker-image/action.yml` → outputs `imageid`/`metadata` unused (only `digest` is consumed, at build-native-multi-arch-image.yml:139) → deleted.
- `.github/actions/run-e2e-tests/action.yml` → output `blob_report_path` declared+computed but never consumed (both callers hardcode the path), `output_file` written to $GITHUB_OUTPUT with no readers; the whole 'Set output paths' step set nothing else and its id had no references → step and output deleted.
- `.github/actions/github-download-artifact/action.yml:36-40` → 'Download all artifacts' fallback fires only when `name` and `pattern` are both empty; all 4 call sites pass one → deleted.
- `.github/actions/setup-env/action.yml:4-7` → `working-directory` declared `required: true` while carrying `default: platform` that two callers rely on (composite required is unenforced) → `required: false` to match reality.

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>