### PR TITLE
fix(apps): enforce tool-invocation policy on the server-scoped MCP app proxy

### DIFF
--- a/platform/backend/src/routes/mcp-server-proxy.test.ts
+++ b/platform/backend/src/routes/mcp-server-proxy.test.ts
@@ -278,4 +278,90 @@ describe("mcpServerProxyRoutes gate pass-through", () => {
       catalogId: catalog.id,
     });
   });
+
+  test("tools/call for a block_always-policied tool is rejected by the invocation policy, not just visibility", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+    makeToolPolicy,
+  }) => {
+    const org = await makeOrganization({ globalToolPolicy: "restrictive" });
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: ADMIN_ROLE_NAME });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+      scope: "org",
+    });
+    const server = await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+    const tool = await makeTool({
+      catalogId: catalog.id,
+      name: "blocked",
+      meta: { _meta: { ui: { visibility: ["app"] } } },
+    });
+    // Unconditional block on every call to this tool.
+    await makeToolPolicy(tool.id, { action: "block_always", conditions: [] });
+    // A policy block must reject at the gate (200 JSON-RPC error); reaching the
+    // transport here would throw and surface as 500.
+    mockCreateServerScopedServer.mockImplementation(() => {
+      throw new Error("transport must not be reached for a blocked tool");
+    });
+    app = await buildApp(user.id, org.id);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/mcp/server/${server.id}`,
+      headers: JSON_HEADERS,
+      payload: rpc("tools/call", { name: "blocked", arguments: {} }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().error?.message).toMatch(/tool-invocation policy/i);
+    expect(mockCreateServerScopedServer).not.toHaveBeenCalled();
+  });
+
+  test("a no-policy tool still passes the gate in a restrictive org (context-trusted app runtime does not over-block)", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const org = await makeOrganization({ globalToolPolicy: "restrictive" });
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: ADMIN_ROLE_NAME });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+      scope: "org",
+    });
+    const server = await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+    await makeTool({
+      catalogId: catalog.id,
+      name: "unpoliced",
+      meta: { _meta: { ui: { visibility: ["app"] } } },
+    });
+    mockCreateServerScopedServer.mockImplementation(() => {
+      throw new Error("transport unavailable in test");
+    });
+    app = await buildApp(user.id, org.id);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/mcp/server/${server.id}`,
+      headers: JSON_HEADERS,
+      payload: rpc("tools/call", { name: "unpoliced", arguments: {} }),
+    });
+
+    // Reached the transport → passed the gate (a rejection would be a 200
+    // JSON-RPC error). A tool with no block/approval policy stays callable.
+    expect(res.statusCode).toBe(500);
+    expect(mockCreateServerScopedServer).toHaveBeenCalled();
+  });
 });

--- a/platform/backend/src/routes/mcp-server-proxy.ts
+++ b/platform/backend/src/routes/mcp-server-proxy.ts
@@ -6,6 +6,7 @@ import QuickLRU from "quick-lru";
 import { z } from "zod";
 import { userHasPermission } from "@/auth/utils";
 import { McpServerModel, ToolModel } from "@/models";
+import { enforceAppRuntimeInvocationPolicy } from "@/services/apps/app-tool-runtime-gate";
 import { ApiError, type McpServer, UuidIdSchema } from "@/types";
 import {
   createStatelessTransport,
@@ -73,7 +74,13 @@ const mcpServerProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       // Gate tools/call on _meta.ui.visibility: model-only tools are not
       // app-callable. Fail-closed on unknown tools. Mirrors the agent proxy.
       if (body.method === "tools/call") {
-        const denied = await rejectDisallowedToolCall(catalogId, body, reply);
+        const denied = await rejectDisallowedToolCall(
+          catalogId,
+          body,
+          reply,
+          userId,
+          organizationId,
+        );
         if (denied) return denied;
       }
 
@@ -145,10 +152,12 @@ async function rejectDisallowedToolCall(
   catalogId: string,
   body: Record<string, unknown>,
   reply: StatusReply,
+  userId: string,
+  organizationId: string,
 ): Promise<object | null> {
   const callParams =
     body.params && typeof body.params === "object"
-      ? (body.params as { name?: unknown })
+      ? (body.params as { name?: unknown; arguments?: unknown })
       : undefined;
   const toolName =
     typeof callParams?.name === "string" ? callParams.name : undefined;
@@ -187,6 +196,29 @@ async function rejectDisallowedToolCall(
       `Tool "${toolName}" is not accessible from MCP Apps (visibility: [${visibility.join(", ")}])`,
     );
   }
+
+  // This runtime dispatches to the upstream with the install's own credentials
+  // and otherwise never touches the policy engine, so tool-invocation policies
+  // must be enforced here — mirroring the owned-app runtime (gateAppToolCall).
+  // The app sandbox is a trusted, no-approval-UI context, so
+  // block_always/require_approval gate the call while a no-policy tool stays
+  // callable. Policy is keyed by the stored (slugified) name.
+  const refusal = await enforceAppRuntimeInvocationPolicy({
+    resolvedToolName: tool.name,
+    displayName: toolName,
+    toolInput:
+      callParams?.arguments && typeof callParams.arguments === "object"
+        ? (callParams.arguments as Record<string, unknown>)
+        : {},
+    organizationId,
+    userId,
+    isContextTrusted: true,
+    treatRequireApprovalAsBlock: true,
+  });
+  if (refusal) {
+    return jsonRpcError(reply, body.id, refusal.code, refusal.reason);
+  }
+
   return null;
 }
 

