### PR TITLE
fix(frontend): Apps sidebar badge says Beta instead of New

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -83,6 +83,8 @@ interface NavItem {
   onClick?: () => void;
   subItems?: NavSubItem[];
   beta?: boolean;
+  /** Chip label shown when `beta` is set; defaults to "New". */
+  badgeLabel?: string;
 }
 
 interface NavGroup {
@@ -115,6 +117,7 @@ const chatsNavItems: NavItem[] = [
     icon: AppWindow,
     customIsActive: (pathname: string) => pathname === "/apps",
     beta: true,
+    badgeLabel: "Beta",
   },
   {
     title: "Connect",
@@ -386,7 +389,7 @@ const NavPrimary = ({
               variant="secondary"
               className="ml-auto px-1.5 py-0 text-[10px] group-data-[collapsible=icon]:hidden"
             >
-              New
+              {item.badgeLabel ?? "New"}
             </Badge>
           )}
         </SidebarPrefetchLink>


### PR DESCRIPTION
## Summary
- The "Apps" item in the main navigation sidebar now shows a **Beta** chip instead of **New**. Projects, Connect, and Skills keep their "New" chip.
- Implemented by adding an optional `badgeLabel` to `NavItem` (defaults to `"New"`), so the existing chip styling is reused rather than duplicated.

## Checks
- `biome ci .` from `platform/frontend` — clean
- `pnpm type-check` in `platform/frontend` — clean
- `vitest run sidebar` — 4 files / 33 tests passed
- No e2e or component test selectors reference the badge text

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>