### PR TITLE
fix(onboarding): don't save a stale model when switching provider key

### DIFF
--- a/platform/frontend/src/app/settings/agents/page.tsx
+++ b/platform/frontend/src/app/settings/agents/page.tsx
@@ -81,10 +81,17 @@ export default function AgentSettingsPage() {
     data: allModels,
     isPending: modelsLoading,
     isLoadingError: isModelsLoadError,
+    isPlaceholderData,
     refetch: refetchModels,
   } = useLlmModels({
     apiKeyId: selectedApiKeyId || undefined,
   });
+
+  // `useLlmModels` uses `keepPreviousData`, so after a key switch `data` still
+  // holds the previous key's models (isPlaceholderData). Treat that as loading
+  // for the new key so the admin can't save a model from the old provider
+  // against the new provider's key.
+  const modelsPending = modelsLoading || isPlaceholderData;
 
   const isLoadError = isApiKeysLoadError || isModelsLoadError;
 
@@ -181,7 +188,7 @@ export default function AgentSettingsPage() {
   };
 
   const modelItems = useMemo(() => {
-    if (!allModels) return [];
+    if (!allModels || isPlaceholderData) return [];
     return allModels.map((model) => ({
       value: model.dbId,
       model: model.displayName ?? model.id,
@@ -190,7 +197,7 @@ export default function AgentSettingsPage() {
       isFree: model.isFree,
       isBest: model.isBest,
     }));
-  }, [allModels]);
+  }, [allModels, isPlaceholderData]);
 
   const selectedApiKey = useMemo(
     () => availableKeys.find((key) => key.id === selectedApiKeyId) ?? null,
@@ -273,7 +280,7 @@ export default function AgentSettingsPage() {
                     placeholder={
                       !selectedApiKeyId
                         ? "Select API key first..."
-                        : modelsLoading
+                        : modelsPending
                           ? "Loading models..."
                           : "Select model..."
                     }
@@ -281,7 +288,7 @@ export default function AgentSettingsPage() {
                     disabled={
                       isSaving ||
                       !hasPermission ||
-                      modelsLoading ||
+                      modelsPending ||
                       !selectedApiKeyId
                     }
                   />

--- a/platform/frontend/src/components/default-model-onboarding.test.tsx
+++ b/platform/frontend/src/components/default-model-onboarding.test.tsx
@@ -12,26 +12,46 @@ const KEY: Key = {
   scope: "org",
 };
 
+const ANTHROPIC_KEY: Key = {
+  id: "key-2",
+  name: "Anthropic - org",
+  provider: "anthropic",
+  scope: "org",
+};
+
+type ModelStub = {
+  id: string;
+  dbId: string;
+  provider: string;
+  displayName: string;
+  isFree: boolean;
+  isBest: boolean;
+};
+
+const OPENAI_MODEL: ModelStub = {
+  id: "model-1",
+  dbId: "model-1",
+  provider: "openai",
+  displayName: "Model 1",
+  isFree: false,
+  isBest: true,
+};
+
 let mockAvailableKeys: Key[] = [KEY];
+// The models query serves this verbatim; tests flip `isPlaceholderData` to
+// simulate `keepPreviousData` holding the previous key's list during a switch.
+let mockModelsResult: {
+  data: ModelStub[];
+  isPending: boolean;
+  isPlaceholderData: boolean;
+} = { data: [OPENAI_MODEL], isPending: false, isPlaceholderData: false };
 
 vi.mock("@/lib/llm-provider-api-keys.query", () => ({
   useAvailableLlmProviderApiKeys: () => ({ data: mockAvailableKeys }),
 }));
 
 vi.mock("@/lib/llm-models.query", () => ({
-  useLlmModels: () => ({
-    data: [
-      {
-        id: "model-1",
-        dbId: "model-1",
-        provider: "openai",
-        displayName: "Model 1",
-        isFree: false,
-        isBest: true,
-      },
-    ],
-    isPending: false,
-  }),
+  useLlmModels: () => mockModelsResult,
 }));
 
 // Presentational stand-ins so the test drives selection deterministically
@@ -59,31 +79,46 @@ vi.mock("@/components/form-dialog", () => ({
 
 vi.mock("@/components/llm-provider-api-key-dropdown", () => ({
   LlmProviderApiKeyDropdown: ({
+    availableKeys,
     onSelectKey,
   }: {
+    availableKeys: { id: string }[];
     onSelectKey: (value: string) => void;
   }) => (
-    <button type="button" onClick={() => onSelectKey("key-1")}>
-      mock-select-key
-    </button>
+    <div>
+      {availableKeys.map((key) => (
+        <button key={key.id} type="button" onClick={() => onSelectKey(key.id)}>
+          select-key-{key.id}
+        </button>
+      ))}
+    </div>
   ),
 }));
 
+// Renders one button per offered option so a test can assert exactly which
+// models the picker exposes (a stale option would be a selectable button).
 vi.mock("@/components/llm-model-select", () => ({
   LlmModelSearchableSelect: ({
+    options,
     onValueChange,
     disabled,
   }: {
+    options: { value: string }[];
     onValueChange: (value: string) => void;
     disabled?: boolean;
   }) => (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={() => onValueChange("model-1")}
-    >
-      mock-select-model
-    </button>
+    <div data-disabled={disabled}>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          disabled={disabled}
+          onClick={() => onValueChange(option.value)}
+        >
+          model-option-{option.value}
+        </button>
+      ))}
+    </div>
   ),
 }));
 
@@ -111,6 +146,11 @@ function renderStep(onDone = vi.fn()) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockAvailableKeys = [KEY];
+  mockModelsResult = {
+    data: [OPENAI_MODEL],
+    isPending: false,
+    isPlaceholderData: false,
+  };
   // Success path returns the updated organization; the step closes only then.
   mutateAsync.mockResolvedValue({ id: "org-1" });
 
@@ -143,7 +183,7 @@ describe("DefaultModelOnboardingStep", () => {
     await user.click(screen.getByRole("button", { name: "Choose model" }));
     // The single available key is preselected, so the model can be picked
     // without choosing a key first.
-    await user.click(screen.getByText("mock-select-model"));
+    await user.click(screen.getByText("model-option-model-1"));
     await user.click(screen.getByRole("button", { name: "Set default" }));
 
     expect(mutateAsync).toHaveBeenCalledWith({
@@ -151,6 +191,29 @@ describe("DefaultModelOnboardingStep", () => {
       defaultLlmApiKeyId: "key-1",
     });
     expect(onDone).toHaveBeenCalled();
+  });
+
+  it("does not offer the previous key's models while the new key is loading", async () => {
+    const user = userEvent.setup();
+    mockAvailableKeys = [KEY, ANTHROPIC_KEY];
+    renderStep();
+
+    await user.click(screen.getByRole("button", { name: "Choose model" }));
+    // key-1 (OpenAI) is preselected and its model is offered.
+    expect(screen.getByText("model-option-model-1")).toBeInTheDocument();
+
+    // Switch to the Anthropic key. `keepPreviousData` keeps serving the OpenAI
+    // list (as placeholder) until the Anthropic fetch resolves — the picker
+    // must not expose that stale model, or the admin could save an OpenAI model
+    // against the Anthropic key.
+    mockModelsResult = {
+      data: [OPENAI_MODEL],
+      isPending: false,
+      isPlaceholderData: true,
+    };
+    await user.click(screen.getByText("select-key-key-2"));
+
+    expect(screen.queryByText("model-option-model-1")).not.toBeInTheDocument();
   });
 
   it("advances to chat from the card without saving when skipped", async () => {
@@ -170,7 +233,7 @@ describe("DefaultModelOnboardingStep", () => {
     const { onDone } = renderStep();
 
     await user.click(screen.getByRole("button", { name: "Choose model" }));
-    await user.click(screen.getByText("mock-select-model"));
+    await user.click(screen.getByText("model-option-model-1"));
     await user.click(screen.getByRole("button", { name: "Set default" }));
 
     expect(mutateAsync).toHaveBeenCalled();

--- a/platform/frontend/src/components/default-model-onboarding.tsx
+++ b/platform/frontend/src/components/default-model-onboarding.tsx
@@ -95,12 +95,22 @@ function SetDefaultModelDialog({
     }
   }, [availableKeys, selectedApiKeyId]);
 
-  const { data: allModels, isPending: modelsLoading } = useLlmModels({
+  const {
+    data: allModels,
+    isPending: modelsLoading,
+    isPlaceholderData,
+  } = useLlmModels({
     apiKeyId: selectedApiKeyId || undefined,
   });
 
+  // `useLlmModels` uses `keepPreviousData`, so right after a key switch `data`
+  // still holds the previous key's models (isPlaceholderData). Treat that as
+  // still-loading for the new key: otherwise the admin could pick a model that
+  // belongs to the old provider and save it against the new provider's key.
+  const modelsPending = modelsLoading || isPlaceholderData;
+
   const modelItems = useMemo(() => {
-    if (!allModels) return [];
+    if (!allModels || isPlaceholderData) return [];
     return allModels.map((model) => ({
       value: model.dbId,
       model: model.displayName ?? model.id,
@@ -109,7 +119,7 @@ function SetDefaultModelDialog({
       isFree: model.isFree,
       isBest: model.isBest,
     }));
-  }, [allModels]);
+  }, [allModels, isPlaceholderData]);
 
   const selectedApiKey = useMemo(
     () => availableKeys.find((key) => key.id === selectedApiKeyId) ?? null,
@@ -174,11 +184,11 @@ function SetDefaultModelDialog({
           placeholder={
             !selectedApiKeyId
               ? "Select API key first..."
-              : modelsLoading
+              : modelsPending
                 ? "Loading models..."
                 : "Select model..."
           }
-          disabled={isSaving || modelsLoading || !selectedApiKeyId}
+          disabled={isSaving || modelsPending || !selectedApiKeyId}
         />
       </DialogBody>
       <DialogStickyFooter>


### PR DESCRIPTION
## Problem

The org default-model pickers read `useLlmModels(...).data` but ignored react-query's `isPlaceholderData`. Because the hook uses `keepPreviousData`, right after the admin switches the API key the picker still holds the *previous* provider's models while the selected key already points at the *new* provider. Picking one then saved a model from provider X paired with provider Y's key.

## Fix

Fold `isPlaceholderData` into a `modelsPending` guard used by the picker's `disabled` state, placeholder text, and option list (emptied while placeholder), so no stale model can be selected or saved for the new key. Applied to the two identical local pickers:

- `components/default-model-onboarding.tsx` — first-run onboarding step (with a regression test that fails pre-fix, passes post-fix).
- `app/settings/agents/page.tsx` — the persistent Settings → Agents "Default Model for Agents and New Chats" control (line-for-line duplicate of the same bug). Mechanism covered by the onboarding regression test; a duplicate full-page render test is omitted as brittle wiring coverage.

## Known follow-up (not in this PR)

Review flagged a **third**, design-sensitive instance: the shared `components/chat/model-selector.tsx` (via `useLlmModelsByProvider`) renders stale options during the placeholder window, and `agent-dialog.tsx` consumes it in a save context. Unlike the two pickers here, that component is *also* used in chat as a display switcher where `keepPreviousData`'s anti-flicker is intentional — so guarding it needs a per-consumer decision (or lifting a shared helper). Deferred for a separate, considered change rather than force-fitting it here.

https://claude.ai/code/session_01XrgWmw4aievNj85q6axVNb

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>