### PR TITLE
fix(apps): serve staging MCP App sandboxes on a dedicated wildcard origin

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -39,6 +39,13 @@ archestra:
     ARCHESTRA_ENTERPRISE_LICENSE_FULL_WHITE_LABELING: "true"
     ARCHESTRA_ENTERPRISE_LICENSE_KNOWLEDGE_BASE_ACTIVATED: "true"
     ARCHESTRA_API_BASE_URL: "https://frontend.archestra.dev,https://backend.archestra.dev"
+    # Dedicated origin for MCP App sandboxes so browser device permissions
+    # (camera/mic/geolocation/clipboard) can be delegated to app iframes. Each
+    # app renders at <hash>.sandbox.archestra.dev (a real cross-origin); without
+    # this, sandboxes fall back to the frontend's opaque origin and browsers
+    # block those features. Requires *.sandbox.archestra.dev DNS + wildcard TLS
+    # + an ingress rule to the frontend service (archestra-ai/infra).
+    ARCHESTRA_MCP_SANDBOX_DOMAIN: "sandbox.archestra.dev"
     ARCHESTRA_GEMINI_VERTEX_AI_ENABLED: "true"
     ARCHESTRA_GEMINI_VERTEX_AI_PROJECT: "friendly-path-465518-r6"
     ARCHESTRA_GEMINI_VERTEX_AI_LOCATION: "us-central1"

--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -43,8 +43,9 @@ archestra:
     # (camera/mic/geolocation/clipboard) can be delegated to app iframes. Each
     # app renders at <hash>.sandbox.archestra.dev (a real cross-origin); without
     # this, sandboxes fall back to the frontend's opaque origin and browsers
-    # block those features. Requires *.sandbox.archestra.dev DNS + wildcard TLS
-    # + an ingress rule to the frontend service (archestra-ai/infra).
+    # block those features. Wildcard DNS + the cert-manager-issued wildcard TLS
+    # secret come from archestra-ai/infra (gke/dns.tf, gke-apps/cert-manager);
+    # the ingress rule + tls entry below route the sandbox hosts to the frontend.
     ARCHESTRA_MCP_SANDBOX_DOMAIN: "sandbox.archestra.dev"
     ARCHESTRA_GEMINI_VERTEX_AI_ENABLED: "true"
     ARCHESTRA_GEMINI_VERTEX_AI_PROJECT: "friendly-path-465518-r6"
@@ -130,6 +131,22 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
+      # MCP App sandbox origins (<hash>.sandbox.archestra.dev) serve the
+      # frontend; its /_sandbox/* Next.js rewrite proxies to the backend.
+      - host: "*.sandbox.archestra.dev"
+        paths:
+          - path: /
+            port: 3000
+            pathType: Prefix
+
+    # Wildcard cert for the sandbox hosts, issued and renewed by cert-manager
+    # (archestra-ai/infra, gke-apps/cert-manager). GKE combines spec.tls
+    # secrets with the ManagedCertificate annotation above. The secret must
+    # exist before this deploys, or ingress-gce fails to sync the Ingress.
+    tls:
+      - hosts:
+          - "*.sandbox.archestra.dev"
+        secretName: archestra-sandbox-wildcard-tls
 
 postgresql:
   # Staging still uses the bundled PostgreSQL chart. This is not HA, but these


### PR DESCRIPTION
## Problem

MCP Apps that declare device permissions (`camera` / `microphone` / `geolocation` / `clipboardWrite`) fail on staging (`frontend.archestra.dev`) with a `SecurityError` when they call the matching browser API (e.g. the **Face Tracker** app's `getUserMedia`).

The `allow` (Permissions-Policy) delegation onto both sandbox iframes is already in place (#6211 / #6212), but powerful features **cannot be delegated to an opaque origin** — the sandbox must run on a *dedicated* origin. Staging sets no sandbox domain, so `getMcpSandboxBaseUrl` (`platform/frontend/src/lib/config/config.ts`) falls into **Mode 3** (production, no domain): the sandbox is served from the frontend's own origin as an opaque origin, and the browser blocks camera/mic/geo regardless of the `allow` attribute.

## Fix (this PR)

`.github/values-staging.yaml` only:

1. **`ARCHESTRA_MCP_SANDBOX_DOMAIN: "sandbox.archestra.dev"`** — switches the frontend to **Mode 1**: each app sandbox is served at `https://<hash>.sandbox.archestra.dev` (a real cross-origin), so the delegated permissions take effect and the browser can prompt for consent.
2. **Ingress host rule** `*.sandbox.archestra.dev` → frontend service (port 3000). The `/_sandbox/*` path is proxied to the backend by the existing Next.js rewrite.
3. **Ingress `spec.tls`** referencing the wildcard secret `archestra-sandbox-wildcard-tls`. GKE combines self-managed `spec.tls` secrets with the existing `ManagedCertificate` annotation, so the frontend/backend certs are untouched.

## Infra prerequisite — ✅ done (archestra-ai/infra#20, merged & applied)

Everything this PR consumes is already live on staging:

- **Wildcard DNS**: `*.sandbox.archestra.dev` → the staging ingress static IP (`34.160.184.91`) — verified resolving.
- **Wildcard TLS**: new `gke-apps/cert-manager` module — cert-manager + Let's Encrypt DNS-01 via Cloud DNS (Workload Identity, no SA keys). The `archestra-sandbox-wildcard-tls` secret exists in the `archestra` namespace: `Certificate` is `Ready=True`, SANs `*.sandbox.archestra.dev` + `sandbox.archestra.dev`, auto-renewed.

Why cert-manager and not a GCP-managed cert: GKE `ManagedCertificate` doesn't support wildcards, and Certificate Manager cert maps only attach to Gateway API — not the classic GKE Ingress staging uses. (Reusing an existing `*.archestra.dev` cert wouldn't work either: TLS wildcards match a single label, so it can't cover `<hash>.sandbox.archestra.dev`.)

**This PR is safe to merge** — the `spec.tls` secret it references already exists, so ingress-gce will sync cleanly.

## Verification (after this deploys)

- `echo | openssl s_client -connect frontend.archestra.dev:443 -servername test.sandbox.archestra.dev | openssl x509 -noout -subject` → `CN=*.sandbox.archestra.dev`.
- Open a camera app (Face Tracker) on staging → browser prompts for camera → stream starts (no `SecurityError`).
- Sandbox iframe `src` is `https://<hash>.sandbox.archestra.dev/_sandbox/mcp-sandbox-proxy.html` (cross-origin), and the #6211 opaque-origin console warning no longer fires.