### PR TITLE
fix(helm): harden the chart against rollout-induced database outages

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -247,6 +247,7 @@ Environment network policies require the chart's default MCP manager RBAC so Arc
 - `archestra.worker.resources` - Resource requests/limits for worker pods (default: 2 vCPU request, 1Gi memory request, 2Gi memory limit)
 - `archestra.worker.deploymentStrategy` - Rolling update strategy for worker pods (default: `maxUnavailable: 25%`, `maxSurge: 25%`)
 - `archestra.migrationJob.enabled` - Run database migrations in a pre-upgrade Job before rolling web and worker pods (default: true)
+- `archestra.migrationJob.lockTimeout` - PostgreSQL `lock_timeout` for the migration session (default: `5s`). Migrations fail fast instead of blocking live traffic behind a table lock. Set to `null` to disable.
 - `archestra.migrationJob.envFromSecrets` - Optional hook-only secret values, usually only needed when `ARCHESTRA_DATABASE_URL` uses Kubernetes `$(VAR)` expansion
 
 #### HorizontalPodAutoscaler
@@ -462,7 +463,9 @@ helm upgrade archestra-platform \
 
 If you don't specify `postgresql.external_database_url`, the chart will deploy a managed PostgreSQL instance using the Bitnami PostgreSQL chart. For PostgreSQL-specific configuration options, see the [Bitnami PostgreSQL Helm chart documentation](https://artifacthub.io/packages/helm/bitnami/postgresql?modal=values-schema).
 
-During Helm upgrades, the chart runs `pnpm db:migrate` in a pre-upgrade Job before rolling the web and worker Deployments. Disable `archestra.migrationJob.enabled` only if your deployment pipeline applies migrations out of band.
+The bundled PostgreSQL image is pinned by digest, so the database version only changes when the chart updates `postgresql.image.digest`. The bundled instance runs a single replica — it restarts during some upgrades, so use an external database where downtime matters.
+
+During Helm upgrades, the chart runs `pnpm db:migrate` in a pre-upgrade Job before rolling the web and worker Deployments. The Job runs with a PostgreSQL `lock_timeout` (`archestra.migrationJob.lockTimeout`, default `5s`) — a migration that cannot get a table lock fails and retries instead of blocking live traffic. Disable `archestra.migrationJob.enabled` only if your deployment pipeline applies migrations out of band.
 
 For external Postgres, the simplest setup is a complete `postgresql.external_database_url`; the chart stores it in a Kubernetes Secret and passes it to the migration Job automatically.
 

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -410,7 +410,8 @@ Handles Vault secret injection, pgvector extension setup, and PostgreSQL readine
 {{- if .Values.postgresql.enabled }}
 # Ensure the pgvector extension exists in the application database.
 - name: setup-postgres-extensions
-  image: {{ printf "%s:%s" (.Values.postgresql.image.repository | default "bitnami/postgresql") (.Values.postgresql.image.tag | default "latest") }}
+  {{- /* Honor the digest pin the same way the Bitnami subchart does: with a digest, the tag is informational and the digest wins. */}}
+  image: {{ printf "%s:%s" (.Values.postgresql.image.repository | default "bitnami/postgresql") (.Values.postgresql.image.tag | default "latest") }}{{ with .Values.postgresql.image.digest }}@{{ . }}{{ end }}
   {{- with .Values.archestra.initContainers.resources }}
   resources:
     {{- toYaml . | nindent 4 }}

--- a/platform/helm/archestra/templates/migration-job.yaml
+++ b/platform/helm/archestra/templates/migration-job.yaml
@@ -66,6 +66,18 @@ spec:
               valueFrom:
                 {{- toYaml .valueFrom | nindent 16 }}
             {{- end }}
+            {{- /*
+            Fail-fast lock acquisition for migration DDL: the hook overlaps
+            live traffic from the previous release, so DDL waiting on a table
+            lock would block that traffic until the lock is granted. Rendered
+            after the operator-supplied env blocks so hook-only env stays
+            first for $(VAR) expansion; skipped entirely when the operator
+            provides their own PGOPTIONS through migrationJob.env.
+            */}}
+            {{- if and .Values.archestra.migrationJob.lockTimeout (not (hasKey .Values.archestra.migrationJob.env "PGOPTIONS")) }}
+            - name: PGOPTIONS
+              value: {{ printf "-c lock_timeout=%s" (toString .Values.archestra.migrationJob.lockTimeout) | quote }}
+            {{- end }}
             {{- include "archestra-platform.env" $migrationContext | nindent 12 }}
           {{- if or .Values.archestra.envFrom .Values.archestra.migrationJob.envFrom }}
           envFrom:

