### PR TITLE
fix(platform): close tool-exclusion enforcement gaps in All mode

### DIFF
--- a/platform/backend/src/archestra-mcp-server/run-tool.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.ts
@@ -12,11 +12,8 @@ import {
   policyBlockToToolError,
 } from "@/guardrails/tool-invocation";
 import logger from "@/logging";
-import { ConversationEnabledToolModel, ToolModel } from "@/models";
-import {
-  agentToolExclusionsService,
-  isToolRowExcluded,
-} from "@/services/agent-tool-exclusions";
+import { ConversationEnabledToolModel } from "@/models";
+import { agentToolExclusionsService } from "@/services/agent-tool-exclusions";
 import { agentOwner, type Tool } from "@/types";
 import { archestraMcpBranding } from "./branding";
 import { isToolEnabledForConversation } from "./conversation-tool-filter";
@@ -200,11 +197,8 @@ async function visibleCandidates(params: {
   // Per-agent exclusions (Auto-tool mode): an excluded tool must not be
   // recovered from a short name, nor disclosed as a "did you mean" candidate.
   // Loaded once and applied to the assigned + discoverable contributions.
-  const exclusionSets =
-    await agentToolExclusionsService.getActiveExclusionSets(agentId);
-  const assigned = (await ToolModel.getMcpToolsByAgent(agentId)).filter(
-    (tool) => !isToolRowExcluded(tool, exclusionSets),
-  );
+  const { tools: assigned, exclusionSets } =
+    await agentToolExclusionsService.getFilteredMcpToolsByAgent(agentId);
   const names = assigned.map((tool) => tool.name);
   if (await dynamicAccessContext(accessParams)) {
     const discoverable = await getUnassignedDiscoverableTools({
@@ -350,12 +344,10 @@ async function dispatchTool({
   // Per-agent exclusions (Auto-tool mode, loaded once per dispatch): an
   // assigned-but-excluded tool drops out of the assigned set here and the
   // dynamic fallback refuses it too, so it resolves to "unavailable".
-  const exclusionSets = await agentToolExclusionsService.getActiveExclusionSets(
-    context.agentId,
-  );
-  const assignedTools = (
-    await ToolModel.getMcpToolsByAgent(context.agentId)
-  ).filter((tool) => !isToolRowExcluded(tool, exclusionSets));
+  const { tools: assignedTools, exclusionSets } =
+    await agentToolExclusionsService.getFilteredMcpToolsByAgent(
+      context.agentId,
+    );
   const assignedToolNames = new Set(assignedTools.map((tool) => tool.name));
   let availableTool: Tool | null = null;
   if (!assignedToolNames.has(resolvedName)) {

--- a/platform/backend/src/archestra-mcp-server/search-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/search-tools.ts
@@ -13,12 +13,8 @@ import {
   ConversationEnabledToolModel,
   InternalMcpCatalogModel,
   McpServerModel,
-  ToolModel,
 } from "@/models";
-import {
-  agentToolExclusionsService,
-  isToolRowExcluded,
-} from "@/services/agent-tool-exclusions";
+import { agentToolExclusionsService } from "@/services/agent-tool-exclusions";
 import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import { archestraMcpBranding } from "./branding";
 import { isToolEnabledForConversation } from "./conversation-tool-filter";
@@ -325,11 +321,8 @@ async function getSearchableTools(params: {
   // Per-agent exclusions (Auto-tool mode): loaded once per search and applied
   // to BOTH the assigned contribution and the discoverable widening below.
   // Empty (no-op) unless the agent's accessAllTools setting is on.
-  const exclusionSets =
-    await agentToolExclusionsService.getActiveExclusionSets(agentId);
-  const assignedTools = (await ToolModel.getMcpToolsByAgent(agentId)).filter(
-    (tool) => !isToolRowExcluded(tool, exclusionSets),
-  );
+  const { tools: assignedTools, exclusionSets } =
+    await agentToolExclusionsService.getFilteredMcpToolsByAgent(agentId);
   const assignedNames = new Set(assignedTools.map((tool) => tool.name));
   // Dynamic tool access: when the agent's "access all tools" setting is on,
   // discovery also spans third-party tools from every catalog the user can

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -35,10 +35,7 @@ import {
   ToolModel,
   UserTokenModel,
 } from "@/models";
-import {
-  agentToolExclusionsService,
-  isToolRowExcluded,
-} from "@/services/agent-tool-exclusions";
+import { agentToolExclusionsService } from "@/services/agent-tool-exclusions";
 import { resolveSessionExternalIdpToken } from "@/services/identity-providers/session-token";
 import type { ClientCapabilitiesWithExtensions } from "@/types/mcp-capabilities";
 import { buildMcpClientInfo } from "@/utils/mcp-client-info";
@@ -1071,15 +1068,10 @@ export async function getChatMcpToolUiResourceUris(
     // Per-agent exclusions (Auto-tool mode): an excluded tool must not emit a
     // UI hint that would mount its app iframe. Empty (no-op) unless the
     // agent's accessAllTools setting is on.
-    const [tools, exclusionSets] = await Promise.all([
-      ToolModel.getMcpToolsByAgent(agentId),
-      agentToolExclusionsService.getActiveExclusionSets(agentId),
-    ]);
+    const { tools } =
+      await agentToolExclusionsService.getFilteredMcpToolsByAgent(agentId);
     const result: Record<string, string> = {};
     for (const tool of tools) {
-      if (isToolRowExcluded(tool, exclusionSets)) {
-        continue;
-      }
       const uriFromMeta = (
         tool.meta as { _meta?: { ui?: McpUiToolMeta } } | undefined
       )?._meta?.ui?.resourceUri;

--- a/platform/backend/src/clients/mcp-client.tool-exclusions.test.ts
+++ b/platform/backend/src/clients/mcp-client.tool-exclusions.test.ts
@@ -172,6 +172,54 @@ describe("McpClient Auto-tool-mode exclusions", () => {
     expect(mockConnect).not.toHaveBeenCalled();
   });
 
+  test("an excluded assigned tool yields precedence to a non-excluded same-named tool from another catalog", async () => {
+    // Tool names are unique only per catalog. Catalog B has an identically
+    // named tool the agent can reach dynamically; only catalog A's ASSIGNED
+    // copy is excluded.
+    const secretB = await secretManager().createSecret(
+      { access_token: "mirror-token" },
+      "mirrortoken",
+    );
+    const catalogB = await InternalMcpCatalogModel.create({
+      name: "github-mirror",
+      serverType: "remote",
+      serverUrl: "https://mirror.example/mcp/",
+    });
+    await McpServerModel.create({
+      name: "github-mirror",
+      secretId: secretB.id,
+      catalogId: catalogB.id,
+      serverType: "remote",
+    });
+    const toolB = await ToolModel.createToolIfNotExists({
+      name: TOOL_NAME,
+      description: "List repos (mirror)",
+      parameters: {},
+      catalogId: catalogB.id,
+    });
+
+    await agentToolExclusionsService.replaceExclusions({
+      agentId,
+      organizationId,
+      excludedToolIds: [toolId],
+    });
+
+    // The dispatcher resolved catalog B's non-excluded row (search_tools /
+    // run_tool advertise it). Execution must resolve to that row instead of
+    // letting the excluded catalog-A assignment hijack the name and refuse the
+    // call as "unavailable" — the resolved row moves on to credential
+    // resolution (which fails here for lack of a token, a DIFFERENT error).
+    const result = await mcpClient.executeToolCallForOwner(
+      { id: "call_cross", name: TOOL_NAME, arguments: {} },
+      agentOwner(agentId),
+      undefined,
+      { availableTool: toolB as any },
+    );
+    expect(JSON.stringify(result.content)).not.toContain(
+      "is available to this agent",
+    );
+  });
+
   test("exclusions are inert when accessAllTools is off (Custom mode untouched)", async () => {
     await agentToolExclusionsService.replaceExclusions({
       agentId,

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1297,6 +1297,40 @@ class McpClient {
 
     let tool: McpToolAssignment | undefined = mcpTools[0];
 
+    const accessAllTools =
+      owner.type === "agent" && (await AgentModel.getAccessAllTools(owner.id));
+
+    // Per-agent exclusions (Auto-tool mode). Loaded once here and reused for
+    // both the precedence resolution just below and the final execution gate
+    // further down, so a single dispatch never queries them twice.
+    const exclusionSets = accessAllTools
+      ? await agentToolExclusionsService.getExclusionSets(owner.id)
+      : null;
+
+    // Assigned rows normally keep precedence over the dispatcher's
+    // dynamically-resolved row. But tool names are unique only per catalog, so a
+    // name can back an assigned row in one catalog AND a discoverable row in
+    // another. When the assigned row is EXCLUDED while the dispatcher resolved a
+    // non-excluded same-named row, letting the assigned row win would refuse a
+    // tool search_tools/run_tool just advertised. Drop the excluded assigned row
+    // so the dynamic row below takes over.
+    if (
+      tool &&
+      exclusionSets &&
+      availableTool &&
+      availableTool.name === toolCall.name &&
+      isToolIdentityExcluded(
+        { catalogId: tool.catalogId, name: tool.toolName },
+        exclusionSets,
+      ) &&
+      !isToolIdentityExcluded(
+        { catalogId: availableTool.catalogId, name: availableTool.name },
+        exclusionSets,
+      )
+    ) {
+      tool = undefined;
+    }
+
     // Dynamic tool access ("All tools" mode): the dispatcher pre-resolved a
     // tool the agent has no assignment row for. Shape it like an assignment so
     // downstream resolution is identical. It has no row to inherit a credential
@@ -1335,42 +1369,35 @@ class McpClient {
       };
     }
 
-    const accessAllTools =
-      owner.type === "agent" && (await AgentModel.getAccessAllTools(owner.id));
-
     // Per-agent exclusions (Auto-tool mode) — the deep execution gate backing
     // every dispatch path (gateway tools/call, run_tool, and chat's CACHED
     // AI-SDK tool wrappers, which execute here without re-entering the gateway
     // handler). Checked by resolved tool identity, after suffix recovery and
     // dynamic-dispatch resolution, so no alias can bypass it. Excluded tools
     // surface as unavailable, matching the discovery-side refusals.
-    if (accessAllTools) {
-      const exclusionSets = await agentToolExclusionsService.getExclusionSets(
-        owner.id,
-      );
-      if (
-        isToolIdentityExcluded(
-          { catalogId: tool.catalogId, name: tool.toolName },
-          exclusionSets,
-        )
-      ) {
-        const message = unavailableThirdPartyToolMessage(toolCall.name);
-        return {
-          error: await this.createErrorResult(
-            toolCall,
-            owner,
+    if (
+      exclusionSets &&
+      isToolIdentityExcluded(
+        { catalogId: tool.catalogId, name: tool.toolName },
+        exclusionSets,
+      )
+    ) {
+      const message = unavailableThirdPartyToolMessage(toolCall.name);
+      return {
+        error: await this.createErrorResult(
+          toolCall,
+          owner,
+          message,
+          tool.catalogName || "unknown",
+          undefined,
+          {
+            type: "tool_state",
+            code: "unknown_tool",
             message,
-            tool.catalogName || "unknown",
-            undefined,
-            {
-              type: "tool_state",
-              code: "unknown_tool",
-              message,
-              toolName: toolCall.name,
-            },
-          ),
-        };
-      }
+            toolName: toolCall.name,
+          },
+        ),
+      };
     }
 
     // "All tools" mode overrides a leftover per-tool credential pin. When the
@@ -3700,12 +3727,11 @@ class McpClient {
     // excluded tools' resource URIs). Callers pass the sets they already
     // loaded; loaded here otherwise. Empty (no-op) unless the agent's
     // accessAllTools setting is on.
-    const effectiveExclusions =
-      exclusionSets ??
-      (await agentToolExclusionsService.getActiveExclusionSets(agentId));
-    const tools = (await ToolModel.getMcpToolsByAgent(agentId)).filter(
-      (tool) => !isToolRowExcluded(tool, effectiveExclusions),
-    );
+    const { tools, exclusionSets: effectiveExclusions } =
+      await agentToolExclusionsService.getFilteredMcpToolsByAgent(
+        agentId,
+        exclusionSets,
+      );
     const assignedTools = await ToolModel.getMcpToolsAssignedToAgent(
       tools.map((tool) => tool.name),
       agentId,

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -341,6 +341,15 @@ class AgentModel {
        * itself so those assignments are not pre-excluded.
        */
       skipExclusionPrefill?: boolean;
+      /**
+       * Skip auto-assigning the creation-default built-in tool set. Used by
+       * clone and import, which set their own authoritative assignment set
+       * right after create (a verbatim copy of the source agent, or the import
+       * payload's tools). Without this, the additive default assignment would
+       * force built-ins the source/payload deliberately lacked (e.g. todo_write)
+       * onto the new agent.
+       */
+      skipCreationDefaultTools?: boolean;
     },
   ): Promise<Agent> {
     // Auto-assign organizationId if not provided
@@ -422,37 +431,43 @@ class AgentModel {
     // Auto-assign the creation-default built-in tool set. Which groups apply
     // is composed by the shared getCreationDefaultArchestraToolShortNames from
     // the same flags the frontend create form reads, so the pre-selected set
-    // in the form and the server-side assignment cannot drift.
-    const organization = await OrganizationModel.getById(organizationId);
-    const creationDefaultShortNames = new Set<ArchestraToolShortName>(
-      getCreationDefaultArchestraToolShortNames({
-        skillsEnabled: organization?.skillToolsEnabled === true,
-        sandboxEnabled: config.skillsSandbox.enabled,
-      }),
-    );
-    const composesGroup = (group: readonly ArchestraToolShortName[]) =>
-      group.every((shortName) => creationDefaultShortNames.has(shortName));
-
-    // Always-on defaults (todo_write, query_knowledge_sources).
-    await ToolModel.assignDefaultArchestraToolsToAgent(createdAgent.id);
-
-    // Agent Skill tools — org opted in via the "Enable and create a new
-    // skill" empty-state action.
-    if (composesGroup(SKILL_ARCHESTRA_TOOL_SHORT_NAMES)) {
-      await ToolModel.assignSkillToolsToAgent(createdAgent.id, organizationId);
-    }
-
-    // MCP App management tools — always on, so new agents can build and use
-    // apps without per-agent setup.
-    await ToolModel.assignAppToolsToAgent(createdAgent.id, organizationId);
-
-    // Code-execution sandbox + persistent-files tools — gated on the sandbox
-    // runtime flag, same as the composer.
-    if (composesGroup(SANDBOX_RUNTIME_ARCHESTRA_TOOL_SHORT_NAMES)) {
-      await ToolModel.assignSandboxToolsToAgent(
-        createdAgent.id,
-        organizationId,
+    // in the form and the server-side assignment cannot drift. Skipped by
+    // clone/import, which install their own authoritative assignment set.
+    if (!options?.skipCreationDefaultTools) {
+      const organization = await OrganizationModel.getById(organizationId);
+      const creationDefaultShortNames = new Set<ArchestraToolShortName>(
+        getCreationDefaultArchestraToolShortNames({
+          skillsEnabled: organization?.skillToolsEnabled === true,
+          sandboxEnabled: config.skillsSandbox.enabled,
+        }),
       );
+      const composesGroup = (group: readonly ArchestraToolShortName[]) =>
+        group.every((shortName) => creationDefaultShortNames.has(shortName));
+
+      // Always-on defaults (todo_write, query_knowledge_sources).
+      await ToolModel.assignDefaultArchestraToolsToAgent(createdAgent.id);
+
+      // Agent Skill tools — org opted in via the "Enable and create a new
+      // skill" empty-state action.
+      if (composesGroup(SKILL_ARCHESTRA_TOOL_SHORT_NAMES)) {
+        await ToolModel.assignSkillToolsToAgent(
+          createdAgent.id,
+          organizationId,
+        );
+      }
+
+      // MCP App management tools — always on, so new agents can build and use
+      // apps without per-agent setup.
+      await ToolModel.assignAppToolsToAgent(createdAgent.id, organizationId);
+
+      // Code-execution sandbox + persistent-files tools — gated on the sandbox
+      // runtime flag, same as the composer.
+      if (composesGroup(SANDBOX_RUNTIME_ARCHESTRA_TOOL_SHORT_NAMES)) {
+        await ToolModel.assignSandboxToolsToAgent(
+          createdAgent.id,
+          organizationId,
+        );
+      }
     }
 
     // Flip All-tools mode on last, atomically with the exclusion pre-fill.
@@ -2772,6 +2787,9 @@ class AgentModel {
           passthroughHeaders: null,
         },
         sourceAgent.scope === "personal" ? userId : undefined,
+        // Copy the source's assignments verbatim below; don't let create's
+        // default assignment force built-ins the source lacked onto the clone.
+        { skipCreationDefaultTools: true },
       );
 
       await AgentToolModel.cloneAssignments({

--- a/platform/backend/src/routes/agent.clone.test.ts
+++ b/platform/backend/src/routes/agent.clone.test.ts
@@ -1,4 +1,7 @@
-import { BUILT_IN_AGENT_IDS } from "@archestra/shared";
+import {
+  BUILT_IN_AGENT_IDS,
+  TOOL_TODO_WRITE_FULL_NAME,
+} from "@archestra/shared";
 import { eq } from "drizzle-orm";
 import { type Mock, vi } from "vitest";
 import {
@@ -153,6 +156,54 @@ describe("clone agent route", () => {
         },
       ]),
     );
+  });
+
+  test("does not force-assign creation-default built-ins the source agent lacked", async ({
+    makeInternalAgent,
+    makeTool,
+    makeAgentTool,
+    makeAgent,
+    seedAndAssignArchestraTools,
+  }) => {
+    // Source is created before the built-ins are seeded, so its own create
+    // can't auto-assign todo_write — it genuinely lacks it.
+    const baseTool = await makeTool({ name: "tool-a" });
+    const sourceAgent = await makeInternalAgent({
+      organizationId,
+      name: "Source Agent",
+      scope: "org",
+      teams: [],
+      labels: [],
+    });
+    await makeAgentTool(sourceAgent.id, baseTool.id, {
+      credentialResolutionMode: "dynamic",
+    });
+
+    // Seed the built-in rows now, so the clone's create COULD force-assign
+    // todo_write (the pre-fix behavior) — the fix must skip that.
+    const seedHost = await makeAgent({ organizationId });
+    await seedAndAssignArchestraTools(seedHost.id);
+    const todoWrite = await ToolModel.findByName(TOOL_TODO_WRITE_FULL_NAME);
+    if (!todoWrite) throw new Error("todo_write not seeded");
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/agents/${sourceAgent.id}/clone`,
+    });
+    expect(response.statusCode).toBe(200);
+    const cloned = response.json() as Agent;
+
+    const clonedToolIds = (
+      await db
+        .select({ toolId: schema.agentToolsTable.toolId })
+        .from(schema.agentToolsTable)
+        .where(eq(schema.agentToolsTable.agentId, cloned.id))
+    ).map((row) => row.toolId);
+
+    // The clone is an exact copy of the source's assignments — the always-on
+    // default todo_write is NOT force-added.
+    expect(clonedToolIds).toContain(baseTool.id);
+    expect(clonedToolIds).not.toContain(todoWrite.id);
   });
 
   test("cannot clone built-in agents", async ({ makeInternalAgent }) => {

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -220,11 +220,8 @@ export async function createAgentServer(
     // filter runs BEFORE filterExposedTools, so an excluded always-exposed
     // built-in is dropped here and never re-admitted below. Empty (no-op)
     // unless the agent's accessAllTools setting is on.
-    const exclusionSets =
-      await agentToolExclusionsService.getActiveExclusionSets(agentId);
-    const mcpTools = (await ToolModel.getMcpToolsByAgent(agentId)).filter(
-      (tool) => !isToolRowExcluded(tool, exclusionSets),
-    );
+    const { tools: mcpTools, exclusionSets } =
+      await agentToolExclusionsService.getFilteredMcpToolsByAgent(agentId);
 
     // An all-tools agent reaches unassigned tools dynamically (search_tools /
     // run_tool already resolve them without an agent_tools row). A UI-providing

--- a/platform/backend/src/services/agent-import.ts
+++ b/platform/backend/src/services/agent-import.ts
@@ -122,6 +122,10 @@ export async function importAgentFromPayload(
       suggestedPrompts: data.suggestedPrompts,
     },
     userId,
+    // The payload's tools (step 8) are the imported agent's authoritative
+    // assignment set; don't let create's default assignment force built-ins the
+    // payload lacked onto the imported agent.
+    { skipCreationDefaultTools: true },
   );
 
   // 8. Resolve and assign tools (after agent creation)

--- a/platform/backend/src/services/agent-tool-exclusions.test.ts
+++ b/platform/backend/src/services/agent-tool-exclusions.test.ts
@@ -1,13 +1,17 @@
 import {
+  ARCHESTRA_MCP_CATALOG_ID,
+  getArchestraToolFullName,
   TOOL_LIST_SKILLS_FULL_NAME,
   TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME,
   TOOL_RUN_COMMAND_FULL_NAME,
   TOOL_RUN_TOOL_FULL_NAME,
   TOOL_SEARCH_TOOLS_FULL_NAME,
   TOOL_WHOAMI_FULL_NAME,
+  TOOL_WHOAMI_SHORT_NAME,
 } from "@archestra/shared";
 import { eq } from "drizzle-orm";
 import { vi } from "vitest";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { clearChatMcpClient } from "@/clients/chat-mcp-client";
 import db, { schema } from "@/database";
 import { AgentExcludedToolModel, ToolModel } from "@/models";
@@ -315,6 +319,61 @@ describe("agentToolExclusionsService", () => {
           sets,
         ),
       ).toBe(false);
+    });
+
+    test("Archestra built-in exclusions match by short name, so the default alias can't bypass a branded exclusion", async ({
+      makeInternalMcpCatalog,
+      makeTool,
+    }) => {
+      // White-labeled deployment: the built-in row stores a branded name, but
+      // dispatch (run_tool / the gateway) reaches the same tool by the default
+      // `archestra__` alias. Both must resolve to the same short-name key.
+      const brandedName = "acme__whoami";
+      const defaultAliasName = getArchestraToolFullName(TOOL_WHOAMI_SHORT_NAME);
+      expect(brandedName).not.toBe(defaultAliasName);
+      const shortNameSpy = vi
+        .spyOn(archestraMcpBranding, "getToolShortName")
+        .mockImplementation((name: string) =>
+          name === brandedName || name === defaultAliasName
+            ? TOOL_WHOAMI_SHORT_NAME
+            : null,
+        );
+      try {
+        await makeInternalMcpCatalog({
+          id: ARCHESTRA_MCP_CATALOG_ID,
+          organizationId,
+        });
+        const branded = await makeTool({
+          name: brandedName,
+          catalogId: ARCHESTRA_MCP_CATALOG_ID,
+        });
+        await agentToolExclusionsService.replaceExclusions({
+          agentId: agent.id,
+          organizationId,
+          excludedToolIds: [branded.id],
+        });
+
+        const sets = await agentToolExclusionsService.getExclusionSets(
+          agent.id,
+        );
+        // Matched under the branded name the row stores...
+        expect(
+          isToolIdentityExcluded(
+            { catalogId: ARCHESTRA_MCP_CATALOG_ID, name: brandedName },
+            sets,
+          ),
+        ).toBe(true);
+        // ...and under the default-prefix alias run_tool / the gateway resolve
+        // to, which must NOT bypass the exclusion on a white-labeled deployment.
+        expect(
+          isToolIdentityExcluded(
+            { catalogId: ARCHESTRA_MCP_CATALOG_ID, name: defaultAliasName },
+            sets,
+          ),
+        ).toBe(true);
+      } finally {
+        shortNameSpy.mockRestore();
+      }
     });
 
     test("getActiveExclusionSets is empty when accessAllTools is off", async ({

--- a/platform/backend/src/services/agent-tool-exclusions.ts
+++ b/platform/backend/src/services/agent-tool-exclusions.ts
@@ -13,7 +13,7 @@ import {
   InternalMcpCatalogModel,
   ToolModel,
 } from "@/models";
-import { type AgentToolExclusions, ApiError } from "@/types";
+import { type AgentToolExclusions, ApiError, type Tool } from "@/types";
 
 /**
  * Per-agent tool exclusions for Auto-tool mode ("access all tools").
@@ -170,6 +170,29 @@ class AgentToolExclusionsService {
     return this.getExclusionSets(agentId);
   }
 
+  /**
+   * The agent's assigned MCP tools with excluded rows removed, plus the
+   * exclusion sets used to filter them. The single chokepoint every dispatch
+   * surface (gateway tools/list, search_tools, run_tool, resource client
+   * resolution, chat UI hints) shares, so the fetch-then-filter pairing lives in
+   * one place and a future enforcement change lands everywhere at once. Callers
+   * that already loaded the sets pass them in to skip the re-query; the two
+   * queries run in parallel otherwise.
+   */
+  async getFilteredMcpToolsByAgent(
+    agentId: string,
+    preloadedExclusionSets?: AgentToolExclusionSets,
+  ): Promise<{ tools: Tool[]; exclusionSets: AgentToolExclusionSets }> {
+    const [rows, exclusionSets] = await Promise.all([
+      ToolModel.getMcpToolsByAgent(agentId),
+      preloadedExclusionSets ?? this.getActiveExclusionSets(agentId),
+    ]);
+    return {
+      tools: rows.filter((tool) => !isToolRowExcluded(tool, exclusionSets)),
+      exclusionSets,
+    };
+  }
+
   // === Private validation helpers ===
 
   private async validateToolIds(
@@ -242,8 +265,23 @@ export const agentToolExclusionsService = new AgentToolExclusionsService();
 
 // === Internal helpers ===
 
+/**
+ * Dispatch-identity key for an exclusion match. Archestra built-in rows are
+ * keyed by SHORT name, not the stored row name: on a white-labeled deployment
+ * the row carries a branded prefix (`acme__list_agents`), but dispatch reaches
+ * the same tool by its short name (`run_tool`) or the default alias
+ * (`archestra__list_agents`) too. Normalizing both the build side
+ * (getExclusionSets) and every check side (isToolIdentityExcluded) through this
+ * one helper keeps the branded row, the branded call, and the default-alias
+ * call all matching the same key. Third-party rows are keyed by name verbatim
+ * (their names carry no branding alias).
+ */
 function toolKey(catalogId: string, name: string): string {
-  return `${catalogId}:${name}`;
+  const identityName =
+    catalogId === ARCHESTRA_MCP_CATALOG_ID
+      ? (archestraMcpBranding.getToolShortName(name) ?? name)
+      : name;
+  return `${catalogId}:${identityName}`;
 }
 
 /**

--- a/platform/backend/src/skills/skill-sandbox-availability.test.ts
+++ b/platform/backend/src/skills/skill-sandbox-availability.test.ts
@@ -1,4 +1,7 @@
+import { TOOL_RUN_COMMAND_FULL_NAME } from "@archestra/shared";
 import config from "@/config";
+import { ToolModel } from "@/models";
+import { agentToolExclusionsService } from "@/services/agent-tool-exclusions";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { isSkillSandboxAvailableForAgent } from "./skill-sandbox-availability";
 
@@ -94,6 +97,46 @@ describe("isSkillSandboxAvailableForAgent", () => {
         agentId: agent.id,
       }),
     ).toBe(true);
+  });
+
+  test("false for accessAllTools when a sandbox tool is excluded", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeCustomRole,
+    makeAgent,
+    seedAndAssignArchestraTools,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const role = await makeCustomRole(org.id, {
+      permission: { sandbox: ["execute"] },
+    });
+    await makeMember(user.id, org.id, { role: role.role });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      name: "Access-all Agent",
+      accessAllTools: true,
+    });
+    // Seed the built-in tool rows so run_command has an id to exclude.
+    await seedAndAssignArchestraTools(agent.id);
+    const runCommand = await ToolModel.findByName(TOOL_RUN_COMMAND_FULL_NAME);
+    if (!runCommand) throw new Error("run_command tool not seeded");
+    await agentToolExclusionsService.replaceExclusions({
+      agentId: agent.id,
+      organizationId: org.id,
+      excludedToolIds: [runCommand.id],
+    });
+
+    // Dynamic access is on, but excluding a sandbox tool means dispatch would
+    // refuse it — so the sandbox must not be advertised as available.
+    expect(
+      await isSkillSandboxAvailableForAgent({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+      }),
+    ).toBe(false);
   });
 
   test("false for accessAllTools without sandbox:execute", async ({

--- a/platform/backend/src/skills/skill-sandbox-availability.ts
+++ b/platform/backend/src/skills/skill-sandbox-availability.ts
@@ -1,4 +1,5 @@
 import {
+  ARCHESTRA_MCP_CATALOG_ID,
   type ArchestraToolShortName,
   TOOL_DOWNLOAD_FILE_SHORT_NAME,
   TOOL_RUN_COMMAND_SHORT_NAME,
@@ -9,6 +10,10 @@ import { dynamicAccessContext } from "@/archestra-mcp-server/dynamic-tools";
 import { userHasPermission } from "@/auth/utils";
 import config from "@/config";
 import { ToolModel } from "@/models";
+import {
+  agentToolExclusionsService,
+  isToolIdentityExcluded,
+} from "@/services/agent-tool-exclusions";
 
 /**
  * Whether the code execution sandbox is genuinely usable for a given agent:
@@ -42,25 +47,45 @@ export async function isSkillSandboxAvailableForAgent(params: {
   );
   if (!allowed) return false;
 
-  // `accessAllTools` agents run the sandbox tools via dynamic dispatch without a
-  // manual assignment; `dynamicAccessContext` is the canonical gate for that
-  // path (real authenticated user, agent opt-in), so reuse it rather than
-  // re-deriving the rule here.
-  const dynamicAccess = await dynamicAccessContext({
-    agentId: params.agentId,
-    userId: params.userId,
-    organizationId: params.organizationId,
-  });
-  if (dynamicAccess) return true;
-
-  const assigned = new Set(
-    (await ToolModel.getMcpToolsByAgent(params.agentId)).map((t) => t.name),
-  );
   const required: ArchestraToolShortName[] = [
     TOOL_RUN_COMMAND_SHORT_NAME,
     TOOL_UPLOAD_FILE_SHORT_NAME,
     TOOL_DOWNLOAD_FILE_SHORT_NAME,
   ];
+
+  // `accessAllTools` agents run the sandbox tools via dynamic dispatch without a
+  // manual assignment; `dynamicAccessContext` is the canonical gate for that
+  // path (real authenticated user, agent opt-in), so reuse it rather than
+  // re-deriving the rule here. But a per-agent exclusion revokes the dynamic
+  // relaxation for that tool, so an excluded sandbox tool would be refused at
+  // dispatch. Advertising the sandbox (activation prompt, attachment staging)
+  // while a call it steers the model toward fails strands the model, so require
+  // that none of the sandbox tools are excluded — matching the all-or-nothing
+  // group semantics the assignment branch below already applies.
+  const dynamicAccess = await dynamicAccessContext({
+    agentId: params.agentId,
+    userId: params.userId,
+    organizationId: params.organizationId,
+  });
+  if (dynamicAccess) {
+    const exclusionSets = await agentToolExclusionsService.getExclusionSets(
+      params.agentId,
+    );
+    return required.every(
+      (shortName) =>
+        !isToolIdentityExcluded(
+          {
+            catalogId: ARCHESTRA_MCP_CATALOG_ID,
+            name: archestraMcpBranding.getToolName(shortName),
+          },
+          exclusionSets,
+        ),
+    );
+  }
+
+  const assigned = new Set(
+    (await ToolModel.getMcpToolsByAgent(params.agentId)).map((t) => t.name),
+  );
   return required.every((shortName) =>
     assigned.has(archestraMcpBranding.getToolName(shortName)),
   );

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -687,6 +687,12 @@ export function AgentDialog({
   const [llmModel, setLlmModel] = useState<string | null>(null);
   const [apiKeySelectorOpen, setApiKeySelectorOpen] = useState(false);
   const [selectedToolsCount, setSelectedToolsCount] = useState(0);
+  // The tools editor's live selection (pending edits included), so the
+  // exclusions editor's seed treats a just-checked-but-unsaved built-in as
+  // assigned instead of disabling it.
+  const [pendingSelectedToolIds, setPendingSelectedToolIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const [identityProviderId, setIdentityProviderId] = useState<
     string | null | undefined
   >(undefined);
@@ -1727,6 +1733,7 @@ export function AgentDialog({
                           ref={agentToolExclusionsEditorRef}
                           agentId={agent?.id}
                           seedDefaultExclusions={seedDefaultExclusions}
+                          pendingAssignedToolIds={pendingSelectedToolIds}
                           onStateChange={setExclusionsState}
                         />
                       </div>
@@ -1766,6 +1773,7 @@ export function AgentDialog({
                             assignmentScope={scope}
                             assignmentTeamIds={assignedTeamIds}
                             onSelectedCountChange={setSelectedToolsCount}
+                            onSelectedToolIdsChange={setPendingSelectedToolIds}
                             environmentScopingEnabled={
                               environmentScopingEnabled
                             }

--- a/platform/frontend/src/components/agent-tool-exclusions-editor.tsx
+++ b/platform/frontend/src/components/agent-tool-exclusions-editor.tsx
@@ -83,6 +83,14 @@ interface AgentToolExclusionsEditorProps {
    */
   seedDefaultExclusions?: boolean;
   /**
+   * The tools editor's live selection (pending edits included). When present it
+   * is unioned into the "assigned" set the seeded default mirror reads, so a
+   * built-in the user just checked in the Custom tab — but hasn't saved — is
+   * treated as assigned rather than seeded as disabled. Falls back to the saved
+   * assignments / creation-default set when absent.
+   */
+  pendingAssignedToolIds?: ReadonlySet<string>;
+  /**
    * Reports `{ initial, current }` normalized exclusion payloads for the
    * dialog's unsaved-changes tracking; called with `null` on unmount. Pass a
    * referentially-stable callback (e.g. a `useState` setter).
@@ -108,7 +116,12 @@ export const AgentToolExclusionsEditor = forwardRef<
   AgentToolExclusionsEditorRef,
   AgentToolExclusionsEditorProps
 >(function AgentToolExclusionsEditor(
-  { agentId, seedDefaultExclusions = false, onStateChange },
+  {
+    agentId,
+    seedDefaultExclusions = false,
+    pendingAssignedToolIds,
+    onStateChange,
+  },
   ref,
 ) {
   const { catalogName } = useArchestraMcpIdentity();
@@ -199,10 +212,20 @@ export const AgentToolExclusionsEditor = forwardRef<
   // assignments, or the creation-default set for a new agent) nor exempt.
   const defaultExcludedToolIds = useMemo(() => {
     if (!seedDefaultExclusions) return [];
+    // "Assigned" = the agent's saved assignments UNIONED with the tools editor's
+    // live pending selection, so a built-in the user just checked in the Custom
+    // tab (unsaved) is treated as assigned and not seeded as disabled.
+    const assignedToolIds = new Set<string>([
+      ...(agentId ? assignedTools.map((tool) => tool.id) : []),
+      ...(pendingAssignedToolIds ?? []),
+    ]);
     return computeDefaultExclusionToolIds({
       builtInTools: toolsByCatalog.get(ARCHESTRA_MCP_CATALOG_ID) ?? [],
+      assignedToolIds,
+      // New agent: the backend auto-assigns the creation-default set; protect it
+      // by short name until the live selection reports those tool ids.
       ...(agentId
-        ? { assignedToolIds: new Set(assignedTools.map((tool) => tool.id)) }
+        ? {}
         : {
             assumedAssignedShortNames: new Set(
               getCreationDefaultArchestraToolShortNames({
@@ -217,6 +240,7 @@ export const AgentToolExclusionsEditor = forwardRef<
     toolsByCatalog,
     agentId,
     assignedTools,
+    pendingAssignedToolIds,
     skillToolsEnabled,
     sandboxEnabled,
   ]);

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -395,8 +395,17 @@ const AgentToolsEditorContent = forwardRef<
     return ids;
   }, [catalogItems, assignedToolsByCatalog, pendingVersion]);
 
+  // Report only when the CONTENT changes. The memo's inputs get fresh
+  // identities on every render while the queries are loading (`data = []`
+  // defaults), so keying the parent's setState off the Set's identity would
+  // loop render → new Set → setState → render forever and crash the dialog.
+  const lastReportedSelectionKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    onSelectedToolIdsChange?.(effectiveSelectedToolIds);
+    if (!onSelectedToolIdsChange) return;
+    const key = [...effectiveSelectedToolIds].sort().join(",");
+    if (lastReportedSelectionKeyRef.current === key) return;
+    lastReportedSelectionKeyRef.current = key;
+    onSelectedToolIdsChange(effectiveSelectedToolIds);
   }, [effectiveSelectedToolIds, onSelectedToolIdsChange]);
 
   // Expose saveChanges method to parent

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -101,6 +101,14 @@ interface AgentToolsEditorProps {
   assignmentTeamIds?: string[];
   onSelectedCountChange?: (count: number) => void;
   /**
+   * Reports the effective set of currently-selected tool ids (pending edits
+   * included, server assignments for untouched catalogs). The exclusions editor
+   * uses it so a built-in the user just checked here — but hasn't saved — is
+   * treated as assigned and not seeded as disabled. Pass a referentially-stable
+   * callback (e.g. a `useState` setter).
+   */
+  onSelectedToolIdsChange?: (toolIds: ReadonlySet<string>) => void;
+  /**
    * When true (the agent-environments feature is on), scope the MCP list to
    * `agentEnvironmentId` and report cross-environment selections via
    * `onConflictsChange`. When false, all catalogs are shown and no conflicts
@@ -139,6 +147,7 @@ export const AgentToolsEditor = forwardRef<
     assignmentScope,
     assignmentTeamIds,
     onSelectedCountChange,
+    onSelectedToolIdsChange,
     environmentScopingEnabled,
     agentEnvironmentId,
     agentEnvironmentName,
@@ -155,6 +164,7 @@ export const AgentToolsEditor = forwardRef<
       assignmentScope={assignmentScope}
       assignmentTeamIds={assignmentTeamIds}
       onSelectedCountChange={onSelectedCountChange}
+      onSelectedToolIdsChange={onSelectedToolIdsChange}
       environmentScopingEnabled={environmentScopingEnabled}
       agentEnvironmentId={agentEnvironmentId}
       agentEnvironmentName={agentEnvironmentName}
@@ -176,6 +186,7 @@ const AgentToolsEditorContent = forwardRef<
     assignmentScope,
     assignmentTeamIds,
     onSelectedCountChange,
+    onSelectedToolIdsChange,
     environmentScopingEnabled = false,
     agentEnvironmentId = null,
     agentEnvironmentName,
@@ -365,6 +376,28 @@ const AgentToolsEditorContent = forwardRef<
     },
     [calculateTotalSelectedCount, onSelectedCountChange],
   );
+
+  // Effective current selection across every catalog: the pending edit when the
+  // user has touched a catalog, otherwise its saved assignments. Reported to the
+  // dialog so the exclusions editor's seed reflects unsaved Custom-tab edits.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pendingVersion triggers re-computation when pendingChangesRef updates
+  const effectiveSelectedToolIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const catalog of catalogItems) {
+      const pending = pendingChangesRef.current.get(catalog.id);
+      if (pending) {
+        for (const id of pending.selectedToolIds) ids.add(id);
+      } else {
+        for (const at of assignedToolsByCatalog.get(catalog.id) ?? [])
+          ids.add(at.tool.id);
+      }
+    }
+    return ids;
+  }, [catalogItems, assignedToolsByCatalog, pendingVersion]);
+
+  useEffect(() => {
+    onSelectedToolIdsChange?.(effectiveSelectedToolIds);
+  }, [effectiveSelectedToolIds, onSelectedToolIdsChange]);
 
   // Expose saveChanges method to parent
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
## What

Follow-up to #6318, fixing enforcement gaps found in review:

- **White-label bypass**: exclusion identity keys for Archestra built-ins are normalized to short names, so the default `archestra__` alias can no longer bypass an exclusion on a branded deployment (via `run_tool` or gateway `tools/call`).
- **Sandbox availability**: an All-mode agent with `run_command`/`upload_file`/`download_file` excluded no longer advertises the sandbox (activation prompt, attachment staging) while every sandbox call is refused.
- **Clone/import**: `AgentModel.create` no longer force-assigns the creation-default built-ins to clones and imports — their assignment set is the verbatim source copy / import payload.
- **Exclusions editor**: the seeded default exclusion set now accounts for unsaved tool selections in the same dialog session, so a built-in checked in the Custom tab isn't persisted as disabled after switching to All.
- **Cross-catalog precedence**: at execution, an excluded assigned tool yields to a non-excluded same-named tool from another catalog instead of refusing the call `search_tools` just advertised.
- **Consolidation**: the six copies of load-exclusions-then-filter-assigned-tools now share `agentToolExclusionsService.getFilteredMcpToolsByAgent`.

## Testing

- New backend tests for the white-label key normalization, excluded-sandbox availability, clone default-assignment, and cross-catalog precedence (each verified to fail without its fix).
- `pnpm type-check`, `pnpm lint`, `pnpm knip` clean; affected backend/frontend suites green.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>