### PR TITLE
refactor(connection): drop dead duplicate edge-recalc layout effect

### DIFF
--- a/platform/frontend/src/app/connection/exposed-servers-summary.tsx
+++ b/platform/frontend/src/app/connection/exposed-servers-summary.tsx
@@ -96,11 +96,6 @@ export function ExposedServersSummary({
     };
   }, [recalcEdges]);
 
-  // Trigger an edge recalc once the server list changes (DOM width shifts).
-  useLayoutEffect(() => {
-    recalcEdges();
-  }, [recalcEdges]);
-
   const scrollByDir = (dir: 1 | -1) => {
     const el = scrollRef.current;
     if (!el) return;


### PR DESCRIPTION
### Subsystem: connection flow

Overnight sweep of the initial-setup/onboarding flow. One cleanup (net -5 lines, no production behavior change).

**exposed-servers-summary.tsx** → removed a dead duplicate layout effect.

`ExposedServersSummary` had two byte-identical `useLayoutEffect(() => recalcEdges(), [recalcEdges])` blocks. `recalcEdges` is a stable empty-dep `useCallback`, so both only ran once on mount and the second could never react to the server list changing despite its comment saying so. The surviving effect and the scroll/resize listener effect are unchanged; `recalcEdges` only reads scroll geometry and toggles CSS classes (idempotent).

Biome clean; 147/147 connection tests green.

Codex verdict: plan gate PASS, diff gate PASS (base-vs-working comparison confirmed behavior-preserving).

sweep-key: platform/frontend/src/app/connection/exposed-servers-summary.tsx:99:dead-duplicate-uselayouteffect

https://claude.ai/code/session_01XrgWmw4aievNj85q6axVNb

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>