### PR TITLE
fix(apps): make owned Apps assignable to chat agents and profiles in Custom-tools mode

### DIFF
--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -156,6 +156,7 @@ import {
   getDescriptionPlaceholder,
   getNamePlaceholder,
   normalizeSuggestedPrompts,
+  shouldOfferAppCatalogs,
   shouldShowDescriptionField,
 } from "./agent-dialog.utils";
 
@@ -1713,7 +1714,9 @@ export function AgentDialog({
                             agentEnvironmentName={agentEnvironmentName}
                             onConflictsChange={setMcpEnvConflicts}
                             openComboboxOnMount={openToolsCombobox}
-                            includeAppCatalogs={agentType === "mcp_gateway"}
+                            includeAppCatalogs={shouldOfferAppCatalogs(
+                              agentType,
+                            )}
                           />
                         </div>
                         <div className="space-y-2">

--- a/platform/frontend/src/components/agent-dialog.utils.test.ts
+++ b/platform/frontend/src/components/agent-dialog.utils.test.ts
@@ -3,6 +3,7 @@ import {
   getDescriptionPlaceholder,
   getNamePlaceholder,
   normalizeSuggestedPrompts,
+  shouldOfferAppCatalogs,
   shouldShowDescriptionField,
 } from "./agent-dialog.utils";
 
@@ -106,5 +107,23 @@ describe("normalizeSuggestedPrompts", () => {
       { summaryTitle: "Label only", prompt: "Label only" },
       { summaryTitle: "Whitespace", prompt: "Whitespace" },
     ]);
+  });
+});
+
+describe("shouldOfferAppCatalogs", () => {
+  it("offers owned Apps to a chat agent (renders inline from the __open tool)", () => {
+    expect(shouldOfferAppCatalogs("agent")).toBe(true);
+  });
+
+  it("offers owned Apps to an MCP gateway (exposes the tool to a connected client)", () => {
+    expect(shouldOfferAppCatalogs("mcp_gateway")).toBe(true);
+  });
+
+  it("offers owned Apps to a legacy profile (a gateway served at /v1/mcp/:profileId)", () => {
+    expect(shouldOfferAppCatalogs("profile")).toBe(true);
+  });
+
+  it("does not offer Apps to an LLM proxy (no app-render surface)", () => {
+    expect(shouldOfferAppCatalogs("llm_proxy")).toBe(false);
   });
 });

