### PR TITLE
fix(apps): degrade gracefully when a third-party MCP UI resource can't be read

### DIFF
--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -407,19 +407,29 @@ export async function createAgentServer(
         );
         return result;
       } catch (error) {
-        logger.error(
-          {
-            agentId,
-            uri,
-            error: error instanceof Error ? error.message : "Unknown error",
-            stack: error instanceof Error ? error.stack : undefined,
-          },
-          "Resource read failed",
-        );
+        // A third-party tool can advertise a `ui://` UI resource whose upstream
+        // server does not actually implement `resources/read` (returning -32601
+        // Method not found) or has no such resource. That is an expected upstream
+        // limitation, not a platform fault — the client degrades to the plain
+        // tool result — so log it at a lower severity to avoid flooding error
+        // logs. Genuine failures still log at error.
+        const message =
+          error instanceof Error ? error.message : "Unknown error";
+        const logContext = {
+          agentId,
+          uri,
+          error: message,
+          stack: error instanceof Error ? error.stack : undefined,
+        };
+        if (isUnavailableResourceError(error)) {
+          logger.info(logContext, "Resource read unavailable (upstream)");
+        } else {
+          logger.error(logContext, "Resource read failed");
+        }
         throw {
           code: -32603,
           message: "Resource read failed",
-          data: error instanceof Error ? error.message : "Unknown error",
+          data: message,
         };
       }
     },
@@ -2018,4 +2028,26 @@ function providesUiResource(tool: {
   const isUiUri = (value: unknown): boolean =>
     typeof value === "string" && value.startsWith("ui://");
   return isUiUri(meta?.ui?.resourceUri) || isUiUri(meta?.["ui/resourceUri"]);
+}
+
+/**
+ * Whether a resource-read failure is an expected "the upstream server can't
+ * serve this" condition — method not found (-32601) or resource not found
+ * (-32002) — rather than a genuine platform fault. A third-party tool can
+ * advertise a `ui://` UI resource whose server never implemented
+ * `resources/read`; the client degrades to the plain tool result, so the
+ * gateway logs this quietly instead of at error level.
+ */
+function isUnavailableResourceError(error: unknown): boolean {
+  if (
+    error instanceof Error &&
+    /method not found|resource not found/i.test(error.message)
+  ) {
+    return true;
+  }
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    return code === -32601 || code === -32002;
+  }
+  return false;
 }

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -1204,21 +1204,54 @@ describe("McpAppSection error handling", () => {
     vi.clearAllMocks();
   });
 
