### PR TITLE
fix(apps): keep tool-call details (and show an empty state) when an app renders blank

### DIFF
--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -218,10 +218,14 @@ describe("McpAppSection", () => {
     });
 
     // The panel is opened deliberately and carries no tool details, so a blank
-    // app must not leave a completely empty panel with no indication.
+    // app must not leave a completely empty panel with no indication — and it
+    // must offer a reload to recover a transient/stale empty resource.
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
     expect(
       screen.getByText("This app rendered nothing to display."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reload app" }),
     ).toBeInTheDocument();
   });
 

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -204,6 +204,27 @@ describe("McpAppSection", () => {
     expect(screen.getByTestId("tool-details")).toBeInTheDocument();
   });
 
+  it("shows an explicit empty state in the panel when the app HTML is empty", async () => {
+    await act(async () => {
+      render(
+        <McpAppSection
+          {...defaultProps}
+          surface="panel"
+          preloadedResource={{
+            html: "<!doctype html><html><body></body></html>",
+          }}
+        />,
+      );
+    });
+
+    // The panel is opened deliberately and carries no tool details, so a blank
+    // app must not leave a completely empty panel with no indication.
+    expect(document.querySelector("iframe")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("This app rendered nothing to display."),
+    ).toBeInTheDocument();
+  });
+
   it("keeps script-driven app HTML because it may render after initialization", async () => {
     await act(async () => {
       render(

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -218,14 +218,10 @@ describe("McpAppSection", () => {
     });
 
     // The panel is opened deliberately and carries no tool details, so a blank
-    // app must not leave a completely empty panel with no indication — and it
-    // must offer a reload to recover a transient/stale empty resource.
+    // app must not leave a completely empty panel with no indication.
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
     expect(
       screen.getByText("This app rendered nothing to display."),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Reload app" }),
     ).toBeInTheDocument();
   });
 

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -185,6 +185,25 @@ describe("McpAppSection", () => {
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
 
+  it("keeps the tool-call details inspectable when the app HTML is empty", async () => {
+    await act(async () => {
+      render(
+        <McpAppSection
+          {...defaultProps}
+          preloadedResource={{
+            html: "<!doctype html><html><body></body></html>",
+          }}
+          toolDetails={<div data-testid="tool-details">details</div>}
+        />,
+      );
+    });
+
+    // A blank app document reserves no canvas, but its tool-call details — the
+    // input/output a user needs to diagnose why it rendered blank — must remain.
+    expect(document.querySelector("iframe")).not.toBeInTheDocument();
+    expect(screen.getByTestId("tool-details")).toBeInTheDocument();
+  });
+
   it("keeps script-driven app HTML because it may render after initialization", async () => {
     await act(async () => {
       render(

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -277,10 +277,8 @@ export function McpAppSection({
     // keep the tool-call details inspectable instead of dropping the section.
     if (surface === "panel") {
       return (
-        <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-muted-foreground">
-          <span>This app rendered nothing to display.</span>
-          {/* A reload recovers a transient/stale empty resource. */}
-          <McpAppRefreshButton onClick={reload} size="bar" />
+        <div className="flex h-full w-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
+          This app rendered nothing to display.
         </div>
       );
     }

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -271,9 +271,17 @@ export function McpAppSection({
   );
 
   if (effectiveResourceState === "empty") {
-    // A blank app document reserves no canvas, but its tool-call details must
-    // stay inspectable — a blank render is usually a bug worth examining. Render
-    // them without mounting the runtime.
+    // A blank app document reserves no canvas (a blank render is usually a bug).
+    // In the panel — which the user opened deliberately and which passes no tool
+    // details — show an explicit empty state rather than a blank panel; inline,
+    // keep the tool-call details inspectable instead of dropping the section.
+    if (surface === "panel") {
+      return (
+        <div className="flex h-full w-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
+          This app rendered nothing to display.
+        </div>
+      );
+    }
     return toolDetails ? <div className="w-full">{toolDetails}</div> : null;
   }
 

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -271,7 +271,10 @@ export function McpAppSection({
   );
 
   if (effectiveResourceState === "empty") {
-    return null;
+    // A blank app document reserves no canvas, but its tool-call details must
+    // stay inspectable — a blank render is usually a bug worth examining. Render
+    // them without mounting the runtime.
+    return toolDetails ? <div className="w-full">{toolDetails}</div> : null;
   }
 
   // A deleted (or no-longer-accessible) owned app: it's already dropped from the

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -277,8 +277,10 @@ export function McpAppSection({
     // keep the tool-call details inspectable instead of dropping the section.
     if (surface === "panel") {
       return (
-        <div className="flex h-full w-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
-          This app rendered nothing to display.
+        <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-muted-foreground">
+          <span>This app rendered nothing to display.</span>
+          {/* A reload recovers a transient/stale empty resource. */}
+          <McpAppRefreshButton onClick={reload} size="bar" />
         </div>
       );
     }


### PR DESCRIPTION
## Summary

When an MCP App's UI resource is a blank document — no script, no content, nothing to render — it's classified "empty" and reserves no canvas (by design, to avoid a blank panel in the chat stream). But `McpAppSection` returned `null` for the *entire* section in that case, which also dropped:

- **inline in chat:** the tool-call **details** card (input/output). A blank render is almost always a bug in the app, which is exactly when a user wants to open the tool details to see what it did — and they were gone.
- **in the right-side panel:** everything. An app the user deliberately opened rendered as a completely blank panel, with no indication it rendered nothing and no way to recover.

Now the empty case renders something useful on each surface: the tool-call details inline, and an explicit "this app rendered nothing to display" empty state in the panel. The blank-canvas behavior itself is unchanged (still no iframe reserved for empty HTML).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>