### PR TITLE
feat(apps): move app HTML lint to Rust and harden the save-gate scan

### DIFF
--- a/platform/archestra-rs/Cargo.lock
+++ b/platform/archestra-rs/Cargo.lock
@@ -29,6 +29,7 @@ version = "0.1.0"
 dependencies = [
  "regex",
  "tl",
+ "url",
 ]
 
 [[package]]

--- a/platform/archestra-rs/app-runtime-core/Cargo.toml
+++ b/platform/archestra-rs/app-runtime-core/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 [dependencies]
 regex = "1"
 tl = "0.7"
+url = "2"

--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -14,7 +14,8 @@
 //! extraction also reads script blocks inside HTML comments; for a security
 //! gate that is the fail-closed direction (dead markup is trivially deleted).
 //! Attribute refs are read from the DOM, tolerant of `tl`'s solidus fusing
-//! (see `resource_ref`).
+//! (see `resource_ref`), with a lexical fallback pass for tag shapes `tl`
+//! drops outright.
 
 use std::sync::LazyLock;
 
@@ -38,6 +39,14 @@ const NO_DOCUMENT_ROOT_WARNING: &str = "html has no <head> or <html> element; pr
 
 static HEAD_OR_HTML: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)<(head|html)[\s>]").expect("static head/html probe regex"));
+
+// Raw-text src/href refs on script/link open tags, quoted (group 3) or
+// unquoted (group 4). Backstops the DOM loops in `scan_app_html` for tag
+// shapes `tl` drops; see the fallback step there.
+static RESOURCE_REF_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?is)<(script|link)\b[^>]*?\b(src|href)\s*=\s*(?:["']([^"']*)["']|([^\s>"']+))"#)
+        .expect("static resource ref fallback regex")
+});
 
 /// Why a scan disqualified the HTML. Carries the offending value so the caller
 /// can build a precise user-facing message (kept on the TypeScript side).
@@ -122,7 +131,39 @@ pub fn scan_app_html(html: &str) -> ScanResult {
         }
     }
 
