### PR TITLE
fix: arm64 native-binary packaging and primary provider-key conflicts

### DIFF
--- a/platform/backend/src/models/llm-provider-api-key.test.ts
+++ b/platform/backend/src/models/llm-provider-api-key.test.ts
@@ -115,6 +115,73 @@ describe("LlmProviderApiKeyModel", () => {
       expect(key.isPrimary).toBe(true);
     });
 
+    test("creating a new primary demotes the current primary in the same scope", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+
+      const first = await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        name: "First Org Key",
+        provider: "openai",
+        scope: "org",
+        isPrimary: true,
+      });
+
+      // Previously this violated chat_api_keys_primary_org_unique and 500'd.
+      const second = await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        name: "Second Org Key",
+        provider: "openai",
+        scope: "org",
+        isPrimary: true,
+      });
+
+      expect(second.isPrimary).toBe(true);
+      const demoted = await LlmProviderApiKeyModel.findById(first.id);
+      expect(demoted?.isPrimary).toBe(false);
+    });
+
+    test("a new primary does not demote primaries in other scopes or providers", async ({
+      makeOrganization,
+      makeUser,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+
+      const personalPrimary = await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        name: "Personal Primary",
+        provider: "openai",
+        scope: "personal",
+        userId: user.id,
+        isPrimary: true,
+      });
+      const otherProviderPrimary = await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        name: "Anthropic Org Primary",
+        provider: "anthropic",
+        scope: "org",
+        isPrimary: true,
+      });
+
+      await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        name: "OpenAI Org Primary",
+        provider: "openai",
+        scope: "org",
+        isPrimary: true,
+      });
+
+      expect(
+        (await LlmProviderApiKeyModel.findById(personalPrimary.id))?.isPrimary,
+      ).toBe(true);
+      expect(
+        (await LlmProviderApiKeyModel.findById(otherProviderPrimary.id))
+          ?.isPrimary,
+      ).toBe(true);
+    });
+
     test("allows personal keys for different providers", async ({
       makeOrganization,
       makeUser,
@@ -299,6 +366,54 @@ describe("LlmProviderApiKeyModel", () => {
 
       expect(updated).toBeDefined();
       expect(updated?.name).toBe("Updated Name");
+    });
+
+    test("promoting a key to primary demotes the current primary in its scope", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+      const currentPrimary = await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        name: "Current Primary",
+        provider: "openai",
+        scope: "org",
+        isPrimary: true,
+      });
+      const challenger = await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        name: "Challenger",
+        provider: "openai",
+        scope: "org",
+      });
+
+      // Previously this violated chat_api_keys_primary_org_unique and 500'd.
+      const promoted = await LlmProviderApiKeyModel.update(challenger.id, {
+        isPrimary: true,
+      });
+
+      expect(promoted?.isPrimary).toBe(true);
+      expect(
+        (await LlmProviderApiKeyModel.findById(currentPrimary.id))?.isPrimary,
+      ).toBe(false);
+    });
+
+    test("re-promoting the current primary is a no-op that keeps it primary", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+      const primary = await LlmProviderApiKeyModel.create({
+        organizationId: org.id,
+        name: "Primary",
+        provider: "openai",
+        scope: "org",
+        isPrimary: true,
+      });
+
+      const updated = await LlmProviderApiKeyModel.update(primary.id, {
+        isPrimary: true,
+      });
+
+      expect(updated?.isPrimary).toBe(true);
     });
   });
 

--- a/platform/backend/src/models/llm-provider-api-key.ts
+++ b/platform/backend/src/models/llm-provider-api-key.ts
@@ -5,10 +5,10 @@ import {
   providerRequiresPerUserCredential,
   type SupportedProvider,
 } from "@archestra/shared";
