### PR TITLE
fix(apps): guard app data-store writes on the last-seen revision by default

### DIFF
--- a/platform/backend/src/services/apps/app-sdk-runtime.test.ts
+++ b/platform/backend/src/services/apps/app-sdk-runtime.test.ts
@@ -196,6 +196,55 @@ describe("Apps SDK runtime", () => {
     });
   });
 
+  test("a set after get returned absent guards insert-if-absent, so a racing create conflicts", async () => {
+    results.push({
+      structuredContent: { value: null, revision: null, owner: null },
+    });
+    expect(await archestra.storage.shared.get("absent_key")).toBeNull();
+    calls.pop();
+
+    results.push({
+      structuredContent: { key: "absent_key", revision: 1, owner: null },
+    });
+    await archestra.storage.shared.set("absent_key", { first: true });
+    expect(calls.pop()).toEqual({
+      name: "archestra__app_data_set",
+      arguments: {
+        key: "absent_key",
+        value: { first: true },
+        scope: "app",
+        expectedRevision: 0,
+      },
+    });
+  });
+
+  test("a set after list guards on the revision list returned for the key", async () => {
+    results.push({
+      structuredContent: {
+        entries: [
+          { key: "list_a", value: 1, revision: 7, owner: null },
+          { key: "list_b", value: 2, revision: 8, owner: null },
+        ],
+      },
+    });
+    await archestra.storage.user.list();
+    calls.pop();
+
+    results.push({
+      structuredContent: { key: "list_b", revision: 9, owner: null },
+    });
+    await archestra.storage.user.set("list_b", 22);
+    expect(calls.pop()).toEqual({
+      name: "archestra__app_data_set",
+      arguments: {
+        key: "list_b",
+        value: 22,
+        scope: "user",
+        expectedRevision: 8,
+      },
+    });
+  });
+
   test("tools.call resolves with structuredContent when present, over text", async () => {
     results.push({
       content: [{ type: "text", text: '{"other": true}' }],

--- a/platform/backend/src/services/apps/app-sdk-runtime.test.ts
+++ b/platform/backend/src/services/apps/app-sdk-runtime.test.ts
@@ -120,6 +120,82 @@ describe("Apps SDK runtime", () => {
     });
   });
 
+  test("set guards on the revision last seen for the key, so a stale write conflicts instead of silently overwriting", async () => {
+    // A read establishes the key's current revision.
+    results.push({
+      structuredContent: { value: { items: [] }, revision: 4, owner: null },
+    });
+    await archestra.storage.user.get("rmw_default");
+    calls.pop();
+
+    // A later write of the same key carries that revision as expectedRevision
+    // without the app passing ifRevision — the backend then rejects it as a
+    // conflict if another instance wrote in between, rather than clobbering.
+    results.push({
+      structuredContent: { key: "rmw_default", revision: 5, owner: null },
+    });
+    await archestra.storage.user.set("rmw_default", { items: ["a"] });
+    expect(calls.pop()).toEqual({
+      name: "archestra__app_data_set",
+      arguments: {
+        key: "rmw_default",
+        value: { items: ["a"] },
+        scope: "user",
+        expectedRevision: 4,
+      },
+    });
+  });
+
+  test("set omits the guard for a key never read this session (a blind write stays last-writer-wins)", async () => {
+    results.push({
+      structuredContent: { key: "blind_key", revision: 1, owner: null },
+    });
+    await archestra.storage.user.set("blind_key", "v");
+    expect(calls.pop()).toEqual({
+      name: "archestra__app_data_set",
+      arguments: { key: "blind_key", value: "v", scope: "user" },
+    });
+  });
+
+  test("an explicit ifRevision overrides the tracked revision", async () => {
+    results.push({
+      structuredContent: { value: 1, revision: 9, owner: null },
+    });
+    await archestra.storage.user.get("explicit_key");
+    calls.pop();
+
+    results.push({
+      structuredContent: { key: "explicit_key", revision: 3, owner: null },
+    });
+    await archestra.storage.user.set("explicit_key", 2, { ifRevision: 2 });
+    expect(calls.pop()).toEqual({
+      name: "archestra__app_data_set",
+      arguments: {
+        key: "explicit_key",
+        value: 2,
+        scope: "user",
+        expectedRevision: 2,
+      },
+    });
+  });
+
+  test("ifRevision null opts out of the guard, forcing last-writer-wins after a read", async () => {
+    results.push({
+      structuredContent: { value: 1, revision: 9, owner: null },
+    });
+    await archestra.storage.user.get("optout_key");
+    calls.pop();
+
+    results.push({
+      structuredContent: { key: "optout_key", revision: 10, owner: null },
+    });
+    await archestra.storage.user.set("optout_key", 2, { ifRevision: null });
+    expect(calls.pop()).toEqual({
+      name: "archestra__app_data_set",
+      arguments: { key: "optout_key", value: 2, scope: "user" },
+    });
+  });
+
   test("tools.call resolves with structuredContent when present, over text", async () => {
     results.push({
       content: [{ type: "text", text: '{"other": true}' }],

--- a/platform/backend/src/static/archestra-app-sdk.js
+++ b/platform/backend/src/static/archestra-app-sdk.js
@@ -327,7 +327,10 @@
           sc && sc.revision != null
             ? { value: sc.value, revision: sc.revision, owner: sc.owner ?? null }
             : null;
-        if (entry) seenRevisions.set(key, entry.revision);
+        // Cache the revision so a later set of this key guards on it. An absent
+        // key caches 0 (insert-if-absent) so two instances racing to create the
+        // same key conflict rather than one silently overwriting the other.
+        seenRevisions.set(key, entry ? entry.revision : 0);
         return entry;
       },
       // By default a write guards on the revision last seen for the key this
@@ -353,9 +356,17 @@
         if (sc && sc.revision != null) seenRevisions.set(key, sc.revision);
         return { revision: sc?.revision, owner: sc?.owner ?? null };
       },
-      list: async () =>
-        (await callTool(APP_DATA_TOOLS.list, { scope })).structuredContent
-          ?.entries || [],
+      list: async () => {
+        const entries =
+          (await callTool(APP_DATA_TOOLS.list, { scope })).structuredContent
+            ?.entries || [];
+        // Cache each listed revision so an edit flow that loads via list() then
+        // saves one record still guards that write on the revision it loaded.
+        for (const e of entries) {
+          if (e && e.revision != null) seenRevisions.set(e.key, e.revision);
+        }
+        return entries;
+      },
       // delete is guarded by ownership (an owned shared key can only be removed
       // by its owner or the app's author/admins), not by revision.
       delete: async (key) => {

--- a/platform/backend/src/static/archestra-app-sdk.js
+++ b/platform/backend/src/static/archestra-app-sdk.js
@@ -10,8 +10,10 @@
  *     (values are plain JSON; get(key) resolves to an entry { value, revision,
  *     owner } or null when absent, list() to [{key, value, revision, owner}];
  *     set(key, value, { ifRevision, owned }) resolves to { revision, owner } and
- *     rejects with { code: "conflict" } on a stale ifRevision or
- *     { code: "forbidden" } on an owned-key violation; delete clears a key)
+ *     by default rejects with { code: "conflict" } when the key changed since
+ *     this app last read it — pass { ifRevision: null } to force last-writer-wins,
+ *     or a number to guard on that exact revision — and { code: "forbidden" } on
+ *     an owned-key violation; delete clears a key)
  *   archestra.llm.complete(prompt, opts) — one host LLM completion (opts: { system, jsonMode });
  *                                     resolves to the text, rejects with { code: "llm_quota" }
  *                                     on a usage limit or { code: "llm_unavailable" } otherwise
@@ -307,32 +309,48 @@
   };
 
   // Each value is an entry { value, revision, owner }: revision powers optimistic
-  // concurrency (pass it back as set opts.ifRevision to fail a write that raced
-  // another viewer — the call rejects with { code: "conflict" }); owner is the
-  // viewer id that claimed the (shared) key, or null when unclaimed. delete is
-  // guarded by ownership rather than revision.
-  const storagePartition = (scope) =>
-    Object.freeze({
+  // concurrency — a later set of the same key guards on it automatically, failing
+  // a write that raced another instance with { code: "conflict" } (opts.ifRevision
+  // overrides the guard); owner is the viewer id that claimed the (shared) key, or
+  // null when unclaimed. delete is guarded by ownership rather than revision.
+  const storagePartition = (scope) => {
+    // The revision last seen for each key, from a get or a successful set. A
+    // write guards on it by default so a read-modify-write that raced another
+    // instance of this app is rejected as a conflict rather than silently
+    // overwriting the other's committed value.
+    const seenRevisions = new Map();
+    return Object.freeze({
       get: async (key) => {
         const sc = (await callTool(APP_DATA_TOOLS.get, { key, scope }))
           .structuredContent;
-        return sc && sc.revision != null
-          ? { value: sc.value, revision: sc.revision, owner: sc.owner ?? null }
-          : null;
+        const entry =
+          sc && sc.revision != null
+            ? { value: sc.value, revision: sc.revision, owner: sc.owner ?? null }
+            : null;
+        if (entry) seenRevisions.set(key, entry.revision);
+        return entry;
       },
-      // opts.ifRevision: write only if the stored revision matches (0 = create,
-      // i.e. fail if the key already exists). opts.owned: claim a new shared key
-      // for the viewer so only they (or the app's author/admins) may overwrite it.
+      // By default a write guards on the revision last seen for the key this
+      // session (a conflict rejects with { code: "conflict" }). opts.ifRevision
+      // overrides that guard: a number writes only if the stored revision
+      // matches (0 = create, i.e. fail if the key already exists); null opts out
+      // entirely (last-writer-wins). opts.owned: claim a new shared key for the
+      // viewer so only they (or the app's author/admins) may overwrite it.
       set: async (key, value, opts) => {
+        const expectedRevision =
+          opts && "ifRevision" in opts
+            ? (opts.ifRevision === null ? undefined : opts.ifRevision)
+            : seenRevisions.get(key);
         const sc = (
           await callTool(APP_DATA_TOOLS.set, {
             key,
             value,
             scope,
-            expectedRevision: opts?.ifRevision,
+            expectedRevision,
             claimOwner: opts?.owned,
           })
         ).structuredContent;
+        if (sc && sc.revision != null) seenRevisions.set(key, sc.revision);
         return { revision: sc?.revision, owner: sc?.owner ?? null };
       },
       list: async () =>
@@ -342,8 +360,10 @@
       // by its owner or the app's author/admins), not by revision.
       delete: async (key) => {
         await callTool(APP_DATA_TOOLS.delete, { key, scope });
+        seenRevisions.delete(key);
       },
     });
+  };
 
   // A single host LLM completion. Runs as the viewer through the org's app
   // runtime model (the app can't pick one); jsonMode steers the model to emit


### PR DESCRIPTION
## Summary

When the same MCP App is open in two live surfaces at once — inline in a chat conversation and in a standalone tab, say — a read-modify-write from one surface could silently overwrite a value the other had already committed, with no error on either side: the user simply lost data. The store already supports optimistic concurrency (each key carries a revision), but the injected app SDK never used it unless an app explicitly passed `{ ifRevision }`, so writes were last-writer-wins by default.

`storage.set` now tracks the revision it last saw for each key (from a `get` or a successful `set`) and sends it as the write guard by default. A stale write — one racing another instance of the same app — is now rejected as `{ code: "conflict" }` for the app to re-read and reconcile, instead of clobbering the committed value. Escape hatches are preserved: `{ ifRevision: null }` forces last-writer-wins, a number guards on that exact revision, and a blind write (a key never read this session) stays last-writer-wins. A single-instance app that reads-then-writes is unaffected — its guard always matches.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>