### PR TITLE
perf(models-dev): single-flight TTL cache and fetch timeout

### DIFF
--- a/platform/backend/src/clients/models-dev-client.test.ts
+++ b/platform/backend/src/clients/models-dev-client.test.ts
@@ -208,11 +208,12 @@ describe("ModelsDevClient", () => {
       expect(recovered.openai).toBeDefined();
     });
 
-    test("caches the raw payload when schema validation fails", async () => {
-      // A provider value that is not an object fails schema validation, so
-      // the client falls back to returning (and caching) the raw payload.
+    test("does not cache the raw fallback when schema validation fails", async () => {
+      // A provider value that is not an object fails schema validation; the
+      // raw fallback is returned but not cached, so a retry refetches instead
+      // of reusing a potentially malformed payload for the whole TTL.
       const invalidPayload = { openai: "not-a-provider-object" };
-      mockFetch.mockResolvedValueOnce({
+      mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(invalidPayload),
       });
@@ -220,7 +221,7 @@ describe("ModelsDevClient", () => {
       const first = await modelsDevClient.fetchModelsFromApi();
       const second = await modelsDevClient.fetchModelsFromApi();
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(first).toEqual(invalidPayload);
       expect(second).toEqual(invalidPayload);
     });

--- a/platform/backend/src/clients/models-dev-client.test.ts
+++ b/platform/backend/src/clients/models-dev-client.test.ts
@@ -158,8 +158,28 @@ describe("ModelsDevClient", () => {
       const second = await modelsDevClient.fetchModelsFromApi();
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(second).toEqual(first);
+      expect(second).toBe(first);
       expect(second.openai.models["gpt-4o"].name).toBe("GPT-4o");
+    });
+
+    test("refetches after the cache TTL expires", async () => {
+      const mockResponse = createMockApiResponse({
+        openai: createMockProvider("openai", {
+          "gpt-4o": createMockModel({ id: "gpt-4o", name: "GPT-4o" }),
+        }),
+      });
+      mockSuccessfulFetchOnce(mockResponse);
+      await modelsDevClient.fetchModelsFromApi();
+
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        vi.advanceTimersByTime(6 * 60 * 1000);
+        mockSuccessfulFetchOnce(mockResponse);
+        await modelsDevClient.fetchModelsFromApi();
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     test("concurrent calls share a single in-flight fetch", async () => {

--- a/platform/backend/src/clients/models-dev-client.test.ts
+++ b/platform/backend/src/clients/models-dev-client.test.ts
@@ -19,7 +19,11 @@ beforeEach(() => {
 });
 
 // Import after mock is defined
-import { modelsDevClient, sanitizeOutputLimit } from "./models-dev-client";
+import {
+  ModelsDevClient,
+  modelsDevClient,
+  sanitizeOutputLimit,
+} from "./models-dev-client";
 
 // The canonical Map-backed fake from src/__mocks__/cache-manager.ts avoids
 // "CacheManager: Not started" errors; the store resets before every test.
@@ -85,6 +89,9 @@ function createMockApiResponse(
 describe("ModelsDevClient", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    // The singleton caches fetched responses in memory; clear between tests
+    // so each case controls its own fetch behavior.
+    modelsDevClient.clearFetchCache();
   });
 
   afterEach(async () => {
@@ -128,6 +135,114 @@ describe("ModelsDevClient", () => {
       const result = await modelsDevClient.fetchModelsFromApi();
 
       expect(result).toEqual({});
+    });
+  });
+
+  describe("fetch caching", () => {
+    function mockSuccessfulFetchOnce(response: ModelsDevApiResponse) {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+    }
+
+    test("second call within TTL reuses the cached response", async () => {
+      const mockResponse = createMockApiResponse({
+        openai: createMockProvider("openai", {
+          "gpt-4o": createMockModel({ id: "gpt-4o", name: "GPT-4o" }),
+        }),
+      });
+      mockSuccessfulFetchOnce(mockResponse);
+
+      const first = await modelsDevClient.fetchModelsFromApi();
+      const second = await modelsDevClient.fetchModelsFromApi();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(second).toEqual(first);
+      expect(second.openai.models["gpt-4o"].name).toBe("GPT-4o");
+    });
+
+    test("concurrent calls share a single in-flight fetch", async () => {
+      const mockResponse = createMockApiResponse({
+        openai: createMockProvider("openai", {
+          "gpt-4o": createMockModel({ id: "gpt-4o", name: "GPT-4o" }),
+        }),
+      });
+      let resolveFetch!: (value: unknown) => void;
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+
+      const firstCall = modelsDevClient.fetchModelsFromApi();
+      const secondCall = modelsDevClient.fetchModelsFromApi();
+      resolveFetch({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+      const [first, second] = await Promise.all([firstCall, secondCall]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(second).toEqual(first);
+      expect(first.openai.models["gpt-4o"].name).toBe("GPT-4o");
+    });
+
+    test("does not cache the empty error result", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network Error"));
+
+      const failed = await modelsDevClient.fetchModelsFromApi();
+      expect(failed).toEqual({});
+
+      const mockResponse = createMockApiResponse({
+        openai: createMockProvider("openai", {
+          "gpt-4o": createMockModel({ id: "gpt-4o", name: "GPT-4o" }),
+        }),
+      });
+      mockSuccessfulFetchOnce(mockResponse);
+
+      const recovered = await modelsDevClient.fetchModelsFromApi();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(recovered.openai).toBeDefined();
+    });
+
+    test("caches the raw payload when schema validation fails", async () => {
+      // A provider value that is not an object fails schema validation, so
+      // the client falls back to returning (and caching) the raw payload.
+      const invalidPayload = { openai: "not-a-provider-object" };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(invalidPayload),
+      });
+
+      const first = await modelsDevClient.fetchModelsFromApi();
+      const second = await modelsDevClient.fetchModelsFromApi();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(first).toEqual(invalidPayload);
+      expect(second).toEqual(invalidPayload);
+    });
+  });
+
+  describe("fetch timeout", () => {
+    test("aborts a hanging fetch and returns an empty result", async () => {
+      const client = new ModelsDevClient({ fetchTimeoutMs: 10 });
+      mockFetch.mockImplementationOnce(
+        (_url: string, options: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options.signal.addEventListener("abort", () =>
+              reject(options.signal.reason),
+            );
+          }),
+      );
+
+      const result = await client.fetchModelsFromApi();
+
+      expect(result).toEqual({});
+      const fetchOptions = mockFetch.mock.calls[0][1];
+      expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
     });
   });
 

--- a/platform/backend/src/clients/models-dev-client.ts
+++ b/platform/backend/src/clients/models-dev-client.ts
@@ -32,6 +32,17 @@ const SYNC_INTERVAL_MS = 24 * TimeInMs.Hour;
 const MODELS_DEV_API_URL = "https://models.dev/api.json";
 
 /**
+ * How long a fetched models.dev API response is served from memory before
+ * hitting the network again.
+ */
+const FETCH_CACHE_TTL_MS = 5 * TimeInMs.Minute;
+
+/**
+ * Default timeout for a single models.dev API fetch.
+ */
+const DEFAULT_FETCH_TIMEOUT_MS = 30 * TimeInMs.Second;
+
+/**
  * Retry configuration for background sync
  */
 const RETRY_CONFIG = {
@@ -249,40 +260,56 @@ export function sanitizeOutputLimit(
  * models.dev Model Registry Client.
  *
  * Fetches model metadata from models.dev API and syncs it to our database.
- * Provides caching to avoid excessive API calls.
+ * Successful fetch results (including the raw fallback used when schema
+ * validation fails) are cached in memory for a short TTL, and concurrent
+ * callers share a single in-flight request. Error results (`{}`) are never
+ * cached, so a transient failure does not stick for the TTL.
+ *
+ * @public — exported so tests can construct instances with custom options
  */
-class ModelsDevClient {
+export class ModelsDevClient {
+  private readonly fetchTimeoutMs: number;
+  private cachedResponse: {
+    data: ModelsDevApiResponse;
+    fetchedAt: number;
+  } | null = null;
+  private inflightFetch: Promise<ModelsDevApiResponse> | null = null;
+
+  constructor(opts?: { fetchTimeoutMs?: number }) {
+    this.fetchTimeoutMs = opts?.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  }
+
   /**
    * Fetches all providers and models from models.dev API.
    * Validates the response against the expected schema.
+   * Serves a cached response within the TTL and deduplicates concurrent calls.
    */
   async fetchModelsFromApi(): Promise<ModelsDevApiResponse> {
-    try {
-      const response = await fetch(MODELS_DEV_API_URL);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const json = await response.json();
-      const parseResult = ModelsDevApiResponseSchema.safeParse(json);
-
-      if (!parseResult.success) {
-        logger.warn(
-          { errors: parseResult.error.format() },
-          "models.dev API response validation failed, using partial data",
-        );
-        // Fall back to casting if validation fails - the API may have added new fields
-        return json as ModelsDevApiResponse;
-      }
-
-      return parseResult.data;
-    } catch (error) {
-      logger.error(
-        { error: error instanceof Error ? error.message : String(error) },
-        "Error fetching models from models.dev API",
-      );
-      return {};
+    if (
+      this.cachedResponse &&
+      Date.now() - this.cachedResponse.fetchedAt < FETCH_CACHE_TTL_MS
+    ) {
+      return this.cachedResponse.data;
     }
+
+    if (this.inflightFetch) {
+      return this.inflightFetch;
+    }
+
+    this.inflightFetch = this.doFetchModelsFromApi();
+    try {
+      return await this.inflightFetch;
+    } finally {
+      this.inflightFetch = null;
+    }
+  }
+
+  /**
+   * Drops the in-memory fetch cache so the next call hits the network.
+   * Useful for manual resyncs; tests use it to isolate cases.
+   */
+  clearFetchCache(): void {
+    this.cachedResponse = null;
   }
 
   /**
@@ -564,6 +591,44 @@ class ModelsDevClient {
    */
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Performs the actual network fetch. Caches successful results (validated
+   * or raw fallback); the `{}` error result is intentionally not cached.
+   */
+  private async doFetchModelsFromApi(): Promise<ModelsDevApiResponse> {
+    try {
+      const response = await fetch(MODELS_DEV_API_URL, {
+        signal: AbortSignal.timeout(this.fetchTimeoutMs),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const json = await response.json();
+      const parseResult = ModelsDevApiResponseSchema.safeParse(json);
+
+      if (!parseResult.success) {
+        logger.warn(
+          { errors: parseResult.error.format() },
+          "models.dev API response validation failed, using partial data",
+        );
+        // Fall back to casting if validation fails - the API may have added new fields
+        const rawData = json as ModelsDevApiResponse;
+        this.cachedResponse = { data: rawData, fetchedAt: Date.now() };
+        return rawData;
+      }
+
+      this.cachedResponse = { data: parseResult.data, fetchedAt: Date.now() };
+      return parseResult.data;
+    } catch (error) {
+      logger.error(
+        { error: error instanceof Error ? error.message : String(error) },
+        "Error fetching models from models.dev API",
+      );
+      return {};
+    }
   }
 
   /**

--- a/platform/backend/src/clients/models-dev-client.ts
+++ b/platform/backend/src/clients/models-dev-client.ts
@@ -269,11 +269,17 @@ export function sanitizeOutputLimit(
  */
 export class ModelsDevClient {
   private readonly fetchTimeoutMs: number;
+  // Hand-rolled instead of cacheManager/LRUCacheManager: single-flight
+  // coalescing needs the in-flight promise as instance state, and the
+  // multi-MB registry payload does not belong in the Postgres-backed cache.
   private cachedResponse: {
     data: ModelsDevApiResponse;
     fetchedAt: number;
   } | null = null;
   private inflightFetch: Promise<ModelsDevApiResponse> | null = null;
+  // Bumped by clearFetchCache so a fetch started before the clear cannot
+  // repopulate the cache with pre-clear data when it settles.
+  private fetchGeneration = 0;
 
   constructor(opts?: { fetchTimeoutMs?: number }) {
     this.fetchTimeoutMs = opts?.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
@@ -296,20 +302,25 @@ export class ModelsDevClient {
       return this.inflightFetch;
     }
 
-    this.inflightFetch = this.doFetchModelsFromApi();
+    const fetchPromise = this.doFetchModelsFromApi();
+    this.inflightFetch = fetchPromise;
     try {
-      return await this.inflightFetch;
+      return await fetchPromise;
     } finally {
-      this.inflightFetch = null;
+      if (this.inflightFetch === fetchPromise) {
+        this.inflightFetch = null;
+      }
     }
   }
 
   /**
-   * Drops the in-memory fetch cache so the next call hits the network.
-   * Useful for manual resyncs; tests use it to isolate cases.
+   * Drops the in-memory fetch cache and detaches any in-flight fetch so the
+   * next call hits the network. Tests use it to isolate cases.
    */
   clearFetchCache(): void {
+    this.fetchGeneration++;
     this.cachedResponse = null;
+    this.inflightFetch = null;
   }
 
   /**
@@ -599,6 +610,7 @@ export class ModelsDevClient {
    * uncached so retries refetch instead of reusing a bad payload.
    */
   private async doFetchModelsFromApi(): Promise<ModelsDevApiResponse> {
+    const generation = this.fetchGeneration;
     try {
       const response = await fetch(MODELS_DEV_API_URL, {
         signal: AbortSignal.timeout(this.fetchTimeoutMs),
@@ -619,7 +631,9 @@ export class ModelsDevClient {
         return json as ModelsDevApiResponse;
       }
 
-      this.cachedResponse = { data: parseResult.data, fetchedAt: Date.now() };
+      if (generation === this.fetchGeneration) {
+        this.cachedResponse = { data: parseResult.data, fetchedAt: Date.now() };
+      }
       return parseResult.data;
     } catch (error) {
       logger.error(

--- a/platform/backend/src/clients/models-dev-client.ts
+++ b/platform/backend/src/clients/models-dev-client.ts
@@ -260,10 +260,10 @@ export function sanitizeOutputLimit(
  * models.dev Model Registry Client.
  *
  * Fetches model metadata from models.dev API and syncs it to our database.
- * Successful fetch results (including the raw fallback used when schema
- * validation fails) are cached in memory for a short TTL, and concurrent
- * callers share a single in-flight request. Error results (`{}`) are never
- * cached, so a transient failure does not stick for the TTL.
+ * Validated fetch results are cached in memory for a short TTL, and
+ * concurrent callers share a single in-flight request. The raw fallback used
+ * when schema validation fails and the `{}` error result are never cached,
+ * so a transient bad response does not stick for the TTL.
  *
  * @public — exported so tests can construct instances with custom options
  */
@@ -594,8 +594,9 @@ export class ModelsDevClient {
   }
 
   /**
-   * Performs the actual network fetch. Caches successful results (validated
-   * or raw fallback); the `{}` error result is intentionally not cached.
+   * Performs the actual network fetch. Only validated responses are cached:
+   * the raw validation-fallback and the `{}` error result are returned
+   * uncached so retries refetch instead of reusing a bad payload.
    */
   private async doFetchModelsFromApi(): Promise<ModelsDevApiResponse> {
     try {
@@ -615,9 +616,7 @@ export class ModelsDevClient {
           "models.dev API response validation failed, using partial data",
         );
         // Fall back to casting if validation fails - the API may have added new fields
-        const rawData = json as ModelsDevApiResponse;
-        this.cachedResponse = { data: rawData, fetchedAt: Date.now() };
-        return rawData;
+        return json as ModelsDevApiResponse;
       }
 
       this.cachedResponse = { data: parseResult.data, fetchedAt: Date.now() };


### PR DESCRIPTION
`fetchModelsFromApi` re-fetched and re-parsed the full models.dev registry on every call — once per API key in sync loops (`model-sync.ts`), per keyless provider (`system-key-manager.ts`), and per lazy route sync — despite the class doc claiming caching. A stalled models.dev also hung syncs for the undici default (~5 min) because the fetch had no timeout.

- Adds a 5-minute in-memory cache with single-flight coalescing: concurrent callers share one request; only schema-validated responses are cached; the Zod-fallback raw payload and the `{}` error result are never cached, so retries always refetch.
- `clearFetchCache()` bumps a generation counter so a fetch started before a clear cannot repopulate the cache with pre-clear data.
- The fetch now uses `AbortSignal.timeout` (default 30s), injectable via constructor for tests.

Tests: TTL reuse, TTL expiry, concurrent single-flight, error-not-cached, fallback-not-cached, and timeout-abort — all written fail-first.

https://claude.ai/code/session_0111LPRAPTkArzWMSFzCjP5a

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>