### PR TITLE
ci(e2e): overlap shard setup with the platform image build

### DIFF
--- a/.github/actions/load-mcp-server-base-image/action.yml
+++ b/.github/actions/load-mcp-server-base-image/action.yml
@@ -15,6 +15,13 @@ inputs:
     description: "Artifact name to download when source=artifact"
     required: false
     default: mcp-server-base-docker-image
+  wait-timeout-seconds:
+    description: |
+      When source=artifact, wait up to this many seconds for the artifact to be uploaded
+      (e.g. by a build job running in parallel with the caller). Requires the calling job
+      to have the actions:read permission. 0 = artifact must already exist.
+    required: false
+    default: "0"
 
 outputs:
   image-tag:
@@ -30,6 +37,29 @@ runs:
       env:
         MCP_SERVER_BASE_IMAGE_TAG: ${{ inputs.image-tag }}
       run: docker pull "${MCP_SERVER_BASE_IMAGE_TAG}"
+
+    - name: Wait for MCP server base image artifact
+      if: ${{ inputs.source == 'artifact' && inputs.wait-timeout-seconds != '0' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        WAIT_TIMEOUT_SECONDS: ${{ inputs.wait-timeout-seconds }}
+      run: |
+        deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
+        while true; do
+          if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" --paginate \
+              --jq '.artifacts[].name' | grep -qxF "${ARTIFACT_NAME}"; then
+            echo "Artifact ${ARTIFACT_NAME} is available"
+            break
+          fi
+          if [ "$(date +%s)" -ge "${deadline}" ]; then
+            echo "Timed out waiting for artifact ${ARTIFACT_NAME} to be uploaded"
+            exit 1
+          fi
+          echo "Artifact ${ARTIFACT_NAME} not uploaded yet, retrying in 15s..."
+          sleep 15
+        done
 
     - name: Download MCP server base image artifact
       if: ${{ inputs.source == 'artifact' }}

--- a/.github/actions/load-platform-image/action.yml
+++ b/.github/actions/load-platform-image/action.yml
@@ -15,6 +15,13 @@ inputs:
     description: "Artifact name to download when source=artifact"
     required: false
     default: platform-docker-image
+  wait-timeout-seconds:
+    description: |
+      When source=artifact, wait up to this many seconds for the artifact to be uploaded
+      (e.g. by a build job running in parallel with the caller). Requires the calling job
+      to have the actions:read permission. 0 = artifact must already exist.
+    required: false
+    default: "0"
 
 outputs:
   image-tag:
@@ -30,6 +37,29 @@ runs:
       env:
         PLATFORM_IMAGE_TAG: ${{ inputs.image-tag }}
       run: docker pull "${PLATFORM_IMAGE_TAG}"
+
+    - name: Wait for platform image artifact
+      if: ${{ inputs.source == 'artifact' && inputs.wait-timeout-seconds != '0' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        WAIT_TIMEOUT_SECONDS: ${{ inputs.wait-timeout-seconds }}
+      run: |
+        deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
+        while true; do
+          if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" --paginate \
+              --jq '.artifacts[].name' | grep -qxF "${ARTIFACT_NAME}"; then
+            echo "Artifact ${ARTIFACT_NAME} is available"
+            break
+          fi
+          if [ "$(date +%s)" -ge "${deadline}" ]; then
+            echo "Timed out waiting for artifact ${ARTIFACT_NAME} to be uploaded"
+            exit 1
+          fi
+          echo "Artifact ${ARTIFACT_NAME} not uploaded yet, retrying in 15s..."
+          sleep 15
+        done
 
     - name: Download platform image artifact
       if: ${{ inputs.source == 'artifact' }}

--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -64,6 +64,14 @@ inputs:
     description: "Pre-built MCP server base image tag to load into Kind. If provided, skips building the image."
     required: false
     default: ""
+  image-pull-timeout-seconds:
+    description: |
+      How long to wait for the platform / MCP server base images to become pullable before failing.
+      With a value > 0, callers may start this action while the image build job is still running:
+      all image-independent setup (Kind cluster, dependency images) happens first, then the pull
+      step polls the registry until the freshly pushed image appears. 0 = single pull attempt.
+    required: false
+    default: "0"
   extra-helm-set:
     description: "Additional Helm --set flags (comma-separated key=value pairs, e.g. 'archestra.env.FOO=bar,archestra.replicaCount=1')"
     required: false
@@ -95,20 +103,6 @@ runs:
         tags: ${{ inputs.platform-image-tag }}
         turbo-team: ${{ inputs.turbo-team }}
         turbo-token: ${{ inputs.turbo-token }}
-
-    - name: Pull Docker image (if not already present)
-      if: ${{ inputs.build-platform-image != 'true' }}
-      shell: bash
-      env:
-        PLATFORM_IMAGE_TAG: ${{ inputs.platform-image-tag }}
-      run: |
-        # Check if image already exists locally (e.g., loaded from artifact)
-        if docker image inspect "${PLATFORM_IMAGE_TAG}" > /dev/null 2>&1; then
-          echo "Image ${PLATFORM_IMAGE_TAG} already exists locally, skipping pull"
-        else
-          echo "Pulling image ${PLATFORM_IMAGE_TAG} from registry..."
-          docker pull "${PLATFORM_IMAGE_TAG}"
-        fi
 
     - name: Cache MCP example OAuth server image
       if: ${{ inputs.deploy-e2e-dependencies == 'true' }}
@@ -186,6 +180,61 @@ runs:
           exit 1
         fi
         echo "All MCP dependency images fetched successfully"
+
+    # Deliberately placed AFTER the Kind cluster and MCP dependency image setup:
+    # everything above is independent of the platform image, so when the caller
+    # starts this action while the platform image build is still running (see
+    # image-pull-timeout-seconds), that work overlaps with the build and the
+    # wait below only covers whatever build time is actually left.
+    - name: Wait for and pull images (if not already present)
+      if: ${{ inputs.build-platform-image != 'true' }}
+      shell: bash
+      env:
+        PLATFORM_IMAGE_TAG: ${{ inputs.platform-image-tag }}
+        MCP_SERVER_BASE_IMAGE_TAG: ${{ inputs.mcp-server-base-image-tag }}
+        PULL_TIMEOUT_SECONDS: ${{ inputs.image-pull-timeout-seconds }}
+      run: |
+        # Pull an image unless it is already in the local daemon (e.g. loaded
+        # from a build artifact on fork PRs). Retries until the deadline so the
+        # image build may still be in flight when this step starts.
+        wait_and_pull() {
+          local image="$1"
+          if docker image inspect "${image}" > /dev/null 2>&1; then
+            echo "Image ${image} already exists locally, skipping pull"
+            return 0
+          fi
+          local deadline=$(( $(date +%s) + PULL_TIMEOUT_SECONDS ))
+          while true; do
+            if docker pull "${image}"; then
+              return 0
+            fi
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              echo "Timed out waiting for ${image} to become pullable"
+              return 1
+            fi
+            echo "Image ${image} not available yet, retrying in 10s..."
+            sleep 10
+          done
+        }
+
+        PIDS=()
+        wait_and_pull "${PLATFORM_IMAGE_TAG}" &
+        PIDS+=($!)
+        if [ -n "${MCP_SERVER_BASE_IMAGE_TAG}" ]; then
+          wait_and_pull "${MCP_SERVER_BASE_IMAGE_TAG}" &
+          PIDS+=($!)
+        fi
+
+        FAILED=0
+        for pid in "${PIDS[@]}"; do
+          if ! wait "$pid"; then
+            FAILED=1
+          fi
+        done
+        if [ "$FAILED" -ne 0 ]; then
+          echo "One or more image pulls failed"
+          exit 1
+        fi
 
     - name: Load all images into Kind in parallel
       shell: bash

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -188,7 +188,15 @@ jobs:
   # Quickstart remains separate because it validates the docker run path.
   platform-e2e-tests-shards:
     name: Platform E2E Tests Shard (${{ matrix.shard }}/2)
-    needs: [platform-e2e-build]
+    # Deliberately NO `needs: [platform-e2e-build]`: the shards start alongside
+    # the image build and do all image-independent setup (checkout, pnpm, Kind
+    # cluster, MCP dependency images) while the build runs. Setup Archestra
+    # Platform then polls the registry (image-pull-timeout-seconds) until the
+    # freshly pushed image appears; fork PRs poll for the build artifact in the
+    # load steps below. This overlap takes ~2.5 min off the merge-queue critical
+    # path. Trade-off: if the build fails, the shards burn the poll deadline
+    # instead of being skipped — the merge is still blocked either way by the
+    # required "Build ... Image" checks.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     # Observed worst-case shard wall-clock is ~10 min (setup + tests); 30 caps a
@@ -203,6 +211,7 @@ jobs:
     permissions:
       contents: read # Required to checkout the repository and read test assets.
       id-token: write # Required for Workload Identity Federation in setup actions.
+      actions: read # Required to poll for build artifacts on fork PRs (wait-timeout-seconds).
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -215,19 +224,25 @@ jobs:
         with:
           working-directory: ./platform
 
-      - name: Load platform image
-        id: load-platform-image
+      # Fork PRs only: the platform image travels as a workflow artifact (forks
+      # get no OIDC-backed registry access), so wait for the build job to upload
+      # it. Trusted runs skip these steps entirely — Setup Archestra Platform
+      # pulls from the registry itself, after the image-independent setup.
+      - name: Load platform image (fork PRs, from artifact)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
         uses: ./.github/actions/load-platform-image
         with:
-          source: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'artifact' || 'registry' }}
-          image-tag: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('archestra-platform:{0}', github.sha) || format('{0}/{1}:{2}', env.PLATFORM_IMAGE_REGISTRY, env.PLATFORM_IMAGE_NAME, github.sha) }}
+          source: artifact
+          image-tag: archestra-platform:${{ github.sha }}
+          wait-timeout-seconds: "900"
 