--- a/platform/helm/archestra/tests/archestra_migration_job_test.yaml
+++ b/platform/helm/archestra/tests/archestra_migration_job_test.yaml
@@ -119,6 +119,50 @@ tests:
             secretRef:
               name: migration-job-env
 
+  - it: sets a PostgreSQL lock_timeout for the migration session by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGOPTIONS
+            value: "-c lock_timeout=5s"
+
+  - it: supports a custom migration lock_timeout
+    set:
+      archestra.migrationJob.lockTimeout: 2500ms
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGOPTIONS
+            value: "-c lock_timeout=2500ms"
+
+  - it: omits the lock_timeout when disabled
+    set:
+      archestra.migrationJob.lockTimeout: null
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGOPTIONS
+          any: true
+
+  - it: defers to operator-supplied PGOPTIONS over the lock_timeout default
+    set:
+      archestra.migrationJob.env:
+        PGOPTIONS: "-c lock_timeout=30s -c statement_timeout=10min"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGOPTIONS
+            value: "-c lock_timeout=30s -c statement_timeout=10min"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGOPTIONS
+            value: "-c lock_timeout=5s"
+
   - it: uses only the vault volume mount and not shared diagnostics mounts
     set:
       archestra.diagnostics.enabled: true

--- a/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_deployment_test.yaml
@@ -391,6 +391,25 @@ tests:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "max_attempts=60"
 
+  - it: pins the setup-postgres-extensions image by digest when postgresql.image.digest is set
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: setup-postgres-extensions
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].image
+          pattern: ^bitnamisecure/postgresql:latest@sha256:[0-9a-f]{64}$
+
+  - it: falls back to the floating tag for setup-postgres-extensions when no digest is pinned
+    documentIndex: 1
+    set:
+      postgresql.image.digest: null
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: bitnamisecure/postgresql:latest
+
   - it: should set ARCHESTRA_DATABASE_URL with postgres:// scheme
     documentIndex: 1
     set:

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -348,6 +348,15 @@ archestra:
     backoffLimit: 3
     # Hard cap on Job runtime. Set to null to disable the deadline.
     activeDeadlineSeconds: 600
+    # PostgreSQL lock_timeout for the migration session (via PGOPTIONS). The
+    # pre-upgrade hook runs while the previous release's pods still serve
+    # traffic, so DDL waiting on an ACCESS EXCLUSIVE lock would queue behind
+    # live queries and stall every later query on that table until it gets the
+    # lock. With a lock_timeout the migration fails fast instead (retried per
+    # backoffLimit; the upgrade aborts cleanly rather than freezing traffic).
+    # Accepts any PostgreSQL duration (e.g. "5s", "2500ms"). Set to null to
+    # disable. Ignored when you provide your own PGOPTIONS via migrationJob.env.
+    lockTimeout: 5s
     # Resource requests/limits for the migration container.
     # If not set, inherits from archestra.resources.
     resources: {}
@@ -938,18 +947,37 @@ postgresql:
       scripts:
         grant-superuser.sql: |
           ALTER USER archestra WITH SUPERUSER;
+    # Appended to postgresql.conf. max_connections must cover every backend
+    # pod's connection pool (ARCHESTRA_DATABASE_POOL_MAX, default 50 per pod)
+    # at peak pod count: web + worker replicas PLUS the extra surge pods that
+    # exist mid-rollout (deploymentStrategy maxSurge, default 25% => +1 pod
+    # per Deployment), plus the migration hook and the metrics exporter.
+    # Default sizing: (1 web + 1 worker + 2 surge) x 50 = 200, with headroom.
+    # Scale this up if you raise replicaCount, HPA maxReplicas, or the pool size.
+    extendedConfiguration: |
+      max_connections = 250
     resources:
       requests:
         cpu: "1000m"
         memory: "1Gi"
       limits:
         cpu: "1000m"
-        memory: "1Gi"
+        # Higher than the request: a hard 1Gi ceiling has OOM-killed the
+        # bundled instance under load, and a single-replica database restart
+        # is a full platform outage until it comes back.
+        memory: "2Gi"
   # PostgreSQL exporter sidecar for Prometheus metrics (port 9187)
   # Metrics are scraped by the observability stack (Grafana Alloy or Prometheus)
   # and visualized in the Application Metrics Grafana dashboard (PostgreSQL section)
   metrics:
     enabled: true
+    # Same repository/digest pinning rationale as postgresql.image below: the
+    # subchart default points at the archived "bitnami" repository with a
+    # floating "latest" tag.
+    image:
+      repository: bitnamisecure/postgres-exporter
+      tag: latest
+      digest: sha256:53ab72a1b940d7637e91619f1000da9ebef14bc7dad74321a78731d65c79f55b
     service:
       ports:
         metrics: 9187
