### PR TITLE
feat(platform): default tool assignments to resolve-at-call-time and rename "All" mode to "Auto"

### DIFF
--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -3,7 +3,7 @@ title: "Authentication"
 category: MCP
 order: 4
 description: "How authentication works for MCP clients and upstream MCP servers"
-lastUpdated: 2026-07-03
+lastUpdated: 2026-07-09
 ---
 
 MCP authentication in Archestra has two separate layers: the client-facing gateway layer and the upstream MCP server layer.
@@ -199,7 +199,7 @@ Auth credentials are stored in the secrets backend, which uses the database by d
 
 ### Credential Resolution
 
-Credential resolution decides which installed MCP server credential should be used for a tool call. A tool assignment can either pin a specific installed connection or ask Archestra to resolve a credential at execution time from the caller identity, following the server's **Agent connections** setting.
+Credential resolution decides which installed MCP server credential should be used for a tool call. A tool assignment can either pin a specific installed connection or ask Archestra to resolve a credential at execution time from the caller identity, following the server's **Default credential** setting. Resolve at call time is the default for new assignments; pinning a connection is an explicit choice.
 
 #### Static Credentials
 
@@ -215,7 +215,7 @@ This means a team-shared connection is governed by the team it is shared with, n
 
 #### Resolve at Call Time
 
-When a tool assignment uses "Resolve at call time" (or an agent has **All tools** dynamic access), Archestra picks the credential at execution time. Which one is used is defined on the MCP server itself — the **Agent connections** setting on the server's Connections page:
+When a tool assignment uses "Resolve at call time" (or an agent is in **Auto** tool mode), Archestra picks the credential at execution time. Which one is used is defined on the MCP server itself — the **Default credential** setting on the server's Credentials tab:
 
 - **On behalf of the user** (default): the chatting identity's own connection takes priority, falling back to a connection it can access. A user token resolves to that user's personal connection, then a connection for a team they belong to, then an org-scoped connection; a team token resolves to that team's connection, then an org-scoped one. A caller with no reachable connection gets an actionable connect prompt.
 - **Always use one account**: every runtime-resolved call goes through the chosen connection, regardless of the caller — a service account. Use this when the whole org or a team should share one upstream account. If that connection is revoked, the server returns to on-behalf-of-the-user resolution.
