### PR TITLE
fix(chat): drop non-chat Bedrock models from the chat model picker

### DIFF
--- a/platform/backend/src/routes/chat/model-fetchers/bedrock.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/bedrock.test.ts
@@ -57,6 +57,96 @@ describe("fetchBedrockModels", () => {
     ]);
   });
 
+  test("excludes non-chat models (embeddings, image, rerank) from the chat picker", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          inferenceProfileSummaries: [
+            {
+              inferenceProfileId: "global.anthropic.claude-opus-4-8",
+              inferenceProfileName: "Claude Opus 4.8",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "global.cohere.embed-v4:0",
+              inferenceProfileName: "Cohere Embed v4",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us.twelvelabs.marengo-embed-3-0-v1:0",
+              inferenceProfileName: "Marengo Embed 3.0",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us.stability.stable-image-inpaint-v1:0",
+              inferenceProfileName: "Stable Image Inpaint",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us.amazon.nova-canvas-v1:0",
+              inferenceProfileName: "Nova Canvas",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us.amazon.nova-reel-v1:1",
+              inferenceProfileName: "Nova Reel",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "cohere.rerank-v3-5:0",
+              inferenceProfileName: "Cohere Rerank 3.5",
+              status: "ACTIVE",
+            },
+          ],
+        }),
+    });
+
+    const models = await fetchBedrockModels("test-api-key");
+
+    // Only the text-generation model survives; embeddings, image/video
+    // generators, and rerank are dropped so a member can't pick one and break
+    // chat. Chat families that merely resemble excluded ones (e.g. nova-lite)
+    // must NOT be filtered.
+    expect(models.map((model) => model.id)).toEqual([
+      "global.anthropic.claude-opus-4-8",
+    ]);
+  });
+
+  test("keeps text-generation models whose names resemble non-chat families", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          inferenceProfileSummaries: [
+            {
+              inferenceProfileId: "us.amazon.nova-lite-v1:0",
+              inferenceProfileName: "Nova Lite",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us.amazon.titan-text-express-v1",
+              inferenceProfileName: "Titan Text Express",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us.cohere.command-r-plus-v1:0",
+              inferenceProfileName: "Command R+",
+              status: "ACTIVE",
+            },
+          ],
+        }),
+    });
+
+    const models = await fetchBedrockModels("test-api-key");
+
+    expect(models.map((model) => model.id)).toEqual([
+      "us.amazon.nova-lite-v1:0",
+      "us.amazon.titan-text-express-v1",
+      "us.cohere.command-r-plus-v1:0",
+    ]);
+  });
+
   test("captures the foundation-model id from the profile's model ARN for pricing", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/platform/backend/src/routes/chat/model-fetchers/bedrock.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/bedrock.ts
@@ -188,7 +188,10 @@ function mapInferenceProfilesToModels(
           }
         : {}),
     }))
-    .filter((model) => model.id);
+    .filter((model) => model.id)
+    .filter(
+      (model) => !isNonChatBedrockModel(model.id, model.underlyingModelName),
+    );
 
   logger.info(
     {
@@ -205,6 +208,35 @@ function mapInferenceProfilesToModels(
   );
 
   return models;
+}
+
+// Bedrock foundation-model families whose output is not chat text — embeddings,
+// rerankers, and image/video generators. They can't serve chat completions, so
+// listing one in the chat model picker lets a user select it and break every
+// message. The inference-profiles endpoint this fetcher uses carries no
+// modality (AWS ListFoundationModels holds the authoritative outputModalities
+// but would cost a second control-plane call per sync), so classify by the
+// stable model id / underlying foundation-model name. Fails open: an id that
+// matches no pattern is kept, so a new chat family is never hidden.
+const NON_CHAT_BEDROCK_MODEL_PATTERNS: RegExp[] = [
+  /embed/i, // cohere.embed, amazon.titan-embed, twelvelabs.marengo-embed
+  /rerank/i, // cohere.rerank
+  /stable-image|stable-diffusion|sdxl|stability\./i, // Stability image models
+  /titan-image|nova-canvas/i, // Amazon image generators
+  /nova-reel|luma\./i, // video generators
+];
+
+function isNonChatBedrockModel(
+  id: string,
+  underlyingModelName?: string | null,
+): boolean {
+  // Match both the profile id and the underlying model name: application
+  // inference profiles have opaque ids, so only the underlying name reveals the
+  // family; system/cross-region profiles encode it in the id.
+  const identifier = `${id} ${underlyingModelName ?? ""}`;
+  return NON_CHAT_BEDROCK_MODEL_PATTERNS.some((pattern) =>
+    pattern.test(identifier),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

The chat model selector lists every AWS Bedrock inference profile, including models that cannot perform chat completions — embeddings (`cohere.embed-v4`, `twelvelabs.marengo-embed`, `amazon.titan-embed`), rerankers (`cohere.rerank`), and image/video generators (`stability.stable-image-*`, `amazon.nova-canvas`, `amazon.nova-reel`). A user who picks one of these — a reasonable choice, since they're presented as valid options — has every message in that conversation fail with a generic "There was an issue with your request," and the selection is sticky across new conversations.

On a Bedrock-backed org this was ~12 of ~61 offered models (~20%). After this change the picker lists only text-generation models.

The Bedrock fetcher reads the **inference-profiles** endpoint, which carries no output-modality, so the non-chat families are identified by the stable model id and underlying foundation-model name and dropped. The classifier fails open — an id matching no pattern is kept — so a newly released chat family is never accidentally hidden. Non-chat models are unlinked from provider API keys on the next model sync, so they leave the picker without a data migration.

Sourcing modality from `ListFoundationModels` (which does return `outputModalities`) would be authoritative but adds a second control-plane call per sync; the id-based denylist avoids that while covering the model families AWS currently ships.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>