### PR TITLE
feat(ai-labs): baton-core — generic preset dimension algebras

### DIFF
--- a/ai-labs/baton/baton-core/examples/demo.rs
+++ b/ai-labs/baton/baton-core/examples/demo.rs
@@ -132,7 +132,7 @@ fn main() {
             name: ToolName::new("web.fetch"),
             requires: Requirements::default(),
             output_label: Label {
-                audience: Audience::Public,
+                audience: Audience::PUBLIC,
                 trust: Trust::SUSPICIOUS,
                 ..Label::identity()
             },

--- a/ai-labs/baton/baton-core/src/contract.rs
+++ b/ai-labs/baton/baton-core/src/contract.rs
@@ -5,8 +5,9 @@ use std::collections::BTreeSet;
 use std::fmt;
 
 use crate::ToolName;
-use crate::dimension::{Adequacy, Effect, KnownTrust, UserId};
+use crate::dimension::{Effect, KnownTrust, UserId};
 use crate::label::Label;
+use crate::preset::Adequacy;
 
 /// A concrete tool invocation the policy is asked to authorize.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,7 +55,7 @@ pub enum AttentionRule {
 /// What a tool demands of the context label before it may run.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Requirements {
-    /// Minimum *known* trust. `Trust::Unknown` never satisfies any bar —
+    /// Minimum *known* trust. `Trust::UNKNOWN` never satisfies any bar —
     /// deliberately over [`KnownTrust`], so "unknown suffices" cannot even be
     /// expressed; unpacking `Unknown` is always an explicit
     /// [`crate::engine::UnknownPolicy`] or authority decision.
@@ -367,7 +368,7 @@ mod tests {
         );
 
         let unknown = Label {
-            trust: Trust::Unknown,
+            trust: Trust::UNKNOWN,
             ..private_trusted_context()
         };
         assert_eq!(
@@ -388,7 +389,7 @@ mod tests {
         let request = ToolRequest::new(ToolName::new("notes.append"));
 
         let unknown = Label {
-            trust: Trust::Unknown,
+            trust: Trust::UNKNOWN,
             ..Label::identity()
         };
         assert_eq!(
@@ -426,7 +427,7 @@ mod tests {
     #[test]
     fn unknown_audience_cannot_bound_recipients() {
         let context = Label {
-            audience: Audience::Unknown,
+            audience: Audience::UNKNOWN,
             ..private_trusted_context()
         };
         let request = ToolRequest::exposing(ToolName::new("email.send"), [user("bob")]);
@@ -439,7 +440,7 @@ mod tests {
     #[test]
     fn public_context_allows_any_recipient() {
         let context = Label {
-            audience: Audience::Public,
+            audience: Audience::PUBLIC,
             ..private_trusted_context()
         };
         let request = ToolRequest::exposing(ToolName::new("email.send"), [user("stranger")]);
@@ -496,7 +497,7 @@ mod tests {
         );
 
         let unknown = Label {
-            effects: Effects::Unknown,
+            effects: Effects::UNKNOWN,
             ..Label::identity()
         };
         assert_eq!(

--- a/ai-labs/baton/baton-core/src/dimension.rs
+++ b/ai-labs/baton/baton-core/src/dimension.rs
@@ -1,18 +1,21 @@
-//! Label dimensions and their combine algebra.
+//! Label dimensions: the crate's three built-in instances of the generic
+//! [`crate::preset`] algebras, plus their value types.
 //!
-//! Each dimension defines its own `combine`: how two values merge when data
-//! from two sources meets in one context. [`crate::label::Label::combine`]
-//! applies these per dimension; nothing else in the crate invents merge
-//! semantics.
+//! Each dimension is a newtype over its preset and delegates its `combine` (the
+//! taint fold) and adequacy relation to it; [`crate::label::Label::combine`]
+//! applies the per-dimension combine, and nothing else in the crate invents
+//! merge semantics.
 //!
 //! Per data dimension the combine is a commutative, idempotent semilattice,
 //! and `Unknown` has a definite position in each (absorbing for audience and
 //! effects; between `Trusted` and `Suspicious` for trust). This is the taint
 //! fold — distinct from the sink-side adequacy relation, where `Unknown` is
-//! instead incomparable.
+//! instead incomparable → [`Adequacy::Unprovable`](crate::preset).
 
 use std::collections::BTreeSet;
 use std::fmt;
+
+use crate::preset::{Adequacy, HasBottom, JoinSet, MeetSet, MinLevel};
 
 /// A user known to the surrounding system (ACLs, directories, ...).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -34,79 +37,72 @@ impl fmt::Display for UserId {
     }
 }
 
-/// The sink-side proof for one dimension: three-valued, not a lattice
-/// comparison. `Holds` when the context satisfies the requirement,
-/// `Fails(witness)` when it provably does not (the witness is exactly what is
-/// wrong — the offending readers, the too-low trust, the present forbidden
-/// effects), and `Unprovable` when `Unknown` blocked the proof either way.
-///
-/// This is where `Unknown` is *incomparable* — the opposite of its definite
-/// position in the taint fold. Resolving an `Unprovable` is an explicit
-/// [`crate::engine::UnknownPolicy`] or [`crate::authority::Authority`]
-/// decision, never a cast.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum Adequacy<W> {
-    Holds,
-    Fails(W),
-    Unprovable,
-}
-
-/// Who is allowed to read a piece of data.
+/// Who is allowed to read a piece of data — an instance of
+/// [`MeetSet<UserId>`](crate::preset::MeetSet).
 ///
 /// The fold is the most-restrictive combine (the confidentiality meet):
 /// readers of a combination are those allowed to read *every* part. The
 /// original design notes said "union", but under union `private ⊔ public =
 /// public`, after which a recipients-within-audience sink check is vacuously
 /// satisfied and private turns egress anywhere. "Who has already touched
-/// this" is provenance — a different dimension, not this one. `Public` is
-/// the identity, `Unknown` is absorbing.
+/// this" is provenance — a different dimension, not this one. [`PUBLIC`] is
+/// the identity, [`UNKNOWN`] is absorbing.
+///
+/// [`PUBLIC`]: Audience::PUBLIC
+/// [`UNKNOWN`]: Audience::UNKNOWN
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Audience {
-    Public,
-    Readers(BTreeSet<UserId>),
-    Unknown,
-}
+pub struct Audience(MeetSet<UserId>);
 
 impl Audience {
+    /// Readable by anyone — the fold identity (`MeetSet::All`).
+    pub const PUBLIC: Self = Self(MeetSet::All);
+    /// Audience unestablished — absorbing in the fold, `Unprovable` at a sink.
+    pub const UNKNOWN: Self = Self(MeetSet::Unknown);
+
     pub fn readers(ids: impl IntoIterator<Item = UserId>) -> Self {
-        Self::Readers(ids.into_iter().collect())
+        Self(MeetSet::Only(ids.into_iter().collect()))
     }
 
     #[must_use]
     pub fn combine(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Unknown, _) | (_, Self::Unknown) => Self::Unknown,
-            (Self::Public, x) | (x, Self::Public) => x,
-            (Self::Readers(a), Self::Readers(b)) => Self::Readers(a.intersection(&b).cloned().collect()),
+        Self(self.0.combine(other.0))
+    }
+
+    /// Adequacy of this audience for a set of recipients: are they all already
+    /// allowed readers? See `MeetSet::covers`.
+    pub(crate) fn covers(&self, recipients: &BTreeSet<UserId>) -> Adequacy<BTreeSet<UserId>> {
+        self.0.covers(recipients)
+    }
+
+    /// Grant application ([`Label::lift`](crate::label::Label::lift)): admit
+    /// `vouched` into the readers. `Public` stays public; `Unknown` becomes
+    /// exactly the vouched readers. Monotone in the adequacy order.
+    pub(crate) fn admitting(&self, vouched: &BTreeSet<UserId>) -> Self {
+        match &self.0 {
+            MeetSet::All => Self(MeetSet::All),
+            MeetSet::Only(s) => Self(MeetSet::Only(s.union(vouched).cloned().collect())),
+            MeetSet::Unknown => Self(MeetSet::Only(vouched.clone())),
         }
     }
 
-    /// Adequacy of this audience for a set of recipients: are they all
-    /// already allowed readers? `Public` holds for anyone; `Unknown` cannot
-    /// bound anyone (so `Unprovable`, never silently treated as `Public`);
-    /// `Readers` holds iff no recipient falls outside, and the `Fails`
-    /// witness is exactly the recipients outside the set.
-    pub(crate) fn covers(&self, recipients: &BTreeSet<UserId>) -> Adequacy<BTreeSet<UserId>> {
-        match self {
-            Self::Unknown => Adequacy::Unprovable,
-            Self::Public => Adequacy::Holds,
-            Self::Readers(allowed) => {
-                let outside: BTreeSet<UserId> = recipients.difference(allowed).cloned().collect();
-                if outside.is_empty() {
-                    Adequacy::Holds
-                } else {
-                    Adequacy::Fails(outside)
-                }
-            }
+    /// `self ⊑ other` in the adequacy (permissiveness) order: `Unknown` bottom,
+    /// `Public` top, `Readers` by inclusion.
+    #[cfg(test)]
+    pub(crate) fn adequacy_le(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (MeetSet::Unknown, _) => true,
+            (_, MeetSet::All) => true,
+            (MeetSet::Only(a), MeetSet::Only(b)) => a.is_subset(b),
+            _ => false,
         }
     }
 }
 
 impl fmt::Display for Audience {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Public => write!(f, "public"),
-            Self::Readers(ids) => {
+        match &self.0 {
+            MeetSet::All => write!(f, "public"),
+            MeetSet::Only(ids) => {
                 write!(f, "{{")?;
                 for (i, id) in ids.iter().enumerate() {
                     if i > 0 {
@@ -116,7 +112,7 @@ impl fmt::Display for Audience {
                 }
                 write!(f, "}}")
             }
-            Self::Unknown => write!(f, "unknown"),
+            MeetSet::Unknown => write!(f, "unknown"),
         }
     }
 }
@@ -128,6 +124,14 @@ pub enum KnownTrust {
     Trusted,
 }
 
+/// `Suspicious` is the least trusted, so it is the bottom `MinLevel` folds
+/// toward (and the element `Unknown` sits just above).
+impl HasBottom for KnownTrust {
+    fn bottom() -> Self {
+        Self::Suspicious
+    }
+}
+
 impl fmt::Display for KnownTrust {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -137,7 +141,8 @@ impl fmt::Display for KnownTrust {
     }
 }
 
-/// How much the provenance of data is trusted — if that is known at all.
+/// How much the provenance of data is trusted — if that is known at all. An
+/// instance of [`MinLevel<KnownTrust>`](crate::preset::MinLevel).
 ///
 /// `Unknown` is structurally separate from the known judgements so nothing
 /// can treat it as "probably fine" by accident: requirements are expressed
@@ -149,45 +154,56 @@ impl fmt::Display for KnownTrust {
 /// missing knowledge, which dominates trust
 /// (`Suspicious ∧ Unknown = Suspicious`, `Trusted ∧ Unknown = Unknown`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Trust {
-    Known(KnownTrust),
-    Unknown,
-}
+pub struct Trust(MinLevel<KnownTrust>);
 
 impl Trust {
-    pub const TRUSTED: Self = Self::Known(KnownTrust::Trusted);
-    pub const SUSPICIOUS: Self = Self::Known(KnownTrust::Suspicious);
+    pub const TRUSTED: Self = Self(MinLevel::Known(KnownTrust::Trusted));
+    pub const SUSPICIOUS: Self = Self(MinLevel::Known(KnownTrust::Suspicious));
+    /// Provenance unestablished — just above bottom in the fold, `Unprovable`
+    /// at a sink.
+    pub const UNKNOWN: Self = Self(MinLevel::Unknown);
 
     #[must_use]
     pub fn combine(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Known(KnownTrust::Suspicious), _) | (_, Self::Known(KnownTrust::Suspicious)) => {
-                Self::Known(KnownTrust::Suspicious)
-            }
-            (Self::Unknown, _) | (_, Self::Unknown) => Self::Unknown,
-            (Self::Known(KnownTrust::Trusted), Self::Known(KnownTrust::Trusted)) => Self::Known(KnownTrust::Trusted),
+        Self(self.0.combine(other.0))
+    }
+
+    /// Adequacy of this trust for a floor. See `MinLevel::at_least`.
+    pub(crate) fn at_least(&self, floor: KnownTrust) -> Adequacy<KnownTrust> {
+        self.0.at_least(floor)
+    }
+
+    /// Grant application ([`Label::lift`](crate::label::Label::lift)): raise
+    /// trust to at least `attested`. A join (`max`), never a demotion — a
+    /// `Trusted` context is never lowered by a weaker attestation, and an
+    /// `Unknown` one becomes the attested judgement.
+    pub(crate) fn raised_to(&self, attested: KnownTrust) -> Self {
+        match self.0 {
+            MinLevel::Known(actual) => Self(MinLevel::Known(actual.max(attested))),
+            MinLevel::Unknown => Self(MinLevel::Known(attested)),
         }
     }
 
-    /// Adequacy of this trust for a floor. A known judgement at or above the
-    /// floor holds; a lower one `Fails`, carrying the actual (too-low)
-    /// judgement as witness. `Unknown` never satisfies any bar — unpacking it
-    /// is an explicit policy/authority decision, never a comparison — so it
-    /// is `Unprovable`.
-    pub(crate) fn at_least(self, floor: KnownTrust) -> Adequacy<KnownTrust> {
-        match self {
-            Self::Known(actual) if actual >= floor => Adequacy::Holds,
-            Self::Known(actual) => Adequacy::Fails(actual),
-            Self::Unknown => Adequacy::Unprovable,
+    /// `self ⊑ other` in the adequacy order: `Unknown` bottom, then
+    /// `Suspicious`, then `Trusted`.
+    #[cfg(test)]
+    pub(crate) fn adequacy_le(&self, other: &Self) -> bool {
+        fn rank(t: &MinLevel<KnownTrust>) -> u8 {
+            match t {
+                MinLevel::Unknown => 0,
+                MinLevel::Known(KnownTrust::Suspicious) => 1,
+                MinLevel::Known(KnownTrust::Trusted) => 2,
+            }
         }
+        rank(&self.0) <= rank(&other.0)
     }
 }
 
 impl fmt::Display for Trust {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Known(known) => write!(f, "{known}"),
-            Self::Unknown => write!(f, "unknown"),
+        match self.0 {
+            MinLevel::Known(known) => write!(f, "{known}"),
+            MinLevel::Unknown => write!(f, "unknown"),
         }
     }
 }
@@ -208,57 +224,65 @@ impl fmt::Display for Effect {
     }
 }
 
-/// Effects that have already happened in a context.
+/// Effects that have already happened in a context — an instance of
+/// [`JoinSet<Effect>`](crate::preset::JoinSet).
 ///
-/// Union fold; `Unknown` (an unannotated tool ran, so anything may have
+/// Union fold; [`none`](Effects::none) (`Has(∅)`) is the identity, and
+/// [`UNKNOWN`](Effects::UNKNOWN) (an unannotated tool ran, so anything may have
 /// happened) is absorbing.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Effects {
-    Declared(BTreeSet<Effect>),
-    Unknown,
-}
+pub struct Effects(JoinSet<Effect>);
 
 impl Effects {
+    /// Effects unestablished — absorbing in the fold, `Unprovable` at a sink.
+    pub const UNKNOWN: Self = Self(JoinSet::Unknown);
+
     pub fn none() -> Self {
-        Self::Declared(BTreeSet::new())
+        Self(JoinSet::empty())
     }
 
     pub fn declared(effects: impl IntoIterator<Item = Effect>) -> Self {
-        Self::Declared(effects.into_iter().collect())
+        Self(JoinSet::Has(effects.into_iter().collect()))
     }
 
     #[must_use]
     pub fn combine(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Unknown, _) | (_, Self::Unknown) => Self::Unknown,
-            (Self::Declared(a), Self::Declared(b)) => Self::Declared(a.union(&b).copied().collect()),
-        }
+        Self(self.0.combine(other.0))
     }
 
     /// Adequacy against a forbidden set: none of `forbidden` may already be
-    /// present. `Unknown` effects cannot attest the absence of anything (an
-    /// unannotated tool ran), so they are `Unprovable`. `Declared` holds iff
-    /// the intersection is empty, and the `Fails` witness is exactly the
-    /// forbidden effects that are present.
+    /// present. See `JoinSet::avoids`.
     pub(crate) fn avoids(&self, forbidden: &BTreeSet<Effect>) -> Adequacy<BTreeSet<Effect>> {
-        match self {
-            Self::Unknown => Adequacy::Unprovable,
-            Self::Declared(present) => {
-                let hit: BTreeSet<Effect> = forbidden.intersection(present).copied().collect();
-                if hit.is_empty() {
-                    Adequacy::Holds
-                } else {
-                    Adequacy::Fails(hit)
-                }
-            }
+        self.0.avoids(forbidden)
+    }
+
+    /// Grant application ([`Label::lift`](crate::label::Label::lift)): waive
+    /// `waived` from the present effects. `Unknown` stays `Unknown` — one
+    /// cannot attest a negative over it, which is why unprovable effects are
+    /// acknowledge-only, never grant-fixable.
+    pub(crate) fn waiving(&self, waived: &BTreeSet<Effect>) -> Self {
+        match &self.0 {
+            JoinSet::Has(present) => Self(JoinSet::Has(present.difference(waived).copied().collect())),
+            JoinSet::Unknown => Self(JoinSet::Unknown),
+        }
+    }
+
+    /// `self ⊑ other` in the adequacy order: `Unknown` bottom, `none()` top,
+    /// fewer present effects is more adequate.
+    #[cfg(test)]
+    pub(crate) fn adequacy_le(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (JoinSet::Unknown, _) => true,
+            (JoinSet::Has(a), JoinSet::Has(b)) => b.is_subset(a),
+            (JoinSet::Has(_), JoinSet::Unknown) => false,
         }
     }
 }
 
 impl fmt::Display for Effects {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Declared(effects) => {
+        match &self.0 {
+            JoinSet::Has(effects) => {
                 write!(f, "{{")?;
                 for (i, e) in effects.iter().enumerate() {
                     if i > 0 {
@@ -268,7 +292,7 @@ impl fmt::Display for Effects {
                 }
                 write!(f, "}}")
             }
-            Self::Unknown => write!(f, "unknown"),
+            JoinSet::Unknown => write!(f, "unknown"),
         }
     }
 }
@@ -292,33 +316,33 @@ mod tests {
     fn audience_disjoint_readers_combine_to_nobody() {
         let a = Audience::readers([user("alice")]);
         let b = Audience::readers([user("bob")]);
-        assert_eq!(a.combine(b), Audience::Readers(BTreeSet::new()));
+        assert_eq!(a.combine(b), Audience::readers(Vec::<UserId>::new()));
     }
 
     #[test]
     fn audience_public_is_identity() {
         let readers = Audience::readers([user("alice")]);
-        assert_eq!(Audience::Public.combine(readers.clone()), readers.clone());
-        assert_eq!(readers.clone().combine(Audience::Public), readers);
-        assert_eq!(Audience::Public.combine(Audience::Public), Audience::Public);
+        assert_eq!(Audience::PUBLIC.combine(readers.clone()), readers.clone());
+        assert_eq!(readers.clone().combine(Audience::PUBLIC), readers);
+        assert_eq!(Audience::PUBLIC.combine(Audience::PUBLIC), Audience::PUBLIC);
     }
 
     #[test]
     fn audience_unknown_is_absorbing() {
-        assert_eq!(Audience::Unknown.combine(Audience::Public), Audience::Unknown);
+        assert_eq!(Audience::UNKNOWN.combine(Audience::PUBLIC), Audience::UNKNOWN);
         assert_eq!(
-            Audience::readers([user("alice")]).combine(Audience::Unknown),
-            Audience::Unknown
+            Audience::readers([user("alice")]).combine(Audience::UNKNOWN),
+            Audience::UNKNOWN
         );
     }
 
     #[test]
     fn audience_combine_is_associative() {
         let samples = [
-            Audience::Public,
+            Audience::PUBLIC,
             Audience::readers([user("alice"), user("bob")]),
             Audience::readers([user("bob")]),
-            Audience::Unknown,
+            Audience::UNKNOWN,
         ];
         for a in &samples {
             for b in &samples {
@@ -340,11 +364,11 @@ mod tests {
 
     #[test]
     fn trust_unknown_sits_between() {
-        assert_eq!(Trust::TRUSTED.combine(Trust::Unknown), Trust::Unknown);
-        assert_eq!(Trust::Unknown.combine(Trust::TRUSTED), Trust::Unknown);
-        assert_eq!(Trust::Unknown.combine(Trust::SUSPICIOUS), Trust::SUSPICIOUS);
-        assert_eq!(Trust::SUSPICIOUS.combine(Trust::Unknown), Trust::SUSPICIOUS);
-        assert_eq!(Trust::Unknown.combine(Trust::Unknown), Trust::Unknown);
+        assert_eq!(Trust::TRUSTED.combine(Trust::UNKNOWN), Trust::UNKNOWN);
+        assert_eq!(Trust::UNKNOWN.combine(Trust::TRUSTED), Trust::UNKNOWN);
+        assert_eq!(Trust::UNKNOWN.combine(Trust::SUSPICIOUS), Trust::SUSPICIOUS);
+        assert_eq!(Trust::SUSPICIOUS.combine(Trust::UNKNOWN), Trust::SUSPICIOUS);
+        assert_eq!(Trust::UNKNOWN.combine(Trust::UNKNOWN), Trust::UNKNOWN);
     }
 
     #[test]
@@ -355,7 +379,7 @@ mod tests {
             mutation.clone().combine(egress),
             Effects::declared([Effect::Mutation, Effect::Egress])
         );
-        assert_eq!(mutation.combine(Effects::Unknown), Effects::Unknown);
+        assert_eq!(mutation.combine(Effects::UNKNOWN), Effects::UNKNOWN);
         assert_eq!(Effects::none().combine(Effects::none()), Effects::none());
     }
 
@@ -365,8 +389,8 @@ mod tests {
 
     #[test]
     fn audience_covers_over_the_three_values() {
-        assert_eq!(Audience::Public.covers(&users(&["stranger"])), Adequacy::Holds);
-        assert_eq!(Audience::Unknown.covers(&users(&["bob"])), Adequacy::Unprovable);
+        assert_eq!(Audience::PUBLIC.covers(&users(&["stranger"])), Adequacy::Holds);
+        assert_eq!(Audience::UNKNOWN.covers(&users(&["bob"])), Adequacy::Unprovable);
 
         let ab = Audience::readers([user("alice"), user("bob")]);
         assert_eq!(ab.covers(&users(&["bob"])), Adequacy::Holds);
@@ -386,8 +410,8 @@ mod tests {
             Trust::SUSPICIOUS.at_least(KnownTrust::Trusted),
             Adequacy::Fails(KnownTrust::Suspicious)
         );
-        assert_eq!(Trust::Unknown.at_least(KnownTrust::Suspicious), Adequacy::Unprovable);
-        assert_eq!(Trust::Unknown.at_least(KnownTrust::Trusted), Adequacy::Unprovable);
+        assert_eq!(Trust::UNKNOWN.at_least(KnownTrust::Suspicious), Adequacy::Unprovable);
+        assert_eq!(Trust::UNKNOWN.at_least(KnownTrust::Trusted), Adequacy::Unprovable);
     }
 
     #[test]
@@ -399,6 +423,6 @@ mod tests {
             Effects::declared([Effect::Mutation, Effect::Egress]).avoids(&forbidden),
             Adequacy::Fails(BTreeSet::from([Effect::Mutation]))
         );
-        assert_eq!(Effects::Unknown.avoids(&forbidden), Adequacy::Unprovable);
+        assert_eq!(Effects::UNKNOWN.avoids(&forbidden), Adequacy::Unprovable);
     }
 }

--- a/ai-labs/baton/baton-core/src/dimension.rs
+++ b/ai-labs/baton/baton-core/src/dimension.rs
@@ -372,6 +372,16 @@ mod tests {
     }
 
     #[test]
+    fn known_trust_bottom_obeys_the_has_bottom_law() {
+        // MinLevel's fold relies on `bottom()` being the Ord-minimum; the
+        // built-in Trust instance must uphold it (Suspicious is least trusted).
+        for t in [KnownTrust::Suspicious, KnownTrust::Trusted] {
+            assert!(KnownTrust::bottom() <= t, "bottom() not <= {t}");
+        }
+        assert_eq!(KnownTrust::bottom(), KnownTrust::Suspicious);
+    }
+
+    #[test]
     fn effects_union_and_unknown_absorbs() {
         let mutation = Effects::declared([Effect::Mutation]);
         let egress = Effects::declared([Effect::Egress]);

--- a/ai-labs/baton/baton-core/src/engine.rs
+++ b/ai-labs/baton/baton-core/src/engine.rs
@@ -566,7 +566,7 @@ mod tests {
         );
         trajectory.push_message(
             Label {
-                audience: Audience::Public,
+                audience: Audience::PUBLIC,
                 trust: Trust::SUSPICIOUS,
                 ..Label::identity()
             },
@@ -986,9 +986,9 @@ mod tests {
             panic!("expected permit, got {decision:?}");
         };
         assert_eq!(engine.authority.consulted.get(), 0);
-        assert_eq!(permit.result_label().audience, Audience::Unknown);
-        assert_eq!(permit.result_label().trust, Trust::Unknown);
-        assert_eq!(permit.result_label().effects, Effects::Unknown);
+        assert_eq!(permit.result_label().audience, Audience::UNKNOWN);
+        assert_eq!(permit.result_label().trust, Trust::UNKNOWN);
+        assert_eq!(permit.result_label().effects, Effects::UNKNOWN);
         assert_eq!(
             permit.result_label().audit,
             vec![AuditEntry::Acknowledged {
@@ -1026,7 +1026,7 @@ mod tests {
         push_user_turn(
             &mut trajectory,
             Label {
-                audience: Audience::Unknown,
+                audience: Audience::UNKNOWN,
                 trust: Trust::SUSPICIOUS,
                 ..Label::identity()
             },
@@ -1070,7 +1070,7 @@ mod tests {
         push_user_turn(
             &mut trajectory,
             Label {
-                audience: Audience::Unknown,
+                audience: Audience::UNKNOWN,
                 trust: Trust::SUSPICIOUS,
                 ..Label::identity()
             },
@@ -1098,7 +1098,7 @@ mod tests {
         push_user_turn(
             &mut trajectory,
             Label {
-                audience: Audience::Unknown,
+                audience: Audience::UNKNOWN,
                 trust: Trust::SUSPICIOUS,
                 ..Label::identity()
             },
@@ -1226,7 +1226,7 @@ mod tests {
         // TrustUnknown: unknown-trust context, audience fine.
         let unknown_trust = context(Label {
             audience: Audience::readers([user("alice"), user("bob")]),
-            trust: Trust::Unknown,
+            trust: Trust::UNKNOWN,
             ..Label::identity()
         });
         assert!(matches!(
@@ -1247,7 +1247,7 @@ mod tests {
 
         // AudienceUnknown: unknown-audience but trusted context.
         let unknown_audience = context(Label {
-            audience: Audience::Unknown,
+            audience: Audience::UNKNOWN,
             trust: Trust::TRUSTED,
             ..Label::identity()
         });
@@ -1366,7 +1366,7 @@ mod tests {
             name: ToolName::new("web.fetch"),
             requires: Requirements::default(),
             output_label: Label {
-                audience: Audience::Public,
+                audience: Audience::PUBLIC,
                 trust: Trust::SUSPICIOUS,
                 ..Label::identity()
             },

--- a/ai-labs/baton/baton-core/src/label.rs
+++ b/ai-labs/baton/baton-core/src/label.rs
@@ -102,7 +102,7 @@ impl Label {
     /// Identity of [`Label::combine`]: neutral in every dimension.
     pub fn identity() -> Self {
         Self {
-            audience: Audience::Public,
+            audience: Audience::PUBLIC,
             trust: Trust::TRUSTED,
             effects: Effects::none(),
             audit: Vec::new(),
@@ -113,9 +113,9 @@ impl Label {
     /// output of a tool nobody annotated.
     pub fn unknown() -> Self {
         Self {
-            audience: Audience::Unknown,
-            trust: Trust::Unknown,
-            effects: Effects::Unknown,
+            audience: Audience::UNKNOWN,
+            trust: Trust::UNKNOWN,
+            effects: Effects::UNKNOWN,
             audit: Vec::new(),
         }
     }
@@ -159,25 +159,15 @@ impl Label {
     #[must_use]
     pub fn lift(&self, grant: &Grant) -> Self {
         let trust = match grant.trust {
-            Some(attested) => match self.trust {
-                Trust::Known(actual) => Trust::Known(actual.max(attested)),
-                Trust::Unknown => Trust::Known(attested),
-            },
+            Some(attested) => self.trust.raised_to(attested),
             None => self.trust,
         };
         let audience = match &grant.audience {
-            Some(vouched) => match &self.audience {
-                Audience::Public => Audience::Public,
-                Audience::Readers(s) => Audience::Readers(s.union(vouched).cloned().collect()),
-                Audience::Unknown => Audience::Readers(vouched.clone()),
-            },
+            Some(vouched) => self.audience.admitting(vouched),
             None => self.audience.clone(),
         };
         let effects = match &grant.effects {
-            Some(waived) => match &self.effects {
-                Effects::Declared(present) => Effects::Declared(present.difference(waived).copied().collect()),
-                Effects::Unknown => Effects::Unknown,
-            },
+            Some(waived) => self.effects.waiving(waived),
             None => self.effects.clone(),
         };
         Self {
@@ -261,7 +251,8 @@ mod tests {
     use super::*;
     use crate::authority::AuthorityName;
     use crate::contract::{Unprovable, Violation};
-    use crate::dimension::{Adequacy, Effect, UserId};
+    use crate::dimension::{Effect, UserId};
+    use crate::preset::Adequacy;
 
     fn audit_entry(reason: &str) -> AuditEntry {
         AuditEntry::Declassified {
@@ -292,7 +283,7 @@ mod tests {
             audit: vec![audit_entry("first")],
         };
         let public_suspicious = Label {
-            audience: Audience::Public,
+            audience: Audience::PUBLIC,
             trust: Trust::SUSPICIOUS,
             effects: Effects::declared([Effect::Mutation]),
             audit: vec![audit_entry("second")],
@@ -310,9 +301,9 @@ mod tests {
     #[test]
     fn unknown_label_poisons_the_fold() {
         let folded = Label::fold([Label::identity(), Label::unknown()]);
-        assert_eq!(folded.audience, Audience::Unknown);
-        assert_eq!(folded.trust, Trust::Unknown);
-        assert_eq!(folded.effects, Effects::Unknown);
+        assert_eq!(folded.audience, Audience::UNKNOWN);
+        assert_eq!(folded.trust, Trust::UNKNOWN);
+        assert_eq!(folded.effects, Effects::UNKNOWN);
     }
 
     fn sample_labels() -> Vec<Label> {
@@ -326,7 +317,7 @@ mod tests {
                 audit: Vec::new(),
             },
             Label {
-                audience: Audience::Public,
+                audience: Audience::PUBLIC,
                 trust: Trust::TRUSTED,
                 effects: Effects::none(),
                 audit: Vec::new(),
@@ -379,49 +370,16 @@ mod tests {
         }
     }
 
-    fn trust_rank(t: Trust) -> u8 {
-        match t {
-            Trust::Unknown => 0,
-            Trust::Known(KnownTrust::Suspicious) => 1,
-            Trust::Known(KnownTrust::Trusted) => 2,
-        }
-    }
-
-    /// `x ⊑ y` in the audience adequacy order: `Unknown` bottom, `Public`
-    /// top, `Readers` by inclusion.
-    fn audience_le(x: &Audience, y: &Audience) -> bool {
-        match (x, y) {
-            (Audience::Unknown, _) => true,
-            (_, Audience::Public) => true,
-            (Audience::Readers(a), Audience::Readers(b)) => a.is_subset(b),
-            _ => false,
-        }
-    }
-
-    /// `x ⊑ y` in the effects adequacy order: `Unknown` bottom, `none()` top,
-    /// fewer present effects is more adequate.
-    fn effects_le(x: &Effects, y: &Effects) -> bool {
-        match (x, y) {
-            (Effects::Unknown, _) => true,
-            (Effects::Declared(a), Effects::Declared(b)) => b.is_subset(a),
-            (Effects::Declared(_), Effects::Unknown) => false,
-        }
-    }
-
     #[test]
     fn lift_is_inflationary_in_the_adequacy_order() {
+        // `lift` may only move a context toward passing a check (`Unknown` is
+        // bottom in every dimension), never demote one.
         for x in sample_labels() {
             for g in sample_grants() {
                 let up = x.lift(&g);
-                assert!(
-                    trust_rank(up.trust) >= trust_rank(x.trust),
-                    "trust demoted: g={g:?} x={x}"
-                );
-                assert!(
-                    audience_le(&x.audience, &up.audience),
-                    "audience demoted: g={g:?} x={x}"
-                );
-                assert!(effects_le(&x.effects, &up.effects), "effects demoted: g={g:?} x={x}");
+                assert!(x.trust.adequacy_le(&up.trust), "trust demoted: g={g:?} x={x}");
+                assert!(x.audience.adequacy_le(&up.audience), "audience demoted: g={g:?} x={x}");
+                assert!(x.effects.adequacy_le(&up.effects), "effects demoted: g={g:?} x={x}");
             }
         }
     }
@@ -474,7 +432,7 @@ mod tests {
         // Unknown is not cleared — this is precisely why it is
         // acknowledge-only rather than grant-fixable.
         let unknown = Label {
-            effects: Effects::Unknown,
+            effects: Effects::UNKNOWN,
             ..Label::identity()
         };
         assert_eq!(unknown.lift(&g).effects.avoids(&forbidden), Adequacy::Unprovable);

--- a/ai-labs/baton/baton-core/src/lib.rs
+++ b/ai-labs/baton/baton-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod contract;
 pub mod dimension;
 pub mod engine;
 pub mod label;
+pub mod preset;
 pub mod turn;
 
 use std::fmt;

--- a/ai-labs/baton/baton-core/src/preset.rs
+++ b/ai-labs/baton/baton-core/src/preset.rs
@@ -28,8 +28,12 @@ use std::collections::BTreeSet;
 /// wrong), and `Unprovable` when `Unknown` blocked the proof either way — the
 /// point where `Unknown` is *incomparable*, the opposite of its definite
 /// position in the taint fold.
+///
+/// This is the public result type of every preset's adequacy relation. The
+/// built-in dimensions delegate to the presets but keep their own adequacy
+/// methods crate-internal, since only the engine consumes them.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum Adequacy<W> {
+pub enum Adequacy<W> {
     Holds,
     Fails(W),
     Unprovable,
@@ -79,7 +83,7 @@ impl<T: Ord + Clone> MeetSet<T> {
     /// inside this set? `All` holds for anything; `Unknown` bounds nothing (so
     /// `Unprovable`, never silently `All`); `Only` holds iff nothing falls
     /// outside, with the `Fails` witness being exactly the members outside.
-    pub(crate) fn covers(&self, need: &BTreeSet<T>) -> Adequacy<BTreeSet<T>> {
+    pub fn covers(&self, need: &BTreeSet<T>) -> Adequacy<BTreeSet<T>> {
         match self {
             Self::Unknown => Adequacy::Unprovable,
             Self::All => Adequacy::Holds,
@@ -122,7 +126,7 @@ impl<T: Ord + Clone> JoinSet<T> {
     /// present. `Unknown` can attest the absence of nothing (so `Unprovable`);
     /// `Has` holds iff the intersection is empty, with the `Fails` witness the
     /// forbidden members that are present.
-    pub(crate) fn avoids(&self, forbidden: &BTreeSet<T>) -> Adequacy<BTreeSet<T>> {
+    pub fn avoids(&self, forbidden: &BTreeSet<T>) -> Adequacy<BTreeSet<T>> {
         match self {
             Self::Unknown => Adequacy::Unprovable,
             Self::Has(present) => {
@@ -169,7 +173,7 @@ impl<T: Ord + Clone> MinLevel<T> {
     /// Adequacy against a floor: a known value at or above the floor holds, a
     /// lower one `Fails` (carrying the actual value), and `Unknown` never
     /// satisfies any bar — unpacking it is an explicit decision, so `Unprovable`.
-    pub(crate) fn at_least(&self, floor: T) -> Adequacy<T> {
+    pub fn at_least(&self, floor: T) -> Adequacy<T> {
         match self {
             Self::Known(actual) if *actual >= floor => Adequacy::Holds,
             Self::Known(actual) => Adequacy::Fails(actual.clone()),
@@ -210,12 +214,7 @@ impl<T: Ord + Clone> MaxLevel<T> {
     /// Adequacy against a ceiling: a known value at or below the ceiling holds,
     /// a higher one `Fails` (carrying the actual value), and `Unknown` is
     /// `Unprovable`.
-    ///
-    /// Reserved: `MaxLevel` has no built-in dimension instance yet (unlike the
-    /// other three presets), so nothing in the crate calls this outside its
-    /// tests until a deployment wires a classification dimension (Step 2).
-    #[allow(dead_code)]
-    pub(crate) fn at_most(&self, ceiling: T) -> Adequacy<T> {
+    pub fn at_most(&self, ceiling: T) -> Adequacy<T> {
         match self {
             Self::Known(actual) if *actual <= ceiling => Adequacy::Holds,
             Self::Known(actual) => Adequacy::Fails(actual.clone()),

--- a/ai-labs/baton/baton-core/src/preset.rs
+++ b/ai-labs/baton/baton-core/src/preset.rs
@@ -1,0 +1,428 @@
+//! Preset dimension kinds: the small library of generic label algebras a
+//! deployment composes from, each generic over its own value type `T`.
+//!
+//! The crate's three built-in dimensions are one instance each of three of
+//! these presets ([`crate::dimension`] re-expresses them):
+//!
+//! | Preset | Built-in instance | Fold (`combine`) | Adequacy |
+//! |---|---|---|---|
+//! | [`MeetSet`] | `Audience` | intersection; `All` identity, `Unknown` absorbing | `covers` |
+//! | [`JoinSet`] | `Effects`  | union; `Has(∅)` identity, `Unknown` absorbing | `avoids` |
+//! | [`MinLevel`]| `Trust`    | min over `bottom < Unknown < rest` | `at_least` |
+//! | [`MaxLevel`]| — (classification) | max over `rest < Unknown < top` | `at_most` |
+//!
+//! Each keeps the two-algebra split the built-ins rely on (see the crate
+//! `CLAUDE.md`): `combine` is the commutative, idempotent **taint fold**, where
+//! `Unknown` has a *definite* position (absorbing for the sets; just above
+//! bottom for `MinLevel`, just below top for `MaxLevel`); the **adequacy**
+//! relation is the three-valued sink-side proof, where `Unknown` is instead
+//! bottom → `Adequacy::Unprovable`. The `Known(T) | Unknown` split stays
+//! two-level so a requirement expressed over `T` can never be satisfied by
+//! `Unknown` — "unknown suffices" remains unrepresentable.
+
+use std::collections::BTreeSet;
+
+/// The sink-side proof for one dimension: three-valued, not a lattice
+/// comparison. `Holds` when the context satisfies the requirement,
+/// `Fails(witness)` when it provably does not (the witness is exactly what is
+/// wrong), and `Unprovable` when `Unknown` blocked the proof either way — the
+/// point where `Unknown` is *incomparable*, the opposite of its definite
+/// position in the taint fold.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Adequacy<W> {
+    Holds,
+    Fails(W),
+    Unprovable,
+}
+
+/// A value type that designates its least element under [`Ord`]. Required by
+/// [`MinLevel`], whose `Unknown` sits *just above* that bottom in the fold.
+///
+/// **Law:** `Self::bottom() <= x` for every `x`. `MinLevel::combine`'s
+/// associativity depends on it — if `bottom()` is not the true minimum, the
+/// fold is not a semilattice.
+pub trait HasBottom: Ord {
+    fn bottom() -> Self;
+}
+
+/// A value type that designates its greatest element under [`Ord`]. Required by
+/// [`MaxLevel`], whose `Unknown` sits *just below* that top in the fold.
+///
+/// **Law:** `Self::top() >= x` for every `x` (the dual of [`HasBottom`]).
+pub trait HasTop: Ord {
+    fn top() -> Self;
+}
+
+/// The confidentiality-meet preset (generalizes `Audience`). The fold is the
+/// most-restrictive combine: a value is `All` (top / identity), a concrete
+/// `Only(set)`, or `Unknown` (absorbing). Adequacy is `covers`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MeetSet<T: Ord> {
+    All,
+    Only(BTreeSet<T>),
+    Unknown,
+}
+
+impl<T: Ord + Clone> MeetSet<T> {
+    /// Intersection fold: `Unknown` absorbs, `All` is the identity, and two
+    /// `Only` sets meet to their intersection.
+    #[must_use]
+    pub fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Unknown, _) | (_, Self::Unknown) => Self::Unknown,
+            (Self::All, x) | (x, Self::All) => x,
+            (Self::Only(a), Self::Only(b)) => Self::Only(a.intersection(&b).cloned().collect()),
+        }
+    }
+
+    /// Adequacy against a required set: is every member of `need` already
+    /// inside this set? `All` holds for anything; `Unknown` bounds nothing (so
+    /// `Unprovable`, never silently `All`); `Only` holds iff nothing falls
+    /// outside, with the `Fails` witness being exactly the members outside.
+    pub(crate) fn covers(&self, need: &BTreeSet<T>) -> Adequacy<BTreeSet<T>> {
+        match self {
+            Self::Unknown => Adequacy::Unprovable,
+            Self::All => Adequacy::Holds,
+            Self::Only(allowed) => {
+                let outside: BTreeSet<T> = need.difference(allowed).cloned().collect();
+                if outside.is_empty() {
+                    Adequacy::Holds
+                } else {
+                    Adequacy::Fails(outside)
+                }
+            }
+        }
+    }
+}
+
+/// The accumulating-union preset (generalizes `Effects`). A value is `Has(set)`
+/// (with `Has(∅)` the identity) or `Unknown` (absorbing). Adequacy is `avoids`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JoinSet<T: Ord> {
+    Has(BTreeSet<T>),
+    Unknown,
+}
+
+impl<T: Ord + Clone> JoinSet<T> {
+    /// The empty accumulation — the fold identity.
+    pub fn empty() -> Self {
+        Self::Has(BTreeSet::new())
+    }
+
+    /// Union fold: `Unknown` absorbs, two `Has` sets combine to their union.
+    #[must_use]
+    pub fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Unknown, _) | (_, Self::Unknown) => Self::Unknown,
+            (Self::Has(a), Self::Has(b)) => Self::Has(a.union(&b).cloned().collect()),
+        }
+    }
+
+    /// Adequacy against a forbidden set: none of `forbidden` may already be
+    /// present. `Unknown` can attest the absence of nothing (so `Unprovable`);
+    /// `Has` holds iff the intersection is empty, with the `Fails` witness the
+    /// forbidden members that are present.
+    pub(crate) fn avoids(&self, forbidden: &BTreeSet<T>) -> Adequacy<BTreeSet<T>> {
+        match self {
+            Self::Unknown => Adequacy::Unprovable,
+            Self::Has(present) => {
+                let hit: BTreeSet<T> = forbidden.intersection(present).cloned().collect();
+                if hit.is_empty() {
+                    Adequacy::Holds
+                } else {
+                    Adequacy::Fails(hit)
+                }
+            }
+        }
+    }
+}
+
+/// The trust-like ordered preset (generalizes `Trust`). Worse = lower, fold =
+/// min, `Unknown` just above bottom, adequacy = `at_least(floor)` — "least wins".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MinLevel<T: Ord> {
+    Known(T),
+    Unknown,
+}
+
+impl<T: Ord + HasBottom> MinLevel<T> {
+    /// Min fold over the total order `bottom < Unknown < rest`: a known bottom
+    /// dominates `Unknown` (it is still lower), while `Unknown` dominates every
+    /// other known value.
+    #[must_use]
+    pub fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Known(a), Self::Known(b)) => Self::Known(a.min(b)),
+            (Self::Known(a), Self::Unknown) | (Self::Unknown, Self::Known(a)) => {
+                if a == T::bottom() {
+                    Self::Known(a)
+                } else {
+                    Self::Unknown
+                }
+            }
+            (Self::Unknown, Self::Unknown) => Self::Unknown,
+        }
+    }
+}
+
+impl<T: Ord + Clone> MinLevel<T> {
+    /// Adequacy against a floor: a known value at or above the floor holds, a
+    /// lower one `Fails` (carrying the actual value), and `Unknown` never
+    /// satisfies any bar — unpacking it is an explicit decision, so `Unprovable`.
+    pub(crate) fn at_least(&self, floor: T) -> Adequacy<T> {
+        match self {
+            Self::Known(actual) if *actual >= floor => Adequacy::Holds,
+            Self::Known(actual) => Adequacy::Fails(actual.clone()),
+            Self::Unknown => Adequacy::Unprovable,
+        }
+    }
+}
+
+/// The classification-like ordered preset (the dual of [`MinLevel`], with no
+/// built-in instance yet). Worse = higher, fold = max, `Unknown` just below
+/// top, adequacy = `at_most(ceiling)` — "most sensitive wins".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaxLevel<T: Ord> {
+    Known(T),
+    Unknown,
+}
+
+impl<T: Ord + HasTop> MaxLevel<T> {
+    /// Max fold over the total order `rest < Unknown < top`: a known top
+    /// dominates `Unknown`, while `Unknown` dominates every other known value.
+    #[must_use]
+    pub fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Known(a), Self::Known(b)) => Self::Known(a.max(b)),
+            (Self::Known(a), Self::Unknown) | (Self::Unknown, Self::Known(a)) => {
+                if a == T::top() {
+                    Self::Known(a)
+                } else {
+                    Self::Unknown
+                }
+            }
+            (Self::Unknown, Self::Unknown) => Self::Unknown,
+        }
+    }
+}
+
+impl<T: Ord + Clone> MaxLevel<T> {
+    /// Adequacy against a ceiling: a known value at or below the ceiling holds,
+    /// a higher one `Fails` (carrying the actual value), and `Unknown` is
+    /// `Unprovable`.
+    ///
+    /// Reserved: `MaxLevel` has no built-in dimension instance yet (unlike the
+    /// other three presets), so nothing in the crate calls this outside its
+    /// tests until a deployment wires a classification dimension (Step 2).
+    #[allow(dead_code)]
+    pub(crate) fn at_most(&self, ceiling: T) -> Adequacy<T> {
+        match self {
+            Self::Known(actual) if *actual <= ceiling => Adequacy::Holds,
+            Self::Known(actual) => Adequacy::Fails(actual.clone()),
+            Self::Unknown => Adequacy::Unprovable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A three-valued ordered sample, so the `MinLevel`/`MaxLevel` `Unknown`
+    /// generalization is exercised past the two-valued `KnownTrust`: `Unknown`
+    /// must sit *just above* `Low` (bottom) and *just below* `High` (top),
+    /// leaving `Mid` on the `Unknown` side of both folds.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    enum Level {
+        Low,
+        Mid,
+        High,
+    }
+
+    impl HasBottom for Level {
+        fn bottom() -> Self {
+            Self::Low
+        }
+    }
+
+    impl HasTop for Level {
+        fn top() -> Self {
+            Self::High
+        }
+    }
+
+    fn set(items: impl IntoIterator<Item = u8>) -> BTreeSet<u8> {
+        items.into_iter().collect()
+    }
+
+    #[test]
+    fn has_bottom_and_top_are_the_extrema() {
+        for x in [Level::Low, Level::Mid, Level::High] {
+            assert!(Level::bottom() <= x, "bottom not <= {x:?}");
+            assert!(Level::top() >= x, "top not >= {x:?}");
+        }
+    }
+
+    #[test]
+    fn meet_set_intersects_with_all_identity_and_unknown_absorbing() {
+        let ab = MeetSet::Only(set([1, 2]));
+        let bc = MeetSet::Only(set([2, 3]));
+        assert_eq!(ab.clone().combine(bc), MeetSet::Only(set([2])));
+        // Disjoint sets meet to nobody, not to All.
+        assert_eq!(
+            MeetSet::Only(set([1])).combine(MeetSet::Only(set([2]))),
+            MeetSet::Only(BTreeSet::new())
+        );
+        assert_eq!(MeetSet::All.combine(ab.clone()), ab);
+        assert_eq!(MeetSet::<u8>::Unknown.combine(MeetSet::All), MeetSet::Unknown);
+    }
+
+    #[test]
+    fn meet_set_covers_over_the_three_values() {
+        assert_eq!(MeetSet::<u8>::All.covers(&set([9])), Adequacy::Holds);
+        assert_eq!(MeetSet::<u8>::Unknown.covers(&set([1])), Adequacy::Unprovable);
+        let ab = MeetSet::Only(set([1, 2]));
+        assert_eq!(ab.covers(&set([2])), Adequacy::Holds);
+        assert_eq!(ab.covers(&BTreeSet::new()), Adequacy::Holds);
+        assert_eq!(ab.covers(&set([2, 3])), Adequacy::Fails(set([3])));
+    }
+
+    #[test]
+    fn join_set_unions_with_empty_identity_and_unknown_absorbing() {
+        let a = JoinSet::Has(set([1]));
+        let b = JoinSet::Has(set([2]));
+        assert_eq!(a.clone().combine(b), JoinSet::Has(set([1, 2])));
+        assert_eq!(JoinSet::empty().combine(a.clone()), a.clone());
+        assert_eq!(a.combine(JoinSet::Unknown), JoinSet::Unknown);
+    }
+
+    #[test]
+    fn join_set_avoids_over_the_three_values() {
+        let forbidden = set([1]);
+        assert_eq!(JoinSet::<u8>::empty().avoids(&forbidden), Adequacy::Holds);
+        assert_eq!(JoinSet::Has(set([2])).avoids(&forbidden), Adequacy::Holds);
+        assert_eq!(JoinSet::Has(set([1, 2])).avoids(&forbidden), Adequacy::Fails(set([1])));
+        assert_eq!(JoinSet::<u8>::Unknown.avoids(&forbidden), Adequacy::Unprovable);
+        // An empty forbidden set is vacuously avoided.
+        assert_eq!(JoinSet::Has(set([1])).avoids(&BTreeSet::new()), Adequacy::Holds);
+    }
+
+    #[test]
+    fn min_level_folds_min_with_unknown_just_above_bottom() {
+        use Level::{High, Low, Mid};
+        // Bottom dominates Unknown (it is still lower); every other known value
+        // is dominated by Unknown.
+        assert_eq!(MinLevel::Known(Low).combine(MinLevel::Unknown), MinLevel::Known(Low));
+        assert_eq!(MinLevel::Known(Mid).combine(MinLevel::Unknown), MinLevel::Unknown);
+        assert_eq!(MinLevel::Known(High).combine(MinLevel::Unknown), MinLevel::Unknown);
+        // Between known values it is plain min.
+        assert_eq!(
+            MinLevel::Known(Low).combine(MinLevel::Known(High)),
+            MinLevel::Known(Low)
+        );
+        assert_eq!(
+            MinLevel::Known(Mid).combine(MinLevel::Known(High)),
+            MinLevel::Known(Mid)
+        );
+        assert_eq!(MinLevel::<Level>::Unknown.combine(MinLevel::Unknown), MinLevel::Unknown);
+    }
+
+    #[test]
+    fn min_level_at_least_over_the_values() {
+        use Level::{High, Low, Mid};
+        assert_eq!(MinLevel::Known(High).at_least(Mid), Adequacy::Holds);
+        assert_eq!(MinLevel::Known(Mid).at_least(Mid), Adequacy::Holds);
+        assert_eq!(MinLevel::Known(Low).at_least(Mid), Adequacy::Fails(Low));
+        assert_eq!(MinLevel::<Level>::Unknown.at_least(Low), Adequacy::Unprovable);
+        assert_eq!(MinLevel::<Level>::Unknown.at_least(High), Adequacy::Unprovable);
+    }
+
+    #[test]
+    fn max_level_folds_max_with_unknown_just_below_top() {
+        use Level::{High, Low, Mid};
+        assert_eq!(MaxLevel::Known(High).combine(MaxLevel::Unknown), MaxLevel::Known(High));
+        assert_eq!(MaxLevel::Known(Mid).combine(MaxLevel::Unknown), MaxLevel::Unknown);
+        assert_eq!(MaxLevel::Known(Low).combine(MaxLevel::Unknown), MaxLevel::Unknown);
+        assert_eq!(
+            MaxLevel::Known(Low).combine(MaxLevel::Known(High)),
+            MaxLevel::Known(High)
+        );
+        assert_eq!(MaxLevel::Known(Low).combine(MaxLevel::Known(Mid)), MaxLevel::Known(Mid));
+        assert_eq!(MaxLevel::<Level>::Unknown.combine(MaxLevel::Unknown), MaxLevel::Unknown);
+    }
+
+    #[test]
+    fn max_level_at_most_over_the_values() {
+        use Level::{High, Low, Mid};
+        assert_eq!(MaxLevel::Known(Low).at_most(Mid), Adequacy::Holds);
+        assert_eq!(MaxLevel::Known(Mid).at_most(Mid), Adequacy::Holds);
+        assert_eq!(MaxLevel::Known(High).at_most(Mid), Adequacy::Fails(High));
+        assert_eq!(MaxLevel::<Level>::Unknown.at_most(Low), Adequacy::Unprovable);
+        assert_eq!(MaxLevel::<Level>::Unknown.at_most(High), Adequacy::Unprovable);
+    }
+
+    fn meet_samples() -> Vec<MeetSet<u8>> {
+        vec![
+            MeetSet::All,
+            MeetSet::Only(set([1, 2])),
+            MeetSet::Only(set([2])),
+            MeetSet::Unknown,
+        ]
+    }
+
+    fn join_samples() -> Vec<JoinSet<u8>> {
+        vec![
+            JoinSet::empty(),
+            JoinSet::Has(set([1])),
+            JoinSet::Has(set([1, 2])),
+            JoinSet::Unknown,
+        ]
+    }
+
+    fn min_samples() -> Vec<MinLevel<Level>> {
+        vec![
+            MinLevel::Known(Level::Low),
+            MinLevel::Known(Level::Mid),
+            MinLevel::Known(Level::High),
+            MinLevel::Unknown,
+        ]
+    }
+
+    fn max_samples() -> Vec<MaxLevel<Level>> {
+        vec![
+            MaxLevel::Known(Level::Low),
+            MaxLevel::Known(Level::Mid),
+            MaxLevel::Known(Level::High),
+            MaxLevel::Unknown,
+        ]
+    }
+
+    /// Every preset fold is a commutative, idempotent semilattice.
+    #[test]
+    fn folds_are_commutative_idempotent_and_associative() {
+        macro_rules! check {
+            ($samples:expr) => {{
+                let samples = $samples;
+                for a in &samples {
+                    assert_eq!(a.clone().combine(a.clone()), *a, "not idempotent: {a:?}");
+                    for b in &samples {
+                        assert_eq!(
+                            a.clone().combine(b.clone()),
+                            b.clone().combine(a.clone()),
+                            "not commutative: {a:?} {b:?}"
+                        );
+                        for c in &samples {
+                            let left = a.clone().combine(b.clone()).combine(c.clone());
+                            let right = a.clone().combine(b.clone().combine(c.clone()));
+                            assert_eq!(left, right, "not associative: {a:?} {b:?} {c:?}");
+                        }
+                    }
+                }
+            }};
+        }
+        check!(meet_samples());
+        check!(join_samples());
+        check!(min_samples());
+        check!(max_samples());
+    }
+}

--- a/ai-labs/baton/baton-core/src/turn.rs
+++ b/ai-labs/baton/baton-core/src/turn.rs
@@ -200,7 +200,7 @@ mod tests {
         );
         trajectory.push_message(
             Label {
-                audience: Audience::Public,
+                audience: Audience::PUBLIC,
                 trust: Trust::SUSPICIOUS,
                 effects: Effects::declared([Effect::Egress]),
                 ..Label::identity()


### PR DESCRIPTION
Step 1 of `baton-core/docs/custom-dimensions.md`: extract the four preset dimension kinds as concrete generic algebras and re-express the three built-in dimensions as instances of them. **Behavior-preserving** — no engine changes, and the closed `Violation`/`Breach` enum stays closed. Delivers the reusable vocabulary; wiring a deployment's own dimension (`Label<Tag>`) is the deferred Step 2.

## What changed
- **New `preset` module** — `MeetSet<T>` (meet/intersection, generalizes `Audience`), `JoinSet<T>` (join/union, generalizes `Effects`), `MinLevel<T>` (least-wins, generalizes `Trust`), `MaxLevel<T>` (most-sensitive-wins classification — no built-in instance yet). Each owns its `combine` (taint fold) and adequacy relation, with property + finite-equivalence tests. `HasBottom`/`HasTop` traits carry the extremum law the ordered folds depend on. `Adequacy` moves here as the shared, now-public adequacy result.
- **`Audience`/`Effects`/`Trust` become newtypes** over `MeetSet<UserId>` / `JoinSet<Effect>` / `MinLevel<KnownTrust>`, delegating the algebra. Domain `Display`, constructors, and `Trust: Copy` preserved. Unit variants are now consts (`Audience::PUBLIC`/`UNKNOWN`, `Effects::UNKNOWN`), consistent with the existing `Trust::TRUSTED`/`SUSPICIOUS`.
- **`Label::lift`** routes each per-dimension step through a domain method (`Trust::raised_to` / `Audience::admitting` / `Effects::waiving`), keeping the newtype fields private and the adequacy-order lift semantics localized (also pre-stages Step 2).

## Behavior preservation
The presets reproduce the old `combine` / `covers` / `avoids` / `at_least` exactly; the existing property tests are the guardrail and pass unchanged in meaning. `Requirements::check` (body + trust→audience→attention→effects emission order) is untouched.

## API note
`Audience`/`Effects`/`Trust` stop being public enums with public variants and become newtypes: constructors are preserved, but external `match`/destructuring of `Audience::Readers(_)` / `Effects::Declared(_)` / `Trust::Known(_)` is no longer possible. The crate is `publish = false` with no external consumers.

## Validation
`cargo test` (70 + 2 doctests), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo run --example demo` (output unchanged), and `cargo doc` all clean. Reviewed by external + internal adversarial passes; findings (complete the preset public API; test the `KnownTrust` bottom law) addressed.

https://claude.ai/code/session_01RBw4UopmTT8E4GxKAn9T8F

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>