### PR TITLE
perf(backend): reduce per-request DB load on gateway, auth, and chat replay hot paths

### DIFF
--- a/platform/backend/src/models/agent.test.ts
+++ b/platform/backend/src/models/agent.test.ts
@@ -3295,6 +3295,44 @@ describe("AgentModel", () => {
     });
   });
 
+  describe("findGatewayAgentById", () => {
+    test("returns the scalar gateway config and labels without full hydration", async () => {
+      const agent = await AgentModel.create({
+        name: "Gateway Hot Path",
+        agentType: "mcp_gateway",
+        scope: "org",
+        teams: [],
+        passthroughHeaders: ["x-correlation-id"],
+        labels: [{ key: "environment", value: "production" }],
+      });
+
+      const fetched = await AgentModel.findGatewayAgentById(agent.id);
+
+      expect(fetched?.id).toBe(agent.id);
+      expect(fetched?.name).toBe("Gateway Hot Path");
+      expect(fetched?.agentType).toBe("mcp_gateway");
+      expect(fetched?.passthroughHeaders).toEqual(["x-correlation-id"]);
+      expect(fetched?.labels).toEqual([
+        expect.objectContaining({ key: "environment", value: "production" }),
+      ]);
+    });
+
+    test("returns null for a soft-deleted agent", async () => {
+      const agent = await AgentModel.create({
+        name: "Soon Deleted Gateway",
+        agentType: "mcp_gateway",
+        scope: "org",
+        teams: [],
+      });
+
+      await AgentModel.delete(agent.id);
+
+      await expect(
+        AgentModel.findGatewayAgentById(agent.id),
+      ).resolves.toBeNull();
+    });
+  });
+
   describe("accessAllTools / toolExposureMode normalization", () => {
     test("create coerces toolExposureMode to search_and_run_only when accessAllTools is true", async () => {
       const agent = await AgentModel.create({

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -48,6 +48,7 @@ import type {
   AgentScope,
   AgentScopeFilter,
   AgentType,
+  GatewayAgent,
   InsertAgent,
   SortingQuery,
   UpdateAgent,
@@ -1694,6 +1695,29 @@ class AgentModel {
     AgentModel.filterUnavailableKnowledgeTools([result]);
 
     return result;
+  }
+
+  /**
+   * Hot-path agent lookup for the MCP gateway: the raw agents row plus labels,
+   * skipping the tools join and the team/knowledge/connector/author/prompt/
+   * resolved-LLM hydration {@link findById} performs. The gateway loads the
+   * agent on every JSON-RPC request only for scalar config (agent type, tool
+   * exposure, passthrough headers, identity provider) and trace-span labels,
+   * so this must stay at two index lookups.
+   */
+  static async findGatewayAgentById(id: string): Promise<GatewayAgent | null> {
+    const [agent] = await db
+      .select()
+      .from(schema.agentsTable)
+      .where(and(eq(schema.agentsTable.id, id), notDeleted(schema.agentsTable)))
+      .limit(1);
+
+    if (!agent) {
+      return null;
+    }
+
+    const labels = await AgentLabelModel.getLabelsForAgent(id);
+    return { ...agent, labels };
   }
 
   /**

--- a/platform/backend/src/models/chat-active-run.test.ts
+++ b/platform/backend/src/models/chat-active-run.test.ts
@@ -85,6 +85,93 @@ test("appends and reads ordered active chat run events", async ({
   ]);
 });
 
+test("readStatusAndEventsAfter returns the run status with events after seq in one read", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  // No events yet: status still comes back with an empty event list.
+  const empty = await ActiveChatRunModel.readStatusAndEventsAfter({
+    runId: run?.id ?? "",
+    seq: 0,
+  });
+  expect(empty).toEqual({ status: "running", events: [] });
+
+  await ActiveChatRunModel.appendEvents({
+    runId: run?.id ?? "",
+    seq: 1,
+    payloads: [{ type: "start" }],
+  });
+  await ActiveChatRunModel.appendEvents({
+    runId: run?.id ?? "",
+    seq: 2,
+    payloads: [{ type: "finish", finishReason: "stop" }],
+  });
+  await ActiveChatRunModel.markTerminal({
+    runId: run?.id ?? "",
+    status: "completed",
+  });
+
+  const afterFirst = await ActiveChatRunModel.readStatusAndEventsAfter({
+    runId: run?.id ?? "",
+    seq: 1,
+  });
+  expect(afterFirst?.status).toBe("completed");
+  expect(afterFirst?.events.map((event) => event.seq)).toEqual([2]);
+  expect(afterFirst?.events[0]?.payloads).toEqual([
+    { type: "finish", finishReason: "stop" },
+  ]);
+
+  const all = await ActiveChatRunModel.readStatusAndEventsAfter({
+    runId: run?.id ?? "",
+    seq: 0,
+  });
+  expect(all?.events.map((event) => event.seq)).toEqual([1, 2]);
+});
+
+test("readStatusAndEventsAfter returns null when the run row is gone", async ({
+  makeAgent,
+  makeConversation,
+  makeOrganization,
+  makeUser,
+}) => {
+  const user = await makeUser();
+  const organization = await makeOrganization();
+  const agent = await makeAgent({ organizationId: organization.id });
+  const conversation = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: organization.id,
+  });
+  const run = await ActiveChatRunModel.create({
+    conversationId: conversation.id,
+    userId: user.id,
+    organizationId: organization.id,
+  });
+
+  await ConversationModel.delete(conversation.id, user.id, organization.id);
+
+  await expect(
+    ActiveChatRunModel.readStatusAndEventsAfter({
+      runId: run?.id ?? "",
+      seq: 0,
+    }),
+  ).resolves.toBeNull();
+});
+
 test("appends active chat run events without touching the run every time", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/models/chat-active-run.ts
+++ b/platform/backend/src/models/chat-active-run.ts
@@ -154,6 +154,57 @@ class ActiveChatRunModel {
       .orderBy(asc(schema.chatActiveRunEventsTable.seq));
   }
 
+  /**
+   * Read the run's status together with its events after `seq` in ONE
+   * statement, for the replay poll loop that wakes twice a second per
+   * reconnected client. Beyond halving the loop's query count, the single
+   * snapshot carries an ordering guarantee separate reads don't: the writer
+   * commits its final events before marking the run terminal, so a snapshot
+   * that observes a terminal status already contains every event — no
+   * follow-up catch-up read is needed.
+   *
+   * Returns null when the run row is gone (its conversation was hard-deleted
+   * and cascaded, which also removes all events).
+   */
+  static async readStatusAndEventsAfter(params: {
+    runId: string;
+    seq: number;
+  }): Promise<{
+    status: ChatActiveRunStatus;
+    events: ChatActiveRunEvent[];
+  } | null> {
+    const rows = await db
+      .select({
+        status: schema.chatActiveRunsTable.status,
+        event: schema.chatActiveRunEventsTable,
+      })
+      .from(schema.chatActiveRunsTable)
+      .leftJoin(
+        schema.chatActiveRunEventsTable,
+        and(
+          eq(
+            schema.chatActiveRunEventsTable.runId,
+            schema.chatActiveRunsTable.id,
+          ),
+          gt(schema.chatActiveRunEventsTable.seq, params.seq),
+        ),
+      )
+      .where(eq(schema.chatActiveRunsTable.id, params.runId))
+      .orderBy(asc(schema.chatActiveRunEventsTable.seq));
+
+    const [first] = rows;
+    if (!first) {
+      return null;
+    }
+
+    return {
+      status: first.status,
+      events: rows
+        .map((row) => row.event)
+        .filter((event): event is ChatActiveRunEvent => event !== null),
+    };
+  }
+
   static async requestStop(params: {
     conversationId: string;
     organizationId: string;

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -822,6 +822,40 @@ describe("IdentityProviderModel", () => {
       ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
     });
 
+    test("caches the trusted provider list until an identity provider write clears it", async ({
+      makeOrganization,
+      makeIdentityProvider,
+    }) => {
+      const org = await makeOrganization();
+
+      // Prime the cache before any custom provider exists.
+      await expect(
+        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
+      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
+
+      // A row inserted behind the model's back stays invisible while the
+      // cached list is live...
+      const provider = await makeIdentityProvider(org.id, {
+        providerId: "cached-oidc",
+        oidcConfig: { clientId: "client-id" },
+      });
+      await expect(
+        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
+      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
+
+      // ...a model write clears the cache, so the next read sees it...
+      await IdentityProviderModel.update(provider.id, {}, org.id);
+      await expect(
+        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
+      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS, "cached-oidc"]);
+
+      // ...and delete clears it again.
+      await IdentityProviderModel.delete(provider.id, org.id);
+      await expect(
+        IdentityProviderModel.getTrustedAccountLinkingProviderIds(),
+      ).resolves.toEqual([...IDENTITY_TRUSTED_PROVIDER_IDS]);
+    });
+
     test("returns the built-in trusted providers before database initialization", async () => {
       vi.resetModules();
       vi.doMock("@/database", async () => {

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -6,6 +6,7 @@ import {
   IDENTITY_PROVIDER_ID,
   IDENTITY_TRUSTED_PROVIDER_IDS,
   MEMBER_ROLE_NAME,
+  TimeInMs,
 } from "@archestra/shared";
 import type { SSOOptions } from "@better-auth/sso";
 import { APIError } from "better-auth";
@@ -16,9 +17,11 @@ import {
   cacheIdpGroups,
   extractGroupsFromClaims,
 } from "@/auth/idp-team-sync-cache.ee";
+import { LRUCacheManager } from "@/cache-manager";
 import config from "@/config";
 import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
+import { registerProcessLocalCache } from "@/process-local-cache-registry";
 import { evaluateRoleMappingTemplate } from "@/templating";
 import type {
   IdentityProvider,
@@ -53,6 +56,21 @@ export type IdpGetRoleData = Parameters<
 >[0];
 
 class IdentityProviderModel {
+  /**
+   * Process-local cache for {@link getTrustedAccountLinkingProviderIds}. The
+   * lookup backs better-auth's account-linking `trustedProviders` option, which
+   * is evaluated on auth requests (including session reads), so without a cache
+   * it costs one `select distinct` per request for a list that only changes
+   * when an admin edits identity providers. Writes in this process clear the
+   * cache immediately; other pods converge within the TTL.
+   */
+  private static readonly trustedProviderIdsCache = registerProcessLocalCache(
+    new LRUCacheManager<string[]>({
+      maxSize: 1,
+      defaultTtl: TimeInMs.Minute,
+    }),
+  );
+
   /**
    * Evaluates role mapping rules against SSO user data using Handlebars templates.
    *
@@ -469,6 +487,13 @@ class IdentityProviderModel {
   }
 
   static async getTrustedAccountLinkingProviderIds(): Promise<string[]> {
+    const cached = IdentityProviderModel.trustedProviderIdsCache.get(
+      TRUSTED_PROVIDER_IDS_CACHE_KEY,
+    );
+    if (cached) {
+      return cached;
+    }
+
     let configuredProviderIds: Array<{ providerId: string }> = [];
 
     try {
@@ -482,13 +507,15 @@ class IdentityProviderModel {
         error instanceof Error &&
         error.message.includes("Database not initialized")
       ) {
+        // Pre-initialization fallback: don't cache it, so the DB-backed list
+        // takes over on the first call after the database comes up.
         return [...IDENTITY_TRUSTED_PROVIDER_IDS];
       }
 
       throw error;
     }
 
-    return [
+    const providerIds = [
       ...new Set([
         ...IDENTITY_TRUSTED_PROVIDER_IDS,
         ...configuredProviderIds
@@ -497,6 +524,13 @@ class IdentityProviderModel {
           .sort((a, b) => a.localeCompare(b)),
       ]),
     ];
+
+    IdentityProviderModel.trustedProviderIdsCache.set(
+      TRUSTED_PROVIDER_IDS_CACHE_KEY,
+      providerIds,
+    );
+
+    return providerIds;
   }
 
   /**
@@ -709,6 +743,8 @@ class IdentityProviderModel {
       throw new Error("Failed to update identity provider after creation");
     }
 
+    IdentityProviderModel.trustedProviderIdsCache.clear();
+
     return {
       ...updatedProvider,
       domainVerified: true,
@@ -788,6 +824,8 @@ class IdentityProviderModel {
 
     if (!updatedProvider) return null;
 
+    IdentityProviderModel.trustedProviderIdsCache.clear();
+
     return {
       ...updatedProvider,
       oidcConfig: updatedProvider.oidcConfig
@@ -849,6 +887,8 @@ class IdentityProviderModel {
         throw new Error("Failed to delete identity provider");
       }
     });
+
+    IdentityProviderModel.trustedProviderIdsCache.clear();
 
     return true;
   }
@@ -913,6 +953,7 @@ export default IdentityProviderModel;
 
 const OIDC_DISCOVERY_TIMEOUT_MS = 10_000;
 const SSO_REGISTRATION_PLACEHOLDER_DOMAIN = "sso-placeholder.example.com";
+const TRUSTED_PROVIDER_IDS_CACHE_KEY = "trusted-provider-ids";
 
 function serializeConfigValue(
   value: string | object | null | undefined,

--- a/platform/backend/src/routes/mcp-gateway.ts
+++ b/platform/backend/src/routes/mcp-gateway.ts
@@ -291,7 +291,7 @@ const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
       };
 
       // Extract passthrough headers from the incoming request per the agent's allowlist
-      const agent = await AgentModel.findById(profileId);
+      const agent = await AgentModel.findGatewayAgentById(profileId);
       if (agent) {
         const passthroughHeaders = extractPassthroughHeaders(
           agent.passthroughHeaders,

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -188,7 +188,10 @@ export async function createAgentServer(
   );
   const { server } = mcpServer;
 
-  const agent = await AgentModel.findById(agentId);
+  // Slim lookup: this runs on every stateless gateway request, and the tool
+  // handlers below only read scalar agent config plus labels — never the
+  // tools/teams/knowledge/connector hydration `findById` performs.
+  const agent = await AgentModel.findGatewayAgentById(agentId);
   if (!agent) throw new Error(`Agent not found: ${agentId}`);
 
   // Fetch the agent's teams and the calling user's teams (with labels) for
@@ -1454,7 +1457,7 @@ export async function validateExternalIdpToken(
 ): Promise<TokenAuthResult | null> {
   try {
     // Look up the agent to check if it has an identity provider configured
-    const agent = await AgentModel.findById(profileId);
+    const agent = await AgentModel.findGatewayAgentById(profileId);
     if (!agent?.identityProviderId) {
       return null;
     }

--- a/platform/backend/src/services/active-chat-run.ts
+++ b/platform/backend/src/services/active-chat-run.ts
@@ -287,30 +287,30 @@ export class ActiveChatRunService {
 
         try {
           while (!isCancelled) {
-            const events = await ActiveChatRunModel.readEventsAfter({
+            // Status and events come from one statement snapshot: observing a
+            // terminal status guarantees every event is already in `events`
+            // (see readStatusAndEventsAfter), so closing right after draining
+            // them can never lose a tail chunk.
+            const snapshot = await ActiveChatRunModel.readStatusAndEventsAfter({
               runId,
               seq: lastSeq,
             });
 
-            for (const event of events) {
+            // Run row gone: its conversation was hard-deleted and cascaded,
+            // taking all events with it. Nothing left to replay.
+            if (!snapshot) {
+              controller.close();
+              return;
+            }
+
+            for (const event of snapshot.events) {
               for (const payload of event.payloads) {
                 controller.enqueue(payload);
               }
               lastSeq = event.seq;
             }
 
-            const run = await ActiveChatRunModel.findById(runId);
-            if (!run || run.status !== "running") {
-              const finalEvents = await ActiveChatRunModel.readEventsAfter({
-                runId,
-                seq: lastSeq,
-              });
-              for (const event of finalEvents) {
-                for (const payload of event.payloads) {
-                  controller.enqueue(payload);
-                }
-                lastSeq = event.seq;
-              }
+            if (snapshot.status !== "running") {
               controller.close();
               return;
             }

--- a/platform/backend/src/types/agent.ts
+++ b/platform/backend/src/types/agent.ts
@@ -203,10 +203,22 @@ function validateIncomingEmailDomain(
   }
 }
 
-export const SelectAgentSchema = createSelectSchema(
+const AgentRowSchema = createSelectSchema(
   schema.agentsTable,
   selectExtendedFields,
-).extend({
+);
+
+/**
+ * Hot-path agent shape for the MCP gateway: the raw agents row plus labels,
+ * without the tools/teams/knowledge/connector/author/prompt/resolved-LLM
+ * hydration a full `Agent` carries. See `AgentModel.findGatewayAgentById`.
+ */
+const GatewayAgentSchema = AgentRowSchema.extend({
+  labels: z.array(AgentLabelWithDetailsSchema),
+});
+export type GatewayAgent = z.infer<typeof GatewayAgentSchema>;
+
+export const SelectAgentSchema = AgentRowSchema.extend({
   tools: z.array(SelectToolSchema),
   teams: z.array(AgentTeamInfoSchema),
   labels: z.array(AgentLabelWithDetailsSchema),


### PR DESCRIPTION
## Summary

Production traces show three backend hot paths putting avoidable query load on the connection pool. This PR trims each one without changing observable behavior.

### 1. MCP gateway: stop hydrating the full agent graph per request

The stateless gateway (`POST /v1/mcp/:profileId` and the proxy path) loaded the agent via `AgentModel.findById` at three per-request call sites — passthrough-header extraction, `createAgentServer`, and external-IdP token validation. `findById` pays for a tools join plus team/knowledge/connector/author/suggested-prompt/resolved-LLM hydration (~10 queries), while these call sites only read scalar agent config and labels.

New `AgentModel.findGatewayAgentById` returns the raw agents row plus labels (two index lookups) and replaces `findById` at all three sites. Follows the existing precedent of `findLlmSelectionFieldsById`.

### 2. Auth: cache trusted account-linking provider ids

better-auth evaluates the `accountLinking.trustedProviders` callback on auth requests (including session reads), which ran `select distinct provider_id from identity_provider` once per request for a list that only changes when an admin edits identity providers. It is now cached in a process-local LRU (60s TTL, same pattern as `AgentModel.resolveIdCache`); identity-provider create/update/delete clear the cache in-process, and other pods converge within the TTL. The pre-database-initialization fallback is intentionally not cached.

### 3. Chat replay: one query per poll wake instead of two (plus terminal re-reads)

The active-run replay loop (`GET /api/chat/conversations/:id/active-run`) wakes ~2×/s per reconnected client and issued two queries per wake (events after seq, then run status), plus a final catch-up read of both when the run turned terminal — dozens of repeated queries over a single long-lived request. New `ActiveChatRunModel.readStatusAndEventsAfter` reads both in one statement. The single snapshot also carries an ordering guarantee separate reads don't: the writer commits its final events before marking the run terminal, so observing a terminal status implies every event is already in the result — the terminal catch-up read is gone entirely.

## Not addressed (follow-up candidates)

- better-auth's internal per-request `user` / `member` lookups on `GET /api/auth/get-session` and the API-key auth path — caching those trades off immediate role/ban propagation (see the deliberate comment on `session.cookieCache` in `better-auth.ts`).
- Per-request `organization_role` reads from the RBAC permission check.

## Tests

- `findGatewayAgentById`: returns scalar config + labels; null for soft-deleted agents.
- Trusted-provider cache: caches until a model write (update/delete) clears it; behind-the-back inserts stay invisible until then.
- `readStatusAndEventsAfter`: status + ordered events after seq in one read; empty event list on a fresh run; null once the run row is cascade-deleted.
- Existing replay/stop/stream and gateway route suites pass unchanged (`mcp-gateway*`, `mcp-proxy`, `active-run-routes`, `stream-route`, `active-chat-run`, `agent`, `identity-provider.ee`).

`pnpm type-check`, `pnpm lint`, and `pnpm knip` (dev + production) are clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>