### PR TITLE
feat(bench): spawn backend from a custom git branch

### DIFF
--- a/ai-labs/CLAUDE.md
+++ b/ai-labs/CLAUDE.md
@@ -43,7 +43,8 @@ platform image instead of the dev repo. Three knobs make that work, all defaulti
 behavior when unset:
 
 - `--platform-dir` / `ARCHESTRA_BENCH_PLATFORM_DIR` — the platform dir is `/app` in the prod image,
-  not `<repo>/platform`.
+  not `<repo>/platform`. (Its local-dev sibling is `--branch` / `ARCHESTRA_BENCH_BACKEND_BRANCH`, which
+  builds the backend from a git worktree of a ref; the two conflict. See the README lifecycle section.)
 - `ARCHESTRA_BENCH_MIGRATE_CMD` — the prod image has no pnpm; it runs `drizzle-kit migrate` directly.
 - The Dagger runner host + CLI bin arrive via **process env**, not `/app/.env`: `build_backend_env`
   force-overwrites those two keys, so `.env` can't steer them (it seeds from `std::env::vars()`, so

--- a/ai-labs/README.md
+++ b/ai-labs/README.md
@@ -283,6 +283,17 @@ second backend runs the already-built `dist/server.mjs` the main stack keeps fre
 starts a competing `tsdown --watch`. Teardown always runs: the backend process group is killed and
 the benchmark database is dropped.
 
+**Spawning from a git branch (`--branch <ref>`).** To A/B a branch against the working tree, pass
+`--branch <ref>` (or `ARCHESTRA_BENCH_BACKEND_BRANCH`). The runner fetches `origin/<ref>`, checks the
+commit out into a throwaway git worktree, runs a full `pnpm install --frozen-lockfile` + `pnpm build`
+(so native `*.node` addons and `dist/server.mjs` come from the branch), and spawns every env's backend
+from it — one build per run, shared by all envs. Prereqs a fresh checkout lacks are sourced from the
+dev tree: `platform/.env` is copied in and `dev/bin/dagger` is symlinked when present (otherwise the
+worktree relies on `ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN`, same as the dev tree). The worktree is
+removed on normal completion and on SIGINT/SIGTERM; `config.json` records `backend_branch` /
+`backend_commit`. This is the slower opt-in path — it conflicts with `--platform-dir`, and the bench's
+own sidecars (Postgres/Dagger) still come from the harness checkout, not the branch.
+
 **Dagger host resolution.** Before booting the backend, the runner resolves a Dagger host and shares
 the first successful result across lanes (so they can't split across engines; a failed attempt isn't
 cached and the next lane re-resolves):

--- a/ai-labs/cli/src/main.rs
+++ b/ai-labs/cli/src/main.rs
@@ -80,6 +80,13 @@ struct CommonBenchArgs {
         help = "Platform directory (the prod image lays the app out at /app); default: <repo>/platform"
     )]
     platform_dir: Option<PathBuf>,
+    #[arg(
+        long,
+        env = "ARCHESTRA_BENCH_BACKEND_BRANCH",
+        conflicts_with = "platform_dir",
+        help = "Build and spawn the backend from a git ref (fetched from origin) instead of the working tree; slower (full install + build), torn down each run"
+    )]
+    branch: Option<String>,
 }
 
 /// Flags shared by `analyze` and `full` — which lanes drive the analysis. Flattened into both.
@@ -359,6 +366,7 @@ async fn guarded_run(
             common.max_workers,
             update_mcp_lock,
             common.platform_dir.as_deref(),
+            common.branch.as_deref(),
         ) => return GuardedRun::Completed(result),
     };
     // run() was dropped mid-flight, so live instances are still registered; shutdown_all tears

--- a/ai-labs/runner/src/lifecycle.rs
+++ b/ai-labs/runner/src/lifecycle.rs
@@ -20,6 +20,8 @@ use crate::client::{ClientError, EvalClient};
 /// so `shutdown_all` kills them all on SIGINT/SIGTERM:
 /// - `Backend`: one backend instance — its process-group child plus the per-run database.
 /// - `DaggerLogs`: the process-wide managed-engine log follower (no database).
+/// - `Worktree`: a git worktree the runner built the backend from (`--branch`); removed so an
+///   interrupted run leaves none behind. Normal exits remove it via [`BranchWorktree::remove`].
 #[derive(Clone)]
 enum Teardown {
     Backend {
@@ -30,6 +32,10 @@ enum Teardown {
     },
     DaggerLogs {
         proc: Arc<Mutex<Option<Child>>>,
+    },
+    Worktree {
+        repo_root: PathBuf,
+        path: PathBuf,
     },
 }
 
@@ -45,7 +51,10 @@ impl Teardown {
                 kill_backend(proc).await;
                 drop_database(db_created, db_name, maint_db_url).await;
             }
-            Teardown::DaggerLogs { proc } => kill_child(proc, "managed Dagger engine log follower").await,
+            Teardown::DaggerLogs { proc } => {
+                kill_child(proc, "managed Dagger engine log follower").await
+            }
+            Teardown::Worktree { repo_root, path } => remove_worktree(repo_root, path).await,
         }
     }
 }
@@ -543,6 +552,204 @@ pub fn resolve_platform_dir(platform_dir: Option<&Path>, repo_root: &Path) -> Pa
     platform_dir
         .map(Path::to_path_buf)
         .unwrap_or_else(|| repo_root.join("platform"))