--- a/platform/backend/src/services/apps/app-tool-runtime-gate.ts
+++ b/platform/backend/src/services/apps/app-tool-runtime-gate.ts
@@ -135,6 +135,56 @@ export async function gateAppToolCall(params: {
   // Policy is keyed by the resolved (stored) name, so a suffix-addressed tool
   // cannot slip past a policy attached to its full name.
   const resolvedToolName = tool.toolName;
+  const refusal = await enforceAppRuntimeInvocationPolicy({
+    resolvedToolName,
+    displayName: toolName,
+    toolInput,
+    organizationId,
+    userId,
+    isContextTrusted: params.isContextTrusted,
+    treatRequireApprovalAsBlock: params.treatRequireApprovalAsBlock,
+  });
+  if (refusal) {
+    return { allowed: false, ...refusal };
+  }
+
+  return { allowed: true, kind: "upstream", resolvedToolName };
+}
+
+/**
+ * Evaluate a resolved tool's invocation policy for an app-runtime call — shared
+ * by every app-runtime entrypoint (the owned-app gate above and the
+ * server-scoped app proxy) so they cannot diverge on enforcement.
+ *
+ * `resolvedToolName` must be the stored (slugified) name the policy is keyed by.
+ * `isContextTrusted` mirrors the caller's trust: iframe runtimes pass `true`, so
+ * only `block_always`/`require_approval` gate and a no-policy tool stays
+ * callable; `preview_app_tool` forwards the chat's real trust so
+ * `block_when_context_is_untrusted` still fires. `treatRequireApprovalAsBlock`
+ * blocks `require_approval` where the caller has no way to present the prompt
+ * (the sandbox runtimes). Permissive orgs short-circuit to allow, as everywhere
+ * in the policy engine. Returns a JSON-RPC refusal `{ code, reason }`, or `null`
+ * when the call is allowed.
+ */
+export async function enforceAppRuntimeInvocationPolicy(params: {
+  resolvedToolName: string;
+  displayName: string;
+  toolInput: Record<string, unknown>;
+  organizationId: string;
+  userId: string;
+  isContextTrusted: boolean;
+  treatRequireApprovalAsBlock: boolean;
+}): Promise<{ code: number; reason: string } | null> {
+  const {
+    resolvedToolName,
+    displayName,
+    toolInput,
+    organizationId,
+    userId,
+    isContextTrusted,
+    treatRequireApprovalAsBlock,
+  } = params;
+
   const organization = await OrganizationModel.getById(organizationId);
   const globalToolPolicy: GlobalToolPolicy =
     organization?.globalToolPolicy ?? "permissive";
@@ -147,18 +197,17 @@ export async function gateAppToolCall(params: {
     "",
     [{ toolCallName: resolvedToolName, toolInput }],
     policyContext,
-    params.isContextTrusted,
+    isContextTrusted,
     globalToolPolicy,
   );
   if (!verdict.isAllowed) {
     return {
-      allowed: false,
       code: -32601,
-      reason: `Tool "${toolName}" is blocked by a tool-invocation policy — a security guardrail enforced by ${archestraMcpBranding.catalogName}, not by the tool itself: ${verdict.reason}`,
+      reason: `Tool "${displayName}" is blocked by a tool-invocation policy — a security guardrail enforced by ${archestraMcpBranding.catalogName}, not by the tool itself: ${verdict.reason}`,
     };
   }
 
-  if (params.treatRequireApprovalAsBlock) {
+  if (treatRequireApprovalAsBlock) {
     const requiresApproval =
       await ToolInvocationPolicyModel.checkApprovalRequired(
         resolvedToolName,
@@ -168,12 +217,11 @@ export async function gateAppToolCall(params: {
       );
     if (requiresApproval) {
       return {
-        allowed: false,
         code: -32601,
-        reason: `Tool "${toolName}" requires human approval, which the app sandbox cannot present; an authoring agent can exercise it via preview_app_tool.`,
+        reason: `Tool "${displayName}" requires human approval, which the app sandbox cannot present; an authoring agent can exercise it via preview_app_tool.`,
       };
     }
   }
 
-  return { allowed: true, kind: "upstream", resolvedToolName };
+  return null;
 }


### PR DESCRIPTION
`POST /api/mcp/server/:mcpServerId` — the runtime that serves an installed MCP server as an app (the Apps page "run" surface) — gated `tools/call` only on `_meta.ui.visibility`. Unlike the main MCP gateway and the owned-app runtime (`gateAppToolCall`), it never evaluated tool-invocation policies. In a restrictive org this left a `block_always` / `require_approval` policy silently unenforced on that path: a member who can view an installed server could invoke a blocked tool through it — with the install's own credentials and no approval prompt — while the identical call is blocked everywhere else.

The invocation-policy evaluation the owned-app runtime already performs is extracted into a shared `enforceAppRuntimeInvocationPolicy` helper and now runs on both entrypoints, so the two app runtimes can't diverge on enforcement again. The app sandbox is treated as a trusted, no-approval-UI context (matching the owned-app iframe runtime): `block_always` and `require_approval` block the call, while a tool with no such policy stays callable, and a permissive org short-circuits to allow as everywhere in the policy engine. Policy is keyed on the stored (slugified) tool name.

Scope is invocation policy only — result/trusted-data policy runs on the LLM-proxy path and has no agent context on this LLM-less app runtime. Two adjacent gaps on this route are left for separate changes: `evaluateBatch` keys policy lookup by tool name (shared by every enforcement path), and `resources/read` here is still visibility-only.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>