@@ -961,6 +989,14 @@ postgresql:
   image:
     repository: bitnamisecure/postgresql
     tag: latest
+    # Bitnami Secure Images only publish a floating "latest" tag for free use,
+    # so pin the exact image by digest: a database must not change versions
+    # whenever its pod happens to be rescheduled onto a new node (a
+    # major-version jump refuses to start against the existing data
+    # directory). This digest is PostgreSQL 18.4.0. Refresh it deliberately
+    # alongside chart updates:
+    #   docker buildx imagetools inspect bitnamisecure/postgresql:latest
+    digest: sha256:91a6c3f4b4d687546c1d07c1ef7c27a5e85e2a0ce8a192fe94cad5bbde0a1aba
   global:
     security:
       allowInsecureImages: true


### PR DESCRIPTION
Follow-up to #6447. That PR made the backend resilient to transient database connectivity failures; this one removes the chart-level causes of those failures during `helm upgrade`. Scope deliberately keeps the bundled PostgreSQL for the out-of-the-box experience — production setups are already documented to use an external database.

## 1. Migration Job: fail fast on table locks instead of blocking live traffic

The migration Job is a `pre-upgrade` hook, so it runs while the previous release's pods still serve requests. A migration waiting on an `ACCESS EXCLUSIVE` lock (most `ALTER TABLE`s) queues behind in-flight queries and then blocks every subsequent query on that table — observed as statement-timeout and pool connect-timeout bursts concentrated on hot routes during upgrade windows.

The Job now runs with `PGOPTIONS="-c lock_timeout=5s"` (new value `archestra.migrationJob.lockTimeout`, `null` disables). A migration that cannot acquire its lock errors quickly and retries per `backoffLimit`; if it keeps losing the race the upgrade aborts cleanly rather than freezing traffic. Rendered after the operator-supplied hook env (preserving `$(VAR)` expansion ordering) and skipped entirely if the operator sets their own `PGOPTIONS`. `node-postgres` reads `PGOPTIONS` from the environment, so no connection-string surgery is needed.

## 2. Pin the bundled database images by digest

Bitnami Secure Images only publish a floating `latest` tag for free use. For a database that means any pod reschedule can silently change the PostgreSQL version — and a major-version jump refuses to start against the existing data directory, turning a routine node drain into an outage.

- `postgresql.image` is now pinned by digest (currently PostgreSQL **18.4.0**), with a values comment explaining how to refresh it deliberately.
- The chart's own `setup-postgres-extensions` init container previously built its image ref from `repository:tag` only; it now honors the digest.
- The metrics exporter moves from the **archived** `bitnami/postgres-exporter` repository (which may disappear) to `bitnamisecure/postgres-exporter`, also digest-pinned.

## 3. Fix the connection arithmetic and the OOM-prone memory limit

Each backend pod opens up to 50 connections (`ARCHESTRA_DATABASE_POOL_MAX` default), and the default `maxSurge: 25%` adds one temporary pod per Deployment mid-rollout: web + worker + 2 surge pods = 200 potential connections against PostgreSQL's default `max_connections = 100`. The bundled instance now sets `max_connections = 250` via `primary.extendedConfiguration`, with the sizing formula documented in values.yaml for anyone raising replicas, HPA limits, or pool size.

The memory limit also rises from a hard 1Gi to 2Gi (request stays 1Gi): the 1Gi ceiling has OOM-killed the single-replica instance under load, and a bundled-database restart is a full platform outage until it recovers.

## Upgrade note

Existing installs using the bundled database will see the PostgreSQL pod restart once on this upgrade (image ref changes from the floating tag to the digest, plus the new `max_connections`/memory settings). The pinned digest is the current `latest`, so recently-pulled installs restart onto the same version. An install whose cached image is an older major version will need a dump/restore — but that was already true of any pod reschedule under the floating tag; the pin makes it a deliberate, upgrade-time event instead of a random one.

## Testing

- `helm lint` clean; `helm unittest` 427/427 passing (17 suites).
- New tests pin: default `lock_timeout=5s` env, custom value, disabled when `null`, operator-supplied `PGOPTIONS` wins (no duplicate env), digest-pinned init-container image, and floating-tag fallback when no digest is set.
- Rendered-manifest verification: all four postgresql image references and the exporter carry the digest; `max_connections = 250` lands in the extended config; the migration Job env contains the `PGOPTIONS` entry.
- Docs: `platform-deployment.md` documents the new value, the digest-pinning behavior, and the single-replica caveat.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>