@@ -224,7 +224,7 @@ When a tool assignment uses "Resolve at call time" (or an agent has **All tools*
 flowchart TD
     A["Tool call arrives<br/>with Gateway Token"] --> B{Assignment resolves<br/>credentials at runtime?}
     B -- No --> C["Use the assignment's<br/>pinned credential"]
-    B -- Yes --> P{Agent connections set to<br/>one shared account?}
+    B -- Yes --> P{Default credential set to<br/>one shared account?}
     P -- Yes --> S["Use that account<br/>(service account)"]
     P -- No --> D{Caller has their<br/>own connection?}
     D -- Yes --> E["Use the caller's<br/>own credential"]

--- a/docs/pages/platform-agents.md
+++ b/docs/pages/platform-agents.md
@@ -3,7 +3,7 @@ title: Overview
 category: Agents
 order: 1
 description: Agent overview, invocation paths, knowledge sources, and prompt templating
-lastUpdated: 2026-07-05
+lastUpdated: 2026-07-09
 ---
 
 Agents are reusable AI workers with instructions, tool access, and optional knowledge retrieval. You can invoke the same agent from chat, external integrations, or automation without rebuilding the workflow each time.
@@ -12,7 +12,7 @@ An agent can include:
 
 - a system prompt that defines behavior
 - suggested prompts for common tasks in chat
-- a **Tools & Knowledge Sources** setting: **All** (every tool and knowledge source the chatting user can access, minus an exclusion list) or **Custom** (only assigned tools and sources)
+- a **Tools & Knowledge Sources** setting: **Auto** (every tool and knowledge source the chatting user can access, minus an exclusion list) or **Custom** (only assigned tools and sources)
 - optional **Load tools when needed** mode for keeping MCP `tools/list` small
 - optional delegation targets to other agents
 - one or more assigned knowledge sources
@@ -28,7 +28,7 @@ For larger toolsets, enable **Load tools when needed**. This keeps the initial t
 
 Use this when the full tool menu is too large to send to the model on every turn, but you still want the agent to keep access to the same assigned toolset.
 
-An agent's **Tools & Knowledge Sources** setting is **All** or **Custom** — tabs in the agent dialog. The tabs govern both tools and [knowledge sources](#knowledge-sources); this section covers the tools half. In **Custom** mode the agent uses only its explicitly assigned tools; new agents get a default set assigned by the backend, and the create form pre-selects that same set. In **All** mode, discovery is not limited to assigned tools: `search_tools` can find and `run_tool` can run every tool the signed-in user can access — Archestra built-in tools and tools from MCP servers — except tools on the agent's [exclusion list](#excluding-servers-and-tools). User permissions still apply. `run_tool` executes such a tool directly with credentials resolved at call time, following the MCP server's **Agent connections** setting: on behalf of the user by default (each person's own connection), or one shared account when the server is configured that way. A caller without a connection gets an actionable prompt to connect — nothing is borrowed from team or organization credentials. Nothing is assigned to the agent, so no permission to modify the agent is involved. This lets [Agent Skills](/docs/platform-agent-skills) reference tools without pre-assigning every tool to every agent.
+An agent's **Tools & Knowledge Sources** setting is **Auto** or **Custom** — tabs in the agent dialog. The tabs govern both tools and [knowledge sources](#knowledge-sources); this section covers the tools half. In **Custom** mode the agent uses only its explicitly assigned tools; new agents get a default set assigned by the backend, and the create form pre-selects that same set. Custom assignments resolve credentials at call time by default; you can pin a specific connection per server instead. In **Auto** mode, discovery is not limited to assigned tools: `search_tools` can find and `run_tool` can run every tool the signed-in user can access — Archestra built-in tools and tools from MCP servers — except tools on the agent's [exclusion list](#excluding-servers-and-tools). User permissions still apply. `run_tool` executes such a tool directly with credentials resolved at call time, following the MCP server's **Default credential** setting: on behalf of the user by default (each person's own connection), or one shared account when the server is configured that way. A caller without a connection gets an actionable prompt to connect — nothing is borrowed from team or organization credentials. Nothing is assigned to the agent, so no permission to modify the agent is involved. This lets [Agent Skills](/docs/platform-agent-skills) reference tools without pre-assigning every tool to every agent.
 
 Tool call policies still apply to the target tool. If the model calls `run_tool` to execute `send_email`, Archestra evaluates policies for `send_email` with the same arguments and context it would use for a direct tool call. See [AI Tool Guardrails - Load Tools When Needed](/docs/platform-ai-tool-guardrails#load-tools-when-needed).
 
@@ -36,15 +36,15 @@ See [MCP Gateway - Load Tools When Needed](/docs/platform-mcp-gateway#load-tools
 
 ### Excluding Servers and Tools
 
-**All** can be too broad: it gives the agent everything the calling user can reach. To carve out exceptions, each agent has an exclusion list — edit it under **Disabled tools** on the **All** tab of the agent dialog (or via `GET`/`PUT /api/agents/:id/tool-exclusions`), excluding whole MCP servers or individual tools. Use this for an agent that should see everything except, say, a payments server or a single destructive tool.
+**Auto** can be too broad: it gives the agent everything the calling user can reach. To carve out exceptions, each agent has an exclusion list — edit it under **Disabled tools** on the **Auto** tab of the agent dialog (or via `GET`/`PUT /api/agents/:id/tool-exclusions`), excluding whole MCP servers or individual tools. Use this for an agent that should see everything except, say, a payments server or a single destructive tool.
 
-While the tools setting is **All**, exclusions cover the agent's entire surface:
+While the tools setting is **Auto**, exclusions cover the agent's entire surface:
 
 - excluded tools do not appear in `search_tools` results and cannot be executed by `run_tool` or called directly by an MCP client
 - the agent's MCP resources and prompts from an excluded server are also unreachable
 - tools explicitly assigned to the agent are excluded too — the assignments stay in place and take effect again in **Custom** mode
 
-Built-in tools are excluded by default. When an agent is created in **All** mode or switched to it, the exclusion list is pre-filled with every built-in tool that is not assigned to the agent — except a small set that always stays available: `search_tools`, `run_tool`, the sandbox and file tools (`run_command`, `upload_file`, `download_file`, `search_files`, `read_file`, `save_file`, `edit_file`, `delete_file`), and `query_knowledge_sources`. So by default an **All**-mode agent cannot use the built-ins that manage the platform itself (creating agents, managing teams, policies, and so on) until an admin removes them from the list. The pre-fill runs on every switch to **All** — to keep a built-in usable across switches, assign it to the agent. When a platform update ships a new built-in tool, agents already in **All** mode get it excluded by default; admins opt in by un-excluding it. Agents that were in **All** mode before exclusions existed keep exactly their capabilities: the unassigned built-ins they could not use are now on their exclusion list, visible and editable.
+Built-in tools are excluded by default. When an agent is created in **Auto** mode or switched to it, the exclusion list is pre-filled with every built-in tool that is not assigned to the agent — except a small set that always stays available: `search_tools`, `run_tool`, the sandbox and file tools (`run_command`, `upload_file`, `download_file`, `search_files`, `read_file`, `save_file`, `edit_file`, `delete_file`), and `query_knowledge_sources`. So by default an **Auto**-mode agent cannot use the built-ins that manage the platform itself (creating agents, managing teams, policies, and so on) until an admin removes them from the list. The pre-fill runs on every switch to **Auto** — to keep a built-in usable across switches, assign it to the agent. When a platform update ships a new built-in tool, agents already in **Auto** mode get it excluded by default; admins opt in by un-excluding it. Agents that were in **Auto** mode before exclusions existed keep exactly their capabilities: the unassigned built-ins they could not use are now on their exclusion list, visible and editable.
 
 Only `search_tools` and `run_tool` can never be excluded; everything else can. Agent delegation tools sit outside the exclusion list — manage them through delegation itself — and the built-in server cannot be excluded as a whole, only tool by tool.
 
@@ -64,7 +64,7 @@ Trigger setup is managed from **Agent Triggers**. Slack, MS Teams, and Incoming 
 
 ## Knowledge Sources
 
-Knowledge follows the same **All** / **Custom** setting as tools (**Tools & Knowledge Sources** in the agent dialog). In **All** mode the agent can search every Knowledge Base and connector the chatting user can access, in its environment. In **Custom** mode it searches only the sources you assign to it. Either mode is still filtered by each user's own visibility.
+Knowledge follows the same **Auto** / **Custom** setting as tools (**Tools & Knowledge Sources** in the agent dialog). In **Auto** mode the agent can search every Knowledge Base and connector the chatting user can access, in its environment. In **Custom** mode it searches only the sources you assign to it. Either mode is still filtered by each user's own visibility.
 
 Whenever an agent has at least one reachable knowledge source, Archestra adds the built-in [`query_knowledge_sources`](/docs/platform-archestra-mcp-server#query_knowledge_sources) tool so the model can search across them during a run.
 

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -3,7 +3,7 @@ title: "Environments"
 category: Administration
 description: "Isolate tools, knowledge, runtimes, and cost limits across deployment environments"
 order: 3
-lastUpdated: 2026-07-03
+lastUpdated: 2026-07-09
 ---
 
 <!--
@@ -53,7 +53,7 @@ An agent, MCP gateway, or LLM proxy assigned to **Production** can only see and 
 
 Matching is strict: a Production resource matches only other Production resources, a Dev resource matches only Dev, and Default matches only Default. Built-in servers (the Archestra control-plane server and Playwright) are exempt and always available.
 
-This applies to both explicitly assigned tools/knowledge and the implicit "All tools" access mode — in both cases cross-environment resources are filtered out before they are listed or executed. In the agent dialog's explicit assignment pickers, resources from another environment are shown disabled.
+This applies to both explicitly assigned tools/knowledge and the implicit **Auto** access mode — in both cases cross-environment resources are filtered out before they are listed or executed. In the agent dialog's explicit assignment pickers, resources from another environment are shown disabled.
 
 ## Network egress policies
 

--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -3,7 +3,7 @@ title: Knowledge
 category: Knowledge
 order: 1
 description: Built-in RAG knowledge — Knowledge Bases, connectors, and retrieval architecture
-lastUpdated: 2026-07-05
+lastUpdated: 2026-07-09
 ---
 
 A Knowledge Base is a set of connectors that index your data for retrieval. Connectors pull from tools such as Jira, Confluence, GitHub, Notion, SharePoint, Google Drive, and Salesforce. An agent assigned a Knowledge Base can query that data to answer questions. The full RAG stack (chunking, embedding, hybrid search, reranking) runs inside Archestra — no external vector database or separate retrieval service required.
@@ -44,7 +44,7 @@ A Knowledge Base is a set of connectors. Create one from the **Knowledge** page 
 
 An agent — or an [MCP Gateway](/docs/platform-mcp-gateway) — reaches knowledge through the **Tools & Knowledge Sources** setting in its dialog, which has two modes:
 
-- **All** — the agent can search every Knowledge Base and connector the chatting user can access, within the agent's environment. Nothing is assigned; the reachable set follows each user's own visibility.
+- **Auto** — the agent can search every Knowledge Base and connector the chatting user can access, within the agent's environment. Nothing is assigned; the reachable set follows each user's own visibility.
 - **Custom** — the agent searches only the Knowledge Bases and connectors you assign to it. Pick them under **Knowledge Sources**; the picker stays disabled until an embedding and reranking model are set (see [Configuration](#configuration)).
 
 Either mode is still filtered by the chatting user's own visibility, so an agent never surfaces a source the user could not read themselves. Once the agent has at least one reachable source, it gains a `query_knowledge_sources` tool that searches across them and returns the most relevant documents.

--- a/docs/pages/platform-mcp-gateway.md
+++ b/docs/pages/platform-mcp-gateway.md
@@ -3,7 +3,7 @@ title: MCP Gateway
 category: MCP
 order: 1
 description: Unified access point for all MCP servers
-lastUpdated: 2026-07-05
+lastUpdated: 2026-07-09
 ---
 
 MCP Gateways are the MCP endpoints you expose to clients such as Cursor, Claude Desktop, Open WebUI, and custom agents. Each gateway presents a curated set of tools through one MCP endpoint, so clients do not need to connect to every MCP server directly.
@@ -30,7 +30,7 @@ An admin picks each gateway tool explicitly. Each assignment can be pinned to a 
 
 Use explicit assignment when different clients need different subsets of the same installed MCP server, or when a gateway should use a shared service-account connection for some tools and caller-specific credentials for others.
 
-A gateway shares the agent **All** / **Custom** **Tools & Knowledge Sources** control. Explicit assignment above is **Custom** mode; **All** mode lets `search_tools`/`run_tool` reach every tool the signed-in user can access (see [Load Tools When Needed](#load-tools-when-needed)). A gateway can also be assigned [knowledge sources](/docs/platform-knowledge#assigning-to-an-agent) under the same setting, giving it a `query_knowledge_sources` tool.
+A gateway shares the agent **Auto** / **Custom** **Tools & Knowledge Sources** control. Explicit assignment above is **Custom** mode; **Auto** mode lets `search_tools`/`run_tool` reach every tool the signed-in user can access (see [Load Tools When Needed](#load-tools-when-needed)). A gateway can also be assigned [knowledge sources](/docs/platform-knowledge#assigning-to-an-agent) under the same setting, giving it a `query_knowledge_sources` tool.
 
 ## Authentication
 
@@ -106,7 +106,7 @@ Those two tools are enabled implicitly and do not appear in the built-in tool pi
 
 Use this when the full tool list is too large or noisy to send to the model on every turn, but the gateway still needs the same underlying tool access.
 
-With **Access all tools** also enabled, a signed-in user's `search_tools` and `run_tool` reach every MCP catalog tool and knowledge source that user can access. Credentials resolve at call time per the MCP server's **Agent connections** setting — on behalf of the user by default, or one shared account when the server is configured that way. Nothing is assigned to the gateway. Sessions authenticated with org or team tokens stay limited to assigned tools, and the org-wide **Dynamic Tool Access** security setting can disable the behavior entirely.
+With **Auto** tool mode also enabled, a signed-in user's `search_tools` and `run_tool` reach every MCP catalog tool and knowledge source that user can access. Credentials resolve at call time per the MCP server's **Default credential** setting — on behalf of the user by default, or one shared account when the server is configured that way. Nothing is assigned to the gateway. Sessions authenticated with org or team tokens stay limited to assigned tools, and the org-wide **Dynamic Tool Access** security setting can disable the behavior entirely.
 
 Tool call policies still apply to the target tool. `run_tool` does not bypass input conditions, team conditions, untrusted-context rules, or approval-required rules.
 

--- a/platform/backend/src/archestra-mcp-server/run-tool.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.ts
@@ -501,7 +501,7 @@ async function dispatchTool({
     // by this key; headless executions use their isolation key so
     // concurrent runs never share a session and cleanup can close it.
     // availableTool lets a tool the agent has no assignment for execute in
-    // "All tools" mode; it is only ever set after the dynamic-access gates
+    // "Auto" mode; it is only ever set after the dynamic-access gates
     // above passed, and the MCP server's connection policy still decides
     // which credential the call uses.
     {

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -2244,7 +2244,7 @@ describe("buildArchestraToolOutput", () => {
     const org = await makeOrganization();
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "admin" });
-    // "All tools" mode: run_tool dispatches to any tool the user can access
+    // "Auto" mode: run_tool dispatches to any tool the user can access
     // without an agent_tools assignment. The UI resource must still attach so
     // the MCP App renders as an iframe instead of a plain tool-call card.
     const agent = await makeAgent({

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -1495,7 +1495,7 @@ describe("McpClient", () => {
         );
       });
 
-      test("All-tools mode ignores a static assignment pin and uses the server's connection policy", async ({
+      test("Auto tool mode ignores a static assignment pin and uses the server's default-credential policy", async ({
         makeAgent,
         makeMember,
         makeOrganization,
@@ -1504,7 +1504,7 @@ describe("McpClient", () => {
         const org = await makeOrganization();
         const user = await makeUser();
         await makeMember(user.id, org.id, { role: "member" });
-        // Agent in "All tools" mode (access_all_tools = true).
+        // Agent in "Auto" mode (access_all_tools = true).
         const allAgent = await makeAgent({
           name: "All Tools Agent",
           organizationId: org.id,
@@ -2398,7 +2398,7 @@ describe("McpClient", () => {
       }) => {
         const testUser = await makeUser({ email: "alltools-auth@example.com" });
 
-        // A catalog the agent was never assigned a tool from. In "All tools"
+        // A catalog the agent was never assigned a tool from. In "Auto"
         // mode the dispatcher pre-resolves the tool and passes it through as
         // `availableTool`, so the assignment carries no catalogName.
         const dynCatalog = await InternalMcpCatalogModel.create({

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1351,13 +1351,13 @@ class McpClient {
       tool = undefined;
     }
 
-    // Dynamic tool access ("All tools" mode): the dispatcher pre-resolved a
+    // Dynamic tool access ("Auto" mode): the dispatcher pre-resolved a
     // tool the agent has no assignment row for. Shape it like an assignment so
     // downstream resolution is identical. It has no row to inherit a credential
     // mode from and can't carry a static pin, so it resolves its connection at
     // call time — which still defers to the MCP server's connection policy
     // (on-behalf-of the caller, or a pinned service account). An assigned row
-    // keeps precedence here; in "All tools" mode the override below then routes
+    // keeps precedence here; in "Auto" mode the override below then routes
     // even a leftover static assignment through the server's connection policy.
     if (!tool && availableTool && availableTool.name === toolCall.name) {
       tool = {
@@ -1421,7 +1421,7 @@ class McpClient {
       };
     }
 
-    // "All tools" mode overrides a leftover per-tool credential pin. When the
+    // "Auto" mode overrides a leftover per-tool credential pin. When the
     // agent has access_all_tools on, credentials follow the MCP server's
     // connection policy (on-behalf-of the caller, or a pinned service account)
     // for every tool — a static assignment left over from Custom mode must not
@@ -1435,7 +1435,7 @@ class McpClient {
           agentId: owner.id,
           mcpServerId: tool.mcpServerId,
         },
-        "All-tools mode: ignoring static assignment pin, resolving via the MCP server's connection policy",
+        "Auto tool mode: ignoring static assignment pin, resolving via the MCP server's default-credential policy",
       );
       tool = {
         ...tool,

--- a/platform/backend/src/database/schemas/agent.ts
+++ b/platform/backend/src/database/schemas/agent.ts
@@ -133,11 +133,12 @@ const agentsTable = softDeletablePgTable(
       .default("full"),
 
     /**
-     * Whether search_tools/run_tool may dynamically discover and run tools the
-     * calling user can access (MCP catalog tools and knowledge sources) beyond
-     * the agent's assigned set. Nothing is assigned to the agent; the MCP
-     * server's connection policy decides which credential each call uses. This
-     * per-agent flag is the sole gate for dynamic tool access.
+     * "Auto" tool mode (vs "Custom"): whether search_tools/run_tool may
+     * dynamically discover and run tools the calling user can access (MCP
+     * catalog tools and knowledge sources) beyond the agent's assigned set.
+     * Nothing is assigned to the agent; the MCP server's default-credential
+     * policy decides which credential each call uses. This per-agent flag is
+     * the sole gate for dynamic tool access.
      */
     accessAllTools: boolean("access_all_tools").notNull().default(false),
 

--- a/platform/backend/src/database/schemas/internal-mcp-catalog.ts
+++ b/platform/backend/src/database/schemas/internal-mcp-catalog.ts
@@ -55,8 +55,10 @@ const internalMcpCatalogTable = pgTable(
      */
     multitenant: boolean("multitenant").notNull().default(false),
     /**
-     * Agent connections policy for call-time ("dynamic") credential
-     * resolution. NULL (default) = resolve at call time: each caller uses its
+     * Default-credential policy for call-time ("dynamic") credential
+     * resolution — surfaced in the UI as the server's "Default credential"
+     * setting. It governs Auto-mode calls and Custom-mode assignments left on
+     * resolve-at-call-time. NULL (default) = each caller uses its
      * own connection (user token → that user's install, team token → that
      * team's install) and gets an actionable connect prompt when none exists.
      * Set to an mcp_servers.id to pin a service account: every

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -345,7 +345,7 @@ async function seedArchestraCatalogAndTools(): Promise<void> {
   await ToolModel.backfillNewSkillToolsToEnabledOrgs(newlyCreatedToolNames);
   await ToolModel.backfillNewAppToolsToEnabledOrgs(newlyCreatedToolNames);
   await ToolModel.backfillNewSandboxToolsToAgents(newlyCreatedToolNames);
-  // A brand-new built-in tool must not silently reach existing All-tools-mode
+  // A brand-new built-in tool must not silently reach existing Auto-mode
   // agents: pre-exclude it for them. Runs after the assignment backfills above
   // so a tool those just assigned is skipped (assignments beat the pre-fill);
   // exempt short names are skipped inside the model method.
@@ -359,7 +359,7 @@ async function seedArchestraCatalogAndTools(): Promise<void> {
   if (excludedRowCount > 0) {
     logger.info(
       { excludedRowCount, newToolCount: newlyCreatedToolIds.length },
-      "Pre-excluded new built-in tools for All-tools-mode agents",
+      "Pre-excluded new built-in tools for Auto-mode agents",
     );
   }
   logger.info("Seeded Archestra catalog and tools");

--- a/platform/backend/src/guardrails/tool-invocation.ts
+++ b/platform/backend/src/guardrails/tool-invocation.ts
@@ -75,7 +75,7 @@ export async function evaluateSingleMcpToolInvocationPolicy(params: {
    * The id of the tool row the gateway resolved to execute. When supplied, the
    * policy is evaluated against this exact row (instead of a name lookup) and
    * the id rides along on the structured block so the chat "Edit policy" modal
-   * can resolve the tool even when it has no agent_tools assignment (All mode).
+   * can resolve the tool even when it has no agent_tools assignment (Auto mode).
    */
   resolvedToolId?: string;
 }): Promise<PolicyBlockResult | null> {

--- a/platform/backend/src/models/agent-excluded-tool.ts
+++ b/platform/backend/src/models/agent-excluded-tool.ts
@@ -79,7 +79,7 @@ class AgentExcludedToolModel {
   }
 
   /**
-   * Pre-fill the agent's exclusion list for "All tools" mode: every built-in
+   * Pre-fill the agent's exclusion list for "Auto" mode: every built-in
    * Archestra tool that is not assigned to the agent and whose short name is
    * not pre-fill-exempt gets an exclusion row. Additive and idempotent —
    * existing rows are never updated or deleted, so callers can re-run it on

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -372,7 +372,7 @@ class AgentModel {
 
     // All-tools agents are inserted with the toggle OFF and flipped on at the
     // end, in one transaction with the exclusion pre-fill (see below), so a
-    // committed agent can never sit in All mode without its pre-filled
+    // committed agent can never sit in Auto mode without its pre-filled
     // exclusions — a failure between insert and flip leaves it in Custom mode
     // (fail-closed) instead of fail-open.
     const enableAccessAllTools = agent.accessAllTools === true;
@@ -2047,7 +2047,7 @@ class AgentModel {
     // Switching accessAllTools off→on pre-fills the agent's exclusion list
     // with every unassigned built-in tool outside the exempt set. Flip and
     // pre-fill commit in ONE transaction (serialized by the same row lock the
-    // exclusions full-replace takes) so the agent can never sit in All mode
+    // exclusions full-replace takes) so the agent can never sit in Auto mode
     // without its pre-fill; every off→on switch re-runs it (additively).
     // on→on or →off updates never touch the exclusion rows.
     const prefillsExclusions =
@@ -2543,7 +2543,7 @@ class AgentModel {
 
       // This raw INSERT creates the gateways directly in All-tools mode, so
       // pre-fill their exclusion lists in the same transaction — none of them
-      // may commit in All mode without the pre-fill.
+      // may commit in Auto mode without the pre-fill.
       await AgentExcludedToolModel.prefillManyForAllToolsMode(
         insertedRows.map((row) => row.id),
         tx,
@@ -2821,7 +2821,7 @@ class AgentModel {
           toolExposureMode: sourceAgent.toolExposureMode,
           // Clone in Custom mode first and flip below, so a crash before the
           // exclusions are copied can only leave a fail-closed (assigned-tools-
-          // only) clone, never one wide open in All mode with no exclusions.
+          // only) clone, never one wide open in Auto mode with no exclusions.
           accessAllTools: false,
           considerContextUntrusted: sourceAgent.considerContextUntrusted,
           incomingEmailEnabled: sourceAgent.incomingEmailEnabled,

--- a/platform/backend/src/models/tool-invocation-policy.ts
+++ b/platform/backend/src/models/tool-invocation-policy.ts
@@ -473,7 +473,7 @@ class ToolInvocationPolicyModel {
         }
       }
 
-      // Names the agent has no assignment for (e.g. All-mode tools reached on
+      // Names the agent has no assignment for (e.g. Auto-mode tools reached on
       // the proxy path) fall back to a deterministically-ordered global lookup.
       const unresolvedNames = [...namesToResolve].filter(
         (name) => !toolIdsByName.has(name),

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -406,7 +406,7 @@ class ToolModel {
    * Read the fields the policy editor needs for a tool the caller can access.
    * Unlike findById, catalog-backed tools (agentId null) are scoped by catalog
    * access rather than returned to anyone, so this is safe for user-facing
-   * reads — including All-mode tools that have no agent_tools assignment.
+   * reads — including Auto-mode tools that have no agent_tools assignment.
    */
   static async findByIdForOrg(params: {
     id: string;
@@ -429,7 +429,7 @@ class ToolModel {
       return null;
     }
 
-    // Catalog-backed tools (including All-mode tools with no agent_tools row) are
+    // Catalog-backed tools (including Auto-mode tools with no agent_tools row) are
     // scoped by catalog access, which is org-scoped even for admins. Mirror the
     // discovery path (getMcpToolsAccessibleToUser): catalog visibility is the
     // gate — a visible catalog stays readable even when the caller has no
@@ -1603,7 +1603,7 @@ class ToolModel {
    * enablement would otherwise never receive it: migration 0332 runs in the
    * pre-upgrade hook, before the seed creates these flag-gated rows, so it
    * cannot backfill them. Matching AgentModel.create, this spans every agent
-   * kind and both tool modes — an All-tools agent advertises only assigned
+   * kind and both tool modes — an Auto-mode agent advertises only assigned
    * built-ins in chat, so it needs the rows too — and skips built-in system
    * agents, which bypass the create-time tool hooks by design. Idempotent:
    * only the newly-created short names are assigned, via

--- a/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
@@ -823,12 +823,15 @@ function computeCanonicalStateByPod(
   return canonicalStateByPod;
 }
 
-// The catalog-level "agent connections" setting as a standard settings row:
+// The catalog-level "default credential" setting as a standard settings row:
 // title, a plain-language description that names the current choice, and a
-// dedicated select whose options are self-explanatory. NULL (default) = agents
-// act on behalf of whoever is chatting, using that person's own connection;
-// an mcp_servers.id = agents always use that one connection. Saves on change;
-// gated by the same authorization as editing the catalog item.
+// dedicated select whose options are self-explanatory. It governs every tool
+// assignment that resolves credentials at call time — Auto mode always, and
+// Custom-mode assignments unless a specific connection is pinned on the
+// assignment itself. NULL (default) = agents act on behalf of whoever is
+// calling, using that person's own connection; an mcp_servers.id = agents
+// always use that one connection. Saves on change; gated by the same
+// authorization as editing the catalog item.
 const ON_BEHALF_OF_VALUE = "__on_behalf_of__";
 
 function AgentConnectionsSection({
@@ -857,26 +860,28 @@ function AgentConnectionsSection({
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
       <div className="max-w-xl space-y-1">
-        <h4 className="text-sm font-medium">Agent connections</h4>
+        <h4 className="text-sm font-medium">Default credential</h4>
         <p className="text-sm text-muted-foreground">
           {!pinnedId ? (
             <>
-              Agents act on behalf of whoever is chatting — each person uses
+              Agents connect on behalf of whoever is calling — each person uses
               their own connection if they have one, otherwise a team or
-              organization connection they can access.
+              organization connection they can access. Applies in Auto mode and
+              to Custom tool assignments that resolve at call time.
             </>
           ) : pinRemoved ? (
             <>
-              The selected connection was removed. Agents act on behalf of
-              whoever is chatting until you choose another one.
+              The selected connection was removed. Agents connect on behalf of
+              whoever is calling until you choose another one.
             </>
           ) : (
             <>
-              Agents always connect as{" "}
+              Agents connect as{" "}
               <span className="font-medium text-foreground">
                 {pinnedConnection ? connectionLabel(pinnedConnection) : ""}
               </span>
-              , no matter who is chatting.
+              , no matter who is calling. Applies in Auto mode and to Custom
+              tool assignments that resolve at call time.
             </>
           )}{" "}
           <ExternalDocsLink

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-assignments-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-assignments-dialog.tsx
@@ -336,13 +336,13 @@ export function McpAssignmentsDialog({
             pending?.credentialId ?? assignment?.credentialId ?? null,
         });
       } else {
-        // Toggle ON: pre-select all tools with default credential
+        // Toggle ON: pre-select all tools. New assignments default to
+        // resolve-at-call-time, which follows the server's default credential
+        // setting; pinning a static credential is an explicit choice.
         const allToolIds = new Set(allTools.map((t) => t.id));
         const defaultCredential =
           pending?.credentialId ??
           assignment?.credentialId ??
-          (prefersEnterpriseManaged ? DYNAMIC_CREDENTIAL_VALUE : null) ??
-          mcpServers[0]?.id ??
           DYNAMIC_CREDENTIAL_VALUE;
         updatePendingChanges(profileId, {
           selectedToolIds: allToolIds,
@@ -350,14 +350,7 @@ export function McpAssignmentsDialog({
         });
       }
     },
-    [
-      pendingChanges,
-      assignmentsByProfile,
-      allTools,
-      mcpServers,
-      prefersEnterpriseManaged,
-      updatePendingChanges,
-    ],
+    [pendingChanges, assignmentsByProfile, allTools, updatePendingChanges],
   );
 
   // Build combobox items and selected IDs for each section
@@ -695,8 +688,9 @@ function ProfileAssignmentPill({
           <div className="p-4 border-b space-y-2 shrink-0">
             <Label className="text-sm font-medium">Connect on behalf of</Label>
             <p className="text-xs text-muted-foreground">
-              Choose whether this tool uses a fixed server connection or
-              resolves credentials for the current caller at runtime.
+              By default, credentials resolve at call time per the server's
+              default credential setting. Pin a specific connection to always
+              use it for these tools instead.
             </p>
             <TokenSelect
               catalogId={catalogId}

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -711,8 +711,8 @@ export function AgentDialog({
   const [passthroughHeaders, setPassthroughHeaders] = useState<string[]>([]);
   const [toolExposureMode, setToolExposureMode] =
     useState<ToolExposureMode>("full");
-  // New agents default to implicit ("All tools") access; editing an existing
-  // agent overwrites this from its stored value.
+  // New agents default to Auto mode (implicit access to all tools); editing an
+  // existing agent overwrites this from its stored value.
   const [accessAllTools, setAccessAllTools] = useState(true);
   // Auto-mode exclusions dirty tracking: { initial, current } normalized
   // payloads reported by the exclusions editor (null until it initializes and
@@ -739,18 +739,19 @@ export function AgentDialog({
         : "The environment for this agent's code sandbox (runtime and network egress) and the tools and knowledge sources it can use.";
   const isBuiltIn = !!agent?.builtIn;
   const agentHooksEnabled = useFeature("agentHooksEnabled");
-  // "All tools" (implicit access) is the default for new agents; admins can
-  // switch an agent to "Custom" (explicitly assigned tools). Implicit access is
-  // scoped to tools/knowledge visible to the user AND in the agent's environment.
-  const allToolsMode = accessAllTools;
-  // Seed the exclusions editor with the backend's All-mode pre-fill whenever
-  // saving would put the agent into All mode from scratch: creating a new
-  // agent on the All tab, or editing an agent whose SAVED accessAllTools is
-  // off while the All tab is selected. An agent already saved in All mode has
+  // "Auto" (implicit access to all tools) is the default for new agents; admins
+  // can switch an agent to "Custom" (explicitly assigned tools). Implicit access
+  // is scoped to tools/knowledge visible to the user AND in the agent's
+  // environment.
+  const autoToolsMode = accessAllTools;
+  // Seed the exclusions editor with the backend's Auto-mode pre-fill whenever
+  // saving would put the agent into Auto mode from scratch: creating a new
+  // agent on the Auto tab, or editing an agent whose SAVED accessAllTools is
+  // off while the Auto tab is selected. An agent already saved in Auto mode has
   // its pre-fill persisted server-side, so the editor just loads it.
   const savedAccessAllTools = (freshAgent || agent)?.accessAllTools ?? false;
   const seedDefaultExclusions =
-    allToolsMode && (agent ? !savedAccessAllTools : true);
+    autoToolsMode && (agent ? !savedAccessAllTools : true);
   const builtInAgentName = agent?.builtInAgentConfig?.name;
   const isPolicyConfigBuiltIn =
     builtInAgentName === BUILT_IN_AGENT_IDS.POLICY_CONFIG;
@@ -845,8 +846,8 @@ export function AgentDialog({
             autoConfigureOnToolDiscovery: false,
             dualLlmMaxRounds: "5",
             passthroughHeaders: [],
-            // New agents default to "All tools" (implicit access); admins can
-            // switch to "Custom" (explicitly assigned tools).
+            // New agents default to "Auto" (implicit access to all tools);
+            // admins can switch to "Custom" (explicitly assigned tools).
             toolExposureMode: "full",
             accessAllTools: true,
           };
@@ -1102,7 +1103,7 @@ export function AgentDialog({
         });
         savedAgentId = updated?.id ?? agent.id;
         // Auto-mode exclusions (full-replace PUT; no-op when unchanged). Runs
-        // AFTER the agent update so that when accessAllTools flips Custom→All,
+        // AFTER the agent update so that when accessAllTools flips Custom→Auto,
         // the backend's switch-time pre-fill lands first and this full replace
         // is the authoritative last write of the set the user saw and edited.
         if (!isBuiltIn) {
@@ -1666,39 +1667,43 @@ export function AgentDialog({
                     <div className="space-y-2">
                       <Label>Tools & Knowledge Sources</Label>
                       <Tabs
-                        value={allToolsMode ? "all" : "specific"}
+                        value={autoToolsMode ? "auto" : "custom"}
                         onValueChange={(value) => {
-                          const all = value === "all";
-                          setAccessAllTools(all);
+                          const auto = value === "auto";
+                          setAccessAllTools(auto);
                           // Dynamic access only works through the search/run
                           // dispatch surface, so picking it enables that mode.
-                          if (all) {
+                          if (auto) {
                             setToolExposureMode("search_and_run_only");
                           }
                         }}
                       >
                         <TabsList className="grid w-full grid-cols-2">
-                          <TabsTrigger value="all">All</TabsTrigger>
-                          <TabsTrigger value="specific">Custom</TabsTrigger>
+                          <TabsTrigger value="auto">Auto</TabsTrigger>
+                          <TabsTrigger value="custom">Custom</TabsTrigger>
                         </TabsList>
                       </Tabs>
-                      {allToolsMode && (
+                      {autoToolsMode ? (
                         <ul className="space-y-1.5 pt-1 text-xs text-muted-foreground">
                           <li className="flex gap-2">
                             <CheckIcon className="mt-px size-3.5 shrink-0" />
-                            Every MCP tool and knowledge source the chatting
-                            user can access, in this agent's environment
+                            Every MCP tool and knowledge source the calling user
+                            can access, in this{" "}
+                            {agentTypeDisplayName[agentType] || "agent"}'s
+                            environment — new servers included automatically
                           </li>
                           <li className="flex gap-2">
                             <CheckIcon className="mt-px size-3.5 shrink-0" />
-                            Connects per the server's policy — on behalf of the
-                            chatting user by default
+                            Credentials resolve at call time per each server's
+                            default credential setting — on behalf of the
+                            calling user unless the server always uses one
+                            account
                           </li>
                           <li className="flex gap-2">
                             <CheckIcon className="mt-px size-3.5 shrink-0" />
                             <span>
-                              Discovered on demand — the catalog never burns
-                              context tokens.{" "}
+                              Tools are discovered on demand — the catalog never
+                              burns context tokens.{" "}
                               <ExternalDocsLink
                                 href={toolExposureDocsUrl}
                                 className="underline"
@@ -1709,6 +1714,12 @@ export function AgentDialog({
                             </span>
                           </li>
                         </ul>
+                      ) : (
+                        <p className="pt-1 text-xs text-muted-foreground">
+                          Only the tools and knowledge sources you assign below
+                          are available to this{" "}
+                          {agentTypeDisplayName[agentType] || "agent"}.
+                        </p>
                       )}
                       {/* Auto-mode exclusions; kept mounted while hidden so
                         pending edits and the save-time ref survive switching
@@ -1716,16 +1727,16 @@ export function AgentDialog({
                       <div
                         className={cn(
                           "space-y-2 pt-2",
-                          !allToolsMode && "hidden",
+                          !autoToolsMode && "hidden",
                         )}
                       >
                         <p className="text-xs font-medium text-muted-foreground">
                           Disabled tools
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          These tools are disabled for this{" "}
+                          These tools stay disabled for this{" "}
                           {agentTypeDisplayName[agentType] || "agent"} while
-                          "All" access is on.
+                          Auto mode is on.
                         </p>
                         <AgentToolExclusionsEditor
                           ref={agentToolExclusionsEditorRef}
@@ -1736,9 +1747,9 @@ export function AgentDialog({
                         />
                       </div>
                       {/* Kept mounted while hidden so pending selections and the
-                        save-time ref survive switching to "All". */}
+                        save-time ref survive switching to "Auto". */}
                       <div
-                        className={cn("space-y-3", allToolsMode && "hidden")}
+                        className={cn("space-y-3", autoToolsMode && "hidden")}
                       >
                         <div className="space-y-2">
                           <p className="text-xs font-medium text-muted-foreground">
@@ -2013,9 +2024,9 @@ export function AgentDialog({
                       </div>
                     </div>
 
-                    {/* Progressive loading is only a choice for custom tools —
-                      "All" requires the search/run dispatch surface. */}
-                    {!allToolsMode && (
+                    {/* Progressive loading is only a choice for Custom mode —
+                      "Auto" requires the search/run dispatch surface. */}
+                    {!autoToolsMode && (
                       <div className="flex items-center justify-between gap-4">
                         <div className="space-y-0.5">
                           <Label htmlFor="load-tools-when-needed">

--- a/platform/frontend/src/components/agent-tool-exclusions-editor.tsx
+++ b/platform/frontend/src/components/agent-tool-exclusions-editor.tsx
@@ -69,12 +69,12 @@ export interface AgentToolExclusionsEditorRef {
 interface AgentToolExclusionsEditorProps {
   agentId?: string;
   /**
-   * Seed the entries with the backend's All-mode exclusion pre-fill: the
+   * Seed the entries with the backend's Auto-mode exclusion pre-fill: the
    * initial state becomes the UNION of the server-saved exclusions and the
    * client-computed default set (every unassigned built-in tool outside the
-   * pre-fill-exempt set). Pass true when saving would put the agent into All
-   * mode from scratch — creating a new agent on the All tab, or editing an
-   * agent whose SAVED accessAllTools is off while the All tab is selected —
+   * pre-fill-exempt set). Pass true when saving would put the agent into Auto
+   * mode from scratch — creating a new agent on the Auto tab, or editing an
+   * agent whose SAVED accessAllTools is off while the Auto tab is selected —
    * so the form shows the pre-filled reality instead of an empty list, and a
    * later full-replace save can't wipe the server pre-fill with a stale
    * baseline. While the underlying queries load (or this prop flips), the
@@ -104,7 +104,7 @@ interface AgentToolExclusionsEditorProps {
 }
 
 /**
- * Auto-mode ("All tools") exclusion editor: pick MCP servers to exclude tools
+ * Auto-mode (access all tools) exclusion editor: pick MCP servers to exclude tools
  * from the agent's implicit tool surface. Tools are grouped by server for
  * display; every selection resolves to individual tool ids in the saved
  * payload (exclusion is purely per-tool — there is no whole-server exclusion).
@@ -131,7 +131,7 @@ export const AgentToolExclusionsEditor = forwardRef<
     useAgentToolExclusions(agentId);
   const updateExclusions = useUpdateAgentToolExclusions();
 
-  // Inputs for the seeded default exclusion set (mirrors the backend All-mode
+  // Inputs for the seeded default exclusion set (mirrors the backend Auto-mode
   // pre-fill): the agent's saved assignments, or — for a new agent — the
   // creation-default set the backend will auto-assign, composed from the same
   // org/deployment flags the create path reads.

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -631,13 +631,13 @@ const AgentToolsEditorContent = forwardRef<
         const tools = (toolQuery?.data as CatalogTool[] | undefined) ?? [];
         const allToolIds = new Set(tools.map((t) => t.id));
 
-        // Get default credential
-        const credentials = allCredentials?.[catalogId] ?? [];
-        const defaultCredential = credentials[0]?.id ?? null;
-
         registerPendingChanges(catalogId, {
           selectedToolIds: allToolIds,
-          credentialSourceId: pending?.credentialSourceId ?? defaultCredential,
+          // Newly assigned tools default to resolve-at-call-time, which follows
+          // the server's default credential setting; pinning a static
+          // credential is an explicit per-assignment choice.
+          credentialSourceId:
+            pending?.credentialSourceId ?? DYNAMIC_CREDENTIAL_VALUE,
           catalogItem: catalog,
           selectAll: true,
           isActive: true,
@@ -648,7 +648,6 @@ const AgentToolsEditorContent = forwardRef<
       catalogItems,
       assignedToolsByCatalog,
       toolCountQueries,
-      allCredentials,
       registerPendingChanges,
     ],
   );
@@ -912,12 +911,13 @@ function McpServerPill({
   const mcpServers = credentials?.[catalogItem.id] ?? [];
   const prefersEnterpriseManaged = catalogItem.enterpriseManagedConfig != null;
 
+  // Static assignments show their pinned connection; everything else —
+  // dynamic, enterprise-managed, or a brand-new assignment — defaults to
+  // resolve-at-call-time.
   const currentCredentialSource =
-    assignedTools[0]?.credentialResolutionMode === "dynamic"
-      ? DYNAMIC_CREDENTIAL_VALUE
-      : assignedTools[0]?.credentialResolutionMode === "enterprise_managed"
-        ? DYNAMIC_CREDENTIAL_VALUE
-        : (assignedTools[0]?.mcpServerId ?? mcpServers[0]?.id ?? null);
+    assignedTools[0]?.credentialResolutionMode === "static"
+      ? (assignedTools[0].mcpServerId ?? DYNAMIC_CREDENTIAL_VALUE)
+      : DYNAMIC_CREDENTIAL_VALUE;
 
   // Currently assigned tool IDs - use sorted string for stable comparison
   const currentAssignedToolIds = useMemo(
@@ -955,6 +955,12 @@ function McpServerPill({
   }, [currentAssignedToolIdsKey]);
 
   useEffect(() => {
+    // Wait until credentials load so a valid static pin isn't reset to
+    // dynamic while the list is still empty.
+    if (!credentials) {
+      return;
+    }
+
     if (selectedCredential === DYNAMIC_CREDENTIAL_VALUE) {
       return;
     }
@@ -966,15 +972,9 @@ function McpServerPill({
       return;
     }
 
-    if (prefersEnterpriseManaged) {
-      setSelectedCredential(DYNAMIC_CREDENTIAL_VALUE);
-      return;
-    }
-
-    if (mcpServers.length > 0) {
-      setSelectedCredential(mcpServers[0].id);
-    }
-  }, [mcpServers, prefersEnterpriseManaged, selectedCredential]);
+    // Unset or stale selection — fall back to resolve-at-call-time.
+    setSelectedCredential(DYNAMIC_CREDENTIAL_VALUE);
+  }, [credentials, mcpServers, selectedCredential]);
 
   // Auto-select all tools when selectAll flag is set and tools finish loading.
   // Use a ref so auto-select only fires once (at mount) and doesn't fight user deselections.
@@ -1064,8 +1064,9 @@ function McpServerPill({
         <div className="p-4 border-b space-y-2 shrink-0">
           <Label className="text-sm font-medium">Connect on behalf of</Label>
           <p className="text-xs text-muted-foreground">
-            Choose whether this tool uses a fixed server connection or resolves
-            credentials for the current caller at runtime.
+            By default, credentials resolve at call time per the server's
+            default credential setting. Pin a specific connection to always use
+            it for these tools instead.
           </p>
           <TokenSelect
             catalogId={catalogItem.id}

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -34,7 +34,10 @@ import { CatalogDocsLink } from "@/components/catalog-docs-link";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import { OAuthConfirmationDialog } from "@/components/oauth-confirmation-dialog";
 import { SystemPromptEditor } from "@/components/system-prompt-editor";
-import { TokenSelect } from "@/components/token-select";
+import {
+  DYNAMIC_CREDENTIAL_VALUE,
+  TokenSelect,
+} from "@/components/token-select";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -280,7 +283,7 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
             <span className="truncate flex-1 text-left">
               {displayAgentName}
             </span>
-            {/* In "All tools" mode the agent reaches everything dynamically,
+            {/* In Auto mode the agent reaches everything dynamically,
                 so the per-server avatar group + its tool selector are
                 meaningless — hide them. */}
             {!currentAgent?.accessAllTools && (
@@ -830,9 +833,11 @@ function AgentSettingsView({
             <Label className="mb-1.5">Tools &amp; Knowledge Sources</Label>
             <p className="rounded-lg border border-dashed p-3 text-xs text-muted-foreground">
               This agent uses{" "}
-              <span className="font-medium text-foreground">All tools</span> —
-              every MCP tool and knowledge source the chatting user can access,
-              discovered on demand.
+              <span className="font-medium text-foreground">
+                Auto tool access
+              </span>{" "}
+              — every MCP tool and knowledge source the chatting user can
+              access, discovered on demand.
             </p>
           </div>
         ) : (
@@ -1453,8 +1458,10 @@ function ConfigureToolView({
   const [selectedToolIds, setSelectedToolIds] = useState<Set<string>>(
     new Set(),
   );
+  // Resolve-at-call-time is the default; pinning a static credential is an
+  // explicit choice.
   const [credential, setCredential] = useState<string | null>(
-    mcpServers[0]?.id ?? null,
+    DYNAMIC_CREDENTIAL_VALUE,
   );
   const [isSaving, setIsSaving] = useState(false);
 
@@ -1469,13 +1476,6 @@ function ConfigureToolView({
     }
   }, [allTools, assignedToolIds]);
 
-  // Auto-set default credential once loaded
-  useEffect(() => {
-    if (!credential && mcpServers.length > 0) {
-      setCredential(mcpServers[0].id);
-    }
-  }, [credential, mcpServers]);
-
   const isBuiltin = catalog.serverType === "builtin";
   const showCredentialSelector = !isBuiltin && mcpServers.length > 0;
 
@@ -1489,12 +1489,24 @@ function ConfigureToolView({
         (id) => !selectedToolIds.has(id),
       );
 
+      const useDynamicCredential =
+        !credential || credential === DYNAMIC_CREDENTIAL_VALUE;
+
       await Promise.all([
         ...toAdd.map((toolId) =>
           assignTool.mutateAsync({
             agentId,
             toolId,
-            mcpServerId: !isBuiltin ? (credential ?? undefined) : undefined,
+            mcpServerId:
+              !isBuiltin && !useDynamicCredential
+                ? (credential ?? undefined)
+                : undefined,
+            ...(!isBuiltin && {
+              resolveAtCallTime: useDynamicCredential,
+              credentialResolutionMode: useDynamicCredential
+                ? ("dynamic" as const)
+                : ("static" as const),
+            }),
             skipInvalidation: true,
           }),
         ),

--- a/platform/frontend/src/components/token-select.test.tsx
+++ b/platform/frontend/src/components/token-select.test.tsx
@@ -54,6 +54,31 @@ vi.mock("@/components/ui/select", () => ({
 }));
 
 describe("TokenSelect", () => {
+  it("defaults to resolve-at-call-time even when static credentials exist", () => {
+    useMcpServersGroupedByCatalogMock.mockReturnValue({
+      "catalog-1": [
+        {
+          id: "user-credential",
+          ownerEmail: "member@example.com",
+          scope: "personal",
+          teamDetails: null,
+        },
+      ],
+    });
+    const onValueChange = vi.fn();
+
+    render(
+      <TokenSelect
+        value={null}
+        onValueChange={onValueChange}
+        catalogId="catalog-1"
+        shouldSetDefaultValue={true}
+      />,
+    );
+
+    expect(onValueChange).toHaveBeenCalledWith(DYNAMIC_CREDENTIAL_VALUE);
+  });
+
   it("renders separate team, organization, and user static credential groups by scope", () => {
     const groupedCredentials = {
       "catalog-1": [

--- a/platform/frontend/src/components/token-select.tsx
+++ b/platform/frontend/src/components/token-select.tsx
@@ -78,15 +78,9 @@ export function TokenSelect({
   // biome-ignore lint/correctness/useExhaustiveDependencies: it's expected here to avoid unneeded invocations
   useEffect(() => {
     if (shouldSetDefaultValue && !value) {
-      if (prefersEnterpriseManaged) {
-        onValueChange(DYNAMIC_CREDENTIAL_VALUE);
-      } else if (mcpServers.length > 0) {
-        // Default to the first credential
-        onValueChange(mcpServers[0].id);
-      } else {
-        // Default to dynamic credential when no static credentials available
-        onValueChange(DYNAMIC_CREDENTIAL_VALUE);
-      }
+      // Resolve-at-call-time is the default; pinning a static credential is an
+      // explicit choice.
+      onValueChange(DYNAMIC_CREDENTIAL_VALUE);
     }
   }, []);
 
@@ -128,7 +122,7 @@ export function TokenSelect({
           description={
             prefersEnterpriseManaged
               ? "Ask your identity provider for a runtime credential for this server."
-              : "Use the caller's available runtime credential instead of a fixed connection."
+              : "Follow the server's default credential setting — the caller's own connection, unless the server always uses one account."
           }
         >
           <div className="flex items-center gap-1">


### PR DESCRIPTION
## Why

Tool assignment for MCP gateways/agents had a confusing credential UX:

- In **Custom** tool-assignment mode, the per-server "Connect on behalf of" selector silently defaulted to the **first available static credential** (whoever selected the tools), so the MCP server's connection policy on the registry page only actually applied to Auto ("All") mode. This just caused a confusing tool-calling bug report internally.
- "All" vs "Custom" as mode names were hard to talk about ("all mode"?), and the Capabilities copy didn't explain how credentials resolve.

## What changed

### 1. Resolve-at-call-time is now the default credential for new assignments

- `agent-tools-editor.tsx` (gateway/agent edit dialog), `mcp-assignments-dialog.tsx` (registry-side assignment dialog), `token-select.tsx`, and the chat tool configurator (`initial-agent-selector.tsx`) all default new assignments to **Resolve at call time** (`credentialResolutionMode: "dynamic"`) instead of pinning the first static credential. Pinning a specific connection is now always an explicit choice.
- Since dynamic resolution consults the catalog's `dynamicConnectionMcpServerId` at execution time, the server-level setting now effectively governs **both Auto and Custom modes** by default — exactly what the registry page copy now says.
- Existing assignments are untouched (static pins keep showing/using their pinned connection).
- Bugfix along the way: the chat tool configurator used to send the `__dynamic__` frontend sentinel as `mcpServerId` if you picked "Resolve at call time"; it now sends a proper dynamic assignment.

### 2. Registry "Agent connections" → "Default credential"

The section on the MCP server's Credentials tab is retitled **Default credential**, with copy stating it applies in Auto mode and to Custom assignments left on resolve-at-call-time. The "Resolve at call time" option in the credential selector now references this setting too, tying the two UIs together.

### 3. "All" mode renamed to "Auto"

- Capabilities tabs are now **Auto / Custom** (tab values `auto`/`custom`), with reworked mode explanations: Auto lists what it reaches, how credentials resolve, and on-demand discovery; Custom states only assigned tools/sources are available.
- Renamed across UI copy, docs pages (`platform-agents`, `platform-mcp-gateway`, `platform-knowledge`, `platform-environments`, `mcp-authentication`), frontend variables, and backend comments/log messages.
- **Not renamed:** the `accessAllTools` API/DB field — renaming it would be a breaking API change for existing clients and the Archestra MCP tools. The name still reads fine ("auto = access all tools").

## Notes for reviewers

- No API or schema changes; `credentialResolutionMode` plumbing already existed — this only changes frontend defaults and copy.
- Frontend test added pinning the new TokenSelect default; full frontend suite + backend `mcp-client.test.ts` pass; `pnpm type-check` and `pnpm lint` clean.
- E2E specs (`static-credentials-management`, `dynamic-credentials`, vault) pick credentials explicitly or via API, so they don't rely on the old first-static default.
- Docs screenshots showing the old "All" tab were not recaptured; happy to follow up.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>