### PR TITLE
fix(apps): make the `hidden` attribute reliably hide in sandboxed apps

### DIFF
--- a/platform/backend/src/static/archestra-app-base.css
+++ b/platform/backend/src/static/archestra-app-base.css
@@ -55,9 +55,12 @@
  * which any app rule that sets `display` on the same element silently overrides —
  * a common footgun that leaves a modal (or any toggled element) stuck visible.
  * `!important` here deliberately breaks the usual "app CSS overrides the base"
- * rule for this one property so the attribute always hides. Apps toggle
- * visibility by adding/removing `hidden` (or a class), never by fighting display. */
-[hidden] {
+ * rule for this one property so ordinary app `display:` no longer defeats the
+ * attribute (an app that fights back with its own `!important` still can). Apps
+ * toggle visibility by adding/removing `hidden` (or a class), not fighting display.
+ * `hidden="until-found"` is excluded: it must stay in layout (styled by the UA as
+ * `content-visibility: hidden`) so find-in-page / scroll-to-text can reveal it. */
+[hidden]:not([hidden="until-found"]) {
   display: none !important;
 }
 

--- a/platform/backend/src/static/archestra-app-base.css
+++ b/platform/backend/src/static/archestra-app-base.css
@@ -51,6 +51,16 @@
   box-sizing: border-box;
 }
 
+/* The `hidden` attribute is styled by the UA sheet (`[hidden] { display: none }`),
+ * which any app rule that sets `display` on the same element silently overrides —
+ * a common footgun that leaves a modal (or any toggled element) stuck visible.
+ * `!important` here deliberately breaks the usual "app CSS overrides the base"
+ * rule for this one property so the attribute always hides. Apps toggle
+ * visibility by adding/removing `hidden` (or a class), never by fighting display. */
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   padding: 1.5rem;

--- a/platform/backend/src/static/archestra-app-sdk.js
+++ b/platform/backend/src/static/archestra-app-sdk.js
@@ -171,10 +171,7 @@
   // ordinary case; this is the backstop for what slips past it — an app that
   // beats the reset with its own `!important`, or a render where the base sheet
   // never loaded. Such a render throws nothing and violates no CSP, so only a DOM
-  // check catches it before validate_app reports "clean". Scans the initial
-  // render: static markup plus anything the app's own `ready.then` handler
-  // painted synchronously (that runs before the frame below, since the SDK
-  // registers this handler first).
+  // check catches it before validate_app reports "clean".
   const reportHiddenOverridden = () => {
     try {
       const offenders = [];
@@ -204,17 +201,24 @@
       // render lint is best-effort; never surface a failure to the app
     }
   };
-  // Two frames after the handshake: late enough that layout is settled (so
-  // getClientRects is meaningful), but before the host's render-settle snapshot
-  // post (~1.5s after the iframe mounts), so a broken render reaches validate_app
-  // instead of being masked by an earlier clean snapshot.
-  ready
-    .then(() => {
-      requestAnimationFrame(() =>
-        requestAnimationFrame(reportHiddenOverridden),
-      );
-    })
-    .catch(() => {});
+  // Scan the DOM twice (the host dedupes): once as soon as the initial markup is
+  // parsed and laid out, and once after the handshake so anything the app's own
+  // `ready.then` handler painted is covered too. The first scan does NOT wait for
+  // `ready` on purpose — posting is a raw postMessage the host records regardless
+  // of the handshake, so scanning at DOMContentLoaded lands the diagnostic before
+  // the host's ~1.5s render-settle snapshot; waiting for a slow handshake would
+  // let that clean snapshot win and mask a statically-broken render from
+  // validate_app. The two rAFs let layout settle before getBoundingClientRect.
+  const scheduleHiddenCheck = () =>
+    requestAnimationFrame(() => requestAnimationFrame(reportHiddenOverridden));
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", scheduleHiddenCheck, {
+      once: true,
+    });
+  } else {
+    scheduleHiddenCheck();
+  }
+  ready.then(scheduleHiddenCheck).catch(() => {});
 
   // A connect that neither resolves nor rejects means the host accepted our
   // postMessage but never answered ui/initialize — its sandbox doesn't relay to

