### PR TITLE
fix(apps): show the MCP server's emoji/icon on external app cards

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -53781,6 +53781,10 @@
                               },
                               "resourceUri": {
                                 "type": "string"
+                              },
+                              "icon": {
+                                "nullable": true,
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -53792,7 +53796,8 @@
                               "catalogId",
                               "mcpServerId",
                               "scope",
-                              "resourceUri"
+                              "resourceUri",
+                              "icon"
                             ],
                             "additionalProperties": false
                           }

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -352,6 +352,7 @@ class McpServerModel {
       mcpServerId: string;
       scope: ResourceVisibilityScope;
       serverName: string;
+      serverIcon: string | null;
       toolName: string;
       toolDescription: string | null;
       resourceUri: string;
@@ -387,6 +388,7 @@ class McpServerModel {
         mcpServerId: install.mcpServerId,
         scope: install.scope,
         serverName: app.serverName,
+        serverIcon: app.serverIcon,
         toolName: app.toolName,
         toolDescription: app.toolDescription,
         resourceUri: app.resourceUri,
@@ -555,6 +557,7 @@ class McpServerModel {
     Array<{
       catalogId: string;
       serverName: string;
+      serverIcon: string | null;
       toolName: string;
       toolDescription: string | null;
       resourceUri: string;
@@ -568,6 +571,7 @@ class McpServerModel {
       .select({
         catalogId: schema.internalMcpCatalogTable.id,
         serverName: schema.internalMcpCatalogTable.name,
+        serverIcon: schema.internalMcpCatalogTable.icon,
         toolName: schema.toolsTable.name,
         toolDescription: schema.toolsTable.description,
         resourceUri: uiResourceUri,
@@ -606,6 +610,7 @@ class McpServerModel {
               {
                 catalogId: row.catalogId,
                 serverName: row.serverName,
+                serverIcon: row.serverIcon,
                 // Strip the server prefix: catalog tools are stored as
                 // `<server>__<tool>`, but the card shows just the tool.
                 toolName: parseFullToolName(row.toolName).toolName,

--- a/platform/backend/src/routes/app/app.routes.ts
+++ b/platform/backend/src/routes/app/app.routes.ts
@@ -177,6 +177,9 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
           name: `${catalogApp.serverName} / ${catalogApp.toolName}`,
           description: catalogApp.toolDescription,
           resourceUri: catalogApp.resourceUri,
+          // The server's registry icon (emoji or data URL) so the card can
+          // show which server the app comes from.
+          icon: catalogApp.serverIcon,
           executionModel: "server-scoped" as const,
           cspOrigin: "author-declared" as const,
         })),

--- a/platform/backend/src/routes/app/list.app.route.test.ts
+++ b/platform/backend/src/routes/app/list.app.route.test.ts
@@ -103,6 +103,7 @@ describe("GET /api/apps", () => {
     const catalog = await makeInternalMcpCatalog({
       organizationId,
       name: "Get Time",
+      icon: "🕒",
       serverType: "remote",
       serverUrl: "https://example.com/mcp",
       scope: "org",
@@ -141,6 +142,8 @@ describe("GET /api/apps", () => {
       resourceUri: "ui://get-time/app.html",
       executionModel: "server-scoped",
       cspOrigin: "author-declared",
+      // The catalog's registry icon rides along so the card can show it.
+      icon: "🕒",
     });
   });
 

--- a/platform/backend/src/test/fixtures.ts
+++ b/platform/backend/src/test/fixtures.ts
@@ -665,6 +665,7 @@ async function makeInternalMcpCatalog(
       InsertInternalMcpCatalog,
       | "id"
       | "name"
+      | "icon"
       | "serverType"
       | "serverUrl"
       | "description"

--- a/platform/backend/src/types/app.ts
+++ b/platform/backend/src/types/app.ts
@@ -96,6 +96,10 @@ export const ExternalAppListItemSchema = AppListItemBaseSchema.extend({
   mcpServerId: z.string(),
   scope: AppScopeSchema,
   resourceUri: z.string(),
+  // The catalog's icon, exactly as the MCP registry renders it: an emoji
+  // character or a base64 image data URL. Null when the server has none (the
+  // card falls back to its generic server glyph).
+  icon: z.string().nullable(),
 });
 
 export const AppListItemSchema = z.discriminatedUnion("source", [

--- a/platform/frontend/src/app/apps/_parts/app-card.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.test.tsx
@@ -36,6 +36,14 @@ vi.mock("./app-delete-dialog", () => ({
     open ? <div data-testid="delete-dialog">Delete {app.name}</div> : null,
 }));
 
+// Stub the catalog icon (its real render pulls appearance settings via react
+// query); the card test only asserts which icon value flows into it.
+vi.mock("@/components/mcp-catalog-icon", () => ({
+  McpCatalogIcon: ({ icon }: { icon?: string | null }) => (
+    <span data-testid="mcp-catalog-icon">{icon ?? "generic-server-icon"}</span>
+  ),
+}));
+
 // Render menu items directly (no Radix portal) so their links are queryable.
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => (
@@ -106,6 +114,7 @@ const externalApp: Extract<AppListItem, { source: "external" }> = {
   resourceUri: "ui://pm/board.html",
   executionModel: "server-scoped",
   cspOrigin: "author-declared",
+  icon: null,
 };
 
 describe("ExternalAppCard", () => {
@@ -156,6 +165,18 @@ describe("ExternalAppCard", () => {
     expect(
       screen.getByRole("link", { name: /manage mcp server/i }),
     ).toHaveAttribute("href", "/mcp/registry/beta/cat-1");
+  });
+
+  it("shows the server's registry icon, falling back to the generic glyph without one", () => {
+    const { rerender } = render(
+      <AppCard app={{ ...externalApp, icon: "🗂️" }} />,
+    );
+    expect(screen.getByTestId("mcp-catalog-icon")).toHaveTextContent("🗂️");
+
+    rerender(<AppCard app={externalApp} />);
+    expect(screen.getByTestId("mcp-catalog-icon")).toHaveTextContent(
+      "generic-server-icon",
+    );
   });
 });
 

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { AppSettingsDialog } from "@/components/mcp-app/app-settings-dialog";
+import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { ScopeBadge } from "@/components/scope-badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardDescription, CardTitle } from "@/components/ui/card";
@@ -98,11 +99,19 @@ function CardOpeningOverlay() {
   );
 }
 
-// The app's type, as the leading icon. The label (what "owned" vs "external"
-// means) rides in the tooltip + aria-label rather than a separate badge. Lifted
-// above the full-card click button so it can be hovered.
-function AppTypeIcon({ owned }: { owned: boolean }) {
-  const Icon = owned ? AppWindow : Server;
+// The app's type, as the leading icon. External cards show the backing MCP
+// server's registry icon (emoji or image) when the catalog has one;
+// McpCatalogIcon falls back to the same generic Server glyph otherwise. The
+// label (what "owned" vs "external" means) rides in the tooltip + aria-label
+// rather than a separate badge. Lifted above the full-card click button so it
+// can be hovered.
+function AppTypeIcon({
+  owned,
+  icon,
+}: {
+  owned: boolean;
+  icon?: string | null;
+}) {
   const label = owned ? "MCP app" : "MCP server app";
   return (
     <Tooltip>
@@ -112,7 +121,11 @@ function AppTypeIcon({ owned }: { owned: boolean }) {
           aria-label={label}
           className="relative z-10 inline-flex text-muted-foreground"
         >
-          <Icon className="h-4 w-4" />
+          {owned ? (
+            <AppWindow className="h-4 w-4" />
+          ) : (
+            <McpCatalogIcon icon={icon} size={16} />
+          )}
         </span>
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>
@@ -276,7 +289,7 @@ function ExternalAppCard({ app }: { app: ExternalApp }) {
       </CardOverflowMenu>
 
       <div className="mb-3 flex items-center gap-1.5 pr-16">
-        <AppTypeIcon owned={false} />
+        <AppTypeIcon owned={false} icon={app.icon} />
       </div>
 
       <CardTitle className="line-clamp-2 leading-snug break-words">

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -15508,6 +15508,7 @@ export type GetAppsResponses = {
             mcpServerId: string;
             scope: 'personal' | 'team' | 'org';
             resourceUri: string;
+            icon: string | null;
         }>;
         pagination: {
             currentPage: number;


### PR DESCRIPTION
## Problem

External MCP-server apps on the Apps page (`source === "external"`) render a generic `Server` glyph, even though the MCP registry already shows each server's icon (an emoji character or a base64 image data URL stored on `internal_mcp_catalog.icon`).

## Change

- **Backend**: `getUiApps` / `findUiCapableForCaller` (`McpServerModel`) now select the catalog's `icon` column alongside the existing fields, and `GET /api/apps` maps it onto external list items. `ExternalAppListItemSchema` gains a nullable `icon` field; OpenAPI spec + generated client regenerated with the CI env flags.
- **Frontend**: `ExternalAppCard`'s leading type icon now renders the server's registry icon via the existing `McpCatalogIcon` component (emoji as text, `data:` URL as image), which falls back to the same generic `Server` glyph when the catalog has no icon. Tooltip/aria-label disclosure unchanged.

## Tests

- `list.app.route.test.ts`: the external-listing test now sets a catalog icon and asserts it flows through the route.
- `app-card.test.tsx`: new test asserting the card passes the server's icon to `McpCatalogIcon` and falls back without one.

## Checks

- backend: `pnpm type-check`, `pnpm knip`, `biome ci`, `vitest run src/routes/app/list.app.route.test.ts` (8 passed)
- frontend: `pnpm type-check`, `biome ci` (run from `platform/frontend`), `vitest run src/app/apps/_parts/app-card.test.tsx` (7 passed)
- shared: `biome ci`

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>