### PR TITLE
fix(gemini): only list Vertex AI models the project can actually invoke

### DIFF
--- a/platform/backend/src/routes/chat/model-fetchers/gemini.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/gemini.test.ts
@@ -186,6 +186,7 @@ describe("gemini model fetchers", () => {
         models: {
           list: vi.fn().mockResolvedValue(mockPager),
           get: vi.fn(),
+          countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
         },
       } as unknown as GoogleGenAI;
 
@@ -265,6 +266,7 @@ describe("gemini model fetchers", () => {
         models: {
           list: vi.fn().mockResolvedValue(mockPager),
           get: mockGet,
+          countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
         },
       } as unknown as GoogleGenAI;
 
@@ -328,6 +330,7 @@ describe("gemini model fetchers", () => {
         models: {
           list: vi.fn().mockResolvedValue(mockPager),
           get: mockGet,
+          countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
         },
       } as unknown as GoogleGenAI;
 
@@ -363,6 +366,111 @@ describe("gemini model fetchers", () => {
           displayName: "Gemini 2.5 Flash Lite",
           provider: "gemini",
         },
+      ]);
+    });
+
+    test("drops catalog models the project cannot invoke (404 access probe)", async () => {
+      const mockPager = {
+        [Symbol.asyncIterator]: async function* () {
+          for (const id of [
+            "gemini-2.5-pro",
+            "gemini-3.1-pro-preview",
+            "gemini-embedding-001",
+          ]) {
+            yield {
+              name: `publishers/google/models/${id}`,
+              version: "default",
+              tunedModelInfo: {},
+            };
+          }
+        },
+      };
+
+      const mockCountTokens = vi.fn(async ({ model }: { model: string }) => {
+        if (model === "gemini-3.1-pro-preview") {
+          // Gated preview: the catalog lists it, but the project is not
+          // allowlisted, so inference-family calls 404.
+          throw Object.assign(
+            new Error(
+              '{"error":{"code":404,"message":"Publisher Model was not found or your project does not have access to it.","status":"NOT_FOUND"}}',
+            ),
+            { status: 404 },
+          );
+        }
+        if (model === "gemini-embedding-001") {
+          // Accessible embedding models reject countTokens with a 400 while
+          // still being fully usable — they must be kept.
+          throw Object.assign(
+            new Error(
+              '{"error":{"code":400,"message":"Should provide instances for text model prediction.","status":"INVALID_ARGUMENT"}}',
+            ),
+            { status: 400 },
+          );
+        }
+        return { totalTokens: 1 };
+      });
+
+      const mockClient = {
+        models: {
+          list: vi.fn().mockResolvedValue(mockPager),
+          get: vi.fn(),
+          countTokens: mockCountTokens,
+        },
+      } as unknown as GoogleGenAI;
+
+      mockCreateGoogleGenAIClient.mockReturnValue(mockClient);
+
+      const models = await fetchGeminiModelsViaVertexAi();
+
+      expect(models.map((model) => model.id)).toEqual([
+        "gemini-2.5-pro",
+        "gemini-embedding-001",
+      ]);
+    });
+
+    test("keeps models when the access probe fails transiently (non-404)", async () => {
+      const mockPager = {
+        [Symbol.asyncIterator]: async function* () {
+          yield {
+            name: "publishers/google/models/gemini-2.5-pro",
+            version: "default",
+            tunedModelInfo: {},
+          };
+          yield {
+            name: "publishers/google/models/gemini-2.5-flash",
+            version: "default",
+            tunedModelInfo: {},
+          };
+          yield {
+            name: "publishers/google/models/gemini-embedding-001",
+            version: "default",
+            tunedModelInfo: {},
+          };
+        },
+      };
+
+      const mockClient = {
+        models: {
+          list: vi.fn().mockResolvedValue(mockPager),
+          get: vi.fn(),
+          countTokens: vi
+            .fn()
+            .mockRejectedValue(
+              Object.assign(new Error("Resource exhausted"), { status: 429 }),
+            ),
+        },
+      } as unknown as GoogleGenAI;
+
+      mockCreateGoogleGenAIClient.mockReturnValue(mockClient);
+
+      const models = await fetchGeminiModelsViaVertexAi();
+
+      // A rate-limited or otherwise transiently failing probe must not empty
+      // the catalog.
+      expect(models.map((model) => model.id)).toEqual([
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-embedding-001",
       ]);
     });
   });

--- a/platform/backend/src/routes/chat/model-fetchers/gemini.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/gemini.ts
@@ -89,7 +89,24 @@ export async function fetchGeminiModelsViaVertexAi(): Promise<ModelInfo[]> {
       !discoveredModels.some((model) => isPrimaryVertexGeminiModel(model.id)),
   });
 
