### PR TITLE
fix(oauth): surface initiate errors to users and logs

### DIFF
--- a/platform/backend/src/routes/oauth-initiate-observability.test.ts
+++ b/platform/backend/src/routes/oauth-initiate-observability.test.ts
@@ -1,0 +1,39 @@
+import { vi } from "vitest";
+
+// Isolated from oauth.test.ts (which stays mock-free / fast path) because this
+// suite mocks @/logging to observe the warn the initiate handler emits.
+vi.mock("@/logging");
+
+import logger from "@/logging";
+import { describe, expect, test, useRouteTestApp } from "@/test";
+import oauthRoutes from "./oauth";
+
+/**
+ * Handled client errors on /api/oauth/initiate are formatted by the centralized
+ * error handler but filtered from Sentry, so the handler warns with the
+ * catalogId to keep a misconfigured catalog entry visible in logs. Assert that
+ * observable via its structured fields, without pinning the log message text.
+ */
+describe("POST /api/oauth/initiate observability", () => {
+  const ctx = useRouteTestApp(oauthRoutes);
+
+  test("warns with catalogId and statusCode when initiate rejects with a client error", async () => {
+    const catalogId = "00000000-0000-4000-8000-000000000000";
+
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: "/api/oauth/initiate",
+      payload: { catalogId },
+    });
+
+    expect(response.statusCode, response.body).toBe(404);
+
+    const warned = vi
+      .mocked(logger.warn)
+      .mock.calls.find(
+        ([context]) =>
+          (context as { catalogId?: string })?.catalogId === catalogId,
+      );
+    expect(warned?.[0]).toMatchObject({ catalogId, statusCode: 404 });
+  });
+});

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -787,172 +787,195 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ body: { catalogId }, organizationId }, reply) => {
-      // Get catalog item to retrieve OAuth configuration (with resolved secrets for runtime)
-      const catalogItem =
-        await InternalMcpCatalogModel.findByIdWithResolvedSecrets(catalogId);
+      try {
+        // Get catalog item to retrieve OAuth configuration (with resolved secrets for runtime)
+        const catalogItem =
+          await InternalMcpCatalogModel.findByIdWithResolvedSecrets(catalogId);
 
-      if (!catalogItem) {
-        throw new ApiError(404, "Catalog item not found");
-      }
-
-      if (!catalogItem.oauthConfig) {
-        throw new ApiError(400, "This server does not support OAuth");
-      }
-
-      const oauthConfig = catalogItem.oauthConfig;
-
-      // Use the redirect URI stored in the catalog (set by frontend based on window.location.origin)
-      // This ensures the redirect URI matches where the user initiated the OAuth flow from
-      const redirectUri = oauthConfig.redirect_uris[0];
-      if (isSsoCallbackRedirectUri(redirectUri)) {
-        throw new ApiError(
-          400,
-          "MCP OAuth redirect URI must use /oauth-callback, not the SSO callback URL.",
-        );
-      }
-
-      let clientId = oauthConfig.client_id;
-      let clientSecret = oauthConfig.client_secret;
-
-      logger.info(
-        {
-          catalogId: catalogItem.id,
-          hasClientSecret: !!clientSecret,
-        },
-        "OAuth init - using client_secret",
-      );
-
-      // Discover actual scopes from the OAuth server (like desktop app does)
-      const { configuredScopes, discoveredScopes, scopesToUse } =
-        await resolveOAuthScopesForAuthorization({
-          oauthConfig,
-        });
-
-      fastify.log.info(
-        {
-          configured: configuredScopes,
-          discovered: discoveredScopes,
-          used: scopesToUse,
-        },
-        "Resolved OAuth scopes",
-      );
-
-      // Check if dynamic registration is needed
-      if (!clientId) {
-        fastify.log.info(
-          "Client ID is empty, checking for cached credentials or performing dynamic registration",
-        );
-      }
-
-      // Discover authorization server metadata to get the correct authorization endpoint
-      let authorizationEndpoint: string;
-      let registrationEndpoint: string | undefined;
-
-      // For proxy servers, skip discovery and use the MCP server URL directly
-      if (oauthConfig.requires_proxy) {
-        fastify.log.info(
-          { serverUrl: oauthConfig.server_url },
-          "Server requires proxy, using MCP server URL as OAuth server",
-        );
-        // GitHub Copilot MCP uses /mcp/oauth/authorize
-        authorizationEndpoint = `${oauthConfig.server_url}/oauth/authorize`;
-        // Proxy servers typically don't support dynamic registration
-        registrationEndpoint = undefined;
-      } else {
-        try {
-          const endpoints = await discoverOAuthEndpoints(
-            oauthConfig,
-            fastify.log,
-          );
-          authorizationEndpoint = endpoints.authorizationEndpoint;
-          registrationEndpoint = endpoints.registrationEndpoint;
-        } catch (error) {
-          fastify.log.error({ error }, "Authorization server discovery failed");
-          throw new ApiError(500, "Failed to discover OAuth endpoints");
+        if (!catalogItem) {
+          throw new ApiError(404, "Catalog item not found");
         }
-      }
 
-      // If we don't have client credentials and registration endpoint is available, try dynamic registration
-      let registrationResult: Record<string, unknown> | undefined;
-      if (!clientId && registrationEndpoint) {
-        try {
-          fastify.log.info(
-            { registrationEndpoint },
-            "Attempting dynamic client registration",
+        if (!catalogItem.oauthConfig) {
+          throw new ApiError(400, "This server does not support OAuth");
+        }
+
+        const oauthConfig = catalogItem.oauthConfig;
+
+        // Use the redirect URI stored in the catalog (set by frontend based on window.location.origin)
+        // This ensures the redirect URI matches where the user initiated the OAuth flow from
+        const redirectUri = oauthConfig.redirect_uris[0];
+        if (isSsoCallbackRedirectUri(redirectUri)) {
+          throw new ApiError(
+            400,
+            "MCP OAuth redirect URI must use /oauth-callback, not the SSO callback URL.",
           );
-          registrationResult = await registerOAuthClient(registrationEndpoint, {
-            client_name: `${await resolveOAuthClientBrandName(organizationId)} - ${catalogItem.name}`,
-            redirect_uris: [redirectUri],
-            grant_types: ["authorization_code", "refresh_token"],
-            response_types: ["code"],
-            scope: scopesToUse.join(" "),
+        }
+
+        let clientId = oauthConfig.client_id;
+        let clientSecret = oauthConfig.client_secret;
+
+        logger.info(
+          {
+            catalogId: catalogItem.id,
+            hasClientSecret: !!clientSecret,
+          },
+          "OAuth init - using client_secret",
+        );
+
+        // Discover actual scopes from the OAuth server (like desktop app does)
+        const { configuredScopes, discoveredScopes, scopesToUse } =
+          await resolveOAuthScopesForAuthorization({
+            oauthConfig,
           });
 
-          clientId = registrationResult?.client_id as string;
-          clientSecret = registrationResult?.client_secret as
-            | string
-            | undefined;
-
-          fastify.log.info(
-            { client_id: clientId },
-            "Dynamic registration successful",
-          );
-        } catch (error) {
-          fastify.log.warn(
-            {
-              error: error instanceof Error ? error.message : String(error),
-              stack: error instanceof Error ? error.stack : undefined,
-            },
-            "Dynamic registration failed, continuing with default client_id",
-          );
-          // Continue with default client_id if registration fails
-        }
-      }
-
-      // Ensure we have a usable client ID (either static or from dynamic registration)
-      if (!clientId) {
-        throw new ApiError(
-          400,
-          "No client ID available. Configure a client_id in the catalog item or ensure the OAuth server supports dynamic client registration.",
+        fastify.log.info(
+          {
+            configured: configuredScopes,
+            discovered: discoveredScopes,
+            used: scopesToUse,
+          },
+          "Resolved OAuth scopes",
         );
+
+        // Check if dynamic registration is needed
+        if (!clientId) {
+          fastify.log.info(
+            "Client ID is empty, checking for cached credentials or performing dynamic registration",
+          );
+        }
+
+        // Discover authorization server metadata to get the correct authorization endpoint
+        let authorizationEndpoint: string;
+        let registrationEndpoint: string | undefined;
+
+        // For proxy servers, skip discovery and use the MCP server URL directly
+        if (oauthConfig.requires_proxy) {
+          fastify.log.info(
+            { serverUrl: oauthConfig.server_url },
+            "Server requires proxy, using MCP server URL as OAuth server",
+          );
+          // GitHub Copilot MCP uses /mcp/oauth/authorize
+          authorizationEndpoint = `${oauthConfig.server_url}/oauth/authorize`;
+          // Proxy servers typically don't support dynamic registration
+          registrationEndpoint = undefined;
+        } else {
+          try {
+            const endpoints = await discoverOAuthEndpoints(
+              oauthConfig,
+              fastify.log,
+            );
+            authorizationEndpoint = endpoints.authorizationEndpoint;
+            registrationEndpoint = endpoints.registrationEndpoint;
+          } catch (error) {
+            fastify.log.error(
+              { error },
+              "Authorization server discovery failed",
+            );
+            throw new ApiError(500, "Failed to discover OAuth endpoints");
+          }
+        }
+
+        // If we don't have client credentials and registration endpoint is available, try dynamic registration
+        let registrationResult: Record<string, unknown> | undefined;
+        if (!clientId && registrationEndpoint) {
+          try {
+            fastify.log.info(
+              { registrationEndpoint },
+              "Attempting dynamic client registration",
+            );
+            registrationResult = await registerOAuthClient(
+              registrationEndpoint,
+              {
+                client_name: `${await resolveOAuthClientBrandName(organizationId)} - ${catalogItem.name}`,
+                redirect_uris: [redirectUri],
+                grant_types: ["authorization_code", "refresh_token"],
+                response_types: ["code"],
+                scope: scopesToUse.join(" "),
+              },
+            );
+
+            clientId = registrationResult?.client_id as string;
+            clientSecret = registrationResult?.client_secret as
+              | string
+              | undefined;
+
+            fastify.log.info(
+              { client_id: clientId },
+              "Dynamic registration successful",
+            );
+          } catch (error) {
+            fastify.log.warn(
+              {
+                error: error instanceof Error ? error.message : String(error),
+                stack: error instanceof Error ? error.stack : undefined,
+              },
+              "Dynamic registration failed, continuing with default client_id",
+            );
+            // Continue with default client_id if registration fails
+          }
+        }
+
+        // Ensure we have a usable client ID (either static or from dynamic registration)
+        if (!clientId) {
+          throw new ApiError(
+            400,
+            "No client ID available. Configure a client_id in the catalog item or ensure the OAuth server supports dynamic client registration.",
+          );
+        }
+
+        // Generate PKCE parameters
+        const codeVerifier = generateCodeVerifier();
+        const codeChallenge = generateCodeChallenge(codeVerifier);
+        const state = randomBytes(16).toString("base64url");
+
+        // Store state temporarily (will be used in callback)
+        await setOAuthState(state, {
+          catalogId,
+          codeVerifier,
+          clientId,
+          clientSecret,
+          registrationResult,
+        });
+
+        // Build authorization URL using the discovered authorization endpoint
+        const authUrl = new URL(authorizationEndpoint);
+        authUrl.searchParams.set("response_type", "code");
+        authUrl.searchParams.set("client_id", clientId);
+        authUrl.searchParams.set("code_challenge", codeChallenge);
+        authUrl.searchParams.set("code_challenge_method", "S256");
+        authUrl.searchParams.set("state", state);
+        authUrl.searchParams.set("scope", scopesToUse.join(" "));
+        authUrl.searchParams.set("redirect_uri", redirectUri);
+
+        // RFC 8707: Include resource parameter for audience binding
+        // Required by MCP servers like Windmill that need to know which
+        // protected resource the token is intended for
+        const oauthResource = getOAuthResource(oauthConfig);
+        if (oauthResource) {
+          authUrl.searchParams.set("resource", oauthResource);
+        }
+
+        return reply.send({
+          authorizationUrl: authUrl.toString(),
+          state,
+        });
+      } catch (error) {
+        // Handled client errors (bad/missing catalog config, no client id, etc.)
+        // are formatted by the centralized error handler but filtered from Sentry,
+        // so surface them here with the catalogId for triage.
+        if (
+          error instanceof ApiError &&
+          error.statusCode >= 400 &&
+          error.statusCode < 500
+        ) {
+          logger.warn(
+            { catalogId, statusCode: error.statusCode, reason: error.message },
+            "OAuth initiate rejected (client error)",
+          );
+        }
+        throw error;
       }
-
-      // Generate PKCE parameters
-      const codeVerifier = generateCodeVerifier();
-      const codeChallenge = generateCodeChallenge(codeVerifier);
-      const state = randomBytes(16).toString("base64url");
-
-      // Store state temporarily (will be used in callback)
-      await setOAuthState(state, {
-        catalogId,
-        codeVerifier,
-        clientId,
-        clientSecret,
-        registrationResult,
-      });
-
-      // Build authorization URL using the discovered authorization endpoint
-      const authUrl = new URL(authorizationEndpoint);
-      authUrl.searchParams.set("response_type", "code");
-      authUrl.searchParams.set("client_id", clientId);
-      authUrl.searchParams.set("code_challenge", codeChallenge);
-      authUrl.searchParams.set("code_challenge_method", "S256");
-      authUrl.searchParams.set("state", state);
-      authUrl.searchParams.set("scope", scopesToUse.join(" "));
-      authUrl.searchParams.set("redirect_uri", redirectUri);
-
-      // RFC 8707: Include resource parameter for audience binding
-      // Required by MCP servers like Windmill that need to know which
-      // protected resource the token is intended for
-      const oauthResource = getOAuthResource(oauthConfig);
-      if (oauthResource) {
-        authUrl.searchParams.set("resource", oauthResource);
-      }
-
-      return reply.send({
-        authorizationUrl: authUrl.toString(),
-        state,
-      });
     },
   );
 

--- a/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/InternalMCPCatalog.tsx
@@ -1084,8 +1084,12 @@ export function InternalMCPCatalog({
 
       // Redirect to OAuth provider
       window.location.href = authorizationUrl;
-    } catch {
-      toast.error("Failed to initiate OAuth flow");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to initiate OAuth flow",
+      );
     }
   };
 

--- a/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
@@ -309,9 +309,13 @@ export function ManageUsersContent({
 
       // Redirect to OAuth provider
       window.location.href = authorizationUrl;
-    } catch {
+    } catch (error) {
       setOAuthMcpServerId(null);
-      toast.error("Failed to initiate re-authentication");
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to initiate re-authentication",
+      );
     }
   };
 

--- a/platform/frontend/src/app/mcp/registry/beta/_parts/InternalMCPCatalog.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/InternalMCPCatalog.tsx
@@ -317,8 +317,12 @@ export function InternalMCPCatalog({
       }
 
       window.location.href = authorizationUrl;
-    } catch {
-      toast.error("Failed to initiate OAuth flow");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to initiate OAuth flow",
+      );
     }
   };
 

--- a/platform/frontend/src/app/mcp/registry/beta/_parts/catalog-setup-wizard.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/catalog-setup-wizard.tsx
@@ -303,8 +303,12 @@ export function TestConnectionStep({ item }: { item: CatalogItem }) {
       // Remember where the install started so the callback returns here
       setOAuthReturnUrl(window.location.href);
       window.location.href = authorizationUrl;
-    } catch {
-      toast.error("Failed to initiate OAuth flow");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to initiate OAuth flow",
+      );
     }
   };
 

