### PR TITLE
fix(embeddings): resolve provider base URL from configured host + stop auditing test-embedding

### DIFF
--- a/platform/backend/src/knowledge-base/kb-llm-client.test.ts
+++ b/platform/backend/src/knowledge-base/kb-llm-client.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/clients/llm-client", () => ({
   createDirectLLMModel: mockCreateDirectLLMModel,
 }));
 
+import config from "@/config";
 import db, { schema } from "@/database";
 import { LlmProviderApiKeyModel, OrganizationModel } from "@/models";
 import { describe, expect, test } from "@/test";
@@ -55,6 +56,33 @@ describe("resolveEmbeddingConfig", () => {
 
     expect(result?.apiKey).toBe("azure-key");
     expect(result?.baseUrl).toBe("https://runtime.example.com/openai");
+  });
+
+  test("falls back to the configured provider base URL when the key has none", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+
+    // A self-hosted Ollama key created with a blank Base URL stores NULL for
+    // both URL columns and needs no secret.
+    const chatApiKey = await LlmProviderApiKeyModel.create({
+      organizationId: org.id,
+      name: "Ollama Key",
+      provider: "ollama",
+      secretId: null,
+      scope: "org",
+      userId: null,
+      teamId: null,
+    });
+
+    // The deployment points Ollama at an in-cluster host, not localhost.
+    config.llm.ollama.baseUrl = "http://ollama:11434/v1";
+
+    const result = await resolveApiKeyFromChatApiKey(chatApiKey.id);
+
+    // Must use the configured host (same source chat/sync use), not the
+    // hardcoded localhost default that previously broke embeddings.
+    expect(result?.baseUrl).toBe("http://ollama:11434/v1");
   });
 
   test("returns config when org has embedding key and model configured", async ({

--- a/platform/backend/src/knowledge-base/kb-llm-client.test.ts
+++ b/platform/backend/src/knowledge-base/kb-llm-client.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/clients/llm-client", () => ({
 import config from "@/config";
 import db, { schema } from "@/database";
 import { LlmProviderApiKeyModel, OrganizationModel } from "@/models";
-import { describe, expect, test } from "@/test";
+import { afterEach, describe, expect, test } from "@/test";
 import {
   getDefaultOrgEmbeddingConfig,
   resolveApiKeyFromChatApiKey,
@@ -32,6 +32,11 @@ async function createSecret(): Promise<string> {
 }
 
 describe("resolveEmbeddingConfig", () => {
+  const originalOllamaBaseUrl = config.llm.ollama.baseUrl;
+  afterEach(() => {
+    config.llm.ollama.baseUrl = originalOllamaBaseUrl;
+  });
+
   test("uses inferenceBaseUrl when resolving a chat API key", async ({
     makeOrganization,
   }) => {

--- a/platform/backend/src/knowledge-base/kb-llm-client.ts
+++ b/platform/backend/src/knowledge-base/kb-llm-client.ts
@@ -3,11 +3,9 @@ import type {
   ModelInputModality,
   SupportedProvider,
 } from "@archestra/shared";
-import {
-  DEFAULT_PROVIDER_BASE_URLS,
-  providerRequiresPerUserCredential,
-} from "@archestra/shared";
+import { providerRequiresPerUserCredential } from "@archestra/shared";
 import { createDirectLLMModel, type LLMModel } from "@/clients/llm-client";
+import { getProviderConfiguredBaseUrl } from "@/config";
 import logger from "@/logging";
 import {
   LlmProviderApiKeyModel,
@@ -145,11 +143,13 @@ export async function resolveApiKeyFromChatApiKey(
   // token belongs to one person. (Copilot also exposes no embeddings.)
   if (providerRequiresPerUserCredential(chatApiKey.provider)) return null;
 
-  // Fall back to the provider's default base URL when none is configured on the key
+  // Fall back to the provider's configured (env-aware) base URL when none is set
+  // on the key — the same source chat and model-sync use, so self-hosted
+  // providers (Ollama/vLLM) resolve the deployment's host, not a hardcoded default.
   const baseUrl =
     chatApiKey.inferenceBaseUrl ||
     chatApiKey.baseUrl ||
-    DEFAULT_PROVIDER_BASE_URLS[chatApiKey.provider] ||
+    getProviderConfiguredBaseUrl(chatApiKey.provider) ||
     null;
 
   // Providers like Ollama don't require an API key — use a placeholder

--- a/platform/backend/src/middleware/audit-log-hook.test.ts
+++ b/platform/backend/src/middleware/audit-log-hook.test.ts
@@ -739,6 +739,17 @@ describe("registerAuditLogHook", () => {
       await settle();
       expect(await getRows()).toHaveLength(0);
     });
+
+    // Read-only embedding connection test — exact denylist entry so a failed
+    // probe never records a misleading "Success" outcome.
+    test("POST /api/organization/knowledge-settings/test-embedding writes zero rows", async () => {
+      await app.inject({
+        method: "POST",
+        url: "/api/organization/knowledge-settings/test-embedding",
+      });
+      await settle();
+      expect(await getRows()).toHaveLength(0);
+    });
   });
 
   describe("denylist — /api/chatops/* must not be swallowed by /api/chat exact entry", () => {

--- a/platform/backend/src/middleware/audit-log-hook.ts
+++ b/platform/backend/src/middleware/audit-log-hook.ts
@@ -280,6 +280,12 @@ const AUDIT_DENYLIST: readonly AuditDenylistEntry[] = [
   // do not mutate org state — exclude them to avoid false-positive audit noise.
   { kind: "exact", value: "/api/skills/github/discover" },
   { kind: "exact", value: "/api/skills/github/preview" },
+  // Read-only embedding connection test: probes the provider but mutates no org
+  // state. Auditing it recorded a misleading "Success" outcome on failed probes.
+  {
+    kind: "exact",
+    value: "/api/organization/knowledge-settings/test-embedding",
+  },
 ];
 
 function isDenylisted(url: string): boolean {

--- a/platform/backend/src/routes/proxy/routes/model-router.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_PROVIDER_BASE_URLS,
   hasArchestraTokenPrefix,
   LLM_PROXY_OAUTH_SCOPE,
   RouteId,
@@ -8,6 +7,7 @@ import {
 import type { FastifyReply, FastifyRequest } from "fastify";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { getProviderConfiguredBaseUrl } from "@/config";
 import logger from "@/logging";
 import {
   AgentModel,
@@ -549,9 +549,8 @@ function getModelRouterEmbeddingsProvider(
     return openAiEmbeddingsAdapterFactory;
   }
   if (provider in openAiWireProviders) {
-    return makeOpenAiCompatibleEmbeddingsAdapterFactory(
-      provider,
-      () => DEFAULT_PROVIDER_BASE_URLS[provider] || undefined,
+    return makeOpenAiCompatibleEmbeddingsAdapterFactory(provider, () =>
+      getProviderConfiguredBaseUrl(provider),
     );
   }
   throw new ApiError(


### PR DESCRIPTION
## What

Two P1 bugs surfaced by a self-hosted Ollama setup.

### 1. Embeddings couldn't connect with a blank Base URL
When a provider key's Base URL is left blank (stored as `NULL`), the embedding path fell back to the hardcoded `DEFAULT_PROVIDER_BASE_URLS` constant (`localhost` for Ollama), while chat and model-sync fall back to the env-aware `config.llm[provider].baseUrl`. On a deployment where `ARCHESTRA_OLLAMA_BASE_URL` points at an in-cluster host, model discovery and chat worked but embeddings dialed `localhost` and failed.

Both embedding base-URL sites (`kb-llm-client.ts`, `model-router.ts`) now resolve through `getProviderConfiguredBaseUrl(provider)`, so all three paths share one env-aware source. Also fixes Azure previously falling through to its placeholder URL. No change for cloud providers (their config defaults equal the old constants).

### 2. `test-embedding` recorded a misleading "Success" in the audit log
`POST /api/organization/knowledge-settings/test-embedding` returns `200 {success:false}` on a failed probe; the audit outcome is derived solely from HTTP status, so failures logged as **Success**, with action **"Unknown create"** (route unregistered). It's a read-only diagnostic that mutates nothing.

Added an exact `AUDIT_DENYLIST` entry, matching the existing treatment of other read-only POST diagnostics (`/api/secrets/check-connectivity`, `/api/skills/github/discover|preview`). Both the false outcome and the bogus label disappear; the endpoint keeps its diagnostic contract and the UI still surfaces the real error.

## Tests
- Base-URL resolution via the real DB-backed `resolveApiKeyFromChatApiKey` — asserts a keyless Ollama key with `NULL` URLs resolves the configured host, not `localhost`.
- Audit denylist — asserts the endpoint writes zero audit rows.

## Validation
`pnpm type-check` · backend tests (65 pass) · `pnpm knip` · lint — all clean.

https://claude.ai/code/session_01AcTvt7NR2PWissdKPNj9qh

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>