### PR TITLE
fix(apps): open external MCP apps via prompt when the tool needs inputs

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -55466,7 +55466,7 @@
         "tags": [
           "Apps"
         ],
-        "description": "Open an external (MCP-server) UI app in chat: create a conversation with the app rendered against the given install (no model turn) and return its id to navigate to.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:read`: View and run MCP Apps within your scope (org, your teams, your own)\n`chat:create`: Start new chat conversations",
+        "description": "Open an external (MCP-server) UI app in chat: create a conversation and return its id to navigate to. When the tool needs no inputs the app is seeded already rendered (no model turn); when it has required inputs the conversation is created empty and the response carries an opening prompt for the client to send.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`app:read`: View and run MCP Apps within your scope (org, your teams, your own)\n`chat:create`: Start new chat conversations",
         "requestBody": {
           "required": true,
           "content": {
@@ -55510,10 +55510,21 @@
                       "type": "string",
                       "format": "uuid",
                       "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "render",
+                        "prompt"
+                      ]
+                    },
+                    "prompt": {
+                      "type": "string"
                     }
                   },
                   "required": [
-                    "conversationId"
+                    "conversationId",
+                    "mode"
                   ],
                   "additionalProperties": false
                 }

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -21,6 +21,7 @@ import type {
   InsertMcpServer,
   McpServer,
   ResourceVisibilityScope,
+  ToolParametersContent,
   UpdateMcpServer,
 } from "@/types";
 import InternalMcpCatalogModel from "./internal-mcp-catalog";