--- a/platform/frontend/src/app/mcp/registry/beta/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/manage-users-dialog.tsx
@@ -297,9 +297,13 @@ export function ManageUsersContent({
 
       // Redirect to OAuth provider
       window.location.href = authorizationUrl;
-    } catch {
+    } catch (error) {
       setOAuthMcpServerId(null);
-      toast.error("Failed to initiate re-authentication");
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to initiate re-authentication",
+      );
     }
   };
 

--- a/platform/frontend/src/app/mcp/registry/beta/_parts/use-catalog-install.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/_parts/use-catalog-install.tsx
@@ -773,8 +773,12 @@ export function useCatalogInstall(opts?: {
 
       // Redirect to OAuth provider
       window.location.href = authorizationUrl;
-    } catch {
-      toast.error("Failed to initiate OAuth flow");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to initiate OAuth flow",
+      );
     }
   };
 

--- a/platform/frontend/src/lib/auth/oauth.query.test.tsx
+++ b/platform/frontend/src/lib/auth/oauth.query.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockInitiateOAuth } = vi.hoisted(() => ({
+  mockInitiateOAuth: vi.fn(),
+}));
+
+vi.mock("@archestra/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@archestra/shared")>();
+  return {
+    ...actual,
+    archestraApiSdk: {
+      ...actual.archestraApiSdk,
+      initiateOAuth: (...args: unknown[]) => mockInitiateOAuth(...args),
+    },
+  };
+});
+
+import { useInitiateOAuth } from "./oauth.query";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useInitiateOAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects with the backend error message so callers can surface it", async () => {
+    // The generated client returns the backend's `{ error: { message, type } }`
+    // envelope; the hook must turn that into an Error whose message is the
+    // backend reason, not the generic fallback.
+    mockInitiateOAuth.mockResolvedValue({
+      error: {
+        error: {
+          message: "No client ID available",
+          type: "api_validation_error",
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useInitiateOAuth(), { wrapper });
+
+    await expect(
+      result.current.mutateAsync({ catalogId: "catalog-1" }),
+    ).rejects.toThrow("No client ID available");
+  });
+
+  it("returns the authorization URL on success", async () => {
+    mockInitiateOAuth.mockResolvedValue({
+      data: {
+        authorizationUrl: "https://provider.example/authorize",
+        state: "state-1",
+      },
+    });
+
+    const { result } = renderHook(() => useInitiateOAuth(), { wrapper });
+
+    await expect(
+      result.current.mutateAsync({ catalogId: "catalog-1" }),
+    ).resolves.toEqual({
+      authorizationUrl: "https://provider.example/authorize",
+      state: "state-1",
+    });
+  });
+});

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSession } from "@/lib/auth/auth.query";
 import { useMcpInstallOrchestrator } from "./mcp-install-orchestrator.hook";
