### PR TITLE
perf(auth): stop minting an unused JWT on every authenticated request

### DIFF
--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -211,6 +211,12 @@ export const auth = betterAuth({
       jwks: {
         keyPairConfig: { alg: "RS256", modulusLength: 2048 },
       },
+      // Without this, the plugin's /get-session after-hook mints a JWT — a
+      // jwks table read plus an RS256 signature — on EVERY authenticated
+      // request (the auth middleware calls getSession per request) just to
+      // set a `set-auth-jwt` response header nothing consumes. The /token
+      // and /jwks endpoints (used by the OAuth/OIDC flows) are unaffected.
+      disableSettingJwtHeader: true,
     }),
     oauthProvider({
       loginPage: OAUTH_PAGES.login,

--- a/platform/backend/src/auth/jwt-session-header.test.ts
+++ b/platform/backend/src/auth/jwt-session-header.test.ts
@@ -1,0 +1,36 @@
+import { makeSignature } from "better-auth/crypto";
+import { betterAuth } from "@/auth";
+import { expect, test } from "@/test";
+
+// The jwt plugin's /get-session after-hook can mint a JWT (a jwks table read
+// plus an RS256 signature) on every session validation just to set a
+// `set-auth-jwt` response header. Nothing consumes that header, and the auth
+// middleware calls getSession on every authenticated request, so the header
+// is disabled (disableSettingJwtHeader). This pins that per-request JWT
+// signing stays off — reverting the flag would silently reintroduce a DB
+// read + RSA sign per request.
+test("getSession does not mint a per-request JWT header", async ({
+  makeUser,
+  makeSession,
+}) => {
+  const user = await makeUser();
+  const session = await makeSession(user.id);
+
+  // Better-auth session cookies are HMAC-signed: `<token>.<signature>` under
+  // the configured cookie name.
+  const ctx = await betterAuth.$context;
+  const cookieName = ctx.authCookies.sessionToken.name;
+  const signedToken = `${session.token}.${await makeSignature(session.token, ctx.secret)}`;
+
+  const { response, headers } = await betterAuth.api.getSession({
+    headers: new Headers({
+      cookie: `${cookieName}=${encodeURIComponent(signedToken)}`,
+    }),
+    returnHeaders: true,
+  });
+
+  // Sanity: the session actually resolved — otherwise the header would be
+  // absent for the wrong reason.
+  expect(response?.user.id).toBe(user.id);
+  expect(headers.get("set-auth-jwt")).toBeNull();
+});


### PR DESCRIPTION
## What

Adds `disableSettingJwtHeader: true` to the better-auth `jwt` plugin config.

## Why

The jwt plugin registers an after-hook on `/get-session` that mints a JWT — one `jwks` table read **plus an RS256 signature** — solely to set a `set-auth-jwt` response header. Our Fastify auth middleware calls `getSession` on every authenticated request, so in production this was a database query and an RSA sign **per API request, platform-wide**. The `jwks` lookup is among the most frequent database operations observed in production deployments, and both the query and the signing CPU contribute to connection-pool pressure under load.

Nothing consumes the header: there are zero references to `set-auth-jwt` (or the JWT-from-session flow) anywhere in the backend, frontend, or shared code. The flag only disables the header hook — the `/api/auth/token` and `/api/auth/jwks` endpoints used by the OAuth/OIDC flows are unaffected.

## Testing

- New behavior test pins that `getSession` resolves a session **without** setting `set-auth-jwt` (verified the test fails when the flag is removed).
- Full backend suite, `type-check`, `lint`, and `knip` pass.

## Triage notes on the remaining slow-query signals

While investigating, the other frequent slow-query/N+1 signals were triaged as not code-fixable here:
- The per-entity limit-usage N+1s on the LLM proxy were already fixed on `main` by #6002 — the reporting deployments are on a release cut before it.
- The enabled-tools conversation loads were fixed in #6306.
- The remaining slow single-row lookups (`user` by PK, `member` by its composite index, agent junction-table reads) have optimal shapes and indexes; they surface as slow only under pool contention, which this change and #6306 both reduce at the source.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>