### PR TITLE
fix(providers): edit-key dialog validation + unsaved-changes parity

### DIFF
--- a/platform/frontend/src/app/llm/model-providers/edit-key-form.utils.test.ts
+++ b/platform/frontend/src/app/llm/model-providers/edit-key-form.utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-key-form";
+import { isEditApiKeyFormValid } from "./edit-key-form.utils";
+
+function makeValues(
+  overrides: Partial<LlmProviderApiKeyFormValues>,
+): LlmProviderApiKeyFormValues {
+  return {
+    name: "My key",
+    provider: "openai",
+    apiKey: null,
+    baseUrl: null,
+    inferenceBaseUrl: null,
+    extraHeaders: [],
+    scope: "personal",
+    teamId: null,
+    vaultSecretPath: null,
+    vaultSecretKey: null,
+    isPrimary: false,
+    bedrockAuthMethod: "api-key",
+    awsAccessKeyId: null,
+    awsSecretAccessKey: null,
+    awsSessionToken: null,
+    ...overrides,
+  };
+}
+
+describe("isEditApiKeyFormValid", () => {
+  it("accepts a personal-scoped key with no team", () => {
+    expect(isEditApiKeyFormValid(makeValues({ scope: "personal" }))).toBe(true);
+  });
+
+  it("accepts an org-scoped key with no team", () => {
+    expect(isEditApiKeyFormValid(makeValues({ scope: "org" }))).toBe(true);
+  });
+
+  it("rejects a team-scoped key with no team selected", () => {
+    expect(
+      isEditApiKeyFormValid(makeValues({ scope: "team", teamId: null })),
+    ).toBe(false);
+  });
+
+  it("accepts a team-scoped key once a team is selected", () => {
+    expect(
+      isEditApiKeyFormValid(makeValues({ scope: "team", teamId: "team-1" })),
+    ).toBe(true);
+  });
+
+  it("does not require an API key (the existing secret is kept on edit)", () => {
+    expect(
+      isEditApiKeyFormValid(makeValues({ scope: "personal", apiKey: null })),
+    ).toBe(true);
+  });
+});

--- a/platform/frontend/src/app/llm/model-providers/edit-key-form.utils.test.ts
+++ b/platform/frontend/src/app/llm/model-providers/edit-key-form.utils.test.ts
@@ -51,4 +51,58 @@ describe("isEditApiKeyFormValid", () => {
       isEditApiKeyFormValid(makeValues({ scope: "personal", apiKey: null })),
     ).toBe(true);
   });