--- a/platform/backend/src/static/archestra-app-sdk.js
+++ b/platform/backend/src/static/archestra-app-sdk.js
@@ -165,12 +165,16 @@
   // app never awaits ready
   ready.catch(() => {});
 
-  // Render lint: an element carrying the `hidden` attribute that still paints
-  // means an app CSS rule is overriding the UA `[hidden] { display: none }` (the
-  // base sheet's `!important` reset normally prevents this) — a modal or toggled
-  // element stuck visible. It throws nothing and violates no CSP, so only a DOM
-  // check catches it. One pass after the handshake + a paint beat, mirroring the
-  // screenshot timing, so async-first-render apps are covered too.
+  // Render lint: an element carrying the `hidden` attribute that still occupies
+  // a visible box means a CSS rule is overriding `hidden`, leaving a modal or
+  // toggled element stuck visible. The base sheet's `[hidden]` reset prevents the
+  // ordinary case; this is the backstop for what slips past it — an app that
+  // beats the reset with its own `!important`, or a render where the base sheet
+  // never loaded. Such a render throws nothing and violates no CSP, so only a DOM
+  // check catches it before validate_app reports "clean". Scans the initial
+  // render: static markup plus anything the app's own `ready.then` handler
+  // painted synchronously (that runs before the frame below, since the SDK
+  // registers this handler first).
   const reportHiddenOverridden = () => {
     try {
       const offenders = [];
@@ -178,7 +182,10 @@
         // `hidden="until-found"` is intentionally in the layout (find-in-page),
         // so it is not an override; only the boolean form should stay unpainted.
         if (el.getAttribute("hidden") === "until-found") continue;
-        if (el.getClientRects().length === 0) continue;
+        // A visible box, not merely a layout box: a collapsed element (height:0,
+        // an app's own animation/disclosure state) is not "stuck visible".
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) continue;
         const id = el.id ? "#" + el.id : "";
         const cls = el.classList.length ? "." + [...el.classList].join(".") : "";
         offenders.push(el.tagName.toLowerCase() + id + cls);
@@ -197,9 +204,15 @@
       // render lint is best-effort; never surface a failure to the app
     }
   };
+  // Two frames after the handshake: late enough that layout is settled (so
+  // getClientRects is meaningful), but before the host's render-settle snapshot
+  // post (~1.5s after the iframe mounts), so a broken render reaches validate_app
+  // instead of being masked by an earlier clean snapshot.
   ready
     .then(() => {
-      setTimeout(reportHiddenOverridden, 1500);
+      requestAnimationFrame(() =>
+        requestAnimationFrame(reportHiddenOverridden),
+      );
     })
     .catch(() => {});
 

--- a/platform/backend/src/static/archestra-app-sdk.js
+++ b/platform/backend/src/static/archestra-app-sdk.js
@@ -215,14 +215,18 @@
   // validate_app. The two rAFs let layout settle before getBoundingClientRect.
   const scheduleHiddenCheck = () =>
     requestAnimationFrame(() => requestAnimationFrame(reportHiddenOverridden));
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", scheduleHiddenCheck, {
-      once: true,
-    });
-  } else {
-    scheduleHiddenCheck();
+  // Guarded for non-browser hosts (e.g. the SDK's own Node unit tests run it
+  // against a minimal window with no `document`).
+  if (typeof document !== "undefined") {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", scheduleHiddenCheck, {
+        once: true,
+      });
+    } else {
+      scheduleHiddenCheck();
+    }
+    ready.then(scheduleHiddenCheck).catch(() => {});
   }
-  ready.then(scheduleHiddenCheck).catch(() => {});
 
   // A connect that neither resolves nor rejects means the host accepted our
   // postMessage but never answered ui/initialize — its sandbox doesn't relay to

--- a/platform/backend/src/static/archestra-app-sdk.js
+++ b/platform/backend/src/static/archestra-app-sdk.js
@@ -189,11 +189,15 @@
         if (offenders.length >= 5) break;
       }
       if (offenders.length > 0) {
+        // `render-check` is the general channel for proactive render-correctness
+        // checks; the specific check is named in brackets so the model — and the
+        // host's dedup, keyed on the message prefix — can tell them apart. A new
+        // check posts here rather than minting its own diagnostic type.
         postDiagnostic(
-          "hidden-overridden",
-          "Element(s) with the `hidden` attribute are still rendered — a CSS rule " +
-            "(e.g. `display:` on the element) is overriding `hidden`, leaving them " +
-            "stuck visible: " +
+          "render-check",
+          "[hidden-overridden] Element(s) with the `hidden` attribute are still " +
+            "rendered — a CSS rule (e.g. `display:` on the element) is overriding " +
+            "`hidden`, leaving them stuck visible: " +
             offenders.join(", "),
         );
       }

