### PR TITLE
chore(frontend): cap local vitest worker count to prevent concurrent-run OOM

### DIFF
--- a/platform/frontend/vitest.config.ts
+++ b/platform/frontend/vitest.config.ts
@@ -27,7 +27,16 @@ export default defineConfig({
     // JSDOM-heavy frontend tests need a larger worker heap on Node 24.
     pool: "forks",
     execArgv: ["--max-old-space-size=8192"],
-    // CI runs backend and frontend tests in parallel, so keep jsdom worker pressure low.
+    // Each fork is a separate process with the heap ceiling above, so worker
+    // count multiplies memory. Cap at half the cores so this suite doesn't
+    // exhaust RAM when it runs alongside the shared/type-check/lint tasks —
+    // locally via `turbo test`, and in CI where `check:ci` stacks them on one
+    // runner (which has shown orphaned fork workers when uncapped).
+    maxWorkers: "50%",
+    // Caps concurrent `test.concurrent` cases within a single file (plain
+    // sequential test() is unaffected). Kept as a low guardrail so a future
+    // concurrent suite can't pile jsdom work into one worker; worker count is
+    // capped separately by maxWorkers above.
     maxConcurrency: 2,
   },
 });

--- a/platform/frontend/vitest.config.ts
+++ b/platform/frontend/vitest.config.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
+const isCI = process.env.CI === "true";
+
 export default defineConfig({
   plugins: [tsconfigPaths()],
   resolve: {
@@ -27,12 +29,12 @@ export default defineConfig({
     // JSDOM-heavy frontend tests need a larger worker heap on Node 24.
     pool: "forks",
     execArgv: ["--max-old-space-size=8192"],
-    // Each fork is a separate process with the heap ceiling above, so worker
-    // count multiplies memory. Cap at half the cores so this suite doesn't
-    // exhaust RAM when it runs alongside the shared/type-check/lint tasks —
-    // locally via `turbo test`, and in CI where `check:ci` stacks them on one
-    // runner (which has shown orphaned fork workers when uncapped).
-    maxWorkers: "50%",
+    // Each fork is a separate process, so worker count multiplies memory. Cap
+    // to half the cores locally so this suite doesn't exhaust RAM when it runs
+    // alongside the shared/type-check/lint tasks under `turbo test`. CI runs on
+    // a dedicated high-RAM runner where the uncapped default is fine, so it's
+    // left alone. Override on a big local machine with `--maxWorkers=<n|%>`.
+    ...(isCI ? {} : { maxWorkers: "50%" }),
     // Caps concurrent `test.concurrent` cases within a single file (plain
     // sequential test() is unaffected). Kept as a low guardrail so a future
     // concurrent suite can't pile jsdom work into one worker; worker count is


### PR DESCRIPTION
## Summary

Locally, `pnpm test` runs the frontend vitest suite concurrently with the backend, shared, type-check, and lint tasks (via `turbo test`) on one machine that also hosts the Tilt/k3s dev stack. The frontend pool set no `maxWorkers`, so it spawned roughly one fork per core. Each fork is a separate process, so the suite's memory scales with fork count — and that count, stacked on top of the concurrent sibling suites and the resident dev stack, overruns available RAM. The failure shows up indirectly: fork workers that fail to start or time out waiting to respond, read as flaky, non-deterministic test failures rather than an obvious out-of-memory error.

Capping `maxWorkers` to `"50%"` of cores (gated behind `!CI`) halves the local fork count and the memory the suite adds, leaving headroom for the sibling tasks. The cap is deliberately CPU-proportional rather than RAM-derived: the OOM is a concurrent-contention problem, and a fixed fraction of cores reliably reserves room where a free-RAM heuristic can't — it would sample memory before the sibling suites have spun up and mis-size.

CI is left untouched. It runs the frontend suite on a dedicated, high-RAM runner with no competing tasks, so there is nothing to relieve there; leaving it uncapped keeps CI identical to `main`.

`pool: "forks"` and the per-fork heap ceiling are unchanged. `maxConcurrency: 2` is retained as a per-file guardrail; its comment, which wrongly described it as a worker throttle, is corrected. A large local machine can opt back into full parallelism with `--maxWorkers=<n|%>`, which overrides the config.