### PR TITLE
feat(baton-core): adopt serde, thiserror, proptest

### DIFF
--- a/ai-labs/Cargo.lock
+++ b/ai-labs/Cargo.lock
@@ -345,7 +345,11 @@ dependencies = [
 name = "baton-core"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "criterion",
+ "proptest",
+ "serde",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2326,6 +2330,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,6 +2381,12 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2511,6 +2540,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -2905,6 +2943,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3752,6 +3802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3883,6 +3939,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/ai-labs/baton/baton-core/CLAUDE.md
+++ b/ai-labs/baton/baton-core/CLAUDE.md
@@ -1,9 +1,10 @@
 # baton-core
 
-Prototype IFC policy engine (edition 2024, `publish = false`). The only
-dependency is `tracing` (workspace-standard facade; `tracing-subscriber` is a
-dev-dependency the `demo` example installs). Concepts and semantics live in
-`src/lib.rs`; this file is the invariants an edit must not silently break.
+Prototype IFC policy engine (edition 2024, `publish = false`). Dependencies:
+`tracing` (facade), `serde` (derive), `thiserror` (the two error types).
+Dev-only: `tracing-subscriber`, `criterion`, `proptest`, `clap`. Concepts and
+semantics live in `src/lib.rs`; this file is the invariants an edit must not
+silently break.
 
 ## Two structures — never conflate them
 
@@ -61,16 +62,26 @@ relations — no `match` on label values, no set-difference. The emission order
   `Permit`. Permits are linear (not `Clone`), bound to trajectory id + head;
   `Trajectory::record_result` enforces freshness. Confirmations are structural
   on user turns, never label state.
+- **serde capability line**: pure data (`Label`, `Grant`, `AuditEntry`,
+  contracts, dimensions and their preset algebras, violations) derives
+  `Serialize + Deserialize`; `Decision`/`Permit`/`BlockReason`/`TrajectoryId`
+  are `Serialize`-only. Never add `Deserialize` to `Permit` (or
+  `Decision`/`TrajectoryId`): a permit has no public constructor by design, so
+  deserializing one forges the linear capability, and a deserialized
+  `TrajectoryId` could alias a live trajectory. `Trajectory` itself is not serde
+  at all.
 - `register` fails on a duplicate contract (contracts are the policy boundary);
   never silently overwrite.
 
 ## Conventions
 
-- `tracing` is the only dependency; no `dyn`/`Box`; prefer newtypes over
-  primitives; prefer pattern matching over `if`-chains. Core ops emit `tracing`
-  events (decision path at `debug!`, algebra at `trace!`) — borrow-only, never
-  behavior-changing; `demo -- -v`/`-vv` selects the level.
+- no `dyn`/`Box`; prefer newtypes over primitives; prefer pattern matching over
+  `if`-chains. Core ops emit `tracing` events (decision path at `debug!`,
+  algebra at `trace!`) — borrow-only, never behavior-changing; `demo -- -v`/`-vv`
+  selects the level.
 - Validate every change: `cargo test`, `cargo clippy --all-targets -- -D warnings`,
   `cargo fmt --check`, `cargo run --example demo`.
-- Tests exercise behavior and algebra **laws** (property tests), not wording.
-  Do not assert on `Display` output or doc text.
+- The algebra **laws** are real `proptest` properties (`combine`/`lift`/`covers`
+  over generated inputs, in `src/test_strategies.rs`), not fixture loops.
+  Commutativity/idempotence hold on the data dimensions only — the `audit`
+  Writer log appends. Do not assert on `Display` output or doc text.

--- a/ai-labs/baton/baton-core/Cargo.toml
+++ b/ai-labs/baton/baton-core/Cargo.toml
@@ -7,10 +7,14 @@ description = "ADT-based information-flow label engine for agent trajectories (p
 
 [dependencies]
 tracing = "0.1"
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
 
 [dev-dependencies]
 criterion = "0.5"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
+proptest = "1"
+clap = { version = "4", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/ai-labs/baton/baton-core/benches/resolution.rs
+++ b/ai-labs/baton/baton-core/benches/resolution.rs
@@ -203,8 +203,8 @@ fn random_label(rng: &mut TinyRng, users: &[UserId]) -> Label {
 
 fn random_audience(rng: &mut TinyRng, users: &[UserId]) -> Audience {
     match rng.below(6) {
-        0 => Audience::Public,
-        1 => Audience::Unknown,
+        0 => Audience::PUBLIC,
+        1 => Audience::UNKNOWN,
         _ => {
             let reader_count = 1 + rng.below(8);
             Audience::readers(random_user_set(rng, users, reader_count))
@@ -214,7 +214,7 @@ fn random_audience(rng: &mut TinyRng, users: &[UserId]) -> Audience {
 
 fn random_trust(rng: &mut TinyRng) -> Trust {
     match rng.below(4) {
-        0 => Trust::Unknown,
+        0 => Trust::UNKNOWN,
         1 => Trust::SUSPICIOUS,
         _ => Trust::TRUSTED,
     }
@@ -222,7 +222,7 @@ fn random_trust(rng: &mut TinyRng) -> Trust {
 
 fn random_effects(rng: &mut TinyRng) -> Effects {
     match rng.below(5) {
-        0 => Effects::Unknown,
+        0 => Effects::UNKNOWN,
         1 => Effects::declared([Effect::Mutation]),
         2 => Effects::declared([Effect::Egress]),
         3 => Effects::declared([Effect::Mutation, Effect::Egress]),

--- a/ai-labs/baton/baton-core/examples/demo.rs
+++ b/ai-labs/baton/baton-core/examples/demo.rs
@@ -122,21 +122,15 @@ fn attempt(engine: &PolicyEngine<Panel>, trajectory: &mut Trajectory, request: T
     println!();
 }
 
-/// `-v` traces the decision path (`debug`), `-vv` also the label algebra
-/// (`trace`); the `v`s accumulate whether written `-vv` or `-v -v`, and
-/// `--verbose` counts as one. `RUST_LOG` overrides the flag.
-fn verbosity() -> u8 {
-    std::env::args().skip(1).fold(0u8, |level, arg| {
-        let bump = match arg.as_str() {
-            "--verbose" => 1,
-            // `-v`, `-vv`, `-vvv`, ...: one step per `v`.
-            s if s.len() > 1 && s.starts_with('-') && s[1..].bytes().all(|b| b == b'v') => {
-                u8::try_from(s.len() - 1).unwrap_or(u8::MAX)
-            }
-            _ => 0,
-        };
-        level.saturating_add(bump)
-    })
+/// The `v`s accumulate whether written `-vv` or `-v -v`, and `--verbose`
+/// counts as one — clap's `Count` action.
+#[derive(clap::Parser)]
+#[command(about = "Toy end-to-end IFC policy run.")]
+struct Cli {
+    /// Trace core ops: `-v` the decision path (debug), `-vv` also the label
+    /// algebra (trace). `RUST_LOG` overrides.
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
 }
 
 /// Logs go to stderr so this demo's stdout narration stays clean.
@@ -156,7 +150,8 @@ fn init_tracing(verbosity: u8) {
 }
 
 fn main() {
-    init_tracing(verbosity());
+    use clap::Parser;
+    init_tracing(Cli::parse().verbose);
 
     // AllowWithAudit for unprovable gaps; the taint knob on so a degrading
     // step is flagged and signed off rather than propagating silently.

--- a/ai-labs/baton/baton-core/src/authority.rs
+++ b/ai-labs/baton/baton-core/src/authority.rs
@@ -2,10 +2,13 @@
 
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 use crate::contract::{ToolRequest, Violation};
 use crate::label::{Grant, Label};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct AuthorityName(String);
 
 impl AuthorityName {
@@ -25,7 +28,7 @@ impl fmt::Display for AuthorityName {
 }
 
 /// The outcome of an escalation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Ruling {
     /// Approve the flow: the engine applies the minted grant, rechecks it
     /// closed, and records the declassification *for this flow only*. The

--- a/ai-labs/baton/baton-core/src/contract.rs
+++ b/ai-labs/baton/baton-core/src/contract.rs
@@ -4,6 +4,7 @@
 use std::collections::BTreeSet;
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
 use tracing::trace;
 
 use crate::ToolName;
@@ -12,7 +13,7 @@ use crate::label::Label;
 use crate::preset::Adequacy;
 
 /// A concrete tool invocation the policy is asked to authorize.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolRequest {
     pub tool: ToolName,
     /// Readers this call would expose context to (e.g. e-mail recipients).
@@ -37,7 +38,7 @@ impl ToolRequest {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AudienceRule {
     #[default]
     Unrestricted,
@@ -46,7 +47,7 @@ pub enum AudienceRule {
     RecipientsWithinContext,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AttentionRule {
     #[default]
     NotRequired,
@@ -55,7 +56,7 @@ pub enum AttentionRule {
 }
 
 /// What a tool demands of the context label before it may run.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Requirements {
     /// Minimum *known* trust. `Trust::UNKNOWN` never satisfies any bar —
     /// deliberately over [`KnownTrust`], so "unknown suffices" cannot even be
@@ -71,7 +72,7 @@ pub struct Requirements {
 }
 
 /// A requirement that is provably not met.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Breach {
     TrustBelow {
         required: KnownTrust,
@@ -134,7 +135,7 @@ impl fmt::Display for Breach {
 /// A requirement that cannot be proven either way because something is
 /// `Unknown`. Kept apart from [`Breach`] so policy can treat missing
 /// knowledge differently from proven violations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Unprovable {
     TrustUnknown,
     AudienceUnknown,
@@ -158,7 +159,7 @@ impl fmt::Display for Unprovable {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Violation {
     Breach(Breach),
     Unprovable(Unprovable),
@@ -218,7 +219,7 @@ impl Violation {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[must_use]
 pub enum Verdict {
     Allow,
@@ -233,7 +234,7 @@ pub enum Verdict {
 /// A label cannot express a user confirmation at all (confirmations are
 /// structural on user turns), so a contract cannot re-arm a confirmation
 /// gate from its own output.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolContract {
     pub name: ToolName,
     pub requires: Requirements,

--- a/ai-labs/baton/baton-core/src/dimension.rs
+++ b/ai-labs/baton/baton-core/src/dimension.rs
@@ -15,10 +15,13 @@
 use std::collections::BTreeSet;
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 use crate::preset::{Adequacy, HasBottom, JoinSet, MeetSet, MinLevel};
 
 /// A user known to the surrounding system (ACLs, directories, ...).
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct UserId(String);
 
 impl UserId {
@@ -50,7 +53,8 @@ impl fmt::Display for UserId {
 ///
 /// [`PUBLIC`]: Audience::PUBLIC
 /// [`UNKNOWN`]: Audience::UNKNOWN
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Audience(MeetSet<UserId>);
 
 impl Audience {
@@ -118,7 +122,7 @@ impl fmt::Display for Audience {
 }
 
 /// A trust judgement that has actually been made.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum KnownTrust {
     Suspicious,
     Trusted,
@@ -153,7 +157,8 @@ impl fmt::Display for KnownTrust {
 /// The fold keeps the strongest bad evidence: definite suspicion dominates
 /// missing knowledge, which dominates trust
 /// (`Suspicious ∧ Unknown = Suspicious`, `Trusted ∧ Unknown = Unknown`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Trust(MinLevel<KnownTrust>);
 
 impl Trust {
@@ -209,7 +214,7 @@ impl fmt::Display for Trust {
 }
 
 /// A side effect a tool has on the world outside the trajectory.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Effect {
     Mutation,
     Egress,
@@ -230,7 +235,8 @@ impl fmt::Display for Effect {
 /// Union fold; [`none`](Effects::none) (`Has(∅)`) is the identity, and
 /// [`UNKNOWN`](Effects::UNKNOWN) (an unannotated tool ran, so anything may have
 /// happened) is absorbing.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Effects(JoinSet<Effect>);
 
 impl Effects {
@@ -299,7 +305,10 @@ impl fmt::Display for Effects {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::*;
+    use crate::test_strategies::{arb_audience, arb_effects, arb_trust};
 
     fn user(id: &str) -> UserId {
         UserId::new(id)
@@ -336,22 +345,34 @@ mod tests {
         );
     }
 
-    #[test]
-    fn audience_combine_is_associative() {
-        let samples = [
-            Audience::PUBLIC,
-            Audience::readers([user("alice"), user("bob")]),
-            Audience::readers([user("bob")]),
-            Audience::UNKNOWN,
-        ];
-        for a in &samples {
-            for b in &samples {
-                for c in &samples {
-                    let left = a.clone().combine(b.clone()).combine(c.clone());
-                    let right = a.clone().combine(b.clone().combine(c.clone()));
-                    assert_eq!(left, right, "a={a} b={b} c={c}");
-                }
-            }
+    proptest! {
+        /// Each data dimension's `combine` is a commutative, idempotent
+        /// semilattice — the taint-fold algebra the whole design rests on.
+        #[test]
+        fn audience_combine_is_a_semilattice(a in arb_audience(), b in arb_audience(), c in arb_audience()) {
+            prop_assert_eq!(
+                a.clone().combine(b.clone()).combine(c.clone()),
+                a.clone().combine(b.clone().combine(c.clone()))
+            );
+            prop_assert_eq!(a.clone().combine(b.clone()), b.clone().combine(a.clone()));
+            prop_assert_eq!(a.clone().combine(a.clone()), a);
+        }
+
+        #[test]
+        fn trust_combine_is_a_semilattice(a in arb_trust(), b in arb_trust(), c in arb_trust()) {
+            prop_assert_eq!(a.combine(b).combine(c), a.combine(b.combine(c)));
+            prop_assert_eq!(a.combine(b), b.combine(a));
+            prop_assert_eq!(a.combine(a), a);
+        }
+
+        #[test]
+        fn effects_combine_is_a_semilattice(a in arb_effects(), b in arb_effects(), c in arb_effects()) {
+            prop_assert_eq!(
+                a.clone().combine(b.clone()).combine(c.clone()),
+                a.clone().combine(b.clone().combine(c.clone()))
+            );
+            prop_assert_eq!(a.clone().combine(b.clone()), b.clone().combine(a.clone()));
+            prop_assert_eq!(a.clone().combine(a.clone()), a);
         }
     }
 

--- a/ai-labs/baton/baton-core/src/engine.rs
+++ b/ai-labs/baton/baton-core/src/engine.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+use serde::Serialize;
 use tracing::{debug, warn};
 
 use crate::ToolName;
@@ -66,7 +67,7 @@ pub enum TaintPolicy {
 ///     let _ = trajectory.record_result(permit, "second");
 /// }
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct Permit {
     request: ToolRequest,
     result_label: Label,
@@ -92,53 +93,29 @@ impl Permit {
 
 /// [`Trajectory::record_result`] refused a permit: it no longer (or never
 /// did) describe that trajectory's context, so the flow must be re-evaluated.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RejectedPermit {
     /// The permit was minted for a different trajectory.
+    #[error("permit was minted for {minted_for}, not {this}")]
     ForeignTrajectory {
         minted_for: TrajectoryId,
         this: TrajectoryId,
     },
     /// The trajectory grew between `evaluate` and the recording.
+    #[error("permit granted at trajectory length {granted_at}, but the trajectory now has {current_len} turns")]
     Stale { granted_at: usize, current_len: usize },
 }
-
-impl fmt::Display for RejectedPermit {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ForeignTrajectory { minted_for, this } => {
-                write!(f, "permit was minted for {minted_for}, not {this}")
-            }
-            Self::Stale {
-                granted_at,
-                current_len,
-            } => write!(
-                f,
-                "permit granted at trajectory length {granted_at}, but the trajectory now has {current_len} turns"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for RejectedPermit {}
 
 /// [`PolicyEngine::register`] refused a contract: a contract for that tool is
 /// already registered. Contracts are the policy boundary, so a silent replace
 /// could weaken policy unnoticed — registration fails loudly instead.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("a contract for `{tool}` is already registered")]
 pub struct DuplicateContract {
     pub tool: ToolName,
 }
 
-impl fmt::Display for DuplicateContract {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "a contract for `{}` is already registered", self.tool)
-    }
-}
-
-impl std::error::Error for DuplicateContract {}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum BlockReason {
     DeniedByAuthority {
         authority: AuthorityName,
@@ -179,7 +156,7 @@ impl fmt::Display for BlockReason {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 #[must_use = "a dropped Decision means the flow was neither executed nor blocked"]
 pub enum Decision {
     Permitted(Permit),
@@ -542,9 +519,12 @@ mod tests {
     use std::cell::{Cell, RefCell};
     use std::collections::BTreeSet;
 
+    use proptest::prelude::*;
+
     use super::*;
     use crate::contract::{AttentionRule, AudienceRule, Breach, Requirements};
     use crate::dimension::{Audience, Effect, Effects, KnownTrust, Trust, UserId};
+    use crate::test_strategies::arb_grant;
     use crate::turn::Speaker;
 
     fn user(id: &str) -> UserId {
@@ -1359,34 +1339,41 @@ mod tests {
         assert!(signed_by(&permit).iter().all(|a| a == "confirms-auth"));
     }
 
-    #[test]
-    fn tuple_nesting_is_associative_for_routing() {
-        let needs = [
-            Grant::empty(),
-            trust_mandate(),
-            audience_mandate(&["bob"]),
-            confirms_mandate(),
-        ];
-        let left = (
-            Mandated::new("a", trust_mandate(), true),
-            (
-                Mandated::new("b", audience_mandate(&["bob"]), true),
-                Mandated::new("c", confirms_mandate(), true),
-            ),
-        );
-        let right = (
-            (
+    proptest! {
+        /// First-success `or_else` is associative, so the two tuple nestings of
+        /// the same three members route any need to the same authority. The
+        /// need space mixes random grants with the four canonical mandates so
+        /// the trust/audience/confirms corners (each routed to a different
+        /// member) are always exercised, not just sampled by chance.
+        #[test]
+        fn tuple_nesting_is_associative_for_routing(
+            need in prop_oneof![
+                Just(Grant::empty()),
+                Just(trust_mandate()),
+                Just(audience_mandate(&["bob"])),
+                Just(confirms_mandate()),
+                arb_grant(),
+            ]
+        ) {
+            let left = (
                 Mandated::new("a", trust_mandate(), true),
-                Mandated::new("b", audience_mandate(&["bob"]), true),
-            ),
-            Mandated::new("c", confirms_mandate(), true),
-        );
-        let request = ToolRequest::new(ToolName::new("noop"));
-        let context = Label::identity();
-        for need in &needs {
-            let left_name = left.rule(need, &request, &context, &[]).map(|(name, _)| name);
-            let right_name = right.rule(need, &request, &context, &[]).map(|(name, _)| name);
-            assert_eq!(left_name, right_name, "need={need:?}");
+                (
+                    Mandated::new("b", audience_mandate(&["bob"]), true),
+                    Mandated::new("c", confirms_mandate(), true),
+                ),
+            );
+            let right = (
+                (
+                    Mandated::new("a", trust_mandate(), true),
+                    Mandated::new("b", audience_mandate(&["bob"]), true),
+                ),
+                Mandated::new("c", confirms_mandate(), true),
+            );
+            let request = ToolRequest::new(ToolName::new("noop"));
+            let context = Label::identity();
+            let left_name = left.rule(&need, &request, &context, &[]).map(|(name, _)| name);
+            let right_name = right.rule(&need, &request, &context, &[]).map(|(name, _)| name);
+            prop_assert_eq!(left_name, right_name);
         }
     }
 

--- a/ai-labs/baton/baton-core/src/label.rs
+++ b/ai-labs/baton/baton-core/src/label.rs
@@ -18,6 +18,7 @@
 use std::collections::BTreeSet;
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
 use tracing::trace;
 
 use crate::ToolName;
@@ -33,7 +34,7 @@ use crate::dimension::{Audience, Effect, Effects, KnownTrust, Trust, UserId};
 /// here ever removes an entry — but a [`Label`] is plain data, so protecting
 /// audit integrity from the surrounding process is the embedding harness's
 /// job.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuditEntry {
     /// An authority minted a [`Grant`] that resolved a set of grant-fixable
     /// violations for one flow (check-transient — the stored context is never
@@ -92,7 +93,7 @@ impl fmt::Display for AuditEntry {
 /// User confirmations are deliberately not here — they are a property of the
 /// interaction, not of data, and live structurally on user turns
 /// ([`crate::turn::Actor::User`]).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Label {
     pub audience: Audience,
     pub trust: Trust,
@@ -194,7 +195,7 @@ impl Label {
 /// authority whose declared mandate [`covers`](Grant::covers) it and (b)
 /// rechecks the lifted context fail-closed. Routing + recheck establish
 /// authority, not the type.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Grant {
     /// Attest that context trust is at least this.
     pub trust: Option<KnownTrust>,
@@ -255,11 +256,14 @@ impl fmt::Display for Label {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::*;
     use crate::authority::AuthorityName;
     use crate::contract::{Unprovable, Violation};
     use crate::dimension::{Effect, UserId};
     use crate::preset::Adequacy;
+    use crate::test_strategies::{arb_grant, arb_known_trust, arb_label, arb_label_no_audit};
 
     fn audit_entry(reason: &str) -> AuditEntry {
         AuditEntry::Declassified {
@@ -313,106 +317,88 @@ mod tests {
         assert_eq!(folded.effects, Effects::UNKNOWN);
     }
 
-    fn sample_labels() -> Vec<Label> {
-        vec![
-            Label::identity(),
-            Label::unknown(),
-            Label {
-                audience: Audience::readers([UserId::new("alice"), UserId::new("bob")]),
-                trust: Trust::SUSPICIOUS,
-                effects: Effects::declared([Effect::Mutation, Effect::Egress]),
-                audit: Vec::new(),
-            },
-            Label {
-                audience: Audience::PUBLIC,
-                trust: Trust::TRUSTED,
-                effects: Effects::none(),
-                audit: Vec::new(),
-            },
-        ]
-    }
-
-    fn sample_grants() -> Vec<Grant> {
-        vec![
-            Grant::empty(),
-            Grant {
-                trust: Some(KnownTrust::Trusted),
-                ..Grant::empty()
-            },
-            Grant {
-                trust: Some(KnownTrust::Suspicious),
-                ..Grant::empty()
-            },
-            Grant {
-                audience: Some(BTreeSet::from([UserId::new("bob")])),
-                ..Grant::empty()
-            },
-            Grant {
-                effects: Some(BTreeSet::from([Effect::Mutation])),
-                ..Grant::empty()
-            },
-            Grant {
-                trust: Some(KnownTrust::Trusted),
-                audience: Some(BTreeSet::from([UserId::new("charlie")])),
-                effects: Some(BTreeSet::from([Effect::Egress])),
-                confirms: true,
-            },
-        ]
-    }
-
-    #[test]
-    fn lift_empty_is_identity() {
-        for x in sample_labels() {
-            assert_eq!(x.lift(&Grant::empty()), x);
+    proptest! {
+        /// `combine` is a monoid append over the *whole* label — associative
+        /// including the audit Writer log's vector append.
+        #[test]
+        fn combine_is_associative(a in arb_label(), b in arb_label(), c in arb_label()) {
+            prop_assert_eq!(
+                a.clone().combine(b.clone()).combine(c.clone()),
+                a.combine(b.combine(c))
+            );
         }
-    }
 
-    #[test]
-    fn lift_is_idempotent() {
-        for x in sample_labels() {
-            for g in sample_grants() {
-                let once = x.lift(&g);
-                assert_eq!(once.lift(&g), once, "grant={g:?} x={x}");
-            }
+        /// Commutativity holds only on the data dimensions (audience/trust/
+        /// effects semilattices); the audit log appends, so these labels carry
+        /// no audit and the whole-label equality is exactly the data-dim claim.
+        #[test]
+        fn combine_is_commutative_on_data(a in arb_label_no_audit(), b in arb_label_no_audit()) {
+            prop_assert_eq!(a.clone().combine(b.clone()), b.combine(a));
         }
-    }
 
-    #[test]
-    fn lift_is_inflationary_in_the_adequacy_order() {
-        // `lift` may only move a context toward passing a check (`Unknown` is
-        // bottom in every dimension), never demote one.
-        for x in sample_labels() {
-            for g in sample_grants() {
-                let up = x.lift(&g);
-                assert!(x.trust.adequacy_le(&up.trust), "trust demoted: g={g:?} x={x}");
-                assert!(x.audience.adequacy_le(&up.audience), "audience demoted: g={g:?} x={x}");
-                assert!(x.effects.adequacy_le(&up.effects), "effects demoted: g={g:?} x={x}");
-            }
+        /// Idempotence, likewise a data-dimension law (appending the same audit
+        /// twice would duplicate it).
+        #[test]
+        fn combine_is_idempotent_on_data(a in arb_label_no_audit()) {
+            prop_assert_eq!(a.clone().combine(a.clone()), a);
         }
-    }
 
-    #[test]
-    fn trust_grant_clears_the_trust_bar() {
-        for floor in [KnownTrust::Suspicious, KnownTrust::Trusted] {
+        #[test]
+        fn lift_empty_is_identity(x in arb_label()) {
+            prop_assert_eq!(x.lift(&Grant::empty()), x);
+        }
+
+        #[test]
+        fn lift_is_idempotent(x in arb_label(), g in arb_grant()) {
+            let once = x.lift(&g);
+            let twice = once.lift(&g);
+            prop_assert_eq!(twice, once);
+        }
+
+        /// `lift` may only move a context toward passing a check (`Unknown` is
+        /// bottom in every dimension), never demote one.
+        #[test]
+        fn lift_is_inflationary_in_the_adequacy_order(x in arb_label(), g in arb_grant()) {
+            let up = x.lift(&g);
+            prop_assert!(x.trust.adequacy_le(&up.trust), "trust demoted");
+            prop_assert!(x.audience.adequacy_le(&up.audience), "audience demoted");
+            prop_assert!(x.effects.adequacy_le(&up.effects), "effects demoted");
+        }
+
+        #[test]
+        fn trust_grant_clears_the_trust_bar(x in arb_label(), floor in arb_known_trust()) {
             let g = Grant {
                 trust: Some(floor),
                 ..Grant::empty()
             };
-            for x in sample_labels() {
-                assert_eq!(x.lift(&g).trust.at_least(floor), Adequacy::Holds, "floor={floor} x={x}");
+            prop_assert_eq!(x.lift(&g).trust.at_least(floor), Adequacy::Holds);
+        }
+
+        #[test]
+        fn audience_grant_covers_the_vouched_recipients(x in arb_label()) {
+            let recipients = BTreeSet::from([UserId::new("bob"), UserId::new("charlie")]);
+            let g = Grant {
+                audience: Some(recipients.clone()),
+                ..Grant::empty()
+            };
+            prop_assert_eq!(x.lift(&g).audience.covers(&recipients), Adequacy::Holds);
+        }
+
+        #[test]
+        fn covers_is_reflexive(g in arb_grant()) {
+            prop_assert!(g.covers(&g));
+        }
+
+        #[test]
+        fn covers_is_transitive(a in arb_grant(), b in arb_grant(), c in arb_grant()) {
+            if a.covers(&b) && b.covers(&c) {
+                prop_assert!(a.covers(&c));
             }
         }
-    }
 
-    #[test]
-    fn audience_grant_covers_the_vouched_recipients() {
-        let recipients = BTreeSet::from([UserId::new("bob"), UserId::new("charlie")]);
-        let g = Grant {
-            audience: Some(recipients.clone()),
-            ..Grant::empty()
-        };
-        for x in sample_labels() {
-            assert_eq!(x.lift(&g).audience.covers(&recipients), Adequacy::Holds, "x={x}");
+        #[test]
+        fn empty_grant_is_covered_by_all(g in arb_grant()) {
+            prop_assert!(g.covers(&Grant::empty()));
         }
     }
 
@@ -446,23 +432,6 @@ mod tests {
     }
 
     #[test]
-    fn covers_is_reflexive_and_transitive() {
-        let grants = sample_grants();
-        for g in &grants {
-            assert!(g.covers(g), "not reflexive: {g:?}");
-        }
-        for a in &grants {
-            for b in &grants {
-                for c in &grants {
-                    if a.covers(b) && b.covers(c) {
-                        assert!(a.covers(c), "not transitive: {a:?} {b:?} {c:?}");
-                    }
-                }
-            }
-        }
-    }
-
-    #[test]
     fn covers_trust_follows_the_known_trust_order() {
         let trusted_mandate = Grant {
             trust: Some(KnownTrust::Trusted),
@@ -487,12 +456,5 @@ mod tests {
         // The empty (None) mandate covers only a None need.
         assert!(Grant::empty().covers(&Grant::empty()));
         assert!(!Grant::empty().covers(&suspicious_need));
-    }
-
-    #[test]
-    fn empty_grant_is_covered_by_all() {
-        for g in sample_grants() {
-            assert!(g.covers(&Grant::empty()), "{g:?} should cover empty");
-        }
     }
 }

--- a/ai-labs/baton/baton-core/src/lib.rs
+++ b/ai-labs/baton/baton-core/src/lib.rs
@@ -42,10 +42,16 @@ pub mod label;
 pub mod preset;
 pub mod turn;
 
+#[cfg(test)]
+mod test_strategies;
+
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 /// Identifier of a tool exposed to the agent.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct ToolName(String);
 
 impl ToolName {

--- a/ai-labs/baton/baton-core/src/preset.rs
+++ b/ai-labs/baton/baton-core/src/preset.rs
@@ -22,6 +22,8 @@
 
 use std::collections::BTreeSet;
 
+use serde::{Deserialize, Serialize};
+
 /// The sink-side proof for one dimension: three-valued, not a lattice
 /// comparison. `Holds` when the context satisfies the requirement,
 /// `Fails(witness)` when it provably does not (the witness is exactly what is
@@ -60,7 +62,7 @@ pub trait HasTop: Ord {
 /// The confidentiality-meet preset (generalizes `Audience`). The fold is the
 /// most-restrictive combine: a value is `All` (top / identity), a concrete
 /// `Only(set)`, or `Unknown` (absorbing). Adequacy is `covers`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MeetSet<T: Ord> {
     All,
     Only(BTreeSet<T>),
@@ -101,7 +103,7 @@ impl<T: Ord + Clone> MeetSet<T> {
 
 /// The accumulating-union preset (generalizes `Effects`). A value is `Has(set)`
 /// (with `Has(∅)` the identity) or `Unknown` (absorbing). Adequacy is `avoids`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum JoinSet<T: Ord> {
     Has(BTreeSet<T>),
     Unknown,
@@ -143,7 +145,7 @@ impl<T: Ord + Clone> JoinSet<T> {
 
 /// The trust-like ordered preset (generalizes `Trust`). Worse = lower, fold =
 /// min, `Unknown` just above bottom, adequacy = `at_least(floor)` — "least wins".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MinLevel<T: Ord> {
     Known(T),
     Unknown,

--- a/ai-labs/baton/baton-core/src/test_strategies.rs
+++ b/ai-labs/baton/baton-core/src/test_strategies.rs
@@ -1,0 +1,110 @@
+//! Shared proptest strategies for the algebra law tests.
+//!
+//! The domains are deliberately small and bounded — a four-name user pool, the
+//! two-variant effect set, and every `Unknown`/`Public`/`None`/`Some(empty)`
+//! corner — so generated inputs actually exercise intersections, subsets, and
+//! the `Unknown` positions the laws hinge on, and so a counterexample shrinks
+//! to something legible.
+
+use std::collections::BTreeSet;
+
+use proptest::prelude::*;
+
+use crate::ToolName;
+use crate::dimension::{Audience, Effect, Effects, KnownTrust, Trust, UserId};
+use crate::label::{AuditEntry, Grant, Label};
+
+const USERS: &[&str] = &["alice", "bob", "charlie", "dave"];
+const TOOLS: &[&str] = &["a.tool", "b.tool"];
+
+pub(crate) fn arb_user() -> impl Strategy<Value = UserId> {
+    prop::sample::select(USERS).prop_map(UserId::new)
+}
+
+pub(crate) fn arb_users() -> impl Strategy<Value = BTreeSet<UserId>> {
+    prop::collection::btree_set(arb_user(), 0..=USERS.len())
+}
+
+pub(crate) fn arb_known_trust() -> impl Strategy<Value = KnownTrust> {
+    prop_oneof![Just(KnownTrust::Suspicious), Just(KnownTrust::Trusted)]
+}
+
+pub(crate) fn arb_audience() -> impl Strategy<Value = Audience> {
+    prop_oneof![
+        Just(Audience::PUBLIC),
+        arb_users().prop_map(Audience::readers),
+        Just(Audience::UNKNOWN),
+    ]
+}
+
+pub(crate) fn arb_trust() -> impl Strategy<Value = Trust> {
+    prop_oneof![Just(Trust::SUSPICIOUS), Just(Trust::TRUSTED), Just(Trust::UNKNOWN)]
+}
+
+pub(crate) fn arb_effect_set() -> impl Strategy<Value = BTreeSet<Effect>> {
+    (any::<bool>(), any::<bool>()).prop_map(|(mutation, egress)| {
+        let mut set = BTreeSet::new();
+        if mutation {
+            set.insert(Effect::Mutation);
+        }
+        if egress {
+            set.insert(Effect::Egress);
+        }
+        set
+    })
+}
+
+pub(crate) fn arb_effects() -> impl Strategy<Value = Effects> {
+    prop_oneof![arb_effect_set().prop_map(Effects::declared), Just(Effects::UNKNOWN)]
+}
+
+fn arb_audit_entry() -> impl Strategy<Value = AuditEntry> {
+    prop::sample::select(TOOLS).prop_map(|tool| AuditEntry::Acknowledged {
+        tool: ToolName::new(tool),
+        facts: Vec::new(),
+        by: None,
+    })
+}
+
+/// A label with a (possibly non-empty) audit log — for the full-monoid laws.
+pub(crate) fn arb_label() -> impl Strategy<Value = Label> {
+    (
+        arb_audience(),
+        arb_trust(),
+        arb_effects(),
+        prop::collection::vec(arb_audit_entry(), 0..3),
+    )
+        .prop_map(|(audience, trust, effects, audit)| Label {
+            audience,
+            trust,
+            effects,
+            audit,
+        })
+}
+
+/// A label with an empty audit log — for the data-dimension laws
+/// (commutativity, idempotence), which hold on the semilattice product but not
+/// on the appending audit Writer log.
+pub(crate) fn arb_label_no_audit() -> impl Strategy<Value = Label> {
+    (arb_audience(), arb_trust(), arb_effects()).prop_map(|(audience, trust, effects)| Label {
+        audience,
+        trust,
+        effects,
+        audit: Vec::new(),
+    })
+}
+
+pub(crate) fn arb_grant() -> impl Strategy<Value = Grant> {
+    (
+        prop::option::of(arb_known_trust()),
+        prop::option::of(arb_users()),
+        prop::option::of(arb_effect_set()),
+        any::<bool>(),
+    )
+        .prop_map(|(trust, audience, effects, confirms)| Grant {
+            trust,
+            audience,
+            effects,
+            confirms,
+        })
+}

--- a/ai-labs/baton/baton-core/src/turn.rs
+++ b/ai-labs/baton/baton-core/src/turn.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use serde::Serialize;
 use tracing::debug;
 
 use crate::ToolName;
@@ -67,7 +68,8 @@ pub struct LabeledTurn {
 
 /// Identity of one trajectory instance, unique within the process; permits
 /// are bound to it so an authorization cannot cross trajectories.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
 pub struct TrajectoryId(u64);
 
 impl TrajectoryId {

--- a/ai-labs/runner/src/lifecycle.rs
+++ b/ai-labs/runner/src/lifecycle.rs
@@ -1401,21 +1401,36 @@ mod tests {
     async fn test_shutdown_all_tears_down_concurrently() {
         let _guard = registry_lock().lock().await;
         // Two real children that trap SIGTERM and take ~2s to exit. Serial teardown would wait ~4s;
-        // concurrent teardown is bounded by the slower single child (~2s). The wall-clock proves the
-        // teardowns overlap (wide margin so it doesn't flake on a loaded CI box), and both process
-        // groups must be reaped.
-        fn spawn_slow_term_child() -> (Arc<Mutex<Option<Child>>>, i32) {
+        // concurrent teardown is bounded by the slower single child (~2s), which the wall-clock proves.
+        // The child blocks in the *shell process itself* (`read` on a test-held stdin), not a forked
+        // `sleep`, so the group SIGTERM interrupts the shell's own read and fires the trap — no
+        // dependency on a grandchild receiving the signal. Readiness is printed only after `trap`, so
+        // the signal can never arrive before the trap exists; that ordering alone makes the teardown
+        // deterministic (~2s) instead of falling through to `kill_child`'s 15s SIGKILL fallback, which
+        // was the flake. The returned `ChildStdin` must be kept alive to keep `read` blocking.
+        async fn spawn_slow_term_child() -> (Arc<Mutex<Option<Child>>>, i32, tokio::process::ChildStdin) {
+            use tokio::io::AsyncBufReadExt;
             let mut cmd = Command::new("sh");
             cmd.arg("-c")
-                .arg("trap 'sleep 2; exit 0' TERM; sleep 30")
-                .process_group(0);
-            let child = cmd.spawn().expect("spawn sh");
+                .arg("trap 'sleep 2; exit 0' TERM; echo ready; read _")
+                .process_group(0)
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped());
+            let mut child = cmd.spawn().expect("spawn sh");
             let pid = child.id().expect("child pid") as i32;
-            (Arc::new(Mutex::new(Some(child))), pid)
+            let stdin = child.stdin.take().expect("piped stdin");
+            let stdout = child.stdout.take().expect("piped stdout");
+            let mut ready = String::new();
+            tokio::io::BufReader::new(stdout)
+                .read_line(&mut ready)
+                .await
+                .expect("read readiness marker");
+            assert_eq!(ready.trim_end(), "ready", "child should announce readiness");
+            (Arc::new(Mutex::new(Some(child))), pid, stdin)
         }
 
-        let (proc_a, pid_a) = spawn_slow_term_child();
-        let (proc_b, pid_b) = spawn_slow_term_child();
+        let (proc_a, pid_a, _stdin_a) = spawn_slow_term_child().await;
+        let (proc_b, pid_b, _stdin_b) = spawn_slow_term_child().await;
         for proc in [&proc_a, &proc_b] {
             register(Teardown::Backend {
                 proc: proc.clone(),
@@ -1432,6 +1447,13 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(3000),
             "teardowns should overlap (~2s), took {elapsed:?}"
+        );
+        // Lower bound: the ~2s floor is the trap's `sleep 2` actually running. A near-instant teardown
+        // would mean a child exited without honoring SIGTERM (e.g. stdin dropped early, EOF-ing `read`),
+        // which would pass the upper bound while proving nothing — this turns that into a real failure.
+        assert!(
+            elapsed > Duration::from_millis(1500),
+            "teardown finished too fast ({elapsed:?}); a trap-honoring child takes ~2s"
         );
         for pid in [pid_a, pid_b] {
             assert!(


### PR DESCRIPTION
Adopts three libraries in `baton-core`, plus clap for the demo. Rebased onto current `main` after #6468 (preset dimension algebras) and #6479 (benchmark).

## What changed
- **serde** — `Serialize + Deserialize` on the pure-data ADTs (dimensions and their `preset` algebras, `Label`, `Grant`, `AuditEntry`, contracts, violations, rulings). `Serialize`-only on `Decision`/`Permit`/`BlockReason`/`TrajectoryId`: a `Permit` is a linear capability with no public constructor, so deserializing one would forge it; `Trajectory` gets no serde at all. Dimension newtypes are `#[serde(transparent)]` over the preset enums.
- **thiserror** — derive `Error` for the two genuine error types (`RejectedPermit`, `DuplicateContract`), replacing hand-rolled `Display`/`Error` (messages byte-identical).
- **proptest** — the algebra laws (combine/lift/covers commutativity, idempotence, associativity, inflationariness) become real generated-input properties (`src/test_strategies.rs`), replacing the example-based fixture loops.
- **clap** — parse the demo's `-v`/`-vv` verbosity via `ArgAction::Count`.

## enumset dropped
The original plan included enumset for the effects set. #6468 (merged since) made `Effects` an instance of the generic `JoinSet<Effect>` preset; an `EnumSet<Effect>` backing would have to pull `Effects` back out of that preset, undoing the unification. So effects stay `BTreeSet<Effect>` and enumset is dropped.

## Also
A second commit fixes a pre-existing break: #6479's benchmark still referenced the pre-#6468 variant names (`Audience::Public`, `Trust::Unknown`, `Effects::Unknown`), which fails `cargo clippy --all-targets`. Renamed to the `PUBLIC`/`UNKNOWN` consts.

## Validation
`cargo test` (76 + 2 doctests), `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --check`, `cargo bench --bench resolution -- --test`, and `cargo run --example demo` (narration unchanged) all clean.

https://claude.ai/code/session_01FauZaesLHGnJArtRNyckTF