### PR TITLE
fix(chat): remove stale error block when regenerating after a failed turn

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -93,7 +93,6 @@ import {
 import {
   fetchConversationEnabledTools,
   invalidateConversationFileQueries,
-  useClearChatErrors,
   useCompactConversation,
   useConversation,
   useConversationFiles,
@@ -1042,25 +1041,20 @@ export function ChatPageContent({
     });
   }, [resendLastUserMessage]);
 
-  // "Try again" on a retryable chat error: resend the last user turn, and only
-  // once the resend is genuinely issued clear the persisted error so the card
-  // disappears. Ordering matters — clearing first would wipe the error card even
-  // if the resend never started. If the resend itself fails, keep the card so the
-  // user still sees the error. Owner-editable chats only (read-only viewers render
+  // "Try again" on a retryable chat error: resend the last user turn. The
+  // session's regenerateUserMessage clears the persisted error rows once the
+  // resend is genuinely issued (so the card disappears without wiping the
+  // error when the resend never starts) — same as the regenerate action on a
+  // message. If the resend itself fails, the card stays so the user still sees
+  // the error. Owner-editable chats only (read-only viewers render
   // MessageThread instead of this).
-  const clearChatErrors = useClearChatErrors();
   const handleChatErrorRetry = useCallback(async () => {
-    if (!conversationId) return;
-    let resent: boolean;
     try {
-      resent = await resendLastUserMessage();
+      await resendLastUserMessage();
     } catch (error) {
       console.error("[Chat] Retry failed to resend the last message", error);
-      return;
     }
-    if (!resent) return;
-    await clearChatErrors.mutateAsync({ id: conversationId });
-  }, [conversationId, clearChatErrors, resendLastUserMessage]);
+  }, [resendLastUserMessage]);
   // Hide the error while the session is auto-recovering (retry scheduled or
   // reattaching to the still-running response) — flashing a "connection
   // error" card for a turn that restores itself a second later reads as