-    // 4. Soft warning: no document root. Probed on the raw input (a parser
+    // 4. Lexical fallback for self-load refs: `tl` drops some browser-loadable
+    //    tag shapes entirely (space-before-solidus `<script /src=…>`, unquoted
+    //    URL values containing `/`), so the DOM loops above cannot be the only
+    //    line of defence. Reads any src/href attribute (quoted or unquoted) on
+    //    a raw script/link open tag, honouring the browser's tag/attribute
+    //    pairing; extra matches this can add (e.g. inside HTML comments) are
+    //    fail-closed for a rejection gate.
+    for capture in RESOURCE_REF_FALLBACK.captures_iter(html) {
+        let tag_name = &capture[1];
+        let attr_name = &capture[2];
+        let value = capture
+            .get(3)
+            .or_else(|| capture.get(4))
+            .map_or("", |m| m.as_str());
+        if tag_name.eq_ignore_ascii_case("script") && attr_name.eq_ignore_ascii_case("src") {
+            if PLATFORM_SCRIPT_SRC_MARKERS
+                .iter()
+                .any(|marker| value.contains(marker))
+            {
+                return reject(RejectionKind::PlatformScriptSrc, value.to_string());
+            }
+        } else if tag_name.eq_ignore_ascii_case("link") && attr_name.eq_ignore_ascii_case("href") {
+            let collapsed: String = value
+                .chars()
+                .filter(|c| !c.is_whitespace() && *c != '\u{feff}')
+                .collect();
+            if collapsed.contains(PLATFORM_BASE_CSS_MARKER) {
+                return reject(RejectionKind::PlatformBaseCss, value.to_string());
+            }
+        }
+    }
+
+    // 5. Soft warning: no document root. Probed on the raw input (a parser
     //    normalizes fragments away), mirroring the TS regex.
     let mut warnings = Vec::new();
     if !HEAD_OR_HTML.is_match(html) {
@@ -157,7 +198,10 @@ pub(crate) fn tag_is(tag: &tl::HTMLTag, expected: &str) -> bool {
 // An attribute ref, recovering the solidus-fused shape `tag_is` matches on:
 // `tl` parses `<script/src="u">` as tag `script/src` with the value under an
 // empty attribute key. A solidus after a space (`<script /src=…>`) makes `tl`
-// drop the tag entirely; that stays a blind spot alongside unquoted URL values.
+// drop the tag entirely — the save gate backstops that with its lexical
+// fallback pass; for the authoring lint it stays a deliberate blind spot
+// alongside unquoted URL values (a soft hint keeps the comment-excluding DOM
+// semantics instead).
 pub(crate) fn resource_ref(tag: &tl::HTMLTag, attr_name: &str) -> Option<String> {
     if let Some(value) = attr(tag, attr_name) {
         return Some(value);
@@ -335,6 +379,49 @@ mod tests {
         assert_eq!(
             scan_app_html(link).rejection.expect("should reject").kind,
             RejectionKind::PlatformBaseCss
+        );
+    }
+
+    #[test]
+    fn space_solidus_self_loads_are_rejected_via_the_lexical_fallback() {
+        // `tl` drops `<script /src=…>`/`<link /href=…>` tags entirely, while
+        // browsers read them as ordinary elements — the raw-text fallback must
+        // keep the gate closed to them.
+        let script =
+            r#"<html><head><script /src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#;
+        let rejection = scan_app_html(script).rejection.expect("should reject");
+        assert_eq!(rejection.kind, RejectionKind::PlatformScriptSrc);
+        assert_eq!(rejection.offender, "/_sandbox/archestra-app-sdk.js");
+        let link = r#"<html><head><link /href="/_sandbox/archestra-app-base.css"></head></html>"#;
+        assert_eq!(
+            scan_app_html(link).rejection.expect("should reject").kind,
+            RejectionKind::PlatformBaseCss
+        );
+    }
+
+    #[test]
+    fn unquoted_self_load_src_is_rejected_via_the_lexical_fallback() {
+        // Unquoted URL values containing `/` also make `tl` drop the tag.
+        let html = "<html><head><script src=/_sandbox/archestra-app-sdk.js></script></head></html>";
+        assert_eq!(
+            scan_app_html(html).rejection.expect("should reject").kind,
+            RejectionKind::PlatformScriptSrc
+        );
+    }
+
+    #[test]
+    fn marker_after_a_gt_inside_a_script_attribute_fails_closed() {
+        // The lexical script-text extraction ends the open tag at the first
+        // `>`, even inside a quoted attribute, so a marker written after it is
+        // read as script text and rejects — although the browser sees an empty
+        // script body. Deliberate: a quote-aware pattern would go fail-open on
+        // unterminated quotes, and marker strings inside attribute values do
+        // not occur in legitimate apps.
+        let html =
+            r#"<html><head><script data-note=">PostMessageTransport"></script></head></html>"#;
+        assert_eq!(
+            scan_app_html(html).rejection.expect("should reject").kind,
+            RejectionKind::SdkBootstrap
         );
     }
 

--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -88,13 +88,12 @@ pub fn scan_app_html(html: &str) -> ScanResult {
 
     // 2. Platform script self-load via <script src>, document order.
     for tag in tags().filter(|tag| tag.name().as_utf8_str().eq_ignore_ascii_case("script")) {
-        if let Some(src) = attr(tag, "src") {
-            if PLATFORM_SCRIPT_SRC_MARKERS
+        if let Some(src) = attr(tag, "src")
+            && PLATFORM_SCRIPT_SRC_MARKERS
                 .iter()
                 .any(|marker| src.contains(marker))
-            {
-                return reject(RejectionKind::PlatformScriptSrc, src);
-            }
+        {
+            return reject(RejectionKind::PlatformScriptSrc, src);
         }
     }
 
@@ -129,8 +128,8 @@ pub fn scan_app_html(html: &str) -> ScanResult {
 // HTML attribute names are case-insensitive, but `tl`'s `Attributes::get` is an
 // exact-case lookup — so we iterate and compare keys with `eq_ignore_ascii_case`
 // (cheerio's `.attr()` matched `SRC`/`HREF` too). A valueless attribute yields
-// `None`, i.e. nothing to scan.
-fn attr(tag: &tl::HTMLTag, name: &str) -> Option<String> {
+// `None`, i.e. nothing to scan. Shared with the authoring lint (`app_html_lint`).
+pub(crate) fn attr(tag: &tl::HTMLTag, name: &str) -> Option<String> {
     tag.attributes()
         .iter()
         .find(|(key, _)| key.eq_ignore_ascii_case(name))

--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -7,15 +7,11 @@
 //! reports the first disqualifying construct (rejection) plus soft warnings.
 //! Parsing failures fail closed (a rejection), never a silent pass.
 //!
-//! Script TEXT is extracted lexically from the raw input, not from the `tl`
-//! DOM: browsers treat script content as raw text until the next `</script>`,
-//! while `tl` has no RAWTEXT mode — a bare `<` in ordinary JS would splinter
-//! the element and let a bootstrap marker slip past the gate. The lexical
-//! extraction also reads script blocks inside HTML comments; for a security
-//! gate that is the fail-closed direction (dead markup is trivially deleted).
-//! Attribute refs are read from the DOM, tolerant of `tl`'s solidus fusing
-//! (see `resource_ref`), with a lexical fallback pass for tag shapes `tl`
-//! drops outright.
+//! Script text is extracted lexically from the raw input, not the `tl` DOM
+//! (`tl` has no RAWTEXT mode; a bare `<` in ordinary JS would hide a marker
+//! from the gate). This also reads script blocks inside HTML comments —
+//! fail-closed for a gate. Attribute refs come from the DOM (see
+//! `resource_ref`), with a lexical fallback for tag shapes `tl` drops.
 
 use std::sync::LazyLock;
 
@@ -41,14 +37,11 @@ static HEAD_OR_HTML: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)<(head|html)[\s>]").expect("static head/html probe regex"));
 
 // Raw-text src/href refs on script/link open tags, quoted (group 3) or
-// unquoted (group 4). Backstops the DOM loops in `scan_app_html` for tag
-// shapes `tl` drops; see the fallback step there. The attribute name must
-// follow a whitespace/solidus/quote boundary so `data-src` and friends do not
-// count. Deliberately regex-grade, not tokenizer-grade: markup crafted to
-// confuse it (a decoy `src=` inside another attribute's value, mixed quotes,
-// entity-spliced markers) can still slip this backstop — evading the gate only
-// breaks the author's own app, and the render-time CSP stays the real
-// security boundary.
+// unquoted (group 4); backstops the DOM loops for tag shapes `tl` drops. The
+// attribute name must follow a whitespace/solidus/quote boundary so `data-src`
+// does not count. Deliberately regex-grade: crafted markup (decoy `src=` in
+// another attribute's value, mixed quotes, entity-spliced markers) can still
+// slip it — the render-time CSP stays the real security boundary.
 static RESOURCE_REF_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r#"(?is)<(script|link)\b[^>]*?[\s/"'](src|href)\s*=\s*(?:["']([^"']*)["']|([^\s>"']+))"#,
@@ -98,9 +91,8 @@ pub fn scan_app_html(html: &str) -> ScanResult {
 
     let tags = || dom.nodes().iter().filter_map(|node| node.as_tag());
 
-    // 1. SDK self-bootstrap inside <script> text — lexical raw-input
-    //    extraction (see module docs on RAWTEXT). Concatenate all script text,
-    //    then test markers in list order (mirrors the TS precedence).
+    // 1. SDK self-bootstrap inside <script> text. Markers are tested in list
+    //    order over the concatenated blocks (mirrors the TS precedence).
     let script_text: String = SCRIPT_BLOCK
         .captures_iter(html)
         .map(|block| block[1].to_string())
@@ -139,13 +131,9 @@ pub fn scan_app_html(html: &str) -> ScanResult {
         }
     }
 
-    // 4. Lexical fallback for self-load refs: `tl` drops some browser-loadable
-    //    tag shapes entirely (space-before-solidus `<script /src=…>`, unquoted
-    //    URL values containing `/`), so the DOM loops above cannot be the only
-    //    line of defence. Reads any src/href attribute (quoted or unquoted) on
-    //    a raw script/link open tag, honouring the browser's tag/attribute
-    //    pairing; extra matches this can add (e.g. inside HTML comments) are
-    //    fail-closed for a rejection gate.
+    // 4. Lexical fallback for self-load refs in tag shapes `tl` drops
+    //    entirely (`<script /src=…>`, unquoted URL values with `/`). Extra
+    //    matches this can add (e.g. inside HTML comments) are fail-closed.
     for capture in RESOURCE_REF_FALLBACK.captures_iter(html) {
         let tag_name = &capture[1];
         let attr_name = &capture[2];
@@ -183,18 +171,16 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     }
 }
 
-// A `<script>` block's raw text: everything between the open tag and the next
-// `</script>`, the same extraction the TS predecessor used and the closest
-// lexical approximation of the browser's RAWTEXT tokenization. Shared with the
-// authoring lint (`app_html_lint`), like the tag helpers below.
+// A `<script>` block's raw text, up to the next `</script>` — the closest
+// lexical approximation of the browser's RAWTEXT tokenization. Shared with
+// the authoring lint (`app_html_lint`), like the tag helpers below.
 pub(crate) static SCRIPT_BLOCK: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?is)<script\b[^>]*>(.*?)</script>").expect("static script block regex")
 });
 
-// Tag-name match tolerant of `tl`'s solidus fusing: browsers treat a solidus
-// inside a tag as attribute-separator whitespace (`<script/src=…>` is a script
-// element), while `tl` fuses it into the tag name (`script/src`) — compare only
-// the part before the first solidus.
+// Tag-name match tolerant of `tl`'s solidus fusing: `<script/src=…>` is a
+// script element to the browser, but `tl` parses the name as `script/src` —
+// compare only the part before the first solidus.
 pub(crate) fn tag_is(tag: &tl::HTMLTag, expected: &str) -> bool {
     let name = tag.name().as_utf8_str();
     name.split('/')
@@ -203,13 +189,10 @@ pub(crate) fn tag_is(tag: &tl::HTMLTag, expected: &str) -> bool {
         .eq_ignore_ascii_case(expected)
 }
 
-// An attribute ref, recovering the solidus-fused shape `tag_is` matches on:
-// `tl` parses `<script/src="u">` as tag `script/src` with the value under an
-// empty attribute key. A solidus after a space (`<script /src=…>`) makes `tl`
-// drop the tag entirely — the save gate backstops that with its lexical
-// fallback pass; for the authoring lint it stays a deliberate blind spot
-// alongside unquoted URL values (a soft hint keeps the comment-excluding DOM
-// semantics instead).
+// An attribute ref, recovering the solidus-fused shape `tag_is` matches on
+// (`tl` leaves the value under an empty attribute key there). `<script /src=…>`
+// makes `tl` drop the tag entirely — the save gate's lexical fallback covers
+// that; the authoring lint deliberately leaves it a blind spot.
 pub(crate) fn resource_ref(tag: &tl::HTMLTag, attr_name: &str) -> Option<String> {
     if let Some(value) = attr(tag, attr_name) {
         return Some(value);
@@ -353,9 +336,8 @@ mod tests {
 
     #[test]
     fn bare_less_than_before_a_marker_cannot_evade_the_bootstrap_rejection() {
-        // `tl` has no RAWTEXT mode, so in its DOM a `<` comparison splinters
-        // the script element and hides what follows; the lexical script-text
-        // extraction must still see the marker.
+        // A `<` comparison splinters the script element in `tl`'s DOM; the
+        // lexical extraction must still see the marker.
         let html = "<html><head><script>if (a < b) { const u = window.__ARCHESTRA_APP_SDK_URL__; }</script></head></html>";
         assert_eq!(
             scan_app_html(html).rejection.expect("should reject").kind,
@@ -365,8 +347,7 @@ mod tests {
 
     #[test]
     fn commented_out_bootstrap_script_fails_closed() {
-        // The lexical extraction reads script blocks inside HTML comments too;
-        // rejecting dead markup is the fail-closed direction for the gate.
+        // The lexical extraction reads script blocks inside HTML comments too.
         let html = "<html><head><!-- <script>PostMessageTransport</script> --></head></html>";
         assert_eq!(
             scan_app_html(html).rejection.expect("should reject").kind,
@@ -376,8 +357,6 @@ mod tests {
 
     #[test]
     fn solidus_fused_platform_self_loads_are_rejected() {
-        // Browsers read `<script/src=…>`/`<link/href=…>` as ordinary elements;
-        // the fused-name recovery must keep the gate closed to them.
         let script =
             r#"<html><head><script/src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#;
         let rejection = scan_app_html(script).rejection.expect("should reject");
@@ -392,9 +371,7 @@ mod tests {
 
     #[test]
     fn space_solidus_self_loads_are_rejected_via_the_lexical_fallback() {
-        // `tl` drops `<script /src=…>`/`<link /href=…>` tags entirely, while
-        // browsers read them as ordinary elements — the raw-text fallback must
-        // keep the gate closed to them.
+        // `tl` drops these tags entirely; browsers load them.
         let script =
             r#"<html><head><script /src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#;
         let rejection = scan_app_html(script).rejection.expect("should reject");
@@ -419,21 +396,17 @@ mod tests {
 
     #[test]
     fn data_src_metadata_is_not_treated_as_a_self_load() {
-        // `data-src` is authored metadata the browser never loads; the
-        // fallback's attribute-boundary requirement must not read its value as
-        // a real `src`.
+        // The browser never loads `data-src`; the fallback's attribute
+        // boundary must not read it as a real `src`.
         let html = r#"<html><head><script data-src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#;
         assert_eq!(scan_app_html(html).rejection, None);
     }
 
     #[test]
     fn marker_after_a_gt_inside_a_script_attribute_fails_closed() {
-        // The lexical script-text extraction ends the open tag at the first
-        // `>`, even inside a quoted attribute, so a marker written after it is
-        // read as script text and rejects — although the browser sees an empty
-        // script body. Deliberate: a quote-aware pattern would go fail-open on
-        // unterminated quotes, and marker strings inside attribute values do
-        // not occur in legitimate apps.
+        // The lexical extraction ends the open tag at the first `>` even
+        // inside a quoted attribute. Deliberate: a quote-aware pattern would
+        // go fail-open on unterminated quotes, which is worse for a gate.
         let html =
             r#"<html><head><script data-note=">PostMessageTransport"></script></head></html>"#;
         assert_eq!(

--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -6,6 +6,15 @@
 //! the envelope module). A scan is pure: it never mutates the HTML, it only
 //! reports the first disqualifying construct (rejection) plus soft warnings.
 //! Parsing failures fail closed (a rejection), never a silent pass.
+//!
+//! Script TEXT is extracted lexically from the raw input, not from the `tl`
+//! DOM: browsers treat script content as raw text until the next `</script>`,
+//! while `tl` has no RAWTEXT mode — a bare `<` in ordinary JS would splinter
+//! the element and let a bootstrap marker slip past the gate. The lexical
+//! extraction also reads script blocks inside HTML comments; for a security
+//! gate that is the fail-closed direction (dead markup is trivially deleted).
+//! Attribute refs are read from the DOM, tolerant of `tl`'s solidus fusing
+//! (see `resource_ref`).
 
 use std::sync::LazyLock;
 
@@ -69,15 +78,15 @@ pub fn scan_app_html(html: &str) -> ScanResult {
             warnings: Vec::new(),
         };
     };
-    let parser = dom.parser();
 
     let tags = || dom.nodes().iter().filter_map(|node| node.as_tag());
 
-    // 1. SDK self-bootstrap inside <script> text. Concatenate all script text,
+    // 1. SDK self-bootstrap inside <script> text — lexical raw-input
+    //    extraction (see module docs on RAWTEXT). Concatenate all script text,
     //    then test markers in list order (mirrors the TS precedence).
-    let script_text: String = tags()
-        .filter(|tag| tag.name().as_utf8_str().eq_ignore_ascii_case("script"))
-        .map(|tag| tag.inner_text(parser).into_owned())
+    let script_text: String = SCRIPT_BLOCK
+        .captures_iter(html)
+        .map(|block| block[1].to_string())
         .collect::<Vec<_>>()
         .join("\n");
     for marker in SDK_BOOTSTRAP_MARKERS {
@@ -87,8 +96,8 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     }
 
     // 2. Platform script self-load via <script src>, document order.
-    for tag in tags().filter(|tag| tag.name().as_utf8_str().eq_ignore_ascii_case("script")) {
-        if let Some(src) = attr(tag, "src")
+    for tag in tags().filter(|tag| tag_is(tag, "script")) {
+        if let Some(src) = resource_ref(tag, "src")
             && PLATFORM_SCRIPT_SRC_MARKERS
                 .iter()
                 .any(|marker| src.contains(marker))
@@ -101,8 +110,8 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     //    browser ignores when resolving the URL so a spliced tab/newline (or a
     //    ZWNBSP, which JS `\s` strips but Rust's `is_whitespace` does not) can't
     //    sneak the marker past.
-    for tag in tags().filter(|tag| tag.name().as_utf8_str().eq_ignore_ascii_case("link")) {
-        if let Some(href) = attr(tag, "href") {
+    for tag in tags().filter(|tag| tag_is(tag, "link")) {
+        if let Some(href) = resource_ref(tag, "href") {
             let collapsed: String = href
                 .chars()
                 .filter(|c| !c.is_whitespace() && *c != '\u{feff}')
@@ -125,11 +134,50 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     }
 }
 
+// A `<script>` block's raw text: everything between the open tag and the next
+// `</script>`, the same extraction the TS predecessor used and the closest
+// lexical approximation of the browser's RAWTEXT tokenization. Shared with the
+// authoring lint (`app_html_lint`), like the tag helpers below.
+pub(crate) static SCRIPT_BLOCK: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)<script\b[^>]*>(.*?)</script>").expect("static script block regex")
+});
+
+// Tag-name match tolerant of `tl`'s solidus fusing: browsers treat a solidus
+// inside a tag as attribute-separator whitespace (`<script/src=…>` is a script
+// element), while `tl` fuses it into the tag name (`script/src`) — compare only
+// the part before the first solidus.
+pub(crate) fn tag_is(tag: &tl::HTMLTag, expected: &str) -> bool {
+    let name = tag.name().as_utf8_str();
+    name.split('/')
+        .next()
+        .unwrap_or(&name)
+        .eq_ignore_ascii_case(expected)
+}
+
+// An attribute ref, recovering the solidus-fused shape `tag_is` matches on:
+// `tl` parses `<script/src="u">` as tag `script/src` with the value under an
+// empty attribute key. A solidus after a space (`<script /src=…>`) makes `tl`
+// drop the tag entirely; that stays a blind spot alongside unquoted URL values.
+pub(crate) fn resource_ref(tag: &tl::HTMLTag, attr_name: &str) -> Option<String> {
+    if let Some(value) = attr(tag, attr_name) {
+        return Some(value);
+    }
+    let name = tag.name().as_utf8_str();
+    let (_, fused) = name.split_once('/')?;
+    if fused
+        .trim_start_matches('/')
+        .eq_ignore_ascii_case(attr_name)
+    {
+        return attr(tag, "");
+    }
+    None
+}
+
 // HTML attribute names are case-insensitive, but `tl`'s `Attributes::get` is an
 // exact-case lookup — so we iterate and compare keys with `eq_ignore_ascii_case`
 // (cheerio's `.attr()` matched `SRC`/`HREF` too). A valueless attribute yields
-// `None`, i.e. nothing to scan. Shared with the authoring lint (`app_html_lint`).
-pub(crate) fn attr(tag: &tl::HTMLTag, name: &str) -> Option<String> {
+// `None`, i.e. nothing to scan.
+fn attr(tag: &tl::HTMLTag, name: &str) -> Option<String> {
     tag.attributes()
         .iter()
         .find(|(key, _)| key.eq_ignore_ascii_case(name))
@@ -249,6 +297,45 @@ mod tests {
         let result = scan_app_html("<p>just a fragment</p>");
         assert_eq!(result.rejection, None);
         assert_eq!(result.warnings, vec![NO_DOCUMENT_ROOT_WARNING.to_string()]);
+    }
+
+    #[test]
+    fn bare_less_than_before_a_marker_cannot_evade_the_bootstrap_rejection() {
+        // `tl` has no RAWTEXT mode, so in its DOM a `<` comparison splinters
+        // the script element and hides what follows; the lexical script-text
+        // extraction must still see the marker.
+        let html = "<html><head><script>if (a < b) { const u = window.__ARCHESTRA_APP_SDK_URL__; }</script></head></html>";
+        assert_eq!(
+            scan_app_html(html).rejection.expect("should reject").kind,
+            RejectionKind::SdkBootstrap
+        );
+    }
+
+    #[test]
+    fn commented_out_bootstrap_script_fails_closed() {
+        // The lexical extraction reads script blocks inside HTML comments too;
+        // rejecting dead markup is the fail-closed direction for the gate.
+        let html = "<html><head><!-- <script>PostMessageTransport</script> --></head></html>";
+        assert_eq!(
+            scan_app_html(html).rejection.expect("should reject").kind,
+            RejectionKind::SdkBootstrap
+        );
+    }
+
+    #[test]
+    fn solidus_fused_platform_self_loads_are_rejected() {
+        // Browsers read `<script/src=…>`/`<link/href=…>` as ordinary elements;
+        // the fused-name recovery must keep the gate closed to them.
+        let script =
+            r#"<html><head><script/src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#;
+        let rejection = scan_app_html(script).rejection.expect("should reject");
+        assert_eq!(rejection.kind, RejectionKind::PlatformScriptSrc);
+        assert_eq!(rejection.offender, "/_sandbox/archestra-app-sdk.js");
+        let link = r#"<html><head><link/href="/_sandbox/archestra-app-base.css"></head></html>"#;
+        assert_eq!(
+            scan_app_html(link).rejection.expect("should reject").kind,
+            RejectionKind::PlatformBaseCss
+        );
     }
 
     #[test]

--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -42,10 +42,18 @@ static HEAD_OR_HTML: LazyLock<Regex> =
 
 // Raw-text src/href refs on script/link open tags, quoted (group 3) or
 // unquoted (group 4). Backstops the DOM loops in `scan_app_html` for tag
-// shapes `tl` drops; see the fallback step there.
+// shapes `tl` drops; see the fallback step there. The attribute name must
+// follow a whitespace/solidus/quote boundary so `data-src` and friends do not
+// count. Deliberately regex-grade, not tokenizer-grade: markup crafted to
+// confuse it (a decoy `src=` inside another attribute's value, mixed quotes,
+// entity-spliced markers) can still slip this backstop — evading the gate only
+// breaks the author's own app, and the render-time CSP stays the real
+// security boundary.
 static RESOURCE_REF_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?is)<(script|link)\b[^>]*?\b(src|href)\s*=\s*(?:["']([^"']*)["']|([^\s>"']+))"#)
-        .expect("static resource ref fallback regex")
+    Regex::new(
+        r#"(?is)<(script|link)\b[^>]*?[\s/"'](src|href)\s*=\s*(?:["']([^"']*)["']|([^\s>"']+))"#,
+    )
+    .expect("static resource ref fallback regex")
 });
 
 /// Why a scan disqualified the HTML. Carries the offending value so the caller
@@ -407,6 +415,15 @@ mod tests {
             scan_app_html(html).rejection.expect("should reject").kind,
             RejectionKind::PlatformScriptSrc
         );
+    }
+
+    #[test]
+    fn data_src_metadata_is_not_treated_as_a_self_load() {
+        // `data-src` is authored metadata the browser never loads; the
+        // fallback's attribute-boundary requirement must not read its value as
+        // a real `src`.
+        let html = r#"<html><head><script data-src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#;
+        assert_eq!(scan_app_html(html).rejection, None);
     }
 
     #[test]

--- a/platform/archestra-rs/app-runtime-core/src/app_html_lint.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html_lint.rs
@@ -11,14 +11,19 @@
 //! (`const s = archestra.storage; s.get()`), computed access
 //! (`archestra["storage"]`), and dynamic names are out of scope by design.
 //!
-//! Unlike the TS predecessor (raw-text regexes), tags are read from the same
-//! `tl` DOM the scan parses: `src` is read on `<script>` and `href` on
-//! `<link>` as real attributes, and markup inside HTML comments is not
+//! Resource refs are read from the same `tl` DOM the scan parses (unlike the
+//! TS predecessor's raw-text regexes): `src` is read on `<script>` and `href`
+//! on `<link>` as real attributes, and markup inside HTML comments is not
 //! scanned — matching what the browser resolves at render time. Unquoted URL
 //! attribute values stay a blind spot (`tl` drops such tags; the TS regex
-//! required quotes). If the HTML does not parse, the findings are empty: the
-//! scan already fails closed with an `unparseable` rejection, and lexical
-//! hints on unparseable input are noise.
+//! required quotes). Script TEXT, in contrast, is extracted lexically from
+//! the raw input, exactly as the TS predecessor did: browsers treat script
+//! content as raw text until the next `</script>`, while `tl` has no RAWTEXT
+//! mode — a bare `<` in ordinary JS (a comparison, a for-loop) would splinter
+//! the element in the DOM, both hiding real script text and leaking the rest
+//! of the document into it. If the HTML does not parse, the findings are
+//! empty: the scan already fails closed with an `unparseable` rejection, and
+//! lexical hints on unparseable input are noise.
 
 use std::sync::LazyLock;
 
@@ -61,18 +66,23 @@ pub fn lint_app_html(html: &str, config: &LintConfig) -> LintFindings {
     let Ok(dom) = tl::parse(html, tl::ParserOptions::default()) else {
         return LintFindings::default();
     };
-    let parser = dom.parser();
     let mut findings = LintFindings::default();
 
+    // Script text: lexical raw-input extraction (see module docs on RAWTEXT).
+    for block in SCRIPT_BLOCK.captures_iter(html) {
+        lint_script_text(&block[1], config, &mut findings);
+    }
+
+    // Resource refs: real DOM attributes.
     for tag in dom.nodes().iter().filter_map(|node| node.as_tag()) {
         let name = tag.name().as_utf8_str();
-        if name.eq_ignore_ascii_case("script") {
-            lint_script_text(&tag.inner_text(parser), config, &mut findings);
-            if let Some(src) = attr(tag, "src") {
+        let base_name = name.split('/').next().unwrap_or(&name);
+        if base_name.eq_ignore_ascii_case("script") {
+            if let Some(src) = resource_ref(tag, "src") {
                 flag_off_allowlist_host(&src, config, &mut findings);
             }
-        } else if name.eq_ignore_ascii_case("link")
-            && let Some(href) = attr(tag, "href")
+        } else if base_name.eq_ignore_ascii_case("link")
+            && let Some(href) = resource_ref(tag, "href")
         {
             flag_off_allowlist_host(&href, config, &mut findings);
         }
@@ -80,9 +90,40 @@ pub fn lint_app_html(html: &str, config: &LintConfig) -> LintFindings {
     findings
 }
 
+// Browsers treat a solidus inside a tag as attribute-separator whitespace, so
+// `<script/src="u">` is a script element loading `u`. `tl` instead fuses the
+// solidus and the attribute name into the tag name (`script/src`) and leaves
+// the value under an empty attribute key — recover the ref from that shape
+// (the base-name match above handles the fused tag name). A solidus after a
+// space (`<script /src=…>`) makes `tl` drop the tag entirely; that stays a
+// blind spot alongside unquoted URL values.
+fn resource_ref(tag: &tl::HTMLTag, attr_name: &str) -> Option<String> {
+    if let Some(value) = attr(tag, attr_name) {
+        return Some(value);
+    }
+    let name = tag.name().as_utf8_str();
+    let (_, fused) = name.split_once('/')?;
+    if fused
+        .trim_start_matches('/')
+        .eq_ignore_ascii_case(attr_name)
+    {
+        return attr(tag, "");
+    }
+    None
+}
+
+// A `<script>` block's raw text: everything between the open tag and the next
+// `</script>`, the same extraction the TS predecessor used and the closest
+// lexical approximation of the browser's RAWTEXT tokenization.
+static SCRIPT_BLOCK: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)<script\b[^>]*>(.*?)</script>").expect("static script block regex")
+});
+
 // `\b`-anchored so `myarchestra.x` is not matched; `window.archestra.<member>`
 // still matches via its `archestra.<member>` substring. Member names use the
-// ASCII identifier class the TS predecessor used.
+// ASCII identifier class the TS predecessor used. (Rust `\b` is Unicode-aware
+// where JS's is ASCII, so a non-ASCII letter abutting `archestra` no longer
+// counts as a boundary — strictly fewer false positives.)
 static ARCHESTRA_TOP_LEVEL: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\barchestra\.([A-Za-z_$][0-9A-Za-z_$]*)").expect("static archestra member regex")
 });
@@ -248,6 +289,45 @@ mod tests {
             </head></html>"#,
         );
         assert_eq!(findings.off_allowlist_hosts, Vec::<String>::new());
+    }
+
+    #[test]
+    fn solidus_fused_attribute_is_recovered() {
+        // Browsers read `<script/src=…>`/`<link/href=…>` as ordinary elements
+        // (the solidus acts as attribute-separator whitespace); `tl` fuses the
+        // attribute name into the tag name. The lint must still see the ref.
+        let findings = lint(
+            r#"<html><head><script/src="https://evil.example.com/a.js"></script><link/href="https://other.example.com/a.css"></head></html>"#,
+        );
+        assert_eq!(
+            findings.off_allowlist_hosts,
+            vec!["evil.example.com", "other.example.com"]
+        );
+    }
+
+    #[test]
+    fn bare_less_than_in_script_does_not_hide_script_text() {
+        // `tl` has no RAWTEXT mode, so in its DOM a `<` comparison splinters
+        // the script element; the lexical script-text extraction must still
+        // see everything up to `</script>`.
+        let findings = lint(
+            r#"<html><head><script>async function main() {
+                const items = await archestra.tools.call("x", {});
+                if (items.length < 5) { localStorage.setItem("cache", "1"); archestra.storage.get("k"); }
+            }</script></head><body/></html>"#,
+        );
+        assert_eq!(findings.browser_storage_apis, vec!["localStorage"]);
+        assert_eq!(findings.storage_misuse, vec!["archestra.storage.get"]);
+    }
+
+    #[test]
+    fn bare_less_than_in_script_does_not_leak_following_prose_into_it() {
+        // The same `tl` misparse swallows the rest of the document as script
+        // children; prose after the script must still not warn.
+        let findings = lint(
+            "<html><head><script>if (a < b) { run(); }</script></head><body><p>This app does not use sessionStorage or archestra.storage.get.</p></body></html>",
+        );
+        assert_eq!(findings, LintFindings::default());
     }
 
     #[test]

--- a/platform/archestra-rs/app-runtime-core/src/app_html_lint.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html_lint.rs
@@ -30,7 +30,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 use url::Url;
 
-use crate::app_html::attr;
+use crate::app_html::{SCRIPT_BLOCK, resource_ref, tag_is};
 
 /// Policy inputs for the lint, owned by the TypeScript caller (single source of
 /// truth for the CDN allowlist and the injected-SDK surface lives there).
@@ -73,15 +73,14 @@ pub fn lint_app_html(html: &str, config: &LintConfig) -> LintFindings {
         lint_script_text(&block[1], config, &mut findings);
     }
 
-    // Resource refs: real DOM attributes.
+    // Resource refs: real DOM attributes, solidus-fused shapes recovered (see
+    // `tag_is`/`resource_ref` in `app_html`).
     for tag in dom.nodes().iter().filter_map(|node| node.as_tag()) {
-        let name = tag.name().as_utf8_str();
-        let base_name = name.split('/').next().unwrap_or(&name);
-        if base_name.eq_ignore_ascii_case("script") {
+        if tag_is(tag, "script") {
             if let Some(src) = resource_ref(tag, "src") {
                 flag_off_allowlist_host(&src, config, &mut findings);
             }
-        } else if base_name.eq_ignore_ascii_case("link")
+        } else if tag_is(tag, "link")
             && let Some(href) = resource_ref(tag, "href")
         {
             flag_off_allowlist_host(&href, config, &mut findings);
@@ -89,35 +88,6 @@ pub fn lint_app_html(html: &str, config: &LintConfig) -> LintFindings {
     }
     findings
 }
-
-// Browsers treat a solidus inside a tag as attribute-separator whitespace, so
-// `<script/src="u">` is a script element loading `u`. `tl` instead fuses the
-// solidus and the attribute name into the tag name (`script/src`) and leaves
-// the value under an empty attribute key — recover the ref from that shape
-// (the base-name match above handles the fused tag name). A solidus after a
-// space (`<script /src=…>`) makes `tl` drop the tag entirely; that stays a
-// blind spot alongside unquoted URL values.
-fn resource_ref(tag: &tl::HTMLTag, attr_name: &str) -> Option<String> {
-    if let Some(value) = attr(tag, attr_name) {
-        return Some(value);
-    }
-    let name = tag.name().as_utf8_str();
-    let (_, fused) = name.split_once('/')?;
-    if fused
-        .trim_start_matches('/')
-        .eq_ignore_ascii_case(attr_name)
-    {
-        return attr(tag, "");
-    }
-    None
-}
-
-// A `<script>` block's raw text: everything between the open tag and the next
-// `</script>`, the same extraction the TS predecessor used and the closest
-// lexical approximation of the browser's RAWTEXT tokenization.
-static SCRIPT_BLOCK: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?is)<script\b[^>]*>(.*?)</script>").expect("static script block regex")
-});
 
 // `\b`-anchored so `myarchestra.x` is not matched; `window.archestra.<member>`
 // still matches via its `archestra.<member>` substring. Member names use the

--- a/platform/archestra-rs/app-runtime-core/src/app_html_lint.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html_lint.rs
@@ -1,29 +1,15 @@
-//! Authoring-time lint of an owned app's HTML for the `validate_app` MCP tool.
-//! Ported from the regex helpers in `services/apps/app-ui-policy.ts`; the
-//! companion save-gate scan lives in `app_html`.
+//! Authoring-time lint of an owned app's HTML for the `validate_app` MCP tool
+//! (the save-gate scan lives in `app_html`). Soft hints only, never a
+//! rejection; the caller supplies the policy inputs and composes the
+//! user-facing messages. Deliberately lexical inside script text: aliasing,
+//! computed access, and dynamic names are out of scope.
 //!
-//! Everything here is a soft hint for the author, never a rejection: hosts the
-//! pinned CSP will block at render time, browser storage APIs the sandbox's
-//! opaque origin breaks, and `window.archestra` members the injected SDK does
-//! not expose. The caller supplies the policy inputs (CDN allowlist, SDK
-//! surface) and composes the user-facing messages; this module only reports
-//! structured findings. The lint stays lexical inside script text: aliasing
-//! (`const s = archestra.storage; s.get()`), computed access
-//! (`archestra["storage"]`), and dynamic names are out of scope by design.
-//!
-//! Resource refs are read from the same `tl` DOM the scan parses (unlike the
-//! TS predecessor's raw-text regexes): `src` is read on `<script>` and `href`
-//! on `<link>` as real attributes, and markup inside HTML comments is not
-//! scanned — matching what the browser resolves at render time. Unquoted URL
-//! attribute values stay a blind spot (`tl` drops such tags; the TS regex
-//! required quotes). Script TEXT, in contrast, is extracted lexically from
-//! the raw input, exactly as the TS predecessor did: browsers treat script
-//! content as raw text until the next `</script>`, while `tl` has no RAWTEXT
-//! mode — a bare `<` in ordinary JS (a comparison, a for-loop) would splinter
-//! the element in the DOM, both hiding real script text and leaking the rest
-//! of the document into it. If the HTML does not parse, the findings are
-//! empty: the scan already fails closed with an `unparseable` rejection, and
-//! lexical hints on unparseable input are noise.
+//! Resource refs come from the `tl` DOM (real `src`/`href` attributes; HTML
+//! comments not scanned), so unquoted URL values stay a blind spot — `tl`
+//! drops such tags. Script text comes from a raw-input extraction instead:
+//! `tl` has no RAWTEXT mode, so a bare `<` in ordinary JS would splinter the
+//! element in its DOM. Unparseable HTML yields empty findings; the scan
+//! already rejects it fail-closed.
 
 use std::sync::LazyLock;
 
@@ -32,20 +18,19 @@ use url::Url;
 
 use crate::app_html::{SCRIPT_BLOCK, resource_ref, tag_is};
 
-/// Policy inputs for the lint, owned by the TypeScript caller (single source of
-/// truth for the CDN allowlist and the injected-SDK surface lives there).
+/// Policy inputs for the lint; the TypeScript caller is the single source of
+/// truth for the CDN allowlist and the injected-SDK surface.
 #[derive(Clone, Debug)]
 pub struct LintConfig {
-    /// Bare hostnames `<script src>`/`<link href>` may point at (exact match,
-    /// mirroring CSP host-source semantics).
+    /// Bare hostnames `<script src>`/`<link href>` may point at (exact match).
     pub resource_host_allowlist: Vec<String>,
-    /// Members the injected `window.archestra` exposes at the top level.
+    /// Top-level members of the injected `window.archestra`.
     pub sdk_top_level_members: Vec<String>,
-    /// Partitions of `archestra.storage` (methods hang off a partition).
+    /// Partitions of `archestra.storage`.
     pub sdk_storage_partitions: Vec<String>,
 }
 
-/// Structured lint findings. Every list is deduplicated in first-seen document
+/// Structured lint findings, each list deduplicated in first-seen document
 /// order; the caller turns each non-empty list into one user-facing warning.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LintFindings {
@@ -53,11 +38,10 @@ pub struct LintFindings {
     pub off_allowlist_hosts: Vec<String>,
     /// Browser storage APIs (`localStorage`, …) referenced in script text.
     pub browser_storage_apis: Vec<String>,
-    /// `archestra.storage.<member>` accesses where `<member>` is no partition,
-    /// as full references (`archestra.storage.get`).
+    /// Full `archestra.storage.<member>` references where `<member>` is no
+    /// partition.
     pub storage_misuse: Vec<String>,
-    /// `archestra.<member>` accesses the SDK does not expose, as full
-    /// references (`archestra.tool`).
+    /// Full `archestra.<member>` references the SDK does not expose.
     pub unknown_top_level: Vec<String>,
 }
 
@@ -68,13 +52,10 @@ pub fn lint_app_html(html: &str, config: &LintConfig) -> LintFindings {
     };
     let mut findings = LintFindings::default();
 
-    // Script text: lexical raw-input extraction (see module docs on RAWTEXT).
     for block in SCRIPT_BLOCK.captures_iter(html) {
         lint_script_text(&block[1], config, &mut findings);
     }
 
-    // Resource refs: real DOM attributes, solidus-fused shapes recovered (see
-    // `tag_is`/`resource_ref` in `app_html`).
     for tag in dom.nodes().iter().filter_map(|node| node.as_tag()) {
         if tag_is(tag, "script") {
             if let Some(src) = resource_ref(tag, "src") {
@@ -89,11 +70,8 @@ pub fn lint_app_html(html: &str, config: &LintConfig) -> LintFindings {
     findings
 }
 
-// `\b`-anchored so `myarchestra.x` is not matched; `window.archestra.<member>`
-// still matches via its `archestra.<member>` substring. Member names use the
-// ASCII identifier class the TS predecessor used. (Rust `\b` is Unicode-aware
-// where JS's is ASCII, so a non-ASCII letter abutting `archestra` no longer
-// counts as a boundary — strictly fewer false positives.)
+// `\b`-anchored so `myarchestra.x` is not matched while `window.archestra.x`
+// still is (via its `archestra.x` substring).
 static ARCHESTRA_TOP_LEVEL: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\barchestra\.([A-Za-z_$][0-9A-Za-z_$]*)").expect("static archestra member regex")
 });
@@ -110,11 +88,9 @@ static JS_BLOCK_COMMENT: LazyLock<Regex> =
 static JS_LINE_COMMENT: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"//[^\n]*").expect("static line comment regex"));
 
-// One script block's text against the storage-API and SDK-member lints. The
-// storage scan sees the raw text (a commented-out `localStorage` still warns,
-// as in the TS predecessor); the SDK-member scan is comment-stripped so a
-// documented counter-example (`// use archestra.storage.user.get, not .get`)
-// does not warn.
+// The storage scan sees raw script text (a commented-out `localStorage` still
+// warns); the SDK-member scan is comment-stripped so a documented
+// counter-example (`// not archestra.storage.get`) does not warn.
 fn lint_script_text(script: &str, config: &LintConfig, findings: &mut LintFindings) {
     for capture in BROWSER_STORAGE_API.captures_iter(script) {
         push_unique(&mut findings.browser_storage_apis, &capture[1]);
@@ -140,11 +116,9 @@ fn lint_script_text(script: &str, config: &LintConfig, findings: &mut LintFindin
     }
 }
 
-// Drop // line and /* */ block comments. Block comments collapse to a space so
-// a comment between tokens can never fuse two identifiers into a spurious
-// `archestra.*`. Only ever deletes spans, so it can miss a call literally
-// inside a comment-shaped string, never invent one; string literals are left
-// as-is (lexically unsafe to strip).
+// Block comments collapse to a space so a comment between tokens can never
+// fuse two identifiers; string literals are left as-is (lexically unsafe to
+// strip), so this can miss but never invent a reference.
 fn strip_js_comments(script: &str) -> String {
     let without_blocks = JS_BLOCK_COMMENT.replace_all(script, " ");
     JS_LINE_COMMENT
@@ -162,9 +136,8 @@ fn flag_off_allowlist_host(reference: &str, config: &LintConfig, findings: &mut 
 }
 
 // The host of an absolute or protocol-relative http(s) URL; `None` for
-// relative, data:, blob:, or otherwise host-less refs (which the resource CSP
-// ignores). The scheme is checked before parsing because `Url::parse` would
-// also accept slashless forms (`https:foo`) the CSP lint never meant to cover.
+// host-less refs the resource CSP ignores. The scheme prefix is checked before
+// parsing because `Url::parse` also accepts slashless forms (`https:foo`).
 fn external_host(reference: &str) -> Option<String> {
     let normalized = if reference.starts_with("//") {
         format!("https:{reference}")
@@ -183,7 +156,6 @@ fn external_host(reference: &str) -> Option<String> {
     Url::parse(&normalized).ok()?.host_str().map(str::to_owned)
 }
 
-// Findings lists are tiny (a handful of entries), so a linear scan beats a set.
 fn push_unique(list: &mut Vec<String>, value: &str) {
     if !list.iter().any(|existing| existing == value) {
         list.push(value.to_string());
@@ -263,9 +235,8 @@ mod tests {
 
     #[test]
     fn solidus_fused_attribute_is_recovered() {
-        // Browsers read `<script/src=…>`/`<link/href=…>` as ordinary elements
-        // (the solidus acts as attribute-separator whitespace); `tl` fuses the
-        // attribute name into the tag name. The lint must still see the ref.
+        // `<script/src=…>` is a script element to the browser; `tl` fuses the
+        // attribute into the tag name.
         let findings = lint(
             r#"<html><head><script/src="https://evil.example.com/a.js"></script><link/href="https://other.example.com/a.css"></head></html>"#,
         );
@@ -277,9 +248,8 @@ mod tests {
 
     #[test]
     fn bare_less_than_in_script_does_not_hide_script_text() {
-        // `tl` has no RAWTEXT mode, so in its DOM a `<` comparison splinters
-        // the script element; the lexical script-text extraction must still
-        // see everything up to `</script>`.
+        // A `<` comparison splinters the script element in `tl`'s DOM; the
+        // lexical extraction must still see everything up to `</script>`.
         let findings = lint(
             r#"<html><head><script>async function main() {
                 const items = await archestra.tools.call("x", {});
@@ -292,8 +262,7 @@ mod tests {
 
     #[test]
     fn bare_less_than_in_script_does_not_leak_following_prose_into_it() {
-        // The same `tl` misparse swallows the rest of the document as script
-        // children; prose after the script must still not warn.
+        // The same misparse swallows the rest of the document as script children.
         let findings = lint(
             "<html><head><script>if (a < b) { run(); }</script></head><body><p>This app does not use sessionStorage or archestra.storage.get.</p></body></html>",
         );
@@ -302,10 +271,8 @@ mod tests {
 
     #[test]
     fn unquoted_url_attribute_is_a_shared_blind_spot() {
-        // `tl` drops a tag whose unquoted attribute value contains `/`, so an
-        // unquoted URL ref is not seen — the same blind spot the TS regex had
-        // (it required a quoted value). Pinned so a `tl` upgrade that starts
-        // parsing these shows up as a deliberate behavior change.
+        // `tl` drops tags whose unquoted attribute value contains `/` (the TS
+        // regex required quotes too); pinned so a `tl` upgrade surfaces here.
         let findings =
             lint("<html><head><script src=https://evil.example.com/a.js></script></head></html>");
         assert_eq!(findings.off_allowlist_hosts, Vec::<String>::new());
@@ -313,8 +280,7 @@ mod tests {
 
     #[test]
     fn refs_inside_html_comments_are_not_scanned() {
-        // Behavior delta vs the TS regex: a commented-out tag never loads, so
-        // it does not warn.
+        // Delta vs the TS regex: a commented-out tag never loads.
         let findings = lint(
             r#"<html><head><!-- <script src="https://evil.example.com/a.js"></script> --></head></html>"#,
         );
@@ -323,8 +289,8 @@ mod tests {
 
     #[test]
     fn src_on_link_and_href_on_script_do_not_match() {
-        // Behavior delta vs the tag-agnostic TS regex: only the attribute the
-        // browser reads on each tag counts.
+        // Delta vs the tag-agnostic TS regex: only the attribute the browser
+        // reads on each tag counts.
         let findings = lint(
             r#"<html><head><link src="https://evil.example.com/a.css"><script href="https://evil.example.com/b.js"></script></head></html>"#,
         );
@@ -333,10 +299,8 @@ mod tests {
 
     #[test]
     fn host_comparison_uses_url_normalization() {
-        // Mixed-case hosts normalize to lowercase (so the allowlist matches);
-        // IDNA hosts normalize to punycode; IPv6 literals keep their brackets
-        // and a trailing-dot host stays distinct — none of those three match a
-        // bare-hostname allowlist.
+        // Case folds, IDNA → punycode; IPv6 brackets and trailing dots stay,
+        // so none of those match a bare-hostname allowlist.
         let findings = lint(
             r#"<html><head>
                 <script src="https://CDN.JSDELIVR.NET/npm/x.js"></script>
@@ -382,8 +346,7 @@ mod tests {
 
     #[test]
     fn browser_storage_scan_does_not_strip_js_comments() {
-        // Parity with the TS predecessor: the storage hint fires even on
-        // commented-out usage (only the SDK-member lint strips comments).
+        // TS parity: only the SDK-member lint strips comments.
         let findings = lint(
             "<html><head><script>// localStorage.getItem\nconst x = 1;</script></head></html>",
         );

--- a/platform/archestra-rs/app-runtime-core/src/app_html_lint.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html_lint.rs
@@ -1,0 +1,412 @@
+//! Authoring-time lint of an owned app's HTML for the `validate_app` MCP tool.
+//! Ported from the regex helpers in `services/apps/app-ui-policy.ts`; the
+//! companion save-gate scan lives in `app_html`.
+//!
+//! Everything here is a soft hint for the author, never a rejection: hosts the
+//! pinned CSP will block at render time, browser storage APIs the sandbox's
+//! opaque origin breaks, and `window.archestra` members the injected SDK does
+//! not expose. The caller supplies the policy inputs (CDN allowlist, SDK
+//! surface) and composes the user-facing messages; this module only reports
+//! structured findings. The lint stays lexical inside script text: aliasing
+//! (`const s = archestra.storage; s.get()`), computed access
+//! (`archestra["storage"]`), and dynamic names are out of scope by design.
+//!
+//! Unlike the TS predecessor (raw-text regexes), tags are read from the same
+//! `tl` DOM the scan parses: `src` is read on `<script>` and `href` on
+//! `<link>` as real attributes, and markup inside HTML comments is not
+//! scanned — matching what the browser resolves at render time. Unquoted URL
+//! attribute values stay a blind spot (`tl` drops such tags; the TS regex
+//! required quotes). If the HTML does not parse, the findings are empty: the
+//! scan already fails closed with an `unparseable` rejection, and lexical
+//! hints on unparseable input are noise.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+use url::Url;
+
+use crate::app_html::attr;
+
+/// Policy inputs for the lint, owned by the TypeScript caller (single source of
+/// truth for the CDN allowlist and the injected-SDK surface lives there).
+#[derive(Clone, Debug)]
+pub struct LintConfig {
+    /// Bare hostnames `<script src>`/`<link href>` may point at (exact match,
+    /// mirroring CSP host-source semantics).
+    pub resource_host_allowlist: Vec<String>,
+    /// Members the injected `window.archestra` exposes at the top level.
+    pub sdk_top_level_members: Vec<String>,
+    /// Partitions of `archestra.storage` (methods hang off a partition).
+    pub sdk_storage_partitions: Vec<String>,
+}
+
+/// Structured lint findings. Every list is deduplicated in first-seen document
+/// order; the caller turns each non-empty list into one user-facing warning.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LintFindings {
+    /// Hosts referenced by `<script src>`/`<link href>` outside the allowlist.
+    pub off_allowlist_hosts: Vec<String>,
+    /// Browser storage APIs (`localStorage`, …) referenced in script text.
+    pub browser_storage_apis: Vec<String>,
+    /// `archestra.storage.<member>` accesses where `<member>` is no partition,
+    /// as full references (`archestra.storage.get`).
+    pub storage_misuse: Vec<String>,
+    /// `archestra.<member>` accesses the SDK does not expose, as full
+    /// references (`archestra.tool`).
+    pub unknown_top_level: Vec<String>,
+}
+
+/// Lint authored app HTML against the supplied policy. See module docs.
+pub fn lint_app_html(html: &str, config: &LintConfig) -> LintFindings {
+    let Ok(dom) = tl::parse(html, tl::ParserOptions::default()) else {
+        return LintFindings::default();
+    };
+    let parser = dom.parser();
+    let mut findings = LintFindings::default();
+
+    for tag in dom.nodes().iter().filter_map(|node| node.as_tag()) {
+        let name = tag.name().as_utf8_str();
+        if name.eq_ignore_ascii_case("script") {
+            lint_script_text(&tag.inner_text(parser), config, &mut findings);
+            if let Some(src) = attr(tag, "src") {
+                flag_off_allowlist_host(&src, config, &mut findings);
+            }
+        } else if name.eq_ignore_ascii_case("link")
+            && let Some(href) = attr(tag, "href")
+        {
+            flag_off_allowlist_host(&href, config, &mut findings);
+        }
+    }
+    findings
+}
+
+// `\b`-anchored so `myarchestra.x` is not matched; `window.archestra.<member>`
+// still matches via its `archestra.<member>` substring. Member names use the
+// ASCII identifier class the TS predecessor used.
+static ARCHESTRA_TOP_LEVEL: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\barchestra\.([A-Za-z_$][0-9A-Za-z_$]*)").expect("static archestra member regex")
+});
+static ARCHESTRA_STORAGE_MEMBER: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\barchestra\.storage\.([A-Za-z_$][0-9A-Za-z_$]*)")
+        .expect("static archestra storage member regex")
+});
+static BROWSER_STORAGE_API: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b(localStorage|sessionStorage|indexedDB)\b")
+        .expect("static browser storage regex")
+});
+static JS_BLOCK_COMMENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)/\*.*?\*/").expect("static block comment regex"));
+static JS_LINE_COMMENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"//[^\n]*").expect("static line comment regex"));
+
+// One script block's text against the storage-API and SDK-member lints. The
+// storage scan sees the raw text (a commented-out `localStorage` still warns,
+// as in the TS predecessor); the SDK-member scan is comment-stripped so a
+// documented counter-example (`// use archestra.storage.user.get, not .get`)
+// does not warn.
+fn lint_script_text(script: &str, config: &LintConfig, findings: &mut LintFindings) {
+    for capture in BROWSER_STORAGE_API.captures_iter(script) {
+        push_unique(&mut findings.browser_storage_apis, &capture[1]);
+    }
+    let stripped = strip_js_comments(script);
+    for capture in ARCHESTRA_TOP_LEVEL.captures_iter(&stripped) {
+        let member = &capture[1];
+        if !config.sdk_top_level_members.iter().any(|m| m == member) {
+            push_unique(
+                &mut findings.unknown_top_level,
+                &format!("archestra.{member}"),
+            );
+        }
+    }
+    for capture in ARCHESTRA_STORAGE_MEMBER.captures_iter(&stripped) {
+        let member = &capture[1];
+        if !config.sdk_storage_partitions.iter().any(|m| m == member) {
+            push_unique(
+                &mut findings.storage_misuse,
+                &format!("archestra.storage.{member}"),
+            );
+        }
+    }
+}
+
+// Drop // line and /* */ block comments. Block comments collapse to a space so
+// a comment between tokens can never fuse two identifiers into a spurious
+// `archestra.*`. Only ever deletes spans, so it can miss a call literally
+// inside a comment-shaped string, never invent one; string literals are left
+// as-is (lexically unsafe to strip).
+fn strip_js_comments(script: &str) -> String {
+    let without_blocks = JS_BLOCK_COMMENT.replace_all(script, " ");
+    JS_LINE_COMMENT
+        .replace_all(&without_blocks, "")
+        .into_owned()
+}
+
+fn flag_off_allowlist_host(reference: &str, config: &LintConfig, findings: &mut LintFindings) {
+    let Some(host) = external_host(reference) else {
+        return;
+    };
+    if !config.resource_host_allowlist.contains(&host) {
+        push_unique(&mut findings.off_allowlist_hosts, &host);
+    }
+}
+
+// The host of an absolute or protocol-relative http(s) URL; `None` for
+// relative, data:, blob:, or otherwise host-less refs (which the resource CSP
+// ignores). The scheme is checked before parsing because `Url::parse` would
+// also accept slashless forms (`https:foo`) the CSP lint never meant to cover.
+fn external_host(reference: &str) -> Option<String> {
+    let normalized = if reference.starts_with("//") {
+        format!("https:{reference}")
+    } else {
+        reference.to_string()
+    };
+    let has_http_scheme = normalized
+        .get(..7)
+        .is_some_and(|p| p.eq_ignore_ascii_case("http://"))
+        || normalized
+            .get(..8)
+            .is_some_and(|p| p.eq_ignore_ascii_case("https://"));
+    if !has_http_scheme {
+        return None;
+    }
+    Url::parse(&normalized).ok()?.host_str().map(str::to_owned)
+}
+
+// Findings lists are tiny (a handful of entries), so a linear scan beats a set.
+fn push_unique(list: &mut Vec<String>, value: &str) {
+    if !list.iter().any(|existing| existing == value) {
+        list.push(value.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> LintConfig {
+        LintConfig {
+            resource_host_allowlist: vec![
+                "cdn.jsdelivr.net".to_string(),
+                "fonts.googleapis.com".to_string(),
+            ],
+            sdk_top_level_members: vec![
+                "ready", "user", "context", "storage", "llm", "tools", "ui",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+            sdk_storage_partitions: vec!["user".to_string(), "shared".to_string()],
+        }
+    }
+
+    fn lint(html: &str) -> LintFindings {
+        lint_app_html(html, &config())
+    }
+
+    #[test]
+    fn clean_document_yields_no_findings() {
+        let findings = lint(
+            r#"<html><head><script src="https://cdn.jsdelivr.net/npm/x.js"></script><script>
+                await archestra.ready;
+                const v = await archestra.storage.user.get("k");
+                await archestra.storage.shared.set("k", 1);
+                await archestra.tools.call("github__x", {});
+            </script></head><body/></html>"#,
+        );
+        assert_eq!(findings, LintFindings::default());
+    }
+
+    // --- off-allowlist resource hosts ---
+
+    #[test]
+    fn off_allowlist_script_host_is_flagged() {
+        let findings = lint(
+            r#"<html><head><script src="https://evil.example.com/a.js"></script></head></html>"#,
+        );
+        assert_eq!(findings.off_allowlist_hosts, vec!["evil.example.com"]);
+    }
+
+    #[test]
+    fn protocol_relative_host_is_flagged_once_across_refs() {
+        let findings = lint(
+            r#"<html><head><link href="//assets.example.org/x.css"><link href="//assets.example.org/y.css"></head></html>"#,
+        );
+        assert_eq!(findings.off_allowlist_hosts, vec!["assets.example.org"]);
+    }
+
+    #[test]
+    fn allowlisted_relative_and_hostless_refs_are_ignored() {
+        let findings = lint(
+            r#"<html><head>
+                <script src="https://cdn.jsdelivr.net/npm/x.js"></script>
+                <link href="https://fonts.googleapis.com/css">
+                <script src="/local.js"></script>
+                <link href="styles.css">
+                <script src="data:text/javascript,1"></script>
+                <link href="blob:abc">
+                <script src="ftp://files.example.com/x.js"></script>
+            </head></html>"#,
+        );
+        assert_eq!(findings.off_allowlist_hosts, Vec::<String>::new());
+    }
+
+    #[test]
+    fn unquoted_url_attribute_is_a_shared_blind_spot() {
+        // `tl` drops a tag whose unquoted attribute value contains `/`, so an
+        // unquoted URL ref is not seen — the same blind spot the TS regex had
+        // (it required a quoted value). Pinned so a `tl` upgrade that starts
+        // parsing these shows up as a deliberate behavior change.
+        let findings =
+            lint("<html><head><script src=https://evil.example.com/a.js></script></head></html>");
+        assert_eq!(findings.off_allowlist_hosts, Vec::<String>::new());
+    }
+
+    #[test]
+    fn refs_inside_html_comments_are_not_scanned() {
+        // Behavior delta vs the TS regex: a commented-out tag never loads, so
+        // it does not warn.
+        let findings = lint(
+            r#"<html><head><!-- <script src="https://evil.example.com/a.js"></script> --></head></html>"#,
+        );
+        assert_eq!(findings, LintFindings::default());
+    }
+
+    #[test]
+    fn src_on_link_and_href_on_script_do_not_match() {
+        // Behavior delta vs the tag-agnostic TS regex: only the attribute the
+        // browser reads on each tag counts.
+        let findings = lint(
+            r#"<html><head><link src="https://evil.example.com/a.css"><script href="https://evil.example.com/b.js"></script></head></html>"#,
+        );
+        assert_eq!(findings.off_allowlist_hosts, Vec::<String>::new());
+    }
+
+    #[test]
+    fn host_comparison_uses_url_normalization() {
+        // Mixed-case hosts normalize to lowercase (so the allowlist matches);
+        // IDNA hosts normalize to punycode; IPv6 literals keep their brackets
+        // and a trailing-dot host stays distinct — none of those three match a
+        // bare-hostname allowlist.
+        let findings = lint(
+            r#"<html><head>
+                <script src="https://CDN.JSDELIVR.NET/npm/x.js"></script>
+                <script src="https://münchen.example/x.js"></script>
+                <script src="https://[::1]/x.js"></script>
+                <script src="https://cdn.jsdelivr.net./x.js"></script>
+            </head></html>"#,
+        );
+        assert_eq!(
+            findings.off_allowlist_hosts,
+            vec!["xn--mnchen-3ya.example", "[::1]", "cdn.jsdelivr.net."]
+        );
+    }
+
+    #[test]
+    fn unparsable_urls_and_slashless_schemes_are_ignored() {
+        let findings = lint(
+            r#"<html><head><script src="https://exa mple.com/x.js"></script><script src="https:evil.example.com/x.js"></script></head></html>"#,
+        );
+        assert_eq!(findings.off_allowlist_hosts, Vec::<String>::new());
+    }
+
+    // --- browser storage APIs ---
+
+    #[test]
+    fn browser_storage_in_script_is_flagged_prose_is_not() {
+        let findings = lint(
+            r#"<html><head><script>window.localStorage.getItem("k");</script></head><body><p>This app does not use sessionStorage.</p></body></html>"#,
+        );
+        assert_eq!(findings.browser_storage_apis, vec!["localStorage"]);
+    }
+
+    #[test]
+    fn browser_storage_apis_dedup_in_first_seen_order() {
+        let findings = lint(
+            "<html><head><script>indexedDB.open(1); localStorage.x; localStorage.y; sessionStorage.z;</script></head></html>",
+        );
+        assert_eq!(
+            findings.browser_storage_apis,
+            vec!["indexedDB", "localStorage", "sessionStorage"]
+        );
+    }
+
+    #[test]
+    fn browser_storage_scan_does_not_strip_js_comments() {
+        // Parity with the TS predecessor: the storage hint fires even on
+        // commented-out usage (only the SDK-member lint strips comments).
+        let findings = lint(
+            "<html><head><script>// localStorage.getItem\nconst x = 1;</script></head></html>",
+        );
+        assert_eq!(findings.browser_storage_apis, vec!["localStorage"]);
+    }
+
+    // --- archestra SDK members ---
+
+    #[test]
+    fn storage_method_on_the_store_is_misuse() {
+        let findings = lint(
+            r#"<html><head><script>const x = await archestra.storage.get("k");</script></head></html>"#,
+        );
+        assert_eq!(findings.storage_misuse, vec!["archestra.storage.get"]);
+        // `storage` itself is a valid top-level member, so no top-level finding.
+        assert_eq!(findings.unknown_top_level, Vec::<String>::new());
+    }
+
+    #[test]
+    fn unknown_top_level_member_is_flagged() {
+        let findings = lint("<html><head><script>archestra.tool.call('x');</script></head></html>");
+        assert_eq!(findings.unknown_top_level, vec!["archestra.tool"]);
+    }
+
+    #[test]
+    fn members_dedup_per_category_in_first_seen_order() {
+        let findings = lint(
+            r#"<html><head><script>
+                archestra.storage.get("a"); archestra.storage.get("b"); archestra.storage.delete("c");
+                archestra.tool.call(); archestra.tool.list();
+            </script></head></html>"#,
+        );
+        assert_eq!(
+            findings.storage_misuse,
+            vec!["archestra.storage.get", "archestra.storage.delete"]
+        );
+        assert_eq!(findings.unknown_top_level, vec!["archestra.tool"]);
+    }
+
+    #[test]
+    fn sdk_members_in_js_comments_do_not_warn() {
+        let findings = lint(
+            "<html><head><script>\n// use archestra.storage.user.get, not archestra.storage.get\n/* archestra.tool.call is also wrong */\nconst x = 1;\n</script></head></html>",
+        );
+        assert_eq!(findings, LintFindings::default());
+    }
+
+    #[test]
+    fn block_comment_between_tokens_cannot_fuse_identifiers() {
+        // `archestra/* */.tool` must not become `archestra.tool` after stripping.
+        let findings = lint("<html><head><script>archestra/* x */.tool;</script></head></html>");
+        assert_eq!(findings.unknown_top_level, Vec::<String>::new());
+    }
+
+    #[test]
+    fn prefixed_identifier_is_not_matched() {
+        let findings =
+            lint("<html><head><script>myarchestra.everything.is.fine;</script></head></html>");
+        assert_eq!(findings, LintFindings::default());
+    }
+
+    #[test]
+    fn window_prefixed_access_is_matched() {
+        let findings =
+            lint("<html><head><script>window.archestra.tool.call();</script></head></html>");
+        assert_eq!(findings.unknown_top_level, vec!["archestra.tool"]);
+    }
+
+    #[test]
+    fn sdk_member_in_prose_does_not_warn() {
+        let findings = lint(
+            "<html><head></head><body><p>Do not call archestra.storage.get directly.</p></body></html>",
+        );
+        assert_eq!(findings, LintFindings::default());
+    }
+}

--- a/platform/archestra-rs/app-runtime-core/src/lib.rs
+++ b/platform/archestra-rs/app-runtime-core/src/lib.rs
@@ -5,11 +5,13 @@
 //! companion that links this crate directly.
 
 mod app_html;
+mod app_html_lint;
 pub mod contract;
 mod diagnostics;
 mod envelope;
 
 pub use app_html::{Rejection, RejectionKind, ScanResult, scan_app_html};
+pub use app_html_lint::{LintConfig, LintFindings, lint_app_html};
 pub use diagnostics::{
     DiagnosticEntry, cap_diagnostic_entries, escape_angle_brackets, format_diagnostic_entry_lines,
     merge_diagnostic_entries,

--- a/platform/archestra-rs/app-runtime-rs/index.cjs
+++ b/platform/archestra-rs/app-runtime-rs/index.cjs
@@ -12,6 +12,7 @@ const nativeBinding = loadNativeBinding({
 // named ESM export (consumers do `import { prepareAppEnvelope } from ...`)
 module.exports.prepareAppEnvelope = wrapSync(nativeBinding, "prepareAppEnvelope");
 module.exports.scanAppHtml = wrapSync(nativeBinding, "scanAppHtml");
+module.exports.lintAppHtml = wrapSync(nativeBinding, "lintAppHtml");
 module.exports.escapeAngleBrackets = wrapSync(nativeBinding, "escapeAngleBrackets");
 module.exports.capDiagnosticEntries = wrapSync(nativeBinding, "capDiagnosticEntries");
 module.exports.mergeDiagnosticEntries = wrapSync(nativeBinding, "mergeDiagnosticEntries");

--- a/platform/archestra-rs/app-runtime-rs/index.d.ts
+++ b/platform/archestra-rs/app-runtime-rs/index.d.ts
@@ -5,6 +5,31 @@ export interface AppDiagnosticEntry {
   message: string
 }
 
+/**
+ * Policy inputs for `lintAppHtml`; the TypeScript side is the single source
+ * of truth for the CDN allowlist and the injected-SDK surface.
+ */
+export interface AppHtmlLintConfig {
+  /** Bare hostnames `<script src>`/`<link href>` may point at (exact match). */
+  resourceHostAllowlist: Array<string>
+  /** Members the injected `window.archestra` exposes at the top level. */
+  sdkTopLevelMembers: Array<string>
+  /** Partitions of `archestra.storage`. */
+  sdkStoragePartitions: Array<string>
+}
+
+/**
+ * Structured lint findings; every list is deduplicated in first-seen
+ * document order. Empty when the HTML does not parse (the scan's
+ * `unparseable` rejection covers that case).
+ */
+export interface AppHtmlLintFindings {
+  offAllowlistHosts: Array<string>
+  browserStorageApis: Array<string>
+  storageMisuse: Array<string>
+  unknownTopLevel: Array<string>
+}
+
 export interface AppHtmlRejection {
   /**
    * Stable discriminant: `sdk_bootstrap` | `platform_script_src` |
@@ -51,6 +76,15 @@ export interface InlineAssets {
   /** The platform baseline stylesheet (same bytes served at the CSS path). */
   baseCss: string
 }
+
+/**
+ * Authoring-time lint of app HTML for the `validate_app` tool: hosts the
+ * pinned CSP would block, browser storage APIs the sandbox breaks, and
+ * `window.archestra` members the injected SDK does not expose. The caller
+ * owns the policy inputs (`config`) and composes the user-facing messages
+ * from the returned structured lists.
+ */
+export declare function lintAppHtml(html: string, config: AppHtmlLintConfig): AppHtmlLintFindings
 
 /** Union and dedup two already-capped entry lists, capping the total. */
 export declare function mergeDiagnosticEntries(existing: Array<AppDiagnosticEntry>, incoming: Array<AppDiagnosticEntry>, maxEntries: number, dedupPrefixLen: number): Array<AppDiagnosticEntry>

--- a/platform/archestra-rs/app-runtime-rs/index.d.ts
+++ b/platform/archestra-rs/app-runtime-rs/index.d.ts
@@ -12,16 +12,15 @@ export interface AppDiagnosticEntry {
 export interface AppHtmlLintConfig {
   /** Bare hostnames `<script src>`/`<link href>` may point at (exact match). */
   resourceHostAllowlist: Array<string>
-  /** Members the injected `window.archestra` exposes at the top level. */
+  /** Top-level members of the injected `window.archestra`. */
   sdkTopLevelMembers: Array<string>
   /** Partitions of `archestra.storage`. */
   sdkStoragePartitions: Array<string>
 }
 
 /**
- * Structured lint findings; every list is deduplicated in first-seen
- * document order. Empty when the HTML does not parse (the scan's
- * `unparseable` rejection covers that case).
+ * Structured lint findings, deduplicated in first-seen document order.
+ * Empty when the HTML does not parse (the scan rejects that fail-closed).
  */
 export interface AppHtmlLintFindings {
   offAllowlistHosts: Array<string>
@@ -81,8 +80,7 @@ export interface InlineAssets {
  * Authoring-time lint of app HTML for the `validate_app` tool: hosts the
  * pinned CSP would block, browser storage APIs the sandbox breaks, and
  * `window.archestra` members the injected SDK does not expose. The caller
- * owns the policy inputs (`config`) and composes the user-facing messages
- * from the returned structured lists.
+ * owns the policy inputs and composes the user-facing messages.
  */
 export declare function lintAppHtml(html: string, config: AppHtmlLintConfig): AppHtmlLintFindings
 

--- a/platform/archestra-rs/app-runtime-rs/smoke.test.cjs
+++ b/platform/archestra-rs/app-runtime-rs/smoke.test.cjs
@@ -43,6 +43,27 @@ assert.equal(
   undefined,
 );
 
+// lintAppHtml: an off-allowlist host and a storage API are reported as
+// structured lists; a clean document yields empty lists.
+const lintConfig = {
+  resourceHostAllowlist: ["cdn.jsdelivr.net"],
+  sdkTopLevelMembers: ["ready", "storage", "tools"],
+  sdkStoragePartitions: ["user", "shared"],
+};
+const linted = appRuntime.lintAppHtml(
+  '<html><head><script src="https://evil.example.com/a.js"></script><script>localStorage.x; archestra.storage.get("k");</script></head></html>',
+  lintConfig,
+);
+assert.deepEqual(linted.offAllowlistHosts, ["evil.example.com"]);
+assert.deepEqual(linted.browserStorageApis, ["localStorage"]);
+assert.deepEqual(linted.storageMisuse, ["archestra.storage.get"]);
+const cleanLint = appRuntime.lintAppHtml(
+  "<html><head></head><body></body></html>",
+  lintConfig,
+);
+assert.deepEqual(cleanLint.offAllowlistHosts, []);
+assert.deepEqual(cleanLint.unknownTopLevel, []);
+
 // Diagnostics: angle brackets escaped, forged type sanitized, lines formatted,
 // dedup by type+prefix. Caps are passed in by the caller.
 assert.equal(appRuntime.escapeAngleBrackets("</x>"), "&lt;/x&gt;");

--- a/platform/archestra-rs/app-runtime-rs/src/lib.rs
+++ b/platform/archestra-rs/app-runtime-rs/src/lib.rs
@@ -73,8 +73,7 @@ pub fn scan_app_html(html: String) -> napi::Result<AppHtmlScanResult> {
 /// Authoring-time lint of app HTML for the `validate_app` tool: hosts the
 /// pinned CSP would block, browser storage APIs the sandbox breaks, and
 /// `window.archestra` members the injected SDK does not expose. The caller
-/// owns the policy inputs (`config`) and composes the user-facing messages
-/// from the returned structured lists.
+/// owns the policy inputs and composes the user-facing messages.
 #[napi(js_name = "lintAppHtml")]
 pub fn lint_app_html(html: String, config: AppHtmlLintConfig) -> napi::Result<AppHtmlLintFindings> {
     std::panic::catch_unwind(move || {
@@ -196,15 +195,14 @@ pub struct AppHtmlScanResult {
 pub struct AppHtmlLintConfig {
     /// Bare hostnames `<script src>`/`<link href>` may point at (exact match).
     pub resource_host_allowlist: Vec<String>,
-    /// Members the injected `window.archestra` exposes at the top level.
+    /// Top-level members of the injected `window.archestra`.
     pub sdk_top_level_members: Vec<String>,
     /// Partitions of `archestra.storage`.
     pub sdk_storage_partitions: Vec<String>,
 }
 
-/// Structured lint findings; every list is deduplicated in first-seen
-/// document order. Empty when the HTML does not parse (the scan's
-/// `unparseable` rejection covers that case).
+/// Structured lint findings, deduplicated in first-seen document order.
+/// Empty when the HTML does not parse (the scan rejects that fail-closed).
 #[napi(object)]
 pub struct AppHtmlLintFindings {
     pub off_allowlist_hosts: Vec<String>,

--- a/platform/archestra-rs/app-runtime-rs/src/lib.rs
+++ b/platform/archestra-rs/app-runtime-rs/src/lib.rs
@@ -76,10 +76,7 @@ pub fn scan_app_html(html: String) -> napi::Result<AppHtmlScanResult> {
 /// owns the policy inputs (`config`) and composes the user-facing messages
 /// from the returned structured lists.
 #[napi(js_name = "lintAppHtml")]
-pub fn lint_app_html(
-    html: String,
-    config: AppHtmlLintConfig,
-) -> napi::Result<AppHtmlLintFindings> {
+pub fn lint_app_html(html: String, config: AppHtmlLintConfig) -> napi::Result<AppHtmlLintFindings> {
     std::panic::catch_unwind(move || {
         let findings = core::lint_app_html(
             &html,

--- a/platform/archestra-rs/app-runtime-rs/src/lib.rs
+++ b/platform/archestra-rs/app-runtime-rs/src/lib.rs
@@ -70,6 +70,35 @@ pub fn scan_app_html(html: String) -> napi::Result<AppHtmlScanResult> {
     .map_err(panic_to_napi_error)
 }
 
+/// Authoring-time lint of app HTML for the `validate_app` tool: hosts the
+/// pinned CSP would block, browser storage APIs the sandbox breaks, and
+/// `window.archestra` members the injected SDK does not expose. The caller
+/// owns the policy inputs (`config`) and composes the user-facing messages
+/// from the returned structured lists.
+#[napi(js_name = "lintAppHtml")]
+pub fn lint_app_html(
+    html: String,
+    config: AppHtmlLintConfig,
+) -> napi::Result<AppHtmlLintFindings> {
+    std::panic::catch_unwind(move || {
+        let findings = core::lint_app_html(
+            &html,
+            &core::LintConfig {
+                resource_host_allowlist: config.resource_host_allowlist,
+                sdk_top_level_members: config.sdk_top_level_members,
+                sdk_storage_partitions: config.sdk_storage_partitions,
+            },
+        );
+        AppHtmlLintFindings {
+            off_allowlist_hosts: findings.off_allowlist_hosts,
+            browser_storage_apis: findings.browser_storage_apis,
+            storage_misuse: findings.storage_misuse,
+            unknown_top_level: findings.unknown_top_level,
+        }
+    })
+    .map_err(panic_to_napi_error)
+}
+
 /// Escape `<`/`>` in untrusted diagnostic text so it cannot break out of the
 /// `<app-render-diagnostics>` delimiter block.
 #[napi(js_name = "escapeAngleBrackets")]
@@ -162,6 +191,29 @@ pub struct AppHtmlRejection {
 pub struct AppHtmlScanResult {
     pub rejection: Option<AppHtmlRejection>,
     pub warnings: Vec<String>,
+}
+
+/// Policy inputs for `lintAppHtml`; the TypeScript side is the single source
+/// of truth for the CDN allowlist and the injected-SDK surface.
+#[napi(object)]
+pub struct AppHtmlLintConfig {
+    /// Bare hostnames `<script src>`/`<link href>` may point at (exact match).
+    pub resource_host_allowlist: Vec<String>,
+    /// Members the injected `window.archestra` exposes at the top level.
+    pub sdk_top_level_members: Vec<String>,
+    /// Partitions of `archestra.storage`.
+    pub sdk_storage_partitions: Vec<String>,
+}
+
+/// Structured lint findings; every list is deduplicated in first-seen
+/// document order. Empty when the HTML does not parse (the scan's
+/// `unparseable` rejection covers that case).
+#[napi(object)]
+pub struct AppHtmlLintFindings {
+    pub off_allowlist_hosts: Vec<String>,
+    pub browser_storage_apis: Vec<String>,
+    pub storage_misuse: Vec<String>,
+    pub unknown_top_level: Vec<String>,
 }
 
 fn into_core(entry: AppDiagnosticEntry) -> core::DiagnosticEntry {

--- a/platform/backend/src/services/apps/app-ui-policy.test.ts
+++ b/platform/backend/src/services/apps/app-ui-policy.test.ts
@@ -165,6 +165,15 @@ describe("validateAppHtmlStatic", () => {
     expect(hostWarnings).toHaveLength(1);
   });
 
+  test("a resource ref inside an HTML comment does not warn", async () => {
+    // The lint reads real DOM attributes (Rust `tl` walk), so a commented-out
+    // tag — which the browser never loads — no longer counts as a reference.
+    const findings = await validateAppHtmlStatic(
+      '<html><head><!-- <script src="https://evil.example.com/a.js"></script> --></head><body/></html>',
+    );
+    expect(findings).toEqual([]);
+  });
+
   test("allowlisted CDN hosts and relative refs are not flagged", async () => {
     const findings = await validateAppHtmlStatic(
       '<html><head><script src="https://cdn.jsdelivr.net/npm/x.js"></script><link rel="stylesheet" href="https://fonts.googleapis.com/css"><script src="/local.js"></script></head><body/></html>',

--- a/platform/backend/src/services/apps/app-ui-policy.test.ts
+++ b/platform/backend/src/services/apps/app-ui-policy.test.ts
@@ -63,6 +63,16 @@ describe("buildValidatedVersionPayload", () => {
     ).rejects.toThrow(/must not bootstrap the MCP App SDK/);
   });
 
+  test("a bare < before the marker cannot evade the bootstrap rejection", async () => {
+    // Script text is raw text to the browser; a comparison operator before the
+    // marker must not hide it from the gate.
+    await expect(
+      buildValidatedVersionPayload({
+        html: "<html><head><script>if (a < b) { const u = window.__ARCHESTRA_APP_SDK_URL__; }</script></head><body/></html>",
+      }),
+    ).rejects.toThrow(/must not bootstrap the MCP App SDK/);
+  });
+
   test("a marker mentioned outside <script> does not reject", async () => {
     const { warnings } = await buildValidatedVersionPayload({
       html: "<html><head></head><body><p>Docs about PostMessageTransport and __ARCHESTRA_APP_SDK_URL__.</p><!-- PostMessageTransport --></body></html>",

--- a/platform/backend/src/services/apps/app-ui-policy.test.ts
+++ b/platform/backend/src/services/apps/app-ui-policy.test.ts
@@ -203,6 +203,18 @@ describe("validateAppHtmlStatic", () => {
     expect(findings).toEqual([]);
   });
 
+  test("a bare < in ordinary script code does not hide the script from the lint", async () => {
+    // Script text is raw text to the browser; a comparison operator must not
+    // splinter the block and swallow what follows it.
+    const findings = await validateAppHtmlStatic(
+      '<html><head><script>if (items.length < 5) { localStorage.setItem("k", "1"); }</script></head><body/></html>',
+    );
+    expect(findings).toContainEqual({
+      severity: "warning",
+      message: expect.stringContaining("Uses browser storage (localStorage)"),
+    });
+  });
+
   test("multiple browser storage APIs are reported once, deduplicated", async () => {
     const findings = await validateAppHtmlStatic(
       "<html><head><script>localStorage.x; localStorage.y; sessionStorage.z;</script></head><body/></html>",

--- a/platform/backend/src/services/apps/app-ui-policy.ts
+++ b/platform/backend/src/services/apps/app-ui-policy.ts
@@ -134,17 +134,13 @@ type AppValidationFinding = {
 
 /**
  * Static, headless validation of an app's stored HTML for the `validate_app`
- * MCP tool. Reuses the save-time Rust scan (SDK self-bootstrap, platform-asset
- * self-loads, missing document root) — surfaced here as findings rather than a
- * thrown rejection so authoring tools can report them — and adds the authoring
- * lint, also Rust-backed (`lintAppHtml` in the app_runtime_core crate):
- * `<script src>`/`<link href>` hosts outside
- * {@link APP_PLATFORM_CSP_RESOURCE_DOMAINS} (which the served CSP blocks at
- * render time), browser storage APIs the sandbox breaks, and window.archestra
- * members the injected SDK does not expose. This module stays the single
- * source of truth for the policy inputs and the warning text; Rust returns
- * structured lists. It cannot exercise runtime behaviour; that gap is what the
- * live diagnostics round-trip covers.
+ * MCP tool: the save-time Rust scan (surfaced as findings rather than a thrown
+ * rejection) plus the Rust-backed authoring lint — off-allowlist
+ * `<script src>`/`<link href>` hosts, browser storage APIs the sandbox breaks,
+ * and window.archestra members the injected SDK does not expose. This module
+ * stays the single source of truth for the policy inputs and the warning text;
+ * Rust returns structured lists. It cannot exercise runtime behaviour; that
+ * gap is what the live diagnostics round-trip covers.
  */
 export async function validateAppHtmlStatic(
   html: string,

--- a/platform/backend/src/services/apps/app-ui-policy.ts
+++ b/platform/backend/src/services/apps/app-ui-policy.ts
@@ -136,17 +136,21 @@ type AppValidationFinding = {
  * Static, headless validation of an app's stored HTML for the `validate_app`
  * MCP tool. Reuses the save-time Rust scan (SDK self-bootstrap, platform-asset
  * self-loads, missing document root) — surfaced here as findings rather than a
- * thrown rejection so authoring tools can report them — and adds the one check
- * the scanner does not do: `<script src>`/`<link href>` hosts outside
- * {@link APP_PLATFORM_CSP_RESOURCE_DOMAINS}, which the served CSP blocks at
- * render time, are flagged as warnings. It cannot exercise runtime behaviour;
- * that gap is what the live diagnostics round-trip covers.
+ * thrown rejection so authoring tools can report them — and adds the authoring
+ * lint, also Rust-backed (`lintAppHtml` in the app_runtime_core crate):
+ * `<script src>`/`<link href>` hosts outside
+ * {@link APP_PLATFORM_CSP_RESOURCE_DOMAINS} (which the served CSP blocks at
+ * render time), browser storage APIs the sandbox breaks, and window.archestra
+ * members the injected SDK does not expose. This module stays the single
+ * source of truth for the policy inputs and the warning text; Rust returns
+ * structured lists. It cannot exercise runtime behaviour; that gap is what the
+ * live diagnostics round-trip covers.
  */
 export async function validateAppHtmlStatic(
   html: string,
 ): Promise<AppValidationFinding[]> {
   const findings: AppValidationFinding[] = [];
-  const { scanAppHtml } = await loadAppRuntimeNative();
+  const { scanAppHtml, lintAppHtml } = await loadAppRuntimeNative();
   const { rejection, warnings } = scanAppHtml(html);
   if (rejection) {
     findings.push({ severity: "error", message: rejectionMessage(rejection) });
@@ -154,7 +158,12 @@ export async function validateAppHtmlStatic(
   for (const warning of warnings) {
     findings.push({ severity: "warning", message: warning });
   }
-  for (const host of offAllowlistResourceHosts(html)) {
+  const lint = lintAppHtml(html, {
+    resourceHostAllowlist: [...APP_PLATFORM_CSP_RESOURCE_DOMAINS],
+    sdkTopLevelMembers: [...ARCHESTRA_APP_SDK_SURFACE.topLevel],
+    sdkStoragePartitions: [...ARCHESTRA_APP_SDK_SURFACE.storage.partitions],
+  });
+  for (const host of lint.offAllowlistHosts) {
     findings.push({
       severity: "warning",
       message: `<script>/<link> references the host "${host}", which is outside the app CDN allowlist (${APP_PLATFORM_CSP_RESOURCE_DOMAINS.join(
@@ -162,28 +171,26 @@ export async function validateAppHtmlStatic(
       )}); the sandbox CSP blocks it at render time. Load client-side assets from an allowlisted CDN, and fetch data through an assigned MCP tool instead.`,
     });
   }
-  const browserStorageApis = browserStorageApisUsed(html);
-  if (browserStorageApis.length > 0) {
+  if (lint.browserStorageApis.length > 0) {
     findings.push({
       severity: "warning",
-      message: `Uses browser storage (${browserStorageApis.join(
+      message: `Uses browser storage (${lint.browserStorageApis.join(
         ", ",
       )}), which is unavailable in the app sandbox (an opaque origin where it throws) and ephemeral browser-local state even where it works. Persist state through the platform-attached store instead: archestra.storage.user.* (private per viewer) or archestra.storage.shared.* (shared across viewers).`,
     });
   }
-  const sdkMisuse = unknownArchestraSdkMembers(html);
-  if (sdkMisuse.storageMisuse.length > 0) {
+  if (lint.storageMisuse.length > 0) {
     findings.push({
       severity: "warning",
-      message: `Accesses ${sdkMisuse.storageMisuse.join(
+      message: `Accesses ${lint.storageMisuse.join(
         ", ",
       )} directly, but the store has no such member — it is partitioned. Call it on a partition instead: archestra.storage.user.* (private per viewer) or archestra.storage.shared.* (shared across viewers), e.g. archestra.storage.user.get(key).`,
     });
   }
-  if (sdkMisuse.unknownTopLevel.length > 0) {
+  if (lint.unknownTopLevel.length > 0) {
     findings.push({
       severity: "warning",
-      message: `Uses ${sdkMisuse.unknownTopLevel.join(
+      message: `Uses ${lint.unknownTopLevel.join(
         ", ",
       )}, which the injected window.archestra SDK does not expose. Its top-level surface is ${ARCHESTRA_APP_SDK_SURFACE.topLevel
         .map((member) => `archestra.${member}`)
@@ -191,115 +198,6 @@ export async function validateAppHtmlStatic(
     });
   }
   return findings;
-}
-
-const SCRIPT_BLOCK_PATTERN = /<script\b[^>]*>([\s\S]*?)<\/script>/gi;
-const BROWSER_STORAGE_API_PATTERN =
-  /\b(localStorage|sessionStorage|indexedDB)\b/g;
-
-// Browser storage APIs referenced inside <script> blocks. Scoped to script
-// content (not the whole html) so prose, comments, and attribute text that
-// merely name an API do not warn — the same structural anchoring the resource
-// check uses. It stays a lexical scan: dynamic access (window["local"+"Storage"])
-// is not detected, which is acceptable for a soft authoring hint. They are
-// unusable in the app sandbox: the opaque-origin iframe throws on access, and
-// where it doesn't the data is ephemeral and browser-local rather than the
-// platform-attached archestra.storage. Returned in first-seen order, deduplicated.
-function browserStorageApisUsed(html: string): string[] {
-  const apis = new Set<string>();
-  for (const block of html.matchAll(SCRIPT_BLOCK_PATTERN)) {
-    for (const match of block[1].matchAll(BROWSER_STORAGE_API_PATTERN)) {
-      apis.add(match[1]);
-    }
-  }
-  return [...apis];
-}
-
-// `archestra.<member>` and `archestra.storage.<member>` accesses inside <script>
-// blocks. Anchored on a word boundary so `myarchestra.x` is not matched, and it
-// also covers the `window.archestra.<member>` form (the `archestra.<member>`
-// substring still matches). Reused across script blocks; matchAll takes a fresh
-// iterator each call so sharing the global regex is safe.
-const ARCHESTRA_TOP_LEVEL_PATTERN = /\barchestra\.([A-Za-z_$][\w$]*)/g;
-const ARCHESTRA_STORAGE_MEMBER_PATTERN =
-  /\barchestra\.storage\.([A-Za-z_$][\w$]*)/g;
-
-// window.archestra members referenced inside <script> blocks that the injected
-// SDK does not expose: the wrong-nesting bug (archestra.storage.get instead of
-// archestra.storage.user.get) and unknown/typo'd top-level members
-// (archestra.tool.call). Script-block scoped like browserStorageApisUsed so
-// prose, comments, and attributes do not warn. Deliberately lexical: aliasing
-// (const s = archestra.storage; s.get()) and computed access
-// (archestra["storage"]) are not detected, and method-level typos under a valid
-// namespace (archestra.tools.calll) are out of scope — acceptable for a soft
-// authoring hint. Full references, first-seen order, deduplicated per category.
-function unknownArchestraSdkMembers(html: string): {
-  storageMisuse: string[];
-  unknownTopLevel: string[];
-} {
-  const topLevel = new Set<string>(ARCHESTRA_APP_SDK_SURFACE.topLevel);
-  const partitions = new Set<string>(
-    ARCHESTRA_APP_SDK_SURFACE.storage.partitions,
-  );
-  const storageMisuse = new Set<string>();
-  const unknownTopLevel = new Set<string>();
-  for (const block of html.matchAll(SCRIPT_BLOCK_PATTERN)) {
-    const script = stripJsComments(block[1]);
-    for (const match of script.matchAll(ARCHESTRA_TOP_LEVEL_PATTERN)) {
-      if (!topLevel.has(match[1])) {
-        unknownTopLevel.add(`archestra.${match[1]}`);
-      }
-    }
-    for (const match of script.matchAll(ARCHESTRA_STORAGE_MEMBER_PATTERN)) {
-      if (!partitions.has(match[1])) {
-        storageMisuse.add(`archestra.storage.${match[1]}`);
-      }
-    }
-  }
-  return {
-    storageMisuse: [...storageMisuse],
-    unknownTopLevel: [...unknownTopLevel],
-  };
-}
-
-// Drop // line and /* */ block comments from a script so a commented-out or
-// documented call (`// use archestra.storage.user.get, not .get`) does not warn.
-// Block comments collapse to a space so a comment between tokens can never fuse
-// two identifiers into a spurious `archestra.*`. Only ever deletes spans, so it
-// can miss a call that is literally inside a comment-shaped string, never invent
-// one; string literals are left as-is (lexically unsafe to strip), a known limit
-// shared with browserStorageApisUsed.
-function stripJsComments(script: string): string {
-  return script.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, "");
-}
-
-const RESOURCE_REF_PATTERN =
-  /<(?:script|link)\b[^>]*?\b(?:src|href)\s*=\s*["']([^"']+)["']/gi;
-
-// External hosts referenced by <script src>/<link href> that are not on the CSP
-// resource allowlist (exact host match, mirroring CSP host-source semantics).
-function offAllowlistResourceHosts(html: string): string[] {
-  const allowlist = new Set<string>(APP_PLATFORM_CSP_RESOURCE_DOMAINS);
-  const hosts = new Set<string>();
-  for (const match of html.matchAll(RESOURCE_REF_PATTERN)) {
-    const host = externalHost(match[1]);
-    if (host && !allowlist.has(host)) {
-      hosts.add(host);
-    }
-  }
-  return [...hosts];
-}
-
-// The host of an absolute or protocol-relative http(s) URL; null for relative,
-// data:, blob:, or otherwise host-less refs (which the resource CSP ignores).
-function externalHost(ref: string): string | null {
-  const normalized = ref.startsWith("//") ? `https:${ref}` : ref;
-  if (!/^https?:\/\//i.test(normalized)) return null;
-  try {
-    return new URL(normalized).hostname;
-  } catch {
-    return null;
-  }
 }
 
 function rejectionMessage(rejection: {


### PR DESCRIPTION
## What

- Migrates the `validate_app` static authoring lint (off-allowlist `<script src>`/`<link href>` hosts, browser-storage APIs, unknown `window.archestra` members) from TS regexes in `app-ui-policy.ts` into `app_runtime_core` (`app_html_lint.rs`), exposed as one new NAPI export `lintAppHtml(html, config)`. TS keeps the CDN allowlist, SDK surface, and all warning text; Rust returns structured, first-seen-deduplicated lists.
- Hardens the save-gate scan against `tl` parser divergences from the browser tokenizer: script text is extracted lexically (no RAWTEXT in `tl` — a bare `<` in ordinary JS used to hide bootstrap markers), solidus-fused tags (`<script/src=…>`) are recovered, and a lexical fallback pass covers tag shapes `tl` drops outright (`<script /src=…>`, unquoted URLs).

## Behavior changes

- Lint: refs inside HTML comments no longer warn; `src` counts only on `<script>` and `href` only on `<link>`; unparseable HTML yields the error finding only.
- Save gate (tightening): bootstrap markers behind a `<` comparison, commented-out bootstrap scripts, solidus/space-solidus/unquoted platform self-loads now reject.

## Known limitations

The lexical fallback is regex-grade: deliberately crafted markup (decoy `src=` inside another attribute's value, mixed quotes, entity-spliced markers) can still evade it, and entity decoding is missing from both scan paths (pre-existing). Tracked for follow-up; the render-time CSP remains the security boundary.

## Testing

73 Rust unit tests (`cargo test -p app_runtime_core`), clippy `-D warnings`, fmt; NAPI smoke tests incl. `lintAppHtml`; 303 backend tests across `services/apps`, `archestra-mcp-server/apps`, and app routes (pre-existing tests pass unchanged); `type-check`, `knip` dev+production.

https://claude.ai/code/session_01BLubggLE3jdFAA9Xg3Rv9j

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>