### PR TITLE
fix(environments): gate "Manage environments" link on environment:admin

### DIFF
--- a/platform/frontend/src/components/environment-selector.test.tsx
+++ b/platform/frontend/src/components/environment-selector.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useEnvironments } from "@/lib/environment.query";
+import { useDefaultEnvironment } from "@/lib/organization.query";
+import { EnvironmentSelector } from "./environment-selector";
+
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/organization.query");
+vi.mock("@/lib/environment.query", () => ({ useEnvironments: vi.fn() }));
+
+function setEnvAdmin(hasAdmin: boolean) {
+  vi.mocked(useHasPermissions).mockReturnValue({
+    data: hasAdmin,
+  } as unknown as ReturnType<typeof useHasPermissions>);
+}
+
+describe("EnvironmentSelector — Manage environments link", () => {
+  beforeEach(() => {
+    vi.mocked(useEnvironments).mockReturnValue({
+      data: { environments: [] },
+    } as unknown as ReturnType<typeof useEnvironments>);
+    vi.mocked(useDefaultEnvironment).mockReturnValue({
+      name: "Default",
+      description: "",
+    } as unknown as ReturnType<typeof useDefaultEnvironment>);
+  });
+
+  test("omits the Manage environments link when the user lacks environment:admin", () => {
+    setEnvAdmin(false);
+    render(<EnvironmentSelector value={null} onChange={vi.fn()} />);
+
+    expect(
+      screen.getByText(/Only the default environment is available/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /manage environments/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders the Manage environments link when the user has environment:admin", () => {
+    setEnvAdmin(true);
+    render(<EnvironmentSelector value={null} onChange={vi.fn()} />);
+
+    expect(
+      screen.getByRole("link", { name: /manage environments/i }),
+    ).toHaveAttribute("href", "/settings/environments");
+  });
+});

--- a/platform/frontend/src/components/environment-selector.tsx
+++ b/platform/frontend/src/components/environment-selector.tsx
@@ -120,13 +120,18 @@ export function EnvironmentSelector({
       ) : null}
       {!hasCustomEnvironmentOptions ? (
         <p className="text-xs text-muted-foreground">
-          Only the default environment is available.{" "}
-          <Link
-            href="/settings/environments"
-            className="underline underline-offset-2"
-          >
-            Manage environments
-          </Link>
+          Only the default environment is available.
+          {hasEnvAdmin ? (
+            <>
+              {" "}
+              <Link
+                href="/settings/environments"
+                className="underline underline-offset-2"
+              >
+                Manage environments
+              </Link>
+            </>
+          ) : null}
         </p>
       ) : null}
     </div>


### PR DESCRIPTION
The environment selector — shown in App, Agent, Knowledge-connector, and MCP-catalog settings whenever only the default environment is available — rendered a "Manage environments" link for every user. `/settings/environments` requires `environment:admin`, so users without it (including default members) followed the link into a full-page "You don't have permission to access this page." dead-end.

The link is now gated on the same `environment:admin` permission the route enforces — already computed in the component as `hasEnvAdmin`. Users who can't manage environments still see the "Only the default environment is available." note, just without the dead-end link; admins are unchanged.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>