### PR TITLE
perf(ci): speed up merge-queue e2e (gate/report split + dependency-deploy overlap)

### DIFF
--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -181,9 +181,78 @@ runs:
         fi
         echo "All MCP dependency images fetched successfully"
 
-    # Deliberately placed AFTER the Kind cluster and MCP dependency image setup:
-    # everything above is independent of the platform image, so when the caller
-    # starts this action while the platform image build is still running (see
+    # Deploy the platform-image-INDEPENDENT e2e dependency stack (Vault,
+    # Keycloak, WireMock, MCP servers) HERE — before the platform image wait
+    # below — so it comes up while the image build is still running instead of
+    # adding to the merge-queue critical path after. The dependency images were
+    # just pulled into the daemon above, so load them into Kind and install the
+    # chart now. Vault in particular gates the platform pod (its vault-secrets
+    # init container), so having it Ready before the platform chart installs
+    # shortens the post-build path.
+    #
+    # Only the foreground+deps path (the merge-queue shards) takes this branch;
+    # the "background" install mode keeps deploying inside "Deploy with Helm"
+    # (see below), and "Load all images into Kind" / "Deploy with Helm" both
+    # skip the dependency work they would otherwise repeat for this path.
+    - name: Deploy e2e dependencies (overlaps platform image build)
+      if: ${{ inputs.deploy-e2e-dependencies == 'true' && inputs.e2e-dependencies-install-mode == 'foreground' }}
+      shell: bash
+      env:
+        KIND_CLUSTER_NAME: ${{ inputs.kind-cluster-name }}
+        PLATFORM_CONTEXT: ${{ inputs.platform-context }}
+        E2E_DEPS_EXTRA_HELM_SET: ${{ inputs.e2e-dependencies-extra-helm-set }}
+        E2E_DEPS_WAIT_FOR_VAULT: ${{ inputs.e2e-dependencies-wait-for-vault }}
+      run: |
+        MCP_OAUTH_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-example-oauth-server:0.0.1"
+        MCP_JWKS_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-jwks-keycloak:0.0.3"
+        MCP_ID_JAG_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-id-jag:0.0.4"
+
+        echo "Loading MCP dependency images into Kind (parallel)..."
+        PIDS=()
+        for img in "${MCP_OAUTH_IMAGE}" "${MCP_JWKS_IMAGE}" "${MCP_ID_JAG_IMAGE}"; do
+          kind load docker-image "${img}" --name "${KIND_CLUSTER_NAME}" &
+          PIDS+=($!)
+        done
+        FAILED=0
+        for pid in "${PIDS[@]}"; do
+          if ! wait "$pid"; then FAILED=1; fi
+        done
+        if [ "$FAILED" -ne 0 ]; then
+          echo "One or more MCP dependency image loads into Kind failed"
+          exit 1
+        fi
+
+        # Build --set flags from comma-separated pairs (mirrors "Deploy with Helm").
+        E2E_DEPS_SET_FLAGS=""
+        if [ -n "${E2E_DEPS_EXTRA_HELM_SET}" ]; then
+          IFS=',' read -ra PAIRS <<< "${E2E_DEPS_EXTRA_HELM_SET}"
+          for pair in "${PAIRS[@]}"; do
+            E2E_DEPS_SET_FLAGS="${E2E_DEPS_SET_FLAGS} --set ${pair}"
+          done
+        fi
+
+        echo "Installing e2e-tests chart (overlapping the platform image build)..."
+        helm install e2e-tests "${PLATFORM_CONTEXT}/helm/e2e-tests" ${E2E_DEPS_SET_FLAGS}
+
+        if [ "${E2E_DEPS_WAIT_FOR_VAULT}" = "true" ]; then
+          echo "Waiting for Vault pod before platform deploy..."
+          if ! kubectl wait --for=condition=Ready pod -l app=vault --timeout=180s; then
+            echo "=== Vault Pod Status ==="
+            kubectl get pods -l app=vault -o wide || true
+            echo "=== Vault Pod Describe ==="
+            kubectl describe pod -l app=vault || true
+            echo "=== Vault Pod Logs ==="
+            kubectl logs -l app=vault --tail=200 || true
+            echo "=== Vault Pod Previous Logs ==="
+            kubectl logs -l app=vault --previous --tail=200 || true
+            exit 1
+          fi
+        fi
+
+    # Deliberately placed AFTER the Kind cluster, MCP dependency image setup, and
+    # (for the merge-queue shards) the e2e dependency deploy above: everything
+    # there is independent of the platform image, so when the caller starts this
+    # action while the platform image build is still running (see
     # image-pull-timeout-seconds), that work overlaps with the build and the
     # wait below only covers whatever build time is actually left.
     - name: Wait for and pull images (if not already present)