+}
+
+/// A git worktree the runner created to build and spawn the backend from a specific ref (`--branch`).
+/// Its `platform_dir` is a drop-in replacement for the dev-tree platform dir the rest of the run
+/// consumes. Owns the normal-path cleanup: [`remove`](Self::remove) tears the worktree down and
+/// deregisters the signal-path teardown, so the worktree is removed exactly once whether the run ends
+/// normally, errors, or is interrupted.
+pub struct BranchWorktree {
+    /// The worktree's `platform` dir — used exactly like a `--platform-dir` override downstream.
+    pub platform_dir: PathBuf,
+    /// The concrete commit the worktree was checked out at, for run metadata / A/B labeling.
+    pub commit: String,
+    repo_root: PathBuf,
+    path: PathBuf,
+    teardown_id: u64,
+}
+
+impl BranchWorktree {
+    pub async fn remove(self) {
+        remove_worktree(&self.repo_root, &self.path).await;
+        deregister(self.teardown_id);
+    }
+}
+
+/// Build a backend from an arbitrary git ref: fetch `origin/<ref>`, check it out into a throwaway git
+/// worktree, provision the prereqs a fresh checkout is gitignored-empty of (`.env`, the dagger CLI),
+/// and run a full `pnpm install` + `pnpm build`. `source_platform` is the dev-tree platform the
+/// prereqs are copied from. On any failure past the worktree checkout, the worktree is removed before
+/// returning so no partial checkout leaks.
+pub async fn prepare_branch_worktree(
+    repo_root: &Path,
+    source_platform: &Path,
+    git_ref: &str,
+    slug: &str,
+) -> Result<BranchWorktree, LifecycleError> {
+    // Sweep any worktree orphaned by a crashed prior run before adding a new one.
+    let _ = git(repo_root, &["worktree", "prune"]).await;
+
+    info!("fetching origin {git_ref} for the backend worktree");
+    git(repo_root, &["fetch", "origin", git_ref])
+        .await
+        .map_err(|e| LifecycleError::Config(format!("git fetch origin {git_ref} failed: {e}")))?;
+
+    // Pin the concrete commit right after the fetch: it labels the run, and checking out the sha rather
+    // than the shared `FETCH_HEAD` narrows the window a second concurrent `--branch` run could race.
+    let commit = git(repo_root, &["rev-parse", "FETCH_HEAD"])
+        .await
+        .map_err(|e| LifecycleError::Config(format!("git rev-parse FETCH_HEAD failed: {e}")))?
+        .trim()
+        .to_string();
+
+    let path =
+        std::env::temp_dir().join(format!("archestra-bench-wt-{slug}-{}", std::process::id()));
+    if path.exists() {
+        remove_worktree(repo_root, &path).await;
+    }
+    let path_str = path.to_string_lossy();
+    git(
+        repo_root,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            path_str.as_ref(),
+            commit.as_str(),
+        ],
+    )
+    .await
+    .map_err(|e| LifecycleError::Config(format!("git worktree add failed: {e}")))?;
+
+    // Register teardown the instant the worktree exists, before the long build: a signal mid-build must
+    // still remove it.
+    let teardown_id = register(Teardown::Worktree {
+        repo_root: repo_root.to_path_buf(),
+        path: path.clone(),
+    });
+
+    let wt_platform = path.join("platform");
+    if let Err(e) = provision_and_build(source_platform, &wt_platform, &commit).await {
+        remove_worktree(repo_root, &path).await;
+        deregister(teardown_id);
+        return Err(e);
+    }
+
+    Ok(BranchWorktree {
+        platform_dir: wt_platform,
+        commit,
+        repo_root: repo_root.to_path_buf(),
+        path,
+        teardown_id,
+    })
+}
+
+/// Provision the gitignored prereqs a fresh worktree lacks and build it. Split out so
+/// `prepare_branch_worktree` can uniformly remove the worktree on any failure here.
+async fn provision_and_build(
+    source_platform: &Path,
+    wt_platform: &Path,
+    commit: &str,
+) -> Result<(), LifecycleError> {
+    // `.env` (gitignored): copy the dev tree's so the worktree backend reads the same config the dev
+    // stack does.
+    let src_env = source_platform.join(".env");
+    if !src_env.is_file() {
+        return Err(LifecycleError::Config(format!(
+            "{} not found; create it from platform/.env.example or start the dev stack",
+            src_env.display()
+        )));
+    }
+    fs::copy(&src_env, wt_platform.join(".env")).await?;
+
+    // Dagger CLI (gitignored): `backend_env` prefers `ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN` (flows via
+    // the copied `.env`/process env) and otherwise resolves `<platform>/dev/bin/dagger`. So only when
+    // the dev tree actually holds that default do we carry it in — a symlink avoids copying the ~60MB
+    // binary. When it's absent the source tree itself relies on the override, and so does the worktree.
+    let src_dagger = source_platform.join("dev").join("bin").join("dagger");
+    if src_dagger.is_file() {
+        let dst_dir = wt_platform.join("dev").join("bin");
+        fs::create_dir_all(&dst_dir).await?;
+        let dst = dst_dir.join("dagger");
+        let _ = fs::remove_file(&dst).await;
+        fs::symlink(&src_dagger, &dst).await?;
+    } else {
+        info!(
+            "{} absent; the branch backend resolves dagger via ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN",
+            src_dagger.display()
+        );
+    }
+
+    let short = &commit[..commit.len().min(12)];
+    info!(
+        "building backend worktree at {} (commit {short})",
+        wt_platform.display()
+    );
+    pnpm(wt_platform, &["install", "--frozen-lockfile"]).await?;
+    pnpm(wt_platform, &["build"]).await?;
+    Ok(())
+}
+
+/// Run a git command in `repo_root`, returning trimmed stdout on success or trimmed stderr as the
+/// error string.
+async fn git(repo_root: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| e.to_string())?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+/// Run a pnpm command in `dir` with inherited stdio (build progress stays visible) and
+/// `kill_on_drop`, so a signal that drops the run future kills the long build instead of orphaning it.
+async fn pnpm(dir: &Path, args: &[&str]) -> Result<(), LifecycleError> {
+    let status = Command::new("pnpm")
+        .args(args)
+        .current_dir(dir)
+        .kill_on_drop(true)
+        .status()
+        .await
+        .map_err(|e| {
+            LifecycleError::Config(format!(
+                "failed to run `pnpm {}` (is pnpm installed?): {e}",
+                args.join(" ")
+            ))
+        })?;
+    if !status.success() {
+        return Err(LifecycleError::Config(format!(
+            "`pnpm {}` failed ({status}) in {}",
+            args.join(" "),
+            dir.display()
+        )));
+    }
+    Ok(())
+}
+
+/// Remove a bench-created git worktree, best-effort. Shared by the normal-path handle and the
+/// signal-teardown registry. Failures are logged, not propagated: a leaked worktree lives in a temp
+/// dir and the next run's `worktree prune` sweeps it.
+async fn remove_worktree(repo_root: &Path, path: &Path) {
+    info!("removing bench worktree {}", path.display());
+    let path_str = path.to_string_lossy();
+    match git(
+        repo_root,
+        &["worktree", "remove", "--force", path_str.as_ref()],
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => warn!("git worktree remove failed for {}: {e}", path.display()),
+    }
+    // Prune the administrative record even if the directory removal above was partial.
+    let _ = git(repo_root, &["worktree", "prune"]).await;
 }
 
 /// Load `<platform>/.env` into a map, requiring the file to exist. Centralizes the
