### PR TITLE
fix(mcp-runtime): self-heal multitenant Deployments with a drifted pod selector

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -6440,3 +6440,101 @@ describe("K8sDeployment image pull failure handling", () => {
     });
   });
 });
+
+describe("K8sDeployment selector self-heal (multitenant drift)", () => {
+  const notFound = { statusCode: 404, message: "not found" };
+
+  function makeDeployment(params: {
+    readNamespacedPod?: ReturnType<typeof vi.fn>;
+    readNamespacedDeployment: ReturnType<typeof vi.fn>;
+    deleteNamespacedDeployment?: ReturnType<typeof vi.fn>;
+  }): K8sDeployment {
+    const mockMcpServer = {
+      id: "current-install-id",
+      name: "test-server",
+      // null catalogId so getCatalogItem() short-circuits without a DB lookup;
+      // the recreate path then fails fast on missing local config, which is all
+      // we need — the assertion is that the drifted deployment was deleted first.
+      catalogId: null,
+    } as unknown as McpServer;
+
+    return new K8sDeployment({
+      mcpServer: mockMcpServer,
+      k8sApi: {
+        readNamespacedPod: params.readNamespacedPod ?? vi.fn(),
+      } as unknown as k8s.CoreV1Api,
+      k8sAppsApi: {
+        readNamespacedDeployment: params.readNamespacedDeployment,
+        deleteNamespacedDeployment:
+          params.deleteNamespacedDeployment ?? vi.fn().mockResolvedValue({}),
+      } as unknown as k8s.AppsV1Api,
+      k8sNetworkingApi: {} as k8s.NetworkingV1Api,
+      k8sAttach: {} as Attach,
+      k8sLog: {} as Log,
+      k8sExec: {} as Exec,
+      namespace: "default",
+      catalogItem: null,
+    });
+  }
+
+  // Regression: a Deployment created before the catalog-stable selector fix
+  // (#6340) keeps its old per-install `mcp-server-id` pod label while the shared
+  // Service's selector is reconciled to the catalog-stable id. The two diverge,
+  // the Service selects zero pods, and every connect/read fails ("fetch failed").
+  // A Deployment selector is immutable, so the only fix is delete + recreate.
+  test("recreates a deployment whose mcp-server-id selector drifted from the target", async () => {
+    const readNamespacedPod = vi.fn().mockRejectedValue(notFound); // no legacy bare pod
+    // 1st read: the deployment exists with a STALE selector (a different
+    // install's id). After deletion every read returns 404, which drains
+    // waitForDeploymentAbsent and sends the recreate down the create path.
+    const readNamespacedDeployment = vi
+      .fn()
+      .mockResolvedValueOnce({
+        spec: {
+          selector: { matchLabels: { "mcp-server-id": "stale-install-id" } },
+        },
+        status: { availableReplicas: 1 },
+      })
+      .mockRejectedValue(notFound);
+    const deleteNamespacedDeployment = vi.fn().mockResolvedValue({});
+
+    const deployment = makeDeployment({
+      readNamespacedPod,
+      readNamespacedDeployment,
+      deleteNamespacedDeployment,
+    });
+
+    // The recreate fails fast in this mock (no catalog/local config) — expected.
+    await expect(deployment.startOrCreateDeployment()).rejects.toThrow();
+
+    expect(deleteNamespacedDeployment).toHaveBeenCalledTimes(1);
+    expect(deleteNamespacedDeployment).toHaveBeenCalledWith(
+      expect.objectContaining({ name: deployment.k8sDeploymentName }),
+    );
+  });
+
+  describe("waitForDeploymentAbsent", () => {
+    test("resolves once the deployment returns 404", async () => {
+      const readNamespacedDeployment = vi
+        .fn()
+        .mockResolvedValueOnce({}) // still present
+        .mockRejectedValue(notFound); // then gone
+      const deployment = makeDeployment({ readNamespacedDeployment });
+
+      await expect(
+        // @ts-expect-error - exercising a private method directly
+        deployment.waitForDeploymentAbsent(5, 1),
+      ).resolves.toBeUndefined();
+    });
+
+    test("throws if the deployment never disappears", async () => {
+      const readNamespacedDeployment = vi.fn().mockResolvedValue({});
+      const deployment = makeDeployment({ readNamespacedDeployment });
+
+      await expect(
+        // @ts-expect-error - exercising a private method directly
+        deployment.waitForDeploymentAbsent(2, 1),
+      ).rejects.toThrow(/was not deleted after 2 attempts/);
+    });
+  });
+});

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -2317,6 +2317,35 @@ export default class K8sDeployment {
             namespace: this.namespace,
           });
 
