### PR TITLE
fix(ci): supply-chain scanner scans .yaml files and all curl POST spellings

### DIFF
--- a/.github/scripts/check-supply-chain-policy.py
+++ b/.github/scripts/check-supply-chain-policy.py
@@ -85,6 +85,7 @@ def main() -> int:
 
 def iter_candidate_files(repo_root: Path):
     yield from sorted((repo_root / ".github").rglob("*.yml"))
+    yield from sorted((repo_root / ".github").rglob("*.yaml"))
     yield from sorted(repo_root.rglob("Dockerfile*"))
     docker_dir = repo_root / "platform" / "docker"
     if docker_dir.exists():
@@ -101,7 +102,12 @@ def looks_like_remote_download(line: str) -> bool:
 
 
 def is_post_only_webhook(line: str) -> bool:
-    return "curl" in line and "-X POST" in line
+    # Only the pre-comment part of the line counts: a POST flag mentioned in a
+    # trailing comment must not exempt an actual download on the same line.
+    code = re.split(r"\s#", line, maxsplit=1)[0]
+    return "curl" in code and bool(
+        re.search(r"(?:-X\s*|--request(?:=|\s+))POST\b", code, re.IGNORECASE)
+    )
 
 
 def has_local_url(line: str) -> bool:

--- a/.github/scripts/test_check_supply_chain_policy.py
+++ b/.github/scripts/test_check_supply_chain_policy.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_supply_chain_policy",
+    Path(__file__).resolve().parent / "check-supply-chain-policy.py",
+)
+policy = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(policy)
+
+
+class IterCandidateFilesTest(unittest.TestCase):
+    def test_scans_both_yml_and_yaml_under_github(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            github = root / ".github"
+            github.mkdir()
+            (github / "workflow.yml").write_text("a: 1\n")
+            (github / "values.yaml").write_text("b: 2\n")
+            (github / "bench").mkdir()
+            (github / "bench" / "job.yaml").write_text("c: 3\n")
+            (root / "Dockerfile").write_text("FROM scratch\n")
+
+            found = {p.relative_to(root).as_posix() for p in policy.iter_candidate_files(root)}
+
+        self.assertIn(".github/workflow.yml", found)
+        self.assertIn(".github/values.yaml", found)
+        self.assertIn(".github/bench/job.yaml", found)
+        self.assertIn("Dockerfile", found)
+
+
+class IsPostOnlyWebhookTest(unittest.TestCase):
+    def test_accepts_equivalent_curl_post_spellings(self) -> None:
+        for line in (
+            'curl -X POST "$HOOK_URL"',
+            'curl -XPOST "$HOOK_URL"',
+            'curl --request POST https://hooks.example.com/x',
+            'curl --request=POST https://hooks.example.com/x',
+            'curl --request post https://hooks.example.com/x',
+        ):
+            self.assertTrue(policy.is_post_only_webhook(line), line)
+
+    def test_rejects_non_post_downloads(self) -> None:
+        for line in (
+            "curl -o tool.tgz https://example.com/tool.tgz",
+            "curl -X GET https://example.com/data",
+            "wget https://example.com/tool.tgz",
+            'echo "POST is mentioned but no curl here"',
+            "curl -X POSTER https://example.com/x",
+            "curl -o tool.tgz https://example.com/tool.tgz # example: -X POST webhook",
+        ):
+            self.assertFalse(policy.is_post_only_webhook(line), line)
+
+
+class LooksLikeRemoteDownloadTest(unittest.TestCase):
+    def test_detects_single_line_downloads(self) -> None:
+        self.assertTrue(
+            policy.looks_like_remote_download("curl -o x https://example.com/x.tgz")
+        )
+        self.assertTrue(
+            policy.looks_like_remote_download("wget https://example.com/x.tgz")
+        )
+
+    def test_ignores_lines_without_urls_or_tools(self) -> None:
+        self.assertFalse(policy.looks_like_remote_download("curl --version"))
+        self.assertFalse(
+            policy.looks_like_remote_download("echo https://example.com/docs")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -137,7 +137,9 @@ jobs:
           fetch-depth: 1
 
       - name: Enforce image pinning and download verification policy
-        run: python3 .github/scripts/check-supply-chain-policy.py
+        run: |
+          python3 -m unittest discover -s .github/scripts -p "test_*.py"
+          python3 .github/scripts/check-supply-chain-policy.py
 
   docs-image-policy:
     name: Docs Image Policy


### PR DESCRIPTION
- `.github/scripts/check-supply-chain-policy.py:87` → `iter_candidate_files` globbed only `.github/**/*.yml`, silently skipping kind.yaml, values-ci.yaml, values-staging.yaml and bench/job.yaml → `*.yaml` added (all four pass the policy today, verified).
- `:103-104` → `is_post_only_webhook` recognized only `-X POST`, so `--request POST`/`--request=POST`/`-XPOST` webhook calls would false-positive as unverified downloads → regex covering the equivalent spellings, matched only against the pre-comment part of the line so a POST flag mentioned in a trailing comment can no longer exempt an actual download (a hazard the old substring check also had).
- New `.github/scripts/test_check_supply_chain_policy.py` (stdlib unittest, no deps): the glob and POST-spelling tests fail on the old code and pass on the new; wired to run before the scan in the existing Supply Chain Policy step.
- Known blind spot deliberately NOT fixed here (needs a human call): backslash-continued downloads are still invisible to the physical-line heuristic; enabling line-joining would flag .devcontainer/Dockerfile:94, which is actually verified via `openssl dgst -sha512` — a marker `has_nearby_verification` doesn't recognize.
- Codex gates: plan PASS; diff FAILed once on the comment-exemption hazard, reworked, re-gate PASS (verified the three real webhook call sites still exempt and the branch scanner passes on the full repo).

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>