@@ -1091,6 +1298,49 @@ mod tests {
         );
     }
 
+    /// `remove_worktree` must actually detach and delete a real git worktree — the highest-risk piece
+    /// of `--branch` cleanup. Real git, real filesystem, no mocks.
+    #[tokio::test]
+    async fn test_remove_worktree_deletes_real_worktree() {
+        fn run_git(dir: &Path, args: &[&str]) {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .status()
+                .expect("git runs");
+            assert!(status.success(), "git {args:?} failed");
+        }
+
+        let repo = tempfile::tempdir().unwrap();
+        let repo_path = repo.path();
+        run_git(repo_path, &["init", "-q"]);
+        run_git(repo_path, &["config", "user.email", "bench@example.com"]);
+        run_git(repo_path, &["config", "user.name", "bench"]);
+        std::fs::write(repo_path.join("f.txt"), "x").unwrap();
+        run_git(repo_path, &["add", "f.txt"]);
+        run_git(repo_path, &["commit", "-q", "-m", "init"]);
+
+        // Add the worktree outside the repo working tree.
+        let wt_parent = tempfile::tempdir().unwrap();
+        let wt = wt_parent.path().join("wt");
+        run_git(
+            repo_path,
+            &["worktree", "add", "--detach", wt.to_str().unwrap(), "HEAD"],
+        );
+        assert!(wt.is_dir(), "worktree created");
+        // Count entries rather than match paths: `git worktree list` prints resolved real paths, which
+        // differ from `wt` under macOS's /var -> /private/var symlink.
+        let before = git(repo_path, &["worktree", "list"]).await.unwrap();
+        assert_eq!(before.lines().count(), 2, "main + worktree listed");
+
+        remove_worktree(repo_path, &wt).await;
+
+        assert!(!wt.exists(), "worktree dir removed");
+        let after = git(repo_path, &["worktree", "list"]).await.unwrap();
+        assert_eq!(after.lines().count(), 1, "only the main worktree remains");
+    }
+
     #[tokio::test]
     async fn test_shutdown_all_kills_registered_process_group() {
         let _guard = registry_lock().lock().await;
@@ -1172,7 +1422,10 @@ mod tests {
         assert_eq!(non_empty(None), None);
         assert_eq!(non_empty(Some(String::new())), None);
         assert_eq!(non_empty(Some("   ".to_string())), None);
-        assert_eq!(non_empty(Some("/app".to_string())), Some("/app".to_string()));
+        assert_eq!(
+            non_empty(Some("/app".to_string())),
+            Some("/app".to_string())
+        );
     }
 
     #[test]

--- a/ai-labs/runner/src/lifecycle.rs
+++ b/ai-labs/runner/src/lifecycle.rs
@@ -51,9 +51,7 @@ impl Teardown {
                 kill_backend(proc).await;
                 drop_database(db_created, db_name, maint_db_url).await;
             }
-            Teardown::DaggerLogs { proc } => {
-                kill_child(proc, "managed Dagger engine log follower").await
-            }
+            Teardown::DaggerLogs { proc } => kill_child(proc, "managed Dagger engine log follower").await,
             Teardown::Worktree { repo_root, path } => remove_worktree(repo_root, path).await,
         }
     }
@@ -94,7 +92,15 @@ pub async fn shutdown_all() {
         "interrupted: tearing down {} live backend instance(s)",
         live.len()
     );