-  it("shows error message when fetch fails (no preloaded resource)", async () => {
-    // Mock global fetch to simulate a network error
+  it("degrades silently for a third-party app when the UI resource can't be read", async () => {
+    // A third-party tool advertises a ui:// resource its upstream server can't
+    // serve (e.g. -32601 Method not found). The tool result is shown regardless,
+    // so the failed app load must fold away rather than show a "Failed to load
+    // app" card. defaultProps is an agent (third-party) render — no appId.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("MCP error -32601: Method not found"));
+
+    await act(async () => {
+      render(
+        <McpAppSection
+          {...defaultProps}
+          toolDetails={<div data-testid="tool-details">details</div>}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    // Flush the rejection handler + re-render.
+    await act(async () => {});
+
+    expect(screen.queryByText(/failed to load app/i)).not.toBeInTheDocument();
+    expect(document.querySelector("iframe")).not.toBeInTheDocument();
+    // The app folded away, but its tool-call details stay inspectable.
+    expect(screen.getByTestId("tool-details")).toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("shows the error for an owned app when the UI resource can't be read", async () => {
+    // Owned (Archestra-authored) apps do not degrade: a load failure is an
+    // authoring bug the author needs to see, so the error card stays.
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockRejectedValue(new Error("Network error"));
 
     await act(async () => {
-      render(<McpAppSection {...defaultProps} />);
+      render(
+        <McpAppSection
+          {...defaultProps}
+          appId="11111111-1111-1111-1111-111111111111"
+        />,
+      );
     });
 
-    // Wait for the async fetch to complete and error state to render
     await vi.waitFor(() => {
-      expect(
-        screen.getByText(/failed to load/i) || screen.getByText(/error/i),
-      ).toBeTruthy();
+      expect(screen.getByText(/failed to load app/i)).toBeInTheDocument();
     });
 
     fetchSpy.mockRestore();

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -439,6 +439,11 @@ export function McpAppEntryContent({
       // which the runtime gates on a non-null version.
       appVersion={appVersion ?? ownedApp?.latestVersion ?? null}
       reloadNonce={reloadNonce}
+      // Third-party apps (no appId) are incidental to a tool call: if their
+      // upstream can't serve the advertised ui:// resource, fold the app away
+      // and keep the plain tool result rather than showing a load error.
+      // Owned apps keep surfacing errors — a failure there is an authoring bug.
+      degradeResourceLoadError={!appId}
     />
   );
 

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -103,6 +103,7 @@ export const McpAppRuntime = function McpAppRuntime({
   containerDimensions,
   reloadNonce,
   inlineInitialHeight,
+  degradeResourceLoadError,
 }: {
   toolResourceUri: string;
   endpoint: McpAppEndpoint;
@@ -129,6 +130,18 @@ export const McpAppRuntime = function McpAppRuntime({
   /** Last measured inline height; seeds the iframe + loading box so a fresh
    * mount (e.g. returning from the panel) doesn't collapse before the app loads. */
   inlineInitialHeight?: number;
+  /**
+   * Degrade silently instead of showing a "Failed to load app" card when the
+   * UI resource can't be read. Set for incidental chat renders of third-party
+   * apps: a tool advertises a `ui://` resource its upstream server may not
+   * actually serve (e.g. a server that added MCP-UI hints without implementing
+   * `resources/read`, which fails with -32601 Method not found), and the tool
+   * result is shown regardless — so a failed app load falls back to that plain
+   * result rather than a scary error. Left false where the app was opened
+   * deliberately (run pages) or is Archestra-authored (an authoring bug the
+   * author must see), so failures stay visible there.
+   */
+  degradeResourceLoadError?: boolean;
 }) {
   const { resolvedTheme } = useTheme();
   // The host only ever caps height (width is unbounded); unpack the SEP-shaped
@@ -178,6 +191,8 @@ export const McpAppRuntime = function McpAppRuntime({
   onSendMessageRef.current = onSendMessage;
   const onResourceStateChangeRef = useRef(onResourceStateChange);
   onResourceStateChangeRef.current = onResourceStateChange;
+  const degradeResourceLoadErrorRef = useRef(degradeResourceLoadError);
+  degradeResourceLoadErrorRef.current = degradeResourceLoadError;
   // Ref to the latest bridge for teardown — avoids capturing a stale closure
   const latestBridgeRef = useRef<AppBridge | null>(null);
   // Monotonic counter for JSON-RPC IDs to avoid collisions from Date.now() in rapid calls.
@@ -581,9 +596,19 @@ export const McpAppRuntime = function McpAppRuntime({
       } catch (err) {
         if (!cancelled && !fetchCancelledRef.current) {
           const error = err instanceof Error ? err : new Error(String(err));
-          setLoadError(error.message);
-          onResourceStateChangeRef.current("renderable");
-          onErrorRef.current?.(error);
+          if (degradeResourceLoadErrorRef.current) {
+            // Incidental third-party app whose upstream couldn't serve the UI
+            // resource: fall back to the plain tool result (state "empty" folds
+            // the app away) rather than a "Failed to load app" card. The tool
+            // output itself is shown independently, so nothing is lost.
+            // biome-ignore lint/suspicious/noConsole: intentional — helps support diagnose a silently-skipped app
+            console.debug("[MCP App] resource unavailable, degrading", error);
+            onResourceStateChangeRef.current("empty");
+          } else {
+            setLoadError(error.message);
+            onResourceStateChangeRef.current("renderable");
+            onErrorRef.current?.(error);
+          }
         }
       }
     })();


### PR DESCRIPTION
## Problem

When a third-party MCP server advertises a `ui://` UI resource in its tool metadata (the MCP-UI / MCP Apps convention) but doesn't actually implement `resources/read`, the chat rendered a red **"Failed to load app"** card — showing `MCP error -32601: Method not found` (or `Resource read failed`) — even though the underlying tool call **succeeded** and the model still answered.

This is triggered by an upstream change (a server starting to emit MCP-UI metadata for tools it doesn't fully back), not an Archestra regression, so it appears across versions. The app panel is a non-essential enhancement over the tool result, which is always shown — a failed load should never produce a scary error.

### Root cause chain
1. Upstream tool metadata now carries `_meta.ui.resourceUri` (`ui://…`).
2. Archestra flags the tool as UI-providing and tries to load the app by reading that resource.
3. The upstream server returns `-32601 Method not found` (it advertised the URI but doesn't serve it).
4. `McpAppRuntime` sets `loadError` → the "Failed to load app" card.

## Fix

- **Frontend graceful degradation** — `McpAppRuntime` gains a `degradeResourceLoadError` flag. The chat container sets it for **third-party** (non-owned) apps, so a UI-resource read failure folds the app away and keeps the plain tool result (state `empty`) instead of an error card. The tool-call details remain inspectable.
- **Owned apps and run pages still surface errors** — an Archestra-authored app failing to load is a real authoring bug, and a deliberately opened run page should show why it couldn't load. The flag is left off there.
- **Backend log noise** — the gateway now logs `resources/read` failures at `info` (not `error`) for the expected method-not-found / resource-not-found case, so servers advertising UI resources they don't serve no longer flood error logs. The thrown JSON-RPC error is unchanged.