### PR TITLE
fix(sandbox): allow Docker Hub image-layer blobs in restricted egress presets

### DIFF
--- a/platform/backend/src/services/environments/network-policy-domains.ts
+++ b/platform/backend/src/services/environments/network-policy-domains.ts
@@ -53,6 +53,10 @@ const COMMON_DEPENDENCY_DOMAINS = Object.freeze([
   "packagist.org",
   "pkg.go.dev",
   "production.cloudflare.docker.com",
+  // Docker Hub blob (image-layer) backends — Docker rotates these between
+  // CloudFront/R2/S3; without them manifests resolve but layer pulls are blocked.
+  "docker-images-prod.r2.cloudflarestorage.com",
+  "docker-images-prod.s3.dualstack.us-east-1.amazonaws.com",
   "pub.dev",
   "pypa.io",
   "pypi.org",
@@ -103,6 +107,10 @@ const PACKAGE_MANAGER_DOMAINS = Object.freeze([
   "docker.io",
   "*.docker.io",
   "production.cloudflare.docker.com",
+  // Docker Hub blob (image-layer) backends — Docker rotates these between
+  // CloudFront/R2/S3; without them manifests resolve but layer pulls are blocked.
+  "docker-images-prod.r2.cloudflarestorage.com",
+  "docker-images-prod.s3.dualstack.us-east-1.amazonaws.com",
   "yarnpkg.com",
 ]);
 


### PR DESCRIPTION
## Summary

A `restricted` environment's egress is a domain allowlist built from the package-manager / common-dependency presets (`network-policy-domains.ts`). Those presets whitelist Docker Hub's registry (`registry-1.docker.io`, `docker.io`, `*.docker.io`) and its CloudFront host (`production.cloudflare.docker.com`), but **not** the storage backend Docker Hub redirects image *layers* to. So a restricted sandbox resolves the manifest and then fails the blob download:

```
dial tcp <s3-ip>:443: i/o timeout
docker-images-prod.s3.dualstack.us-east-1.amazonaws.com/...
```

i.e. `docker.io` alone is insufficient to pull any Docker Hub image in restricted mode. This adds the currently-known blob backends (Cloudflare R2 + AWS S3).

**Draft, because this is a best-effort patch, not a real fix.** Docker rotates its blob backend between CloudFront, Cloudflare R2, and multi-region AWS S3, and the domain list is explicitly documented as changing ([Docker allowlist](https://docs.docker.com/desktop/setup/allow-list/), [docker/docs#21960](https://github.com/docker/docs/issues/21960)). Domain-allowlisting Docker Hub will always be whack-a-mole; the durable path for locked-down environments is an in-cluster mirror or a prebuilt base image (see the sandbox base-image ADR). Opening this to decide between shipping the best-effort domains vs. steering restricted users toward a mirror.

Independent of #6430 / #6471 (a different mechanism — the domain allowlist, not the DNS-resolution floor).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>