### PR TITLE
fix(chat): app tool calls render as pills in one row with consistent gaps

### DIFF
--- a/platform/frontend/src/components/chat/apps-context.tsx
+++ b/platform/frontend/src/components/chat/apps-context.tsx
@@ -58,6 +58,12 @@ interface AppsContextValue {
   isAppOpen: (toolCallId: string) => boolean;
   /** Toggle one app's inline expansion (canonicalized), leaving other open apps alone. */
   toggleAppOpen: (toolCallId: string) => void;
+  /**
+   * Make this render its app's visible one and ensure it is open — without the
+   * toggle semantics. Used when a pill click dismisses the panel-hosted copy:
+   * the app must expand under the clicked pill, not wherever it last was.
+   */
+  focusAppRender: (toolCallId: string) => void;
   /** The single app the right panel hosts: the explicit pick, else the latest still-open app, else the latest — never blank. */
   panelToolCallId: string | null;
   /** Point the right panel at an app (pill selector / "Open in right panel"). */
@@ -89,6 +95,7 @@ const NOOP_VALUE: AppsContextValue = {
   apps: [],
   isAppOpen: () => false,
   toggleAppOpen: () => {},
+  focusAppRender: () => {},
   panelToolCallId: null,
   setPanelApp: () => {},
   canonicalToolCallId: (id) => id,
@@ -179,6 +186,27 @@ export function AppsProvider({
     [groupByToolCallId, closedKeys],
   );
 
+  // Non-toggling variant of toggleAppOpen: point the app's group at this
+  // render and open it, regardless of prior open/pick state.
+  const focusAppRender = useCallback(
+    (id: string) => {
+      const group = groupByToolCallId.get(id);
+      const key = group?.key ?? id;
+      const appId = group?.appId ?? null;
+      if (appId) {
+        setPickedOwnedRender((prev) => new Map(prev).set(appId, id));
+      }
+      setClosedKeys((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setSettingsOpen(false);
+    },
+    [groupByToolCallId],
+  );
+
   // Switching the panel app drops the previous app's settings form.
   const setPanelApp = useCallback(
     (id: string) => {
@@ -229,6 +257,7 @@ export function AppsProvider({
       apps,
       isAppOpen,
       toggleAppOpen,
+      focusAppRender,
       panelToolCallId,
       setPanelApp,
       canonicalToolCallId,
@@ -243,6 +272,7 @@ export function AppsProvider({
       apps,
       isAppOpen,
       toggleAppOpen,
+      focusAppRender,
       panelToolCallId,
       setPanelApp,
       canonicalToolCallId,

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -144,6 +144,22 @@ vi.mock("@/components/chat/mcp-app-container", () => ({
       data-uri={props.uiResourceUri}
     />
   ),
+  McpAppEntryPill: (props: { appId?: string; toolName: string }) => (
+    <div
+      data-testid="mcp-app-pill"
+      data-app-id={props.appId ?? ""}
+      data-tool-name={props.toolName}
+    />
+  ),
+  // The content half carries the app-binding contract (uri + appId), so it
+  // keeps the mcp-app-section testid the binding assertions target.
+  McpAppEntryContent: (props: { uiResourceUri: string; appId?: string }) => (
+    <div
+      data-testid="mcp-app-section"
+      data-app-id={props.appId ?? ""}
+      data-uri={props.uiResourceUri}
+    />
+  ),
   McpToolOutput: null,
 }));
 

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1,14 +1,11 @@
 import type { UIMessage } from "@ai-sdk/react";
 import {
   APP_RENDERING_ARCHESTRA_TOOL_SHORT_NAMES,
-  ARCHESTRA_MCP_CATALOG_ID,
   type ArchestraToolShortName,
   type archestraApiTypes,
   ChatMessageMetadataSchema,
-  getArchestraAppResourceUri,
   getArchestraToolFullName,
   HOOK_RUN_PART_TYPE,
-  isAppRenderingArchestraToolShortName,
   parseArchestraAppResourceUri,
   parseFullToolName,
   type ResourceVisibilityScope,
@@ -75,7 +72,6 @@ import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useProfileToolsWithIds } from "@/lib/chat/chat.query";
 import { useUpdateChatMessage } from "@/lib/chat/chat-message.query";
 import {
-  getCompactToolState,
   getToolErrorText,
   getToolHeaderState,
   getToolNameFromPart,
@@ -107,7 +103,6 @@ import { AuthErrorTool, type AuthErrorToolProps } from "./auth-error-tool";
 import {
   collectSubagentToolCalls,
   extractFileAttachments,
-  extractOwnedAppRender,
   filterOptimisticToolCalls,
   hasTextPart,
   identifyCompactToolGroups,
@@ -600,7 +595,7 @@ export function ChatMessages({
                           group.startIndex,
                         ),
                         parts: group.entries.flatMap((entry) =>
-                          entry.kind === "tool"
+                          entry.kind === "tool" || entry.kind === "app"
                             ? [entry.toolResultPart ?? entry.part]
                             : [],
                         ),
@@ -621,38 +616,61 @@ export function ChatMessages({
                                     key: `${message.id}-hook-${entry.partIndex}`,
                                     data: entry.data,
                                   }
-                                : {
-                                    kind: "tool" as const,
-                                    key: getToolEntryKey(message.id, entry),
-                                    toolName: entry.toolName,
-                                    part: entry.part,
-                                    toolResultPart: entry.toolResultPart,
-                                    errorText: entry.errorText,
-                                    nestedToolCalls:
-                                      subagentParentToolCallIds.has(
-                                        entry.part.toolCallId ?? "",
-                                      ) ? (
-                                        <SubagentToolCalls
-                                          parentToolCallId={
-                                            entry.part.toolCallId ?? ""
-                                          }
-                                          subagentToolCalls={subagentToolCalls}
-                                          isDebugging={isDebugging}
-                                          canExpandToolCalls={
-                                            canExpandToolCalls
-                                          }
-                                          connectedCatalogIds={
-                                            orchestrator.connectedCatalogIds
-                                          }
-                                          getToolShortName={getToolShortName}
-                                          toolIconMap={toolIconMap}
-                                        />
-                                      ) : null,
-                                  },
+                                : entry.kind === "app"
+                                  ? {
+                                      kind: "app" as const,
+                                      key: getToolEntryKey(message.id, entry),
+                                      toolName: entry.toolName,
+                                      part: entry.part,
+                                      toolResultPart: entry.toolResultPart,
+                                      errorText: entry.errorText,
+                                    }
+                                  : {
+                                      kind: "tool" as const,
+                                      key: getToolEntryKey(message.id, entry),
+                                      toolName: entry.toolName,
+                                      part: entry.part,
+                                      toolResultPart: entry.toolResultPart,
+                                      errorText: entry.errorText,
+                                      nestedToolCalls:
+                                        subagentParentToolCallIds.has(
+                                          entry.part.toolCallId ?? "",
+                                        ) ? (
+                                          <SubagentToolCalls
+                                            parentToolCallId={
+                                              entry.part.toolCallId ?? ""
+                                            }
+                                            subagentToolCalls={
+                                              subagentToolCalls
+                                            }
+                                            isDebugging={isDebugging}
+                                            canExpandToolCalls={
+                                              canExpandToolCalls
+                                            }
+                                            connectedCatalogIds={
+                                              orchestrator.connectedCatalogIds
+                                            }
+                                            getToolShortName={getToolShortName}
+                                            toolIconMap={toolIconMap}
+                                          />
+                                        ) : null,
+                                    },
                             )}
                             toolIconMap={toolIconMap}
                             canExpandToolCalls={canExpandToolCalls}
                             onToolApprovalResponse={onToolApprovalResponse}
+                            appContext={{
+                              agentId,
+                              earlyToolUiStarts,
+                              onSendMessage: (text) =>
+                                session?.sendMessage({
+                                  role: "user",
+                                  parts: [{ type: "text", text }],
+                                  metadata: {
+                                    createdAt: new Date().toISOString(),
+                                  },
+                                }),
+                            }}
                           />
                         ),
                       });
@@ -1646,28 +1664,6 @@ const MessageTool = memo(
     const output = mcpOutput?.content ?? rawOutput;
     const errorText = getToolErrorText({ part, toolResultPart });
 
-    // Owned-app management result (create/update/render_app): mount the
-    // app-bound runtime from structuredContent.id. Standard UI resources,
-    // errors, and denials take priority — those results keep their text.
-    const ownedApp =
-      !uiResourceUri && !errorText && part.state !== "output-denied"
-        ? extractOwnedAppRender({
-            toolName: mcpAppToolName,
-            output: rawOutput,
-            getToolShortName,
-          })
-        : null;
-
-    // An owned-app management tool (scaffold/edit/render_app), detected by name
-    // even before its result lands. Lets the still-pending call render as the
-    // same compact Archestra-logo circle as the finished one, instead of the
-    // full-width tool card it would otherwise fall through to.
-    const appMgmtShortName = getToolShortName(mcpAppToolName);
-    const isOwnedAppMgmtTool =
-      appMgmtShortName !== null
-        ? isAppRenderingArchestraToolShortName(appMgmtShortName)
-        : isAppRenderingArchestraToolShortName(mcpAppToolName);
-
     const isApprovalRequested = part.state === "approval-requested";
     const isToolDenied = part.state === "output-denied";
     const approvalDisplay = getApprovalToolDisplay({
@@ -1823,138 +1819,6 @@ const MessageTool = memo(
     const logsButton = errorText ? (
       <ToolErrorLogsButton toolName={toolName} />
     ) : null;
-
-    // MCP App tools: compact circle + canvas below (no collapsible wrapper).
-    // Owned-app management tools use this compact form even while pending (before
-    // a result identifies the app), so "Edit app" streaming looks like every
-    // other tool call rather than a full-width card.
-    if (
-      (uiResourceUri || ownedApp || isOwnedAppMgmtTool) &&
-      !isApprovalRequested &&
-      !isToolDenied &&
-      !errorText
-    ) {
-      const compactState = getCompactToolState({ part, toolResultPart });
-      // Unwrap run_tool so the circle carries the target tool's server icon.
-      const shortName = parseFullToolName(mcpAppToolName).toolName.replace(
-        /_/g,
-        " ",
-      );
-      const iconInfo = toolIconMap?.get(mcpAppToolName);
-      // Fall back to the Archestra catalog icon for owned-app / archestra tools
-      // whose icon isn't in the map yet (e.g. a still-pending management call).
-      const catalogId =
-        iconInfo?.catalogId ??
-        (appMgmtShortName !== null ? ARCHESTRA_MCP_CATALOG_ID : undefined);
-
-      // Expanded tool-call details (input/output). Handed to McpAppSection so it
-      // can place them above the app in the column below the circle+marker row.
-      const toolDetails = isOpen ? (
-        <Tool defaultOpen={true}>
-          <ToolHeader
-            type={`tool-${displayToolName}`}
-            state={getHeaderState({
-              state: part.state || "input-available",
-              toolResultPart,
-              errorText,
-            })}
-            isCollapsible={!!hasInput}
-          />
-          <ToolContent>
-            {hasInput ? <ToolInput input={displayInput} /> : null}
-            {toolResultPart && (
-              <ToolOutput
-                label="Result"
-                output={mcpOutput?.content ?? toolResultPart.output}
-              />
-            )}
-          </ToolContent>
-        </Tool>
-      ) : undefined;
-
-      // Tool-call circle and the app marker share the flex-wrap row's first line;
-      // the tool details + inline app card stack in a full-width column below.
-      return (
-        <div className="mb-4">
-          <div className="flex flex-wrap items-start gap-1.5">
-            <TooltipProvider delayDuration={200}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => handleOpenChange(!isOpen)}
-                    className={cn(
-                      "relative inline-flex items-center justify-center size-8 rounded-full border transition-all hover:bg-accent hover:border-accent-foreground/20",
-                      isOpen &&
-                        "bg-accent border-accent-foreground/20 ring-2 ring-primary/20",
-                      !isOpen && "bg-background",
-                    )}
-                  >
-                    {iconInfo?.icon || catalogId ? (
-                      <McpCatalogIcon
-                        icon={iconInfo?.icon}
-                        catalogId={catalogId}
-                        size={16}
-                      />
-                    ) : (
-                      <BotIcon className="size-3.5 text-muted-foreground" />
-                    )}
-                    <span
-                      className={cn(
-                        "absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-background",
-                        compactState === "completed" && "bg-green-500",
-                        compactState === "running" &&
-                          "bg-blue-500 animate-pulse",
-                        compactState === "error" && "bg-destructive",
-                      )}
-                    />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="text-xs">
-                  {shortName}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            {agentId &&
-              (uiResourceUri ? (
-                <McpAppSection
-                  uiResourceUri={uiResourceUri}
-                  mcpServerId={uiMcpServerId}
-                  appId={uiAppId ?? undefined}
-                  agentId={agentId}
-                  toolName={mcpAppToolName}
-                  toolCallId={part.toolCallId}
-                  toolInput={mcpAppToolInput}
-                  rawOutput={mcpOutput}
-                  toolDetails={toolDetails}
-                  preloadedResource={
-                    earlyToolUiData?.html
-                      ? {
-                          html: earlyToolUiData.html,
-                          csp: earlyToolUiData.csp,
-                          permissions: earlyToolUiData.permissions,
-                        }
-                      : undefined
-                  }
-                  onSendMessage={onSendMessage}
-                />
-              ) : ownedApp ? (
-                <McpAppSection
-                  uiResourceUri={getArchestraAppResourceUri(ownedApp.appId)}
-                  appId={ownedApp.appId}
-                  appName={ownedApp.appName}
-                  appVersion={ownedApp.latestVersion}
-                  agentId={agentId}
-                  toolName={mcpAppToolName}
-                  toolCallId={part.toolCallId}
-                  toolDetails={toolDetails}
-                  onSendMessage={onSendMessage}
-                />
-              ) : null)}
-          </div>
-        </div>
-      );
-    }
 
     const isExpandable =
       hasContent && (canExpandToolCalls || isApprovalRequested);

--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -1014,6 +1014,94 @@ describe("identifyCompactToolGroups", () => {
     expect(consumedIndices.has(2)).toBe(true);
     expect(consumedIndices.has(3)).toBe(true);
   });
+
+  it("groups consecutive MCP-app renders and regular tools into one row", () => {
+    const parts = [
+      {
+        type: "tool-slack__post_message",
+        toolCallId: "call_app1",
+        state: "output-available",
+        input: {},
+        output: {
+          content: "ok",
+          _meta: { ui: { resourceUri: "ui://slack/compose" } },
+        },
+      },
+      {
+        type: "tool-calendar__create_event",
+        toolCallId: "call_app2",
+        state: "output-available",
+        input: {},
+        output: {
+          content: "ok",
+          _meta: { ui: { resourceUri: "ui://calendar/event" } },
+        },
+      },
+      {
+        type: "tool-google__search",
+        toolCallId: "call_3",
+        state: "output-available",
+        input: { q: "weather" },
+        output: "sunny",
+      },
+    ] as UIMessage["parts"];
+
+    const { groupMap, consumedIndices } = identifyCompactToolGroups(parts, {
+      getToolShortName: () => null,
+    });
+
+    // One row: app pill, app pill, tool circle — not three separate blocks.
+    expect(groupMap.size).toBe(1);
+    expect(groupMap.get(0)?.entries.map((entry) => entry.kind)).toEqual([
+      "app",
+      "app",
+      "tool",
+    ]);
+    expect(consumedIndices).toEqual(new Set([0, 1, 2]));
+  });
+
+  it("classifies an owned-app management call as an app entry even while pending", () => {
+    const parts = [
+      {
+        type: "tool-archestra__edit_app",
+        toolCallId: "call_edit",
+        state: "input-streaming",
+        input: {},
+      },
+    ] as UIMessage["parts"];
+
+    const { groupMap } = identifyCompactToolGroups(parts, {
+      getToolShortName: (toolName) =>
+        toolName === "archestra__edit_app" ? "edit_app" : null,
+    });
+
+    expect(groupMap.get(0)?.entries.map((entry) => entry.kind)).toEqual([
+      "app",
+    ]);
+  });
+
+  it("keeps a failed app render out of the row so it renders the full card", () => {
+    const parts = [
+      {
+        type: "tool-slack__post_message",
+        toolCallId: "call_app1",
+        state: "output-error",
+        input: {},
+        errorText: "boom",
+        output: {
+          content: "boom",
+          _meta: { ui: { resourceUri: "ui://slack/compose" } },
+        },
+      },
+    ] as unknown as UIMessage["parts"];
+
+    const { groupMap, consumedIndices } = identifyCompactToolGroups(parts, {
+      getToolShortName: () => null,
+    });
+
+    expect(groupMap.size).toBe(0);
+    expect(consumedIndices.size).toBe(0);
+  });
 });
 
 describe("collectSubagentToolCalls", () => {

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -37,6 +37,19 @@ export type CompactToolGroupEntry =
       errorText: string | undefined;
     }
   | {
+      /**
+       * An MCP-App-rendering tool call (UI-resource result, early UI start, or
+       * owned-app management tool). Renders as an app pill in the circle row
+       * with its app content below the row.
+       */
+      kind: "app";
+      partIndex: number;
+      toolName: string;
+      part: DynamicToolUIPart | ToolUIPart;
+      toolResultPart: DynamicToolUIPart | ToolUIPart | null;
+      errorText: string | undefined;
+    }
+  | {
       /** An inline `data-hook-run` debug entry rendered as a circle in the row. */
       kind: "hook";
       partIndex: number;
@@ -298,6 +311,88 @@ export function deriveAppsFromMessages(
   return apps;
 }
 
+/**
+ * Everything an app group entry needs to mount its runtime, resolved from the
+ * tool part the same way the full-card path resolves it: an external MCP-UI
+ * result (or early UI start) yields the URI-bound render; an owned-app
+ * management result yields the app-bound render. `null` means the call is an
+ * app-rendering tool with nothing to mount yet (e.g. a still-streaming
+ * scaffold/edit call) — render it as a plain tool circle until the result lands.
+ */
+export type AppEntryRender = {
+  uiResourceUri: string;
+  appId?: string;
+  mcpServerId?: string | null;
+  appName?: string | null;
+  appVersion?: number | null;
+  /** Full tool name with any run_tool wrapper already unwrapped. */
+  mcpAppToolName: string;
+  toolInput?: Record<string, unknown>;
+  rawOutput?: McpToolOutput;
+};
+
+export function resolveAppEntryRender(params: {
+  part: DynamicToolUIPart | ToolUIPart;
+  toolResultPart: DynamicToolUIPart | ToolUIPart | null;
+  early?: { uiResourceUri?: string; toolName?: string };
+  getToolShortName: (toolName: string) => ArchestraToolShortName | null;
+}): AppEntryRender | null {
+  const { part, toolResultPart, early, getToolShortName } = params;
+  const output = (toolResultPart?.output ?? part.output) as
+    | McpToolOutput
+    | undefined;
+  const fullToolName = getToolName(part) ?? early?.toolName ?? "";
+  const mcpAppToolName = resolveRunToolTargetName(part, fullToolName, {
+    getToolShortName,
+  });
+
+  const ui = output?._meta?.ui as
+    | { resourceUri?: string; mcpServerId?: string }
+    | undefined;
+  const outputUri = ui?.resourceUri ?? early?.uiResourceUri ?? null;
+  if (outputUri) {
+    // An owned app's own render (e.g. its `__open` launch tool) carries a
+    // `ui://archestra-app/<appId>` URI; bind it so the app runs against the
+    // app-bound endpoint (/api/mcp/app/:appId), not the agent gateway.
+    const uriAppId = parseArchestraAppResourceUri(outputUri);
+    // When the model dispatched through run_tool, the app belongs to the
+    // *target* tool: forward its real arguments, not the run_tool wrapper's.
+    const runToolInput =
+      getToolShortName(fullToolName) === TOOL_RUN_TOOL_SHORT_NAME
+        ? (part.input as { tool_args?: Record<string, unknown> } | null)
+            ?.tool_args
+        : undefined;
+    return {
+      uiResourceUri: outputUri,
+      appId: uriAppId ?? undefined,
+      mcpServerId: ui?.mcpServerId ?? null,
+      mcpAppToolName,
+      toolInput: runToolInput ?? (part.input as Record<string, unknown>),
+      rawOutput: output,
+    };
+  }
+
+  // Owned-app management result (scaffold/edit/render_app): mount the
+  // app-bound runtime from structuredContent.id. The management tool's
+  // input/result are not forwarded into the iframe (they are not app data).
+  const ownedApp = extractOwnedAppRender({
+    toolName: mcpAppToolName,
+    output,
+    getToolShortName,
+  });
+  if (ownedApp) {
+    return {
+      uiResourceUri: getArchestraAppResourceUri(ownedApp.appId),
+      appId: ownedApp.appId,
+      appName: ownedApp.appName,
+      appVersion: ownedApp.latestVersion,
+      mcpAppToolName,
+    };
+  }
+
+  return null;
+}
+
 /** Unwrap a run_tool dispatch to the target tool name (no-op for other tools). */
 export function resolveRunToolTargetName(
   part: DynamicToolUIPart | ToolUIPart,
@@ -477,27 +572,7 @@ export function identifyCompactToolGroups(
       invocationIndices.push(i);
       continue;
     }
-    // Skip non-tool parts and MCP App tools (they render their own UI)
-    // biome-ignore lint/suspicious/noExplicitAny: checking nested _meta shape on unknown output
-    if (!isToolPart(part) || (part.output as any)?._meta?.ui?.resourceUri)
-      continue;
-    // Also skip tools identified as MCP Apps via early UI start or earlyToolUiStarts
-    if (part.toolCallId && mcpAppCallIds.has(part.toolCallId)) continue;
-    // Owned-app renders escape compaction by OUTPUT, not name, so a run_tool
-    // dispatch targeting create/update/render_app is covered too (its raw name
-    // is run_tool, which nonCompactToolNames deliberately does not contain).
-    if (
-      options?.getToolShortName &&
-      extractOwnedAppRender({
-        toolName: resolveRunToolTargetName(part, getToolName(part) ?? "", {
-          getToolShortName: options.getToolShortName,
-        }),
-        output: part.output,
-        getToolShortName: options.getToolShortName,
-      })
-    ) {
-      continue;
-    }
+    if (!isToolPart(part)) continue;
 
     const callId = part.toolCallId;
     if (callId && seenToolCallIds.has(callId)) {
@@ -552,6 +627,46 @@ export function identifyCompactToolGroups(
       part: rawPart as never,
       toolResultPart: toolResultPart as never,
     });
+
+    // MCP-App-rendering calls join the row as app pills (their app content
+    // renders below the row). Errors, approvals, and denials keep the full
+    // tool card, exactly like non-compact tools.
+    if (
+      isAppRenderPart({
+        part: rawPart,
+        toolResultPart,
+        mcpAppCallIds,
+        getToolShortName: options?.getToolShortName,
+      })
+    ) {
+      const state = (toolResultPart ?? rawPart).state;
+      const appEligible =
+        !errorText &&
+        state !== "approval-requested" &&
+        state !== "output-denied";
+      if (appEligible) {
+        if (!currentGroup) {
+          currentGroup = { startIndex: idx, entries: [] };
+        }
+        currentGroup.entries.push({
+          kind: "app",
+          partIndex: idx,
+          toolName,
+          part: rawPart,
+          toolResultPart,
+          errorText,
+        });
+        consumedIndices.add(idx);
+        if (resultIdx !== undefined) {
+          consumedIndices.add(resultIdx);
+        }
+      } else {
+        finalizeCurrentGroup({ currentGroup, groupMap });
+        currentGroup = null;
+      }
+      continue;
+    }
+
     const isEligible =
       !options?.nonCompactToolNames?.has(toolName) &&
       isCompactEligible({
@@ -585,6 +700,36 @@ export function identifyCompactToolGroups(
 
   finalizeCurrentGroup({ currentGroup, groupMap });
   return { groupMap, consumedIndices };
+}
+
+/**
+ * Detect an MCP-App-rendering tool call: a UI-resource result (on the
+ * invocation or its result part), an early `data-tool-ui-start` announcement,
+ * or an owned-app management tool (scaffold/edit/render_app — matched by name
+ * so a still-pending call renders compact from the moment it streams).
+ */
+function isAppRenderPart(params: {
+  part: DynamicToolUIPart | ToolUIPart;
+  toolResultPart: DynamicToolUIPart | ToolUIPart | null;
+  mcpAppCallIds: Set<string>;
+  getToolShortName?: (toolName: string) => ArchestraToolShortName | null;
+}): boolean {
+  const { part, toolResultPart, mcpAppCallIds, getToolShortName } = params;
+  const output = toolResultPart?.output ?? part.output;
+  // biome-ignore lint/suspicious/noExplicitAny: checking nested _meta shape on unknown output
+  if ((output as any)?._meta?.ui?.resourceUri) return true;
+  if (part.toolCallId && mcpAppCallIds.has(part.toolCallId)) return true;
+  if (!getToolShortName) return false;
+  // Owned-app management tools, unwrapping run_tool so a dispatch targeting
+  // scaffold/edit/render_app is covered too (its raw name is run_tool, which
+  // nonCompactToolNames deliberately does not contain).
+  const targetName = resolveRunToolTargetName(part, getToolName(part) ?? "", {
+    getToolShortName,
+  });
+  const shortName = getToolShortName(targetName);
+  return shortName !== null
+    ? isAppRenderingArchestraToolShortName(shortName)
+    : isAppRenderingArchestraToolShortName(targetName);
 }
 
 function isHookRunPart(

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -29,8 +29,13 @@ import {
 } from "@/lib/chat/chat-tools-display.utils";
 import { useArchestraMcpIdentity } from "@/lib/mcp/archestra-mcp-server";
 import { cn } from "@/lib/utils";
-import { resolveRunToolTargetName } from "./chat-messages.utils";
+import {
+  type AppEntryRender,
+  resolveAppEntryRender,
+  resolveRunToolTargetName,
+} from "./chat-messages.utils";
 import { HookRunChip, type HookRunChipData } from "./hook-run-chip";
+import { McpAppEntryContent, McpAppEntryPill } from "./mcp-app-container";
 import { SkillPill } from "./skill-pill";
 import { ToolErrorLogsButton } from "./tool-error-logs-button";
 import { ToolStatusRow } from "./tool-status-row";
@@ -47,13 +52,49 @@ type CompactToolEntry = {
   nestedToolCalls?: React.ReactNode;
 };
 
+type CompactAppEntry = {
+  /** An MCP-App-rendering call: app pill in the row, app content below it. */
+  kind: "app";
+  key: string;
+  toolName: string;
+  part: ToolUIPart | DynamicToolUIPart;
+  toolResultPart: ToolUIPart | DynamicToolUIPart | null;
+  errorText: string | undefined;
+  /** Never set for app entries; present so ExpandedToolCard can take either. */
+  nestedToolCalls?: React.ReactNode;
+};
+
 type CompactHookEntry = {
   kind: "hook";
   key: string;
   data: HookRunChipData;
 };
 
-type CompactEntry = CompactToolEntry | CompactHookEntry;
+type CompactEntry = CompactToolEntry | CompactAppEntry | CompactHookEntry;
+
+/**
+ * Conversation-level context an app entry needs to mount its runtime. Absent
+ * (e.g. in subagent rows), app entries degrade to plain tool circles.
+ */
+type CompactAppContext = {
+  agentId?: string;
+  earlyToolUiStarts?: Record<
+    string,
+    {
+      uiResourceUri: string;
+      html?: string;
+      csp?: { connectDomains?: string[]; resourceDomains?: string[] };
+      permissions?: {
+        camera?: boolean;
+        microphone?: boolean;
+        geolocation?: boolean;
+        clipboardWrite?: boolean;
+      };
+      toolName?: string;
+    }
+  >;
+  onSendMessage?: (text: string) => void;
+};
 
 function CompactCircle({
   toolName,
@@ -242,6 +283,7 @@ export function CompactToolGroup({
   toolIconMap,
   canExpandToolCalls = true,
   onToolApprovalResponse,
+  appContext,
 }: {
   tools: CompactEntry[];
   toolIconMap?: ToolIconMap;
@@ -251,6 +293,7 @@ export function CompactToolGroup({
     approved: boolean;
     reason?: string;
   }) => void;
+  appContext?: CompactAppContext;
 }) {
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
   const { isToolName, getToolShortName } = useArchestraMcpIdentity();
@@ -261,6 +304,35 @@ export function CompactToolGroup({
   };
 
   const expandedEntry = tools.find((t) => t.key === expandedKey);
+
+  // Resolve each app entry's render once: the pill needs the app identity, the
+  // content below the row needs the full mount props. A `null` render (e.g. a
+  // still-streaming scaffold/edit call) degrades to a plain tool circle.
+  const appRenders = new Map<string, AppEntryRender>();
+  if (appContext?.agentId) {
+    for (const entry of tools) {
+      if (entry.kind !== "app") continue;
+      const render = resolveAppEntryRender({
+        part: entry.part,
+        toolResultPart: entry.toolResultPart,
+        early: entry.part.toolCallId
+          ? appContext.earlyToolUiStarts?.[entry.part.toolCallId]
+          : undefined,
+        getToolShortName,
+      });
+      if (render) appRenders.set(entry.key, render);
+    }
+  }
+
+  const circleIconProps = (displayToolName: string) => {
+    const iconInfo = toolIconMap?.get(displayToolName);
+    return {
+      icon: iconInfo?.icon,
+      catalogId:
+        iconInfo?.catalogId ??
+        (isToolName(displayToolName) ? ARCHESTRA_MCP_CATALOG_ID : undefined),
+    };
+  };
 
   return (
     <div className="mb-4">
@@ -281,6 +353,50 @@ export function CompactToolGroup({
             part: entry.part,
             toolResultPart: entry.toolResultPart,
           });
+          if (entry.kind === "app") {
+            const render = appRenders.get(entry.key);
+            if (!render) {
+              // No render to mount (still streaming, or no agent context):
+              // a regular circle that expands the tool details.
+              const displayToolName = resolveRunToolTargetName(
+                entry.part,
+                entry.toolName,
+                { getToolShortName },
+              );
+              const iconProps = circleIconProps(displayToolName);
+              return (
+                <CompactCircle
+                  key={entry.key}
+                  toolName={displayToolName}
+                  state={state}
+                  isExpanded={expandedKey === entry.key}
+                  isExpandable={canExpandToolCalls}
+                  onClick={() => handleToggle(entry.key)}
+                  {...iconProps}
+                />
+              );
+            }
+            const iconProps = circleIconProps(render.mcpAppToolName);
+            return (
+              <McpAppEntryPill
+                key={entry.key}
+                appId={render.appId}
+                appName={render.appName}
+                toolName={render.mcpAppToolName}
+                toolCallId={entry.part.toolCallId}
+                state={state}
+                icon={
+                  iconProps.icon || iconProps.catalogId ? (
+                    <McpCatalogIcon
+                      icon={iconProps.icon}
+                      catalogId={iconProps.catalogId}
+                      size={16}
+                    />
+                  ) : undefined
+                }
+              />
+            );
+          }
           if (getToolShortName(entry.toolName) === TOOL_LOAD_SKILL_SHORT_NAME) {
             const input = (entry.part.input ?? {}) as {
               name?: unknown;
@@ -349,6 +465,49 @@ export function CompactToolGroup({
           )}
         </div>
       )}
+      {appContext?.agentId
+        ? tools.map((entry) => {
+            if (entry.kind !== "app") return null;
+            const render = appRenders.get(entry.key);
+            if (!render) return null;
+            const early = entry.part.toolCallId
+              ? appContext.earlyToolUiStarts?.[entry.part.toolCallId]
+              : undefined;
+            return (
+              <McpAppEntryContent
+                key={entry.key}
+                uiResourceUri={render.uiResourceUri}
+                appId={render.appId}
+                mcpServerId={render.mcpServerId}
+                appName={render.appName}
+                appVersion={render.appVersion}
+                agentId={appContext.agentId as string}
+                toolName={render.mcpAppToolName}
+                toolCallId={entry.part.toolCallId}
+                toolInput={render.toolInput}
+                rawOutput={render.rawOutput}
+                preloadedResource={
+                  early?.html
+                    ? {
+                        html: early.html,
+                        csp: early.csp,
+                        permissions: early.permissions,
+                      }
+                    : undefined
+                }
+                // Surfaced only when the app renders nothing to display, so the
+                // call stays inspectable instead of the section going blank.
+                toolDetails={
+                  <ExpandedToolCard
+                    tool={entry}
+                    onToolApprovalResponse={onToolApprovalResponse}
+                  />
+                }
+                onSendMessage={appContext.onSendMessage}
+              />
+            );
+          })
+        : null}
     </div>
   );
 }
@@ -357,7 +516,7 @@ function ExpandedToolCard({
   tool,
   onToolApprovalResponse,
 }: {
-  tool: CompactToolEntry;
+  tool: CompactToolEntry | CompactAppEntry;
   onToolApprovalResponse?: (params: {
     id: string;
     approved: boolean;

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/chat/chat-tools-display.utils";
 import { useArchestraMcpIdentity } from "@/lib/mcp/archestra-mcp-server";
 import { cn } from "@/lib/utils";
+import { useApps } from "./apps-context";
 import {
   type AppEntryRender,
   resolveAppEntryRender,
@@ -297,9 +298,25 @@ export function CompactToolGroup({
 }) {
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
   const { isToolName, getToolShortName } = useArchestraMcpIdentity();
+  const { isAppOpen, toggleAppOpen, portalTarget } = useApps();
 
   const handleToggle = (key: string) => {
     if (!canExpandToolCalls) return;
+    // Expanding a tool card collapses any inline app open in this row — the
+    // mirror of an app pill collapsing an expanded tool card, so only one
+    // thing unfolds under the row at a time. Panel-hosted apps are untouched
+    // (nothing is expanded inline while the panel hosts).
+    if (expandedKey !== key && !portalTarget) {
+      for (const entry of tools) {
+        if (
+          entry.kind === "app" &&
+          entry.part.toolCallId &&
+          isAppOpen(entry.part.toolCallId)
+        ) {
+          toggleAppOpen(entry.part.toolCallId);
+        }
+      }
+    }
     setExpandedKey((prev) => (prev === key ? null : key));
   };
 
@@ -376,7 +393,8 @@ export function CompactToolGroup({
                 />
               );
             }
-            const iconProps = circleIconProps(render.mcpAppToolName);
+            // No icon override: the pill keeps the generic app-window glyph —
+            // the app pill identifies the APP, not the serving MCP catalog.
             return (
               <McpAppEntryPill
                 key={entry.key}
@@ -385,15 +403,9 @@ export function CompactToolGroup({
                 toolName={render.mcpAppToolName}
                 toolCallId={entry.part.toolCallId}
                 state={state}
-                icon={
-                  iconProps.icon || iconProps.catalogId ? (
-                    <McpCatalogIcon
-                      icon={iconProps.icon}
-                      catalogId={iconProps.catalogId}
-                      size={16}
-                    />
-                  ) : undefined
-                }
+                // Opening an app collapses an expanded tool-call card so only
+                // one thing unfolds under the row at a time.
+                onClick={() => setExpandedKey(null)}
               />
             );
           }

--- a/platform/frontend/src/components/chat/editable-user-message.tsx
+++ b/platform/frontend/src/components/chat/editable-user-message.tsx
@@ -122,7 +122,9 @@ export function EditableUserMessage({
       className="group/message"
       onMouseLeave={() => setIsRegenerateConfirming(false)}
     >
-      <div className="relative flex flex-col items-end pb-2 w-full">
+      {/* No bottom padding here: the message row's mb-4 IS the 16px rhythm gap
+          to the next block (see chat/CLAUDE.md); extra padding would compound. */}
+      <div className="relative flex flex-col items-end w-full">
         {/* Skill invoked via slash command — same pill shape as the tool-call
             SkillPill so the slash-command attribution and the model-driven
             load_skill call read as the same thing. Right-aligned (inheriting

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -988,31 +988,34 @@ describe("McpAppSection unavailable owned app", () => {
     >);
   });
 
-  it("shows a plain pill and reveals the error message only when expanded", async () => {
+  it("shows the error message while expanded and never mounts the runtime", async () => {
     const user = userEvent.setup();
 
     await act(async () => {
       render(
-        <McpAppSection
-          {...defaultProps}
-          appId={APP_ID}
-          appName="Dashboard"
-          toolCallId="tc1"
-          preloadedResource={preloadedResource}
-        />,
+        <AppsProvider apps={[]}>
+          <McpAppSection
+            {...defaultProps}
+            appId={APP_ID}
+            appName="Dashboard"
+            toolCallId="tc1"
+            preloadedResource={preloadedResource}
+          />
+        </AppsProvider>,
       );
     });
 
-    // Collapsed: just the pill, no error text, and never the runtime (would 404).
+    // Apps default open, so the unavailable message shows immediately — but
+    // the runtime never mounts (it would 404).
     const pill = screen.getByRole("button", { name: "Dashboard" });
-    expect(screen.queryByText(/no longer available/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/no longer available/i)).toBeInTheDocument();
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
 
-    // Expanding shows the unavailable message; the runtime still never mounts.
+    // Collapsing via the pill hides the message like any other app content.
     await act(async () => {
       await user.click(pill);
     });
-    expect(screen.getByText(/no longer available/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no longer available/i)).not.toBeInTheDocument();
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -188,6 +188,7 @@ export function McpAppEntryPill({
   toolCallId,
   icon,
   state,
+  onClick,
 }: {
   appId?: string;
   appName?: string | null;
@@ -198,10 +199,14 @@ export function McpAppEntryPill({
   icon?: React.ReactNode;
   /** Tool-call state for the status dot, matching the tool-call circles. */
   state?: "running" | "completed" | "error";
+  /** Runs on every pill click, before the app toggle (e.g. to collapse an
+   * expanded tool-call card so only one thing opens under the row). */
+  onClick?: () => void;
 }) {
   const {
     isAppOpen,
     toggleAppOpen,
+    focusAppRender,
     panelToolCallId,
     setPanelApp,
     canonicalToolCallId,
@@ -239,12 +244,19 @@ export function McpAppEntryPill({
       pressed={pressed}
       hasError={hasRuntimeError || ownedAppUnavailable}
       onClick={() => {
+        onClick?.();
         if (!toolCallId) return;
         // With the panel open, pills select the hosted app; otherwise they toggle
         // this app's inline render, leaving other open apps alone.
         if (portalTarget) {
-          if (isPanelFocused) closePanel();
-          else setPanelApp(toolCallId);
+          if (isPanelFocused) {
+            // Dismissing the panel via a pill expands the app inline under
+            // THIS pill — not wherever the app was last expanded.
+            closePanel();
+            focusAppRender(toolCallId);
+          } else {
+            setPanelApp(toolCallId);
+          }
         } else {
           toggleAppOpen(toolCallId);
         }

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -17,7 +17,7 @@ import { AppSettingsDialog } from "@/components/mcp-app/app-settings-dialog";
 import { McpAppCard } from "@/components/mcp-app/mcp-app-card";
 import {
   McpAppFullscreenExitButton,
-  McpAppMarkerCircle,
+  McpAppPill,
   McpAppRefreshButton,
   McpAppSettingsButton,
   McpAppStandaloneButton,
@@ -107,27 +107,7 @@ function useInlineHeightCap() {
   return cap;
 }
 
-/**
- * Self-contained MCP App section for use inside a Tool collapsible.
- * Owns display-mode / size state and the rawToolResult derivation so the
- * parent only needs to forward the raw output from the tool part.
- */
-export function McpAppSection({
-  uiResourceUri,
-  agentId,
-  appId,
-  mcpServerId,
-  appName,
-  appVersion,
-  toolName,
-  toolCallId,
-  toolInput,
-  rawOutput,
-  preloadedResource,
-  toolDetails,
-  onSendMessage,
-  surface = "inline",
-}: {
+type McpAppSectionProps = {
   uiResourceUri: string;
   agentId: string;
   /**
@@ -168,16 +148,140 @@ export function McpAppSection({
   toolDetails?: React.ReactNode;
   /** Called when the MCP App sends a ui/message request to inject a user message into the conversation */
   onSendMessage?: (text: string) => void;
+};
+
+/**
+ * Self-contained MCP App section for use inside a Tool collapsible or the
+ * right panel. On the inline surface it composes the app pill (row element)
+ * with the app content below; the compact tool row renders those two halves
+ * separately via {@link McpAppEntryPill} and {@link McpAppEntryContent} so
+ * consecutive pills share one line.
+ */
+export function McpAppSection(props: McpAppSectionProps) {
+  if (props.surface === "panel") {
+    return <McpAppEntryContent {...props} />;
+  }
+  return (
+    <>
+      <McpAppEntryPill
+        appId={props.appId}
+        appName={props.appName}
+        toolName={props.toolName}
+        toolCallId={props.toolCallId}
+      />
+      <McpAppEntryContent {...props} />
+    </>
+  );
+}
+
+/**
+ * The app pill in the compact tool-call row: app icon + name, pressed while
+ * the app's inline render is expanded. Clicking toggles the inline render, or
+ * selects/collapses the panel-hosted copy while the right panel is open.
+ * State is shared with {@link McpAppEntryContent} through the apps context
+ * (keyed by toolCallId), so the two halves can live in different DOM slots.
+ */
+export function McpAppEntryPill({
+  appId,
+  appName,
+  toolName,
+  toolCallId,
+  icon,
+  state,
+}: {
+  appId?: string;
+  appName?: string | null;
+  /** Full prefixed tool name — fallback label when no app name is known. */
+  toolName: string;
+  toolCallId?: string;
+  /** App icon (e.g. an McpCatalogIcon); falls back to the generic app glyph. */
+  icon?: React.ReactNode;
+  /** Tool-call state for the status dot, matching the tool-call circles. */
+  state?: "running" | "completed" | "error";
 }) {
+  const {
+    isAppOpen,
+    toggleAppOpen,
+    panelToolCallId,
+    setPanelApp,
+    canonicalToolCallId,
+    closePanel,
+    portalTarget,
+  } = useApps();
+  // Owned apps can be renamed from settings; read the live app so the label
+  // stays in sync after an edit (the appName prop is captured at render time).
+  const { data: ownedApp, isSuccess: ownedAppResolved } = useApp(appId ?? null);
+  const ownedAppUnavailable = !!appId && ownedAppResolved && ownedApp === null;
+  const headerName = ownedApp?.name || appName || mcpToolLabel(toolName);
+
+  const standalone = !toolCallId;
+  const canonicalId = toolCallId ? canonicalToolCallId(toolCallId) : undefined;
+  const isPanelFocused =
+    !!portalTarget && !!canonicalId && panelToolCallId === canonicalId;
+  const pressed =
+    !portalTarget && (standalone || (!!toolCallId && isAppOpen(toolCallId)));
+
+  // Runtime-error count for the pill's status dot (owned apps only).
+  const diagnosticCounts = useSyncExternalStore(
+    subscribeAppDiagnostics,
+    getAppDiagnosticCounts,
+    getAppDiagnosticCounts,
+  );
+  const hasRuntimeError = appId
+    ? (diagnosticCounts.get(appId)?.errors ?? 0) > 0
+    : false;
+
+  return (
+    <McpAppPill
+      label={headerName}
+      icon={icon}
+      state={state}
+      pressed={pressed}
+      hasError={hasRuntimeError || ownedAppUnavailable}
+      onClick={() => {
+        if (!toolCallId) return;
+        // With the panel open, pills select the hosted app; otherwise they toggle
+        // this app's inline render, leaving other open apps alone.
+        if (portalTarget) {
+          if (isPanelFocused) closePanel();
+          else setPanelApp(toolCallId);
+        } else {
+          toggleAppOpen(toolCallId);
+        }
+      }}
+    />
+  );
+}
+
+/**
+ * The app's content below the tool-call row: the inline app card (while
+ * expanded), its panel/diagnostics affordances, or the panel-surface fill
+ * card. Owns display-mode / size state and the rawToolResult derivation so
+ * the parent only needs to forward the raw output from the tool part.
+ * Renders nothing while the app is collapsed inline.
+ */
+export function McpAppEntryContent({
+  uiResourceUri,
+  agentId,
+  appId,
+  mcpServerId,
+  appName,
+  appVersion,
+  toolName,
+  toolCallId,
+  toolInput,
+  rawOutput,
+  preloadedResource,
+  toolDetails,
+  onSendMessage,
+  surface = "inline",
+}: McpAppSectionProps) {
   const resourceKey = `${agentId}:${uiResourceUri}`;
   const { displayMode, setDisplayMode, toggleFullscreen, reloadNonce, reload } =
     useAppRuntimeControls();
   const [size, setSize] = useState<{ width: number; height: number } | null>(
     null,
   );
-  // An unavailable (deleted / access-lost) owned app isn't in the registry, so
-  // its pill can't use the shared open state — it toggles its error locally.
-  const [unavailableOpen, setUnavailableOpen] = useState(false);
   const [resourceState, setResourceState] = useState<{
     key: string;
     state: "unknown" | "renderable" | "empty";
@@ -194,12 +298,8 @@ export function McpAppSection({
 
   const {
     isAppOpen,
-    toggleAppOpen,
-    panelToolCallId,
     setPanelApp,
-    canonicalToolCallId,
     openRightPanel,
-    closePanel,
     portalTarget,
     settingsOpen,
     setSettingsOpen,
@@ -218,19 +318,12 @@ export function McpAppSection({
   const headerName = ownedApp?.name || appName || mcpToolLabel(toolName);
   const isPanelSurface = surface === "panel";
   const standalone = !toolCallId;
-  const canonicalId = toolCallId ? canonicalToolCallId(toolCallId) : undefined;
   // Expanded inline when the panel isn't hosting and this render is standalone or
   // the open canonical one. Multiple apps can be expanded at once.
   const expandedInline =
     !isPanelSurface &&
     !portalTarget &&
     (standalone || (!!toolCallId && isAppOpen(toolCallId)));
-  // This render is the one hosted in the right panel; inline collapses to a marker.
-  const isPanelFocused =
-    !isPanelSurface &&
-    !!portalTarget &&
-    !!canonicalId &&
-    panelToolCallId === canonicalId;
 
   // Reconstruct McpCallToolResult for AppFrame. Owned apps get none — the
   // management tool's result is not app data.
@@ -253,16 +346,6 @@ export function McpAppSection({
     openRightPanel();
   };
 
-  // Runtime-error count for the pill's status dot (owned apps only).
-  const diagnosticCounts = useSyncExternalStore(
-    subscribeAppDiagnostics,
-    getAppDiagnosticCounts,
-    getAppDiagnosticCounts,
-  );
-  const hasRuntimeError = appId
-    ? (diagnosticCounts.get(appId)?.errors ?? 0) > 0
-    : false;
-
   const handleResourceStateChange = useCallback(
     (state: "renderable" | "empty") => {
       setResourceState({ key: resourceKey, state });
@@ -274,7 +357,8 @@ export function McpAppSection({
     // A blank app document reserves no canvas (a blank render is usually a bug).
     // In the panel — which the user opened deliberately and which passes no tool
     // details — show an explicit empty state rather than a blank panel; inline,
-    // keep the tool-call details inspectable instead of dropping the section.
+    // keep the tool-call details inspectable (while the pill is expanded)
+    // instead of dropping the section.
     if (surface === "panel") {
       return (
         <div className="flex h-full w-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
@@ -282,31 +366,23 @@ export function McpAppSection({
         </div>
       );
     }
-    return toolDetails ? <div className="w-full">{toolDetails}</div> : null;
+    return expandedInline && toolDetails ? (
+      <div className="mt-2 w-full">{toolDetails}</div>
+    ) : null;
   }
 
   // A deleted (or no-longer-accessible) owned app: it's already dropped from the
-  // panel, so this only shows in the chat stream. It renders as a regular app
-  // pill with a red error dot; expanding it shows the unavailable message styled
-  // as an error instead of mounting the runtime (which would 404).
+  // panel, so this only shows in the chat stream. Its pill carries a red error
+  // dot; while expanded, show the unavailable message styled as an error instead
+  // of mounting the runtime (which would 404).
   if (ownedAppUnavailable) {
+    if (!expandedInline) return null;
     return (
-      <>
-        <McpAppMarkerCircle
-          label={headerName}
-          pressed={unavailableOpen}
-          hasError
-          onClick={() => setUnavailableOpen((open) => !open)}
-        />
-        <div className="flex w-full flex-col items-start gap-2">
-          {toolDetails ? <div className="w-full">{toolDetails}</div> : null}
-          {unavailableOpen ? (
-            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
-              {headerName} app is no longer available
-            </div>
-          ) : null}
+      <div className="mt-2 flex w-full flex-col items-start gap-2">
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+          {headerName} app is no longer available
         </div>
-      </>
+      </div>
     );
   }
 
@@ -420,67 +496,41 @@ export function McpAppSection({
     );
   }
 
+  // Nothing below the row while the app is collapsed inline (or hosted in the
+  // right panel). The component stays mounted so the last measured size
+  // survives a collapse/expand cycle.
+  if (!expandedInline) {
+    return null;
+  }
+
   // Runtime-error / log summary lives below the app in the chat stream, never
   // inside the height-constrained panel (item 3).
   const diagnostics = appId ? <AppDiagnosticsPanel appId={appId} /> : null;
 
-  // The marker sits on the host tool-call circle's row. Pressed = expanded inline;
-  // a red dot flags a runtime error. Clicking toggles this app's inline render.
-  const pressed = expandedInline;
-  const marker = (
-    <McpAppMarkerCircle
-      label={headerName}
-      pressed={pressed}
-      hasError={hasRuntimeError}
-      onClick={() => {
-        if (!toolCallId) return;
-        // With the panel open, pills select the hosted app; otherwise they toggle
-        // this app's inline render, leaving other open apps alone.
-        if (portalTarget) {
-          if (isPanelFocused) closePanel();
-          else setPanelApp(toolCallId);
-        } else {
-          toggleAppOpen(toolCallId);
-        }
-      }}
-    />
-  );
-
-  // Under the marker row: tool-call details, then (only while expanded inline) the
-  // app card, its "Open in right panel" button, and the diagnostics summary.
-  const belowColumn = (
-    <div className="flex w-full flex-col items-start gap-2">
-      {toolDetails ? <div className="w-full">{toolDetails}</div> : null}
-      {expandedInline ? (
-        <div className="flex w-full flex-col items-start gap-2">
-          {liveSurface}
-          {toolCallId && displayMode !== "fullscreen" ? (
-            // Match the card's 80% width and right-justify so the buttons line
-            // up with the app's right edge, not the full chat width.
-            <div className="flex w-full max-w-[80%] justify-end gap-1">
-              {appId ? <McpAppStandaloneButton appId={appId} /> : null}
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-auto gap-1.5 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
-                onClick={handleShowInPanel}
-              >
-                <PanelRight className="h-3.5 w-3.5" />
-                Open in right panel
-              </Button>
-            </div>
-          ) : null}
-          {diagnostics}
+  // The app card, its "Open in right panel" button, and the diagnostics
+  // summary. mt-2 matches the row → expanded-tool-card gap so every panel
+  // opening under the pill row sits 8px below it.
+  return (
+    <div className="mt-2 flex w-full flex-col items-start gap-2">
+      {liveSurface}
+      {toolCallId && displayMode !== "fullscreen" ? (
+        // Match the card's 80% width and right-justify so the buttons line
+        // up with the app's right edge, not the full chat width.
+        <div className="flex w-full max-w-[80%] justify-end gap-1">
+          {appId ? <McpAppStandaloneButton appId={appId} /> : null}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-auto gap-1.5 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+            onClick={handleShowInPanel}
+          >
+            <PanelRight className="h-3.5 w-3.5" />
+            Open in right panel
+          </Button>
         </div>
       ) : null}
+      {diagnostics}
     </div>
-  );
-
-  return (
-    <>
-      {marker}
-      {belowColumn}
-    </>
   );
 }

--- a/platform/frontend/src/components/mcp-app/mcp-app-chrome.test.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-chrome.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   McpAppFullscreenExitButton,
-  McpAppMarkerCircle,
+  McpAppPill,
   McpAppStandaloneButton,
 } from "./mcp-app-chrome";
 
@@ -35,21 +35,21 @@ describe("address-pill action buttons", () => {
   });
 });
 
-describe("McpAppMarkerCircle", () => {
-  it("labels the pill with the app name without mounting an iframe", () => {
+describe("McpAppPill", () => {
+  it("shows the app name inline without mounting an iframe", () => {
     const { container } = render(
-      <McpAppMarkerCircle label="Dashboard" onClick={() => {}} />,
+      <McpAppPill label="Dashboard" onClick={() => {}} />,
     );
 
-    expect(
-      screen.getByRole("button", { name: "Dashboard" }),
-    ).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: "Dashboard" });
+    // The name is visible pill text, not just a tooltip/aria label.
+    expect(button).toHaveTextContent("Dashboard");
     expect(container.querySelector("iframe")).not.toBeInTheDocument();
   });
 
   it("toggles on click and reflects its pressed state", async () => {
     const onClick = vi.fn();
-    render(<McpAppMarkerCircle label="Dashboard" pressed onClick={onClick} />);
+    render(<McpAppPill label="Dashboard" pressed onClick={onClick} />);
 
     const button = screen.getByRole("button", { name: "Dashboard" });
     expect(button).toHaveAttribute("aria-pressed", "true");

--- a/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
@@ -146,27 +146,36 @@ export function McpAppStandaloneButton({ appId }: { appId: string }) {
 }
 
 /**
- * Interactive app-icon pill shown next to a tool-call circle in the chat, and
- * the toggle for the app's inline render — like a tool-call pill toggles its
- * content. `pressed` means the app is visible inline (its content is expanded
- * under the pill). It reads unpressed while the app is hosted in the right panel
- * (you're looking at the panel copy). `hasError` shows a red status dot for a
- * runtime error, matching the tool-call circles.
+ * Interactive app pill in the chat's tool-call row: the app's icon plus its
+ * name, in the same chrome as the Skill pill and the tool-call circles (32px
+ * tall, rounded-full, bordered). Clicking toggles the app's inline render —
+ * like a tool-call circle toggles its detail card. `pressed` means the app is
+ * visible inline (its content is expanded under the pill). It reads unpressed
+ * while the app is hosted in the right panel (you're looking at the panel
+ * copy). `state` drives the status dot exactly like the tool-call circles;
+ * `hasError` overrides it with red for an app runtime error.
  */
-export function McpAppMarkerCircle({
+export function McpAppPill({
   label,
+  icon,
+  state,
   pressed = false,
   hasError = false,
   onClick,
 }: {
-  /** Tooltip text — the app name. */
+  /** The app name, shown inline and in the tooltip. */
   label: string;
+  /** App icon (e.g. an McpCatalogIcon); falls back to the generic app glyph. */
+  icon?: React.ReactNode;
+  /** Tool-call state for the status dot; omitted renders no dot. */
+  state?: "running" | "completed" | "error";
   /** Pressed = the app's inline render is expanded under the pill. */
   pressed?: boolean;
   /** Show a red status dot for an app runtime error. */
   hasError?: boolean;
   onClick: () => void;
 }) {
+  const dotState = hasError ? "error" : state;
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
@@ -177,15 +186,25 @@ export function McpAppMarkerCircle({
             aria-label={label}
             aria-pressed={pressed}
             className={cn(
-              "relative inline-flex size-8 items-center justify-center rounded-full border transition-all hover:border-accent-foreground/20 hover:bg-accent hover:text-foreground",
+              "relative inline-flex h-8 items-center gap-1.5 rounded-full border px-3 transition-all hover:border-accent-foreground/20 hover:bg-accent hover:text-foreground",
               pressed
                 ? "border-accent-foreground/20 bg-accent text-foreground ring-2 ring-primary/20"
-                : "bg-background text-muted-foreground",
+                : "bg-background",
             )}
           >
-            <AppWindow className="h-4 w-4" />
-            {hasError ? (
-              <span className="absolute -right-0.5 -bottom-0.5 size-2.5 rounded-full border-2 border-background bg-destructive" />
+            {icon ?? <AppWindow className="h-4 w-4 text-muted-foreground" />}
+            <span className="whitespace-nowrap text-xs font-medium">
+              {label}
+            </span>
+            {dotState ? (
+              <span
+                className={cn(
+                  "absolute -right-0.5 -bottom-0.5 size-2.5 rounded-full border-2 border-background",
+                  dotState === "completed" && "bg-green-500",
+                  dotState === "running" && "bg-blue-500 animate-pulse",
+                  dotState === "error" && "bg-destructive",
+                )}
+              />
             ) : null}
           </button>
         </TooltipTrigger>


### PR DESCRIPTION
Fixes T-489 ("Circles should be on one line, gaps should be consistent").

- MCP-app tool calls now join the compact tool row as skill-style pills (app icon + name + status dot) instead of a separate circle pair per call, so consecutive calls share one wrapping line.
- `McpAppSection` split into `McpAppEntryPill` (row) + `McpAppEntryContent` (below-row), state shared via apps-context; panel surface unchanged.
- Vertical rhythm unified: user message → next block is 16px (dropped stray `pb-2`), app content opens 8px below the row like expanded tool cards.
- One open panel per row: app pill and tool circle collapse each other; dismissing the panel-hosted app via a pill expands it under that pill (`focusAppRender`).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>