### PR TITLE
fix(onboarding): allow saving an image-only onboarding wizard page

### DIFF
--- a/platform/frontend/src/app/settings/organization/_components/onboarding-wizards-editor.utils.test.ts
+++ b/platform/frontend/src/app/settings/organization/_components/onboarding-wizards-editor.utils.test.ts
@@ -85,6 +85,18 @@ describe("onboarding-wizards-editor utils", () => {
       ).toEqual({ pages: "Add at least one page with content." });
     });
 
+    it("accepts a wizard whose only page is image-only", () => {
+      expect(
+        validateOnboardingWizard(
+          {
+            label: "Setup",
+            pages: [{ content: " ", image: "data:image/png;base64,AAA" }],
+          },
+          { requireComplete: true },
+        ),
+      ).toEqual({});
+    });
+
     it("rejects more than 10 pages", () => {
       expect(
         validateOnboardingWizard({

--- a/platform/frontend/src/app/settings/organization/_components/onboarding-wizards-editor.utils.ts
+++ b/platform/frontend/src/app/settings/organization/_components/onboarding-wizards-editor.utils.ts
@@ -17,6 +17,9 @@ interface ValidateOptions {
   requireComplete?: boolean;
 }
 
+const pageHasContent = (page: OnboardingWizardPageValue): boolean =>
+  page.content.trim().length > 0 || (page.image ?? "") !== "";
+
 export function sanitizeOnboardingWizard(
   wizard: OnboardingWizardValue | null,
 ): OnboardingWizardValue | null {
@@ -27,9 +30,7 @@ export function sanitizeOnboardingWizard(
       image: page.image ?? null,
       content: page.content,
     }))
-    .filter(
-      (page) => page.content.trim().length > 0 || (page.image ?? "") !== "",
-    );
+    .filter(pageHasContent);
   if (label.length === 0 || pages.length === 0) return null;
   return { label, pages };
 }
@@ -45,10 +46,7 @@ export function validateOnboardingWizard(
   const errors: OnboardingWizardValidationError = {};
 
   const hasAnyContent =
-    trimmedLabel.length > 0 ||
-    wizard.pages.some(
-      (page) => page.content.trim().length > 0 || (page.image ?? "") !== "",
-    );
+    trimmedLabel.length > 0 || wizard.pages.some(pageHasContent);
 
   if (!hasAnyContent) return {};
 
@@ -58,9 +56,7 @@ export function validateOnboardingWizard(
     errors.label = "Label must be 25 characters or fewer.";
   }
 
-  const nonEmptyPages = wizard.pages.filter(
-    (page) => page.content.trim().length > 0,
-  );
+  const nonEmptyPages = wizard.pages.filter(pageHasContent);
 
   if (nonEmptyPages.length === 0) {
     if (requireComplete) {


### PR DESCRIPTION
### Subsystem: onboarding wizard editor

Overnight sweep of the initial-setup/onboarding flow. One bugfix.

**onboarding-wizards-editor.utils.ts:61-63** → image-only wizard page could not be saved → validation now agrees with sanitize.

`validateOnboardingWizard` counted a page as non-empty only when it had trimmed **text**, while `sanitizeOnboardingWizard` (which decides what actually persists) accepts a page with **text or an image**. An image-only page therefore failed the `requireComplete` check and blocked the settings Save bar, even though it would have persisted fine. The three call sites now share one `pageHasContent` predicate.

Regression test added (image-only page + `requireComplete` → `{}`); verified fail-before / pass-after locally. Type-check and Biome clean; 11/11 utils tests green.

Codex verdict: plan gate PASS, diff gate PASS (adversarial, independent).

sweep-key: platform/frontend/src/app/settings/organization/_components/onboarding-wizards-editor.utils.ts:61-63:wizard-validate-ignores-image

https://claude.ai/code/session_01XrgWmw4aievNj85q6axVNb

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>