### PR TITLE
fix(apps): revert the staging MCP sandbox domain — all apps render dead frames

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -39,14 +39,6 @@ archestra:
     ARCHESTRA_ENTERPRISE_LICENSE_FULL_WHITE_LABELING: "true"
     ARCHESTRA_ENTERPRISE_LICENSE_KNOWLEDGE_BASE_ACTIVATED: "true"
     ARCHESTRA_API_BASE_URL: "https://frontend.archestra.dev,https://backend.archestra.dev"
-    # Dedicated origin for MCP App sandboxes so browser device permissions
-    # (camera/mic/geolocation/clipboard) can be delegated to app iframes. Each
-    # app renders at <hash>.sandbox.archestra.dev (a real cross-origin); without
-    # this, sandboxes fall back to the frontend's opaque origin and browsers
-    # block those features. Wildcard DNS + the cert-manager-issued wildcard TLS
-    # secret come from archestra-ai/infra (gke/dns.tf, gke-apps/cert-manager);
-    # the ingress rule + tls entry below route the sandbox hosts to the frontend.
-    ARCHESTRA_MCP_SANDBOX_DOMAIN: "sandbox.archestra.dev"
     ARCHESTRA_GEMINI_VERTEX_AI_ENABLED: "true"
     ARCHESTRA_GEMINI_VERTEX_AI_PROJECT: "friendly-path-465518-r6"
     ARCHESTRA_GEMINI_VERTEX_AI_LOCATION: "us-central1"
@@ -131,22 +123,6 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
-      # MCP App sandbox origins (<hash>.sandbox.archestra.dev) serve the
-      # frontend; its /_sandbox/* Next.js rewrite proxies to the backend.
-      - host: "*.sandbox.archestra.dev"
-        paths:
-          - path: /
-            port: 3000
-            pathType: Prefix
-
-    # Wildcard cert for the sandbox hosts, issued and renewed by cert-manager
-    # (archestra-ai/infra, gke-apps/cert-manager). GKE combines spec.tls
-    # secrets with the ManagedCertificate annotation above. The secret must
-    # exist before this deploys, or ingress-gce fails to sync the Ingress.
-    tls:
-      - hosts:
-          - "*.sandbox.archestra.dev"
-        secretName: archestra-sandbox-wildcard-tls
 
 postgresql:
   # Staging still uses the bundled PostgreSQL chart. This is not HA, but these


### PR DESCRIPTION
## 🚨 Incident revert

**Symptom**: since ~12:55 UTC every MCP App on staging renders a broken/blank frame (e.g. Archestra PM `show_board`) — reported as "archestra pm broken for everyone".

**Root cause**: #6272 switched app sandboxes to `https://<hash>.sandbox.archestra.dev` (Mode 1). The Ingress manifest is correct, but **ingress-gce cannot sync any change to the GCP load balancer** — every sync fails with:

```
Error syncing to GCP: error running backend syncing routine: Errored updating IAP Settings
for service archestra/archestra-platform: Cannot switch to default OAuth once IAP
credentials have been set
```

IAP credentials were set on the LB backend service at some point out-of-band; the Ingress spec hadn't changed in ~8 months so the broken sync was invisible. #6272 was the first spec change since: the new host rule + wildcard cert never reached the LB (SNI `*.sandbox.archestra.dev` still serves the `frontend.archestra.dev` cert → TLS failure), while the already-deployed env var made the frontend point every app iframe at those unservable origins.

**This PR** reverts the staging values change (env var + host rule + spec.tls), returning apps to the same-origin Mode 3 that worked before. The infra pieces (wildcard DNS, cert-manager, the issued cert — archestra-ai/infra#20) stay in place; they're inert and correct.

## Re-land plan

1. Fix the IAP sync blocker (clear/align the IAP settings on the `archestra-platform` backend services, or add a matching `iap` block to the BackendConfig) so ingress-gce can sync again.
2. Confirm `kubectl describe ingress -n archestra` shows a clean sync and SNI `test.sandbox.archestra.dev` serves `CN=*.sandbox.archestra.dev`.
3. Re-apply the #6272 values change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>