### PR TITLE
fix(chat): flow collapsed app pills on one line

### DIFF
--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -103,6 +103,7 @@ import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useMcpInstallOrchestrator } from "@/lib/mcp/mcp-install-orchestrator.hook";
 import { useOrganization } from "@/lib/organization.query";
 import { cn } from "@/lib/utils";
+import { useApps } from "./apps-context";
 import { AuthErrorTool, type AuthErrorToolProps } from "./auth-error-tool";
 import {
   collectSubagentToolCalls,
@@ -1691,6 +1692,10 @@ const MessageTool = memo(
     const shouldDefaultOpen = isApprovalRequested;
 
     // Hooks must be called before any early returns
+    // Whether this render's app is expanded inline (mirrors McpAppSection's
+    // `expandedInline`): with the panel hosting, every inline render collapses
+    // to a pill; otherwise the app is open unless the user collapsed it.
+    const { isAppOpen, portalTarget } = useApps();
     const [isOpen, setIsOpen] = useState(shouldDefaultOpen);
     const [userDenied, setUserDenied] = useState(false);
     const [userHasInteracted, setUserHasInteracted] = useState(false);
@@ -1874,8 +1879,24 @@ const MessageTool = memo(
 
       // Tool-call circle and the app marker share the flex-wrap row's first line;
       // the tool details + inline app card stack in a full-width column below.
+      // While nothing full-width shows (tool details closed, app collapsed or
+      // hosted in the panel, or no app section at all), the row is an inline
+      // box so consecutive pill-only renders flow on one line instead of
+      // stacking one row per tool call.
+      const rendersAppSection = !!agentId && (!!uiResourceUri || !!ownedApp);
+      const appExpandedInline =
+        rendersAppSection &&
+        !portalTarget &&
+        (!part.toolCallId || isAppOpen(part.toolCallId));
       return (
-        <div className="mb-4">
+        <div
+          className={cn(
+            "mb-4",
+            !isOpen &&
+              !appExpandedInline &&
+              "mr-1.5 inline-flex max-w-full align-top",
+          )}
+        >
           <div className="flex flex-wrap items-start gap-1.5">
             <TooltipProvider delayDuration={200}>
               <Tooltip>

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -262,8 +262,17 @@ export function CompactToolGroup({
 
   const expandedEntry = tools.find((t) => t.key === expandedKey);
 
+  // While no entry is expanded the group is an inline box, so consecutive
+  // pill-only groups (and collapsed MCP App renders) flow on one line instead
+  // of stacking one row per group. Expanding an entry needs the full chat
+  // width for its card, so the group becomes a block again.
   return (
-    <div className="mb-4">
+    <div
+      className={cn(
+        "mb-4",
+        !expandedEntry && "mr-1.5 inline-flex max-w-full align-top",
+      )}
+    >
       <div className="flex flex-wrap gap-1.5 items-center">
         {tools.map((entry) => {
           if (entry.kind === "hook") {

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -298,14 +298,16 @@ export function McpAppSection({
           hasError
           onClick={() => setUnavailableOpen((open) => !open)}
         />
-        <div className="flex w-full flex-col items-start gap-2">
-          {toolDetails ? <div className="w-full">{toolDetails}</div> : null}
-          {unavailableOpen ? (
-            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
-              {headerName} app is no longer available
-            </div>
-          ) : null}
-        </div>
+        {toolDetails || unavailableOpen ? (
+          <div className="flex w-full flex-col items-start gap-2">
+            {toolDetails ? <div className="w-full">{toolDetails}</div> : null}
+            {unavailableOpen ? (
+              <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+                {headerName} app is no longer available
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </>
     );
   }
@@ -448,34 +450,38 @@ export function McpAppSection({
 
   // Under the marker row: tool-call details, then (only while expanded inline) the
   // app card, its "Open in right panel" button, and the diagnostics summary.
-  const belowColumn = (
-    <div className="flex w-full flex-col items-start gap-2">
-      {toolDetails ? <div className="w-full">{toolDetails}</div> : null}
-      {expandedInline ? (
-        <div className="flex w-full flex-col items-start gap-2">
-          {liveSurface}
-          {toolCallId && displayMode !== "fullscreen" ? (
-            // Match the card's 80% width and right-justify so the buttons line
-            // up with the app's right edge, not the full chat width.
-            <div className="flex w-full max-w-[80%] justify-end gap-1">
-              {appId ? <McpAppStandaloneButton appId={appId} /> : null}
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-auto gap-1.5 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
-                onClick={handleShowInPanel}
-              >
-                <PanelRight className="h-3.5 w-3.5" />
-                Open in right panel
-              </Button>
-            </div>
-          ) : null}
-          {diagnostics}
-        </div>
-      ) : null}
-    </div>
-  );
+  // Rendered only when it has content — an always-present `w-full` sibling would
+  // force a line break in the host's flex-wrap row, so consecutive collapsed
+  // pills couldn't share a line.
+  const belowColumn =
+    !toolDetails && !expandedInline ? null : (
+      <div className="flex w-full flex-col items-start gap-2">
+        {toolDetails ? <div className="w-full">{toolDetails}</div> : null}
+        {expandedInline ? (
+          <div className="flex w-full flex-col items-start gap-2">
+            {liveSurface}
+            {toolCallId && displayMode !== "fullscreen" ? (
+              // Match the card's 80% width and right-justify so the buttons line
+              // up with the app's right edge, not the full chat width.
+              <div className="flex w-full max-w-[80%] justify-end gap-1">
+                {appId ? <McpAppStandaloneButton appId={appId} /> : null}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto gap-1.5 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+                  onClick={handleShowInPanel}
+                >
+                  <PanelRight className="h-3.5 w-3.5" />
+                  Open in right panel
+                </Button>
+              </div>
+            ) : null}
+            {diagnostics}
+          </div>
+        ) : null}
+      </div>
+    );
 
   return (
     <>


### PR DESCRIPTION
## Problem

In a chat turn with several MCP tool calls / app renders, each collapsed circular indicator (tool circle + app-window marker) rendered on its own row: every `CompactToolGroup` and every MCP-app tool render wraps its pills in its own block-level `div.mb-4`, so consecutive pill-only renders stacked vertically even though each row held only one or two 32px circles. Most visible with the apps side panel open, where every inline render collapses to a pill.

**Before** (same conversation, old code): first turn renders a lone tool circle on one row, then the app render's circle + marker on the next row (measured y: -2481 vs -2433, 48px apart).

**After**: all three circles share one line (measured y: 193 for all, x: 256 / 294 / 332 — 6px gaps, consistent with the in-row `gap-1.5`).

## Fix

Collapsed pill groups become inline boxes so they flow on one line (wrapping only at the container edge); anything full-width flips the wrapper back to a block:

- `compact-tool-call.tsx`: `CompactToolGroup`'s root is `inline-flex` while no entry is expanded; expanding an entry (full-width card below the row) makes it a block again.
- `chat-messages.tsx`: the MCP-app tool render's root is `inline-flex` while nothing full-width shows — tool details closed and the app collapsed / panel-hosted / no app section yet (pending management call). `MessageTool` mirrors `McpAppSection`'s `expandedInline` via the apps context (`isAppOpen` / `portalTarget`), so the wrapper and the section always agree.
- `mcp-app-container.tsx`: the below-the-row column (tool details + inline app card) renders only when it has content — the previous always-present empty `w-full` sibling would force a line break in the shared flow.

Expanded app sections, tool details, text parts, and the panel surface are untouched; a `w-full` child inside the flex-wrap row still takes its own full-width line, so mixed collapsed/expanded states degrade to exactly the old layout.

## Verification

- `pnpm --filter @frontend type-check` clean; biome clean.
- `mcp-app-container` / `chat-messages` / `compact-tool-call` suites: 80 tests pass; full `src/components/chat` + `src/components/mcp-app` run: 308 tests pass.
- Ran the worktree frontend on :3001 against the shared backend (:9000) and inspected a real conversation with 3 app renders + 4 tool calls, before (:3000, old code) vs after (:3001): collapsed pills now share one line; with the panel closed all apps still expand inline as block rows; collapsing one app flips its wrapper to `inline-flex` and unmounts its iframe, re-expanding restores block + iframe; pill clicks with the panel open still select/close the panel app.

Limitation: pills still can't flow across two adjacent assistant messages (each message is its own block wrapper); within a message — the common case, since a turn's tool parts accumulate in one message — they now share a line.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>