### PR TITLE
fix(apps): correct panel and sandbox state

### DIFF
--- a/platform/frontend/src/app/apps/_parts/app-create-dialog.test.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-create-dialog.test.tsx
@@ -57,4 +57,14 @@ describe("AppCreateDialog", () => {
 
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/a/app-123"));
   });
+
+  it("does not create an app with a whitespace-only name", async () => {
+    const user = userEvent.setup();
+    render(<AppCreateDialog open onOpenChange={() => {}} />);
+
+    await user.type(screen.getByLabelText("Name"), "   ");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(createMutateMock).not.toHaveBeenCalled();
+  });
 });

--- a/platform/frontend/src/app/apps/_parts/app-create-dialog.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-create-dialog.tsx
@@ -88,8 +88,18 @@ export function AppCreateDialog({
         <Input
           id="app-name"
           placeholder="e.g. Sales dashboard, Task tracker, Content calendar"
-          {...form.register("name", { required: true, maxLength: 100 })}
+          aria-invalid={!!form.formState.errors.name}
+          {...form.register("name", {
+            required: "Name is required.",
+            maxLength: 100,
+            validate: (value) => value.trim().length > 0 || "Name is required.",
+          })}
         />
+        {form.formState.errors.name?.message ? (
+          <p className="text-xs text-destructive">
+            {form.formState.errors.name.message}
+          </p>
+        ) : null}
       </div>
     </StandardFormDialog>
   );

--- a/platform/frontend/src/components/chat/apps-context.tsx
+++ b/platform/frontend/src/components/chat/apps-context.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -137,7 +138,9 @@ export function AppsProvider({
     knownToolCallIds: ReadonlySet<string>;
   } | null>(null);
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsToolCallId, setSettingsToolCallId] = useState<string | null>(
+    null,
+  );
 
   // One group per app: owned renders fold into a shared group with a single
   // visible `activeRender` (the user's pick while present, else the latest);
@@ -187,7 +190,7 @@ export function AppsProvider({
           return next;
         });
       }
-      setSettingsOpen(false);
+      setSettingsToolCallId(null);
     },
     [groupByToolCallId, closedKeys],
   );
@@ -208,7 +211,7 @@ export function AppsProvider({
         next.delete(key);
         return next;
       });
-      setSettingsOpen(false);
+      setSettingsToolCallId(null);
     },
     [groupByToolCallId],
   );
@@ -220,7 +223,7 @@ export function AppsProvider({
         toolCallId: canonicalToolCallId(id),
         knownToolCallIds: new Set(apps.map((a) => a.toolCallId)),
       });
-      setSettingsOpen(false);
+      setSettingsToolCallId(null);
     },
     [canonicalToolCallId, apps],
   );
@@ -259,12 +262,27 @@ export function AppsProvider({
     return latestOpen ?? latestBy(isActive);
   }, [explicitPanel, apps, closedKeys, groupByToolCallId]);
 
+  const settingsOpen =
+    settingsToolCallId !== null && settingsToolCallId === panelToolCallId;
+  const setSettingsOpen = useCallback(
+    (open: boolean) => {
+      setSettingsToolCallId(open ? panelToolCallId : null);
+    },
+    [panelToolCallId],
+  );
+
+  useEffect(() => {
+    if (settingsToolCallId !== null && !settingsOpen) {
+      setSettingsToolCallId(null);
+    }
+  }, [settingsOpen, settingsToolCallId]);
+
   const openRightPanel = useCallback(() => {
     onShowInPanel?.();
   }, [onShowInPanel]);
 
   const closePanel = useCallback(() => {
-    setSettingsOpen(false);
+    setSettingsToolCallId(null);
     onClosePanel?.();
   }, [onClosePanel]);
 
@@ -296,6 +314,7 @@ export function AppsProvider({
       portalTarget,
       closePanel,
       settingsOpen,
+      setSettingsOpen,
     ],
   );
 

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -88,7 +88,7 @@ import {
   reportAppDiagnostic,
 } from "@/lib/chat/app-diagnostics-store";
 import { useFeature } from "@/lib/config/config.query";
-import { AppsProvider, useApps } from "./apps-context";
+import { AppsProvider, type PanelApp, useApps } from "./apps-context";
 import { McpAppSection } from "./mcp-app-container";
 
 const mockUseApp = vi.mocked(useApp);
