### PR TITLE
ci: pipeline staging deploys instead of queueing whole runs

### DIFF
--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -14,13 +14,24 @@ on:
 # Each job will explicitly declare the permissions it needs
 permissions: {}
 
-concurrency:
-  group: on-commits-to-main-${{ github.ref }}
-  cancel-in-progress: false
+# Concurrency is handled per-job (below) rather than per-workflow so that a new
+# commit doesn't have to wait for the previous run to finish end-to-end:
+#   - builds for superseded commits are cancelled (safe: images are pushed
+#     per-sha and the newer commit contains the older one's changes)
+#   - deploys are NEVER cancelled mid-flight (killing `helm upgrade` leaves the
+#     release stuck in a pending-upgrade state); instead they queue, and GitHub
+#     keeps at most one pending job per group, cancelling older pending ones, so
+#     queued deploys collapse to the newest commit
 
 jobs:
   deploy-dev-platform-images:
     name: Build Platform Staging and MCP Server Base Images
+    # A newer commit's build supersedes an in-flight one, so cancel it and let
+    # the build for the newest commit start immediately (it can also run while
+    # the previous commit's deploy is still in progress)
+    concurrency:
+      group: on-commits-to-main-build-${{ github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/deploy-dev-platform-images.yml
     permissions:
       contents: read # Required to invoke the reusable image publishing workflow.
@@ -38,6 +49,13 @@ jobs:
     name: Deploy to staging
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: [deploy-dev-platform-images]
+    # cancel-in-progress MUST stay false here: cancelling `helm upgrade`
+    # mid-flight has previously left the release wedged in pending-upgrade.
+    # A running deploy always finishes; pending deploys collapse to the newest
+    # commit because GitHub cancels older pending jobs in the same group
+    concurrency:
+      group: on-commits-to-main-deploy-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: read # Required to checkout the repository and deploy the chart.
       id-token: write # Required for Workload Identity Federation.


### PR DESCRIPTION
## Problem

`on-commits-to-main` used a single workflow-level concurrency group with `cancel-in-progress: false`, so runs queued end-to-end: a new commit couldn't even start **building** until the previous commit's build **and** helm deploy fully finished. With a busy main, staging (frontend.archestra.dev) lagged several commits behind.

We can't just flip `cancel-in-progress: true` at the workflow level — we've previously seen that cancelling `helm upgrade` mid-flight wedges the release in a `pending-upgrade` state.

## Change

Split concurrency to per-job groups:

- **Build job** (`on-commits-to-main-build-<ref>`, `cancel-in-progress: true`): a newer commit cancels a stale in-flight build. Safe because images are pushed per-sha and the newer commit contains the older one's changes. It also lets the newest commit build *while the previous deploy is still running*, instead of waiting for the whole prior run.
- **Deploy job** (`on-commits-to-main-deploy-<ref>`, `cancel-in-progress: false`): a running `helm upgrade` is never cancelled. Pending deploys automatically collapse to the newest commit, because GitHub keeps at most one pending job per concurrency group and cancels older pending ones.

## Why out-of-order deploys can't happen

For an older commit to deploy *after* a newer one, its build would have to still be alive after the newer commit's build started — but the newer build cancels it (same build group). If the older build already finished, its deploy queued first (FIFO), and any deploy still pending when a newer one queues is cancelled by the pending-collapse rule. So the deploy sequence is always monotonically newer.

## Net effect

- Previous behavior: N commits → N sequential build+deploy cycles.
- New behavior: the in-flight helm upgrade finishes untouched, superseded builds are cancelled, and exactly one deploy (the newest commit) runs next.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>