### PR TITLE
fix(chat): run a tool the user approved instead of dropping it

### DIFF
--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -741,7 +741,7 @@ test("does NOT synthesize an interrupted result for an approved tool call (the S
 
   // Sanity: the approval-response the SDK needs to resume execution is present.
   const approvalResponses = modelMessages
-    .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+    .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
     .filter((p) => (p as { type?: string }).type === "tool-approval-response");
   expect(approvalResponses).toHaveLength(1);
 
@@ -751,14 +751,14 @@ test("does NOT synthesize an interrupted result for an approved tool call (the S
   // assistant content; if a future SDK stopped doing so the exclusion would
   // silently break and drop the approved call again.
   const approvalRequests = modelMessages
-    .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+    .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
     .filter((p) => (p as { type?: string }).type === "tool-approval-request");
   expect(approvalRequests).toHaveLength(1);
 
   // The bug: a synthetic error-text tool-result is fabricated for the approved
   // call, so the SDK's collectToolApprovals skips executing it.
   const fabricated = modelMessages
-    .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+    .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
     .find(
       (p) =>
         (p as { type?: string }).type === "tool-result" &&

--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -767,6 +767,103 @@ test("does NOT synthesize an interrupted result for an approved tool call (the S
   expect(fabricated).toBeUndefined();
 });
 
+test("does NOT synthesize an interrupted result for a declined tool call (the SDK denies it on resume)", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  // The user declined the approval. Like an approved call, the SDK's
+  // approval-resume owns the outcome — it produces the denial itself — so the
+  // call must be left result-less; a synthetic "interrupted" result would
+  // pre-empt that and the model would see the wrong reason.
+  const messages: ChatMessage[] = [
+    { role: "user", parts: [{ type: "text", text: "delete the file" }] },
+    {
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "filesystem__delete",
+          toolCallId: "call-declined",
+          state: "approval-responded",
+          input: { path: "/tmp/x" },
+          approval: { id: "approval-1", approved: false },
+        },
+      ],
+    },
+  ] as unknown as ChatMessage[];
+
+  const { modelMessages } = await __test.buildModelMessagesForProvider({
+    messages,
+    provider: "anthropic",
+    conversationId: conversation.id,
+    sandboxAvailable: false,
+  });
+
+  const fabricated = modelMessages
+    .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
+    .find(
+      (p) =>
+        (p as { type?: string }).type === "tool-result" &&
+        (p as { toolCallId?: string }).toolCallId === "call-declined",
+    );
+  expect(fabricated).toBeUndefined();
+});
+
+test("excludes every approved call when a turn carries multiple approvals", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  // The model requested two tools in one turn and the user approved both. The
+  // exclusion must apply per-call, not just to the first, so neither approved
+  // call is stranded with a synthetic result.
+  const messages: ChatMessage[] = [
+    { role: "user", parts: [{ type: "text", text: "do both" }] },
+    {
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "tool_a",
+          toolCallId: "call-a",
+          state: "approval-responded",
+          input: {},
+          approval: { id: "approval-a", approved: true },
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "tool_b",
+          toolCallId: "call-b",
+          state: "approval-responded",
+          input: {},
+          approval: { id: "approval-b", approved: true },
+        },
+      ],
+    },
+  ] as unknown as ChatMessage[];
+
+  const { modelMessages } = await __test.buildModelMessagesForProvider({
+    messages,
+    provider: "anthropic",
+    conversationId: conversation.id,
+    sandboxAvailable: false,
+  });
+
+  const toolResults = modelMessages
+    .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
+    .filter((p) => (p as { type?: string }).type === "tool-result");
+  expect(toolResults).toHaveLength(0);
+});
+
 test("merges synthetic results into an existing tool message when only some calls resolved", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -701,6 +701,72 @@ test("synthesizes an interrupted tool result for a tool call parked at approval-
   expect(results[0].output.value).toContain("interrupted");
 });
 
