### PR TITLE
test(e2e): parallelize chat provider suite to de-flake and speed up e2e shard 1

### DIFF
--- a/platform/e2e-tests/tests/chat.spec.ts
+++ b/platform/e2e-tests/tests/chat.spec.ts
@@ -12,9 +12,16 @@ import {
 } from "../utils";
 import { expect, test } from "./api-fixtures";
 
-// Run all provider tests sequentially to avoid WireMock stub timing issues.
-// Retries handle transient streaming/WireMock flakiness in CI.
-test.describe.configure({ mode: "serial", retries: 2 });
+// Provider tests are mutually independent — each drives its own model in a fresh
+// conversation, and the WireMock chat stubs are stateless (matched only on the
+// "chat-ui-e2e-test" body marker), so they run in parallel to fill the CI workers
+// instead of serializing all ~16 providers onto one. This matters twice over: serial
+// mode both left 13 of the 14 CI workers idle behind one long provider chain (the
+// dominant reason this file was the slow long-pole of e2e shard 1) and, because a
+// serial group retries as a unit, let a single flaky provider skip and re-run every
+// other provider. Parallel mode scopes each retry to the one provider that flaked.
+// retries stay at 2 to absorb transient streaming/WireMock hiccups in CI.
+test.describe.configure({ mode: "parallel", retries: 2 });
 
 interface ChatProviderTestConfig {
   providerName: string;
@@ -248,13 +255,20 @@ for (const config of testConfigs) {
       // Submit the message by pressing Enter
       await page.keyboard.press("Enter");
 
-      // Wait for the response to appear
-      // The mocked response should contain our expected text
-      // Use generous timeout - streaming responses in CI can be slow
-      // (WireMock + streaming + CI resource contention can take >60s)
-      await expect(page.getByText(config.expectedResponse)).toBeVisible({
-        timeout: 90_000,
-      });
+      // Wait for the response to appear.
+      // The mocked response should contain our expected text. Use a generous
+      // timeout — streaming responses in CI can be slow (WireMock + streaming +
+      // CI resource contention can take >60s).
+      // Scope to the first (settled) assistant bubble: while the response is
+      // still streaming the client can transiently hold two assistant bubbles
+      // before they reconcile (the same double-render documented in the reconnect
+      // FIXME below), which would otherwise trip strict mode with "resolved to 2
+      // elements" and fail the assertion.
+      await expect(page.getByText(config.expectedResponse).first()).toBeVisible(
+        {
+          timeout: 90_000,
+        },
+      );
 
       // Verify the user's message also appears in the chat
       // Use .first() because the message text may also appear in the sidebar title


### PR DESCRIPTION
## Problem

E2E **shard 1/2** is systematically slower than shard 2/2 **and** carries essentially all the merge-queue flakiness. Pulling job durations from **28 recent `merge_group` runs**:

| | Shard 1 | Shard 2 |
|---|---|---|
| Mean wall-clock | **8:13** | 6:58 |
| Max | **11:04** | 8:59 |
| Slower than sibling | **26 / 28 runs** | — |
| **Failure rate** | **6 / 28 = 21%** | **0 / 28 = 0%** |

~5–6 min of every job is fixed kind/Helm/Vault setup, so the *test-time* spread is proportionally much larger than the wall-clock gap suggests. **Every** shard-1 failure and every slow tail traced to a single file: `e2e-tests/tests/chat.spec.ts`.

## Root cause

`chat.spec.ts` ran its ~16-provider `Chat-UI-<provider>` matrix under `test.describe.configure({ mode: "serial", retries: 2 })`. Two consequences:

1. **Serial pinned all 16 providers onto one CI worker** while the other ~13 sat idle — the dominant reason this file was the slow long-pole. (Playwright's `--shard=N/2` splits the sorted test list into contiguous halves; the whole `chat*` cluster sorts into the first half → shard 1.)
2. **A serial group retries as a unit.** One flaky provider failing near the end skipped the rest (the "1 did not run" seen in reports) and re-ran the *entire* group on retry — each provider awaits a streamed mock with a 90s ceiling, so a single flake could add up to ~4.5 min and redden the whole shard.

Observed flaky providers rotated run-to-run (MiniMax, OpenAI, DeepSeek, Ollama, vLLM, ZhipuAI…) — classic flake, not a deterministic break — via two signatures: (a) the 90s streaming-visibility timeout, and (b) a strict-mode `resolved to 2 elements` on the response assertion.

## Fix

**`mode: "serial"` → `mode: "parallel"`.** Providers now fan out across the CI workers, and each retry is scoped to the single provider that flaked instead of the whole group.

This is safe on every shared-state axis (verified):
- **WireMock stubs are stateless** — matched only on the `chat-ui-e2e-test` body marker, no scenarios/state, so concurrent requests don't interfere.
- **Model / API-key selection is per-page** (localStorage + per-conversation); the tests never touch the org-level default-key control.
- **Sessions are isolated** — each test gets its own browser context and creates its own fresh conversation.
- Peak concurrency is unchanged (the runner already caps at `workers: 90%` ≈ 14, and every other spec already runs `fullyParallel`) — de-serializing just lets chat tests fill those slots instead of running one-at-a-time after everyone else.

**Assertion scoped to `.first()`.** While the response is still streaming the client can transiently hold two assistant bubbles before they reconcile (the same double-render already documented in the reconnect `FIXME` in this file), which tripped strict mode with `resolved to 2 elements`. `.first()` targets the settled bubble — mirroring the `.first()` already used for the user-message assertion on the next line. `retries` stays at 2 to absorb transient streaming hiccups.

## Scope / risk

- One file changed (`chat.spec.ts`), test-only — no product code touched.
- `biome` + `tsgo` clean; `playwright --list` confirms all 16 providers still collect.
- The underlying double-assistant-bubble render is a real (pre-existing) frontend reconciliation quirk; `.first()` is the test-side mitigation, consistent with the existing FIXME. Left as a separate follow-up.

_Empirical data gathered from the last ~28 `Platform E2E Tests` merge-queue runs._

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>