--- a/platform/backend/src/static/archestra-app-sdk.js
+++ b/platform/backend/src/static/archestra-app-sdk.js
@@ -165,6 +165,44 @@
   // app never awaits ready
   ready.catch(() => {});
 
+  // Render lint: an element carrying the `hidden` attribute that still paints
+  // means an app CSS rule is overriding the UA `[hidden] { display: none }` (the
+  // base sheet's `!important` reset normally prevents this) — a modal or toggled
+  // element stuck visible. It throws nothing and violates no CSP, so only a DOM
+  // check catches it. One pass after the handshake + a paint beat, mirroring the
+  // screenshot timing, so async-first-render apps are covered too.
+  const reportHiddenOverridden = () => {
+    try {
+      const offenders = [];
+      for (const el of document.querySelectorAll("[hidden]")) {
+        // `hidden="until-found"` is intentionally in the layout (find-in-page),
+        // so it is not an override; only the boolean form should stay unpainted.
+        if (el.getAttribute("hidden") === "until-found") continue;
+        if (el.getClientRects().length === 0) continue;
+        const id = el.id ? "#" + el.id : "";
+        const cls = el.classList.length ? "." + [...el.classList].join(".") : "";
+        offenders.push(el.tagName.toLowerCase() + id + cls);
+        if (offenders.length >= 5) break;
+      }
+      if (offenders.length > 0) {
+        postDiagnostic(
+          "hidden-overridden",
+          "Element(s) with the `hidden` attribute are still rendered — a CSS rule " +
+            "(e.g. `display:` on the element) is overriding `hidden`, leaving them " +
+            "stuck visible: " +
+            offenders.join(", "),
+        );
+      }
+    } catch {
+      // render lint is best-effort; never surface a failure to the app
+    }
+  };
+  ready
+    .then(() => {
+      setTimeout(reportHiddenOverridden, 1500);
+    })
+    .catch(() => {});
+
   // A connect that neither resolves nor rejects means the host accepted our
   // postMessage but never answered ui/initialize — its sandbox doesn't relay to
   // an MCP-Apps bridge (a wrapper/proxy frame, or a non-conformant host). That

--- a/platform/e2e-tests/tests/apps.spec.ts
+++ b/platform/e2e-tests/tests/apps.spec.ts
@@ -113,6 +113,98 @@ test("create an app from a template and run it standalone", async ({
   }
 });
 
