### PR TITLE
fix(mcp): allow cluster-DNS resolution in the MCP egress floor under AWS network policy

### DIFF
--- a/platform/helm/archestra/templates/mcp-network-policy.yaml
+++ b/platform/helm/archestra/templates/mcp-network-policy.yaml
@@ -73,6 +73,24 @@ spec:
               - ::1/128
               - fc00::/7
               - fe80::/10
+    {{- with .Values.archestra.orchestrator.kubernetes.networkPolicy.clusterDnsCidrs }}
+    # Rule 4: Explicit cluster-resolver DNS allow. Some enforcers (notably the AWS
+    # VPC CNI ApplicationNetworkPolicy agent) ignore the ports-only DNS rule above
+    # because it has no `to`, and the cluster resolver falls inside an
+    # except-denied private range — so name resolution needs the resolver CIDR(s)
+    # spelled out. Additive: the ports-only rule stays for providers that depend
+    # on it (e.g. a link-local NodeLocal DNSCache resolver). Empty by default.
+    - to:
+        {{- range . }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
     {{- with .Values.archestra.orchestrator.kubernetes.networkPolicy.additionalEgressRules }}
     # Additional user-configured egress rules (e.g., to allow specific internal services)
     {{- toYaml . | nindent 4 }}

--- a/platform/helm/archestra/tests/archestra_platform_mcp_network_policy_test.yaml
+++ b/platform/helm/archestra/tests/archestra_platform_mcp_network_policy_test.yaml
@@ -257,6 +257,29 @@ tests:
           path: spec.egress
           count: 3
 
+  - it: should add an explicit cluster-DNS egress rule when clusterDnsCidrs is set
+    set:
+      archestra.orchestrator.kubernetes.networkPolicy.create: true
+      archestra.orchestrator.kubernetes.networkPolicy.clusterDnsCidrs:
+        - 10.100.0.10/32
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 4
+      - equal:
+          path: spec.egress[3].to[0].ipBlock.cidr
+          value: 10.100.0.10/32
+      - contains:
+          path: spec.egress[3].ports
+          content:
+            protocol: UDP
+            port: 53
+      - contains:
+          path: spec.egress[3].ports
+          content:
+            protocol: TCP
+            port: 53
+
   - it: should include additional egress rules when configured
     set:
       archestra.orchestrator.kubernetes.networkPolicy.create: true

--- a/platform/helm/archestra/values.yaml
+++ b/platform/helm/archestra/values.yaml
@@ -544,6 +544,16 @@ archestra:
         #     - 203.0.113.0/24     # Documentation range
         additionalDeniedCidrs: []
 
+        # Explicit cluster-DNS resolver CIDR(s) allowed on :53, in addition to the
+        # ports-only DNS rule. Set on clusters whose NetworkPolicy enforcement
+        # ignores a ports-only rule with no `to` (e.g. the AWS VPC CNI
+        # ApplicationNetworkPolicy agent), where the resolver otherwise falls in a
+        # denied private range and DNS resolution breaks. Leave empty elsewhere.
+        # Example:
+        #   clusterDnsCidrs:
+        #     - 10.100.0.10/32
+        clusterDnsCidrs: []
+
         # Additional egress rules to add to the NetworkPolicy.
         # Use this to allow MCP server pods to reach specific internal Kubernetes
         # services that would otherwise be blocked by the private range deny rules.


### PR DESCRIPTION
## Summary

MCP server pods are protected by an always-on egress NetworkPolicy (`*-mcp-server-ssrf-protection`) that allows DNS via a **ports-only** rule (`:53`, no `to`) and otherwise permits public egress while denying private ranges.

On clusters whose NetworkPolicy enforcement ignores a ports-only rule — notably the **AWS VPC CNI `ApplicationNetworkPolicy` agent** — that DNS rule matches nothing, and the cluster resolver (which sits inside the floor's `except`-denied private range) becomes unreachable. MCP server pods on such clusters then cannot resolve names, so no outbound connectivity works at all.

This adds an operator-configurable `archestra.orchestrator.kubernetes.networkPolicy.clusterDnsCidrs`. When set, an additional egress rule allows `:53` to those resolver CIDRs, **in addition to** the existing ports-only rule — which is kept so providers that front cluster DNS with a link-local NodeLocal DNSCache resolver keep working. Empty by default, so existing clusters are unchanged; set it to the cluster DNS service/pod CIDR(s) on AWS-style clusters (e.g. `["10.100.0.10/32"]`).

Companion to the same fix on the Dagger engine floor in #6430; this is the MCP-server-pod half.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>