### PR TITLE
fix(apps): gate resources/read on the server-scoped MCP App proxy to ui:// resources

### DIFF
--- a/platform/backend/src/routes/mcp-server-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-server-gateway.utils.ts
@@ -20,11 +20,12 @@ type McpListTool = ListToolsResult["tools"][number];
  * Build the server-scoped MCP server backing the Apps run path
  * (`POST /api/mcp/server/:mcpServerId`). It serves one installed external
  * server's runtime — `tools/list` (from discovered tools), `resources/read`
- * (its `ui://` resource), and `tools/call` — all bound to the route's
- * `mcpServerId`, with no agent/owner context. The connection only ever talks to
- * this one installed server, so a `resources/read` can reach only this server's
- * own resources. Access (`mcpServerInstallation:read`) and the
- * `_meta.ui.visibility` model-only gate are enforced by the route before here.
+ * (restricted to `ui://` UI resources), and `tools/call` — all bound to the
+ * route's `mcpServerId`, with no agent/owner context. `resources/read` refuses
+ * any non-`ui://` URI so sandboxed app code cannot read the installed server's
+ * model-facing data resources through the install's own credentials. Access
+ * (`mcpServerInstallation:read`), the `_meta.ui.visibility` model-only tool
+ * gate, and tool-invocation policy are enforced by the route before here.
  */
 export function createServerScopedServer(params: {
   mcpServerId: string;
@@ -69,11 +70,20 @@ export function createServerScopedServer(params: {
 
   server.setRequestHandler(
     ReadResourceRequestSchema,
-    async ({ params: { uri } }) =>
-      (await mcpClient.readResourceForServer({
+    async ({ params: { uri } }) => {
+      // The app sandbox may read only `ui://` UI resources. A non-`ui://` URI is
+      // one of the installed server's model-facing data resources; proxying it
+      // here would let sandboxed app code exfiltrate it through the install's own
+      // credentials. Refuse rather than forward (mirrors the owned-app gateway,
+      // which serves only its own `ui://` resource).
+      if (!uri.startsWith("ui://")) {
+        throw { code: -32002, message: `Resource not found: ${uri}` };
+      }
+      return (await mcpClient.readResourceForServer({
         mcpServerId,
         uri,
-      })) as ReadResourceResult,
+      })) as ReadResourceResult;
+    },
   );
 
   server.setRequestHandler(

--- a/platform/backend/src/routes/mcp-server-proxy.ui-resource.test.ts
+++ b/platform/backend/src/routes/mcp-server-proxy.ui-resource.test.ts
@@ -197,6 +197,54 @@ describe("external UI server served as an MCP App (POST /api/mcp/server/:id)", (
     });
   });
 
+  test("resources/read of a non-ui:// resource is rejected without reaching the upstream server", async ({
+    makeUser,
+    makeOrganization,
+    makeMember,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: ADMIN_ROLE_NAME });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+      scope: "org",
+    });
+    const server = await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+    await makeTool({
+      catalogId: catalog.id,
+      name: "show_clock",
+      meta: { _meta: { ui: { resourceUri: UI_RESOURCE_URI } } },
+    });
+
+    const readSpy = vi
+      .spyOn(mcpClient, "readResourceForServer")
+      .mockResolvedValue({
+        contents: [{ uri: "x", text: "SHOULD NOT BE READ" }],
+      } as Awaited<ReturnType<typeof mcpClient.readResourceForServer>>);
+
+    app = await buildApp(user.id, org.id);
+
+    // A non-ui:// URI addresses the server's model-facing data resources, not an
+    // app UI template — the sandbox must not be able to reach it.
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/mcp/server/${server.id}`,
+      headers: JSON_RPC_HEADERS,
+      payload: rpc("resources/read", { uri: "resource://internal/secrets" }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().error?.code).toBe(-32002);
+    // The refused read must never reach the upstream (no exfiltration through
+    // the app runtime's install credentials).
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
   test("tools/call is delegated to the installed server's own runtime", async ({
     makeUser,
     makeOrganization,


### PR DESCRIPTION
The server-scoped MCP App runtime — `POST /api/mcp/server/:mcpServerId`, which serves an installed external MCP server as an app on the Apps page — gated `tools/call` on `_meta.ui.visibility` (and, recently, tool-invocation policy) but forwarded **every** `resources/read` straight to the upstream server via the install's own credentials, with no gate at all. A sandboxed app iframe (untrusted code) could therefore call `resources/read` with any URI and read the installed server's model-facing data resources — anything the server exposes under a non-`ui://` scheme — which the app must never see. This is a data-exfiltration path unique to this route: the owned-app gateway already restricts `resources/read` to the app's own `ui://` resource.

The `ReadResourceRequestSchema` handler now refuses any URI that does not begin with `ui://` before proxying (JSON-RPC `-32002`, matching the owned-app gateway). A non-`ui://` scheme is exactly the class of model-facing data resource the sandbox should never reach, and a scheme gate cannot false-positive a legitimate UI read — including `ui://` sub-resources an app fetches at runtime beyond the single tool-declared `resourceUri`, which a stricter declared-URI allowlist would wrongly reject. Scope is deliberately narrow: `tools/list` on this route is still not visibility-filtered (it can list model-only tools' metadata to the sandbox — a separate metadata-only concern), and is left for a follow-up.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>