### PR TITLE
perf(ci): warm the platform build cache from main to shrink the merge-queue cold-build tail

### DIFF
--- a/.github/workflows/warm-e2e-build-cache.yml
+++ b/.github/workflows/warm-e2e-build-cache.yml
@@ -1,0 +1,79 @@
+name: Warm E2E Build Cache
+
+# The platform image build swings ~85s (warm) to ~226s (cold) purely on how hot
+# the BuildKit layer cache is. Merge-queue entries run on ephemeral
+# gh-readonly-queue/* refs and land on whichever Blacksmith runner is free, so
+# they routinely hit a cold/evicted layer cache and pay the full ~226s on the
+# merge-queue critical path (the build gates every e2e shard).
+#
+# This job rebuilds the platform image from main on a schedule so the EXPENSIVE,
+# rarely-changing base layers — the go-builder toolchain, `pnpm install`
+# node_modules, the dagger-engine assets — stay hot in the Blacksmith layer
+# cache and the Turborepo remote cache. Even when a queue entry changes app
+# source, only the cheap top layers rebuild; the heavy base is reused. That is
+# the difference between the ~85s and ~226s paths.
+#
+# It deliberately does NOT push (push: false, load: false): the only product is a
+# warm cache, not an image. It runs on the same runner class as the real build
+# (blacksmith-16vcpu-ubuntu-2404) so it shares that pool's sticky-disk cache.
+#
+# Mirrors the trigger shape of warm-e2e-image-caches.yml: daily before European
+# hours, plus an immediate re-warm on push to main when a base-layer input
+# changes (Dockerfile, lockfile, or the build actions themselves).
+
+on:
+  schedule:
+    # Daily, before European working hours; staggered a little ahead of the
+    # tarball warmer (17 4 * * *) so both are hot by the morning queue.
+    - cron: "39 3 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      # Base-layer-defining inputs. A change to any of these invalidates the
+      # heavy cached layers, so re-warm immediately rather than waiting for the
+      # next scheduled run.
+      - "platform/Dockerfile"
+      - "platform/pnpm-lock.yaml"
+      - ".github/actions/build-docker-image/action.yml"
+      - ".github/actions/blacksmith-build-push/action.yml"
+      - ".github/actions/setup-blacksmith-builder/action.yml"
+      - ".github/workflows/warm-e2e-build-cache.yml"
+
+permissions: {}
+
+concurrency:
+  group: warm-e2e-build-cache
+  cancel-in-progress: false
+
+jobs:
+  warm-build-cache:
+    name: Warm E2E Build Cache
+    # Same runner class as platform-e2e-tests.yml's Build Platform Image leg so
+    # this warms the layer cache on the pool the merge queue actually builds on.
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: read # Checkout only. No id-token: this build never pushes.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      # Same action, context, and cache credentials as the real merge-queue
+      # build (platform-e2e-tests.yml), but push: false / load: false — the run
+      # exists solely to populate the BuildKit layer cache and Turborepo remote
+      # cache. provenance: false matches the e2e build so the cached layers line
+      # up byte-for-byte with what the queue produces.
+      - name: Warm platform image build cache
+        uses: ./.github/actions/build-docker-image
+        with:
+          context: ./platform
+          push: "false"
+          load: "false"
+          provenance: "false"
+          turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
+          turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}


### PR DESCRIPTION
## What & why

Item **#2** of the "make CI super fast" roadmap — the cleanest high-leverage caching win.

The platform image build **gates every e2e shard** in the merge queue and swings **~85s (warm layer cache) ↔ ~226s (cold)** purely on cache warmth. Merge-queue entries run on ephemeral `gh-readonly-queue/*` refs and land on whichever Blacksmith runner is free, so they routinely hit a cold/evicted BuildKit layer cache and pay the full ~226s **on the merge-queue critical path**.

## Change

A scheduled `Warm E2E Build Cache` workflow that rebuilds the platform image **from `main`** with `push: false` / `load: false` — the only product is a warm cache, not an image. It runs on the same `blacksmith-16vcpu-ubuntu-2404` class the real build uses, so it warms the layer cache on the pool the queue actually builds on, and it passes the same Turborepo remote-cache credentials.

Effect: the expensive, rarely-changing base layers (go-builder toolchain, `pnpm install` node_modules, dagger assets) and the turbo cache stay hot. Even when a queue entry changes app source, only the cheap top layers rebuild — the heavy base is reused. That's the difference between the ~85s and ~226s paths.

## Triggers (mirrors `warm-e2e-image-caches.yml`)

- **Daily** at `39 3 * * *` (before European hours, staggered ahead of the tarball warmer's `17 4`).
- **`workflow_dispatch`** for on-demand warming.
- **Push to `main`** only when a base-layer input changes (`platform/Dockerfile`, `platform/pnpm-lock.yaml`, or the build actions) — an immediate re-warm instead of waiting for the nightly.

## Safety

- Purely **additive and off the critical path** — it cannot fail or slow the merge-queue gate; worst case it's simply less effective than hoped.
- No registry writes (`push: false`), no `id-token` permission, `contents: read` only.
- `provenance: false` matches the e2e build so cached layers line up with what the queue produces.
- zizmor clean; YAML validated.

## Validation

The warm/cold delta is best confirmed empirically: after this merges and the first scheduled run populates the cache, compare `Build Platform Image` durations on subsequent merge-queue entries against the ~226s cold baseline. Paired with roadmap item **#1** (tree-hash image reuse), the build comes off the critical path entirely in the common case.

🤖 Recovered and implemented from a prior "make CI super fast" analysis session.

https://claude.ai/code/session_01JmQgvqQcexvxA5qqpL3vJd

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>