### PR TITLE
chore(frontend): default local dev to the turbopack bundler

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -133,6 +133,10 @@ ARCHESTRA_INTERNAL_API_BASE_URL="http://localhost:9000"
 # Frontend URL - The URL where users access the frontend
 ARCHESTRA_FRONTEND_URL=http://localhost:3000
 
+# Next.js dev bundler (turbopack | webpack). turbopack: 2-6x faster compiles
+# but leaks GPU memory on Apple Silicon (vercel/next.js#92055); webpack is safe.
+ARCHESTRA_DEV_BUNDLER=turbopack
+
 # Optional for local dev
 # Cookie Domain - Required if different domains or subdomains for frontend and backend are used
 # Should be set to the domain of the ARCHESTRA_FRONTEND_URL, e.g. "example.com"


### PR DESCRIPTION
Adds `ARCHESTRA_DEV_BUNDLER` to `platform/.env.example` set to `turbopack`, so fresh local setups (which seed `.env` from this template) default to Turbopack for Next.js dev — 2-6x faster compiles than webpack.

The var is a passthrough override read by `frontend/scripts/dev.mjs`; when it is unset the existing auto-selector still applies (webpack on Apple Silicon to avoid the `@next/swc-darwin-arm64` GPU-memory leak in `vercel/next.js#92055`, turbopack elsewhere). Anyone hitting that leak can set `ARCHESTRA_DEV_BUNDLER=webpack` in their own `.env`.

Existing `.env` files are untouched — the template is only copied on first run.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>