### PR TITLE
fix(apps): propagate the host theme into MCP app iframes via color-scheme

### DIFF
--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -1126,9 +1126,7 @@ export function isRenderableMcpAppHtml(html: string): boolean {
  * before the `useTheme()` hook has hydrated).
  */
 function readDocumentTheme(): "light" | "dark" {
-  return document.documentElement.classList.contains("dark")
-    ? "dark"
-    : "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
 }
 
 /** Reads a CSS custom property value from :root */

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -300,7 +300,12 @@ export const McpAppRuntime = function McpAppRuntime({
       {
         hostContext: {
           displayMode: displayModeRef.current,
-          theme: (resolvedThemeRef.current ?? "light") as "light" | "dark",
+          // Fall back to the <html> class when the theme hook hasn't hydrated
+          // yet (hard load): next-themes stamps the class pre-React, so a
+          // dark-mode page never announces itself as light.
+          theme: (resolvedThemeRef.current ?? readDocumentTheme()) as
+            | "light"
+            | "dark",
           platform: "web",
           availableDisplayModes: AVAILABLE_DISPLAY_MODES,
           containerDimensions: containerDimensionsHint(
@@ -605,9 +610,7 @@ export const McpAppRuntime = function McpAppRuntime({
     if (!bridge) return;
     const observer = new MutationObserver(() => {
       bridge.setHostContext({
-        theme: document.documentElement.classList.contains("dark")
-          ? "dark"
-          : "light",
+        theme: readDocumentTheme(),
         styles: { variables: buildMcpUiStyleVariables() },
       });
     });
@@ -829,6 +832,21 @@ function SandboxIframe({
     iframe.style.height = `${initialHeightRef.current}px`;
     iframe.style.border = "none";
     iframe.style.backgroundColor = "transparent";
+    // Propagate the host theme into the sandbox chain: per CSS Color
+    // Adjustment, the frame element's used color-scheme sets the embedded
+    // document's *preferred* color scheme, and the proxy hands it on to the
+    // app frame (`color-scheme: inherit` + its `light dark` meta). Apps that
+    // theme via `@media (prefers-color-scheme)` / `light-dark()` instead of
+    // the bridge's hostContext.theme then follow the app theme rather than
+    // the OS — matching how desktop MCP hosts render them.
+    iframe.style.colorScheme = readDocumentTheme();
+    const themeObserver = new MutationObserver(() => {
+      iframe.style.colorScheme = readDocumentTheme();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
     // With dedicated subdomain: allow-same-origin is safe (different origin from backend).
     // Without: no allow-same-origin → opaque origin for security isolation.
     iframe.setAttribute(
@@ -926,6 +944,7 @@ function SandboxIframe({
     return () => {
       cancelled = true;
       clearTimeout(timeout);
+      themeObserver.disconnect();
       window.removeEventListener("message", onMessage);
       window.removeEventListener("message", onDiagnosticMessage);
       iframe.remove();
@@ -1100,6 +1119,17 @@ export function isRenderableMcpAppHtml(html: string): boolean {
 }
 
 // ── Host-theme bridging helpers ──────────────────────────────────────────────
+
+/**
+ * The host's light/dark theme, read from the class next-themes stamps on
+ * `<html>` (set synchronously by its inline script, so it's correct even
+ * before the `useTheme()` hook has hydrated).
+ */
+function readDocumentTheme(): "light" | "dark" {
+  return document.documentElement.classList.contains("dark")
+    ? "dark"
+    : "light";
+}
 
 /** Reads a CSS custom property value from :root */
 function getCssVar(name: string): string {


### PR DESCRIPTION
## Problem

The Confluence MCP app renders correctly in Archestra's light theme but breaks in dark theme (renders light inside dark chrome), while the same app renders correctly in Claude Desktop and other MCP apps in Archestra are fine.

## Root cause

We send the theme to guests over the ext-apps bridge (`hostContext.theme` + MCP-UI style variables), and apps that consume those render correctly in both themes. But apps that theme themselves with plain CSS — `@media (prefers-color-scheme: dark)` / `light-dark()` — never look at the bridge. Inside a cross-origin/sandboxed iframe, `prefers-color-scheme` is derived from the **used `color-scheme` of the host's iframe element** (CSS Color Adjustment), and Archestra never set `color-scheme` anywhere. So those guests fell back to the OS scheme: light OS + dark Archestra → light app in dark chrome. Desktop hosts (Claude Desktop) propagate their theme natively, which is why the same app looks right there.

The sandbox proxy was already built to receive this — it declares `<meta name="color-scheme" content="light dark">` and gives the inner app frame `color-scheme: inherit` — the missing link was the host never stamping the outer iframe.

## Fix

- `SandboxIframe` sets `iframe.style.colorScheme` from the `dark` class next-themes stamps on `<html>`, and tracks theme flips with a MutationObserver (same pattern as the existing bridge theme sync). The guest's `prefers-color-scheme` now follows the app theme end to end.
- The initial `hostContext.theme` now falls back to the `<html>` class instead of hard-coding `"light"` when the `useTheme()` hook hasn't hydrated yet (hard load), so a dark page never announces itself as light.
- Shared `readDocumentTheme()` helper replaces the inline classList check in the bridge observer.

## Verification

Reproduced the exact chain in Chrome (host page → `sandbox="allow-scripts"` proxy iframe with the `light dark` meta → nested guest iframe with `color-scheme: inherit`, guest reporting `matchMedia("(prefers-color-scheme: dark)")`):

- No `color-scheme` on the frame → guest follows the **OS** scheme (the bug).
- `color-scheme` set on the frame → guest follows the frame's scheme, overriding the OS.
- Flipping the frame's `colorScheme` at runtime → the guest's media query updates live.

`pnpm type-check`, biome, and the mcp-app component tests pass.

## Notes / caveats

- One behavior change from the spec's canvas rule: in dark mode, a light-only guest (declares no dark support) now gets an opaque canvas of its own scheme instead of a transparent one — i.e. it correctly renders as a light app instead of inheriting a see-through dark backdrop it was never designed for. This matches desktop-host behavior.
- Apps that read `hostContext.theme`/style variables are unaffected (they already worked).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>