### PR TITLE
perf(ci): fast-cancel e2e when an image build fails

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -183,6 +183,34 @@ jobs:
           retention-days: 1
           compression-level: 0 # Already gzipped
 
+  # Fast-cancel the run when an image build fails. The shards deliberately have
+  # no `needs: [platform-e2e-build]` so they can set up in parallel with the
+  # build (see the shards job), and then poll the registry for the pushed image
+  # up to image-pull-timeout-seconds (900s). That overlap is a win when the build
+  # succeeds, but when it FAILS the shards would otherwise burn the full ~15-min
+  # poll deadline on a 16vcpu runner for an image that will never arrive. The
+  # merge is already blocked by the failed required "Build ... Image" check, so
+  # cancelling the run here only reclaims that wasted shard time — it changes no
+  # merge outcome. (quickstart already fast-fails: it `needs` the build and is
+  # skipped on failure. Only the poll-based shards need this.)
+  platform-e2e-cancel-on-build-failure:
+    name: Cancel E2E on build failure
+    needs: [platform-e2e-build]
+    if: ${{ failure() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    permissions:
+      actions: write # Required to cancel this workflow run.
+    steps:
+      - name: Cancel run so shards stop polling for an image that will never arrive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "An image build failed; cancelling run ${RUN_ID} so the e2e shards stop burning the image-pull deadline."
+          gh api --method POST "repos/${REPO}/actions/runs/${RUN_ID}/cancel"
+
   # E2E tests - runs the generic non-quickstart suites plus the Vault K8s startup
   # coverage against one shared CI deployment in the standard DB secrets mode.
   # Quickstart remains separate because it validates the docker run path.


### PR DESCRIPTION
## What & why

Item **#2** of the follow-up list: fast-cancel e2e when an image build fails, instead of letting the shards burn the poll deadline.

The e2e shards deliberately run **without** `needs: [platform-e2e-build]` so their setup (checkout, pnpm, Kind, MCP dep images) overlaps the image build; they then poll the registry for the pushed image up to `image-pull-timeout-seconds` (**900s**). That overlap is a win when the build succeeds — but when it **fails**, each shard otherwise waits out the full ~15-min deadline on a 16vcpu runner for an image that will never arrive.

## Change

A small `Cancel E2E on build failure` job that `needs: [platform-e2e-build]`, fires only on `failure()`, and cancels the run via the Actions API.

- The merge is **already blocked** by the failed required `Build … Image` check, so this changes **no merge outcome** — it only reclaims wasted shard time (up to ~15 min × 2 shards × 16vcpu per failed build).
- Quickstart already fast-fails (it `needs` the build → skipped on failure). Only the poll-based shards needed this.
- Minimal permission: `actions: write` on that one job.
- If the build is *cancelled* rather than *failed* (e.g. superseded by a newer commit), `failure()` is false → this job is skipped, no double-cancel.

zizmor clean; YAML validated.

## Note on item #3 (shrink the ~173s setup)

Investigated and intentionally **not** bundled here — it doesn't reduce to a clean, safe, in-repo change:
- **Pre-bake Kind node image** — the kindest-node tarball is already cached (`warm-e2e-image-caches`); going further means a Blacksmith custom-runner image (infra, not a repo PR).
- **GAR region co-location** — investigative + Blacksmith config; not changeable from this repo, and image reuse/warm-cache (#6373/#6372) already avoid most builds+pushes.
- **Lighter helm readiness gate** — the only real in-repo lever, but the platform install is `helm --atomic --wait`; loosening it risks tests starting before the backend/migrations are ready (a flaky *required* gate) and needs a live `run-e2e` validation to land safely.

Happy to take the helm-gate change on as its own validated PR if wanted.

🤖 From the recovered "make CI super fast" analysis.

https://claude.ai/code/session_01JmQgvqQcexvxA5qqpL3vJd

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>