### PR TITLE
feat(platform): make MCP gateway tool-call timeout configurable

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1243,6 +1243,12 @@ Each MCP server automatically gets a unique hash-based subdomain (e.g., `a1b2c3d
 
 The sandbox inherits origin restrictions from `ARCHESTRA_FRONTEND_URL` and `ARCHESTRA_AUTH_ADDITIONAL_TRUSTED_ORIGINS` (the same variables that control CORS). When set, only those origins can embed the sandbox iframe. When neither is set (local dev), all origins are accepted.
 
+### MCP Gateway
+
+- **`ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS`** - Per-request timeout, in milliseconds, for an upstream MCP tool call made through the gateway.
+  - Default: `60000` (60 seconds)
+  - Raise it for tools that take a long time to run — a slow scraper or report builder, for example — that otherwise fail with a request-timeout error.
+
 ### MCP Server Orchestrator
 
 - **`ARCHESTRA_ORCHESTRATOR_K8S_NAMESPACE`** - Kubernetes namespace to run MCP server pods.

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -82,6 +82,10 @@ ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai
 # If you are making changes to the MCP catalog, point it to the port the archestra-ai/website listens on.
 # ARCHESTRA_MCP_CATALOG_API_BASE_URL=http://localhost:3001/mcp-catalog/api
 
+# Per-request timeout (ms) for an upstream MCP tool call made through the gateway.
+# Defaults to 60000 (60s); raise it for tools that take a long time to execute.
+# ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS=60000
+
 # Database URL
 ARCHESTRA_DATABASE_URL="postgresql://archestra:archestra_dev_password@localhost:5432/archestra_dev?schema=public"
 # Per-connection statement timeout in ms; kills runaway queries (default 30000, 0 disables)

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -288,7 +288,10 @@ describe("McpClient", () => {
     expect(mockCallTool).toHaveBeenCalledWith(
       { name: "list_repos", arguments: { owner: "octocat" } },
       undefined,
-      { signal: controller.signal },
+      {
+        signal: controller.signal,
+        timeout: config.mcpGateway.toolCallTimeoutMs,
+      },
     );
     // Name resolution (listTools) is on the same cancellable path.
     expect(mockListTools).toHaveBeenCalledWith(undefined, {
@@ -1903,7 +1906,7 @@ describe("McpClient", () => {
             arguments: { input: "test" },
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
 
         // Verify result
@@ -2027,7 +2030,7 @@ describe("McpClient", () => {
             arguments: { input: "test" },
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
 
         // Verify result
@@ -2146,7 +2149,7 @@ describe("McpClient", () => {
             arguments: {},
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
 
         expect(result).toMatchObject({
@@ -2205,7 +2208,7 @@ describe("McpClient", () => {
             arguments: {},
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
 
         expect(result).toMatchObject({
@@ -2254,7 +2257,7 @@ describe("McpClient", () => {
             arguments: {},
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
 
         expect(result).toMatchObject({
@@ -5591,7 +5594,7 @@ describe("McpClient", () => {
             arguments: {},
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
       });
 
@@ -5631,7 +5634,7 @@ describe("McpClient", () => {
             arguments: {},
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
       });
 
@@ -5670,7 +5673,7 @@ describe("McpClient", () => {
             arguments: {},
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
       });
 
@@ -5711,7 +5714,7 @@ describe("McpClient", () => {
             arguments: {},
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
       });
 
@@ -5751,7 +5754,7 @@ describe("McpClient", () => {
             arguments: {},
           },
           undefined,
-          { signal: undefined },
+          { signal: undefined, timeout: config.mcpGateway.toolCallTimeoutMs },
         );
       });
     });

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -625,7 +625,10 @@ class McpClient {
         if (resourceUri) {
           const result = await client.readResource(
             { uri: resourceUri },
-            { signal: options?.abortSignal },
+            {
+              signal: options?.abortSignal,
+              timeout: config.mcpGateway.toolCallTimeoutMs,
+            },
           );
           return await this.createSuccessResult({
             toolCall,
@@ -662,7 +665,10 @@ class McpClient {
             arguments: toolCall.arguments,
           },
           undefined,
-          { signal: options?.abortSignal },
+          {
+            signal: options?.abortSignal,
+            timeout: config.mcpGateway.toolCallTimeoutMs,
+          },
         );
 
         const isOAuthServer = !!catalogItem.oauthConfig;
@@ -3180,11 +3186,15 @@ class McpClient {
         throw new Error("toolName is required for tools/call");
       }
       return await this.raceWithTimeout(
-        client.callTool({
-          name: params.toolName,
-          arguments: params.toolArguments ?? {},
-        }),
-        60000,
+        client.callTool(
+          {
+            name: params.toolName,
+            arguments: params.toolArguments ?? {},
+          },
+          undefined,
+          { timeout: config.mcpGateway.toolCallTimeoutMs },
+        ),
+        config.mcpGateway.toolCallTimeoutMs,
         "Tool call timeout",
       );
     } finally {
@@ -3264,11 +3274,15 @@ class McpClient {
   }): Promise<unknown> {
     return this.withDirectServerClient(params.mcpServerId, (client) =>
       this.raceWithTimeout(
-        client.callTool({
-          name: params.name,
-          arguments: params.arguments ?? {},
-        }),
-        60000,
+        client.callTool(
+          {
+            name: params.name,
+            arguments: params.arguments ?? {},
+          },
+          undefined,
+          { timeout: config.mcpGateway.toolCallTimeoutMs },
+        ),
+        config.mcpGateway.toolCallTimeoutMs,
         "Tool call timeout",
       ),
     );

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -1164,6 +1164,45 @@ describe("chat active run config", () => {
   });
 });
 
+describe("mcp gateway config", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.ARCHESTRA_DATABASE_URL =
+      "postgresql://archestra:pass@localhost:5432/archestra";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test("defaults the tool call timeout to 60s", async () => {
+    delete process.env.ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS;
+
+    const { default: cfg } = await import("./config");
+
+    expect(cfg.mcpGateway.toolCallTimeoutMs).toBe(60000);
+  });
+
+  test("reads the tool call timeout from the env var", async () => {
+    process.env.ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS = "300000";
+
+    const { default: cfg } = await import("./config");
+
+    expect(cfg.mcpGateway.toolCallTimeoutMs).toBe(300000);
+  });
+
+  test("falls back to the default for invalid values", async () => {
+    process.env.ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS = "-1";
+
+    const { default: cfg } = await import("./config");
+
+    expect(cfg.mcpGateway.toolCallTimeoutMs).toBe(60000);
+  });
+});
+
 describe("getCorsOrigins", () => {
   const originalEnv = process.env;
 

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1086,6 +1086,16 @@ const config = {
   },
   mcpGateway: {
     endpoint: "/v1/mcp",
+    /**
+     * Per-request timeout (ms) for an upstream MCP tool call made through the
+     * gateway. The MCP SDK defaults to 60s, which is too short for tools that
+     * do slow work (long-running scrapers, report builders, etc.). Raise this
+     * env var to give such tools more time before the request times out.
+     */
+    toolCallTimeoutMs: parsePositiveInt(
+      process.env.ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS,
+      60000,
+    ),
   },
   skillMarketplace: {
     endpoint: SKILL_MARKETPLACE_PREFIX,


### PR DESCRIPTION
## Problem

Upstream MCP tool calls made through the gateway used the MCP SDK's default request timeout of 60 seconds. Tools that take a long time to execute (long-running scrapers, report builders, etc.) failed with `MCP error -32001: Request timed out`, with no way to give them more time.

## Change

Add a configurable timeout and apply it to every gateway tool-call path.

- **New env var `ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS`** (`config.mcpGateway.toolCallTimeoutMs`), default `60000` — behavior is unchanged unless raised.
- **`mcp-client.ts`** passes `timeout: config.mcpGateway.toolCallTimeoutMs` on every upstream tool-call path:
  - the main gateway `callTool` and synthetic-resource `readResource` (`executeToolCallForOwner`)
  - the server-scoped run path (`callToolForServer`) and the inspector path, which previously hardcoded `60000` in both the SDK call and their race-timeout wrapper.
- Documented in `.env.example` and `docs/pages/platform-deployment.md` (new "MCP Gateway" subsection).

## Usage

Set e.g. `ARCHESTRA_MCP_GATEWAY_TOOL_CALL_TIMEOUT_MS=300000` (5 minutes) in the deployment env and restart the backend.

## Testing

- Added 3 config tests (default / reads env / falls back on invalid value).
- `pnpm type-check` clean, new config tests pass, Biome lint clean.
- Confirmed against the installed MCP SDK that `RequestOptions.timeout` is the correct field and that `DEFAULT_REQUEST_TIMEOUT_MSEC = 60000` is the source of the 60s limit.

https://claude.ai/code/session_01YK2JBy3MMTdR4DJPH5DStG

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK2JBy3MMTdR4DJPH5DStG)_

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>