### PR TITLE
ci: back github-cache with useblacksmith/cache so warmed caches survive CodeQL's eviction pressure

### DIFF
--- a/.github/actions/github-cache/action.yml
+++ b/.github/actions/github-cache/action.yml
@@ -1,5 +1,13 @@
 name: GitHub Cache
-description: Wrapper around actions/cache pinned to a vetted version.
+# Backed by useblacksmith/cache (a drop-in for actions/cache) rather than
+# actions/cache. GitHub's Actions cache has a ~10 GB per-repo LRU budget, and
+# CodeQL default setup churns ~11 GB of per-commit overlay-database caches into
+# it, evicting these entries (e2e image tarballs, Playwright browsers) within
+# minutes of them being written. Blacksmith's cache is a separate, larger
+# backend not subject to that budget, so warmed caches actually survive to the
+# hot path. All consumers run on blacksmith-* runners, which this backend
+# requires. Interface (inputs/outputs) is identical to actions/cache.
+description: Wrapper around useblacksmith/cache pinned to a vetted version.
 inputs:
   path:
     description: Files, directories, and wildcard patterns to cache.
@@ -24,7 +32,7 @@ runs:
   steps:
     - name: Cache
       id: cache
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.0.2
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}


### PR DESCRIPTION
## Why

While speeding up e2e on the merge queue, we kept seeing `Cache not found for input keys: mcp-jwks-server-0.0.3-X64` (and the other e2e image tarballs) on merge-queue runs — even though `warm-e2e-image-caches` was succeeding and saving them from `main`.

Root cause is **not** the warm workflow. It's cache eviction:

- GitHub's Actions cache has a **~10 GB per-repo LRU budget**.
- CodeQL **default setup** (7 languages, runs on every push/PR) writes a fresh **~515 MB per-commit "overlay database" cache** on each analysis. These are keyed per-SHA and never reused.
- In a busy merge queue that's **~11 GB/day of unique caches** — the repo is already **over** the 10 GB limit from CodeQL alone (measured: 11.17 GB total, 63 × codeql-overlay caches = 11.10 GB, **zero** `mcp-*`/`kindest` caches surviving).
- So LRU evicts the warmed e2e image tarballs (and the Playwright browser cache) within **minutes** of them being written.

Net effect: warmed caches were gone by the time consumers restored them → cache miss → fresh `docker pull` (~60–80s/shard), the exact cost the warm workflow exists to eliminate. It also explains the `Cache hit for: X` immediately followed by `Failed to restore: Cache not found` — the entry was evicted between lookup and download.

## What

Swap the single backing action inside the `github-cache` composite from `actions/cache` to **`useblacksmith/cache`** — a drop-in with an identical input/output interface. Blacksmith's cache is a **separate, larger backend** not subject to GitHub's 10 GB budget or CodeQL's churn, so warmed caches actually survive to the hot path. As a bonus it frees GitHub's budget for CodeQL.

## Safety

- Every consumer of `github-cache` already runs on `blacksmith-*` runners (which this backend requires):
  - `warm-e2e-image-caches.yml` — `blacksmith-2vcpu`
  - `platform-e2e-tests` → `setup-archestra-platform` + `install-kind-cluster` — `blacksmith-16vcpu`
  - `on-pull-requests` → `frontend-integration-tests` Playwright cache — `blacksmith-4vcpu`
- `useblacksmith/*` actions are already used and trusted in this repo (`setup-docker-builder`, `build-push-action`).
- Pinned to a commit SHA (`v5.0.2`), satisfying the repo's `sha_pinning_required` policy.

## Not in this PR (follow-up worth considering)

The underlying CodeQL bloat is still there — default setup lists `javascript`, `typescript`, **and** the combined `javascript-typescript` (the last already covers both, so two are redundant). Trimming those and/or disabling overlay-database caching would cut the CodeQL footprint at the source, but that's a separate change to the code-scanning config.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>