### PR TITLE
fix(backend): return correct statuses for message-edit and secrets failures, cut expected error noise

### DIFF
--- a/platform/backend/src/models/message.test.ts
+++ b/platform/backend/src/models/message.test.ts
@@ -715,6 +715,64 @@ describe("MessageModel", () => {
     });
   });
 
+  describe("updateTextPartAndDeleteSubsequent", () => {
+    // A stale client can PATCH a part index that no longer exists (e.g. the
+    // message changed under it). That's a client-input problem, so it must
+    // surface as a 400 ApiError rather than an unhandled 500.
+    test("rejects an out-of-range part index with a 400 ApiError", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+    }) => {
+      const user = await makeUser();
+      const org = await makeOrganization();
+      const agent = await makeAgent({ name: "Edit Part Agent", teams: [] });
+
+      const conversation = await ConversationModel.create({
+        userId: user.id,
+        organizationId: org.id,
+        agentId: agent.id,
+        title: "Edit Part Test",
+      });
+
+      const message = await MessageModel.create({
+        conversationId: conversation.id,
+        role: "user",
+        content: {
+          id: "temp-id",
+          role: "user",
+          parts: [{ type: "text", text: "only part" }],
+        },
+      });
+
+      await expect(
+        MessageModel.updateTextPartAndDeleteSubsequent(
+          message.id,
+          5,
+          "new text",
+          false,
+        ),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Invalid part index",
+      });
+    });
+
+    test("rejects an unknown message id with a 404 ApiError", async () => {
+      await expect(
+        MessageModel.updateTextPartAndDeleteSubsequent(
+          "00000000-0000-0000-0000-000000000000",
+          0,
+          "text",
+          false,
+        ),
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Message not found",
+      });
+    });
+  });
+
   describe("deleteAfterMessage", () => {
     test("deletes messages created after target message", async ({
       makeUser,

--- a/platform/backend/src/models/message.ts
+++ b/platform/backend/src/models/message.ts
@@ -1,6 +1,6 @@
 import { and, eq, gt, inArray, or, sql } from "drizzle-orm";
 import db, { schema, withDbTransaction } from "@/database";
-import type { InsertMessage, Message } from "@/types";
+import { ApiError, type InsertMessage, type Message } from "@/types";
 import { isUuid, uuidv7 } from "@/utils/uuid";
 
 type DbExecutor =
@@ -152,7 +152,7 @@ class MessageModel {
     const message = await MessageModel.findById(messageId);
 
     if (!message) {
-      throw new Error("Message not found");
+      throw new ApiError(404, "Message not found");
     }
 
     // biome-ignore lint/suspicious/noExplicitAny: UIMessage content is dynamic
@@ -160,13 +160,14 @@ class MessageModel {
 
     // Validate that the part exists
     if (!content.parts?.[partIndex]) {
-      throw new Error("Invalid part index");
+      throw new ApiError(400, "Invalid part index");
     }
 
     // Validate that the part is a text part to prevent data corruption
     // Only text parts can have their text property modified
     if (content.parts[partIndex].type !== "text") {
-      throw new Error(
+      throw new ApiError(
+        400,
         `Cannot update non-text part: part at index ${partIndex} is of type "${content.parts[partIndex].type}"`,
       );
     }
@@ -288,7 +289,7 @@ class MessageModel {
         .where(eq(schema.messagesTable.id, messageId));
 
       if (!message) {
-        throw new Error("Message not found");
+        throw new ApiError(404, "Message not found");
       }
 
       // biome-ignore lint/suspicious/noExplicitAny: UIMessage content is dynamic
@@ -296,12 +297,13 @@ class MessageModel {
 
       // Validate that the part exists
       if (!content.parts?.[partIndex]) {
-        throw new Error("Invalid part index");
+        throw new ApiError(400, "Invalid part index");
       }
 
       // Validate that the part is a text part to prevent data corruption
       if (content.parts[partIndex].type !== "text") {
-        throw new Error(
+        throw new ApiError(
+          400,
           `Cannot update non-text part: part at index ${partIndex} is of type "${content.parts[partIndex].type}"`,
         );
       }

--- a/platform/backend/src/observability/sentry.ts
+++ b/platform/backend/src/observability/sentry.ts
@@ -9,7 +9,7 @@ import * as Sentry from "@sentry/node";
 import config from "@/config";
 import { getTransientDbErrorCode } from "@/database/retry";
 import logger from "@/logging";
-import { ApiError } from "@/types";
+import { ApiError, SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
 import {
   isNoiseRoute,
   isNoisyMcpGatewayGetRoute,
@@ -166,6 +166,21 @@ const initSentry = async (): Promise<void> => {
           ...event.tags,
           error_type: "db_transient",
           db_error_code: transientDbErrorCode,
+        };
+      }
+
+      // A secrets-backend (e.g. Vault) outage fails every route that touches
+      // secrets, fragmenting one incident into an issue per endpoint and per
+      // upstream error message. Group by the root condition instead, same as
+      // the transient-DB handling above.
+      if (
+        error instanceof ApiError &&
+        error.internalCode === SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE
+      ) {
+        event.fingerprint = [SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE];
+        event.tags = {
+          ...event.tags,
+          error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
         };
       }
 

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -7,6 +7,7 @@ import {
   GeminiErrorCodes,
   GeminiErrorReasons,
   OpenAIErrorTypes,
+  TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
   ZhipuaiErrorTypes,
 } from "@archestra/shared";
 import { vi } from "vitest";
@@ -1733,6 +1734,20 @@ describe("mapProviderError - Sentry raw error capture", () => {
     const result = mapProviderError(error, "openai");
 
     expect(result.code).toBe(ChatErrorCode.ServerError);
+    expect(mockSentryCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("does not capture approval-gated tool blocks in autonomous sessions", () => {
+    // Thrown by the chat tool builder when a "Require approval" policy fires
+    // in a session with no human to approve (A2A, Slack, MS Teams,
+    // sub-agents). Policy enforcement working as designed, not a provider
+    // failure — it must stay out of error tracking.
+    const error = new Error(
+      TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
+    );
+
+    mapProviderError(error, "bedrock");
+
     expect(mockSentryCaptureException).not.toHaveBeenCalled();
   });
 

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -11,6 +11,7 @@ import {
   OpenAIErrorTypes,
   RetryableErrorCodes,
   type SupportedProvider,
+  TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
   VllmErrorTypes,
   ZhipuaiErrorTypes,
 } from "@archestra/shared";
@@ -1798,7 +1799,12 @@ export function mapProviderError(
   // indicate a bug.
   const isExpectedProviderError =
     (statusCode !== undefined && statusCode >= 400 && statusCode < 500) ||
-    RetryableErrorCodes.has(errorCode);
+    RetryableErrorCodes.has(errorCode) ||
+    // An approval-gated tool call rejected in an autonomous session (A2A,
+    // Slack, MS Teams, sub-agents) is our own policy enforcement doing its
+    // job, not a provider failure. It reaches this mapper as a bare Error
+    // with no HTTP envelope, so match the policy reason it was thrown with.
+    isToolApprovalPolicyBlockError(errorMessage);
 
   if (!isTerminatedStream && !isExpectedProviderError) {
     captureRawProviderErrorInSentry({
@@ -1854,6 +1860,13 @@ function isStreamTerminatedError(error: unknown): boolean {
 
 function isUpstreamIdleTimeoutError(message: string): boolean {
   return /idle timeout/i.test(message);
+}
+
+// `includes` rather than equality: the error may pick up wrapper prefixes on
+// its way through the tool-execution stack, but the thrown message is always
+// the shared policy-reason constant verbatim.
+function isToolApprovalPolicyBlockError(message: string): boolean {
+  return message.includes(TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON);
 }
 
 function isUpstreamProviderError(message: string): boolean {

--- a/platform/backend/src/secrets-manager/readonly-vault.ee.ts
+++ b/platform/backend/src/secrets-manager/readonly-vault.ee.ts
@@ -5,6 +5,7 @@ import {
   ApiError,
   type ISecretManager,
   parseVaultSecretReference,
+  SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
   type SecretsConnectivityResult,
   type SecretValue,
   type SelectSecret,
@@ -175,8 +176,9 @@ export default class ReadonlyVaultSecretManager
       }
 
       throw new ApiError(
-        500,
+        503,
         "Failed to resolve vault secret references. Please verify the paths exist and Archestra has read access.",
+        SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
       );
     }
   }

--- a/platform/backend/src/secrets-manager/secrets-manager.test.ts
+++ b/platform/backend/src/secrets-manager/secrets-manager.test.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 import config from "@/config";
 import SecretModel from "@/models/secret";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
 import { DbSecretsManager } from "./db";
 import {
   createSecretManager,
@@ -923,9 +924,15 @@ describe("SecretsManager", async () => {
           new Error("Vault unavailable"),
         );
 
-        await expect(vaultManager.getSecret(created.id)).rejects.toThrow(
-          "An error occurred while accessing secrets. Please try again later or contact your administrator.",
-        );
+        // A secrets-backend failure is an upstream outage, not an app bug:
+        // it must surface as a retryable 503 tagged with the internal code
+        // that error tracking uses to group one outage into one issue.
+        await expect(vaultManager.getSecret(created.id)).rejects.toMatchObject({
+          statusCode: 503,
+          internalCode: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+          message:
+            "An error occurred while accessing secrets. Please try again later or contact your administrator.",
+        });
 
         // Cleanup
         await SecretModel.delete(created.id);

--- a/platform/backend/src/secrets-manager/vault-client.ee.ts
+++ b/platform/backend/src/secrets-manager/vault-client.ee.ts
@@ -5,10 +5,11 @@ import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import { SignatureV4 } from "@smithy/signature-v4";
 import Vault from "node-vault";
 import logger from "@/logging";
-import type {
-  VaultConfig,
-  VaultFolderConnectivityResult,
-  VaultSecretListItem,
+import {
+  SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+  type VaultConfig,
+  type VaultFolderConnectivityResult,
+  type VaultSecretListItem,
 } from "@/types/secrets-manager";
 import { extractVaultErrorMessage } from "./utils";
 
@@ -245,7 +246,11 @@ export class VaultClient {
       this.initialized = true;
     } catch (error) {
       logger.error({ error }, "VaultClient: initialization failed");
-      throw new ApiError(500, extractVaultErrorMessage(error));
+      throw new ApiError(
+        503,
+        extractVaultErrorMessage(error),
+        SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+      );
     }
   }
 
@@ -263,7 +268,11 @@ export class VaultClient {
       throw error;
     }
 
-    throw new ApiError(500, extractVaultErrorMessage(error));
+    throw new ApiError(
+      503,
+      extractVaultErrorMessage(error),
+      SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+    );
   }
 
   /**
@@ -443,7 +452,11 @@ export class VaultClient {
         { error, tokenPath, role: this.config.k8sRole },
         "VaultClient: Kubernetes authentication failed",
       );
-      throw new ApiError(500, extractVaultErrorMessage(error));
+      throw new ApiError(
+        503,
+        extractVaultErrorMessage(error),
+        SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+      );
     }
   }
 

--- a/platform/backend/src/secrets-manager/vault.ee.ts
+++ b/platform/backend/src/secrets-manager/vault.ee.ts
@@ -4,6 +4,7 @@ import SecretModel from "@/models/secret";
 import {
   ApiError,
   type ISecretManager,
+  SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
   type SecretsConnectivityResult,
   type SecretValue,
   type SelectSecret,
@@ -63,8 +64,9 @@ export default class VaultSecretManager
     }
 
     throw new ApiError(
-      500,
+      503,
       "An error occurred while accessing secrets. Please try again later or contact your administrator.",
+      SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
     );
   }
 
@@ -218,7 +220,11 @@ export default class VaultSecretManager
         { error, listBasePath, kvVersion: this.config.kvVersion },
         "VaultSecretManager.checkConnectivity: failed to list secrets",
       );
-      throw new ApiError(500, extractVaultErrorMessage(error));
+      throw new ApiError(
+        503,
+        extractVaultErrorMessage(error),
+        SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+      );
     }
   }
 

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -95,6 +95,7 @@ import {
   OpenAi,
   Openrouter,
   Perplexity,
+  SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
   Vllm,
   Xai,
   Zhipuai,
@@ -613,6 +614,13 @@ export const createFastifyInstance = () =>
               error_type: "api_error",
               status_code: statusCode,
               ...(internalCode && { internal_code: internalCode }),
+              // A secrets-backend outage fails every route that reads
+              // secrets — group by the root condition, not per endpoint.
+              ...(internalCode ===
+                SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE && {
+                $exception_fingerprint:
+                  SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+              }),
             });
           }
         } else if (statusCode >= 400) {

--- a/platform/backend/src/types/secrets-manager.ts
+++ b/platform/backend/src/types/secrets-manager.ts
@@ -2,6 +2,14 @@ import type { SecretsManagerType } from "@archestra/shared";
 import type { SecretValue, SelectSecret } from "./secret";
 
 /**
+ * `ApiError.internalCode` set when the external secrets backend (e.g. Vault)
+ * cannot be reached or fails an operation. Lets error tracking group one
+ * secrets-backend outage into a single issue instead of one per endpoint.
+ */
+export const SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE =
+  "secrets_manager_unavailable";
+
+/**
  * SecretManager interface for managing secrets
  * Can be implemented for different secret storage backends (database, AWS Secrets Manager, etc.)
  */


### PR DESCRIPTION
## Summary

Three related error-handling fixes observed in production deployments:

### 1. Message edits with a stale part index returned 500
`PATCH /api/chat/messages/:id` crashed with an unhandled `Error: Invalid part index` when a client edited a message part that no longer exists (e.g. the message changed underneath a stale tab). `MessageModel.updateTextPart` / `updateTextPartAndDeleteSubsequent` now throw `ApiError`:
- `400` for an out-of-range or non-text part index
- `404` for a missing message

### 2. Secrets-backend (Vault) failures surfaced as fragmented 500s
When Vault is unreachable or an operation fails, every route that reads secrets (e.g. `POST /api/mcp_server/:id/inspect`, both directly and via catalog secret expansion) returned a 500, and error tracking fragmented one outage into many separate groups (one per endpoint / upstream message).

Vault errors now throw `ApiError(503)` — an upstream availability condition, retryable by clients — carrying a stable `internal_code` (`secrets_manager_unavailable`). Sentry `beforeSend` and the PostHog capture in the central error handler fingerprint on that code, so one secrets-backend outage groups into a single issue. This mirrors the existing transient-DB-error handling.

### 3. Approval-gated tool blocks in autonomous sessions reported as provider errors
When a "Require approval" tool policy fires in an autonomous session (A2A, Slack, MS Teams, sub-agents) there is no human to approve, so the tool call is rejected by design. The chat error mapper treated this as an unclassified provider failure and reported it to error tracking. It is now recognized as an expected condition (matched against the shared policy-reason constant it is thrown with) and kept out of capture, alongside the existing 4xx/retryable gating.

## Tests
- `MessageModel.updateTextPartAndDeleteSubsequent`: new tests pinning the 400/404 ApiError contract
- `VaultSecretManager.getSecret`: failure test now pins 503 + `secrets_manager_unavailable` internal code
- `mapProviderError`: new test asserting autonomous approval blocks are not captured

`pnpm lint`, `pnpm type-check`, `pnpm knip`, and the affected vitest suites (213 tests) all pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>