### PR TITLE
fix(mcp-runtime): reconcile existing Service selector to current mcp-server-id

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -3393,6 +3393,104 @@ describe("K8sDeployment.deleteK8sService", () => {
   });
 });
 
+describe("K8sDeployment.createServiceForHttpServer (selector reconciliation)", () => {
+  function createK8sDeploymentWithMockedApi(
+    mockK8sApi: Partial<k8s.CoreV1Api>,
+  ): K8sDeployment {
+    const mockMcpServer = {
+      id: "new-server-id",
+      name: "test-server",
+      catalogId: "test-catalog-id",
+      secretId: null,
+      ownerId: null,
+      reinstallRequired: false,
+      localInstallationStatus: "idle",
+      localInstallationError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as McpServer;
+
+    return new K8sDeployment({
+      mcpServer: mockMcpServer,
+      k8sApi: mockK8sApi as k8s.CoreV1Api,
+      k8sAppsApi: {} as k8s.AppsV1Api,
+      k8sAttach: {} as Attach,
+      k8sLog: {} as Log,
+      k8sExec: {} as Exec,
+      namespace: "default",
+      catalogItem: null,
+    });
+  }
+
+  type PrivateCreateService = {
+    createServiceForHttpServer: (
+      httpPort: number,
+      nodePort?: number,
+    ) => Promise<void>;
+  };
+
+  // Regression: a service whose selector still targets a stale mcp-server-id
+  // (left over after the server record was recreated with a new id) selects
+  // zero pods and gets no endpoints, so every read/connect fails. An existing
+  // service must be reconciled to the current id, not skipped.
+  test("reconciles an existing service's selector to the current mcp-server-id", async () => {
+    const mockRead = vi.fn().mockResolvedValue({}); // service already exists
+    const mockPatch = vi.fn().mockResolvedValue({});
+    const mockCreate = vi.fn().mockResolvedValue({});
+    const mockK8sApi = {
+      readNamespacedService: mockRead,
+      patchNamespacedService: mockPatch,
+      createNamespacedService: mockCreate,
+    };
+
+    const k8sDeployment = createK8sDeploymentWithMockedApi(mockK8sApi);
+    await (
+      k8sDeployment as unknown as PrivateCreateService
+    ).createServiceForHttpServer(8080);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockPatch).toHaveBeenCalledTimes(1);
+    const patchArg = mockPatch.mock.calls[0][0] as {
+      name: string;
+      namespace: string;
+      body: {
+        metadata: { labels: Record<string, string> };
+        spec: { selector: Record<string, string> };
+      };
+    };
+    expect(patchArg.name).toBe("mcp-test-server-service");
+    expect(patchArg.namespace).toBe("default");
+    expect(patchArg.body.spec.selector["mcp-server-id"]).toBe("new-server-id");
+    expect(patchArg.body.metadata.labels["mcp-server-id"]).toBe(
+      "new-server-id",
+    );
+  });
+
+  test("creates the service when it does not yet exist", async () => {
+    const notFound = { statusCode: 404, message: "Service not found" };
+    const mockRead = vi.fn().mockRejectedValue(notFound);
+    const mockPatch = vi.fn().mockResolvedValue({});
+    const mockCreate = vi.fn().mockResolvedValue({});
+    const mockK8sApi = {
+      readNamespacedService: mockRead,
+      patchNamespacedService: mockPatch,
+      createNamespacedService: mockCreate,
+    };
+
+    const k8sDeployment = createK8sDeploymentWithMockedApi(mockK8sApi);
+    await (
+      k8sDeployment as unknown as PrivateCreateService
+    ).createServiceForHttpServer(8080);
+
+    expect(mockPatch).not.toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const createArg = mockCreate.mock.calls[0][0] as {
+      body: { spec: { selector: Record<string, string> } };
+    };
+    expect(createArg.body.spec.selector["mcp-server-id"]).toBe("new-server-id");
+  });
+});
+
 describe("K8sDeployment.constructHttpServiceName", () => {
   function createK8sDeploymentForServiceName(
     serverName: string,

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -2793,14 +2793,44 @@ export default class K8sDeployment {
   ): Promise<void> {
     const serviceName = this.constructHttpServiceName();
 
+    // System-managed identity labels shared by the service metadata and its
+    // pod selector. The service NAME is derived from the (stable) deployment
+    // name, but the selector targets `mcp-server-id`, which changes whenever
+    // the server record is recreated. A Deployment's selector is immutable, so
+    // on such a change the Deployment is deleted + recreated with the new id —
+    // but the like-named Service already exists. If we skipped it (the previous
+    // behaviour), the Service kept selecting the OLD id, matched zero pods, and
+    // was left with no endpoints, so every connect/read failed with a generic
+    // "Resource read failed". Reconcile an existing Service's selector/labels
+    // to the current id instead of skipping.
+    const identityLabels = sanitizeMetadataLabels({
+      app: "mcp-server",
+      "mcp-server-id": this.mcpServer.id,
+    });
+
     try {
-      // Check if service already exists
+      // If the service already exists, reconcile its selector + labels to the
+      // current mcp-server-id (see note above) rather than leaving it stale.
       try {
         await this.k8sApi.readNamespacedService({
           name: serviceName,
           namespace: this.namespace,
         });
-        logger.info(`Service ${serviceName} already exists`);
+        await this.k8sApi.patchNamespacedService(
+          {
+            name: serviceName,
+            namespace: this.namespace,
+            body: {
+              metadata: { labels: identityLabels },
+              spec: { selector: identityLabels },
+            },
+          },
+          setHeaderOptions("Content-Type", PatchStrategy.MergePatch),
+        );
+        logger.info(
+          { mcpServerId: this.mcpServer.id, serviceName },
+          `Service ${serviceName} already exists — reconciled selector to current mcp-server-id`,
+        );
         return;
       } catch (error: unknown) {
         // Service doesn't exist, we'll create it below
@@ -2819,16 +2849,10 @@ export default class K8sDeployment {
       const serviceSpec: k8s.V1Service = {
         metadata: {
           name: serviceName,
-          labels: sanitizeMetadataLabels({
-            app: "mcp-server",
-            "mcp-server-id": this.mcpServer.id,
-          }),
+          labels: identityLabels,
         },
         spec: {
-          selector: sanitizeMetadataLabels({
-            app: "mcp-server",
-            "mcp-server-id": this.mcpServer.id,
-          }),
+          selector: identityLabels,
           ports: [
             {
               protocol: "TCP",


### PR DESCRIPTION
## Problem

A local MCP server's app (`ui://…` resource) can fail to load with a generic **"Failed to load app / Resource read failed"**, even though the server pod is healthy and serving. Under the hood the app gateway fails to reach the server with `ECONNREFUSED` / connect-timeout to the Service's ClusterIP.

Root cause: the MCP server's k8s **Service has no Endpoints** because its selector points at a **stale `mcp-server-id`**.

- The Service **name** is derived from the (stable) deployment name, but its **selector** targets `mcp-server-id`.
- `mcp-server-id` changes when the server record is recreated. A Deployment's selector is immutable, so on such a change the Deployment is deleted + recreated with the new id.
- But `createServiceForHttpServer` did *create-if-missing*: it saw the like-named Service already exist, logged `Service … already exists`, and **returned without updating the selector**.
- Result: the Service keeps selecting the **old** id → matches zero pods → no Endpoints → every connect/read to the server fails.

This was hit in staging after an MCP server (`archestra-pm`) was redeployed several times: the Service selector was left at an orphaned `mcp-server-id` with no matching pod, so the app bricked on both the new and the rolled-back image until the selector was hand-patched.

## Fix

In `createServiceForHttpServer`, when the Service already exists, **reconcile its selector + labels to the current `mcp-server-id`** via a merge patch (using the existing `PatchStrategy.MergePatch` helper) instead of skipping. The Service now self-heals to the running Deployment on the next reconcile. Creation of a brand-new Service is unchanged.

## Tests

- New regression tests in `k8s-deployment.test.ts`:
  - existing Service → **patched** to the current id (not skipped, not recreated),
  - missing Service → still created.
- `vitest` full file: **194/194 pass** (192 existing + 2 new).
- `biome check` clean on both changed files.

## Notes / rollout

- Effect is forward-only: the fix kicks in on the **next** deploy/reconcile of each server. Existing servers already stuck on a stale selector need a one-off `kubectl patch svc … --type=merge -p '{"spec":{"selector":{"mcp-server-id":"<current>"}}}'` (or a redeploy once this ships).
- Only touches the "service already exists" branch; the create path and all other behavior are unchanged.