### PR TITLE
perf(ci): sticky-disk-backed local registry for MCP e2e images (spike)

### DIFF
--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -181,6 +181,48 @@ runs:
         fi
         echo "All MCP dependency images fetched successfully"
 
+    # Sticky-disk-backed local image registry for the static MCP dependency
+    # images. Serving them from a same-host registry lets the pods pull from
+    # local NVMe (via the kind.yaml containerd mirror) instead of paying the ~16s
+    # `kind load` of these three images on the merge-queue critical path. The
+    # sticky disk persists the registry's storage across runs (Blacksmith evicts
+    # after 7d of inactivity; the merge queue keeps it warm). Merge-queue/deps
+    # path only.
+    - name: Mount sticky disk for the local MCP image registry
+      if: ${{ inputs.deploy-e2e-dependencies == 'true' && inputs.e2e-dependencies-install-mode == 'foreground' }}
+      uses: useblacksmith/stickydisk@4c034ba57b706cf0e3b4b0ce098c2a3b1071580c # v1
+      with:
+        key: ${{ github.repository }}-e2e-mcp-registry
+        path: /tmp/kind-registry-data
+
+    - name: Start local MCP image registry
+      if: ${{ inputs.deploy-e2e-dependencies == 'true' && inputs.e2e-dependencies-install-mode == 'foreground' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        # registry:2 on the sticky disk, published on host :5001 and joined to the
+        # kind network as `kind-registry` (the endpoint the kind.yaml mirror maps
+        # localhost:5001 -> http://kind-registry:5000 points at).
+        if [ -z "$(docker ps -q -f 'name=^kind-registry$')" ]; then
+          docker run -d --restart=always \
+            -p 127.0.0.1:5001:5000 \
+            -v /tmp/kind-registry-data:/var/lib/registry \
+            --name kind-registry registry:2
+        fi
+        docker network connect kind kind-registry 2>/dev/null || true
+
+        # Mirror the three static MCP images into the registry (the host daemon
+        # already has them from the fetch step above). Idempotent — on a warm
+        # sticky disk the layers already exist, so re-push is near-instant.
+        push_image() {
+          local src="$1" ref="localhost:5001/$2"
+          docker tag "${src}" "${ref}"
+          docker push "${ref}"
+        }
+        push_image "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-example-oauth-server:0.0.1" "mcp-example-oauth-server:0.0.1"
+        push_image "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-jwks-keycloak:0.0.3" "mcp-server-jwks-keycloak:0.0.3"
+        push_image "europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-id-jag:0.0.4" "mcp-server-id-jag:0.0.4"
+
     # Deploy the platform-image-INDEPENDENT e2e dependency stack (Vault,
     # Keycloak, WireMock, MCP servers) HERE — before the platform image wait
     # below — so it comes up while the image build is still running instead of
@@ -203,36 +245,27 @@ runs:
         E2E_DEPS_EXTRA_HELM_SET: ${{ inputs.e2e-dependencies-extra-helm-set }}
         E2E_DEPS_WAIT_FOR_VAULT: ${{ inputs.e2e-dependencies-wait-for-vault }}
       run: |
-        MCP_OAUTH_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-example-oauth-server:0.0.1"
-        MCP_JWKS_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-jwks-keycloak:0.0.3"
-        MCP_ID_JAG_IMAGE="europe-west1-docker.pkg.dev/friendly-path-465518-r6/archestra-public/mcp-server-id-jag:0.0.4"
+        # The MCP dependency images are served from the sticky-disk-backed local
+        # registry (see "Start local MCP image registry"): point the chart at
+        # localhost:5001 so the pods pull them from local NVMe instead of us
+        # `kind load`-ing all three onto the critical path. Only the repository is
+        # overridden; the chart keeps its pinned tags.
+        E2E_DEPS_SET_FLAGS=(
+          --set mcpExampleOAuth.image.repository=localhost:5001/mcp-example-oauth-server
+          --set mcpServerJwks.image.repository=localhost:5001/mcp-server-jwks-keycloak
+          --set mcpServerIdJag.image.repository=localhost:5001/mcp-server-id-jag
+        )
 
-        echo "Loading MCP dependency images into Kind (parallel)..."
-        PIDS=()
-        for img in "${MCP_OAUTH_IMAGE}" "${MCP_JWKS_IMAGE}" "${MCP_ID_JAG_IMAGE}"; do
-          kind load docker-image "${img}" --name "${KIND_CLUSTER_NAME}" &
-          PIDS+=($!)
-        done
-        FAILED=0
-        for pid in "${PIDS[@]}"; do
-          if ! wait "$pid"; then FAILED=1; fi
-        done
-        if [ "$FAILED" -ne 0 ]; then
-          echo "One or more MCP dependency image loads into Kind failed"
-          exit 1
-        fi
-
-        # Build --set flags from comma-separated pairs (mirrors "Deploy with Helm").
-        E2E_DEPS_SET_FLAGS=""
+        # Append --set flags from comma-separated pairs (mirrors "Deploy with Helm").
         if [ -n "${E2E_DEPS_EXTRA_HELM_SET}" ]; then
           IFS=',' read -ra PAIRS <<< "${E2E_DEPS_EXTRA_HELM_SET}"
           for pair in "${PAIRS[@]}"; do
-            E2E_DEPS_SET_FLAGS="${E2E_DEPS_SET_FLAGS} --set ${pair}"
+            E2E_DEPS_SET_FLAGS+=(--set "${pair}")
           done
         fi
 
         echo "Installing e2e-tests chart (overlapping the platform image build)..."
-        helm install e2e-tests "${PLATFORM_CONTEXT}/helm/e2e-tests" ${E2E_DEPS_SET_FLAGS}
+        helm install e2e-tests "${PLATFORM_CONTEXT}/helm/e2e-tests" "${E2E_DEPS_SET_FLAGS[@]}"
 
         if [ "${E2E_DEPS_WAIT_FOR_VAULT}" = "true" ]; then
           echo "Waiting for Vault pod before platform deploy..."

--- a/.github/actions/setup-archestra-platform/action.yml
+++ b/.github/actions/setup-archestra-platform/action.yml
@@ -198,11 +198,12 @@ runs:
     - name: Start local MCP image registry
       if: ${{ inputs.deploy-e2e-dependencies == 'true' && inputs.e2e-dependencies-install-mode == 'foreground' }}
       shell: bash
+      env:
+        KIND_CLUSTER_NAME: ${{ inputs.kind-cluster-name }}
       run: |
         set -euo pipefail
         # registry:2 on the sticky disk, published on host :5001 and joined to the
-        # kind network as `kind-registry` (the endpoint the kind.yaml mirror maps
-        # localhost:5001 -> http://kind-registry:5000 points at).
+        # kind network as `kind-registry`.
         if [ -z "$(docker ps -q -f 'name=^kind-registry$')" ]; then
           docker run -d --restart=always \
             -p 127.0.0.1:5001:5000 \
@@ -210,6 +211,15 @@ runs:
             --name kind-registry registry:2
         fi
         docker network connect kind kind-registry 2>/dev/null || true
+
+        # Point each node's containerd at the in-network registry for the
+        # localhost:5001 host, via a hosts.toml under the certs.d dir configured
+        # in kind.yaml (the containerd 2.x-compatible mechanism).
+        for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+          docker exec "${node}" mkdir -p "/etc/containerd/certs.d/localhost:5001"
+          echo '[host."http://kind-registry:5000"]' \
+            | docker exec -i "${node}" cp /dev/stdin "/etc/containerd/certs.d/localhost:5001/hosts.toml"
+        done
 
         # Mirror the three static MCP images into the registry (the host daemon
         # already has them from the fetch step above). Idempotent — on a warm

--- a/.github/kind.yaml
+++ b/.github/kind.yaml
@@ -1,6 +1,17 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: archestra-ci-cluster
+# Local image registry (e2e merge-queue/deps path only): setup-archestra-platform
+# runs a registry:2 backed by a Blacksmith sticky disk, connected to the kind
+# network as `kind-registry`, pre-populated with the static MCP dependency
+# images. Those pods reference images as `localhost:5001/...` and containerd
+# resolves that to the in-network registry, so they pull from local NVMe instead
+# of being `kind load`ed. Inert on every other path: when no manifest references
+# localhost:5001 (i.e. the registry isn't set up), this mirror is never consulted.
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+      endpoint = ["http://kind-registry:5000"]
 # Uses Kind's default CNI (kindnet) which has built-in NetworkPolicy enforcement
 # since Kind v0.24.0 via kubernetes-sigs/kube-network-policies.
 # https://kind.sigs.k8s.io/docs/user/configuration/#disable-default-cni

--- a/.github/kind.yaml
+++ b/.github/kind.yaml
@@ -5,13 +5,19 @@ name: archestra-ci-cluster
 # runs a registry:2 backed by a Blacksmith sticky disk, connected to the kind
 # network as `kind-registry`, pre-populated with the static MCP dependency
 # images. Those pods reference images as `localhost:5001/...` and containerd
-# resolves that to the in-network registry, so they pull from local NVMe instead
-# of being `kind load`ed. Inert on every other path: when no manifest references
-# localhost:5001 (i.e. the registry isn't set up), this mirror is never consulted.
+# resolves that to the in-network registry (via a hosts.toml the setup action
+# writes under certs.d), so they pull from local NVMe instead of being
+# `kind load`ed.
+#
+# Use config_path (not the removed inline `registry.mirrors` syntax — containerd
+# 2.x, shipped in kindest/node v1.34, rejects it and refuses to start): it just
+# points containerd at a directory of per-registry hosts.toml files. An empty
+# directory is a no-op, so this is inert on every path where the setup action
+# doesn't write a hosts.toml.
 containerdConfigPatches:
   - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
-      endpoint = ["http://kind-registry:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
 # Uses Kind's default CNI (kindnet) which has built-in NetworkPolicy enforcement
 # since Kind v0.24.0 via kubernetes-sigs/kube-network-policies.
 # https://kind.sigs.k8s.io/docs/user/configuration/#disable-default-cni


### PR DESCRIPTION
**Spike** — the sticky-disk image cache for the static MCP e2e dependency images. Draft + `run-e2e` to battle-test the wiring.

## Idea
The three static MCP dependency images (oauth / jwks / id-jag) are `kind load`ed onto the merge-queue critical path (~16s). Serve them from a **same-host registry backed by a Blacksmith sticky disk** so the Kind node pulls them from local NVMe instead.

## Change (merge-queue/deps path only)
- **`kind.yaml`**: containerd mirror `localhost:5001` → `http://kind-registry:5000`. Inert on every path that doesn't reference `localhost:5001`, so it's safe everywhere else.
- **`setup-archestra-platform`**: mount a `useblacksmith/stickydisk`, run `registry:2` on it as `kind-registry` joined to the Kind network, mirror the three MCP images into it (persisted across runs), and point the `e2e-tests` chart at `localhost:5001/...` via `--set` instead of `kind load`.

## Honest caveats (why this is a draft)
- **Untestable locally** — sticky disks and the Kind/registry/containerd wiring only exist on Blacksmith runners, so `run-e2e` is the test. Expect a couple of iterations to shake out network/containerd details.
- **New beta dependency**: `useblacksmith/stickydisk` (pinned by SHA) must clear the repo's **Supply Chain Policy** check — that may need an allowlist entry.
- **Scope/ceiling**: only the ~16s of static-MCP `kind load` is addressed. The **bigger fish is the per-commit platform image `kind load` (~34s)**, which can't be pre-baked this way (it changes every commit) — worth a separate look (containerd-direct-pull or a build-pushed same-host registry).
- Still keeps the existing image fetch/cache (host daemon needs the images to seed the registry); a follow-up could drop that once the registry path is proven.

🤖 From the "make CI super fast" work.

https://claude.ai/code/session_01JmQgvqQcexvxA5qqpL3vJd

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>