-import { and, asc, desc, eq, ilike, inArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, inArray, ne, or, sql } from "drizzle-orm";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
-import db, { schema } from "@/database";
+import db, { schema, type Transaction } from "@/database";
 import { computeSecretStorageType } from "@/secrets-manager/utils";
 import type {
   InsertLlmProviderApiKey,
@@ -25,16 +25,33 @@ import ConversationModel from "./conversation";
 class LlmProviderApiKeyModel {
   /**
    * Create a new LLM provider API key.
+   *
+   * "Primary" is exclusive per (organization, provider, scope[, user/team]) —
+   * enforced by partial unique indexes. Creating a new primary demotes the
+   * current one in the same transaction, so callers can mark a key primary
+   * without first hunting down and unsetting the old one.
    */
   static async create(
     data: InsertLlmProviderApiKey,
   ): Promise<LlmProviderApiKey> {
-    const [apiKey] = await db
-      .insert(schema.llmProviderApiKeysTable)
-      .values(data)
-      .returning();
+    return await db.transaction(async (tx) => {
+      if (data.isPrimary) {
+        await demoteCurrentPrimary(tx, {
+          organizationId: data.organizationId,
+          provider: data.provider,
+          scope: data.scope,
+          userId: data.userId ?? null,
+          teamId: data.teamId ?? null,
+        });
+      }
 
-    return apiKey;
+      const [apiKey] = await tx
+        .insert(schema.llmProviderApiKeysTable)
+        .values(data)
+        .returning();
+
+      return apiKey;
+    });
   }
 
   /**
@@ -621,13 +638,34 @@ class LlmProviderApiKeyModel {
     id: string,
     data: UpdateLlmProviderApiKey,
   ): Promise<LlmProviderApiKey | null> {
-    const [updated] = await db
-      .update(schema.llmProviderApiKeysTable)
-      .set(data)
-      .where(eq(schema.llmProviderApiKeysTable.id, id))
-      .returning();
+    return await db.transaction(async (tx) => {
+      // Promoting a key to primary demotes the current primary in its
+      // (post-update) partition — see create() for the exclusivity rules.
+      if (data.isPrimary) {
+        const [existing] = await tx
+          .select()
+          .from(schema.llmProviderApiKeysTable)
+          .where(eq(schema.llmProviderApiKeysTable.id, id));
+        if (existing) {
+          await demoteCurrentPrimary(tx, {
+            organizationId: existing.organizationId,
+            provider: existing.provider as SupportedProvider,
+            scope: (data.scope ?? existing.scope) as ResourceVisibilityScope,
+            userId: data.userId !== undefined ? data.userId : existing.userId,
+            teamId: data.teamId !== undefined ? data.teamId : existing.teamId,
+            excludeId: id,
+          });
+        }
+      }
 
-    return updated ?? null;
+      const [updated] = await tx
+        .update(schema.llmProviderApiKeysTable)
+        .set(data)
+        .where(eq(schema.llmProviderApiKeysTable.id, id))
+        .returning();
+
+      return updated ?? null;
+    });
   }
 
   /**
@@ -816,6 +854,49 @@ function parseVaultReferenceFromSecret(
     };
   }
   return null;
+}
+
+/**
+ * Unset is_primary on the current primary key of the given partition, matching
+ * the partial unique indexes (chat_api_keys_primary_{org,personal,team}_unique):
+ * org scope is exclusive per (organization, provider); personal and team scopes
+ * additionally key on the user / team.
+ */
+async function demoteCurrentPrimary(
+  tx: Transaction,
+  partition: {
+    organizationId: string;
+    provider: SupportedProvider;
+    scope: ResourceVisibilityScope;
+    userId: string | null;
+    teamId: string | null;
+    excludeId?: string;
+  },
+): Promise<void> {
+  const conditions = [
+    eq(schema.llmProviderApiKeysTable.organizationId, partition.organizationId),
+    eq(schema.llmProviderApiKeysTable.provider, partition.provider),
+    eq(schema.llmProviderApiKeysTable.scope, partition.scope),
+    eq(schema.llmProviderApiKeysTable.isPrimary, true),
+  ];
+  if (partition.scope === "personal" && partition.userId) {
+    conditions.push(
+      eq(schema.llmProviderApiKeysTable.userId, partition.userId),
+    );
+  }
+  if (partition.scope === "team" && partition.teamId) {
+    conditions.push(
+      eq(schema.llmProviderApiKeysTable.teamId, partition.teamId),
+    );
+  }
+  if (partition.excludeId) {
+    conditions.push(ne(schema.llmProviderApiKeysTable.id, partition.excludeId));
+  }
+
+  await tx
+    .update(schema.llmProviderApiKeysTable)
+    .set({ isPrimary: false })
+    .where(and(...conditions));
 }
 
 function canUseProviderApiKey(

--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -46,6 +46,7 @@ import {
   SelectLlmProviderApiKeySchema,
   type SelectSecret,
 } from "@/types";
+import { isUniqueConstraintError } from "@/utils/db";
 import { dockerLocalhostConnectionHint } from "@/utils/docker-localhost-hint";
 
 async function testApiKeyOrThrow(
@@ -501,20 +502,35 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         );
       }
 
-      // Create the API key record
-      const createdApiKey = await LlmProviderApiKeyModel.create({
-        organizationId,
-        name: body.name,
-        provider: body.provider,
-        secretId: secret?.id ?? null,
-        baseUrl: body.baseUrl ?? null,
-        inferenceBaseUrl: body.inferenceBaseUrl ?? null,
-        extraHeaders: body.extraHeaders ?? null,
-        scope: body.scope,
-        userId: body.scope === "personal" ? user.id : null,
-        teamId: body.scope === "team" ? body.teamId : null,
-        isPrimary: body.isPrimary ?? false,
-      });
+      // Create the API key record. The model demotes the current primary in
+      // the same transaction; a unique violation here means a concurrent
+      // writer won the race — surface it as a conflict, not a 500.
+      let createdApiKey: Awaited<
+        ReturnType<typeof LlmProviderApiKeyModel.create>
+      >;
+      try {
+        createdApiKey = await LlmProviderApiKeyModel.create({
+          organizationId,
+          name: body.name,
+          provider: body.provider,
+          secretId: secret?.id ?? null,
+          baseUrl: body.baseUrl ?? null,
+          inferenceBaseUrl: body.inferenceBaseUrl ?? null,
+          extraHeaders: body.extraHeaders ?? null,
+          scope: body.scope,
+          userId: body.scope === "personal" ? user.id : null,
+          teamId: body.scope === "team" ? body.teamId : null,
+          isPrimary: body.isPrimary ?? false,
+        });
+      } catch (error) {
+        if (isUniqueConstraintError(error)) {
+          throw new ApiError(
+            409,
+            "Another primary key for this provider and scope was set concurrently. Please retry.",
+          );
+        }
+        throw error;
+      }
 
       // Sync models for the new API key before returning so the frontend
       // can immediately show available models after creation.
@@ -932,7 +948,17 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       }
 
       if (Object.keys(updateData).length > 0) {
-        await LlmProviderApiKeyModel.update(params.id, updateData);
+        try {
+          await LlmProviderApiKeyModel.update(params.id, updateData);
+        } catch (error) {
+          if (isUniqueConstraintError(error)) {
+            throw new ApiError(
+              409,
+              "Another primary key for this provider and scope was set concurrently. Please retry.",
+            );
+          }
+          throw error;
+        }
       }
 
       const updated = await LlmProviderApiKeyModel.findById(params.id);

--- a/platform/turbo.json
+++ b/platform/turbo.json
@@ -8,6 +8,18 @@
       "outputs": [".next/**", "!.next/cache/**", "dist/**", "*.node"],
       "env": ["VERSION"]
     },
