### PR TITLE
ci: drop unreachable issues trigger; append to system prompt instead of replacing

### DIFF
--- a/.github/workflows/claude-coreteam-mentions-shared.yml
+++ b/.github/workflows/claude-coreteam-mentions-shared.yml
@@ -18,8 +18,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 60
     permissions:
@@ -46,6 +45,5 @@ jobs:
           use_sticky_comment: "true"
           additional_permissions: |
             actions: read
-          assignee_trigger: "claude-bot"
           allowed_tools: 'Bash(pnpm install),Bash(pnpm add:*),Bash(pnpm test),Bash(pnpm type-check),Bash(pnpm codegen:*)'
-          additional_claude_args: '--system-prompt "Keep responses concise and to the point. Avoid lengthy explanations unless specifically requested."'
+          additional_claude_args: '--append-system-prompt "Keep responses concise and to the point. Avoid lengthy explanations unless specifically requested."'

--- a/.github/workflows/claude-coreteam-mentions.yml
+++ b/.github/workflows/claude-coreteam-mentions.yml
@@ -14,8 +14,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
- No job condition in claude-coreteam-mentions.yml ever matches the `issues` event, so the trigger, the shared workflow's issues clause, and `assignee_trigger` were dead config.
- `--system-prompt` fully replaced the claude-code-action default system prompt where an additive style note was intended; `--append-system-prompt` keeps the defaults.

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>