### PR TITLE
fix(mcp): make multi-install external apps interactive in chat

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -722,6 +722,51 @@ describe("McpClient", () => {
         ),
       ).toBe(pinned.id);
     });
+
+    test("declines to bind an enterprise-managed catalog with more than one install", async ({
+      makeAgent,
+      makeAgentTool,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeMember,
+      makeOrganization,
+      makeTool,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id, { role: "member" });
+      const agent = await makeAgent({ organizationId: org.id });
+      const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+      await makeMcpServer({
+        catalogId: catalog.id,
+        ownerId: user.id,
+        scope: "personal",
+      });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+      // Enterprise-managed credentials resolve the runtime install by their own
+      // mechanism (which run_tool honors in all-tools mode), so the own→team→org
+      // resolution here could pick a different install than execution uses.
+      await db
+        .update(schema.internalMcpCatalogTable)
+        .set({ enterpriseManagedConfig: {} })
+        .where(eq(schema.internalMcpCatalogTable.id, catalog.id));
+      const uri = "ui://excalidraw/mcp-app.html";
+      const tool = await makeTool({
+        name: "excalidraw__create_view",
+        catalogId: catalog.id,
+        meta: { _meta: { ui: { resourceUri: uri } } },
+      });
+      await makeAgentTool(agent.id, tool.id);
+
+      expect(
+        await mcpClient.resolveUiAppInstallIdForCaller(
+          uri,
+          agent.id,
+          callerAuth(user.id, org.id),
+        ),
+      ).toBeNull();
+    });
   });
 
   describe("executeToolCallForOwner", () => {

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -619,7 +619,62 @@ describe("McpClient", () => {
       expect(resolved).toBeNull();
     });
 
-    test("returns null when the catalog has more than one install (pin could diverge)", async ({
+    test("binds each caller to their own install when the catalog has a per-user install for several users", async ({
+      makeAgent,
+      makeAgentTool,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeMember,
+      makeOrganization,
+      makeTool,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const userA = await makeUser();
+      const userB = await makeUser();
+      await makeMember(userA.id, org.id, { role: "member" });
+      await makeMember(userB.id, org.id, { role: "member" });
+      const agent = await makeAgent({ organizationId: org.id });
+      const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+      // Per-user credentials: each user connects their own install of the same
+      // catalog, so the catalog has more than one install.
+      const installA = await makeMcpServer({
+        catalogId: catalog.id,
+        ownerId: userA.id,
+        scope: "personal",
+      });
+      const installB = await makeMcpServer({
+        catalogId: catalog.id,
+        ownerId: userB.id,
+        scope: "personal",
+      });
+      const uri = "ui://excalidraw/mcp-app.html";
+      const tool = await makeTool({
+        name: "excalidraw__create_view",
+        catalogId: catalog.id,
+        meta: { _meta: { ui: { resourceUri: uri } } },
+      });
+      await makeAgentTool(agent.id, tool.id);
+
+      // Each caller's render binds to their OWN install — interactive for both,
+      // never the other user's install, never null.
+      expect(
+        await mcpClient.resolveUiAppInstallIdForCaller(
+          uri,
+          agent.id,
+          callerAuth(userA.id, org.id),
+        ),
+      ).toBe(installA.id);
+      expect(
+        await mcpClient.resolveUiAppInstallIdForCaller(
+          uri,
+          agent.id,
+          callerAuth(userB.id, org.id),
+        ),
+      ).toBe(installB.id);
+    });
+
+    test("binds every caller to the catalog's service-account pin over their own install", async ({
       makeAgent,
       makeAgentTool,
       makeInternalMcpCatalog,
@@ -631,14 +686,24 @@ describe("McpClient", () => {
     }) => {
       const org = await makeOrganization();
       const user = await makeUser();
-      await makeMember(user.id, org.id, { role: "admin" });
+      await makeMember(user.id, org.id, { role: "member" });
       const agent = await makeAgent({ organizationId: org.id });
       const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
-      // Two installs for the same catalog: run_tool's credential policy could pin
-      // execution to one while the caller-scoped resolution here picks the other,
-      // so no binding is emitted (callbacks fail cleanly instead of misrouting).
-      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
-      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+      await makeMcpServer({
+        catalogId: catalog.id,
+        ownerId: user.id,
+        scope: "personal",
+      });
+      const pinned = await makeMcpServer({
+        catalogId: catalog.id,
+        scope: "org",
+      });
+      // A service-account pin routes every caller's runtime through this one
+      // install, regardless of their own→team→org resolution.
+      await db
+        .update(schema.internalMcpCatalogTable)
+        .set({ dynamicConnectionMcpServerId: pinned.id })
+        .where(eq(schema.internalMcpCatalogTable.id, catalog.id));
       const uri = "ui://excalidraw/mcp-app.html";
       const tool = await makeTool({
         name: "excalidraw__create_view",
@@ -647,13 +712,15 @@ describe("McpClient", () => {
       });
       await makeAgentTool(agent.id, tool.id);
 
-      const resolved = await mcpClient.resolveUiAppInstallIdForCaller(
-        uri,
-        agent.id,
-        callerAuth(user.id, org.id),
-      );
-
-      expect(resolved).toBeNull();
+      // The callback binds to the pinned install run_tool executes against — not
+      // the caller's own personal install.
+      expect(
+        await mcpClient.resolveUiAppInstallIdForCaller(
+          uri,
+          agent.id,
+          callerAuth(user.id, org.id),
+        ),
+      ).toBe(pinned.id);
     });
   });
 

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -3417,16 +3417,16 @@ class McpClient {
    * (buildExternalAppRenderResult), whose absence otherwise misroutes the app's
    * `callServerTool` to the agent gateway.
    *
+   * Binds to the same install run_tool executes against, for any number of
+   * installs: a valid service-account pin (`dynamicConnectionMcpServerId`)
+   * routes every caller to one install; otherwise the caller's own→team→org
+   * connection policy resolves it (`findMcpServerForResource`), so a
+   * per-user-credentialed catalog binds each caller to their own install.
+   *
    * Returns null (render stays unbound, callbacks fail cleanly rather than
-   * misrouting) when:
-   * - the resource is an owned-app backing (`serverType === "app"`, rendered by
-   *   app id via render_app), or
-   * - the catalog has anything other than exactly one install. This method
-   *   resolves the install by the caller's own→team→org connection policy, but
-   *   run_tool executes against the install chosen by the *tool's* credential
-   *   policy (a static/service-account pin can point elsewhere). Those agree
-   *   only when there is a single install, so binding is limited to that case —
-   *   a different install would route callbacks to the wrong server/account.
+   * misrouting) when the caller has no accessible install for the resource, or
+   * the resource is an owned-app backing (`serverType === "app"`, rendered by
+   * app id via render_app).
    */
   async resolveUiAppInstallIdForCaller(
     resourceUri: string,
@@ -3441,11 +3441,14 @@ class McpClient {
     if (!resolved || resolved.catalogItem.serverType === "app") {
       return null;
     }
-    const installs = await McpServerModel.findByCatalogId(
-      resolved.catalogItem.id,
-    );
-    if (installs.length !== 1) {
-      return null;
+    const pinnedId = resolved.catalogItem.dynamicConnectionMcpServerId;
+    if (pinnedId) {
+      const installs = await McpServerModel.findByCatalogId(
+        resolved.catalogItem.id,
+      );
+      if (installs.some((server) => server.id === pinnedId)) {
+        return pinnedId;
+      }
     }
     return resolved.server.id;
   }

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -3424,9 +3424,11 @@ class McpClient {
    * per-user-credentialed catalog binds each caller to their own install.
    *
    * Returns null (render stays unbound, callbacks fail cleanly rather than
-   * misrouting) when the caller has no accessible install for the resource, or
-   * the resource is an owned-app backing (`serverType === "app"`, rendered by
-   * app id via render_app).
+   * misrouting) when the caller has no accessible install for the resource, the
+   * resource is an owned-app backing (`serverType === "app"`, rendered by app id
+   * via render_app), or the catalog is enterprise-managed with more than one
+   * install — enterprise credentials resolve the runtime install by their own
+   * mechanism, which can pick a different install than the own→team→org policy.
    */
   async resolveUiAppInstallIdForCaller(
     resourceUri: string,
@@ -3441,13 +3443,22 @@ class McpClient {
     if (!resolved || resolved.catalogItem.serverType === "app") {
       return null;
     }
-    const pinnedId = resolved.catalogItem.dynamicConnectionMcpServerId;
-    if (pinnedId) {
-      const installs = await McpServerModel.findByCatalogId(
-        resolved.catalogItem.id,
-      );
-      if (installs.some((server) => server.id === pinnedId)) {
+    const { catalogItem } = resolved;
+    const pinnedId = catalogItem.dynamicConnectionMcpServerId;
+    const enterpriseManaged = catalogItem.enterpriseManagedConfig != null;
+    if (pinnedId || enterpriseManaged) {
+      const installs = await McpServerModel.findByCatalogId(catalogItem.id);
+      // A valid service-account pin routes every caller through one install.
+      if (pinnedId && installs.some((server) => server.id === pinnedId)) {
         return pinnedId;
+      }
+      // Enterprise-managed credentials resolve the runtime install by their own
+      // mechanism (an explicit pin or the first install), which can diverge from
+      // the own→team→org resolution when the catalog has more than one install —
+      // a single install cannot diverge. Decline rather than bind callbacks to
+      // an install run_tool did not execute against.
+      if (enterpriseManaged && installs.length > 1) {
+        return null;
       }
     }
     return resolved.server.id;


### PR DESCRIPTION
## Summary

An external UI-providing MCP app rendered inline in chat only became interactive when its catalog had exactly one install. Any catalog with two or more installs — for example a server using per-user credentials, where each user connects their own install — rendered the app's HTML but routed the app's in-app SDK data-store writes and tool calls to the agent gateway, which rejects the bare tool name. So the app looked alive while every in-app interaction silently failed, and it failed for **every** caller (the guard counted installs across all users and orgs), not only when a second user connected.

The app's callbacks now bind to the install `run_tool` actually executes against, for any number of installs:

- a valid service-account pin (`dynamicConnectionMcpServerId`) routes every caller to the pinned install;
- otherwise each caller's own → team → org resolution binds them to their own install, so a per-user-credentialed catalog is interactive for everyone, each against their own connection.

An enterprise-managed catalog with more than one install stays unbound (renders but non-interactive) rather than risk misrouting: enterprise credentials resolve the runtime install by their own mechanism, which can pick a different install than the per-caller resolution. The callback route continues to re-authorize each caller's access to the bound install, so binding is a routing decision, not an authorization grant.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>