### PR TITLE
fix: restore error-status fidelity for upstream provider and client errors

### DIFF
--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -872,7 +872,13 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
               { error },
               "Authorization server discovery failed",
             );
-            throw new ApiError(500, "Failed to discover OAuth endpoints");
+            // 502, not 500: discovery failed against the user-configured
+            // external server, so surface its failure (with the cause, so the
+            // user can act on it) rather than reporting a crash of ours.
+            throw new ApiError(
+              502,
+              `Failed to discover OAuth endpoints: ${error instanceof Error ? error.message : String(error)}. Verify the server's OAuth metadata (.well-known) endpoints are reachable.`,
+            );
           }
         }
 

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -999,13 +999,12 @@ export async function handleLLMProxy<
       userTeams,
     };
 
-    // `return await`, not `return`: a bare `return promise` inside try/catch
-    // lets the promise's rejection bypass the catch below entirely — upstream
-    // provider failures then skip handleError's status mapping (clients get a
-    // generic 500 instead of the provider's 429/404/…), skip the failed-
-    // interaction record, and get captured as unhandled server exceptions.
+    // handleStreaming is self-contained: it persists its own failed-interaction
+    // record and routes errors through handleError before its promise settles,
+    // so it returns a bare promise (awaiting it here would double-persist via
+    // the catch below).
     if (requestAdapter.isStreaming()) {
-      return await handleStreaming(
+      return handleStreaming(
         client,
         finalRequest,
         reply,
@@ -1014,15 +1013,14 @@ export async function handleLLMProxy<
         ctx,
         ensureStreamHeaders,
       );
-    } else {
-      return await handleNonStreaming(
-        client,
-        finalRequest,
-        reply,
-        provider,
-        ctx,
-      );
     }
+    // `return await`, not `return`: handleNonStreaming relies on THIS catch for
+    // provider failures. A bare `return promise` inside try/catch lets the
+    // rejection bypass the catch entirely — upstream failures then skip
+    // handleError's status mapping (clients get a generic 500 instead of the
+    // provider's 429/404/…), skip the failed-interaction record, and get
+    // captured as unhandled server exceptions.
+    return await handleNonStreaming(client, finalRequest, reply, provider, ctx);
   } catch (error) {
     // Persist failed interactions so they appear in LLM logs
     try {

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -999,8 +999,13 @@ export async function handleLLMProxy<
       userTeams,
     };
 
+    // `return await`, not `return`: a bare `return promise` inside try/catch
+    // lets the promise's rejection bypass the catch below entirely — upstream
+    // provider failures then skip handleError's status mapping (clients get a
+    // generic 500 instead of the provider's 429/404/…), skip the failed-
+    // interaction record, and get captured as unhandled server exceptions.
     if (requestAdapter.isStreaming()) {
-      return handleStreaming(
+      return await handleStreaming(
         client,
         finalRequest,
         reply,
@@ -1010,7 +1015,13 @@ export async function handleLLMProxy<
         ensureStreamHeaders,
       );
     } else {
-      return handleNonStreaming(client, finalRequest, reply, provider, ctx);
+      return await handleNonStreaming(
+        client,
+        finalRequest,
+        reply,
+        provider,
+        ctx,
+      );
     }
   } catch (error) {
     // Persist failed interactions so they appear in LLM logs

--- a/platform/backend/src/routes/proxy/routes/openai.test.ts
+++ b/platform/backend/src/routes/proxy/routes/openai.test.ts
@@ -345,6 +345,64 @@ describe("OpenAI cost tracking", () => {
     expect(typeof interaction.baselineCost).toBe("string");
   });
 
+  test("maps an upstream provider error to its status code and records the failed interaction", async ({
+    makeAgent,
+  }) => {
+    // An SDK error carrying the upstream HTTP status (e.g. a provider 429)
+    // must reach the client with that status — not as a generic 500 — and the
+    // failed call must land in LLM logs. Regression test for the proxy's
+    // `return promise` (without await) letting rejections bypass its catch.
+    vi.spyOn(openaiAdapterFactory, "createClient").mockImplementation(
+      () =>
+        ({
+          chat: {
+            completions: {
+              create: async () => {
+                throw Object.assign(
+                  new Error(
+                    "429 You've exceeded the rate limit, please slow down",
+                  ),
+                  { status: 429 },
+                );
+              },
+            },
+          },
+        }) as never,
+    );
+
+    const app = createOpenAiRouteTestApp();
+    await app.register(openAiProxyRoutes);
+    const agent = await makeAgent({ name: "Upstream Error Agent" });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-key",
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello!" }],
+        stream: false,
+      },
+    });
+
+    expect(response.statusCode).toBe(429);
+    expect(response.json().error.message).toContain("rate limit");
+
+    // The failed call is persisted so it appears in LLM logs.
+    const { InteractionModel } = await import("@/models");
+    const interactions = await InteractionModel.getAllInteractionsForProfile(
+      agent.id,
+    );
+    expect(interactions.length).toBeGreaterThan(0);
+    expect(interactions[interactions.length - 1].response).toMatchObject({
+      error: expect.stringContaining("rate limit"),
+    });
+  });
+
   test("creates embeddings through OpenAI proxy routes", async ({
     makeAgent,
   }) => {

--- a/platform/backend/src/server.test.ts
+++ b/platform/backend/src/server.test.ts
@@ -63,6 +63,65 @@ describe("createFastifyInstance", () => {
       });
     });
 
