### PR TITLE
fix(apps): correct search and screenshot validation

### DIFF
--- a/platform/backend/src/models/app.ts
+++ b/platform/backend/src/models/app.ts
@@ -14,6 +14,7 @@ import { softDelete } from "@/database/soft-delete";
 import { ApiError } from "@/types";
 import type { App, InsertApp } from "@/types/app";
 import { isUniqueConstraintError } from "@/utils/db";
+import { escapeLikePattern } from "@/utils/sql-search";
 import AppAccessModel from "./app-access";
 import AppVersionModel, { type VersionPayload } from "./app-version";
 import McpCatalogTeamModel from "./mcp-catalog-team";
@@ -50,17 +51,20 @@ function buildOrgFilters(params: {
   accessibleAppIds?: string[];
 }) {
   const normalizedSearch = params.search?.trim();
+  const searchPattern = normalizedSearch
+    ? `%${escapeLikePattern(normalizedSearch)}%`
+    : undefined;
   return [
     eq(schema.appsTable.organizationId, params.organizationId),
     notDeleted(schema.appsTable),
     ...(params.accessibleAppIds !== undefined
       ? [inArray(schema.appsTable.id, params.accessibleAppIds)]
       : []),
-    ...(normalizedSearch
+    ...(searchPattern
       ? [
           or(
-            ilike(schema.appsTable.name, `%${normalizedSearch}%`),
-            ilike(schema.appsTable.description, `%${normalizedSearch}%`),
+            ilike(schema.appsTable.name, searchPattern),
+            ilike(schema.appsTable.description, searchPattern),
           ),
         ]
       : []),

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -25,6 +25,7 @@ import type {
   ToolParametersContent,
   UpdateMcpServer,
 } from "@/types";
+import { escapeLikePattern } from "@/utils/sql-search";
 import { toolRequiresInputs } from "@/utils/tool-inputs";
 import InternalMcpCatalogModel from "./internal-mcp-catalog";
 import McpCatalogTeamModel from "./mcp-catalog-team";
@@ -619,6 +620,9 @@ class McpServerModel {
     const { catalogIds, search } = params;
     if (catalogIds.length === 0) return [];
     const searchTerm = search?.trim();
+    const searchPattern = searchTerm
+      ? `%${escapeLikePattern(searchTerm)}%`
+      : undefined;
     const uiResourceUri = toolUiResourceUriSql();
     const rows = await db
       .select({
@@ -643,15 +647,15 @@ class McpServerModel {
           // the platform CSP — never surfaced as external apps.
           ne(schema.internalMcpCatalogTable.serverType, "app"),
           sql`${uiResourceUri} IS NOT NULL`,
-          searchTerm
+          searchPattern
             ? or(
-                ilike(schema.internalMcpCatalogTable.name, `%${searchTerm}%`),
+                ilike(schema.internalMcpCatalogTable.name, searchPattern),
                 ilike(
                   schema.internalMcpCatalogTable.description,
-                  `%${searchTerm}%`,
+                  searchPattern,
                 ),
-                ilike(schema.toolsTable.name, `%${searchTerm}%`),
-                ilike(schema.toolsTable.description, `%${searchTerm}%`),
+                ilike(schema.toolsTable.name, searchPattern),
+                ilike(schema.toolsTable.description, searchPattern),
               )
             : undefined,
         ),

--- a/platform/backend/src/routes/app/app.routes.ts
+++ b/platform/backend/src/routes/app/app.routes.ts
@@ -856,7 +856,7 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(400, "invalid image data URL.");
       }
       const [, mimeType, data] = match;
-      if (!/^[A-Za-z0-9+/]+={0,2}$/.test(data)) {
+      if (!isCanonicalBase64(data)) {
         throw new ApiError(400, "image data is not valid base64.");
       }
       await AppRenderScreenshotModel.record({
@@ -981,6 +981,13 @@ function isAssignmentError(
   result: ToolAssignmentError | "duplicate" | "updated" | null,
 ): result is ToolAssignmentError {
   return result !== null && result !== "duplicate" && result !== "updated";
+}
+
+function isCanonicalBase64(value: string): boolean {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return false;
+
+  const canonical = Buffer.from(value, "base64").toString("base64");
+  return value === canonical || value === canonical.replace(/=+$/, "");
 }
 
 /**

--- a/platform/backend/src/routes/app/list.app.route.test.ts
+++ b/platform/backend/src/routes/app/list.app.route.test.ts
@@ -129,6 +129,94 @@ describe("GET /api/apps", () => {
     });
   });
 
+  test("treats wildcard characters literally in external app search", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    const makeExternalApp = async (params: {
+      catalogName: string;
+      catalogDescription: string;
+      toolName: string;
+      toolDescription: string;
+    }) => {
+      const catalog = await makeInternalMcpCatalog({
+        organizationId,
+        name: params.catalogName,
+        description: params.catalogDescription,
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+        scope: "org",
+      });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+      await makeTool({
+        catalogId: catalog.id,
+        name: params.toolName,
+        description: params.toolDescription,
+        meta: {
+          _meta: { ui: { resourceUri: `ui://${catalog.id}/app.html` } },
+        },
+      });
+      return catalog;
+    };
+
+    const percentName = await makeExternalApp({
+      catalogName: "100% External",
+      catalogDescription: "Catalog name marker",
+      toolName: "percentname",
+      toolDescription: "Ordinary description",
+    });
+    const underscoreDescription = await makeExternalApp({
+      catalogName: "Underscore Description",
+      catalogDescription: "Contains an _ marker",
+      toolName: "underscoredescription",
+      toolDescription: "Ordinary description",
+    });
+    const backslashToolName = await makeExternalApp({
+      catalogName: "Backslash Tool Name",
+      catalogDescription: "Tool name marker",
+      toolName: "back\\slash",
+      toolDescription: "Ordinary description",
+    });
+    const percentToolDescription = await makeExternalApp({
+      catalogName: "Tool Description Marker",
+      catalogDescription: "Ordinary catalog description",
+      toolName: "percentdescription",
+      toolDescription: "MiXeD needle with a % marker",
+    });
+
+    const searchExternal = async (search: string) => {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/apps?limit=100&offset=0&search=${encodeURIComponent(search)}`,
+      });
+      expect(response.statusCode).toBe(200);
+      const body = response.json<AppListResponse>();
+      const catalogIds = body.data
+        .filter((item) => item.source === "external")
+        .map((item) => item.catalogId)
+        .sort();
+      return { catalogIds, total: body.pagination.total };
+    };
+
+    expect(await searchExternal("%")).toEqual({
+      catalogIds: [percentName.id, percentToolDescription.id].sort(),
+      total: 2,
+    });
+    expect(await searchExternal("_")).toEqual({
+      catalogIds: [underscoreDescription.id],
+      total: 1,
+    });
+    expect(await searchExternal("\\")).toEqual({
+      catalogIds: [backslashToolName.id],
+      total: 1,
+    });
+    expect(await searchExternal("mixed NEEDLE")).toEqual({
+      catalogIds: [percentToolDescription.id],
+      total: 1,
+    });
+  });
+
   test("includes assigned team names for a team-scoped owned app", async ({
     makeApp,
     makeTeam,

--- a/platform/backend/src/routes/app/list.app.route.test.ts
+++ b/platform/backend/src/routes/app/list.app.route.test.ts
@@ -2,7 +2,12 @@ import { ADMIN_ROLE_NAME } from "@archestra/shared";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
-import type { User } from "@/types";
+import type { AppListItem, User } from "@/types";
+
+type AppListResponse = {
+  data: AppListItem[];
+  pagination: { total: number };
+};
 
 describe("GET /api/apps", () => {
   let app: FastifyInstanceWithZod;
@@ -47,6 +52,81 @@ describe("GET /api/apps", () => {
       owned.id,
     );
     expect(response.json().pagination.total).toBeGreaterThanOrEqual(1);
+  });
+
+  test("treats wildcard characters literally in owned app search", async ({
+    makeApp,
+  }) => {
+    const percentName = await makeApp({
+      organizationId,
+      scope: "org",
+      name: "100% Ready",
+    });
+    const percentDescription = await makeApp({
+      organizationId,
+      scope: "org",
+      name: "Percent Description",
+      description: "Contains a % marker",
+    });
+    const underscoreName = await makeApp({
+      organizationId,
+      scope: "org",
+      name: "Under_score Name",
+    });
+    const underscoreDescription = await makeApp({
+      organizationId,
+      scope: "org",
+      name: "Underscore Description",
+      description: "Contains an _ marker",
+    });
+    const backslashName = await makeApp({
+      organizationId,
+      scope: "org",
+      name: "Back\\slash Name",
+    });
+    const backslashDescription = await makeApp({
+      organizationId,
+      scope: "org",
+      name: "Backslash Description",
+      description: "Contains a \\ marker",
+    });
+    await makeApp({
+      organizationId,
+      scope: "org",
+      name: "Plain App",
+      description: "Contains no special marker",
+    });
+
+    const searchOwned = async (search: string) => {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/apps?limit=100&offset=0&search=${encodeURIComponent(search)}`,
+      });
+      expect(response.statusCode).toBe(200);
+      const body = response.json<AppListResponse>();
+      const ids = body.data
+        .filter((item) => item.source === "owned")
+        .map((item) => item.id)
+        .sort();
+      return { ids, total: body.pagination.total };
+    };
+
+    expect(await searchOwned("%")).toEqual({
+      ids: [percentName.id, percentDescription.id].sort(),
+      total: 2,
+    });
+    expect(await searchOwned("_")).toEqual({
+      ids: [underscoreName.id, underscoreDescription.id].sort(),
+      total: 2,
+    });
+    expect(await searchOwned("\\")).toEqual({
+      ids: [backslashName.id, backslashDescription.id].sort(),
+      total: 2,
+    });
+    expect(await searchOwned("READY")).toEqual({
+      ids: [percentName.id],
+      total: 1,
+    });
   });
 
   test("includes assigned team names for a team-scoped owned app", async ({

--- a/platform/backend/src/routes/app/screenshot.app.route.test.ts
+++ b/platform/backend/src/routes/app/screenshot.app.route.test.ts
@@ -1,4 +1,5 @@
 import { ADMIN_ROLE_NAME } from "@archestra/shared";
+import AppRenderScreenshotModel from "@/models/app-render-screenshot";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -65,5 +66,60 @@ describe("POST /api/apps/:appId/screenshot", () => {
       payload: { version: 99, dataUrl: "data:image/png;base64,QUJD" },
     });
     expect(futureVersion.statusCode).toBe(400);
+  });
+
+  test("accepts only canonical padded or unpadded base64", async ({
+    makeApp,
+  }) => {
+    const created = await makeApp({
+      organizationId,
+      authorId: user.id,
+      name: "Canonical Shots",
+      scope: "org",
+    });
+    const appId = created.id;
+
+    for (const data of ["TQ==", "TQ", "TWE=", "TWE"]) {
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/apps/${appId}/screenshot`,
+        payload: { version: 1, dataUrl: `data:image/png;base64,${data}` },
+      });
+      expect(response.statusCode, data).toBe(200);
+    }
+
+    const stableData = "QUJD";
+    const stable = await app.inject({
+      method: "POST",
+      url: `/api/apps/${appId}/screenshot`,
+      payload: {
+        version: 1,
+        dataUrl: `data:image/png;base64,${stableData}`,
+      },
+    });
+    expect(stable.statusCode).toBe(200);
+
+    for (const data of [
+      "A",
+      "AAAAA",
+      "TQ=",
+      "TWE==",
+      "QUJD=",
+      "TR==",
+      "TR",
+      "T Q==",
+      "____",
+      "***",
+    ]) {
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/apps/${appId}/screenshot`,
+        payload: { version: 1, dataUrl: `data:image/png;base64,${data}` },
+      });
+      expect(response.statusCode, data).toBe(400);
+      expect(
+        (await AppRenderScreenshotModel.getForUser(appId, user.id))?.data,
+      ).toBe(stableData);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Treat `%`, `_`, and `\` literally in owned App search.
- Apply the same literal semantics across external catalog and tool fields.
- Reject malformed and noncanonical screenshot Base64 before storage.

## Validation

- 12 targeted backend tests
- TypeScript type-check
- Biome
- Knip development and production

sweep-key: platform/backend/src/models/app.ts:47-67:owned-app-search-treats-wildcards
sweep-key: platform/backend/src/models/mcp-server.ts:619-655:external-app-search-treats-wildcards
sweep-key: platform/backend/src/routes/app/app.routes.ts:852-861:malformed-base64-screenshot-accepted

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>