### PR TITLE
fix(dev): wire the Tilt sandbox build on Dagger host presence

### DIFF
--- a/platform/Tiltfile
+++ b/platform/Tiltfile
@@ -41,9 +41,14 @@ watch_file('.env')
 # Load sub-Tiltfiles by label
 load_dynamic('./dev/Tiltfile.database')
 
-# Code execution runtime (Dagger Engine) — loaded only when enabled, so a
-# privileged engine is not deployed unless ARCHESTRA_CODE_RUNTIME_ENABLED=true.
-if os.getenv('ARCHESTRA_CODE_RUNTIME_ENABLED') == 'true':
+# Code execution runtime (Dagger Engine) — loaded when the local toggle is on or
+# a runner host is configured (the backend enables the sandbox on host presence,
+# so its native addon must be built either way). With a host set, Tiltfile.coderuntime
+# skips deploying the privileged engine and only builds the addon.
+if (
+    os.getenv('ARCHESTRA_CODE_RUNTIME_ENABLED') == 'true'
+    or os.getenv('ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST')
+):
   load_dynamic('./dev/Tiltfile.coderuntime')
 
 # S3 file storage (MinIO) — only when the file-storage provider is s3, so the

--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -61,7 +61,12 @@ def get_frontend_env():
 
 frontend_env_vars = get_frontend_env()
 
-code_runtime_enabled = os.getenv('ARCHESTRA_CODE_RUNTIME_ENABLED') == 'true'
+# The backend enables the sandbox when a runner host is configured, so wire its
+# local build/engine deps on host presence too, not just the local toggle.
+code_runtime_enabled = (
+    os.getenv('ARCHESTRA_CODE_RUNTIME_ENABLED') == 'true'
+    or bool(os.getenv('ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST'))
+)
 backend_resource_deps = ['db-migrate']
 if code_runtime_enabled:
   # Skip the local port-forward dep when pointing at an external engine — that


### PR DESCRIPTION
## Summary

Follow-up to #6248, stacked on its branch.

In #6248 the backend began enabling the code sandbox whenever `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST` is set, rather than on the `ARCHESTRA_CODE_RUNTIME_ENABLED` flag. The dev Tilt stack still wired the sandbox's native-addon build (and the Dagger engine deploy / port-forward) only on that old toggle. So a dev stack pointed at a runner host directly — the path `.env.example` now describes — booted the backend with the sandbox enabled but without building the `@archestra/sandbox-rs` addon, giving broken or stale sandbox execution.

Wire the local sandbox build on host presence too: the root `Tiltfile` loads `Tiltfile.coderuntime`, and the backend gains its `sandbox-rs-build` dependency, when either `ARCHESTRA_CODE_RUNTIME_ENABLED=true` **or** a runner host is configured. `Tiltfile.coderuntime` already skips deploying the privileged engine when a host is set and only builds the addon, so no second engine is deployed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>