@@ -243,6 +312,7 @@ runs:
         MCP_SERVER_BASE_IMAGE_TAG: ${{ inputs.mcp-server-base-image-tag }}
         KIND_CLUSTER_NAME: ${{ inputs.kind-cluster-name }}
         DEPLOY_E2E_DEPS: ${{ inputs.deploy-e2e-dependencies }}
+        E2E_DEPS_INSTALL_MODE: ${{ inputs.e2e-dependencies-install-mode }}
       run: |
         PIDS=()
 
@@ -256,7 +326,10 @@ runs:
           PIDS+=($!)
         fi
 
-        if [ "${DEPLOY_E2E_DEPS}" == "true" ]; then
+        # The foreground path already loaded the MCP dependency images into Kind
+        # in "Deploy e2e dependencies (overlaps platform image build)" above, so
+        # only the background path needs to load them here.
+        if [ "${DEPLOY_E2E_DEPS}" == "true" ] && [ "${E2E_DEPS_INSTALL_MODE}" != "foreground" ]; then
           MCP_OAUTH_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-example-oauth-server:0.0.1"
           MCP_JWKS_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-jwks-keycloak:0.0.3"
           MCP_ID_JAG_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-id-jag:0.0.4"
@@ -339,15 +412,10 @@ runs:
         E2E_PID=""
         if [ "${DEPLOY_E2E_DEPS}" == "true" ]; then
           if [ "${E2E_DEPS_INSTALL_MODE}" = "foreground" ]; then
-            echo "Installing e2e-tests chart before platform deploy..."
-            install_e2e_dependencies
-            if [ "${E2E_DEPS_WAIT_FOR_VAULT}" = "true" ]; then
-              echo "Waiting for Vault pod before platform deploy..."
-              if ! kubectl wait --for=condition=Ready pod -l app=vault --timeout=180s; then
-                show_vault_diagnostics
-                exit 1
-              fi
-            fi
+            # Already installed (and Vault already waited on) in the earlier
+            # "Deploy e2e dependencies (overlaps platform image build)" step, so
+            # the release exists before we get here — nothing to do.
+            echo "e2e-tests chart already deployed earlier (overlapped the image build); skipping."
           else
             echo "Starting e2e-tests Helm install in background..."
             install_e2e_dependencies &

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -597,10 +597,66 @@ jobs:
           docker volume rm archestra-ci-postgres-data 2>/dev/null || true
           docker volume rm archestra-ci-app-data 2>/dev/null || true
 
+  # The merge queue's e2e gate. This is the required "Merge E2E Test Reports"
+  # status check — the per-shard jobs are NOT required, so this job is the only
+  # thing standing between a red shard and main.
+  #
+  # It deliberately does NOTHING but read the shard/quickstart results: no
+  # checkout, no pnpm install, no artifact download. Report MERGING (which needs
+  # all of that) moved to the separate, non-required `platform-e2e-report` job
+  # below so it runs OFF the merge-queue critical path. Merging the report used
+  # to cost ~40-50s of checkout + `pnpm install` + blob download here, and this
+  # job is the LAST required check to go green (it needs the shards), so every
+  # one of those seconds delayed the merge. Stripped down, the gate reports
+  # green within runner-spinup time of the last shard finishing.
+  #
+  # Keep the job `name:` EXACTLY "Merge E2E Test Reports" — it is the context
+  # named in the branch ruleset's required status checks. Renaming it silently
+  # un-gates the queue.
   platform-e2e-merge-reports:
     name: Merge E2E Test Reports
     needs: [platform-e2e-tests-shards, platform-quickstart-e2e-tests]
+    # `!cancelled()` (not `always()`) so a cancelled upstream still cancels the
+    # gate; the event guard keeps it running on merge_group / on-demand runs but
+    # reporting skipped (and thus satisfying the ruleset) on ordinary PR pushes.
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    # No permissions needed: this job only inspects `needs.*.result`.
+    permissions: {}
+    steps:
+      # Without this the job would succeed whenever it starts, so red shards
+      # would ride through the queue unnoticed — which is exactly how a broken
+      # production image (MODULE_NOT_FOUND on @archestra/napi-loader) once
+      # shipped while apps.spec.ts failed every queue run.
+      - name: Fail if any e2e job failed
+        env:
+          SHARDS_RESULT: ${{ needs.platform-e2e-tests-shards.result }}
+          QUICKSTART_RESULT: ${{ needs.platform-quickstart-e2e-tests.result }}
+        run: |
+          failed=0
+          for pair in "shards:$SHARDS_RESULT" "quickstart:$QUICKSTART_RESULT"; do
+            name="${pair%%:*}"; result="${pair##*:}"
+            echo "$name: $result"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              failed=1
+            fi
+          done
+          if [ "$failed" = "1" ]; then
+            echo "::error::One or more e2e jobs failed - failing the merge-queue gate."
+            exit 1
+          fi
+          echo "All e2e jobs green."
+
+  # Merges the per-shard Playwright blob reports into a single HTML/JSON report
+  # and writes the job summary. NOT a required check and NOT on the merge-queue
+  # critical path — it runs in parallel with the gate above so the queue never
+  # waits on report generation. `always()` so a failed run still publishes its
+  # (more valuable) report artifact for debugging.
+  platform-e2e-report:
+    name: Publish E2E Report
+    needs: [platform-e2e-tests-shards, platform-quickstart-e2e-tests]
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
@@ -653,29 +709,4 @@ jobs:
         with:
           report-file: platform/e2e-tests/results.json
           job-summary: true