+    test("returns Fastify's own 4xx status instead of coercing it to a 500", async () => {
+      const app = createFastifyInstance();
+      app.post("/test-media-type", async () => ({ ok: true }));
+
+      // An unsupported content type makes Fastify raise its typed 415 error
+      // before the handler runs; the error handler must preserve that status.
+      const response = await app.inject({
+        method: "POST",
+        url: "/test-media-type",
+        headers: { "content-type": "application/x-unknown" },
+        payload: "raw",
+      });
+
+      expect(response.statusCode).toBe(415);
+      expect(response.json().error.type).not.toBe("api_internal_server_error");
+    });
+
+    test("captures 500s but not upstream-fault 502/504s to error tracking", async () => {
+      const { posthogErrorTrackingService } = await import(
+        "@/services/error-tracking"
+      );
+      const captureSpy = vi.spyOn(
+        posthogErrorTrackingService,
+        "captureException",
+      );
+
+      const app = createFastifyInstance();
+      app.get("/test-upstream-502", async () => {
+        throw new ApiError(502, "Upstream provider failed");
+      });
+      app.get("/test-upstream-504", async () => {
+        throw new ApiError(504, "Upstream provider timed out");
+      });
+      app.get("/test-internal-500", async () => {
+        throw new ApiError(500, "We crashed");
+      });
+
+      const res502 = await app.inject({
+        method: "GET",
+        url: "/test-upstream-502",
+      });
+      const res504 = await app.inject({
+        method: "GET",
+        url: "/test-upstream-504",
+      });
+      expect(res502.statusCode).toBe(502);
+      expect(res504.statusCode).toBe(504);
+      expect(captureSpy).not.toHaveBeenCalled();
+
+      const res500 = await app.inject({
+        method: "GET",
+        url: "/test-internal-500",
+      });
+      expect(res500.statusCode).toBe(500);
+      expect(captureSpy).toHaveBeenCalledTimes(1);
+
+      captureSpy.mockRestore();
+    });
+
     test("handles standard Error objects correctly", async () => {
       const app = createFastifyInstance();
 

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -530,6 +530,34 @@ export const createFastifyInstance = () =>
         });
       }
 
