### PR TITLE
fix(chat): prepend a leading user turn for Gemini so owned-app chats don't 400

### DIFF
--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -513,3 +513,125 @@ test("an inlineable text-document attachment counts toward the context gate", as
     ContextWindowExceededError,
   );
 });
+
+const RENDER_APP_APP_ID = "402e041f-a78c-40a0-b8b3-a14d91633fce";
+
+// Mirrors an owned-app chat seeded by createSeededAppConversation: the first
+// message is a synthetic render_app assistant tool-call, followed by the user's
+// first real prompt.
+function renderAppSeedMessages(): ChatMessage[] {
+  return [
+    {
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "archestra__render_app",
+          toolCallId: "call_render_1",
+          state: "output-available",
+          input: { appId: RENDER_APP_APP_ID },
+          output: { content: [{ type: "text", text: "app rendered" }] },
+        },
+      ],
+    },
+    {
+      role: "user",
+      parts: [{ type: "text", text: "make a simple shopping list app" }],
+    },
+  ] as unknown as ChatMessage[];
+}
+
+function firstToolCall(
+  messages: ModelMessage[],
+): { toolName?: string; input?: unknown } | undefined {
+  for (const message of messages) {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      continue;
+    }
+    for (const part of message.content) {
+      if ((part as { type?: string }).type === "tool-call") {
+        return part as { toolName?: string; input?: unknown };
+      }
+    }
+  }
+  return undefined;
+}
+
+test("gemini: render_app-seeded history gets a leading user turn so contents don't open with a functionCall", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  const { modelMessages } = await __test.buildModelMessagesForProvider({
+    messages: renderAppSeedMessages(),
+    provider: "gemini",
+    conversationId: conversation.id,
+    sandboxAvailable: false,
+  });
+
+  // The whole sequence must map to valid Gemini contents: a leading user turn,
+  // then the seed's functionCall (assistant) immediately paired with its
+  // functionResponse (tool), then the real user prompt — i.e.
+  // user -> model(functionCall) -> user(functionResponse) -> user(text). Pin the
+  // full order so a regression that strands the functionCall (Gemini 400) is
+  // caught here, not only in an end-to-end call.
+  expect(modelMessages.map((message) => message.role)).toEqual([
+    "user",
+    "assistant",
+    "tool",
+    "user",
+  ]);
+  // The functionCall/functionResponse pair references the same seeded tool call.
+  const toolCall = firstToolCall(modelMessages);
+  expect(toolCall?.toolName).toBe("archestra__render_app");
+  // The render_app seed is preserved (not dropped) — its tool result carries the
+  // app id the app tools require to edit the bound app.
+  expect(JSON.stringify(toolCall?.input)).toContain(RENDER_APP_APP_ID);
+});
+
+test("non-gemini: render_app-seeded history keeps the assistant tool-call first (no leading user turn injected)", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  const { modelMessages } = await __test.buildModelMessagesForProvider({
+    messages: renderAppSeedMessages(),
+    provider: "openai",
+    conversationId: conversation.id,
+    sandboxAvailable: false,
+  });
+
+  expect(modelMessages[0]?.role).toBe("assistant");
+});
+
+test("gemini: a normal user-first history is left unchanged (no synthetic turn added)", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  const messages: ChatMessage[] = [
+    { role: "user", parts: [{ type: "text", text: "hello" }] },
+  ] as unknown as ChatMessage[];
+
+  const { modelMessages } = await __test.buildModelMessagesForProvider({
+    messages,
+    provider: "gemini",
+    conversationId: conversation.id,
+    sandboxAvailable: false,
+  });
+
+  expect(modelMessages).toHaveLength(1);
+  expect(modelMessages[0]?.role).toBe("user");
+});

--- a/platform/backend/src/routes/chat/prepare-model-messages.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.ts
@@ -198,12 +198,48 @@ async function buildModelMessagesForProvider(params: {
   // placeholders survive while other providers never see an empty turn. An
   // empty assistant message has no tool-call block, so removing it cannot
   // orphan a tool result.
+  const nonEmpty = modelMessages.filter(
+    (message) => !isEmptyAssistantModelMessage(message),
+  );
+
   return {
-    modelMessages: modelMessages.filter(
-      (message) => !isEmptyAssistantModelMessage(message),
-    ),
+    modelMessages:
+      params.provider === "gemini"
+        ? ensureGeminiLeadingUserTurn(nonEmpty)
+        : nonEmpty,
     preparedMessages: providerPreparedMessages,
   };
+}
+
+// Owned-app chats are seeded with a synthetic `render_app` assistant tool-call
+// as the conversation's first message (see app-chat-conversation.ts), so their
+// history opens with an assistant turn. Gemini maps that to a `contents[0]` of
+// role `model` carrying a `functionCall`, and rejects it with 400 "function
+// call turn comes immediately after a user turn or after a function response
+// turn" — Gemini requires the first turn to be from the user. Prepend a minimal
+// user turn (after any leading system messages, which Gemini lifts into
+// `systemInstruction`) so the required leading user turn is present without
+// dropping the seed, whose tool result carries the app id the app tools need.
+// Gemini-only: other providers accept a leading assistant/tool turn.
+const GEMINI_LEADING_USER_TURN_TEXT = "Continue.";
+
+function ensureGeminiLeadingUserTurn(messages: ModelMessage[]): ModelMessage[] {
+  const firstContentIndex = messages.findIndex(
+    (message) => message.role !== "system",
+  );
+  if (firstContentIndex === -1 || messages[firstContentIndex].role === "user") {
+    return messages;
+  }
+
+  const leadingUserTurn: ModelMessage = {
+    role: "user",
+    content: [{ type: "text", text: GEMINI_LEADING_USER_TURN_TEXT }],
+  };
+  return [
+    ...messages.slice(0, firstContentIndex),
+    leadingUserTurn,
+    ...messages.slice(firstContentIndex),
+  ];
 }
 
 function isEmptyAssistantModelMessage(message: {


### PR DESCRIPTION
## Summary

Opening or building an owned MCP App in chat fails with a red "There was an issue with your request" whenever the chat agent runs on **Gemini** — the app never builds. The app-open flow seeds the conversation with a synthetic `render_app` assistant tool-call as its **first** message, so the history opens with an assistant turn. Gemini maps that to a `contents[0]` of role `model` carrying a `functionCall` and rejects the request with `400 "function call turn comes immediately after a user turn or after a function response turn"` — it requires the conversation's first turn to be from the user. Anthropic and other providers accept a leading assistant/tool turn, so the failure only surfaces on Gemini.

`ensureGeminiLeadingUserTurn` (Gemini-only, in `prepare-model-messages.ts`) prepends a minimal user turn when the first non-system model message isn't a user turn. The render_app seed is **preserved**, not dropped: its tool result carries the app `id` that every app tool (`edit_app`, `refine_app`, `read_app`, …) requires to edit the bound app — dropping it would make the model scaffold a duplicate app instead of editing the one on screen. The guard lives at the Gemini message-assembly boundary because a conversation that opens by rendering an app is inherently model-first, which the seed layer can't change.

User-visible result: an owned-app chat on Gemini now builds and edits the bound app normally, matching the existing Anthropic behavior.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>