### PR TITLE
fix(platform): retry skopeo blob fetches when pre-baking dagger engine

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -127,7 +127,9 @@ FROM ${NODE_IMAGE} AS dagger-engine-image
 ARG TARGETARCH
 ARG DAGGER_VERSION
 RUN apk add --no-cache skopeo
-RUN skopeo copy --override-os linux --override-arch "${TARGETARCH}" \
+# --retry-times: the engine image has ~100 layers and registry.dagger.io
+# intermittently 504s on individual blob fetches, which is fatal without retries
+RUN skopeo copy --retry-times 5 --override-os linux --override-arch "${TARGETARCH}" \
         "docker://registry.dagger.io/engine:${DAGGER_VERSION}" \
         "docker-archive:/dagger-engine.tar:registry.dagger.io/engine:${DAGGER_VERSION}"
 


### PR DESCRIPTION
## Problem

The platform 1.3.0 release ([run 28805632240](https://github.com/archestra-ai/archestra/actions/runs/28805632240)) failed **three consecutive attempts** on the `Build platform (linux/arm64)` job, each time with:

```
skopeo copy ... registry.dagger.io/engine:v0.21.5
fatal msg="... fetching blob: received unexpected HTTP status: 504 Gateway Timeout"
```

Each attempt failed on a *different* small blob (16:16, 16:31, 16:38 UTC), i.e. registry.dagger.io is intermittently 504ing on individual blob fetches. The engine image has ~100 layers and `skopeo copy` aborts on the first failed fetch, so even a 1–2% registry error rate reliably kills the build.

## Fix

Add `--retry-times 5` to the `skopeo copy` that pre-bakes the Dagger engine tarball, so transient blob-fetch failures are retried instead of fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>