### PR TITLE
fix(apps): keep search results in the responsive grid layout

### DIFF
--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -119,10 +119,14 @@ export default function AppsPage() {
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {filtered.map((app) => (
               <AppCard
+                // Several tools of one server can share a widget resource, so
+                // (mcpServerId, resourceUri) alone collides; duplicate keys make
+                // React duplicate/omit cards on search re-renders, breaking the
+                // grid. The tool-scoped name disambiguates.
                 key={
                   app.source === "owned"
                     ? app.id
-                    : `${app.mcpServerId}:${app.resourceUri}`
+                    : `${app.mcpServerId}:${app.resourceUri}:${app.name}`
                 }
                 app={app}
               />


### PR DESCRIPTION
## Bug

Typing a search term on the Apps page corrupts the card list: cards duplicate, stagger down the page, and overflow past the page footer. The default (no-search) view looks fine.

## Root cause

Not a CSS/container issue — both branches render the same `grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3`. The external-app card key is

```tsx
key={`${app.mcpServerId}:${app.resourceUri}`}
```

but several tools of one MCP server share a widget resource (six Jira tools all render `ui://widget/jira-widget.html`, three Confluence tools share `ui://widget/confluence-widget.html`), so keys collide. React warns:

> Encountered two children with the same key… Non-unique keys may cause children to be duplicated and/or omitted

On first render this is only a warning. Searching triggers repeated list reconciliation (debounced URL param + `placeholderData` keeping the previous page while fetching), and with colliding keys React leaves phantom stale card nodes behind.

## Before / after (measured on a live dev stack)

Typed `jira` → `excalidraw` → `e` and compared the grid DOM against `GET /api/apps?search=e` (19 items):

| | grid DOM children | phantom cards | duplicate-key errors |
|---|---|---|---|
| before | **31** | `getjiraissue` x4, `createjiraissue` x3, stale cards from previous searches mixed in, grid overflowing below the footer | 15+ |
| after | **19** (matches data exactly) | none — only genuinely distinct installs repeat a title | 0 |

## Fix

Scope the key by the tool-qualified name (`Server / tool`), which is unique per (install, tool):

```tsx
key={`${app.mcpServerId}:${app.resourceUri}:${app.name}`}
```

One-line change in `page.client.tsx`, deliberately kept off `app-card.tsx` and the grid markup to avoid conflicts with concurrent Apps-page work.

## Verification

- Reproduced before/after in Chrome against a running dev stack (frontend from this branch on :3001, shared backend on :9000), driving the real search input and measuring grid DOM vs API data.
- `pnpm type-check` and `pnpm lint` pass in `platform/frontend`.

Co-Authored-By: Claude <noreply@anthropic.com>

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>