### PR TITLE
fix(frontend): skip mcp_server and projects list fetches for roles without the permission

### DIFF
--- a/platform/frontend/src/lib/mcp/mcp-server.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-server.query.ts
@@ -9,7 +9,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { invalidateToolAssignmentQueries } from "@/lib/agent-tools.hook";
-import { useSession } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { handleApiError, throwOnApiError } from "@/lib/utils";
 import websocketService from "@/lib/websocket/websocket";
@@ -34,6 +34,12 @@ type McpServersParams = McpServersQuery & {
 };
 
 export function useMcpServers(params?: McpServersParams) {
+  // The endpoint requires mcpServerInstallation:read; skip the request for
+  // users whose role lacks it instead of letting it 403.
+  const { data: canReadInstallations } = useHasPermissions({
+    mcpServerInstallation: ["read"],
+  });
+
   return useQuery({
     // Include catalogId in queryKey only when provided to maintain cache separation
     queryKey: [
@@ -65,7 +71,7 @@ export function useMcpServers(params?: McpServersParams) {
       return data ?? [];
     },
     initialData: params?.initialData,
-    enabled: params?.enabled,
+    enabled: (params?.enabled ?? true) && !!canReadInstallations,
     refetchInterval: params?.hasInstallingServers ? 2000 : false,
   });
 }

--- a/platform/frontend/src/lib/projects/projects.query.ts
+++ b/platform/frontend/src/lib/projects/projects.query.ts
@@ -6,6 +6,7 @@ import {
 } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import {
   readFileAsBase64,
   summarizeUploadResults,
@@ -52,6 +53,9 @@ export function useProjects(
   const authorIds = options?.authorIds;
   const excludeAuthorIds = options?.excludeAuthorIds;
   const toastOnError = options?.toastOnError;
+  // The endpoint requires project:read; skip the request for users whose role
+  // lacks it (e.g. the sidebar mounts this for everyone) instead of 403ing.
+  const { data: canReadProjects } = useHasPermissions({ project: ["read"] });
   return useQuery({
     queryKey: [
       "projects",
@@ -64,7 +68,7 @@ export function useProjects(
         excludeAuthorIds: excludeAuthorIds ?? null,
       },
     ],
-    enabled: options?.enabled ?? true,
+    enabled: (options?.enabled ?? true) && !!canReadProjects,
     queryFn: async () => {
       const { data, error } = await getProjects({
         query: { scope, search, teamIds, authorIds, excludeAuthorIds },


### PR DESCRIPTION
## What

The chat page and sidebar mount `useMcpServers` (Playwright install status) and `useProjects` (pinned projects) for every user, but the endpoints require `mcpServerInstallation:read` / `project:read`. Custom roles without those permissions got an ambient 403 on every page load.

Both hooks now check `useHasPermissions` in their `enabled` condition (same pattern as `useApiKeys`), so the request is skipped and the query stays empty for roles that can't read those resources. This also closes the race where the Playwright query fired while permissions were still loading.

## Testing

- `pnpm type-check`, `pnpm lint`, and the test files covering the touched hooks pass.
- Verified in the app: an admin still fetches both endpoints (200s); a role without the permissions no longer issues the requests.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>