### PR TITLE
feat(baton-core): trace core ops via tracing; demo -v/-vv verbosity

### DIFF
--- a/ai-labs/Cargo.lock
+++ b/ai-labs/Cargo.lock
@@ -338,6 +338,10 @@ dependencies = [
 [[package]]
 name = "baton-core"
 version = "0.1.0"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "bench-dashboard"

--- a/ai-labs/baton/baton-core/CLAUDE.md
+++ b/ai-labs/baton/baton-core/CLAUDE.md
@@ -1,8 +1,9 @@
 # baton-core
 
-Zero-dependency prototype IFC policy engine (edition 2024, `publish = false`).
-Concepts and semantics live in `src/lib.rs`; this file is the invariants an
-edit must not silently break.
+Prototype IFC policy engine (edition 2024, `publish = false`). The only
+dependency is `tracing` (workspace-standard facade; `tracing-subscriber` is a
+dev-dependency the `demo` example installs). Concepts and semantics live in
+`src/lib.rs`; this file is the invariants an edit must not silently break.
 
 ## Two structures — never conflate them
 
@@ -65,8 +66,10 @@ relations — no `match` on label values, no set-difference. The emission order
 
 ## Conventions
 
-- No dependencies; no `dyn`/`Box`; prefer newtypes over primitives; prefer
-  pattern matching over `if`-chains.
+- `tracing` is the only dependency; no `dyn`/`Box`; prefer newtypes over
+  primitives; prefer pattern matching over `if`-chains. Core ops emit `tracing`
+  events (decision path at `debug!`, algebra at `trace!`) — borrow-only, never
+  behavior-changing; `demo -- -v`/`-vv` selects the level.
 - Validate every change: `cargo test`, `cargo clippy --all-targets -- -D warnings`,
   `cargo fmt --check`, `cargo run --example demo`.
 - Tests exercise behavior and algebra **laws** (property tests), not wording.

--- a/ai-labs/baton/baton-core/Cargo.toml
+++ b/ai-labs/baton/baton-core/Cargo.toml
@@ -5,5 +5,11 @@ edition = "2024"
 publish = false
 description = "ADT-based information-flow label engine for agent trajectories (prototype)"
 
+[dependencies]
+tracing = "0.1"
+
+[dev-dependencies]
+tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
+
 [lints]
 workspace = true

--- a/ai-labs/baton/baton-core/examples/demo.rs
+++ b/ai-labs/baton/baton-core/examples/demo.rs
@@ -123,16 +123,20 @@ fn attempt(engine: &PolicyEngine<Panel>, trajectory: &mut Trajectory, request: T
 }
 
 /// `-v` traces the decision path (`debug`), `-vv` also the label algebra
-/// (`trace`); repeated `-v` accumulates. `RUST_LOG` overrides the flag.
+/// (`trace`); the `v`s accumulate whether written `-vv` or `-v -v`, and
+/// `--verbose` counts as one. `RUST_LOG` overrides the flag.
 fn verbosity() -> u8 {
-    std::env::args()
-        .skip(1)
-        .map(|arg| match arg.as_str() {
-            "-v" | "--verbose" => 1,
-            "-vv" => 2,
+    std::env::args().skip(1).fold(0u8, |level, arg| {
+        let bump = match arg.as_str() {
+            "--verbose" => 1,
+            // `-v`, `-vv`, `-vvv`, ...: one step per `v`.
+            s if s.len() > 1 && s.starts_with('-') && s[1..].bytes().all(|b| b == b'v') => {
+                u8::try_from(s.len() - 1).unwrap_or(u8::MAX)
+            }
             _ => 0,
-        })
-        .sum()
+        };
+        level.saturating_add(bump)
+    })
 }
 
 /// Logs go to stderr so this demo's stdout narration stays clean.

--- a/ai-labs/baton/baton-core/examples/demo.rs
+++ b/ai-labs/baton/baton-core/examples/demo.rs
@@ -122,7 +122,38 @@ fn attempt(engine: &PolicyEngine<Panel>, trajectory: &mut Trajectory, request: T
     println!();
 }
 
+/// `-v` traces the decision path (`debug`), `-vv` also the label algebra
+/// (`trace`); repeated `-v` accumulates. `RUST_LOG` overrides the flag.
+fn verbosity() -> u8 {
+    std::env::args()
+        .skip(1)
+        .map(|arg| match arg.as_str() {
+            "-v" | "--verbose" => 1,
+            "-vv" => 2,
+            _ => 0,
+        })
+        .sum()
+}
+
+/// Logs go to stderr so this demo's stdout narration stays clean.
+fn init_tracing(verbosity: u8) {
+    let default = match verbosity {
+        0 => "warn",
+        1 => "baton_core=debug",
+        _ => "baton_core=trace",
+    };
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default)),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+}
+
 fn main() {
+    init_tracing(verbosity());
+
     // AllowWithAudit for unprovable gaps; the taint knob on so a degrading
     // step is flagged and signed off rather than propagating silently.
     let mut engine = PolicyEngine::new((HumanInTheLoop, OnCallAdmin), UnknownPolicy::AllowWithAudit)

--- a/ai-labs/baton/baton-core/src/contract.rs
+++ b/ai-labs/baton/baton-core/src/contract.rs
@@ -4,6 +4,8 @@
 use std::collections::BTreeSet;
 use std::fmt;
 
+use tracing::trace;
+
 use crate::ToolName;
 use crate::dimension::{Adequacy, Effect, KnownTrust, UserId};
 use crate::label::Label;
@@ -309,8 +311,10 @@ impl Requirements {
         }
 
         if violations.is_empty() {
+            trace!(tool = %request.tool, "check: allow");
             Verdict::Allow
         } else {
+            trace!(tool = %request.tool, violations = ?violations, "check: escalate");
             Verdict::Escalate(violations)
         }
     }

