### PR TITLE
docs(bench): document OPENROUTER_API_KEY as a required bench secret

### DIFF
--- a/.github/bench/README.md
+++ b/.github/bench/README.md
@@ -50,11 +50,16 @@ gcloud storage buckets add-iam-policy-binding gs://archestra-bench-history \
 
 ### 2. GitHub secrets
 
-Both are synced into the `archestra-bench-secrets` k8s secret each run, where the pod reads them:
+All three are synced into the `archestra-bench-secrets` k8s secret each run, where the pod reads them:
 
 - `ZAI_API_KEY` — the glm lane key (`api_key_env = ZAI_API_KEY` in `archestra-bench/lanes.toml`).
+- `OPENROUTER_API_KEY` — the key for every `provider = "openrouter"` lane in
+  `archestra-bench/lanes.toml` (their default `api_key_env`).
 - `SLACK_BENCH_WEBHOOK_URL` — Slack incoming webhook for the summary message. If unset, the pod skips
   the Slack post.
+
+These cover every lane in `job.yaml`'s `BENCH_LANES` set. The `kimi` lane is not in that set and its
+`KIMI_API_KEY` is not synced — add both if you ever put it on the CI roster.
 
 The WIF auth and GKE creds reuse the existing
 `DEVELOPMENT_OAUTH_PROXY_RELEASER_GCP_SERVICE_ACCOUNT_NAME` /


### PR DESCRIPTION
- `.github/bench/README.md:51-57` → the GitHub-secrets section said "Both are synced" listing only `ZAI_API_KEY` and `SLACK_BENCH_WEBHOOK_URL`, but `benchmark.yml:145-156` syncs a third — `OPENROUTER_API_KEY` — and `job.yaml:82-86` consumes it with no optional flag. A missing secret would break every OpenRouter-served lane at runtime while the setup doc claimed completeness.
- Adds the third bullet and a note that the `kimi` lane sits outside the CI `BENCH_LANES` set (its `KIMI_API_KEY` is deliberately not synced).
- Codex diff gate: PASS on re-gate (verified against BENCH_LANES, the synced secret list, and lanes.toml).

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>