### PR TITLE
fix(apps): refresh app scope in UI after publishing via tool

### DIFF
--- a/platform/frontend/src/lib/chat/archestra-tool-invalidations.test.ts
+++ b/platform/frontend/src/lib/chat/archestra-tool-invalidations.test.ts
@@ -1,0 +1,95 @@
+import { getArchestraToolShortName } from "@archestra/shared";
+import { describe, expect, it } from "vitest";
+import { collectArchestraToolInvalidations } from "./archestra-tool-invalidations";
+
+const getToolShortName = (toolName: string) =>
+  getArchestraToolShortName(toolName, { includeDefaultPrefix: true });
+
+const publishPart = (overrides: Record<string, unknown> = {}) => ({
+  type: "tool-archestra__publish_app",
+  toolCallId: "call-1",
+  state: "output-available",
+  input: { appId: "app-1", scope: "org" },
+  output: { id: "app-1", scope: "org", runUrl: "/a/app-1" },
+  ...overrides,
+});
+
+describe("collectArchestraToolInvalidations", () => {
+  it("invalidates the app caches for a successful publish_app result", () => {
+    expect(
+      collectArchestraToolInvalidations({
+        parts: [{ type: "text", text: "Publishing your app…" }, publishPart()],
+        getToolShortName,
+      }),
+    ).toEqual([["apps"], ["mcp-catalog"]]);
+  });
+
+  it("resolves dynamic-tool parts through their toolName field", () => {
+    expect(
+      collectArchestraToolInvalidations({
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "archestra__publish_app",
+            state: "output-available",
+            output: { id: "app-1", scope: "org" },
+          },
+        ],
+        getToolShortName,
+      }),
+    ).toEqual([["apps"], ["mcp-catalog"]]);
+  });
+
+  it("dedupes query keys when a turn publishes twice", () => {
+    expect(
+      collectArchestraToolInvalidations({
+        parts: [publishPart(), publishPart({ toolCallId: "call-2" })],
+        getToolShortName,
+      }),
+    ).toEqual([["apps"], ["mcp-catalog"]]);
+  });
+
+  it("skips a call that never produced output (e.g. aborted mid-call)", () => {
+    expect(
+      collectArchestraToolInvalidations({
+        parts: [publishPart({ state: "input-available", output: undefined })],
+        getToolShortName,
+      }),
+    ).toEqual([]);
+  });
+
+  it("skips errored results — a refused publish mutated nothing", () => {
+    expect(
+      collectArchestraToolInvalidations({
+        parts: [
+          publishPart({ state: "output-error", errorText: "boom" }),
+          publishPart({
+            output: {
+              archestraError: { type: "generic", message: "not allowed" },
+            },
+          }),
+        ],
+        getToolShortName,
+      }),
+    ).toEqual([]);
+  });
+
+  it("ignores non-mutating archestra tools and non-archestra tools", () => {
+    expect(
+      collectArchestraToolInvalidations({
+        parts: [
+          publishPart({ type: "tool-archestra__list_apps" }),
+          publishPart({ type: "tool-slack__slack_send_message" }),
+          publishPart({ type: "tool-publish_app" }), // no server prefix
+        ],
+        getToolShortName,
+      }),
+    ).toEqual([]);
+  });
+
+  it("handles messages without parts", () => {
+    expect(
+      collectArchestraToolInvalidations({ parts: undefined, getToolShortName }),
+    ).toEqual([]);
+  });
+});

