### PR TITLE
fix: always seed the app-opened chat greeting and simplify its copy

### DIFF
--- a/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
@@ -57,7 +57,7 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     return created.json().id;
   }
 
-  // Forks a new version (latestVersion 1 → 2), so the open-in-chat greeting fires.
+  // Forks a new version (latestVersion 1 → 2).
   async function editApp(appId: string): Promise<void> {
     const edited = await app.inject({
       method: "PATCH",
@@ -97,9 +97,10 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     const part = message.content.parts[0] as { type: string; text: string };
     expect(part.type).toBe("text");
     expect(part.text).toContain(appName);
-    expect(part.text).toContain("Your connected MCP tools & servers");
-    expect(part.text).toContain("A private + shared data store");
-    expect(part.text).toContain("Built-in AI to summarize & generate");
+    expect(part.text).toContain("Want to change the app? Tell me how!");
+    expect(part.text).toContain(
+      "Want to use the app? Use the UI 👉, or ask me to!",
+    );
     return part.text;
   }
 
@@ -121,7 +122,7 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     expectSeededGreeting(messages[1], "Notes");
   });
 
-  test("seeds only the render (no greeting) for a brand-new scaffold app", async () => {
+  test("seeds a render plus a greeting for a brand-new scaffold app", async () => {
     const appId = await createApp("Fresh");
 
     const res = await app.inject({
@@ -131,11 +132,12 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     const { conversationId } = res.json();
 
     const messages = await MessageModel.findByConversation(conversationId);
-    expect(messages).toHaveLength(1);
+    expect(messages).toHaveLength(2);
     expect(expectSeededRender(messages[0])).toBe(appId);
+    expectSeededGreeting(messages[1], "Fresh");
   });
 
-  test("create with openInChat seeds only the render (still the scaffold)", async () => {
+  test("create with openInChat seeds a render plus a greeting", async () => {
     const created = await app.inject({
       method: "POST",
       url: "/api/apps",
@@ -146,8 +148,9 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     expect(conversationId).toBeTruthy();
 
     const messages = await MessageModel.findByConversation(conversationId);
-    expect(messages).toHaveLength(1);
+    expect(messages).toHaveLength(2);
     expect(expectSeededRender(messages[0])).toBe(id);
+    expectSeededGreeting(messages[1], "Inline");
   });
 
   test("the seeded greeting omits the app description", async () => {

--- a/platform/backend/src/services/apps/app-chat-conversation.ts
+++ b/platform/backend/src/services/apps/app-chat-conversation.ts
@@ -66,9 +66,7 @@ export async function createSeededAppConversation(params: {
       input: { appId: app.id },
       output: buildAppRenderResult(app),
     },
-    // Skip for a brand-new app: its default template already lists these capabilities.
-    greeting:
-      app.latestVersion > 1 ? buildAppOpenedGreeting(app.name) : undefined,
+    greeting: buildAppOpenedGreeting(app.name),
   });
 }
 
@@ -217,12 +215,8 @@ async function resolveDefaultChatAgentId(params: {
 /** Markdown greeting seeded when an owned app is opened in chat. */
 function buildAppOpenedGreeting(name: string): string {
   return (
-    `Here's **${name}**, up and running.\n\n` +
-    `It's an MCP app, so it can use:\n` +
-    `- Your connected MCP tools & servers\n` +
-    `- A private + shared data store\n` +
-    `- Built-in AI to summarize & generate\n\n` +
-    `Use it as-is, or tell me what you'd like to change or add ` +
-    `— I'll update it live.`
+    `Here's **${name}**.\n\n` +
+    `Want to change the app? Tell me how!\n\n` +
+    `Want to use the app? Use the UI 👉, or ask me to!`
   );
 }


### PR DESCRIPTION
Opening an app in chat now always seeds the greeting message — previously it was skipped for brand-new (v1) scaffold apps.

New copy:

> Here's **{app name}**.
>
> Want to change the app? Tell me how!
>
> Want to use the app? Use the UI 👉, or ask me to!

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>