### PR TITLE
fix(mcp): reflect Custom→Auto tool-surface switch without stale caches

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -1068,3 +1068,60 @@ describe("getChatMcpTools failure and cache gating", () => {
     expect(Object.keys(toolsB)).toEqual(["extsrv__b"]);
   });
 });
+
+describe("getChatMcpTools surface-eviction race (Custom→Auto)", () => {
+  test("drops the tool-cache write when the agent surface is evicted mid-fetch", async () => {
+    // Reproduces the Custom→Auto race: a tools/list fetch begins in Custom mode
+    // (full menu), the mode switch fires clearChatMcpClient() to evict caches,
+    // then the in-flight fetch completes and would re-poison toolCache with the
+    // stale full list for the whole cache TTL. Suspend tools/list to interleave
+    // the eviction between the fetch and the toolCache.set that follows it.
+    let releaseListTools: (() => void) | undefined;
+    const listToolsGate = new Promise<void>((resolve) => {
+      releaseListTools = resolve;
+    });
+    const customModeClient = {
+      ping: vi.fn().mockResolvedValue({}),
+      listTools: vi.fn().mockImplementation(async () => {
+        await listToolsGate;
+        return { tools: [externalTool("custom_only_tool")] };
+      }),
+      callTool: vi.fn(),
+      close: vi.fn(),
+    } as unknown as Client;
+
+    const { agent, user, conversation, baseParams } = await setupChatToolEnv({
+      gatewayClient: customModeClient,
+    });
+    if (!conversation) throw new Error("expected a conversation scope");
+    const scopeKey = conversation.id;
+
+    // Fetch starts in Custom mode and suspends inside tools/list.
+    const inflight = chatClient.getChatMcpTools(baseParams);
+    await vi.waitFor(() =>
+      expect(customModeClient.listTools).toHaveBeenCalled(),
+    );
+
+    // User switches Custom→Auto: the update path evicts the agent's caches.
+    chatClient.clearChatMcpClient(agent.id);
+
+    // The suspended Custom-mode fetch now resolves and tries to populate cache.
+    releaseListTools?.();
+    const firstTools = await inflight;
+    expect(firstTools.custom_only_tool).toBeDefined();
+
+    // The new Auto-mode surface exposes only the dispatch tool. Seed it.
+    const autoModeClient = buildMockGatewayClient([externalTool("run_tool")]);
+    chatClient.__test.setCachedClient(
+      chatClient.__test.getCacheKey(agent.id, user.id, scopeKey),
+      autoModeClient,
+    );
+
+    // A fresh run must reflect the Auto surface, not a cache poisoned by the
+    // raced write from the pre-switch Custom fetch.
+    const secondTools = await chatClient.getChatMcpTools(baseParams);
+    expect(secondTools.run_tool).toBeDefined();
+    expect(secondTools.custom_only_tool).toBeUndefined();
+    expect(autoModeClient.listTools).toHaveBeenCalledTimes(1);
+  });
+});

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -145,6 +145,18 @@ const toolCache = new LRUCacheManager<CachedToolSet>({
 
 const clientLastValidatedAt = new Map<string, number>();
 
+// Per-agent tool-surface generation. clearChatMcpClient() bumps it whenever an
+// agent's surface changes; getChatMcpTools captures it before fetching and skips
+// its toolCache write if it advanced during the fetch. Without this, a tools/list
+// fetch that began before a surface change (e.g. switching Custom→Auto) can land
+// its now-stale result in the cache AFTER the eviction cleared it, pinning the
+// old surface for the whole cache TTL.
+const agentSurfaceGeneration = new Map<string, number>();
+
+function getAgentSurfaceGeneration(agentId: string): number {
+  return agentSurfaceGeneration.get(agentId) ?? 0;
+}
+
 /**
  * UI resource cache TTL — 60 seconds.
  * UI resources (MCP App HTML) rarely change during a conversation, so a
@@ -350,6 +362,10 @@ export function clearChatMcpClient(agentId: string): void {
 
   let clientClearedCount = 0;
   let toolClearedCount = 0;
+
+  // Invalidate any tools/list fetch already in flight for this agent: its
+  // post-fetch toolCache write will be dropped rather than re-poison the cache.
+  agentSurfaceGeneration.set(agentId, getAgentSurfaceGeneration(agentId) + 1);
 
   // Find and remove all client cache entries for this agentId (any user)
   // Collect keys first to avoid iterator invalidation during deletion
@@ -821,6 +837,10 @@ export async function getChatMcpTools({
   const scopeKey = isolationKey ?? conversationId;
   const toolCacheKey = getToolCacheKey(agentId, userId, scopeKey);
   const shouldUseToolCache = !abortSignal;
+  // Snapshot the agent's surface generation before the fetch; if a concurrent
+  // clearChatMcpClient() bumps it while we fetch, the result is stale and must
+  // not be cached (see agentSurfaceGeneration).
+  const surfaceGenerationAtFetchStart = getAgentSurfaceGeneration(agentId);
 
   // Check in-memory tool cache first (cannot use distributed cacheManager - Tool objects have execute functions)
   // LRU eviction and TTL are handled automatically by LRUCacheManager
@@ -1018,8 +1038,13 @@ export async function getChatMcpTools({
       }
     }
 
-    // Cache tools in-memory (LRU eviction and TTL handled by LRUCacheManager)
-    if (shouldUseToolCache) {
+    // Cache tools in-memory (LRU eviction and TTL handled by LRUCacheManager).
+    // Skip the write if the agent's surface was evicted while we fetched — the
+    // result predates the change and would otherwise re-poison the cache.
+    if (
+      shouldUseToolCache &&
+      getAgentSurfaceGeneration(agentId) === surfaceGenerationAtFetchStart
+    ) {
       toolCache.set(toolCacheKey, { tools: aiTools, context: toolContext });
     }
 

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -151,7 +151,15 @@ const clientLastValidatedAt = new Map<string, number>();
 // fetch that began before a surface change (e.g. switching Custom→Auto) can land
 // its now-stale result in the cache AFTER the eviction cleared it, pinning the
 // old surface for the whole cache TTL.
-const agentSurfaceGeneration = new Map<string, number>();
+//
+// LRU-bounded so a long-lived pod serving many distinct agents can't grow it
+// without bound. maxSize far exceeds the agents that could have a tools/list
+// fetch in flight at once, and the default TTL dwarfs any fetch, so a live
+// entry is never evicted mid-fetch — which would reset it to the absent default
+// and let a superseded write slip through.
+const agentSurfaceGeneration = new LRUCacheManager<number>({
+  maxSize: 10_000,
+});
 
 function getAgentSurfaceGeneration(agentId: string): number {
   return agentSurfaceGeneration.get(agentId) ?? 0;

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -50,6 +50,7 @@ import type {
   AgentType,
   InsertAgent,
   SortingQuery,
+  ToolExposureMode,
   UpdateAgent,
 } from "@/types";
 import { isUniqueConstraintError } from "@/utils/db";
@@ -1672,6 +1673,24 @@ class AgentModel {
     AgentModel.filterUnavailableKnowledgeTools([result]);
 
     return result;
+  }
+
+  /**
+   * The agent's mutable toolExposureMode, without findById's tool join and
+   * team/label/knowledge/connector/author/prompt hydration. The MCP gateway's
+   * tools/list handler re-reads it per request so a reused (cached) server
+   * reflects a mode change made after it was built.
+   */
+  static async findToolExposureModeById(
+    id: string,
+  ): Promise<{ toolExposureMode: ToolExposureMode } | null> {
+    const [row] = await db
+      .select({ toolExposureMode: schema.agentsTable.toolExposureMode })
+      .from(schema.agentsTable)
+      .where(
+        and(eq(schema.agentsTable.id, id), notDeleted(schema.agentsTable)),
+      );
+    return row ?? null;
   }
 
   /**

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1490,6 +1490,61 @@ describe("createAgentServer tools/list", () => {
     ).toBe(false);
   });
 
+  test("reflects a toolExposureMode change on a reused server instead of the surface frozen at build time", async ({
+    makeAgent,
+    makeMember,
+    makeOrganization,
+    makeUser,
+    seedAndAssignArchestraTools,
+  }) => {
+    const org = await makeOrganization();
+    const adminUser = await makeUser();
+    await makeMember(adminUser.id, org.id, { role: "admin" });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      toolExposureMode: "full",
+    });
+    await seedAndAssignArchestraTools(agent.id);
+
+    // The MCP-App proxy reuses a cached server across requests, so the handler
+    // must not close over the agent's exposure fields captured at build time.
+    const { server } = await createAgentServer(agent.id, {
+      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+      teamId: null,
+      isOrganizationToken: false,
+      organizationId: org.id,
+      isUserToken: true,
+      userId: adminUser.id,
+    });
+    const listToolsHandler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, TestListToolsHandler>;
+      }
+    )._requestHandlers.get("tools/list");
+    if (!listToolsHandler) {
+      throw new Error("Expected tools/list handler to be registered");
+    }
+
+    // Custom "full" surface: assigned built-ins are listed, no dispatch meta tools.
+    const before = await listToolsHandler({ method: "tools/list", params: {} });
+    const beforeNames = before.tools.map((tool) => tool.name);
+    expect(beforeNames).toContain(TOOL_TODO_WRITE_FULL_NAME);
+    expect(beforeNames).not.toContain(TOOL_RUN_TOOL_FULL_NAME);
+
+    // Switch the agent to progressive loading while the server stays cached.
+    const { AgentModel } = await import("@/models");
+    await AgentModel.update(agent.id, {
+      toolExposureMode: "search_and_run_only",
+    });
+
+    // The SAME reused server must serve the new surface, not the frozen one.
+    const after = await listToolsHandler({ method: "tools/list", params: {} });
+    const afterNames = after.tools.map((tool) => tool.name);
+    expect(afterNames).toContain(TOOL_RUN_TOOL_FULL_NAME);
+    expect(afterNames).toContain(TOOL_SEARCH_TOOLS_FULL_NAME);
+    expect(afterNames).not.toContain(TOOL_TODO_WRITE_FULL_NAME);
+  });
+
   test("keeps assigned skill and sandbox runtime tools top-level in search_and_run_only", async ({
     makeAgent,
     makeMember,

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -210,6 +210,18 @@ export async function createAgentServer(
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
+    // The MCP-App proxy reuses a cached server across requests, so the `agent`
+    // captured at build time can predate a toolExposureMode change (e.g. the
+    // switch to progressive loading in Custom→Auto). Re-read it fresh — the
+    // assigned tools below are already fetched fresh by agentId — so the list
+    // reflects the current mode. accessAllTools stays the build-time value so
+    // this list and the tools/call dynamic-access gate on the same cached server
+    // agree on it (refreshing only here would advertise dynamic tools that
+    // tools/call still rejects).
+    const surface = await AgentModel.findToolExposureModeById(agentId);
+    const toolExposureMode =
+      surface?.toolExposureMode ?? agent.toolExposureMode;
+
     // Get MCP tools (from connected MCP servers + Archestra built-in tools)
     // Excludes proxy-discovered tools
     // Fetch fresh on every request to ensure we get newly assigned tools
@@ -255,7 +267,7 @@ export async function createAgentServer(
     ).filter((tool) => !isToolRowExcluded(tool, exclusionSets));
 
     const implicitMetaTools =
-      agent.toolExposureMode === "search_and_run_only"
+      toolExposureMode === "search_and_run_only"
         ? getImplicitArchestraMetaTools()
         : [];
     const candidateTools = dedupeToolsByName(
@@ -269,7 +281,7 @@ export async function createAgentServer(
       tokenAuth?.organizationId,
     );
     const exposureFiltered = filterExposedTools({
-      toolExposureMode: agent.toolExposureMode ?? "full",
+      toolExposureMode: toolExposureMode ?? "full",
       tools: candidateTools.filter((t) => permittedNames.has(t.name)),
     });
     // render_app renders only inside Archestra's own chat (the chat frontend


### PR DESCRIPTION
## Summary

Switching an agent from **Custom** tools to **Auto** tools could leave it exposing its entire Custom tool list for up to the ~30s cache TTL, instead of the compact progressive-loading surface Auto mode is supposed to show. Two independent in-memory caches froze the pre-switch surface — the persisted agent row was always correct, so the bug only showed as a stale tool list handed to the model / MCP client.

**Chat path — `toolCache` re-poison race.** `getChatMcpTools` wrote its fetched tool set into `toolCache` unconditionally after the async gateway fetch. A fetch that started while the agent was still in Custom mode could complete *after* the mode switch fired `clearChatMcpClient()`, landing its now-stale full list back in the cache and pinning it for the TTL — so subsequent turns kept loading all tools. A per-agent surface generation counter, bumped on eviction and re-checked immediately before the write, drops these superseded writes so the next turn re-fetches the current surface.

**MCP-App proxy path — reused server froze `toolExposureMode`.** The gateway `tools/list` handler read `toolExposureMode` from the `agent` snapshot captured once at `createAgentServer` build time. On the proxy path a server instance is reused across requests, so a mode change made after the server was built was never reflected and the handler kept dumping the full menu. The handler now re-reads `toolExposureMode` fresh per request (a single indexed lookup, alongside the tool queries it already runs). `accessAllTools` deliberately stays the build-time value so `tools/list` and the `tools/call` dynamic-access gate on the same cached server continue to agree — refreshing only the list side would advertise dynamic tools that `tools/call` still rejects.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>