### PR TITLE
fix(e2e): export image tarballs only for fork PRs

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -158,19 +158,24 @@ jobs:
           load: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'true' || 'false' }}
           tags: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('{0}/{1}:{2}', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME, github.sha) || format('{0}:{1}', matrix.local-tag-prefix, github.sha) }}
 
-      # Export as artifact for fast co-located downloads in E2E jobs
+      # Export as artifact for fast co-located downloads in E2E jobs. Fork PRs
+      # only: they are the sole consumer (shards use source=artifact for forks,
+      # registry otherwise), and only the fork path loads a local tag to save.
       - name: Export Docker image as tarball
-        if: ${{ !matrix.use-build-action || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
         env:
           GIT_SHA: ${{ github.sha }}
           LOCAL_TAG_PREFIX: ${{ matrix.local-tag-prefix }}
           TARBALL_NAME: ${{ matrix.tarball-name }}
+        # Explicit bash turns on pipefail so a failed docker save cannot be
+        # masked by gzip succeeding on empty input.
+        shell: bash
         run: |
           docker save "${LOCAL_TAG_PREFIX}:${GIT_SHA}" | gzip > "/tmp/${TARBALL_NAME}"
           ls -lh "/tmp/${TARBALL_NAME}"
 
       - name: Upload Docker image artifact
-        if: ${{ !matrix.use-build-action || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
         uses: ./.github/actions/github-upload-artifact
         with:
           name: ${{ matrix.artifact-name }}


### PR DESCRIPTION
- `.github/workflows/platform-e2e-tests.yml:163,173` → the export/upload condition `!matrix.use-build-action || (pull_request && fork)` was always true for the MCP Server Base leg, but trusted runs (merge queue, nightly, dispatch, labeled non-fork PRs) build that image with `push: true`/`load: false` under a registry tag, so the local tag `docker save` targets never exists. Without pipefail the failure was masked by gzip: every trusted run uploaded a 20-byte empty-gzip artifact (observed in run 28626341159, step green, artifact 20 bytes).
- Trusted shards pull via `source: registry` and the quickstart job uses the public `:latest` base, so fork PRs are the artifact's only consumer → both steps now gate on fork PRs, matching the Platform leg's effective semantics.
- The export step gets `shell: bash` (enables pipefail) so a failed `docker save` can never be masked again.
- Codex gates: plan PASS (with a full event×leg blast-radius table), diff PASS (re-verified every artifact consumer).

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>