+      // Fastify's own typed errors (unsupported media type, malformed
+      // content-type, …) carry the intended 4xx status. Without this branch
+      // they fall through to the generic handler below, which miscodes a
+      // client mistake as a 500 and captures it as a server exception.
+      const errorStatusCode = (error as { statusCode?: unknown }).statusCode;
+      if (
+        !(error instanceof ApiError) &&
+        typeof errorStatusCode === "number" &&
+        errorStatusCode >= 400 &&
+        errorStatusCode < 500
+      ) {
+        const coerced = new ApiError(
+          errorStatusCode,
+          error.message || "Bad Request",
+        );
+        this.log.info(
+          {
+            ...requestContext,
+            error: coerced.message,
+            statusCode: coerced.statusCode,
+          },
+          "HTTP 40x request error occurred",
+        );
+        return reply.status(coerced.statusCode).send({
+          error: { message: coerced.message, type: coerced.type },
+        });
+      }
+
       // Handle ApiError objects
       if (error instanceof ApiError) {
         const { statusCode, message, type, internalCode } = error;
@@ -542,11 +570,16 @@ export const createFastifyInstance = () =>
 
         if (statusCode >= 500) {
           this.log.error(logPayload, "HTTP 50x request error occurred");
-          captureServerException(request, error, {
-            error_type: "api_error",
-            status_code: statusCode,
-            ...(internalCode && { internal_code: internalCode }),
-          });
+          // 502/504 report an upstream's failure (a user-configured provider
+          // or external server), not a crash of ours — log them, but keep
+          // them out of exception tracking.
+          if (statusCode !== 502 && statusCode !== 504) {
+            captureServerException(request, error, {
+              error_type: "api_error",
+              status_code: statusCode,
+              ...(internalCode && { internal_code: internalCode }),
+            });
+          }
         } else if (statusCode >= 400) {
           this.log.info(logPayload, "HTTP 40x request error occurred");
         } else {


### PR DESCRIPTION
Restores error-status fidelity in two places where failures were being miscoded as generic 500s (and mis-tracked as server exceptions), plus stops treating upstream-fault statuses as our crashes.

## 1. `fix(llm-proxy)`: non-streaming upstream errors bypassed the proxy's catch

The proxy's request handler did `return handleNonStreaming(...)` inside its try/catch. A bare `return promise` inside `try` lets the promise's rejection skip the `catch` — so **every** upstream provider failure on the non-streaming path (rate limits, missing Azure deployments, auth errors):

- reached the client as a generic 500 instead of the provider's real status (verified in production telemetry: a provider 429 on the current release surfaced as `status_code: 500, error_type: unhandled_error`),
- skipped the failed-interaction record, so failed calls were missing from LLM logs,
- was captured as an unhandled server exception.

`return await` on the non-streaming leg restores all three (the outer catch persists the failed interaction and `handleError` maps the status).

**Streaming is deliberately left as a bare `return`.** `handleStreaming` is self-contained — it persists its own failed-interaction record and routes errors through `handleError` before its promise settles. Awaiting it would route its thrown `ApiError` through the outer catch too, double-persisting the error interaction (a full-suite regression test caught exactly this during development). Its bare-return rejection still reaches Fastify's handler, which maps the `ApiError` status correctly.

A regression test drives a non-streaming completion whose mocked SDK client rejects with a status-carrying error and pins: client receives 429 (verified it received 500 before the fix), and the failed interaction is persisted.

## 2. `fix(api)`: central error handler status fidelity

- **Fastify's own typed 4xx errors** (unsupported media type, malformed content-type, …) carry a `statusCode` the central error handler discarded — a client mistake came back as a 500 and was captured as a server exception. Their status now passes through. Pinned by a test posting an unsupported content type and expecting 415.
- **502/504 are upstream-fault statuses** — they report a user-configured provider or external server failing, not a crash of ours. They're still logged as errors but no longer captured into exception tracking. Pinned by tests asserting 502/504 skip capture while 500 still captures.
- **OAuth endpoint discovery failures** against a user-configured external server returned a bare 500 with no cause. They now return 502 with the underlying error message and a hint about the server's `.well-known` metadata, so the user can actually fix their configuration.

## Testing

Full backend suite (610 files / 10,504 tests), `type-check`, `lint`, `knip` pass. Both new regression tests verified to fail without their fixes.
