### PR TITLE
fix(a2a): strip inline <thinking> blocks from A2A output

### DIFF
--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -200,7 +200,7 @@ describe("executeA2AMessage real stream boundary", () => {
     expect(textPart?.text).toBe("Answer. Done.");
   });
 
-  test("drops a thinking-only turn to empty text and no leftover text part", async ({
+  test("reduces a thinking-only turn to empty text while keeping the (empty) text part", async ({
     makeOrganization,
     makeUser,
     makeInternalAgent,
@@ -209,7 +209,8 @@ describe("executeA2AMessage real stream boundary", () => {
     const user = await makeUser();
     const agent = await makeInternalAgent({ organizationId: org.id });
     // The pre-strip stream is non-empty, so the empty-response recovery does not
-    // re-trigger; stripping then leaves no visible answer.
+    // re-trigger; stripping leaves no visible answer, but the text part is kept
+    // (not dropped) so the message never collapses to zero parts.
     primeAgent(
       modelEmitting(textChunks("<thinking>only reasoning</thinking>")),
     );
@@ -223,9 +224,10 @@ describe("executeA2AMessage real stream boundary", () => {
     });
 
     expect(result.text).toBe("");
-    expect(result.responseUiMessage.parts.some((p) => p.type === "text")).toBe(
-      false,
+    const textPart = result.responseUiMessage.parts.find(
+      (p): p is Extract<typeof p, { type: "text" }> => p.type === "text",
     );
+    expect(textPart?.text).toBe("");
   });
 
   test("surfaces the captured provider cause, not a generic NoOutputGeneratedError", async ({

--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -171,6 +171,63 @@ describe("executeA2AMessage real stream boundary", () => {
     expect(result.usage?.completionTokens).toBe(2);
   });
 
+  test("strips inline <thinking> blocks from the text and the response message", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    primeAgent(
+      modelEmitting(
+        textChunks("Answer.<thinking>secret reasoning</thinking> Done."),
+      ),
+    );
+
+    const result = await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: "conv-1",
+    });
+
+    expect(result.text).toBe("Answer. Done.");
+    const textPart = result.responseUiMessage.parts.find(
+      (p): p is Extract<typeof p, { type: "text" }> => p.type === "text",
+    );
+    expect(textPart?.text).toBe("Answer. Done.");
+  });
+
+  test("drops a thinking-only turn to empty text and no leftover text part", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    // The pre-strip stream is non-empty, so the empty-response recovery does not
+    // re-trigger; stripping then leaves no visible answer.
+    primeAgent(
+      modelEmitting(textChunks("<thinking>only reasoning</thinking>")),
+    );
+
+    const result = await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: "conv-1",
+    });
+
+    expect(result.text).toBe("");
+    expect(result.responseUiMessage.parts.some((p) => p.type === "text")).toBe(
+      false,
+    );
+  });
+
   test("surfaces the captured provider cause, not a generic NoOutputGeneratedError", async ({
     makeOrganization,
     makeUser,

--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -17,6 +17,7 @@ import {
   type ToolCallRepeatTracker,
 } from "@/clients/tool-call-repeat-tracker";
 import { ProviderError } from "@/routes/chat/errors";
+import { THINKING_ONLY_NOTICE } from "@/utils/strip-thinking-blocks";
 import { executeA2AMessage } from "./a2a-executor";
 
 const {
@@ -200,7 +201,7 @@ describe("executeA2AMessage real stream boundary", () => {
     expect(textPart?.text).toBe("Answer. Done.");
   });
 
-  test("reduces a thinking-only turn to empty text while keeping the (empty) text part", async ({
+  test("substitutes a notice when a thinking-only turn strips to nothing", async ({
     makeOrganization,
     makeUser,
     makeInternalAgent,
@@ -209,8 +210,8 @@ describe("executeA2AMessage real stream boundary", () => {
     const user = await makeUser();
     const agent = await makeInternalAgent({ organizationId: org.id });
     // The pre-strip stream is non-empty, so the empty-response recovery does not
-    // re-trigger; stripping leaves no visible answer, but the text part is kept
-    // (not dropped) so the message never collapses to zero parts.
+    // re-trigger; stripping leaves no visible answer, so the notice stands in —
+    // in both the headless text and the message's text part.
     primeAgent(
       modelEmitting(textChunks("<thinking>only reasoning</thinking>")),
     );
@@ -223,11 +224,11 @@ describe("executeA2AMessage real stream boundary", () => {
       conversationId: "conv-1",
     });
 
-    expect(result.text).toBe("");
+    expect(result.text).toBe(THINKING_ONLY_NOTICE);
     const textPart = result.responseUiMessage.parts.find(
       (p): p is Extract<typeof p, { type: "text" }> => p.type === "text",
     );
-    expect(textPart?.text).toBe("");
+    expect(textPart?.text).toBe(THINKING_ONLY_NOTICE);
   });
 
   test("surfaces the captured provider cause, not a generic NoOutputGeneratedError", async ({

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -481,26 +481,22 @@ export async function executeA2AMessage(
         );
       }
 
-      // Strip inline `<thinking>...</thinking>` blocks from the model's text
-      // output at this single A2A boundary, so every consumer (protocol reply,
-      // delegation tool result, email, scheduled-run persistence) shares the
-      // invariant. Text parts that become empty are dropped. Structured
-      // `reasoning` parts are left intact — they never reach a chat (the
-      // protocol keeps only text parts) and are needed for provider replay of
-      // the persisted history.
+      // Strip inline `<thinking>...</thinking>` text from the model's output at
+      // this single A2A boundary, so every consumer (protocol reply, delegation
+      // tool result, email, scheduled-run persistence) shares the invariant.
+      // Text parts are stripped in place — an emptied part is kept (not removed)
+      // so a thinking-only turn never collapses to a zero-part assistant message,
+      // which some providers reject when the persisted history is replayed.
+      // Structured `reasoning` parts are left untouched: the A2A protocol reply
+      // excludes them (only text parts survive), and where they are surfaced
+      // (the scheduled-run chat view) they render via the chat's reasoning UI,
+      // exactly as interactive chat does — stripping them is out of scope here.
       finalText = stripThinkingBlocks(finalText);
-      responseUiMessage = {
-        ...responseUiMessage,
-        parts: responseUiMessage.parts.flatMap<UIMessage["parts"][number]>(
-          (part) => {
-            if (part.type !== "text") {
-              return [part];
-            }
-            const text = stripThinkingBlocks(part.text);
-            return text.length === 0 ? [] : [{ ...part, text }];
-          },
-        ),
-      };
+      for (const part of responseUiMessage.parts) {
+        if (part.type === "text") {
+          part.text = stripThinkingBlocks(part.text);
+        }
+      }
 
       // Surface this run's tool calls on the caller's conversation, attributed
       // to the delegation call that invoked this agent. Nested delegations'

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -46,6 +46,7 @@ import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availabi
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
 import type { ChatMessage } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
+import { stripThinkingBlocks } from "@/utils/strip-thinking-blocks";
 import {
   type StageResult,
   stageAttachmentsIntoSandbox,
@@ -479,6 +480,27 @@ export async function executeA2AMessage(
           "A2A execution failed: no response UIMessage generated",
         );
       }
+
+      // Strip inline `<thinking>...</thinking>` blocks from the model's text
+      // output at this single A2A boundary, so every consumer (protocol reply,
+      // delegation tool result, email, scheduled-run persistence) shares the
+      // invariant. Text parts that become empty are dropped. Structured
+      // `reasoning` parts are left intact — they never reach a chat (the
+      // protocol keeps only text parts) and are needed for provider replay of
+      // the persisted history.
+      finalText = stripThinkingBlocks(finalText);
+      responseUiMessage = {
+        ...responseUiMessage,
+        parts: responseUiMessage.parts.flatMap<UIMessage["parts"][number]>(
+          (part) => {
+            if (part.type !== "text") {
+              return [part];
+            }
+            const text = stripThinkingBlocks(part.text);
+            return text.length === 0 ? [] : [{ ...part, text }];
+          },
+        ),
+      };
 
       // Surface this run's tool calls on the caller's conversation, attributed
       // to the delegation call that invoked this agent. Nested delegations'

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -46,7 +46,10 @@ import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availabi
 import { executionSandboxRegistry } from "@/skills-sandbox/execution-sandbox-registry";
 import type { ChatMessage } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
-import { stripThinkingBlocks } from "@/utils/strip-thinking-blocks";
+import {
+  stripThinkingBlocks,
+  THINKING_ONLY_NOTICE,
+} from "@/utils/strip-thinking-blocks";
 import {
   type StageResult,
   stageAttachmentsIntoSandbox,
@@ -491,6 +494,7 @@ export async function executeA2AMessage(
       // excludes them (only text parts survive), and where they are surfaced
       // (the scheduled-run chat view) they render via the chat's reasoning UI,
       // exactly as interactive chat does — stripping them is out of scope here.
+      const hadTextBeforeStrip = finalText.trim() !== "";
       finalText = stripThinkingBlocks(finalText);
       for (const part of responseUiMessage.parts) {
         if (part.type === "text") {
@@ -519,6 +523,22 @@ export async function executeA2AMessage(
         repeatTracker.hasReachedTerminationCeiling()
       ) {
         finalText = REPEAT_CALL_TERMINATION_NOTICE;
+      } else if (hadTextBeforeStrip && finalText.trim() === "") {
+        // The whole textual answer was `<thinking>` and stripped to nothing.
+        // Substitute the notice in both the headless `text` and the message so
+        // the protocol reply / persistence (built from text parts) carries it.
+        finalText = THINKING_ONLY_NOTICE;
+        const firstTextPart = responseUiMessage.parts.find(
+          (p) => p.type === "text",
+        );
+        if (firstTextPart?.type === "text") {
+          firstTextPart.text = THINKING_ONLY_NOTICE;
+        } else {
+          responseUiMessage.parts.push({
+            type: "text",
+            text: THINKING_ONLY_NOTICE,
+          });
+        }
       }
     } catch (streamError) {
       const capturedStreamError = getCapturedStreamError();

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -27,6 +27,7 @@ import type {
   SkippedAttachment,
 } from "@/types";
 import { LlmProviderAuthRequiredError } from "@/utils/llm-provider-auth-error";
+import { stripThinkingBlocks } from "@/utils/strip-thinking-blocks";
 import type { InteractionSource } from "../../../../shared";
 import {
   buildApprovalDecisionSendMessageRequest,
@@ -2064,15 +2065,6 @@ async function getDefaultOrganizationId(): Promise<string> {
 }
 
 /**
- * Strip `<thinking>...</thinking>` blocks from LLM responses.
- * These are internal reasoning blocks that should not be shown to users.
- *
- * Uses non-greedy matching (`*?`) so multiple separate thinking blocks are
- * stripped independently without eating content between them. This assumes
- * blocks are not nested — nested `<thinking>` tags would leave the tail
- * visible, but LLMs do not produce nested thinking blocks in practice.
- */
-/**
  * Build a deterministic session ID for chatops messages.
  * Uses the thread ID when available (threaded conversations), otherwise
  * falls back to the channel ID (non-threaded DMs/channels).
@@ -2100,10 +2092,6 @@ export function buildChatOpsSessionId(
 // Prometheus exemplar labels allow 128 UTF-8 chars total (keys + values).
 // traceID (7+32) + spanID (6+16) = 61; remaining for sessionID key (9) + value = 58.
 const MAX_SESSION_ID_LENGTH = 58;
-
-function stripThinkingBlocks(text: string): string {
-  return text.replace(/<thinking>[\s\S]*?<\/thinking>/gi, "").trim();
-}
 
 /**
  * Strip bot footer from message text to avoid the LLM repeating it.

--- a/platform/backend/src/services/scheduled-run-conversation.test.ts
+++ b/platform/backend/src/services/scheduled-run-conversation.test.ts
@@ -166,6 +166,96 @@ test("backfillRunConversationMessages materializes chat messages from a run's in
   );
 });
 
+test("backfillRunConversationMessages strips inline <thinking> blocks from the reconstructed transcript", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  makeScheduleTrigger,
+  makeScheduleTriggerRun,
+}) => {
+  const org = await makeOrganization();
+  const actor = await makeUser();
+  await makeMember(actor.id, org.id, { role: "admin" });
+  const agent = await makeAgent({ organizationId: org.id, authorId: actor.id });
+  const project = await projectService.create({
+    organizationId: org.id,
+    userId: actor.id,
+    name: "runs",
+    description: null,
+  });
+  const trigger = await makeScheduleTrigger({
+    organizationId: org.id,
+    actorUserId: actor.id,
+    agentId: agent.id,
+    projectId: project.id,
+    messageTemplate: "write a joke",
+  });
+  const run = await makeScheduleTriggerRun(trigger.id, {
+    organizationId: org.id,
+    runKind: "due",
+  });
+
+  const conversation = await createAndLinkRunConversation({
+    run,
+    trigger,
+    ownerUserId: actor.id,
+    organizationId: org.id,
+  });
+
+  // The stored interaction carries the model's raw output, including inline
+  // thinking tags that bypass the A2A executor's sanitization.
+  await InteractionModel.create({
+    profileId: agent.id,
+    userId: actor.id,
+    sessionId: `scheduled-${run.id}`,
+    request: {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "write a joke" }],
+    },
+    response: {
+      id: "resp-1",
+      object: "chat.completion",
+      created: Date.now(),
+      model: "gpt-4",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "Here is a joke.<thinking>pick a good one</thinking> Ha!",
+            refusal: null,
+          },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+    },
+    type: "openai:chatCompletions",
+  });
+
+  await backfillRunConversationMessages({
+    conversation,
+    trigger,
+    run,
+    ownerUserId: actor.id,
+  });
+
+  const messages = await MessageModel.findByConversation(conversation.id);
+  const assistant = messages.find((m) => m.role === "assistant");
+  const parts = (
+    assistant?.content as { parts?: { type: string; text?: string }[] }
+  ).parts;
+  const text = (parts ?? [])
+    .filter((p) => p.type === "text")
+    .map((p) => p.text ?? "")
+    .join("");
+  expect(text).not.toContain("<thinking>");
+  expect(text).not.toContain("pick a good one");
+  expect(text).toContain("Here is a joke.");
+  expect(text).toContain("Ha!");
+});
+
 test("persistRunConversationMessages writes [user, assistant] from the executor result, once", async ({
   makeOrganization,
   makeUser,

--- a/platform/backend/src/services/scheduled-run-conversation.test.ts
+++ b/platform/backend/src/services/scheduled-run-conversation.test.ts
@@ -14,6 +14,7 @@ import {
   recordRunConversationError,
 } from "@/services/scheduled-run-conversation";
 import { expect, test } from "@/test";
+import { THINKING_ONLY_NOTICE } from "@/utils/strip-thinking-blocks";
 
 test("createAndLinkRunConversation makes a project-scoped, schedule-origin chat and links it once", async ({
   makeOrganization,
@@ -254,6 +255,93 @@ test("backfillRunConversationMessages strips inline <thinking> blocks from the r
   expect(text).not.toContain("pick a good one");
   expect(text).toContain("Here is a joke.");
   expect(text).toContain("Ha!");
+});
+
+test("backfillRunConversationMessages substitutes a notice for a thinking-only assistant turn", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  makeScheduleTrigger,
+  makeScheduleTriggerRun,
+}) => {
+  const org = await makeOrganization();
+  const actor = await makeUser();
+  await makeMember(actor.id, org.id, { role: "admin" });
+  const agent = await makeAgent({ organizationId: org.id, authorId: actor.id });
+  const project = await projectService.create({
+    organizationId: org.id,
+    userId: actor.id,
+    name: "runs",
+    description: null,
+  });
+  const trigger = await makeScheduleTrigger({
+    organizationId: org.id,
+    actorUserId: actor.id,
+    agentId: agent.id,
+    projectId: project.id,
+    messageTemplate: "write a joke",
+  });
+  const run = await makeScheduleTriggerRun(trigger.id, {
+    organizationId: org.id,
+    runKind: "due",
+  });
+
+  const conversation = await createAndLinkRunConversation({
+    run,
+    trigger,
+    ownerUserId: actor.id,
+    organizationId: org.id,
+  });
+
+  // The whole assistant answer was inline thinking, so stripping empties it.
+  await InteractionModel.create({
+    profileId: agent.id,
+    userId: actor.id,
+    sessionId: `scheduled-${run.id}`,
+    request: {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "write a joke" }],
+    },
+    response: {
+      id: "resp-1",
+      object: "chat.completion",
+      created: Date.now(),
+      model: "gpt-4",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "<thinking>I can't think of one</thinking>",
+            refusal: null,
+          },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+    },
+    type: "openai:chatCompletions",
+  });
+
+  await backfillRunConversationMessages({
+    conversation,
+    trigger,
+    run,
+    ownerUserId: actor.id,
+  });
+
+  const messages = await MessageModel.findByConversation(conversation.id);
+  const assistant = messages.find((m) => m.role === "assistant");
+  const parts = (
+    assistant?.content as { parts?: { type: string; text?: string }[] }
+  ).parts;
+  const text = (parts ?? [])
+    .filter((p) => p.type === "text")
+    .map((p) => p.text ?? "")
+    .join("");
+  expect(text).not.toContain("<thinking>");
+  expect(text).toBe(THINKING_ONLY_NOTICE);
 });
 
 test("persistRunConversationMessages writes [user, assistant] from the executor result, once", async ({

--- a/platform/backend/src/services/scheduled-run-conversation.ts
+++ b/platform/backend/src/services/scheduled-run-conversation.ts
@@ -19,7 +19,10 @@ import type {
   ScheduleTriggerRun,
 } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
-import { stripThinkingBlocks } from "@/utils/strip-thinking-blocks";
+import {
+  stripThinkingBlocks,
+  THINKING_ONLY_NOTICE,
+} from "@/utils/strip-thinking-blocks";
 
 /**
  * Shared helpers for the chat conversation backing a scheduled trigger run.
@@ -334,11 +337,32 @@ function buildMessagesFromInteractions(
     // Reconstructed from raw LLM-proxy interactions, which bypass the A2A
     // executor's sanitization, so strip inline `<thinking>` blocks here too.
     // These messages are freshly built above, so mutate text parts in place.
+    // An assistant turn whose text was entirely `<thinking>` strips to nothing;
+    // substitute the notice so it matches the live executor path rather than
+    // rendering a blank bubble.
     for (const message of messages) {
+      let hadText = false;
+      let hasVisibleText = false;
+      let noticeTarget: { text: string } | null = null;
       for (const part of message.parts) {
         if (part.type === "text" && typeof part.text === "string") {
+          if (part.text.trim() !== "") {
+            hadText = true;
+          }
           part.text = stripThinkingBlocks(part.text);
+          if (part.text !== "") {
+            hasVisibleText = true;
+          }
+          noticeTarget ??= part;
         }
+      }
+      if (
+        message.role === "assistant" &&
+        hadText &&
+        !hasVisibleText &&
+        noticeTarget
+      ) {
+        noticeTarget.text = THINKING_ONLY_NOTICE;
       }
     }
     return messages;

--- a/platform/backend/src/services/scheduled-run-conversation.ts
+++ b/platform/backend/src/services/scheduled-run-conversation.ts
@@ -19,6 +19,7 @@ import type {
   ScheduleTriggerRun,
 } from "@/types";
 import { resolveConversationLlmSelectionForAgent } from "@/utils/llm-resolution";
+import { stripThinkingBlocks } from "@/utils/strip-thinking-blocks";
 
 /**
  * Shared helpers for the chat conversation backing a scheduled trigger run.
@@ -330,6 +331,16 @@ function buildMessagesFromInteractions(
   }
 
   if (messages.length > 0) {
+    // Reconstructed from raw LLM-proxy interactions, which bypass the A2A
+    // executor's sanitization, so strip inline `<thinking>` blocks here too.
+    // These messages are freshly built above, so mutate text parts in place.
+    for (const message of messages) {
+      for (const part of message.parts) {
+        if (part.type === "text" && typeof part.text === "string") {
+          part.text = stripThinkingBlocks(part.text);
+        }
+      }
+    }
     return messages;
   }
 

--- a/platform/backend/src/utils/strip-thinking-blocks.test.ts
+++ b/platform/backend/src/utils/strip-thinking-blocks.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { stripThinkingBlocks } from "./strip-thinking-blocks";
+
+describe("stripThinkingBlocks", () => {
+  it("removes a block and keeps the surrounding text", () => {
+    expect(stripThinkingBlocks("a<thinking>b</thinking>c")).toBe("ac");
+  });
+
+  it("removes multiple independent blocks without eating content between them", () => {
+    expect(
+      stripThinkingBlocks(
+        "keep1<thinking>x</thinking>keep2<thinking>y</thinking>keep3",
+      ),
+    ).toBe("keep1keep2keep3");
+  });
+
+  it("matches the tag case-insensitively", () => {
+    expect(stripThinkingBlocks("a<THINKING>b</Thinking>c")).toBe("ac");
+  });
+
+  it("strips a multiline block", () => {
+    expect(stripThinkingBlocks("a<thinking>line1\nline2</thinking>b")).toBe(
+      "ab",
+    );
+  });
+
+  it("trims the result and returns empty when only a block remains", () => {
+    expect(stripThinkingBlocks("  <thinking>all</thinking>  ")).toBe("");
+  });
+
+  it("leaves text without blocks unchanged except for trimming", () => {
+    expect(stripThinkingBlocks("plain answer")).toBe("plain answer");
+  });
+});

--- a/platform/backend/src/utils/strip-thinking-blocks.ts
+++ b/platform/backend/src/utils/strip-thinking-blocks.ts
@@ -1,0 +1,12 @@
+/**
+ * Strip `<thinking>...</thinking>` blocks from LLM responses.
+ * These are internal reasoning blocks that should not be shown to users.
+ *
+ * Uses non-greedy matching (`*?`) so multiple separate thinking blocks are
+ * stripped independently without eating content between them. This assumes
+ * blocks are not nested — nested `<thinking>` tags would leave the tail
+ * visible, but LLMs do not produce nested thinking blocks in practice.
+ */
+export function stripThinkingBlocks(text: string): string {
+  return text.replace(/<thinking>[\s\S]*?<\/thinking>/gi, "").trim();
+}

--- a/platform/backend/src/utils/strip-thinking-blocks.ts
+++ b/platform/backend/src/utils/strip-thinking-blocks.ts
@@ -10,3 +10,11 @@
 export function stripThinkingBlocks(text: string): string {
   return text.replace(/<thinking>[\s\S]*?<\/thinking>/gi, "").trim();
 }
+
+/**
+ * Stands in for an assistant turn whose entire text output was inline
+ * `<thinking>` and stripped to nothing, so a user-facing surface (A2A reply,
+ * reconstructed transcript) carries an explanation rather than a blank message.
+ */
+export const THINKING_ONLY_NOTICE =
+  "The agent produced only internal reasoning and no visible response.";


### PR DESCRIPTION
## Problem

Inline `<thinking>...</thinking>` text emitted by a model leaked into A2A conversations — external A2A protocol clients, agent-to-agent delegation results, email replies, and scheduled-run chat views. Only Slack/Teams ChatOps stripped it, at its own consumption boundary; every other A2A consumer received the raw text.

## Fix

- Extract the strip helper (previously private to `chatops-manager.ts`) into `utils/strip-thinking-blocks.ts`; ChatOps imports it.
- Strip `<thinking>` at the single A2A executor boundary — `finalText` and the response message's text parts — so all consumers share the invariant. Stripped in place (emptied parts kept) so a thinking-only turn never collapses to a zero-part message that a provider could reject on replay.
- The scheduled-run backfill reconstructs a transcript from raw LLM-proxy interactions (bypassing the executor), so it strips there too.
- When a turn's entire text was `<thinking>` and stripping leaves nothing, substitute a short notice instead of a blank reply — consistently in the executor and the backfill.

Structured `reasoning` parts are deliberately preserved: the A2A protocol reply already excludes them, and where surfaced (scheduled-run chat) they render via the chat's reasoning UI exactly as interactive chat does.

## Tests

Real-boundary executor stream tests (strip + thinking-only notice), real-DB backfill tests (strip + notice), and a unit test for the helper.

https://claude.ai/code/session_01SZLFzCREWigHnot9cA4Ux2

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>