--- a/platform/frontend/src/lib/chat/chat.query.ts
+++ b/platform/frontend/src/lib/chat/chat.query.ts
@@ -497,9 +497,10 @@ export function useCompactConversation() {
 }
 
 /**
- * Clear a conversation's recorded chat errors. Used by the scheduled-run
- * "Try again" affordance: after wiping the error rows we invalidate the
- * conversation so the inline error card disappears before the prompt is resent.
+ * Clear a conversation's recorded chat errors. Used by the chat session's
+ * regenerate flow ("Try again" on the error card, the regenerate action on a
+ * user message, edited resends): after wiping the error rows we invalidate the
+ * conversation so the stale inline error card disappears.
  */
 export function useClearChatErrors() {
   const queryClient = useQueryClient();

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -38,15 +38,21 @@ vi.mock("ai", () => ({
 
 vi.mock("sonner");
 
-vi.mock("@tanstack/react-query", () => ({
-  useQueryClient: () => ({
+vi.mock("@tanstack/react-query", () => {
+  // The real useQueryClient returns a stable client. A fresh object per call
+  // would destabilize callbacks that list it as a dependency (e.g.
+  // regenerateUserMessage) and loop the session-sync effect.
+  const queryClient = {
     getQueryData: mocks.getQueryData,
     invalidateQueries: mocks.invalidateQueries,
-  }),
-  useMutation: () => ({
-    mutateAsync: mocks.mutateAsync,
-  }),
-}));
+  };
+  return {
+    useQueryClient: () => queryClient,
+    useMutation: () => ({
+      mutateAsync: mocks.mutateAsync,
+    }),
+  };
+});
 
 const conversationMock = vi.hoisted(() => ({
   data: { title: null as string | null } as { title: string | null } | null,
@@ -300,6 +306,85 @@ describe("ChatProvider retries", () => {
       await chatOptions?.onFinish?.({ message: { parts: [] }, isAbort: false });
     });
 
+    expect(mocks.clearChatErrors).not.toHaveBeenCalled();
+  });
+
+  it("clears persisted chat errors once a user-message regenerate is issued", async () => {
+    const latestSessionRef: { current: ChatSessionSnapshot } = {
+      current: undefined,
+    };
+    // The conversation cache holds a persisted error card from the failed turn.
+    mocks.getQueryData.mockReturnValue({
+      chatErrors: [{ id: "chat-error-1" }],
+    });
+    mocks.clearChatErrors.mockResolvedValue({ success: true });
+    // updateChatMessage returns the saved thread keyed by DB ids.
+    mocks.mutateAsync.mockResolvedValue({
+      messages: [
+        { id: "user-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      ],
+    });
+
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+        <CaptureChatSession
+          onSession={(session) => {
+            latestSessionRef.current = session;
+          }}
+        />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(latestSessionRef.current).toBeDefined());
+
+    await act(async () => {
+      await latestSessionRef.current?.regenerateUserMessage({
+        messageId: "user-1",
+        partIndex: 0,
+        text: "hi",
+      });
+    });
+
+    expect(mocks.regenerate).toHaveBeenCalledWith({ messageId: "user-1" });
+    expect(mocks.clearChatErrors).toHaveBeenCalledWith({
+      id: "conversation-1",
+    });
+  });
+
+  it("does not clear chat errors on regenerate when the conversation has none", async () => {
+    const latestSessionRef: { current: ChatSessionSnapshot } = {
+      current: undefined,
+    };
+    mocks.getQueryData.mockReturnValue({ chatErrors: [] });
+    mocks.mutateAsync.mockResolvedValue({
+      messages: [
+        { id: "user-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      ],
+    });
+
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+        <CaptureChatSession
+          onSession={(session) => {
+            latestSessionRef.current = session;
+          }}
+        />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(latestSessionRef.current).toBeDefined());
+
+    await act(async () => {
+      await latestSessionRef.current?.regenerateUserMessage({
+        messageId: "user-1",
+        partIndex: 0,
+        text: "hi",
+      });
+    });
+
+    expect(mocks.regenerate).toHaveBeenCalledWith({ messageId: "user-1" });
     expect(mocks.clearChatErrors).not.toHaveBeenCalled();
   });
 

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -1026,6 +1026,29 @@ function ChatSessionHook({
     );
   }, [stableMessages, optimisticToolCalls.length]);
 
+  // A regenerate replaces the failed turn, so any persisted chat-error rows
+  // are now stale — the backend never clears them on its own, and left behind
+  // they keep rendering an error card above the regenerated answer (also after
+  // a reload). Clear them only once the re-run is genuinely issued (clearing
+  // before would wipe the card even when the resend never starts), and only
+  // when the conversation actually has rows. Destructure the stable mutateAsync
+  // like updateChatMessageAsync above so regenerateUserMessage stays
+  // referentially stable.
+  const { mutateAsync: clearChatErrorsAsync } = clearChatErrors;
+  const clearStalePersistedChatErrors = useCallback(() => {
+    const conversation = queryClient.getQueryData<{ chatErrors?: unknown[] }>([
+      "conversation",
+      conversationId,
+    ]);
+    if (!conversation?.chatErrors?.length) return;
+    clearChatErrorsAsync({ id: conversationId }).catch((error) => {
+      console.error(
+        "[ChatSession] Failed to clear stale chat errors after regenerate",
+        error,
+      );
+    });
+  }, [queryClient, clearChatErrorsAsync, conversationId]);
+
   // Save the user message's text, then re-run the assistant turn from it.
   const regenerateUserMessage = useCallback(
     async ({
@@ -1072,6 +1095,7 @@ function ChatSessionHook({
         // regenerate from it. The server replaces the turn atomically.
         setMessages(canonical);
         void regenerate({ messageId: anchorId });
+        clearStalePersistedChatErrors();
         return;
       }
 
@@ -1091,8 +1115,14 @@ function ChatSessionHook({
         }),
       );
       void regenerate({ messageId });
+      clearStalePersistedChatErrors();
     },
-    [updateChatMessageAsync, setMessages, regenerate],
+    [
+      updateChatMessageAsync,
+      setMessages,
+      regenerate,
+      clearStalePersistedChatErrors,
+    ],
   );
 
   // Always keep the session ref up-to-date with the latest values (including


### PR DESCRIPTION
## Bug

When an assistant turn fails, an inline error card is rendered in the conversation ("The model ended its turn without a reply…", metadata chips, "Try again", "Error Details"). Retrying the turn left the old error card in place: it sat above the new assistant message, and because the error is persisted server-side (`conversation_chat_errors` rows returned as `conversation.chatErrors`), it also reappeared after a page refresh.

## Root cause

The persisted error rows were only cleared by one retry affordance — the error card's own "Try again" button, via a page-level handler (`handleChatErrorRetry` → `useClearChatErrors`). Every other path that re-runs the failed turn funnels through the session's `regenerateUserMessage` and never cleared the rows:

- the **Regenerate** action on a user message (message actions),
- an **edited resend** of a user message,
- the **provider-connect auto-rerun**.

The backend never clears the rows on its own (`persistConversationChatError` only inserts; only `DELETE /api/chat/conversations/:id/chat-errors` removes them), so after any of those retries the stale card stayed forever.

## Fix

Clear the conversation's persisted chat errors inside `regenerateUserMessage` (global-chat.context.tsx), right after the re-run is genuinely issued — clearing earlier could wipe the card when the resend never starts — and only when the cached conversation actually has error rows. All retry paths now share one clear; the page's "Try again" handler drops its duplicated clear and just resends.

Also stabilizes the test file's `useQueryClient` mock (a fresh object per call destabilized the new callback dependency and looped the session-sync effect — the real `useQueryClient` returns a stable client).

## Tests

- New: `regenerateUserMessage` clears persisted errors once the regenerate is issued; and does not fire the clear when the conversation has none (`global-chat.context.test.tsx`).
- Ran: `pnpm vitest run src/lib/chat/global-chat.context.test.tsx` (27 passed), `inline-chat-error` + `chat-messages` + `chat-retry.utils` + `chat.query` suites (90 passed), `pnpm type-check`, `pnpm biome check` on changed files — all green.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>