### PR TITLE
fix(docker): patch CVE-2026-23949 by upgrading vendored jaraco.context to 6.1.0

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -371,6 +371,27 @@ RUN apk add --no-cache supervisor && \
            /usr/lib/python*/site-packages/setuptools/_vendor/wheel-*.dist-info \
            /usr/lib/python*/ensurepip
 
+# CVE-2026-23949: jaraco.context 5.3.0, also vendored inside py3-setuptools.
+# Unlike the vendored wheel above it can't be deleted — jaraco.text imports
+# jaraco.context at setuptools/pkg_resources import time — so replace it with
+# the fixed 6.1.0 wheel from PyPI, pinned by sha256. 6.1.0 ships jaraco/context
+# as a package directory (5.3.0 was a single context.py module), hence the
+# directory copy.
+RUN wget -O /tmp/jaraco_context-6.1.0-py3-none-any.whl \
+        "https://files.pythonhosted.org/packages/8d/48/aa685dbf1024c7bd82bede569e3a85f82c32fd3d79ba5fea578f0159571a/jaraco_context-6.1.0-py3-none-any.whl" && \
+    echo "a43b5ed85815223d0d3cfdb6d7ca0d2bc8946f28f30b6f3216bda070f68badda  /tmp/jaraco_context-6.1.0-py3-none-any.whl" | sha256sum -c - && \
+    VENDOR=$(echo /usr/lib/python3*/site-packages/setuptools/_vendor) && \
+    python3 -m zipfile -e /tmp/jaraco_context-6.1.0-py3-none-any.whl /tmp/jaraco_context && \
+    rm -rf "$VENDOR"/jaraco/context.py \
+           "$VENDOR"/jaraco/__pycache__/context.* \
+           "$VENDOR"/jaraco.context-*.dist-info && \
+    cp -r /tmp/jaraco_context/jaraco/context "$VENDOR"/jaraco/context && \
+    cp -r /tmp/jaraco_context/jaraco_context-6.1.0.dist-info "$VENDOR"/ && \
+    rm -rf /tmp/jaraco_context /tmp/jaraco_context-6.1.0-py3-none-any.whl && \
+    # sanity check: the swapped-in module must keep the setuptools import chain intact
+    python3 -c "import pkg_resources, setuptools" && \
+    supervisord --version
+
 # Create postgres directories (user already exists from postgresql package)
 RUN mkdir -p /var/lib/postgresql/data /run/postgresql && \
     chown -R postgres:postgres /var/lib/postgresql /run/postgresql


### PR DESCRIPTION
## Summary

The **Docker Image Scanning (Platform)** job is failing in the merge queue (blocking all PRs from landing) on **HIGH CVE-2026-23949** (CVSS 8.6): `jaraco-context` 5.3.0, affected range `>=5.2.0 <6.1.0`, fixed in 6.1.0.

The package is vendored inside `py3-setuptools` (`setuptools/_vendor/`), which Alpine pulls in as a dependency of `supervisor` — the same situation as the vendored `wheel` copy handled for CVE-2026-24049 in the layer above.

## Fix

Unlike the vendored `wheel` (only used for builds), `jaraco.context` **cannot simply be deleted**: `jaraco.text` imports it at `setuptools`/`pkg_resources` import time, so removal breaks the setuptools import chain (verified empirically). Instead, the vendored 5.3.0 copy is replaced with the fixed **6.1.0** wheel from PyPI:

- Downloaded from files.pythonhosted.org and **pinned by sha256** (matching the Dockerfile's existing pinned-download pattern)
- Extracted with the stdlib `zipfile` module (no pip in the runtime stage — `ensurepip` is deliberately removed)
- 6.1.0 ships `jaraco/context` as a package directory (5.3.0 was a single `context.py` module), hence the directory swap
- The old module, its `__pycache__` entry, and the 5.3.0 dist-info are all removed so the scanner sees only 6.1.0
- The same layer sanity-checks `import pkg_resources, setuptools` and `supervisord --version` so a future base-image change that breaks the swap fails the build instead of the runtime

## Verification

Replayed the exact block on the pinned `node:24-alpine3.23` base image with `supervisor` installed:
- sha256 check passes; no 5.3.0 artifacts remain (only the 6.1.0 package dir + dist-info)
- `import pkg_resources, setuptools` OK, `supervisord --version` → 4.3.0, and a full `supervisord` + `supervisorctl status` roundtrip works

The MCP Server Base image doesn't install supervisor/setuptools, so only the platform Dockerfile needs this.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>