### PR TITLE
fix(frontend): remove unreachable "Enable and create a new skill" button

### DIFF
--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -44,10 +44,8 @@ import {
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useSession } from "@/lib/auth/auth.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
-import { useOrganization } from "@/lib/organization.query";
 import {
   useDeleteSkill,
-  useEnableSkillToolDefaults,
   useResetSkill,
   useSkillSourceRepos,
   useSkillsPaginated,
@@ -430,18 +428,6 @@ function parseRepoFromSourceRef(sourceRef: string | null): string | null {
 }
 
 function SkillsEmptyState() {
-  const router = useRouter();
-  const { data: organization } = useOrganization();
-  const enableDefaults = useEnableSkillToolDefaults();
-  const alreadyEnabled = organization?.skillToolsEnabled === true;
-
-  const handleEnableAndCreate = useCallback(async () => {
-    const result = await enableDefaults.mutateAsync();
-    if (result) {
-      router.push("/skills/new");
-    }
-  }, [enableDefaults, router]);
-
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
       <div className="max-w-md text-center">
@@ -449,36 +435,17 @@ function SkillsEmptyState() {
           <BookOpen className="h-7 w-7 text-primary" />
         </div>
         <h2 className="mb-2 text-xl font-semibold">No skills yet</h2>
-        <p className="mb-2 text-sm text-muted-foreground">
+        <p className="mb-6 text-sm text-muted-foreground">
           A skill is a set of instructions and files. Agents pick the right one
           by name and follow it on demand.
         </p>
-        {!alreadyEnabled && (
-          <p className="mb-6 text-sm text-muted-foreground">
-            Turning skills on makes them available to every agent in this
-            organization.
-          </p>
-        )}
         <div className="flex items-center justify-center">
-          {alreadyEnabled ? (
-            <PermissionButton permissions={{ skill: ["create"] }} asChild>
-              <Link href="/skills/new">
-                <Plus className="mr-2 h-4 w-4" />
-                Add your first skill
-              </Link>
-            </PermissionButton>
-          ) : (
-            <PermissionButton
-              permissions={{ skill: ["admin"] }}
-              onClick={handleEnableAndCreate}
-              disabled={enableDefaults.isPending}
-            >
+          <PermissionButton permissions={{ skill: ["create"] }} asChild>
+            <Link href="/skills/new">
               <Plus className="mr-2 h-4 w-4" />
-              {enableDefaults.isPending
-                ? "Enabling…"
-                : "Enable and create a new skill"}
-            </PermissionButton>
-          )}
+              Add your first skill
+            </Link>
+          </PermissionButton>
         </div>
       </div>
     </div>

--- a/platform/frontend/src/lib/skills/skill.query.ts
+++ b/platform/frontend/src/lib/skills/skill.query.ts
@@ -19,7 +19,6 @@ const {
   searchSkillCatalog,
   previewGithubSkill,
   importGithubSkills,
-  enableSkillToolDefaults,
 } = archestraApiSdk;
 
 export type SkillCatalogResult =
@@ -214,35 +213,6 @@ export function usePreviewGithubSkill(
       });
       throwOnApiError(error);
       return data;
-    },
-  });
-}
-
-export function useEnableSkillToolDefaults() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async () => {
-      const { data, error } = await enableSkillToolDefaults();
-      if (error) {
-        handleApiError(error);
-        return null;
-      }
-      return data;
-    },
-    onSuccess: (data) => {
-      if (!data) return;
-      // Backfill has added skill tools to every agent in the org — invalidate
-      // all agent/tool caches so the gateway and other agent pages refresh.
-      queryClient.invalidateQueries({ queryKey: ["organization"] });
-      queryClient.invalidateQueries({ queryKey: ["agents"] });
-      queryClient.invalidateQueries({ queryKey: ["agent-tools"] });
-      queryClient.invalidateQueries({ queryKey: ["tools"] });
-      const { agentsBackfilled } = data;
-      toast.success(
-        `Skill tools enabled for ${agentsBackfilled} agent${
-          agentsBackfilled === 1 ? "" : "s"
-        }`,
-      );
     },
   });
 }


### PR DESCRIPTION
## What

Removes the "Enable and create a new skill" button from the /skills empty state. The empty state now always shows "Add your first skill" (`skill:create`).

## Why

The button rendered only when the org had zero skills and `skillToolsEnabled=false`. Case by case:

- **If** the skills env flag (`ARCHESTRA_AGENTS_SKILLS_ENABLED` / `ARCHESTRA_BETA`) is off, **then** /skills redirects to /agents — the button is unreachable.
- **If** the flag is on, **then** every backend startup sets `skillToolsEnabled=true` for all existing orgs (`enableSkillToolsWhenFeatureEnabled`) — the button's condition is false for them.
- **If** the flag is on, **then** startup also seeds the built-in skills into every org and re-inserts them when deleted (`syncBuiltInSkills`) — the org never has zero skills, so the empty state itself never renders.
- **If** an org is created after the last startup, **then** the button could appear until the next restart — the only reachable case, and it resolves itself on restart.

So the button never shows in practice. Reaching it for a screenshot required manually deleting the seeded built-in skills and flipping the org flag in the database.

## Notes

- `POST /api/skills/enable-defaults` is untouched. It remains the only way to backfill skill tools to agents created before skills were enabled; the removed button was its only UI caller.
- `useEnableSkillToolDefaults` is removed together with its single consumer.

## Testing

`pnpm type-check` and biome on the touched files. No tests referenced the removed UI.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>