### PR TITLE
ci(e2e): reuse images across e2e-only changes; drop duplicate typecheck from next build

### DIFF
--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -141,10 +141,14 @@ jobs:
           GIT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # git tree OID of the ./platform build context — identical iff the
-          # context bytes are identical (checkout is shallow but has the full
-          # tree of HEAD, which is all `rev-parse HEAD:platform` needs).
-          TREE_HASH=$(git rev-parse "HEAD:platform")
+          # Hash of what the image build actually consumes: the ./platform
+          # tree minus e2e-tests (tests run from the checkout, never from the
+          # image; nothing in the Dockerfile references that directory — keep
+          # it that way or remove this exclusion). Merges that only touch e2e
+          # tests then reuse the existing image instead of rebuilding an
+          # identical one. The derived hash is stable: ls-tree output is
+          # sorted and includes each entry's own tree OID.
+          TREE_HASH=$(git ls-tree "HEAD:platform" | grep -v $'\te2e-tests$' | git hash-object --stdin)
           TREE_TAG="${IMAGE_REPO}:tree-${TREE_HASH}"
           SLIM_TREE_TAG="${TREE_TAG}-slim"
           SHA_TAG="${IMAGE_REPO}:${GIT_SHA}"

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -146,7 +146,10 @@ WORKDIR /app
 
 # Copy package files for all workspaces
 # pnpm-workspace.yaml contains pnpm v11 project settings.
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json .npmrc ./
+# turbo.json deliberately NOT copied here: `pnpm install` never reads it, and
+# including it made every turbo.json edit bust this stage's ~30s install layer.
+# The builder stage below copies it alongside the source files.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY backend/package.json backend/
 COPY frontend/package.json frontend/
 COPY shared/package.json shared/

--- a/platform/e2e-tests/playwright.config.ts
+++ b/platform/e2e-tests/playwright.config.ts
@@ -1,3 +1,7 @@
+// NOTE: nothing under e2e-tests/ is part of the platform Docker image — CI's
+// image-reuse key deliberately excludes this directory, so e2e-only changes
+// reuse the previously built image instead of rebuilding it (see the
+// "Resolve platform image reuse" step in .github/workflows/platform-e2e-tests.yml).
 import { defineConfig, devices } from "@playwright/test";
 import { adminAuthFile, IS_CI } from "./consts";
 

--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -20,6 +20,11 @@ const nextConfig: NextConfig = {
   // alongside the main one without colliding on `.next/dev/lock`.
   distDir: process.env.NEXT_DIST_DIR || ".next",
   output: "standalone",
+  // CI runs the authoritative type check separately (`pnpm type-check`), so
+  // the in-build check is pure duplication — ~15s of every image build.
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   // Version skew protection during rolling deployments.
   // https://nextjs.org/docs/app/api-reference/config/next-config-js/deploymentId
   // VERSION is set as a build arg by CI and baked into the


### PR DESCRIPTION
Two build-cost cuts for the merge queue, from profiling real merge-queue builds:

1. **The image-reuse key over-triggered.** It hashed the whole `./platform` tree, but the Docker build consumes none of `platform/e2e-tests` (tests run from the checkout). Any e2e-test-only merge — a large share of platform-touching PRs — paid a full ~4 min image build for a byte-identical image. The key now hashes the platform tree minus `e2e-tests`, so those merges retag in seconds. Conservative by construction: anything the Dockerfile can see still invalidates.

2. **`next build` duplicated the type check** (~15s of every build) that CI already runs as a separate required job (`pnpm type-check`). Disabled in-build via `typescript.ignoreBuildErrors`; verified locally ('Skipping validation of types', compile unaffected). Note: the Turbopack compile itself is only ~9s — the frontend was never the build bottleneck.

Validation plan on this PR: first `run-e2e` run builds cold and publishes tree tags under the new key; a follow-up e2e-only commit then demonstrates the reuse hit (~30s build job instead of ~4min).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>