### PR TITLE
refactor(apps): reuse the MCP gateway pill selector for App-settings tools

### DIFF
--- a/platform/frontend/src/app/apps/_parts/app-tools-editor.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-editor.test.tsx
@@ -117,6 +117,23 @@ function renderTab() {
   );
 }
 
+// The staged host (the app settings form) drives selection as a controlled
+// Set; toggles report up via onSelectionChange instead of persisting live.
+function renderControlled(onSelectionChange: (next: Set<string>) => void) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AppToolsEditor
+        appId={APP_ID}
+        selectedToolIds={new Set(["t-create"])}
+        onSelectionChange={onSelectionChange}
+      />
+    </QueryClientProvider>,
+  );
+}
+
 describe("AppToolsEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -214,6 +231,60 @@ describe("AppToolsEditor", () => {
     // live editor fired no assignment — the user picks tools deliberately.
     expect(await screen.findByLabelText("create_page")).not.toBeChecked();
     expect(assignMutate).not.toHaveBeenCalled();
+  });
+
+  it("stages every tool of a server added in the settings form, persisting nothing", async () => {
+    const user = userEvent.setup();
+    const NOTION_ID = "notion-catalog";
+    useInternalMcpCatalogMock.mockReturnValue({
+      data: [makeCatalog(), makeCatalog({ id: NOTION_ID, name: "Notion" })],
+    });
+    fetchCatalogToolsMock.mockImplementation((id: string) =>
+      Promise.resolve(
+        id === NOTION_ID
+          ? [
+              {
+                id: "n-page",
+                name: "create_page",
+                description: null,
+                catalogId: NOTION_ID,
+              },
+              {
+                id: "n-db",
+                name: "query_db",
+                description: null,
+                catalogId: NOTION_ID,
+              },
+            ]
+          : [makeTool("t-create", "create_issue")],
+      ),
+    );
+    const onSelectionChange = vi.fn();
+    renderControlled(onSelectionChange);
+
+    await screen.findByRole("button", { name: /JIRA/ });
+    await user.click(screen.getByRole("button", { name: /add/i }));
+    await user.click(
+      await screen.findByRole("menuitemcheckbox", { name: /notion/i }),
+    );
+
+    // Staged mode merges every tool of the added server into the selection and
+    // fires no live mutation — the opposite of the uncontrolled host above.
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      new Set(["t-create", "n-page", "n-db"]),
+    );
+    expect(assignMutate).not.toHaveBeenCalled();
+    expect(unassignMutate).not.toHaveBeenCalled();
+  });
+
+  it("flags an assigned server that sits outside the app's environment", async () => {
+    useInternalMcpCatalogMock.mockReturnValue({
+      data: [makeCatalog({ environmentId: "env-other" })],
+    });
+    renderTab();
+
+    const pill = await screen.findByRole("button", { name: /JIRA/ });
+    expect(pill).toHaveTextContent("outside this environment");
   });
 
   it("surfaces an assignment with no listed MCP server as a removable fallback", async () => {

--- a/platform/frontend/src/app/apps/_parts/app-tools-editor.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-editor.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Radix Accordion/Checkbox measure layout and use pointer capture, which jsdom
+// Radix Popover/Checkbox measure layout and use pointer capture, which jsdom
 // doesn't implement.
 global.ResizeObserver = class {
   observe() {}
@@ -14,6 +14,39 @@ Element.prototype.scrollIntoView = vi.fn();
 Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
 Element.prototype.setPointerCapture = vi.fn();
 Element.prototype.releasePointerCapture = vi.fn();
+
+// The "+ Add" combobox is a Radix dropdown on floating-ui, which needs a real
+// ResizeObserver, layout rects, and DOMRect to position.
+Element.prototype.getBoundingClientRect =
+  Element.prototype.getBoundingClientRect ??
+  (() =>
+    ({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 20,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      left: 0,
+      toJSON: () => {},
+    }) as DOMRect);
+if (typeof globalThis.DOMRect === "undefined") {
+  globalThis.DOMRect = class DOMRect {
+    x = 0;
+    y = 0;
+    width = 0;
+    height = 0;
+    top = 0;
+    right = 0;
+    bottom = 0;
+    left = 0;
+    toJSON() {}
+    static fromRect() {
+      return new DOMRect();
+    }
+  } as unknown as typeof globalThis.DOMRect;
+}
 
 const {
   assignMutate,
@@ -104,13 +137,15 @@ describe("AppToolsEditor", () => {
   });
 
   it("groups an app's tools under their MCP server and reflects the assigned set", async () => {
+    const user = userEvent.setup();
     renderTab();
 
-    // The server (catalog) heading renders, with the assigned-count badge.
-    expect(await screen.findByText("JIRA")).toBeInTheDocument();
-    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    // The server renders as a pill showing its selected-tool count.
+    const pill = await screen.findByRole("button", { name: /JIRA/ });
+    expect(pill).toHaveTextContent("(1)");
 
-    // Tools load into the default-open section; the assigned one is checked.
+    // Open the pill; tools load into the popover and the assigned one is checked.
+    await user.click(pill);
     const created = await screen.findByLabelText("create_issue");
     const deleted = await screen.findByLabelText("delete_issue");
     expect(created).toBeChecked();
@@ -121,6 +156,7 @@ describe("AppToolsEditor", () => {
     const user = userEvent.setup();
     renderTab();
 
+    await user.click(await screen.findByRole("button", { name: /JIRA/ }));
     await user.click(await screen.findByLabelText("delete_issue"));
 
     expect(assignMutate).toHaveBeenCalledWith({
@@ -135,12 +171,48 @@ describe("AppToolsEditor", () => {
     const user = userEvent.setup();
     renderTab();
 
+    await user.click(await screen.findByRole("button", { name: /JIRA/ }));
     await user.click(await screen.findByLabelText("create_issue"));
 
     expect(unassignMutate).toHaveBeenCalledWith({
       appId: APP_ID,
       toolId: "t-create",
     });
+    expect(assignMutate).not.toHaveBeenCalled();
+  });
+
+  it("adds a server from the '+ Add' menu without live-assigning its tools", async () => {
+    const user = userEvent.setup();
+    const NOTION_ID = "notion-catalog";
+    useInternalMcpCatalogMock.mockReturnValue({
+      data: [makeCatalog(), makeCatalog({ id: NOTION_ID, name: "Notion" })],
+    });
+    fetchCatalogToolsMock.mockImplementation((id: string) =>
+      Promise.resolve(
+        id === NOTION_ID
+          ? [
+              {
+                id: "n-page",
+                name: "create_page",
+                description: null,
+                catalogId: NOTION_ID,
+              },
+            ]
+          : [makeTool("t-create", "create_issue")],
+      ),
+    );
+    renderTab();
+
+    await screen.findByRole("button", { name: /JIRA/ });
+    await user.click(screen.getByRole("button", { name: /add/i }));
+    // findBy waits out the "no tools" disabled state until Notion's tools load.
+    await user.click(
+      await screen.findByRole("menuitemcheckbox", { name: /notion/i }),
+    );
+
+    // The added server's popover pops open showing its tool unselected, and the
+    // live editor fired no assignment — the user picks tools deliberately.
+    expect(await screen.findByLabelText("create_page")).not.toBeChecked();
     expect(assignMutate).not.toHaveBeenCalled();
   });
 

--- a/platform/frontend/src/app/apps/_parts/app-tools-editor.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-editor.tsx
@@ -7,7 +7,7 @@ import {
 } from "@archestra/shared";
 import { useQueries } from "@tanstack/react-query";
 import { Trash2 } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ToolChecklist } from "@/components/agent-tools-editor";
 import {
   isCatalogInEnvironment,
@@ -15,13 +15,11 @@ import {
 } from "@/components/agent-tools-editor.utils";
 import { LoadingWrapper } from "@/components/loading";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
+import { McpServerPillShell } from "@/components/mcp-server-pill-shell";
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
-import { Badge } from "@/components/ui/badge";
+  AssignmentCombobox,
+  type AssignmentComboboxItem,
+} from "@/components/ui/assignment-combobox";
 import { Button } from "@/components/ui/button";
 import {
   useApp,
@@ -34,7 +32,6 @@ import {
   fetchCatalogTools,
   useInternalMcpCatalog,
 } from "@/lib/mcp/internal-mcp-catalog.query";
-import { cn } from "@/lib/utils";
 
 type CatalogItem =
   archestraApiTypes.GetInternalMcpCatalogResponses["200"][number];
@@ -58,7 +55,6 @@ export function AppToolsEditor({
   environmentId,
   selectedToolIds,
   onSelectionChange,
-  unbounded = false,
 }: {
   appId: string;
   /**
@@ -76,13 +72,6 @@ export function AppToolsEditor({
    */
   selectedToolIds?: Set<string>;
   onSelectionChange?: (next: Set<string>) => void;
-  /**
-   * Let each server's tool list flow at its full height instead of capping it
-   * at a scrollable `max-h-96` box. Set when embedding in a surface that already
-   * scrolls (e.g. the inline settings form) so its wheel scroll isn't captured
-   * by a nested scroller.
-   */
-  unbounded?: boolean;
 }) {
   const { data: app } = useApp(appId);
   const { data: assigned, isPending } = useAppTools(appId);
@@ -210,14 +199,6 @@ export function AppToolsEditor({
     );
   }, [candidates, toolsByCatalog, assignedIdsByCatalog]);
 
-  const defaultOpen = useMemo(
-    () =>
-      visibleCatalogs
-        .filter((c) => assignedIdsByCatalog.has(c.id))
-        .map((c) => c.id),
-    [visibleCatalogs, assignedIdsByCatalog],
-  );
-
   // Assigned tools that map to no listed catalog (server removed, or the
   // catalog list failed/has not loaded) would otherwise be invisible and
   // unremovable in the grouped view; surface them as a removable fallback.
@@ -235,7 +216,114 @@ export function AppToolsEditor({
     [orphanedAssigned, selection],
   );
 
-  const toolsLoading = toolQueries.some((q) => q.isLoading);
+  // A pill stays visible while a server is added this session, even if the user
+  // then deselects all its tools inside the popover (mirrors the gateway).
+  const [activeCatalogIds, setActiveCatalogIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  // The pill whose popover should pop open right after it's added.
+  const [autoOpenCatalogId, setAutoOpenCatalogId] = useState<string | null>(
+    null,
+  );
+
+  // Selected tool ids grouped by their catalog. A selected id belongs to a
+  // catalog if its tool is loaded there or it's a persisted assignment of it —
+  // the latter keeps the count right before catalog tools load.
+  const selectedByCatalog = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const catalog of visibleCatalogs) {
+      const catalogTools = toolsByCatalog.get(catalog.id) ?? EMPTY_TOOLS;
+      const catalogToolIds = new Set(catalogTools.map((t) => t.id));
+      const persisted =
+        assignedIdsByCatalog.get(catalog.id) ?? new Set<string>();
+      map.set(
+        catalog.id,
+        new Set(
+          [...selection].filter(
+            (id) => catalogToolIds.has(id) || persisted.has(id),
+          ),
+        ),
+      );
+    }
+    return map;
+  }, [visibleCatalogs, toolsByCatalog, assignedIdsByCatalog, selection]);
+
+  // Pilled servers: those with a selection, plus ones just added and not yet
+  // removed. Sorted (assigned first) via visibleCatalogs.
+  const shownCatalogs = useMemo(
+    () =>
+      visibleCatalogs.filter(
+        (c) =>
+          (selectedByCatalog.get(c.id)?.size ?? 0) > 0 ||
+          activeCatalogIds.has(c.id),
+      ),
+    [visibleCatalogs, selectedByCatalog, activeCatalogIds],
+  );
+  const shownCatalogIds = useMemo(
+    () => shownCatalogs.map((c) => c.id),
+    [shownCatalogs],
+  );
+
+  // Add a server (select all its tools) or remove it (clear all its tools),
+  // toggled from the "+ Add" combobox or the pill's remove button.
+  const toggleCatalog = (catalogId: string) => {
+    const catalog = candidates.find((c) => c.id === catalogId);
+    if (!catalog) return;
+    const catalogTools = toolsByCatalog.get(catalogId) ?? EMPTY_TOOLS;
+    const shown =
+      (selectedByCatalog.get(catalogId)?.size ?? 0) > 0 ||
+      activeCatalogIds.has(catalogId);
+    if (shown) {
+      changeCatalogSelection(catalogTools, new Set());
+      setActiveCatalogIds((prev) => {
+        const next = new Set(prev);
+        next.delete(catalogId);
+        return next;
+      });
+    } else {
+      // Staged mode pre-selects every tool (nothing persists until Save). Live
+      // mode leaves them unselected: a burst of assign mutations here, followed
+      // by a quick remove, would derive its unassigns from a not-yet-refetched
+      // selection and strand the grants — so the user picks tools in the popover
+      // instead, one assignment at a time.
+      if (controlled) {
+        changeCatalogSelection(
+          catalogTools,
+          new Set(catalogTools.map((t) => t.id)),
+        );
+      }
+      setActiveCatalogIds((prev) => new Set(prev).add(catalogId));
+    }
+  };
+
+  const comboboxItems: AssignmentComboboxItem[] = useMemo(
+    () =>
+      candidates.map((catalog) => {
+        const total = toolsByCatalog.get(catalog.id)?.length ?? 0;
+        const selected = selectedByCatalog.get(catalog.id)?.size ?? 0;
+        const disabled = total === 0;
+        return {
+          id: catalog.id,
+          name: catalog.name,
+          description: catalog.description || undefined,
+          icon: (
+            <McpCatalogIcon
+              icon={catalog.icon}
+              catalogId={catalog.id}
+              size={16}
+            />
+          ),
+          badge: disabled
+            ? undefined
+            : selected > 0
+              ? `${selected}/${total}`
+              : `${total} tools`,
+          disabled,
+          disabledReason: disabled ? "No tools" : undefined,
+        };
+      }),
+    [candidates, toolsByCatalog, selectedByCatalog],
+  );
 
   if (canEdit !== true) {
     return (
@@ -250,82 +338,56 @@ export function AppToolsEditor({
   return (
     <div className="flex max-w-2xl flex-col gap-4">
       <LoadingWrapper isPending={isPending && !assigned}>
-        {visibleCatalogs.length === 0 && orphanedVisible.length === 0 ? (
-          candidates.length > 0 && toolsLoading ? (
-            <p className="text-sm text-muted-foreground">Loading tools…</p>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              No MCP servers are available in this app's environment. The app
-              can still use its data store.
-            </p>
-          )
+        {candidates.length === 0 && orphanedVisible.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No MCP servers are available in this app's environment. The app can
+            still use its data store.
+          </p>
         ) : (
           <>
-            {visibleCatalogs.length > 0 ? (
-              <Accordion type="multiple" defaultValue={defaultOpen}>
-                {visibleCatalogs.map((catalog) => {
-                  const catalogTools =
-                    toolsByCatalog.get(catalog.id) ?? EMPTY_TOOLS;
-                  // A selected id belongs to this catalog if its tool is loaded
-                  // here or it's a persisted assignment of this catalog — the
-                  // latter keeps the count correct before catalog tools load.
-                  const catalogToolIds = new Set(catalogTools.map((t) => t.id));
-                  const persistedInCatalog =
-                    assignedIdsByCatalog.get(catalog.id) ?? new Set<string>();
-                  const selectedInCatalog = new Set(
-                    [...selection].filter(
-                      (id) =>
-                        catalogToolIds.has(id) || persistedInCatalog.has(id),
-                    ),
-                  );
-                  const outOfEnv =
-                    !isPlaywrightCatalogItem(catalog.id) &&
-                    !isCatalogInEnvironment(catalog, appEnvironmentId);
-                  return (
-                    <AccordionItem key={catalog.id} value={catalog.id}>
-                      <AccordionTrigger>
-                        <div className="flex w-full items-center gap-2 pr-2">
-                          <McpCatalogIcon
-                            icon={catalog.icon}
-                            catalogId={catalog.id}
-                            size={20}
-                          />
-                          <span className="truncate font-medium">
-                            {catalog.name}
-                          </span>
-                          {outOfEnv ? (
-                            <span className="shrink-0 text-xs font-normal text-muted-foreground">
-                              (outside this environment)
-                            </span>
-                          ) : null}
-                          {selectedInCatalog.size > 0 ? (
-                            <Badge variant="secondary" className="ml-auto">
-                              {selectedInCatalog.size} selected
-                            </Badge>
-                          ) : null}
-                        </div>
-                      </AccordionTrigger>
-                      <AccordionContent>
-                        <div
-                          className={cn(
-                            "flex flex-col rounded-md border",
-                            !unbounded && "max-h-96",
-                          )}
-                        >
-                          <AppCatalogToolList
-                            tools={catalogTools}
-                            selectedToolIds={selectedInCatalog}
-                            onSelectionChange={(next) =>
-                              changeCatalogSelection(catalogTools, next)
-                            }
-                          />
-                        </div>
-                      </AccordionContent>
-                    </AccordionItem>
-                  );
-                })}
-              </Accordion>
-            ) : null}
+            <div className="flex flex-wrap gap-2">
+              {shownCatalogs.map((catalog) => {
+                const catalogTools =
+                  toolsByCatalog.get(catalog.id) ?? EMPTY_TOOLS;
+                const selectedInCatalog =
+                  selectedByCatalog.get(catalog.id) ?? new Set<string>();
+                const persistedInCatalog =
+                  assignedIdsByCatalog.get(catalog.id) ?? new Set<string>();
+                const outOfEnv =
+                  !isPlaywrightCatalogItem(catalog.id) &&
+                  !isCatalogInEnvironment(catalog, appEnvironmentId);
+                return (
+                  <AppMcpServerPill
+                    key={catalog.id}
+                    catalog={catalog}
+                    tools={catalogTools}
+                    selectedToolIds={selectedInCatalog}
+                    highlighted={
+                      !setsEqual(selectedInCatalog, persistedInCatalog)
+                    }
+                    note={outOfEnv ? "(outside this environment)" : undefined}
+                    onSelectionChange={(next) =>
+                      changeCatalogSelection(catalogTools, next)
+                    }
+                    onRemove={() => toggleCatalog(catalog.id)}
+                    autoOpen={catalog.id === autoOpenCatalogId}
+                    onAutoOpened={() => setAutoOpenCatalogId(null)}
+                  />
+                );
+              })}
+              <AssignmentCombobox
+                items={comboboxItems}
+                selectedIds={shownCatalogIds}
+                onToggle={toggleCatalog}
+                onItemAdded={setAutoOpenCatalogId}
+                placeholder="Search MCP servers..."
+                emptyMessage="No MCP servers found."
+                createAction={{
+                  label: "Install New MCP Server",
+                  href: "/mcp/registry",
+                }}
+              />
+            </div>
             {orphanedVisible.length > 0 ? (
               <OrphanedAssignedTools
                 tools={orphanedVisible}
@@ -337,6 +399,12 @@ export function AppToolsEditor({
       </LoadingWrapper>
     </div>
   );
+}
+
+function setsEqual(a: Set<string>, b: Set<string>) {
+  if (a.size !== b.size) return false;
+  for (const value of a) if (!b.has(value)) return false;
+  return true;
 }
 
 function OrphanedAssignedTools({
@@ -381,29 +449,70 @@ function OrphanedAssignedTools({
   );
 }
 
-function AppCatalogToolList({
+// One MCP server as a pill: the shared visual shell (trigger + popover chrome)
+// wrapping this app's tool checklist. Fully controlled by the parent's selection
+// — toggling a tool routes straight back through `onSelectionChange`.
+function AppMcpServerPill({
+  catalog,
   tools,
   selectedToolIds,
+  highlighted,
+  note,
   onSelectionChange,
+  onRemove,
+  autoOpen,
+  onAutoOpened,
 }: {
+  catalog: CatalogItem;
   tools: CatalogTool[];
   selectedToolIds: Set<string>;
+  highlighted: boolean;
+  note?: string;
   onSelectionChange: (next: Set<string>) => void;
+  onRemove: () => void;
+  autoOpen: boolean;
+  onAutoOpened: () => void;
 }) {
-  if (tools.length === 0) {
-    return (
-      <p className="px-4 py-3 text-sm text-muted-foreground">
-        This server exposes no tools yet.
-      </p>
-    );
-  }
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (autoOpen) {
+      setOpen(true);
+      onAutoOpened();
+    }
+  }, [autoOpen, onAutoOpened]);
 
   return (
-    <ToolChecklist
-      tools={tools}
-      selectedToolIds={selectedToolIds}
-      onSelectionChange={onSelectionChange}
-    />
+    <McpServerPillShell
+      icon={
+        <McpCatalogIcon icon={catalog.icon} catalogId={catalog.id} size={14} />
+      }
+      displayName={catalog.name}
+      count={selectedToolIds.size}
+      isEmpty={selectedToolIds.size === 0}
+      highlighted={highlighted}
+      note={note}
+      description={catalog.description}
+      docsUrl={catalog.docsUrl}
+      open={open}
+      onOpenChange={setOpen}
+      onRemove={onRemove}
+      removeAriaLabel={`Remove ${catalog.name}`}
+    >
+      {tools.length === 0 ? (
+        <p className="p-4 text-sm text-muted-foreground">
+          This server exposes no tools yet.
+        </p>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <ToolChecklist
+            tools={tools}
+            selectedToolIds={selectedToolIds}
+            onSelectionChange={onSelectionChange}
+          />
+        </div>
+      )}
+    </McpServerPillShell>
   );
 }
 

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -10,7 +10,7 @@ import {
   parseFullToolName,
 } from "@archestra/shared";
 import { useQueries } from "@tanstack/react-query";
-import { Loader2, Pencil, Search, X } from "lucide-react";
+import { Loader2, Search } from "lucide-react";
 import {
   forwardRef,
   useCallback,
@@ -28,11 +28,6 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { useInvalidateToolAssignmentQueries } from "@/lib/agent-tools.hook";
 import { useAssignTool, useUnassignTool } from "@/lib/agent-tools.query";
 import { useProfileToolsWithIds } from "@/lib/chat/chat.query";
@@ -52,8 +47,8 @@ import {
   sortAndFilterTools,
   sortCatalogItems,
 } from "./agent-tools-editor.utils";
-import { CatalogDocsLink } from "./catalog-docs-link";
 import { McpCatalogIcon } from "./mcp-catalog-icon";
+import { McpServerPillShell } from "./mcp-server-pill-shell";
 import { DYNAMIC_CREDENTIAL_VALUE, TokenSelect } from "./token-select";
 
 type InternalMcpCatalogItem =
@@ -982,140 +977,78 @@ function McpServerPill({
     !isPlaywright &&
     mcpServers.length > 0;
   return (
-    <Popover
+    <McpServerPillShell
+      icon={
+        <McpCatalogIcon
+          icon={catalogItem.icon}
+          catalogId={catalogItem.id}
+          size={14}
+        />
+      }
+      displayName={displayName}
+      count={displayedCount}
+      isEmpty={isEmpty}
+      highlighted={hasPendingChanges}
+      description={catalogItem.description}
+      docsUrl={catalogItem.docsUrl}
       open={open}
       onOpenChange={(v) => {
         setOpen(v);
         if (v) setChangedInSession(false);
       }}
-      modal
+      onRemove={() => onRemove(catalogItem.id)}
+      removeAriaLabel={`Remove ${catalogItem.name}`}
+      triggerTestId={getAgentToolCatalogPillTestId(catalogItem.name)}
     >
-      <div className="flex items-center">
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            size="sm"
-            className={cn(
-              "h-8 px-3 gap-1.5 text-xs",
-              isEmpty && "border-dashed opacity-50",
-              isEmpty && "rounded-r-none border-r-0",
-              hasPendingChanges && "border-primary opacity-100",
-            )}
-            data-testid={getAgentToolCatalogPillTestId(catalogItem.name)}
-          >
-            <McpCatalogIcon
-              icon={catalogItem.icon}
-              catalogId={catalogItem.id}
-              size={14}
-            />
-            <span className="font-medium">{displayName}</span>
-            <span className="text-muted-foreground">({displayedCount})</span>
-            <Pencil className="h-3 w-3 shrink-0 text-muted-foreground" />
-          </Button>
-        </PopoverTrigger>
-        {isEmpty && (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 w-8 p-0 rounded-l-none border-dashed opacity-50 hover:opacity-100"
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove(catalogItem.id);
+      {showCredentialSelector && (
+        <div className="p-4 border-b space-y-2 shrink-0">
+          <Label className="text-sm font-medium">Connect on behalf of</Label>
+          <p className="text-xs text-muted-foreground">
+            Choose whether this tool uses a fixed server connection or resolves
+            credentials for the current caller at runtime.
+          </p>
+          <TokenSelect
+            catalogId={catalogItem.id}
+            assignmentScope={assignmentScope}
+            assignmentTeamIds={assignmentTeamIds}
+            value={selectedCredential}
+            onValueChange={setSelectedCredential}
+            shouldSetDefaultValue={false}
+            prefersEnterpriseManaged={prefersEnterpriseManaged}
+          />
+        </div>
+      )}
+
+      {isLoadingTools ? (
+        <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>Loading tools...</span>
+        </div>
+      ) : totalCount === 0 ? (
+        <div className="p-4 text-sm text-muted-foreground">
+          No tools available for this server.
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+          <ToolChecklist
+            tools={allTools}
+            selectedToolIds={selectedToolIds}
+            onSelectionChange={(ids) => {
+              setSelectedToolIds(ids);
+              setChangedInSession(true);
             }}
-            aria-label={`Remove ${catalogItem.name}`}
-          >
-            <X className="h-3 w-3" />
-          </Button>
-        )}
-      </div>
-      <PopoverContent
-        className="w-[420px] max-h-[min(500px,var(--radix-popover-content-available-height))] p-0 flex flex-col overflow-hidden"
-        side="bottom"
-        align="start"
-        sideOffset={8}
-        avoidCollisions
-        collisionPadding={16}
-      >
-        <div className="p-4 border-b flex items-start justify-between gap-2 shrink-0">
-          <div>
-            <h4 className="font-semibold">{displayName}</h4>
-            {catalogItem.description && (
-              <p className="text-sm text-muted-foreground mt-1">
-                {catalogItem.description}
-                {catalogItem.docsUrl ? (
-                  <>
-                    {" "}
-                    <CatalogDocsLink
-                      url={catalogItem.docsUrl}
-                      className="inline-flex items-center gap-1 text-primary hover:underline"
-                    />
-                  </>
-                ) : null}
-              </p>
-            )}
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 w-6 p-0 shrink-0"
-            onClick={() => setOpen(false)}
-          >
-            <X className="h-4 w-4" />
+          />
+        </div>
+      )}
+
+      {changedInSession && (
+        <div className="p-2 border-t shrink-0">
+          <Button size="sm" className="w-full" onClick={() => setOpen(false)}>
+            OK
           </Button>
         </div>
-
-        {/* Credential Selector */}
-        {showCredentialSelector && (
-          <div className="p-4 border-b space-y-2 shrink-0">
-            <Label className="text-sm font-medium">Connect on behalf of</Label>
-            <p className="text-xs text-muted-foreground">
-              Choose whether this tool uses a fixed server connection or
-              resolves credentials for the current caller at runtime.
-            </p>
-            <TokenSelect
-              catalogId={catalogItem.id}
-              assignmentScope={assignmentScope}
-              assignmentTeamIds={assignmentTeamIds}
-              value={selectedCredential}
-              onValueChange={setSelectedCredential}
-              shouldSetDefaultValue={false}
-              prefersEnterpriseManaged={prefersEnterpriseManaged}
-            />
-          </div>
-        )}
-
-        {/* Tool Checklist */}
-        {isLoadingTools ? (
-          <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            <span>Loading tools...</span>
-          </div>
-        ) : totalCount === 0 ? (
-          <div className="p-4 text-sm text-muted-foreground">
-            No tools available for this server.
-          </div>
-        ) : (
-          <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-            <ToolChecklist
-              tools={allTools}
-              selectedToolIds={selectedToolIds}
-              onSelectionChange={(ids) => {
-                setSelectedToolIds(ids);
-                setChangedInSession(true);
-              }}
-            />
-          </div>
-        )}
-
-        {changedInSession && (
-          <div className="p-2 border-t shrink-0">
-            <Button size="sm" className="w-full" onClick={() => setOpen(false)}>
-              OK
-            </Button>
-          </div>
-        )}
-      </PopoverContent>
-    </Popover>
+      )}
+    </McpServerPillShell>
   );
 }
 

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -238,7 +238,6 @@ export function AppSettingsForm({
                 environmentId={environmentId}
                 selectedToolIds={selectedToolIds}
                 onSelectionChange={setSelectedToolIds}
-                unbounded
               />
             </div>
           </>

--- a/platform/frontend/src/components/mcp-server-pill-shell.tsx
+++ b/platform/frontend/src/components/mcp-server-pill-shell.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Pencil, X } from "lucide-react";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { CatalogDocsLink } from "./catalog-docs-link";
+
+interface McpServerPillShellProps {
+  /** Rendered inside the pill trigger, e.g. an `<McpCatalogIcon />`. */
+  icon: React.ReactNode;
+  displayName: string;
+  /** Number shown in the pill as `(count)`. */
+  count: number;
+  /** No tools selected: the pill goes dashed and grows an adjacent remove button. */
+  isEmpty: boolean;
+  /** Draws the primary border to mark unsaved/pending selection. */
+  highlighted?: boolean;
+  /** Muted qualifier shown after the count, e.g. an out-of-environment flag. */
+  note?: string;
+  description?: string | null;
+  docsUrl?: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRemove: () => void;
+  removeAriaLabel?: string;
+  triggerTestId?: string;
+  /** The popover body below the header (e.g. a `ToolChecklist`). */
+  children: React.ReactNode;
+}
+
+/**
+ * The visual chrome shared by every MCP-server pill — the trigger button, the
+ * empty/remove affordance, and the popover header. Callers own the popover body
+ * (passed as children) and all data/state, so the agent and app tool editors
+ * render an identical pill without sharing their (incompatible) data wiring.
+ */
+export function McpServerPillShell({
+  icon,
+  displayName,
+  count,
+  isEmpty,
+  highlighted,
+  note,
+  description,
+  docsUrl,
+  open,
+  onOpenChange,
+  onRemove,
+  removeAriaLabel,
+  triggerTestId,
+  children,
+}: McpServerPillShellProps) {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange} modal>
+      <div className="flex items-center">
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn(
+              "h-8 px-3 gap-1.5 text-xs",
+              isEmpty && "border-dashed opacity-50",
+              isEmpty && "rounded-r-none border-r-0",
+              highlighted && "border-primary opacity-100",
+            )}
+            data-testid={triggerTestId}
+          >
+            {icon}
+            <span className="font-medium">{displayName}</span>
+            <span className="text-muted-foreground">({count})</span>
+            {note ? (
+              <span className="shrink-0 font-normal text-muted-foreground">
+                {note}
+              </span>
+            ) : null}
+            <Pencil className="h-3 w-3 shrink-0 text-muted-foreground" />
+          </Button>
+        </PopoverTrigger>
+        {isEmpty && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 w-8 p-0 rounded-l-none border-dashed opacity-50 hover:opacity-100"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            aria-label={removeAriaLabel ?? `Remove ${displayName}`}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+      <PopoverContent
+        className="w-[420px] max-h-[min(500px,var(--radix-popover-content-available-height))] p-0 flex flex-col overflow-hidden"
+        side="bottom"
+        align="start"
+        sideOffset={8}
+        avoidCollisions
+        collisionPadding={16}
+      >
+        <div className="p-4 border-b flex items-start justify-between gap-2 shrink-0">
+          <div>
+            <h4 className="font-semibold">{displayName}</h4>
+            {description && (
+              <p className="text-sm text-muted-foreground mt-1">
+                {description}
+                {docsUrl ? (
+                  <>
+                    {" "}
+                    <CatalogDocsLink
+                      url={docsUrl}
+                      className="inline-flex items-center gap-1 text-primary hover:underline"
+                    />
+                  </>
+                ) : null}
+              </p>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 shrink-0"
+            onClick={() => onOpenChange(false)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/platform/frontend/src/components/mcp-server-pill-shell.tsx
+++ b/platform/frontend/src/components/mcp-server-pill-shell.tsx
@@ -61,6 +61,7 @@ export function McpServerPillShell({
       <div className="flex items-center">
         <PopoverTrigger asChild>
           <Button
+            type="button"
             variant="outline"
             size="sm"
             className={cn(
@@ -84,6 +85,7 @@ export function McpServerPillShell({
         </PopoverTrigger>
         {isEmpty && (
           <Button
+            type="button"
             variant="outline"
             size="sm"
             className="h-8 w-8 p-0 rounded-l-none border-dashed opacity-50 hover:opacity-100"
@@ -124,10 +126,12 @@ export function McpServerPillShell({
             )}
           </div>
           <Button
+            type="button"
             variant="ghost"
             size="sm"
             className="h-6 w-6 p-0 shrink-0"
             onClick={() => onOpenChange(false)}
+            aria-label="Close"
           >
             <X className="h-4 w-4" />
           </Button>


### PR DESCRIPTION
## Summary

The **App settings** dialog and the **Edit MCP Gateway** dialog both let a user pick which MCP tools a resource can call, but App settings used a separate vertical-accordion UI while the gateway uses a row of server **pills** + a dashed **"+ Add"** combobox. This aligns App settings to the gateway's selector so the two surfaces look and behave the same.

User-visible: the App-settings **Tools** section now shows one pill per MCP server (`icon · name · (count) · pencil`); clicking a pill opens a popover with that server's tool checklist (Select All / Deselect All, a search box past 5 tools, per-tool checkboxes). A dashed **"+ Add"** opens a searchable server list; adding a server pre-selects its tools. Assignments outside the app's bound environment are still flagged "(outside this environment)".

Rather than copy the gateway's pill markup (which would drift), the pill chrome — trigger button, empty/remove affordance, and popover header — is extracted into a shared `McpServerPillShell` that both the gateway (`AgentToolsEditor`) and the app editor (`AppToolsEditor`) render, each keeping its own data wiring. The apps-side contract is unchanged: the staged App-settings form and the live MCP-registry-beta Tools tab both keep the `Set<string>` + `onSelectionChange` selection model and dynamic-credential assignment. Adding a server pre-selects all its tools only in the staged form; the live editor leaves them unselected so a single add never fires a burst of assignments.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>