### PR TITLE
fix(chat): sanitize foreign tool-call ids for Anthropic and Bedrock

### DIFF
--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
@@ -130,3 +130,88 @@ describe("prepareMessagesForProvider — generic and gemini providers", () => {
     );
   });
 });
+
+describe("prepareMessagesForProvider — tool-call id sanitization", () => {
+  function toolConversation(toolCallId: string): ChatMessage[] {
+    return [
+      { role: "user", parts: [{ type: "text", text: "look this up" }] },
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "search",
+            toolCallId,
+            state: "output-available",
+            input: { q: "x" },
+            output: { hits: 1 },
+          },
+        ],
+      },
+    ];
+  }
+
+  function extractToolCallId(messages: ChatMessage[]): string | undefined {
+    return messages[1].parts?.[0]?.toolCallId as string | undefined;
+  }
+
+  it.each([
+    "anthropic",
+    "bedrock",
+  ] as const)("%s: rewrites a foreign tool id into the accepted character set, deterministically", (provider) => {
+    const prepare = () =>
+      extractToolCallId(
+        prepareMessagesForProvider({
+          messages: toolConversation("functions.search:0"),
+          provider,
+        }),
+      );
+
+    const sanitized = prepare();
+    expect(sanitized).toMatch(/^[a-zA-Z0-9_-]+$/);
+    // Deterministic: the same original id maps to the same sanitized id on
+    // every request, so tool-call/result pairing survives across turns.
+    expect(prepare()).toBe(sanitized);
+  });
+
+  it("keeps already-valid tool ids untouched", () => {
+    const messages = prepareMessagesForProvider({
+      messages: toolConversation("toolu_01AbCdEfGh"),
+      provider: "anthropic",
+    });
+    expect(extractToolCallId(messages)).toBe("toolu_01AbCdEfGh");
+  });
+
+  it("two distinct raw ids that clean to the same string stay distinct", () => {
+    const first = extractToolCallId(
+      prepareMessagesForProvider({
+        messages: toolConversation("call.0"),
+        provider: "anthropic",
+      }),
+    );
+    const second = extractToolCallId(
+      prepareMessagesForProvider({
+        messages: toolConversation("call:0"),
+        provider: "anthropic",
+      }),
+    );
+    expect(first).not.toBe(second);
+  });
+
+  it("sanitizes on the anthropic-compatible (non-native) endpoint branch too", () => {
+    const messages = prepareMessagesForProvider({
+      messages: toolConversation("functions.search:0"),
+      provider: "anthropic",
+      anthropicNativeEndpoint: false,
+    });
+    expect(extractToolCallId(messages)).toMatch(/^[a-zA-Z0-9_-]+$/);
+  });
+
+  it("leaves other providers' tool ids alone", () => {
+    const messages = prepareMessagesForProvider({
+      messages: toolConversation("functions.search:0"),
+      provider: "openai",
+    });
+    expect(extractToolCallId(messages)).toBe("functions.search:0");
+  });
+});

--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   isInlineableTextMimeType,
   type SupportedProvider,
@@ -36,14 +37,18 @@ export function prepareMessagesForProvider(params: {
   const { messages, provider, anthropicNativeEndpoint = true } = params;
 
   if (provider === "anthropic" && anthropicNativeEndpoint) {
-    return messages.map(normalizeAnthropicMessageFileParts);
+    return messages
+      .map(normalizeAnthropicMessageFileParts)
+      .map(sanitizeMessageToolCallIds);
   }
 
   if (provider === "anthropic") {
     // Anthropic-compatible third-party endpoint: inline text documents as
     // decoded text (content preserved — the data: bytes are decoded into the
     // message, not dropped) so the upstream doesn't reject a `document` block.
-    return messages.map(inlineTextDocumentMessageFileParts);
+    return messages
+      .map(inlineTextDocumentMessageFileParts)
+      .map(sanitizeMessageToolCallIds);
   }
 
   if (provider === "bedrock") {
@@ -53,10 +58,51 @@ export function prepareMessagesForProvider(params: {
         ensureBedrockMessageHasContent(
           ensureBedrockUserMessageHasTextPart(message),
         ),
-      );
+      )
+      .map(sanitizeMessageToolCallIds);
   }
 
   return messages.map(inlineTextDocumentMessageFileParts);
+}
+
+// ===== Tool-call id sanitization (Anthropic / Bedrock) =====
+
+// Anthropic (tool_use.id) and Bedrock (toolUseId) both require tool ids to
+// match this pattern and reject the whole request otherwise. Ids minted by
+// other providers can violate it (e.g. containing dots or colons), and they
+// live on in a conversation's history when the user switches models — so a
+// single foreign tool call in history would permanently break the
+// conversation on these providers. Retrying can't help: the id is persisted.
+const SAFE_TOOL_CALL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function sanitizeMessageToolCallIds(message: ChatMessage): ChatMessage {
+  if (!message.parts?.length) {
+    return message;
+  }
+
+  let changed = false;
+  const parts = message.parts.map((part) => {
+    if (
+      typeof part.toolCallId !== "string" ||
+      SAFE_TOOL_CALL_ID_PATTERN.test(part.toolCallId)
+    ) {
+      return part;
+    }
+    changed = true;
+    return { ...part, toolCallId: sanitizeToolCallId(part.toolCallId) };
+  });
+
+  return changed ? { ...message, parts } : message;
+}
+
+// Deterministic, so the same original id maps to the same sanitized id on
+// every request (tool-call/tool-result pairing survives across turns). The
+// digest suffix keeps two distinct raw ids that clean to the same string
+// (e.g. "call.0" vs "call:0") from colliding.
+function sanitizeToolCallId(id: string): string {
+  const cleaned = id.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const digest = createHash("sha256").update(id).digest("hex").slice(0, 8);
+  return `${cleaned.slice(0, 40) || "tool_call"}_${digest}`;
 }
 
 // ===== Inline-as-text path (providers that reject document file parts) =====


### PR DESCRIPTION
## Summary

Anthropic (`tool_use.id`) and Bedrock (`toolUseId`) require tool ids to match `^[a-zA-Z0-9_-]+$` and reject the **entire request** with a 400 validation error otherwise. Tool-call ids minted by other providers can violate that pattern (dots, colons, etc.), and they live on in a conversation's persisted history. So after switching a conversation to an Anthropic (or Bedrock) model, a single foreign tool call earlier in the thread permanently breaks every subsequent turn — and retrying can't help, because the offending id is persisted. This has been intermittently breaking real conversations for a couple of months.

## Fix

`prepareMessagesForProvider` (the per-provider message normalization every model path funnels through — chat, agent-to-agent, and context compaction) now rewrites non-conforming tool-call ids on the `anthropic` (native **and** compatible-endpoint) and `bedrock` branches:

- Invalid characters become underscores, suffixed with a short sha256 digest of the original id
- **Deterministic**: the same original id maps to the same sanitized id on every request, so tool-call/tool-result pairing survives across turns
- **Collision-safe**: two distinct raw ids that clean to the same string (e.g. `call.0` vs `call:0`) get different digests
- Already-valid ids (e.g. Anthropic's own `toolu_…`) and all other providers are left untouched
- Only the outbound provider payload is affected — persisted history keeps the original ids

## Tests

New coverage in `prepare-for-provider.test.ts`: rewrite to the accepted character set on both anthropic and bedrock (parameterized), determinism across calls, valid ids untouched, collision-safety, the anthropic-compatible endpoint branch, and other providers left alone.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>