### PR TITLE
ci: run docker-scan placeholder for labeled fork PRs; fix codegen env comment

### DIFF
--- a/.github/workflows/docker-image-scanning.yml
+++ b/.github/workflows/docker-image-scanning.yml
@@ -20,10 +20,12 @@ concurrency:
 
 jobs:
   # Required-check placeholders for ordinary PR updates. The real scans remain
-  # merge-queue-only unless a trusted PR is explicitly labeled.
+  # merge-queue-only unless a trusted PR is explicitly labeled. Fork PRs always
+  # get the placeholder — the real scan needs trusted context, and without this
+  # a labeled fork PR would run neither job, leaving the required check pending.
   docker-image-scanning-placeholder:
     name: Docker Image Scanning (${{ matrix.name }})
-    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-docker-scan') }}
+    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name != 'run-docker-scan' || github.event.pull_request.head.repo.fork == true) }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -309,7 +309,8 @@ jobs:
           IS_RELEASE_PLEASE_PR: ${{ steps.check-release-please.outputs.is-release-please }}
           # Generate the full Archestra MCP tool catalog and route surface
           # (incl. flag-gated app tools and the Projects/My Files routes) so
-          # codegen matches the committed docs/spec; mirrors values-ci.yaml.
+          # codegen matches the committed docs/spec. Broader than values-ci.yaml,
+          # which enables apps but not Projects, so e2e runs with Projects off.
           ARCHESTRA_APPS_ENABLED: "true"
           ARCHESTRA_PROJECTS_ENABLED: "true"
         run: |


### PR DESCRIPTION
- A fork PR labeled `run-docker-scan` previously matched neither the real scan (fork-excluded) nor the placeholder (label-excluded), leaving the required check pending forever. The placeholder now covers that case; trusted-PR and merge_group behavior unchanged (conditions partition all pull_request events exactly).
- Corrects the codegen-check comment that claimed to mirror values-ci.yaml, which does not enable Projects.

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>