+    "@archestra/app-runtime-rs#build": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
+    "@archestra/sandbox-rs#build": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
+    "@archestra/image-rs#build": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "dev": {
       "persistent": true,
       "cache": false,


### PR DESCRIPTION
Fixes two bugs observed in self-hosted deployments.

## 1. `fix(build)`: arm64 images can ship the wrong native binary

The turbo `build` task hashes nothing architecture-specific (verified via `turbo --dry=json`: hash inputs are sources, lockfile, env vars, and node engines only) while caching the compiled `*.node` artifacts. Two ways this corrupts multi-arch builds:

- a multi-arch `docker buildx` build shares the `/app/.turbo` cache mount between platform legs, so the second leg gets a task-hash hit and replays the first leg's binary;
- our release pipeline builds each arch on its own native runner but shares the turbo remote cache, so an arm64 leg can hit an amd64-cached build.

Either way the arm64 image ships without an arm64 `.node`, and every code path that loads the addon fails at runtime with `Unable to load @archestra/app-runtime-rs for linux/arm64` (same exposure for `sandbox-rs` and `image-rs`). Turbo caching is now disabled for the three NAPI packages; cargo's incremental compilation plus the cached target dir keep rebuild cost low.

## 2. `fix(llm-keys)`: making a provider key primary 500s if a primary exists

Primary keys are exclusive per (organization, provider, scope[, user/team]) via partial unique indexes, but both the create and update paths passed `isPrimary` straight through — so marking a key primary while another primary existed failed with a raw unique-constraint 500, with no way forward from the UI. Now:

- `LlmProviderApiKeyModel.create`/`update` demote the current primary of the (post-update) partition in the same transaction, so "make primary" just works;
- the routes map residual (genuinely concurrent) unique violations to a 409 with an actionable message instead of a 500.

Covered by model tests: create-demotes-existing, scope/provider isolation, update-promotion demotes, and re-promoting the current primary stays a no-op.

## Testing

Full backend suite, `type-check`, `lint`, `knip` pass. Turbo dry-run confirms `cache: false` resolves for exactly the three NAPI build tasks.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>