@@ -46,6 +47,8 @@ vi.mock("@/lib/mcp/mcp-server.query", () => ({
 }));
 
 vi.mock("@/lib/auth/auth.query");
+
+vi.mock("sonner");
 
 vi.mock("@/lib/auth/oauth.query", () => ({
   useInitiateOAuth: () => ({
@@ -150,5 +153,23 @@ describe("useMcpInstallOrchestrator", () => {
     expect(redirectBrowserToUrlMock).toHaveBeenCalledWith(
       "https://posthog.example.com/oauth/authorize",
     );
+  });
+
+  it("surfaces the backend error message when initiating OAuth fails", async () => {
+    mutateAsyncMock.mockRejectedValue(new Error("No client ID available"));
+
+    const { result } = renderHook(() => useMcpInstallOrchestrator());
+
+    act(() => {
+      result.current.triggerReauthByCatalogIdAndServerId(
+        "catalog-posthog",
+        "server-123",
+      );
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("No client ID available");
+    });
+    expect(redirectBrowserToUrlMock).not.toHaveBeenCalled();
   });
 });

--- a/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
+++ b/platform/frontend/src/lib/mcp/mcp-install-orchestrator.hook.ts
@@ -126,8 +126,12 @@ export function useMcpInstallOrchestrator(options?: { enabled?: boolean }) {
         }
 
         redirectBrowserToUrl(authorizationUrl);
-      } catch {
-        toast.error("Failed to initiate OAuth flow");
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to initiate OAuth flow",
+        );
       }
     },
     [initiateOAuthMutation, installedServers],


