### PR TITLE
fix(ai-labs): make analyzer CLI respond to Ctrl-C during the analyze phase

### DIFF
--- a/ai-labs/Cargo.lock
+++ b/ai-labs/Cargo.lock
@@ -1067,6 +1067,10 @@ name = "futures-timer"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -1141,6 +1145,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "h2"
@@ -1747,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "nitpicker-agent"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8778a16fe6116174eba6e5c38840983a71f2b590b70d905ddf51fe41b4058707"
+checksum = "6b781c64e21684fa776f5d925137386794db1cd9c6fe1c5753a0b10acb6881db"
 dependencies = [
  "base64",
  "chrono",
@@ -2471,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "rig-core"
-version = "0.38.2"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557f11c26c2c2ea61d9cb843ce5adff138cc5785f58ff4b87d779de8acaa32ae"
+checksum = "80a4bc7a93b329c4e1a66d5fd211d79990e7331e3c701f057c29f135f548686d"
 dependencies = [
  "as-any",
  "async-stream",
@@ -2485,6 +2501,7 @@ dependencies = [
  "futures-timer",
  "glob",
  "http",
+ "indexmap",
  "mime",
  "mime_guess",
  "nanoid",
@@ -2505,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.38.2"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643eb495acbd4bd5976164cd068f186d534f741def8d5d052f860266b98d07f8"
+checksum = "5531bfa887b371eab658a92de7db35003370bbeee208ff5e68bbb81a5ae92d3d"
 dependencies = [
  "convert_case",
  "deluxe",
@@ -2761,6 +2778,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"

--- a/ai-labs/analyzer/Cargo.toml
+++ b/ai-labs/analyzer/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/lib.rs"
 
 [dependencies]
 archestra-bench-core = { path = "../core" }
-nitpicker-agent = "0.1"
-rig-core = "0.38"
+nitpicker-agent = "0.1.1"
+rig-core = "0.39"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 eyre = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/ai-labs/cli/src/main.rs
+++ b/ai-labs/cli/src/main.rs
@@ -209,12 +209,12 @@ async fn run_benchmark(a: BenchArgs) -> ExitCode {
     )
     .await
     {
-        None => ExitCode::FAILURE,
-        Some(Err(e)) => {
+        GuardedRun::Interrupted(code) => ExitCode::from(code),
+        GuardedRun::Completed(Err(e)) => {
             tracing::error!("benchmark failed: {e}");
             ExitCode::FAILURE
         }
-        Some(Ok(outcome)) => benchmark_exit(&outcome),
+        GuardedRun::Completed(Ok(outcome)) => benchmark_exit(&outcome),
     }
 }
 
@@ -228,13 +228,16 @@ async fn run_analyze(a: AnalyzeArgs) -> ExitCode {
         explore_root: a.knobs.explore_root,
         concurrency: a.knobs.concurrency,
     };
-    match analyze(cfg).await {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(e) => {
-            eprintln!("✗ analyze failed: {e:#}");
-            ExitCode::FAILURE
+    run_until_signal(async move {
+        match analyze(cfg).await {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("✗ analyze failed: {e:#}");
+                ExitCode::FAILURE
+            }
         }
-    }
+    })
+    .await
 }
 
 /// Render the run's trajectories and print the manifest as JSON on stdout. Synchronous: no network,
@@ -268,25 +271,28 @@ async fn run_dashboard(a: DashboardArgs) -> ExitCode {
         experiments_dir,
         port: a.port,
     };
-    match bench_dashboard::serve(cfg).await {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(e) => {
-            eprintln!("✗ dashboard failed: {e:#}");
-            ExitCode::FAILURE
+    run_until_signal(async move {
+        match bench_dashboard::serve(cfg).await {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("✗ dashboard failed: {e:#}");
+                ExitCode::FAILURE
+            }
         }
-    }
+    })
+    .await
 }
 
 async fn run_full(a: FullArgs) -> ExitCode {
     // A fresh run dir every time (no --run-dir): `full` must never overwrite an existing run's
     // config.json/aggregate.json. `run()` picks the timestamped dir and returns it for the analyze step.
     let outcome = match guarded_run(&a.common, None, None, false).await {
-        None => return ExitCode::FAILURE,
-        Some(Err(e)) => {
+        GuardedRun::Interrupted(code) => return ExitCode::from(code),
+        GuardedRun::Completed(Err(e)) => {
             tracing::error!("benchmark failed: {e}");
             return ExitCode::FAILURE;
         }
-        Some(Ok(outcome)) => outcome,
+        GuardedRun::Completed(Ok(outcome)) => outcome,
     };
     let bench_code = benchmark_exit(&outcome);
 
@@ -299,33 +305,48 @@ async fn run_full(a: FullArgs) -> ExitCode {
         explore_root: a.knobs.explore_root,
         concurrency: a.knobs.concurrency,
     };
-    match analyze(cfg).await {
-        Ok(()) => bench_code,
-        Err(e) => {
-            eprintln!("✗ analyze failed: {e:#}");
-            ExitCode::FAILURE
+    run_until_signal(async move {
+        match analyze(cfg).await {
+            Ok(()) => bench_code,
+            Err(e) => {
+                eprintln!("✗ analyze failed: {e:#}");
+                ExitCode::FAILURE
+            }
         }
-    }
+    })
+    .await
+}
+
+/// Conventional 128+signo exit codes for a signal-terminated process, shared by both signal guards.
+const SIGINT_EXIT: u8 = 130;
+const SIGTERM_EXIT: u8 = 143;
+
+/// Outcome of a signal-guarded benchmark run: either it ran to completion (carrying `run`'s own
+/// result) or a signal interrupted it after teardown, carrying the conventional exit code to
+/// propagate so every interrupt path exits 130/143 alike.
+enum GuardedRun {
+    Completed(Result<RunOutcome, RunError>),
+    Interrupted(u8),
 }
 
 /// Run the benchmark under a signal guard: on SIGINT/SIGTERM the `run` future is dropped mid-flight,
 /// so any still-registered instances (process groups + benchmark DBs) are torn down before exit.
-/// `None` means a signal fired; `Some(result)` is the completed run.
+/// `Interrupted` means a signal fired; `Completed` is the finished run.
 async fn guarded_run(
     common: &CommonBenchArgs,
     out: Option<&Path>,
     run_dir: Option<&Path>,
     update_mcp_lock: bool,
-) -> Option<Result<RunOutcome, RunError>> {
-    let result = tokio::select! {
+) -> GuardedRun {
+    let signal_code = tokio::select! {
         biased;
         _ = tokio::signal::ctrl_c() => {
             info!("received SIGINT, tearing down live instances...");
-            None
+            SIGINT_EXIT
         }
         _ = sigterm() => {
             info!("received SIGTERM, tearing down live instances...");
-            None
+            SIGTERM_EXIT
         }
         result = run(
             &common.bench_dir,
@@ -338,26 +359,47 @@ async fn guarded_run(
             common.max_workers,
             update_mcp_lock,
             common.platform_dir.as_deref(),
-        ) => Some(result),
+        ) => return GuardedRun::Completed(result),
     };
-    if result.is_none() {
-        // run() was dropped mid-flight, so live instances are still registered; shutdown_all tears
-        // them down now. Race it against a second signal so the user can force-exit immediately —
-        // that may leave still-draining process groups / benchmark DBs un-cleaned, acceptable as an
-        // explicit user-requested abort.
-        tokio::select! {
-            _ = shutdown_all() => {}
-            _ = tokio::signal::ctrl_c() => {
-                warn!("second interrupt — exiting now, teardown may be incomplete");
-                std::process::exit(130);
-            }
-            _ = sigterm() => {
-                warn!("SIGTERM during teardown — exiting now, teardown may be incomplete");
-                std::process::exit(143);
-            }
+    // run() was dropped mid-flight, so live instances are still registered; shutdown_all tears
+    // them down now. Race it against a second signal so the user can force-exit immediately —
+    // that may leave still-draining process groups / benchmark DBs un-cleaned, acceptable as an
+    // explicit user-requested abort.
+    tokio::select! {
+        _ = shutdown_all() => {}
+        _ = tokio::signal::ctrl_c() => {
+            warn!("second interrupt — exiting now, teardown may be incomplete");
+            std::process::exit(SIGINT_EXIT as i32);
+        }
+        _ = sigterm() => {
+            warn!("SIGTERM during teardown — exiting now, teardown may be incomplete");
+            std::process::exit(SIGTERM_EXIT as i32);
         }
     }
-    result
+    GuardedRun::Interrupted(signal_code)
+}
+
+/// Race an interruptible phase future against SIGINT/SIGTERM so it stays killable even after the
+/// benchmark phase installed tokio's process-global signal handler. That handler replaces the OS
+/// default "terminate" disposition the first time `ctrl_c()` is created (in `guarded_run`); once it
+/// exists, a later phase that awaits nothing on the signal — the analyze phase of `full` — would
+/// hang on Ctrl-C. Wrapping the phase here keeps every long-running async command responsive,
+/// whether or not a handler was already installed. On a signal the phase future is dropped, so its
+/// own cleanup runs (the reduce `TempDir` is removed, in-flight requests are cancelled), and we exit
+/// with the conventional 128+signo code.
+async fn run_until_signal(work: impl std::future::Future<Output = ExitCode>) -> ExitCode {
+    tokio::select! {
+        biased;
+        _ = tokio::signal::ctrl_c() => {
+            warn!("received SIGINT, aborting");
+            ExitCode::from(SIGINT_EXIT)
+        }
+        _ = sigterm() => {
+            warn!("received SIGTERM, aborting");
+            ExitCode::from(SIGTERM_EXIT)
+        }
+        code = work => code,
+    }
 }
 
 fn benchmark_exit(outcome: &RunOutcome) -> ExitCode {


### PR DESCRIPTION
## Problem

`archestra-bench full …` ignored Ctrl-C throughout its analyze/reduce phase — the long, many-LLM-call phase — so a running analysis couldn't be aborted.

## Root cause

tokio installs a **process-global** SIGINT handler the first time `tokio::signal::ctrl_c()` is created (in `guarded_run`, used by `benchmark`/`full`). That handler permanently replaces the OS default "terminate" disposition. Once the benchmark phase drops its `ctrl_c()` future and nothing awaits SIGINT, the signal is silently swallowed — so the analyze phase of `full` no longer responds to Ctrl-C.

Reproduced with a minimal tokio binary: a build that never touches `ctrl_c()` dies on SIGINT (default disposition); a build that creates+drops a `ctrl_c()` future once thereafter ignores SIGINT. Not a `nitpicker-agent` bug — it installs no signal handlers.

## Fix

- `run_until_signal`: races each long-running async phase (`analyze`, `full`'s analyze phase, `dashboard`) against SIGINT/SIGTERM and exits 130/143. Dropping the phase future runs its own cleanup (the reduce `TempDir` is removed, in-flight requests cancelled).
- `guarded_run` now returns a `GuardedRun` enum carrying the signal-derived exit code, so an interrupt during the **benchmark** phase also exits 130/143 instead of a generic failure — every interrupt path is consistent.
- Benchmark graceful two-phase teardown is otherwise unchanged; the synchronous `prepare` command never installs a handler and already responds.

## Dependency bump (second commit)

`nitpicker-agent` 0.1.0 → 0.1.1 and `rig-core` 0.38 → 0.39 (coupled: nitpicker 0.1.1 requires rig 0.39). Analyzer public-API usage unchanged; single `rig-core` in the lockfile.

## Validation

- `cargo clippy --all-targets -- -D warnings` clean; `cargo test` green (49 tests).
- Interrupt behavior driven end-to-end: a reproduction mirroring `full`'s register-then-drop structure now exits 130 on SIGINT, and the real `archestra-bench dashboard` binary exits 130 on SIGINT.

https://claude.ai/code/session_015jfWRzCw8X7YxCaMAcseiX

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>