### PR TITLE
perf(websocket): share one deployment-status poller across subscribers

### DIFF
--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -41,8 +41,10 @@ interface McpExecSubscription {
 }
 
 interface McpDeploymentStatusSubscription {
-  interval: NodeJS.Timeout;
-  lastStatuses: Record<string, McpDeploymentStatusEntry>;
+  buildStatuses: (
+    summary: typeof McpServerRuntimeManager.statusSummary,
+  ) => Record<string, McpDeploymentStatusEntry>;
+  lastStatusesJson: string;
 }
 
 const service = websocketService as unknown as {
@@ -59,6 +61,7 @@ const service = websocketService as unknown as {
   mcpLogsSubscriptions: Map<WS, McpLogsSubscription>;
   mcpExecSubscriptions: Map<WS, McpExecSubscription>;
   mcpDeploymentStatusSubscriptions: Map<WS, McpDeploymentStatusSubscription>;
+  mcpDeploymentStatusPollInterval: NodeJS.Timeout | null;
   initBrowserStreamContextForTesting: () => void;
   wss: { clients: Set<WS> } | null;
 };
@@ -571,10 +574,11 @@ describe("websocket MCP deployment statuses", () => {
   });
 
   afterEach(() => {
-    for (const subscription of service.mcpDeploymentStatusSubscriptions.values()) {
-      clearInterval(subscription.interval);
-    }
     service.mcpDeploymentStatusSubscriptions.clear();
+    if (service.mcpDeploymentStatusPollInterval) {
+      clearInterval(service.mcpDeploymentStatusPollInterval);
+      service.mcpDeploymentStatusPollInterval = null;
+    }
   });
 
   test("sends initial deployment statuses for accessible local servers", async ({
@@ -805,7 +809,7 @@ describe("websocket MCP deployment statuses", () => {
     );
   });
 
-  test("unsubscribes and clears interval on unsubscribe message", async ({
+  test("unsubscribes and stops the shared poller on unsubscribe message", async ({
     makeOrganization,
     makeUser,
     makeMcpServer,
@@ -850,8 +854,7 @@ describe("websocket MCP deployment statuses", () => {
     );
 
     expect(service.mcpDeploymentStatusSubscriptions.has(ws)).toBe(true);
-    const subscription = service.mcpDeploymentStatusSubscriptions.get(ws);
-    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    expect(service.mcpDeploymentStatusPollInterval).not.toBeNull();
 
     // Now unsubscribe
     await service.handleMessage(
@@ -863,7 +866,8 @@ describe("websocket MCP deployment statuses", () => {
     );
 
     expect(service.mcpDeploymentStatusSubscriptions.has(ws)).toBe(false);
-    expect(clearIntervalSpy).toHaveBeenCalledWith(subscription?.interval);
+    // Last subscriber gone: the shared poller must be stopped
+    expect(service.mcpDeploymentStatusPollInterval).toBeNull();
   });
 
   test("cleans up previous subscription when subscribing again", async ({
@@ -912,10 +916,8 @@ describe("websocket MCP deployment statuses", () => {
 
     const firstSubscription = service.mcpDeploymentStatusSubscriptions.get(ws);
     expect(firstSubscription).toBeDefined();
-    const firstInterval = firstSubscription?.interval;
-    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 
-    // Subscribe again - should clean up the first subscription
+    // Subscribe again - should replace the first subscription
     await service.handleMessage(
       {
         type: "subscribe_mcp_deployment_statuses",
@@ -924,13 +926,277 @@ describe("websocket MCP deployment statuses", () => {
       ws,
     );
 
-    // First interval should have been cleared
-    expect(clearIntervalSpy).toHaveBeenCalledWith(firstInterval);
-
-    // A new subscription should exist
     const secondSubscription = service.mcpDeploymentStatusSubscriptions.get(ws);
     expect(secondSubscription).toBeDefined();
-    expect(secondSubscription?.interval).not.toBe(firstInterval);
+    expect(secondSubscription).not.toBe(firstSubscription);
+    expect(service.mcpDeploymentStatusSubscriptions.size).toBe(1);
+    expect(service.mcpDeploymentStatusPollInterval).not.toBeNull();
+  });
+});
+
+describe("websocket MCP deployment statuses shared poller", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // Only fake interval timers: real timeouts stay real so DB access keeps working
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    service.clientContexts.clear();
+    service.mcpDeploymentStatusSubscriptions.clear();
+  });
+
+  afterEach(() => {
+    service.mcpDeploymentStatusSubscriptions.clear();
+    if (service.mcpDeploymentStatusPollInterval) {
+      clearInterval(service.mcpDeploymentStatusPollInterval);
+      service.mcpDeploymentStatusPollInterval = null;
+    }
+    vi.useRealTimers();
+  });
+
+  const makeWs = () =>
+    ({
+      readyState: WS.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+    }) as unknown as WS;
+
+  const subscribe = (ws: WS) =>
+    service.handleMessage(
+      { type: "subscribe_mcp_deployment_statuses", payload: {} },
+      ws,
+    );
+
+  test("one tick triggers a single shared refresh for multiple subscribers", async ({
+    makeOrganization,
+    makeUser,
+    makeMcpServer,
+    makeInternalMcpCatalog,
+    makeTeam,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+    await makeMcpServer({
+      scope: "team",
+      catalogId: catalog.id,
+      ownerId: user.id,
+      teamId: team.id,
+    });
+
+    const refreshSpy = vi
+      .spyOn(McpServerRuntimeManager, "refreshAllStates")
+      .mockResolvedValue(undefined);
+    vi.spyOn(McpServerRuntimeManager, "statusSummary", "get").mockReturnValue({
+      status: "running",
+      mcpServers: {},
+    });
+
+    const ws1 = makeWs();
+    const ws2 = makeWs();
+    const context = {
+      userId: user.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: true,
+    };
+    service.clientContexts.set(ws1, context);
+    service.clientContexts.set(ws2, context);
+
+    await subscribe(ws1);
+    await subscribe(ws2);
+    expect(service.mcpDeploymentStatusSubscriptions.size).toBe(2);
+
+    refreshSpy.mockClear();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("sends per-subscriber updates scoped to each subscriber's accessible servers", async ({
+    makeOrganization,
+    makeUser,
+    makeMcpServer,
+    makeInternalMcpCatalog,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const org = await makeOrganization();
+    const userA = await makeUser();
+    const userB = await makeUser();
+    const teamA = await makeTeam(org.id, userA.id);
+    const teamB = await makeTeam(org.id, userB.id);
+    await makeTeamMember(teamA.id, userA.id);
+    await makeTeamMember(teamB.id, userB.id);
+    const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+    const serverA = await makeMcpServer({
+      scope: "team",
+      catalogId: catalog.id,
+      ownerId: userA.id,
+      teamId: teamA.id,
+    });
+    const serverB = await makeMcpServer({
+      scope: "team",
+      catalogId: catalog.id,
+      ownerId: userB.id,
+      teamId: teamB.id,
+    });
+
+    vi.spyOn(McpServerRuntimeManager, "refreshAllStates").mockResolvedValue(
+      undefined,
+    );
+    let summary: typeof McpServerRuntimeManager.statusSummary = {
+      status: "running",
+      mcpServers: {},
+    };
+    vi.spyOn(
+      McpServerRuntimeManager,
+      "statusSummary",
+      "get",
+    ).mockImplementation(() => summary);
+
+    const wsA = makeWs();
+    const wsB = makeWs();
+    service.clientContexts.set(wsA, {
+      userId: userA.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: false,
+    });
+    service.clientContexts.set(wsB, {
+      userId: userB.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: false,
+    });
+
+    await subscribe(wsA);
+    await subscribe(wsB);
+    (wsA.send as ReturnType<typeof vi.fn>).mockClear();
+    (wsB.send as ReturnType<typeof vi.fn>).mockClear();
+
+    // Both deployments transition to running
+    summary = {
+      status: "running",
+      mcpServers: {
+        [serverA.id]: {
+          state: "running",
+          message: "Deployment is running",
+          error: null,
+          serverName: "server-a",
+          deploymentName: `mcp-${serverA.id}`,
+          namespace: "default",
+        },
+        [serverB.id]: {
+          state: "running",
+          message: "Deployment is running",
+          error: null,
+          serverName: "server-b",
+          deploymentName: `mcp-${serverB.id}`,
+          namespace: "default",
+        },
+      },
+    };
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(wsA.send).toHaveBeenCalledTimes(1);
+    const messageA = JSON.parse(
+      (wsA.send as ReturnType<typeof vi.fn>).mock.calls[0][0] as string,
+    );
+    expect(messageA.type).toBe("mcp_deployment_statuses");
+    expect(Object.keys(messageA.payload.statuses)).toEqual([serverA.id]);
+    expect(messageA.payload.statuses[serverA.id].state).toBe("running");
+
+    expect(wsB.send).toHaveBeenCalledTimes(1);
+    const messageB = JSON.parse(
+      (wsB.send as ReturnType<typeof vi.fn>).mock.calls[0][0] as string,
+    );
+    expect(messageB.type).toBe("mcp_deployment_statuses");
+    expect(Object.keys(messageB.payload.statuses)).toEqual([serverB.id]);
+    expect(messageB.payload.statuses[serverB.id].state).toBe("running");
+  });
+
+  test("does not resend when statuses are unchanged", async ({
+    makeOrganization,
+    makeUser,
+    makeMcpServer,
+    makeInternalMcpCatalog,
+    makeTeam,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+    await makeMcpServer({
+      scope: "team",
+      catalogId: catalog.id,
+      ownerId: user.id,
+      teamId: team.id,
+    });
+
+    vi.spyOn(McpServerRuntimeManager, "refreshAllStates").mockResolvedValue(
+      undefined,
+    );
+    vi.spyOn(McpServerRuntimeManager, "statusSummary", "get").mockReturnValue({
+      status: "running",
+      mcpServers: {},
+    });
+
+    const ws = makeWs();
+    service.clientContexts.set(ws, {
+      userId: user.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: true,
+    });
+
+    await subscribe(ws);
+    (ws.send as ReturnType<typeof vi.fn>).mockClear();
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  test("unsubscribing the last subscriber stops polling", async ({
+    makeOrganization,
+    makeUser,
+    makeMcpServer,
+    makeInternalMcpCatalog,
+    makeTeam,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+    await makeMcpServer({
+      scope: "team",
+      catalogId: catalog.id,
+      ownerId: user.id,
+      teamId: team.id,
+    });
+
+    const refreshSpy = vi
+      .spyOn(McpServerRuntimeManager, "refreshAllStates")
+      .mockResolvedValue(undefined);
+    vi.spyOn(McpServerRuntimeManager, "statusSummary", "get").mockReturnValue({
+      status: "running",
+      mcpServers: {},
+    });
+
+    const ws = makeWs();
+    service.clientContexts.set(ws, {
+      userId: user.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: true,
+    });
+
+    await subscribe(ws);
+    await service.handleMessage(
+      { type: "unsubscribe_mcp_deployment_statuses", payload: {} },
+      ws,
+    );
+
+    refreshSpy.mockClear();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(service.mcpDeploymentStatusPollInterval).toBeNull();
   });
 });
 

--- a/platform/backend/src/websocket.test.ts
+++ b/platform/backend/src/websocket.test.ts
@@ -1198,6 +1198,188 @@ describe("websocket MCP deployment statuses shared poller", () => {
     expect(refreshSpy).not.toHaveBeenCalled();
     expect(service.mcpDeploymentStatusPollInterval).toBeNull();
   });
+
+  test("a hung refresh does not freeze the poller past the refresh bound", async ({
+    makeOrganization,
+    makeUser,
+    makeMcpServer,
+    makeInternalMcpCatalog,
+    makeTeam,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+    await makeMcpServer({
+      scope: "team",
+      catalogId: catalog.id,
+      ownerId: user.id,
+      teamId: team.id,
+    });
+
+    // The refresh bound uses setTimeout: fake it too, for this test only
+    vi.useFakeTimers({
+      toFake: ["setInterval", "clearInterval", "setTimeout", "clearTimeout"],
+    });
+
+    // Second call (first tick) hangs forever; all others resolve
+    let refreshCalls = 0;
+    const refreshSpy = vi
+      .spyOn(McpServerRuntimeManager, "refreshAllStates")
+      .mockImplementation(() => {
+        refreshCalls++;
+        return refreshCalls === 2
+          ? new Promise<void>(() => {})
+          : Promise.resolve();
+      });
+    vi.spyOn(McpServerRuntimeManager, "statusSummary", "get").mockReturnValue({
+      status: "running",
+      mcpServers: {},
+    });
+
+    const ws = makeWs();
+    service.clientContexts.set(ws, {
+      userId: user.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: true,
+    });
+
+    await subscribe(ws);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+    // First tick starts the hung refresh
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(refreshSpy).toHaveBeenCalledTimes(2);
+
+    // Advance well past the refresh bound: the guard must be released and a
+    // later tick must run a fresh refresh instead of being frozen forever
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(refreshSpy.mock.calls.length).toBeGreaterThan(2);
+  });
+
+  test("a failed send is retried on the next tick", async ({
+    makeOrganization,
+    makeUser,
+    makeMcpServer,
+    makeInternalMcpCatalog,
+    makeTeam,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+    const mcpServer = await makeMcpServer({
+      scope: "team",
+      catalogId: catalog.id,
+      ownerId: user.id,
+      teamId: team.id,
+    });
+
+    vi.spyOn(McpServerRuntimeManager, "refreshAllStates").mockResolvedValue(
+      undefined,
+    );
+    let summary: typeof McpServerRuntimeManager.statusSummary = {
+      status: "running",
+      mcpServers: {},
+    };
+    vi.spyOn(
+      McpServerRuntimeManager,
+      "statusSummary",
+      "get",
+    ).mockImplementation(() => summary);
+
+    const ws = makeWs();
+    service.clientContexts.set(ws, {
+      userId: user.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: true,
+    });
+
+    await subscribe(ws);
+    const sendMock = ws.send as ReturnType<typeof vi.fn>;
+    sendMock.mockClear();
+
+    summary = {
+      status: "running",
+      mcpServers: {
+        [mcpServer.id]: {
+          state: "running",
+          message: "Deployment is running",
+          error: null,
+          serverName: "test-server",
+          deploymentName: `mcp-${mcpServer.id}`,
+          namespace: "default",
+        },
+      },
+    };
+
+    // Tick N: send blows up — the update must not be marked as delivered
+    sendMock.mockImplementationOnce(() => {
+      throw new Error("socket write failed");
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+
+    // Tick N+1: the same (still-changed) payload is retried and delivered
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    const retried = JSON.parse(sendMock.mock.calls[1][0] as string);
+    expect(retried.type).toBe("mcp_deployment_statuses");
+    expect(retried.payload.statuses[mcpServer.id].state).toBe("running");
+  });
+
+  test("socket closed during subscribe awaits is not registered and poller stays off", async ({
+    makeOrganization,
+    makeUser,
+    makeMcpServer,
+    makeInternalMcpCatalog,
+    makeTeam,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const team = await makeTeam(org.id, user.id);
+    const catalog = await makeInternalMcpCatalog({ serverType: "local" });
+    await makeMcpServer({
+      scope: "team",
+      catalogId: catalog.id,
+      ownerId: user.id,
+      teamId: team.id,
+    });
+
+    let resolveRefresh: (() => void) | undefined;
+    const refreshSpy = vi
+      .spyOn(McpServerRuntimeManager, "refreshAllStates")
+      .mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      );
+    vi.spyOn(McpServerRuntimeManager, "statusSummary", "get").mockReturnValue({
+      status: "running",
+      mcpServers: {},
+    });
+
+    const ws = makeWs();
+    service.clientContexts.set(ws, {
+      userId: user.id,
+      organizationId: org.id,
+      userIsMcpServerAdmin: true,
+    });
+
+    const subscribePromise = subscribe(ws);
+    // setTimeout is real in this describe, so waitFor can poll
+    await vi.waitFor(() => expect(refreshSpy).toHaveBeenCalled());
+
+    // Socket closes while subscribe is still awaiting the refresh
+    (ws as { readyState: number }).readyState = WS.CLOSED;
+    resolveRefresh?.();
+    await subscribePromise;
+
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(service.mcpDeploymentStatusSubscriptions.has(ws)).toBe(false);
+    expect(service.mcpDeploymentStatusPollInterval).toBeNull();
+  });
 });
 
 describe("websocket MCP exec", () => {

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -688,6 +688,13 @@ class WebSocketService {
 
     // Refresh (through the shared in-flight guard) and build initial statuses
     await this.refreshMcpDeploymentStates();
+
+    // The awaits above (DB + refresh) may outlive the socket: revalidate
+    // before registering, or we would start polling for a dead client
+    if (ws.readyState !== WS.OPEN) {
+      return;
+    }
+
     const statuses = buildStatuses(McpServerRuntimeManager.statusSummary);
 
     // Send initial statuses
@@ -757,11 +764,13 @@ class WebSocketService {
         const statuses = sub.buildStatuses(summary);
         const statusesJson = JSON.stringify(statuses);
         if (statusesJson !== sub.lastStatusesJson) {
-          sub.lastStatusesJson = statusesJson;
           this.sendToClient(ws, {
             type: "mcp_deployment_statuses",
             payload: { statuses },
           });
+          // Mark delivered only after a successful send, so a throwing send
+          // is retried on the next tick
+          sub.lastStatusesJson = statusesJson;
         }
       } catch (error) {
         logger.error(
@@ -775,16 +784,34 @@ class WebSocketService {
   /**
    * refreshAllStates mutates per-deployment state and is not concurrency-safe,
    * so overlapping invocations are skipped; a skipping caller reads the summary
-   * left by the previous refresh.
+   * left by the previous refresh. The awaited refresh is bounded: a K8s call
+   * that never settles must not hold the guard forever and freeze polling for
+   * every subscriber.
    */
   private async refreshMcpDeploymentStates(): Promise<void> {
     if (this.mcpDeploymentStatusRefreshInFlight) {
       return;
     }
     this.mcpDeploymentStatusRefreshInFlight = true;
+    let timeoutTimer: NodeJS.Timeout | undefined;
     try {
-      await McpServerRuntimeManager.refreshAllStates();
+      const result = await Promise.race([
+        McpServerRuntimeManager.refreshAllStates(),
+        new Promise<"timeout">((resolve) => {
+          timeoutTimer = setTimeout(
+            () => resolve("timeout"),
+            MCP_DEPLOYMENT_STATUS_REFRESH_TIMEOUT_MS,
+          );
+        }),
+      ]);
+      if (result === "timeout") {
+        logger.warn(
+          { timeoutMs: MCP_DEPLOYMENT_STATUS_REFRESH_TIMEOUT_MS },
+          "MCP deployment state refresh timed out; releasing poll guard",
+        );
+      }
     } finally {
+      clearTimeout(timeoutTimer);
       this.mcpDeploymentStatusRefreshInFlight = false;
     }
   }
@@ -1019,6 +1046,10 @@ export function broadcastConversationUpdated(
 }
 
 export default websocketService;
+
+// Upper bound on one shared deployment-status refresh: releases the poll
+// guard even if a K8s call never settles.
+const MCP_DEPLOYMENT_STATUS_REFRESH_TIMEOUT_MS = 60_000;
 
 // How much exec output we keep to diagnose why a session ended. The OCI
 // start-failure error is short and arrives first, so a small head is plenty.

--- a/platform/backend/src/websocket.ts
+++ b/platform/backend/src/websocket.ts
@@ -40,8 +40,12 @@ interface McpExecSubscription {
 }
 
 interface McpDeploymentStatusSubscription {
-  interval: NodeJS.Timeout;
-  lastStatuses: Record<string, McpDeploymentStatusEntry>;
+  /** Projects the shared runtime summary onto this subscriber's accessible servers. */
+  buildStatuses: (
+    summary: typeof McpServerRuntimeManager.statusSummary,
+  ) => Record<string, McpDeploymentStatusEntry>;
+  /** Serialized last-sent statuses, for change detection. */
+  lastStatusesJson: string;
 }
 
 interface WebSocketClientContext {
@@ -67,6 +71,10 @@ class WebSocketService {
   private clientContexts: Map<WebSocket, WebSocketClientContext> = new Map();
   private browserStreamContext: BrowserStreamSocketClientContext | null = null;
   private deploymentMetricsInterval: NodeJS.Timeout | null = null;
+  // One poller shared by all deployment-status subscribers; runs while the
+  // subscription map is non-empty.
+  private mcpDeploymentStatusPollInterval: NodeJS.Timeout | null = null;
+  private mcpDeploymentStatusRefreshInFlight = false;
 
   /**
    * Proxy object for browser subscriptions - exposes Map-like interface for testing.
@@ -678,10 +686,9 @@ class WebSocketService {
       return result;
     };
 
-    // Refresh and build initial statuses from the runtime manager
-    await McpServerRuntimeManager.refreshAllStates();
-    const runtimeSummary = McpServerRuntimeManager.statusSummary;
-    const statuses = buildStatuses(runtimeSummary);
+    // Refresh (through the shared in-flight guard) and build initial statuses
+    await this.refreshMcpDeploymentStates();
+    const statuses = buildStatuses(McpServerRuntimeManager.statusSummary);
 
     // Send initial statuses
     this.sendToClient(ws, {
@@ -689,56 +696,96 @@ class WebSocketService {
       payload: { statuses },
     });
 
-    // Store subscription with initial statuses for change detection
-    const lastStatuses = { ...statuses };
-
-    // Start polling interval (10s)
-    const interval = setInterval(async () => {
-      if (ws.readyState !== WS.OPEN) {
-        this.unsubscribeMcpDeploymentStatuses(ws);
-        return;
-      }
-
-      try {
-        // Refresh deployment states from K8s before reading cached summaries
-        await McpServerRuntimeManager.refreshAllStates();
-
-        const currentSummary = McpServerRuntimeManager.statusSummary;
-        const currentStatuses = buildStatuses(currentSummary);
-
-        // Only send if statuses changed
-        const sub = this.mcpDeploymentStatusSubscriptions.get(ws);
-        if (!sub) return;
-
-        const changed =
-          JSON.stringify(currentStatuses) !== JSON.stringify(sub.lastStatuses);
-
-        if (changed) {
-          sub.lastStatuses = { ...currentStatuses };
-          this.sendToClient(ws, {
-            type: "mcp_deployment_statuses",
-            payload: { statuses: currentStatuses },
-          });
-        }
-      } catch (error) {
-        logger.error({ error }, "Failed to poll MCP deployment statuses");
-      }
-    }, 10_000);
-
     this.mcpDeploymentStatusSubscriptions.set(ws, {
-      interval,
-      lastStatuses,
+      buildStatuses,
+      lastStatusesJson: JSON.stringify(statuses),
     });
+    this.startMcpDeploymentStatusPollingIfNeeded();
 
     logger.info("MCP deployment status client subscribed");
   }
 
   private unsubscribeMcpDeploymentStatuses(ws: WebSocket): void {
-    const subscription = this.mcpDeploymentStatusSubscriptions.get(ws);
-    if (subscription) {
-      clearInterval(subscription.interval);
-      this.mcpDeploymentStatusSubscriptions.delete(ws);
+    if (this.mcpDeploymentStatusSubscriptions.delete(ws)) {
       logger.info("MCP deployment status client unsubscribed");
+    }
+    if (
+      this.mcpDeploymentStatusSubscriptions.size === 0 &&
+      this.mcpDeploymentStatusPollInterval
+    ) {
+      clearInterval(this.mcpDeploymentStatusPollInterval);
+      this.mcpDeploymentStatusPollInterval = null;
+    }
+  }
+
+  private startMcpDeploymentStatusPollingIfNeeded(): void {
+    if (this.mcpDeploymentStatusPollInterval) {
+      return;
+    }
+    this.mcpDeploymentStatusPollInterval = setInterval(() => {
+      void this.pollMcpDeploymentStatuses();
+    }, 10_000);
+  }
+
+  /**
+   * One shared tick for all subscribers: a single runtime refresh, then each
+   * subscriber gets their own projection of the summary (subscribers may see
+   * different servers, so payloads are per-subscriber and never broadcast).
+   */
+  private async pollMcpDeploymentStatuses(): Promise<void> {
+    // A previous tick (or a subscribe-time refresh) is still running; skip.
+    if (this.mcpDeploymentStatusRefreshInFlight) {
+      return;
+    }
+
+    try {
+      await this.refreshMcpDeploymentStates();
+    } catch (error) {
+      logger.error({ error }, "Failed to poll MCP deployment statuses");
+      return;
+    }
+
+    const summary = McpServerRuntimeManager.statusSummary;
+    for (const [ws, sub] of this.mcpDeploymentStatusSubscriptions) {
+      // Isolate subscribers: one failing send must not stop the others
+      try {
+        if (ws.readyState !== WS.OPEN) {
+          this.unsubscribeMcpDeploymentStatuses(ws);
+          continue;
+        }
+
+        const statuses = sub.buildStatuses(summary);
+        const statusesJson = JSON.stringify(statuses);
+        if (statusesJson !== sub.lastStatusesJson) {
+          sub.lastStatusesJson = statusesJson;
+          this.sendToClient(ws, {
+            type: "mcp_deployment_statuses",
+            payload: { statuses },
+          });
+        }
+      } catch (error) {
+        logger.error(
+          { error },
+          "Failed to send MCP deployment statuses to subscriber",
+        );
+      }
+    }
+  }
+
+  /**
+   * refreshAllStates mutates per-deployment state and is not concurrency-safe,
+   * so overlapping invocations are skipped; a skipping caller reads the summary
+   * left by the previous refresh.
+   */
+  private async refreshMcpDeploymentStates(): Promise<void> {
+    if (this.mcpDeploymentStatusRefreshInFlight) {
+      return;
+    }
+    this.mcpDeploymentStatusRefreshInFlight = true;
+    try {
+      await McpServerRuntimeManager.refreshAllStates();
+    } finally {
+      this.mcpDeploymentStatusRefreshInFlight = false;
     }
   }
 


### PR DESCRIPTION
Each MCP deployment-status subscriber ran its own 10s `setInterval` awaiting the process-global `McpServerRuntimeManager.refreshAllStates()`, so K8s API load scaled with subscribers × deployments, and overlapping refreshes raced the manager's per-deployment state (`runningMissCount` et al.).

- One shared poller runs while at least one subscription exists (started on first subscribe, stopped when the map empties — unsubscribe, socket close/error, service stop).
- Ticks are guarded against overlap, and the awaited refresh is bounded at 60s so a hung K8s call degrades to a warning instead of freezing polling for everyone.
- Payloads remain strictly per-subscriber (each caller only sees their accessible local servers); the change detector stores the serialized snapshot, advanced only after a successful send so failed sends retry next tick.
- The subscribe path revalidates the socket after its async work before registering.

Tests: shared-refresh-per-tick, per-subscriber scoping, poller teardown, hung-refresh recovery, failed-send retry, close-during-subscribe — all written fail-first.

https://claude.ai/code/session_0111LPRAPTkArzWMSFzCjP5a

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>