### PR TITLE
fix(e2e): make vault diagnostics callable in the health-check step

### DIFF
--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -350,6 +350,19 @@ runs:
         DEPLOY_E2E_DEPS: ${{ inputs.deploy-e2e-dependencies }}
         E2E_DEPS_WAIT_FOR_VAULT: ${{ inputs.e2e-dependencies-wait-for-vault }}
       run: |
+        # Redefined here: shell functions from the "Deploy with Helm" step do
+        # not survive into this step (each composite run block is its own shell).
+        show_vault_diagnostics() {
+          echo "=== Vault Pod Status ==="
+          kubectl get pods -l app=vault -o wide || true
+          echo "=== Vault Pod Describe ==="
+          kubectl describe pod -l app=vault || true
+          echo "=== Vault Pod Logs ==="
+          kubectl logs -l app=vault --tail=200 || true
+          echo "=== Vault Pod Previous Logs ==="
+          kubectl logs -l app=vault --previous --tail=200 || true
+        }
+
         echo "Waiting for platform pods to be ready..."
         kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=archestra-platform --timeout=90s
         echo "Platform pods are ready"


### PR DESCRIPTION
- `.github/actions/setup-archestra-platform/action.yml:366` → the 'Wait for services to be healthy' step calls `show_vault_diagnostics` on a Vault readiness timeout, but the function is defined only inside the earlier 'Deploy with Helm' step. Composite-action run blocks are separate shell processes, so the call resolved to command-not-found (exit 127) and the diagnostics never printed exactly when they were needed.
- Fix: redefine the function (byte-identical) at the top of the health-check step, with a comment explaining why it's duplicated. Failure-path-only change; success path untouched.
- Codex gates: plan PASS (duplication judged the right minimal fix given the repo's inline-bash convention), diff PASS (verified the two definitions are identical).

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>