### PR TITLE
fix(mcp-gateway): keep dynamically-reached UI tools out of the internal chat tool list

### DIFF
--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -758,13 +758,6 @@ class ToolModel {
      * both need to hold; they are independent filters.
      */
     requireUiResource?: boolean;
-    /**
-     * Drop tools whose backing catalog is an owned app (`serverType: "app"`).
-     * The internal chat opens owned apps via `render_app`, so it excludes their
-     * launch tools from the dynamic UI-tool widening to keep the list compact;
-     * external UI apps and the gateway keep them.
-     */
-    excludeAppBackings?: boolean;
   }): Promise<Tool[]> {
     const catalogIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
       params.userId,
@@ -790,28 +783,6 @@ class ToolModel {
       return [];
     }
 
-    // The internal chat drops owned-app backings from the discovery space so it
-    // opens owned apps via render_app instead of a launch tool per app.
-    let discoverableCatalogIds = scopedCatalogIds;
-    if (params.excludeAppBackings) {
-      const appBackings = await db
-        .select({ id: schema.internalMcpCatalogTable.id })
-        .from(schema.internalMcpCatalogTable)
-        .where(
-          and(
-            inArray(schema.internalMcpCatalogTable.id, scopedCatalogIds),
-            eq(schema.internalMcpCatalogTable.serverType, "app"),
-          ),
-        );
-      const appBackingIds = new Set(appBackings.map((c) => c.id));
-      discoverableCatalogIds = scopedCatalogIds.filter(
-        (id) => !appBackingIds.has(id),
-      );
-      if (discoverableCatalogIds.length === 0) {
-        return [];
-      }
-    }
-
     // Secondary sort on id keeps the ordering deterministic when createdAt
     // ties (bulk-inserted MCP tools share a timestamp), so search_tools and
     // run_tool auto-assignment resolve a duplicate name to the same row.
@@ -820,7 +791,7 @@ class ToolModel {
       .from(schema.toolsTable)
       .where(
         and(
-          inArray(schema.toolsTable.catalogId, discoverableCatalogIds),
+          inArray(schema.toolsTable.catalogId, scopedCatalogIds),
           eq(schema.toolsTable.clonedPendingDiscovery, false),
           toolInEnvironmentPredicate(params.environmentId),
           params.name !== undefined

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -758,6 +758,13 @@ class ToolModel {
      * both need to hold; they are independent filters.
      */
     requireUiResource?: boolean;
+    /**
+     * Drop tools whose backing catalog is an owned app (`serverType: "app"`).
+     * The internal chat opens owned apps via `render_app`, so it excludes their
+     * launch tools from the dynamic UI-tool widening to keep the list compact;
+     * external UI apps and the gateway keep them.
+     */
+    excludeAppBackings?: boolean;
   }): Promise<Tool[]> {
     const catalogIds = await McpCatalogTeamModel.getUserAccessibleCatalogIds(
       params.userId,
@@ -783,6 +790,28 @@ class ToolModel {
       return [];
     }
 
+    // The internal chat drops owned-app backings from the discovery space so it
+    // opens owned apps via render_app instead of a launch tool per app.
+    let discoverableCatalogIds = scopedCatalogIds;
+    if (params.excludeAppBackings) {
+      const appBackings = await db
+        .select({ id: schema.internalMcpCatalogTable.id })
+        .from(schema.internalMcpCatalogTable)
+        .where(
+          and(
+            inArray(schema.internalMcpCatalogTable.id, scopedCatalogIds),
+            eq(schema.internalMcpCatalogTable.serverType, "app"),
+          ),
+        );
+      const appBackingIds = new Set(appBackings.map((c) => c.id));
+      discoverableCatalogIds = scopedCatalogIds.filter(
+        (id) => !appBackingIds.has(id),
+      );
+      if (discoverableCatalogIds.length === 0) {
+        return [];
+      }
+    }
+
     // Secondary sort on id keeps the ordering deterministic when createdAt
     // ties (bulk-inserted MCP tools share a timestamp), so search_tools and
     // run_tool auto-assignment resolve a duplicate name to the same row.
@@ -791,7 +820,7 @@ class ToolModel {
       .from(schema.toolsTable)
       .where(
         and(
-          inArray(schema.toolsTable.catalogId, scopedCatalogIds),
+          inArray(schema.toolsTable.catalogId, discoverableCatalogIds),
           eq(schema.toolsTable.clonedPendingDiscovery, false),
           toolInEnvironmentPredicate(params.environmentId),
           params.name !== undefined

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1774,7 +1774,7 @@ describe("createAgentServer tools/list", () => {
     expect(names.has("get_time__open")).toBe(false);
   });
 
-  test("chat agent still advertises an external UI-providing tool reached via dynamic access", async ({
+  test("external UI-providing tool is dropped in chat but kept on the gateway", async ({
     makeAgent,
     makeInternalMcpCatalog,
     makeMcpServer,
@@ -1786,13 +1786,8 @@ describe("createAgentServer tools/list", () => {
     const org = await makeOrganization();
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "admin" });
-    const agent = await makeAgent({
-      organizationId: org.id,
-      accessAllTools: true,
-      agentType: "agent",
-    });
-    // An external UI-providing app (serverType remote) has no render_app path,
-    // so its UI tool must stay advertised in chat.
+    // An external (serverType remote) UI-providing tool, reachable only via
+    // dynamic access — not assigned to any agent.
     const extCatalog = await makeInternalMcpCatalog({
       organizationId: org.id,
       name: "maps",
@@ -1807,28 +1802,37 @@ describe("createAgentServer tools/list", () => {
       meta: { _meta: { ui: { resourceUri: "ui://maps/show" } } },
     });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
-    });
-    const listToolsHandler = (
-      server.server as unknown as {
-        _requestHandlers: Map<string, TestListToolsHandler>;
-      }
-    )._requestHandlers.get("tools/list");
-    if (!listToolsHandler) {
-      throw new Error("Expected tools/list handler to be registered");
-    }
-    const response = await listToolsHandler({
-      method: "tools/list",
-      params: {},
-    });
-    const names = new Set(response.tools.map((tool) => tool.name));
-    expect(names.has("maps__show")).toBe(true);
+    const listNames = async (agentType: "agent" | "mcp_gateway") => {
+      const agent = await makeAgent({
+        organizationId: org.id,
+        accessAllTools: true,
+        agentType,
+      });
+      const { server } = await createAgentServer(agent.id, {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      });
+      const handler = (
+        server.server as unknown as {
+          _requestHandlers: Map<string, TestListToolsHandler>;
+        }
+      )._requestHandlers.get("tools/list");
+      if (!handler)
+        throw new Error("Expected tools/list handler to be registered");
+      const response = await handler({ method: "tools/list", params: {} });
+      return new Set(response.tools.map((tool) => tool.name));
+    };
+
+    // Chat resolves any UI tool's ui:// resource from its own catalog when the
+    // model invokes it (run_tool), so it need not advertise the dynamic UI tool.
+    expect((await listNames("agent")).has("maps__show")).toBe(false);
+    // An external MCP client on the gateway discovers UI-providing tools only
+    // from tools/list, so the gateway must keep advertising it.
+    expect((await listNames("mcp_gateway")).has("maps__show")).toBe(true);
   });
 
   test("chat agent still advertises an assigned owned-app launch tool", async ({

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1647,10 +1647,13 @@ describe("createAgentServer tools/list", () => {
     const org = await makeOrganization();
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "admin" });
-    // accessAllTools reaches unassigned UI tools dynamically (dynamicUiTools).
+    // A gateway (external) surface: accessAllTools reaches unassigned UI tools
+    // dynamically, and owned-app launch tools stay advertised there — unlike
+    // the internal chat, which opens owned apps via render_app.
     const agent = await makeAgent({
       organizationId: org.id,
       accessAllTools: true,
+      agentType: "mcp_gateway",
     });
     const catalog = await makeInternalMcpCatalog({
       organizationId: org.id,
@@ -1709,6 +1712,182 @@ describe("createAgentServer tools/list", () => {
     expect(names.has("bug_tracker__open_shown")).toBe(true);
     // ...but the excluded one must not be advertised.
     expect(names.has("bug_tracker__open_excluded")).toBe(false);
+  });
+
+  test("chat agent does not advertise an owned-app launch tool reached via dynamic access", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeOrganization,
+    makeTool,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    // Default agentType is "agent" — the internal chat surface, which opens
+    // owned apps via render_app, so their launch tools must not bloat the list.
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: true,
+      agentType: "agent",
+    });
+    const appCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "get-time",
+      serverType: "app",
+      scope: "org",
+    });
+    await makeMcpServer({ catalogId: appCatalog.id, scope: "org" });
+    // Unassigned owned-app launch tool — reachable only through dynamic access.
+    await makeTool({
+      catalogId: appCatalog.id,
+      name: "get_time__open",
+      parameters: { type: "object", properties: {} },
+      meta: { _meta: { ui: { resourceUri: "ui://archestra-app/get-time" } } },
+    });
+
+    const { server } = await createAgentServer(agent.id, {
+      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+      teamId: null,
+      isOrganizationToken: false,
+      organizationId: org.id,
+      isUserToken: true,
+      userId: user.id,
+    });
+    const listToolsHandler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, TestListToolsHandler>;
+      }
+    )._requestHandlers.get("tools/list");
+    if (!listToolsHandler) {
+      throw new Error("Expected tools/list handler to be registered");
+    }
+
+    const response = await listToolsHandler({
+      method: "tools/list",
+      params: {},
+    });
+    const names = new Set(response.tools.map((tool) => tool.name));
+    // Not advertised — a chat agent opens owned apps via render_app.
+    expect(names.has("get_time__open")).toBe(false);
+  });
+
+  test("chat agent still advertises an external UI-providing tool reached via dynamic access", async ({
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeOrganization,
+    makeTool,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: true,
+      agentType: "agent",
+    });
+    // An external UI-providing app (serverType remote) has no render_app path,
+    // so its UI tool must stay advertised in chat.
+    const extCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "maps",
+      serverType: "remote",
+      scope: "org",
+    });
+    await makeMcpServer({ catalogId: extCatalog.id, scope: "org" });
+    await makeTool({
+      catalogId: extCatalog.id,
+      name: "maps__show",
+      parameters: { type: "object", properties: {} },
+      meta: { _meta: { ui: { resourceUri: "ui://maps/show" } } },
+    });
+
+    const { server } = await createAgentServer(agent.id, {
+      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+      teamId: null,
+      isOrganizationToken: false,
+      organizationId: org.id,
+      isUserToken: true,
+      userId: user.id,
+    });
+    const listToolsHandler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, TestListToolsHandler>;
+      }
+    )._requestHandlers.get("tools/list");
+    if (!listToolsHandler) {
+      throw new Error("Expected tools/list handler to be registered");
+    }
+    const response = await listToolsHandler({
+      method: "tools/list",
+      params: {},
+    });
+    const names = new Set(response.tools.map((tool) => tool.name));
+    expect(names.has("maps__show")).toBe(true);
+  });
+
+  test("chat agent still advertises an assigned owned-app launch tool", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeOrganization,
+    makeTool,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: true,
+      agentType: "agent",
+    });
+    const appCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "todo",
+      serverType: "app",
+      scope: "org",
+    });
+    await makeMcpServer({ catalogId: appCatalog.id, scope: "org" });
+    const openTool = await makeTool({
+      catalogId: appCatalog.id,
+      name: "todo__open",
+      parameters: { type: "object", properties: {} },
+      meta: { _meta: { ui: { resourceUri: "ui://archestra-app/todo" } } },
+    });
+    // Explicitly assigned — not "merely reached through dynamic access", so it
+    // stays advertised (the strip only drops the dynamic-widening entries).
+    await makeAgentTool(agent.id, openTool.id);
+
+    const { server } = await createAgentServer(agent.id, {
+      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+      teamId: null,
+      isOrganizationToken: false,
+      organizationId: org.id,
+      isUserToken: true,
+      userId: user.id,
+    });
+    const listToolsHandler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, TestListToolsHandler>;
+      }
+    )._requestHandlers.get("tools/list");
+    if (!listToolsHandler) {
+      throw new Error("Expected tools/list handler to be registered");
+    }
+    const response = await listToolsHandler({
+      method: "tools/list",
+      params: {},
+    });
+    const names = new Set(response.tools.map((tool) => tool.name));
+    expect(names.has("todo__open")).toBe(true);
   });
 
   test("full mode lists a UI-providing tool with its resource", async ({

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1726,8 +1726,8 @@ describe("createAgentServer tools/list", () => {
     const org = await makeOrganization();
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "admin" });
-    // Default agentType is "agent" — the internal chat surface, which opens
-    // owned apps via render_app, so their launch tools must not bloat the list.
+    // agentType "agent" is the internal chat surface, which opens owned apps
+    // via render_app, so their launch tools must not bloat its list.
     const agent = await makeAgent({
       organizationId: org.id,
       accessAllTools: true,

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -247,6 +247,10 @@ export async function createAgentServer(
               "admin",
             ),
             requireUiResource: true,
+            // The internal chat opens owned apps via render_app, so keep their
+            // launch tools out of the dynamic widening; external UI apps
+            // (no render_app) and non-chat surfaces (the gateway) keep them.
+            excludeAppBackings: agent.agentType === "agent",
           })
         : []
     ).filter((tool) => !isToolRowExcluded(tool, exclusionSets));

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -223,19 +223,22 @@ export async function createAgentServer(
     const { tools: mcpTools, exclusionSets } =
       await agentToolExclusionsService.getFilteredMcpToolsByAgent(agentId);
 
-    // An all-tools agent reaches unassigned tools dynamically (search_tools /
-    // run_tool already resolve them without an agent_tools row). A UI-providing
-    // tool reached only that way would otherwise never become a candidate below,
-    // so filterExposedTools' "keep top-level" check never runs on it — and an
-    // MCP Apps host, which renders a UI only from a tool DEFINITION listed at
-    // tools/list time (never from a run_tool call result), could never discover
-    // or render it. Widen the candidate pool with the caller's dynamically
-    // accessible UI-providing tools so they get the same top-level treatment as
-    // an assigned one. Gated strictly on accessAllTools (not toolExposureMode
-    // alone) — a search_and_run_only agent without it is deliberately scoped to
-    // its assigned set for context-window management, not dynamic reach.
+    // A non-chat gateway serves external MCP clients that discover a UI-providing
+    // tool only from its tools/list DEFINITION (per the MCP Apps extension) and
+    // render it when called — so an all-tools gateway must widen its list with
+    // the caller's dynamically accessible UI-providing tools, which have no
+    // agent_tools row and would otherwise never be advertised. The internal chat
+    // is host and server both: it resolves a tool's ui:// resource from its own
+    // catalog when the model invokes it (render_app for owned apps, run_tool for
+    // any UI tool), so it needs no such widening — skipping it keeps the list
+    // compact instead of adding one entry per accessible app. Gated on
+    // accessAllTools (an agent without it is scoped to its assigned set) and
+    // skipped for the chat surface.
     const dynamicUiTools = (
-      agent.accessAllTools && tokenAuth?.userId && tokenAuth.organizationId
+      agent.accessAllTools &&
+      agent.agentType !== "agent" &&
+      tokenAuth?.userId &&
+      tokenAuth.organizationId
         ? await ToolModel.getMcpToolsAccessibleToUser({
             userId: tokenAuth.userId,
             organizationId: tokenAuth.organizationId,
@@ -247,10 +250,6 @@ export async function createAgentServer(
               "admin",
             ),
             requireUiResource: true,
-            // The internal chat opens owned apps via render_app, so keep their
-            // launch tools out of the dynamic widening; external UI apps
-            // (no render_app) and non-chat surfaces (the gateway) keep them.
-            excludeAppBackings: agent.agentType === "agent",
           })
         : []
     ).filter((tool) => !isToolRowExcluded(tool, exclusionSets));


### PR DESCRIPTION
## Summary

An "all tools" (`accessAllTools`) chat agent advertised a UI-providing tool for **every** app the caller could reach dynamically — a `…__open` launch tool per owned app, *plus* every external UI-providing server's tool. In `search_and_run_only` mode — whose purpose is a small tool list reached through `search_tools`/`run_tool` — this grew the advertised list by one entry per app/server, diluting the model's tool selection and spending context on every request. It scales badly: dozens of apps or several UI-providing MCP servers put dozens of extra tools in front of the model each turn.

The internal chat doesn't need any of them advertised: it resolves a tool's `ui://` resource from its own catalog when the model invokes the tool and renders from the result — owned apps via the generic `render_app` tool, any UI-providing tool via `run_tool`. So this skips the dynamic UI-tool widening entirely for the chat surface (`agentType: "agent"`). The advertised chat list stays compact (meta tools + app-authoring tools + skills + assigned tools) regardless of how many apps or UI servers exist.

Opening behavior is unchanged for the user:
- **Owned apps** → opened via `render_app` (still advertised).
- **External UI apps** → the model finds them via `search_tools` (whose description names the connected servers) and opens them via `run_tool`, which renders them inline.

Deliberately unchanged:
- **Non-chat gateways** (serving external MCP clients) keep advertising UI-providing tools — an external client discovers a tool's UI capability only from its `tools/list` definition, so dropping them there would make those apps unrenderable for it.
- **Explicitly-assigned** tools stay advertised (assignment is intentional, not the dynamic widening).
- UI-providing tools stay reachable on demand through `search_tools`/`run_tool`; only their top-level advertising in chat is dropped.

Net effect: the all-tools chat tool list stays compact no matter how many apps or UI-providing servers the caller can access, while every app remains openable.