--- a/ai-labs/baton/baton-core/src/engine.rs
+++ b/ai-labs/baton/baton-core/src/engine.rs
@@ -3,6 +3,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+use tracing::{debug, warn};
+
 use crate::ToolName;
 use crate::authority::{Authority, AuthorityName, Ruling};
 use crate::contract::{Breach, Fixability, Requirements, ToolContract, ToolRequest, Unprovable, Verdict, Violation};
@@ -221,8 +223,10 @@ impl<A: Authority> PolicyEngine<A> {
     /// error, not a silent overwrite.
     pub fn register(&mut self, contract: ToolContract) -> Result<(), DuplicateContract> {
         if self.contracts.contains_key(&contract.name) {
+            debug!(tool = %contract.name, "register: duplicate contract refused");
             return Err(DuplicateContract { tool: contract.name });
         }
+        debug!(tool = %contract.name, "register: contract registered");
         self.contracts.insert(contract.name.clone(), contract);
         Ok(())
     }
@@ -255,11 +259,13 @@ impl<A: Authority> PolicyEngine<A> {
     /// evaluate → execute → [`Trajectory::record_result`] loop of the
     /// embedding harness; the permit's binding to the trajectory head keeps
     /// that loop honest.
+    #[tracing::instrument(level = "debug", skip_all, fields(tool = %request.tool))]
     pub fn evaluate(&self, trajectory: &Trajectory, request: &ToolRequest) -> Decision {
         let context = trajectory.context_label();
         let confirmation = trajectory.pending_confirmation();
         let trajectory_id = trajectory.id();
         let basis = trajectory.turns().len();
+        debug!(%context, confirmation = ?confirmation, basis, "evaluate: folded context");
 
         let permit = |result_label| {
             Decision::Permitted(Permit {
@@ -283,6 +289,7 @@ impl<A: Authority> PolicyEngine<A> {
                 Label::unknown(),
             ),
         };
+        debug!(has_contract = contract.is_some(), "evaluate: contract lookup");
 
         let mut violations = match verdict {
             Verdict::Allow => Vec::new(),
@@ -297,16 +304,20 @@ impl<A: Authority> PolicyEngine<A> {
             None
         };
         if let Some(taint) = taint {
+            debug!("evaluate: taint flagged (output would degrade context)");
             violations.push(taint);
         }
 
         if violations.is_empty() {
+            debug!("evaluate: permitted (no violations)");
             return permit(result_label);
         }
+        debug!(violations = ?violations, "evaluate: triaging violations");
 
         // Axis: fixability. A structural violation is an integration bug no
         // authority may override — block before consulting anyone.
         if violations.iter().any(|v| v.fixability() == Fixability::Structural) {
+            debug!("evaluate: blocked (structural fix required)");
             return Decision::Blocked {
                 violations,
                 reason: BlockReason::RequiresStructuralFix,
@@ -321,11 +332,18 @@ impl<A: Authority> PolicyEngine<A> {
         let mut result_label = result_label;
         let mut escalating = breaches;
         let mut audited_unknowns = Vec::new();
+        debug!(
+            policy = ?self.unknown_policy,
+            unprovable = unprovable.len(),
+            breaches = escalating.len(),
+            "evaluate: unknown-policy disposition",
+        );
         match self.unknown_policy {
             UnknownPolicy::Escalate => escalating.extend(unprovable),
             UnknownPolicy::Deny => {
                 if !unprovable.is_empty() {
                     escalating.extend(unprovable);
+                    debug!("evaluate: blocked (unknown-policy deny)");
                     return Decision::Blocked {
                         violations: escalating,
                         reason: BlockReason::UnknownDenied,
@@ -337,12 +355,17 @@ impl<A: Authority> PolicyEngine<A> {
 
         if escalating.is_empty() {
             if !audited_unknowns.is_empty() {
+                debug!(
+                    count = audited_unknowns.len(),
+                    "evaluate: acknowledging policy-audited unknowns"
+                );
                 result_label.audit.push(AuditEntry::Acknowledged {
                     tool: request.tool.clone(),
                     facts: audited_unknowns,
                     by: None,
                 });
             }
+            debug!("evaluate: permitted (no escalation)");
             return permit(result_label);
         }
 
@@ -354,6 +377,7 @@ impl<A: Authority> PolicyEngine<A> {
             Some(c) => needed_grant(&escalating, request, &c.requires),
             None => Grant::empty(),
         };
+        debug!(grant = ?needed, escalating = ?escalating, "evaluate: derived grant, routing to authority");
 
         // Route and adjudicate in one traversal: the authority names the
         // deciding member and returns its ruling together, so attribution is
@@ -361,15 +385,18 @@ impl<A: Authority> PolicyEngine<A> {
         // — block without consulting anyone.
         let full_picture: Vec<Violation> = escalating.iter().chain(audited_unknowns.iter()).cloned().collect();
         let Some((authority_name, ruling)) = self.authority.rule(&needed, request, &context, &full_picture) else {
+            debug!("evaluate: blocked (no competent authority)");
             escalating.extend(audited_unknowns);
             return Decision::Blocked {
                 violations: escalating,
                 reason: BlockReason::NoCompetentAuthority,
             };
         };
+        debug!(authority = %authority_name, "evaluate: routed to authority");
 
         match ruling {
             Ruling::Approve { reason } => {
+                debug!(authority = %authority_name, "evaluate: authority approved");
                 // Fail closed (a control-flow check, not a debug_assert that
                 // vanishes in release): the grant must actually clear every
                 // grant-fixable gap it targeted. Acknowledge-only violations
@@ -396,12 +423,17 @@ impl<A: Authority> PolicyEngine<A> {
                         Verdict::Escalate(remaining) => remaining.iter().any(|v| targeted.contains(v)),
                     };
                     if uncovered {
+                        warn!(
+                            authority = %authority_name,
+                            "evaluate: recheck failed — grant did not clear targeted gaps, failing closed",
+                        );
                         escalating.extend(audited_unknowns);
                         return Decision::Blocked {
                             violations: escalating,
                             reason: BlockReason::InternalInvariantFailed,
                         };
                     }
+                    debug!("evaluate: recheck cleared targeted gaps");
                 }
 
                 // Record one declassification for the grant-fixable gaps the
@@ -433,9 +465,11 @@ impl<A: Authority> PolicyEngine<A> {
                         by: None,
                     });
                 }
+                debug!("evaluate: permitted (approved, declassification recorded)");
                 permit(result_label)
             }
             Ruling::Deny { reason } => {
+                debug!(authority = %authority_name, reason = %reason, "evaluate: blocked (denied by authority)");
                 // Report the full picture: the audited unknowns did not cause
                 // the block, but they were part of this flow's evaluation.
                 escalating.extend(audited_unknowns);

--- a/ai-labs/baton/baton-core/src/engine.rs
+++ b/ai-labs/baton/baton-core/src/engine.rs
@@ -265,7 +265,7 @@ impl<A: Authority> PolicyEngine<A> {
         let confirmation = trajectory.pending_confirmation();
         let trajectory_id = trajectory.id();
         let basis = trajectory.turns().len();
-        debug!(%context, confirmation = ?confirmation, basis, "evaluate: folded context");
+        debug!(%context, confirmation = ?confirmation, basis, "folded context");
 
         let permit = |result_label| {
             Decision::Permitted(Permit {
@@ -289,7 +289,7 @@ impl<A: Authority> PolicyEngine<A> {
                 Label::unknown(),
             ),
         };
-        debug!(has_contract = contract.is_some(), "evaluate: contract lookup");
+        debug!(has_contract = contract.is_some(), "contract lookup");
 
         let mut violations = match verdict {
             Verdict::Allow => Vec::new(),
@@ -304,20 +304,20 @@ impl<A: Authority> PolicyEngine<A> {
             None
         };
         if let Some(taint) = taint {
-            debug!("evaluate: taint flagged (output would degrade context)");
+            debug!("taint flagged (output would degrade context)");
             violations.push(taint);
         }
 
         if violations.is_empty() {
-            debug!("evaluate: permitted (no violations)");
+            debug!("permitted (no violations)");
             return permit(result_label);
         }
-        debug!(violations = ?violations, "evaluate: triaging violations");
+        debug!(violations = ?violations, "triaging violations");
 
         // Axis: fixability. A structural violation is an integration bug no
         // authority may override — block before consulting anyone.
         if violations.iter().any(|v| v.fixability() == Fixability::Structural) {
-            debug!("evaluate: blocked (structural fix required)");
+            debug!("blocked (structural fix required)");
             return Decision::Blocked {
                 violations,
                 reason: BlockReason::RequiresStructuralFix,
@@ -336,14 +336,14 @@ impl<A: Authority> PolicyEngine<A> {
             policy = ?self.unknown_policy,
             unprovable = unprovable.len(),
             breaches = escalating.len(),
-            "evaluate: unknown-policy disposition",
+            "unknown-policy disposition",
         );
         match self.unknown_policy {
             UnknownPolicy::Escalate => escalating.extend(unprovable),
             UnknownPolicy::Deny => {
                 if !unprovable.is_empty() {
                     escalating.extend(unprovable);
-                    debug!("evaluate: blocked (unknown-policy deny)");
+                    debug!("blocked (unknown-policy deny)");
                     return Decision::Blocked {
                         violations: escalating,
                         reason: BlockReason::UnknownDenied,
@@ -355,17 +355,14 @@ impl<A: Authority> PolicyEngine<A> {
 
         if escalating.is_empty() {
             if !audited_unknowns.is_empty() {
-                debug!(
-                    count = audited_unknowns.len(),
-                    "evaluate: acknowledging policy-audited unknowns"
-                );
+                debug!(count = audited_unknowns.len(), "acknowledging policy-audited unknowns");
                 result_label.audit.push(AuditEntry::Acknowledged {
                     tool: request.tool.clone(),
                     facts: audited_unknowns,
                     by: None,
                 });
             }
-            debug!("evaluate: permitted (no escalation)");
+            debug!("permitted (no escalation)");
             return permit(result_label);
         }
 
@@ -377,7 +374,7 @@ impl<A: Authority> PolicyEngine<A> {
             Some(c) => needed_grant(&escalating, request, &c.requires),
             None => Grant::empty(),
         };
-        debug!(grant = ?needed, escalating = ?escalating, "evaluate: derived grant, routing to authority");
+        debug!(grant = ?needed, escalating = ?escalating, "derived grant, routing to authority");
 
         // Route and adjudicate in one traversal: the authority names the
         // deciding member and returns its ruling together, so attribution is
@@ -385,18 +382,18 @@ impl<A: Authority> PolicyEngine<A> {
         // — block without consulting anyone.
         let full_picture: Vec<Violation> = escalating.iter().chain(audited_unknowns.iter()).cloned().collect();
         let Some((authority_name, ruling)) = self.authority.rule(&needed, request, &context, &full_picture) else {
-            debug!("evaluate: blocked (no competent authority)");
+            debug!("blocked (no competent authority)");
             escalating.extend(audited_unknowns);
             return Decision::Blocked {
                 violations: escalating,
                 reason: BlockReason::NoCompetentAuthority,
             };
         };
-        debug!(authority = %authority_name, "evaluate: routed to authority");
+        debug!(authority = %authority_name, "routed to authority");
 
         match ruling {
             Ruling::Approve { reason } => {
-                debug!(authority = %authority_name, "evaluate: authority approved");
+                debug!(authority = %authority_name, "authority approved");
                 // Fail closed (a control-flow check, not a debug_assert that
                 // vanishes in release): the grant must actually clear every
                 // grant-fixable gap it targeted. Acknowledge-only violations
@@ -425,7 +422,7 @@ impl<A: Authority> PolicyEngine<A> {
                     if uncovered {
                         warn!(
                             authority = %authority_name,
-                            "evaluate: recheck failed — grant did not clear targeted gaps, failing closed",
+                            "recheck failed — grant did not clear targeted gaps, failing closed",
                         );
                         escalating.extend(audited_unknowns);
                         return Decision::Blocked {
@@ -433,7 +430,7 @@ impl<A: Authority> PolicyEngine<A> {
                             reason: BlockReason::InternalInvariantFailed,
                         };
                     }
-                    debug!("evaluate: recheck cleared targeted gaps");
+                    debug!("recheck cleared targeted gaps");
                 }
 
                 // Record one declassification for the grant-fixable gaps the
@@ -465,11 +462,11 @@ impl<A: Authority> PolicyEngine<A> {
                         by: None,
                     });
                 }
-                debug!("evaluate: permitted (approved, declassification recorded)");
+                debug!("permitted (authority approved)");
                 permit(result_label)
             }
             Ruling::Deny { reason } => {
-                debug!(authority = %authority_name, reason = %reason, "evaluate: blocked (denied by authority)");
+                debug!(authority = %authority_name, reason = %reason, "blocked (denied by authority)");
                 // Report the full picture: the audited unknowns did not cause
                 // the block, but they were part of this flow's evaluation.
                 escalating.extend(audited_unknowns);

--- a/ai-labs/baton/baton-core/src/label.rs
+++ b/ai-labs/baton/baton-core/src/label.rs
@@ -18,6 +18,8 @@
 use std::collections::BTreeSet;
 use std::fmt;
 
+use tracing::trace;
+
 use crate::ToolName;
 use crate::authority::AuthorityName;
 use crate::contract::Violation;
@@ -126,6 +128,7 @@ impl Label {
     /// turn order to keep the trail chronological.
     #[must_use]
     pub fn combine(self, newer: Self) -> Self {
+        trace!(older = %self, newer = %newer, "combine");
         let mut audit = self.audit;
         audit.extend(newer.audit);
         Self {
@@ -137,7 +140,9 @@ impl Label {
     }
 
     pub fn fold(labels: impl IntoIterator<Item = Self>) -> Self {
-        labels.into_iter().fold(Self::identity(), Self::combine)
+        let folded = labels.into_iter().fold(Self::identity(), Self::combine);
+        trace!(result = %folded, "fold");
+        folded
     }
 
     /// Apply an authority-minted [`Grant`] to produce a **check-transient**
@@ -180,12 +185,14 @@ impl Label {
             },
             None => self.effects.clone(),
         };
-        Self {
+        let lifted = Self {
             audience,
             trust,
             effects,
             audit: self.audit.clone(),
-        }
+        };
+        trace!(grant = ?grant, base = %self, result = %lifted, "lift");
+        lifted
     }
 }
 

--- a/ai-labs/baton/baton-core/src/turn.rs
+++ b/ai-labs/baton/baton-core/src/turn.rs
@@ -3,6 +3,8 @@
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use tracing::debug;
+
 use crate::ToolName;
 use crate::dimension::UserId;
 use crate::engine::{Permit, RejectedPermit};
@@ -129,17 +131,24 @@ impl Trajectory {
     pub fn record_result(&mut self, permit: Permit, content: impl Into<String>) -> Result<(), RejectedPermit> {
         let (request, label, trajectory, basis) = permit.into_parts();
         if trajectory != self.id {
+            debug!(minted_for = %trajectory, this = %self.id, "record_result: rejected (foreign trajectory)");
             return Err(RejectedPermit::ForeignTrajectory {
                 minted_for: trajectory,
                 this: self.id,
             });
         }
         if basis != self.turns.len() {
+            debug!(
+                granted_at = basis,
+                current_len = self.turns.len(),
+                "record_result: rejected (stale permit)"
+            );
             return Err(RejectedPermit::Stale {
                 granted_at: basis,
                 current_len: self.turns.len(),
             });
         }
+        debug!(tool = %request.tool, basis, "record_result: recorded tool result");
         self.turns.push(LabeledTurn {
             label,
             turn: Turn {


### PR DESCRIPTION
Instruments baton-core's core operations with `tracing` so the demo can be run with `-v`/`-vv` to trace what the engine does. No behavior change — events are borrow-only and never touch control flow.

## What you get

- `cargo run --example demo` — output unchanged; engine silent (only a `warn!` on the fail-closed `InternalInvariantFailed` path surfaces).
- `cargo run --example demo -- -v` — decision path at `debug!`: each `evaluate` (contract lookup, verdict, taint flag, unknown-policy disposition, grant derivation, authority routing + ruling, fail-closed recheck, final decision), plus `register` and `record_result`.
- `cargo run --example demo -- -vv` — adds the label algebra at `trace!`: context fold, `combine` steps, `lift`, and `Requirements::check` verdicts (with the ordered violation list).
- `RUST_LOG` overrides the flag; logs go to stderr so stdout narration stays clean (mirrors the cli's `init_tracing`).

## Notes

- Adds `tracing` as a dependency and `tracing-subscriber` as a dev-dependency (example only) — matching runner/cli/dashboard. CLAUDE.md's "zero-dependency" wording updated accordingly.
- Deliberately no log-assertion tests (they'd pin generated text); validation is the existing behavior/law suite staying green + the three demo tiers.

## Validation

`cargo test` (59 + 2 doctests), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and all three `-v` tiers — all green.

https://claude.ai/code/session_01FauZaesLHGnJArtRNyckTF

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>