### PR TITLE
Revert "chore(frontend): default local dev to the turbopack bundler"

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -141,10 +141,6 @@ ARCHESTRA_INTERNAL_API_BASE_URL="http://localhost:9000"
 # Frontend URL - The URL where users access the frontend
 ARCHESTRA_FRONTEND_URL=http://localhost:3000
 
-# Next.js dev bundler (turbopack | webpack). turbopack: 2-6x faster compiles
-# but leaks GPU memory on Apple Silicon (vercel/next.js#92055); webpack is safe.
-ARCHESTRA_DEV_BUNDLER=turbopack
-
 # Optional for local dev
 # Cookie Domain - Required if different domains or subdomains for frontend and backend are used
 # Should be set to the domain of the ARCHESTRA_FRONTEND_URL, e.g. "example.com"


### PR DESCRIPTION
Reverts archestra-ai/archestra#6456

Already done in https://github.com/archestra-ai/archestra/pull/6446

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>