+
+  it("requires AWS credentials when Bedrock SigV4 is selected", () => {
+    expect(
+      isEditApiKeyFormValid(
+        makeValues({
+          provider: "bedrock",
+          bedrockAuthMethod: "sigv4",
+          awsAccessKeyId: null,
+          awsSecretAccessKey: null,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts Bedrock SigV4 once both AWS keys are provided", () => {
+    expect(
+      isEditApiKeyFormValid(
+        makeValues({
+          provider: "bedrock",
+          bedrockAuthMethod: "sigv4",
+          awsAccessKeyId: "AKIA...",
+          awsSecretAccessKey: "secret",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not require AWS credentials for Bedrock IAM or API-key auth", () => {
+    expect(
+      isEditApiKeyFormValid(
+        makeValues({ provider: "bedrock", bedrockAuthMethod: "iam" }),
+      ),
+    ).toBe(true);
+    expect(
+      isEditApiKeyFormValid(
+        makeValues({ provider: "bedrock", bedrockAuthMethod: "api-key" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("still enforces team scope for Bedrock SigV4", () => {
+    expect(
+      isEditApiKeyFormValid(
+        makeValues({
+          provider: "bedrock",
+          bedrockAuthMethod: "sigv4",
+          awsAccessKeyId: "AKIA...",
+          awsSecretAccessKey: "secret",
+          scope: "team",
+          teamId: null,
+        }),
+      ),
+    ).toBe(false);
+  });
 });

--- a/platform/frontend/src/app/llm/model-providers/edit-key-form.utils.ts
+++ b/platform/frontend/src/app/llm/model-providers/edit-key-form.utils.ts
@@ -1,0 +1,14 @@
+import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-key-form";
+
+/**
+ * Whether the edit-key form can be submitted. Editing never re-collects the
+ * existing secret (the API key shows as a masked placeholder and AWS keys
+ * aren't prefilled), so requiring a secret would wrongly block a name-only
+ * edit. The only thing the edit dialog can meaningfully re-validate is
+ * team-scope consistency: a team-scoped key must name a team.
+ */
+export function isEditApiKeyFormValid(
+  values: LlmProviderApiKeyFormValues,
+): boolean {
+  return values.scope !== "team" || Boolean(values.teamId);
+}

--- a/platform/frontend/src/app/llm/model-providers/edit-key-form.utils.ts
+++ b/platform/frontend/src/app/llm/model-providers/edit-key-form.utils.ts
@@ -1,14 +1,21 @@
 import type { LlmProviderApiKeyFormValues } from "@/components/llm-provider-api-key-form";
 
 /**
- * Whether the edit-key form can be submitted. Editing never re-collects the
- * existing secret (the API key shows as a masked placeholder and AWS keys
- * aren't prefilled), so requiring a secret would wrongly block a name-only
- * edit. The only thing the edit dialog can meaningfully re-validate is
- * team-scope consistency: a team-scoped key must name a team.
+ * Whether the edit-key form can be submitted. Editing keeps the existing secret
+ * (the API key shows as a masked placeholder and AWS keys aren't prefilled), so
+ * a name-only edit needs no secret. Beyond team-scope consistency, the one thing
+ * the edit dialog can still require is Bedrock SigV4 credentials: the auth-method
+ * tabs always open on "API Key", so SigV4 is only ever reached by a deliberate
+ * user switch — one that must supply the AWS keys it is switching to.
  */
 export function isEditApiKeyFormValid(
   values: LlmProviderApiKeyFormValues,
 ): boolean {
-  return values.scope !== "team" || Boolean(values.teamId);
+  const scopeOk = values.scope !== "team" || Boolean(values.teamId);
+  if (values.provider === "bedrock" && values.bedrockAuthMethod === "sigv4") {
+    return (
+      scopeOk && Boolean(values.awsAccessKeyId && values.awsSecretAccessKey)
+    );
+  }
+  return scopeOk;
 }

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -59,6 +59,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { DialogCancelButton } from "@/components/unsaved-changes-guard";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useFeature } from "@/lib/config/config.query";
 import { getFrontendDocsUrl } from "@/lib/docs/docs";
@@ -72,6 +73,7 @@ import {
 import { useOrganization } from "@/lib/organization.query";
 import { useAllVirtualApiKeys } from "@/lib/virtual-api-keys.query";
 import { MODEL_NAV_TABS } from "../model-nav-tabs";
+import { isEditApiKeyFormValid } from "./edit-key-form.utils";
 
 const SCOPE_ICONS: Record<ResourceVisibilityScope, React.ReactNode> = {
   personal: <User className="h-3 w-3" />,
@@ -283,7 +285,7 @@ export default function ApiKeysPage() {
 
   // Validation for edit form
   const editFormValues = editForm.watch();
-  const isEditValid = Boolean(editFormValues.name);
+  const isEditValid = isEditApiKeyFormValid(editFormValues);
 
   const addApiKeyButton = (
     <PermissionButton
@@ -559,6 +561,7 @@ export default function ApiKeysPage() {
           description="Update the name, API key value, or scope"
           size="small"
           className="sm:max-w-xl"
+          isDirty={editForm.formState.isDirty}
         >
           <DialogForm
             onSubmit={handleEdit}
@@ -577,13 +580,7 @@ export default function ApiKeysPage() {
               )}
             </DialogBody>
             <DialogStickyFooter className="mt-0">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setIsEditDialogOpen(false)}
-              >
-                Cancel
-              </Button>
+              <DialogCancelButton>Cancel</DialogCancelButton>
               <Button
                 type="submit"
                 disabled={!isEditValid || updateMutation.isPending}

--- a/platform/frontend/src/components/llm-provider-api-key-form.dirty.test.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.dirty.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type UseFormReturn, useForm } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/config/config.query");
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/teams/team.query");
+
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useFeature, useProviderBaseUrls } from "@/lib/config/config.query";
+import { useTeams } from "@/lib/teams/team.query";
+import {
+  LlmProviderApiKeyForm,
+  type LlmProviderApiKeyFormValues,
+} from "./llm-provider-api-key-form";
+
+const DEFAULTS: LlmProviderApiKeyFormValues = {
+  name: "My key",
+  provider: "openai",
+  apiKey: null,
+  baseUrl: null,
+  inferenceBaseUrl: null,
+  extraHeaders: [],
+  scope: "personal",
+  teamId: null,
+  vaultSecretPath: null,
+  vaultSecretKey: null,
+  isPrimary: false,
+  bedrockAuthMethod: "api-key",
+  awsAccessKeyId: null,
+  awsSecretAccessKey: null,
+  awsSessionToken: null,
+};
+
+let form: UseFormReturn<LlmProviderApiKeyFormValues>;
+
+function Harness() {
+  form = useForm<LlmProviderApiKeyFormValues>({ defaultValues: DEFAULTS });
+  // Read isDirty during render so RHF's formState proxy subscribes and
+  // recomputes it, and expose it for assertion.
+  return (
+    <>
+      <div data-testid="is-dirty">{String(form.formState.isDirty)}</div>
+      <LlmProviderApiKeyForm form={form} mode="full" showConsoleLink={false} />
+    </>
+  );
+}
+
+function renderForm() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <Harness />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useFeature).mockReturnValue(false);
+  vi.mocked(useProviderBaseUrls).mockReturnValue({
+    data: {},
+  } as unknown as ReturnType<typeof useProviderBaseUrls>);
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: true,
+  } as unknown as ReturnType<typeof useHasPermissions>);
+  vi.mocked(useTeams).mockReturnValue({
+    data: [],
+  } as unknown as ReturnType<typeof useTeams>);
+});
+
+describe("LlmProviderApiKeyForm dirty tracking", () => {
+  // The unsaved-changes guard keys off formState.isDirty; the scope selector
+  // updates the form via setValue, which only marks dirty when shouldDirty is
+  // passed — otherwise the guard never fires for a scope change.
+  it("marks the form dirty when the scope changes", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    expect(screen.getByTestId("is-dirty")).toHaveTextContent("false");
+
+    // The scope selector is collapsed to the current choice ("Personal");
+    // expand it, then pick "Organization" — that change must dirty the form.
+    await user.click(screen.getByRole("button", { name: /personal/i }));
+    await user.click(screen.getByRole("button", { name: /organization/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("is-dirty")).toHaveTextContent("true");
+    });
+  });
+});

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -510,17 +510,27 @@ export function LlmProviderApiKeyForm({
         teamId={teamId}
         selectedSecretPath={form.getValues("vaultSecretPath")}
         selectedSecretKey={form.getValues("vaultSecretKey")}
-        onSecretPathChange={(value) => form.setValue("vaultSecretPath", value)}
-        onSecretKeyChange={(value) => form.setValue("vaultSecretKey", value)}
+        onSecretPathChange={(value) =>
+          form.setValue("vaultSecretPath", value, { shouldDirty: true })
+        }
+        onSecretKeyChange={(value) =>
+          form.setValue("vaultSecretKey", value, { shouldDirty: true })
+        }
       />
     ) : (
       <ExternalSecretSelector
         selectedTeamId={teamId}
         selectedSecretPath={form.getValues("vaultSecretPath")}
         selectedSecretKey={form.getValues("vaultSecretKey")}
-        onTeamChange={(value) => form.setValue("teamId", value)}
-        onSecretChange={(value) => form.setValue("vaultSecretPath", value)}
-        onSecretKeyChange={(value) => form.setValue("vaultSecretKey", value)}
+        onTeamChange={(value) =>
+          form.setValue("teamId", value, { shouldDirty: true })
+        }
+        onSecretChange={(value) =>
+          form.setValue("vaultSecretPath", value, { shouldDirty: true })
+        }
+        onSecretKeyChange={(value) =>
+          form.setValue("vaultSecretKey", value, { shouldDirty: true })
+        }
       />
     );
 
@@ -848,9 +858,9 @@ export function LlmProviderApiKeyForm({
               value={scope}
               options={visibilityOptions}
               onValueChange={(nextScope) => {
-                form.setValue("scope", nextScope);
+                form.setValue("scope", nextScope, { shouldDirty: true });
                 if (nextScope !== "team") {
-                  form.setValue("teamId", null);
+                  form.setValue("teamId", null, { shouldDirty: true });
                 }
               }}
             >
@@ -875,7 +885,9 @@ export function LlmProviderApiKeyForm({
                   <Label htmlFor="llm-provider-api-key-team">Team</Label>
                   <Select
                     value={teamId ?? undefined}
-                    onValueChange={(value) => form.setValue("teamId", value)}
+                    onValueChange={(value) =>
+                      form.setValue("teamId", value, { shouldDirty: true })
+                    }
                     disabled={isPending || !canReadTeams || teams.length === 0}
                   >
                     <SelectTrigger
@@ -911,7 +923,7 @@ export function LlmProviderApiKeyForm({
                 id="llm-provider-api-key-is-primary"
                 checked={form.watch("isPrimary")}
                 onCheckedChange={(checked) =>
-                  form.setValue("isPrimary", checked)
+                  form.setValue("isPrimary", checked, { shouldDirty: true })
                 }
                 disabled={isPending || Boolean(existingPrimaryKey)}
               />

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -631,6 +631,7 @@ export function LlmProviderApiKeyForm({
                   form.setValue(
                     "bedrockAuthMethod",
                     value as "api-key" | "sigv4" | "iam",
+                    { shouldDirty: true },
                   )
                 }
               >


### PR DESCRIPTION
## Problem

The Edit API Key dialog (`app/llm/model-providers/page.tsx`) diverged from Create:

- **Validation** gated submit on `Boolean(name)` only — it allowed saving a team-scoped key with no team, allowed switching a key to Bedrock SigV4 with no AWS credentials (a broken partial update), and needlessly required the (optional) name.
- **No unsaved-changes guard** — Esc/backdrop/Cancel discarded edits silently.

## Fix

- **Validation**: new pure util `isEditApiKeyFormValid`. It requires team-scope consistency (`scope !== "team" || teamId`) and, when the user selects Bedrock SigV4, the AWS access key + secret — matching Create. It deliberately does not require the API key: editing keeps the existing secret (masked placeholder; AWS keys not prefilled), so a name-only edit needs none. Requiring SigV4 creds is safe for name-only edits because the auth-method tabs always open on "API Key" (`editForm.reset` hardcodes it), so SigV4 is only ever reached by a deliberate user switch. Unit-tested.
- **Guard**: pass `isDirty` and swap the plain Cancel button for `DialogCancelButton`, matching the Create dialog so every close path prompts on unsaved changes.
- **Dirty-tracking (shared form)**: the guard keys off `formState.isDirty`, but the scope/team/primary/vault/Bedrock-auth-method controls updated the form via bare `form.setValue(...)` without `{ shouldDirty: true }`, so React Hook Form never marked those changes dirty — the guard would have stayed silent for them (this also silently affected the Create dialog's guard). Added `shouldDirty` to those user-driven handlers. (Provider selection is left bare — it's disabled in edit mode.)

## Tests

- `edit-key-form.utils.test.ts` — pure unit test of the validation predicate (team-scope + SigV4/IAM/API-key branches).
- `llm-provider-api-key-form.dirty.test.tsx` — renders the real form and asserts a scope change flips `isDirty` (fails without the `shouldDirty` fix).

## Note

Touches `components/llm-provider-api-key-form.tsx` (also modified by the sibling provider-switch-clear-credentials PR, in a different region) — merge/rebase as needed.

https://claude.ai/code/session_01XrgWmw4aievNj85q6axVNb