### PR TITLE
feat(mcp-registry): accept JSON array format in the Arguments textarea

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/arguments-parser.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/arguments-parser.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parseArgumentsInput } from "./arguments-parser";
+
+describe("parseArgumentsInput", () => {
+  it("parses one argument per line", () => {
+    expect(parseArgumentsInput("/path/to/server.js\n--verbose")).toEqual([
+      "/path/to/server.js",
+      "--verbose",
+    ]);
+  });
+
+  it("parses a JSON array of arguments", () => {
+    expect(
+      parseArgumentsInput('["-y", "@modelcontextprotocol/server-github"]'),
+    ).toEqual(["-y", "@modelcontextprotocol/server-github"]);
+  });
+
+  it("parses a JSON array with surrounding whitespace/newlines", () => {
+    expect(parseArgumentsInput('\n  ["-y", "pkg"]  \n')).toEqual(["-y", "pkg"]);
+  });
+
+  it("coerces numbers inside a JSON array to strings", () => {
+    expect(parseArgumentsInput('["--port", 8080]')).toEqual(["--port", "8080"]);
+  });
+
+  it("drops empty entries in a JSON array", () => {
+    expect(parseArgumentsInput('["-y", "", "  ", "pkg"]')).toEqual([
+      "-y",
+      "pkg",
+    ]);
+  });
+
+  it("falls back to line parsing for malformed JSON", () => {
+    expect(parseArgumentsInput("[not-json\n--flag")).toEqual([
+      "[not-json",
+      "--flag",
+    ]);
+  });
+
+  it("trims whitespace and ignores blank lines", () => {
+    expect(parseArgumentsInput("  --a  \n\n   \n--b")).toEqual(["--a", "--b"]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseArgumentsInput("")).toEqual([]);
+    expect(parseArgumentsInput("   \n  ")).toEqual([]);
+  });
+
+  it("returns an empty array for undefined/null", () => {
+    expect(parseArgumentsInput(undefined)).toEqual([]);
+    expect(parseArgumentsInput(null)).toEqual([]);
+  });
+
+  it("treats non-array JSON as a single line", () => {
+    expect(parseArgumentsInput('{"a":1}')).toEqual(['{"a":1}']);
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/arguments-parser.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/arguments-parser.ts
@@ -1,0 +1,61 @@
+/**
+ * Parses the free-form "Arguments" textarea value into an array of argument
+ * strings.
+ *
+ * Two input formats are supported:
+ *
+ * 1. One argument per line (the original format):
+ *      /path/to/server.js
+ *      --verbose
+ *
+ * 2. A JSON array, the way most MCP catalogs present args:
+ *      ["-y", "@modelcontextprotocol/server-github"]
+ *
+ * A JSON array is detected when the trimmed input starts with "[". If it parses
+ * to an array, its items are used (coerced to trimmed strings, blanks dropped).
+ * Anything else - including malformed JSON - falls back to line-by-line
+ * parsing, so existing one-per-line configs keep working unchanged.
+ *
+ * @param input - Raw textarea value (may be undefined/null)
+ * @returns Array of non-empty, trimmed argument strings
+ *
+ * @example
+ * parseArgumentsInput("--verbose\n/path/to/server.js")
+ * // ["--verbose", "/path/to/server.js"]
+ *
+ * @example
+ * parseArgumentsInput('["-y", "@modelcontextprotocol/server-github"]')
+ * // ["-y", "@modelcontextprotocol/server-github"]
+ */
+export function parseArgumentsInput(
+  input: string | undefined | null,
+): string[] {
+  if (!input) return [];
+
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return [];
+
+  // JSON array format, e.g. ["-y", "@scope/pkg", "--port", "8080"]
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .filter(
+            (item): item is string | number =>
+              typeof item === "string" || typeof item === "number",
+          )
+          .map((item) => String(item).trim())
+          .filter((item) => item.length > 0);
+      }
+    } catch {
+      // Not valid JSON - fall through to line-by-line parsing.
+    }
+  }
+
+  // Original format: one argument per line.
+  return trimmed
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useCreateMcpServerInstallationRequest } from "@/lib/mcp/mcp-server-installation-request.query";
+import { parseArgumentsInput } from "./arguments-parser";
 
 const customServerRequestSchema = z
   .object({
@@ -119,10 +120,7 @@ export function CustomServerRequestDialog({
             serverType: "local" as const,
             localConfig: {
               command: values.command,
-              arguments: values.arguments
-                .split("\n")
-                .map((arg) => arg.trim())
-                .filter((arg) => arg.length > 0),
+              arguments: parseArgumentsInput(values.arguments),
               environment:
                 values.environment.length > 0 ? values.environment : undefined,
             },
@@ -276,7 +274,9 @@ export function CustomServerRequestDialog({
                     name="arguments"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Arguments (one per line)</FormLabel>
+                        <FormLabel>
+                          Arguments (one per line or JSON array)
+                        </FormLabel>
                         <FormControl>
                           <Textarea
                             placeholder={`/path/to/server.js\n--verbose`}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1297,7 +1297,7 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments (one per line or JSON array)
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -6,6 +6,7 @@ import {
   isVaultReference,
   parseVaultReference,
 } from "@archestra/shared";
+import { parseArgumentsInput } from "./arguments-parser";
 import { parseDockerArgsToLocalConfig } from "./docker-args-parser";
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 
@@ -34,13 +35,8 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
-    const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
-      : [];
+    // Parse arguments string into array (supports one-per-line or JSON array)
+    const argumentsArray = parseArgumentsInput(values.localConfig.arguments);
 
     data.localConfig = {
       command: values.localConfig.command || undefined,


### PR DESCRIPTION
Closes #3859

## What
The "Arguments" textarea accepted only one argument per line, but most MCP
catalogs present args as a JSON array, e.g.
["-y", "@modelcontextprotocol/server-github"]. This makes the field accept
both formats.

## How
- Added `arguments-parser.ts` with a small `parseArgumentsInput()` helper
  (mirrors the existing `docker-args-parser.ts`). A JSON array is detected when
  the trimmed input starts with `[`; if it parses to an array, its items are
  used (coerced to trimmed strings, blanks dropped). Anything else — including
  malformed JSON — falls back to the original one-per-line parsing, so existing
  configs are unaffected.
- Used the helper in both places that parse this textarea:
  `mcp-catalog-form.utils.ts` and `custom-server-request-dialog.tsx`.
- Updated both field labels to "Arguments (one per line or JSON array)".
- Added vitest coverage for both formats, whitespace/blank handling, numbers,
  malformed-JSON fallback, and empty/undefined input.

## Follow-up (kept out of this PR to stay focused)
The issue also suggests extending the same JSON convenience to the rest of the
server config (Command, Envs, Type). Happy to do that as a follow-up.

/claim #3859