### PR TITLE
fix(a2a): stop unbounded agent-to-agent delegation recursion

### DIFF
--- a/platform/backend/src/agents/a2a-delegation-loop.test.ts
+++ b/platform/backend/src/agents/a2a-delegation-loop.test.ts
@@ -217,7 +217,9 @@ describe("A2A delegation loop safeguards", () => {
     // Nested executes settle inside-out, so the refusal is the first to land.
     const refusals = toolResults.filter((r) => r.isError);
     expect(refusals).toHaveLength(1);
-    expect(errorText(refusals[0])).toMatch(/already in this delegation chain/i);
+    expect(errorText(refusals[0])).toMatch(
+      /already in the current delegation chain/i,
+    );
 
     expect(result.text).toBe("ok");
   });

--- a/platform/backend/src/agents/a2a-delegation-loop.test.ts
+++ b/platform/backend/src/agents/a2a-delegation-loop.test.ts
@@ -1,0 +1,295 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test harness drives the AI SDK surface
+import { AGENT_TOOL_PREFIX, slugify } from "@archestra/shared";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { describe, vi } from "vitest";
+import { executeArchestraTool } from "@/archestra-mcp-server";
+import { ToolModel } from "@/models";
+import { expect, test } from "@/test";
+import type { Agent } from "@/types";
+import { executeA2AMessage, MAX_DELEGATION_DEPTH } from "./a2a-executor";
+
+const {
+  mockStreamText,
+  mockGetChatMcpTools,
+  mockCreateLLMModelForAgent,
+  mockResolveConversationLlmSelectionForAgent,
+  mockBuildSkillCatalogPrompt,
+} = vi.hoisted(() => ({
+  mockStreamText: vi.fn(),
+  mockGetChatMcpTools: vi.fn(),
+  mockCreateLLMModelForAgent: vi.fn(),
+  mockResolveConversationLlmSelectionForAgent: vi.fn(),
+  mockBuildSkillCatalogPrompt: vi.fn(),
+}));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    streamText: (...args: unknown[]) => mockStreamText(...args),
+    stepCountIs: vi.fn(() => undefined),
+  };
+});
+
+vi.mock("@/clients/chat-mcp-client", () => ({
+  closeChatMcpClient: vi.fn(),
+  getChatMcpTools: (...args: unknown[]) => mockGetChatMcpTools(...args),
+}));
+
+vi.mock("@/clients/llm-client", () => ({
+  createLLMModelForAgent: (...args: unknown[]) =>
+    mockCreateLLMModelForAgent(...args),
+}));
+
+vi.mock("@/utils/llm-resolution", async () => {
+  const actual = await vi.importActual<typeof import("@/utils/llm-resolution")>(
+    "@/utils/llm-resolution",
+  );
+  return {
+    ...actual,
+    resolveConversationLlmSelectionForAgent: (...args: unknown[]) =>
+      mockResolveConversationLlmSelectionForAgent(...args),
+  };
+});
+
+vi.mock("@/features/browser-stream/services/browser-stream.feature", () => ({
+  browserStreamFeature: {
+    isEnabled: vi.fn().mockReturnValue(false),
+    closeTab: vi.fn(),
+  },
+}));
+
+vi.mock("@/clients/mcp-client", () => ({
+  default: { closeSession: vi.fn() },
+}));
+
+vi.mock("@/skills/skill-catalog-prompt", () => ({
+  buildSkillCatalogPrompt: (...args: unknown[]) =>
+    mockBuildSkillCatalogPrompt(...args),
+}));
+
+function renderableFullStream(): AsyncIterable<{ type: string }> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "text-delta" };
+      yield { type: "finish", finishReason: "stop" };
+    },
+  };
+}
+
+// Backstop so a regression cannot hang the suite: the harness refuses to
+// delegate past this many nested runs. Any assertion that depends on this
+// value being reached indicates the product guard did not fire.
+const HARNESS_RUNAWAY_CAP = 60;
+
+/**
+ * Wires a set of agents into a delegation graph and drives it with a model that
+ * issues exactly one delegation call per run (never a repeat, so the per-run
+ * repeat ceiling can never trip). Returns what the recursion actually did.
+ */
+function driveDelegationGraph(
+  organizationId: string,
+  /** agentId -> the single agent it delegates to */
+  nextHop: Record<string, Agent>,
+) {
+  const runs: string[] = [];
+  const toolResults: CallToolResult[] = [];
+
+  mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
+    chatApiKeyId: "org-key",
+    selectedModel: "gemini-2.5-pro",
+    selectedProvider: "gemini",
+  });
+  mockCreateLLMModelForAgent.mockImplementation(
+    async ({ externalAgentId }: any) => {
+      // externalAgentId is the delegation chain the executor just built.
+      runs.push(externalAgentId);
+      return {
+        model: { provider: "mock" },
+        provider: "gemini",
+        apiKeySource: "org",
+      };
+    },
+  );
+
+  // The real delegation tool, reached through the real executeArchestraTool ->
+  // handleDelegation. Only the MCP tool *fetch* is stubbed.
+  mockGetChatMcpTools.mockImplementation(
+    async ({ agentId, delegationChain }: any) => {
+      const target = nextHop[agentId];
+      if (!target) return {};
+      const toolName = `${AGENT_TOOL_PREFIX}${slugify(target.name)}`;
+      return {
+        [toolName]: {
+          execute: (args: any) =>
+            executeArchestraTool(toolName, args, {
+              agent: { id: agentId, name: agentId },
+              agentId,
+              organizationId,
+              delegationChain,
+            } as any),
+        },
+      };
+    },
+  );
+
+  mockStreamText.mockImplementation((cfg: any) => {
+    const entry = Object.entries(cfg.tools ?? {})[0] as
+      | [string, any]
+      | undefined;
+    const delegated =
+      entry && runs.length < HARNESS_RUNAWAY_CAP
+        ? entry[1]
+            .execute({ message: "ask the other agent for help" })
+            .then((r: CallToolResult) => {
+              toolResults.push(r);
+              return r;
+            })
+        : Promise.resolve(null);
+
+    return {
+      toUIMessageStream: vi.fn((options: any) => {
+        const responseMessage = {
+          id: `msg-${runs.length}`,
+          role: "assistant",
+          parts: [{ type: "text", text: "ok" }],
+        };
+        options?.onFinish?.({
+          messages: [responseMessage],
+          isContinuation: false,
+          isAborted: false,
+          responseMessage,
+          finishReason: "stop",
+        });
+        return new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        });
+      }),
+      fullStream: renderableFullStream(),
+      text: delegated.then(() => "ok"),
+      usage: Promise.resolve(undefined),
+      finishReason: Promise.resolve("stop"),
+    };
+  });
+
+  return { runs, toolResults };
+}
+
+function errorText(result: CallToolResult): string {
+  return (result.content[0] as any)?.text ?? "";
+}
+
+describe("A2A delegation loop safeguards", () => {
+  test("refuses to re-enter an agent already in the delegation chain", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+    makeAgentTool,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const legal = await makeInternalAgent({ name: "Legal Agent" });
+    const tech = await makeInternalAgent({ name: "Tech Agent" });
+
+    const toTech = await ToolModel.findOrCreateDelegationTool(tech.id);
+    const toLegal = await ToolModel.findOrCreateDelegationTool(legal.id);
+    await makeAgentTool(legal.id, toTech.id);
+    await makeAgentTool(tech.id, toLegal.id);
+
+    const { runs, toolResults } = driveDelegationGraph(org.id, {
+      [legal.id]: tech,
+      [tech.id]: legal,
+    });
+
+    const result = await executeA2AMessage({
+      agentId: legal.id,
+      message: "Kick things off",
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    // Legal ran, delegated to Tech, Tech tried to delegate back and was refused.
+    expect(runs).toEqual([legal.id, `${legal.id}:${tech.id}`]);
+
+    // The refusal reached the model as a recoverable tool error, not a crash.
+    // Nested executes settle inside-out, so the refusal is the first to land.
+    const refusals = toolResults.filter((r) => r.isError);
+    expect(refusals).toHaveLength(1);
+    expect(errorText(refusals[0])).toMatch(/already in this delegation chain/i);
+
+    expect(result.text).toBe("ok");
+  });
+
+  test("refuses to delegate past the depth ceiling", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+    makeAgentTool,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+
+    // A strictly linear chain of distinct agents — no cycle, so only the depth
+    // ceiling can stop it. One longer than the ceiling allows.
+    const agents: Agent[] = [];
+    for (let i = 0; i < MAX_DELEGATION_DEPTH + 1; i++) {
+      agents.push(await makeInternalAgent({ name: `Agent ${i}` }));
+    }
+    const nextHop: Record<string, Agent> = {};
+    for (let i = 0; i < agents.length - 1; i++) {
+      const tool = await ToolModel.findOrCreateDelegationTool(agents[i + 1].id);
+      await makeAgentTool(agents[i].id, tool.id);
+      nextHop[agents[i].id] = agents[i + 1];
+    }
+
+    const { runs, toolResults } = driveDelegationGraph(org.id, nextHop);
+
+    await executeA2AMessage({
+      agentId: agents[0].id,
+      message: "Kick things off",
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    // Exactly MAX_DELEGATION_DEPTH agents ran; the next hop was refused.
+    expect(runs.length).toBe(MAX_DELEGATION_DEPTH);
+    expect(runs[runs.length - 1].split(":").length).toBe(MAX_DELEGATION_DEPTH);
+
+    const refusals = toolResults.filter((r) => r.isError);
+    expect(refusals).toHaveLength(1);
+    expect(errorText(refusals[0])).toMatch(/depth limit of 5 reached/i);
+  });
+
+  test("a legitimate non-cyclic delegation still executes", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+    makeAgentTool,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const planner = await makeInternalAgent({ name: "Planner Agent" });
+    const worker = await makeInternalAgent({ name: "Worker Agent" });
+
+    const toWorker = await ToolModel.findOrCreateDelegationTool(worker.id);
+    await makeAgentTool(planner.id, toWorker.id);
+
+    // Worker has no delegation tool, so the graph terminates naturally.
+    const { runs, toolResults } = driveDelegationGraph(org.id, {
+      [planner.id]: worker,
+    });
+
+    await executeA2AMessage({
+      agentId: planner.id,
+      message: "Do the thing",
+      organizationId: org.id,
+      userId: user.id,
+    });
+
+    expect(runs).toEqual([planner.id, `${planner.id}:${worker.id}`]);
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].isError).toBe(false);
+  });
+});

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -225,12 +225,12 @@ export async function executeA2AMessage(
   const ancestors = parentDelegationChain?.split(":") ?? [];
   if (ancestors.includes(agentId)) {
     throw new DelegationLoopError(
-      `Agent ${agentId} is already in this delegation chain (${delegationChain}). Answer directly instead of delegating back to it.`,
+      "That agent is already in the current delegation chain. Answer directly instead of delegating back to it.",
     );
   }
   if (ancestors.length + 1 > MAX_DELEGATION_DEPTH) {
     throw new DelegationLoopError(
-      `Delegation depth limit of ${MAX_DELEGATION_DEPTH} reached (${delegationChain}). Answer directly instead of delegating further.`,
+      `Delegation depth limit of ${MAX_DELEGATION_DEPTH} reached. Answer directly instead of delegating further.`,
     );
   }
 

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -20,6 +20,7 @@ import {
 import { resolveAgentMaxOutputTokens } from "@/agents/agent-output-budget";
 import { MAX_AGENT_STEPS, runAgentStream } from "@/agents/agent-run-stream";
 import { buildAgentSystemPrompt } from "@/agents/agent-system-prompt";
+import { DelegationLoopError } from "@/agents/errors";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
 import { createStepContextGuard } from "@/agents/step-context-guard";
 import { subagentExecutionTracker } from "@/agents/subagent-execution-tracker";
@@ -68,6 +69,14 @@ export interface A2AAttachment {
   /** Optional filename for context */
   name?: string;
 }
+
+/**
+ * Longest delegation chain (root agent + delegated descendants) allowed before
+ * a further hop is refused. Mirrors MAX_AGENT_STEPS: a named constant, not
+ * configuration.
+ * @public exported for tests; used internally otherwise.
+ */
+export const MAX_DELEGATION_DEPTH = 5;
 
 /** @public — exported for testability */
 export interface A2AExecuteParams {
@@ -206,6 +215,24 @@ export async function executeA2AMessage(
   const delegationChain = parentDelegationChain
     ? `${parentDelegationChain}:${agentId}`
     : agentId;
+
+  // The parent chain is this run's ancestor path, so re-entering an agent
+  // already on it is a delegation cycle that would recurse until the LLM budget
+  // runs out. Both existing loop guards are per-run (a fresh step budget and a
+  // fresh repeat tracker per delegation), so neither sees it. Refuse before any
+  // I/O; `handleDelegation` turns the throw into a tool error the model can
+  // recover from. Agent ids are uuids, so ":" cannot appear inside one.
+  const ancestors = parentDelegationChain?.split(":") ?? [];
+  if (ancestors.includes(agentId)) {
+    throw new DelegationLoopError(
+      `Agent ${agentId} is already in this delegation chain (${delegationChain}). Answer directly instead of delegating back to it.`,
+    );
+  }
+  if (ancestors.length + 1 > MAX_DELEGATION_DEPTH) {
+    throw new DelegationLoopError(
+      `Delegation depth limit of ${MAX_DELEGATION_DEPTH} reached (${delegationChain}). Answer directly instead of delegating further.`,
+    );
+  }
 
   // Fetch the internal agent
   const agent = await AgentModel.findById(agentId);

--- a/platform/backend/src/agents/errors.ts
+++ b/platform/backend/src/agents/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Raised when a delegation would re-enter an agent already on the caller's
+ * ancestor path, or would exceed the delegation depth ceiling. Lives outside
+ * `a2a-executor` so the delegation tool can recognize it without importing a
+ * module that most agent tests replace with a mock.
+ */
+export class DelegationLoopError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DelegationLoopError";
+  }
+}

--- a/platform/backend/src/archestra-mcp-server/delegation.test.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.test.ts
@@ -2,6 +2,7 @@
 import { AGENT_TOOL_PREFIX, slugify } from "@archestra/shared";
 import { vi } from "vitest";
 import { ToolModel } from "@/models";
+import { ProviderError } from "@/routes/chat/errors";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { type ArchestraContext, executeArchestraTool } from ".";
@@ -259,5 +260,62 @@ describe("delegation tool execution", () => {
         parentContextIsTrusted: undefined,
       }),
     );
+  });
+});
+
+describe("delegation error propagation", () => {
+  let callerAgent: Agent;
+  let baseContext: ArchestraContext;
+  let toolName: string;
+
+  beforeEach(async ({ makeAgent, makeAgentTool }) => {
+    vi.clearAllMocks();
+    callerAgent = await makeAgent({ name: "Caller Agent" });
+    const targetAgent = await makeAgent({ name: "Target Agent" });
+    const delegationTool = await ToolModel.findOrCreateDelegationTool(
+      targetAgent.id,
+    );
+    await makeAgentTool(callerAgent.id, delegationTool.id);
+    toolName = `${AGENT_TOOL_PREFIX}${slugify(targetAgent.name)}`;
+    baseContext = {
+      agent: { id: callerAgent.id, name: callerAgent.name },
+      agentId: callerAgent.id,
+      organizationId: "org-123",
+    };
+  });
+
+  test("surfaces a subagent failure to the model as a tool error", async () => {
+    mockExecuteA2AMessage.mockRejectedValue(new Error("subagent exploded"));
+
+    const result = await executeArchestraTool(
+      toolName,
+      { message: "hello" },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain("subagent exploded");
+  });
+
+  test("rethrows a ProviderError so the parent stream reports the provider", async () => {
+    const providerError = new ProviderError({
+      message: "upstream is down",
+      authenticated: false,
+    } as any);
+    mockExecuteA2AMessage.mockRejectedValue(providerError);
+
+    await expect(
+      executeArchestraTool(toolName, { message: "hello" }, baseContext),
+    ).rejects.toBe(providerError);
+  });
+
+  test("rethrows an abort so cancellation propagates instead of becoming a tool error", async () => {
+    const abortError = new Error("The operation was aborted");
+    abortError.name = "AbortError";
+    mockExecuteA2AMessage.mockRejectedValue(abortError);
+
+    await expect(
+      executeArchestraTool(toolName, { message: "hello" }, baseContext),
+    ).rejects.toBe(abortError);
   });
 });

--- a/platform/backend/src/archestra-mcp-server/delegation.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.ts
@@ -136,6 +136,10 @@ export async function handleDelegation(
     }
   }
 