+test("does NOT synthesize an interrupted result for an approved tool call (the SDK executes it on resume)", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  // Resume turn: the model called a tool that needs approval and the user
+  // approved it. The tool has not executed yet — the AI SDK executes an
+  // approved call itself on this request, but only when no tool-result exists
+  // for the call. Fabricating an "interrupted" result here strands the approval
+  // and the tool silently never runs.
+  const messages: ChatMessage[] = [
+    { role: "user", parts: [{ type: "text", text: "delete the file" }] },
+    {
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "filesystem__delete",
+          toolCallId: "call-approved",
+          state: "approval-responded",
+          input: { path: "/tmp/x" },
+          approval: { id: "approval-1", approved: true },
+        },
+      ],
+    },
+  ] as unknown as ChatMessage[];
+
+  const { modelMessages } = await __test.buildModelMessagesForProvider({
+    messages,
+    provider: "anthropic",
+    conversationId: conversation.id,
+    sandboxAvailable: false,
+  });
+
+  // Sanity: the approval-response the SDK needs to resume execution is present.
+  const approvalResponses = modelMessages
+    .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+    .filter((p) => (p as { type?: string }).type === "tool-approval-response");
+  expect(approvalResponses).toHaveLength(1);
+
+  // The exclusion maps approvalId -> toolCallId via the assistant's
+  // tool-approval-request part. convertToModelMessages (not the internal
+  // language-model converter that strips them later) emits it into the
+  // assistant content; if a future SDK stopped doing so the exclusion would
+  // silently break and drop the approved call again.
+  const approvalRequests = modelMessages
+    .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+    .filter((p) => (p as { type?: string }).type === "tool-approval-request");
+  expect(approvalRequests).toHaveLength(1);
+
+  // The bug: a synthetic error-text tool-result is fabricated for the approved
+  // call, so the SDK's collectToolApprovals skips executing it.
+  const fabricated = modelMessages
+    .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+    .find(
+      (p) =>
+        (p as { type?: string }).type === "tool-result" &&
+        (p as { toolCallId?: string }).toolCallId === "call-approved",
+    );
+  expect(fabricated).toBeUndefined();
+});
+
 test("merges synthetic results into an existing tool message when only some calls resolved", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -755,6 +755,18 @@ test("does NOT synthesize an interrupted result for an approved tool call (the S
     .filter((p) => (p as { type?: string }).type === "tool-approval-request");
   expect(approvalRequests).toHaveLength(1);
 
+  // The approved tool-call itself must survive — it is what the SDK executes on
+  // resume. A regression that dropped it entirely would also produce no
+  // fabricated result, so assert its presence, not just the absence below.
+  const approvedToolCall = modelMessages
+    .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
+    .find(
+      (p) =>
+        (p as { type?: string }).type === "tool-call" &&
+        (p as { toolCallId?: string }).toolCallId === "call-approved",
+    );
+  expect(approvedToolCall).toBeDefined();
+
   // The bug: a synthetic error-text tool-result is fabricated for the approved
   // call, so the SDK's collectToolApprovals skips executing it.
   const fabricated = modelMessages
@@ -862,6 +874,16 @@ test("excludes every approved call when a turn carries multiple approvals", asyn
     .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
     .filter((p) => (p as { type?: string }).type === "tool-result");
   expect(toolResults).toHaveLength(0);
+
+  // Both approved calls must survive for the SDK to execute — dropping one would
+  // also leave zero fabricated results, so assert presence explicitly.
+  const survivingToolCallIds = modelMessages
+    .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
+    .filter((p) => (p as { type?: string }).type === "tool-call")
+    .map((p) => (p as { toolCallId?: string }).toolCallId);
+  expect(survivingToolCallIds).toEqual(
+    expect.arrayContaining(["call-a", "call-b"]),
+  );
 });
 
 test("merges synthetic results into an existing tool message when only some calls resolved", async ({

--- a/platform/backend/src/routes/chat/prepare-model-messages.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.ts
@@ -256,12 +256,14 @@ function ensureGeminiLeadingUserTurn(messages: ModelMessage[]): ModelMessage[] {
 // answered by a `tool_result` in the message that immediately follows — and
 // once such a turn is persisted, every subsequent request in the conversation
 // fails the same way. Histories can legitimately contain unanswered calls:
-// a tool part parked in `approval-requested` / `approval-responded` (the user
-// sent a new message instead of resolving the approval, or the run was blocked
-// in an autonomous session) converts to a tool-call with no result, and
-// provider mappers silently drop the SDK's approval bookkeeping parts.
-// Synthesize an "interrupted" result for every unanswered call so the replay
-// stays valid for any provider.
+// a tool part parked in `approval-requested` (the user sent a new message
+// instead of resolving the approval, or the run was blocked in an autonomous
+// session) converts to a tool-call with no result, and provider mappers
+// silently drop the SDK's approval bookkeeping parts. Synthesize an
+// "interrupted" result for those so the replay stays valid for any provider.
+// A call the user just approved/declined (`approval-responded`) is deliberately
+// left result-less: the SDK's own approval-resume executes or denies it on this
+// request, and a synthetic result would pre-empt that (see the filter below).
 const INTERRUPTED_TOOL_RESULT_TEXT =
   "Tool execution was interrupted before it produced a result (for example an unresolved approval request or an aborted run). The tool did not run; do not assume it did.";
 
@@ -287,11 +289,32 @@ function ensureToolCallsHaveResults(messages: ModelMessage[]): ModelMessage[] {
         .map((part) => part.toolCallId),
     );
 
+    // A tool call whose approval the user just answered is resolved by the AI
+    // SDK's own approval-resume on this request: `collectToolApprovals` executes
+    // an approved call (and denies a declined one) as long as no tool-result
+    // exists for the call yet. Synthesizing an "interrupted" result here would
+    // add exactly that result, so the SDK skips the call and the approved tool
+    // silently never runs. Treat a call with a matching tool-approval-response
+    // as already handled and leave it result-less for the SDK to resolve.
+    const approvalRequestToolCallIds = new Map<string, string>();
+    for (const part of message.content) {
+      if (part.type === "tool-approval-request") {
+        approvalRequestToolCallIds.set(part.approvalId, part.toolCallId);
+      }
+    }
+    const approvalRespondedToolCallIds = new Set(
+      (followingToolMessage?.content ?? [])
+        .filter((part) => part.type === "tool-approval-response")
+        .map((part) => approvalRequestToolCallIds.get(part.approvalId))
+        .filter((toolCallId): toolCallId is string => toolCallId != null),
+    );
+
     const unansweredToolCalls = message.content.filter(
       (part): part is ToolCallPart =>
         part.type === "tool-call" &&
         part.providerExecuted !== true &&
-        !answeredToolCallIds.has(part.toolCallId),
+        !answeredToolCallIds.has(part.toolCallId) &&
+        !approvalRespondedToolCallIds.has(part.toolCallId),
     );
     if (unansweredToolCalls.length === 0) {
       continue;


### PR DESCRIPTION
Approving a human-in-the-loop tool call in chat did nothing: the tool never ran, the model received an "interrupted" result, and the turn dead-ended — Approve behaved exactly like Decline. Any agent gated by a "Require approval" tool-call policy was effectively unusable, since approving could not let the tool proceed.

On the approval resume, `ensureToolCallsHaveResults` fabricated a placeholder "interrupted" `tool-result` for the approved-but-unexecuted call, because it counted only a `tool-result` as answering a call and ignored a pending `tool-approval-response`. AI SDK v6 executes an approved call only when no `tool-result` exists for it, so the fabricated result made the SDK skip execution.

Now a call that carries a matching `tool-approval-response` is left result-less so the SDK's approval-resume runs approved calls and denies declined ones. Genuinely-unresolved `approval-requested` calls (the user moved on without answering) still get the interrupted placeholder that keeps provider replay valid.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>