### PR TITLE
feat(mcp-gateway): name every searchable MCP server in the search_tools description

### DIFF
--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -2448,7 +2448,7 @@ describe("createAgentServer tools/list", () => {
     expect(chatResponse.structuredContent).toMatchObject({ id: app.id });
   });
 
-  test("adds assigned MCP server context to search_tools description", async ({
+  test("adds assigned MCP server names and descriptions to search_tools description", async ({
     makeAgent,
     makeAgentTool,
     makeInternalMcpCatalog,
@@ -2460,20 +2460,32 @@ describe("createAgentServer tools/list", () => {
       organizationId: org.id,
       toolExposureMode: "search_and_run_only",
     });
-    const sentryCatalog = await makeInternalMcpCatalog({
+    const errorTrackerCatalog = await makeInternalMcpCatalog({
       organizationId: org.id,
-      name: "sentry",
+      name: "error-tracker",
+      description: "Error tracking and\nperformance   monitoring",
     });
-    await McpCatalogLabelModel.syncCatalogLabels(sentryCatalog.id, [
+    await McpCatalogLabelModel.syncCatalogLabels(errorTrackerCatalog.id, [
       { key: "app", value: "observability" },
-      { key: "type", value: "errors" },
     ]);
-    const sentryTool = await makeTool({
-      catalogId: sentryCatalog.id,
-      name: "sentry__list_issues",
+    const errorTrackerTool = await makeTool({
+      catalogId: errorTrackerCatalog.id,
+      name: "error_tracker__list_issues",
       parameters: { type: "object", properties: {} },
     });
-    await makeAgentTool(agent.id, sentryTool.id);
+    await makeAgentTool(agent.id, errorTrackerTool.id);
+
+    // A catalog without a description renders as a bare name.
+    const notesCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "notes",
+    });
+    const notesTool = await makeTool({
+      catalogId: notesCatalog.id,
+      name: "notes__create_note",
+      parameters: { type: "object", properties: {} },
+    });
+    await makeAgentTool(agent.id, notesTool.id);
 
     const { server } = await createAgentServer(agent.id);
     const listToolsHandler = (
@@ -2495,11 +2507,142 @@ describe("createAgentServer tools/list", () => {
       (tool) => tool.name === TOOL_SEARCH_TOOLS_FULL_NAME,
     );
 
+    // Server description is whitespace-collapsed and rendered in parens.
     expect(searchTool?.description).toContain(
-      "Available MCP servers for this gateway include: sentry",
+      "error-tracker (Error tracking and performance monitoring)",
     );
-    expect(searchTool?.description).toContain("app:observability");
-    expect(searchTool?.description).toContain("type:errors");
+    expect(searchTool?.description).toContain("notes");
+    // Labels are no longer part of the summary.
+    expect(searchTool?.description).not.toContain("app:observability");
+  });
+
+  test("search_tools description lists every assigned server, not a top-10 slice", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeOrganization,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({
+      organizationId: org.id,
+      toolExposureMode: "search_and_run_only",
+    });
+
+    const catalogNames = Array.from(
+      { length: 12 },
+      (_, i) => `server-${String(i).padStart(2, "0")}`,
+    );
+    for (const name of catalogNames) {
+      const catalog = await makeInternalMcpCatalog({
+        organizationId: org.id,
+        name,
+      });
+      const tool = await makeTool({
+        catalogId: catalog.id,
+        name: `${name.replace(/-/g, "_")}__do_thing`,
+        parameters: { type: "object", properties: {} },
+      });
+      await makeAgentTool(agent.id, tool.id);
+    }
+
+    const { server } = await createAgentServer(agent.id);
+    const listToolsHandler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, TestListToolsHandler>;
+      }
+    )._requestHandlers.get("tools/list");
+    if (!listToolsHandler) {
+      throw new Error("Expected tools/list handler to be registered");
+    }
+
+    const response = await listToolsHandler({
+      method: "tools/list",
+      params: {},
+    });
+    const searchTool = response.tools.find(
+      (tool) => tool.name === TOOL_SEARCH_TOOLS_FULL_NAME,
+    );
+
+    for (const name of catalogNames) {
+      expect(searchTool?.description).toContain(name);
+    }
+    expect(searchTool?.description).not.toContain("more");
+  });
+
+  test("search_tools description includes dynamically discoverable servers for all-tools agents", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeMember,
+    makeOrganization,
+    makeTool,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      toolExposureMode: "search_and_run_only",
+      accessAllTools: true,
+    });
+
+    const assignedCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "assigned-server",
+    });
+    const assignedTool = await makeTool({
+      catalogId: assignedCatalog.id,
+      name: "assigned_server__do_thing",
+      parameters: { type: "object", properties: {} },
+    });
+    await makeAgentTool(agent.id, assignedTool.id);
+
+    // Accessible to the user but not assigned to the agent — reachable only
+    // through the search_tools/run_tool dynamic dispatch surface.
+    const discoverableCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "github",
+      description: "Repositories, issues, and pull requests",
+    });
+    await makeTool({
+      catalogId: discoverableCatalog.id,
+      name: "github__search_repositories",
+      parameters: { type: "object", properties: {} },
+    });
+    await makeMcpServer({ catalogId: discoverableCatalog.id, scope: "org" });
+
+    const { server } = await createAgentServer(agent.id, {
+      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+      teamId: null,
+      isOrganizationToken: false,
+      organizationId: org.id,
+      isUserToken: true,
+      userId: user.id,
+    });
+    const listToolsHandler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, TestListToolsHandler>;
+      }
+    )._requestHandlers.get("tools/list");
+    if (!listToolsHandler) {
+      throw new Error("Expected tools/list handler to be registered");
+    }
+
+    const response = await listToolsHandler({
+      method: "tools/list",
+      params: {},
+    });
+    const searchTool = response.tools.find(
+      (tool) => tool.name === TOOL_SEARCH_TOOLS_FULL_NAME,
+    );
+
+    expect(searchTool?.description).toContain("assigned-server");
+    expect(searchTool?.description).toContain(
+      "github (Repositories, issues, and pull requests)",
+    );
   });
 
   test("preserves user context when calling restricted Archestra tools", async ({

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -37,7 +37,10 @@ import {
   filterToolNamesByPermission,
   getArchestraMcpTools,
 } from "@/archestra-mcp-server";
-import { resolveDynamicTool } from "@/archestra-mcp-server/dynamic-tools";
+import {
+  getUnassignedDiscoverableTools,
+  resolveDynamicTool,
+} from "@/archestra-mcp-server/dynamic-tools";
 import { userHasPermission } from "@/auth/utils";
 import { LRUCacheManager } from "@/cache-manager";
 import mcpClient, { type TokenAuthContext } from "@/clients/mcp-client";
@@ -291,11 +294,28 @@ export async function createAgentServer(
       return catalog?.serverType === "app" ? `Open ${catalog.name}` : undefined;
     };
 
-    // Dynamically enrich the knowledge sources tool description with
-    // the agent's actual knowledge base names and connector types
+    // Dynamically enrich the knowledge sources tool description with the
+    // agent's actual knowledge base names and connector types, and the
+    // search_tools description with the servers in its search space. The
+    // latter involves resolving the dynamically discoverable tool space, so
+    // skip it when search_tools is not in the advertised list anyway ("full"
+    // exposure mode hides the meta tools).
+    const advertisesSearchTools = permittedTools.some(
+      (tool) =>
+        archestraMcpBranding.getToolShortName(tool.name) ===
+        TOOL_SEARCH_TOOLS_SHORT_NAME,
+    );
     const [kbToolDescription, searchToolsDescription] = await Promise.all([
       buildKnowledgeSourcesDescription(agentId),
-      buildSearchToolsDescription(mcpTools, catalogsById),
+      advertisesSearchTools
+        ? buildSearchToolsDescription({
+            mcpTools,
+            agentId,
+            userId: tokenAuth?.userId,
+            organizationId: tokenAuth?.organizationId,
+            prefetchedCatalogs: catalogsById,
+          })
+        : null,
     ]);
 
     const toolsList: McpListTool[] = permittedTools.map(
@@ -1727,6 +1747,7 @@ function filterExposedTools(params: {
 type McpListTool = ListToolsResult["tools"][number];
 
 type McpToolForSearchDescription = {
+  name: string;
   catalogId: string | null;
 };
 
@@ -1780,12 +1801,23 @@ function dedupeToolsByName<T extends { name: string }>(tools: T[]) {
   return Array.from(deduped.values());
 }
 
-async function buildSearchToolsDescription(
-  mcpTools: McpToolForSearchDescription[],
+// Caps for the server list appended to the search_tools description: how many
+// servers are named (past this the list degrades to ", and N more") and how
+// much of each server's own description is quoted alongside its name.
+const SEARCH_TOOLS_DESCRIPTION_MAX_SERVERS = 100;
+const SEARCH_TOOLS_DESCRIPTION_MAX_SERVER_DESCRIPTION_LENGTH = 200;
+
+async function buildSearchToolsDescription(params: {
+  mcpTools: McpToolForSearchDescription[];
+  agentId: string;
+  userId?: string;
+  organizationId?: string;
   prefetchedCatalogs?: Awaited<
     ReturnType<typeof InternalMcpCatalogModel.getByIds>
-  >,
-) {
+  >;
+}) {
+  const { agentId, mcpTools, organizationId, prefetchedCatalogs, userId } =
+    params;
   const searchTool = getArchestraMcpTools().find(
     (tool) =>
       archestraMcpBranding.getToolShortName(tool.name) ===
@@ -1796,9 +1828,20 @@ async function buildSearchToolsDescription(
     return null;
   }
 
+  // Mirror search_tools' actual search space: the catalogs backing the
+  // assigned tools, widened by the dynamically discoverable ones when the
+  // agent's "access all tools" setting is on (getUnassignedDiscoverableTools
+  // self-gates on that setting and a real authenticated user).
+  const discoverableTools = await getUnassignedDiscoverableTools({
+    assignedToolNames: new Set(mcpTools.map((tool) => tool.name)),
+    agentId,
+    userId,
+    organizationId,
+  });
+
   const catalogIds = [
     ...new Set(
-      mcpTools
+      [...mcpTools, ...discoverableTools]
         .map((tool) => tool.catalogId)
         .filter(
           (catalogId): catalogId is string =>
@@ -1811,29 +1854,45 @@ async function buildSearchToolsDescription(
     return baseDescription;
   }
 
-  const catalogs =
-    prefetchedCatalogs ?? (await InternalMcpCatalogModel.getByIds(catalogIds));
-  const catalogSummaries = catalogIds
+  const catalogs = new Map(prefetchedCatalogs ?? []);
+  const missingCatalogIds = catalogIds.filter((id) => !catalogs.has(id));
+  if (missingCatalogIds.length > 0) {
+    const fetched = await InternalMcpCatalogModel.getByIds(missingCatalogIds);
+    for (const [id, catalog] of fetched) {
+      catalogs.set(id, catalog);
+    }
+  }
+
+  const resolvedCatalogs = catalogIds
     .map((catalogId) => catalogs.get(catalogId))
-    .filter((catalog) => catalog !== undefined)
-    .slice(0, 10)
-    .map((catalog) => {
-      const labels = catalog.labels
-        .slice(0, 3)
-        .map((label) => `${label.key}:${label.value}`)
-        .join(", ");
-      return labels ? `${catalog.name} (labels: ${labels})` : catalog.name;
-    });
+    .filter((catalog) => catalog !== undefined);
+  const catalogSummaries = resolvedCatalogs
+    .slice(0, SEARCH_TOOLS_DESCRIPTION_MAX_SERVERS)
+    .map((catalog) =>
+      catalog.description
+        ? `${catalog.name} (${summarizeCatalogDescription(catalog.description)})`
+        : catalog.name,
+    );
 
   if (catalogSummaries.length === 0) {
     return baseDescription;
   }
 
-  const remainingCount = catalogIds.length - catalogSummaries.length;
+  const remainingCount = resolvedCatalogs.length - catalogSummaries.length;
   const remainingText =
     remainingCount > 0 ? `, and ${remainingCount} more` : "";
 
   return `${baseDescription} Available MCP servers for this gateway include: ${catalogSummaries.join(", ")}${remainingText}. Use this tool first when the user names one of these servers or asks for capabilities that may be provided by connected MCP servers.`;
+}
+
+// One-line, length-capped rendering of a catalog's own description for
+// embedding in the search_tools description.
+function summarizeCatalogDescription(description: string): string {
+  const collapsed = description.replace(/\s+/g, " ").trim();
+  return collapsed.length >
+    SEARCH_TOOLS_DESCRIPTION_MAX_SERVER_DESCRIPTION_LENGTH
+    ? `${collapsed.slice(0, SEARCH_TOOLS_DESCRIPTION_MAX_SERVER_DESCRIPTION_LENGTH)}…`
+    : collapsed;
 }
 
 /** @public — also consumed by the app MCP server (mcp-app-gateway.utils.ts). */


### PR DESCRIPTION
## What

The `search_tools` tool definition advertised at `tools/list` time is dynamically enriched with the MCP servers it fronts, so models see — by name — that this one tool is the doorway to many servers. This PR makes that server list complete and more informative:

- **Name + description**: each server renders as `name (description)` — the catalog's own description, whitespace-collapsed and capped at 200 chars — instead of the previous `name (labels: k:v, …)` format. Labels are dropped.
- **All servers, not a top-10 slice**: the cap goes from 10 to 100 (overflow still degrades to `, and N more`).
- **Dynamic search space included**: for agents with **Access all tools** on, the list now also names the catalogs reachable only through the `search_tools`/`run_tool` dynamic dispatch surface (via `getUnassignedDiscoverableTools`, the same source of truth `search_tools` itself searches). Previously only catalogs backing *assigned* tools were named — precisely the wrong subset for all-tools gateways like the personal "My Gateway", where unassigned servers are the ones models most need steering toward.

## Why

Models decide whether to reach for `search_tools` from its description alone. Naming every server it fronts (with what each does) should improve tool-selection accuracy, especially when the user names a server or asks for a capability a connected server provides.

## Notes

- The description now mirrors `search_tools`' actual search space in both exposure modes. In `full` exposure mode the meta tools remain hidden from `tools/list` (unchanged), so the handler now skips building the description there instead of computing and discarding it — this also avoids the extra discoverable-space query on full-mode gateways.
- `getUnassignedDiscoverableTools` self-gates on `accessAllTools` + a real authenticated user, so assigned-tools-only gateways see no behavior change beyond the format and cap.