### PR TITLE
fix: smooth new-chat to conversation transition

### DIFF
--- a/platform/frontend/next.config.ts
+++ b/platform/frontend/next.config.ts
@@ -59,6 +59,10 @@ const nextConfig: NextConfig = {
     // the backend's runtime value.) Anything the proxy lets through still gets
     // sized-checked by the backend's bodyLimit, which is the authoritative cap.
     proxyClientMaxBodySize: "200mb",
+    // React <ViewTransition> integration (animates the new-chat → conversation
+    // handoff; see src/lib/view-transition.tsx). Browsers without the View
+    // Transitions API just skip the animation.
+    viewTransition: true,
   },
   httpAgentOptions: {
     keepAlive: true,

--- a/platform/frontend/src/app/chat/chat-initial-state.test.ts
+++ b/platform/frontend/src/app/chat/chat-initial-state.test.ts
@@ -270,7 +270,6 @@ describe("isAutoSendHandoffInProgress", () => {
     hasAttachmentsMarker: false,
     hasPendingHandoffFiles: false,
     autoSendTriggered: false,
-    isCreatingConversation: false,
   };
 
   test("true on first render of a prompt handoff (before the send fires)", () => {
@@ -296,10 +295,12 @@ describe("isAutoSendHandoffInProgress", () => {
     ).toBe(true);
   });
 
-  test("true while the create-conversation mutation is pending", () => {
-    expect(
-      isAutoSendHandoffInProgress({ ...base, isCreatingConversation: true }),
-    ).toBe(true);
+  test("false during an interactive submit (no handoff signals)", () => {
+    // Pressing Enter on the splash runs the same create mutation, but the
+    // splash must stay visible: its composer keeps focus and is the old half
+    // of the shared-element morph into the conversation view. Handoffs are
+    // identified by their own signals, never by the mutation being pending.
+    expect(isAutoSendHandoffInProgress(base)).toBe(false);
   });
 
   test("true for a files-only handoff whose stashed files are still in memory", () => {
@@ -337,7 +338,6 @@ describe("isAutoSendHandoffInProgress", () => {
         conversationId: "conv-1",
         initialUserPrompt: "Say hello",
         autoSendTriggered: true,
-        isCreatingConversation: true,
       }),
     ).toBe(false);
   });

--- a/platform/frontend/src/app/chat/chat-initial-state.ts
+++ b/platform/frontend/src/app/chat/chat-initial-state.ts
@@ -205,10 +205,17 @@ export function shouldResetInitialChatState(params: {
  * or the empty home flashes before the conversation view mounts.
  *
  * Mirrors the auto-send effect's trigger conditions. `autoSendTriggered` (the
- * effect's ref) keeps it true across the frame where `user_prompt` has been
- * stripped from the URL but the create mutation has not yet reported pending. A
- * files-only handoff whose stashed files were lost (e.g. a hard reload) has no
- * prompt and no pending files, so this stays false and the composer shows.
+ * effect's ref, set synchronously before the create fires) keeps it true from
+ * the frame where `user_prompt` is stripped from the URL through the whole
+ * create request. A files-only handoff whose stashed files were lost (e.g. a
+ * hard reload) has no prompt and no pending files, so this stays false and the
+ * composer shows.
+ *
+ * Deliberately NOT keyed on the create mutation being pending: an interactive
+ * submit from the splash also runs that mutation, and the splash must stay on
+ * screen during it — the composer keeps focus and is the "old" half of the
+ * shared-element morph into the conversation view. Only true handoffs (which
+ * always set one of the signals below) suppress the splash.
  */
 export function isAutoSendHandoffInProgress(params: {
   conversationId?: string;
@@ -216,7 +223,6 @@ export function isAutoSendHandoffInProgress(params: {
   hasAttachmentsMarker: boolean;
   hasPendingHandoffFiles: boolean;
   autoSendTriggered: boolean;
-  isCreatingConversation: boolean;
 }): boolean {
   if (params.conversationId) {
     return false;
@@ -225,7 +231,6 @@ export function isAutoSendHandoffInProgress(params: {
   return (
     Boolean(params.initialUserPrompt) ||
     (params.hasAttachmentsMarker && params.hasPendingHandoffFiles) ||
-    params.autoSendTriggered ||
-    params.isCreatingConversation
+    params.autoSendTriggered
   );
 }

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -14,6 +14,7 @@ import {
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
+  startTransition,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -157,6 +158,7 @@ import { useScheduleTriggerRun } from "@/lib/schedule-trigger.query";
 import { useSkill, useSkillsPaginated } from "@/lib/skills/skill.query";
 import { useTeams } from "@/lib/teams/team.query";
 import { cn } from "@/lib/utils";
+import { ViewTransition } from "@/lib/view-transition";
 import {
   buildCreateConversationInput,
   isAutoSendHandoffInProgress,
@@ -555,15 +557,36 @@ export function ChatPageContent({
   // Update URL when conversation changes
   const selectConversation = useCallback(
     (id: string | undefined) => {
-      setConversationId(id);
+      // A React Transition so the <ViewTransition> boundaries below animate
+      // the splash → conversation swap (plain setState swaps instantly).
+      startTransition(() => setConversationId(id));
       if (id) {
-        router.push(`/chat/${id}`);
+        // Shallow-route to the canonical URL: history.pushState syncs
+        // usePathname/useSearchParams without an RSC navigation, so this
+        // instance keeps rendering the conversation it just started. A real
+        // router.push to /chat/[conversationId] would mount that segment's
+        // keyed page and remount everything mid-stream (visible flicker).
+        // Refresh, deep links, and back/forward still resolve through the
+        // /chat/[conversationId] route.
+        window.history.pushState(null, "", `/chat/${id}`);
       } else {
         router.push("/chat");
       }
     },
     [router],
   );
+
+  // After the shallow pushState above, this /chat instance stays mounted while
+  // the URL reads /chat/<id> — so navigating back to /chat (sidebar "New
+  // Chat", browser back) can land on this same instance instead of a fresh
+  // mount. Derive the reset from the URL: when the pathname returns to /chat,
+  // clear the selection so the New Chat splash renders again.
+  const isNewChatUrl = !routeConversationId && pathname === "/chat";
+  useEffect(() => {
+    if (isNewChatUrl) {
+      startTransition(() => setConversationId(undefined));
+    }
+  }, [isNewChatUrl]);
 
   // App render diagnostics are conversation-scoped: drop any leftovers when
   // switching conversations so they never attach to an unrelated send.
@@ -1395,17 +1418,24 @@ export function ChatPageContent({
     }
 
     const initialAppDiagnostics = drainAppDiagnostics();
-    sendMessage({
-      role: "user",
-      parts: ensureNonEmptyParts(parts),
-      metadata: {
-        createdAt: new Date().toISOString(),
-        ...(skillToSend ? { skill: skillToSend } : {}),
-        ...(sandboxCommandToSend ? { sandboxCommand: true as const } : {}),
-        ...(initialAppDiagnostics.length > 0
-          ? { appDiagnostics: initialAppDiagnostics }
-          : {}),
-      },
+    // This effect fires right after the splash → conversation swap commits,
+    // while its view transition (the composer morph) is still animating. An
+    // urgent update here would make React skip that animation mid-flight, so
+    // schedule the optimistic user-message append as a transition too — it
+    // joins the running animation instead of snapping it to the end.
+    startTransition(() => {
+      sendMessage({
+        role: "user",
+        parts: ensureNonEmptyParts(parts),
+        metadata: {
+          createdAt: new Date().toISOString(),
+          ...(skillToSend ? { skill: skillToSend } : {}),
+          ...(sandboxCommandToSend ? { sandboxCommand: true as const } : {}),
+          ...(initialAppDiagnostics.length > 0
+            ? { appDiagnostics: initialAppDiagnostics }
+            : {}),
+        },
+      });
     });
 
     trackEvent("message_sent", {
@@ -2306,7 +2336,6 @@ export function ChatPageContent({
     hasAttachmentsMarker: searchParams.get("attachments") === "1",
     hasPendingHandoffFiles: hasPendingChatHandoffFiles(),
     autoSendTriggered: autoSendTriggeredRef.current,
-    isCreatingConversation: createConversationMutation.isPending,
   });
 
   return (
@@ -2390,73 +2419,77 @@ export function ChatPageContent({
 
               {conversationId ? (
                 <>
-                  {/* Chat content - hidden on mobile when panels are open */}
-                  <div
-                    className={cn(
-                      "flex-1 min-h-0 relative",
-                      isRightPanelOpen && "hidden md:block",
-                    )}
-                  >
-                    {isScheduledRunInProgress ? (
-                      <ScheduledRunInProgress />
-                    ) : isReadOnlyConversation ? (
-                      <MessageThread
-                        messages={sharedConversationMessages}
-                        chatErrors={conversation?.chatErrors ?? []}
-                        conversationId={conversationId}
-                        containerClassName="h-full"
-                        hideDivider
-                        profileId={conversation?.agent?.id}
-                        agentName={conversation?.agent?.name}
-                        selectedModel={conversation?.modelId ?? undefined}
-                      />
-                    ) : (
-                      <ChatMessages
-                        conversationId={conversationId}
-                        agentId={
-                          currentProfileId || initialAgentId || undefined
-                        }
-                        messages={messages}
-                        status={status}
-                        isContextCompacting={isContextCompacting}
-                        contextCompactionFeedback={manualCompactionFeedback}
-                        optimisticToolCalls={optimisticToolCalls}
-                        isLoadingConversation={isLoadingConversation}
-                        onMessagesUpdate={setMessages}
-                        agentName={
-                          (currentProfileId
-                            ? internalAgents.find(
-                                (a) => a.id === currentProfileId,
-                              )
-                            : internalAgents.find(
-                                (a) => a.id === initialAgentId,
-                              )
-                          )?.name
-                        }
-                        selectedModel={conversation?.modelId ?? initialModel}
-                        modelSource={
-                          conversationModelSource ?? initialModelSource
-                        }
-                        chatErrors={conversation?.chatErrors ?? []}
-                        compactions={conversation?.compactions ?? []}
-                        onRegenerateUserMessage={regenerateUserMessage}
-                        onProviderConnected={handleProviderConnected}
-                        onChatErrorRetry={handleChatErrorRetry}
-                        error={error}
-                        onToolApprovalResponse={
-                          addToolApprovalResponse
-                            ? ({ id, approved, reason }) => {
-                                addToolApprovalResponse({
-                                  id,
-                                  approved,
-                                  reason,
-                                });
-                              }
-                            : undefined
-                        }
-                      />
-                    )}
-                  </div>
+                  {/* Chat content - hidden on mobile when panels are open.
+                      The ViewTransition eases the thread in when the splash
+                      (or another page) hands off to a conversation. */}
+                  <ViewTransition enter="chat-thread-enter" default="none">
+                    <div
+                      className={cn(
+                        "flex-1 min-h-0 relative",
+                        isRightPanelOpen && "hidden md:block",
+                      )}
+                    >
+                      {isScheduledRunInProgress ? (
+                        <ScheduledRunInProgress />
+                      ) : isReadOnlyConversation ? (
+                        <MessageThread
+                          messages={sharedConversationMessages}
+                          chatErrors={conversation?.chatErrors ?? []}
+                          conversationId={conversationId}
+                          containerClassName="h-full"
+                          hideDivider
+                          profileId={conversation?.agent?.id}
+                          agentName={conversation?.agent?.name}
+                          selectedModel={conversation?.modelId ?? undefined}
+                        />
+                      ) : (
+                        <ChatMessages
+                          conversationId={conversationId}
+                          agentId={
+                            currentProfileId || initialAgentId || undefined
+                          }
+                          messages={messages}
+                          status={status}
+                          isContextCompacting={isContextCompacting}
+                          contextCompactionFeedback={manualCompactionFeedback}
+                          optimisticToolCalls={optimisticToolCalls}
+                          isLoadingConversation={isLoadingConversation}
+                          onMessagesUpdate={setMessages}
+                          agentName={
+                            (currentProfileId
+                              ? internalAgents.find(
+                                  (a) => a.id === currentProfileId,
+                                )
+                              : internalAgents.find(
+                                  (a) => a.id === initialAgentId,
+                                )
+                            )?.name
+                          }
+                          selectedModel={conversation?.modelId ?? initialModel}
+                          modelSource={
+                            conversationModelSource ?? initialModelSource
+                          }
+                          chatErrors={conversation?.chatErrors ?? []}
+                          compactions={conversation?.compactions ?? []}
+                          onRegenerateUserMessage={regenerateUserMessage}
+                          onProviderConnected={handleProviderConnected}
+                          onChatErrorRetry={handleChatErrorRetry}
+                          error={error}
+                          onToolApprovalResponse={
+                            addToolApprovalResponse
+                              ? ({ id, approved, reason }) => {
+                                  addToolApprovalResponse({
+                                    id,
+                                    approved,
+                                    reason,
+                                  });
+                                }
+                              : undefined
+                          }
+                        />
+                      )}
+                    </div>
+                  </ViewTransition>
 
                   {isScheduledRunInProgress ? null : isReadOnlyConversation ? (
                     <div className="sticky bottom-0 bg-background border-t p-4">
@@ -2526,60 +2559,72 @@ export function ChatPageContent({
                   ) : (
                     activeAgentId && (
                       <div className="sticky bottom-0 bg-background border-t p-4">
-                        <div className="max-w-4xl mx-auto space-y-3">
-                          <ArchestraPromptInput
-                            onSubmit={handleSubmit}
-                            onStop={handleStopStreaming}
-                            status={status}
-                            selectedModel={conversation?.modelId ?? ""}
-                            onModelChange={handleModelChange}
-                            agentId={promptAgentId ?? activeAgentId}
-                            conversationId={conversationId}
-                            currentConversationChatApiKeyId={
-                              conversation?.chatApiKeyId
-                            }
-                            currentProvider={currentProvider}
-                            textareaRef={textareaRef}
-                            onProviderChange={handleProviderChange}
-                            allowFileUploads={
-                              organization?.allowChatFileUploads ?? false
-                            }
-                            isModelsLoading={isModelsLoading}
-                            tokensUsed={tokensUsed}
-                            cachedTokens={tokenUsage?.cacheReadTokens}
-                            maxContextLength={selectedModelContextLength}
-                            contextWindow={contextWindow}
-                            lastCompaction={contextCompaction?.lastCompaction}
-                            inputModalities={selectedModelInputModalities}
-                            agentLlmApiKeyId={
-                              conversation?.agent?.llmApiKeyId ?? null
-                            }
-                            submitDisabled={isPlaywrightSetupVisible}
-                            isContextCompacting={isContextCompacting}
-                            onCompactConversation={handleCompactConversation}
-                            isPlaywrightSetupVisible={isPlaywrightSetupVisible}
-                            selectorAgentId={activeAgentId}
-                            selectorAgentName={swappedAgentName ?? undefined}
-                            onAgentChange={handleConversationAgentChange}
-                            modelSource={conversationModelSource}
-                            onResetModelOverride={
-                              handleConversationResetModelOverride
-                            }
-                            agentRequiresPerUserConnect={
-                              conversationPerUserConnect.needsConnect
-                            }
-                            agentModelDisplayName={
-                              conversationPerUserConnect.needsConnect
-                                ? conversationPerUserConnect.modelName
-                                : undefined
-                            }
-                            prefillText={composerPrefill}
-                            onPrefillApplied={handleComposerPrefillApplied}
-                          />
-                          <div className="text-center">
-                            <Version inline />
+                        {/* Shared-element pair with the centered New Chat
+                            composer (and the project-page composer): on the
+                            splash → conversation swap the box morphs from
+                            center screen to its bottom anchor. */}
+                        <ViewTransition
+                          name="chat-composer"
+                          share="chat-composer-morph"
+                          default="none"
+                        >
+                          <div className="max-w-4xl mx-auto space-y-3">
+                            <ArchestraPromptInput
+                              onSubmit={handleSubmit}
+                              onStop={handleStopStreaming}
+                              status={status}
+                              selectedModel={conversation?.modelId ?? ""}
+                              onModelChange={handleModelChange}
+                              agentId={promptAgentId ?? activeAgentId}
+                              conversationId={conversationId}
+                              currentConversationChatApiKeyId={
+                                conversation?.chatApiKeyId
+                              }
+                              currentProvider={currentProvider}
+                              textareaRef={textareaRef}
+                              onProviderChange={handleProviderChange}
+                              allowFileUploads={
+                                organization?.allowChatFileUploads ?? false
+                              }
+                              isModelsLoading={isModelsLoading}
+                              tokensUsed={tokensUsed}
+                              cachedTokens={tokenUsage?.cacheReadTokens}
+                              maxContextLength={selectedModelContextLength}
+                              contextWindow={contextWindow}
+                              lastCompaction={contextCompaction?.lastCompaction}
+                              inputModalities={selectedModelInputModalities}
+                              agentLlmApiKeyId={
+                                conversation?.agent?.llmApiKeyId ?? null
+                              }
+                              submitDisabled={isPlaywrightSetupVisible}
+                              isContextCompacting={isContextCompacting}
+                              onCompactConversation={handleCompactConversation}
+                              isPlaywrightSetupVisible={
+                                isPlaywrightSetupVisible
+                              }
+                              selectorAgentId={activeAgentId}
+                              selectorAgentName={swappedAgentName ?? undefined}
+                              onAgentChange={handleConversationAgentChange}
+                              modelSource={conversationModelSource}
+                              onResetModelOverride={
+                                handleConversationResetModelOverride
+                              }
+                              agentRequiresPerUserConnect={
+                                conversationPerUserConnect.needsConnect
+                              }
+                              agentModelDisplayName={
+                                conversationPerUserConnect.needsConnect
+                                  ? conversationPerUserConnect.modelName
+                                  : undefined
+                              }
+                              prefillText={composerPrefill}
+                              onPrefillApplied={handleComposerPrefillApplied}
+                            />
+                            <div className="text-center">
+                              <Version inline />
+                            </div>
                           </div>
-                        </div>
+                        </ViewTransition>
                       </div>
                     )
                   )}
@@ -2592,127 +2637,143 @@ export function ChatPageContent({
               ) : (
                 /* No active chat: centered prompt input */
                 newChatAgentId && (
-                  // biome-ignore lint/a11y/noStaticElementInteractions: click-to-focus container
-                  // biome-ignore lint/a11y/useKeyWithClickEvents: click-to-focus container
-                  <div
-                    className="relative flex-1 flex flex-col min-h-0"
-                    onClick={(e) => {
-                      // Focus textarea when clicking empty space outside interactive elements
-                      if (
-                        e.target === e.currentTarget ||
-                        !(e.target as HTMLElement).closest(
-                          "button, a, input, textarea, [role=combobox], [data-slot=input-group]",
-                        )
-                      ) {
-                        textareaRef.current?.focus();
-                      }
-                    }}
-                  >
-                    {((organization?.chatLinks?.length ?? 0) > 0 ||
-                      organization?.onboardingWizard) && (
-                      <div className="absolute top-4 right-4 z-10 flex flex-wrap justify-end gap-2 max-w-[min(100%,36rem)]">
-                        {organization?.chatLinks?.map((link) => (
-                          <ChatLinkButton
-                            key={`link-${link.label}-${link.url}`}
-                            url={link.url}
-                            label={link.label}
-                          />
-                        ))}
-                        {organization?.onboardingWizard && (
-                          <OnboardingWizardButton
-                            wizard={organization.onboardingWizard}
-                          />
-                        )}
-                      </div>
-                    )}
-                    {isPlaywrightSetupRequired && canUpdateAgent && (
-                      <PlaywrightInstallDialog
-                        agentId={playwrightSetupAgentId}
-                        conversationId={conversationId}
-                      />
-                    )}
-                    <div className="flex-1 flex flex-col items-center justify-center p-4 gap-8">
-                      <div className="scale-150">
-                        <AppLogo />
-                      </div>
-                      {(() => {
-                        const currentAgent = internalAgents.find(
-                          (a) => a.id === initialAgentId,
-                        );
-                        const prompts = currentAgent?.suggestedPrompts;
-                        if (!prompts || prompts.length === 0) return null;
-                        return (
-                          <div className="flex flex-wrap items-center justify-center gap-2 max-w-2xl">
-                            {prompts.map((sp) => (
-                              <Suggestion
-                                key={`${sp.summaryTitle}-${sp.prompt}`}
-                                suggestion={sp.summaryTitle}
-                                onClick={() => {
-                                  trackEvent("prompt_selected", {
-                                    agentId: initialAgentId ?? undefined,
-                                    promptLength: sp.prompt.length,
-                                  });
-                                  submitInitialMessage({
-                                    text: sp.prompt,
-                                    files: [],
-                                  });
-                                }}
-                              />
-                            ))}
-                          </div>
-                        );
-                      })()}
-                      <div className="w-full max-w-4xl">
-                        <ArchestraPromptInput
-                          onSubmit={handleInitialSubmit}
-                          status={
-                            createConversationMutation.isPending
-                              ? "submitted"
-                              : "ready"
-                          }
-                          selectedModel={initialModel}
-                          onModelChange={handleInitialModelChange}
-                          agentId={newChatAgentId}
-                          currentProvider={initialProvider}
-                          textareaRef={textareaRef}
-                          initialApiKeyId={initialApiKeyId}
-                          onApiKeyChange={setInitialApiKeyId}
-                          onProviderChange={handleInitialProviderChange}
-                          allowFileUploads={
-                            organization?.allowChatFileUploads ?? false
-                          }
-                          isModelsLoading={isModelsLoading}
-                          inputModalities={selectedModelInputModalities}
-                          agentLlmApiKeyId={
-                            (
-                              internalAgents.find(
-                                (a) => a.id === initialAgentId,
-                              ) as Record<string, unknown> | undefined
-                            )?.llmApiKeyId as string | null
-                          }
-                          submitDisabled={isPlaywrightSetupVisible}
-                          isPlaywrightSetupVisible={isPlaywrightSetupVisible}
-                          selectorAgentId={initialAgentId}
-                          onAgentChange={handleInitialAgentChange}
-                          modelSource={initialModelSource}
-                          onResetModelOverride={handleResetModelOverride}
-                          agentRequiresPerUserConnect={
-                            initialPerUserConnect.needsConnect
-                          }
-                          agentModelDisplayName={
-                            initialPerUserConnect.needsConnect
-                              ? initialPerUserConnect.modelName
-                              : undefined
-                          }
-                          prefillText={composerPrefill}
-                          onPrefillApplied={handleComposerPrefillApplied}
+                  /* The exit fade covers the splash decoration (logo,
+                     suggestions) when a conversation takes over; the composer
+                     below is excluded — it carries its own shared name and
+                     morphs to the bottom-anchored composer instead. */
+                  <ViewTransition exit="chat-splash-exit" default="none">
+                    {/* biome-ignore lint/a11y/noStaticElementInteractions: click-to-focus container */}
+                    {/* biome-ignore lint/a11y/useKeyWithClickEvents: click-to-focus container */}
+                    <div
+                      className="relative flex-1 flex flex-col min-h-0"
+                      onClick={(e) => {
+                        // Focus textarea when clicking empty space outside interactive elements
+                        if (
+                          e.target === e.currentTarget ||
+                          !(e.target as HTMLElement).closest(
+                            "button, a, input, textarea, [role=combobox], [data-slot=input-group]",
+                          )
+                        ) {
+                          textareaRef.current?.focus();
+                        }
+                      }}
+                    >
+                      {((organization?.chatLinks?.length ?? 0) > 0 ||
+                        organization?.onboardingWizard) && (
+                        <div className="absolute top-4 right-4 z-10 flex flex-wrap justify-end gap-2 max-w-[min(100%,36rem)]">
+                          {organization?.chatLinks?.map((link) => (
+                            <ChatLinkButton
+                              key={`link-${link.label}-${link.url}`}
+                              url={link.url}
+                              label={link.label}
+                            />
+                          ))}
+                          {organization?.onboardingWizard && (
+                            <OnboardingWizardButton
+                              wizard={organization.onboardingWizard}
+                            />
+                          )}
+                        </div>
+                      )}
+                      {isPlaywrightSetupRequired && canUpdateAgent && (
+                        <PlaywrightInstallDialog
+                          agentId={playwrightSetupAgentId}
+                          conversationId={conversationId}
                         />
+                      )}
+                      <div className="flex-1 flex flex-col items-center justify-center p-4 gap-8">
+                        <div className="scale-150">
+                          <AppLogo />
+                        </div>
+                        {(() => {
+                          const currentAgent = internalAgents.find(
+                            (a) => a.id === initialAgentId,
+                          );
+                          const prompts = currentAgent?.suggestedPrompts;
+                          if (!prompts || prompts.length === 0) return null;
+                          return (
+                            <div className="flex flex-wrap items-center justify-center gap-2 max-w-2xl">
+                              {prompts.map((sp) => (
+                                <Suggestion
+                                  key={`${sp.summaryTitle}-${sp.prompt}`}
+                                  suggestion={sp.summaryTitle}
+                                  onClick={() => {
+                                    trackEvent("prompt_selected", {
+                                      agentId: initialAgentId ?? undefined,
+                                      promptLength: sp.prompt.length,
+                                    });
+                                    submitInitialMessage({
+                                      text: sp.prompt,
+                                      files: [],
+                                    });
+                                  }}
+                                />
+                              ))}
+                            </div>
+                          );
+                        })()}
+                        {/* Shared-element pair with the conversation composer —
+                          see the bottom-anchored ViewTransition above. */}
+                        <ViewTransition
+                          name="chat-composer"
+                          share="chat-composer-morph"
+                          default="none"
+                        >
+                          <div className="w-full max-w-4xl">
+                            <ArchestraPromptInput
+                              onSubmit={handleInitialSubmit}
+                              status={
+                                createConversationMutation.isPending
+                                  ? "submitted"
+                                  : "ready"
+                              }
+                              selectedModel={initialModel}
+                              onModelChange={handleInitialModelChange}
+                              agentId={newChatAgentId}
+                              currentProvider={initialProvider}
+                              textareaRef={textareaRef}
+                              initialApiKeyId={initialApiKeyId}
+                              onApiKeyChange={setInitialApiKeyId}
+                              onProviderChange={handleInitialProviderChange}
+                              allowFileUploads={
+                                organization?.allowChatFileUploads ?? false
+                              }
+                              isModelsLoading={isModelsLoading}
+                              inputModalities={selectedModelInputModalities}
+                              agentLlmApiKeyId={
+                                (
+                                  internalAgents.find(
+                                    (a) => a.id === initialAgentId,
+                                  ) as Record<string, unknown> | undefined
+                                )?.llmApiKeyId as string | null
+                              }
+                              submitDisabled={isPlaywrightSetupVisible}
+                              isPlaywrightSetupVisible={
+                                isPlaywrightSetupVisible
+                              }
+                              selectorAgentId={initialAgentId}
+                              onAgentChange={handleInitialAgentChange}
+                              modelSource={initialModelSource}
+                              onResetModelOverride={handleResetModelOverride}
+                              agentRequiresPerUserConnect={
+                                initialPerUserConnect.needsConnect
+                              }
+                              agentModelDisplayName={
+                                initialPerUserConnect.needsConnect
+                                  ? initialPerUserConnect.modelName
+                                  : undefined
+                              }
+                              prefillText={composerPrefill}
+                              onPrefillApplied={handleComposerPrefillApplied}
+                            />
+                          </div>
+                        </ViewTransition>
+                      </div>
+                      <div className="p-4 text-center">
+                        <Version inline />
                       </div>
                     </div>
-                    <div className="p-4 text-center">
-                      <Version inline />
-                    </div>
-                  </div>
+                  </ViewTransition>
                 )
               )}
             </div>

--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -386,3 +386,76 @@ div:has(> [data-testid="emoji-picker-list-header"]) {
   transform-origin: 70% 75%;
   animation: feedback-wave 1.8s ease-in-out 0.4s 2;
 }
+
+/* === Chat new-chat → conversation view transition ===
+   Drives the React <ViewTransition> boundaries in app/chat/page.tsx and
+   components/chat/new-chat-composer.tsx. The composer is a shared element
+   (name "chat-composer") that morphs from the centered splash (or a project
+   page) to the conversation's bottom anchor; the splash decoration leaves
+   fast, the message thread eases in slightly later. Timing is asymmetric on
+   purpose: old content leaves quickly, new content arrives gently. */
+
+:root {
+  /* Damped-spring position curve (zeta 0.72), ~4% overshoot then settle —
+     gives the morph a soft physical landing instead of a linear glide. */
+  --chat-transition-spring: linear(
+    0, 0.065, 0.211, 0.387, 0.559, 0.708, 0.827, 0.914, 0.974, 1.011, 1.03,
+    1.038, 1.038, 1.033, 1.027, 1.02, 1.014, 1.008, 1.005, 1.002, 1, 0.999,
+    0.999, 0.999, 1
+  );
+  /* Luxurious decelerating glide (easeOutExpo-ish) for fades. */
+  --chat-transition-glide: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+::view-transition-group(.chat-composer-morph) {
+  animation-duration: 500ms;
+  animation-timing-function: var(--chat-transition-spring);
+}
+::view-transition-image-pair(.chat-composer-morph) {
+  animation-name: chat-composer-blur;
+}
+/* A touch of mid-flight blur hides pixel interpolation artifacts while the
+   composer snapshot is stretched between its two sizes. */
+@keyframes chat-composer-blur {
+  30% {
+    filter: blur(1.5px);
+  }
+}
+
+::view-transition-old(.chat-splash-exit) {
+  animation: 160ms ease-out both chat-transition-fade reverse;
+}
+::view-transition-new(.chat-thread-enter) {
+  animation:
+    300ms var(--chat-transition-glide) 90ms both chat-transition-fade,
+    460ms var(--chat-transition-spring) both chat-transition-rise;
+}
+
+@keyframes chat-transition-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes chat-transition-rise {
+  from {
+    transform: translateY(16px);
+  }
+  to {
+    transform: none;
+  }
+}
+
+/* Motion sensitivity: collapse every view transition to an instant swap (the
+   browser's non-animated default). */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-image-pair(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}

--- a/platform/frontend/src/components/chat/new-chat-composer.tsx
+++ b/platform/frontend/src/components/chat/new-chat-composer.tsx
@@ -9,6 +9,7 @@ import { useInitialChatModelState } from "@/lib/chat/use-initial-chat-model-stat
 import { useLlmModels, useLlmModelsByProvider } from "@/lib/llm-models.query";
 import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
 import { useOrganization } from "@/lib/organization.query";
+import { ViewTransition } from "@/lib/view-transition";
 
 /**
  * The /chat "new conversation" composer as a standalone component: the SAME
@@ -78,47 +79,57 @@ export function NewChatComposer({
   if (!agentId) return null;
 
   return (
-    // auto-height wrapper: ArchestraPromptInput's own `size-full justify-end`
-    // shell (built for the bottom-anchored /chat layout) collapses against it
-    // instead of stretching to the surrounding column.
-    <div className="w-full">
-      <ArchestraPromptInput
-        onSubmit={(message) => {
-          const text = message.text?.trim() ?? "";
-          const files = message.files ?? [];
-          // Nothing to start a chat with.
-          if (!text && files.length === 0) return;
-          // Data URLs are too large to pass inline, so stash attachments in
-          // memory for the caller to drain once the conversation exists. Always
-          // set — an empty array clears any abandoned prior set so a text-only
-          // handoff never inherits stale files.
-          setPendingChatHandoffFiles(files);
-          onSubmit({ text, agentId, modelId, apiKeyId });
-        }}
-        status="ready"
-        selectedModel={modelId}
-        onModelChange={onModelChange}
-        agentId={agentId}
-        currentProvider={provider}
-        initialApiKeyId={apiKeyId}
-        onApiKeyChange={setApiKeyId}
-        onProviderChange={onProviderChange}
-        allowFileUploads={organization?.allowChatFileUploads ?? false}
-        isModelsLoading={isModelsLoading}
-        inputModalities={inputModalities}
-        agentLlmApiKeyId={
-          (
-            internalAgents.find((a) => a.id === agentId) as
-              | Record<string, unknown>
-              | undefined
-          )?.llmApiKeyId as string | null
-        }
-        isPlaywrightSetupVisible={false}
-        selectorAgentId={agentId}
-        onAgentChange={onAgentChange}
-        modelSource={modelSource}
-        onResetModelOverride={onResetModelOverride}
-      />
-    </div>
+    // Shared-element pair with the /chat composer: when the started chat
+    // navigates to /chat/<id>, the composer morphs from its spot on this page
+    // to the conversation's bottom-anchored composer instead of hard-cutting.
+    <ViewTransition
+      name="chat-composer"
+      share="chat-composer-morph"
+      default="none"
+    >
+      {/* auto-height wrapper: ArchestraPromptInput's own `size-full
+          justify-end` shell (built for the bottom-anchored /chat layout)
+          collapses against it instead of stretching to the surrounding
+          column. */}
+      <div className="w-full">
+        <ArchestraPromptInput
+          onSubmit={(message) => {
+            const text = message.text?.trim() ?? "";
+            const files = message.files ?? [];
+            // Nothing to start a chat with.
+            if (!text && files.length === 0) return;
+            // Data URLs are too large to pass inline, so stash attachments in
+            // memory for the caller to drain once the conversation exists. Always
+            // set — an empty array clears any abandoned prior set so a text-only
+            // handoff never inherits stale files.
+            setPendingChatHandoffFiles(files);
+            onSubmit({ text, agentId, modelId, apiKeyId });
+          }}
+          status="ready"
+          selectedModel={modelId}
+          onModelChange={onModelChange}
+          agentId={agentId}
+          currentProvider={provider}
+          initialApiKeyId={apiKeyId}
+          onApiKeyChange={setApiKeyId}
+          onProviderChange={onProviderChange}
+          allowFileUploads={organization?.allowChatFileUploads ?? false}
+          isModelsLoading={isModelsLoading}
+          inputModalities={inputModalities}
+          agentLlmApiKeyId={
+            (
+              internalAgents.find((a) => a.id === agentId) as
+                | Record<string, unknown>
+                | undefined
+            )?.llmApiKeyId as string | null
+          }
+          isPlaywrightSetupVisible={false}
+          selectorAgentId={agentId}
+          onAgentChange={onAgentChange}
+          modelSource={modelSource}
+          onResetModelOverride={onResetModelOverride}
+        />
+      </div>
+    </ViewTransition>
   );
 }

--- a/platform/frontend/src/lib/view-transition.tsx
+++ b/platform/frontend/src/lib/view-transition.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+type ViewTransitionProps = {
+  /** Shared-element identity: elements with the same name on the old and new
+   * tree are morphed between their positions/sizes. */
+  name?: string;
+  /** Animation class applied when this element is paired with a same-named
+   * element across a transition (targeted via ::view-transition-*(.class)). */
+  share?: string;
+  /** Animation class applied when this element enters during a transition. */
+  enter?: string;
+  /** Animation class applied when this element exits during a transition. */
+  exit?: string;
+  /** Fallback for activations not covered above; "none" opts out of the
+   * default crossfade during unrelated transitions. */
+  default?: string;
+  children?: React.ReactNode;
+};
+
+// React's <ViewTransition> ships in the React canary that Next bundles for the
+// App Router (integration enabled via experimental.viewTransition in
+// next.config.ts), but not in the standalone `react` package that TypeScript
+// and vitest resolve. Fall back to rendering children unwrapped there — the UI
+// is identical, just without the animation (same graceful degradation as
+// browsers without the View Transitions API).
+const ReactViewTransition = (
+  React as unknown as {
+    ViewTransition?: React.ComponentType<ViewTransitionProps>;
+  }
+).ViewTransition;
+
+export const ViewTransition: React.ComponentType<ViewTransitionProps> =
+  ReactViewTransition ?? (({ children }) => <>{children}</>);


### PR DESCRIPTION
Typing a prompt on /chat (or a project page) redirected to /chat/<id>, remounting the whole chat page mid-stream — visible flicker, focus loss, and a hard layout cut.

- Shallow-route /chat -> /chat/<id> via history.pushState: the mounted page keeps rendering the conversation it just created; deep links, refresh, and back/forward still resolve through the /chat/[conversationId] route. Navigating back to /chat reuses the instance, so the selection now resets from the pathname.
- Animate the handoff with React <ViewTransition> (experimental.viewTransition): the composer is a shared element that morphs from the centered splash (and from the project-page composer) to the conversation's bottom anchor; splash fades out, thread rises in. Falls back to an instant swap on browsers without the View Transitions API and under prefers-reduced-motion.
- Keep the splash mounted during interactive submits: isAutoSendHandoffInProgress no longer treats a pending create-conversation mutation as a deep-link handoff (that unmounted the focused composer and flashed an empty pane on every Enter).
- Send the deferred first message inside startTransition so its commit joins the running animation instead of cancelling it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>