### PR TITLE
chore(dev): default Tilt local dev to Turbopack for the Next dev server

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -146,6 +146,12 @@ ARCHESTRA_FRONTEND_URL=http://localhost:3000
 # Should be set to the domain of the ARCHESTRA_FRONTEND_URL, e.g. "example.com"
 ARCHESTRA_AUTH_COOKIE_DOMAIN=""
 
+# Next.js dev bundler ("turbopack" or "webpack"). Tilt defaults local dev to
+# Turbopack; set "webpack" to opt out (e.g. if you hit the @next/swc-darwin-arm64
+# IOAccelerator memory leak on macOS arm64, vercel/next.js#92055). Outside Tilt,
+# `pnpm dev` auto-selects per platform — see frontend/scripts/dev.mjs.
+# ARCHESTRA_DEV_BUNDLER=turbopack
+
 # Cookie name prefix for auth cookies (default "archestra"). Set a unique value
 # per instance when running several Archestra stacks on different localhost
 # ports, so their session cookies don't overwrite each other (browsers scope

--- a/platform/dev/Tiltfile.dev
+++ b/platform/dev/Tiltfile.dev
@@ -132,9 +132,17 @@ else:
     deps=['../.env', 'run-backend-dev.sh'],
   )
 
+  # Standardize Tilt local dev on Turbopack for the Next dev server. Left to
+  # itself, scripts/dev.mjs falls back to webpack on macOS arm64 (the
+  # @next/swc-darwin-arm64 IOAccelerator memory leak under Turbopack,
+  # vercel/next.js#92055). Set ARCHESTRA_DEV_BUNDLER=webpack in .env (or the
+  # shell) to opt back out.
+  dev_bundler = os.getenv('ARCHESTRA_DEV_BUNDLER', 'turbopack')
+
   # Frontend dev server - waits for backend to be ready
   frontend_serve_env = dict(frontend_env_vars)
   frontend_serve_env['PORT'] = frontend_port
+  frontend_serve_env['ARCHESTRA_DEV_BUNDLER'] = dev_bundler
   local_resource(
     dev_resource_name + '-frontend',
     serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; pnpm dev --filter @frontend & wait $!',
@@ -155,14 +163,15 @@ else:
   local_resource(
     dev_resource_name + '-frontend-int-tests',
     # Route through scripts/dev.mjs so the int-tests frontend gets the same
-    # platform-aware bundler choice as `pnpm dev`: Turbopack on Linux/CI, webpack
-    # on macOS arm64 (the unfixed @next/swc-darwin-arm64 memory bug, see the
-    # "//dev" comment in frontend/package.json). The script adds `-H 127.0.0.1`.
+    # bundler handling as `pnpm dev` (ARCHESTRA_DEV_BUNDLER validation plus the
+    # platform-aware fallback outside Tilt — see the "//dev" comment in
+    # frontend/package.json). The script adds `-H 127.0.0.1`.
     serve_cmd='trap "pkill -TERM -P $$" EXIT INT TERM; cd ../frontend && node ./scripts/dev.mjs -p ' + frontend_int_tests_port + ' & wait $!',
     serve_cmd_bat='cd ..\\frontend && node .\\scripts\\dev.mjs -p ' + frontend_int_tests_port,
     labels=['dev'],
     deps=['../.env'],
     serve_env={
+      'ARCHESTRA_DEV_BUNDLER': dev_bundler,
       'NEXT_DIST_DIR': '.next-pw',
       'NEXT_PUBLIC_API_MOCKING': 'enabled',
       # Both must be pinned: the SSR path reads ARCHESTRA_INTERNAL_API_BASE_URL,


### PR DESCRIPTION
## Summary

Sets `ARCHESTRA_DEV_BUNDLER=turbopack` in the Tiltfile (`dev/Tiltfile.dev`) so everyone gets Turbopack for local development, on both frontend dev resources:

- `pnpm-dev-frontend`
- `pnpm-dev-frontend-int-tests`

Previously `frontend/scripts/dev.mjs` fell back to webpack on macOS arm64 (the `@next/swc-darwin-arm64` IOAccelerator memory-leak workaround, vercel/next.js#92055). Tilt-launched dev servers now standardize on Turbopack everywhere.

Opting out is still possible: a `.env` (or shell) `ARCHESTRA_DEV_BUNDLER=webpack` wins over the Tilt default, since the Tiltfile only fills the value in when it's unset. Documented in `.env.example`. Non-Tilt `pnpm dev` keeps the existing platform-aware auto-selection.

## Testing

- `tilt alpha tiltfile-result` evaluates cleanly and shows `ARCHESTRA_DEV_BUNDLER=turbopack` in the serve env of both frontend resources.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>