### PR TITLE
fix(auth): gate CompleteOnboarding behind org-admin

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -217120,7 +217120,7 @@
         "tags": [
           "Organization"
         ],
-        "description": "Mark organization onboarding as complete\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\nNone (no additional RBAC permission required)",
+        "description": "Mark organization onboarding as complete\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`organizationSettings:update`: Customize organization appearance, authentication, etc",
         "requestBody": {
           "required": true,
           "content": {
@@ -217918,9 +217918,10 @@
           }
         },
         "x-required-permissions": {
-          "kind": "none",
-          "note": "None (no additional RBAC permission required)",
-          "permissions": []
+          "kind": "static",
+          "permissions": [
+            "organizationSettings:update"
+          ]
         }
       }
     },

--- a/platform/shared/access-control.test.ts
+++ b/platform/shared/access-control.test.ts
@@ -88,6 +88,27 @@ describe("access-control", () => {
     });
   });
 
+  describe("complete-onboarding route", () => {
+    // Completing onboarding flips the org-wide onboardingComplete flag, so it
+    // must require admin-level organizationSettings:update, not merely
+    // authentication — otherwise any member could flip it.
+    test("CompleteOnboarding requires organizationSettings:update", () => {
+      const required =
+        requiredEndpointPermissionsMap[RouteId.CompleteOnboarding];
+      expect(required?.organizationSettings).toContain("update");
+    });
+
+    test("the member role cannot complete onboarding", () => {
+      expect(memberPermissions.organizationSettings).not.toContain("update");
+    });
+
+    test("GetOrganization stays authenticated-only", () => {
+      expect(requiredEndpointPermissionsMap[RouteId.GetOrganization]).toEqual(
+        {},
+      );
+    });
+  });
+
   describe("sandbox artifact route", () => {
     // the download_file tool (sandbox:execute) hands out this artifact URL, so
     // the fetch route must require the same permission — otherwise a role that

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -464,11 +464,13 @@ export const requiredEndpointPermissionsMap: Partial<
   Record<RouteId, Permissions>
 > = {
   /**
-   * Getting basic info about the organization and marking onboarding as complete
-   * require the user to be authenticated but don't require any specific permissions.
+   * Getting basic info about the organization requires the user to be
+   * authenticated but no specific permission.
    */
   [RouteId.GetOrganization]: {},
-  [RouteId.CompleteOnboarding]: {},
+  // Completing onboarding flips an org-wide flag, so gate it on admin-level
+  // organization-settings update, like the other org-settings routes.
+  [RouteId.CompleteOnboarding]: { organizationSettings: ["update"] },
 
   // Connection setup: resource-level checks (mcpGateway/llmProxy read access,
   // skill admin) are conditional on what the setup includes and enforced in

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -5307,7 +5307,7 @@ export const testEmbeddingConnection = <ThrowOnError extends boolean = false>(op
  *
  * Authorization:
  *
- * None (no additional RBAC permission required)
+ * `organizationSettings:update`: Customize organization appearance, authentication, etc
  */
 export const completeOnboarding = <ThrowOnError extends boolean = false>(options: Options<CompleteOnboardingData, ThrowOnError>) => (options.client ?? client).post<CompleteOnboardingResponses, CompleteOnboardingErrors, ThrowOnError>({
     url: '/api/organization/complete-onboarding',


### PR DESCRIPTION
## Problem

`POST /api/organization/complete-onboarding` was mapped to `{}` in `requiredEndpointPermissionsMap`, which the auth middleware treats as "any authenticated user." So any member — not just an admin — could flip the org-wide `onboardingComplete` flag.

## Fix

Require `organizationSettings: ["update"]`, matching the other org-settings routes. The member role lacks that permission (editor/admin have it), so members can no longer complete onboarding. No non-admin flow depends on this: first-run bootstrap seeds a default admin before onboarding runs, and the frontend wizard only fires an analytics event.

This is defense-in-depth — the flag currently has no security-relevant consumer — but it closes a latent authz gap before one is wired in.

## Tests

`access-control.test.ts`: asserts the route requires `organizationSettings:update`, that the member role lacks it, and that `GetOrganization` stays authenticated-only. The first assertion fails against the old `{}`.

https://claude.ai/code/session_01XrgWmw4aievNj85q6axVNb

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>