@@ -397,10 +398,12 @@ class McpServerModel {
   /**
    * Validate that `mcpServerId` is an install the caller can reach and that it
    * exposes a `ui://` resource matching `resourceUri`, returning the catalog +
-   * label parts (server/tool names) for that resource. Backs external
-   * open-in-chat (a card's `(mcpServerId, resourceUri)` must resolve to a real,
-   * accessible UI resource before a conversation is seeded). Returns null when
-   * the install is not accessible or exposes no such resource.
+   * label parts (server/tool names) and the tool's input schema for that
+   * resource. Backs external open-in-chat (a card's `(mcpServerId,
+   * resourceUri)` must resolve to a real, accessible UI resource before a
+   * conversation is seeded; the input schema decides render-vs-prompt mode).
+   * Returns null when the install is not accessible or exposes no such
+   * resource.
    */
   static async findInstalledUiResourceForCaller(params: {
     userId: string;
@@ -411,6 +414,7 @@ class McpServerModel {
     serverName: string;
     toolName: string;
     resourceUri: string;
+    toolParameters: ToolParametersContent;
   } | null> {
     const accessibleServerIds = await McpServerModel.getAccessibleInstallIds(
       params.userId,
@@ -431,6 +435,7 @@ class McpServerModel {
       serverName: match.serverName,
       toolName: match.toolName,
       resourceUri: match.resourceUri,
+      toolParameters: match.toolParameters,
     };
   }
 
@@ -558,6 +563,7 @@ class McpServerModel {
       toolName: string;
       toolDescription: string | null;
       resourceUri: string;
+      toolParameters: ToolParametersContent;
     }>
   > {
     const { catalogIds, search } = params;
@@ -571,6 +577,7 @@ class McpServerModel {
         toolName: schema.toolsTable.name,
         toolDescription: schema.toolsTable.description,
         resourceUri: uiResourceUri,
+        toolParameters: schema.toolsTable.parameters,
       })
       .from(schema.internalMcpCatalogTable)
       .innerJoin(
@@ -611,6 +618,7 @@ class McpServerModel {
                 toolName: parseFullToolName(row.toolName).toolName,
                 toolDescription: row.toolDescription,
                 resourceUri: row.resourceUri,
+                toolParameters: row.toolParameters,
               },
             ]
           : [],

--- a/platform/backend/src/routes/app/app.routes.ts
+++ b/platform/backend/src/routes/app/app.routes.ts
@@ -93,6 +93,15 @@ const OpenAppInChatResponseSchema = z.object({
   conversationId: z.string().uuid(),
 });
 
+// The external variant also says how the conversation was set up: "render"
+// seeds the app already mounted; "prompt" leaves it empty and the client sends
+// `prompt` as the first user message (the tool has required inputs the agent
+// must collect before calling it).
+const OpenExternalAppInChatResponseSchema = OpenAppInChatResponseSchema.extend({
+  mode: z.enum(["render", "prompt"]),
+  prompt: z.string().optional(),
+});
+
 // The single-app GET resolves the app's team assignments so the detail page can
 // render team-name badges and seed the visibility editor.
 const AppWithTeamsSchema = SelectAppSchema.extend({
@@ -366,11 +375,11 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
       schema: {
         operationId: RouteId.OpenExternalAppInChat,
         description:
-          "Open an external (MCP-server) UI app in chat: create a conversation with the app rendered against the given install (no model turn) and return its id to navigate to.",
+          "Open an external (MCP-server) UI app in chat: create a conversation and return its id to navigate to. When the tool needs no inputs the app is seeded already rendered (no model turn); when it has required inputs the conversation is created empty and the response carries an opening prompt for the client to send.",
         tags: ["Apps"],
         params: z.object({ mcpServerId: UuidIdSchema }),
         body: z.object({ resourceUri: z.string().min(1) }),
-        response: constructResponseSchema(OpenAppInChatResponseSchema),
+        response: constructResponseSchema(OpenExternalAppInChatResponseSchema),
       },
     },
     async (
@@ -379,13 +388,13 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
     ) => {
       // The service re-checks install access + that the resource exists (404s
       // otherwise).
-      const { conversationId } = await createSeededExternalAppConversation({
+      const result = await createSeededExternalAppConversation({
         mcpServerId,
         resourceUri,
         userId: user.id,
         organizationId,
       });
-      return reply.send({ conversationId });
+      return reply.send(result);
     },
   );
 

--- a/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
@@ -1,6 +1,6 @@
 import { ADMIN_ROLE_NAME } from "@archestra/shared";
 import config from "@/config";
-import { MemberModel, MessageModel } from "@/models";
+import { ConversationModel, MemberModel, MessageModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -72,8 +72,10 @@ describe("POST /api/apps/external/:mcpServerId/open-in-chat", () => {
       payload: { resourceUri: "ui://pm/board.html" },
     });
     expect(res.statusCode).toBe(200);
-    const { conversationId } = res.json();
+    const { conversationId, mode, prompt } = res.json();
     expect(conversationId).toBeTruthy();
+    expect(mode).toBe("render");
+    expect(prompt).toBeUndefined();
 
     const messages = await MessageModel.findByConversation(conversationId);
     // External apps are read-only from chat, so no greeting.
@@ -91,6 +93,102 @@ describe("POST /api/apps/external/:mcpServerId/open-in-chat", () => {
       resourceUri: "ui://pm/board.html",
       mcpServerId: install.id,
     });
+  });
+
+  test("returns prompt mode (empty conversation) when the tool has required inputs", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "Atlassian",
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+      scope: "org",
+    });
+    const install = await makeMcpServer({
+      catalogId: catalog.id,
+      scope: "org",
+    });
+    // Rendering this tool with input {} cannot succeed, so opening it must go
+    // through a model turn that collects the inputs first.
+    await makeTool({
+      catalogId: catalog.id,
+      name: "createjiraissue",
+      parameters: {
+        type: "object",
+        properties: {
+          projectKey: { type: "string" },
+          summary: { type: "string" },
+        },
+        required: ["projectKey", "summary"],
+      },
+      meta: { _meta: { ui: { resourceUri: "ui://jira/create-issue.html" } } },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/apps/external/${install.id}/open-in-chat`,
+      payload: { resourceUri: "ui://jira/create-issue.html" },
+    });
+    expect(res.statusCode).toBe(200);
+    const { conversationId, mode, prompt } = res.json();
+    expect(mode).toBe("prompt");
+    // The opening prompt names the app so the agent can find and call the tool.
+    expect(prompt).toContain("Atlassian / createjiraissue");
+
+    // No seeded render: the client sends `prompt` as the first user message,
+    // which triggers the model turn.
+    const messages = await MessageModel.findByConversation(conversationId);
+    expect(messages).toHaveLength(0);
+
+    // Same conversation title as the seeded-render mode.
+    const conversation = await ConversationModel.findById({
+      id: conversationId,
+      userId: user.id,
+      organizationId,
+    });
+    expect(conversation?.title).toBe("Atlassian / createjiraissue");
+  });
+
+  test("seeds the render when the tool's inputs are all optional", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "Archestra PM",
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+      scope: "org",
+    });
+    const install = await makeMcpServer({
+      catalogId: catalog.id,
+      scope: "org",
+    });
+    await makeTool({
+      catalogId: catalog.id,
+      name: "show_board",
+      parameters: {
+        type: "object",
+        properties: { filter: { type: "string" } },
+      },
+      meta: { _meta: { ui: { resourceUri: "ui://pm/board.html" } } },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/apps/external/${install.id}/open-in-chat`,
+      payload: { resourceUri: "ui://pm/board.html" },
+    });
+    expect(res.statusCode).toBe(200);
+    const { conversationId, mode } = res.json();
+    expect(mode).toBe("render");
+    expect(await MessageModel.findByConversation(conversationId)).toHaveLength(
+      1,
+    );
   });
 
   test("404s for an install the caller cannot access", async () => {

--- a/platform/backend/src/services/apps/app-chat-conversation.ts
+++ b/platform/backend/src/services/apps/app-chat-conversation.ts
@@ -73,13 +73,33 @@ export async function createSeededAppConversation(params: {
 }
 
 /**
- * Create a chat conversation with an external (MCP-server) UI app already
- * mounted, the external analogue of {@link createSeededAppConversation}. It
- * seeds a synthetic tool-call message whose output carries the UI pointer
- * (`_meta.ui.resourceUri`) plus the concrete `mcpServerId`, so the chat mounts
- * the app against that install via the server endpoint with no model turn.
- * Backs the apps-page deep-link for an MCP-server app card. Returns the
- * conversation id to navigate to (`/chat/<id>`).
+ * How an external app conversation was set up: `render` seeds the app already
+ * mounted (no model turn); `prompt` leaves the conversation empty and hands the
+ * client an opening user prompt to send through the normal chat path, so the
+ * agent collects the tool's required inputs before calling it.
+ */
+type ExternalAppOpenResult = {
+  conversationId: string;
+  mode: "render" | "prompt";
+  /** The opening user message to send; present only for `mode: "prompt"`. */
+  prompt?: string;
+};
+
+/**
+ * Create a chat conversation for an external (MCP-server) UI app, the external
+ * analogue of {@link createSeededAppConversation}. Backs the apps-page
+ * deep-link for an MCP-server app card. Returns the conversation id to
+ * navigate to (`/chat/<id>`) plus the open mode.
+ *
+ * Two modes, decided by the tool's input schema:
+ * - No required inputs: seed a synthetic tool-call message whose output
+ *   carries the UI pointer (`_meta.ui.resourceUri`) plus the concrete
+ *   `mcpServerId`, so the chat mounts the app against that install via the
+ *   server endpoint with no model turn (`mode: "render"`).
+ * - Required inputs: rendering with input `{}` would mount a broken app, so
+ *   the conversation is created empty and the caller gets an opening prompt
+ *   (`mode: "prompt"`) to send as the first user message — the agent asks for
+ *   the inputs, calls the tool, and the tool result mounts the app.
  */
 export async function createSeededExternalAppConversation(params: {
   mcpServerId: string;
@@ -88,7 +108,7 @@ export async function createSeededExternalAppConversation(params: {
   organizationId: string;
   /** Agent to bind the chat to; defaults to the caller's default chat agent. */
   agentId?: string;
-}): Promise<{ conversationId: string }> {
+}): Promise<ExternalAppOpenResult> {
   const { mcpServerId, resourceUri, userId, organizationId } = params;
 
   const uiResource = await McpServerModel.findInstalledUiResourceForCaller({
@@ -103,7 +123,25 @@ export async function createSeededExternalAppConversation(params: {
   // The card title: "<server> / <tool>" — also the seeded part's tool name, so
   // the chat's `mcpToolLabel` derives the same label.
   const label = `${uiResource.serverName} / ${uiResource.toolName}`;
-  return seedConversationWithRender({
+
+  if (toolRequiresInputs(uiResource.toolParameters)) {
+    const { conversationId } = await createAppChatConversation({
+      userId,
+      organizationId,
+      agentId: params.agentId,
+      title: label,
+    });
+    return {
+      conversationId,
+      mode: "prompt",
+      prompt:
+        `Open the ${label} app. ` +
+        `Ask me for any inputs you need first, then call the ` +
+        `${uiResource.toolName} tool on the ${uiResource.serverName} MCP server.`,
+    };
+  }
+
+  const { conversationId } = await seedConversationWithRender({
     userId,
     organizationId,
     agentId: params.agentId,
@@ -121,26 +159,42 @@ export async function createSeededExternalAppConversation(params: {
       }),
     },
   });
+  return { conversationId, mode: "render" };
 }
 
 // === internal ===
 
 /**
- * Shared seeding: bind a new conversation to the caller's chat agent (resolving
- * its LLM selection) and persist a single hand-built assistant message whose one
- * part renders an app inline — no model turn. The part is typed as the AI SDK's
- * `UIMessage` part so the synthetic shape is compile-checked (the `content`
- * column is `$type<any>`) and is indistinguishable from a model-driven render.
+ * Whether calling the tool with input `{}` cannot succeed: its input schema
+ * declares required properties. Mirrors `normalizeToolInputSchema`
+ * (routes/mcp-gateway.utils.ts): anything that isn't a `type: "object"` schema
+ * normalizes to an empty object schema, i.e. no required inputs.
  */
-async function seedConversationWithRender(params: {
+function toolRequiresInputs(parameters: unknown): boolean {
+  if (
+    typeof parameters !== "object" ||
+    parameters === null ||
+    Array.isArray(parameters)
+  ) {
+    return false;
+  }
+  const schema = parameters as { type?: unknown; required?: unknown };
+  if (schema.type !== "object") return false;
+  return Array.isArray(schema.required) && schema.required.length > 0;
+}
+
+/**
+ * Bind a new, empty conversation to the caller's chat agent (resolving its LLM
+ * selection). Shared by the render seeding below and the prompt-mode external
+ * open (which leaves the conversation empty for the client's first send).
+ */
+async function createAppChatConversation(params: {
   userId: string;
   organizationId: string;
   agentId?: string;
   title: string;
-  part: UIMessage["parts"][number];
-  greeting?: string;
 }): Promise<{ conversationId: string }> {
-  const { userId, organizationId, title, part, greeting } = params;
+  const { userId, organizationId, title } = params;
 
   const agentId =
     params.agentId ??
@@ -168,6 +222,33 @@ async function seedConversationWithRender(params: {
     chatApiKeyId: llmSelection.chatApiKeyId,
   });
 
+  return { conversationId: conversation.id };
+}
+
+/**
+ * Shared seeding: bind a new conversation to the caller's chat agent (resolving
+ * its LLM selection) and persist a single hand-built assistant message whose one
+ * part renders an app inline — no model turn. The part is typed as the AI SDK's
+ * `UIMessage` part so the synthetic shape is compile-checked (the `content`
+ * column is `$type<any>`) and is indistinguishable from a model-driven render.
+ */
+async function seedConversationWithRender(params: {
+  userId: string;
+  organizationId: string;
+  agentId?: string;
+  title: string;
+  part: UIMessage["parts"][number];
+  greeting?: string;
+}): Promise<{ conversationId: string }> {
+  const { userId, organizationId, agentId, title, part, greeting } = params;
+
+  const { conversationId } = await createAppChatConversation({
+    userId,
+    organizationId,
+    agentId,
+    title,
+  });
+
   const content: UIMessage = {
     id: generateId(),
     role: "assistant",
@@ -175,7 +256,7 @@ async function seedConversationWithRender(params: {
   };
 
   await MessageModel.create({
-    conversationId: conversation.id,
+    conversationId,
     role: "assistant",
     content,
   });
@@ -183,7 +264,7 @@ async function seedConversationWithRender(params: {
   // Separate message so the render above stays a byte-for-byte model-driven render.
   if (greeting) {
     await MessageModel.create({
-      conversationId: conversation.id,
+      conversationId,
       role: "assistant",
       content: {
         id: generateId(),
@@ -193,7 +274,7 @@ async function seedConversationWithRender(params: {
     });
   }
 
-  return { conversationId: conversation.id };
+  return { conversationId };
 }
 
 async function resolveDefaultChatAgentId(params: {

--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { takePendingProjectChatHandoff } from "@/lib/chat/pending-project-chat-handoff";
 import { AppCard } from "./app-card";
 
 type AppListItem = archestraApiTypes.GetAppsResponses["200"]["data"][number];
@@ -127,7 +128,10 @@ describe("ExternalAppCard", () => {
   });
 
   it("opens the install in chat and navigates to the seeded conversation", async () => {
-    openExternalMutate.mockResolvedValue({ conversationId: "conv-1" });
+    openExternalMutate.mockResolvedValue({
+      conversationId: "conv-1",
+      mode: "render",
+    });
     render(<AppCard app={externalApp} />);
 
     fireEvent.click(
@@ -141,6 +145,31 @@ describe("ExternalAppCard", () => {
       resourceUri: "ui://pm/board.html",
     });
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/chat/conv-1"));
+    // A seeded render needs no opening prompt.
+    expect(takePendingProjectChatHandoff("conv-1")).toBeNull();
+  });
+
+  it("stashes the opening prompt for prompt-mode opens (tool needs inputs)", async () => {
+    openExternalMutate.mockResolvedValue({
+      conversationId: "conv-2",
+      mode: "prompt",
+      prompt: "Open the Archestra PM / show_board app.",
+    });
+    render(<AppCard app={externalApp} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open Archestra PM / show_board in new chat",
+      }),
+    );
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/chat/conv-2"));
+    // The prompt rides the pending-chat handoff so /chat/<id> sends it as the
+    // conversation's first user message (which triggers the model turn).
+    expect(takePendingProjectChatHandoff("conv-2")).toEqual({
+      conversationId: "conv-2",
+      prompt: "Open the Archestra PM / show_board app.",
+    });
   });
 
   it("links 'Open in new tab' to the install-pinned run page and 'Manage MCP server'", () => {

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useOpenAppInChat, useOpenExternalAppInChat } from "@/lib/app.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { setPendingProjectChatHandoff } from "@/lib/chat/pending-project-chat-handoff";
 import { cn } from "@/lib/utils";
 import { AppDeleteDialog } from "./app-delete-dialog";
 
@@ -219,8 +220,12 @@ function OwnedAppCard({ app }: { app: OwnedApp }) {
   );
 }
 
-// External MCP-server apps open in chat exactly like owned apps: clicking seeds
-// a conversation with the UI rendered against this install and navigates to it.
+// External MCP-server apps open in chat like owned apps: clicking creates a
+// conversation and navigates to it. When the app's tool needs no inputs the
+// backend seeds the UI already rendered against this install; when it has
+// required inputs the backend returns an opening prompt instead, which rides
+// the pending-chat handoff so `/chat/<id>` sends it as the first user message —
+// the agent asks for the inputs, calls the tool, and the result mounts the app.
 // Each card is one concrete install (only accessible installs are listed), so
 // the whole card is always a click target. The title is the chat-style
 // "<server> / <tool>" label (the catalog display name, never the slug prefix).
@@ -242,6 +247,12 @@ function ExternalAppCard({ app }: { app: ExternalApp }) {
       resourceUri: app.resourceUri,
     });
     if (result?.conversationId) {
+      if (result.mode === "prompt" && result.prompt) {
+        setPendingProjectChatHandoff({
+          conversationId: result.conversationId,
+          prompt: result.prompt,
+        });
+      }
       router.push(`/chat/${result.conversationId}`);
     } else {
       setIsOpening(false);

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -459,12 +459,13 @@ export function ChatPageContent({
     return searchParams.get("user_prompt") || undefined;
   }, [searchParams]);
 
-  // A chat started from a project is created up front by the project composer,
-  // which stashes its opening prompt and navigates straight here. Drain that
-  // prompt (and any attachments the composer stashed) into the
-  // pending-initial-message refs so the shared send effect delivers them as the
-  // conversation's first message. Gated on the conversation id, so an ordinary
-  // /chat/<id> open never consumes it.
+  // A chat whose conversation was created up front (by the project composer, or
+  // by the apps page for an external app whose tool needs inputs) stashes its
+  // opening prompt and navigates straight here. Drain that prompt (and any
+  // attachments the composer stashed) into the pending-initial-message refs so
+  // the shared send effect delivers them as the conversation's first message.
+  // Gated on the conversation id, so an ordinary /chat/<id> open never
+  // consumes it.
   useEffect(() => {
     if (!conversationId) return;
     const handoff = takePendingProjectChatHandoff(conversationId);

--- a/platform/frontend/src/lib/app.query.ts
+++ b/platform/frontend/src/lib/app.query.ts
@@ -136,8 +136,11 @@ export function useOpenAppInChat() {
 }
 
 // Opens an external (MCP-server) app in chat against a concrete install: the
-// backend seeds a conversation with the UI rendered inline and returns its id.
-// The caller navigates to `/chat/<conversationId>` on success.
+// backend creates a conversation and returns its id plus how it was set up —
+// `mode: "render"` (UI seeded inline) or `mode: "prompt"` (empty conversation
+// plus an opening prompt for the caller to send, used when the tool has
+// required inputs). The caller navigates to `/chat/<conversationId>` on
+// success.
 export function useOpenExternalAppInChat() {
   return useMutation({
     mutationFn: async (params: {

--- a/platform/frontend/src/lib/chat/pending-project-chat-handoff.ts
+++ b/platform/frontend/src/lib/chat/pending-project-chat-handoff.ts
@@ -1,12 +1,17 @@
 /**
- * In-memory carrier for the opening prompt of a chat started from a project.
+ * In-memory carrier for the opening prompt of a chat whose conversation was
+ * created before navigating to it.
  *
- * The project composer creates the conversation up front — so the project page
- * stays on screen instead of routing through an empty `/chat` that flashes the
- * New Chat splash — then navigates straight to `/chat/<id>`. The prompt rides
- * this module-level singleton across that one client-side navigation, and
- * `/chat/<id>` drains it (together with any attachments from
- * `pending-chat-handoff-files`) into the conversation's first message.
+ * Two flows use it. The project composer creates the conversation up front — so
+ * the project page stays on screen instead of routing through an empty `/chat`
+ * that flashes the New Chat splash — then navigates straight to `/chat/<id>`.
+ * The apps page does the same when an external MCP app's tool has required
+ * inputs: the backend creates an empty conversation and returns an opening
+ * prompt, which rides here so the agent's first turn collects the inputs. In
+ * both, the prompt rides this module-level singleton across that one
+ * client-side navigation, and `/chat/<id>` drains it (together with any
+ * attachments from `pending-chat-handoff-files`) into the conversation's first
+ * message.
  *
  * Keyed by the created conversation id so an unrelated `/chat/<id>` open never
  * inherits a stale handoff; a hard reload starts empty, which is fine for a

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -666,7 +666,7 @@ export const getAppTemplates = <ThrowOnError extends boolean = false>(options?: 
 export const openAppInChat = <ThrowOnError extends boolean = false>(options: Options<OpenAppInChatData, ThrowOnError>) => (options.client ?? client).post<OpenAppInChatResponses, OpenAppInChatErrors, ThrowOnError>({ url: '/api/apps/{appId}/open-in-chat', ...options });
 
 /**
- * Open an external (MCP-server) UI app in chat: create a conversation with the app rendered against the given install (no model turn) and return its id to navigate to.
+ * Open an external (MCP-server) UI app in chat: create a conversation and return its id to navigate to. When the tool needs no inputs the app is seeded already rendered (no model turn); when it has required inputs the conversation is created empty and the response carries an opening prompt for the client to send.
  *
  * Authentication:
  *

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -16003,6 +16003,8 @@ export type OpenExternalAppInChatResponses = {
      */
     200: {
         conversationId: string;
+        mode: 'render' | 'prompt';
+        prompt?: string;
     };
 };
 


### PR DESCRIPTION
## Problem

Clicking an external MCP-server app on the Apps page (a tool on an installed server with a `ui://` resource, e.g. **Atlassian / createjiraissue**) seeded a synthetic assistant tool-call message that renders the tool's UI resource with input `{}` and no model turn. For tools that actually require inputs this mounts a broken app ("Failed to load app — … Unauthorized" / empty panel) over an empty conversation.

## Fix

**Needs-inputs heuristic (server-side):** the external open-in-chat endpoint already resolves the tool; it now also reads the tool's stored input schema (`tools.parameters`). Mirroring `normalizeToolInputSchema`, anything that isn't a `type: "object"` schema counts as an empty schema; a non-empty `required` array means the app cannot render from `{}`.

- **Tool has required inputs → `mode: "prompt"`**: the conversation is created empty (same "<server> / <tool>" title, same agent binding + LLM resolution) and the response carries an opening prompt: *"Open the <server> / <tool> app. Ask me for any inputs you need first, then call the <tool> tool on the <server> MCP server."*
- **No required inputs → `mode: "render"`**: unchanged seeded-render behavior.
- **Owned apps**: untouched.

**Triggering the first model turn:** there is no backend mechanism that runs a turn for an un-answered seeded user message — generation only starts from the frontend streaming path. So the fix reuses the existing pending-chat handoff that project chats already use (`pending-project-chat-handoff.ts`): the app card stashes `{ conversationId, prompt }`, navigates to `/chat/<id>`, and the chat page's existing drain + deferred-send effects deliver the prompt as the first user message through the normal send path — the turn streams normally, and the model-initiated tool call's output (`_meta.ui.resourceUri` + `mcpServerId`) mounts the app in the chat panel as it already does today. No server-side LLM loop was added. (Same trade-off as project handoffs: a hard reload mid-navigation loses the one-shot prompt and leaves an empty titled conversation with the composer focused.)

**Tool availability:** the seeded conversation binds to the member's default chat agent. The bootstrapped personal chat agent (`ensurePersonalChatAgent`) is created with `accessAllTools: true`, which coerces `toolExposureMode` to `search_and_run_only` — its `search_tools`/`run_tool` discovery space is scoped to the caller's accessible installs (`getAccessibleInstallCatalogIds`), and the install behind an Apps-page card is by definition accessible (`findInstalledUiResourceForCaller` checks it). So the agent can find and call the tool without any new authz path. If an org points the member's default agent at a locked-down agent without dynamic tool access, the agent simply won't find the tool — the same outcome as typing the request manually.

## Changes

- `backend/src/models/mcp-server.ts`: `getUiApps`/`findInstalledUiResourceForCaller` now also return the tool's `parameters`.
- `backend/src/services/apps/app-chat-conversation.ts`: render-vs-prompt branch; conversation creation extracted into a shared helper; prompt text builder.
- `backend/src/routes/app/app.routes.ts`: external open-in-chat response extended with `mode` (+ optional `prompt`).
- `frontend/src/app/apps/_parts/app-card.tsx`: prompt-mode results ride `setPendingProjectChatHandoff` before navigation.
- `frontend/src/lib/chat/pending-project-chat-handoff.ts`, `frontend/src/app/chat/page.tsx`, `frontend/src/lib/app.query.ts`: doc comments updated for the second consumer.
- `docs/openapi.json`, `shared/hey-api/clients/api/*`: regenerated (`CODEGEN=true` + `ARCHESTRA_APPS_ENABLED`/`ARCHESTRA_PROJECTS_ENABLED`, matching CI).

## Tests / checks

- `open-in-chat-external.app.route.test.ts`: new cases — required inputs → `mode: "prompt"`, empty conversation, prompt names the app, title preserved; all-optional schema → `mode: "render"` with the seeded message; existing render case now asserts `mode`.
- `app-card.test.tsx`: prompt-mode opens stash the handoff; render-mode opens don't.
- Backend + frontend + shared `type-check`, backend + frontend `knip`, biome on changed files: green. Related suites (`mcp-server.test.ts`, apps list/external routes): green. Pre-existing local-env failures in `create.app.route.test.ts`/`mcp-backing.app.route.test.ts` (500s on app creation) reproduce identically on a clean tree and are unrelated.

## Caveats

- An unauthenticated/broken install still fails at tool-call time — expected; it now surfaces in-chat as a failed tool call instead of a broken app panel.
- The needs-inputs signal trusts the stored schema; a tool that declares no `required` but rejects `{}` at runtime still opens via seeded render (unchanged from today).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>