### PR TITLE
fix(onboarding): forward the survey to the website at most once per org

### DIFF
--- a/platform/backend/src/models/organization.test.ts
+++ b/platform/backend/src/models/organization.test.ts
@@ -711,4 +711,43 @@ describe("OrganizationModel", () => {
       expect(await OrganizationModel.enableSkillToolsForAllOrgs()).toBe(0);
     });
   });
+
+  describe("markOnboardingSurveyCompleted", () => {
+    test("returns true only for the call that flips the flag", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+
+      expect(
+        await OrganizationModel.markOnboardingSurveyCompleted(org.id),
+      ).toBe(true);
+      // A second submission finds the flag already set and must not re-claim,
+      // so the route never forwards the survey to the website twice.
+      expect(
+        await OrganizationModel.markOnboardingSurveyCompleted(org.id),
+      ).toBe(false);
+
+      const [row] = await db
+        .select({ at: schema.organizationsTable.onboardingSurveyCompletedAt })
+        .from(schema.organizationsTable)
+        .where(eq(schema.organizationsTable.id, org.id));
+      expect(row?.at).not.toBeNull();
+    });
+
+    test("concurrent claims resolve to exactly one winner", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+
+      const results = await Promise.all([
+        OrganizationModel.markOnboardingSurveyCompleted(org.id),
+        OrganizationModel.markOnboardingSurveyCompleted(org.id),
+        OrganizationModel.markOnboardingSurveyCompleted(org.id),
+      ]);
+
+      // The guarded `WHERE ... IS NULL` update lets only the first committed
+      // write claim the flag; the others match zero rows.
+      expect(results.filter(Boolean)).toHaveLength(1);
+    });
+  });
 });

--- a/platform/backend/src/models/organization.ts
+++ b/platform/backend/src/models/organization.ts
@@ -2,7 +2,7 @@ import {
   DEFAULT_THEME_ID,
   type OrganizationCustomFont,
 } from "@archestra/shared";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { CacheKey, cacheManager } from "@/cache-manager";
 import db, { schema } from "@/database";
 import logger from "@/logging";
@@ -166,13 +166,26 @@ class OrganizationModel {
   }
 
   /**
-   * Record that the first-login onboarding survey was submitted for this
-   * organization; the survey is never shown again once set.
+   * Atomically record that the first-login onboarding survey was submitted for
+   * this organization. Returns true only for the call that actually flipped the
+   * flag (it was previously null), so the caller can forward the survey exactly
+   * once even when two admins submit concurrently. Never shown again once set.
    */
-  static async markOnboardingSurveyCompleted(id: string): Promise<void> {
-    await OrganizationModel.patch(id, {
-      onboardingSurveyCompletedAt: new Date(),
-    });
+  static async markOnboardingSurveyCompleted(id: string): Promise<boolean> {
+    const rows = await db
+      .update(schema.organizationsTable)
+      .set({ onboardingSurveyCompletedAt: new Date() })
+      .where(
+        and(
+          eq(schema.organizationsTable.id, id),
+          isNull(schema.organizationsTable.onboardingSurveyCompletedAt),
+        ),
+      )
+      .returning({ id: schema.organizationsTable.id });
+    if (rows.length > 0) {
+      await cacheManager.delete(getOrganizationSettingsCacheKey(id));
+    }
+    return rows.length > 0;
   }
 
   /**

--- a/platform/backend/src/routes/onboarding/onboarding.routes.ts
+++ b/platform/backend/src/routes/onboarding/onboarding.routes.ts
@@ -96,17 +96,15 @@ const onboardingRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async ({ body, organizationId }, reply) => {
-      const organization = await OrganizationModel.getById(organizationId);
-      // Another admin already submitted — resolve cleanly without a duplicate
-      // website record.
-      if (organization?.onboardingSurveyCompletedAt != null) {
-        return reply.send({ ok: true });
+      // Atomically claim the survey for this org; only the caller that flips
+      // the flag forwards, so two admins submitting concurrently can't create a
+      // duplicate website record. Best-effort forward: the flag is set either
+      // way, so an unreachable website (airgapped deployments) never re-nags.
+      const isFirstSubmission =
+        await OrganizationModel.markOnboardingSurveyCompleted(organizationId);
+      if (isFirstSubmission) {
+        await forwardSurveyToWebsite(body);
       }
-
-      // Best-effort forward: the admin answered, so record it and never ask
-      // again even when the website is unreachable (airgapped deployments).
-      await forwardSurveyToWebsite(body);
-      await OrganizationModel.markOnboardingSurveyCompleted(organizationId);
       return reply.send({ ok: true });
     },
   );


### PR DESCRIPTION
## Problem

`POST /api/onboarding/survey` read `organization.onboardingSurveyCompletedAt`, and if null forwarded the answers to the external website, then marked the org completed. The mark (`markOnboardingSurveyCompleted`) was an **unconditional** UPDATE. So two admins submitting concurrently (or a double-firing client) both passed the stale read and both forwarded — creating duplicate records on the website. The local DB row ends up fine (flag set once), which is why it's invisible locally.

## Fix

Make `markOnboardingSurveyCompleted` a guarded compare-and-set — `UPDATE ... WHERE id = $1 AND onboarding_survey_completed_at IS NULL RETURNING id` (mirroring the existing `enableSkillToolsForAllOrgs`) — returning whether *this* call flipped the flag. The route marks first and forwards **only when it claimed** the flag, so at most one forward per org.

Preserves the best-effort/airgapped semantics: `forwardSurveyToWebsite` swallows its own errors, and the flag is set regardless of the forward's outcome, so an unreachable website never re-nags the admin. The route still returns `{ ok: true }` in every case.

## Tests

Two model-level tests in `organization.test.ts`: `markOnboardingSurveyCompleted` returns `true` on the claiming call and `false` when already set (with a DB read confirming the timestamp), and `Promise.all` of concurrent claims resolves to exactly one winner. Both fail against the old `void`-returning method. The flaky, harness-dependent route-level race test was intentionally not used.

https://claude.ai/code/session_01XrgWmw4aievNj85q6axVNb

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>