### PR TITLE
fix(mcp): make the registry install deep link survive a lost dialog

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.test.tsx
@@ -1,0 +1,205 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// A stable, mutable stand-in for the router's search params so a test can flip
+// them (e.g. simulate the deep-link param being stripped) between renders.
+const nav = vi.hoisted(() => ({ search: new URLSearchParams() }));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => nav.search,
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  usePathname: () => "/mcp/registry",
+}));
+
+vi.mock("@/lib/mcp/internal-mcp-catalog.query");
+vi.mock("@/lib/mcp/mcp-server.query");
+vi.mock("@/lib/auth/oauth.query");
+vi.mock("@/lib/mcp/enterprise-managed-install-auth", () => ({
+  useEnterpriseManagedInstallConnectUrl: () => async () => null,
+  getPendingEnterpriseManagedInstall: () => null,
+  setPendingEnterpriseManagedInstall: vi.fn(),
+  clearPendingEnterpriseManagedInstall: vi.fn(),
+}));
+vi.mock("@/lib/websocket/websocket", () => ({ default: { send: vi.fn() } }));
+
+// The install dialogs are stubbed to a single testid so the test asserts the
+// hook's open/re-open/clear behavior, not each dialog's internals. Every
+// variant collapses to the same "install-dialog" marker plus a dismiss button
+// wired to the close/cancel handler.
+type StubDialogProps = {
+  open?: boolean;
+  isOpen?: boolean;
+  onClose?: () => void;
+  onCancel?: () => void;
+  onOpenChange?: (open: boolean) => void;
+};
+function StubDialog({
+  open,
+  isOpen,
+  onClose,
+  onCancel,
+  onOpenChange,
+}: StubDialogProps) {
+  if (!(open || isOpen)) return null;
+  const dismiss = onCancel ?? onClose ?? (() => onOpenChange?.(false));
+  return (
+    <div data-testid="install-dialog">
+      <button
+        type="button"
+        data-testid="install-dialog-dismiss"
+        onClick={dismiss}
+      >
+        dismiss
+      </button>
+    </div>
+  );
+}
+vi.mock("@/components/oauth-confirmation-dialog", () => ({
+  OAuthConfirmationDialog: (props: StubDialogProps) => (
+    <StubDialog {...props} />
+  ),
+}));
+vi.mock("./remote-server-install-dialog", () => ({
+  RemoteServerInstallDialog: (props: StubDialogProps) => (
+    <StubDialog {...props} />
+  ),
+}));
+vi.mock("./no-auth-install-dialog", () => ({
+  NoAuthInstallDialog: (props: StubDialogProps) => <StubDialog {...props} />,
+}));
+vi.mock("./local-server-install-dialog", () => ({
+  LocalServerInstallDialog: (props: StubDialogProps) => (
+    <StubDialog {...props} />
+  ),
+}));
+
+import { useInitiateOAuth } from "@/lib/auth/oauth.query";
+import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
+import { useInstallMcpServer, useMcpServers } from "@/lib/mcp/mcp-server.query";
+import {
+  clearPendingInstall,
+  setPendingInstall,
+} from "@/lib/mcp/pending-install";
+import type { CatalogItem } from "./mcp-server-card";
+import { useCatalogInstall } from "./use-catalog-install";
+
+const CATALOG_ID = "cat-oauth-1";
+
+// A remote server with an OAuth config and no user config — installRemote takes
+// the OAuth-dialog branch, so the deep link opens a dialog we can observe.
+const oauthItem = {
+  id: CATALOG_ID,
+  name: "deeplink-server",
+  serverType: "remote",
+  oauthConfig: { name: "deeplink-server" },
+  userConfig: {},
+} as unknown as CatalogItem;
+
+// Mirrors how InternalMCPCatalog drives the deep link: fire the consume-params
+// handler on mount. The durable re-open lives inside the hook itself.
+function Harness() {
+  const install = useCatalogInstall();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount, like the registry effect
+  useEffect(() => {
+    install.installFromSearchParams();
+  }, []);
+  return <>{install.dialogs}</>;
+}
+
+function renderHarness() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <Harness />
+    </QueryClientProvider>,
+  );
+}
+
+describe("useCatalogInstall — deep-link install", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    nav.search = new URLSearchParams();
+    vi.mocked(useInternalMcpCatalog).mockReturnValue({
+      data: [oauthItem],
+    } as unknown as ReturnType<typeof useInternalMcpCatalog>);
+    vi.mocked(useMcpServers).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useMcpServers>);
+    vi.mocked(useInstallMcpServer).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useInstallMcpServer>);
+    vi.mocked(useInitiateOAuth).mockReturnValue({
+      mutateAsync: vi.fn(),
+    } as unknown as ReturnType<typeof useInitiateOAuth>);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens the install dialog when ?install={catalogId} is present", async () => {
+    nav.search = new URLSearchParams(`install=${CATALOG_ID}`);
+
+    renderHarness();
+
+    expect(await screen.findByTestId("install-dialog")).toBeInTheDocument();
+  });
+
+  // The regression guard: the deep link opened the dialog and the param was
+  // stripped, then the dialog was torn down (a route re-render remounting the
+  // registry, an OAuth/enterprise redirect return, etc.). A fresh mount — with
+  // the param already gone — must re-open the dialog from the stashed intent
+  // rather than strand the user on the bare registry.
+  it("re-opens the dialog after a teardown while the connection is still missing", async () => {
+    nav.search = new URLSearchParams(`install=${CATALOG_ID}`);
+    const view = renderHarness();
+    await screen.findByTestId("install-dialog");
+
+    // The param is stripped after the deep link is consumed; simulate that plus
+    // the teardown that lost the dialog in the bug.
+    nav.search = new URLSearchParams();
+    view.unmount();
+    expect(screen.queryByTestId("install-dialog")).not.toBeInTheDocument();
+
+    // Fresh mount: local dialog state is reset and the URL no longer carries the
+    // param, so only the durable intent can bring the dialog back.
+    renderHarness();
+    expect(await screen.findByTestId("install-dialog")).toBeInTheDocument();
+  });
+
+  it("does not re-open after the user dismisses the dialog", async () => {
+    const user = userEvent.setup();
+    nav.search = new URLSearchParams(`install=${CATALOG_ID}`);
+    const view = renderHarness();
+
+    await user.click(await screen.findByTestId("install-dialog-dismiss"));
+
+    // Dismiss dropped the intent; a later teardown/remount must not resurrect it.
+    nav.search = new URLSearchParams();
+    view.unmount();
+    renderHarness();
+    await Promise.resolve();
+    expect(screen.queryByTestId("install-dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not re-open when the caller already has a connection", async () => {
+    // The deep link ran earlier (intent stashed), but a connection now exists.
+    setPendingInstall({ catalogId: CATALOG_ID });
+    vi.mocked(useMcpServers).mockReturnValue({
+      data: [{ catalogId: CATALOG_ID }],
+    } as unknown as ReturnType<typeof useMcpServers>);
+    nav.search = new URLSearchParams();
+
+    renderHarness();
+    await Promise.resolve();
+
+    expect(screen.queryByTestId("install-dialog")).not.toBeInTheDocument();
+    clearPendingInstall();
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/use-catalog-install.tsx
@@ -7,7 +7,13 @@ import {
 } from "@archestra/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { type ReactNode, useCallback, useEffect, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "sonner";
 import {
   OAuthConfirmationDialog,
@@ -40,6 +46,12 @@ import {
 } from "@/lib/mcp/enterprise-managed-install-auth";
 import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
 import { useInstallMcpServer, useMcpServers } from "@/lib/mcp/mcp-server.query";
+import {
+  clearPendingInstall,
+  getPendingInstall,
+  registerPendingInstallReopen,
+  setPendingInstall,
+} from "@/lib/mcp/pending-install";
 import { buildRemoteInstallCredentialPayload } from "@/lib/mcp/remote-install-payload";
 import websocketService from "@/lib/websocket/websocket";
 import {
@@ -127,6 +139,13 @@ export function useCatalogInstall(opts?: {
   const [firstInstallationServerIds, setFirstInstallationServerIds] = useState<
     Set<string>
   >(new Set());
+
+  // True once this mount has opened the install dialog straight from the
+  // `?install=` deep link. Lets the durable re-open effect below tell "the deep
+  // link already handled it on this mount" (skip) apart from "the dialog was
+  // torn down and the intent is still pending" (reopen) — on a remount the ref
+  // is fresh, so the re-open effect takes over from the stashed intent.
+  const deepLinkHandledRef = useRef(false);
 
   // Pre-selected team ID when adding a shared connection from manage dialog
   const [preselectedTeamId, setPreselectedTeamId] = useState<string | null>(
@@ -523,6 +542,33 @@ export function useCatalogInstall(opts?: {
     }
   };
 
+  // Open the right install flow for a catalog item, honoring an optional
+  // pre-targeted scope (from the deep link's &scope/&team params). Shared by the
+  // deep-link handler and the durable re-open effect so both open identically.
+  const openInstallForCatalogItem = (
+    catalogItem: CatalogItem,
+    scope?: McpServerInstallScope,
+    teamId?: string,
+  ) => {
+    if (scope === "personal") {
+      addPersonalConnection(catalogItem);
+      return;
+    }
+    if (scope === "team" && teamId) {
+      addSharedConnection(catalogItem, teamId);
+      return;
+    }
+    if (scope === "org") {
+      addOrgConnection(catalogItem);
+      return;
+    }
+    if (catalogItem.serverType === "local") {
+      installLocal(catalogItem);
+    } else {
+      installRemote(catalogItem);
+    }
+  };
+
   // Deep-link: auto-open install dialog when ?install={catalogId} is present.
   // Optional &scope=personal|team|org (and &team={teamId} for team scope)
   // pre-target the connection — used by the item detail page's add-connection
@@ -537,8 +583,23 @@ export function useCatalogInstall(opts?: {
     );
     if (!catalogItem) return;
 
-    const scopeParam = searchParams.get(MCP_CATALOG_INSTALL_SCOPE_QUERY_PARAM);
+    const scopeParam = searchParams.get(
+      MCP_CATALOG_INSTALL_SCOPE_QUERY_PARAM,
+    ) as McpServerInstallScope | null;
     const teamParam = searchParams.get(MCP_CATALOG_INSTALL_TEAM_QUERY_PARAM);
+
+    // Persist the intent before touching the URL or opening the dialog. The
+    // dialog is local state and the deep-link param is stripped below, so if the
+    // dialog is torn down before the user acts (a route re-render that remounts
+    // the registry, a full-page return from an OAuth/enterprise connect
+    // redirect, etc.) there would otherwise be nothing left to re-open it — the
+    // user would land on the bare registry and have to find the server by hand.
+    setPendingInstall({
+      catalogId: catalogItem.id,
+      ...(scopeParam ? { scope: scopeParam } : {}),
+      ...(scopeParam === "team" && teamParam ? { teamId: teamParam } : {}),
+    });
+    deepLinkHandledRef.current = true;
 
     // Clear the install params from URL to prevent re-triggering on refresh
     const params = new URLSearchParams(searchParams.toString());
@@ -550,26 +611,54 @@ export function useCatalogInstall(opts?: {
       : pathname;
     router.replace(newUrl, { scroll: false });
 
-    if (scopeParam === "personal") {
-      addPersonalConnection(catalogItem);
-      return;
-    }
-    if (scopeParam === "team" && teamParam) {
-      addSharedConnection(catalogItem, teamParam);
-      return;
-    }
-    if (scopeParam === "org") {
-      addOrgConnection(catalogItem);
+    openInstallForCatalogItem(
+      catalogItem,
+      scopeParam ?? undefined,
+      teamParam ?? undefined,
+    );
+  }, [searchParams, catalogItems, pathname, router]);
+
+  // Durable re-open: if the deep-link dialog was lost before the user acted, the
+  // intent survives in sessionStorage. Once catalog + installs are loaded, and
+  // the deep link did NOT just open the dialog on this mount, re-open it — unless
+  // the connection now exists (fulfilled) or a dialog is already up. Capped so a
+  // genuinely un-openable intent or a close-loop cannot re-open forever.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: install handlers are stable within a render; only react to catalog/install data settling
+  useEffect(() => {
+    if (deepLinkHandledRef.current) return;
+    if (!catalogItems || !installedServers) return;
+
+    const pending = getPendingInstall();
+    if (!pending) return;
+
+    const catalogItem = catalogItems.find(
+      (item) => item.id === pending.catalogId,
+    );
+    if (!catalogItem) {
+      clearPendingInstall();
       return;
     }
 
-    // Trigger the appropriate install dialog
-    if (catalogItem.serverType === "local") {
-      installLocal(catalogItem);
-    } else {
-      installRemote(catalogItem);
+    // Already fulfilled — the caller has an accessible connection for it now.
+    if (installedServers.some((s) => s.catalogId === pending.catalogId)) {
+      clearPendingInstall();
+      return;
     }
-  }, [searchParams, catalogItems, pathname, router]);
+
+    // A dialog is already open for it — don't stack another.
+    if (
+      isDialogOpened("remote-install") ||
+      isDialogOpened("local-install") ||
+      isDialogOpened("oauth") ||
+      isDialogOpened("no-auth")
+    ) {
+      return;
+    }
+
+    if (!registerPendingInstallReopen()) return;
+    deepLinkHandledRef.current = true;
+    openInstallForCatalogItem(catalogItem, pending.scope, pending.teamId);
+  }, [catalogItems, installedServers, isDialogOpened]);
 
   // Resume an enterprise-managed install after linking the configured IdP.
   // biome-ignore lint/correctness/useExhaustiveDependencies: consume the one-shot sessionStorage intent when catalog data becomes available
@@ -771,6 +860,12 @@ export function useCatalogInstall(opts?: {
       // Remember where the install started so the callback returns here
       setOAuthReturnUrl(window.location.href);
 
+      // The user has committed to authorizing; the deep-link intent is now
+      // being fulfilled through the OAuth flow (which has its own return
+      // handling), so drop the pending-install intent to avoid the registry
+      // re-opening this dialog when the OAuth callback returns.
+      clearPendingInstall();
+
       // Redirect to OAuth provider
       window.location.href = authorizationUrl;
     } catch (error) {
@@ -820,6 +915,9 @@ export function useCatalogInstall(opts?: {
       <RemoteServerInstallDialog
         isOpen={isDialogOpened("remote-install")}
         onClose={() => {
+          // User dismissed the deep-linked install — drop the intent so the
+          // durable re-open below does not bring it back.
+          clearPendingInstall();
           closeDialog("remote-install");
           setSelectedCatalogItem(null);
           setPreselectedTeamId(null);
@@ -838,12 +936,16 @@ export function useCatalogInstall(opts?: {
         open={isDialogOpened("oauth")}
         onOpenChange={(open) => {
           if (!open) {
+            // Dismissed (Escape / outside click) — drop the intent so the
+            // durable re-open does not bring it back.
+            clearPendingInstall();
             closeDialog("oauth");
           }
         }}
         serverName={selectedCatalogItem?.name || ""}
         onConfirm={handleOAuthConfirm}
         onCancel={() => {
+          clearPendingInstall();
           closeDialog("oauth");
           setSelectedCatalogItem(null);
           setPreselectedTeamId(null);
@@ -859,6 +961,7 @@ export function useCatalogInstall(opts?: {
       <NoAuthInstallDialog
         isOpen={isDialogOpened("no-auth")}
         onClose={() => {
+          clearPendingInstall();
           closeDialog("no-auth");
           setNoAuthCatalogItem(null);
           setPreselectedTeamId(null);
@@ -877,6 +980,7 @@ export function useCatalogInstall(opts?: {
         <LocalServerInstallDialog
           isOpen={isDialogOpened("local-install")}
           onClose={() => {
+            clearPendingInstall();
             closeDialog("local-install");
             setLocalServerCatalogItem(null);
             setPreselectedTeamId(null);

--- a/platform/frontend/src/lib/mcp/pending-install.test.ts
+++ b/platform/frontend/src/lib/mcp/pending-install.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearPendingInstall,
+  getPendingInstall,
+  MAX_PENDING_INSTALL_REOPENS,
+  registerPendingInstallReopen,
+  setPendingInstall,
+} from "./pending-install";
+
+describe("pending-install intent", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("round-trips a stashed intent", () => {
+    setPendingInstall({ catalogId: "cat-1", scope: "team", teamId: "team-9" });
+    expect(getPendingInstall()).toEqual({
+      catalogId: "cat-1",
+      scope: "team",
+      teamId: "team-9",
+    });
+  });
+
+  it("returns null when nothing is stashed", () => {
+    expect(getPendingInstall()).toBeNull();
+  });
+
+  it("clears a stashed intent", () => {
+    setPendingInstall({ catalogId: "cat-1" });
+    clearPendingInstall();
+    expect(getPendingInstall()).toBeNull();
+  });
+
+  it("ignores a malformed stashed value", () => {
+    sessionStorage.setItem("archestra:pending-install", "{not json");
+    expect(getPendingInstall()).toBeNull();
+  });
+
+  it("allows re-opens up to the cap, then gives up and clears the intent", () => {
+    setPendingInstall({ catalogId: "cat-1" });
+
+    // The first open comes straight from the deep link and does not register;
+    // only re-opens after a loss are counted here.
+    for (let i = 0; i < MAX_PENDING_INSTALL_REOPENS; i++) {
+      expect(registerPendingInstallReopen()).toBe(true);
+      // The intent survives while still under the cap.
+      expect(getPendingInstall()).not.toBeNull();
+    }
+
+    // One past the cap: refused, and the intent is dropped so it stops being
+    // reconsidered.
+    expect(registerPendingInstallReopen()).toBe(false);
+    expect(getPendingInstall()).toBeNull();
+  });
+
+  it("resets the re-open counter when a fresh intent is stashed", () => {
+    setPendingInstall({ catalogId: "cat-1" });
+    for (let i = 0; i < MAX_PENDING_INSTALL_REOPENS; i++) {
+      registerPendingInstallReopen();
+    }
+    // A new deep link stashes a fresh intent — its re-open budget starts over.
+    setPendingInstall({ catalogId: "cat-2" });
+    expect(registerPendingInstallReopen()).toBe(true);
+  });
+});

--- a/platform/frontend/src/lib/mcp/pending-install.ts
+++ b/platform/frontend/src/lib/mcp/pending-install.ts
@@ -1,0 +1,84 @@
+/**
+ * Durable "install this catalog item" intent for the MCP Registry deep link
+ * (`/mcp/registry?install={catalogId}`).
+ *
+ * The deep link auto-opens the install dialog once, then strips the query param
+ * so a refresh does not re-trigger it. That makes the open a one-shot: if
+ * anything tears the dialog down before the user acts — a route re-render that
+ * remounts the registry subtree, a full-page return from an OAuth/enterprise
+ * connect redirect, etc. — the intent is gone and the user is dropped onto the
+ * bare registry with no popup, left to find and install the server by hand.
+ *
+ * Stashing the intent in sessionStorage lets the registry re-open the dialog
+ * when it detects the intent is still unfulfilled. sessionStorage (tab-scoped,
+ * cleared on tab close) holds only the catalog id and target scope — no
+ * credentials. A small attempt cap keeps a genuinely un-openable intent (or a
+ * remount loop) from re-opening forever.
+ */
+
+import type { McpServerInstallScope } from "@/app/mcp/registry/_parts/select-mcp-server-credential-type-and-teams";
+
+export interface PendingInstall {
+  catalogId: string;
+  scope?: McpServerInstallScope;
+  teamId?: string;
+}
+
+// Max times the registry will auto-reopen the dialog for one stashed intent
+// after it is lost, before giving up — so a close-loop cannot reopen forever.
+// The first open straight from the deep link does not count.
+export const MAX_PENDING_INSTALL_REOPENS = 3;
+
+export function setPendingInstall(pending: PendingInstall): void {
+  try {
+    sessionStorage.setItem(PENDING_INSTALL_KEY, JSON.stringify(pending));
+    sessionStorage.removeItem(PENDING_INSTALL_REOPENS_KEY);
+  } catch {
+    // sessionStorage unavailable (privacy mode / SSR) — degrade to the prior
+    // one-shot behavior rather than throwing.
+  }
+}
+
+export function getPendingInstall(): PendingInstall | null {
+  try {
+    const raw = sessionStorage.getItem(PENDING_INSTALL_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PendingInstall;
+    return typeof parsed?.catalogId === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingInstall(): void {
+  try {
+    sessionStorage.removeItem(PENDING_INSTALL_KEY);
+    sessionStorage.removeItem(PENDING_INSTALL_REOPENS_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Record one auto-reopen attempt and report whether it is still under the cap.
+ * Returns true when the caller may reopen the dialog; false once the intent has
+ * been reopened MAX_PENDING_INSTALL_REOPENS times (the intent is cleared on
+ * exhaustion so it stops being considered).
+ */
+export function registerPendingInstallReopen(): boolean {
+  try {
+    const attempts =
+      Number(sessionStorage.getItem(PENDING_INSTALL_REOPENS_KEY) ?? "0") + 1;
+    if (attempts > MAX_PENDING_INSTALL_REOPENS) {
+      clearPendingInstall();
+      return false;
+    }
+    sessionStorage.setItem(PENDING_INSTALL_REOPENS_KEY, String(attempts));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const PENDING_INSTALL_KEY = "archestra:pending-install";
+const PENDING_INSTALL_REOPENS_KEY = "archestra:pending-install-reopens";


### PR DESCRIPTION
## Summary

The MCP Registry install deep link (`/mcp/registry?install={catalogId}`) — returned by the call-time "authentication required" tool error so a user can connect a server on demand — auto-opens the install dialog once and then strips the query param. That open is a **one-shot held in local component state**: if the dialog is torn down before the user acts, the intent is gone and the user lands on the bare registry with no popup, left to find and install the server by hand.

The teardown is timing-sensitive. The registry page is `force-dynamic` and server-fetches the full catalog + installs on every load. On a slow environment, the param-stripping `router.replace` re-renders the tree right as the dialog is opening, and the just-opened dialog never becomes visible. On a fast environment the dialog opens and stays — so the failure only reproduces under real latency.

## Fix

Persist the install intent in `sessionStorage` (catalog id + target scope only — **no credentials**) and re-open the dialog from it when the registry loads and finds the intent still unfulfilled:

- Re-open only when there is no accessible connection for the catalog yet **and** no install dialog is already open.
- Re-opens are **capped** so a genuinely un-openable intent or a close-loop cannot re-open forever.
- The intent is cleared when the user acts (dismiss, or commit to the OAuth flow) or once the connection exists, so the happy path is unchanged.

This is robust to whatever tears the dialog down — a route re-render that remounts the registry subtree, a full-page return from an OAuth/enterprise connect redirect, etc. — because the intent survives in sessionStorage and the registry re-opens it on the next stable render.