--- a/platform/frontend/src/components/agent-dialog.utils.ts
+++ b/platform/frontend/src/components/agent-dialog.utils.ts
@@ -27,6 +27,24 @@ export function shouldShowDescriptionField(params: {
   return !params.isBuiltIn;
 }
 
+/**
+ * Whether the Custom-tools picker offers owned Apps (serverType:"app" backing
+ * catalogs) for this agent type. A chat agent renders an app inline from its
+ * `__open` tool result; an MCP gateway or legacy profile — both served at
+ * `/v1/mcp/:profileId` — expose that tool to a connected MCP client. LLM
+ * proxies have no app-render surface. The backend still gates the catalog on
+ * `app:read`, so this only decides which dialogs request the rows.
+ */
+export function shouldOfferAppCatalogs(agentType: AgentType): boolean {
+  const offered: Record<AgentType, boolean> = {
+    agent: true,
+    mcp_gateway: true,
+    profile: true,
+    llm_proxy: false,
+  };
+  return offered[agentType];
+}
+
 export function normalizeSuggestedPrompts(
   prompts: Array<{ summaryTitle: string; prompt: string }>,
 ): Array<{ summaryTitle: string; prompt: string }> {

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -125,9 +125,10 @@ interface AgentToolsEditorProps {
   /** When true, the "Add MCP server" combobox starts open. */
   openComboboxOnMount?: boolean;
   /**
-   * Include assignable App backing catalogs in the picker. Only the MCP gateway
-   * dialog sets this — Apps launch through a gateway, and the backend still
-   * gates their inclusion on `app:read`.
+   * Include assignable App backing catalogs in the picker. Chat agents, MCP
+   * gateways, and legacy profiles set this — a chat agent renders an app inline
+   * from its `__open` tool, a gateway/profile exposes that tool to a connected
+   * MCP client. The backend still gates their inclusion on `app:read`.
    */
   includeAppCatalogs?: boolean;
 }

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -9,6 +9,7 @@ import {
   getArchestraToolFullName,
   HOOK_RUN_PART_TYPE,
   isAppRenderingArchestraToolShortName,
+  parseArchestraAppResourceUri,
   parseFullToolName,
   type ResourceVisibilityScope,
   SWAP_AGENT_FAILED_POKE_TEXT,
@@ -1617,6 +1618,12 @@ const MessageTool = memo(
     // A server-scoped deep link (apps-page open-in-chat) stamps the concrete
     // install so the chat mounts against it instead of the agent gateway.
     const uiMcpServerId = uiMeta?.mcpServerId;
+    // An owned app's own render (e.g. its `__open` launch tool) carries a
+    // `ui://archestra-app/<appId>` URI; bind it so the app runs against the
+    // app-bound endpoint (/api/mcp/app/:appId), not the agent gateway.
+    const uiAppId = uiResourceUri
+      ? parseArchestraAppResourceUri(uiResourceUri)
+      : null;
 
     // When the model dispatched through run_tool, the MCP App belongs to the
     // *target* tool. Unwrap so the app receives the target tool's name (for the
@@ -1913,6 +1920,7 @@ const MessageTool = memo(
                 <McpAppSection
                   uiResourceUri={uiResourceUri}
                   mcpServerId={uiMcpServerId}
+                  appId={uiAppId ?? undefined}
                   agentId={agentId}
                   toolName={mcpAppToolName}
                   toolCallId={part.toolCallId}
@@ -2022,6 +2030,7 @@ const MessageTool = memo(
               <McpAppSection
                 uiResourceUri={uiResourceUri}
                 mcpServerId={uiMcpServerId}
+                appId={uiAppId ?? undefined}
                 agentId={agentId}
                 toolName={mcpAppToolName}
                 toolCallId={part.toolCallId}

--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -468,6 +468,54 @@ describe("deriveAppsFromMessages", () => {
     });
   });
 
+  it("routes an owned-app __open render (ui://archestra-app URI) app-bound via appId", () => {
+    const APP_ID = "947051c7-ea8e-48ed-8077-a3cc904d9d61";
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-simple_todo__open",
+            toolCallId: "call_open",
+            state: "output-available",
+            output: {
+              _meta: { ui: { resourceUri: `ui://archestra-app/${APP_ID}` } },
+            },
+          },
+        ],
+      },
+    ] as never;
+
+    const apps = deriveAppsFromMessages(messages, {}, getToolShortName);
+    expect(apps).toHaveLength(1);
+    expect(apps[0]).toMatchObject({
+      toolCallId: "call_open",
+      appId: APP_ID,
+      uiResourceUri: `ui://archestra-app/${APP_ID}`,
+    });
+  });
+
+  it("keeps a non-Archestra MCP-UI render un-app-bound (appId null)", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-excalidraw__draw",
+            toolCallId: "call_ext",
+            state: "output-available",
+            output: { _meta: { ui: { resourceUri: "ui://excalidraw" } } },
+          },
+        ],
+      },
+    ] as never;
+
+    const apps = deriveAppsFromMessages(messages, {}, getToolShortName);
+    expect(apps[0]).toMatchObject({ toolCallId: "call_ext", appId: null });
+  });
+
   it("returns an app labeled with the app name for an owned-app edit_app result", () => {
     const messages = [
       {

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -5,6 +5,7 @@ import {
   HOOK_RUN_PART_TYPE,
   isAppRenderingArchestraToolShortName,
   isBrowserMcpTool,
+  parseArchestraAppResourceUri,
   parseFullToolName,
   SUBAGENT_TOOL_CALL_PART_TYPE,
   type SubagentToolCallPartData,
@@ -204,6 +205,31 @@ export function deriveAppsFromMessages(
         part,
         earlyToolUiStarts[part.toolCallId],
       );
+
+      // An owned app rendered by its own render (e.g. its `__open` launch tool)
+      // carries a `ui://archestra-app/<appId>` URI. Route it by `appId` to the
+      // app-bound endpoint so its SDK storage and app-scoped tool calls reach
+      // `/api/mcp/app/:appId`, not the generic agent gateway. Its head version
+      // is served from that endpoint, so the inline result isn't seeded.
+      const uriAppId = outputUri
+        ? parseArchestraAppResourceUri(outputUri)
+        : null;
+      if (uriAppId) {
+        seen.add(part.toolCallId);
+        apps.push({
+          toolCallId: part.toolCallId,
+          label: mcpToolLabel(fullToolName),
+          uiResourceUri: outputUri as string,
+          appId: uriAppId,
+          toolName: resolveRunToolTargetName(part, fullToolName, {
+            getToolShortName,
+          }),
+          version: null,
+          createdAt: createdAt ?? 0,
+        });
+
+        continue;
+      }
 
       // An external MCP-UI render carries its own URI in the result. It never
       // dedups: the same URI can represent entirely different content across

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -335,7 +335,10 @@ export function McpAppSection({
       preloadedResource={preloadedResource}
       onResourceStateChange={handleResourceStateChange}
       onSendMessage={onSendMessage}
-      appVersion={appVersion}
+      // Fall back to the resolved app's head version so a render bound only by
+      // appId (e.g. an `__open` launch) still persists diagnostics/screenshots,
+      // which the runtime gates on a non-null version.
+      appVersion={appVersion ?? ownedApp?.latestVersion ?? null}
       reloadNonce={reloadNonce}
     />
   );

--- a/platform/shared/archestra-mcp-server.test.ts
+++ b/platform/shared/archestra-mcp-server.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
 import { AGENT_TOOL_PREFIX, isAgentTool } from "./agents";
 import {
+  getArchestraAppResourceUri,
   getArchestraMcpServerName,
   getArchestraToolFullName,
   getArchestraToolPrefix,
   getArchestraToolShortName,
   isAlwaysExposedArchestraToolShortName,
   isArchestraMcpServerTool,
+  parseArchestraAppResourceUri,
   TOOL_CREATE_AGENT_FULL_NAME,
 } from "./archestra-mcp-server";
 
@@ -126,5 +128,28 @@ describe("archestra MCP tool names", () => {
     ]) {
       expect(isAlwaysExposedArchestraToolShortName(shortName)).toBe(false);
     }
+  });
+});
+
+describe("parseArchestraAppResourceUri", () => {
+  test("round-trips an owned-app id", () => {
+    const appId = "947051c7-ea8e-48ed-8077-a3cc904d9d61";
+    expect(
+      parseArchestraAppResourceUri(getArchestraAppResourceUri(appId)),
+    ).toBe(appId);
+  });
+
+  test("returns null for a non-app UI URI", () => {
+    expect(parseArchestraAppResourceUri("ui://excalidraw")).toBeNull();
+  });
+
+  test("returns null for the bare prefix (no app id)", () => {
+    expect(parseArchestraAppResourceUri("ui://archestra-app/")).toBeNull();
+  });
+
+  test("returns null when the URI has a path past the app id", () => {
+    expect(
+      parseArchestraAppResourceUri("ui://archestra-app/abc/extra"),
+    ).toBeNull();
   });
 });

--- a/platform/shared/archestra-mcp-server.ts
+++ b/platform/shared/archestra-mcp-server.ts
@@ -626,6 +626,19 @@ export function getArchestraAppResourceUri(appId: string): string {
   return `ui://archestra-app/${appId}`;
 }
 
+/**
+ * Inverse of {@link getArchestraAppResourceUri}: the owned-app id if `uri` is an
+ * `ui://archestra-app/<appId>` URI, else null. A chat host uses this to route an
+ * owned app's render (e.g. its `__open` launch tool) to the app-bound endpoint
+ * instead of treating it as a generic external MCP-UI render.
+ */
+export function parseArchestraAppResourceUri(uri: string): string | null {
+  const prefix = getArchestraAppResourceUri("");
+  if (!uri.startsWith(prefix)) return null;
+  const appId = uri.slice(prefix.length);
+  return appId.length > 0 && !appId.includes("/") ? appId : null;
+}
+
 export function isArchestraMcpServerTool(
   toolName: string,
   options?: ArchestraMcpIdentityOptions & { includeDefaultPrefix?: boolean },


### PR DESCRIPTION
## Summary

Owned Apps (`serverType:"app"` catalogs) were assignable only in the MCP gateway capabilities picker. A chat agent — or a legacy profile — in Custom-tools mode could not see or assign an App at all: the Custom-tools tool selector filtered app backings out, so the only way to use an App with a chat agent was All-tools mode. Selecting a specific App for a Custom-mode agent was impossible.

This offers App backings in the Custom-tools selector for chat agents and profiles as well — still gated on `app:read`, the same boundary the Apps page uses — matching what MCP gateways already allow. `llm_proxy` agents have no App render surface and stay excluded.

It also completes the render path. An owned App opened in chat via its `__open` launch tool carries a `ui://archestra-app/<appId>` resource URI. The chat now recovers that `appId` and binds the render to the app runtime endpoint `/api/mcp/app/:appId`, on both the inline message surface and the side panel. Previously such a render fell through to the generic agent gateway with no app id, so the App loaded its HTML but every in-app SDK storage write and app-scoped tool call was misrouted and silently failed — the App looked alive but nothing it did persisted. Now those callbacks resolve against the App and persist, and a render bound only by `appId` reports its runtime diagnostics against the app's head version.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>