### PR TITLE
ci(bench): drop claude-haiku-45 from daily benchmark lanes

### DIFF
--- a/.github/bench/job.yaml
+++ b/.github/bench/job.yaml
@@ -63,7 +63,7 @@ spec:
             - name: BENCH_ENVS
               value: "basic"
             - name: BENCH_LANES
-              value: "glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-54-nano,gpt-54-mini,claude-haiku-45,mimo-25,qwen36-35b-a3b,qwen36-27b"
+              value: "glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-54-nano,gpt-54-mini,mimo-25,qwen36-35b-a3b,qwen36-27b"
             # Dagger runner host is resolved from the live staging Deployment by CI.
             # Setting it also turns on the code sandbox (gated on the host's presence).
             - name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST


### PR DESCRIPTION
Removes `claude-haiku-45` from the `BENCH_LANES` list in the daily benchmark Job, so the scheduled run no longer includes it.

The lane definition stays in `ai-labs/lanes.toml` so it remains available for ad-hoc runs.

https://claude.ai/code/session_01JVqR3R7wRFedtjMvWWw1NL

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>