### PR TITLE
ci: fail loudly on deploy-hook, bench-guard, and staging-deploy errors

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,9 +63,12 @@ jobs:
       # start if a benchmark Job is still active, before spending a build on it.
       - name: Guard against an overlapping run
         run: |
-          set -uo pipefail
-          if kubectl get jobs -n archestra -l app=archestra-bench \
-               -o jsonpath='{.items[*].status.active}' 2>/dev/null | grep -q '[1-9]'; then
+          set -euo pipefail
+          # Fail closed: if the check itself errors (bad credentials, API outage),
+          # abort rather than proceed as "no active job".
+          ACTIVE=$(kubectl get jobs -n archestra -l app=archestra-bench \
+            -o jsonpath='{.items[*].status.active}')
+          if grep -q '[1-9]' <<<"$ACTIVE"; then
             echo "::error::a benchmark Job is still active in archestra; refusing to start an overlapping run"
             exit 1
           fi

--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -100,5 +100,5 @@ jobs:
             --set "archestra.env.ARCHESTRA_AGENTS_INCOMING_EMAIL_OUTLOOK_CLIENT_SECRET=${ARCHESTRA_STAGING_OUTLOOK_CLIENT_SECRET}" \
             --set "archestra.env.ARCHESTRA_CHAT_ANTHROPIC_API_KEY=${ARCHESTRA_STAGING_CHAT_ANTHROPIC_API_KEY}" \
             --values .github/values-staging.yaml \
-            --wait \
+            --atomic \
             --timeout 15m

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -294,7 +294,7 @@ jobs:
       - name: Trigger website deploy
         env:
           VERCEL_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK_URL }}
-        run: curl -X POST "$VERCEL_DEPLOY_HOOK_URL"
+        run: curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL"
 
   notify-release-failure:
     name: Notify release failure

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -23,4 +23,4 @@ jobs:
         env:
           VERCEL_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK_URL }}
         run: |
-          curl -X POST "$VERCEL_DEPLOY_HOOK_URL"
+          curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL"


### PR DESCRIPTION
Three silent failure paths in CI now fail loudly:

- Both Vercel deploy hook calls use `curl -fsS`: HTTP 4xx/5xx and connection failures fail the step, and in release-please trip `notify-release-failure` instead of reporting success on a broken hook.
- The benchmark overlapping-run guard fails closed: `kubectl` output is captured before grepping under `set -euo pipefail`, so an errored check aborts the run instead of proceeding as "no active job".
- The staging helm upgrade uses `--atomic` (implies `--wait`): a failed upgrade rolls back instead of leaving staging half-upgraded. CI already runs `--atomic` on the same runner family (setup-archestra-platform).

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>