### PR TITLE
fix(frontend): show built-in environment egress as unrestricted, not restricted

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import { resolveEditorDraftPolicy } from "./environment-policy-draft";
+
+type NetworkPolicy = NonNullable<
+  Parameters<typeof resolveEditorDraftPolicy>[0]["policy"]
+>;
+
+const restricted: NetworkPolicy = {
+  egressMode: "restricted",
+  domainPreset: "none",
+  allowedDomains: ["api.example.com"],
+  allowedCidrs: ["10.0.0.0/8"],
+};
+
+describe("resolveEditorDraftPolicy", () => {
+  test("an explicit policy is returned as-is in every mode", () => {
+    for (const mode of ["create", "edit", "default"] as const) {
+      expect(
+        resolveEditorDraftPolicy({
+          mode,
+          policy: restricted,
+          orgDefaultPolicy: null,
+        }),
+      ).toBe(restricted);
+    }
+  });
+
+  test("create with no policy seeds the locked-down restricted default", () => {
+    expect(
+      resolveEditorDraftPolicy({
+        mode: "create",
+        policy: null,
+        orgDefaultPolicy: null,
+      }),
+    ).toMatchObject({ egressMode: "restricted" });
+  });
+
+  test("the org-default editor with no policy seeds unrestricted (built-in floor), not restricted", () => {
+    expect(
+      resolveEditorDraftPolicy({
+        mode: "default",
+        policy: null,
+        orgDefaultPolicy: null,
+      }),
+    ).toMatchObject({ egressMode: "unrestricted" });
+  });
+
+  test("an existing environment with no policy inherits the org default", () => {
+    expect(
+      resolveEditorDraftPolicy({
+        mode: "edit",
+        policy: null,
+        orgDefaultPolicy: restricted,
+      }),
+    ).toBe(restricted);
+  });
+
+  test("an existing environment with no policy and no org default seeds unrestricted (built-in), not restricted", () => {
+    expect(
+      resolveEditorDraftPolicy({
+        mode: "edit",
+        policy: null,
+        orgDefaultPolicy: null,
+      }),
+    ).toMatchObject({ egressMode: "unrestricted" });
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { resolveEditorDraftPolicy } from "./environment-policy-draft";
+import {
+  buildEditorNetworkPolicy,
+  resolveEditorDraftPolicy,
+  resolveNetworkPolicyUpdate,
+} from "./environment-policy-draft";
 
 type NetworkPolicy = NonNullable<
   Parameters<typeof resolveEditorDraftPolicy>[0]["policy"]
@@ -19,51 +23,253 @@ describe("resolveEditorDraftPolicy", () => {
         resolveEditorDraftPolicy({
           mode,
           policy: restricted,
+          orgDefaultPolicy: null,
           policyLoaded: true,
         }),
       ).toBe(restricted);
     }
   });
 
-  test("create with no policy seeds the locked-down restricted default", () => {
+  test("create with no policy seeds the locked-down restricted default, ignoring the org default", () => {
+    // `restricted` (the org default here) shares egressMode with the create seed,
+    // so assert the seed's empty allowlist to prove the org default is not returned.
     expect(
       resolveEditorDraftPolicy({
         mode: "create",
         policy: null,
+        orgDefaultPolicy: restricted,
         policyLoaded: true,
       }),
-    ).toMatchObject({ egressMode: "restricted" });
+    ).toMatchObject({ egressMode: "restricted", allowedDomains: [] });
   });
 
-  test("editing a named environment with no policy seeds restricted, never widening it open", () => {
+  test("a null policy with no org default seeds the built-in unrestricted floor", () => {
+    // The org default (its own null) and a named env whose org default is also
+    // null both land on the floor — showing "restricted" would falsely read as
+    // locked down.
+    for (const mode of ["edit", "default"] as const) {
+      expect(
+        resolveEditorDraftPolicy({
+          mode,
+          policy: null,
+          orgDefaultPolicy: null,
+          policyLoaded: true,
+        }),
+      ).toMatchObject({ egressMode: "unrestricted" });
+    }
+  });
+
+  test("a null-policy env inheriting a restrictive org default seeds restricted, not unrestricted", () => {
+    // The env falls through to the org default, so the editor must show that
+    // default's restriction — not the floor, which would under-state it and let a
+    // touched save widen the env open.
     expect(
       resolveEditorDraftPolicy({
         mode: "edit",
         policy: null,
+        orgDefaultPolicy: restricted,
         policyLoaded: true,
       }),
-    ).toMatchObject({ egressMode: "restricted" });
+    ).toBe(restricted);
   });
 
-  test("the org-default editor with a loaded, absent policy seeds unrestricted (built-in floor)", () => {
+  test("a null policy whose org query is not yet loaded seeds restricted, not unrestricted", () => {
+    // A null from an unresolved/failed org query must not seed open egress that a
+    // deliberate touch-then-save during load could persist over a real default.
+    for (const mode of ["edit", "default"] as const) {
+      expect(
+        resolveEditorDraftPolicy({
+          mode,
+          policy: null,
+          orgDefaultPolicy: null,
+          policyLoaded: false,
+        }),
+      ).toMatchObject({ egressMode: "restricted" });
+    }
+  });
+});
+
+describe("buildEditorNetworkPolicy", () => {
+  const base = {
+    enforcementUnavailable: false,
+    egressMode: "restricted" as const,
+    domainPreset: "none" as const,
+    allowedDomainsText: "",
+    allowedCidrsText: "",
+    originalPolicy: null,
+  };
+
+  test("restricted mode parses the CIDR and domain textareas", () => {
     expect(
-      resolveEditorDraftPolicy({
-        mode: "default",
-        policy: null,
-        policyLoaded: true,
+      buildEditorNetworkPolicy({
+        ...base,
+        allowedDomainsText: "api.example.com\n*.registry.example.com",
+        allowedCidrsText: "203.0.113.0/24, 2001:db8::/32",
+      }),
+    ).toEqual({
+      egressMode: "restricted",
+      domainPreset: "none",
+      allowedDomains: ["api.example.com", "*.registry.example.com"],
+      allowedCidrs: ["203.0.113.0/24", "2001:db8::/32"],
+    });
+  });
+
+  test("off/unrestricted modes drop all allowlists", () => {
+    for (const egressMode of ["off", "unrestricted"] as const) {
+      expect(
+        buildEditorNetworkPolicy({
+          ...base,
+          egressMode,
+          allowedCidrsText: "203.0.113.0/24",
+          allowedDomainsText: "api.example.com",
+        }),
+      ).toEqual({
+        egressMode,
+        domainPreset: "none",
+        allowedDomains: [],
+        allowedCidrs: [],
+      });
+    }
+  });
+
+  test("a CIDR-only edit keeps the seeded (inherited) domain allowlist even when the env has no policy of its own", () => {
+    // With no FQDN provider the domain/preset fields are disabled but still hold
+    // the effective policy the editor seeded them with — an env inheriting the org
+    // default's domain rules keeps them (originalPolicy is null here), rather than
+    // materializing an override that silently drops rules the form can't re-enter.
+    expect(
+      buildEditorNetworkPolicy({
+        ...base,
+        domainPreset: "common_dependencies",
+        allowedDomainsText: "api.example.com",
+        allowedCidrsText: "203.0.113.0/24",
+        originalPolicy: null,
+      }),
+    ).toEqual({
+      egressMode: "restricted",
+      domainPreset: "common_dependencies",
+      allowedDomains: ["api.example.com"],
+      allowedCidrs: ["203.0.113.0/24"],
+    });
+  });
+
+  test("no enforcer keeps the existing policy rather than persisting a deny-all", () => {
+    const stored = {
+      egressMode: "restricted" as const,
+      domainPreset: "none" as const,
+      allowedDomains: [],
+      allowedCidrs: ["10.0.0.0/8"],
+    };
+    expect(
+      buildEditorNetworkPolicy({
+        ...base,
+        enforcementUnavailable: true,
+        originalPolicy: stored,
+      }),
+    ).toBe(stored);
+  });
+
+  test("no enforcer on a policy-less target seeds a non-enforcing (unrestricted) policy", () => {
+    expect(
+      buildEditorNetworkPolicy({
+        ...base,
+        enforcementUnavailable: true,
+        originalPolicy: null,
       }),
     ).toMatchObject({ egressMode: "unrestricted" });
   });
+});
 
-  test("the org-default editor whose policy is not yet loaded seeds restricted, not unrestricted", () => {
-    // A null policy from an unresolved/failed org query must not seed open egress
-    // that a save could persist over a restrictive real default.
+describe("resolveNetworkPolicyUpdate", () => {
+  const drafted: NetworkPolicy = {
+    egressMode: "unrestricted",
+    domainPreset: "none",
+    allowedDomains: [],
+    allowedCidrs: [],
+  };
+
+  test("create always sends the policy, even when the user never touched egress", () => {
     expect(
-      resolveEditorDraftPolicy({
-        mode: "default",
-        policy: null,
-        policyLoaded: false,
+      resolveNetworkPolicyUpdate({
+        mode: "create",
+        egressDirty: false,
+        originalPolicy: null,
+        orgLoaded: false,
+        networkPolicy: drafted,
       }),
-    ).toMatchObject({ egressMode: "restricted" });
+    ).toEqual({ networkPolicy: drafted });
+  });
+
+  test("an unchanged edit omits networkPolicy so the stored policy is left as-is", () => {
+    expect(
+      resolveNetworkPolicyUpdate({
+        mode: "edit",
+        egressDirty: false,
+        originalPolicy: null,
+        orgLoaded: true,
+        networkPolicy: drafted,
+      }),
+    ).toEqual({});
+  });
+
+  test("an unchanged org-default save omits networkPolicy, never widening the built-in floor", () => {
+    // The default editor seeds the egress control to `unrestricted` for display;
+    // omitting on an untouched save is what stops that seed reaching the backend
+    // and clearing a real restrictive default.
+    expect(
+      resolveNetworkPolicyUpdate({
+        mode: "default",
+        egressDirty: false,
+        originalPolicy: null,
+        orgLoaded: true,
+        networkPolicy: drafted,
+      }),
+    ).toEqual({});
+  });
+
+  test("a touched edit of an inheriting (null) policy waits for the org baseline to load", () => {
+    // While the org query is unresolved the draft is seeded from the locked-down
+    // fallback, not the real effective policy, so persisting a dirty edit could
+    // widen a narrower real one. Hold it back until the baseline loads, then send.
+    for (const mode of ["edit", "default"] as const) {
+      expect(
+        resolveNetworkPolicyUpdate({
+          mode,
+          egressDirty: true,
+          originalPolicy: null,
+          orgLoaded: false,
+          networkPolicy: drafted,
+        }),
+      ).toEqual({});
+      expect(
+        resolveNetworkPolicyUpdate({
+          mode,
+          egressDirty: true,
+          originalPolicy: null,
+          orgLoaded: true,
+          networkPolicy: drafted,
+        }),
+      ).toEqual({ networkPolicy: drafted });
+    }
+  });
+
+  test("a touched edit of an env's own explicit policy is sent even while the org query is down", () => {
+    // An explicit policy is its own baseline — it doesn't inherit — so an
+    // unavailable org query must not silently drop the admin's egress change.
+    const explicit: NetworkPolicy = {
+      egressMode: "restricted",
+      domainPreset: "none",
+      allowedDomains: [],
+      allowedCidrs: ["10.0.0.0/8"],
+    };
+    expect(
+      resolveNetworkPolicyUpdate({
+        mode: "edit",
+        egressDirty: true,
+        originalPolicy: explicit,
+        orgLoaded: false,
+        networkPolicy: drafted,
+      }),
+    ).toEqual({ networkPolicy: drafted });
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.test.ts
@@ -19,7 +19,7 @@ describe("resolveEditorDraftPolicy", () => {
         resolveEditorDraftPolicy({
           mode,
           policy: restricted,
-          orgDefaultPolicy: null,
+          policyLoaded: true,
         }),
       ).toBe(restricted);
     }
@@ -30,38 +30,40 @@ describe("resolveEditorDraftPolicy", () => {
       resolveEditorDraftPolicy({
         mode: "create",
         policy: null,
-        orgDefaultPolicy: null,
+        policyLoaded: true,
       }),
     ).toMatchObject({ egressMode: "restricted" });
   });
 
-  test("the org-default editor with no policy seeds unrestricted (built-in floor), not restricted", () => {
+  test("editing a named environment with no policy seeds restricted, never widening it open", () => {
+    expect(
+      resolveEditorDraftPolicy({
+        mode: "edit",
+        policy: null,
+        policyLoaded: true,
+      }),
+    ).toMatchObject({ egressMode: "restricted" });
+  });
+
+  test("the org-default editor with a loaded, absent policy seeds unrestricted (built-in floor)", () => {
     expect(
       resolveEditorDraftPolicy({
         mode: "default",
         policy: null,
-        orgDefaultPolicy: null,
+        policyLoaded: true,
       }),
     ).toMatchObject({ egressMode: "unrestricted" });
   });
 
-  test("an existing environment with no policy inherits the org default", () => {
+  test("the org-default editor whose policy is not yet loaded seeds restricted, not unrestricted", () => {
+    // A null policy from an unresolved/failed org query must not seed open egress
+    // that a save could persist over a restrictive real default.
     expect(
       resolveEditorDraftPolicy({
-        mode: "edit",
+        mode: "default",
         policy: null,
-        orgDefaultPolicy: restricted,
+        policyLoaded: false,
       }),
-    ).toBe(restricted);
-  });
-
-  test("an existing environment with no policy and no org default seeds unrestricted (built-in), not restricted", () => {
-    expect(
-      resolveEditorDraftPolicy({
-        mode: "edit",
-        policy: null,
-        orgDefaultPolicy: null,
-      }),
-    ).toMatchObject({ egressMode: "unrestricted" });
+    ).toMatchObject({ egressMode: "restricted" });
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.ts
@@ -1,0 +1,42 @@
+import type { EnvironmentWithAssignedCount } from "@/lib/environment.query";
+
+type NetworkPolicy = NonNullable<EnvironmentWithAssignedCount["networkPolicy"]>;
+
+// Draft seed when creating a *new* environment — a safe, locked-down starting point.
+const NEW_ENVIRONMENT_DEFAULT_POLICY: NetworkPolicy = {
+  egressMode: "restricted",
+  domainPreset: "none",
+  allowedDomains: [],
+  allowedCidrs: [],
+};
+
+// Draft seed for an environment (or the org default) with no explicit policy. The
+// backend treats a null/built-in policy as unrestricted — the SSRF floor: public
+// egress with reserved ranges blocked — so the editor must show that. Seeding
+// "restricted" here would mislabel an open environment as locked down.
+const BUILT_IN_NETWORK_POLICY: NetworkPolicy = {
+  egressMode: "unrestricted",
+  domainPreset: "none",
+  allowedDomains: [],
+  allowedCidrs: [],
+};
+
+/**
+ * The policy the environment editor should seed when it opens, matching what the
+ * backend actually resolves and enforces for that target:
+ * - an explicit policy → itself;
+ * - creating a new environment → the locked-down default;
+ * - an existing environment with no policy → the org default it inherits, else
+ *   the built-in unrestricted floor;
+ * - the org-default editor with no policy → the built-in unrestricted floor.
+ */
+export function resolveEditorDraftPolicy(params: {
+  mode: "create" | "edit" | "default";
+  policy: NetworkPolicy | null;
+  orgDefaultPolicy: NetworkPolicy | null;
+}): NetworkPolicy {
+  if (params.policy) return params.policy;
+  if (params.mode === "create") return NEW_ENVIRONMENT_DEFAULT_POLICY;
+  if (params.mode === "default") return BUILT_IN_NETWORK_POLICY;
+  return params.orgDefaultPolicy ?? BUILT_IN_NETWORK_POLICY;
+}

--- a/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.ts
@@ -22,25 +22,104 @@ const BUILT_IN_NETWORK_POLICY: NetworkPolicy = {
 };
 
 /**
- * The policy the environment editor should seed when it opens, chosen to match
- * what the backend enforces while never seeding — and letting a save persist —
- * open egress it can't confirm:
+ * The policy the environment editor should seed when it opens, resolved to the
+ * egress the backend actually enforces for the target so the control never reads
+ * as more locked-down (or more open) than reality:
  * - an explicit policy → itself;
- * - the org-default editor whose policy is *known* absent (`policyLoaded`, i.e.
- *   the org query has resolved) → the built-in unrestricted floor the backend
- *   enforces for a null policy;
- * - everything else — creating a new environment, editing a named one, or the
- *   org default not yet loaded/failed — → the locked-down "restricted" default,
- *   so an unresolved query can never widen a restrictive policy to open egress.
+ * - a null policy, once the org query has resolved (`policyLoaded`), follows the
+ *   backend's fall-through: a named environment inherits `orgDefaultPolicy`, and
+ *   the org default (or a named env whose org default is also null) lands on the
+ *   built-in unrestricted floor. So an env inheriting a restrictive default shows
+ *   "restricted", and a genuinely open one shows "unrestricted" — never the
+ *   reverse, which would mislabel an open environment as locked down;
+ * - creating a new environment, or a null policy while the org query is still
+ *   loading/failed → the locked-down "restricted" seed. A save never persists
+ *   this seed on its own (see resolveNetworkPolicyUpdate — an untouched egress
+ *   control is omitted), so it is safe against an unresolved query while it keeps
+ *   a deliberate touch-then-save during load from widening a real default.
  */
 export function resolveEditorDraftPolicy(params: {
   mode: "create" | "edit" | "default";
   policy: NetworkPolicy | null;
+  orgDefaultPolicy: NetworkPolicy | null;
   policyLoaded: boolean;
 }): NetworkPolicy {
   if (params.policy) return params.policy;
-  if (params.mode === "default" && params.policyLoaded) {
-    return BUILT_IN_NETWORK_POLICY;
+  if (params.mode === "create" || !params.policyLoaded) {
+    return NEW_ENVIRONMENT_DEFAULT_POLICY;
   }
-  return NEW_ENVIRONMENT_DEFAULT_POLICY;
+  return params.orgDefaultPolicy ?? BUILT_IN_NETWORK_POLICY;
+}
+
+/**
+ * Decides what to send for `networkPolicy` in an environment save, as a partial
+ * to spread into the mutation body. Creating always sends an explicit policy — a
+ * new environment starts from a locked-down default. Editing an environment or
+ * the org default only sends egress the user actually changed (`egressDirty`),
+ * and only once the baseline the draft was seeded against is known: an explicit
+ * stored policy (`originalPolicy`) is its own baseline, but a null one is seeded
+ * from the org default, so its edit waits for `orgLoaded` — a dirty edit made
+ * against a still-loading (or failed) org default is seeded from the locked-down
+ * fallback, not the real effective policy, and persisting it could widen a
+ * narrower real one. Otherwise the field is omitted, telling the backend to leave
+ * the stored policy as-is — so a passive save (name-only, off a stale cache, or
+ * against an unresolved baseline) never rewrites, widens, or clears the built-in
+ * (`null`) sentinel; and an edit to an env's own explicit policy is never dropped
+ * just because the unrelated org query is unavailable.
+ */
+export function resolveNetworkPolicyUpdate(params: {
+  mode: "create" | "edit" | "default";
+  egressDirty: boolean;
+  originalPolicy: NetworkPolicy | null;
+  orgLoaded: boolean;
+  networkPolicy: NetworkPolicy;
+}): { networkPolicy?: NetworkPolicy } {
+  if (params.mode === "create") {
+    return { networkPolicy: params.networkPolicy };
+  }
+  const baselineLoaded = params.originalPolicy !== null || params.orgLoaded;
+  if (params.egressDirty && baselineLoaded) {
+    return { networkPolicy: params.networkPolicy };
+  }
+  return {};
+}
+
+/**
+ * Builds the network policy the editor would submit from its current form state.
+ * The domain/preset fields carry whatever the draft was seeded with — the target's
+ * effective (possibly inherited) policy — even while disabled because no FQDN
+ * provider is available. Building domains straight from that form state means a
+ * CIDR-only edit persists the existing allowlist rather than erasing rules the
+ * form couldn't let the user re-enter. With no enforcer at all the whole egress
+ * section is disabled, so persisting the default restricted + empty allowlists
+ * would become a deny-all once an enforcer is installed — return the existing
+ * policy (or a non-enforcing seed) instead.
+ */
+export function buildEditorNetworkPolicy(params: {
+  enforcementUnavailable: boolean;
+  egressMode: NetworkPolicy["egressMode"];
+  domainPreset: NetworkPolicy["domainPreset"];
+  allowedDomainsText: string;
+  allowedCidrsText: string;
+  originalPolicy: NetworkPolicy | null;
+}): NetworkPolicy {
+  if (params.enforcementUnavailable) {
+    return params.originalPolicy ?? BUILT_IN_NETWORK_POLICY;
+  }
+  const restricted = params.egressMode === "restricted";
+  return {
+    egressMode: params.egressMode,
+    domainPreset: restricted ? params.domainPreset : "none",
+    allowedDomains: restricted
+      ? splitPolicyList(params.allowedDomainsText)
+      : [],
+    allowedCidrs: restricted ? splitPolicyList(params.allowedCidrsText) : [],
+  };
+}
+
+function splitPolicyList(value: string): string[] {
+  return value
+    .split(/\r?\n|,/)
+    .map((item) => item.trim())
+    .filter(Boolean);
 }

--- a/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/environment-policy-draft.ts
@@ -22,21 +22,25 @@ const BUILT_IN_NETWORK_POLICY: NetworkPolicy = {
 };
 
 /**
- * The policy the environment editor should seed when it opens, matching what the
- * backend actually resolves and enforces for that target:
+ * The policy the environment editor should seed when it opens, chosen to match
+ * what the backend enforces while never seeding — and letting a save persist —
+ * open egress it can't confirm:
  * - an explicit policy → itself;
- * - creating a new environment → the locked-down default;
- * - an existing environment with no policy → the org default it inherits, else
- *   the built-in unrestricted floor;
- * - the org-default editor with no policy → the built-in unrestricted floor.
+ * - the org-default editor whose policy is *known* absent (`policyLoaded`, i.e.
+ *   the org query has resolved) → the built-in unrestricted floor the backend
+ *   enforces for a null policy;
+ * - everything else — creating a new environment, editing a named one, or the
+ *   org default not yet loaded/failed — → the locked-down "restricted" default,
+ *   so an unresolved query can never widen a restrictive policy to open egress.
  */
 export function resolveEditorDraftPolicy(params: {
   mode: "create" | "edit" | "default";
   policy: NetworkPolicy | null;
-  orgDefaultPolicy: NetworkPolicy | null;
+  policyLoaded: boolean;
 }): NetworkPolicy {
   if (params.policy) return params.policy;
-  if (params.mode === "create") return NEW_ENVIRONMENT_DEFAULT_POLICY;
-  if (params.mode === "default") return BUILT_IN_NETWORK_POLICY;
-  return params.orgDefaultPolicy ?? BUILT_IN_NETWORK_POLICY;
+  if (params.mode === "default" && params.policyLoaded) {
+    return BUILT_IN_NETWORK_POLICY;
+  }
+  return NEW_ENVIRONMENT_DEFAULT_POLICY;
 }

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -51,6 +51,7 @@ import {
   ENVIRONMENT_EDIT_PARAM,
   setEnvironmentEditParam,
 } from "./environment-edit-link";
+import { resolveEditorDraftPolicy } from "./environment-policy-draft";
 import { compileValidationRegex } from "./environment-validation-helpers";
 
 const NETWORK_POLICY_DOCS_URL = getDocsUrl(
@@ -268,6 +269,7 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
         open={editTargetOpen}
         onOpenChange={(open) => !open && closeEditor()}
         environment={editEnvironment}
+        defaultEnvironment={defaultEnvironment}
         capabilities={capabilities}
       />
 
@@ -338,13 +340,6 @@ function NetworkPolicyCell({ policy }: { policy: NetworkPolicy | null }) {
 // the environment inherits the org default). shadcn Select can't use "".
 const NAMESPACE_DEFAULT_VALUE = "__default_namespace__";
 
-const EMPTY_NETWORK_POLICY: NetworkPolicy = {
-  egressMode: "restricted",
-  domainPreset: "none",
-  allowedDomains: [],
-  allowedCidrs: [],
-};
-
 function EnvironmentEditorDialog({
   mode,
   open,
@@ -399,12 +394,11 @@ function EnvironmentEditorDialog({
   const [registryDraft, setRegistryDraft] = useState("");
   const [registryError, setRegistryError] = useState<string | null>(null);
   const [showConfirm, setShowConfirm] = useState(false);
-  const syncNetworkPolicyDraft = useCallback((policy: NetworkPolicy | null) => {
-    const nextPolicy = policy ?? EMPTY_NETWORK_POLICY;
-    setEgressMode(nextPolicy.egressMode);
-    setDomainPreset(nextPolicy.domainPreset);
-    setAllowedDomainsText(nextPolicy.allowedDomains.join("\n"));
-    setAllowedCidrsText(nextPolicy.allowedCidrs.join("\n"));
+  const syncNetworkPolicyDraft = useCallback((policy: NetworkPolicy) => {
+    setEgressMode(policy.egressMode);
+    setDomainPreset(policy.domainPreset);
+    setAllowedDomainsText(policy.allowedDomains.join("\n"));
+    setAllowedCidrsText(policy.allowedCidrs.join("\n"));
   }, []);
 
   // Sync drafts whenever the dialog (re)opens for a target.
@@ -417,7 +411,13 @@ function EnvironmentEditorDialog({
         setName(defaultEnvironment?.name ?? "");
         setNamespace(defaultEnvironment?.namespace ?? "");
         setDescription(defaultEnvironment?.description ?? "");
-        syncNetworkPolicyDraft(defaultEnvironment?.networkPolicy ?? null);
+        syncNetworkPolicyDraft(
+          resolveEditorDraftPolicy({
+            mode: "default",
+            policy: defaultEnvironment?.networkPolicy ?? null,
+            orgDefaultPolicy: null,
+          }),
+        );
         setRestricted(defaultEnvironment?.restricted ?? false);
         setValidationRegex(defaultEnvironment?.validationRegex ?? "");
         setTrustedImageRegistries(
@@ -427,7 +427,13 @@ function EnvironmentEditorDialog({
         setName(environment?.name ?? "");
         setNamespace(environment?.namespace ?? "");
         setDescription(environment?.description ?? "");
-        syncNetworkPolicyDraft(environment?.networkPolicy ?? null);
+        syncNetworkPolicyDraft(
+          resolveEditorDraftPolicy({
+            mode,
+            policy: environment?.networkPolicy ?? null,
+            orgDefaultPolicy: defaultEnvironment?.networkPolicy ?? null,
+          }),
+        );
         setRestricted(environment?.restricted ?? false);
         setValidationRegex(environment?.validationRegex ?? "");
         setTrustedImageRegistries(environment?.trustedImageRegistries ?? []);

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -52,7 +52,11 @@ import {
   ENVIRONMENT_EDIT_PARAM,
   setEnvironmentEditParam,
 } from "./environment-edit-link";
-import { resolveEditorDraftPolicy } from "./environment-policy-draft";
+import {
+  buildEditorNetworkPolicy,
+  resolveEditorDraftPolicy,
+  resolveNetworkPolicyUpdate,
+} from "./environment-policy-draft";
 import { compileValidationRegex } from "./environment-validation-helpers";
 
 const NETWORK_POLICY_DOCS_URL = getDocsUrl(
@@ -270,6 +274,7 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
         open={editTargetOpen}
         onOpenChange={(open) => !open && closeEditor()}
         environment={editEnvironment}
+        defaultEnvironment={defaultEnvironment}
         capabilities={capabilities}
       />
 
@@ -386,6 +391,10 @@ function EnvironmentEditorDialog({
   const [domainPreset, setDomainPreset] = useState<DomainPreset>("none");
   const [allowedDomainsText, setAllowedDomainsText] = useState("");
   const [allowedCidrsText, setAllowedCidrsText] = useState("");
+  // Whether the user changed any egress control since the dialog opened. Only a
+  // touched policy is persisted — see resolveNetworkPolicyUpdate — so seeding the
+  // controls for display never lets a passive save rewrite the stored policy.
+  const [egressDirty, setEgressDirty] = useState(false);
   const [restricted, setRestricted] = useState(false);
   const [validationRegex, setValidationRegex] = useState("");
   const [trustedImageRegistries, setTrustedImageRegistries] = useState<
@@ -411,6 +420,10 @@ function EnvironmentEditorDialog({
       setShowConfirm(false);
       setRegistryDraft("");
       setRegistryError(null);
+      setEgressDirty(false);
+      // The org default a null-policy env falls through to. Only trustworthy once
+      // the org query has resolved (orgLoaded), so the seed gates on it.
+      const orgDefaultPolicy = defaultEnvironment?.networkPolicy ?? null;
       if (mode === "default") {
         setName(defaultEnvironment?.name ?? "");
         setNamespace(defaultEnvironment?.namespace ?? "");
@@ -418,7 +431,8 @@ function EnvironmentEditorDialog({
         syncNetworkPolicyDraft(
           resolveEditorDraftPolicy({
             mode: "default",
-            policy: defaultEnvironment?.networkPolicy ?? null,
+            policy: orgDefaultPolicy,
+            orgDefaultPolicy,
             policyLoaded: orgLoaded,
           }),
         );
@@ -435,7 +449,8 @@ function EnvironmentEditorDialog({
           resolveEditorDraftPolicy({
             mode,
             policy: environment?.networkPolicy ?? null,
-            policyLoaded: true,
+            orgDefaultPolicy,
+            policyLoaded: orgLoaded,
           }),
         );
         setRestricted(environment?.restricted ?? false);
@@ -496,32 +511,25 @@ function EnvironmentEditorDialog({
   const supportsFqdn = capabilities?.networkPolicy.supportsFqdn === true;
   const enforcementUnavailable =
     capabilities?.networkPolicy.provider === "none";
-  // With no enforcer the egress controls are disabled, so the form can't express
-  // intent. Persisting the default "restricted" + empty allowlists would silently
-  // become a deny-all once an enforcer is installed. Keep an existing policy
-  // untouched; for a new/policy-less environment save a non-enforcing one.
   const originalNetworkPolicy =
     mode === "default"
       ? (defaultEnvironment?.networkPolicy ?? null)
       : (environment?.networkPolicy ?? null);
-  const networkPolicy: NetworkPolicy = enforcementUnavailable
-    ? (originalNetworkPolicy ?? {
-        egressMode: "unrestricted",
-        domainPreset: "none",
-        allowedDomains: [],
-        allowedCidrs: [],
-      })
-    : {
-        egressMode,
-        domainPreset:
-          egressMode === "restricted" && supportsFqdn ? domainPreset : "none",
-        allowedDomains:
-          egressMode === "restricted" && supportsFqdn
-            ? splitPolicyList(allowedDomainsText)
-            : [],
-        allowedCidrs:
-          egressMode === "restricted" ? splitPolicyList(allowedCidrsText) : [],
-      };
+  // A null-policy target is seeded from the org default, so its egress can't be
+  // edited until that query resolves — otherwise a change would be seeded off the
+  // locked-down fallback and dropped on save (see resolveNetworkPolicyUpdate),
+  // acknowledged as saved but never applied. An explicit policy is its own
+  // baseline and stays editable regardless. Create needs no baseline.
+  const egressBaselineLoaded =
+    mode === "create" || originalNetworkPolicy !== null || orgLoaded;
+  const networkPolicy = buildEditorNetworkPolicy({
+    enforcementUnavailable,
+    egressMode,
+    domainPreset,
+    allowedDomainsText,
+    allowedCidrsText,
+    originalPolicy: originalNetworkPolicy,
+  });
 
   // The current value is included so editing an environment whose namespace
   // predates the configured list never silently drops it.
@@ -541,13 +549,20 @@ function EnvironmentEditorDialog({
     const namespaceValue = trimmedNamespace === "" ? null : trimmedNamespace;
     const descriptionValue =
       trimmedDescription === "" ? null : trimmedDescription;
+    const policyPatch = resolveNetworkPolicyUpdate({
+      mode,
+      egressDirty,
+      originalPolicy: originalNetworkPolicy,
+      orgLoaded,
+      networkPolicy,
+    });
     if (mode === "create") {
       createMutation.mutate(
         {
           name: trimmedName,
           namespace: namespaceValue,
           description: descriptionValue,
-          networkPolicy,
+          ...policyPatch,
           restricted,
           validationRegex: validationRegexValue,
           trustedImageRegistries: trustedImageRegistriesValue,
@@ -560,7 +575,7 @@ function EnvironmentEditorDialog({
           name: trimmedName,
           namespace: namespaceValue,
           description: descriptionValue,
-          networkPolicy,
+          ...policyPatch,
           restricted,
           validationRegex: validationRegexValue,
           trustedImageRegistries: trustedImageRegistriesValue,
@@ -575,7 +590,7 @@ function EnvironmentEditorDialog({
             name: trimmedName,
             namespace: namespaceValue,
             description: descriptionValue,
-            networkPolicy,
+            ...policyPatch,
             restricted,
             validationRegex: validationRegexValue,
             trustedImageRegistries: trustedImageRegistriesValue,
@@ -794,16 +809,29 @@ function EnvironmentEditorDialog({
 
           <NetworkPolicyFields
             egressMode={egressMode}
-            setEgressMode={setEgressMode}
+            setEgressMode={(value) => {
+              setEgressMode(value);
+              setEgressDirty(true);
+            }}
             domainPreset={domainPreset}
-            setDomainPreset={setDomainPreset}
+            setDomainPreset={(value) => {
+              setDomainPreset(value);
+              setEgressDirty(true);
+            }}
             allowedDomainsText={allowedDomainsText}
-            setAllowedDomainsText={setAllowedDomainsText}
+            setAllowedDomainsText={(value) => {
+              setAllowedDomainsText(value);
+              setEgressDirty(true);
+            }}
             allowedCidrsText={allowedCidrsText}
-            setAllowedCidrsText={setAllowedCidrsText}
+            setAllowedCidrsText={(value) => {
+              setAllowedCidrsText(value);
+              setEgressDirty(true);
+            }}
             supportsFqdn={supportsFqdn}
             provider={capabilities?.networkPolicy.provider ?? null}
-            disabled={isPending}
+            baselineLoaded={egressBaselineLoaded}
+            disabled={isPending || !egressBaselineLoaded}
           />
         </section>
       </DialogBody>
@@ -844,6 +872,7 @@ function NetworkPolicyFields({
   setAllowedCidrsText,
   supportsFqdn,
   provider,
+  baselineLoaded,
   disabled,
 }: {
   egressMode: EgressMode;
@@ -856,6 +885,7 @@ function NetworkPolicyFields({
   setAllowedCidrsText: (value: string) => void;
   supportsFqdn: boolean;
   provider: string | null;
+  baselineLoaded: boolean;
   disabled: boolean;
 }) {
   // No enforcer on the cluster: every rule below would be accepted but never
@@ -876,6 +906,16 @@ function NetworkPolicyFields({
             <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
               View docs
             </ExternalDocsLink>
+          </AlertDescription>
+        </Alert>
+      ) : !baselineLoaded ? (
+        <Alert variant="info">
+          <Info className="h-4 w-4" />
+          <AlertTitle>Organization default not loaded</AlertTitle>
+          <AlertDescription className="block leading-6">
+            This environment inherits its egress from the organization default,
+            which hasn't loaded. Editing is disabled until it's available, so a
+            change isn't saved against the wrong baseline.
           </AlertDescription>
         </Alert>
       ) : !supportsFqdn ? (
@@ -1016,13 +1056,6 @@ function FieldLabel({
       </Popover>
     </div>
   );
-}
-
-function splitPolicyList(value: string): string[] {
-  return value
-    .split(/\r?\n|,/)
-    .map((item) => item.trim())
-    .filter(Boolean);
 }
 
 function formatEgressMode(mode: EgressMode) {

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/lib/environment.query";
 import {
   useDefaultEnvironment,
+  useOrganization,
   useUpdateDefaultEnvironment,
 } from "@/lib/organization.query";
 import {
@@ -269,7 +270,6 @@ export function EnvironmentsSection({ canEdit }: { canEdit: boolean }) {
         open={editTargetOpen}
         onOpenChange={(open) => !open && closeEditor()}
         environment={editEnvironment}
-        defaultEnvironment={defaultEnvironment}
         capabilities={capabilities}
       />
 
@@ -401,6 +401,10 @@ function EnvironmentEditorDialog({
     setAllowedCidrsText(policy.allowedCidrs.join("\n"));
   }, []);
 
+  // Whether the org query has resolved — so a null org default policy can be
+  // trusted as genuinely absent (→ unrestricted floor) rather than still-loading.
+  const { isSuccess: orgLoaded } = useOrganization();
+
   // Sync drafts whenever the dialog (re)opens for a target.
   useEffect(() => {
     if (open) {
@@ -415,7 +419,7 @@ function EnvironmentEditorDialog({
           resolveEditorDraftPolicy({
             mode: "default",
             policy: defaultEnvironment?.networkPolicy ?? null,
-            orgDefaultPolicy: null,
+            policyLoaded: orgLoaded,
           }),
         );
         setRestricted(defaultEnvironment?.restricted ?? false);
@@ -431,7 +435,7 @@ function EnvironmentEditorDialog({
           resolveEditorDraftPolicy({
             mode,
             policy: environment?.networkPolicy ?? null,
-            orgDefaultPolicy: defaultEnvironment?.networkPolicy ?? null,
+            policyLoaded: true,
           }),
         );
         setRestricted(environment?.restricted ?? false);
@@ -439,7 +443,14 @@ function EnvironmentEditorDialog({
         setTrustedImageRegistries(environment?.trustedImageRegistries ?? []);
       }
     }
-  }, [open, mode, environment, defaultEnvironment, syncNetworkPolicyDraft]);
+  }, [
+    open,
+    mode,
+    environment,
+    defaultEnvironment,
+    orgLoaded,
+    syncNetworkPolicyDraft,
+  ]);
 
   const isPending =
     createMutation.isPending ||

--- a/platform/frontend/src/lib/organization.query.ts
+++ b/platform/frontend/src/lib/organization.query.ts
@@ -6,6 +6,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Invitation } from "better-auth/plugins/organization";
 import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 import { toast } from "sonner";
 import { useSession } from "@/lib/auth/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
@@ -512,16 +513,22 @@ export function useUpdateDefaultEnvironment(
  */
 export function useDefaultEnvironment() {
   const { data: organization } = useOrganization();
-  return {
-    name: organization?.defaultEnvironmentName ?? "Default",
-    namespace: organization?.defaultEnvironmentNamespace ?? null,
-    description: organization?.defaultEnvironmentDescription ?? null,
-    networkPolicy: organization?.defaultNetworkPolicy ?? null,
-    restricted: organization?.defaultEnvironmentRestricted ?? false,
-    validationRegex: organization?.defaultEnvironmentValidationRegex ?? null,
-    trustedImageRegistries:
-      organization?.defaultEnvironmentTrustedImageRegistries ?? null,
-  };
+  // Memoized on the query data so the object is reference-stable across renders:
+  // consumers seed a form off it in an effect, and a fresh object each render
+  // would re-run that effect on every background refetch and wipe unsaved edits.
+  return useMemo(
+    () => ({
+      name: organization?.defaultEnvironmentName ?? "Default",
+      namespace: organization?.defaultEnvironmentNamespace ?? null,
+      description: organization?.defaultEnvironmentDescription ?? null,
+      networkPolicy: organization?.defaultNetworkPolicy ?? null,
+      restricted: organization?.defaultEnvironmentRestricted ?? false,
+      validationRegex: organization?.defaultEnvironmentValidationRegex ?? null,
+      trustedImageRegistries:
+        organization?.defaultEnvironmentTrustedImageRegistries ?? null,
+    }),
+    [organization],
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

The environment editor derives the egress-mode control's initial value from a default constant that used `restricted`. When an environment (or the organization default) has no explicit network policy — the built-in case — the backend resolves and enforces it as `unrestricted`. But the editor rendered "restricted" for that `null` policy.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>