### PR TITLE
docs: managed Dagger engine requirements + correct Helm disable path

### DIFF
--- a/docs/pages/platform-code-sandbox.md
+++ b/docs/pages/platform-code-sandbox.md
@@ -52,7 +52,7 @@ Each command runs under fixed caps: 30 seconds of CPU, 1 GiB of memory, and 120 
 
 ## Enabling the Sandbox
 
-The quickstart Docker image and the Helm chart enable the sandbox by default. To turn it off, set `ARCHESTRA_CODE_RUNTIME_ENABLED=false` in Docker, or `archestra.codeRuntime.enabled=false` in Helm values. A manual deployment needs a Dagger runner host in `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`. Without a reachable runner host, the feature stays off. `ARCHESTRA_CODE_RUNTIME_ENABLED` only controls whether local dev, quickstart, and Helm deploy the embedded Dagger engine. See [Deployment](./platform-deployment#code-sandbox) for the full list.
+The quickstart Docker image and the Helm chart enable the sandbox by default. To turn it off, set `ARCHESTRA_CODE_RUNTIME_ENABLED=false` in Docker, or set both `archestra.codeRuntime.enabled=false` and `archestra.codeRuntime.dagger.managed.enabled=false` in Helm values — the second is what stops the managed Dagger engine pod from being deployed. A manual deployment needs a Dagger runner host in `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`. Without a reachable runner host, the feature stays off. `ARCHESTRA_CODE_RUNTIME_ENABLED` only controls whether local dev, quickstart, and Helm deploy the embedded Dagger engine. See [Deployment](./platform-deployment#code-sandbox) for the full list.
 
 Running a command needs the `sandbox:execute` permission. See [Access Control](./platform-access-control).
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -823,18 +823,14 @@ The following environment variables can be used to configure Archestra Platform.
 
 ### Code Sandbox
 
-> **The default Helm install runs a managed Dagger Engine.** With `archestra.codeRuntime.enabled`
-> and `archestra.codeRuntime.dagger.managed.enabled` both on by default, the chart deploys a Dagger
-> Engine StatefulSet (`dagger-runtime-engine`) in the release namespace. Its pod runs **privileged**,
-> adds **all** Linux capabilities, runs as **root (UID 0)**, and claims a **50Gi `ReadWriteOnce` PVC**
-> for its cache. The engine schedules only where your cluster's pod-security/admission policy admits
-> those settings and its PVC can bind. If your nodes can't host it, either:
-> - **run the engine elsewhere** — deploy the companion `platform/helm/dagger-runtime` chart (or any
->   Dagger Engine you operate), set `archestra.codeRuntime.dagger.managed.enabled=false`, and point
->   `archestra.codeRuntime.dagger.runnerHost` / `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST` at it; or
-> - **turn the sandbox off** — set both `archestra.codeRuntime.enabled=false` **and**
->   `archestra.codeRuntime.dagger.managed.enabled=false` in Helm (the second is what actually stops
->   the engine pod), or `ARCHESTRA_CODE_RUNTIME_ENABLED=false` for the Docker quickstart.
+By default the Helm chart runs a managed Dagger Engine. `archestra.codeRuntime.enabled` and `archestra.codeRuntime.dagger.managed.enabled` are both on, so the chart deploys the engine as a StatefulSet (`dagger-runtime-engine`) in the release namespace. That pod runs privileged, adds all Linux capabilities, runs as root, and needs a 50Gi `ReadWriteOnce` PVC for its cache. It schedules only on nodes whose pod-security policy allows those settings and where the PVC can bind.
+
+The bundled engine is a convenience, not a requirement. The sandbox reaches its engine over `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, a `tcp://` or `kube-pod://` address. Run the engine however you like — the companion `platform/helm/dagger-runtime` chart, a Docker container, a standalone binary, or a separate cluster — as long as it is a reachable Dagger Engine.
+
+If your nodes can't host the managed pod, you have two options:
+
+- Run the engine elsewhere. Set `archestra.codeRuntime.dagger.managed.enabled=false` and point `archestra.codeRuntime.dagger.runnerHost` (or `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`) at it.
+- Turn the sandbox off. Set both `archestra.codeRuntime.enabled=false` and `archestra.codeRuntime.dagger.managed.enabled=false` in Helm. The second key is what stops the engine pod. For the Docker quickstart, set `ARCHESTRA_CODE_RUNTIME_ENABLED=false`.
 
 - **`ARCHESTRA_CODE_RUNTIME_ENABLED`** - Enables the code runtime — the per-conversation [code sandbox](./platform-code-sandbox) where agents run shell commands and Python, execute skill scripts, and run agent hooks. Needs a Dagger runner host (below) to run; without one the feature stays off. When off, `run_command` and the other sandbox tools are unavailable and skills cannot execute. The quickstart Docker image and the Helm chart set both variables by default; opt out with `ARCHESTRA_CODE_RUNTIME_ENABLED=false` in Docker or `archestra.codeRuntime.enabled=false` in Helm values.
   - Default: `false`

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -825,7 +825,7 @@ The following environment variables can be used to configure Archestra Platform.
 
 By default the Helm chart runs a managed Dagger Engine. `archestra.codeRuntime.enabled` and `archestra.codeRuntime.dagger.managed.enabled` are both on, so the chart deploys the engine as a StatefulSet (`dagger-runtime-engine`) in the release namespace. That pod runs privileged, adds all Linux capabilities, runs as root, and needs a 50Gi `ReadWriteOnce` PVC for its cache. It schedules only on nodes whose pod-security policy allows those settings and where the PVC can bind.
 
-The bundled engine is a convenience, not a requirement. The sandbox reaches its engine over `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, a `tcp://` or `kube-pod://` address. Run the engine however you like — the companion `platform/helm/dagger-runtime` chart, a Docker container, a standalone binary, or a separate cluster — as long as it is a reachable Dagger Engine.
+The bundled engine is a convenience, not a requirement. The sandbox reaches its engine over `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST`, a `tcp://` or `kube-pod://` address. Run the engine however you like — the companion `platform/helm/dagger-runtime` chart, a Docker container, a standalone binary, or a separate cluster — as long as it is a reachable Dagger Engine. See Dagger's [custom runner](https://docs.dagger.io/reference/configuration/custom-runner) and [deployment](https://docs.dagger.io/reference/#deployment) references for the runner host schemes and engine requirements.
 
 If your nodes can't host the managed pod, you have two options:
 

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -823,6 +823,19 @@ The following environment variables can be used to configure Archestra Platform.
 
 ### Code Sandbox
 
+> **The default Helm install runs a managed Dagger Engine.** With `archestra.codeRuntime.enabled`
+> and `archestra.codeRuntime.dagger.managed.enabled` both on by default, the chart deploys a Dagger
+> Engine StatefulSet (`dagger-runtime-engine`) in the release namespace. Its pod runs **privileged**,
+> adds **all** Linux capabilities, runs as **root (UID 0)**, and claims a **50Gi `ReadWriteOnce` PVC**
+> for its cache. The engine schedules only where your cluster's pod-security/admission policy admits
+> those settings and its PVC can bind. If your nodes can't host it, either:
+> - **run the engine elsewhere** — deploy the companion `platform/helm/dagger-runtime` chart (or any
+>   Dagger Engine you operate), set `archestra.codeRuntime.dagger.managed.enabled=false`, and point
+>   `archestra.codeRuntime.dagger.runnerHost` / `ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST` at it; or
+> - **turn the sandbox off** — set both `archestra.codeRuntime.enabled=false` **and**
+>   `archestra.codeRuntime.dagger.managed.enabled=false` in Helm (the second is what actually stops
+>   the engine pod), or `ARCHESTRA_CODE_RUNTIME_ENABLED=false` for the Docker quickstart.
+
 - **`ARCHESTRA_CODE_RUNTIME_ENABLED`** - Enables the code runtime — the per-conversation [code sandbox](./platform-code-sandbox) where agents run shell commands and Python, execute skill scripts, and run agent hooks. Needs a Dagger runner host (below) to run; without one the feature stays off. When off, `run_command` and the other sandbox tools are unavailable and skills cannot execute. The quickstart Docker image and the Helm chart set both variables by default; opt out with `ARCHESTRA_CODE_RUNTIME_ENABLED=false` in Docker or `archestra.codeRuntime.enabled=false` in Helm values.
   - Default: `false`
   - Values: `true`, `false`


### PR DESCRIPTION
## What

Two docs fixes prompted by a customer whose code sandbox failed to schedule on EKS Fargate.

- **`platform-deployment.md` → Code Sandbox**: add a note stating what the managed Dagger engine *requires* (privileged pod, all capabilities, root UID, a bindable 50Gi `ReadWriteOnce` PVC) rather than blocklisting specific platforms. Covers the external-engine path (companion `platform/helm/dagger-runtime` chart + `runnerHost`) and the disable path. Also documents the `dagger.managed`/`runnerHost` Helm keys, which were undocumented.
- **`platform-code-sandbox.md` → Enabling the Sandbox**: correct the Helm disable guidance.

## Why the disable fix matters

`archestra.codeRuntime.enabled=false` in Helm only stops env-var injection. The managed engine StatefulSet is a chart dependency gated on `archestra.codeRuntime.dagger.managed.enabled` (`Chart.yaml`), so the failing pod is still deployed. Disabling on Helm requires setting `dagger.managed.enabled=false` too.

Claims verified against `platform/helm/archestra/values.yaml`, `Chart.yaml`, the vendored `dagger-helm` templates, and `helm template` render output.

https://claude.ai/code/session_01Msn1o9KTy4S3W9ZdqZeYSh

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>