### PR TITLE
fix(mcp-gateway): don't advertise assigned UI tools in the internal chat auto mode

### DIFF
--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1649,7 +1649,7 @@ describe("createAgentServer tools/list", () => {
     await makeMember(user.id, org.id, { role: "admin" });
     // The chat counterpart of the gateway test above: a chat agent renders an
     // app from the tool RESULT (render_app / run_tool), so an assigned UI tool
-    // must NOT be advertised — the list stays meta + always-exposed set (FR-2).
+    // must NOT be advertised — the list stays meta + always-exposed set.
     const agent = await makeAgent({
       organizationId: org.id,
       agentType: "agent",
@@ -1698,8 +1698,8 @@ describe("createAgentServer tools/list", () => {
   });
 
   // The realistic auto-mode matrix, both surfaces, for a DYNAMICALLY-reached
-  // (unassigned, accessAllTools) UI tool in search_and_run_only. Both assert
-  // current correct behavior the fix must preserve.
+  // (unassigned, accessAllTools) UI tool in search_and_run_only: the gateway
+  // advertises it (its client renders from the definition), the chat does not.
   for (const surface of [
     { agentType: "agent" as const, advertised: false },
     { agentType: "mcp_gateway" as const, advertised: true },
@@ -1979,7 +1979,7 @@ describe("createAgentServer tools/list", () => {
     await makeMember(user.id, org.id, { role: "admin" });
     // accessAllTools forces search_and_run_only. Assignment does not change the
     // chat rule: a UI tool is opened via render_app/run_tool from the result, so
-    // even an explicitly-assigned launch tool is not advertised here (FR-2).
+    // even an explicitly-assigned launch tool is not advertised here.
     const agent = await makeAgent({
       organizationId: org.id,
       accessAllTools: true,
@@ -2038,8 +2038,8 @@ describe("createAgentServer tools/list", () => {
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "admin" });
     // The other half of the chat matrix: in full mode (custom tool selection,
-    // accessAllTools off) every assigned tool is advertised (FR-2), so the fix
-    // that hides UI tools in search_and_run_only must NOT reach into full mode.
+    // accessAllTools off) every assigned tool is advertised, a UI tool included;
+    // the search_and_run_only compaction does not apply here.
     const agent = await makeAgent({
       organizationId: org.id,
       accessAllTools: false,

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1635,6 +1635,135 @@ describe("createAgentServer tools/list", () => {
     expect(byName.has("bug_tracker__list")).toBe(false);
   });
 
+  test("chat agent does NOT advertise an assigned UI tool in search_and_run_only", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeOrganization,
+    makeTool,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    // The chat counterpart of the gateway test above: a chat agent renders an
+    // app from the tool RESULT (render_app / run_tool), so an assigned UI tool
+    // must NOT be advertised — the list stays meta + always-exposed set (FR-2).
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "agent",
+      toolExposureMode: "search_and_run_only",
+    });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "bug-tracker",
+    });
+    const uiTool = await makeTool({
+      catalogId: catalog.id,
+      name: "bug_tracker__open",
+      parameters: { type: "object", properties: {} },
+      meta: {
+        _meta: { ui: { resourceUri: "ui://archestra-app/bug-tracker" } },
+      },
+    });
+    await makeAgentTool(agent.id, uiTool.id);
+
+    const { server } = await createAgentServer(agent.id, {
+      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+      teamId: null,
+      isOrganizationToken: false,
+      organizationId: org.id,
+      isUserToken: true,
+      userId: user.id,
+    });
+    const listToolsHandler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, TestListToolsHandler>;
+      }
+    )._requestHandlers.get("tools/list");
+    if (!listToolsHandler) {
+      throw new Error("Expected tools/list handler to be registered");
+    }
+    const response = await listToolsHandler({
+      method: "tools/list",
+      params: {},
+    });
+    const names = new Set(response.tools.map((tool) => tool.name));
+    // The assigned UI tool is reachable via search_tools/run_tool, not advertised.
+    expect(names.has("bug_tracker__open")).toBe(false);
+    // The meta tools stay — the model reaches the UI tool through them.
+    expect(names.has("archestra__search_tools")).toBe(true);
+    expect(names.has("archestra__run_tool")).toBe(true);
+  });
+
+  // The realistic auto-mode matrix, both surfaces, for a DYNAMICALLY-reached
+  // (unassigned, accessAllTools) UI tool in search_and_run_only. Both assert
+  // current correct behavior the fix must preserve.
+  for (const surface of [
+    { agentType: "agent" as const, advertised: false },
+    { agentType: "mcp_gateway" as const, advertised: true },
+  ]) {
+    test(`${surface.agentType} ${surface.advertised ? "advertises" : "does NOT advertise"} a dynamically-reached UI tool in search_and_run_only`, async ({
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeOrganization,
+      makeTool,
+      makeUser,
+      makeMember,
+    }) => {
+      const org = await makeOrganization();
+      const user = await makeUser();
+      await makeMember(user.id, org.id, { role: "admin" });
+      const agent = await makeAgent({
+        organizationId: org.id,
+        agentType: surface.agentType,
+        accessAllTools: true,
+        toolExposureMode: "search_and_run_only",
+      });
+      const catalog = await makeInternalMcpCatalog({
+        organizationId: org.id,
+        name: "bug-tracker",
+        serverType: "remote",
+        scope: "org",
+      });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+      // Not assigned — reached only through accessAllTools dynamic access.
+      await makeTool({
+        catalogId: catalog.id,
+        name: "bug_tracker__open",
+        parameters: { type: "object", properties: {} },
+        meta: {
+          _meta: { ui: { resourceUri: "ui://archestra-app/bug-tracker" } },
+        },
+      });
+
+      const { server } = await createAgentServer(agent.id, {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      });
+      const listToolsHandler = (
+        server.server as unknown as {
+          _requestHandlers: Map<string, TestListToolsHandler>;
+        }
+      )._requestHandlers.get("tools/list");
+      if (!listToolsHandler) {
+        throw new Error("Expected tools/list handler to be registered");
+      }
+      const response = await listToolsHandler({
+        method: "tools/list",
+        params: {},
+      });
+      const names = new Set(response.tools.map((tool) => tool.name));
+      expect(names.has("bug_tracker__open")).toBe(surface.advertised);
+    });
+  }
+
   test("Auto-tool mode: an excluded unassigned UI tool is not advertised in tools/list", async ({
     makeAgent,
     makeInternalMcpCatalog,
@@ -1835,7 +1964,7 @@ describe("createAgentServer tools/list", () => {
     expect((await listNames("mcp_gateway")).has("maps__show")).toBe(true);
   });
 
-  test("chat agent still advertises an assigned owned-app launch tool", async ({
+  test("chat agent in search_and_run_only does NOT advertise an assigned owned-app launch tool", async ({
     makeAgent,
     makeAgentTool,
     makeInternalMcpCatalog,
@@ -1848,6 +1977,9 @@ describe("createAgentServer tools/list", () => {
     const org = await makeOrganization();
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "admin" });
+    // accessAllTools forces search_and_run_only. Assignment does not change the
+    // chat rule: a UI tool is opened via render_app/run_tool from the result, so
+    // even an explicitly-assigned launch tool is not advertised here (FR-2).
     const agent = await makeAgent({
       organizationId: org.id,
       accessAllTools: true,
@@ -1866,8 +1998,67 @@ describe("createAgentServer tools/list", () => {
       parameters: { type: "object", properties: {} },
       meta: { _meta: { ui: { resourceUri: "ui://archestra-app/todo" } } },
     });
-    // Explicitly assigned — not "merely reached through dynamic access", so it
-    // stays advertised (the strip only drops the dynamic-widening entries).
+    await makeAgentTool(agent.id, openTool.id);
+
+    const { server } = await createAgentServer(agent.id, {
+      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+      teamId: null,
+      isOrganizationToken: false,
+      organizationId: org.id,
+      isUserToken: true,
+      userId: user.id,
+    });
+    const listToolsHandler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, TestListToolsHandler>;
+      }
+    )._requestHandlers.get("tools/list");
+    if (!listToolsHandler) {
+      throw new Error("Expected tools/list handler to be registered");
+    }
+    const response = await listToolsHandler({
+      method: "tools/list",
+      params: {},
+    });
+    const names = new Set(response.tools.map((tool) => tool.name));
+    expect(names.has("todo__open")).toBe(false);
+  });
+
+  test("chat agent in full mode DOES advertise an assigned owned-app launch tool", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeOrganization,
+    makeTool,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    // The other half of the chat matrix: in full mode (custom tool selection,
+    // accessAllTools off) every assigned tool is advertised (FR-2), so the fix
+    // that hides UI tools in search_and_run_only must NOT reach into full mode.
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: false,
+      toolExposureMode: "full",
+      agentType: "agent",
+    });
+    const appCatalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "todo",
+      serverType: "app",
+      scope: "org",
+    });
+    await makeMcpServer({ catalogId: appCatalog.id, scope: "org" });
+    const openTool = await makeTool({
+      catalogId: appCatalog.id,
+      name: "todo__open",
+      parameters: { type: "object", properties: {} },
+      meta: { _meta: { ui: { resourceUri: "ui://archestra-app/todo" } } },
+    });
     await makeAgentTool(agent.id, openTool.id);
 
     const { server } = await createAgentServer(agent.id, {

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -223,20 +223,34 @@ export async function createAgentServer(
     const { tools: mcpTools, exclusionSets } =
       await agentToolExclusionsService.getFilteredMcpToolsByAgent(agentId);
 
-    // A non-chat gateway serves external MCP clients that discover a UI-providing
-    // tool only from its tools/list DEFINITION (per the MCP Apps extension) and
-    // render it when called — so an all-tools gateway must widen its list with
-    // the caller's dynamically accessible UI-providing tools, which have no
-    // agent_tools row and would otherwise never be advertised. The internal chat
-    // is host and server both: it resolves a tool's ui:// resource from its own
-    // catalog when the model invokes it (render_app for owned apps, run_tool for
-    // any UI tool), so it needs no such widening — skipping it keeps the list
-    // compact instead of adding one entry per accessible app. Gated on
-    // accessAllTools (an agent without it is scoped to its assigned set) and
-    // skipped for the chat surface.
+    // A tools/list is served to one of two surfaces, and the whole gateway/chat
+    // difference lives in this policy. An internal chat (agentType "agent") is
+    // host and server both: it mounts an app from the tool RESULT — render_app
+    // for owned apps, run_tool for any UI tool — resolving the `ui://` resource
+    // from its own catalog, so it advertises render_app and NO UI-providing tool,
+    // keeping the list compact regardless of dynamic reach. An external MCP client
+    // on any other surface (mcp_gateway, legacy profile) renders only from a
+    // discovery-time tool DEFINITION (per the MCP Apps extension), so it must
+    // advertise UI-providing tools — both assigned and dynamically-reached, which
+    // have no agent_tools row — and drops render_app, which no-ops for it. The
+    // three flags are independently motivated; they coincide on agentType, the
+    // surface signal this codebase keys on throughout.
+    const surface =
+      agent.agentType === "agent"
+        ? {
+            widenDynamicUiTools: false,
+            advertiseUiTools: false,
+            keepRenderApp: true,
+          }
+        : {
+            widenDynamicUiTools: true,
+            advertiseUiTools: true,
+            keepRenderApp: false,
+          };
+
     const dynamicUiTools = (
       agent.accessAllTools &&
-      agent.agentType !== "agent" &&
+      surface.widenDynamicUiTools &&
       tokenAuth?.userId &&
       tokenAuth.organizationId
         ? await ToolModel.getMcpToolsAccessibleToUser({
@@ -270,25 +284,16 @@ export async function createAgentServer(
     );
     const exposureFiltered = filterExposedTools({
       toolExposureMode: agent.toolExposureMode ?? "full",
+      advertiseUiResourceTools: surface.advertiseUiTools,
       tools: candidateTools.filter((t) => permittedNames.has(t.name)),
     });
-    // render_app renders only inside Archestra's own chat (the chat frontend
-    // mounts the app from the tool result); on an external MCP host it renders
-    // nothing while its result text reads as success, so models keep picking
-    // it over the app's own __open launch tool — the only path that renders
-    // there. Only chat ("agent"-type) agents keep the tool: every other agent
-    // type (mcp_gateway, legacy profile) is an external connection surface.
-    // The rest of the authoring surface (scaffold/read/edit/validate) works
-    // from external clients and stays. The render_app handler itself steers
-    // external callers the same way, since run_tool can still dispatch it.
-    const permittedTools =
-      agent.agentType !== "agent"
-        ? exposureFiltered.filter(
-            (tool) =>
-              archestraMcpBranding.getToolShortName(tool.name) !==
-              TOOL_RENDER_APP_SHORT_NAME,
-          )
-        : exposureFiltered;
+    const permittedTools = surface.keepRenderApp
+      ? exposureFiltered
+      : exposureFiltered.filter(
+          (tool) =>
+            archestraMcpBranding.getToolShortName(tool.name) !==
+            TOOL_RENDER_APP_SHORT_NAME,
+        );
 
     // Resolve the backing catalogs of the assigned tools once: their names feed
     // both the search_tools description and the app launch-tool titles below.
@@ -1792,20 +1797,23 @@ export async function buildKnowledgeSourcesDescription(
 
 function filterExposedTools(params: {
   toolExposureMode: ToolExposureMode;
+  advertiseUiResourceTools: boolean;
   tools: McpListToolCandidate[];
 }) {
-  const { toolExposureMode, tools } = params;
+  const { toolExposureMode, advertiseUiResourceTools, tools } = params;
   return tools.filter((tool) => {
     // `search_and_run_only` normally hides every tool behind search_tools/run_tool,
     // but the meta tools themselves and the always-exposed skill path must stay
     // top-level. UI-providing tools (app launch tools, external ext-apps tools)
-    // must too: an MCP Apps host renders a UI only from a tool DEFINITION listed
-    // at discovery time, so a tool hidden behind search/run can never render its
-    // `ui://` resource. `full` mode hides only the meta tools.
+    // stay too ONLY on a surface that advertises them: an MCP Apps host renders a
+    // UI from a tool DEFINITION listed at discovery time, so a gateway must keep
+    // it top-level; the chat surface renders from the tool result instead, so it
+    // reaches UI tools through search_tools/run_tool and keeps its list compact.
+    // `full` mode hides only the meta tools.
     return toolExposureMode === "search_and_run_only"
       ? isArchestraMetaTool(tool.name) ||
           isAlwaysExposedTool(tool.name) ||
-          providesUiResource(tool)
+          (advertiseUiResourceTools && providesUiResource(tool))
       : !isArchestraMetaTool(tool.name);
   });
 }


### PR DESCRIPTION
## Summary

An internal chat agent switched to "auto" tool mode (`accessAllTools`, which forces `search_and_run_only`) still advertised its **assigned** UI/launch tools in the model's `tools/list` — e.g. an app's `…__open` launch tool selected earlier in "custom" mode. In `search_and_run_only`, only the two meta tools and the always-exposed set belong in the list; every other tool — an app launch tool included — is meant to be reached through `search_tools`/`run_tool`, so a leftover assigned launch tool both bloats the model's context and pulls it toward "Open X" over the compact discovery path.

The root cause: the exposure filter kept **every** UI-providing tool top-level in `search_and_run_only` regardless of surface. That rule exists so an external MCP client on a gateway — which can render an app UI only from a discovery-time tool *definition* — can discover and render it. The internal chat has no such need: it renders an app from the tool *result* when the model invokes it (`render_app` for owned apps, `run_tool` for any UI tool), so it needs no UI tool advertised at all. A prior change stripped only the dynamically-reached UI tools from chat and left the assigned ones flowing through this un-scoped branch.

This scopes UI-tool advertising to the surface. The whole gateway/chat split now reads from one per-surface policy (`{ widenDynamicUiTools, advertiseUiTools, keepRenderApp }`): the chat surface advertises no UI-providing tool in `search_and_run_only` (assigned or dynamically reached) and keeps `render_app`; every external gateway surface keeps advertising UI tools and drops `render_app` — its behavior is unchanged. `full` mode is untouched: it still advertises every assigned tool, so a custom-mode chat agent keeps listing the tools its user selected.

Net effect: an all-tools chat's `tools/list` stays compact regardless of what the agent was assigned before, while every app remains openable (owned via `render_app`, external via `search_tools`/`run_tool`), and external MCP clients on gateways keep listing and rendering apps exactly as before.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>