+  // The caller's ancestor path, which the executor checks for cycles. A root
+  // caller carries no chain yet, so it is the first hop.
+  const parentDelegationChain = context.delegationChain || context.agentId;
+
   try {
     // Use sessionId from context, or fall back to the conversation/execution
     // scope so delegated requests still group together in logs
@@ -161,7 +165,7 @@ export async function handleDelegation(
       userId: userId || "system",
       sessionId,
       // Pass the current delegation chain so the child can extend it
-      parentDelegationChain: context.delegationChain || context.agentId,
+      parentDelegationChain,
       // Propagate the real conversation id (absent in headless executions) and
       // the isolation scope separately: the child must never mistake an
       // execution key for a persisted conversation.
@@ -196,7 +200,7 @@ export async function handleDelegation(
         {
           agentId,
           targetAgentId: delegation.targetAgent.id,
-          delegationChain: context.delegationChain,
+          parentDelegationChain,
         },
         "Agent delegation refused to avoid a delegation loop",
       );

--- a/platform/backend/src/archestra-mcp-server/delegation.ts
+++ b/platform/backend/src/archestra-mcp-server/delegation.ts
@@ -2,6 +2,7 @@ import { AGENT_TOOL_PREFIX, slugify } from "@archestra/shared";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { executeA2AMessage } from "@/agents/a2a-executor";
+import { DelegationLoopError } from "@/agents/errors";
 import { userHasPermission } from "@/auth/utils";
 import logger from "@/logging";
 import { AgentTeamModel, ToolModel } from "@/models";
@@ -189,6 +190,17 @@ export async function handleDelegation(
         "Agent delegation was aborted",
       );
       throw error;
+    }
+    if (error instanceof DelegationLoopError) {
+      logger.info(
+        {
+          agentId,
+          targetAgentId: delegation.targetAgent.id,
+          delegationChain: context.delegationChain,
+        },
+        "Agent delegation refused to avoid a delegation loop",
+      );
+      return errorResult(error.message);
     }
     logger.error(
       { error, agentId, targetAgentId: delegation.targetAgent.id },

--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -732,6 +732,34 @@ describe("getChatMcpTools agent delegation execute pipeline", () => {
     expect(gatewayClient.listTools).toHaveBeenCalledTimes(3);
   });
 
+  test("__test.clearToolCache(cacheKey) drops every chain variant for that scope", async () => {
+    const { agent, user, org, conversation, baseParams, gatewayClient } =
+      await setupChatToolEnv();
+    await makeAssignedDelegationTool({
+      agentId: agent.id,
+      organizationId: org.id,
+      childName: "Child Worker",
+    });
+
+    await chatClient.getChatMcpTools({
+      ...baseParams,
+      delegationChain: `root-agent:${agent.id}`,
+    });
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(1);
+
+    // Scoped clearing must reclaim chain variants too, or a case leaks tool
+    // entries into the next one.
+    await chatClient.__test.clearToolCache(
+      chatClient.__test.getCacheKey(agent.id, user.id, conversation?.id),
+    );
+
+    await chatClient.getChatMcpTools({
+      ...baseParams,
+      delegationChain: `root-agent:${agent.id}`,
+    });
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(2);
+  });
+
   test("tools cached for one delegation chain never serve another chain", async () => {
     const { agent, org, baseParams } = await setupChatToolEnv();
     const { targetAgent, delegationTool } = await makeAssignedDelegationTool({

--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -760,6 +760,52 @@ describe("getChatMcpTools agent delegation execute pipeline", () => {
     expect(gatewayClient.listTools).toHaveBeenCalledTimes(2);
   });
 
+  test("clearing one scope leaves a sibling scope whose key is a string prefix of it", async () => {
+    const { agent, user, org, baseParams, gatewayClient } =
+      await setupChatToolEnv({ isolationKey: "exec-1" });
+    await makeAssignedDelegationTool({
+      agentId: agent.id,
+      organizationId: org.id,
+      childName: "Child Worker",
+    });
+
+    // "exec-1" is a string prefix of "exec-10", so a prefix delete that does not
+    // stop at the ":" separator would reclaim the sibling execution's tools too.
+    const seedClient = (key: string) =>
+      chatClient.__test.setCachedClient(
+        chatClient.__test.getCacheKey(agent.id, user.id, key),
+        gatewayClient,
+      );
+    seedClient("exec-10");
+
+    const chain = `root-agent:${agent.id}`;
+    const shortScope = {
+      ...baseParams,
+      isolationKey: "exec-1",
+      delegationChain: chain,
+    };
+    const longScope = {
+      ...baseParams,
+      isolationKey: "exec-10",
+      delegationChain: chain,
+    };
+
+    await chatClient.getChatMcpTools(shortScope);
+    await chatClient.getChatMcpTools(longScope);
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(2);
+
+    chatClient.closeChatMcpClient(agent.id, user.id, "exec-1");
+
+    // The sibling execution keeps its cached tools.
+    await chatClient.getChatMcpTools(longScope);
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(2);
+
+    // The cleared execution refetches.
+    seedClient("exec-1");
+    await chatClient.getChatMcpTools(shortScope);
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(3);
+  });
+
   test("tools cached for one delegation chain never serve another chain", async () => {
     const { agent, org, baseParams } = await setupChatToolEnv();
     const { targetAgent, delegationTool } = await makeAssignedDelegationTool({

--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -654,6 +654,49 @@ describe("getChatMcpTools agent delegation execute pipeline", () => {
     );
   });
 
+  test("a run reuses the cached tool set instead of refetching from the gateway", async () => {
+    const { agent, org, baseParams, gatewayClient } = await setupChatToolEnv();
+    await makeAssignedDelegationTool({
+      agentId: agent.id,
+      organizationId: org.id,
+      childName: "Child Worker",
+    });
+
+    const params = { ...baseParams, delegationChain: agent.id };
+    await chatClient.getChatMcpTools(params);
+    await chatClient.getChatMcpTools(params);
+
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(1);
+  });
+
+  test("clearChatMcpClient purges tool entries whose key carries a delegation chain", async () => {
+    const { agent, user, org, conversation, baseParams, gatewayClient } =
+      await setupChatToolEnv();
+    await makeAssignedDelegationTool({
+      agentId: agent.id,
+      organizationId: org.id,
+      childName: "Child Worker",
+    });
+
+    const params = {
+      ...baseParams,
+      delegationChain: `root-agent:${agent.id}`,
+    };
+    await chatClient.getChatMcpTools(params);
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(1);
+
+    // Invalidation matches tool-cache keys by their `<agentId>:` prefix, so a
+    // chain appended to the key must not push the agent id out of that prefix.
+    chatClient.clearChatMcpClient(agent.id);
+    chatClient.__test.setCachedClient(
+      chatClient.__test.getCacheKey(agent.id, user.id, conversation?.id),
+      gatewayClient,
+    );
+
+    await chatClient.getChatMcpTools(params);
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(2);
+  });
+
   test("tools cached for one delegation chain never serve another chain", async () => {
     const { agent, org, baseParams } = await setupChatToolEnv();
     const { targetAgent, delegationTool } = await makeAssignedDelegationTool({

--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -697,6 +697,41 @@ describe("getChatMcpTools agent delegation execute pipeline", () => {
     expect(gatewayClient.listTools).toHaveBeenCalledTimes(2);
   });
 
+  test("closeChatMcpClient purges tool entries for every chain in the execution", async () => {
+    const isolationKey = "headless-exec-close";
+    const { agent, user, org, baseParams, gatewayClient } =
+      await setupChatToolEnv({ isolationKey });
+    await makeAssignedDelegationTool({
+      agentId: agent.id,
+      organizationId: org.id,
+      childName: "Child Worker",
+    });
+
+    // One execution reaches this agent at two depths, so the execution owns two
+    // tool-cache entries. Cleanup must reclaim both, not just a chainless key.
+    await chatClient.getChatMcpTools({
+      ...baseParams,
+      delegationChain: agent.id,
+    });
+    await chatClient.getChatMcpTools({
+      ...baseParams,
+      delegationChain: `root-agent:${agent.id}`,
+    });
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(2);
+
+    chatClient.closeChatMcpClient(agent.id, user.id, isolationKey);
+    chatClient.__test.setCachedClient(
+      chatClient.__test.getCacheKey(agent.id, user.id, isolationKey),
+      gatewayClient,
+    );
+
+    await chatClient.getChatMcpTools({
+      ...baseParams,
+      delegationChain: agent.id,
+    });
+    expect(gatewayClient.listTools).toHaveBeenCalledTimes(3);
+  });
+
   test("tools cached for one delegation chain never serve another chain", async () => {
     const { agent, org, baseParams } = await setupChatToolEnv();
     const { targetAgent, delegationTool } = await makeAssignedDelegationTool({

--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -653,6 +653,112 @@ describe("getChatMcpTools agent delegation execute pipeline", () => {
       }),
     );
   });
+
+  test("tools cached for one delegation chain never serve another chain", async () => {
+    const { agent, org, baseParams } = await setupChatToolEnv();
+    const { targetAgent, delegationTool } = await makeAssignedDelegationTool({
+      agentId: agent.id,
+      organizationId: org.id,
+      childName: "Child Worker",
+    });
+
+    mockExecuteA2AMessage.mockResolvedValue({
+      messageId: "child-msg-1",
+      text: "child says hi",
+      finishReason: "stop",
+    });
+
+    // The same agent, at two depths of one delegation tree. Both share an
+    // isolation key, so a chain-agnostic cache would hand the second run the
+    // first run's ancestors — hiding them from the executor's cycle check.
+    const shallowChain = agent.id;
+    const deeperChain = `root-agent:middle-agent:${agent.id}`;
+
+    const shallowTools = await chatClient.getChatMcpTools({
+      ...baseParams,
+      delegationChain: shallowChain,
+    });
+    const deeperTools = await chatClient.getChatMcpTools({
+      ...baseParams,
+      delegationChain: deeperChain,
+    });
+
+    await deeperTools[delegationTool.name].execute?.(
+      { message: "do the work" },
+      execOptions("call-deep-chain"),
+    );
+    expect(mockExecuteA2AMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        agentId: targetAgent.id,
+        parentDelegationChain: deeperChain,
+      }),
+    );
+
+    // The shallow run's tools still carry their own ancestors: the two runs
+    // hold separate contexts rather than overwriting a shared one.
+    await shallowTools[delegationTool.name].execute?.(
+      { message: "do the work" },
+      execOptions("call-shallow-chain"),
+    );
+    expect(mockExecuteA2AMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        agentId: targetAgent.id,
+        parentDelegationChain: shallowChain,
+      }),
+    );
+  });
+
+  test("a delegation dispatched through run_tool carries the caller's chain", async () => {
+    const { agent, org, baseParams } = await setupChatToolEnv({
+      gatewayTools: [
+        {
+          name: getArchestraToolFullName("run_tool"),
+          description: "Run tool",
+          inputSchema: {
+            type: "object",
+            properties: {
+              tool_name: { type: "string" },
+              tool_args: { type: "object" },
+            },
+            required: ["tool_name"],
+          },
+        },
+      ],
+    });
+    const { targetAgent, delegationTool } = await makeAssignedDelegationTool({
+      agentId: agent.id,
+      organizationId: org.id,
+      childName: "Child Worker",
+    });
+
+    mockExecuteA2AMessage.mockResolvedValue({
+      messageId: "child-msg-1",
+      text: "child says hi",
+      finishReason: "stop",
+    });
+
+    const chain = `root-agent:${agent.id}`;
+    const tools = await chatClient.getChatMcpTools({
+      ...baseParams,
+      delegationChain: chain,
+    });
+    await tools[getArchestraToolFullName("run_tool")].execute?.(
+      {
+        tool_name: delegationTool.name,
+        tool_args: { message: "do the work" },
+      },
+      execOptions("call-run-tool-delegation"),
+    );
+
+    // run_tool dispatches delegations too, so its context must name the
+    // caller's ancestors — otherwise the chain restarts and cycles go unseen.
+    expect(mockExecuteA2AMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: targetAgent.id,
+        parentDelegationChain: chain,
+      }),
+    );
+  });
 });
 
 describe("getChatMcpTools approval gating", () => {

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -1245,10 +1245,8 @@ async function filterToolsByEnabledIds(
  * isolation key, so a scope owns one entry per chain, all sharing this prefix.
  */
 function deleteToolCacheScope(toolCacheKey: string): void {
-  const scoped = [...toolCache.keys()].filter(
-    (key) => key === toolCacheKey || key.startsWith(`${toolCacheKey}:`),
-  );
-  for (const key of scoped) {
-    toolCache.delete(key);
-  }
+  toolCache.delete(toolCacheKey);
+  // The separator keeps the match on a key boundary: isolation key `exec-1`
+  // must not reclaim `exec-10`'s entries.
+  toolCache.deleteByPrefix(`${toolCacheKey}:`);
 }

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -210,7 +210,7 @@ export const __test = {
   },
   async clearToolCache(cacheKey?: string) {
     if (cacheKey) {
-      toolCache.delete(`${CacheKey.ChatMcpTools}-${cacheKey}`);
+      deleteToolCacheScope(`${CacheKey.ChatMcpTools}-${cacheKey}`);
     } else {
       toolCache.clear();
     }
@@ -457,16 +457,8 @@ export function closeChatMcpClient(
     clientLastValidatedAt.delete(cacheKey);
   }
 
-  // Also clear tool cache for this conversation/execution. An execution holds
-  // one entry per delegation chain it reached this agent through, so reclaim
-  // every chain variant rather than the chainless key alone.
-  const toolCacheKey = getToolCacheKey(agentId, userId, isolationKey);
-  const chainVariants = [...toolCache.keys()].filter(
-    (key) => key === toolCacheKey || key.startsWith(`${toolCacheKey}:`),
-  );
-  for (const key of chainVariants) {
-    toolCache.delete(key);
-  }
+  // Also clear tool cache for this conversation/execution
+  deleteToolCacheScope(getToolCacheKey(agentId, userId, isolationKey));
 }
 
 /**
@@ -1245,4 +1237,18 @@ async function filterToolsByEnabledIds(
   );
 
   return filteredTools;
+}
+
+/**
+ * Deletes a scope's tool-cache entry and every per-delegation-chain variant of
+ * it. One agent can run at several depths of a delegation tree under a single
+ * isolation key, so a scope owns one entry per chain, all sharing this prefix.
+ */
+function deleteToolCacheScope(toolCacheKey: string): void {
+  const scoped = [...toolCache.keys()].filter(
+    (key) => key === toolCacheKey || key.startsWith(`${toolCacheKey}:`),
+  );
+  for (const key of scoped) {
+    toolCache.delete(key);
+  }
 }

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -457,9 +457,16 @@ export function closeChatMcpClient(
     clientLastValidatedAt.delete(cacheKey);
   }
 
-  // Also clear tool cache for this conversation/execution
+  // Also clear tool cache for this conversation/execution. An execution holds
+  // one entry per delegation chain it reached this agent through, so reclaim
+  // every chain variant rather than the chainless key alone.
   const toolCacheKey = getToolCacheKey(agentId, userId, isolationKey);
-  toolCache.delete(toolCacheKey);
+  const chainVariants = [...toolCache.keys()].filter(
+    (key) => key === toolCacheKey || key.startsWith(`${toolCacheKey}:`),
+  );
+  for (const key of chainVariants) {
+    toolCache.delete(key);
+  }
 }
 
 /**

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -187,10 +187,15 @@ function getToolCacheKey(
   agentId: string,
   userId: string,
   isolationKey?: string,
+  delegationChain?: string,
 ): `${typeof CacheKey.ChatMcpTools}-${string}` {
   const baseKey = getCacheKey(agentId, userId);
   const parts = [baseKey];
   if (isolationKey) parts.push(isolationKey);
+  // One agent can run at several depths of a delegation tree, concurrently and
+  // under one isolation key. Each depth needs its own entry: the tools close
+  // over the chain, which the executor reads to detect delegation cycles.
+  if (delegationChain) parts.push(delegationChain);
   return `${CacheKey.ChatMcpTools}-${parts.join(":")}`;
 }
 
@@ -819,7 +824,12 @@ export async function getChatMcpTools({
   repeatTracker?: ToolCallRepeatTracker;
 }): Promise<Record<string, Tool>> {
   const scopeKey = isolationKey ?? conversationId;
-  const toolCacheKey = getToolCacheKey(agentId, userId, scopeKey);
+  const toolCacheKey = getToolCacheKey(
+    agentId,
+    userId,
+    scopeKey,
+    delegationChain,
+  );
   const shouldUseToolCache = !abortSignal;
 
   // Check in-memory tool cache first (cannot use distributed cacheManager - Tool objects have execute functions)

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -217,6 +217,9 @@ export function buildMcpGatewayTool(params: {
                 abortSignal: ctx.abortSignal,
                 elicitation: ctx.elicitation,
                 contextIsTrusted: toolExecutionContext.contextIsTrusted,
+                // `run_tool` can dispatch a delegation tool, so this context
+                // needs the caller's ancestors for the executor's cycle check.
+                delegationChain: ctx.delegationChain,
                 approvalRequiredPoliciesHandled: true,
                 tokenAuth: buildTokenAuthContext({
                   mcpGwToken: ctx.mcpGwToken,


### PR DESCRIPTION
Closes #4462

## Summary

Two agents each configured to delegate to the other recurse until the LLM budget runs out. A user prompt to a "Legal Agent" that asks a "Tech Agent" for help, which asks the Legal Agent back, produces an unbounded chain of delegation calls — hundreds of LLM requests in seconds, with no user-visible stop.

`executeA2AMessage` already built a `delegationChain` of agent ids, but only ever used it as a log label. Nothing validated it. The two existing loop guards cannot see this: `stepCountIs(MAX_AGENT_STEPS)` and `ToolCallRepeatTracker` are both **per-run**, so every recursive delegation starts with a fresh 500-step budget and a fresh tracker, and a cycle that issues exactly one delegation call per run never accumulates a repeat streak.

A delegation is now refused when it would re-enter an agent already on the caller's ancestor path, or when it would exceed `MAX_DELEGATION_DEPTH`. The refusal happens before any I/O, and `handleDelegation` surfaces it to the model as a tool error — so the model is told to answer directly instead of delegating back, rather than the run failing. An operator whose agents are misconfigured now sees a bounded chain and a recovered answer instead of a drained API quota.

The guard is only as good as the chain that reaches it, and the chain was not trustworthy. The tool cache is keyed by `(agentId, userId, scopeKey)`, and the isolation key is shared across an entire delegation tree, so an agent reached at two different depths was served tools closing over the ancestors it had the *first* time. A cycle-check reading that value is blind exactly where it matters most — in headless runs (scheduled triggers, incoming email, the A2A route), which bypass no cache because they carry no abort signal, and where no user is watching to hit Stop. The delegation chain is therefore part of the tool cache key. `run_tool` can dispatch a delegation independently of the advertised tool list, so its context carries the chain too; without that, the chain restarted at the caller's own id and the guard saw nothing.

`MAX_DELEGATION_DEPTH` is a named constant rather than configuration, matching `MAX_AGENT_STEPS` and `REPEAT_CALL_TERMINATION_CEILING`.

## Scope

This bounds delegation *depth*, not aggregate spend. A single run can still fan out to many distinct agents, each with its own step budget, so a per-root delegation budget remains a separate concern. Inbound external A2A requests (`routes/a2a.ts`) start a fresh chain by design, so a cycle that leaves this platform and returns through an external agent card is not detected.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>