-      - name: Load MCP server base image
-        id: load-mcp-server-base-image
+      - name: Load MCP server base image (fork PRs, from artifact)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
         uses: ./.github/actions/load-mcp-server-base-image
         with:
-          source: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'artifact' || 'registry' }}
-          image-tag: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('mcp-server-base:{0}', github.sha) || format('{0}/{1}:{2}', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME, github.sha) }}
+          source: artifact
+          image-tag: mcp-server-base:${{ github.sha }}
+          wait-timeout-seconds: "900"
 
       - name: Prepare blob report workspace
         run: |
@@ -246,9 +261,10 @@ jobs:
           e2e-dependencies-extra-helm-set: "vault.k8sAuth.enabled=true,vault.k8sAuth.boundServiceAccountName=archestra-platform,vault.k8sAuth.boundServiceAccountNamespace=default"
           e2e-dependencies-wait-for-vault: "true"
           build-platform-image: "false"
-          platform-image-tag: ${{ steps.load-platform-image.outputs.image-tag }}
+          platform-image-tag: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('archestra-platform:{0}', github.sha) || format('{0}/{1}:{2}', env.PLATFORM_IMAGE_REGISTRY, env.PLATFORM_IMAGE_NAME, github.sha) }}
           platform-context: ./platform
-          mcp-server-base-image-tag: ${{ steps.load-mcp-server-base-image.outputs.image-tag }}
+          mcp-server-base-image-tag: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && format('mcp-server-base:{0}', github.sha) || format('{0}/{1}:{2}', env.MCP_SERVER_BASE_IMAGE_REGISTRY, env.MCP_SERVER_BASE_IMAGE_NAME, github.sha) }}
+          image-pull-timeout-seconds: "900"
 
       - name: Run all non-quickstart E2E tests
         id: e2e


