### PR TITLE
fix(ci): supply-chain scanner handles backslash-continued downloads

### DIFF
--- a/.github/scripts/check-supply-chain-policy.py
+++ b/.github/scripts/check-supply-chain-policy.py
@@ -25,14 +25,28 @@ def main() -> int:
             ["git", "rev-parse", "--show-toplevel"], text=True
         ).strip()
     )
-    candidate_files = list(iter_candidate_files(repo_root))
+    failures = collect_failures(repo_root)
+
+    if failures:
+        print("Supply-chain policy violations found:", file=sys.stderr)
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+
+    print("Supply-chain policy checks passed.")
+    return 0
+
+
+def collect_failures(repo_root: Path) -> list[str]:
     failures: list[str] = []
 
-    for file_path in candidate_files:
+    for file_path in iter_candidate_files(repo_root):
         relative_path = file_path.relative_to(repo_root)
-        lines = file_path.read_text(encoding="utf-8").splitlines()
+        physical_lines = file_path.read_text(encoding="utf-8").splitlines()
+        logical_lines = fold_continuations(physical_lines)
+        texts = [text for _, text in logical_lines]
 
-        for line_number, line in enumerate(lines, start=1):
+        for index, (line_number, line) in enumerate(logical_lines):
             stripped = line.strip()
             if not stripped or stripped.startswith("#"):
                 continue
