### PR TITLE
test(e2e): fix skill-share hydration flake and drop redundant e2e fan-in job

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -359,28 +359,12 @@ jobs:
           echo "The non-quickstart E2E run (shard ${SHARD}/2) failed."
           exit 1
 
-  # Fan-in gate that carries the "Platform E2E Tests" required status check.
-  # The sharded matrix above emits per-shard check names, which never match the
-  # required context, so this job reproduces the exact name and is green only
-  # when every shard succeeded. !cancelled() keeps it from being skipped — a
-  # skipped required check stalls the merge queue just like a missing one.
-  platform-e2e-tests:
-    name: Platform E2E Tests
-    needs: [platform-e2e-tests-shards]
-    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check shard results
-        env:
-          SHARDS_RESULT: ${{ needs.platform-e2e-tests-shards.result }}
-        run: |
-          echo "Aggregated shard result: ${SHARDS_RESULT}"
-          if [ "${SHARDS_RESULT}" != "success" ]; then
-            echo "One or more non-quickstart E2E shards did not succeed."
-            exit 1
-          fi
-          echo "All non-quickstart E2E shards passed."
-
+  # NOTE: there is deliberately no separate "Platform E2E Tests" fan-in job. The
+  # shard results are already gated by "Merge E2E Test Reports" below (its "Fail
+  # if any e2e job failed" step fails when any shard or the quickstart leg is not
+  # green), and that is the required status check for the merge queue. A second
+  # fan-in job checking the same shard result was redundant and not referenced by
+  # the branch ruleset, so it was removed.
 
   platform-quickstart-e2e-tests:
     name: Platform E2E Tests (Quickstart)

--- a/platform/e2e-tests/tests/skill-share.spec.ts
+++ b/platform/e2e-tests/tests/skill-share.spec.ts
@@ -32,16 +32,25 @@ test.describe("Skills marketplace step on /connection", () => {
       await goToPage(page, "/connection");
       await page.waitForLoadState("domcontentloaded");
 
-      // Pick "Any client" so the generic (client-agnostic) snippets render.
-      await page
+      // Pick "Any Client" so the generic (client-agnostic) snippets render, and
+      // the "Install shared skills" step expands so the create button mounts.
+      //
+      // The client tile is server-rendered, so a click that lands before React
+      // hydration attaches its onClick handler is silently lost — Playwright
+      // reports the click as successful (the SSR button is visible/enabled), but
+      // no client is selected, the skills step never opens, and the create
+      // button never renders. A longer timeout can't recover it: once the click
+      // is dropped the state stays unset for the life of the page. Selecting a
+      // client is idempotent (it sets, never toggles), so retry the click until
+      // the step has opened and the create button is visible.
+      const anyClient = page
         .getByRole("button", { name: /Any Client/i })
-        .first()
-        .click();
-
-      // The "Install shared skills" step expands once a client is picked, so
-      // the create button is reachable directly.
+        .first();
       const createButton = page.getByTestId("skills-marketplace-create");
-      await expect(createButton).toBeVisible({ timeout: 20_000 });
+      await expect(async () => {
+        await anyClient.click();
+        await expect(createButton).toBeVisible({ timeout: 3_000 });
+      }).toPass({ timeout: 20_000 });
 
       const createResponsePromise = page.waitForResponse(
         (response) =>


### PR DESCRIPTION
Two focused e2e reliability changes, both from empirical merge-queue data.

## 1. Fix the last shard-1 flake — `skill-share.spec.ts` (lost pre-hydration click)

After parallelizing the chat suite (#6338), the only remaining shard-1 flake was `skill-share.spec.ts:22` — `getByTestId('skills-marketplace-create')` intermittently "not found" within 20s, passing on retry.

**Root cause is a lost pre-hydration click, not a slow render.** The `/connection` "Any Client" tile is server-rendered. When Playwright's click lands *before* React hydration attaches the tile's `onClick`, the click reports success (the SSR button is visible/enabled) but `selectClient` never runs → no client is selected → the "Install shared skills" step never expands → the create button (gated behind `expanded && !!client`) never mounts. Playwright doesn't re-fire a click after it lands, so the state stays unset for the life of the page — **a longer timeout provably cannot recover it.** It only passes on a fresh-navigation retry, where the warm server lets hydration win the race.

**Fix:** wrap the click + visibility check in `expect(...).toPass()`, so a dropped pre-hydration click is retried until the step opens and the button renders. Selecting a client is idempotent (`selectClient` sets `clientId` and *adds* open steps — it never toggles), so re-clicking is safe. Same 20s outer budget, now hydration-safe.

## 2. Drop the redundant `Platform E2E Tests` fan-in job

The sharded matrix emits per-shard check names, so a fan-in job (`platform-e2e-tests`) reproduced the `Platform E2E Tests` name purely to aggregate shard success. But checking the actual `main` ruleset, that name is **not** a required status check — the required e2e gates are **`Merge E2E Test Reports`** and **`Platform E2E Tests (Quickstart)`**. And `Merge E2E Test Reports` already has a `Fail if any e2e job failed` step that fails when any shard *or* the quickstart leg is not green. So the fan-in job was a second, redundant gate on the same shard result, nothing `needs` it, and it's not referenced by the ruleset. Removed, with a note so it isn't re-added.

(The job's own comment claimed it "carries the required status check" — that was stale; the ruleset shows otherwise.)

## Validation

- `biome` + `tsgo` clean; `playwright --list` confirms the test still collects; workflow YAML parses and no job `needs` the removed one.
- I'll exercise the flake fix directly by toggling the `run-e2e` label to run the full sharded suite several times and confirming zero flakes before merge.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>