### PR TITLE
fix: chat header selector border and stuck tab highlight

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -419,7 +419,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
               <ModelSelectorLogo provider={logoProvider} className="size-4" />
             </Button>
           ) : (
-            <div className="flex items-center h-8 rounded-full border border-border bg-muted/50 overflow-hidden">
+            <div className="flex items-center h-8 rounded-full bg-muted/50 overflow-hidden">
               {(conversationId || onApiKeyChange) && (
                 <LlmProviderApiKeySelector
                   conversationId={conversationId}

--- a/platform/frontend/src/components/chat/conversation-header.test.tsx
+++ b/platform/frontend/src/components/chat/conversation-header.test.tsx
@@ -69,6 +69,24 @@ describe("ConversationHeader — top-bar tab strip", () => {
     expect(screen.getByRole("tab", { name: "Apps" })).toBeInTheDocument();
   });
 
+  it("highlights the active tab only while the panel is open", () => {
+    renderHeader({ isOpen: true, activeTab: "files" });
+    expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("highlights no tab while the panel is collapsed", () => {
+    renderHeader({ isOpen: false, activeTab: "files" });
+    for (const name of ["Files", "Browser", "Apps"]) {
+      expect(screen.getByRole("tab", { name })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    }
+  });
+
   it("clicking a DIFFERENT tab switches to it and does not close", async () => {
     const user = userEvent.setup();
     // "files" is active + open; clicking Browser must switch, not collapse

--- a/platform/frontend/src/components/chat/conversation-header.tsx
+++ b/platform/frontend/src/components/chat/conversation-header.tsx
@@ -36,7 +36,7 @@ type Conversation = archestraApiTypes.GetChatConversationResponses["200"];
 /** Right-panel state + handlers the header needs to drive open/close/tab. */
 interface PanelControls {
   isOpen: boolean;
-  /** The tab currently selected (highlighted even while the panel is collapsed). */
+  /** The tab currently selected (highlighted only while the panel is open). */
   activeTab: RightPanelTab;
   /** Set for scheduled-run chats — enables the Runs tab. */
   scheduledRun: { triggerId: string; runId: string | null } | null;
@@ -93,23 +93,23 @@ export function ConversationHeader({
     onCreateProject,
   };
 
-  // Which tab is highlighted — mirror the panel's fallbacks so the strip never
-  // highlights a tab the panel can't actually show.
+  // Which tab the panel would show — mirror the panel's fallbacks so the strip
+  // never highlights a tab the panel can't actually show. Only highlighted
+  // while the panel is open; collapsing clears the highlight.
   const canShowBrowser =
     panel.showBrowserButton && !panel.isPlaywrightSetupVisible;
   let resolvedTab: RightPanelTab = panel.activeTab;
   if (resolvedTab === "browser" && !canShowBrowser) resolvedTab = "files";
   if (resolvedTab === "runs" && !panel.scheduledRun) resolvedTab = "files";
 
-  // Radix Tabs flip the active tab on mousedown (before onClick), so detect a
-  // click on the ALREADY-active tab here, where resolvedTab is still pre-click:
-  // active + open collapses, active + collapsed opens. A different tab is left
-  // to onValueChange, which switches. Left button only (mirrors Radix's guard).
+  // Radix won't fire onValueChange when the clicked tab already equals the
+  // controlled value, so collapsing on an active-tab click has to happen here,
+  // on mousedown, where resolvedTab is still pre-click. Opens (different tab,
+  // or any tab while collapsed — value is "" then, so every click is a change)
+  // flow through onValueChange. Left button only (mirrors Radix's guard).
   const handleTabMouseDown = (tab: RightPanelTab) => (e: React.MouseEvent) => {
     if (e.button !== 0 || e.ctrlKey) return;
-    if (resolvedTab !== tab) return;
-    if (panel.isOpen) panel.onClose();
-    else panel.onOpenTab(tab);
+    if (panel.isOpen && resolvedTab === tab) panel.onClose();
   };
 
   return (
@@ -193,14 +193,14 @@ export function ConversationHeader({
             there is no separate collapse button. */}
         <div className="hidden md:flex items-center flex-shrink-0">
           <Tabs
-            value={resolvedTab}
+            value={panel.isOpen ? resolvedTab : ""}
             onValueChange={(value) => {
-              // Radix fires this on every mousedown, even on the active tab —
-              // guard so it only switches on a real change and never reopens
-              // right after handleTabMouseDown collapses the panel. Keyboard
-              // activation flows through here too.
-              const tab = value as RightPanelTab;
-              if (tab !== resolvedTab) panel.onOpenTab(tab);
+              // Fires on any tab click while collapsed (value is "") and on a
+              // different-tab click while open. It never fires for the
+              // active-tab-while-open click (value unchanged), so it can't
+              // reopen right after handleTabMouseDown collapses the panel.
+              // Keyboard activation flows through here too.
+              panel.onOpenTab(value as RightPanelTab);
             }}
           >
             <TabsList className="h-8">


### PR DESCRIPTION
- Remove the border around the provider key + model selector pill in the chat input.
- Clear the Files/Browser/Apps tab highlight in the conversation header when clicking the active tab collapses the right panel; highlight now only shows while the panel is open. Tests added.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>