-    futures::future::join_all(live.iter().map(|t| t.run())).await;
+    // Kill process-owning teardowns (backends, the build/log process groups) before removing any
+    // worktree: a backend or build spawned from inside a worktree must be dead before its directory is
+    // deleted, else `git worktree remove` races a live `node`/`pnpm` reading from it. Within each phase
+    // the teardowns run concurrently.
+    let (worktrees, processes): (Vec<Teardown>, Vec<Teardown>) = live
+        .into_iter()
+        .partition(|t| matches!(t, Teardown::Worktree { .. }));
+    futures::future::join_all(processes.iter().map(|t| t.run())).await;
+    futures::future::join_all(worktrees.iter().map(|t| t.run())).await;
 }
 
 async fn kill_backend(proc: &Arc<Mutex<Option<Child>>>) {
@@ -587,24 +593,34 @@ pub async fn prepare_branch_worktree(
     git_ref: &str,
     slug: &str,
 ) -> Result<BranchWorktree, LifecycleError> {
-    // Sweep any worktree orphaned by a crashed prior run before adding a new one.
+    // Prune stale worktree admin records (those whose directory a prior cleanup already deleted) so a
+    // leftover registration can't trip up `worktree add`. Leftover temp *directories* from a hard crash
+    // aren't reaped here — paths are unique per run (pid + run id) so they never collide, and OS temp
+    // cleanup reclaims them.
     let _ = git(repo_root, &["worktree", "prune"]).await;
 
+    // Fetch into a run-private ref, never the shared `FETCH_HEAD`: two concurrent `--branch` runs both
+    // write `FETCH_HEAD`, so reading it back could hand this run the *other* run's commit and silently
+    // mislabel the A/B result. A per-run ref (unique by pid, dots flattened for ref-name legality) is
+    // immune. The ref is deleted once the worktree is checked out (the detached worktree HEAD then keeps
+    // the commit reachable on its own).
+    let pid = std::process::id();
+    let temp_ref = format!("refs/archestra-bench/{}-{pid}", slug.replace('.', "-"));
     info!("fetching origin {git_ref} for the backend worktree");
-    git(repo_root, &["fetch", "origin", git_ref])
-        .await
-        .map_err(|e| LifecycleError::Config(format!("git fetch origin {git_ref} failed: {e}")))?;
+    git(
+        repo_root,
+        &["fetch", "origin", &format!("{git_ref}:{temp_ref}")],
+    )
+    .await
+    .map_err(|e| LifecycleError::Config(format!("git fetch origin {git_ref} failed: {e}")))?;
 
-    // Pin the concrete commit right after the fetch: it labels the run, and checking out the sha rather
-    // than the shared `FETCH_HEAD` narrows the window a second concurrent `--branch` run could race.
-    let commit = git(repo_root, &["rev-parse", "FETCH_HEAD"])
+    let commit = git(repo_root, &["rev-parse", &temp_ref])
         .await
-        .map_err(|e| LifecycleError::Config(format!("git rev-parse FETCH_HEAD failed: {e}")))?
+        .map_err(|e| LifecycleError::Config(format!("git rev-parse {temp_ref} failed: {e}")))?
         .trim()
         .to_string();
 
-    let path =
-        std::env::temp_dir().join(format!("archestra-bench-wt-{slug}-{}", std::process::id()));
+    let path = std::env::temp_dir().join(format!("archestra-bench-wt-{slug}-{pid}"));
     if path.exists() {
         remove_worktree(repo_root, &path).await;
     }
@@ -622,12 +638,16 @@ pub async fn prepare_branch_worktree(
     .await
     .map_err(|e| LifecycleError::Config(format!("git worktree add failed: {e}")))?;
 
-    // Register teardown the instant the worktree exists, before the long build: a signal mid-build must
-    // still remove it.
+    // Register teardown the instant the worktree exists — synchronously, with no `.await` between the
+    // `worktree add` above and this call, so a cancellation can never strand an unregistered worktree.
     let teardown_id = register(Teardown::Worktree {
         repo_root: repo_root.to_path_buf(),
         path: path.clone(),
     });
+
+    // The detached worktree HEAD now pins the commit; drop the fetch ref. Ordered after registration so
+    // a signal during this await still leaves the worktree registered for teardown.
+    let _ = git(repo_root, &["update-ref", "-d", &temp_ref]).await;
 
     let wt_platform = path.join("platform");
     if let Err(e) = provision_and_build(source_platform, &wt_platform, &commit).await {
@@ -661,7 +681,14 @@ async fn provision_and_build(
             src_env.display()
         )));
     }
-    fs::copy(&src_env, wt_platform.join(".env")).await?;
+    let dst_env = wt_platform.join(".env");
+    fs::copy(&src_env, &dst_env).await.map_err(|e| {
+        LifecycleError::Config(format!(
+            "copying {} to {} failed: {e}",
+            src_env.display(),
+            dst_env.display()
+        ))
+    })?;
 
     // Dagger CLI (gitignored): `backend_env` prefers `ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN` (flows via
     // the copied `.env`/process env) and otherwise resolves `<platform>/dev/bin/dagger`. So only when
@@ -670,10 +697,18 @@ async fn provision_and_build(
     let src_dagger = source_platform.join("dev").join("bin").join("dagger");
     if src_dagger.is_file() {
         let dst_dir = wt_platform.join("dev").join("bin");
-        fs::create_dir_all(&dst_dir).await?;
+        fs::create_dir_all(&dst_dir).await.map_err(|e| {
+            LifecycleError::Config(format!("creating {} failed: {e}", dst_dir.display()))
+        })?;
         let dst = dst_dir.join("dagger");
         let _ = fs::remove_file(&dst).await;
-        fs::symlink(&src_dagger, &dst).await?;
+        fs::symlink(&src_dagger, &dst).await.map_err(|e| {
+            LifecycleError::Config(format!(
+                "symlinking dagger {} -> {} failed: {e}",
+                src_dagger.display(),
+                dst.display()
+            ))
+        })?;
     } else {
         info!(
             "{} absent; the branch backend resolves dagger via ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN",
@@ -708,21 +743,46 @@ async fn git(repo_root: &Path, args: &[&str]) -> Result<String, String> {
     }
 }
 
-/// Run a pnpm command in `dir` with inherited stdio (build progress stays visible) and
-/// `kill_on_drop`, so a signal that drops the run future kills the long build instead of orphaning it.
+/// SIGKILLs a process group on drop unless disarmed. `kill_on_drop` reaps only the direct child, but a
+/// `pnpm` build spawns a tree (turbo, tsdown, the napi `cargo` build); on cancellation those
+/// descendants must die too, or they keep writing into a worktree that is about to be removed.
+struct KillGroupOnDrop(Option<i32>);
+
+impl KillGroupOnDrop {
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for KillGroupOnDrop {
+    fn drop(&mut self) {
+        if let Some(pgid) = self.0 {
+            let _ = signal::killpg(Pid::from_raw(pgid), Signal::SIGKILL);
+        }
+    }
+}
+
+/// Run a pnpm command in `dir` with inherited stdio (build progress stays visible), in its own process
+/// group so a cancelled run (signal drops the run future) kills the whole build tree rather than
+/// orphaning `pnpm`'s descendants.
 async fn pnpm(dir: &Path, args: &[&str]) -> Result<(), LifecycleError> {
-    let status = Command::new("pnpm")
+    let mut child = Command::new("pnpm")
         .args(args)
         .current_dir(dir)
+        .process_group(0)
         .kill_on_drop(true)
-        .status()
-        .await
+        .spawn()
         .map_err(|e| {
             LifecycleError::Config(format!(
                 "failed to run `pnpm {}` (is pnpm installed?): {e}",
                 args.join(" ")
             ))
         })?;
+    let mut guard = KillGroupOnDrop(child.id().map(|p| p as i32));
+    let status = child.wait().await.map_err(|e| {
+        LifecycleError::Config(format!("`pnpm {}` failed to run: {e}", args.join(" ")))
+    })?;
+    guard.disarm();
     if !status.success() {
         return Err(LifecycleError::Config(format!(
             "`pnpm {}` failed ({status}) in {}",
@@ -734,8 +794,9 @@ async fn pnpm(dir: &Path, args: &[&str]) -> Result<(), LifecycleError> {
 }
 
 /// Remove a bench-created git worktree, best-effort. Shared by the normal-path handle and the
-/// signal-teardown registry. Failures are logged, not propagated: a leaked worktree lives in a temp
-/// dir and the next run's `worktree prune` sweeps it.
+/// signal-teardown registry. Failures are logged loudly, not propagated — same disposition as a failed
+/// benchmark-DB drop: the worktree sits in a unique temp dir, so a rare leak wastes disk until OS temp
+/// cleanup, never correctness. (`worktree prune` clears only the admin record, not a leaked directory.)
 async fn remove_worktree(repo_root: &Path, path: &Path) {
     info!("removing bench worktree {}", path.display());
     let path_str = path.to_string_lossy();
@@ -1298,20 +1359,19 @@ mod tests {
         );
     }
 
-    /// `remove_worktree` must actually detach and delete a real git worktree — the highest-risk piece
-    /// of `--branch` cleanup. Real git, real filesystem, no mocks.
-    #[tokio::test]
-    async fn test_remove_worktree_deletes_real_worktree() {
-        fn run_git(dir: &Path, args: &[&str]) {
-            let status = std::process::Command::new("git")
-                .arg("-C")
-                .arg(dir)
-                .args(args)
-                .status()
-                .expect("git runs");
-            assert!(status.success(), "git {args:?} failed");
-        }
+    fn run_git(dir: &Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .status()
+            .expect("git runs");
+        assert!(status.success(), "git {args:?} failed");
+    }
 
+    /// A real git repo with one commit plus a detached worktree outside its working tree. Returns
+    /// (repo tempdir, worktree-parent tempdir, worktree path); keep both tempdirs alive for the test.
+    fn repo_with_worktree() -> (tempfile::TempDir, tempfile::TempDir, PathBuf) {
         let repo = tempfile::tempdir().unwrap();
         let repo_path = repo.path();
         run_git(repo_path, &["init", "-q"]);
@@ -1320,14 +1380,21 @@ mod tests {
         std::fs::write(repo_path.join("f.txt"), "x").unwrap();
         run_git(repo_path, &["add", "f.txt"]);
         run_git(repo_path, &["commit", "-q", "-m", "init"]);
-
-        // Add the worktree outside the repo working tree.
         let wt_parent = tempfile::tempdir().unwrap();
         let wt = wt_parent.path().join("wt");
         run_git(
             repo_path,
             &["worktree", "add", "--detach", wt.to_str().unwrap(), "HEAD"],
         );
+        (repo, wt_parent, wt)
+    }
+
+    /// `remove_worktree` must actually detach and delete a real git worktree — the highest-risk piece
+    /// of `--branch` cleanup. Real git, real filesystem, no mocks.
+    #[tokio::test]
+    async fn test_remove_worktree_deletes_real_worktree() {
+        let (repo, _wt_parent, wt) = repo_with_worktree();
+        let repo_path = repo.path();
         assert!(wt.is_dir(), "worktree created");
         // Count entries rather than match paths: `git worktree list` prints resolved real paths, which
         // differ from `wt` under macOS's /var -> /private/var symlink.
@@ -1339,6 +1406,38 @@ mod tests {
         assert!(!wt.exists(), "worktree dir removed");
         let after = git(repo_path, &["worktree", "list"]).await.unwrap();
         assert_eq!(after.lines().count(), 1, "only the main worktree remains");
+    }
+
+    /// `BranchWorktree::remove` must both delete the worktree and deregister its signal-path teardown,
+    /// so cleanup runs exactly once — no leaked registry entry that `shutdown_all` would re-run.
+    #[tokio::test]
+    async fn test_branch_worktree_remove_deletes_and_deregisters() {
+        let _guard = registry_lock().lock().await;
+        let (repo, _wt_parent, wt) = repo_with_worktree();
+        let repo_path = repo.path();
+
+        let teardown_id = register(Teardown::Worktree {
+            repo_root: repo_path.to_path_buf(),
+            path: wt.clone(),
+        });
+        let handle = BranchWorktree {
+            platform_dir: wt.join("platform"),
+            commit: "deadbeef".to_string(),
+            repo_root: repo_path.to_path_buf(),
+            path: wt.clone(),
+            teardown_id,
+        };
+
+        handle.remove().await;
+
+        assert!(!wt.exists(), "worktree removed by the handle");
+        assert!(
+            !registry()
+                .lock()
+                .expect("teardown registry")
+                .contains_key(&teardown_id),
+            "teardown deregistered"
+        );
     }
 
     #[tokio::test]
@@ -1422,10 +1521,7 @@ mod tests {
         assert_eq!(non_empty(None), None);
         assert_eq!(non_empty(Some(String::new())), None);
         assert_eq!(non_empty(Some("   ".to_string())), None);
-        assert_eq!(
-            non_empty(Some("/app".to_string())),
-            Some("/app".to_string())
-        );
+        assert_eq!(non_empty(Some("/app".to_string())), Some("/app".to_string()));
     }
 
     #[test]

--- a/ai-labs/runner/src/run.rs
+++ b/ai-labs/runner/src/run.rs
@@ -148,105 +148,145 @@ pub async fn run(
     max_workers: Option<usize>,
     update_mcp_lock: bool,
     platform_dir: Option<&Path>,
+    branch: Option<&str>,
 ) -> Result<RunOutcome, RunError> {
-    let envs_dir = bench_dir.join("envs");
-    let envs = load_envs(&envs_dir).map_err(|e| RunError::Config(e.to_string()))?;
-    let default_lanes_path = bench_dir.join("lanes.toml");
-    let lanes_path = lanes_file.unwrap_or(&default_lanes_path);
-    let lane_list =
-        load_lanes(lanes_path, lanes_filter).map_err(|e| RunError::Config(e.to_string()))?;
-    let workers = resolve_workers(max_workers, lane_list.len());
-    // Lane keys prefer `platform/.env` over the process env, so the same `.env` that configures the
-    // backend also seeds the bench's own provider clients. The `.env` is already a hard requirement of
-    // every run (preflight below also loads it).
-    let platform = crate::lifecycle::resolve_platform_dir(platform_dir, &repo_root());
-    let platform_env = crate::lifecycle::load_platform_env(&platform)?;
-    let api_keys = lane_api_keys(&lane_list, &platform_env)?;
-
-    // Fetch OpenRouter prices once up front. A failure is non-fatal: every run then reports cost n/a.
-    let (prices, price_status) = match pricing::fetch_price_book().await {
-        Ok(book) => (book, "ok".to_string()),
-        Err(e) => {
-            warn!("OpenRouter price fetch failed, run costs will be n/a: {e}");
-            (PriceBook::default(), format!("failed: {e}"))
+    // `--branch` builds the backend from a git worktree of that ref, once per run; downstream it is
+    // just another platform dir. `--branch` conflicts with `--platform-dir` (see the CLI), so when a
+    // branch is set `platform_dir` is `None` and the source of the copied prereqs is `<repo>/platform`.
+    let worktree = match branch {
+        Some(git_ref) => {
+            let source = crate::lifecycle::resolve_platform_dir(platform_dir, &repo_root());
+            Some(
+                crate::lifecycle::prepare_branch_worktree(
+                    &repo_root(),
+                    &source,
+                    git_ref,
+                    &sanitize_slug(git_ref, &run_id()),
+                )
+                .await?,
+            )
         }
+        None => None,
     };
-    let prices = Arc::new(prices);
+    let effective_platform_dir: Option<PathBuf> = worktree
+        .as_ref()
+        .map(|w| w.platform_dir.clone())
+        .or_else(|| platform_dir.map(Path::to_path_buf));
+    let backend_branch = branch.map(str::to_string);
+    let backend_commit = worktree.as_ref().map(|w| w.commit.clone());
 
-    let selected = select_envs(&envs, env_filter, task_filter)?;
-    let plan = build_run_plan(selected, lane_list);
+    // Everything after worktree creation runs inside this block so the worktree is removed on every
+    // normal exit — success or error (`?` returns from the block, not the fn) — while the signal path
+    // is covered by the registered teardown.
+    let outcome: Result<RunOutcome, RunError> = async {
+        let envs_dir = bench_dir.join("envs");
+        let envs = load_envs(&envs_dir).map_err(|e| RunError::Config(e.to_string()))?;
+        let default_lanes_path = bench_dir.join("lanes.toml");
+        let lanes_path = lanes_file.unwrap_or(&default_lanes_path);
+        let lane_list =
+            load_lanes(lanes_path, lanes_filter).map_err(|e| RunError::Config(e.to_string()))?;
+        let workers = resolve_workers(max_workers, lane_list.len());
+        // Lane keys prefer `platform/.env` over the process env, so the same `.env` that configures the
+        // backend also seeds the bench's own provider clients. The `.env` is already a hard requirement of
+        // every run (preflight below also loads it).
+        let platform =
+            crate::lifecycle::resolve_platform_dir(effective_platform_dir.as_deref(), &repo_root());
+        let platform_env = crate::lifecycle::load_platform_env(&platform)?;
+        let api_keys = lane_api_keys(&lane_list, &platform_env)?;
 
-    // Preflight the sandbox once, before any artifact is written: a broken sandbox (managed bench
-    // Postgres can't come up, Dagger runner host won't resolve) aborts the whole run here with a
-    // single error instead of every backend boot failing the same way and fanning out one
-    // agent_error per (task × lane). Warms the same OnceCells `Instance::start` reads, so a healthy
-    // run pays nothing.
-    crate::lifecycle::preflight(&repo_root(), platform_dir).await?;
+        // Fetch OpenRouter prices once up front. A failure is non-fatal: every run then reports cost n/a.
+        let (prices, price_status) = match pricing::fetch_price_book().await {
+            Ok(book) => (book, "ok".to_string()),
+            Err(e) => {
+                warn!("OpenRouter price fetch failed, run costs will be n/a: {e}");
+                (PriceBook::default(), format!("failed: {e}"))
+            }
+        };
+        let prices = Arc::new(prices);
 
-    // An explicit `--run-dir` is reused (create_dir_all); an auto dir must be brand-new — the base name
-    // is seconds-granular, so two runs started in the same second would otherwise share a root and
-    // overwrite each other's config.json/aggregate.json.
-    let (root_run_dir, run_id) = match run_dir {
-        Some(p) => {
-            fs::create_dir_all(p).await?;
-            (p.to_path_buf(), run_id())
+        let selected = select_envs(&envs, env_filter, task_filter)?;
+        let plan = build_run_plan(selected, lane_list);
+
+        // Preflight the sandbox once, before any artifact is written: a broken sandbox (managed bench
+        // Postgres can't come up, Dagger runner host won't resolve) aborts the whole run here with a
+        // single error instead of every backend boot failing the same way and fanning out one
+        // agent_error per (task × lane). Warms the same OnceCells `Instance::start` reads, so a healthy
+        // run pays nothing.
+        crate::lifecycle::preflight(&repo_root(), effective_platform_dir.as_deref()).await?;
+
+        // An explicit `--run-dir` is reused (create_dir_all); an auto dir must be brand-new — the base name
+        // is seconds-granular, so two runs started in the same second would otherwise share a root and
+        // overwrite each other's config.json/aggregate.json.
+        let (root_run_dir, run_id) = match run_dir {
+            Some(p) => {
+                fs::create_dir_all(p).await?;
+                (p.to_path_buf(), run_id())
+            }
+            None => create_fresh_run_dir(bench_dir).await?,
+        };
+
+        write_run_config(
+            &root_run_dir,
+            &run_id,
+            &plan,
+            workers,
+            &prices,
+            &price_status,
+            backend_branch.as_deref(),
+            backend_commit.as_deref(),
+        )
+        .await?;
+
+        // Stream the managed Dagger engine's container logs into the run dir so a future engine crash is
+        // root-causeable (managed tier only; non-fatal). The host was resolved by `preflight` above.
+        let dagger_compose = repo_root()
+            .join("ai-labs")
+            .join("dev")
+            .join("docker-compose.bench-dagger.yml");
+        let dagger_logs =
+            crate::lifecycle::capture_managed_dagger_logs(&dagger_compose, &root_run_dir).await;
+
+        let ctx = RunCtx {
+            root_run_dir,
+            run_id,
+            api_keys,
+            envs_dir,
+            update_mcp_lock,
+            platform_dir: effective_platform_dir.clone(),
+            prices,
+        };
+
+        let results = execute_plan(plan, ctx.clone(), workers).await;
+
+        // All sandbox work is done; stop the engine-log follower (no-op if capture was skipped). The
+        // remaining report/aggregate steps touch no sandbox, so an early `?` return below cannot leak it.
+        if let Some(guard) = dagger_logs {
+            guard.stop().await;
         }
-        None => create_fresh_run_dir(bench_dir).await?,
-    };
 
-    write_run_config(
-        &root_run_dir,
-        &run_id,
-        &plan,
-        workers,
-        &prices,
-        &price_status,
-    )
-    .await?;
+        let results = crate::results::build_report(results).map_err(RunError::Config)?;
+        let report = render_markdown(&results);
+        write_report(&report, out).await?;
 
-    // Stream the managed Dagger engine's container logs into the run dir so a future engine crash is
-    // root-causeable (managed tier only; non-fatal). The host was resolved by `preflight` above.
-    let dagger_compose = repo_root()
-        .join("ai-labs")
-        .join("dev")
-        .join("docker-compose.bench-dagger.yml");
-    let dagger_logs =
-        crate::lifecycle::capture_managed_dagger_logs(&dagger_compose, &root_run_dir).await;
+        let aggregate = crate::results::aggregate(&results);
+        let aggregate_path = ctx.root_run_dir.join("aggregate.json");
+        fs::write(
+            &aggregate_path,
+            serde_json::to_string_pretty(&aggregate.to_json()).unwrap_or_default() + "\n",
+        )
+        .await?;
 
-    let ctx = RunCtx {
-        root_run_dir,
-        run_id,
-        api_keys,
-        envs_dir,
-        update_mcp_lock,
-        platform_dir: platform_dir.map(Path::to_path_buf),
-        prices,
-    };
-
-    let results = execute_plan(plan, ctx.clone(), workers).await;
-
-    // All sandbox work is done; stop the engine-log follower (no-op if capture was skipped). The
-    // remaining report/aggregate steps touch no sandbox, so an early `?` return below cannot leak it.
-    if let Some(guard) = dagger_logs {
-        guard.stop().await;
+        Ok(RunOutcome {
+            results,
+            run_dir: ctx.root_run_dir,
+        })
     }
+    .await;
 
-    let results = crate::results::build_report(results).map_err(RunError::Config)?;
-    let report = render_markdown(&results);
-    write_report(&report, out).await?;
-
-    let aggregate = crate::results::aggregate(&results);
-    let aggregate_path = ctx.root_run_dir.join("aggregate.json");
-    fs::write(
-        &aggregate_path,
-        serde_json::to_string_pretty(&aggregate.to_json()).unwrap_or_default() + "\n",
-    )
-    .await?;
-
-    Ok(RunOutcome {
-        results,
-        run_dir: ctx.root_run_dir,
-    })
+    if let Some(w) = worktree {
+        w.remove().await;
+    }
+    outcome
 }
 
 fn resolve_workers(requested: Option<usize>, lane_count: usize) -> usize {
@@ -634,8 +674,14 @@ async fn seed_env_mcps(
     let fixture = FixtureMcp::start(FIXTURE_MCP_NAME)
         .await
         .map_err(|e| e.to_string())?;
-    if let Err(e) =
-        register_remote_mcp(client, fixture.name(), fixture.base_url(), "org", Some(agent_ids)).await
+    if let Err(e) = register_remote_mcp(
+        client,
+        fixture.name(),
+        fixture.base_url(),
+        "org",
+        Some(agent_ids),
+    )
+    .await
     {
         fixture.stop().await;
         return Err(e.to_string());
@@ -806,15 +852,15 @@ async fn run_isolated_lane(
         }
     };
 
-    let fixture_mcp = match seed_env_mcps(&client, &env, &ctx, std::slice::from_ref(&agent_id)).await
-    {
-        Ok(fixture) => fixture,
-        Err(e) => {
-            mcp.stop().await;
-            let _ = instance.shutdown().await;
-            return infra_results_for_lane(&env, &tasks, &lane, &ctx, &progress, &e);
-        }
-    };
+    let fixture_mcp =
+        match seed_env_mcps(&client, &env, &ctx, std::slice::from_ref(&agent_id)).await {
+            Ok(fixture) => fixture,
+            Err(e) => {
+                mcp.stop().await;
+                let _ = instance.shutdown().await;
+                return infra_results_for_lane(&env, &tasks, &lane, &ctx, &progress, &e);
+            }
+        };
 
     let results = run_lane(
         client,
@@ -981,8 +1027,10 @@ fn require_id(value: &HashMap<String, serde_json::Value>, what: &str) -> Result<
         .map(str::to_string)
         .ok_or_else(|| {
             RunError::Client(
-                ContractError(format!("{what}: API response missing non-empty string `id`"))
-                    .into(),
+                ContractError(format!(
+                    "{what}: API response missing non-empty string `id`"
+                ))
+                .into(),
             )
         })
 }
@@ -1559,7 +1607,10 @@ async fn grade_rollout(
         }
         nudges_sent += 1;
         artifacts
-            .append("submit_nudge", serde_json::json!({ "attempt": nudges_sent }))
+            .append(
+                "submit_nudge",
+                serde_json::json!({ "attempt": nudges_sent }),
+            )
             .await;
         let nudge = Stage {
             text: SUBMIT_NUDGE.to_string(),
@@ -2752,6 +2803,22 @@ fn timestamp() -> String {
         .replace("+00:00", "Z")
 }
 
+/// Filesystem-safe slug for the `--branch` worktree directory: map every char that isn't
+/// alnum/`-`/`_`/`.` (e.g. the `/` in `feature/foo`) to `-`, and suffix the run id so repeat runs of
+/// the same ref don't collide on the path.
+fn sanitize_slug(git_ref: &str, run_id: &str) -> String {
+    format!("{git_ref}-{run_id}")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
 async fn write_run_config(
     run_dir: &Path,
     run_id: &str,
@@ -2759,6 +2826,8 @@ async fn write_run_config(
     max_workers: usize,
     prices: &PriceBook,
     price_status: &str,
+    backend_branch: Option<&str>,
+    backend_commit: Option<&str>,
 ) -> Result<(), RunError> {
     let environments: Vec<serde_json::Value> = plan
         .iter()
@@ -2813,6 +2882,10 @@ async fn write_run_config(
         "lanes": lanes,
         "max_workers": max_workers,
         "git_commit": git_commit,
+        // When `--branch` is used the backend runs from a worktree of this ref/commit, not the harness
+        // checkout `git_commit` above; null on a normal run. Lets A/B results name the backend they ran.
+        "backend_branch": backend_branch,
+        "backend_commit": backend_commit,
         "temperature": crate::client::BENCH_TEMPERATURE,
         "pricing": {
             "source": "openrouter",
@@ -2847,6 +2920,19 @@ mod tests {
 
     fn files_payload(json: serde_json::Value) -> HashMap<String, serde_json::Value> {
         serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn test_sanitize_slug_is_filesystem_safe() {
+        // Slashes and other non-`[A-Za-z0-9._-]` chars collapse to `-`; the run id is appended.
+        assert_eq!(sanitize_slug("feature/foo", "rid1"), "feature-foo-rid1");
+        assert_eq!(sanitize_slug("release/v1.2", "r2"), "release-v1.2-r2");
+        assert_eq!(sanitize_slug("a b:c@d", "r"), "a-b-c-d-r");
+        assert!(
+            sanitize_slug("origin/x", "id")
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        );
     }
 
     #[test]
@@ -3445,9 +3531,18 @@ mod tests {
         let lanes = vec![dummy_lane("l1"), dummy_lane("l2")];
         let plan = build_run_plan(envs, lanes);
         let tmp = tempfile::tempdir().unwrap();
-        write_run_config(tmp.path(), "rid", &plan, 2, &PriceBook::default(), "ok")
-            .await
-            .unwrap();
+        write_run_config(
+            tmp.path(),
+            "rid",
+            &plan,
+            2,
+            &PriceBook::default(),
+            "ok",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let config: serde_json::Value =
             serde_json::from_slice(&std::fs::read(tmp.path().join("config.json")).unwrap())
                 .unwrap();

--- a/ai-labs/runner/src/run.rs
+++ b/ai-labs/runner/src/run.rs
@@ -156,6 +156,12 @@ pub async fn run(
     let worktree = match branch {
         Some(git_ref) => {
             let source = crate::lifecycle::resolve_platform_dir(platform_dir, &repo_root());
+            // Fail fast on a broken sandbox BEFORE the multi-minute build: preflight the source
+            // platform dir (whose `.env` is what the worktree copies) so a down Docker/Dagger aborts
+            // the run now rather than after the build. Preserves preflight's "abort before spending
+            // work" property, which building first would silently defeat; the in-block preflight below
+            // then hits the warmed OnceCells.
+            crate::lifecycle::preflight(&repo_root(), Some(&source)).await?;
             Some(
                 crate::lifecycle::prepare_branch_worktree(
                     &repo_root(),
@@ -674,14 +680,8 @@ async fn seed_env_mcps(
     let fixture = FixtureMcp::start(FIXTURE_MCP_NAME)
         .await
         .map_err(|e| e.to_string())?;
-    if let Err(e) = register_remote_mcp(
-        client,
-        fixture.name(),
-        fixture.base_url(),
-        "org",
-        Some(agent_ids),
-    )
-    .await
+    if let Err(e) =
+        register_remote_mcp(client, fixture.name(), fixture.base_url(), "org", Some(agent_ids)).await
     {
         fixture.stop().await;
         return Err(e.to_string());
@@ -852,15 +852,15 @@ async fn run_isolated_lane(
         }
     };
 
-    let fixture_mcp =
-        match seed_env_mcps(&client, &env, &ctx, std::slice::from_ref(&agent_id)).await {
-            Ok(fixture) => fixture,
-            Err(e) => {
-                mcp.stop().await;
-                let _ = instance.shutdown().await;
-                return infra_results_for_lane(&env, &tasks, &lane, &ctx, &progress, &e);
-            }
-        };
+    let fixture_mcp = match seed_env_mcps(&client, &env, &ctx, std::slice::from_ref(&agent_id)).await
+    {
+        Ok(fixture) => fixture,
+        Err(e) => {
+            mcp.stop().await;
+            let _ = instance.shutdown().await;
+            return infra_results_for_lane(&env, &tasks, &lane, &ctx, &progress, &e);
+        }
+    };
 
     let results = run_lane(
         client,
@@ -1027,10 +1027,8 @@ fn require_id(value: &HashMap<String, serde_json::Value>, what: &str) -> Result<
         .map(str::to_string)
         .ok_or_else(|| {
             RunError::Client(
-                ContractError(format!(
-                    "{what}: API response missing non-empty string `id`"
-                ))
-                .into(),
+                ContractError(format!("{what}: API response missing non-empty string `id`"))
+                    .into(),
             )
         })
 }
@@ -1607,10 +1605,7 @@ async fn grade_rollout(
         }
         nudges_sent += 1;
         artifacts
-            .append(
-                "submit_nudge",
-                serde_json::json!({ "attempt": nudges_sent }),
-            )
+            .append("submit_nudge", serde_json::json!({ "attempt": nudges_sent }))
             .await;
         let nudge = Stage {
             text: SUBMIT_NUDGE.to_string(),


### PR DESCRIPTION
## What

Adds `--branch <ref>` (env `ARCHESTRA_BENCH_BACKEND_BRANCH`) to archestra-bench so a run builds and spawns its per-run backend from a git worktree of an arbitrary ref, for A/B benchmarking a branch against the working tree. Conflicts with `--platform-dir`.

## How

On a `--branch` run, once per run:
1. Fetch `origin/<ref>` into a per-run private ref, `git worktree add --detach` the resolved commit into a temp worktree.
2. Copy the dev tree's `.env` in and symlink `dev/bin/dagger` when present (else the worktree relies on `ARCHESTRA_CODE_RUNTIME_DAGGER_CLI_BIN`, same as the dev tree).
3. Full `pnpm install --frozen-lockfile` + `pnpm build` (turbo → napi `*.node`, backend `dist/server.mjs`, frontend).
4. Every env's backend spawns from the worktree; it's removed on normal completion, on error, and on SIGINT/SIGTERM. `config.json` records `backend_branch` / `backend_commit`.

A fully provisioned worktree is just another platform dir, so it rides the existing `--platform-dir` plumbing (`resolve_platform_dir` → `preflight` → `Instance::new`) unchanged. Without `--branch`, behavior is byte-identical to today. Bench sidecars (Postgres/Dagger compose, run dir) intentionally stay on the harness checkout.

## Signal-safety

- Backend build runs in its own process group with a kill-group-on-drop guard, so a cancelled run reaps the whole build tree, not just `pnpm`.
- `shutdown_all` kills process groups before removing worktrees, so `git worktree remove` never races a live backend.
- Fetch uses a per-run private ref (not the shared `FETCH_HEAD`) so concurrent `--branch` runs can't read each other's commit.

## Testing

`cargo clippy --all-targets -- -D warnings` clean; `cargo test` green (164 tests), including real-git tests for worktree removal and `BranchWorktree::remove` (dir deletion + teardown deregistration). Docs updated in `ai-labs/README.md` and `ai-labs/CLAUDE.md`.

https://claude.ai/code/session_01QGcxT4kKZdfvdzSWeC9K1B

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>