### PR TITLE
feat(helm): enable code runtime and managed Dagger Engine by default

### DIFF
--- a/docs/pages/platform-code-sandbox.md
+++ b/docs/pages/platform-code-sandbox.md
@@ -3,7 +3,7 @@ title: Code Sandbox
 category: Agents
 order: 5
 description: A private Linux container where an agent runs code during a chat
-lastUpdated: 2026-07-05
+lastUpdated: 2026-07-06
 ---
 
 The code sandbox is a private Linux container where an agent runs code during a chat. It runs shell commands and Python, isolated from your own infrastructure — no host access, and no network beyond what the agent's [environment](./platform-environments) allows. Each conversation gets its own sandbox, created the first time the agent runs something.
@@ -30,7 +30,7 @@ Each command runs under fixed caps: 30 seconds of CPU, 1 GiB of memory, and 120 
 
 ## Enabling the Sandbox
 
-The sandbox is an admin feature, off by default. It needs two settings: `ARCHESTRA_CODE_RUNTIME_ENABLED=true` and a Dagger runner host in `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`. Without a reachable runner host, the feature stays off. See [Deployment](./platform-deployment#code-sandbox) for the full list.
+The quickstart Docker image and the Helm chart enable the sandbox by default. To turn it off, set `ARCHESTRA_CODE_RUNTIME_ENABLED=false` in Docker, or `archestra.codeRuntime.enabled=false` in Helm values. A manual deployment needs two settings: `ARCHESTRA_CODE_RUNTIME_ENABLED=true` and a Dagger runner host in `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`. Without a reachable runner host, the feature stays off. See [Deployment](./platform-deployment#code-sandbox) for the full list.
 
 Running a command needs the `sandbox:execute` permission. See [Access Control](./platform-access-control).
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -820,7 +820,7 @@ The following environment variables can be used to configure Archestra Platform.
 
 ### Code Sandbox
 
-- **`ARCHESTRA_CODE_RUNTIME_ENABLED`** - Enables the code runtime — the per-conversation [code sandbox](./platform-code-sandbox) where agents run shell commands and Python, execute skill scripts, and run agent hooks. Needs a Dagger runner host (below) to run; without one the feature stays off. When off, `run_command` and the other sandbox tools are unavailable and skills cannot execute.
+- **`ARCHESTRA_CODE_RUNTIME_ENABLED`** - Enables the code runtime — the per-conversation [code sandbox](./platform-code-sandbox) where agents run shell commands and Python, execute skill scripts, and run agent hooks. Needs a Dagger runner host (below) to run; without one the feature stays off. When off, `run_command` and the other sandbox tools are unavailable and skills cannot execute. The quickstart Docker image and the Helm chart set both variables by default; opt out with `ARCHESTRA_CODE_RUNTIME_ENABLED=false` in Docker or `archestra.codeRuntime.enabled=false` in Helm values.
   - Default: `false`
   - Values: `true`, `false`
 

--- a/platform/helm/archestra/tests/archestra_code_runtime_dagger_service_account_test.yaml
+++ b/platform/helm/archestra/tests/archestra_code_runtime_dagger_service_account_test.yaml
@@ -2,14 +2,14 @@ suite: test archestra platform -- managed Dagger ServiceAccount
 templates:
   - code-runtime-dagger-serviceaccount.yaml
 tests:
-  - it: should not create managed Dagger ServiceAccount by default
+  - it: should not create managed Dagger ServiceAccount when managed Dagger is disabled
+    set:
+      archestra.codeRuntime.dagger.managed.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: should create a tokenless ServiceAccount when managed Dagger is enabled
-    set:
-      archestra.codeRuntime.dagger.managed.enabled: true
+  - it: should create a tokenless ServiceAccount by default
     asserts:
       - isKind:
           of: ServiceAccount
@@ -25,7 +25,6 @@ tests:
 
   - it: should support managed Dagger ServiceAccount annotations
     set:
-      archestra.codeRuntime.dagger.managed.enabled: true
       archestra.codeRuntime.dagger.managed.serviceAccount.annotations:
         iam.gke.io/gcp-service-account: dagger@example.iam.gserviceaccount.com
     asserts:

--- a/platform/helm/archestra/tests/archestra_code_runtime_rbac_test.yaml
+++ b/platform/helm/archestra/tests/archestra_code_runtime_rbac_test.yaml
@@ -2,21 +2,21 @@ suite: test archestra platform -- code runtime RBAC
 templates:
   - code-runtime-rbac.yaml
 tests:
-  - it: should not create code runtime RBAC by default
+  - it: should not create code runtime RBAC when code runtime is disabled
+    set:
+      archestra.codeRuntime.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: should create narrow Dagger pod exec Role when code runtime is enabled
+  - it: should create narrow Dagger pod exec Role by default
     documentIndex: 0
-    set:
-      archestra.codeRuntime.enabled: true
     asserts:
       - isKind:
           of: Role
       - equal:
           path: metadata.namespace
-          value: dagger
+          value: NAMESPACE
       - contains:
           path: rules
           content:
@@ -32,14 +32,12 @@ tests:
 
   - it: should bind Dagger pod exec Role to the Archestra ServiceAccount
     documentIndex: 1
-    set:
-      archestra.codeRuntime.enabled: true
     asserts:
       - isKind:
           of: RoleBinding
       - equal:
           path: metadata.namespace
-          value: dagger
+          value: NAMESPACE
       - equal:
           path: subjects[0].kind
           value: ServiceAccount
@@ -53,26 +51,23 @@ tests:
   - it: should support a custom Dagger RBAC namespace
     documentIndex: 0
     set:
-      archestra.codeRuntime.enabled: true
       archestra.codeRuntime.dagger.rbac.namespace: code-runtime
     asserts:
       - equal:
           path: metadata.namespace
           value: code-runtime
 
-  - it: should use the release namespace for managed Dagger RBAC
+  - it: should use the external companion-chart namespace when managed Dagger is disabled
     documentIndex: 0
     set:
-      archestra.codeRuntime.enabled: true
-      archestra.codeRuntime.dagger.managed.enabled: true
+      archestra.codeRuntime.dagger.managed.enabled: false
     asserts:
       - equal:
           path: metadata.namespace
-          value: NAMESPACE
+          value: dagger
 
   - it: should not create code runtime RBAC for explicit TCP runner hosts
     set:
-      archestra.codeRuntime.enabled: true
       archestra.codeRuntime.dagger.runnerHost: tcp://dagger-runtime.dagger.svc.cluster.local:1234
     asserts:
       - hasDocuments:
@@ -80,7 +75,6 @@ tests:
 
   - it: should allow disabling code runtime RBAC
     set:
-      archestra.codeRuntime.enabled: true
       archestra.codeRuntime.dagger.rbac.create: false
     asserts:
       - hasDocuments:

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -432,6 +432,10 @@ tests:
               value: NAMESPACE
             - name: ARCHESTRA_ORCHESTRATOR_LOAD_KUBECONFIG_FROM_CURRENT_CLUSTER
               value: "true"
+            - name: ARCHESTRA_CODE_RUNTIME_ENABLED
+              value: "true"
+            - name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
+              value: kube-pod://dagger-runtime-engine-0?namespace=NAMESPACE&container=dagger-engine
             - name: ARCHESTRA_PROCESS_TYPE
               value: "web"
 
@@ -453,22 +457,8 @@ tests:
             name: CUSTOM_VAR
             value: "custom-value"
 
-  - it: should not set code runtime environment variables by default
+  - it: should set code runtime environment variables by default
     documentIndex: 1
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ARCHESTRA_CODE_RUNTIME_ENABLED
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
-
-  - it: should set code runtime environment variables when enabled
-    documentIndex: 1
-    set:
-      archestra.codeRuntime.enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -479,12 +469,36 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
+            value: kube-pod://dagger-runtime-engine-0?namespace=NAMESPACE&container=dagger-engine
+
+  - it: should not set code runtime environment variables when disabled
+    documentIndex: 1
+    set:
+      archestra.codeRuntime.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
+
+  - it: should target the external companion-chart namespace when managed Dagger is disabled
+    documentIndex: 1
+    set:
+      archestra.codeRuntime.dagger.managed.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
             value: kube-pod://dagger-runtime-engine-0?namespace=dagger&container=dagger-engine
 
   - it: should support custom code runtime Dagger runner host
     documentIndex: 1
     set:
-      archestra.codeRuntime.enabled: true
       archestra.codeRuntime.dagger.runnerHost: tcp://dagger-runtime.custom.svc.cluster.local:1234
     asserts:
       - contains:
@@ -493,22 +507,9 @@ tests:
             name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
             value: tcp://dagger-runtime.custom.svc.cluster.local:1234
 
-  - it: should use the release namespace for managed code runtime Dagger pod
-    documentIndex: 1
-    set:
-      archestra.codeRuntime.enabled: true
-      archestra.codeRuntime.dagger.managed.enabled: true
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
-            value: kube-pod://dagger-runtime-engine-0?namespace=NAMESPACE&container=dagger-engine
-
   - it: should support custom code runtime Dagger pod settings
     documentIndex: 1
     set:
-      archestra.codeRuntime.enabled: true
       archestra.codeRuntime.dagger.pod.name: dagger-engine-3
       archestra.codeRuntime.dagger.pod.namespace: code-runtime
       archestra.codeRuntime.dagger.pod.container: custom-engine

--- a/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_worker_deployment_test.yaml
@@ -124,9 +124,7 @@ tests:
             mountPath: /var/diagnostics
             readOnly: false
 
-  - it: worker receives code runtime environment variables when enabled
-    set:
-      archestra.codeRuntime.enabled: true
+  - it: worker receives code runtime environment variables by default
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -137,7 +135,20 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
-            value: kube-pod://dagger-runtime-engine-0?namespace=dagger&container=dagger-engine
+            value: kube-pod://dagger-runtime-engine-0?namespace=NAMESPACE&container=dagger-engine
+
+  - it: worker does not receive code runtime environment variables when disabled
+    set:
+      archestra.codeRuntime.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
 
   - it: worker sets heap snapshot env var when diagnostics heap snapshots are enabled
     set:

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -174,7 +174,9 @@ archestra:
   # ARCHESTRA_DAGGER_RUNTIME_IMAGE through archestra.env only when required.
   codeRuntime:
     # enable or disable code execution runtime support.
-    enabled: false
+    # enabled by default, backed by the managed Dagger Engine below; set to
+    # false to deploy without a code sandbox.
+    enabled: true
 
     # runtime limits (timeouts, concurrency, output caps) are env-driven via
     # ARCHESTRA_SKILLS_SANDBOX_* / ARCHESTRA_DAGGER_RUNTIME_* in archestra.env.
@@ -186,9 +188,10 @@ archestra:
       runnerHost: ""
 
       managed:
-        # deploy a Dagger Engine as part of this Helm release. When false, point
-        # dagger.pod at an externally deployed Dagger Engine pod instead.
-        enabled: false
+        # deploy a Dagger Engine as part of this Helm release (the default).
+        # When false, point dagger.pod at an externally deployed Dagger Engine
+        # pod instead. Note the engine pod is privileged.
+        enabled: true
         serviceAccount:
           # create a tokenless service account for the privileged engine pod.
           create: true


### PR DESCRIPTION
## What

- Flip `archestra.codeRuntime.enabled` and `archestra.codeRuntime.dagger.managed.enabled` to `true` in the chart defaults. A stock `helm install` now deploys the Dagger Engine StatefulSet (release namespace, `kube-pod://` transport, tokenless ServiceAccount, narrow pod-exec RBAC) and sets `ARCHESTRA_CODE_RUNTIME_ENABLED` / `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST` on the platform, worker, and migration containers — matching the quickstart Docker image, which already enables the sandbox by default.
- Opt out with `archestra.codeRuntime.enabled=false`; the external-engine path (`dagger.managed.enabled=false` + companion chart) is unchanged.
- Docs: `platform-code-sandbox.md` and `platform-deployment.md` no longer describe the sandbox as off by default in packaged deployments.

## Notes

- The managed Dagger Engine pod is privileged and memory-hungry; default installs now schedule it.

## Testing

- `helm unittest .` — 415/415 pass (default-on assertions plus new opt-out tests).
- `helm lint` clean; `helm template` on defaults renders the engine StatefulSet and the runner-host env on all Archestra containers.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>