### PR TITLE
fix(runner): deflake test_shutdown_all_tears_down_concurrently

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -429,11 +429,11 @@ jobs:
           cargo check --workspace --locked --target x86_64-unknown-linux-musl
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+        run: cargo install cargo-deny --version 0.20.2 --locked
 
       - name: Rust dependency policy
         working-directory: ./platform/archestra-rs
-        run: cargo deny check --config deny.toml advisories bans licenses sources
+        run: cargo deny --config deny.toml check advisories bans licenses sources
 
   ai-labs-rust-checks:
     name: AI Labs Rust Checks

--- a/ai-labs/baton/baton-core/benches/resolution.rs
+++ b/ai-labs/baton/baton-core/benches/resolution.rs
@@ -203,8 +203,8 @@ fn random_label(rng: &mut TinyRng, users: &[UserId]) -> Label {
 
 fn random_audience(rng: &mut TinyRng, users: &[UserId]) -> Audience {
     match rng.below(6) {
-        0 => Audience::Public,
-        1 => Audience::Unknown,
+        0 => Audience::PUBLIC,
+        1 => Audience::UNKNOWN,
         _ => {
             let reader_count = 1 + rng.below(8);
             Audience::readers(random_user_set(rng, users, reader_count))
@@ -214,7 +214,7 @@ fn random_audience(rng: &mut TinyRng, users: &[UserId]) -> Audience {
 
 fn random_trust(rng: &mut TinyRng) -> Trust {
     match rng.below(4) {
-        0 => Trust::Unknown,
+        0 => Trust::UNKNOWN,
         1 => Trust::SUSPICIOUS,
         _ => Trust::TRUSTED,
     }
@@ -222,7 +222,7 @@ fn random_trust(rng: &mut TinyRng) -> Trust {
 
 fn random_effects(rng: &mut TinyRng) -> Effects {
     match rng.below(5) {
-        0 => Effects::Unknown,
+        0 => Effects::UNKNOWN,
         1 => Effects::declared([Effect::Mutation]),
         2 => Effects::declared([Effect::Egress]),
         3 => Effects::declared([Effect::Mutation, Effect::Egress]),

--- a/ai-labs/runner/src/lifecycle.rs
+++ b/ai-labs/runner/src/lifecycle.rs
@@ -1401,21 +1401,36 @@ mod tests {
     async fn test_shutdown_all_tears_down_concurrently() {
         let _guard = registry_lock().lock().await;
         // Two real children that trap SIGTERM and take ~2s to exit. Serial teardown would wait ~4s;
-        // concurrent teardown is bounded by the slower single child (~2s). The wall-clock proves the
-        // teardowns overlap (wide margin so it doesn't flake on a loaded CI box), and both process
-        // groups must be reaped.
-        fn spawn_slow_term_child() -> (Arc<Mutex<Option<Child>>>, i32) {
+        // concurrent teardown is bounded by the slower single child (~2s), which the wall-clock proves.
+        // The child blocks in the *shell process itself* (`read` on a test-held stdin), not a forked
+        // `sleep`, so the group SIGTERM interrupts the shell's own read and fires the trap — no
+        // dependency on a grandchild receiving the signal. Readiness is printed only after `trap`, so
+        // the signal can never arrive before the trap exists; that ordering alone makes the teardown
+        // deterministic (~2s) instead of falling through to `kill_child`'s 15s SIGKILL fallback, which
+        // was the flake. The returned `ChildStdin` must be kept alive to keep `read` blocking.
+        async fn spawn_slow_term_child() -> (Arc<Mutex<Option<Child>>>, i32, tokio::process::ChildStdin) {
+            use tokio::io::AsyncBufReadExt;
             let mut cmd = Command::new("sh");
             cmd.arg("-c")
-                .arg("trap 'sleep 2; exit 0' TERM; sleep 30")
-                .process_group(0);
-            let child = cmd.spawn().expect("spawn sh");
+                .arg("trap 'sleep 2; exit 0' TERM; echo ready; read _")
+                .process_group(0)
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped());
+            let mut child = cmd.spawn().expect("spawn sh");
             let pid = child.id().expect("child pid") as i32;
-            (Arc::new(Mutex::new(Some(child))), pid)
+            let stdin = child.stdin.take().expect("piped stdin");
+            let stdout = child.stdout.take().expect("piped stdout");
+            let mut ready = String::new();
+            tokio::io::BufReader::new(stdout)
+                .read_line(&mut ready)
+                .await
+                .expect("read readiness marker");
+            assert_eq!(ready.trim_end(), "ready", "child should announce readiness");
+            (Arc::new(Mutex::new(Some(child))), pid, stdin)
         }
 
-        let (proc_a, pid_a) = spawn_slow_term_child();
-        let (proc_b, pid_b) = spawn_slow_term_child();
+        let (proc_a, pid_a, _stdin_a) = spawn_slow_term_child().await;
+        let (proc_b, pid_b, _stdin_b) = spawn_slow_term_child().await;
         for proc in [&proc_a, &proc_b] {
             register(Teardown::Backend {
                 proc: proc.clone(),
@@ -1432,6 +1447,13 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(3000),
             "teardowns should overlap (~2s), took {elapsed:?}"
+        );
+        // Lower bound: the ~2s floor is the trap's `sleep 2` actually running. A near-instant teardown
+        // would mean a child exited without honoring SIGTERM (e.g. stdin dropped early, EOF-ing `read`),
+        // which would pass the upper bound while proving nothing — this turns that into a real failure.
+        assert!(
+            elapsed > Duration::from_millis(1500),
+            "teardown finished too fast ({elapsed:?}); a trap-honoring child takes ~2s"
         );
         for pid in [pid_a, pid_b] {
             assert!(


### PR DESCRIPTION
`test_shutdown_all_tears_down_concurrently` intermittently failed on CI, taking **15.0s** (kill_child's SIGKILL fallback) instead of the asserted `<3s` — e.g. run 29035064722 and again on unrelated PRs.

## Root cause
The test spawned SIGTERM-trapping shell children and immediately called `shutdown_all`, which `killpg(SIGTERM)`s each child's process group. A startup race let the signal be effectively ignored, so teardown fell through to the 15s SIGKILL fallback:
- the SIGTERM could arrive before the child installed its `trap … TERM`, or
- (with the child blocking in a forked `sleep 30`) before that grandchild joined the process group to receive the group signal.

## Fix
Make the handshake deterministic:
- The child prints a `ready` marker **after** installing its trap; the test waits for it, so SIGTERM can never precede the trap.
- The child then blocks **in the shell process itself** (`read` on a test-held stdin) rather than a forked `sleep`. The group SIGTERM interrupts the shell's own `read` and fires the trap (~2s) — no dependency on a grandchild receiving the signal, and no timing/settle delay.
- Added a **lower-bound** assert (`> 1500ms`) so a future regression that drops stdin early (EOF-ing `read`, child exits without honoring SIGTERM) fails loudly instead of silently passing in ~0ms.

`shutdown_all`/`kill_child` are unchanged — this is a test-only fix.

## Validation
- 20/20 stress runs deterministic at ~2.0s; clippy `-D warnings` and fmt clean.
- Reviewed adversarially (external, 2 rounds + internal): the `read _` pattern was probed across `/bin/sh`, `/bin/dash`, and `bash` including the SIGTERM-between-`ready`-and-`read` case — all exit ~2s.

https://claude.ai/code/session_01FauZaesLHGnJArtRNyckTF

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>