### PR TITLE
fix(organization): scope org members endpoint to the caller's visible users

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -218774,7 +218774,7 @@
         "tags": [
           "Organization"
         ],
-        "description": "Get all members of the organization\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\n`member:read`: View organization members and their roles",
+        "description": "Get all members of the organization\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\nNone (no additional RBAC permission required)",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -219036,10 +219036,9 @@
           }
         },
         "x-required-permissions": {
-          "kind": "static",
-          "permissions": [
-            "member:read"
-          ]
+          "kind": "none",
+          "note": "None (no additional RBAC permission required)",
+          "permissions": []
         }
       }
     },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -218774,7 +218774,7 @@
         "tags": [
           "Organization"
         ],
-        "description": "Get all members of the organization\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\nNone (no additional RBAC permission required)",
+        "description": "List organization members visible to the caller. Callers with the member:read permission (admins and equivalent custom roles) receive the full organization roster; other authenticated users receive only the members they share a team with.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\nNone (no additional RBAC permission required)",
         "responses": {
           "200": {
             "description": "Default Response",

--- a/platform/backend/src/models/member.ts
+++ b/platform/backend/src/models/member.ts
@@ -214,6 +214,41 @@ class MemberModel {
     return results;
   }
 
+  /**
+   * Members of the organization whose user id is in `userIds`, same shape as
+   * findAllByOrganization. Lets a caller resolve a known subset (e.g. a member's
+   * teammates) without scanning the full roster.
+   */
+  static async findByUserIdsInOrganization(params: {
+    organizationId: string;
+    userIds: string[];
+  }) {
+    const { organizationId, userIds } = params;
+    if (userIds.length === 0) {
+      return [];
+    }
+    return db
+      .select({
+        id: schema.usersTable.id,
+        name: schema.usersTable.name,
+        email: schema.usersTable.email,
+        role: schema.membersTable.role,
+        systemRole: schema.usersTable.role,
+      })
+      .from(schema.membersTable)
+      .innerJoin(
+        schema.usersTable,
+        eq(schema.membersTable.userId, schema.usersTable.id),
+      )
+      .where(
+        and(
+          eq(schema.membersTable.organizationId, organizationId),
+          inArray(schema.usersTable.id, userIds),
+        ),
+      )
+      .orderBy(schema.usersTable.name);
+  }
+
   static async findUserIdsInOrganization(params: {
     organizationId: string;
     userIds: string[];

--- a/platform/backend/src/models/team.ts
+++ b/platform/backend/src/models/team.ts
@@ -819,6 +819,46 @@ class TeamModel {
   }
 
   /**
+   * Distinct user IDs sharing at least one team with `userId` within the given
+   * organization (self excluded). Org-scoped so a shared team in another org
+   * never surfaces someone as a teammate here.
+   */
+  static async getTeammateUserIdsInOrganization(params: {
+    userId: string;
+    organizationId: string;
+  }): Promise<string[]> {
+    const { userId, organizationId } = params;
+    const userTeamIds = (
+      await db
+        .select({ teamId: schema.teamMembersTable.teamId })
+        .from(schema.teamMembersTable)
+        .innerJoin(
+          schema.teamsTable,
+          eq(schema.teamsTable.id, schema.teamMembersTable.teamId),
+        )
+        .where(
+          and(
+            eq(schema.teamMembersTable.userId, userId),
+            eq(schema.teamsTable.organizationId, organizationId),
+          ),
+        )
+    ).map((row) => row.teamId);
+
+    if (userTeamIds.length === 0) {
+      return [];
+    }
+
+    const teammates = await db
+      .select({ userId: schema.teamMembersTable.userId })
+      .from(schema.teamMembersTable)
+      .where(inArray(schema.teamMembersTable.teamId, userTeamIds));
+
+    return [...new Set(teammates.map((t) => t.userId))].filter(
+      (id) => id !== userId,
+    );
+  }
+
+  /**
    * Get all teams for an agent with their compression settings
    */
   static async getTeamsForAgent(agentId: string): Promise<Team[]> {

--- a/platform/backend/src/routes/organization-members.test.ts
+++ b/platform/backend/src/routes/organization-members.test.ts
@@ -2,7 +2,7 @@ import { type Mock, vi } from "vitest";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
-import type { User } from "@/types";
+import type { SelectServiceAccount, User } from "@/types";
 
 vi.mock("@/auth");
 
@@ -20,10 +20,12 @@ describe("GET /api/organization/members — visibility scope", () => {
   let app: FastifyInstanceWithZod;
   let organizationId: string;
   let currentUser: User;
+  let currentServiceAccount: SelectServiceAccount | undefined;
 
   beforeEach(async ({ makeOrganization }) => {
     vi.clearAllMocks();
     mockHasPermission.mockResolvedValue({ success: true, error: null });
+    currentServiceAccount = undefined;
     organizationId = (await makeOrganization()).id;
 
     app = createFastifyInstance();
@@ -31,6 +33,11 @@ describe("GET /api/organization/members — visibility scope", () => {
       (request as typeof request & { user: User }).user = currentUser;
       (request as typeof request & { organizationId: string }).organizationId =
         organizationId;
+      (
+        request as typeof request & {
+          serviceAccount: SelectServiceAccount | undefined;
+        }
+      ).serviceAccount = currentServiceAccount;
     });
 
     const { default: routes } = await import("./organization");
@@ -116,6 +123,32 @@ describe("GET /api/organization/members — visibility scope", () => {
       .map((m) => m.email)
       .sort();
     expect(emails).toEqual(["admin@example.com", "other@example.com"]);
+  });
+
+  test("forwards the service account to the permission check so service accounts are not checked as the synthetic user", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    // A service-account request: the middleware sets a synthetic user id
+    // (service-account:<id>) that carries no member record, so member:read must
+    // be evaluated against the service account itself. hasPermission checks its
+    // serviceAccount arg before userContext, so the handler must forward it.
+    const me = await makeUser({ email: "sa-caller@example.com" });
+    await makeMember(me.id, organizationId, { role: "member" });
+    currentUser = me;
+    currentServiceAccount = {
+      id: "svc-1",
+      organizationId,
+    } as unknown as SelectServiceAccount;
+
+    await get();
+
+    expect(mockHasPermission).toHaveBeenCalledWith(
+      { member: ["read"] },
+      expect.anything(),
+      currentServiceAccount,
+      { userId: me.id, organizationId },
+    );
   });
 
   test("a non-member:read caller's teammates expose only identity fields, not roles", async ({

--- a/platform/backend/src/routes/organization-members.test.ts
+++ b/platform/backend/src/routes/organization-members.test.ts
@@ -1,0 +1,160 @@
+import { type Mock, vi } from "vitest";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+vi.mock("@/auth");
+
+import { hasPermission } from "@/auth";
+
+const mockHasPermission = hasPermission as Mock;
+
+/**
+ * GET /api/organization/members returns the users the caller is allowed to see:
+ * the full roster with member:read, otherwise only the caller's teammates. The
+ * route is open to any authenticated user, so the handler is the authorization
+ * boundary — `hasPermission` is mocked to drive each branch.
+ */
+describe("GET /api/organization/members — visibility scope", () => {
+  let app: FastifyInstanceWithZod;
+  let organizationId: string;
+  let currentUser: User;
+
+  beforeEach(async ({ makeOrganization }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+    organizationId = (await makeOrganization()).id;
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (request as typeof request & { user: User }).user = currentUser;
+      (request as typeof request & { organizationId: string }).organizationId =
+        organizationId;
+    });
+
+    const { default: routes } = await import("./organization");
+    await app.register(routes);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  function get() {
+    return app.inject({ method: "GET", url: "/api/organization/members" });
+  }
+
+  test("caller without member:read sees only teammates, not the whole org", async ({
+    makeUser,
+    makeMember,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const me = await makeUser({ name: "Me", email: "me@example.com" });
+    const teammate = await makeUser({
+      name: "Teammate",
+      email: "teammate@example.com",
+    });
+    const stranger = await makeUser({
+      name: "Stranger",
+      email: "stranger@example.com",
+    });
+    await makeMember(me.id, organizationId, { role: "member" });
+    await makeMember(teammate.id, organizationId, { role: "member" });
+    await makeMember(stranger.id, organizationId, { role: "member" });
+
+    const team = await makeTeam(organizationId, me.id);
+    await makeTeamMember(team.id, me.id);
+    await makeTeamMember(team.id, teammate.id);
+    // stranger shares no team with me
+
+    currentUser = me;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const res = await get();
+
+    expect(res.statusCode).toBe(200);
+    const emails = (res.json() as Array<{ email: string }>).map((m) => m.email);
+    expect(emails).toEqual(["teammate@example.com"]);
+  });
+
+  test("caller without member:read and no teams sees an empty list", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const me = await makeUser({ email: "loner@example.com" });
+    const other = await makeUser({ email: "other@example.com" });
+    await makeMember(me.id, organizationId, { role: "member" });
+    await makeMember(other.id, organizationId, { role: "member" });
+
+    currentUser = me;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const res = await get();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  test("caller with member:read sees every organization member", async ({
+    makeUser,
+    makeMember,
+  }) => {
+    const me = await makeUser({ name: "Admin", email: "admin@example.com" });
+    const other = await makeUser({ name: "Other", email: "other@example.com" });
+    await makeMember(me.id, organizationId, { role: "admin" });
+    await makeMember(other.id, organizationId, { role: "member" });
+
+    currentUser = me;
+
+    const res = await get();
+
+    expect(res.statusCode).toBe(200);
+    const emails = (res.json() as Array<{ email: string }>)
+      .map((m) => m.email)
+      .sort();
+    expect(emails).toEqual(["admin@example.com", "other@example.com"]);
+  });
+
+  test("excludes a teammate whose only shared team is in another organization", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const orgB = (await makeOrganization()).id;
+
+    const me = await makeUser({ email: "me@example.com" });
+    const teammate = await makeUser({ email: "teammate@example.com" });
+    const crossOrg = await makeUser({ email: "cross-org@example.com" });
+
+    await makeMember(me.id, organizationId, { role: "member" });
+    await makeMember(teammate.id, organizationId, { role: "member" });
+    await makeMember(crossOrg.id, organizationId, { role: "member" });
+
+    // Shared team in the caller's org: me + teammate.
+    const teamHere = await makeTeam(organizationId, me.id);
+    await makeTeamMember(teamHere.id, me.id);
+    await makeTeamMember(teamHere.id, teammate.id);
+
+    // Shared team in a different org: me + crossOrg. crossOrg is also a member
+    // of the caller's org, so only org-scoped team lookup keeps them out.
+    await makeMember(me.id, orgB, { role: "member" });
+    await makeMember(crossOrg.id, orgB, { role: "member" });
+    const teamElsewhere = await makeTeam(orgB, me.id);
+    await makeTeamMember(teamElsewhere.id, me.id);
+    await makeTeamMember(teamElsewhere.id, crossOrg.id);
+
+    currentUser = me;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const res = await get();
+
+    expect(res.statusCode).toBe(200);
+    const emails = (res.json() as Array<{ email: string }>).map((m) => m.email);
+    expect(emails).toEqual(["teammate@example.com"]);
+  });
+});

--- a/platform/backend/src/routes/organization-members.test.ts
+++ b/platform/backend/src/routes/organization-members.test.ts
@@ -118,6 +118,35 @@ describe("GET /api/organization/members — visibility scope", () => {
     expect(emails).toEqual(["admin@example.com", "other@example.com"]);
   });
 
+  test("a non-member:read caller's teammates expose only identity fields, not roles", async ({
+    makeUser,
+    makeMember,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const me = await makeUser({ name: "Me", email: "me@example.com" });
+    const teammate = await makeUser({
+      name: "Teammate",
+      email: "teammate@example.com",
+    });
+    await makeMember(me.id, organizationId, { role: "member" });
+    // Give the teammate a privileged role so a leak would be visible.
+    await makeMember(teammate.id, organizationId, { role: "admin" });
+    const team = await makeTeam(organizationId, me.id);
+    await makeTeamMember(team.id, me.id);
+    await makeTeamMember(team.id, teammate.id);
+
+    currentUser = me;
+    mockHasPermission.mockResolvedValue({ success: false, error: null });
+
+    const res = await get();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<Record<string, unknown>>;
+    expect(body).toHaveLength(1);
+    expect(Object.keys(body[0]).sort()).toEqual(["email", "id", "name"]);
+  });
+
   test("excludes a teammate whose only shared team is in another organization", async ({
     makeOrganization,
     makeUser,

--- a/platform/backend/src/routes/organization.ts
+++ b/platform/backend/src/routes/organization.ts
@@ -927,20 +927,21 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
         undefined,
         { userId: user.id, organizationId },
       );
-      if (canSeeAllMembers) {
-        return reply.send(
-          await MemberModel.findAllByOrganization(organizationId),
-        );
-      }
-      const teammateIds = await TeamModel.getTeammateUserIdsInOrganization({
-        userId: user.id,
-        organizationId,
-      });
+      const members = canSeeAllMembers
+        ? await MemberModel.findAllByOrganization(organizationId)
+        : await MemberModel.findByUserIdsInOrganization({
+            organizationId,
+            userIds: await TeamModel.getTeammateUserIdsInOrganization({
+              userId: user.id,
+              organizationId,
+            }),
+          });
+      // These model queries also select role/systemRole for admin surfaces that
+      // reuse them; this endpoint exposes identity only. Project explicitly so
+      // the privileged fields never depend on response-schema serialization to
+      // be dropped — a member without member:read must not learn teammates' roles.
       return reply.send(
-        await MemberModel.findByUserIdsInOrganization({
-          organizationId,
-          userIds: teammateIds,
-        }),
+        members.map(({ id, name, email }) => ({ id, name, email })),
       );
     },
   );

--- a/platform/backend/src/routes/organization.ts
+++ b/platform/backend/src/routes/organization.ts
@@ -902,7 +902,8 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
     {
       schema: {
         operationId: RouteId.GetOrganizationMembers,
-        description: "Get all members of the organization",
+        description:
+          "List organization members visible to the caller. Callers with the member:read permission (admins and equivalent custom roles) receive the full organization roster; other authenticated users receive only the members they share a team with.",
         tags: ["Organization"],
         response: constructResponseSchema(
           z.array(
@@ -923,6 +924,8 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const { success: canSeeAllMembers } = await hasPermission(
         { member: ["read"] },
         headers,
+        undefined,
+        { userId: user.id, organizationId },
       );
       if (canSeeAllMembers) {
         return reply.send(

--- a/platform/backend/src/routes/organization.ts
+++ b/platform/backend/src/routes/organization.ts
@@ -10,6 +10,7 @@ import {
 import { and, eq, inArray, like } from "drizzle-orm";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { hasPermission } from "@/auth";
 import config from "@/config";
 import db, { schema } from "@/database";
 import { syncBuiltInSkillsForOrganization } from "@/database/seed";
@@ -29,6 +30,7 @@ import {
   MemberModel,
   ModelModel,
   OrganizationModel,
+  TeamModel,
   ToolModel,
   UserModel,
   UserTokenModel,
@@ -913,9 +915,30 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ),
       },
     },
-    async ({ organizationId }, reply) => {
-      const members = await MemberModel.findAllByOrganization(organizationId);
-      return reply.send(members);
+    async ({ organizationId, user, headers }, reply) => {
+      // member:read (admins, custom roles) sees the whole roster; everyone else
+      // sees only the users they share a team with, so a member can pick a chat
+      // share recipient without the org directory being exposed to (or scanned
+      // for) them.
+      const { success: canSeeAllMembers } = await hasPermission(
+        { member: ["read"] },
+        headers,
+      );
+      if (canSeeAllMembers) {
+        return reply.send(
+          await MemberModel.findAllByOrganization(organizationId),
+        );
+      }
+      const teammateIds = await TeamModel.getTeammateUserIdsInOrganization({
+        userId: user.id,
+        organizationId,
+      });
+      return reply.send(
+        await MemberModel.findByUserIdsInOrganization({
+          organizationId,
+          userIds: teammateIds,
+        }),
+      );
     },
   );
 

--- a/platform/backend/src/routes/organization.ts
+++ b/platform/backend/src/routes/organization.ts
@@ -916,15 +916,18 @@ const organizationRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ),
       },
     },
-    async ({ organizationId, user, headers }, reply) => {
+    async ({ organizationId, user, headers, serviceAccount }, reply) => {
       // member:read (admins, custom roles) sees the whole roster; everyone else
       // sees only the users they share a team with, so a member can pick a chat
       // share recipient without the org directory being exposed to (or scanned
-      // for) them.
+      // for) them. Forward serviceAccount + the resolved userContext exactly as
+      // the auth middleware does, so service-account callers are checked against
+      // their own permissions (not the synthetic user) and user callers against
+      // request.organizationId rather than the session cookie.
       const { success: canSeeAllMembers } = await hasPermission(
         { member: ["read"] },
         headers,
-        undefined,
+        serviceAccount,
         { userId: user.id, organizationId },
       );
       const members = canSeeAllMembers

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -644,7 +644,8 @@ export function useTestEmbeddingConnection() {
 }
 
 /**
- * Get all members of the organization (for admin filtering)
+ * Users the current caller can see: the full organization roster with
+ * member:read, otherwise only the caller's teammates (may be empty).
  */
 export function useOrganizationMembers(enabled = true) {
   return useQuery({

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -1181,7 +1181,10 @@ export const requiredEndpointPermissionsMap: Partial<
   [RouteId.GetFeedbackPopupActivation]: { organizationSettings: ["update"] }, // Feedback pop-up activation signal - admins only (the pop-up is admin-only)
   [RouteId.GetMemberSignupStatus]: {}, // Member signup status - available to all authenticated users
   [RouteId.GetMembers]: { member: ["read"] }, // List organization members (paginated)
-  [RouteId.GetOrganizationMembers]: { member: ["read"] }, // List organization members
+  // Visibility is scoped in the handler: member:read sees the full roster,
+  // everyone else only the users they share a team with (the chat share
+  // recipient picker), so the route itself is open to any authenticated user.
+  [RouteId.GetOrganizationMembers]: {},
   [RouteId.GetOrganizationMember]: { member: ["read"] }, // Get organization member by ID or email
   [RouteId.DeletePendingSignupMember]: { member: ["delete"] }, // Delete auto-provisioned member who hasn't signed up
   [RouteId.GetUserPermissions]: {}, // User permissions route - available to all authenticated users (no specific permissions required)

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -5366,7 +5366,7 @@ export const deletePendingSignupMember = <ThrowOnError extends boolean = false>(
  *
  * Authorization:
  *
- * `member:read`: View organization members and their roles
+ * None (no additional RBAC permission required)
  */
 export const getOrganizationMembers = <ThrowOnError extends boolean = false>(options?: Options<GetOrganizationMembersData, ThrowOnError>) => (options?.client ?? client).get<GetOrganizationMembersResponses, GetOrganizationMembersErrors, ThrowOnError>({ url: '/api/organization/members', ...options });
 

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -5358,7 +5358,7 @@ export const getMemberSignupStatus = <ThrowOnError extends boolean = false>(opti
 export const deletePendingSignupMember = <ThrowOnError extends boolean = false>(options: Options<DeletePendingSignupMemberData, ThrowOnError>) => (options.client ?? client).delete<DeletePendingSignupMemberResponses, DeletePendingSignupMemberErrors, ThrowOnError>({ url: '/api/organization/members/{userId}/pending-signup', ...options });
 
 /**
- * Get all members of the organization
+ * List organization members visible to the caller. Callers with the member:read permission (admins and equivalent custom roles) receive the full organization roster; other authenticated users receive only the members they share a team with.
  *
  * Authentication:
  *


### PR DESCRIPTION
Opening the "Share conversation" dialog fetches the organization member list to populate the recipient picker, but `GET /api/organization/members` required `member:read` — a permission the default member role does not have. So a member sharing their own chat hit a "Forbidden" error toast and an empty recipient picker, even though a conversation owner is meant to be able to share to specific users.

The endpoint now returns the users the caller is allowed to see: the full roster with `member:read` (admins and custom roles — unchanged), otherwise only the users the caller shares a team with in the current organization (empty if they share none). The route is open to any authenticated user with visibility enforced in the handler, and the teammate lookup is org-scoped so a shared team in another organization never surfaces someone here. A member can now pick a teammate as a share recipient without the whole org directory being exposed to them.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>