### PR TITLE
fix: build missing NAPI addons in dev-stack up

### DIFF
--- a/platform/scripts/dev-stack.sh
+++ b/platform/scripts/dev-stack.sh
@@ -58,6 +58,30 @@ require_platform_cwd() {
   fi
 }
 
+# The backend lazily loads three NAPI addons (@archestra/app-runtime-rs,
+# sandbox-rs, image-rs) whose compiled `.node` binaries are gitignored and are
+# never built by `pnpm install` (install scripts are disabled repo-wide), so a
+# fresh worktree fails with "Unable to load @archestra/<crate> for <platform>"
+# the first time an app/sandbox/image feature is touched. Build the missing
+# ones before launching Tilt. Skip crates whose binary already exists — a
+# stale-but-present binary is rebuilt manually via `pnpm --filter <pkg> build`
+# — so restarts stay fast.
+ensure_native_addons() {
+  local platform_dir="$1" crate filters=()
+  for crate in app-runtime-rs sandbox-rs image-rs; do
+    if ! ls "$platform_dir/archestra-rs/$crate"/*.node >/dev/null 2>&1; then
+      filters+=("--filter" "@archestra/$crate")
+    fi
+  done
+  [ ${#filters[@]} -eq 0 ] && return 0
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "⚠ Rust toolchain not found; skipping native addon build. App/sandbox/image features will fail until you install Rust and run: pnpm --filter '@archestra/*-rs' build" >&2
+    return 0
+  fi
+  echo "→ Building missing native addons (first build takes a few minutes): ${filters[*]}" >&2
+  (cd "$platform_dir" && pnpm "${filters[@]}" build)
+}
+
 cmd_up() {
   local detach=false namespace=""
   while [ $# -gt 0 ]; do
@@ -221,6 +245,8 @@ PYEOF
 ================================================================
 
 EOF
+
+  ensure_native_addons "$platform_dir"
 
   if [ "$detach" = "true" ]; then
     local log_file="$worktree_dir/.dev-stack.log"


### PR DESCRIPTION
The backend lazily loads three NAPI addons (@archestra/app-runtime-rs, sandbox-rs, image-rs) whose .node binaries are gitignored and never built by pnpm install (install scripts are disabled repo-wide). Every fresh worktree stack failed with "Unable to load @archestra/app-runtime-rs for darwin/arm64" on first app use.

dev-stack.sh up now builds the missing binaries before launching Tilt. Crates with an existing binary are skipped so restarts stay fast; if the Rust toolchain is absent it warns and continues.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>