### PR TITLE
fix(apps): route staging sandbox hosts to the backend, not the frontend

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -131,12 +131,13 @@ archestra:
           - path: /
             port: 9000
             pathType: Prefix
-      # MCP App sandbox origins (<hash>.sandbox.archestra.dev) serve the
-      # frontend; its /_sandbox/* Next.js rewrite proxies to the backend.
+      # MCP App sandbox origins (<hash>.sandbox.archestra.dev) go straight to
+      # the backend, which serves /_sandbox/* itself and validates the Host
+      # header (routing via the frontend rewrites the Host header -> 403).
       - host: "*.sandbox.archestra.dev"
         paths:
           - path: /
-            port: 3000
+            port: 9000
             pathType: Prefix
 
     # Wildcard cert for the sandbox hosts, issued and renewed by cert-manager


### PR DESCRIPTION
## Incident follow-up — final piece

MCP Apps on staging broke after #6272 deployed. Two stacked causes:

1. **Ingress sync was dead** (pre-existing): an out-of-band `iap: {enabled: false}` block on the BackendConfigs made ingress-gce request the one IAP transition GCP permanently refuses ('Cannot switch to default OAuth once IAP credentials have been set'), aborting every sync — so the wildcard cert + host rule from #6272 never reached the LB. **Fixed live** by removing the `iap` blocks (restores what Terraform declares; IAP remains unused and disabled). The LB now serves `CN=*.sandbox.archestra.dev` and the sync events are clean.
2. **Wrong routing target** (#6272's mistake, this PR): the wildcard host rule pointed at the frontend (port 3000). The backend serves `/_sandbox/*` itself and **validates the Host header**; the frontend's Next.js rewrite proxies with a rewritten Host, so every sandbox request 403'd. Per `docs/pages/platform-deployment.md` ("route *.mcp.example.com to the backend (port 9000)"), point the rule at the backend.

Verified against the live backend: `GET /_sandbox/mcp-sandbox-proxy.html` with `Host: probe.sandbox.archestra.dev` → **200**; wrong host → 403.

After this deploys, sandbox iframes load from `https://<hash>.sandbox.archestra.dev` end-to-end, and apps using device Web APIs (camera/mic/geolocation) get the real cross-origin sandbox with working permission prompts.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
