### PR TITLE
fix(connection): handle GitHub Copilot device-flow errors in Windows setup

### DIFF
--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -1063,6 +1063,28 @@ describe("renderSetupScript (windows)", () => {
     expect(script).toContain("$ArchGhcpToken");
   });
 
+  test("copilot-cli github-copilot passthrough: recovers HTTP 400 error body so switch handler is reachable", () => {
+    const script = renderSetupScript({
+      ...fullContext("copilot-cli", "windows"),
+      proxy: GITHUB_COPILOT_PROXY,
+    });
+    expect(script).toContain(
+      "function Convert-ArchHttpErrorBodyToJson($arch_error)",
+    );
+    expect(script).toContain("$arch_error.ErrorDetails.Message");
+    expect(script).toContain("$arch_error.Exception.Response");
+    expect(script).toContain("GetResponseStream");
+    expect(script).toContain(
+      "$arch_poll = Convert-ArchHttpErrorBodyToJson $PSItem",
+    );
+    expect(script).toContain("if (-not $arch_poll) { continue }");
+    expect(script).toContain(
+      "'slow_down' { $arch_interval = $arch_interval + 5 }",
+    );
+    expect(script).not.toContain("GITHUB_TOKEN");
+    expect(script).toContain("$ArchGhcpToken");
+  });
+
   test("cursor: merges mcp.json and prints manual model steps", () => {
     const script = renderSetupScript(fullContext("cursor", "windows"));
     expect(script).toContain(".cursor\\mcp.json");

--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -1075,6 +1075,11 @@ describe("renderSetupScript (windows)", () => {
     expect(script).toContain("$arch_error.Exception.Response");
     expect(script).toContain("GetResponseStream");
     expect(script).toContain(
+      "$arch_err_stream = $arch_err_resp.GetResponseStream()",
+    );
+    expect(script).toContain("$arch_reader.Dispose()");
+    expect(script).toContain("$arch_err_stream.Dispose()");
+    expect(script).toContain(
       "$arch_poll = Convert-ArchHttpErrorBodyToJson $PSItem",
     );
     expect(script).toContain("if (-not $arch_poll) { continue }");

--- a/platform/backend/src/services/connection-setup-script.windows.ts
+++ b/platform/backend/src/services/connection-setup-script.windows.ts
@@ -722,12 +722,22 @@ function Convert-ArchHttpErrorBodyToJson($arch_error) {
       return $arch_err_msg | ConvertFrom-Json
     }
     $arch_err_resp = $arch_error.Exception.Response
-    if ($arch_err_resp -and $arch_err_resp.GetResponseStream()) {
-      $arch_reader = New-Object System.IO.StreamReader($arch_err_resp.GetResponseStream())
-      $arch_err_body = $arch_reader.ReadToEnd()
-      if (-not [string]::IsNullOrEmpty($arch_err_body)) {
-        return $arch_err_body | ConvertFrom-Json
+    $arch_err_stream = $null
+    $arch_reader = $null
+    try {
+      if ($arch_err_resp) {
+        $arch_err_stream = $arch_err_resp.GetResponseStream()
+        if ($arch_err_stream) {
+          $arch_reader = New-Object System.IO.StreamReader($arch_err_stream)
+          $arch_err_body = $arch_reader.ReadToEnd()
+          if (-not [string]::IsNullOrEmpty($arch_err_body)) {
+            return $arch_err_body | ConvertFrom-Json
+          }
+        }
       }
+    } finally {
+      if ($arch_reader) { $arch_reader.Dispose() }
+      if ($arch_err_stream) { $arch_err_stream.Dispose() }
     }
   } catch { }
   return $null

--- a/platform/backend/src/services/connection-setup-script.windows.ts
+++ b/platform/backend/src/services/connection-setup-script.windows.ts
@@ -712,6 +712,27 @@ function Test-ArchGhcp($arch_tok) {
   }
 }
 
+# Invoke-RestMethod throws on HTTP 400, swallowing the response body.
+# Recover the device-flow error JSON so the switch can handle slow_down and
+# terminal errors. The ErrorRecord is passed in explicitly.
+function Convert-ArchHttpErrorBodyToJson($arch_error) {
+  try {
+    $arch_err_msg = $arch_error.ErrorDetails.Message
+    if (-not [string]::IsNullOrEmpty($arch_err_msg)) {
+      return $arch_err_msg | ConvertFrom-Json
+    }
+    $arch_err_resp = $arch_error.Exception.Response
+    if ($arch_err_resp -and $arch_err_resp.GetResponseStream()) {
+      $arch_reader = New-Object System.IO.StreamReader($arch_err_resp.GetResponseStream())
+      $arch_err_body = $arch_reader.ReadToEnd()
+      if (-not [string]::IsNullOrEmpty($arch_err_body)) {
+        return $arch_err_body | ConvertFrom-Json
+      }
+    }
+  } catch { }
+  return $null
+}
+
 # 1. Reuse a GitHub token already stored by the Copilot CLI / VS Code.
 $arch_ghcp_paths = @(
   (Join-Path $env:USERPROFILE '.config\\github-copilot\\apps.json'),
@@ -776,10 +797,12 @@ if ([string]::IsNullOrEmpty($ArchGhcpToken)) {
     }
     Start-Sleep -Seconds $arch_interval
     $arch_poll_body = (@{ client_id = ${psq(gh.clientId)}; device_code = $arch_device_code; grant_type = 'urn:ietf:params:oauth:grant-type:device_code' } | ConvertTo-Json -Compress)
+    $arch_poll = $null
     try {
       $arch_poll = Invoke-RestMethod -Method Post -Uri ${psq(accessTokenUrl)} -TimeoutSec 30 -Headers @{ 'accept' = 'application/json' } -ContentType 'application/json' -Body $arch_poll_body
     } catch {
-      continue
+      $arch_poll = Convert-ArchHttpErrorBodyToJson $PSItem
+      if (-not $arch_poll) { continue }
     }
     if ($arch_poll.access_token) {
       $ArchGhcpToken = $arch_poll.access_token


### PR DESCRIPTION
This fixes a Windows-only issue in the GitHub Copilot passthrough device flow generated by the connection setup script. `Invoke-RestMethod` throws on GitHub HTTP 400 polling responses, so the previous `catch { continue }` discarded the JSON error body before the existing switch could handle `authorization_pending`, `slow_down`, or terminal errors.

The PowerShell renderer now recovers the response body from the ErrorRecord and passes it back into the existing switch path, restoring parity with the bash renderer. I added a regression test for the Windows renderer and validated the change with the connection setup script unit test, Biome, and backend typecheck.