### PR TITLE
test(e2e): fix agents create-button pre-hydration flake

### DIFF
--- a/platform/e2e-tests/tests/agents.spec.ts
+++ b/platform/e2e-tests/tests/agents.spec.ts
@@ -39,35 +39,46 @@ test(
     const createButton = page.getByTestId(E2eTestId.CreateAgentButton);
     await waitForElementWithReload(page, createButton);
 
-    // The Create-Agent button is server-rendered, so a click that lands before
-    // React hydration attaches its onClick handler is silently lost: Playwright
-    // reports the click as successful (the SSR button is visible/enabled), but
-    // the create dialog never opens and its "Name" field never mounts, so the
-    // fill below times out for the life of the page — no retry recovers it.
-    // (This was the top remaining merge-queue flake on shard 1; the same
-    // pre-hydration lost-click race was fixed for the skills marketplace step
-    // in #6339.) Retry the click until the dialog's Name field appears. Opening
-    // the dialog is NOT idempotent (a second click would land on the modal
-    // overlay), so guard the re-click on the field not already being visible.
-    const nameField = page.getByRole("textbox", { name: "Name" });
+    // The create dialog (its trigger, the name input, and the submit button) is
+    // rendered before React finishes hydrating, so any interaction that lands
+    // in that window is silently lost — Playwright sees a visible/enabled
+    // element and reports success, but the handler never ran. This bit three
+    // controls in a row across merge-queue runs: the trigger click (dialog
+    // never opened), the name fill (the input's onChange never fired, so the
+    // form's name stayed empty and the required-name-gated Create button stayed
+    // disabled), and the submit click (no POST /api/agents dispatched). A longer
+    // timeout can't recover any of them — the dropped interaction leaves the
+    // page in a stuck state for its lifetime. So drive each step by its
+    // observable end-state and retry until that state is reached. (Same
+    // pre-hydration class as the skills marketplace fix in #6339.)
+    const dialog = page.getByRole("dialog", { name: /Create Agent/i });
+    const nameField = dialog.getByRole("textbox", { name: "Name" });
+    const submitButton = dialog.getByRole("button", { name: "Create" });
+
+    // 1. Open the dialog — retry the trigger until the name field mounts.
+    //    Guarded on visibility so a landed click is never re-sent through the
+    //    modal overlay (opening the dialog is not idempotent).
     await expect(async () => {
       if (!(await nameField.isVisible())) {
         await createButton.click();
       }
       await expect(nameField).toBeVisible({ timeout: 3_000 });
     }).toPass({ timeout: 20_000 });
-    await nameField.fill(AGENT_NAME);
 
-    // Submit the create form. The "Create" button has the same pre-hydration
-    // hazard as the dialog trigger above: a click that lands before React
-    // wires its submit handler is silently lost, so no POST /api/agents ever
-    // fires and the response wait below would time out for the life of the
-    // page. Retry the click until the request is actually dispatched.
-    // waitForRequest resolves the instant the handler runs, so a click that
-    // landed is detected immediately and never re-clicked — there is no window
-    // in which a second agent could be created. (Also subsumes the earlier
-    // webkit fix: waiting for the POST before polling the table.)
-    const submitButton = page.getByRole("button", { name: "Create" });
+    // 2. Fill the name — retry until the form actually registered it, which the
+    //    Create button becoming enabled confirms (it is disabled while the name
+    //    is empty). fill() is idempotent, so re-filling after the input hydrates
+    //    is safe and is what flips the button from disabled to enabled.
+    await expect(async () => {
+      await nameField.fill(AGENT_NAME);
+      await expect(submitButton).toBeEnabled({ timeout: 2_000 });
+    }).toPass({ timeout: 20_000 });
+
+    // 3. Submit — retry the click until the POST is dispatched. waitForRequest
+    //    resolves the instant the handler runs, so a click that landed is
+    //    detected immediately and never re-clicked — there is no window in which
+    //    a second agent could be created. (Also subsumes the earlier webkit fix:
+    //    waiting for the POST before polling the table.)
     const createResponsePromise = page.waitForResponse(
       (response) =>
         response.url().includes("/api/agents") &&

--- a/platform/e2e-tests/tests/agents.spec.ts
+++ b/platform/e2e-tests/tests/agents.spec.ts
@@ -38,8 +38,25 @@ test(
 
     const createButton = page.getByTestId(E2eTestId.CreateAgentButton);
     await waitForElementWithReload(page, createButton);
-    await createButton.click();
-    await page.getByRole("textbox", { name: "Name" }).fill(AGENT_NAME);
+
+    // The Create-Agent button is server-rendered, so a click that lands before
+    // React hydration attaches its onClick handler is silently lost: Playwright
+    // reports the click as successful (the SSR button is visible/enabled), but
+    // the create dialog never opens and its "Name" field never mounts, so the
+    // fill below times out for the life of the page — no retry recovers it.
+    // (This was the top remaining merge-queue flake on shard 1; the same
+    // pre-hydration lost-click race was fixed for the skills marketplace step
+    // in #6339.) Retry the click until the dialog's Name field appears. Opening
+    // the dialog is NOT idempotent (a second click would land on the modal
+    // overlay), so guard the re-click on the field not already being visible.
+    const nameField = page.getByRole("textbox", { name: "Name" });
+    await expect(async () => {
+      if (!(await nameField.isVisible())) {
+        await createButton.click();
+      }
+      await expect(nameField).toBeVisible({ timeout: 3_000 });
+    }).toPass({ timeout: 20_000 });
+    await nameField.fill(AGENT_NAME);
 
     // Wait for the POST /api/agents response before polling the table.
     // On webkit, clicking submit and immediately continuing leaves a window

--- a/platform/e2e-tests/tests/agents.spec.ts
+++ b/platform/e2e-tests/tests/agents.spec.ts
@@ -58,19 +58,34 @@ test(
     }).toPass({ timeout: 20_000 });
     await nameField.fill(AGENT_NAME);
 
-    // Wait for the POST /api/agents response before polling the table.
-    // On webkit, clicking submit and immediately continuing leaves a window
-    // where the API call hasn't fired (or response hasn't been processed)
-    // and waitForLoadState("domcontentloaded") returns instantly because
-    // there's no navigation. That made the subsequent "agent in table"
-    // poll exhaust its timeout on webkit while passing on chromium/firefox.
+    // Submit the create form. The "Create" button has the same pre-hydration
+    // hazard as the dialog trigger above: a click that lands before React
+    // wires its submit handler is silently lost, so no POST /api/agents ever
+    // fires and the response wait below would time out for the life of the
+    // page. Retry the click until the request is actually dispatched.
+    // waitForRequest resolves the instant the handler runs, so a click that
+    // landed is detected immediately and never re-clicked — there is no window
+    // in which a second agent could be created. (Also subsumes the earlier
+    // webkit fix: waiting for the POST before polling the table.)
+    const submitButton = page.getByRole("button", { name: "Create" });
     const createResponsePromise = page.waitForResponse(
       (response) =>
         response.url().includes("/api/agents") &&
         response.request().method() === "POST",
       { timeout: 30_000 },
     );
-    await page.getByRole("button", { name: "Create" }).click();
+    await expect(async () => {
+      const requestDispatched = page
+        .waitForRequest(
+          (request) =>
+            request.url().includes("/api/agents") &&
+            request.method() === "POST",
+          { timeout: 3_000 },
+        )
+        .catch(() => null);
+      await submitButton.click();
+      expect(await requestDispatched).not.toBeNull();
+    }).toPass({ timeout: 20_000 });
     await createResponsePromise;
     await page.waitForLoadState("domcontentloaded");
 


### PR DESCRIPTION
## What

Fixes the top remaining hard failure in the merge-queue e2e suite after the skill-share flake was fixed in #6339: `agents.spec.ts` → **"can create and delete an agent"**.

## Root cause (same class as #6339)

Empirically, post-#6339 failed merge_group runs fail here at line 42:
```
TimeoutError: locator.fill: Timeout 15000ms exceeded.
  - waiting for getByRole('textbox', { name: 'Name' })
> 42 |     await page.getByRole("textbox", { name: "Name" }).fill(AGENT_NAME);
```
…on **all 3 retries**. The Create-Agent button is server-rendered, so a click that lands **before React hydration** attaches its `onClick` is silently lost — Playwright reports the click as successful (the SSR button is visible/enabled), but the create dialog never opens, its `Name` field never mounts, and the fill times out for the life of the page. No timeout recovers it, so every retry fails.

## Fix

Wrap the click + `Name`-field visibility check in `expect(...).toPass()` so a dropped pre-hydration click is retried until the dialog opens — the proven remedy from #6339. Adaptation: opening the dialog is **not** idempotent (unlike #6339's client select), so the re-click is guarded on the `Name` field not already being visible, to avoid clicking through an open modal overlay.

## Context (data-backed)

I analyzed 20 failed shard logs across recent failed queue runs. After #6339, `skill-share` is gone from failures; the current hard-failure ranking is: `agents.spec.ts` (this PR), the `@quickstart` pair (`quickstart.spec.ts` + `mcp-install.spec.ts`, likely a quickstart-container readiness issue — separate follow-up), and `static-credentials-management.spec.ts`. The `chat.spec.ts` provider matrix is very flaky but mostly retries green.

## Validation

Carries the `run-e2e` label so the full suite validates here (e2e only runs in the merge queue or under this label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>