### PR TITLE
feat(apps): filter Apps page by Apps vs MCP Server Apps

### DIFF
--- a/platform/frontend/src/app/apps/page.client.test.ts
+++ b/platform/frontend/src/app/apps/page.client.test.ts
@@ -1,0 +1,54 @@
+import type { archestraApiTypes } from "@archestra/shared";
+import { describe, expect, it, vi } from "vitest";
+import { matchesKind } from "./page.client";
+
+vi.mock("next/navigation");
+
+type AppListItem = archestraApiTypes.GetAppsResponses["200"]["data"][number];
+
+const ownedApp: Extract<AppListItem, { source: "owned" }> = {
+  source: "owned",
+  id: "owned-1",
+  name: "My Owned App",
+  description: "An owned app",
+  scope: "org",
+  authorId: "user-1",
+  latestVersion: 1,
+  teams: [],
+  executionModel: "viewer-scoped",
+  cspOrigin: "platform-pinned",
+};
+
+const externalApp: Extract<AppListItem, { source: "external" }> = {
+  source: "external",
+  catalogId: "cat-1",
+  mcpServerId: "srv-1",
+  scope: "org",
+  name: "Archestra PM / show_board",
+  description: "Shows the project board",
+  resourceUri: "ui://pm/board.html",
+  executionModel: "server-scoped",
+  cspOrigin: "author-declared",
+};
+
+describe("matchesKind", () => {
+  it("matches every app when kind is all", () => {
+    expect(matchesKind(ownedApp, "all")).toBe(true);
+    expect(matchesKind(externalApp, "all")).toBe(true);
+  });
+
+  it("matches only platform-authored apps when kind is owned", () => {
+    expect(matchesKind(ownedApp, "owned")).toBe(true);
+    expect(matchesKind(externalApp, "owned")).toBe(false);
+  });
+
+  it("matches only MCP server apps when kind is external", () => {
+    expect(matchesKind(ownedApp, "external")).toBe(false);
+    expect(matchesKind(externalApp, "external")).toBe(true);
+  });
+
+  it("matches every app for an unknown kind param", () => {
+    expect(matchesKind(ownedApp, "bogus")).toBe(true);
+    expect(matchesKind(externalApp, "bogus")).toBe(true);
+  });
+});

--- a/platform/frontend/src/app/apps/page.client.tsx
+++ b/platform/frontend/src/app/apps/page.client.tsx
@@ -31,6 +31,7 @@ export default function AppsPage() {
   const searchParams = useSearchParams();
   const search = searchParams.get("search") ?? "";
   const filter = searchParams.get("filter") ?? "all";
+  const kind = searchParams.get("kind") ?? "all";
 
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
@@ -46,10 +47,11 @@ export default function AppsPage() {
 
   const filtered = useMemo(
     () =>
-      (data?.data ?? []).filter((app) =>
-        matchesFilter(app, filter, currentUserId),
+      (data?.data ?? []).filter(
+        (app) =>
+          matchesKind(app, kind) && matchesFilter(app, filter, currentUserId),
       ),
-    [data, filter, currentUserId],
+    [data, kind, filter, currentUserId],
   );
 
   const setParam = (name: string, value: string | null) => {
@@ -95,6 +97,21 @@ export default function AppsPage() {
             <SelectItem value="org">Organization</SelectItem>
           </SelectContent>
         </Select>
+        <Select
+          value={kind}
+          onValueChange={(value) =>
+            setParam("kind", value === "all" ? null : value)
+          }
+        >
+          <SelectTrigger className="w-[160px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent position="popper" side="bottom" align="start">
+            <SelectItem value="all">All kinds</SelectItem>
+            <SelectItem value="owned">Apps</SelectItem>
+            <SelectItem value="external">MCP Server Apps</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       <LoadingWrapper isPending={isPending && !data}>
@@ -134,6 +151,15 @@ export default function AppsPage() {
       <AppCreateDialog open={createOpen} onOpenChange={setCreateOpen} />
     </PageLayout>
   );
+}
+
+// "Apps" are authored inside the platform (source "owned"); "MCP Server Apps"
+// are ui:// resources exposed by installed external MCP servers (source
+// "external"). Exported for tests.
+export function matchesKind(app: AppListItem, kind: string): boolean {
+  if (kind === "owned") return app.source === "owned";
+  if (kind === "external") return app.source === "external";
+  return true;
 }
 
 function matchesFilter(


### PR DESCRIPTION
## What

Adds a second filter dimension to the Apps page alongside the existing scope filter: **app kind**.

- **All kinds** (default) — no filtering
- **Apps** — apps authored inside the platform (`source === "owned"`)
- **MCP Server Apps** — `ui://` resources exposed by installed external MCP servers (`source === "external"`)

## How

- Mirrors the existing scope filter exactly: a second shadcn `Select` in the same filter row, client-side predicate, and the choice persisted in the URL as `?kind=owned|external` via the page's existing `setParam` mechanism (param values match the `AppListItemSchema` `source` discriminant, the same way the scope filter's values match the scope schema).
- Filtering stays client-side, matching the scope filter. `search` is the only server-side param; with `PAGE_SIZE = 100` and a single page fetched, client-side kind filtering doesn't change pagination behavior relative to the existing scope filter.

## Notes for reviewers

- Diff is deliberately scoped to the `kind` param, the new `Select`, and the `matchesKind` predicate — no restructuring of the list rendering, to stay out of the way of #6278/#6280 which also touch this file.
- `matchesKind` is exported for the unit test (frontend knip has the unused-exports rule off).

## Testing

- New `page.client.test.ts` covering `matchesKind` for all/owned/external/unknown params.
- `pnpm type-check`, `biome ci .` (from `platform/frontend`), `pnpm knip`, and the apps-directory vitest suite all pass.