### PR DESCRIPTION
## Problem

The e2e workflow is the critical path of every merge-queue group (~11.6m wall-clock), and most of a shard's time is spin-up, not tests. Step timings from a recent merge-group run, per shard:

| Phase | Time |
|---|---|
| Wait for image build via `needs` | ~4.3m (idle) |
| Checkout + pnpm setup | ~27s |
| Pull platform + MCP base images | 44s |
| Create Kind cluster | 34s |
| Fetch MCP dependency images | ~26s |
| `kind load` images | 38s |
| Helm deploy + health wait | 62s |
| **Run tests** | **~2m** |

Of the ~4m of setup, only ~1.7m (platform image pull, kind-load, helm deploy) actually needs the built image. Everything else could have happened while the image was still building.

## Change

- **Shards no longer `need` the build job.** They start alongside it and do all image-independent setup (checkout, pnpm, Kind cluster, MCP dependency images) while the platform image builds.
- **`setup-archestra-platform`**: the platform-image pull moves *after* the dependency-image fetch and becomes a deadline-bounded polling pull (`image-pull-timeout-seconds`, shards pass 900s) that now covers the MCP base image too, both pulled in parallel. Default `0` preserves the old single-attempt semantics.
- **Fork PRs** (image travels as a workflow artifact, no OIDC registry access): the `load-platform-image` / `load-mcp-server-base-image` actions gain `wait-timeout-seconds` — a poll of the run's artifacts API (new `actions: read` job permission) before downloading. The fork-only load steps in the shard job are now explicitly gated to fork PRs.
- **Quickstart keeps its `needs`** — it finishes well under the shard critical path, so overlapping it buys nothing.

## Effect

Merge-group critical path: build (4.3m) → shard catch-up (~1.7m) → tests (~2m) → report merge, i.e. **~11.6m → ~9m**, with zero added runner spend — the shards burn the same minutes, just earlier. Combined with a merge-queue build-concurrency bump this takes worst-case time-to-merge during bursts from ~24m to ~9m.

## Trade-off

If the image build fails, shards now poll until the 900s deadline and fail, instead of being skipped. The merge is blocked either way (the "Build … Image" checks are required); the cost is bounded wasted runner time on an already-red run.

## Validation

- zizmor: no findings on all four changed files
- `run-e2e` label added to this PR to exercise the new overlap path (trusted-PR registry flow: build + shards racing, registry poll) before it hits the merge queue

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>