-
-      # This job is the merge queue's only e2e gate ("Merge E2E Test Reports"
-      # is the required check; the per-shard jobs are not). Without this step
-      # the job succeeds whenever report-merging succeeds, so red shards ride
-      # through the queue unnoticed — which is exactly how a broken production
-      # image (MODULE_NOT_FOUND on @archestra/napi-loader) shipped while
-      # apps.spec.ts failed every queue run.
-      - name: Fail if any e2e job failed
-        env:
-          SHARDS_RESULT: ${{ needs.platform-e2e-tests-shards.result }}
-          QUICKSTART_RESULT: ${{ needs.platform-quickstart-e2e-tests.result }}
-        run: |
-          failed=0
-          for pair in "shards:$SHARDS_RESULT" "quickstart:$QUICKSTART_RESULT"; do
-            name="${pair%%:*}"; result="${pair##*:}"
-            echo "$name: $result"
-            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-              failed=1
-            fi
-          done
-          if [ "$failed" = "1" ]; then
-            echo "::error::One or more e2e jobs failed - failing the merge-queue gate."
-            exit 1
-          fi
-          echo "All e2e jobs green."
 


### PR DESCRIPTION
## Goal

Make merge-queue CI faster so "merge when ready" lands sooner. The queue already batches (≤10 entries) and is well-optimized, so this targets **per-entry latency** on the long pole: `platform-e2e-tests` on `merge_group` (empirically p50 ~8 min).

## Empirical critical path (one clean ~9.6-min queue run, step-level)

| Phase | Time | |
|---|---|---|
| Build Platform Image | 226s | gates the shards; deps layers all CACHED |
| Shard `setup-archestra-platform` | 314s | **142s idle-waiting for the build**, +41s load-into-Kind, +63s Helm deploy (Vault/Keycloak/WireMock + platform) |
| Run e2e tests (slow shard) | 159s | actual tests |
| "Merge E2E Test Reports" (required gate) | 49s | 22s pnpm-install + 12s download + 6s checkout **for a 0s pass/fail** |

Note: more sharding barely helps — each shard re-pays the ~314s setup; tests are only ~159s of it.

## Changes

**1. Split the merge-queue gate from report publishing** (`platform-e2e-tests.yml`)
`Merge E2E Test Reports` is the *last* required check to go green and spent ~40-50s on checkout + `pnpm install` + blob download to run a 0s result check. Stripped it to only inspect `needs.*.result`; moved the Playwright report merge/upload/summary into a new **non-required** `Publish E2E Report` job off the critical path. Required context name unchanged. **~40s off the tail.**

**2. Deploy the e2e dependency stack during the image build** (`setup-archestra-platform/action.yml`)
Vault/Keycloak/WireMock/MCP servers are platform-image-independent but were deployed *after* the shard finished waiting ~142s for the build. Moved that deploy (load dep images into Kind + `helm install e2e-tests` + Vault readiness) into a new step **before** the image wait, converting idle build-wait into useful work. Vault is Ready before the platform chart installs (its `vault-secrets` init container depends on it). Gated to the shard (foreground+deps) path; background mode untouched. **~15-40s off the post-build path.**

## Validation

YAML parses, every composite shell block passes `bash -n`, step order confirmed. Change 2 touches the required merge gate and **e2e only runs in the queue or under the `run-e2e` label** — this PR carries the label so the full suite validates here before merge.

## Not in this PR (data-backed follow-ups)
- **27% queue-failure rate** — each failure re-runs the whole ~9-min pipeline; de-flaking is the highest-leverage next step.
- Build (226s) — inherent, well-cached; no safe big win found.
- Shard rebalancing (~77s imbalance) — Playwright has no native duration-based balancing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>