### PR TITLE
chore(ai-labs): add baton resolution benchmark

### DIFF
--- a/ai-labs/Cargo.lock
+++ b/ai-labs/Cargo.lock
@@ -35,6 +35,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +344,9 @@ dependencies = [
 [[package]]
 name = "baton-core"
 version = "0.1.0"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "bench-dashboard"
@@ -432,6 +441,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +499,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -656,6 +698,73 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -846,6 +955,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email_address"
@@ -1182,6 +1297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1333,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -1525,10 +1657,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1934,6 +2086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,6 +2197,34 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2323,6 +2509,26 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3161,6 +3367,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/ai-labs/baton/baton-core/Cargo.toml
+++ b/ai-labs/baton/baton-core/Cargo.toml
@@ -7,3 +7,10 @@ description = "ADT-based information-flow label engine for agent trajectories (p
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "resolution"
+harness = false

--- a/ai-labs/baton/baton-core/Cargo.toml
+++ b/ai-labs/baton/baton-core/Cargo.toml
@@ -9,13 +9,11 @@ description = "ADT-based information-flow label engine for agent trajectories (p
 tracing = "0.1"
 
 [dev-dependencies]
+criterion = "0.5"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 
 [lints]
 workspace = true
-
-[dev-dependencies]
-criterion = "0.5"
 
 [[bench]]
 name = "resolution"

--- a/ai-labs/baton/baton-core/benches/resolution.rs
+++ b/ai-labs/baton/baton-core/benches/resolution.rs
@@ -1,0 +1,326 @@
+use std::collections::BTreeSet;
+
+use baton_core::{
+    AttentionRule, Audience, AudienceRule, Authority, AuthorityName, Decision, Effect, Effects, Grant, KnownTrust,
+    Label, PolicyEngine, Requirements, Ruling, Speaker, ToolContract, ToolName, ToolRequest, Trajectory, Trust,
+    UnknownPolicy, UserId, Violation,
+};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+
+const TOOL_COUNT: usize = 50;
+const AUTHORITY_COUNT: usize = 10;
+const USER_COUNT: usize = 20;
+const REQUEST_COUNT: usize = 1_024;
+const TURN_COUNTS: [usize; 3] = [500, 5_000, 50_000];
+
+struct World {
+    engine: PolicyEngine<AuthoritySet>,
+    trajectory: Trajectory,
+    requests: Vec<ToolRequest>,
+}
+
+impl World {
+    fn new(turn_count: usize) -> Self {
+        let mut rng = TinyRng::new(0x5eed_5eed_f00d ^ turn_count as u64);
+        let users: Vec<UserId> = (0..USER_COUNT).map(user).collect();
+        let tool_names: Vec<ToolName> = (0..TOOL_COUNT).map(tool).collect();
+
+        let mut engine = PolicyEngine::new(authorities(&users), UnknownPolicy::Escalate);
+        for name in &tool_names {
+            engine
+                .register(random_contract(&mut rng, name.clone(), &users))
+                .expect("benchmark tool names are unique");
+        }
+
+        Self {
+            engine,
+            trajectory: random_trajectory(&mut rng, turn_count, &users, &tool_names),
+            requests: (0..REQUEST_COUNT)
+                .map(|_| random_request(&mut rng, &tool_names, &users))
+                .collect(),
+        }
+    }
+}
+
+struct AuthoritySet {
+    members: [BenchAuthority; AUTHORITY_COUNT],
+}
+
+impl Authority for AuthoritySet {
+    fn rule(
+        &self,
+        needed: &Grant,
+        request: &ToolRequest,
+        context: &Label,
+        violations: &[Violation],
+    ) -> Option<(AuthorityName, Ruling)> {
+        self.members
+            .iter()
+            .find_map(|member| member.rule(needed, request, context, violations))
+    }
+}
+
+struct BenchAuthority {
+    name: AuthorityName,
+    mandate: Grant,
+}
+
+impl Authority for BenchAuthority {
+    fn rule(&self, needed: &Grant, _: &ToolRequest, _: &Label, _: &[Violation]) -> Option<(AuthorityName, Ruling)> {
+        self.mandate.covers(needed).then(|| {
+            (
+                self.name.clone(),
+                Ruling::Approve {
+                    reason: "benchmark approval".to_owned(),
+                },
+            )
+        })
+    }
+}
+
+fn authorities(users: &[UserId]) -> AuthoritySet {
+    let user_set = |limit: usize| users.iter().take(limit).cloned().collect();
+    AuthoritySet {
+        members: [
+            authority(0, Grant::empty()),
+            authority(
+                1,
+                Grant {
+                    trust: Some(KnownTrust::Suspicious),
+                    ..Grant::empty()
+                },
+            ),
+            authority(
+                2,
+                Grant {
+                    trust: Some(KnownTrust::Trusted),
+                    ..Grant::empty()
+                },
+            ),
+            authority(
+                3,
+                Grant {
+                    audience: Some(user_set(5)),
+                    ..Grant::empty()
+                },
+            ),
+            authority(
+                4,
+                Grant {
+                    audience: Some(user_set(15)),
+                    ..Grant::empty()
+                },
+            ),
+            authority(
+                5,
+                Grant {
+                    confirms: true,
+                    ..Grant::empty()
+                },
+            ),
+            authority(
+                6,
+                Grant {
+                    effects: Some(BTreeSet::from([Effect::Mutation])),
+                    ..Grant::empty()
+                },
+            ),
+            authority(
+                7,
+                Grant {
+                    effects: Some(BTreeSet::from([Effect::Egress])),
+                    ..Grant::empty()
+                },
+            ),
+            authority(
+                8,
+                Grant {
+                    trust: Some(KnownTrust::Trusted),
+                    audience: Some(user_set(USER_COUNT)),
+                    ..Grant::empty()
+                },
+            ),
+            authority(
+                9,
+                Grant {
+                    trust: Some(KnownTrust::Trusted),
+                    audience: Some(user_set(USER_COUNT)),
+                    effects: Some(BTreeSet::from([Effect::Mutation, Effect::Egress])),
+                    confirms: true,
+                },
+            ),
+        ],
+    }
+}
+
+fn authority(index: usize, mandate: Grant) -> BenchAuthority {
+    BenchAuthority {
+        name: AuthorityName::new(format!("bench-authority-{index}")),
+        mandate,
+    }
+}
+
+fn random_contract(rng: &mut TinyRng, name: ToolName, users: &[UserId]) -> ToolContract {
+    ToolContract {
+        name,
+        requires: Requirements {
+            trust: random_trust_requirement(rng),
+            audience: random_audience_requirement(rng),
+            attention: random_attention_requirement(rng),
+            forbid_prior_effects: random_forbidden_effects(rng),
+        },
+        output_label: random_label(rng, users),
+    }
+}
+
+fn random_trajectory(rng: &mut TinyRng, turn_count: usize, users: &[UserId], tool_names: &[ToolName]) -> Trajectory {
+    let mut trajectory = Trajectory::new();
+    for turn_index in 0..turn_count {
+        let speaker = match rng.below(8) {
+            0 => Speaker::confirming(random_user(rng, users), random_tool(rng, tool_names)),
+            1..=4 => Speaker::user(random_user(rng, users)),
+            _ => Speaker::Assistant,
+        };
+        trajectory.push_message(random_label(rng, users), speaker, format!("turn-{turn_index}"));
+    }
+    trajectory
+}
+
+fn random_request(rng: &mut TinyRng, tool_names: &[ToolName], users: &[UserId]) -> ToolRequest {
+    let recipient_count = 1 + rng.below(4);
+    let recipients: Vec<UserId> = (0..recipient_count).map(|_| random_user(rng, users)).collect();
+    ToolRequest::exposing(random_tool(rng, tool_names), recipients)
+}
+
+fn random_label(rng: &mut TinyRng, users: &[UserId]) -> Label {
+    Label {
+        audience: random_audience(rng, users),
+        trust: random_trust(rng),
+        effects: random_effects(rng),
+        audit: Vec::new(),
+    }
+}
+
+fn random_audience(rng: &mut TinyRng, users: &[UserId]) -> Audience {
+    match rng.below(6) {
+        0 => Audience::Public,
+        1 => Audience::Unknown,
+        _ => {
+            let reader_count = 1 + rng.below(8);
+            Audience::readers(random_user_set(rng, users, reader_count))
+        }
+    }
+}
+
+fn random_trust(rng: &mut TinyRng) -> Trust {
+    match rng.below(4) {
+        0 => Trust::Unknown,
+        1 => Trust::SUSPICIOUS,
+        _ => Trust::TRUSTED,
+    }
+}
+
+fn random_effects(rng: &mut TinyRng) -> Effects {
+    match rng.below(5) {
+        0 => Effects::Unknown,
+        1 => Effects::declared([Effect::Mutation]),
+        2 => Effects::declared([Effect::Egress]),
+        3 => Effects::declared([Effect::Mutation, Effect::Egress]),
+        _ => Effects::none(),
+    }
+}
+
+fn random_trust_requirement(rng: &mut TinyRng) -> Option<KnownTrust> {
+    match rng.below(4) {
+        0 => None,
+        1 => Some(KnownTrust::Suspicious),
+        _ => Some(KnownTrust::Trusted),
+    }
+}
+
+fn random_audience_requirement(rng: &mut TinyRng) -> AudienceRule {
+    match rng.below(2) {
+        0 => AudienceRule::Unrestricted,
+        _ => AudienceRule::RecipientsWithinContext,
+    }
+}
+
+fn random_attention_requirement(rng: &mut TinyRng) -> AttentionRule {
+    match rng.below(5) {
+        0 => AttentionRule::ExplicitConfirmation,
+        _ => AttentionRule::NotRequired,
+    }
+}
+
+fn random_forbidden_effects(rng: &mut TinyRng) -> BTreeSet<Effect> {
+    match rng.below(4) {
+        0 => BTreeSet::from([Effect::Mutation]),
+        1 => BTreeSet::from([Effect::Egress]),
+        2 => BTreeSet::from([Effect::Mutation, Effect::Egress]),
+        _ => BTreeSet::new(),
+    }
+}
+
+fn random_user_set(rng: &mut TinyRng, users: &[UserId], count: usize) -> BTreeSet<UserId> {
+    (0..count).map(|_| random_user(rng, users)).collect()
+}
+
+fn random_user(rng: &mut TinyRng, users: &[UserId]) -> UserId {
+    users[rng.below(users.len())].clone()
+}
+
+fn random_tool(rng: &mut TinyRng, tool_names: &[ToolName]) -> ToolName {
+    tool_names[rng.below(tool_names.len())].clone()
+}
+
+fn user(index: usize) -> UserId {
+    UserId::new(format!("user-{index:02}"))
+}
+
+fn tool(index: usize) -> ToolName {
+    ToolName::new(format!("tool-{index:02}"))
+}
+
+#[derive(Clone, Copy)]
+struct TinyRng(u64);
+
+impl TinyRng {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        self.0
+    }
+
+    fn below(&mut self, upper: usize) -> usize {
+        (self.next() as usize) % upper
+    }
+}
+
+fn bench_resolution(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolution");
+    for turn_count in TURN_COUNTS {
+        let world = World::new(turn_count);
+        let mut request_index = 0;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{turn_count}_turns")),
+            &world,
+            |b, world| {
+                b.iter(|| {
+                    let request = &world.requests[request_index % world.requests.len()];
+                    request_index = request_index.wrapping_add(1);
+                    let decision = world.engine.evaluate(black_box(&world.trajectory), black_box(request));
+                    match black_box(decision) {
+                        Decision::Permitted(_) | Decision::Blocked { .. } => {}
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_resolution);
+criterion_main!(benches);

--- a/ai-labs/baton/baton-core/src/lib.rs
+++ b/ai-labs/baton/baton-core/src/lib.rs
@@ -72,4 +72,4 @@ pub use engine::{
     BlockReason, Decision, DuplicateContract, Permit, PolicyEngine, RejectedPermit, TaintPolicy, UnknownPolicy,
 };
 pub use label::{AuditEntry, Grant, Label};
-pub use turn::{Actor, LabeledTurn, Speaker, Trajectory, TrajectoryId, Turn};
+pub use turn::{Actor, LabeledTurn, Speaker, Trajectory, TrajectoryId, Turn, UserTurn};

--- a/ai-labs/baton/baton-core/src/turn.rs
+++ b/ai-labs/baton/baton-core/src/turn.rs
@@ -8,16 +8,20 @@ use crate::dimension::UserId;
 use crate::engine::{Permit, RejectedPermit};
 use crate::label::Label;
 
+/// A user's contribution to a turn: who spoke, and whether they explicitly
+/// confirmed one named tool. The `confirms` field is structural, not a label:
+/// only user turns carry it, so "only the user confirms" holds by construction
+/// rather than by a runtime check — an assistant or tool actor has no such
+/// field to forge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserTurn {
+    pub id: UserId,
+    pub confirms: Option<ToolName>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Actor {
-    User {
-        id: UserId,
-        /// An explicit confirmation of one named tool. Structural, not a
-        /// label: only user turns can carry it, so "only the user confirms"
-        /// holds by construction rather than by a runtime check — an
-        /// assistant or tool actor has no such field to forge.
-        confirms: Option<ToolName>,
-    },
+    User(UserTurn),
     Assistant,
     Tool(ToolName),
 }
@@ -26,23 +30,23 @@ pub enum Actor {
 /// they enter a trajectory only through [`Trajectory::record_result`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Speaker {
-    User { id: UserId, confirms: Option<ToolName> },
+    User(UserTurn),
     Assistant,
 }
 
 impl Speaker {
     pub fn user(id: UserId) -> Self {
-        Self::User { id, confirms: None }
+        Self::User(UserTurn { id, confirms: None })
     }
 
     /// A user message that explicitly confirms one named tool. The
     /// confirmation is valid only while this is the newest turn — see
     /// [`Trajectory::pending_confirmation`].
     pub fn confirming(id: UserId, tool: ToolName) -> Self {
-        Self::User {
+        Self::User(UserTurn {
             id,
             confirms: Some(tool),
-        }
+        })
     }
 }
 
@@ -110,7 +114,7 @@ impl Trajectory {
     /// trusted input from the embedding harness.
     pub fn push_message(&mut self, label: Label, speaker: Speaker, content: impl Into<String>) {
         let actor = match speaker {
-            Speaker::User { id, confirms } => Actor::User { id, confirms },
+            Speaker::User(user) => Actor::User(user),
             Speaker::Assistant => Actor::Assistant,
         };
         self.turns.push(LabeledTurn {
@@ -164,9 +168,9 @@ impl Trajectory {
                 turn:
                     Turn {
                         actor:
-                            Actor::User {
+                            Actor::User(UserTurn {
                                 confirms: Some(tool), ..
-                            },
+                            }),
                         ..
                     },
                 ..


### PR DESCRIPTION
Summary:
- Add a Criterion benchmark for Baton policy resolution over 500, 5_000, and 50_000-turn trajectories.
- Keep the synthetic world deterministic with 50 tools, 10 authorities, and a 1_024-request pool.
- Introduce a reusable `UserTurn` struct for user-authored turns and re-export it.

Tests:
- cargo fmt --check
- cargo check -p baton-core
- cargo check -p baton-core --benches
- cargo clippy -p baton-core --all-targets -- -D warnings
- cargo test -p baton-core
- cargo bench -p baton-core --bench resolution -- --test