### PR TITLE
feat(mcp-inspector): static-height tools sidebar with search

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-inspector.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-inspector.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { archestraApiSdk } from "@archestra/shared";
-import { ChevronDown, CircuitBoard, Loader2, Play, Zap } from "lucide-react";
+import {
+  ChevronDown,
+  CircuitBoard,
+  Loader2,
+  Play,
+  Search,
+  Zap,
+} from "lucide-react";
 import {
   type PointerEvent as ReactPointerEvent,
   useCallback,
@@ -15,6 +22,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import { filterMcpTools } from "./mcp-tool-search";
 
 interface McpTool {
   name: string;
@@ -56,6 +64,7 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
   const [paramValues, setParamValues] = useState<Record<string, string>>({});
   const [isCallingTool, setIsCallingTool] = useState(false);
   const [showSchema, setShowSchema] = useState(false);
+  const [toolSearch, setToolSearch] = useState("");
   const [requestLog, setRequestLog] = useState<RequestLogEntry[]>([]);
   const logIdRef = useRef(0);
   const [logPanelRatio, setLogPanelRatio] = useState(0.4);
@@ -154,6 +163,7 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
       setTools([]);
       setSelectedTool(null);
       setParamValues({});
+      setToolSearch("");
       setRequestLog([]);
       logIdRef.current = 0;
       loadTools();
@@ -255,6 +265,7 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
 
   const properties = selectedTool?.inputSchema?.properties ?? {};
   const requiredParams = selectedTool?.inputSchema?.required ?? [];
+  const filteredTools = filterMcpTools(tools, toolSearch);
 
   return (
     <div className="flex flex-col flex-1 min-h-0 gap-3">
@@ -286,12 +297,25 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
               Tools
             </span>
             <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
-              {tools.length}
+              {toolSearch.trim()
+                ? `${filteredTools.length}/${tools.length}`
+                : tools.length}
             </span>
           </div>
-          <ScrollArea className="flex-1 min-h-0">
+          <div className="px-1.5 pt-1.5 flex-shrink-0">
+            <div className="relative">
+              <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+              <Input
+                value={toolSearch}
+                onChange={(e) => setToolSearch(e.target.value)}
+                placeholder="Search tools"
+                className="h-7 pl-7 font-mono text-xs"
+              />
+            </div>
+          </div>
+          <ScrollArea className="h-[480px]">
             <div className="p-1.5 space-y-0.5">
-              {tools.map((tool) => {
+              {filteredTools.map((tool) => {
                 const isSelected = selectedTool?.name === tool.name;
                 return (
                   <button
@@ -326,9 +350,9 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
                   </button>
                 );
               })}
-              {tools.length === 0 && (
+              {filteredTools.length === 0 && (
                 <div className="px-3 py-8 text-xs text-muted-foreground text-center font-mono tracking-[0.08em]">
-                  No tools
+                  {tools.length === 0 ? "No tools" : "No matching tools"}
                 </div>
               )}
             </div>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-tool-search.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-tool-search.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { filterMcpTools } from "./mcp-tool-search";
+
+const tools = [
+  { name: "create_pull_request", description: "Create a new pull request" },
+  { name: "get_file_contents", description: "Get the contents of a file" },
+  { name: "fork_repository" },
+];
+
+describe("filterMcpTools", () => {
+  it("returns all tools for an empty or whitespace-only query", () => {
+    expect(filterMcpTools(tools, "")).toEqual(tools);
+    expect(filterMcpTools(tools, "   ")).toEqual(tools);
+  });
+
+  it("matches tool names case-insensitively", () => {
+    expect(filterMcpTools(tools, "FORK")).toEqual([
+      { name: "fork_repository" },
+    ]);
+  });
+
+  it("matches descriptions too", () => {
+    expect(filterMcpTools(tools, "contents of a file")).toEqual([
+      { name: "get_file_contents", description: "Get the contents of a file" },
+    ]);
+  });
+
+  it("trims the query before matching", () => {
+    expect(filterMcpTools(tools, "  pull_request ")).toEqual([
+      { name: "create_pull_request", description: "Create a new pull request" },
+    ]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(filterMcpTools(tools, "nonexistent")).toEqual([]);
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-tool-search.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-tool-search.ts
@@ -1,0 +1,13 @@
+// Case-insensitive filter over MCP tools by name or description, used by the
+// inspector's tools sidebar search.
+export function filterMcpTools<
+  T extends { name: string; description?: string },
+>(tools: T[], query: string): T[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return tools;
+  return tools.filter(
+    (tool) =>
+      tool.name.toLowerCase().includes(normalized) ||
+      tool.description?.toLowerCase().includes(normalized),
+  );
+}


### PR DESCRIPTION
## Summary

On the MCP registry detail page, the inspector's tools sidebar grew with the tool count (the panel has `min-h-[480px]` with no cap), so a server with many tools (e.g. 44) stretched the entire page.

- Pin the tools list to a fixed 480px scroll area so it scrolls internally instead of growing the page
- Add a search input above the list that filters tools by name or description (case-insensitive)
- Header count shows `matched/total` while filtering; empty filter results show "No matching tools" (vs "No tools" when the server exposes none)
- Extract the filter into a pure helper (`mcp-tool-search.ts`) with unit tests, following the `_parts` convention