### PR TITLE
fix: enforce masking and reveal toggle for provider secrets (#6286)

### DIFF
--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -753,6 +753,7 @@ export function LlmProviderApiKeyForm({
                       id="llm-provider-api-key-value"
                       placeholder={providerConfig.placeholder}
                       disabled={isPending}
+                      masked={true}
                       // Offer the reveal toggle when adding a key so the user
                       // can verify what they typed or pasted. Editing keeps the
                       // "configured" check in that same corner instead, and
@@ -794,6 +795,8 @@ export function LlmProviderApiKeyForm({
                     id="llm-provider-aws-access-key-id"
                     placeholder="AKIA..."
                     disabled={isPending}
+                    masked={true}
+                    revealable
                     {...form.register("awsAccessKeyId")}
                   />
                 </div>
@@ -805,6 +808,8 @@ export function LlmProviderApiKeyForm({
                     id="llm-provider-aws-secret-access-key"
                     placeholder="••••••••"
                     disabled={isPending}
+                    masked={true}
+                    revealable
                     {...form.register("awsSecretAccessKey")}
                   />
                 </div>
@@ -819,6 +824,8 @@ export function LlmProviderApiKeyForm({
                     id="llm-provider-aws-session-token"
                     placeholder="Required for temporary credentials (STS / AssumeRole)"
                     disabled={isPending}
+                    masked={true}
+                    revealable
                     {...form.register("awsSessionToken")}
                   />
                 </div>


### PR DESCRIPTION
**### What:**
Explicitly passed `masked={true}` and `revealable` props to all `SecretInput` fields within the LLM provider configuration form.

**### Why:**
Resolves #6286 by ensuring all sensitive credentials (primary API keys, AWS Access Keys, AWS Secret Keys, and AWS Session Tokens) are visually masked by default on load, while providing users the eye-toggle to safely reveal them for verification. 

This change prevents accidental visual exposure of sensitive keys in the UI.

fix related to  #6286