--- a/platform/frontend/src/lib/chat/archestra-tool-invalidations.ts
+++ b/platform/frontend/src/lib/chat/archestra-tool-invalidations.ts
@@ -1,0 +1,62 @@
+import {
+  extractMcpToolError,
+  TOOL_PUBLISH_APP_SHORT_NAME,
+} from "@archestra/shared";
+import { getRenderedToolName } from "@/lib/chat/swap-agent.utils";
+
+/** The slice of a UIMessage tool part this module inspects. */
+type ToolResultPart = {
+  type?: string;
+  toolName?: string;
+  state?: string;
+  output?: unknown;
+  errorText?: string;
+};
+
+/**
+ * Archestra MCP tools that mutate data server-side, inside the chat loop —
+ * bypassing the frontend mutation hooks whose onSuccess normally invalidates
+ * the affected caches — mapped to the query keys those hooks would have
+ * invalidated. `publish_app` mirrors `useUpdateApp` (app.query.ts): `["apps"]`
+ * covers the paginated list and every `["apps", appId]` detail (the scope
+ * shown in the settings dialog), `["mcp-catalog"]` because publishing writes
+ * the new scope through to the app's backing catalog, which drives the MCP
+ * registry card.
+ */
+const ARCHESTRA_TOOL_INVALIDATIONS = new Map<string, readonly string[][]>([
+  [TOOL_PUBLISH_APP_SHORT_NAME, [["apps"], ["mcp-catalog"]]],
+]);
+
+/**
+ * Query keys to invalidate for the archestra tool results in a finished
+ * assistant message. Only delivered, successful results count: the server-side
+ * write has provably happened, so the refetch cannot race it (invalidating on
+ * the tool *call* instead would let an active observer refetch before the
+ * write and re-cache the stale value for another staleTime window), and an
+ * errored tool mutated nothing.
+ */
+export function collectArchestraToolInvalidations(params: {
+  parts: unknown[] | undefined;
+  getToolShortName: (toolName: string) => string | null;
+}): string[][] {
+  const collected = new Map<string, string[]>();
+  for (const rawPart of params.parts ?? []) {
+    if (typeof rawPart !== "object" || rawPart === null) continue;
+    const part = rawPart as ToolResultPart;
+    const toolName = getRenderedToolName(part);
+    if (!toolName) continue;
+    const shortName = params.getToolShortName(toolName);
+    if (!shortName) continue;
+    const queryKeys = ARCHESTRA_TOOL_INVALIDATIONS.get(shortName);
+    if (!queryKeys) continue;
+    if (part.state !== "output-available") continue;
+    if (typeof part.errorText === "string" && part.errorText.length > 0) {
+      continue;
+    }
+    if (extractMcpToolError(part.output) !== null) continue;
+    for (const queryKey of queryKeys) {
+      collected.set(JSON.stringify(queryKey), [...queryKey]);
+    }
+  }
+  return [...collected.values()];
+}

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1436,6 +1436,95 @@ describe("context window breakdown state", () => {
   });
 });
 
