### PR TITLE
feat(dagger): apply egress NetworkPolicy by default across engines

### DIFF
--- a/platform/backend/src/k8s/dagger-environment-runtime/network-policy.test.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/network-policy.test.ts
@@ -57,29 +57,64 @@ const restrictedDomains: NetworkPolicy = {
 };
 
 describe("buildDaggerEgressPolicies (reuses MCP machinery for the dagger engine)", () => {
-  it("manages nothing for an unrestricted environment", () => {
-    expect(
-      buildDaggerEgressPolicies({
-        environmentId: ENV_ID,
-        effectivePolicy: effective({
-          egressMode: "unrestricted",
-          domainPreset: "none",
-          allowedDomains: [],
-          allowedCidrs: [],
-        }),
-        capabilities: caps({}),
+  it("applies an open-egress floor for an unrestricted environment", () => {
+    const policies = buildDaggerEgressPolicies({
+      environmentId: ENV_ID,
+      effectivePolicy: effective({
+        egressMode: "unrestricted",
+        domainPreset: "none",
+        allowedDomains: [],
+        allowedCidrs: [],
       }),
-    ).toEqual([]);
+      capabilities: caps({}),
+    });
+    expect(policies).toHaveLength(1);
+    expect(policies[0].kind).toBe("NetworkPolicy");
+    const np = policies[0].object as unknown as PolicyManifest;
+
+    // scoped to the per-environment dagger engine pod
+    expect(np.spec.podSelector?.matchLabels).toEqual(
+      daggerEnginePodLabels(ENV_ID),
+    );
+    expect(np.spec.policyTypes).toEqual(["Egress"]);
+
+    const egress = np.spec.egress as Array<{
+      to?: Array<{ ipBlock?: { cidr?: string; except?: string[] } }>;
+      ports?: unknown;
+    }>;
+    const json = JSON.stringify(egress);
+    // private ranges blocked
+    expect(json).toContain("169.254.0.0/16");
+    expect(json).toContain("10.0.0.0/8");
+    expect(json).toContain("fc00::/7");
+
+    // DNS allowed to any resolver: a :53 rule with no destination selector
+    const dns = egress.find((r) => r.ports !== undefined && r.to === undefined);
+    expect(dns).toBeDefined();
+
+    // the public IPv4 rule allows ALL ports (no port cap)
+    const publicV4 = egress.find((r) =>
+      r.to?.some((t) => t.ipBlock?.cidr === "0.0.0.0/0"),
+    );
+    expect(publicV4).toBeDefined();
+    expect(publicV4?.ports).toBeUndefined();
+    expect(publicV4?.to?.[0].ipBlock?.except).toContain("169.254.0.0/16");
   });
 
-  it("manages nothing when the environment has no policy (built-in)", () => {
-    expect(
-      buildDaggerEgressPolicies({
-        environmentId: ENV_ID,
-        effectivePolicy: effective(null),
-        capabilities: caps({}),
-      }),
-    ).toEqual([]);
+  it("applies the open-egress floor when the environment has no policy (built-in)", () => {
+    const policies = buildDaggerEgressPolicies({
+      environmentId: ENV_ID,
+      effectivePolicy: effective(null),
+      capabilities: caps({}),
+    });
+    expect(policies).toHaveLength(1);
+    expect(policies[0].kind).toBe("NetworkPolicy");
+    const np = policies[0].object as unknown as PolicyManifest;
+    expect(np.spec.podSelector?.matchLabels).toEqual(
+      daggerEnginePodLabels(ENV_ID),
+    );
+    // private ranges blocked in the built-in default too
+    expect(JSON.stringify(np.spec.egress)).toContain("169.254.0.0/16");
   });
 
   it("emits a deny-all-egress NetworkPolicy for egressMode=off", () => {

--- a/platform/backend/src/k8s/dagger-environment-runtime/network-policy.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/network-policy.ts
@@ -65,16 +65,11 @@ export type DaggerEgressPolicyObject =
  * pod, given the environment's effective egress policy and the cluster's CNI
  * capabilities. Pure — performs no cluster calls — so it is unit-testable.
  *
- * Returns `[]` when the environment policy is `unrestricted` or absent (nothing
- * to manage; the engine keeps fully open egress). There is NO metadata/RFC1918
- * floor in the per-env path — unlike the chart's default engine, these pods carry
- * no egress-firewall sidecar — so an `unrestricted` environment can reach
- * link-local, RFC1918, and the cloud metadata endpoint. Confining egress is what
- * a non-`unrestricted` policy is for; `unrestricted` is an explicit allow-all
- * opt-in. Mirrors the provider precedence in
- * `K8sDeployment.applyK8sNetworkPolicy`: Cilium > GKE-FQDN > AWS > Kubernetes;
- * the GKE-FQDN path additionally emits a plain NetworkPolicy for the CIDR rules
- * (FQDN policies only carry domains).
+ * `unrestricted` (and the built-in default) get an open-egress floor: all public
+ * egress is allowed, private/link-local ranges are not. `off`/`restricted` use
+ * the shared MCP builders, mirroring the provider precedence in
+ * `K8sDeployment.applyK8sNetworkPolicy`: Cilium > GKE-FQDN > AWS > Kubernetes
+ * (the GKE-FQDN path additionally emits a plain NetworkPolicy for the CIDR rules).
  */
 export function buildDaggerEgressPolicies(params: {
   environmentId: string;
@@ -90,14 +85,20 @@ export function buildDaggerEgressPolicies(params: {
   const { environmentId, effectivePolicy, capabilities } = params;
   const clusterDnsIps = params.clusterDnsIps ?? [];
 
-  if (!shouldManageK8sNetworkPolicy(effectivePolicy)) {
-    return [];
-  }
-
   const podSelectorLabels = daggerEnginePodLabels(environmentId);
   const name = constructManagedNetworkPolicyName(
     daggerEngineDeploymentName(environmentId),
   );
+
+  if (!shouldManageK8sNetworkPolicy(effectivePolicy)) {
+    // unrestricted / built-in default: open public egress, private ranges blocked.
+    return [
+      {
+        kind: "NetworkPolicy",
+        object: buildUnrestrictedFloorPolicy({ name, podSelectorLabels }),
+      },
+    ];
+  }
 
   if (shouldUseCiliumNetworkPolicy({ effectivePolicy, capabilities })) {
     return [
@@ -157,4 +158,56 @@ export function buildDaggerEgressPolicies(params: {
       }),
     },
   ];
+}
+
+// Private/link-local ranges excluded from the open-egress floor.
+const FLOOR_DENIED_IPV4_CIDRS = [
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+  "169.254.0.0/16",
+  "100.64.0.0/10",
+  "127.0.0.0/8",
+  "0.0.0.0/32",
+];
+const FLOOR_DENIED_IPV6_CIDRS = ["::1/128", "fc00::/7", "fe80::/10"];
+
+// Open-egress floor for `unrestricted` engines: DNS + all public egress with the
+// ranges above blocked.
+function buildUnrestrictedFloorPolicy(params: {
+  name: string;
+  podSelectorLabels: Record<string, string>;
+}): k8s.V1NetworkPolicy {
+  return {
+    apiVersion: "networking.k8s.io/v1",
+    kind: "NetworkPolicy",
+    metadata: {
+      name: params.name,
+      labels: {
+        "app.kubernetes.io/managed-by": "archestra",
+        "archestra.io/resource": "dagger-egress-policy",
+      },
+    },
+    spec: {
+      podSelector: { matchLabels: params.podSelectorLabels },
+      policyTypes: ["Egress"],
+      egress: [
+        // DNS on :53 to any resolver.
+        {
+          ports: [
+            { protocol: "UDP", port: 53 as unknown as k8s.IntOrString },
+            { protocol: "TCP", port: 53 as unknown as k8s.IntOrString },
+          ],
+        },
+        {
+          to: [
+            { ipBlock: { cidr: "0.0.0.0/0", except: FLOOR_DENIED_IPV4_CIDRS } },
+          ],
+        },
+        {
+          to: [{ ipBlock: { cidr: "::/0", except: FLOOR_DENIED_IPV6_CIDRS } }],
+        },
+      ],
+    },
+  };
 }

--- a/platform/helm/archestra/templates/dagger-network-policy.yaml
+++ b/platform/helm/archestra/templates/dagger-network-policy.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.archestra.codeRuntime.dagger.managed.enabled .Values.archestra.codeRuntime.dagger.managed.networkPolicy.create }}
+---
+# Egress NetworkPolicy for the managed Dagger engine pod.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "archestra-platform.fullname" . }}-dagger-engine
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "archestra-platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dagger-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      name: {{ .Values.dagger.fullnameOverride | default "dagger-runtime" }}-engine
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+              - 100.64.0.0/10
+              - 127.0.0.0/8
+              - 0.0.0.0/32
+              {{- range .Values.archestra.codeRuntime.dagger.managed.networkPolicy.additionalDeniedCidrs }}
+              - {{ . }}
+              {{- end }}
+    {{- if .Values.archestra.codeRuntime.dagger.managed.networkPolicy.allowIpv6 }}
+    - to:
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - ::1/128
+              - fc00::/7
+              - fe80::/10
+    {{- end }}
+{{- end }}

--- a/platform/helm/archestra/tests/dagger_network_policy_test.yaml
+++ b/platform/helm/archestra/tests/dagger_network_policy_test.yaml
@@ -1,0 +1,75 @@
+suite: test archestra platform -- Dagger Engine NetworkPolicy
+templates:
+  - dagger-network-policy.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: creates the dagger engine NetworkPolicy by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.podSelector.matchLabels.name
+          value: dagger-runtime-engine
+      - equal:
+          path: spec.policyTypes
+          value:
+            - Egress
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: dagger-network-policy
+
+  - it: does not create the NetworkPolicy when disabled
+    set:
+      archestra.codeRuntime.dagger.managed.networkPolicy.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not create the NetworkPolicy when the managed engine is disabled
+    set:
+      archestra.codeRuntime.dagger.managed.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: allows DNS and all-ports public egress by default
+    asserts:
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+      - equal:
+          path: spec.egress[1].to[0].ipBlock.cidr
+          value: 0.0.0.0/0
+      - notExists:
+          path: spec.egress[1].ports
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 169.254.0.0/16
+      - lengthEqual:
+          path: spec.egress[1].to[0].ipBlock.except
+          count: 7
+
+  - it: includes additional denied CIDRs when configured
+    set:
+      archestra.codeRuntime.dagger.managed.networkPolicy.additionalDeniedCidrs:
+        - 34.118.224.0/20
+    asserts:
+      - contains:
+          path: spec.egress[1].to[0].ipBlock.except
+          content: 34.118.224.0/20
+      - lengthEqual:
+          path: spec.egress[1].to[0].ipBlock.except
+          count: 8
+
+  - it: omits IPv6 egress when allowIpv6 is false
+    set:
+      archestra.codeRuntime.dagger.managed.networkPolicy.allowIpv6: false
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 2

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -198,6 +198,15 @@ archestra:
           automountServiceAccountToken: false
           annotations: {}
 
+        networkPolicy:
+          # egress NetworkPolicy for the managed engine; on by default. Actual
+          # enforcement depends on the cluster CNI supporting NetworkPolicy.
+          create: true
+          # extra IPv4 CIDRs to block from the public egress rule (e.g. the
+          # cluster Service/Pod CIDRs when they fall outside RFC1918).
+          additionalDeniedCidrs: []
+          allowIpv6: true
+
       pod:
         # pod created by the managed Dagger subchart or companion chart.
         name: dagger-runtime-engine-0

--- a/platform/helm/dagger-runtime/Chart.yaml
+++ b/platform/helm/dagger-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: archestra-dagger-runtime
 description: Hardened Dagger runtime for Archestra code execution
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.21.5"
 
 dependencies:

--- a/platform/helm/dagger-runtime/templates/networkpolicy.yaml
+++ b/platform/helm/dagger-runtime/templates/networkpolicy.yaml
@@ -66,9 +66,6 @@ spec:
               {{- range .Values.networkPolicy.egress.additionalDeniedCidrs }}
               - {{ . }}
               {{- end }}
-      ports:
-        - protocol: TCP
-          port: 443
     {{- if .Values.networkPolicy.egress.allowIpv6 }}
     - to:
         - ipBlock:
@@ -77,9 +74,6 @@ spec:
               - ::1/128
               - fc00::/7
               - fe80::/10
-      ports:
-        - protocol: TCP
-          port: 443
     {{- end }}
     {{- with .Values.networkPolicy.egress.additionalRules }}
     {{- toYaml . | nindent 4 }}

--- a/platform/helm/dagger-runtime/tests/dagger_runtime_test.yaml
+++ b/platform/helm/dagger-runtime/tests/dagger_runtime_test.yaml
@@ -39,8 +39,19 @@ tests:
           path: spec.selector.name
           value: dagger-runtime-engine
 
-  - it: does not create NetworkPolicies by default
+  - it: creates the egress NetworkPolicy by default
     template: networkpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.podSelector.matchLabels.name
+          value: dagger-runtime-engine
+
+  - it: does not create NetworkPolicies when disabled
+    template: networkpolicy.yaml
+    set:
+      networkPolicy.create: false
     asserts:
       - hasDocuments:
           count: 0
@@ -78,10 +89,8 @@ tests:
           path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
           value: archestra-prod
 
-  - it: restricts egress to DNS and public HTTPS by default
+  - it: allows DNS and all-ports public egress by default
     template: networkpolicy.yaml
-    set:
-      networkPolicy.create: true
     asserts:
       - equal:
           path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
@@ -93,8 +102,10 @@ tests:
           path: spec.egress[0].ports[0].port
           value: 53
       - equal:
-          path: spec.egress[1].ports[0].port
-          value: 443
+          path: spec.egress[1].to[0].ipBlock.cidr
+          value: 0.0.0.0/0
+      - notExists:
+          path: spec.egress[1].ports
       - contains:
           path: spec.egress[1].to[0].ipBlock.except
           content: 169.254.0.0/16

--- a/platform/helm/dagger-runtime/values.yaml
+++ b/platform/helm/dagger-runtime/values.yaml
@@ -9,8 +9,8 @@ serviceAccount:
   automountServiceAccountToken: false
 
 networkPolicy:
-  # optional hardening only; enforcement depends on the cluster CNI.
-  create: false
+  # enforcement depends on the cluster CNI; set false to disable.
+  create: true
 
   ingress:
     # allow pods carrying these labels to reach Dagger. With no `namespace`,


### PR DESCRIPTION
---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>