### PR TITLE
fix(chat): auto-open newly rendered MCP app after manual toggles

### DIFF
--- a/platform/frontend/src/components/chat/apps-context.tsx
+++ b/platform/frontend/src/components/chat/apps-context.tsx
@@ -58,7 +58,7 @@ interface AppsContextValue {
   isAppOpen: (toolCallId: string) => boolean;
   /** Toggle one app's inline expansion (canonicalized), leaving other open apps alone. */
   toggleAppOpen: (toolCallId: string) => void;
-  /** The single app the right panel hosts: the explicit pick, else the latest still-open app, else the latest — never blank. */
+  /** The single app the right panel hosts: the explicit pick (until a newer render arrives), else the latest still-open app, else the latest — never blank. */
   panelToolCallId: string | null;
   /** Point the right panel at an app (pill selector / "Open in right panel"). */
   setPanelApp: (toolCallId: string) => void;
@@ -121,8 +121,14 @@ export function AppsProvider({
   // absent → the latest. Clicking an older owned pill points it here.
   const [pickedOwnedRender, setPickedOwnedRender] =
     useState<ReadonlyMap<string, string>>(EMPTY_MAP);
-  // Explicit right-panel pick; null falls back to the latest still-open app.
-  const [explicitPanelId, setExplicitPanelId] = useState<string | null>(null);
+  // Explicit right-panel pick, plus a snapshot of the renders that existed when
+  // it was made. The pick pins the panel only against those renders: a render
+  // arriving later (a new model-triggered app) supersedes it, so the panel
+  // returns to the latest-still-open default and hosts the new app.
+  const [explicitPanel, setExplicitPanel] = useState<{
+    toolCallId: string;
+    knownToolCallIds: ReadonlySet<string>;
+  } | null>(null);
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
@@ -182,17 +188,27 @@ export function AppsProvider({
   // Switching the panel app drops the previous app's settings form.
   const setPanelApp = useCallback(
     (id: string) => {
-      setExplicitPanelId(canonicalToolCallId(id));
+      setExplicitPanel({
+        toolCallId: canonicalToolCallId(id),
+        knownToolCallIds: new Set(apps.map((a) => a.toolCallId)),
+      });
       setSettingsOpen(false);
     },
-    [canonicalToolCallId],
+    [canonicalToolCallId, apps],
   );
 
   // One hosted app, never blank: explicit pick, else latest still-open active
   // render, else the latest active render overall.
   const panelToolCallId = useMemo(() => {
-    if (explicitPanelId && groupByToolCallId.has(explicitPanelId)) {
-      return explicitPanelId;
+    // Honor the pick only while no render has arrived since it was made — a
+    // newly rendered app supersedes it and takes the panel via the fallbacks.
+    const pick = explicitPanel;
+    if (
+      pick &&
+      groupByToolCallId.has(pick.toolCallId) &&
+      apps.every((a) => pick.knownToolCallIds.has(a.toolCallId))
+    ) {
+      return pick.toolCallId;
     }
     const isActive = (a: PanelApp) =>
       groupByToolCallId.get(a.toolCallId)?.activeRender.toolCallId ===
@@ -213,7 +229,7 @@ export function AppsProvider({
         ),
     );
     return latestOpen ?? latestBy(isActive);
-  }, [explicitPanelId, apps, closedKeys, groupByToolCallId]);
+  }, [explicitPanel, apps, closedKeys, groupByToolCallId]);
 
   const openRightPanel = useCallback(() => {
     onShowInPanel?.();

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -717,6 +717,120 @@ describe("McpAppSection panel hosting", () => {
   });
 });
 
+describe("AppsProvider newly rendered app after manual toggles", () => {
+  // The repro: app A rendered → user closes → user opens (manual toggles) →
+  // app B rendered. B must open automatically on both surfaces.
+  const appA = {
+    toolCallId: "tc-a",
+    label: "First App",
+    uiResourceUri: "resource://test-server/ui-a",
+    createdAt: 1,
+  };
+  const appB = {
+    toolCallId: "tc-b",
+    label: "Second App",
+    uiResourceUri: "resource://test-server/ui-b",
+    createdAt: 2,
+  };
+
+  function Probe() {
+    const { panelToolCallId, isAppOpen, toggleAppOpen, setPanelApp } =
+      useApps();
+    return (
+      <div>
+        <div data-testid="panel">{panelToolCallId ?? "none"}</div>
+        <div data-testid="open-a">{String(isAppOpen("tc-a"))}</div>
+        <div data-testid="open-b">{String(isAppOpen("tc-b"))}</div>
+        <button type="button" onClick={() => toggleAppOpen("tc-a")}>
+          toggle a
+        </button>
+        <button type="button" onClick={() => setPanelApp("tc-a")}>
+          pick a
+        </button>
+      </div>
+    );
+  }
+
+  it("hosts a newly rendered app in the panel even after an explicit manual pick", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <AppsProvider apps={[appA]}>
+        <Probe />
+      </AppsProvider>,
+    );
+
+    // Step 1: the user collapses the app, reopens it, and pins it to the panel
+    // ("Open in right panel" / a pill click while the panel hosts).
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "toggle a" }));
+      await user.click(screen.getByRole("button", { name: "toggle a" }));
+      await user.click(screen.getByRole("button", { name: "pick a" }));
+    });
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc-a");
+
+    // Step 2: the model renders a second, different app.
+    rerender(
+      <AppsProvider apps={[appA, appB]}>
+        <Probe />
+      </AppsProvider>,
+    );
+
+    // The new render supersedes the manual pick: it takes the panel, open.
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc-b");
+    expect(screen.getByTestId("open-b")).toHaveTextContent("true");
+  });
+
+  it("keeps honoring the manual panel pick while no new render arrives", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppsProvider apps={[appA, appB]}>
+        <Probe />
+      </AppsProvider>,
+    );
+
+    // tc-b is newest and hosted by default; picking tc-a moves the panel and it
+    // stays there — supersession needs a render that postdates the pick.
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "pick a" }));
+    });
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc-a");
+
+    // An unrelated inline collapse doesn't unseat the pick either.
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "toggle a" }));
+    });
+    expect(screen.getByTestId("panel")).toHaveTextContent("tc-a");
+  });
+
+  it("keeps a newly rendered app expanded inline alongside a manually reopened one", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <AppsProvider apps={[appA]}>
+        <Probe />
+      </AppsProvider>,
+    );
+
+    // Step 1 with no panel: collapse the app, then reopen it.
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "toggle a" }));
+    });
+    expect(screen.getByTestId("open-a")).toHaveTextContent("false");
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "toggle a" }));
+    });
+    expect(screen.getByTestId("open-a")).toHaveTextContent("true");
+
+    // Step 2: the model renders a second app — both stay expanded inline.
+    rerender(
+      <AppsProvider apps={[appA, appB]}>
+        <Probe />
+      </AppsProvider>,
+    );
+    expect(screen.getByTestId("open-a")).toHaveTextContent("true");
+    expect(screen.getByTestId("open-b")).toHaveTextContent("true");
+  });
+});
+
 describe("McpAppSection older renders (no suppression)", () => {
   const APP_ID = "947051c7-ea8e-48ed-8077-a3cc904d9d61";
 


### PR DESCRIPTION
## Bug

In a chat with the right panel hosting an MCP app: close the app, reopen it (manual toggle / "Open in right panel"), then ask the model to render a second, different app. The first app stays hosted and the second one stays a collapsed pill — the newest model-triggered app never opens.

Repro sequence: app A rendered → user closes → user opens → app B rendered → **B must be open**.

## Root cause

`AppsProvider` (`apps-context.tsx`) resolves the panel-hosted app as `explicitPanelId ?? latest-still-open ?? latest`. Any manual selection (`setPanelApp` — a pill click while the panel hosts, or "Open in right panel") set `explicitPanelId` **permanently**. Once set, the "latest still-open" auto-host fallback was dead for the rest of the conversation, so a newly rendered app could never take the panel. And while the panel hosts, every inline section collapses to a pill — so the new app looked collapsed everywhere.

## Fix

The explicit pick now carries a snapshot of the render `toolCallId`s that existed when it was made. It pins the panel only against those renders: a render arriving later supersedes the pick, and `panelToolCallId` falls back to the latest-still-open default — the new app takes the panel. Picking again re-pins with a fresh snapshot. Stateless derivation, no effects.

## Multi-open when the panel is closed

Evaluated per the ask — **already the current behavior, no change needed**: inline apps default to open (`closedKeys` only tracks user-collapsed groups) and multiple inline apps expand simultaneously. The "only one active" constraint applies only to the panel host (inline sections collapse to pills while the panel hosts — by design). The new inline test documents the repro sequence passing there.

## Verification

- New test "hosts a newly rendered app in the panel even after an explicit manual pick" **fails on the pre-fix code** with exactly the reported symptom (panel stays `tc-a`, expected `tc-b`) and passes with the fix.
- Two more tests guard: the manual pick is still honored while no new render arrives; inline multi-open keeps A and B both expanded after the toggle sequence.
- `pnpm type-check` clean, `biome check` clean, all 303 chat component tests pass (26 files).

Verified via unit tests at the provider level (in-browser boot skipped: ports occupied by the running dev stack).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>