### PR TITLE
ci: quote shell expansions flagged by shellcheck (SC2086)

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -109,20 +109,20 @@ jobs:
       - name: Generate full license report (on failure)
         if: failure()
         run: |
-          echo "## License Compliance Report" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "❌ License check failed. See details below:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          pnpm license-check 2>&1 | head -100 >> $GITHUB_STEP_SUMMARY || true
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "## License Compliance Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "❌ License check failed. See details below:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          pnpm license-check 2>&1 | head -100 >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Add success summary
         if: success()
         run: |
-          echo "## ✅ License Compliance Check Passed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "No GPL/AGPL/Unknown licenses found in dependencies." >> $GITHUB_STEP_SUMMARY
+          echo "## ✅ License Compliance Check Passed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No GPL/AGPL/Unknown licenses found in dependencies." >> "$GITHUB_STEP_SUMMARY"
 
   supply-chain-policy:
     name: Supply Chain Policy

--- a/.github/workflows/publish-platform-helm-chart.yml
+++ b/.github/workflows/publish-platform-helm-chart.yml
@@ -60,11 +60,11 @@ jobs:
           IMAGE_TAG: ${{ inputs.version }}
           ARCHESTRA_ANALYTICS: disabled
         run: |
-          helm package . --version $IMAGE_TAG --app-version $IMAGE_TAG
+          helm package . --version "$IMAGE_TAG" --app-version "$IMAGE_TAG"
 
       - name: helm push
         if: inputs.push_chart
         env:
           IMAGE_TAG: ${{ inputs.version }}
         run: |
-          helm push archestra-platform-$IMAGE_TAG.tgz oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/helm-charts
+          helm push "archestra-platform-${IMAGE_TAG}.tgz" oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/helm-charts


### PR DESCRIPTION
- `.github/workflows/publish-platform-helm-chart.yml:63,70` → `$IMAGE_TAG` reaches `helm package`/`helm push` unquoted, and it flows from release-please.yml's unconstrained `workflow_dispatch` `version` input — a value with spaces or globs word-splits into extra helm arguments. Quoted, a malformed value becomes a single loudly-invalid argument; well-formed versions behave identically (argv-level check in review).
- `.github/workflows/on-pull-requests.yml:112-125` → `$GITHUB_STEP_SUMMARY` redirects quoted (SC2086).
- Deliberately untouched: build-native-multi-arch-image.yml's SC2153 (false positive — DIGEST comes from step env) and SC2046 (intentional word-splitting feeding `imagetools create`).
- Recorded shellcheck baseline for .github: 17 findings → 4 (the two deliberate ones above + 2× SC2129 style).
- Codex diff gate: PASS on re-gate (argv simulations for benign and hostile IMAGE_TAG values).

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>