### PR TITLE
fix(proxy): recognize client-decorated Archestra gateway tools in auto-discovery

### DIFF
--- a/platform/backend/src/archestra-mcp-server/branding.ts
+++ b/platform/backend/src/archestra-mcp-server/branding.ts
@@ -8,6 +8,7 @@ import {
   getArchestraToolFullName,
   getArchestraToolPrefix,
   getArchestraToolShortName,
+  isLikelyArchestraToolName,
   POLICY_EVALUATED_ARCHESTRA_TOOL_SHORT_NAMES,
 } from "@archestra/shared";
 import config from "@/config";
@@ -79,6 +80,20 @@ class ArchestraMcpBranding {
 
   isToolName(toolName: string): boolean {
     return this.getToolShortName(toolName) !== null;
+  }
+
+  /**
+   * Looser recognizer for the LLM-proxy auto-discovery filter ONLY: matches
+   * gateway tool names that MCP clients have decorated with their own labels
+   * (e.g. `archestra_staging__my_mcp_gateway_1234567__run_tool`), which the
+   * strict {@link isToolName} misses. Never use for dispatch, RBAC, or policy
+   * decisions — those must stay strict.
+   */
+  isLikelyToolName(toolName: string): boolean {
+    return isLikelyArchestraToolName(toolName, {
+      ...this.identity,
+      includeDefaultPrefix: true,
+    });
   }
 
   /**

--- a/platform/backend/src/routes/proxy/utils/tools.test.ts
+++ b/platform/backend/src/routes/proxy/utils/tools.test.ts
@@ -172,6 +172,66 @@ describe("persistTools", () => {
     expect(await ToolModel.findByName("regular-tool")).not.toBeNull();
   });
 
+  test("skips client-decorated gateway tools but discovers foreign look-alikes", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "Test Agent" });
+
+    // White-labeled org: the gateway server name slugifies to `archestra_staging`.
+    archestraMcpBranding.syncFromOrganization({
+      appName: "Archestra Staging",
+      iconLogo: null,
+    });
+
+    const tools = [
+      {
+        // Client inserts its own MCP-server label between our server name and the
+        // tool short name — the shape this fix targets.
+        toolName: "archestra_staging__my_mcp_gateway_1234567__run_tool",
+        toolParameters: { type: "object" },
+        toolDescription: "decorated gateway tool",
+      },
+      {
+        // Same decoration, but under the off-brand default server name.
+        toolName: "archestra__my_mcp_gateway_1234567__search_tools",
+        toolParameters: { type: "object" },
+        toolDescription: "decorated off-brand gateway tool",
+      },
+      {
+        // A known short name behind a foreign server segment — must still be
+        // discovered (no Archestra server name present).
+        toolName: "unrelated_server__run_tool",
+        toolParameters: { type: "object" },
+        toolDescription: "foreign look-alike",
+      },
+      {
+        // A genuinely external tool — must still be discovered.
+        toolName: "custom__list_issues",
+        toolParameters: { type: "object" },
+        toolDescription: "genuine external tool",
+      },
+    ];
+
+    await persistTools(tools, agent.id);
+
+    // Decorated gateway tools are recognized as ours and NOT auto-discovered…
+    expect(
+      await ToolModel.findByName(
+        "archestra_staging__my_mcp_gateway_1234567__run_tool",
+      ),
+    ).toBeNull();
+    expect(
+      await ToolModel.findByName(
+        "archestra__my_mcp_gateway_1234567__search_tools",
+      ),
+    ).toBeNull();
+    // …while foreign look-alikes and genuine external tools still are.
+    expect(
+      await ToolModel.findByName("unrelated_server__run_tool"),
+    ).not.toBeNull();
+    expect(await ToolModel.findByName("custom__list_issues")).not.toBeNull();
+  });
+
   test("skips agent delegation tools (agent__*)", async ({ makeAgent }) => {
     const agent = await makeAgent({ name: "Test Agent" });
 

--- a/platform/backend/src/routes/proxy/utils/tools.ts
+++ b/platform/backend/src/routes/proxy/utils/tools.ts
@@ -48,17 +48,20 @@ export const persistTools = async (
   // tools, or are agent delegation tools (agent__*). Also deduplicate by tool name
   // to avoid constraint violations.
   //
-  // Built-ins are matched with `archestraMcpBranding.isToolName`, which recognizes
-  // BOTH the default `archestra__` prefix and the org's branded prefix
-  // (e.g. `archestra_staging__`). A client (including chat routed through this proxy)
-  // can hand us a built-in under the off-brand prefix; matching only the current
-  // brand would auto-discover that twin, and seeding would later promote it into the
-  // catalog as a duplicate built-in.
+  // Built-ins are matched with `archestraMcpBranding.isLikelyToolName`, the loose
+  // discovery-only recognizer. It recognizes BOTH the default `archestra__` prefix
+  // and the org's branded prefix (e.g. `archestra_staging__`), AND the same
+  // built-in when a client decorates it with its own label between the server name
+  // and the short name (e.g. `archestra_staging__my_mcp_gateway_1234567__run_tool`).
+  // A client (including chat routed through this proxy) can hand us a built-in under
+  // any of these shapes; matching only the strict prefix would auto-discover the
+  // twin, and seeding would later promote it into the catalog as a duplicate
+  // built-in.
   const seenToolNames = new Set<string>();
   const toolsToAutoDiscover = tools.filter(({ toolName }) => {
     if (
       existingToolNamesSet.has(toolName) ||
-      archestraMcpBranding.isToolName(toolName) ||
+      archestraMcpBranding.isLikelyToolName(toolName) ||
       isAgentTool(toolName) ||
       seenToolNames.has(toolName)
     ) {
@@ -77,7 +80,7 @@ export const persistTools = async (
         existingToolNamesSet.has(t.toolName),
       ).length,
       skippedArchestraTools: tools.filter((t) =>
-        archestraMcpBranding.isToolName(t.toolName),
+        archestraMcpBranding.isLikelyToolName(t.toolName),
       ).length,
       skippedAgentTools: tools.filter((t) => isAgentTool(t.toolName)).length,
     },

--- a/platform/shared/archestra-mcp-server.test.ts
+++ b/platform/shared/archestra-mcp-server.test.ts
@@ -11,6 +11,7 @@ import {
   getCreationDefaultArchestraToolShortNames,
   isAlwaysExposedArchestraToolShortName,
   isArchestraMcpServerTool,
+  isLikelyArchestraToolName,
   PROJECTS_FILE_ARCHESTRA_TOOL_SHORT_NAMES,
   parseArchestraAppResourceUri,
   SANDBOX_RUNTIME_ARCHESTRA_TOOL_SHORT_NAMES,
@@ -190,6 +191,54 @@ describe("archestra MCP tool names", () => {
     ]) {
       expect(isAlwaysExposedArchestraToolShortName(shortName)).toBe(false);
     }
+  });
+});
+
+describe("isLikelyArchestraToolName (loose auto-discovery matcher)", () => {
+  test("matches the canonical default and branded prefixes", () => {
+    expect(isLikelyArchestraToolName("archestra__run_tool")).toBe(true);
+
+    const branding = { appName: "Acme Copilot", fullWhiteLabeling: true };
+    const branded = getArchestraToolFullName("run_tool", branding);
+    expect(isLikelyArchestraToolName(branded, branding)).toBe(true);
+  });
+
+  test("matches names a client decorated between the server name and short name", () => {
+    // Branded server name slugifies to `archestra_staging`; the client appends
+    // its own MCP-server label before the tool short name.
+    const branding = { appName: "Archestra Staging", fullWhiteLabeling: true };
+    expect(
+      isLikelyArchestraToolName(
+        "archestra_staging__my_mcp_gateway_1234567__run_tool",
+        branding,
+      ),
+    ).toBe(true);
+    // The off-brand default server name is still recognized under decoration.
+    expect(
+      isLikelyArchestraToolName(
+        "archestra__my_mcp_gateway_1234567__search_tools",
+        branding,
+      ),
+    ).toBe(true);
+  });
+
+  test("does NOT match a bare short name with no server segment", () => {
+    expect(isLikelyArchestraToolName("run_tool")).toBe(false);
+  });
+
+  test("does NOT match a known short name behind a foreign server segment", () => {
+    expect(isLikelyArchestraToolName("unrelated_server__run_tool")).toBe(false);
+    // Decorated, but no allowed server name anywhere in the segments.
+    expect(
+      isLikelyArchestraToolName(
+        "custom_client_id__mcp-server-my_mcp_gateway__run_tool",
+      ),
+    ).toBe(false);
+  });
+
+  test("does NOT match a genuinely foreign tool whose tail is not a short name", () => {
+    expect(isLikelyArchestraToolName("archestra__list_issues")).toBe(false);
+    expect(isLikelyArchestraToolName("custom__list_issues")).toBe(false);
   });
 });
 

--- a/platform/shared/archestra-mcp-server.ts
+++ b/platform/shared/archestra-mcp-server.ts
@@ -713,6 +713,68 @@ export function getArchestraToolShortName(
   return rawToolName;
 }
 
+/**
+ * Looser sibling of {@link isArchestraMcpServerTool} for the LLM-proxy
+ * auto-discovery filter ONLY — never for tool dispatch, RBAC, or policy
+ * evaluation, which must stay strict (use {@link getArchestraToolShortName}).
+ *
+ * Real MCP clients decorate our gateway tool names with their own labels, e.g.
+ * `archestra_staging__my_mcp_gateway_1234567__run_tool`, where the client
+ * inserts its own MCP-server label between our server name and the tool's short
+ * name. The strict parser splits on the LAST `__` and requires everything
+ * before it to be exactly an allowed server name, so it misses these decorated
+ * twins and they get re-recorded as "discovered" proxy tools — duplicates of
+ * tools we already serve.
+ *
+ * This matcher returns true when, after splitting the full name on
+ * {@link MCP_SERVER_TOOL_NAME_SEPARATOR}:
+ *  1. the trailing segment(s) form a known Archestra tool short name, AND
+ *  2. some earlier segment equals one of the allowed server names (the default
+ *     `archestra` or the org's branded name).
+ *
+ * Bare short names (`run_tool` with no server segment) are intentionally NOT
+ * matched — an unrelated external MCP server could legitimately expose a tool
+ * with the same short name, and there is no server segment to disambiguate.
+ */
+export function isLikelyArchestraToolName(
+  toolName: string,
+  options?: ArchestraMcpIdentityOptions & { includeDefaultPrefix?: boolean },
+): boolean {
+  // The canonical `<server>__<short>` shape is already covered strictly.
+  if (getArchestraToolShortName(toolName, options) !== null) {
+    return true;
+  }
+
+  const segments = toolName.split(MCP_SERVER_TOOL_NAME_SEPARATOR);
+  // Need at least a server segment plus a short-name segment.
+  if (segments.length < 2) {
+    return false;
+  }
+
+  const allowedServerNames = getAllowedServerNames(options);
+
+  // Longest-match the trailing segment(s) against a known short name so a short
+  // name that ever contains `__` still matches. `tailStart >= 1` guarantees at
+  // least one preceding segment to carry the server name, which also excludes
+  // bare short names.
+  for (let tailStart = 1; tailStart < segments.length; tailStart++) {
+    const candidateShortName = segments
+      .slice(tailStart)
+      .join(MCP_SERVER_TOOL_NAME_SEPARATOR);
+    if (!isArchestraToolShortName(candidateShortName)) {
+      continue;
+    }
+    const precedesShortName = segments
+      .slice(0, tailStart)
+      .some((segment) => allowedServerNames.has(segment));
+    if (precedesShortName) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function getArchestraToolFullName<
   ShortName extends ArchestraToolShortName,
 >(shortName: ShortName): ArchestraToolFullName<ShortName>;
@@ -785,6 +847,22 @@ function parseArchestraToolName(params: {
   const rawToolName = toolName.slice(
     separatorIndex + MCP_SERVER_TOOL_NAME_SEPARATOR.length,
   );
+
+  if (!getAllowedServerNames(options).has(serverName)) {
+    return { serverName: null, toolName: rawToolName };
+  }
+
+  return { serverName, toolName: rawToolName };
+}
+
+/**
+ * Server names accepted as "one of ours": the org's (possibly branded) server
+ * name, plus the default `archestra` unless the caller opts out via
+ * `includeDefaultPrefix: false`.
+ */
+function getAllowedServerNames(
+  options?: ArchestraMcpIdentityOptions & { includeDefaultPrefix?: boolean },
+): Set<string> {
   const allowedServerNames = new Set<string>([
     getArchestraMcpServerName(options),
   ]);
@@ -793,9 +871,5 @@ function parseArchestraToolName(params: {
     allowedServerNames.add(ARCHESTRA_MCP_SERVER_NAME);
   }
 
-  if (!allowedServerNames.has(serverName)) {
-    return { serverName: null, toolName: rawToolName };
-  }
-
-  return { serverName, toolName: rawToolName };
+  return allowedServerNames;
 }

--- a/platform/shared/archestra-mcp-server.ts
+++ b/platform/shared/archestra-mcp-server.ts
@@ -751,12 +751,12 @@ export function isLikelyArchestraToolName(
     return false;
   }
 
-  const allowedServerNames = getAllowedServerNames(options);
-
-  // Longest-match the trailing segment(s) against a known short name so a short
-  // name that ever contains `__` still matches. `tailStart >= 1` guarantees at
-  // least one preceding segment to carry the server name, which also excludes
-  // bare short names.
+  // Try each trailing-segment span as a candidate short name (from the longest
+  // tail down to the last segment alone), requiring an allowed server name in
+  // the segments that precede it. `tailStart >= 1` guarantees at least one
+  // preceding segment to carry the server name, which also excludes bare short
+  // names. This is a membership test, not a disambiguation: any matching span
+  // wins, so the iteration order does not affect the result.
   for (let tailStart = 1; tailStart < segments.length; tailStart++) {
     const candidateShortName = segments
       .slice(tailStart)
@@ -766,7 +766,7 @@ export function isLikelyArchestraToolName(
     }
     const precedesShortName = segments
       .slice(0, tailStart)
-      .some((segment) => allowedServerNames.has(segment));
+      .some((segment) => isAllowedServerName(segment, options));
     if (precedesShortName) {
       return true;
     }
@@ -848,7 +848,7 @@ function parseArchestraToolName(params: {
     separatorIndex + MCP_SERVER_TOOL_NAME_SEPARATOR.length,
   );
 
-  if (!getAllowedServerNames(options).has(serverName)) {
+  if (!isAllowedServerName(serverName, options)) {
     return { serverName: null, toolName: rawToolName };
   }
 
@@ -856,20 +856,18 @@ function parseArchestraToolName(params: {
 }
 
 /**
- * Server names accepted as "one of ours": the org's (possibly branded) server
- * name, plus the default `archestra` unless the caller opts out via
- * `includeDefaultPrefix: false`.
+ * Whether `serverName` is accepted as "one of ours": the org's (possibly
+ * branded) server name, or the default `archestra` unless the caller opts out
+ * via `includeDefaultPrefix: false`. A direct comparison rather than a Set —
+ * it runs on every tool-name parse, so it must not allocate.
  */
-function getAllowedServerNames(
+function isAllowedServerName(
+  serverName: string,
   options?: ArchestraMcpIdentityOptions & { includeDefaultPrefix?: boolean },
-): Set<string> {
-  const allowedServerNames = new Set<string>([
-    getArchestraMcpServerName(options),
-  ]);
-
-  if (options?.includeDefaultPrefix !== false) {
-    allowedServerNames.add(ARCHESTRA_MCP_SERVER_NAME);
-  }
-
-  return allowedServerNames;
+): boolean {
+  return (
+    serverName === getArchestraMcpServerName(options) ||
+    (options?.includeDefaultPrefix !== false &&
+      serverName === ARCHESTRA_MCP_SERVER_NAME)
+  );
 }


### PR DESCRIPTION
The LLM-proxy auto-discovery filter skipped our own gateway tools only when they arrived under the exact `<server>__<short>` shape (default `archestra` or the org's branded server name). Real MCP clients decorate tool names with their own labels — e.g. `archestra_staging__my_mcp_gateway_1234567__run_tool` — so the strict parser (splits on the last `__`) missed the twin and re-recorded it as a discovered proxy tool, duplicating a tool we already serve.

Add a loose, discovery-only matcher `isLikelyArchestraToolName` (shared) exposed via `archestraMcpBranding.isLikelyToolName`: a name is ours when a trailing segment is a known Archestra short name AND some earlier segment equals an allowed server name. Dispatch, RBAC, and policy paths keep the strict parser untouched.

Decisions: bare short names (`run_tool`) are not matched (foreign servers could expose the same name); names carrying only a gateway label but no Archestra server segment stay out of scope; cleanup of already-polluted rows is deferred to a separate reviewable migration.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>