### PR TITLE
ci: unify create-github-app-token pin; bump auth-to-gar setup-gcloud to v3

### DIFF
--- a/.github/actions/auth-to-gar/action.yml
+++ b/.github/actions/auth-to-gar/action.yml
@@ -17,7 +17,7 @@ runs:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
 
     - name: Set up Google Cloud
-      uses: google-github-actions/setup-gcloud@6a7c903a70c8625ed6700fa299f5ddb4ca6022e9 # v2.1.5
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
     - name: Configure Docker for Artifact Registry
       shell: bash

--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Create GitHub App token
       id: create-token
-      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}


### PR DESCRIPTION
- `github-app-token` wrapper moves to the create-github-app-token v3.2.0 SHA all four inline call sites already use — pin dedup only.
- `auth-to-gar` setup-gcloud v2.1.5 → v3.0.1 (the SHA on-commits-to-main already runs). This is a real major bump (node24 runtime, tool-cache off by default); node24 actions already run green on every runner flavor auth-to-gar reaches, including the arm64 Blacksmith host (actions/checkout v7 is node24 in the same jobs).

End state: exactly one pinned SHA per action across .github/.

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>