### PR TITLE
fix(e2e): deflake team sync spec with a test id on the external group mapping row

### DIFF
--- a/platform/e2e-tests/tests/identity-providers.ee.spec.ts
+++ b/platform/e2e-tests/tests/identity-providers.ee.spec.ts
@@ -664,10 +664,15 @@ test.describe("Identity Provider Team Sync E2E", () => {
       timeout: 10000,
     });
 
-    // Also verify the group appears in the current mappings list (not just the input)
-    await expect(page.getByRole("dialog").getByText(externalGroup)).toBeVisible(
-      { timeout: 5000 },
-    );
+    // Also verify the group appears in the current mappings list (not just the
+    // input). Scope to the mapping row: the dialog also shows the "Latest ID
+    // Token Claims" debug panel, whose decoded claims JSON can contain the same
+    // group name and would make a dialog-wide text match strict-mode ambiguous.
+    await expect(
+      page
+        .getByTestId(E2eTestId.TeamExternalGroupMappingRow)
+        .filter({ hasText: externalGroup }),
+    ).toBeVisible({ timeout: 5000 });
 
     // Close the dialog - use first() to target the text button, not the X icon
     await clickButton({

--- a/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
+++ b/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
@@ -4,6 +4,7 @@ import {
   archestraApiSdk,
   type archestraApiTypes,
   DocsPage,
+  E2eTestId,
   getDocsUrl,
 } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -339,7 +340,10 @@ function ExternalGroupRow({
   onRemove: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between rounded-lg border p-3">
+    <div
+      className="flex items-center justify-between rounded-lg border p-3"
+      data-testid={E2eTestId.TeamExternalGroupMappingRow}
+    >
       <div className="flex-1 min-w-0">
         <p className="text-sm font-mono truncate">{group.groupIdentifier}</p>
         <p className="text-xs text-muted-foreground">

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -23,6 +23,7 @@ export const E2eTestId = {
   CredentialTeamSelect: "credential-team-select",
   ManageCredentialsButton: "manage-credentials-button",
   ConfigureIdpTeamSyncButton: "configure-idp-team-sync-button",
+  TeamExternalGroupMappingRow: "team-external-group-mapping-row",
   IdentityProviderCard: "identity-provider-card",
   IdentityProviderOpenDialogButton: "identity-provider-open-dialog-button",
   IdentityProviderCreateButton: "identity-provider-create-button",


### PR DESCRIPTION
## Summary

`identity-providers.ee.spec.ts › Identity Provider Team Sync E2E › should sync user to team based on SSO group membership` fails intermittently in CI (including merge-queue runs) with a Playwright strict-mode violation:

```
Error: strict mode violation: getByRole('dialog').getByText('archestra-admins') resolved to 2 elements
```

The team-management dialog's **External Group Sync** section also renders the **"Latest ID Token Claims"** debug panel. When the signed-in admin already has recorded SSO claims for the provider, the decoded claims JSON shown in that panel contains the same group name the test just mapped — so the dialog-wide `getByText(externalGroup)` matched both the claims `<pre>` and the mapping row. Whether the panel has content depends on whether an SSO sign-in was recorded before the dialog opens, which is why the failure comes and goes with test ordering (a re-run of the same commit passed).

## Fix

- Add `E2eTestId.TeamExternalGroupMappingRow` and stamp it on the mapping row in `team-management-external-sync.ee.tsx`.
- Scope the spec's assertion to that test id (`getByTestId(...).filter({ hasText: externalGroup })`) instead of a dialog-wide text match.