+describe("ChatProvider app-tool cache invalidation", () => {
+  let chatOptions: Parameters<typeof mocks.useChat>[0] | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chatOptions = undefined;
+    const messages: UIMessage[] = [];
+    mocks.useChat.mockImplementation((options) => {
+      chatOptions = options;
+      return {
+        addToolApprovalResponse: mocks.addToolApprovalResponse,
+        addToolResult: mocks.addToolResult,
+        error: undefined,
+        messages,
+        regenerate: mocks.regenerate,
+        resumeStream: mocks.resumeStream,
+        sendMessage: mocks.sendMessage,
+        setMessages: mocks.setMessages,
+        status: "ready",
+        stop: mocks.stop,
+      };
+    });
+  });
+
+  const publishMessage = (partOverrides: Record<string, unknown> = {}) =>
+    ({
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-archestra__publish_app",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { appId: "app-1", scope: "org" },
+          output: { id: "app-1", scope: "org", runUrl: "/a/app-1" },
+          ...partOverrides,
+        },
+      ],
+    }) as unknown as UIMessage;
+
+  it("invalidates the app caches when a publish_app result finishes", async () => {
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(mocks.useChat).toHaveBeenCalled());
+
+    // publish_app mutates the app's scope server-side, inside the chat loop —
+    // no frontend mutation hook runs, so onFinish must mark the app caches
+    // stale or the settings dialog serves the pre-publish scope from cache.
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: publishMessage(),
+        isAbort: false,
+      });
+    });
+
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["apps"],
+    });
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["mcp-catalog"],
+    });
+  });
+
+  it("does not invalidate the app caches for an errored publish_app", async () => {
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(mocks.useChat).toHaveBeenCalled());
+
+    await act(async () => {
+      await chatOptions?.onFinish?.({
+        message: publishMessage({ state: "output-error", errorText: "denied" }),
+        isAbort: false,
+      });
+    });
+
+    expect(mocks.invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ["apps"],
+    });
+  });
+});
+
 function CaptureTitleAnimation({
   onValue,
 }: {

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -40,6 +40,7 @@ import {
   type ChatMcpElicitationRequest,
   McpElicitationDialog,
 } from "@/components/chat/mcp-elicitation-dialog";
+import { collectArchestraToolInvalidations } from "@/lib/chat/archestra-tool-invalidations";
 import {
   useClearChatErrors,
   useConversationUpdatedCacheSync,
@@ -613,6 +614,22 @@ function ChatSessionHook({
       const conversationsSidebarInvalidate = queryClient.invalidateQueries({
         queryKey: ["conversations"],
       });
+
+      // Archestra tools that mutate data server-side inside the chat loop
+      // (e.g. publish_app) bypass the frontend mutation hooks that normally
+      // invalidate the affected caches. Without this, opening the app's
+      // Settings right after a publish serves the cached pre-publish scope
+      // until the staleTime window lapses or a hard refresh. Invalidating
+      // here — on the finished message's successful tool results, not in
+      // onToolCall — guarantees the refetch cannot race the server-side
+      // write (onToolCall fires before the tool executes).
+      for (const queryKey of collectArchestraToolInvalidations({
+        parts: message.parts,
+        getToolShortName: (toolName) =>
+          getCurrentArchestraToolShortName(toolName, appName),
+      })) {
+        queryClient.invalidateQueries({ queryKey });
+      }
 
       // After a swap_agent stop, poke the new agent so it responds.
       // The new /api/chat POST re-reads the conversation from DB and


### PR DESCRIPTION
## Bug

Publishing an owned app through the chat MCP tool (`archestra__publish_app`) changes the app's scope server-side, but opening that app's Settings right afterwards still showed **personal**. Only a hard page refresh showed **organization**.

## Root cause

The settings dialog reads the app via `useApp` (`["apps", appId]`, `platform/frontend/src/lib/app.query.ts`). The chat surface keeps that query warm (the app pill/header reads it too), and the QueryClient default is `staleTime: 60s`. `publish_app` runs server-side inside the chat loop — no frontend mutation hook fires, so nothing marks `["apps"]` stale. Opening Settings within the staleTime window mounts an observer that serves the cached pre-publish app without refetching; a hard refresh empties the cache, which is why it "fixed" it.

## Mechanism chosen

Tool-result-driven cache invalidation in the chat pipeline (not `staleTime`/refetch-on-open — that would only patch the dialog and add refetch churn to every `useApp` observer; the Apps list and registry card were equally stale).

- New `collectArchestraToolInvalidations` (`platform/frontend/src/lib/chat/archestra-tool-invalidations.ts`): a narrow map of archestra tool short names → query keys, applied to a finished assistant message's tool parts. `publish_app` → `["apps"]` + `["mcp-catalog"]`, mirroring `useUpdateApp`'s `onSuccess` (publish writes the scope through to the app's backing catalog, which drives the registry card).
- Wired into `onFinish` in `global-chat.context.tsx`, next to the existing per-tool handling (swap-agent poke, `create_agent` → `["agents"]`). Deliberately **not** in `onToolCall`: that fires before the tool executes, so an active observer could refetch pre-write and re-cache the stale scope for another 60s. Only delivered, successful results (`state: "output-available"`, no `errorText`/`archestraError`) invalidate — an errored publish mutated nothing.

The map is the extension point if other server-side app mutations (delete/scaffold) need the same treatment later.

## Checks

- `pnpm type-check` — clean
- `biome ci` (from `platform/frontend`) — clean
- `pnpm knip` — clean
- `pnpm vitest run src/lib/chat src/components/chat src/lib/app.query.ts src/components/mcp-app` — 58 files, 692 tests passed, including new unit tests for the collector and two `ChatProvider` integration tests (publish result → `["apps"]`/`["mcp-catalog"]` invalidated; errored publish → not invalidated)

Not verified in-browser: the repro needs a live model turn calling `publish_app`; the integration tests drive the real `ChatProvider` `onFinish` path instead.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>