+// Two `hidden` elements, both with a display override. `#reset-hides` uses an
+// ordinary rule the injected base sheet's `[hidden]` reset must still beat;
+// `#stuck-visible` fights back with `!important` and stays painted — the footgun
+// the SDK render lint is the backstop for. The lint must flag only the latter.
+const HIDDEN_LINT_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>e2e hidden lint probe</title>
+<style>
+  #reset-hides { display: flex; position: fixed; inset: 0; }
+  #stuck-visible { display: flex !important; position: fixed; inset: 0; }
+</style></head>
+<body>
+  <div id="reset-hides" hidden>the base reset must hide this</div>
+  <div id="stuck-visible" hidden>stuck visible despite the hidden attribute</div>
+  <p id="status">loading…</p>
+  <script>
+    window.archestra.ready.then(() => {
+      document.getElementById("status").textContent = "Ready.";
+    });
+  </script>
+</body>
+</html>`;
+
+test("the render lint flags a hidden element an app override left visible", async ({
+  page,
+  request,
+  makeApiRequest,
+}) => {
+  await page.addInitScript(() => {
+    const w = window as unknown as { __appDiagnostics: unknown[] };
+    w.__appDiagnostics = [];
+    window.addEventListener("message", (event) => {
+      const type = (event.data as { type?: string } | null)?.type;
+      if (
+        type === "mcp-apps:runtime-error" ||
+        type === "mcp-apps:csp-violation"
+      ) {
+        w.__appDiagnostics.push(event.data);
+      }
+    });
+  });
+
+  const name = `e2e-app-${Date.now()}`;
+  const createRes = await makeApiRequest({
+    request,
+    method: "post",
+    urlSuffix: "/api/apps",
+    data: { name, scope: "personal" },
+  });
+  const app = (await createRes.json()) as { id: string };
+
+  const hiddenOverridden = () =>
+    page.evaluate(() =>
+      (
+        window as unknown as {
+          __appDiagnostics: { errorType?: string; message?: string }[];
+        }
+      ).__appDiagnostics.filter((d) => d.errorType === "hidden-overridden"),
+    );
+
+  try {
+    const patchRes = await makeApiRequest({
+      request,
+      method: "patch",
+      urlSuffix: `/api/apps/${app.id}`,
+      data: { html: HIDDEN_LINT_HTML },
+    });
+    expect(patchRes.ok()).toBeTruthy();
+
+    await goToPage(page, `/a/${app.id}`);
+    await expect(page).toHaveTitle(name);
+    const appFrame = page.frameLocator("iframe").frameLocator("iframe");
+    await expect(appFrame.getByText("Ready.")).toBeVisible({ timeout: 20_000 });
+
+    // The lint runs a couple frames after the handshake, so poll until it forwards.
+    await expect.poll(hiddenOverridden, { timeout: 10_000 }).not.toEqual([]);
+    const lint = await hiddenOverridden();
+    // Only the `!important` override is stuck visible; the reset-hidden element
+    // must not be flagged.
+    expect(lint).toHaveLength(1);
+    expect(lint[0].message).toContain("stuck-visible");
+    expect(lint[0].message).not.toContain("reset-hides");
+  } finally {
+    await makeApiRequest({
+      request,
+      method: "delete",
+      urlSuffix: `/api/apps/${app.id}`,
+      ignoreStatusCheck: true,
+    });
+  }
+});
+
 // Probe for the `archestra.tools.call` unwrapping contract: the fixture tool
 // returns `{"tasks":[...]}` serialized into content[0].text, so `call` must
 // resolve with the parsed object (the probe reads `result.tasks.length`

--- a/platform/e2e-tests/tests/apps.spec.ts
+++ b/platform/e2e-tests/tests/apps.spec.ts
@@ -170,7 +170,11 @@ test("the render lint flags a hidden element an app override left visible", asyn
         window as unknown as {
           __appDiagnostics: { errorType?: string; message?: string }[];
         }
-      ).__appDiagnostics.filter((d) => d.errorType === "hidden-overridden"),
+      ).__appDiagnostics.filter(
+        (d) =>
+          d.errorType === "render-check" &&
+          (d.message ?? "").includes("[hidden-overridden]"),
+      ),
     );
 
   try {

--- a/platform/e2e-tests/tests/apps.spec.ts
+++ b/platform/e2e-tests/tests/apps.spec.ts
@@ -164,18 +164,27 @@ test("the render lint flags a hidden element an app override left visible", asyn
   });
   const app = (await createRes.json()) as { id: string };
 
+  // The SDK scans twice by design (at DOMContentLoaded and again after `ready`),
+  // so the raw postMessage stream carries the same diagnostic more than once; the
+  // host store dedups on type+message before it reaches the model. This probe
+  // reads the raw stream, so dedup by message here to assert on the distinct
+  // offender set the store would keep.
   const hiddenOverridden = () =>
-    page.evaluate(() =>
-      (
+    page.evaluate(() => {
+      const seen = new Set<string>();
+      return (
         window as unknown as {
           __appDiagnostics: { errorType?: string; message?: string }[];
         }
-      ).__appDiagnostics.filter(
-        (d) =>
-          d.errorType === "render-check" &&
-          (d.message ?? "").includes("[hidden-overridden]"),
-      ),
-    );
+      ).__appDiagnostics.filter((d) => {
+        if (d.errorType !== "render-check") return false;
+        const message = d.message ?? "";
+        if (!message.includes("[hidden-overridden]")) return false;
+        if (seen.has(message)) return false;
+        seen.add(message);
+        return true;
+      });
+    });
 
   try {
     const patchRes = await makeApiRequest({

--- a/platform/frontend/src/lib/chat/app-diagnostics-store.test.ts
+++ b/platform/frontend/src/lib/chat/app-diagnostics-store.test.ts
@@ -36,17 +36,15 @@ describe("parseForwardedDiagnostic", () => {
     expect(entry).toEqual({ type: errorType, message: "hello from the app" });
   });
 
-  it("accepts the hidden-overridden render lint over the runtime-error lane", () => {
+  it("accepts a render-check diagnostic over the runtime-error lane", () => {
     const entry = parseForwardedDiagnostic({
       type: "mcp-apps:runtime-error",
-      errorType: "hidden-overridden",
-      message:
-        "Element(s) with the `hidden` attribute are still rendered: #modal",
+      errorType: "render-check",
+      message: "[hidden-overridden] #modal is still rendered",
     });
     expect(entry).toEqual({
-      type: "hidden-overridden",
-      message:
-        "Element(s) with the `hidden` attribute are still rendered: #modal",
+      type: "render-check",
+      message: "[hidden-overridden] #modal is still rendered",
     });
   });
 
@@ -125,10 +123,10 @@ describe("diagnostics store", () => {
     expect(getAppDiagnosticCounts().get(APP)).toEqual({ errors: 2, logs: 3 });
   });
 
-  it("counts the hidden-overridden render lint as an error, not a log", () => {
+  it("counts a render-check diagnostic as an error, not a log", () => {
     reportAppDiagnostic(APP, 1, {
-      type: "hidden-overridden",
-      message: "stuck modal: #confirm-modal",
+      type: "render-check",
+      message: "[hidden-overridden] stuck modal: #confirm-modal",
     });
     expect(getAppDiagnosticCounts().get(APP)).toEqual({ errors: 1, logs: 0 });
   });

--- a/platform/frontend/src/lib/chat/app-diagnostics-store.test.ts
+++ b/platform/frontend/src/lib/chat/app-diagnostics-store.test.ts
@@ -36,6 +36,20 @@ describe("parseForwardedDiagnostic", () => {
     expect(entry).toEqual({ type: errorType, message: "hello from the app" });
   });
 
+  it("accepts the hidden-overridden render lint over the runtime-error lane", () => {
+    const entry = parseForwardedDiagnostic({
+      type: "mcp-apps:runtime-error",
+      errorType: "hidden-overridden",
+      message:
+        "Element(s) with the `hidden` attribute are still rendered: #modal",
+    });
+    expect(entry).toEqual({
+      type: "hidden-overridden",
+      message:
+        "Element(s) with the `hidden` attribute are still rendered: #modal",
+    });
+  });
+
   it("maps a CSP violation to a readable message", () => {
     const entry = parseForwardedDiagnostic({
       type: "mcp-apps:csp-violation",
@@ -109,6 +123,14 @@ describe("diagnostics store", () => {
     reportAppDiagnostic(APP, 1, { type: "console.warn", message: "careful" });
     reportAppDiagnostic(APP, 1, { type: "console.info", message: "fyi" });
     expect(getAppDiagnosticCounts().get(APP)).toEqual({ errors: 2, logs: 3 });
+  });
+
+  it("counts the hidden-overridden render lint as an error, not a log", () => {
+    reportAppDiagnostic(APP, 1, {
+      type: "hidden-overridden",
+      message: "stuck modal: #confirm-modal",
+    });
+    expect(getAppDiagnosticCounts().get(APP)).toEqual({ errors: 1, logs: 0 });
   });
 
   it("a newer version resets the collection; a stale mount is ignored", () => {

--- a/platform/frontend/src/lib/chat/app-diagnostics-store.ts
+++ b/platform/frontend/src/lib/chat/app-diagnostics-store.ts
@@ -14,21 +14,23 @@ export type AppDiagnosticType =
   | "unhandledrejection"
   | "console.error"
   | "csp-violation"
-  | "hidden-overridden"
+  | "render-check"
   | "console.log"
   | "console.warn"
   | "console.info";
 
 // Error-class diagnostics signal an actual failure (rendered prominently);
 // the remaining console.{log,warn,info} types are ordinary log output.
-// `hidden-overridden` is the SDK render lint (an element's `hidden` attribute is
-// overridden by app CSS) — a broken render that throws nothing, so it counts.
+// `render-check` is the SDK's proactive render-correctness channel (e.g. a
+// `hidden` element left painted by app CSS) — a broken render that throws
+// nothing. Only objective contract violations post here, since it gates publish;
+// heuristic "looks broken" checks should be advisory, not this class.
 const ERROR_DIAGNOSTIC_TYPES: ReadonlySet<AppDiagnosticType> = new Set([
   "error",
   "unhandledrejection",
   "console.error",
   "csp-violation",
-  "hidden-overridden",
+  "render-check",
 ]);
 
 export function isErrorDiagnostic(type: AppDiagnosticType): boolean {
@@ -57,7 +59,7 @@ const DIAGNOSTIC_TYPES: readonly AppDiagnosticType[] = [
   "unhandledrejection",
   "console.error",
   "csp-violation",
-  "hidden-overridden",
+  "render-check",
   "console.log",
   "console.warn",
   "console.info",

--- a/platform/frontend/src/lib/chat/app-diagnostics-store.ts
+++ b/platform/frontend/src/lib/chat/app-diagnostics-store.ts
@@ -14,17 +14,21 @@ export type AppDiagnosticType =
   | "unhandledrejection"
   | "console.error"
   | "csp-violation"
+  | "hidden-overridden"
   | "console.log"
   | "console.warn"
   | "console.info";
 
 // Error-class diagnostics signal an actual failure (rendered prominently);
 // the remaining console.{log,warn,info} types are ordinary log output.
+// `hidden-overridden` is the SDK render lint (an element's `hidden` attribute is
+// overridden by app CSS) — a broken render that throws nothing, so it counts.
 const ERROR_DIAGNOSTIC_TYPES: ReadonlySet<AppDiagnosticType> = new Set([
   "error",
   "unhandledrejection",
   "console.error",
   "csp-violation",
+  "hidden-overridden",
 ]);
 
 export function isErrorDiagnostic(type: AppDiagnosticType): boolean {
@@ -53,6 +57,7 @@ const DIAGNOSTIC_TYPES: readonly AppDiagnosticType[] = [
   "unhandledrejection",
   "console.error",
   "csp-violation",
+  "hidden-overridden",
   "console.log",
   "console.warn",
   "console.info",


### PR DESCRIPTION
## Problem

A sandboxed app that sets `display:` on an element it also toggles with the HTML `hidden` attribute silently overrides the UA `[hidden]{display:none}` rule — author CSS beats UA by cascade origin. `hidden` becomes inert, leaving modals/toggled elements stuck visible (Cancel/close can't hide them). It throws no JS error and violates no CSP, so `validate_app`'s "live render clean" gate — which only captures runtime errors + CSP violations — passed a fully-broken render.

## Fix

- **Prevent:** `[hidden]:not([hidden="until-found"]){display:none!important}` in the injected `archestra-app-base.css`, so the attribute hides even when an app sets `display:` on the element. `until-found` is exempt (it must stay in layout for find-in-page). Ordinary overrides lose; an app's own `!important` can still win by design.
- **Detect:** an SDK render lint scans for elements still occupying a visible box while carrying `hidden`, and posts a `render-check` diagnostic (check named in the message, `[hidden-overridden] …`) — so the gate/authoring model catches renders that break without throwing. It scans at DOMContentLoaded (before the host's render-settle snapshot, independent of the handshake) and again after `ready` (async content); the host dedupes. `until-found` is exempt; a collapsed `height:0` box is not flagged.

`render-check` is a general channel: new render-correctness checks post here rather than minting a new diagnostic type. Only objective contract violations use it (it gates publish); heuristic "looks broken" checks should be advisory.

## Tests

- Store unit tests: a `render-check` diagnostic parses through the gate and counts as error-class.
- e2e: renders an app whose `!important` override beats the reset and asserts only that element is flagged (the reset-hidden one is not).

## Follow-up

The general "does this render look broken" detector is a vision pass over the render screenshot `get_app_diagnostics` already captures — advisory, not a hard gate. Deferred: #6273

https://claude.ai/code/session_01Nve4Z53CUzaRZ5hTExFdTU