### PR TITLE
fix(apps): resolve app tool names to the canonical row instead of erroring on duplicates

### DIFF
--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -1848,6 +1848,48 @@ describe("scaffold_app tools param", () => {
     expect(created.isError).toBe(true);
     expect((created.content[0] as any).text).toContain("Unknown tool name");
   });
+
+  test("an unassigned, installed tool is not assignable when the agent lacks dynamic access", async ({
+    makeAgent,
+    makeUser,
+    makeMember,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    // Assignable-by-name == discoverable-by-this-agent: with "access all tools"
+    // off, an unassigned tool is invisible to search_tools, so it must not be
+    // assignable by name — even though its catalog is installed. (The by-id REST
+    // path stays as the unrestricted programmatic escape hatch.)
+    const strictAgent = await makeAgent({
+      name: "Strict Agent",
+      accessAllTools: false,
+    });
+    const user = await makeUser();
+    await makeMember(user.id, strictAgent.organizationId, {
+      role: ADMIN_ROLE_NAME,
+    });
+    const strictContext = {
+      agent: { id: strictAgent.id, name: strictAgent.name },
+      organizationId: strictAgent.organizationId,
+      userId: user.id,
+    };
+
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: strictAgent.organizationId,
+    });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+    const gatedName = `gated__tool_${crypto.randomUUID().slice(0, 8)}`;
+    await makeTool({ name: gatedName, catalogId: catalog.id });
+
+    const created = await executeArchestraTool(
+      getArchestraToolFullName(TOOL_SCAFFOLD_APP_SHORT_NAME),
+      { name: "Gated", tools: [gatedName] },
+      strictContext,
+    );
+    expect(created.isError).toBe(true);
+    expect((created.content[0] as any).text).toContain("Unknown tool name");
+  });
 });
 
 describe("set_app_tools", () => {

--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -23,6 +23,7 @@ import {
   TOOL_VALIDATE_APP_SHORT_NAME,
 } from "@archestra/shared";
 import { vi } from "vitest";
+import { resolveDynamicTool } from "@/archestra-mcp-server/dynamic-tools";
 import {
   type ChatMcpElicitationWriter,
   createChatMcpElicitationBridge,
@@ -1138,9 +1139,13 @@ describe("preview_app_tool", () => {
       makeUser,
       makeMember,
       makeInternalMcpCatalog,
+      makeMcpServer,
       makeTool,
     }) => {
-      const agent = await makeAgent({ name: "Preview Agent" });
+      const agent = await makeAgent({
+        name: "Preview Agent",
+        accessAllTools: true,
+      });
       organizationId = agent.organizationId;
       const user = await makeUser();
       await makeMember(user.id, organizationId, { role: ADMIN_ROLE_NAME });
@@ -1153,6 +1158,7 @@ describe("preview_app_tool", () => {
       };
 
       const catalog = await makeInternalMcpCatalog({ organizationId });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
       toolName = `hf__search_${crypto.randomUUID().slice(0, 8)}`;
       await makeTool({ name: toolName, catalogId: catalog.id });
 
@@ -1681,9 +1687,16 @@ describe("scaffold_app tools param", () => {
       makeUser,
       makeMember,
       makeInternalMcpCatalog,
+      makeMcpServer,
       makeTool,
     }) => {
-      const agent = await makeAgent({ name: "Tools Agent" });
+      // Dynamic access on: an unassigned tool is only assignable-by-name when the
+      // agent can discover it (mirrors search_tools), which needs the setting on
+      // and an accessible install of its catalog.
+      const agent = await makeAgent({
+        name: "Tools Agent",
+        accessAllTools: true,
+      });
       organizationId = agent.organizationId;
       const user = await makeUser();
       await makeMember(user.id, organizationId, { role: ADMIN_ROLE_NAME });
@@ -1694,6 +1707,7 @@ describe("scaffold_app tools param", () => {
       };
 
       const catalog = await makeInternalMcpCatalog({ organizationId });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
       paperSearchName = `hf__paper_search_${crypto.randomUUID().slice(0, 8)}`;
       await makeTool({ name: paperSearchName, catalogId: catalog.id });
     },
@@ -1759,6 +1773,81 @@ describe("scaffold_app tools param", () => {
     expect(created.isError).toBe(true);
     expect((created.content[0] as any).text).toContain("Unknown tool name");
   });
+
+  test("a duplicate tool name resolves to the canonical row, not an ambiguity error", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    // A second installed catalog carries a tool with the SAME name — tools.name
+    // is unique only per catalog. The old path rejected this as "matches more
+    // than one installed tool"; it must now resolve to the one row discovery and
+    // the app runtime pick.
+    const catalog2 = await makeInternalMcpCatalog({ organizationId });
+    await makeMcpServer({ catalogId: catalog2.id, scope: "org" });
+    await makeTool({ name: paperSearchName, catalogId: catalog2.id });
+
+    const canonical = await resolveDynamicTool({
+      toolName: paperSearchName,
+      agentId: context.agent.id,
+      userId: context.userId,
+      organizationId,
+    });
+    expect(canonical).not.toBeNull();
+
+    const created = await scaffold({ name: "Dupes", tools: [paperSearchName] });
+    expect(created.isError).toBe(false);
+
+    const assignments = await AppToolModel.getAssignmentsForApp(
+      structured(created).id as string,
+    );
+    expect(assignments.map((a) => a.tool.id)).toEqual([canonical?.id]);
+  });
+
+  test("an assigned duplicate wins over a newer installed one, matching search_tools", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+    makeAgentTool,
+  }) => {
+    const dupName = `dup__tool_${crypto.randomUUID().slice(0, 8)}`;
+    // Assigned row, created first so it is the OLDER of the two duplicates.
+    const assignedCatalog = await makeInternalMcpCatalog({ organizationId });
+    await makeMcpServer({ catalogId: assignedCatalog.id, scope: "org" });
+    const assignedRow = await makeTool({
+      name: dupName,
+      catalogId: assignedCatalog.id,
+    });
+    await makeAgentTool(context.agent.id, assignedRow.id);
+    // Newer, unassigned duplicate in another installed catalog.
+    const newerCatalog = await makeInternalMcpCatalog({ organizationId });
+    await makeMcpServer({ catalogId: newerCatalog.id, scope: "org" });
+    await makeTool({ name: dupName, catalogId: newerCatalog.id });
+
+    const created = await scaffold({ name: "Assigned", tools: [dupName] });
+    expect(created.isError).toBe(false);
+    const assignments = await AppToolModel.getAssignmentsForApp(
+      structured(created).id as string,
+    );
+    // The assigned (older) row wins: search_tools ranks assigned before
+    // discoverable, and the app runtime executes the app-assigned row.
+    expect(assignments.map((a) => a.tool.id)).toEqual([assignedRow.id]);
+  });
+
+  test("a tool in a catalog with no accessible install is not assignable by name", async ({
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    // No install → not discoverable via search_tools, so not assignable by name
+    // either (the resolver matches what the user can actually reach and run).
+    const uninstalled = await makeInternalMcpCatalog({ organizationId });
+    const orphanName = `orphan__tool_${crypto.randomUUID().slice(0, 8)}`;
+    await makeTool({ name: orphanName, catalogId: uninstalled.id });
+
+    const created = await scaffold({ name: "Orphan", tools: [orphanName] });
+    expect(created.isError).toBe(true);
+    expect((created.content[0] as any).text).toContain("Unknown tool name");
+  });
 });
 
 describe("set_app_tools", () => {
@@ -1773,9 +1862,13 @@ describe("set_app_tools", () => {
       makeUser,
       makeMember,
       makeInternalMcpCatalog,
+      makeMcpServer,
       makeTool,
     }) => {
-      const agent = await makeAgent({ name: "Set Tools Agent" });
+      const agent = await makeAgent({
+        name: "Set Tools Agent",
+        accessAllTools: true,
+      });
       organizationId = agent.organizationId;
       const user = await makeUser();
       userId = user.id;
@@ -1787,6 +1880,7 @@ describe("set_app_tools", () => {
       };
 
       const catalog = await makeInternalMcpCatalog({ organizationId });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
       toolName = `acme__search_${crypto.randomUUID().slice(0, 8)}`;
       await makeTool({ name: toolName, catalogId: catalog.id });
     },
@@ -1843,6 +1937,7 @@ describe("set_app_tools", () => {
 
   test("resolves tools in the app's bound environment, not the org default", async ({
     makeInternalMcpCatalog,
+    makeMcpServer,
     makeTool,
     makeApp,
   }) => {
@@ -1854,6 +1949,7 @@ describe("set_app_tools", () => {
       organizationId,
       environmentId: env.id,
     });
+    await makeMcpServer({ catalogId: envCatalog.id, scope: "org" });
     const envToolName = `acme__env_${crypto.randomUUID().slice(0, 8)}`;
     await makeTool({ name: envToolName, catalogId: envCatalog.id });
 

--- a/platform/backend/src/archestra-mcp-server/apps.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.ts
@@ -373,6 +373,8 @@ const registry = defineArchestraTools([
       // path), so tools resolve within the default environment — not the
       // authoring agent's — keeping assignments consistent with the app's env.
       const toolsResolution = await resolveToolsParam({
+        agentId: context.agent.id,
+        userId: context.userId,
         organizationId: context.organizationId,
         tools: args.tools,
         environmentId: null,
@@ -890,6 +892,8 @@ const registry = defineArchestraTools([
       // Fence resolution against the app's bound environment (not the org
       // default scaffold_app uses), so a tool only valid elsewhere is rejected.
       const resolution = await resolveToolsParam({
+        agentId: context.agent.id,
+        userId,
         organizationId,
         tools: args.tools,
         environmentId: app.environmentId,
@@ -1895,6 +1899,8 @@ type ResolvedTools = Array<{ id: string; name: string }>;
  * "leave assignments untouched"; `[]` clears them.
  */
 async function resolveToolsParam(params: {
+  agentId: string;
+  userId: string;
   organizationId: string;
   tools: string[] | undefined;
   environmentId: string | null;
@@ -1903,6 +1909,8 @@ async function resolveToolsParam(params: {
 > {
   if (params.tools === undefined) return { ok: true, tools: undefined };
   const resolution = await resolveAppToolsByName({
+    agentId: params.agentId,
+    userId: params.userId,
     organizationId: params.organizationId,
     toolNames: params.tools,
     environmentId: params.environmentId,

--- a/platform/backend/src/archestra-mcp-server/apps.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.ts
@@ -510,6 +510,9 @@ const registry = defineArchestraTools([
         userId,
         organizationId,
         agentId: context.agentId ?? context.agent.id,
+        // Ground in the app's environment (set_app_tools/runtime resolve there),
+        // not the authoring agent's — an app is bound to a deliberate env.
+        environmentId: app.environmentId,
       });
 
       // Seed the model from the app's current spec, or derive a minimal one from

--- a/platform/backend/src/archestra-mcp-server/dynamic-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/dynamic-tools.ts
@@ -341,7 +341,9 @@ async function getAccessibleTools(
 // Catalog visibility uses the same admin notion as the catalog list endpoint
 // (routes/internal-mcp-catalog.ts): mcpServerInstallation:admin sees all
 // catalogs in the organization, including team-scoped ones.
-function userIsCatalogAdmin(
+/** @public — shared with the app-assignable tool resolver so both surfaces
+ * derive catalog visibility from the same admin notion. */
+export function userIsCatalogAdmin(
   userId: string,
   organizationId: string,
 ): Promise<boolean> {

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -606,6 +606,11 @@ class ToolModel {
                 ),
               ),
               desc(schema.toolsTable.createdAt),
+              // Total order on ties (bulk-inserted tools share createdAt), so a
+              // duplicate assigned name resolves to the same row every time —
+              // matching getMcpToolsAccessibleToUser and keeping search_tools /
+              // app tool assignment deterministic.
+              asc(schema.toolsTable.id),
             )
         : [];
 
@@ -1760,10 +1765,10 @@ class ToolModel {
    * catalog-backed (non-null catalogId, which app dispatch requires), org-visible
    * (the catalog belongs to the org or is a global org-less entry), not an
    * Archestra built-in, not a clone pending discovery, and in the environment.
-   * The by-id, install-agnostic gate {@link resolveAppAssignableToolRows} applies
-   * to the agent's *assigned* tools — an assigned tool is reachable through its
-   * assignment without a separate discoverable install, but must still be
-   * org-visible and in-environment.
+   * This is the by-id, install-agnostic gate {@link resolveAppAssignableToolRows}
+   * applies to the agent's *assigned* tools — an assigned tool is reachable
+   * through its assignment without a separate discoverable install, but must
+   * still be org-visible and in-environment.
    */
   static async filterAppAssignableToolIds(
     organizationId: string,

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -1756,27 +1756,23 @@ class ToolModel {
   }
 
   /**
-   * Resolve upstream tool names to rows assignable to an MCP App, scoped to
-   * the caller's organization (a tool is reachable when its catalog entry
-   * belongs to the org or is a global, org-less entry). Archestra built-ins
-   * are excluded — apps reach the data store through `archestra.storage`, and
-   * the management tools are not app-dispatchable. The catalog join also
-   * guarantees a non-null catalogId, which app dispatch requires.
+   * Of `toolIds`, the subset assignable to an MCP App in `environmentId`:
+   * catalog-backed (non-null catalogId, which app dispatch requires), org-visible
+   * (the catalog belongs to the org or is a global org-less entry), not an
+   * Archestra built-in, not a clone pending discovery, and in the environment.
+   * The by-id, install-agnostic gate {@link resolveAppAssignableToolRows} applies
+   * to the agent's *assigned* tools — an assigned tool is reachable through its
+   * assignment without a separate discoverable install, but must still be
+   * org-visible and in-environment.
    */
-  static async findAppAssignableToolsByNames(
+  static async filterAppAssignableToolIds(
     organizationId: string,
-    names: readonly string[],
+    toolIds: string[],
     environmentId: string | null,
-  ): Promise<
-    Array<{ id: string; name: string; clonedPendingDiscovery: boolean }>
-  > {
-    if (names.length === 0) return [];
-    return await db
-      .select({
-        id: schema.toolsTable.id,
-        name: schema.toolsTable.name,
-        clonedPendingDiscovery: schema.toolsTable.clonedPendingDiscovery,
-      })
+  ): Promise<Set<string>> {
+    if (toolIds.length === 0) return new Set();
+    const rows = await db
+      .select({ id: schema.toolsTable.id })
       .from(schema.toolsTable)
       .innerJoin(
         schema.internalMcpCatalogTable,
@@ -1784,10 +1780,9 @@ class ToolModel {
       )
       .where(
         and(
-          inArray(schema.toolsTable.name, [...names]),
+          inArray(schema.toolsTable.id, toolIds),
           ne(schema.toolsTable.catalogId, ARCHESTRA_MCP_CATALOG_ID),
-          // Environment isolation: an app may only be assigned tools in the
-          // requesting agent's environment.
+          eq(schema.toolsTable.clonedPendingDiscovery, false),
           toolInEnvironmentPredicate(environmentId),
           or(
             eq(schema.internalMcpCatalogTable.organizationId, organizationId),
@@ -1795,13 +1790,17 @@ class ToolModel {
           ),
         ),
       );
+    return new Set(rows.map((row) => row.id));
   }
 
   /**
-   * By-id counterpart of {@link findAppAssignableToolsByNames}: resolves a tool
-   * only within the caller's organization (catalog-backed, org-owned or global).
-   * A tool from another org — or a non-catalog/built-in tool — returns null, so
-   * the raw-id assignment endpoint cannot attach (or probe for) foreign tools.
+   * Resolve a single app-assignable tool by id within the caller's organization
+   * (catalog-backed, org-owned or global). A tool from another org — or a
+   * non-catalog/built-in tool — returns null, so the raw-id assignment endpoint
+   * cannot attach (or probe for) foreign tools. Name-based app assignment goes
+   * through {@link resolveAppAssignableToolRows} instead, which resolves a
+   * duplicate name to the same canonical row search_tools and the app runtime
+   * pick.
    */
   static async findAppAssignableToolById(
     organizationId: string,

--- a/platform/backend/src/services/agent-tool-assignment.ts
+++ b/platform/backend/src/services/agent-tool-assignment.ts
@@ -11,6 +11,7 @@ import {
   TeamModel,
   ToolModel,
 } from "@/models";
+import { resolveAppAssignableToolRows } from "@/services/apps/app-assignable-tools";
 import type {
   AgentScope,
   CredentialResolutionMode,
@@ -166,18 +167,21 @@ export async function validateAssignment(
 }
 
 /**
- * Resolve a declarative tool-name list (the `tools` param of the
- * `scaffold_app` chat tool) to assignable tool rows — clean or
- * fail, never a silent partial set. Names resolve strictly within the caller's
- * organization (`ToolModel.findAppAssignableToolsByNames`; a global lookup
- * would let a caller attach another org's tool row), built-ins are rejected,
- * and an ambiguous or unknown name errors with the offenders listed. The
- * resulting assignments use dynamic credential resolution: the server (and so
- * the credential) is picked per viewing user at call time, which both makes
- * the assignment valid without an explicit mcpServerId and gives shared apps
- * per-viewer auth.
+ * Resolve a declarative tool-name list (the `tools` param of `scaffold_app` /
+ * `set_app_tools`) to assignable tool rows — clean or fail, never a silent
+ * partial set. Names resolve through {@link resolveAppAssignableToolRows}, the
+ * shared surface `search_tools` and the app runtime resolve against, so a
+ * duplicate name (unique only per catalog) collapses to the SAME canonical row
+ * the model saw and the app will execute — never an ambiguity error the caller
+ * cannot disambiguate. Built-ins are rejected and an unknown name errors with
+ * the offenders listed. The resulting assignments use dynamic credential
+ * resolution: the server (and so the credential) is picked per viewing user at
+ * call time, which both makes the assignment valid without an explicit
+ * mcpServerId and gives shared apps per-viewer auth.
  */
 export async function resolveAppToolsByName(params: {
+  agentId: string;
+  userId: string;
   organizationId: string;
   toolNames: readonly string[];
   /** Environment to resolve tools within (the app's bound environment; the org
@@ -197,15 +201,12 @@ export async function resolveAppToolsByName(params: {
     );
   }
 
-  const rows = await ToolModel.findAppAssignableToolsByNames(
-    params.organizationId,
-    requested,
-    params.environmentId,
-  );
-  const byName = new Map<string, typeof rows>();
-  for (const row of rows) {
-    byName.set(row.name, [...(byName.get(row.name) ?? []), row]);
-  }
+  const byName = await resolveAppAssignableToolRows({
+    agentId: params.agentId,
+    userId: params.userId,
+    organizationId: params.organizationId,
+    environmentId: params.environmentId,
+  });
 
   const unknown = requested.filter((name) => !byName.has(name));
   if (unknown.length > 0) {
@@ -213,25 +214,11 @@ export async function resolveAppToolsByName(params: {
       `Unknown tool name(s) for this organization: ${unknown.join(", ")}. Use search_tools to discover available tools.`,
     );
   }
-  const ambiguous = requested.filter(
-    (name) => (byName.get(name) ?? []).length > 1,
-  );
-  if (ambiguous.length > 0) {
-    return appToolsValidationError(
-      `Tool name(s) match more than one installed tool and cannot be assigned by name: ${ambiguous.join(", ")}.`,
-    );
-  }
-  const pendingDiscovery = rows.filter((row) => row.clonedPendingDiscovery);
-  if (pendingDiscovery.length > 0) {
-    return appToolsValidationError(
-      `Tool(s) not available until their server is installed: ${pendingDiscovery.map((row) => row.name).join(", ")}`,
-    );
-  }
 
   return {
     tools: requested.map((name) => {
       // biome-ignore lint/style/noNonNullAssertion: unknown names errored above
-      const row = byName.get(name)![0];
+      const row = byName.get(name)!;
       return { id: row.id, name: row.name };
     }),
   };

--- a/platform/backend/src/services/apps/app-assignable-tools.ts
+++ b/platform/backend/src/services/apps/app-assignable-tools.ts
@@ -1,4 +1,4 @@
-import { ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
+import { AGENT_TOOL_PREFIX, ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
 import {
   dynamicAccessContext,
   userIsCatalogAdmin,
@@ -94,6 +94,9 @@ function isAppAssignable(tool: Tool): boolean {
   return (
     tool.catalogId != null &&
     tool.catalogId !== ARCHESTRA_MCP_CATALOG_ID &&
+    // Reserved delegation-tool prefix, hidden from search_tools; a catalog tool
+    // reusing it must not be assignable through this discovery-matched path.
+    !tool.name.startsWith(AGENT_TOOL_PREFIX) &&
     !tool.clonedPendingDiscovery
   );
 }

--- a/platform/backend/src/services/apps/app-assignable-tools.ts
+++ b/platform/backend/src/services/apps/app-assignable-tools.ts
@@ -1,0 +1,99 @@
+import { ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
+import {
+  dynamicAccessContext,
+  userIsCatalogAdmin,
+} from "@/archestra-mcp-server/dynamic-tools";
+import { filterToolNamesByPermission } from "@/archestra-mcp-server/rbac";
+import { ToolModel } from "@/models";
+import type { Tool } from "@/types";
+
+/**
+ * Resolve the tools an app may be assigned by name, mapped to the single
+ * canonical row per name — the SAME row `search_tools` shows and `run_tool` /
+ * `archestra.tools.call` execute. This is the one place app tool assignment
+ * (`resolveAppToolsByName`) and app grounding (`buildAppCapabilityContext`)
+ * share, so the name the model discovers, the row it assigns, and the row the
+ * app runtime dispatches can never disagree.
+ *
+ * `tools.name` (`<server>__<tool>`) is unique only per catalog, so a name can
+ * back more than one row (e.g. an installed catalog plus a legacy/global
+ * duplicate). We mirror `search_tools`'s candidate set and ordering: the agent's
+ * assigned tools (always, no dynamic-access gate) plus — only when the agent has
+ * "access all tools" — the tools the user can otherwise reach; assigned rows win
+ * over discoverable ones, and among discoverable rows the newest wins
+ * (`getMcpToolsAccessibleToUser` returns them newest-first).
+ *
+ * Discoverable candidates are install-scoped to what the user can actually reach
+ * and run; assigned tools are reachable through their assignment without a
+ * separate install. Both are fenced to `environmentId` (the assignment target:
+ * the org default for scaffold_app, the app's bound env for set_app_tools),
+ * exclude Archestra built-ins (apps reach the data store through
+ * archestra.storage), and are RBAC-filtered the same way search/grounding are.
+ */
+export async function resolveAppAssignableToolRows(params: {
+  agentId: string;
+  userId: string;
+  organizationId: string;
+  environmentId: string | null;
+}): Promise<Map<string, Tool>> {
+  const { agentId, userId, organizationId, environmentId } = params;
+
+  const [assignedTools, gate] = await Promise.all([
+    ToolModel.getMcpToolsByAgent(agentId),
+    dynamicAccessContext({ agentId, userId, organizationId }),
+  ]);
+
+  // Assigned tools are assignable through their assignment without a separate
+  // discoverable install, but must still be org-visible and in the assignment-
+  // target environment (getMcpToolsByAgent scopes to the AGENT's env, which can
+  // differ from the app's env; it also does not exclude a foreign-org catalog).
+  const assignedAssignableIds = await ToolModel.filterAppAssignableToolIds(
+    organizationId,
+    assignedTools.map((tool) => tool.id),
+    environmentId,
+  );
+
+  // Discoverable universe: only when the agent has "access all tools" (matching
+  // search_tools), install-scoped and newest-first, fenced to the target env.
+  const discoverableTools = gate
+    ? await ToolModel.getMcpToolsAccessibleToUser({
+        userId,
+        organizationId,
+        environmentId,
+        isAdmin: await userIsCatalogAdmin(userId, organizationId),
+      })
+    : [];
+
+  const byName = new Map<string, Tool>();
+  for (const tool of assignedTools) {
+    if (assignedAssignableIds.has(tool.id) && !byName.has(tool.name)) {
+      byName.set(tool.name, tool);
+    }
+  }
+  for (const tool of discoverableTools) {
+    if (isAppAssignable(tool) && !byName.has(tool.name)) {
+      byName.set(tool.name, tool);
+    }
+  }
+
+  const permitted = await filterToolNamesByPermission(
+    [...byName.keys()],
+    userId,
+    organizationId,
+  );
+  for (const name of [...byName.keys()]) {
+    if (!permitted.has(name)) {
+      byName.delete(name);
+    }
+  }
+
+  return byName;
+}
+
+function isAppAssignable(tool: Tool): boolean {
+  return (
+    tool.catalogId != null &&
+    tool.catalogId !== ARCHESTRA_MCP_CATALOG_ID &&
+    !tool.clonedPendingDiscovery
+  );
+}

--- a/platform/backend/src/services/apps/app-capability-context.test.ts
+++ b/platform/backend/src/services/apps/app-capability-context.test.ts
@@ -58,6 +58,49 @@ describe("buildAppCapabilityContext", () => {
     ]);
   });
 
+  test("a duplicate tool name is grounded once, not dropped as ambiguous", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeTool,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id);
+    // Dynamic access on, so discoverable (unassigned) tools are grounded.
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: true,
+    });
+
+    // Two installed catalogs carry a tool with the SAME name — unique only per
+    // catalog. The old grounding dropped such names; it must now list the name
+    // once (the canonical row's description), matching what is assignable.
+    const dupName = "acme__do_thing";
+    for (const _ of [0, 1]) {
+      const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+      await makeTool({
+        name: dupName,
+        description: "Do a thing",
+        catalogId: catalog.id,
+      });
+    }
+
+    const context = await buildAppCapabilityContext({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+    });
+
+    expect(context.tools.filter((tool) => tool.name === dupName)).toEqual([
+      { name: dupName, description: "Do a thing" },
+    ]);
+  });
+
   test("describes the window.archestra SDK surface", async ({
     makeOrganization,
     makeUser,

--- a/platform/backend/src/services/apps/app-capability-context.test.ts
+++ b/platform/backend/src/services/apps/app-capability-context.test.ts
@@ -1,4 +1,5 @@
 import { resolveDynamicTool } from "@/archestra-mcp-server/dynamic-tools";
+import { EnvironmentModel } from "@/models";
 import { describe, expect, test } from "@/test";
 import { buildAppCapabilityContext } from "./app-capability-context";
 
@@ -52,6 +53,7 @@ describe("buildAppCapabilityContext", () => {
       userId: user.id,
       organizationId: org.id,
       agentId: agent.id,
+      environmentId: null,
     });
 
     expect(context.tools).toEqual([
@@ -100,11 +102,62 @@ describe("buildAppCapabilityContext", () => {
       userId: user.id,
       organizationId: org.id,
       agentId: agent.id,
+      environmentId: null,
     });
 
     expect(context.tools.filter((tool) => tool.name === dupName)).toEqual([
       { name: dupName, description: canonical?.description ?? "" },
     ]);
+  });
+
+  test("grounds in the app's environment, not the authoring agent's", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeTool,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id);
+    // Agent runs in the default environment; the app is bound elsewhere.
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: true,
+    });
+    const appEnv = await EnvironmentModel.create({
+      organizationId: org.id,
+      name: `Prod ${crypto.randomUUID().slice(0, 8)}`,
+    });
+
+    // A tool only in the app's (non-default) environment.
+    const appEnvCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      environmentId: appEnv.id,
+    });
+    await makeMcpServer({ catalogId: appEnvCatalog.id, scope: "org" });
+    await makeTool({ name: "prod__deploy", catalogId: appEnvCatalog.id });
+
+    // A tool only in the default environment (the agent's env).
+    const defaultCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+    });
+    await makeMcpServer({ catalogId: defaultCatalog.id, scope: "org" });
+    await makeTool({ name: "default__thing", catalogId: defaultCatalog.id });
+
+    const context = await buildAppCapabilityContext({
+      userId: user.id,
+      organizationId: org.id,
+      agentId: agent.id,
+      environmentId: appEnv.id,
+    });
+
+    const names = context.tools.map((tool) => tool.name);
+    // Grounds the app-env tool, not the agent-env one.
+    expect(names).toContain("prod__deploy");
+    expect(names).not.toContain("default__thing");
   });
 
   test("describes the window.archestra SDK surface", async ({
@@ -122,6 +175,7 @@ describe("buildAppCapabilityContext", () => {
       userId: user.id,
       organizationId: org.id,
       agentId: agent.id,
+      environmentId: null,
     });
 
     expect(context.sdkSummary.length).toBeGreaterThan(0);

--- a/platform/backend/src/services/apps/app-capability-context.test.ts
+++ b/platform/backend/src/services/apps/app-capability-context.test.ts
@@ -1,3 +1,4 @@
+import { resolveDynamicTool } from "@/archestra-mcp-server/dynamic-tools";
 import { describe, expect, test } from "@/test";
 import { buildAppCapabilityContext } from "./app-capability-context";
 
@@ -58,7 +59,7 @@ describe("buildAppCapabilityContext", () => {
     ]);
   });
 
-  test("a duplicate tool name is grounded once, not dropped as ambiguous", async ({
+  test("a duplicate tool name is grounded once, resolved to the canonical row", async ({
     makeOrganization,
     makeUser,
     makeMember,
@@ -76,19 +77,24 @@ describe("buildAppCapabilityContext", () => {
       accessAllTools: true,
     });
 
-    // Two installed catalogs carry a tool with the SAME name — unique only per
-    // catalog. The old grounding dropped such names; it must now list the name
-    // once (the canonical row's description), matching what is assignable.
+    // Two installed catalogs carry a tool with the SAME name (unique only per
+    // catalog) but DIFFERENT descriptions, so the assertion pins which row won.
+    // The old grounding dropped such names; it must now list the name once,
+    // described by the same canonical row search_tools/run_tool resolve.
     const dupName = "acme__do_thing";
-    for (const _ of [0, 1]) {
+    for (const description of ["first catalog", "second catalog"]) {
       const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
       await makeMcpServer({ catalogId: catalog.id, scope: "org" });
-      await makeTool({
-        name: dupName,
-        description: "Do a thing",
-        catalogId: catalog.id,
-      });
+      await makeTool({ name: dupName, description, catalogId: catalog.id });
     }
+
+    const canonical = await resolveDynamicTool({
+      toolName: dupName,
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
+    });
+    expect(canonical).not.toBeNull();
 
     const context = await buildAppCapabilityContext({
       userId: user.id,
@@ -97,7 +103,7 @@ describe("buildAppCapabilityContext", () => {
     });
 
     expect(context.tools.filter((tool) => tool.name === dupName)).toEqual([
-      { name: dupName, description: "Do a thing" },
+      { name: dupName, description: canonical?.description ?? "" },
     ]);
   });
 

--- a/platform/backend/src/services/apps/app-capability-context.ts
+++ b/platform/backend/src/services/apps/app-capability-context.ts
@@ -1,5 +1,4 @@
 import { ARCHESTRA_APP_SDK_SUMMARY } from "@/archestra-mcp-server/app-authoring-guidance";
-import { AgentModel } from "@/models";
 import { resolveAppAssignableToolRows } from "./app-assignable-tools";
 
 interface AppCapabilityTool {
@@ -28,20 +27,29 @@ interface AppCapabilityContext {
  * because apps reach the data store through archestra.storage), so the grounding
  * lists exactly the names that can really be attached and each description comes
  * from the row that would actually be assigned and run.
+ *
+ * Grounding resolves in the *app's* `environmentId`, not the authoring agent's:
+ * an app is bound to a deliberate environment (e.g. staging/prod) and its tools
+ * are assigned (set_app_tools) and executed (runtime gate) there, so the
+ * capability list must reflect that environment even when the agent editing the
+ * app runs in a different one.
  */
 export async function buildAppCapabilityContext(params: {
   userId: string;
   organizationId: string;
-  /** The chat agent making the request (for agent-scoped tool resolution). */
+  /** The chat agent making the request (for its assigned tools + dynamic-access
+   * gate; the environment comes from the app, not the agent). */
   agentId: string;
+  /** The app's bound environment — the tools it can actually assign and run. */
+  environmentId: string | null;
 }): Promise<AppCapabilityContext> {
-  const { agentId, organizationId, userId } = params;
+  const { agentId, environmentId, organizationId, userId } = params;
 
   const byName = await resolveAppAssignableToolRows({
     agentId,
     userId,
     organizationId,
-    environmentId: await AgentModel.findEnvironmentId(agentId),
+    environmentId,
   });
 
   const tools: AppCapabilityTool[] = [...byName.values()]

--- a/platform/backend/src/services/apps/app-capability-context.ts
+++ b/platform/backend/src/services/apps/app-capability-context.ts
@@ -1,7 +1,6 @@
 import { ARCHESTRA_APP_SDK_SUMMARY } from "@/archestra-mcp-server/app-authoring-guidance";
-import { getUnassignedDiscoverableTools } from "@/archestra-mcp-server/dynamic-tools";
-import { filterToolNamesByPermission } from "@/archestra-mcp-server/rbac";
-import { AgentModel, ToolModel } from "@/models";
+import { AgentModel } from "@/models";
+import { resolveAppAssignableToolRows } from "./app-assignable-tools";
 
 interface AppCapabilityTool {
   /** Full MCP tool name as used by archestra.tools.call(...). */
@@ -23,12 +22,12 @@ interface AppCapabilityContext {
  *
  * The tool set is the same candidate space search_tools exposes — the agent's
  * assigned MCP tools plus, when the agent has dynamic access, the tools the
- * user can otherwise reach — RBAC-filtered the identical way, then narrowed to
- * the app-assignable rows (external catalog-backed tools; Archestra built-ins
- * are excluded because apps reach the data store through archestra.storage).
- * That narrowing reuses {@link ToolModel.findAppAssignableToolsByNames}, the
- * exact gate resolveAppToolsByName applies at assignment time, so the grounding
- * matches what can really be attached.
+ * user can otherwise reach — resolved through {@link resolveAppAssignableToolRows},
+ * the exact surface `resolveAppToolsByName` assigns from. Each name maps to its
+ * canonical row (RBAC-filtered, install-scoped, Archestra built-ins excluded
+ * because apps reach the data store through archestra.storage), so the grounding
+ * lists exactly the names that can really be attached and each description comes
+ * from the row that would actually be assigned and run.
  */
 export async function buildAppCapabilityContext(params: {
   userId: string;
@@ -38,50 +37,15 @@ export async function buildAppCapabilityContext(params: {
 }): Promise<AppCapabilityContext> {
   const { agentId, organizationId, userId } = params;
 
-  const assignedTools = await ToolModel.getMcpToolsByAgent(agentId);
-  const assignedNames = new Set(assignedTools.map((tool) => tool.name));
-  const discoverableTools = await getUnassignedDiscoverableTools({
-    assignedToolNames: assignedNames,
+  const byName = await resolveAppAssignableToolRows({
     agentId,
     userId,
     organizationId,
+    environmentId: await AgentModel.findEnvironmentId(agentId),
   });
 
-  // First occurrence wins on duplicate names (assigned before discoverable),
-  // matching the search_tools ordering so a name resolves to the same row's
-  // description the model would otherwise see.
-  const descriptionByName = new Map<string, string>();
-  for (const tool of [...assignedTools, ...discoverableTools]) {
-    if (!descriptionByName.has(tool.name)) {
-      descriptionByName.set(tool.name, tool.description ?? "");
-    }
-  }
-
-  const permittedNames = await filterToolNamesByPermission(
-    [...descriptionByName.keys()],
-    userId,
-    organizationId,
-  );
-  const assignableRows = await ToolModel.findAppAssignableToolsByNames(
-    organizationId,
-    [...permittedNames].filter((name) => descriptionByName.has(name)),
-    await AgentModel.findEnvironmentId(agentId),
-  );
-
-  // A name backed by more than one assignable row is ambiguous and cannot be
-  // assigned by name (resolveAppToolsByName rejects it), so it is not a real
-  // grounding capability — drop ambiguous names and keep unique ones.
-  const rowCountByName = new Map<string, number>();
-  for (const row of assignableRows) {
-    if (row.clonedPendingDiscovery) {
-      continue;
-    }
-    rowCountByName.set(row.name, (rowCountByName.get(row.name) ?? 0) + 1);
-  }
-
-  const tools: AppCapabilityTool[] = [...rowCountByName.entries()]
-    .filter(([, count]) => count === 1)
-    .map(([name]) => ({ name, description: descriptionByName.get(name) ?? "" }))
+  const tools: AppCapabilityTool[] = [...byName.values()]
+    .map((tool) => ({ name: tool.name, description: tool.description ?? "" }))
     .sort((left, right) => left.name.localeCompare(right.name));
 
   return { tools, sdkSummary: ARCHESTRA_APP_SDK_SUMMARY };


### PR DESCRIPTION
## Problem

MCP tool display names (`<server>__<tool>`) are unique only **per catalog**, so a name can back more than one installed tool row (an installed catalog plus a legacy or global duplicate). `search_tools` and the app runtime resolve such a name to one deterministic canonical row and work fine, but the by-name **app-assignment** path failed closed with `matches more than one installed tool and cannot be assigned by name` — with no way for the caller to disambiguate — and app **grounding** silently dropped the name. A build-app agent shown one clean, valid tool by `search_tools` could never assign it.

## Fix

A single shared resolver (`services/apps/app-assignable-tools.ts::resolveAppAssignableToolRows`) maps each name to the one canonical row `search_tools` shows: the agent's assigned tools first (org-visible + in the target env, no install required), then — only when the agent has "access all tools" — the install-scoped discoverable set (newest-first), first-occurrence wins, RBAC-filtered. Both `resolveAppToolsByName` (assignment) and `buildAppCapabilityContext` (grounding) use it, so the name the model discovers, the row it assigns, and the row the app runtime dispatches always agree. Added `ToolModel.filterAppAssignableToolIds`; removed the divergent `findAppAssignableToolsByNames`.

## Behavior change

Assignment now follows **assignable-by-name == discoverable-by-this-agent**: an agent with "access all tools" off can no longer attach an *unassigned* tool by name (it can't discover the name in `search_tools` either). The by-id assignment path stays unrestricted. This also fixes a latent bug where a non-routable (uninstalled) tool could be attached.

## Environment consistency (refine_app)

An app is bound to a deliberate environment (e.g. staging/prod); its tools are assigned (`set_app_tools`) and executed (runtime gate) there. `refine_app` previously grounded its capability list in the *authoring agent's* environment, so editing an app bound to a different env surfaced the wrong tool set. `buildAppCapabilityContext` now resolves in the **app's** `environmentId` (the agent still supplies its assigned tools and the dynamic-access gate). No change when the agent and app share an environment.

`scaffold_app` deliberately stays environment-agnostic (creates at the default env, bind to staging/prod later) — an app's environment is an explicit deployment choice, not inherited from the authoring agent.

## Tests

New tests assert **row identity**, not wiring: assignment resolves a duplicate name to the same row `resolveDynamicTool` picks; an assigned duplicate wins over a newer installed one; no-install and access-all-off both yield `Unknown tool name`; grounding lists a duplicate once with the canonical row's description; grounding resolves in the app's environment rather than the agent's. Existing app/tool suites updated to seed real installs. type-check, biome, knip (dev+prod) all clean.

https://claude.ai/code/session_016XnzfwMRAJLxeucUk4s9PK