### PR TITLE
fix(providers): clear credential fields when the provider changes

### DIFF
--- a/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
@@ -77,6 +77,12 @@ describe("LlmProviderApiKeyForm", () => {
     act(() => {
       form.setValue("apiKey", "sk-openai-secret");
       form.setValue("baseUrl", "https://openai.example");
+      form.setValue("inferenceBaseUrl", "https://openai.example/infer");
+      form.setValue("vaultSecretPath", "secret/openai");
+      form.setValue("vaultSecretKey", "api_key");
+      form.setValue("awsAccessKeyId", "AKIA-openai");
+      form.setValue("awsSecretAccessKey", "aws-secret");
+      form.setValue("awsSessionToken", "aws-session");
     });
     expect(form.getValues("apiKey")).toBe("sk-openai-secret");
 
@@ -86,8 +92,16 @@ describe("LlmProviderApiKeyForm", () => {
     });
 
     await waitFor(() => {
+      // Every provider-specific credential field must be cleared, not just the
+      // API key — the AWS/vault fields are the most sensitive to leak across.
       expect(form.getValues("apiKey")).toBeNull();
       expect(form.getValues("baseUrl")).toBeNull();
+      expect(form.getValues("inferenceBaseUrl")).toBeNull();
+      expect(form.getValues("vaultSecretPath")).toBeNull();
+      expect(form.getValues("vaultSecretKey")).toBeNull();
+      expect(form.getValues("awsAccessKeyId")).toBeNull();
+      expect(form.getValues("awsSecretAccessKey")).toBeNull();
+      expect(form.getValues("awsSessionToken")).toBeNull();
     });
   });
 

--- a/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
@@ -1,0 +1,106 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, waitFor } from "@testing-library/react";
+import { type UseFormReturn, useForm } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/config/config.query");
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/teams/team.query");
+
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature, useProviderBaseUrls } from "@/lib/config/config.query";
+import { useTeams } from "@/lib/teams/team.query";
+import {
+  LlmProviderApiKeyForm,
+  type LlmProviderApiKeyFormValues,
+} from "./llm-provider-api-key-form";
+
+const DEFAULTS: LlmProviderApiKeyFormValues = {
+  name: "",
+  provider: "openai",
+  apiKey: null,
+  baseUrl: null,
+  inferenceBaseUrl: null,
+  extraHeaders: [],
+  scope: "personal",
+  teamId: null,
+  vaultSecretPath: null,
+  vaultSecretKey: null,
+  isPrimary: false,
+  bedrockAuthMethod: "api-key",
+  awsAccessKeyId: null,
+  awsSecretAccessKey: null,
+  awsSessionToken: null,
+};
+
+// The form receives `form` as a prop; the harness owns a real react-hook-form
+// instance so the test can drive provider changes the way the Select does
+// (`form.setValue("provider", ...)`) without wrestling the Radix combobox.
+let form: UseFormReturn<LlmProviderApiKeyFormValues>;
+
+function Harness() {
+  form = useForm<LlmProviderApiKeyFormValues>({ defaultValues: DEFAULTS });
+  return (
+    <LlmProviderApiKeyForm form={form} mode="full" showConsoleLink={false} />
+  );
+}
+
+function renderForm() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <Harness />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useFeature).mockReturnValue(false);
+  vi.mocked(useProviderBaseUrls).mockReturnValue({
+    data: {},
+  } as unknown as ReturnType<typeof useProviderBaseUrls>);
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: true,
+  } as unknown as ReturnType<typeof useHasPermissions>);
+  vi.mocked(useTeams).mockReturnValue({
+    data: [],
+  } as unknown as ReturnType<typeof useTeams>);
+});
+
+describe("LlmProviderApiKeyForm", () => {
+  it("clears provider-specific credentials when the provider changes", async () => {
+    renderForm();
+
+    act(() => {
+      form.setValue("apiKey", "sk-openai-secret");
+      form.setValue("baseUrl", "https://openai.example");
+    });
+    expect(form.getValues("apiKey")).toBe("sk-openai-secret");
+
+    // A key typed for OpenAI must not be submitted against Anthropic.
+    act(() => {
+      form.setValue("provider", "anthropic");
+    });
+
+    await waitFor(() => {
+      expect(form.getValues("apiKey")).toBeNull();
+      expect(form.getValues("baseUrl")).toBeNull();
+    });
+  });
+
+  it("keeps the credential when the provider is unchanged", async () => {
+    renderForm();
+
+    act(() => {
+      form.setValue("apiKey", "sk-openai-secret");
+    });
+
+    // No provider change: re-renders must not wipe the typed key.
+    await waitFor(() => {
+      expect(form.getValues("apiKey")).toBe("sk-openai-secret");
+    });
+  });
+});