@@ -40,7 +54,7 @@ def main() -> int:
                 continue
 
             if ":latest" in line and not has_inline_or_previous_marker(
-                lines, line_number - 1, LATEST_ALLOW_MARKER
+                texts, index, LATEST_ALLOW_MARKER
             ):
                 failures.append(
                     format_failure(
@@ -54,7 +68,7 @@ def main() -> int:
             if not looks_like_remote_download(line):
                 continue
 
-            if has_inline_or_previous_marker(lines, line_number - 1, DOWNLOAD_ALLOW_MARKER):
+            if has_inline_or_previous_marker(texts, index, DOWNLOAD_ALLOW_MARKER):
                 continue
 
             if is_post_only_webhook(line):
@@ -63,7 +77,7 @@ def main() -> int:
             if has_local_url(line):
                 continue
 
-            if not has_nearby_verification(lines, line_number - 1):
+            if not has_nearby_verification(texts, index):
                 failures.append(
                     format_failure(
                         relative_path,
@@ -73,14 +87,34 @@ def main() -> int:
                     )
                 )
 
-    if failures:
-        print("Supply-chain policy violations found:", file=sys.stderr)
-        for failure in failures:
-            print(failure, file=sys.stderr)
-        return 1
+    return failures
 
-    print("Supply-chain policy checks passed.")
-    return 0
+
+def fold_continuations(lines: list[str]) -> list[tuple[int, str]]:
+    """Join backslash-continued physical lines into logical lines so multi-line
+    commands are matched whole; each logical line keeps its first physical
+    line's number for reporting. Comment lines never continue."""
+    folded: list[tuple[int, str]] = []
+    index = 0
+    while index < len(lines):
+        start_line_number = index + 1
+        line = lines[index]
+        while ends_with_continuation(line) and index + 1 < len(lines):
+            line = line[:-1].rstrip() + " " + lines[index + 1].strip()
+            index += 1
+        folded.append((start_line_number, line))
+        index += 1
+    return folded
+
+
+def ends_with_continuation(line: str) -> bool:
+    # Shell semantics: only an odd count of trailing backslashes continues the
+    # line (an even count is escaped literal backslashes), and the backslash
+    # must be the final character — no trailing whitespace after it.
+    if not line.endswith("\\") or line.strip().startswith("#"):
+        return False
+    trailing_backslashes = len(line) - len(line.rstrip("\\"))
+    return trailing_backslashes % 2 == 1
 
 
 def iter_candidate_files(repo_root: Path):
@@ -124,7 +158,15 @@ def has_nearby_verification(lines: list[str], index: int) -> bool:
         "gpg --verify",
         "minisign -Vm",
     )
-    return any(marker in window for marker in verification_markers)
+    if any(marker in window for marker in verification_markers):
+        return True
+    # A bare `openssl dgst` only prints a hash; it counts as verification only
+    # next to an actual pass/fail check: a signature check (-verify) or a
+    # comparison of the digest against a pinned value (test "$X" = "$Y").
+    return "openssl dgst" in window and (
+        "-verify" in window
+        or re.search(r'\btest\s+"[^"]*"\s*==?\s', window) is not None
+    )
 
 
 def has_inline_or_previous_marker(

--- a/.github/scripts/test_check_supply_chain_policy.py
+++ b/.github/scripts/test_check_supply_chain_policy.py
@@ -58,6 +58,126 @@ class IsPostOnlyWebhookTest(unittest.TestCase):
             self.assertFalse(policy.is_post_only_webhook(line), line)
 
 
+class FoldContinuationsTest(unittest.TestCase):
+    def test_joins_backslash_continued_lines_keeping_first_line_number(self) -> None:
+        folded = policy.fold_continuations(
+            [
+                "curl -fsSL \\",
+                "  -o /tmp/tool.tgz \\",
+                "  https://example.com/tool.tgz",
+                "echo done",
+            ]
+        )
+        self.assertEqual(
+            folded,
+            [
+                (1, "curl -fsSL -o /tmp/tool.tgz https://example.com/tool.tgz"),
+                (4, "echo done"),
+            ],
+        )
+
+    def test_comment_lines_do_not_continue(self) -> None:
+        folded = policy.fold_continuations(["# trailing backslash \\", "FROM scratch"])
+        self.assertEqual(folded, [(1, "# trailing backslash \\"), (2, "FROM scratch")])
+
+    def test_even_trailing_backslashes_are_literal_not_continuation(self) -> None:
+        # `echo foo \\` in shell is an escaped literal backslash; the statement
+        # ends there and the next line is an independent command.
+        folded = policy.fold_continuations(["echo foo \\\\", "echo bar"])
+        self.assertEqual(folded, [(1, "echo foo \\\\"), (2, "echo bar")])
+
+    def test_odd_trailing_backslashes_continue(self) -> None:
+        folded = policy.fold_continuations(["echo foo \\\\\\", "bar"])
+        self.assertEqual(folded, [(1, "echo foo \\\\ bar")])
+
+    def test_trailing_whitespace_after_backslash_is_not_continuation(self) -> None:
+        folded = policy.fold_continuations(["echo foo \\  ", "echo bar"])
+        self.assertEqual(folded, [(1, "echo foo \\  "), (2, "echo bar")])
+
+
+class CollectFailuresTest(unittest.TestCase):
+    def _scan(self, workflow_body: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "x.yml").write_text(workflow_body)
+            return policy.collect_failures(root)
+
+    def test_flags_continued_line_download(self) -> None:
+        failures = self._scan(
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          curl -fsSL \\\n"
+            "            -o /tmp/tool.tgz \\\n"
+            "            https://example.com/tool.tgz\n"
+        )
+        self.assertEqual(len(failures), 1)
+        self.assertIn(".github/workflows/x.yml:5", failures[0])
+
+    def test_continued_download_with_openssl_dgst_verification_passes(self) -> None:
+        failures = self._scan(
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          curl -fsSL \\\n"
+            "            -o /tmp/tool.tgz \\\n"
+            "            https://example.com/tool.tgz\n"
+            "          openssl dgst -sha512 -verify /keys/pub.pem \\\n"
+            "            -signature /tmp/tool.tgz.sig /tmp/tool.tgz\n"
+        )
+        self.assertEqual(failures, [])
+
+    def test_bare_openssl_dgst_hash_print_is_not_verification(self) -> None:
+        failures = self._scan(
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          curl -o /tmp/tool.tgz https://example.com/tool.tgz\n"
+            "          openssl dgst -sha256 /tmp/tool.tgz\n"
+        )
+        self.assertEqual(len(failures), 1)
+
+    def test_openssl_dgst_with_pinned_hash_comparison_passes(self) -> None:
+        failures = self._scan(
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          curl -o /tmp/tool.tgz https://example.com/tool.tgz\n"
+            '          HASH=$(openssl dgst -sha512 -binary /tmp/tool.tgz | openssl base64 -A)\n'
+            '          test "${HASH}" = "${PINNED_HASH}"\n'
+        )
+        self.assertEqual(failures, [])
+
+    def test_openssl_dgst_with_truthiness_test_is_not_verification(self) -> None:
+        # `test "${H}"` only checks non-emptiness; it compares nothing.
+        failures = self._scan(
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          curl -o /tmp/tool.tgz https://example.com/tool.tgz\n"
+            '          H=$(openssl dgst -sha256 /tmp/tool.tgz)\n'
+            '          test "${H}"\n'
+        )
+        self.assertEqual(len(failures), 1)
+
+    def test_single_line_unverified_download_still_flagged(self) -> None:
+        failures = self._scan(
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - run: curl -o /tmp/tool.tgz https://example.com/tool.tgz\n"
+        )
+        self.assertEqual(len(failures), 1)
+        self.assertIn(".github/workflows/x.yml:4", failures[0])
+
+
 class LooksLikeRemoteDownloadTest(unittest.TestCase):
     def test_detects_single_line_downloads(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
Backslash-continued `curl`/`wget` invocations were invisible to the per-physical-line heuristic (a three-line continued download matched nothing). Changes:

- Fold continuations into logical lines before matching, reporting the first physical line. Shell semantics respected: only an odd count of trailing backslashes continues, backslash must be the final character, comments never continue.
- Recognize `openssl dgst` as a verification marker — but only next to an actual pass/fail check (`-verify` or `test "$X" = "$Y"` against a pinned value); a bare digest print still gets flagged. This is the pattern `.devcontainer/Dockerfile` uses, which the folding would otherwise have newly flagged.
- Extract `collect_failures(repo_root)` so the scan loop is testable; 8 new behavior tests (16 total), which error/fail on the pre-change code.

https://claude.ai/code/session_01LJJwAXa1EPDsnHfiraupJ4

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>