### PR TITLE
fix(backend): group transient DB connectivity errors and harden query retry

### DIFF
--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -2,6 +2,7 @@ import { vi } from "vitest";
 import { afterEach, describe, expect, test } from "@/test";
 
 import {
+  getTransientDbErrorCode,
   installDbErrorSafetyNet,
   isTransientDbError,
   withDbRetry,
@@ -38,6 +39,14 @@ describe("isTransientDbError", () => {
 
   test("detects ETIMEDOUT", () => {
     expect(isTransientDbError(new Error("connect ETIMEDOUT"))).toBe(true);
+  });
+
+  test("detects EAI_AGAIN (temporary DNS resolution failure)", () => {
+    expect(
+      isTransientDbError(
+        new Error("getaddrinfo EAI_AGAIN db.example.internal"),
+      ),
+    ).toBe(true);
   });
 
   test("detects 'Connection terminated'", () => {
@@ -122,6 +131,46 @@ describe("isTransientDbError", () => {
       error = new Error(`wrapper ${i}`, { cause: error });
     }
     expect(isTransientDbError(error)).toBe(false);
+  });
+});
+
+describe("getTransientDbErrorCode", () => {
+  test("returns a stable code for socket-level errors", () => {
+    expect(
+      getTransientDbErrorCode(new Error("connect ECONNREFUSED 10.0.0.1:5432")),
+    ).toBe("ECONNREFUSED");
+    expect(
+      getTransientDbErrorCode(new Error("getaddrinfo EAI_AGAIN db.internal")),
+    ).toBe("EAI_AGAIN");
+  });
+
+  test("maps message patterns to low-cardinality codes", () => {
+    expect(
+      getTransientDbErrorCode(
+        new Error("timeout exceeded when trying to connect"),
+      ),
+    ).toBe("pool_connect_timeout");
+    expect(
+      getTransientDbErrorCode(new Error("Connection terminated unexpectedly")),
+    ).toBe("connection_terminated");
+  });
+
+  test("returns the SQLSTATE code for transient PostgreSQL errors", () => {
+    const error = Object.assign(new Error("db error"), { code: "57P01" });
+    expect(getTransientDbErrorCode(error)).toBe("57P01");
+  });
+
+  test("unwraps the cause chain (DrizzleQueryError pattern)", () => {
+    const drizzleError = new Error("Failed query: select 1", {
+      cause: new Error("getaddrinfo EAI_AGAIN db.internal"),
+    });
+    expect(getTransientDbErrorCode(drizzleError)).toBe("EAI_AGAIN");
+  });
+
+  test("returns null for non-transient errors", () => {
+    expect(getTransientDbErrorCode(new Error("duplicate key"))).toBeNull();
+    expect(getTransientDbErrorCode("not an error")).toBeNull();
+    expect(getTransientDbErrorCode(null)).toBeNull();
   });
 });
 
@@ -211,6 +260,26 @@ describe("withDbRetry", () => {
     const result = await withDbRetry(fn);
     expect(result).toEqual([{ id: 1 }]);
     expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("stops retrying when the time budget is exhausted", async () => {
+    vi.useFakeTimers();
+    const fn = vi
+      .fn()
+      .mockRejectedValue(new Error("connect ECONNREFUSED 10.2.124.50:5432"));
+
+    // Budget allows the first backoff (~100-125ms) but not the second
+    // (~200-250ms on top of ~100-125ms elapsed).
+    const promise = withDbRetry(fn, { maxRetries: 5, budgetMs: 250 });
+    const assertion = expect(promise).rejects.toThrow("ECONNREFUSED");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await assertion;
+
+    // 1 initial + 1 retry, then the budget cuts it off despite maxRetries: 5
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
   });
 
   test("applies backoff delay between retries", async () => {

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -12,8 +12,17 @@ import logger from "@/logging";
 /**
  * Maximum number of retry attempts for transient database errors.
  * Total attempts = MAX_RETRIES + 1 (initial attempt + retries).
+ * The effective limit is usually {@link RETRY_BUDGET_MS}: retries stop as
+ * soon as the next backoff would overrun the time budget.
  */
-const MAX_RETRIES = 3;
+const MAX_RETRIES = 8;
+
+/**
+ * Wall-clock budget for a single retried operation. Sized to ride out a
+ * short database restart or failover instead of giving up within the first
+ * second, while still bounding how long a request can hang on the pool.
+ */
+const RETRY_BUDGET_MS = 15_000;
 
 /** Base delay in milliseconds for exponential backoff */
 const BASE_DELAY_MS = 100;
@@ -40,17 +49,27 @@ const TRANSIENT_PG_CODES = new Set([
 ]);
 
 /**
- * Error message substrings that indicate transient connection issues.
- * These cover errors from node-postgres (pg) and the TCP/socket layer.
+ * Error message substrings that indicate transient connection issues, each
+ * paired with a stable code used to group occurrences in error tracking.
+ * These cover errors from node-postgres (pg), DNS resolution, and the
+ * TCP/socket layer.
  */
-const TRANSIENT_ERROR_PATTERNS = [
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "EPIPE",
-  "ETIMEDOUT",
-  "Connection terminated",
-  "timeout exceeded when trying to connect",
-  "timeout expired",
+const TRANSIENT_ERROR_PATTERNS: ReadonlyArray<{
+  pattern: string;
+  code: string;
+}> = [
+  { pattern: "ECONNREFUSED", code: "ECONNREFUSED" },
+  { pattern: "ECONNRESET", code: "ECONNRESET" },
+  { pattern: "EPIPE", code: "EPIPE" },
+  { pattern: "ETIMEDOUT", code: "ETIMEDOUT" },
+  // Temporary DNS resolution failure (getaddrinfo). By definition retryable.
+  { pattern: "EAI_AGAIN", code: "EAI_AGAIN" },
+  { pattern: "Connection terminated", code: "connection_terminated" },
+  {
+    pattern: "timeout exceeded when trying to connect",
+    code: "pool_connect_timeout",
+  },
+  { pattern: "timeout expired", code: "timeout_expired" },
 ];
 
 /** Maximum depth for cause-chain traversal to guard against circular references */
@@ -63,25 +82,42 @@ const MAX_CAUSE_DEPTH = 5;
  * checks the underlying cause (bounded to {@link MAX_CAUSE_DEPTH} levels).
  * @public — exported for testability
  */
-export function isTransientDbError(error: unknown, depth = 0): boolean {
-  if (!(error instanceof Error)) return false;
-  if (depth > MAX_CAUSE_DEPTH) return false;
+export function isTransientDbError(error: unknown): boolean {
+  return getTransientDbErrorCode(error) !== null;
+}
+
+/**
+ * Resolve a transient database error to a stable, low-cardinality code
+ * (e.g. "EAI_AGAIN", "ECONNREFUSED", "pool_connect_timeout", or a SQLSTATE
+ * connection code). Returns null for non-transient errors.
+ *
+ * Used to fingerprint transient connectivity failures in error tracking so
+ * one outage groups into one issue per root cause instead of one issue per
+ * query that happened to be in flight.
+ */
+export function getTransientDbErrorCode(
+  error: unknown,
+  depth = 0,
+): string | null {
+  if (!(error instanceof Error)) return null;
+  if (depth > MAX_CAUSE_DEPTH) return null;
 
   // Check PostgreSQL error code (set by node-postgres on query errors)
   const pgCode = (error as Error & { code?: string }).code;
-  if (pgCode && TRANSIENT_PG_CODES.has(pgCode)) return true;
+  if (pgCode && TRANSIENT_PG_CODES.has(pgCode)) return pgCode;
 
   // Check error message for known transient patterns
   const message = error.message;
-  if (TRANSIENT_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) {
-    return true;
-  }
+  const matched = TRANSIENT_ERROR_PATTERNS.find(({ pattern }) =>
+    message.includes(pattern),
+  );
+  if (matched) return matched.code;
 
   // DrizzleQueryError wraps the underlying pg error as `cause`
   const cause = (error as Error & { cause?: unknown }).cause;
-  if (cause) return isTransientDbError(cause, depth + 1);
+  if (cause) return getTransientDbErrorCode(cause, depth + 1);
 
-  return false;
+  return null;
 }
 
 /**
@@ -116,16 +152,19 @@ function sleep(ms: number): Promise<void> {
  */
 export async function withDbRetry<T>(
   fn: () => Promise<T>,
-  options?: { maxRetries?: number },
+  options?: { maxRetries?: number; budgetMs?: number },
 ): Promise<T> {
   const maxRetries = options?.maxRetries ?? MAX_RETRIES;
+  const budgetMs = options?.budgetMs ?? RETRY_BUDGET_MS;
+  const startedAt = Date.now();
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn();
     } catch (error) {
-      if (isTransientDbError(error) && attempt < maxRetries) {
-        const delay = calculateBackoff(attempt);
+      const delay = calculateBackoff(attempt);
+      const withinBudget = Date.now() - startedAt + delay <= budgetMs;
+      if (isTransientDbError(error) && attempt < maxRetries && withinBudget) {
         logger.warn(
           {
             err: error,

--- a/platform/backend/src/observability/sentry.ts
+++ b/platform/backend/src/observability/sentry.ts
@@ -7,6 +7,7 @@ import type {
 } from "@sentry/core";
 import * as Sentry from "@sentry/node";
 import config from "@/config";
+import { getTransientDbErrorCode } from "@/database/retry";
 import logger from "@/logging";
 import { ApiError } from "@/types";
 import {
@@ -152,6 +153,21 @@ const initSentry = async (): Promise<void> => {
      */
     beforeSend(event: ErrorEvent, hint: EventHint): ErrorEvent | null {
       const error = hint.originalException;
+
+      // Transient database connectivity failures (DNS lookup, connection
+      // refused during a database restart, pool connect timeouts) get
+      // wrapped per-query by the ORM, which fragments one availability
+      // incident into an issue per SQL statement. Fingerprint them by root
+      // cause instead so each outage groups into a single issue.
+      const transientDbErrorCode = getTransientDbErrorCode(error);
+      if (transientDbErrorCode) {
+        event.fingerprint = ["db-transient", transientDbErrorCode];
+        event.tags = {
+          ...event.tags,
+          error_type: "db_transient",
+          db_error_code: transientDbErrorCode,
+        };
+      }
 
       // Filter out ApiError instances with 4xx status codes
       if (error instanceof ApiError) {

--- a/platform/backend/src/server.test.ts
+++ b/platform/backend/src/server.test.ts
@@ -122,6 +122,48 @@ describe("createFastifyInstance", () => {
       captureSpy.mockRestore();
     });
 
+    test("maps transient database connectivity errors to a retryable 503 with root-cause grouping", async () => {
+      const { posthogErrorTrackingService } = await import(
+        "@/services/error-tracking"
+      );
+      const captureSpy = vi.spyOn(
+        posthogErrorTrackingService,
+        "captureException",
+      );
+
+      const app = createFastifyInstance();
+      // Mimic the ORM's per-query wrapper around an underlying DNS failure
+      app.get("/test-db-unavailable", async () => {
+        throw new Error('Failed query: select "id" from "agents"', {
+          cause: new Error("getaddrinfo EAI_AGAIN db.example.internal"),
+        });
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/test-db-unavailable",
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json()).toEqual({
+        error: {
+          message: "Database temporarily unavailable, please retry",
+          type: "api_service_unavailable_error",
+        },
+      });
+
+      // Captured once, grouped by root cause rather than by query text
+      expect(captureSpy).toHaveBeenCalledTimes(1);
+      expect(captureSpy.mock.calls[0][0].properties).toMatchObject({
+        error_type: "db_unavailable",
+        db_error_code: "EAI_AGAIN",
+        status_code: 503,
+        $exception_fingerprint: "db-transient/EAI_AGAIN",
+      });
+
+      captureSpy.mockRestore();
+    });
+
     test("handles standard Error objects correctly", async () => {
       const app = createFastifyInstance();
 

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -55,6 +55,7 @@ import { fastifyAuthPlugin } from "@/auth";
 import { cacheManager } from "@/cache-manager";
 import config, { shouldRunWebServer, shouldRunWorker } from "@/config";
 import { initializeDatabase, isDatabaseHealthy } from "@/database";
+import { getTransientDbErrorCode } from "@/database/retry";
 import { seedRequiredStartingData } from "@/database/seed";
 import { enterpriseTier } from "@/enterprise-tier";
 import { daggerEnvironmentRuntimeManager } from "@/k8s/dagger-environment-runtime/manager";
@@ -556,6 +557,39 @@ export const createFastifyInstance = () =>
         );
         return reply.status(coerced.statusCode).send({
           error: { message: coerced.message, type: coerced.type },
+        });
+      }
+
+      // Transient database connectivity failures (DNS lookup, connection
+      // refused during a database restart, pool connect timeouts) that
+      // survived the retry budget are availability incidents, not bugs in
+      // whichever route happened to be in flight. Respond with a retryable
+      // 503 instead of a 500, and group them in error tracking by root
+      // cause rather than by the query text the ORM wraps them in.
+      const transientDbErrorCode = getTransientDbErrorCode(error);
+      if (transientDbErrorCode) {
+        this.log.error(
+          {
+            ...requestContext,
+            error: error.message,
+            statusCode: 503,
+            dbErrorCode: transientDbErrorCode,
+          },
+          "HTTP 503 database temporarily unavailable",
+        );
+
+        captureServerException(request, error, {
+          error_type: "db_unavailable",
+          db_error_code: transientDbErrorCode,
+          status_code: 503,
+          $exception_fingerprint: `db-transient/${transientDbErrorCode}`,
+        });
+
+        return reply.status(503).send({
+          error: {
+            message: "Database temporarily unavailable, please retry",
+            type: "api_service_unavailable_error",
+          },
         });
       }
 

--- a/platform/shared/types.ts
+++ b/platform/shared/types.ts
@@ -29,6 +29,7 @@ export const ApiErrorTypeSchema = z.enum([
   "unknown_api_error",
   "api_conflict_error",
   "api_payload_too_large_error",
+  "api_service_unavailable_error",
 ]);
 
 /**
@@ -65,6 +66,9 @@ export class ApiError extends Error {
         break;
       case 413:
         this.type = "api_payload_too_large_error";
+        break;
+      case 503:
+        this.type = "api_service_unavailable_error";
         break;
       default:
         this.type = "unknown_api_error";


### PR DESCRIPTION
## Problem

Transient database connectivity failures — temporary DNS resolution errors (`EAI_AGAIN`), `ECONNREFUSED` during a database restart, and pool connect timeouts — surface as one 500 per in-flight query, wrapped in the ORM's per-query `Failed query: <sql>` message. One short availability incident therefore fans out into dozens of unrelated-looking error-tracking issues (one per query shape, or even per parameter value), each too small to demand ownership, and the client gets a non-retryable 500 for what is actually a retryable outage.

Two gaps in the existing `withDbRetry` layer made this worse:

- `EAI_AGAIN` was not classified as transient, so DNS blips were never retried at all.
- The retry budget was 3 attempts with 100/200/400 ms backoff (~1 s total) — far too short to ride out a database restart or failover, so retries exhausted and every in-flight route threw.

## Changes

**`backend/src/database/retry.ts`**
- Add `EAI_AGAIN` (temporary DNS failure — by definition retryable) to the transient patterns.
- Replace the ~1 s effective retry window with a 15 s wall-clock budget (`RETRY_BUDGET_MS`, up to 8 attempts, backoff still capped at 2 s). Retries stop as soon as the next backoff would overrun the budget, so fast-failing errors get more useful attempts while connect-timeout storms stay bounded.
- New `getTransientDbErrorCode()` resolves any transient error (walking the `cause` chain) to a stable low-cardinality code: `EAI_AGAIN`, `ECONNREFUSED`, `pool_connect_timeout`, `connection_terminated`, SQLSTATE codes, etc.

**`backend/src/server.ts`**
- The central error handler now maps requests failing on a transient DB error to a retryable **503** `api_service_unavailable_error` instead of a 500, and captures the exception to error tracking fingerprinted by root-cause code (`db-transient/<code>`) rather than by query text.

**`backend/src/observability/sentry.ts`**
- The `beforeSend` hook applies the same root-cause fingerprint (plus `error_type: db_transient` / `db_error_code` tags), so any capture path collapses one outage into one issue per cause instead of one per SQL statement.

**`shared/types.ts`**
- Add `api_service_unavailable_error` to `ApiErrorTypeSchema` and map `ApiError(503, ...)` to it (previously fell through to `unknown_api_error`).

Statement-timeout errors (genuinely slow queries) are intentionally **not** classified as transient — they keep per-query grouping because there the query text *is* the bug.

## Notes

- The 503 response follows the existing 413 precedent: sent by the central handler without a per-route response schema, so the OpenAPI spec and generated client are unchanged.
- No docs changes: no env vars or user-facing configuration were added; retry constants are internal.

## Testing

- `backend/src/database/retry.test.ts`: EAI_AGAIN detection, `getTransientDbErrorCode` mapping (patterns, SQLSTATE, cause-chain unwrap, null for non-transient), and a fake-timer test pinning that the time budget cuts retries off despite a higher `maxRetries`.
- `backend/src/server.test.ts`: a route throwing an ORM-style wrapped DNS failure returns 503 with `api_service_unavailable_error` and is captured once with `db_error_code: EAI_AGAIN` and the root-cause fingerprint.
- `pnpm type-check` green across all workspaces; `pnpm knip` (dev+production) green in backend.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>