### PR TITLE
fix(frontend): clarify the virtual key owner picker and fix its width

### DIFF
--- a/platform/frontend/src/app/llm/credentials/oauth-clients/page.tsx
+++ b/platform/frontend/src/app/llm/credentials/oauth-clients/page.tsx
@@ -498,6 +498,14 @@ function CreateOAuthClientDialog({
 
           <GrantTypeField value={grantType} onChange={setGrantType} />
 
+          <OauthClientVisibilityField
+            resource="llmOauthClient"
+            scope={scope}
+            onScopeChange={setScope}
+            teamIds={teamIds}
+            onTeamIdsChange={setTeamIds}
+          />
+
           {isAuthorizationCode ? (
             <>
               <RedirectUrisField
@@ -533,14 +541,6 @@ function CreateOAuthClientDialog({
               />
             </>
           )}
-
-          <OauthClientVisibilityField
-            resource="llmOauthClient"
-            scope={scope}
-            onScopeChange={setScope}
-            teamIds={teamIds}
-            onTeamIdsChange={setTeamIds}
-          />
         </DialogBody>
         <DialogStickyFooter>
           <Button
@@ -646,6 +646,15 @@ function EditOAuthClientDialog({
             />
           </div>
 
+          <OauthClientVisibilityField
+            resource="llmOauthClient"
+            scope={scope}
+            onScopeChange={setScope}
+            teamIds={teamIds}
+            onTeamIdsChange={setTeamIds}
+            initialScope={oauthClient?.scope}
+          />
+
           {isAuthorizationCode ? (
             <>
               <RedirectUrisField
@@ -681,15 +690,6 @@ function EditOAuthClientDialog({
               />
             </>
           )}
-
-          <OauthClientVisibilityField
-            resource="llmOauthClient"
-            scope={scope}
-            onScopeChange={setScope}
-            teamIds={teamIds}
-            onTeamIdsChange={setTeamIds}
-            initialScope={oauthClient?.scope}
-          />
         </DialogBody>
         <DialogStickyFooter>
           <Button

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/owner-select-field.test.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/owner-select-field.test.tsx
@@ -6,7 +6,9 @@ const useMembersPaginated = vi.fn();
 
 // Stable reference, like the real TanStack Query session, so the component's
 // accumulator effect doesn't re-run every render.
-const mockSession = { data: { user: { id: "u-self" } } };
+const mockSession = {
+  data: { user: { id: "u-self", email: "self@example.com" } },
+};
 
 vi.mock("@/lib/auth/auth.query");
 
@@ -49,12 +51,15 @@ describe("OwnerSelectField", () => {
     });
   });
 
-  it("excludes the signed-in user from the options", async () => {
+  it("lists the signed-in user as 'Yourself' instead of their member entry", async () => {
     const user = userEvent.setup();
     render(<OwnerSelectField value="" onChange={vi.fn()} />);
 
     await user.click(screen.getByRole("combobox"));
 
+    expect(
+      screen.getByRole("button", { name: /Yourself/i }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Alice Anderson/i }),
     ).toBeInTheDocument();
@@ -64,12 +69,19 @@ describe("OwnerSelectField", () => {
     expect(
       screen.queryByRole("button", { name: /Self Admin/i }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("self@example.com")).not.toBeInTheDocument();
   });
 
-  it("defaults to a 'Yourself' label when nothing is selected", () => {
+  it("shows 'Yourself' as the selected owner when nothing is picked", () => {
     render(<OwnerSelectField value="" onChange={vi.fn()} />);
     expect(screen.getByRole("combobox")).toHaveTextContent("Yourself");
+  });
+
+  it("explains what the field is for", () => {
+    render(<OwnerSelectField value="" onChange={vi.fn()} />);
+    expect(screen.getByText("Key owner")).toBeInTheDocument();
+    expect(
+      screen.getByText(/on behalf of another member/i),
+    ).toBeInTheDocument();
   });
 
   it("reports the picked user's id via onChange", async () => {
@@ -81,6 +93,17 @@ describe("OwnerSelectField", () => {
     await user.click(screen.getByRole("button", { name: /Bob Brown/i }));
 
     expect(onChange).toHaveBeenCalledWith("u-b");
+  });
+
+  it("resets to an empty owner when 'Yourself' is re-picked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<OwnerSelectField value="u-b" onChange={onChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("button", { name: /Yourself/i }));
+
+    expect(onChange).toHaveBeenCalledWith("");
   });
 
   it("drives a server-side member query as the user types", async () => {

--- a/platform/frontend/src/app/llm/credentials/virtual-keys/owner-select-field.tsx
+++ b/platform/frontend/src/app/llm/credentials/virtual-keys/owner-select-field.tsx
@@ -11,7 +11,7 @@ import { useDebouncedValue } from "@/lib/hooks/use-debounced-value";
 import { useMembersPaginated } from "@/lib/member.query";
 
 /**
- * Whether the admin-only "Person" owner picker applies: only admins, and only
+ * Whether the admin-only "Key owner" picker applies: only admins, and only
  * for personal-scope keys. Used both to render the field and to decide whether
  * to send an ownerId on create.
  */
@@ -40,7 +40,7 @@ export function OwnerSelectField({
 
   // Accumulate every other member we've seen so a chosen owner stays
   // selectable even when a later search filters them out. The signed-in user
-  // is excluded — picking yourself is the default (an empty selection).
+  // is listed as a pinned "Yourself" option instead of their member entry.
   const [knownUsers, setKnownUsers] = useState<
     Record<string, UserSelectOption>
   >({});
@@ -60,19 +60,35 @@ export function OwnerSelectField({
     });
   }, [membersData, session?.user?.id]);
 
-  const users = useMemo(() => Object.values(knownUsers), [knownUsers]);
+  const selfId = session?.user?.id ?? "";
+  const selfEmail = session?.user?.email ?? null;
+  const users = useMemo(() => {
+    const others = Object.values(knownUsers);
+    if (!selfId) {
+      return others;
+    }
+    // "Yourself" stays at the top so the default owner is an explicit,
+    // re-selectable choice rather than only an empty placeholder.
+    return [{ userId: selfId, name: "Yourself", email: selfEmail }, ...others];
+  }, [knownUsers, selfId, selfEmail]);
 
   return (
     <div className="space-y-2">
-      <Label>Person</Label>
+      <div className="space-y-1">
+        <Label>Key owner</Label>
+        <p className="text-xs text-muted-foreground">
+          Create this key on behalf of another member — it becomes their
+          personal key to view and manage.
+        </p>
+      </div>
       <UserSearchableSelect
-        value={value}
-        onValueChange={onChange}
+        className="w-full"
+        value={value || selfId}
+        onValueChange={(userId) => onChange(userId === selfId ? "" : userId)}
         users={users}
         placeholder="Yourself"
         onSearchQueryChange={setSearch}
         emptyMessage={isSearching ? "Searching…" : "No matching users found."}
-        hint="Pick a user to create this key on their behalf. Leave empty to own it yourself."
       />
     </div>
   );

--- a/platform/frontend/src/components/proxy-auth-provider-key-fields.tsx
+++ b/platform/frontend/src/components/proxy-auth-provider-key-fields.tsx
@@ -28,9 +28,9 @@ export function ProviderKeyAccessFields({
       <div className="space-y-1">
         <h3 className="text-sm font-semibold">Provider Keys</h3>
         <p className="text-sm text-muted-foreground">
-          Map one or more Model Provider keys this credential can use.
-          Provider-specific proxy routes use the matching provider key, and
-          Model Router requests use the provider prefix in the requested model.{" "}
+          Choose which provider API keys this credential can use. Each request
+          uses the key matching its provider — from the proxy route, or the
+          model&apos;s provider prefix for Model Router requests.{" "}
           <a
             href={docsUrl}
             target="_blank"

--- a/platform/frontend/src/components/proxy-auth-provider-key-fields.tsx
+++ b/platform/frontend/src/components/proxy-auth-provider-key-fields.tsx
@@ -6,7 +6,7 @@ import {
   type ProviderApiKeyMap,
   ProviderKeyMappingsField,
 } from "@/components/provider-key-mappings-field";
-import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 
 export function ProviderKeyAccessFields({
   providerApiKeyIds,
@@ -23,9 +23,10 @@ export function ProviderKeyAccessFields({
   );
 
   return (
-    <div className="space-y-4 rounded-md border p-4">
+    <div className="space-y-4">
+      <Separator />
       <div className="space-y-1">
-        <Label className="font-medium">Provider Keys</Label>
+        <h3 className="text-sm font-semibold">Provider Keys</h3>
         <p className="text-sm text-muted-foreground">
           Map one or more Model Provider keys this credential can use.
           Provider-specific proxy routes use the matching provider key, and


### PR DESCRIPTION
## Summary

The admin-only **"Person"** field in the Create Virtual API Key dialog was confusing: the label didn't say what the field was for (its explanation was buried inside the select popover), and the control rendered at the `SearchableSelect` default 200px width — which also made the popover narrow and truncated its search placeholder.

### Changes

- Renamed the label to **"Key owner"** and moved the explanation out of the popover into visible helper text under the label: *"Create this key on behalf of another member — it becomes their personal key to view and manage."*
- Made the select **full width** like the dialog's other fields; since the popover matches the trigger width, this fixes the narrow/funky dropdown as well
- The signed-in admin is now listed as an explicit, pinned **"Yourself"** option (previously only an empty placeholder), so after picking another member the choice is reversible — re-picking "Yourself" resets the owner. The external contract is unchanged: an empty value still means "own it yourself" and no `ownerId` is sent

### Before / after

| Before | After |
| --- | --- |
| Label "Person" with no visible explanation; 200px trigger; narrow popover with the hint wedged between the search bar and the list | Label "Key owner" with helper text; full-width trigger and popover; "Yourself" is a real, checked option |