### PR TITLE
fix(mcp-runtime): catalog-stable pod selector for multitenant MCP servers

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -409,24 +409,23 @@ describe("K8sDeployment.constructDeploymentName", () => {
       id: "123e4567-e89b-12d3-a456-426614174000",
       expected: "mcp-server.name",
     },
-  ])("converts server name '$name' with id '$id' to deployment name '$expected'", ({
-    name,
-    id,
-    expected,
-  }) => {
-    // biome-ignore lint/suspicious/noExplicitAny: Minimal mock for testing
-    const mockServer = { name, id } as any;
-    const result = K8sDeployment.constructDeploymentName(mockServer);
-    expect(result).toBe(expected);
+  ])(
+    "converts server name '$name' with id '$id' to deployment name '$expected'",
+    ({ name, id, expected }) => {
+      // biome-ignore lint/suspicious/noExplicitAny: Minimal mock for testing
+      const mockServer = { name, id } as any;
+      const result = K8sDeployment.constructDeploymentName(mockServer);
+      expect(result).toBe(expected);
 
-    // Verify all results are valid Kubernetes DNS subdomain names
-    // Must match pattern: lowercase alphanumeric, '-' or '.', start and end with alphanumeric
-    expect(result).toMatch(/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/);
-    // Must be no longer than 253 characters
-    expect(result.length).toBeLessThanOrEqual(253);
-    // Must start with 'mcp-'
-    expect(result).toMatch(/^mcp-/);
-  });
+      // Verify all results are valid Kubernetes DNS subdomain names
+      // Must match pattern: lowercase alphanumeric, '-' or '.', start and end with alphanumeric
+      expect(result).toMatch(/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/);
+      // Must be no longer than 253 characters
+      expect(result.length).toBeLessThanOrEqual(253);
+      // Must start with 'mcp-'
+      expect(result).toMatch(/^mcp-/);
+    },
+  );
 
   test("handles very long server names by truncating to 253 characters", () => {
     const longName = "a".repeat(300); // 300 character name
@@ -3488,6 +3487,68 @@ describe("K8sDeployment.createServiceForHttpServer (selector reconciliation)", (
       body: { spec: { selector: Record<string, string> } };
     };
     expect(createArg.body.spec.selector["mcp-server-id"]).toBe("new-server-id");
+  });
+});
+
+describe("K8sDeployment multitenant selector stability", () => {
+  function make(
+    // biome-ignore lint/suspicious/noExplicitAny: minimal catalog mock for tests
+    catalogItem: any,
+  ): K8sDeployment {
+    const mcpServer = {
+      id: "install-abc-123",
+      name: "archestra-pm",
+      catalogId: "cat9999-0000-0000-0000-000000000000",
+      // biome-ignore lint/suspicious/noExplicitAny: mock server for tests
+    } as any as McpServer;
+    return new K8sDeployment({
+      mcpServer,
+      k8sApi: {} as k8s.CoreV1Api,
+      k8sAppsApi: {} as k8s.AppsV1Api,
+      k8sAttach: {} as Attach,
+      k8sLog: {} as Log,
+      k8sExec: {} as Exec,
+      namespace: "default",
+      catalogItem,
+    });
+  }
+  const localConfig: z.infer<typeof LocalConfigSchema> = {
+    command: "node",
+    arguments: ["server.js"],
+  };
+
+  // Multitenant catalogs share ONE catalog-named Deployment + Service across all
+  // installs. If the selector used the per-install id, two installs would fight
+  // over the shared resource and leave the Service with zero endpoints. The
+  // selector must be catalog-stable so every install reconciles to the same one.
+  test("multitenant: deployment selector + pod labels use the catalog id (not the per-install id)", () => {
+    const catalogItem = { multitenant: true, name: "Archestra PM" };
+    const spec = make(catalogItem).generateDeploymentSpec(
+      "img:latest",
+      localConfig,
+      true,
+      8080,
+    );
+    expect(spec.spec?.selector.matchLabels?.["mcp-server-id"]).toBe(
+      "cat9999-0000-0000-0000-000000000000",
+    );
+    expect(spec.spec?.template.metadata?.labels?.["mcp-server-id"]).toBe(
+      "cat9999-0000-0000-0000-000000000000",
+    );
+    // The name is catalog-derived too, so name and selector stay in lockstep.
+    expect(spec.metadata?.name).toContain("mcp-mt-cat9999-");
+  });
+
+  test("single-tenant (no catalog item): selector keeps the per-install id", () => {
+    const spec = make(null).generateDeploymentSpec(
+      "img:latest",
+      localConfig,
+      true,
+      8080,
+    );
+    expect(spec.spec?.selector.matchLabels?.["mcp-server-id"]).toBe(
+      "install-abc-123",
+    );
   });
 });
 

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -409,23 +409,24 @@ describe("K8sDeployment.constructDeploymentName", () => {
       id: "123e4567-e89b-12d3-a456-426614174000",
       expected: "mcp-server.name",
     },
-  ])(
-    "converts server name '$name' with id '$id' to deployment name '$expected'",
-    ({ name, id, expected }) => {
-      // biome-ignore lint/suspicious/noExplicitAny: Minimal mock for testing
-      const mockServer = { name, id } as any;
-      const result = K8sDeployment.constructDeploymentName(mockServer);
-      expect(result).toBe(expected);
+  ])("converts server name '$name' with id '$id' to deployment name '$expected'", ({
+    name,
+    id,
+    expected,
+  }) => {
+    // biome-ignore lint/suspicious/noExplicitAny: Minimal mock for testing
+    const mockServer = { name, id } as any;
+    const result = K8sDeployment.constructDeploymentName(mockServer);
+    expect(result).toBe(expected);
 
-      // Verify all results are valid Kubernetes DNS subdomain names
-      // Must match pattern: lowercase alphanumeric, '-' or '.', start and end with alphanumeric
-      expect(result).toMatch(/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/);
-      // Must be no longer than 253 characters
-      expect(result.length).toBeLessThanOrEqual(253);
-      // Must start with 'mcp-'
-      expect(result).toMatch(/^mcp-/);
-    },
-  );
+    // Verify all results are valid Kubernetes DNS subdomain names
+    // Must match pattern: lowercase alphanumeric, '-' or '.', start and end with alphanumeric
+    expect(result).toMatch(/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/);
+    // Must be no longer than 253 characters
+    expect(result.length).toBeLessThanOrEqual(253);
+    // Must start with 'mcp-'
+    expect(result).toMatch(/^mcp-/);
+  });
 
   test("handles very long server names by truncating to 253 characters", () => {
     const longName = "a".repeat(300); // 300 character name

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -1483,9 +1483,34 @@ export default class K8sDeployment {
   private getSystemLabels(): Record<string, string> {
     return sanitizeMetadataLabels({
       app: "mcp-server",
-      "mcp-server-id": this.mcpServer.id,
+      "mcp-server-id": this.getPodSelectorServerId(),
       "mcp-server-name": this.mcpServer.name,
     });
+  }
+
+  /**
+   * The identity stamped into the `mcp-server-id` pod label + selector (and the
+   * matching Service selector / pod lookups).
+   *
+   * Multitenant catalogs share ONE catalog-named Deployment + Service across
+   * every install (see {@link constructDeploymentName}, which keys the name on
+   * `catalogId` for multitenant). Keying the *selector* on the per-install
+   * `mcpServer.id` lets whichever install reconciles the shared resource last
+   * overwrite it, so the Deployment's pods and the Service's selector can end up
+   * bound to different installs — the Service then selects zero pods, has no
+   * Endpoints, and every connect/read fails ("Resource read failed").
+   *
+   * Use the catalog-stable id for multitenant so every install reconciles to the
+   * exact same selector. Single-tenant servers keep their per-install id (their
+   * Deployment/Service are not shared, so the name and selector are per-install).
+   * This uses the same condition as `constructDeploymentName`, so the selector is
+   * catalog-stable exactly when the resource is catalog-shared.
+   */
+  private getPodSelectorServerId(): string {
+    if (this.catalogItem?.multitenant && this.mcpServer.catalogId) {
+      return this.mcpServer.catalogId;
+    }
+    return this.mcpServer.id;
   }
 
   /**
@@ -1755,12 +1780,9 @@ export default class K8sDeployment {
       envValues,
     );
 
-    // System-managed labels that must always be present
-    const labels = sanitizeMetadataLabels({
-      app: "mcp-server",
-      "mcp-server-id": this.mcpServer.id,
-      "mcp-server-name": this.mcpServer.name,
-    });
+    // System-managed labels that must always be present (catalog-stable selector
+    // id for multitenant — see getPodSelectorServerId).
+    const labels = this.getSystemLabels();
 
     // Parse YAML and merge with system values
     const deployment = customYamlToDeployment(resolvedYaml, {
@@ -2431,7 +2453,7 @@ export default class K8sDeployment {
    */
   private async findPodForDeployment(): Promise<k8s.V1Pod | undefined> {
     try {
-      const sanitizedId = sanitizeLabelValue(this.mcpServer.id);
+      const sanitizedId = sanitizeLabelValue(this.getPodSelectorServerId());
       const pods = await this.k8sApi.listNamespacedPod({
         namespace: this.namespace,
         labelSelector: `mcp-server-id=${sanitizedId}`,
@@ -2477,7 +2499,7 @@ export default class K8sDeployment {
    */
   private async findAnyPodForDeployment(): Promise<k8s.V1Pod | undefined> {
     try {
-      const sanitizedId = sanitizeLabelValue(this.mcpServer.id);
+      const sanitizedId = sanitizeLabelValue(this.getPodSelectorServerId());
       const pods = await this.k8sApi.listNamespacedPod({
         namespace: this.namespace,
         labelSelector: `mcp-server-id=${sanitizedId}`,
@@ -2664,7 +2686,7 @@ export default class K8sDeployment {
     let transientImagePullMessage: string | null = null;
 
     try {
-      const sanitizedId = sanitizeLabelValue(this.mcpServer.id);
+      const sanitizedId = sanitizeLabelValue(this.getPodSelectorServerId());
       const pods = await this.k8sApi.listNamespacedPod({
         namespace: this.namespace,
         labelSelector: `mcp-server-id=${sanitizedId}`,
@@ -2795,17 +2817,16 @@ export default class K8sDeployment {
 
     // System-managed identity labels shared by the service metadata and its
     // pod selector. The service NAME is derived from the (stable) deployment
-    // name, but the selector targets `mcp-server-id`, which changes whenever
-    // the server record is recreated. A Deployment's selector is immutable, so
-    // on such a change the Deployment is deleted + recreated with the new id —
-    // but the like-named Service already exists. If we skipped it (the previous
-    // behaviour), the Service kept selecting the OLD id, matched zero pods, and
-    // was left with no endpoints, so every connect/read failed with a generic
-    // "Resource read failed". Reconcile an existing Service's selector/labels
-    // to the current id instead of skipping.
+    // name, but the selector targets `mcp-server-id`. For multitenant catalogs
+    // the Deployment + Service are shared across installs, so this uses the
+    // catalog-stable id (getPodSelectorServerId) — every install reconciles to
+    // the same selector, matching the Deployment's pod labels. It still changes
+    // on a genuine identity change, so an existing Service is reconciled here
+    // (not skipped): otherwise it kept selecting a stale id, matched zero pods,
+    // had no endpoints, and every connect/read failed ("Resource read failed").
     const identityLabels = sanitizeMetadataLabels({
       app: "mcp-server",
-      "mcp-server-id": this.mcpServer.id,
+      "mcp-server-id": this.getPodSelectorServerId(),
     });
 
     try {
@@ -2950,7 +2971,7 @@ export default class K8sDeployment {
         }
 
         // Check for failures in latest pods
-        const sanitizedId = sanitizeLabelValue(this.mcpServer.id);
+        const sanitizedId = sanitizeLabelValue(this.getPodSelectorServerId());
         const pods = await this.k8sApi.listNamespacedPod({
           namespace: this.namespace,
           labelSelector: `mcp-server-id=${sanitizedId}`,


### PR DESCRIPTION
## Problem

A **multitenant** MCP server's app can fail to load with **"Failed to load app / Resource read failed"** even though the server pod is healthy — the app gateway can't reach it (`ECONNREFUSED` / connect-timeout to the Service ClusterIP) because the **Service has no Endpoints**.

Root cause: for multitenant catalogs, `constructDeploymentName` keys the Deployment/Service **name** on `catalogId`, so **all installs of the catalog share one Deployment + one Service**. But the pod label and the Deployment/Service **selector** were stamped with the **per-install `mcpServer.id`**. So whichever install reconciled the shared resource last overwrote its selector — and the Deployment's pods vs the Service's selector could end up bound to **different installs**:

- Deployment's pods labeled `mcp-server-id: <install A>`
- Service selector `mcp-server-id: <install B>`
- → Service matches 0 pods → 0 Endpoints → every read/connect fails.

Observed in staging: repeated redeploys of a multitenant server left the shared Service selector cycling through distinct install ids (`1e29fc6c → 42c12059 → 653fcc14 → 4be8ba10…`), none matching the running pod — so the app stayed broken across image tags (and rollbacks), and only a manual `kubectl patch svc … selector` restored it.

## Fix

Add `getPodSelectorServerId()`:

```ts
private getPodSelectorServerId(): string {
  if (this.catalogItem?.multitenant && this.mcpServer.catalogId) {
    return this.mcpServer.catalogId;   // catalog-stable → shared by all installs
  }
  return this.mcpServer.id;            // single-tenant → per-install (unchanged)
}
```

It uses the **same condition as `constructDeploymentName`**, so the selector is catalog-stable *exactly when* the resource is catalog-shared. Every install then reconciles the shared Deployment + Service to the **same** selector, which always matches the pods.

Routed through it (the pod-selector identity domain):
- `getSystemLabels()` → Deployment metadata/selector/pod-template labels **and** the network-policy `podSelector`.
- the Service selector (`createServiceForHttpServer`).
- the custom-YAML label path.
- the pod-lookup label selectors (`findPodForDeployment`, `findAnyPodForDeployment`, pod-failure checks).

Left **per-install** (separate identity domain, intentionally unchanged): regcred/secret labels + lookup, and event correlation that matches on the involved-object **name**.

## Relationship to the prior fix
This complements the earlier change that reconciled an *existing* Service's selector instead of skipping it. That stopped a stale Service from being ignored; **this** stops multiple installs of a shared multitenant catalog from fighting over the selector in the first place.

## Migration / rollout
- Forward-only: takes effect on each server's next reconcile/redeploy. A multitenant Deployment's selector is immutable, so the reconcile deletes+recreates it with the catalog-stable selector, and the Service is patched to match.
- Single-tenant servers are unaffected (identical labels/selector as before).

## Tests
- New: multitenant → selector + pod labels use the catalog id; single-tenant → per-install id.
- `vitest src/k8s/mcp-server-runtime/`: **283 pass**. `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>