### PR TITLE
fix(frontend): bound MCP registry Logs/YAML viewer height so only the log pane scrolls

### DIFF
--- a/platform/frontend/src/app/mcp/registry/beta/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/registry/beta/[id]/page.client.tsx
@@ -629,7 +629,7 @@ function CatalogItemDetails({ item }: { item: CatalogItem }) {
           pod selector and live stream survive switching between them. */}
       {isLogsTab && (
         <Card className="py-0">
-          <div className="flex min-h-[480px] flex-col p-6">
+          <div className="flex h-[calc(100vh-16rem)] min-h-[480px] flex-col p-6">
             <McpLogsContent
               isActive={isLogsTab}
               serverName={item.name}
@@ -646,7 +646,7 @@ function CatalogItemDetails({ item }: { item: CatalogItem }) {
 
       {effectiveTab === "yaml" && (
         <Card className="py-0">
-          <div className="flex min-h-[480px] flex-col p-6">
+          <div className="flex h-[calc(100vh-16rem)] min-h-[480px] flex-col p-6">
             <YamlConfigContent item={item} onClose={() => {}} hideHeader />
           </div>
         </Card>


### PR DESCRIPTION
## Problem

On the MCP registry server detail page (`/mcp/registry/beta/[id]`), the **Logs** tab's "Pod Logs" viewer had no bounded height. The log-lines container relies on a `flex-1 min-h-0` chain down to its `ScrollArea`, but the outermost wrapper only set `min-h-[480px]` with no max/fixed height. With nothing constraining the container height, the `<pre>` of log text grew the container instead of scrolling internally, so the **whole page scrolled** far beyond the viewport on servers with lots of log output.

## Fix

Give the top of the flex chain a determinate height so the existing `flex-1 min-h-0` ancestors correctly bound the `ScrollArea` and only the log pane scrolls:

- `min-h-[480px]` → `h-[calc(100vh-16rem)] min-h-[480px]`

`h-[calc(100vh-16rem)]` fills most of the viewport (accounting for the page header/tabs) while `min-h-[480px]` keeps a usable floor on short viewports. The identical unbounded container was also used for the **K8s YAML** tab, which has the same latent bug for large manifests, so both were fixed for consistency.

Single-file, CSS-only change (`page.client.tsx`).