### PR DESCRIPTION
## Problem

Installing an MCP server via OAuth failed opaquely. A catalog entry with no usable `client_id` (e.g. a Slack entry against Slack's OAuth server, which offers no dynamic client registration) makes `/api/oauth/initiate` throw `ApiError(400, "No client ID available…")`. But:

- The frontend collapsed **any** initiate error into a generic `toast.error("Failed to initiate OAuth flow")`, discarding the specific reason the hook had already extracted.
- Handled 4xx `ApiError`s are deliberately filtered from Sentry/PostHog, so the failure was only reconstructable from info-level trace logs — no `catalogId`, no alerting.

## Changes

**Frontend — surface the specific message.** The 7 initiate/re-auth `catch` sites now bind the error and toast `error.message`, keeping their prior string only as a fallback. No new abstraction; the hook already rejects with the backend message.

**Backend — observability.** `/api/oauth/initiate` wraps its handler and emits `logger.warn({ catalogId, statusCode, reason })` on any handled 4xx, then rethrows. The centralized error handler still formats/responds unchanged, and the global 4xx→Sentry filter is left intact.

## Tests

- `oauth-initiate-observability.test.ts` — real route (`useRouteTestApp`), asserts the warn fires with `{ catalogId, statusCode }` on a 404 initiate (structured fields, not message prose).
- `oauth.query.test.tsx` — mocks the generated SDK (network boundary), asserts `useInitiateOAuth` converts the backend `{ error: { message } }` envelope into `Error.message`.
- Extended `mcp-install-orchestrator.hook.test.tsx` — asserts a rejected initiate toasts the backend message and does not redirect.

Validation: `pnpm type-check` ✓, `biome` ✓, targeted backend + frontend tests ✓.

https://claude.ai/code/session_01U2mbCo4pyzo6rxqDqnZfev

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>