### PR TITLE
fix(apps): show the app's own icon for pinned apps in the sidebar

### DIFF
--- a/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
@@ -76,6 +76,7 @@ let mockApps: Array<{
   mcpServerId?: string;
   resourceUri?: string;
   name: string;
+  icon?: string | null;
   pinnedAt: string | null;
 }> = [];
 
@@ -118,6 +119,13 @@ vi.mock("@/lib/app.query", () => ({
 vi.mock("@/components/agent-icon", () => ({
   AgentIcon: ({ icon }: { icon?: string | null }) => (
     <span data-testid="project-emoji">{icon}</span>
+  ),
+}));
+
+// External pinned apps render the backing MCP server's registry icon.
+vi.mock("@/components/mcp-catalog-icon", () => ({
+  McpCatalogIcon: ({ icon }: { icon?: string | null }) => (
+    <span data-testid="app-catalog-icon">{icon}</span>
   ),
 }));
 
@@ -456,6 +464,7 @@ describe("ChatSidebarSection", () => {
         mcpServerId: "server-1",
         resourceUri: "ui://pm/board.html",
         name: "Archestra PM / show_board",
+        icon: "📋",
         pinnedAt: "2026-01-04T00:00:00Z",
       },
       {
@@ -472,6 +481,28 @@ describe("ChatSidebarSection", () => {
     expect(screen.getByText("Sprint Board")).toBeInTheDocument();
     expect(screen.getByText("Archestra PM / show_board")).toBeInTheDocument();
     expect(screen.queryByText("Unpinned App")).not.toBeInTheDocument();
+    // The external app shows its MCP server's registry icon; the owned app
+    // keeps the generic AppWindow glyph (exactly one catalog icon rendered).
+    expect(screen.getByTestId("app-catalog-icon")).toHaveTextContent("📋");
+  });
+
+  it("renders the catalog icon fallback for an external app without an icon", () => {
+    mockApps = [
+      {
+        source: "external",
+        mcpServerId: "server-1",
+        resourceUri: "ui://pm/board.html",
+        name: "Archestra PM / show_board",
+        icon: null,
+        pinnedAt: "2026-01-04T00:00:00Z",
+      },
+    ];
+
+    render(<ChatSidebarSection fadeIn={fadeIn} />);
+
+    // McpCatalogIcon owns the fallback (generic Server glyph); the sidebar
+    // still routes the null icon through it rather than a hardcoded glyph.
+    expect(screen.getByTestId("app-catalog-icon")).toBeEmptyDOMElement();
   });
 
   it("shows a chat's project emoji and name when its project has an emoji", () => {

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -13,7 +13,6 @@ import {
   Pencil,
   Pin,
   PinOff,
-  Server,
   Sparkles,
   Trash2,
   UsersRound,
@@ -25,6 +24,7 @@ import { CreateProjectFromChatDialog } from "@/app/_parts/create-project-from-ch
 import { isScheduledRunConversation } from "@/app/_parts/scheduled-run-sidebar.utils";
 import { AgentIcon } from "@/components/agent-icon";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
+import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { TruncatedText } from "@/components/truncated-text";
 import { Button } from "@/components/ui/button";
 import {
@@ -633,7 +633,6 @@ export function ChatSidebarSection({
         ? `app:${appItem.id}`
         : `app:${appItem.mcpServerId}:${appItem.resourceUri}`;
     const isMenuOpen = openMenuId === menuKey;
-    const AppIcon = appItem.source === "owned" ? AppWindow : Server;
 
     return (
       <SidebarMenuSubItem key={menuKey}>
@@ -643,7 +642,13 @@ export function ChatSidebarSection({
             className="cursor-pointer flex-1 justify-between"
           >
             <span className="flex items-center gap-2 min-w-0 flex-1">
-              <AppIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              {appItem.source === "owned" ? (
+                <AppWindow className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              ) : (
+                // The backing MCP server's registry icon, matching the app's
+                // card on the Apps page (falls back to the Server glyph).
+                <McpCatalogIcon icon={appItem.icon} size={14} />
+              )}
               <TruncatedText
                 message={appItem.name}
                 maxLength={MAX_TITLE_LENGTH}


### PR DESCRIPTION
## Problem

Pinned external MCP-server apps in the main sidebar's Pinned section always rendered a generic `Server` glyph, ignoring the app's `icon` (the backing MCP catalog's registry icon — an emoji or a base64 image data URL). The Apps page card already renders it correctly via `McpCatalogIcon`.

## Fix

`renderAppItem` in `chat-sidebar-section.tsx` now routes external apps through `McpCatalogIcon icon={appItem.icon} size={14}`, matching the card. `McpCatalogIcon` owns the fallback, so apps whose catalog has no icon keep the same generic Server glyph as before. Owned apps keep the `AppWindow` glyph.

## Verification

- `tsc --noEmit`: clean
- `biome ci` (frontend): clean
- `vitest chat-sidebar-section.test.tsx`: 19/19 passed (extended the pinned-apps test with emoji passthrough + null-icon fallback assertions)
- `knip`: clean
- In-browser (MSW-mocked `/api/apps`): owned app shows AppWindow, emoji icon renders, data-URL image icon renders, null icon falls back to the Server glyph

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>