### PR TITLE
ci: drop no-op steps and branches from four workflows

### DIFF
--- a/.github/workflows/good-first-issue-welcome.yml
+++ b/.github/workflows/good-first-issue-welcome.yml
@@ -16,16 +16,9 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.label.name == 'good first issue'
     permissions:
-      contents: read # Required to checkout the repository for local workflow context.
       issues: write # Required to post the welcome comment on the labeled issue.
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 1
-          persist-credentials: false
 
+    steps:
       - name: Post welcome comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -245,14 +245,6 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
 
       - name: Checkout project
-        if: ${{ steps.check-release-please.outputs.is-release-please != 'true' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 1
-
-      - name: Checkout project for release-please PR
-        if: ${{ steps.check-release-please.outputs.is-release-please == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/publish-platform-helm-chart.yml
+++ b/.github/workflows/publish-platform-helm-chart.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
           ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
 
@@ -58,7 +58,6 @@ jobs:
       - name: helm package
         env:
           IMAGE_TAG: ${{ inputs.version }}
-          ARCHESTRA_ANALYTICS: disabled
         run: |
           helm package . --version $IMAGE_TAG --app-version $IMAGE_TAG
 

--- a/.github/workflows/toggle-release-freeze.yml
+++ b/.github/workflows/toggle-release-freeze.yml
@@ -43,16 +43,8 @@ jobs:
         run: |
           echo "Setting RELEASE_FREEZE to: $RELEASE_FREEZE_VALUE"
 
-          # Check if variable exists
-          if gh variable list | grep -q "^RELEASE_FREEZE"; then
-            # Update existing variable
-            gh variable set RELEASE_FREEZE --body "$RELEASE_FREEZE_VALUE"
-            echo "✅ Updated RELEASE_FREEZE variable to: $RELEASE_FREEZE_VALUE"
-          else
-            # Create new variable
-            gh variable set RELEASE_FREEZE --body "$RELEASE_FREEZE_VALUE"
-            echo "✅ Created RELEASE_FREEZE variable with value: $RELEASE_FREEZE_VALUE"
-          fi
+          gh variable set RELEASE_FREEZE --body "$RELEASE_FREEZE_VALUE"
+          echo "✅ RELEASE_FREEZE variable set to: $RELEASE_FREEZE_VALUE"
 
           if [ "$RELEASE_FREEZE_VALUE" = "true" ]; then
             echo ""


### PR DESCRIPTION
- `.github/workflows/good-first-issue-welcome.yml:23-27` → checkout step (plus its `contents: read` justification) before a job whose only step posts a hardcoded comment via github-script → deleted.
- `.github/workflows/on-pull-requests.yml:247-259` → two byte-identical checkout steps with complementary `if:` conditions (one always ran) → collapsed to one unconditional checkout; the later credentialed release-please re-checkout is untouched.
- `.github/workflows/toggle-release-freeze.yml:46-55` → `gh variable list | grep` existence check branched into two identical `gh variable set` calls (set is an upsert) → single call; only log wording changes.
- `.github/workflows/publish-platform-helm-chart.yml:47` → `fetch-depth: 0` on a job that only runs `helm package`/`helm push` (no git history consumed; `.helmignore` excludes `.git/`) → depth 1.
- `.github/workflows/publish-platform-helm-chart.yml:61` → `ARCHESTRA_ANALYTICS: disabled` env on `helm package`, which reads no env vars (it's a runtime app setting used as a Helm value elsewhere) → deleted.
- Codex diff gate: PASS (verified no packaging-time dependency on env/git in the chart, and release-please checkout sequencing).
- Net -28/+4 lines.

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>