### PR TITLE
fix(auth): configurable cookie prefix so parallel local stacks don't clobber sessions

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -937,6 +937,11 @@ My Files is the persistent byte-storage layer used by Projects and the `search_f
   - Example: If frontend is at `https://frontend.example.com`, set to `example.com`
   - Required when using different domains or subdomains for frontend and backend
 
+- **`ARCHESTRA_AUTH_COOKIE_PREFIX`** - Prefix for auth cookie names (`<prefix>.session_token`, etc.).
+  - Default: `archestra`
+  - Browsers scope cookies to the host without the port, so multiple Archestra instances on different ports of the same host overwrite each other's session cookies. Give each instance a unique prefix to keep their sessions independent.
+  - Mainly useful for local development with parallel stacks; single-instance deployments can leave the default
+
 - **`ARCHESTRA_AUTH_DISABLE_BASIC_AUTH`** - Hides the username/password login form on the sign-in page.
   - Default: `false`
   - Set to `true` to disable basic authentication and require users to authenticate via SSO only

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -129,6 +129,13 @@ ARCHESTRA_FRONTEND_URL=http://localhost:3000
 # Should be set to the domain of the ARCHESTRA_FRONTEND_URL, e.g. "example.com"
 ARCHESTRA_AUTH_COOKIE_DOMAIN=""
 
+# Cookie name prefix for auth cookies (default "archestra"). Set a unique value
+# per instance when running several Archestra stacks on different localhost
+# ports, so their session cookies don't overwrite each other (browsers scope
+# cookies to the host without the port). scripts/dev-stack.sh sets this
+# automatically for parallel stacks.
+# ARCHESTRA_AUTH_COOKIE_PREFIX="archestra"
+
 # Analytics configuration for PostHog. Governs frontend product analytics +
 # session replay, backend instance heartbeats, and backend error tracking
 # (5xx exceptions + preceding logs sent to PostHog Error Tracking).

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -58,7 +58,12 @@ const APP_NAME = DEFAULT_APP_NAME;
 const {
   api: { apiKeyAuthorizationHeaderName },
   frontendBaseUrl,
-  auth: { secret, cookieDomain, trustedOrigins: staticTrustedOrigins },
+  auth: {
+    secret,
+    cookieDomain,
+    cookiePrefix,
+    trustedOrigins: staticTrustedOrigins,
+  },
 } = config;
 
 const ac = createAccessControl(allAvailableActions);
@@ -308,7 +313,7 @@ export const auth = betterAuth({
   },
 
   advanced: {
-    cookiePrefix: "archestra",
+    cookiePrefix,
     defaultCookieAttributes: {
       ...(cookieDomain ? { domain: cookieDomain } : {}),
       // "lax" is required for OAuth/SSO flows because the callback is a cross-site top-level navigation

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1149,6 +1149,14 @@ const config = {
       process.env[DEFAULT_ADMIN_PASSWORD_ENV_VAR_NAME] ||
       DEFAULT_ADMIN_PASSWORD,
     cookieDomain: process.env.ARCHESTRA_AUTH_COOKIE_DOMAIN,
+    /**
+     * Prefix for auth cookie names (`<prefix>.session_token` etc.). Browsers
+     * scope cookies to the host without the port, so parallel local instances
+     * on different localhost ports clobber each other's sessions unless each
+     * uses a distinct prefix.
+     */
+    cookiePrefix:
+      process.env.ARCHESTRA_AUTH_COOKIE_PREFIX?.trim() || "archestra",
     disableBasicAuth: process.env.ARCHESTRA_AUTH_DISABLE_BASIC_AUTH === "true",
     disableInvitations:
       process.env.ARCHESTRA_AUTH_DISABLE_INVITATIONS === "true",

--- a/platform/scripts/dev-stack.sh
+++ b/platform/scripts/dev-stack.sh
@@ -153,6 +153,9 @@ EOF
   # ARCHESTRA_INTERNAL_API_BASE_URL it mirrors: Tiltfile.dev's sync only fills
   # NEXT_PUBLIC_* when the file doesn't already set it, so leaving an inherited
   # value in place would point the parallel frontend at the main backend.
+  # ARCHESTRA_AUTH_COOKIE_PREFIX gets the namespace so this stack's session
+  # cookies don't clobber other localhost stacks' (browsers ignore the port
+  # when scoping cookies, and every stack otherwise uses the same names).
   ARCHESTRA_DATABASE_URL="postgresql://archestra:archestra_dev_password@localhost:${pg_port}/archestra_dev?schema=public" \
   ARCHESTRA_INTERNAL_API_BASE_URL="http://localhost:${backend_port}" \
   NEXT_PUBLIC_ARCHESTRA_INTERNAL_API_BASE_URL="http://localhost:${backend_port}" \
@@ -165,6 +168,7 @@ EOF
   ARCHESTRA_FRONTEND_PORT="$frontend_port" \
   ARCHESTRA_FRONTEND_INT_TESTS_PORT="$int_tests_port" \
   ARCHESTRA_TILT_PORT="$tilt_port" \
+  ARCHESTRA_AUTH_COOKIE_PREFIX="$namespace" \
   python3 - "$env_file" <<'PYEOF'
 import os, re, sys
 keys = [
@@ -180,6 +184,7 @@ keys = [
   "ARCHESTRA_FRONTEND_PORT",
   "ARCHESTRA_FRONTEND_INT_TESTS_PORT",
   "ARCHESTRA_TILT_PORT",
+  "ARCHESTRA_AUTH_COOKIE_PREFIX",
 ]
 overrides = {k: os.environ[k] for k in keys}
 path = sys.argv[1]


### PR DESCRIPTION
Browsers scope cookies to the host without the port, so multiple Archestra instances on different localhost ports overwrite each other's `archestra.*` session cookies — logging into one stack logs you out of the others.

- Add `ARCHESTRA_AUTH_COOKIE_PREFIX` (default `archestra`), consumed in `config.ts` and passed to Better Auth's `cookiePrefix`.
- `dev-stack.sh` sets it to the stack's namespace, so parallel worktree stacks get isolated cookie namespaces automatically.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>