### PR TITLE
fix(chat): show a declined tool with an orange dot, not a stuck blue one

### DIFF
--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -107,7 +107,7 @@ function CompactCircle({
   catalogId,
 }: {
   toolName: string;
-  state: "running" | "completed" | "error";
+  state: "running" | "completed" | "error" | "denied";
   isExpanded: boolean;
   isExpandable?: boolean;
   onClick: () => void;
@@ -143,6 +143,7 @@ function CompactCircle({
                 state === "completed" && "bg-green-500",
                 state === "running" && "bg-blue-500 animate-pulse",
                 state === "error" && "bg-destructive",
+                state === "denied" && "bg-orange-500",
               )}
             />
           </button>
@@ -153,7 +154,9 @@ function CompactCircle({
             ? " (running)"
             : state === "error"
               ? " (error)"
-              : ""}
+              : state === "denied"
+                ? " (denied)"
+                : ""}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -177,7 +180,7 @@ function ToolCallSkillPill({
 }: {
   toolName: string;
   skillName: string | null;
-  state: "running" | "completed" | "error";
+  state: "running" | "completed" | "error" | "denied";
 }) {
   const tooltipLabel = (() => {
     const base = skillName ? `Skill: ${skillName}` : "Loading skill";

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -198,7 +198,7 @@ export function McpAppEntryPill({
   /** App icon (e.g. an McpCatalogIcon); falls back to the generic app glyph. */
   icon?: React.ReactNode;
   /** Tool-call state for the status dot, matching the tool-call circles. */
-  state?: "running" | "completed" | "error";
+  state?: "running" | "completed" | "error" | "denied";
   /** Runs on every pill click, before the app toggle (e.g. to collapse an
    * expanded tool-call card so only one thing opens under the row). */
   onClick?: () => void;

--- a/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
@@ -168,7 +168,7 @@ export function McpAppPill({
   /** App icon (e.g. an McpCatalogIcon); falls back to the generic app glyph. */
   icon?: React.ReactNode;
   /** Tool-call state for the status dot; omitted renders no dot. */
-  state?: "running" | "completed" | "error";
+  state?: "running" | "completed" | "error" | "denied";
   /** Pressed = the app's inline render is expanded under the pill. */
   pressed?: boolean;
   /** Show a red status dot for an app runtime error. */
@@ -203,6 +203,7 @@ export function McpAppPill({
                   dotState === "completed" && "bg-green-500",
                   dotState === "running" && "bg-blue-500 animate-pulse",
                   dotState === "error" && "bg-destructive",
+                  dotState === "denied" && "bg-orange-500",
                 )}
               />
             ) : null}

--- a/platform/frontend/src/lib/chat/chat-tools-display.utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-tools-display.utils.test.ts
@@ -321,5 +321,17 @@ describe("tool display helpers", () => {
         toolResultPart: null,
       }),
     ).toBe("completed");
+
+    // A declined approval is terminal: it must map to "denied" (orange dot), not
+    // fall through to "running" (a blue pulsing dot that never resolves).
+    expect(
+      getCompactToolState({
+        part: {
+          type: "tool-github__create_issue",
+          state: "output-denied",
+        } as never,
+        toolResultPart: null,
+      }),
+    ).toBe("denied");
   });
 });

--- a/platform/frontend/src/lib/chat/chat-tools-display.utils.ts
+++ b/platform/frontend/src/lib/chat/chat-tools-display.utils.ts
@@ -107,13 +107,19 @@ export function getCompactToolState({
 }: {
   part: ToolUIPart | DynamicToolUIPart;
   toolResultPart: ToolUIPart | DynamicToolUIPart | null;
-}): "running" | "completed" | "error" {
+}): "running" | "completed" | "error" | "denied" {
   if (getToolErrorText({ part, toolResultPart })) {
     return "error";
   }
 
   if (toolResultPart || part.state === "output-available") {
     return "completed";
+  }
+
+  // A declined approval is terminal — without this it would fall through to
+  // "running" and render a blue pulsing dot forever. Surface it as "denied".
+  if (part.state === "output-denied") {
+    return "denied";
   }
 
   return "running";


### PR DESCRIPTION
A tool call the user **declined** rendered its status dot as a blue, pulsing "running" indicator that never resolved — visually indistinguishable from an in-progress call, even though the tool was terminally denied.

`getCompactToolState` mapped a tool part to the circle state but had no case for `output-denied`, so a declined call fell through to `"running"` (`bg-blue-500 animate-pulse`). Add a `"denied"` state that renders an **orange** dot, matching the color already used for a denied tool in the expanded card badge (`getStatusBadge`) and for a blocked hook run. The declined circle now reads as denied at a glance instead of appearing stuck mid-run.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>