### PR TITLE
test(apps): pin inline __open owned-app render routing

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -1598,6 +1598,70 @@ describe("owned-app inline rendering", () => {
     expect(screen.queryByTestId("mcp-app-section")).not.toBeInTheDocument();
   });
 
+  it("app-binds an owned app opened via its __open launch tool (ui://archestra-app URI)", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-simple_todo__open",
+            toolCallId: "call-open-1",
+            state: "output-available",
+            input: {},
+            output: {
+              _meta: { ui: { resourceUri: `ui://archestra-app/${APP_ID}` } },
+            },
+          },
+        ],
+      },
+    ] as unknown as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        agentId="agent-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    const section = screen.getByTestId("mcp-app-section");
+    expect(section).toHaveAttribute("data-app-id", APP_ID);
+    expect(section).toHaveAttribute("data-uri", `ui://archestra-app/${APP_ID}`);
+  });
+
+  it("does not app-bind an external MCP-UI render (non-owned-app URI)", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-excalidraw__draw",
+            toolCallId: "call-ext-1",
+            state: "output-available",
+            input: {},
+            output: { _meta: { ui: { resourceUri: "ui://excalidraw" } } },
+          },
+        ],
+      },
+    ] as unknown as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        agentId="agent-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    const section = screen.getByTestId("mcp-app-section");
+    expect(section).toHaveAttribute("data-app-id", "");
+    expect(section).toHaveAttribute("data-uri", "ui://excalidraw");
+  });
+
   // refine_app/validate_app return an app id but are not rendering tools: they
   // must not mount a canvas (would otherwise re-render the app on every refine).
   it.each([


### PR DESCRIPTION
## Summary

Regression tests for the inline chat render path shipped in #6244. An owned App opened via its `__open` launch tool carries a `ui://archestra-app/<appId>` resource URI, and the chat binds that render to the app runtime endpoint by recovering `appId` from the URI. These pin that contract on the inline message surface (`chat-messages.tsx`), which the merged change covered only with manual QA:

- an owned-app `ui://archestra-app/<id>` render mounts app-bound (`appId` set), so its in-app SDK storage and app-scoped tool calls reach `/api/mcp/app/:appId`;
- an external MCP-UI render (e.g. `ui://excalidraw`) does not app-bind.

Dropping the `appId` derivation fails the first test; a parser that matched non-App URIs too broadly fails the second.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>