-  return dedupeModelsById([...discoveredModels, ...fallbackModels]);
+  const candidateModels = dedupeModelsById([
+    ...discoveredModels,
+    ...fallbackModels,
+  ]);
+  const accessibleModels = await filterToAccessibleVertexModels({
+    ai,
+    models: candidateModels,
+  });
+
+  logger.info(
+    {
+      candidateCount: candidateModels.length,
+      accessibleCount: accessibleModels.length,
+    },
+    "Filtered Vertex AI Gemini models to those the project can access",
+  );
+
+  return accessibleModels;
 }
 
 const VERTEX_GEMINI_FALLBACK_MODEL_IDS = [
@@ -174,6 +191,60 @@ async function fetchVertexGeminiFallbackModels(params: {
   );
 
   return validatedModels;
+}
+
+/**
+ * The Vertex AI model list is the Model Garden publisher catalog, not the set
+ * of models the project can invoke: gated previews (allowlist-only) and models
+ * unavailable in the configured region are listed too, and `models.get` also
+ * succeeds for them — only an inference-family call reveals real access. Probe
+ * each candidate with `countTokens` (free — it bills nothing and generates no
+ * tokens) and drop the ones the project cannot use, so the catalog never
+ * advertises a model that would 404 on the first chat request.
+ *
+ * Only a 404 ("Publisher Model was not found or your project does not have
+ * access to it") means inaccessible. Accessible embedding models answer
+ * 400/501 to countTokens, and transient failures (429/5xx) must not empty the
+ * catalog — every non-404 outcome keeps the model.
+ */
+async function filterToAccessibleVertexModels(params: {
+  ai: ReturnType<typeof createGoogleGenAIClient>;
+  models: ModelInfo[];
+}): Promise<ModelInfo[]> {
+  const { ai, models } = params;
+
+  const probed = await Promise.all(
+    models.map(async (model) => {
+      try {
+        await ai.models.countTokens({
+          model: model.id,
+          contents: "access probe",
+        });
+        return model;
+      } catch (error) {
+        if (isVertexModelInaccessibleError(error)) {
+          logger.info(
+            { modelId: model.id },
+            "Dropping Vertex AI Gemini model the project cannot access",
+          );
+          return null;
+        }
+        return model;
+      }
+    }),
+  );
+
+  return probed.filter((model): model is ModelInfo => model !== null);
+}
+
+function isVertexModelInaccessibleError(error: unknown): boolean {
+  // The @google/genai ApiError carries the HTTP status on `.status`; fall back
+  // to the serialized response body for other error shapes.
+  const status = (error as { status?: unknown } | null)?.status;
+  if (typeof status === "number") {
+    return status === 404;
+  }
+  return error instanceof Error && /"code"\s*:\s*404/.test(error.message);
 }
 
 function dedupeModelsById(models: ModelInfo[]): ModelInfo[] {


### PR DESCRIPTION
## Problem

With Vertex AI mode enabled, `GET /models` advertises Gemini models the project can't actually use. Selecting one (e.g. `gemini-3.1-pro-preview`) fails every request with:

> Publisher Model `projects/<project>/locations/<location>/publishers/google/models/gemini-3.1-pro-preview` was not found or your project does not have access to it.

## Root cause (verified against a live Vertex project via ADC)

- `models.list()` on Vertex returns the **entire Model Garden publisher catalog** (139 entries on the test project — including bert, resnet, veo, lyria, …). Per Google's docs this is the catalog, **not** the set of models the project can invoke: Gemini 3.x preview models are **allowlist-gated per project** (access is requested through Model Garden), and non-allowlisted projects get exactly this 404 even though the model is listed.
- Our catalog filter is purely id-based (family/generation/modality), so gated previews pass through.
- `models.get()` is not a usable access check either — verified it returns OK for models the project cannot invoke (which also means the fetcher's existing fallback probe couldn't catch this).
- `countTokens` discriminates precisely: OK (or a non-404 semantic error) for every model the project can use, 404 for every gated/inaccessible one. It's also documented as **free** — bills nothing and generates no tokens.

## Fix

After listing (and the existing fallback probing), probe every candidate in parallel with `countTokens` and drop the ones that 404:

- Accessible embedding models answer 400 (`INVALID_ARGUMENT`) or 501 (`UNIMPLEMENTED`) to countTokens while being fully usable — every non-404 outcome keeps the model, so only a proven access failure drops anything and transient failures (429/5xx) can't empty the catalog.
- Probes run where the fetcher runs — system-key model sync (startup / explicit refresh), not per catalog read — so no request-path latency.

## Verification

Ran the patched fetcher against a live Vertex project (us-central1) with ADC: **15 catalog candidates → 5 usable models** (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-embedding-001`, `gemma-4-26b-a4b-it-maas`), with `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3.5-flash`, and the other gated previews dropped. Unit tests cover the 404-drop, the embedding 400-keep, and the transient-failure fail-open.

Note: models this project gains access to later (e.g. after a Model Garden allowlist approval) appear automatically on the next model sync.

Sources: [Vertex AI model versions](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions), [Gemini 3 preview allowlisting on Vertex AI](https://discuss.ai.google.dev/t/request-allowlist-access-for-gemini-3-preview-models-in-vertex-ai/135686)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>