@@ -1136,6 +1136,7 @@ describe("McpAppSection unavailable owned app", () => {
 
 describe("McpAppSection owned-app panel chrome", () => {
   const APP_ID = "947051c7-ea8e-48ed-8077-a3cc904d9d61";
+  const SECOND_APP_ID = "6bc05a26-0ffc-4131-a073-c874701d2b91";
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1172,6 +1173,30 @@ describe("McpAppSection owned-app panel chrome", () => {
     });
   }
 
+  function OwnedPanelHost({ apps }: { apps: PanelApp[] }) {
+    const { panelToolCallId, setPanelApp } = useApps();
+    const panelApp = apps.find((app) => app.toolCallId === panelToolCallId);
+
+    return (
+      <>
+        <button type="button" onClick={() => setPanelApp("tc1")}>
+          Switch to first app
+        </button>
+        <div data-testid="panel-app">{panelApp?.appId ?? "none"}</div>
+        {panelApp?.appId ? (
+          <McpAppSection
+            {...defaultProps}
+            surface="panel"
+            appId={panelApp.appId}
+            toolCallId={panelApp.toolCallId}
+            uiResourceUri={panelApp.uiResourceUri}
+            preloadedResource={preloadedResource}
+          />
+        ) : null}
+      </>
+    );
+  }
+
   it("opens the app settings dialog from the panel gear", async () => {
     const user = userEvent.setup();
     await renderOwnedPanel();
@@ -1196,6 +1221,54 @@ describe("McpAppSection owned-app panel chrome", () => {
     expect(
       screen.getByRole("button", { name: /^settings$/i }),
     ).toBeInTheDocument();
+  });
+
+  it("closes settings when a newly rendered app takes the panel", async () => {
+    const user = userEvent.setup();
+    const apps: PanelApp[] = [
+      {
+        toolCallId: "tc1",
+        label: "First App",
+        uiResourceUri: "ui://first/app.html",
+        appId: APP_ID,
+        createdAt: 1,
+      },
+      {
+        toolCallId: "tc2",
+        label: "Second App",
+        uiResourceUri: "ui://second/app.html",
+        appId: SECOND_APP_ID,
+        createdAt: 2,
+      },
+    ];
+    mockUseApp.mockImplementation(
+      (appId) =>
+        ({ data: { id: appId, name: "Panel App" } }) as ReturnType<
+          typeof useApp
+        >,
+    );
+
+    const { rerender } = render(
+      <AppsProvider apps={[apps[0]]}>
+        <OwnedPanelHost apps={apps} />
+      </AppsProvider>,
+    );
+    await user.click(screen.getByRole("button", { name: /^settings$/i }));
+    expect(screen.getByTestId("settings-form")).toBeInTheDocument();
+
+    rerender(
+      <AppsProvider apps={apps}>
+        <OwnedPanelHost apps={apps} />
+      </AppsProvider>,
+    );
+    expect(screen.getByTestId("panel-app")).toHaveTextContent(SECOND_APP_ID);
+    expect(screen.queryByTestId("settings-form")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Switch to first app" }),
+    );
+    expect(screen.getByTestId("panel-app")).toHaveTextContent(APP_ID);
+    expect(screen.queryByTestId("settings-form")).not.toBeInTheDocument();
   });
 });
 

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mock heavy dependencies before module import ─────────────────────────────
 
@@ -522,6 +522,96 @@ describe("McpAppContainer inline height (via McpAppSection)", () => {
         content: [{ type: "text", text: "some result" }],
       }),
     );
+  });
+});
+
+describe("McpAppContainer sandbox timeout recovery", () => {
+  const SANDBOX_PROXY_READY = "ui/notifications/sandbox-proxy-ready";
+  const SANDBOX_ORIGIN = "http://127.0.0.1:9000";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function renderTimedApp(connect: () => Promise<void>) {
+    const { AppBridge } = await import(
+      "@modelcontextprotocol/ext-apps/app-bridge"
+    );
+    await act(async () => {
+      render(
+        <McpAppSection
+          {...defaultProps}
+          preloadedResource={preloadedResource}
+        />,
+      );
+    });
+
+    const iframe = document.querySelector("iframe");
+    if (!iframe) throw new Error("iframe did not mount");
+    const bridge = (AppBridge as ReturnType<typeof vi.fn>).mock.instances.at(
+      -1,
+    ) as { connect: ReturnType<typeof vi.fn> } | undefined;
+    if (!bridge) throw new Error("bridge did not initialize");
+    bridge.connect.mockImplementation(connect);
+    return { bridge, iframe };
+  }
+
+  function dispatchReady(iframe: HTMLIFrameElement, origin: string) {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframe.contentWindow,
+        origin,
+        data: { method: SANDBOX_PROXY_READY },
+      }),
+    );
+  }
+
+  it("clears a timeout after the same sandbox connects late", async () => {
+    let resolveConnect: () => void = () => {};
+    const connectPromise = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+    const { bridge, iframe } = await renderTimedApp(() => connectPromise);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    act(() => dispatchReady(iframe, "https://invalid.example"));
+    expect(bridge.connect).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    act(() => dispatchReady(iframe, SANDBOX_ORIGIN));
+    expect(bridge.connect).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveConnect();
+      await connectPromise;
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("keeps an error visible when the late connection fails", async () => {
+    const { iframe } = await renderTimedApp(() =>
+      Promise.reject(new Error("late connection failed")),
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    await act(async () => {
+      dispatchReady(iframe, SANDBOX_ORIGIN);
+    });
+    expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 });
 

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -964,7 +964,10 @@ function SandboxIframe({
         appBridge
           .connect(transport)
           .then(() => {
-            if (!cancelled) setConnectedBridge(appBridge);
+            if (!cancelled) {
+              setError(null);
+              setConnectedBridge(appBridge);
+            }
           })
           .catch((err) => {
             if (!cancelled) {
@@ -1116,7 +1119,7 @@ function SandboxIframe({
       }}
     >
       {error && (
-        <div style={{ color: "red", padding: "1rem" }}>
+        <div role="alert" style={{ color: "red", padding: "1rem" }}>
           Error: {error.message}
         </div>
       )}


### PR DESCRIPTION
## Summary

- Bind panel settings to the App render identity so automatic switches close stale settings.
- Reject whitespace-only App names before calling the create mutation.
- Clear a sandbox timeout after the same late iframe connects successfully.

## Validation

- 38 targeted frontend tests
- TypeScript type-check
- Biome
- Knip

sweep-key: platform/frontend/src/components/chat/apps-context.tsx:135-260:settings-state-follows-wrong-panel-app
sweep-key: platform/frontend/src/app/apps/_parts/app-create-dialog.tsx:43-92:whitespace-only-name-submitted
sweep-key: platform/frontend/src/components/mcp-app/mcp-app-view.tsx:938-975:sandbox-timeout-error-persists-after-ready

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>