### PR TITLE
ci(claude): fix dead grants in the coreteam mentions allowlist

### DIFF
--- a/.github/workflows/claude-coreteam-mentions-shared.yml
+++ b/.github/workflows/claude-coreteam-mentions-shared.yml
@@ -47,5 +47,5 @@ jobs:
           additional_permissions: |
             actions: read
           assignee_trigger: "claude-bot"
-          allowed_tools: 'Bash(pnpm install),Bash(pnpm add:*),Bash(pnpm test),Bash(pnpm typecheck),Bash(pnpm codegen:*),Bash(pnpm prettier:*)'
+          allowed_tools: 'Bash(pnpm install),Bash(pnpm add:*),Bash(pnpm test),Bash(pnpm type-check),Bash(pnpm codegen:*)'
           additional_claude_args: '--system-prompt "Keep responses concise and to the point. Avoid lengthy explanations unless specifically requested."'


### PR DESCRIPTION
- `.github/workflows/claude-coreteam-mentions-shared.yml:50` → `Bash(pnpm typecheck)` grants a command that can never work: no package in the monorepo defines a `typecheck` script — every one defines `type-check` (turbo.json likewise) → renamed to `Bash(pnpm type-check)`.
- Same line → `Bash(pnpm prettier:*)` removed: no `prettier` script, dependency, or binary exists in the pnpm workspace (formatting is Biome), so the grant could never execute anything. The devcontainer's Prettier VS Code extension setting is editor-side and irrelevant to what `pnpm prettier` resolves in CI.
- Codex gates: plan PASS with positively-confirmed premises (per-package script list verified), diff PASS on re-gate.

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>