### PR TITLE
fix: think blocks leak to a2a chats

### DIFF
--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -201,6 +201,36 @@ describe("executeA2AMessage real stream boundary", () => {
     expect(textPart?.text).toBe("Answer. Done.");
   });
 
+  test("strips Qwen-style <think> blocks so reasoning does not leak into the A2A reply", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    primeAgent(
+      modelEmitting(
+        textChunks("<think>The user wants a task.</think>Created the task."),
+      ),
+    );
+
+    const result = await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: "conv-1",
+    });
+
+    expect(result.text).toBe("Created the task.");
+    expect(result.text).not.toContain("<think>");
+    const textPart = result.responseUiMessage.parts.find(
+      (p): p is Extract<typeof p, { type: "text" }> => p.type === "text",
+    );
+    expect(textPart?.text).toBe("Created the task.");
+  });
+
   test("substitutes a notice when a thinking-only turn strips to nothing", async ({
     makeOrganization,
     makeUser,

--- a/platform/backend/src/utils/strip-thinking-blocks.test.ts
+++ b/platform/backend/src/utils/strip-thinking-blocks.test.ts
@@ -31,4 +31,28 @@ describe("stripThinkingBlocks", () => {
   it("leaves text without blocks unchanged except for trimming", () => {
     expect(stripThinkingBlocks("plain answer")).toBe("plain answer");
   });
+
+  it("removes a `<think>` block (Qwen-style spelling)", () => {
+    expect(stripThinkingBlocks("a<think>b</think>c")).toBe("ac");
+  });
+
+  it("strips a multiline `<think>` block", () => {
+    expect(stripThinkingBlocks("a<think>line1\nline2</think>b")).toBe("ab");
+  });
+
+  it("matches the `<think>` tag case-insensitively", () => {
+    expect(stripThinkingBlocks("a<THINK>b</Think>c")).toBe("ac");
+  });
+
+  it("strips a mix of `<think>` and `<thinking>` blocks", () => {
+    expect(
+      stripThinkingBlocks(
+        "keep1<think>x</think>keep2<thinking>y</thinking>keep3",
+      ),
+    ).toBe("keep1keep2keep3");
+  });
+
+  it("returns empty when only a `<think>` block remains", () => {
+    expect(stripThinkingBlocks("  <think>all</think>  ")).toBe("");
+  });
 });

--- a/platform/backend/src/utils/strip-thinking-blocks.ts
+++ b/platform/backend/src/utils/strip-thinking-blocks.ts
@@ -1,14 +1,16 @@
 /**
- * Strip `<thinking>...</thinking>` blocks from LLM responses.
- * These are internal reasoning blocks that should not be shown to users.
+ * Strip inline reasoning blocks from LLM responses. Matches both the
+ * `<thinking>...</thinking>` spelling and the `<think>...</think>` spelling
+ * emitted by Qwen and similar models. These are internal reasoning blocks that
+ * should not leak into user-facing surfaces or A2A protocol replies.
  *
  * Uses non-greedy matching (`*?`) so multiple separate thinking blocks are
  * stripped independently without eating content between them. This assumes
- * blocks are not nested — nested `<thinking>` tags would leave the tail
- * visible, but LLMs do not produce nested thinking blocks in practice.
+ * blocks are not nested — nested thinking tags would leave the tail visible,
+ * but LLMs do not produce nested thinking blocks in practice.
  */
 export function stripThinkingBlocks(text: string): string {
-  return text.replace(/<thinking>[\s\S]*?<\/thinking>/gi, "").trim();
+  return text.replace(/<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>/gi, "").trim();
 }
 
 /**


### PR DESCRIPTION


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>