--- a/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.test.tsx
@@ -91,6 +91,30 @@ describe("LlmProviderApiKeyForm", () => {
     });
   });
 
+  it("resets a stale Bedrock auth method when leaving Bedrock", async () => {
+    renderForm();
+
+    act(() => {
+      form.setValue("provider", "bedrock");
+    });
+    // Set IAM only after the bedrock switch settles, so the switch effect
+    // doesn't clobber it first.
+    act(() => {
+      form.setValue("bedrockAuthMethod", "iam");
+    });
+    expect(form.getValues("bedrockAuthMethod")).toBe("iam");
+
+    // A stale "iam" would hide the API key input on the next provider, so
+    // leaving Bedrock must restore the default auth method.
+    act(() => {
+      form.setValue("provider", "anthropic");
+    });
+
+    await waitFor(() => {
+      expect(form.getValues("bedrockAuthMethod")).toBe("api-key");
+    });
+  });
+
   it("keeps the credential when the provider is unchanged", async () => {
     renderForm();
 

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -521,6 +521,9 @@ export function LlmProviderApiKeyForm({
     form.setValue("awsAccessKeyId", null);
     form.setValue("awsSecretAccessKey", null);
     form.setValue("awsSessionToken", null);
+    // Reset the Bedrock auth method too: a stale "iam" would otherwise keep the
+    // API key input hidden after switching to a non-Bedrock provider.
+    form.setValue("bedrockAuthMethod", "api-key");
   }, [form, isEditMode, provider]);
 
   const vaultSecretSelector =

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -504,6 +504,25 @@ export function LlmProviderApiKeyForm({
     form.setValue("vaultSecretKey", null);
   }, [form, scope]);
 
+  // Clear provider-specific credentials when the provider changes, so a key (or
+  // base URL / AWS credential) typed for one provider can't be submitted against
+  // another. Create only — the provider picker is disabled while editing. Skips
+  // the initial render via the ref so it never wipes prefilled defaults.
+  const prevProviderRef = useRef(provider);
+  useEffect(() => {
+    if (isEditMode || prevProviderRef.current === provider) return;
+    prevProviderRef.current = provider;
+    form.setValue("apiKey", null);
+    form.setValue("baseUrl", null);
+    form.setValue("inferenceBaseUrl", null);
+    form.setValue("extraHeaders", []);
+    form.setValue("vaultSecretPath", null);
+    form.setValue("vaultSecretKey", null);
+    form.setValue("awsAccessKeyId", null);
+    form.setValue("awsSecretAccessKey", null);
+    form.setValue("awsSessionToken", null);
+  }, [form, isEditMode, provider]);
+
   const vaultSecretSelector =
     scope === "team" ? (
       <InlineVaultSecretSelector


### PR DESCRIPTION
## Problem

In the "Add API Key" (Create) dialog, the provider `Select` only updated the `provider` field. The API key, base URLs, extra headers, vault path/key, and AWS credentials kept their values. So typing an OpenAI key, then switching to Anthropic, submitted the OpenAI-shaped key tagged as Anthropic. (Edit mode is unaffected — the provider picker is disabled there.)

## Fix

A provider-change `useEffect` (create-mode only, guarded by `isEditMode`; skips the initial render via a ref so prefilled defaults aren't wiped) clears the provider-specific fields when the provider changes: `apiKey`, `baseUrl`, `inferenceBaseUrl`, `extraHeaders`, vault path/key, the AWS credentials, and `bedrockAuthMethod`.

Resetting `bedrockAuthMethod` matters: the API-key input is hidden whenever `bedrockAuthMethod === "iam"` (the check doesn't gate on `provider === "bedrock"`), so picking Bedrock + IAM then switching to another provider would otherwise leave the key input hidden.

## Tests

New `llm-provider-api-key-form.test.tsx` renders the real form with a react-hook-form harness (mocking only the collaborator query hooks) and drives a provider switch: asserts every credential field (incl. vault/AWS) clears, that a Bedrock `iam` auth method resets on leaving Bedrock, and that an unchanged provider leaves a typed key intact. The clearing tests fail pre-fix.

https://claude.ai/code/session_01XrgWmw4aievNj85q6axVNb

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>