+        // SELF-HEAL: a Deployment created before the catalog-stable selector fix
+        // (#6340) still labels its pods with the per-install `mcpServer.id`, while
+        // the shared Service's selector is now reconciled to the catalog-stable id
+        // (getPodSelectorServerId). For multitenant catalogs those differ, so the
+        // Service selects zero pods, has no Endpoints, and every connect/read fails
+        // with ECONNREFUSED ("fetch failed"). A Deployment's `spec.selector` is
+        // immutable, so the only way to realign the pod labels is delete+recreate.
+        const existingSelectorId =
+          existingDeployment.spec?.selector?.matchLabels?.["mcp-server-id"];
+        const desiredSelectorId = this.getSystemLabels()["mcp-server-id"];
+        if (existingSelectorId && existingSelectorId !== desiredSelectorId) {
+          logger.warn(
+            {
+              deploymentName: this.deploymentName,
+              existingSelectorId,
+              desiredSelectorId,
+            },
+            `Deployment ${this.deploymentName} has a stale mcp-server-id selector; ` +
+              "recreating it so its pod labels match the Service selector",
+          );
+          await this.k8sAppsApi.deleteNamespacedDeployment({
+            name: this.deploymentName,
+            namespace: this.namespace,
+          });
+          await this.waitForDeploymentAbsent();
+          // Recreate from scratch with the correct catalog-stable pod labels.
+          return this.startOrCreateDeployment(resolvedImagePullSecretNames);
+        }
+
         if (existingDeployment.status?.availableReplicas) {
           this.state = "running";
 
@@ -3069,6 +3098,35 @@ export default class K8sDeployment {
           ? ` (last image pull error: ${lastImagePullError})`
           : ""
       }`,
+    );
+  }
+
+  /**
+   * Poll until the Deployment is fully gone (404). Used before recreating a
+   * Deployment whose immutable selector drifted — creating the replacement while
+   * the old object is still terminating would 409 ("already exists"). Bounded so
+   * a stuck finalizer can't hang the reconcile forever.
+   */
+  private async waitForDeploymentAbsent(
+    maxAttempts = 30,
+    intervalMs = 1000,
+  ): Promise<void> {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        await this.k8sAppsApi.readNamespacedDeployment({
+          name: this.deploymentName,
+          namespace: this.namespace,
+        });
+      } catch (error: unknown) {
+        if (isK8sNotFoundError(error)) {
+          return;
+        }
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    throw new Error(
+      `Deployment ${this.deploymentName} was not deleted after ${maxAttempts} attempts`,
     );
   }
 


### PR DESCRIPTION
## Problem

PR #6340 made the shared K8s Service selector for **multitenant** MCP catalogs use the catalog-stable `mcp-server-id` (the catalog id) so every install reconciles to the same selector. However, a `Deployment`'s `spec.selector` is **immutable**.

A multitenant Deployment created **before** #6340 keeps its old per-install `mcp-server-id` pod label, while the shared Service's selector is now reconciled to the catalog id. The two diverge:

- Service selector: `mcp-server-id=<catalogId>`
- Deployment/pod label: `mcp-server-id=<perInstallId>`

→ the Service selects **zero pods**, has **no Endpoints**, and every connect/read to that server fails with `ECONNREFUSED`. For streamable-HTTP MCP apps this surfaces in the UI as **"Failed to load app" / "fetch failed"** (the backend returns the undici `fetch failed` error as a JSON-RPC error).

The `startOrCreateDeployment` "deployment already exists" path only reconciled the **Service** selector — it never touched the **Deployment**, so the drift persisted indefinitely.

## Fix

In the "deployment already exists" path, compare the existing Deployment's `mcp-server-id` selector against the catalog-stable target (`getPodSelectorServerId`). If they differ, delete and recreate the Deployment (the selector can't be patched in place). A new bounded `waitForDeploymentAbsent` helper waits for full deletion first so the recreate doesn't 409 against the terminating object.

Stale multitenant Deployments now **self-heal on the next reconcile** instead of requiring a manual delete.