### PR TITLE
feat(frontend): WCAG 2.2 A/AA accessibility pass + icon-button lint guard

### DIFF
--- a/platform/biome-plugins/icon-button-aria-label.grit
+++ b/platform/biome-plugins/icon-button-aria-label.grit
@@ -1,0 +1,42 @@
+// Project-specific Biome (GritQL) lint plugin — accessibility regression guard.
+//
+// Flags a shadcn `<Button>` rendered at an icon size (`icon`, `icon-sm`,
+// `icon-lg`) whose only content is an icon (a self-closing JSX element such as
+// a lucide `<X />`) and which has no accessible name. Icon-only buttons render
+// no readable text, so without a name they are invisible to screen-reader and
+// voice-control users — a WCAG 2.2 SC 4.1.2 (Name, Role, Value) / 1.1.1
+// (Non-text Content) failure. This was the single most common gap found in the
+// WCAG 2.2 A/AA audit, and Biome's built-in a11y rules cannot detect it
+// (they can't reason about an element's computed accessible name), so this
+// plugin guards against the pattern regressing.
+//
+// A button is considered named — and is intentionally NOT flagged — when it
+// carries `aria-label`, `aria-labelledby`, or `title`, contains a
+// visually-hidden `className="sr-only"` text child (the other convention used
+// in this codebase), or uses `asChild` to delegate rendering to a child that
+// carries the name. Icon-sized buttons whose content is visible text (e.g. a
+// day number or an hour in a picker) are not flagged, because that text is
+// itself the accessible name.
+//
+// If an icon button is genuinely named some other way this plugin can't see,
+// give it an explicit `aria-label` (plugin diagnostics are not suppressible via
+// biome-ignore).
+language js
+
+`<Button $props>$children</Button>` where {
+  $props <: or {
+    contains `size="icon"`,
+    contains `size="icon-sm"`,
+    contains `size="icon-lg"`
+  },
+  $props <: not contains `asChild`,
+  $props <: not contains `aria-label`,
+  $props <: not contains `aria-labelledby`,
+  $props <: not contains `title`,
+  $children <: contains jsx_self_closing_element(),
+  $children <: not contains `className="sr-only"`,
+  register_diagnostic(
+    span = $props,
+    message = "Icon-only <Button> needs an accessible name: add aria-label or a visually-hidden sr-only text child (WCAG 2.2 SC 4.1.2 Name, Role, Value)."
+  )
+}

--- a/platform/biome-plugins/icon-button-aria-label.grit
+++ b/platform/biome-plugins/icon-button-aria-label.grit
@@ -1,42 +1,60 @@
 // Project-specific Biome (GritQL) lint plugin — accessibility regression guard.
 //
-// Flags a shadcn `<Button>` rendered at an icon size (`icon`, `icon-sm`,
-// `icon-lg`) whose only content is an icon (a self-closing JSX element such as
-// a lucide `<X />`) and which has no accessible name. Icon-only buttons render
-// no readable text, so without a name they are invisible to screen-reader and
-// voice-control users — a WCAG 2.2 SC 4.1.2 (Name, Role, Value) / 1.1.1
-// (Non-text Content) failure. This was the single most common gap found in the
-// WCAG 2.2 A/AA audit, and Biome's built-in a11y rules cannot detect it
-// (they can't reason about an element's computed accessible name), so this
-// plugin guards against the pattern regressing.
+// Flags icon-only buttons that have no accessible name. Icon-only buttons
+// render no readable text, so without a name they are invisible to
+// screen-reader and voice-control users — a WCAG 2.2 SC 4.1.2 (Name, Role,
+// Value) / 1.1.1 (Non-text Content) failure. These were the most common gaps
+// found in the WCAG 2.2 A/AA audit, and Biome's built-in a11y rules cannot
+// detect them (they can't reason about an element's computed accessible name),
+// so this plugin guards against the pattern regressing. It is enforced by the
+// existing `biome ci` step.
 //
-// A button is considered named — and is intentionally NOT flagged — when it
-// carries `aria-label`, `aria-labelledby`, or `title`, contains a
-// visually-hidden `className="sr-only"` text child (the other convention used
-// in this codebase), or uses `asChild` to delegate rendering to a child that
-// carries the name. Icon-sized buttons whose content is visible text (e.g. a
-// day number or an hour in a picker) are not flagged, because that text is
-// itself the accessible name.
+// Two shapes are covered:
+//   1. The shadcn `<Button>` at an icon size (`icon`, `icon-sm`, `icon-lg`)
+//      whose content includes an icon (a self-closing JSX element).
+//   2. A native `<button>` whose SOLE child is an icon (a self-closing JSX
+//      element). The single-child requirement is deliberate: a native
+//      `<button>` with an icon AND visible text (e.g. `<button><Plus/> Add
+//      </button>`) is named by its text and is correctly NOT flagged.
+//
+// A button is considered named — and NOT flagged — when it carries
+// `aria-label`, `aria-labelledby`, or `title`, contains a visually-hidden
+// `className="sr-only"` text child (the other convention used in this
+// codebase), or (shadcn only) uses `asChild` to delegate rendering to a child
+// that carries the name. Buttons whose content is visible text are not flagged,
+// because that text is itself the accessible name.
 //
 // If an icon button is genuinely named some other way this plugin can't see,
 // give it an explicit `aria-label` (plugin diagnostics are not suppressible via
 // biome-ignore).
 language js
 
-`<Button $props>$children</Button>` where {
-  $props <: or {
-    contains `size="icon"`,
-    contains `size="icon-sm"`,
-    contains `size="icon-lg"`
+or {
+  `<Button $props>$children</Button>` where {
+    $props <: or {
+      contains `size="icon"`,
+      contains `size="icon-sm"`,
+      contains `size="icon-lg"`
+    },
+    $props <: not contains `asChild`,
+    $props <: not contains `aria-label`,
+    $props <: not contains `aria-labelledby`,
+    $props <: not contains `title`,
+    $children <: contains jsx_self_closing_element(),
+    $children <: not contains `className="sr-only"`,
+    register_diagnostic(
+      span = $props,
+      message = "Icon-only <Button> needs an accessible name: add aria-label or a visually-hidden sr-only text child (WCAG 2.2 SC 4.1.2 Name, Role, Value)."
+    )
   },
-  $props <: not contains `asChild`,
-  $props <: not contains `aria-label`,
-  $props <: not contains `aria-labelledby`,
-  $props <: not contains `title`,
-  $children <: contains jsx_self_closing_element(),
-  $children <: not contains `className="sr-only"`,
-  register_diagnostic(
-    span = $props,
-    message = "Icon-only <Button> needs an accessible name: add aria-label or a visually-hidden sr-only text child (WCAG 2.2 SC 4.1.2 Name, Role, Value)."
-  )
+  `<button $props>$child</button>` where {
+    $props <: not contains `aria-label`,
+    $props <: not contains `aria-labelledby`,
+    $props <: not contains `title`,
+    $child <: jsx_self_closing_element(),
+    register_diagnostic(
+      span = $props,
+      message = "Icon-only <button> needs an accessible name: add aria-label or a visually-hidden sr-only text child (WCAG 2.2 SC 4.1.2 Name, Role, Value)."
+    )
+  }
 }

--- a/platform/biome.json
+++ b/platform/biome.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "plugins": ["./biome-plugins/icon-button-aria-label.grit"],
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/platform/frontend/src/app/_parts/app-shell.tsx
+++ b/platform/frontend/src/app/_parts/app-shell.tsx
@@ -42,6 +42,11 @@ const SITE_NOTIFICATION_READ_PERMISSION: Permissions = {
   siteNotification: ["read"],
 };
 
+// Target for the "skip to main content" link (WCAG 2.4.1 Bypass Blocks). The
+// <main> element carries this id and tabIndex={-1} so activating the link moves
+// keyboard focus past the sidebar navigation and into the page content.
+const MAIN_CONTENT_ID = "main-content";
+
 interface AppShellProps {
   children: React.ReactNode;
 }
@@ -121,10 +126,15 @@ export function AppShell({ children }: AppShellProps) {
       ) : (
         <NavigationStatusProvider>
           <SidebarProvider defaultOpen={!shouldCollapse}>
+            <SkipToContentLink />
             <AppSidebar />
             <NavAwareSidebarCircleToggle />
             <MaintenanceModeOverlay />
-            <main className="h-screen w-full flex flex-col bg-background min-w-0 relative overflow-y-auto">
+            <main
+              id={MAIN_CONTENT_ID}
+              tabIndex={-1}
+              className="h-screen w-full flex flex-col bg-background min-w-0 relative overflow-y-auto focus:outline-none"
+            >
               <ConnectivityBar />
               <EnvSiteNotificationBar />
               {notification && (
@@ -180,6 +190,19 @@ function NavAwareSidebarCircleToggle() {
       loading={isNavigating}
       showDot={showCollapsedToggleDot}
     />
+  );
+}
+
+// Visually hidden until focused; the first tab stop on every authenticated
+// page, letting keyboard and screen-reader users jump past the sidebar nav.
+function SkipToContentLink() {
+  return (
+    <a
+      href={`#${MAIN_CONTENT_ID}`}
+      className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-foreground focus:shadow-md focus:ring-2 focus:ring-ring"
+    >
+      Skip to main content
+    </a>
   );
 }
 

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -348,6 +348,7 @@ export function ChatSidebarSection({
             <div className="flex items-center gap-1 flex-1">
               <Input
                 ref={inputRef}
+                aria-label="Conversation title"
                 value={editingTitle}
                 onChange={(e) => setEditingTitle(e.target.value)}
                 onBlur={() => handleSaveEdit(conv.id)}
@@ -366,6 +367,7 @@ export function ChatSidebarSection({
                   <TooltipTrigger asChild>
                     <Button
                       type="button"
+                      aria-label="Regenerate title"
                       size="icon-sm"
                       variant="ghost"
                       onMouseDown={(e) => {

--- a/platform/frontend/src/app/_parts/create-project-from-chat-dialog.tsx
+++ b/platform/frontend/src/app/_parts/create-project-from-chat-dialog.tsx
@@ -109,6 +109,7 @@ export function CreateProjectFromChatDialog({
           <Input
             autoFocus
             placeholder="Project name"
+            aria-label="Project name"
             maxLength={PROJECT_NAME_MAX_LENGTH}
             aria-invalid={!!form.formState.errors.name}
             {...form.register("name", {
@@ -126,6 +127,7 @@ export function CreateProjectFromChatDialog({
           )}
           <Textarea
             placeholder="Description (optional)"
+            aria-label="Project description"
             rows={3}
             maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
             aria-invalid={!!form.formState.errors.description}

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -37,6 +37,7 @@ import { BrowserPanel } from "@/components/chat/browser-panel";
 import { ChatLinkButton } from "@/components/chat/chat-help-link";
 import { ChatMessages } from "@/components/chat/chat-messages";
 import { collectBrowserToolCallIds } from "@/components/chat/chat-messages.utils";
+import { ChatStatusAnnouncer } from "@/components/chat/chat-status-announcer";
 import { ConversationFilesPanel } from "@/components/chat/conversation-files-panel";
 import { ConversationHeader } from "@/components/chat/conversation-header";
 import { InitialAgentSelector } from "@/components/chat/initial-agent-selector";
@@ -2317,6 +2318,7 @@ export function ChatPageContent({
       onClosePanel={closeRightPanel}
     >
       <div className="flex flex-col h-full w-full min-h-0">
+        <ChatStatusAnnouncer status={status} />
         {/* Full-width top bar: title + the Files/Browser/Apps tab strip. It
             sits above the [chat | panel] split so the panel's resize divider
             only spans the content area below it. */}

--- a/platform/frontend/src/app/connection/connect-settings-section.tsx
+++ b/platform/frontend/src/app/connection/connect-settings-section.tsx
@@ -431,6 +431,7 @@ export function ConnectSettingsSection() {
                             </div>
                             <Input
                               id={inputId}
+                              aria-label="URL description"
                               value={meta.description}
                               onChange={(e) =>
                                 setBaseUrlDescription(url, e.target.value)

--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
@@ -312,7 +312,12 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
           </Tooltip>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon" className="h-8 w-8">
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Connector actions"
+              >
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
@@ -488,6 +493,7 @@ function KnowledgeBasesMetadataItem({ connectorId }: { connectorId: string }) {
             size="icon"
             className="h-5 w-5"
             onClick={() => setIsAddDialogOpen(true)}
+            aria-label="Add knowledge base"
           >
             <Plus className="h-3.5 w-3.5" />
           </Button>
@@ -504,6 +510,7 @@ function KnowledgeBasesMetadataItem({ connectorId }: { connectorId: string }) {
                 className="h-4 w-4 ml-0.5 hover:bg-destructive/20"
                 onClick={() => handleUnassign(kb.id)}
                 disabled={unassignMutation.isPending}
+                aria-label="Remove knowledge base"
               >
                 <X className="h-3 w-3" />
               </Button>
@@ -515,6 +522,7 @@ function KnowledgeBasesMetadataItem({ connectorId }: { connectorId: string }) {
             className="h-5 w-5"
             onClick={() => setIsAddDialogOpen(true)}
             disabled={availableKbs.length === 0}
+            aria-label="Add knowledge base"
           >
             <Plus className="h-3.5 w-3.5" />
           </Button>

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
@@ -221,6 +221,7 @@ export function CreateConnectorDialog({
                     size="icon"
                     className="h-7 w-7"
                     onClick={handleBackToChooser}
+                    aria-label="Go back"
                   >
                     <ArrowLeft className="h-4 w-4" />
                   </Button>
@@ -284,6 +285,7 @@ export function CreateConnectorDialog({
                     size="icon"
                     className="h-7 w-7"
                     onClick={handleBack}
+                    aria-label="Go back"
                   >
                     <ArrowLeft className="h-4 w-4" />
                   </Button>

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -120,6 +120,7 @@ function KnowledgeBasesList() {
             e.stopPropagation();
             row.toggleExpanded();
           }}
+          aria-label="Toggle row"
         >
           {row.getIsExpanded() ? (
             <ChevronDown className="h-4 w-4" />
@@ -517,6 +518,7 @@ function AddConnectorDialog({
                   setStep("choose");
                   setSelectedIds(new Set());
                 }}
+                aria-label="Go back"
               >
                 <ArrowLeft className="h-4 w-4" />
               </Button>

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -977,6 +977,7 @@ export default function LimitsPage() {
             <div className="space-y-2">
               <Label>Limit value ($)</Label>
               <Input
+                aria-label="Limit value"
                 value={formatNumericInput(formState.limitValue)}
                 onChange={(event) =>
                   setFormState((current) => ({

--- a/platform/frontend/src/app/llm/(costs)/optimization-rules/_parts/condition.tsx
+++ b/platform/frontend/src/app/llm/(costs)/optimization-rules/_parts/condition.tsx
@@ -99,6 +99,7 @@ export function Condition({
         <Input
           type="number"
           name="maxTokens"
+          aria-label="Count"
           value={maxLength}
           placeholder="count"
           className="px-2 h-7 w-20 bg-background"

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -1113,6 +1113,7 @@ function ModalitySelectField<T extends string>(params: {
               {option.label}
               <Button
                 type="button"
+                aria-label="Remove option"
                 variant="ghost"
                 size="icon"
                 className="h-4 w-4"

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
@@ -609,6 +609,7 @@ export function ToolsAndGuardrailsStep({ item }: { item: CatalogItem }) {
       {tools.length > 5 && (
         <Input
           placeholder="Filter tools by name"
+          aria-label="Filter tools"
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           className="max-w-xs"

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-assignments-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-assignments-dialog.tsx
@@ -678,6 +678,7 @@ function ProfileAssignmentPill({
             size="sm"
             className="h-6 w-6 p-0 shrink-0"
             onClick={() => setOpen(false)}
+            aria-label="Close"
           >
             <X className="h-4 w-4" />
           </Button>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1669,6 +1669,7 @@ export function McpCatalogForm({
                             variant="ghost"
                             size="icon"
                             onClick={() => removeImagePullSecret(index)}
+                            aria-label="Remove image pull secret"
                           >
                             <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
                           </Button>
@@ -1693,6 +1694,7 @@ export function McpCatalogForm({
                               <Label className="text-xs">Server</Label>
                               <Input
                                 placeholder="e.g. quay.io"
+                                aria-label="Server"
                                 className="font-mono"
                                 autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                                 value={watchField("server")}
@@ -1705,6 +1707,7 @@ export function McpCatalogForm({
                               <Label className="text-xs">Username</Label>
                               <Input
                                 placeholder="username"
+                                aria-label="Username"
                                 autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                                 value={watchField("username")}
                                 onChange={(e) =>
@@ -1732,6 +1735,7 @@ export function McpCatalogForm({
                               </Label>
                               <Input
                                 placeholder="email@example.com"
+                                aria-label="Email"
                                 autoComplete={MCP_CONFIG_AUTOCOMPLETE}
                                 value={watchField("email")}
                                 onChange={(e) =>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-inspector.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-inspector.tsx
@@ -332,6 +332,7 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
                 value={toolSearch}
                 onChange={(e) => setToolSearch(e.target.value)}
                 placeholder="Search tools"
+                aria-label="Search tools"
                 className="h-7 pl-7 font-mono text-xs"
               />
             </div>
@@ -445,6 +446,7 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
                             </Label>
                             <Input
                               placeholder={prop.description || `Enter ${name}`}
+                              aria-label={name}
                               value={paramValues[name] ?? ""}
                               onChange={(e) =>
                                 setParamValues((prev) => ({

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -480,6 +480,7 @@ export function McpServerCard({
       className="h-8 w-8"
       data-testid={`${E2eTestId.McpServerSettingsButton}-${item.name}`}
       onClick={() => goToItemPage()}
+      aria-label="Server settings"
     >
       <Pencil className="h-4 w-4" />
     </Button>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-tools-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-tools-dialog.tsx
@@ -141,6 +141,7 @@ export function McpToolsDialog({
           <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Search tools by name..."
+            aria-label="Search tools"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-9"

--- a/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/registry-list-controls.tsx
@@ -163,6 +163,7 @@ function FilterOptionList({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={`Search ${searchLabel}`}
+          aria-label={`Search ${searchLabel}`}
           className="mb-1.5 h-8"
         />
       )}

--- a/platform/frontend/src/app/mcp/registry/installation-requests/[id]/page.tsx
+++ b/platform/frontend/src/app/mcp/registry/installation-requests/[id]/page.tsx
@@ -128,7 +128,11 @@ export default function InstallationRequestDetailPage({
     <div>
       <div className="flex items-center gap-4 mb-2">
         <Link href="/mcp/registry/installation-requests">
-          <Button variant="ghost" size="icon">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Back to installation requests"
+          >
             <ArrowLeft className="h-5 w-5" />
           </Button>
         </Link>
@@ -389,6 +393,7 @@ export default function InstallationRequestDetailPage({
                     <div className="space-y-3">
                       <Textarea
                         placeholder="Optional message to the requester..."
+                        aria-label="Approval message"
                         value={adminResponse}
                         onChange={(e) => setAdminResponse(e.target.value)}
                         rows={3}
@@ -424,6 +429,7 @@ export default function InstallationRequestDetailPage({
                     <div className="space-y-3">
                       <Textarea
                         placeholder="Reason for declining (optional)..."
+                        aria-label="Decline reason"
                         value={adminResponse}
                         onChange={(e) => setAdminResponse(e.target.value)}
                         rows={3}
@@ -467,6 +473,7 @@ export default function InstallationRequestDetailPage({
                 <div className="space-y-2">
                   <Textarea
                     placeholder="Add a note or comment..."
+                    aria-label="Note"
                     value={newNote}
                     onChange={(e) => setNewNote(e.target.value)}
                     rows={3}

--- a/platform/frontend/src/app/projects/page.client.tsx
+++ b/platform/frontend/src/app/projects/page.client.tsx
@@ -464,6 +464,7 @@ function CreateProjectDialog({
         <div className="flex-1 space-y-3 min-w-0">
           <Input
             autoFocus
+            aria-label="Project name"
             placeholder="Project name"
             maxLength={PROJECT_NAME_MAX_LENGTH}
             aria-invalid={!!form.formState.errors.name}
@@ -481,6 +482,7 @@ function CreateProjectDialog({
             </p>
           )}
           <Textarea
+            aria-label="Project description"
             placeholder="Description (optional)"
             rows={3}
             maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}

--- a/platform/frontend/src/app/settings/api-keys/page.tsx
+++ b/platform/frontend/src/app/settings/api-keys/page.tsx
@@ -278,6 +278,7 @@ export default function ApiKeysSettingsPage() {
                 <div className="flex gap-2">
                   <Input
                     readOnly
+                    aria-label="API key"
                     value={createdApiKeyValue}
                     className="font-mono text-xs"
                   />

--- a/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/oidc-config-form.ee.tsx
@@ -427,6 +427,7 @@ export function OidcConfigForm({
             <FormLabel>Scopes</FormLabel>
             <div className="flex gap-2">
               <Input
+                aria-label="Add scope"
                 placeholder="Add scope (e.g., profile)"
                 value={newScope}
                 onChange={(e) => setNewScope(e.target.value)}
@@ -439,6 +440,7 @@ export function OidcConfigForm({
               />
               <Button
                 type="button"
+                aria-label="Add scope"
                 onClick={addScope}
                 size="icon"
                 variant="outline"
@@ -457,6 +459,7 @@ export function OidcConfigForm({
                     {scope}
                     <button
                       type="button"
+                      aria-label="Remove scope"
                       onClick={() => removeScope(scope)}
                       className="ml-1 hover:bg-destructive/20 rounded-full p-0.5"
                     >

--- a/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.test.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.test.tsx
@@ -106,9 +106,7 @@ function getAddRuleButton() {
 }
 
 function getDeleteButtons() {
-  return screen
-    .getAllByRole("button", { name: "" })
-    .filter((btn) => btn.querySelector("svg.lucide-trash-2") !== null);
+  return screen.getAllByRole("button", { name: "Remove role mapping" });
 }
 
 beforeEach(() => {

--- a/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.tsx
+++ b/platform/frontend/src/app/settings/identity-providers/_parts/role-mapping-form.ee.tsx
@@ -433,6 +433,7 @@ function RoleMappingRuleRow({
       </div>
       <Button
         type="button"
+        aria-label="Remove role mapping"
         variant="ghost"
         size="icon"
         className="shrink-0 mt-6 text-destructive hover:text-destructive"

--- a/platform/frontend/src/app/settings/llm/_parts/default-user-limits-section.tsx
+++ b/platform/frontend/src/app/settings/llm/_parts/default-user-limits-section.tsx
@@ -321,6 +321,7 @@ export function DefaultUserLimitsSection() {
             <div className="space-y-2">
               <Label>Limit value ($)</Label>
               <Input
+                aria-label="Limit value"
                 value={formatNumericInput(formState.limitValue)}
                 onChange={(event) =>
                   setFormState((current) => ({

--- a/platform/frontend/src/app/settings/organization/_components/chat-links-editor.tsx
+++ b/platform/frontend/src/app/settings/organization/_components/chat-links-editor.tsx
@@ -88,6 +88,7 @@ export function ChatLinksEditor({
                 <p className="text-sm font-medium">Link {index + 1}</p>
                 <Button
                   type="button"
+                  aria-label="Remove link"
                   variant="ghost"
                   size="sm"
                   onClick={() => handleRemove(index)}

--- a/platform/frontend/src/app/settings/organization/_components/chat-placeholders-editor.tsx
+++ b/platform/frontend/src/app/settings/organization/_components/chat-placeholders-editor.tsx
@@ -63,6 +63,7 @@ export function ChatPlaceholdersEditor({
         {placeholders.map((placeholder, index) => (
           <div key={keysRef.current[index]} className="flex items-center gap-2">
             <Input
+              aria-label={`Chat placeholder ${index + 1}`}
               value={placeholder}
               onChange={(e) => handleChange(index, e.target.value)}
               placeholder={`Placeholder ${index + 1}`}
@@ -70,6 +71,7 @@ export function ChatPlaceholdersEditor({
             />
             <Button
               type="button"
+              aria-label="Remove placeholder"
               variant="ghost"
               size="sm"
               onClick={() => handleRemove(index)}

--- a/platform/frontend/src/app/settings/organization/_components/image-upload.tsx
+++ b/platform/frontend/src/app/settings/organization/_components/image-upload.tsx
@@ -130,6 +130,7 @@ export function ImageUpload({
         <input
           ref={fileInputRef}
           type="file"
+          aria-label="Upload image"
           accept="image/png"
           className="hidden"
           onChange={handleFileSelect}

--- a/platform/frontend/src/app/settings/organization/_components/logos-section.tsx
+++ b/platform/frontend/src/app/settings/organization/_components/logos-section.tsx
@@ -211,6 +211,7 @@ function LogoRow({
       <input
         ref={fileInputRef}
         type="file"
+        aria-label="Upload logo image"
         accept="image/png,image/svg+xml"
         className="hidden"
         onChange={handleFileSelect}

--- a/platform/frontend/src/app/settings/organization/_components/site-notifications-section.tsx
+++ b/platform/frontend/src/app/settings/organization/_components/site-notifications-section.tsx
@@ -165,6 +165,7 @@ export function SiteNotificationsSection() {
               </div>
               {tab === "markdown" ? (
                 <Textarea
+                  aria-label="Notification content"
                   value={effectiveContent}
                   onChange={(event) => setContent(event.target.value)}
                   placeholder="Write your notification content using markdown."

--- a/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
@@ -476,7 +476,12 @@ function CreatedTokenDialog({
             token requires creating a new one.
           </p>
           <div className="flex flex-col gap-2 sm:flex-row">
-            <Input readOnly value={token ?? ""} className="font-mono text-xs" />
+            <Input
+              readOnly
+              aria-label="Service account token"
+              value={token ?? ""}
+              className="font-mono text-xs"
+            />
             <Button type="button" onClick={onCopy}>
               <Copy className="h-4 w-4" />
               Copy to clipboard

--- a/platform/frontend/src/app/skills/_parts/import-skills-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/import-skills-dialog.tsx
@@ -299,6 +299,7 @@ export function ImportSkillsDialog({
                 size="icon"
                 className="h-7 w-7"
                 onClick={backToDiscover}
+                aria-label="Go back"
               >
                 <ArrowLeft className="h-4 w-4" />
               </Button>

--- a/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
@@ -607,6 +607,7 @@ export function SkillEditorDialog({
                 <Textarea
                   value={editorValue}
                   onChange={(e) => setEditorValue(e.target.value)}
+                  aria-label="File contents"
                   placeholder={
                     openFile ? "File contents..." : MANIFEST_PLACEHOLDER
                   }
@@ -801,6 +802,7 @@ function NewFileRow({
         }}
         placeholder={placeholder}
         className="h-7 flex-1 font-mono text-xs"
+        aria-label="File name"
       />
       <Button
         type="button"
@@ -818,6 +820,7 @@ function NewFileRow({
         size="icon"
         className="h-7 w-7"
         onClick={onCancel}
+        aria-label="Cancel"
       >
         <X className="h-3.5 w-3.5" />
       </Button>
@@ -892,6 +895,7 @@ function NewFolderRow({
         }}
         placeholder="folder name"
         className="h-7 flex-1 font-mono text-xs"
+        aria-label="Folder name"
       />
       <Button
         type="button"
@@ -909,6 +913,7 @@ function NewFolderRow({
         size="icon"
         className="h-7 w-7"
         onClick={onCancel}
+        aria-label="Cancel"
       >
         <X className="h-3.5 w-3.5" />
       </Button>

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -1630,7 +1630,7 @@ export function AgentDialog({
                                   }
                                   placeholder="e.g. Summarize recent changes"
                                   maxLength={MAX_SUGGESTED_PROMPT_TITLE_LENGTH}
-                                  aria-label="Suggested prompt title"
+                                  aria-label="Button Label"
                                 />
                               </div>
                               <div className="space-y-1">

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -276,6 +276,7 @@ function SubagentPill({ agent, isSelected, onToggle }: SubagentPillProps) {
           size="sm"
           className="h-8 w-7 p-0 rounded-l-none text-muted-foreground hover:text-destructive"
           onClick={() => onToggle(agent.id)}
+          aria-label="Remove agent"
         >
           <X className="h-3 w-3" />
         </Button>
@@ -303,6 +304,7 @@ function SubagentPill({ agent, isSelected, onToggle }: SubagentPillProps) {
             size="sm"
             className="h-6 w-6 p-0 shrink-0"
             onClick={() => setOpen(false)}
+            aria-label="Close"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -1596,6 +1598,7 @@ export function AgentDialog({
                                 variant="ghost"
                                 size="icon"
                                 className="absolute top-2 right-2 h-6 w-6"
+                                aria-label="Remove suggested prompt"
                                 onClick={() => {
                                   setSuggestedPrompts((prev) => {
                                     const next = prev.filter(
@@ -1627,6 +1630,7 @@ export function AgentDialog({
                                   }
                                   placeholder="e.g. Summarize recent changes"
                                   maxLength={MAX_SUGGESTED_PROMPT_TITLE_LENGTH}
+                                  aria-label="Suggested prompt title"
                                 />
                               </div>
                               <div className="space-y-1">
@@ -1645,6 +1649,7 @@ export function AgentDialog({
                                   placeholder="The full prompt sent when clicked"
                                   className="min-h-[60px]"
                                   maxLength={MAX_SUGGESTED_PROMPT_TEXT_LENGTH}
+                                  aria-label="Suggested prompt"
                                 />
                               </div>
                             </div>
@@ -2273,6 +2278,7 @@ export function AgentDialog({
                                       variant="ghost"
                                       size="icon"
                                       className="h-4 w-4 p-0 hover:bg-transparent"
+                                      aria-label="Remove header"
                                       onClick={() =>
                                         setPassthroughHeaders((prev) =>
                                           prev.filter((h) => h !== header),
@@ -2288,6 +2294,7 @@ export function AgentDialog({
                                 MAX_PASSTHROUGH_HEADERS && (
                                 <Input
                                   placeholder="Type header name and press Enter"
+                                  aria-label="Add passthrough header"
                                   onKeyDown={(e) => {
                                     if (e.key !== "Enter") return;
                                     e.preventDefault();

--- a/platform/frontend/src/components/agent-labels.tsx
+++ b/platform/frontend/src/components/agent-labels.tsx
@@ -191,6 +191,7 @@ export const ProfileLabels = forwardRef<ProfileLabelsRef, ProfileLabelsProps>(
                   type="button"
                   onClick={() => handleRemoveLabel(label.key)}
                   className="ml-1 hover:bg-destructive/20 rounded-full p-0.5"
+                  aria-label="Remove label"
                 >
                   <X className="h-3 w-3" />
                 </button>

--- a/platform/frontend/src/components/agent-scope-filter.tsx
+++ b/platform/frontend/src/components/agent-scope-filter.tsx
@@ -415,6 +415,7 @@ export function ActiveFilterBadges({
                 type="button"
                 onClick={() => handleRemoveTeam(team.id)}
                 className="ml-0.5 rounded-full hover:bg-muted-foreground/20 p-0.5"
+                aria-label="Remove team from filter"
               >
                 <X className="h-3 w-3" />
               </button>
@@ -444,6 +445,7 @@ export function ActiveFilterBadges({
                 type="button"
                 onClick={() => handleRemoveUser(user.id)}
                 className="ml-0.5 rounded-full hover:bg-muted-foreground/20 p-0.5"
+                aria-label="Remove user from filter"
               >
                 <X className="h-3 w-3" />
               </button>

--- a/platform/frontend/src/components/agent-tool-exclusions-editor.tsx
+++ b/platform/frontend/src/components/agent-tool-exclusions-editor.tsx
@@ -529,6 +529,7 @@ function ExclusionPill({
             size="sm"
             className="h-6 w-6 p-0 shrink-0"
             onClick={() => setOpen(false)}
+            aria-label="Close"
           >
             <X className="h-4 w-4" />
           </Button>

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -1300,6 +1300,7 @@ export function ToolChecklist({
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="h-7 pl-7 text-xs"
+              aria-label="Search tools"
             />
           </div>
         </div>

--- a/platform/frontend/src/components/call-policy-toggle.tsx
+++ b/platform/frontend/src/components/call-policy-toggle.tsx
@@ -75,6 +75,7 @@ export function CallPolicyToggle({
               size="sm"
               variant="ghost"
               className={getButtonClassName("allow_when_context_is_untrusted")}
+              aria-label="Allow always"
               disabled={disabled}
               onClick={(e) => {
                 e.stopPropagation();
@@ -96,6 +97,7 @@ export function CallPolicyToggle({
               size="sm"
               variant="ghost"
               className={getButtonClassName("block_when_context_is_untrusted")}
+              aria-label="Block in sensitive context"
               disabled={disabled}
               onClick={(e) => {
                 e.stopPropagation();
@@ -117,6 +119,7 @@ export function CallPolicyToggle({
               size="sm"
               variant="ghost"
               className={getButtonClassName("require_approval")}
+              aria-label="Require approval"
               disabled={disabled}
               onClick={(e) => {
                 e.stopPropagation();
@@ -141,6 +144,7 @@ export function CallPolicyToggle({
               size="sm"
               variant="ghost"
               className={getButtonClassName("block_always")}
+              aria-label="Block always"
               disabled={disabled}
               onClick={(e) => {
                 e.stopPropagation();

--- a/platform/frontend/src/components/chat/browser-preview-content.tsx
+++ b/platform/frontend/src/components/chat/browser-preview-content.tsx
@@ -299,6 +299,7 @@ export function BrowserPreviewContent({
                   </p>
                   <Textarea
                     placeholder="Text to type..."
+                    aria-label="Text to type"
                     value={typeText}
                     onChange={(e) => setTypeText(e.target.value)}
                     className="text-xs min-h-[60px]"
@@ -413,6 +414,7 @@ export function BrowserPreviewContent({
           <Input
             type="text"
             placeholder="Enter URL..."
+            aria-label="URL to navigate"
             value={urlInput}
             onChange={(e) => {
               setIsEditingUrl(true);
@@ -470,19 +472,22 @@ export function BrowserPreviewContent({
               alt="Browser screenshot"
               className="block w-full h-full object-contain object-top"
             />
-            {/* Clickable overlay */}
-            {/* biome-ignore lint/a11y/useSemanticElements: Need div for absolute positioning overlay */}
+            {/*
+              Pointer-coordinate overlay: forwards the exact click position to
+              the remote browser (see handleImageClick, which maps clientX/clientY
+              to a viewport coordinate). It is intentionally mouse/pointer-only and
+              is NOT a focusable control — a keyboard Enter/Space has no (x,y) to
+              forward, so exposing role="button"/tabIndex here would advertise a
+              keyboard interaction we cannot fulfil (a worse a11y outcome than
+              omitting it). Full keyboard control of the embedded browser would
+              require forwarding key events to the remote session — a separate
+              feature tracked outside this accessibility pass.
+            */}
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer-coordinate overlay for the remote browser; no keyboard equivalent by design (see comment above) */}
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: pointer-coordinate overlay for the remote browser; no keyboard equivalent by design (see comment above) */}
             <div
               className="absolute inset-0 cursor-pointer"
               onClick={handleImageClick}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                }
-              }}
-              role="button"
-              tabIndex={0}
-              aria-label="Click to interact with browser"
             />
           </div>
         )}

--- a/platform/frontend/src/components/chat/chat-status-announcer.tsx
+++ b/platform/frontend/src/components/chat/chat-status-announcer.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Visually-hidden polite live region that announces coarse chat stream state to
+ * screen-reader users (WCAG 4.1.3 Status Messages). Streaming the assistant's
+ * tokens through a live region would be far too chatty, so this announces only
+ * the transitions a non-sighted user needs: that the assistant started
+ * responding, finished, or errored. Renders nothing visible and has no layout
+ * footprint, so it is safe to drop anywhere in the chat tree.
+ */
+export function ChatStatusAnnouncer({ status }: { status: string }) {
+  const [message, setMessage] = useState("");
+  const previousStatus = useRef(status);
+
+  useEffect(() => {
+    const previous = previousStatus.current;
+    previousStatus.current = status;
+
+    const wasResponding = previous === "submitted" || previous === "streaming";
+    const isResponding = status === "submitted" || status === "streaming";
+
+    if (isResponding && !wasResponding) {
+      setMessage("Assistant is responding");
+    } else if (status === "ready" && wasResponding) {
+      setMessage("Assistant response ready");
+    } else if (status === "error" && previous !== "error") {
+      setMessage("Assistant response failed");
+    }
+  }, [status]);
+
+  return (
+    // <output> carries an implicit role="status" polite live region.
+    <output aria-live="polite" className="sr-only">
+      {message}
+    </output>
+  );
+}

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -256,6 +256,7 @@ function HookCircle({
                 ? "bg-accent border-accent-foreground/20 ring-2 ring-primary/20"
                 : "bg-background",
             )}
+            aria-label="Show hook run details"
           >
             <WebhookIcon className="size-3.5 text-muted-foreground" />
             <span

--- a/platform/frontend/src/components/chat/editable-message-editor.tsx
+++ b/platform/frontend/src/components/chat/editable-message-editor.tsx
@@ -155,6 +155,7 @@ export function EditableMessageEditor({
             className={textareaClassName}
             disabled={isSaving}
             placeholder={placeholder}
+            aria-label={placeholder || "Edit message"}
           />
           <div className="flex gap-2 py-3 justify-between items-start">
             {banner}

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -308,6 +308,7 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
               <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground pointer-events-none" />
               <Input
                 placeholder="Search..."
+                aria-label="Search agents"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="h-8 pl-8 text-sm rounded-lg border-0 bg-muted/50 focus-visible:ring-1"
@@ -742,6 +743,7 @@ function AgentSettingsView({
           ) : (
             <button
               type="button"
+              aria-label="Edit agent icon"
               className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted cursor-pointer"
               onDoubleClick={() => setIsEditingIcon(true)}
             >
@@ -752,6 +754,7 @@ function AgentSettingsView({
             {isEditingName ? (
               <Input
                 ref={nameInputRef}
+                aria-label="Agent name"
                 value={editedName}
                 onChange={(e) => setEditedName(e.target.value)}
                 onBlur={() => saveName(editedName)}
@@ -1262,6 +1265,7 @@ function AddToolView({
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Search MCP servers..."
+            aria-label="Search MCP servers"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9"
@@ -1690,6 +1694,7 @@ function AddDelegationView({
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Search agents..."
+            aria-label="Search agents"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9"
@@ -1895,6 +1900,7 @@ function EditKnowledgeSourcesView({
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 placeholder="Search knowledge sources..."
+                aria-label="Search knowledge sources"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="pl-9"

--- a/platform/frontend/src/components/chat/mcp-elicitation-dialog.tsx
+++ b/platform/frontend/src/components/chat/mcp-elicitation-dialog.tsx
@@ -152,6 +152,7 @@ export function McpElicitationDialog({
               }))
             }
             placeholder="Response"
+            aria-label="Response"
             className="min-h-24"
           />
         ) : (

--- a/platform/frontend/src/components/chat/onboarding-wizard-dialog.tsx
+++ b/platform/frontend/src/components/chat/onboarding-wizard-dialog.tsx
@@ -282,6 +282,7 @@ function EditPageDialog({
                 setDraft((prev) => ({ ...prev, content: e.target.value }))
               }
               placeholder="Write page content as markdown. Headings, lists, links, and code blocks are supported."
+              aria-label="Page content"
               className="flex-1 border-0 rounded-none font-mono text-xs resize-none focus-visible:ring-0"
             />
           ) : (
@@ -347,6 +348,7 @@ function EditPageDialog({
           ref={fileInputRef}
           type="file"
           accept="image/png,image/gif"
+          aria-label="Upload image"
           className="hidden"
           onChange={handleFileSelect}
         />

--- a/platform/frontend/src/components/chat/plain-text-editor.tsx
+++ b/platform/frontend/src/components/chat/plain-text-editor.tsx
@@ -39,6 +39,7 @@ export function PlainTextEditor({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        aria-label={placeholder || "Text editor"}
         className="min-h-40 flex-1 resize-none font-mono text-xs"
         autoFocus
       />

--- a/platform/frontend/src/components/enterprise-managed-credential-fields.tsx
+++ b/platform/frontend/src/components/enterprise-managed-credential-fields.tsx
@@ -106,6 +106,7 @@ export function EnterpriseManagedCredentialFields({
       <div className="space-y-1.5">
         <Label className="text-xs">Managed Resource Identifier</Label>
         <Input
+          aria-label="Managed resource identifier"
           value={config.resourceIdentifier ?? ""}
           onChange={(event) =>
             onChange({
@@ -120,6 +121,7 @@ export function EnterpriseManagedCredentialFields({
       <div className="space-y-1.5">
         <Label className="text-xs">External Provider Alias</Label>
         <Input
+          aria-label="External provider alias"
           value={config.requestedIssuer ?? ""}
           onChange={(event) =>
             onChange({
@@ -139,6 +141,7 @@ export function EnterpriseManagedCredentialFields({
       <div className="space-y-1.5">
         <Label className="text-xs">Response Field Path</Label>
         <Input
+          aria-label="Response field path"
           value={config.responseFieldPath ?? ""}
           onChange={(event) =>
             onChange({
@@ -158,6 +161,7 @@ export function EnterpriseManagedCredentialFields({
         <div className="space-y-1.5">
           <Label className="text-xs">Header Name</Label>
           <Input
+            aria-label="Header name"
             value={config.headerName ?? ""}
             onChange={(event) =>
               onChange({

--- a/platform/frontend/src/components/invite-by-link-card.tsx
+++ b/platform/frontend/src/components/invite-by-link-card.tsx
@@ -119,6 +119,7 @@ function InviteByLinkCardContent({
             <Label>Invitation Link</Label>
             <div className="flex items-center gap-2">
               <Input
+                aria-label="Invitation link"
                 value={invitationLink}
                 readOnly
                 className="flex-1"
@@ -129,6 +130,7 @@ function InviteByLinkCardContent({
                 size="icon"
                 variant="outline"
                 onClick={handleCopyLink}
+                aria-label="Copy invitation link"
                 data-testid={E2eTestId.InvitationLinkCopyButton}
               >
                 {isCopied ? (

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -1069,12 +1069,14 @@ export function LlmProviderApiKeyForm({
               {extraHeadersFieldArray.fields.map((field, index) => (
                 <div key={field.id} className="flex items-start gap-2">
                   <Input
+                    aria-label="Header name"
                     placeholder="Header name"
                     disabled={isPending}
                     className="flex-1"
                     {...form.register(`extraHeaders.${index}.name` as const)}
                   />
                   <Input
+                    aria-label="Header value"
                     placeholder="Header value"
                     disabled={isPending}
                     className="flex-1"

--- a/platform/frontend/src/components/loading.tsx
+++ b/platform/frontend/src/components/loading.tsx
@@ -19,14 +19,28 @@ export function LoadingSkeletons({
   );
 }
 
-export function LoadingSpinner({ className }: { className?: string }) {
+export function LoadingSpinner({
+  className,
+  label = "Loading",
+}: {
+  className?: string;
+  /**
+   * Accessible name announced to assistive tech (WCAG 4.1.3 Status Messages).
+   * The spinner is a polite live region, so screen-reader users hear this when
+   * it appears. Pass a context-specific label (e.g. "Loading tools") where the
+   * generic default is unhelpful.
+   */
+  label?: string;
+}) {
   return (
-    <div
+    <output
       className={cn(
-        "animate-spin rounded-full h-6 w-6 border-b-2 border-primary mx-auto",
+        "block animate-spin rounded-full h-6 w-6 border-b-2 border-primary mx-auto",
         className,
       )}
-    />
+    >
+      <span className="sr-only">{label}</span>
+    </output>
   );
 }
 

--- a/platform/frontend/src/components/ms-teams-setup-dialog.tsx
+++ b/platform/frontend/src/components/ms-teams-setup-dialog.tsx
@@ -355,6 +355,7 @@ function StepBotSettings({
             <span className="pt-0.5 flex-1">
               Copy the <strong>Microsoft App ID</strong>
               <Input
+                aria-label="Microsoft App ID"
                 value={appId}
                 onChange={(e) => onAppIdChange(e.target.value)}
                 placeholder="Paste your Microsoft App ID"
@@ -374,6 +375,7 @@ function StepBotSettings({
               <span className="text-muted-foreground">(optional)</span> — for
               single-tenant bots
               <Input
+                aria-label="Microsoft Tenant ID"
                 value={showTenantMask ? savedTenantIdMask : tenantId}
                 onChange={(e) => onTenantIdChange(e.target.value)}
                 onFocus={() => setTenantFocused(true)}

--- a/platform/frontend/src/components/ngrok-setup-dialog.tsx
+++ b/platform/frontend/src/components/ngrok-setup-dialog.tsx
@@ -123,6 +123,7 @@ export function NgrokSetupDialog({
           </div>
           <div className="space-y-1.5">
             <Input
+              aria-label="Reserved domain"
               placeholder="reserved domain (optional)"
               value={domain}
               onChange={(e) => {

--- a/platform/frontend/src/components/projects/edit-project-dialog.tsx
+++ b/platform/frontend/src/components/projects/edit-project-dialog.tsx
@@ -194,6 +194,7 @@ function EditProjectDialogForm({
         />
         <div className="flex-1 space-y-3 min-w-0">
           <Input
+            aria-label="Project name"
             placeholder="Project name"
             maxLength={PROJECT_NAME_MAX_LENGTH}
             aria-invalid={!!form.formState.errors.name}
@@ -211,6 +212,7 @@ function EditProjectDialogForm({
             </p>
           )}
           <Textarea
+            aria-label="Project description"
             placeholder="What is this project about?"
             rows={3}
             maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}

--- a/platform/frontend/src/components/searchable-multi-select.test.tsx
+++ b/platform/frontend/src/components/searchable-multi-select.test.tsx
@@ -135,7 +135,9 @@ describe("SearchableMultiSelect", () => {
       />,
     );
 
-    const badges = screen.getAllByRole("button", { name: "" });
+    const badges = screen.getAllByRole("button", {
+      name: "Remove selected item",
+    });
     await user.click(badges[0]);
 
     expect(onValueChange).toHaveBeenCalledWith(["item-2"]);

--- a/platform/frontend/src/components/searchable-multi-select.tsx
+++ b/platform/frontend/src/components/searchable-multi-select.tsx
@@ -128,6 +128,7 @@ export function SearchableMultiSelect({
                     {item.selectedContent ?? item.label}
                     <button
                       type="button"
+                      aria-label="Remove selected item"
                       className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                       onKeyDown={(e) => {
                         if (e.key === "Enter") {
@@ -176,6 +177,7 @@ export function SearchableMultiSelect({
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
           )}
           <input
+            aria-label={searchPlaceholder || "Search options"}
             placeholder={searchPlaceholder}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}

--- a/platform/frontend/src/components/service-logo-picker.tsx
+++ b/platform/frontend/src/components/service-logo-picker.tsx
@@ -533,6 +533,7 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
         <div className="relative">
           <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
           <Input
+            aria-label="Search logos"
             placeholder="Search logos..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}

--- a/platform/frontend/src/components/slack-setup-dialog.tsx
+++ b/platform/frontend/src/components/slack-setup-dialog.tsx
@@ -502,6 +502,7 @@ function StepManifestWebhook({
               From <strong>Basic Information &rarr; App Credentials</strong>,
               copy the <strong>App ID</strong>
               <Input
+                aria-label="Slack App ID"
                 value={appId}
                 onChange={(e) => onAppIdChange(e.target.value)}
                 placeholder="Paste your App ID"
@@ -620,6 +621,7 @@ function StepManifestSocket({
               From <strong>Basic Information &rarr; App Credentials</strong>,
               copy the <strong>App ID</strong>
               <Input
+                aria-label="Slack App ID"
                 value={appId}
                 onChange={(e) => onAppIdChange(e.target.value)}
                 placeholder="Paste your App ID"

--- a/platform/frontend/src/components/teams/team-management-dialog.tsx
+++ b/platform/frontend/src/components/teams/team-management-dialog.tsx
@@ -629,6 +629,7 @@ function TokenSection({ token }: { token?: TeamToken }) {
         <Label>Token</Label>
         <div className="flex gap-2">
           <Input
+            aria-label="Token"
             readOnly
             value={
               showValue && displayedValue

--- a/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
+++ b/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
@@ -190,7 +190,11 @@ export function TeamManagementExternalSyncSection({
                   : "Group Extraction Source"}
               </Label>
               <Input
-                aria-label="Group extraction source"
+                aria-label={
+                  selectedGroupsExpression
+                    ? "Group Extraction Template"
+                    : "Group Extraction Source"
+                }
                 readOnly
                 className="font-mono text-sm"
                 value={

--- a/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
+++ b/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
@@ -190,6 +190,7 @@ export function TeamManagementExternalSyncSection({
                   : "Group Extraction Source"}
               </Label>
               <Input
+                aria-label="Group extraction source"
                 readOnly
                 className="font-mono text-sm"
                 value={
@@ -235,6 +236,7 @@ export function TeamManagementExternalSyncSection({
           <Label>Add External Group Mapping</Label>
           <div className="flex gap-2">
             <Input
+              aria-label="Group identifier"
               placeholder="e.g., archestra-admins, cn=engineering,ou=groups,dc=example,dc=com"
               value={newGroupIdentifier}
               onChange={(event) => setNewGroupIdentifier(event.target.value)}

--- a/platform/frontend/src/components/tokens/platform-token-manager-dialog.tsx
+++ b/platform/frontend/src/components/tokens/platform-token-manager-dialog.tsx
@@ -107,6 +107,7 @@ export function PlatformTokenManagerDialog({
           <Label>Token</Label>
           <div className="flex gap-2">
             <Input
+              aria-label="Token"
               readOnly
               value={
                 showValue && displayedValue

--- a/platform/frontend/src/components/ui/assignment-combobox.tsx
+++ b/platform/frontend/src/components/ui/assignment-combobox.tsx
@@ -111,6 +111,7 @@ export function AssignmentCombobox({
       >
         <div className="px-2 py-1.5">
           <Input
+            aria-label={placeholder || "Search"}
             placeholder={placeholder}
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/platform/frontend/src/components/ui/cron-expression-picker.tsx
+++ b/platform/frontend/src/components/ui/cron-expression-picker.tsx
@@ -140,6 +140,7 @@ export function CronExpressionPicker({
           </p>
           <div className="flex items-center gap-1.5">
             <Input
+              aria-label="Custom cron expression"
               placeholder={customPlaceholder}
               value={customDraft}
               onChange={(event) => setCustomDraft(event.target.value)}

--- a/platform/frontend/src/components/ui/multi-select-combobox.tsx
+++ b/platform/frontend/src/components/ui/multi-select-combobox.tsx
@@ -137,6 +137,7 @@ export function MultiSelectCombobox({
               {option.label}
               <button
                 type="button"
+                aria-label="Remove selected option"
                 onClick={(e) => handleRemove(option.value, e)}
                 className="hover:bg-muted-foreground/20 rounded-sm"
               >
@@ -146,6 +147,7 @@ export function MultiSelectCombobox({
           ))}
           <input
             ref={inputRef}
+            aria-label="Search options"
             value={search}
             disabled={disabled}
             onChange={(e) => {

--- a/platform/frontend/src/components/ui/multi-select.tsx
+++ b/platform/frontend/src/components/ui/multi-select.tsx
@@ -109,6 +109,7 @@ export function MultiSelect({
                   {item.label}
                   <button
                     type="button"
+                    aria-label="Remove selected item"
                     className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
@@ -142,6 +143,7 @@ export function MultiSelect({
           <div className="flex items-center border-b px-3 pb-2 pt-3">
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
             <input
+              aria-label="Search options"
               placeholder="Search..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/platform/frontend/src/components/ui/searchable-select.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.tsx
@@ -126,6 +126,7 @@ export function SearchableSelect({
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
           )}
           <input
+            aria-label={searchPlaceholder || "Search options"}
             placeholder={searchPlaceholder}
             value={searchQuery}
             onChange={(e) => {

--- a/platform/frontend/src/components/user-searchable-multi-select.test.tsx
+++ b/platform/frontend/src/components/user-searchable-multi-select.test.tsx
@@ -137,7 +137,9 @@ describe("UserSearchableMultiSelect", () => {
       />,
     );
 
-    const badges = screen.getAllByRole("button", { name: "" });
+    const badges = screen.getAllByRole("button", {
+      name: "Remove selected item",
+    });
     await user.click(badges[0]);
 
     expect(onValueChange).toHaveBeenCalledWith(["user-2"]);


### PR DESCRIPTION
## What

A WCAG 2.2 **Level A/AA** accessibility audit and remediation of the frontend, plus a CI guard so the most common gap can't regress.

The app is already in good shape — it's built on Radix/shadcn primitives (dialogs, menus, selects get focus-trap + ARIA for free), ARIA usage is valid, images are labeled, base theme-token contrast passes AA, drag has a keyboard sensor, and all icon-button sizes are ≥24px. The gaps were a concentrated, mostly-mechanical set rather than anything structural.

## Fixes

| Area | WCAG SC | Change |
|---|---|---|
| Accessible names | 4.1.2 / 1.1.1 / 3.3.2 (A) | Added names (`aria-label`, or the existing `sr-only` convention) to ~112 icon-only buttons and unlabeled form controls — search inputs, hidden file inputs, inline-add fields, and readonly value displays. Reusable select/combobox/upload primitives are fixed once at the root so every call site benefits. |
| Bypass blocks | 2.4.1 (A) | Skip-to-content link as the first tab stop, with `<main>` as a focus target. |
| Status messages | 4.1.3 (AA) | `LoadingSpinner` is now an `<output role=status>` live region (used in ~41 places), plus a visually-hidden `ChatStatusAnnouncer` that announces chat stream state (responding / ready / failed) without reading every token. |
| Keyboard | 2.1.1 (A) | Removed the fake `role="button"`/`tabIndex`/no-op `onKeyDown` from the browser-preview overlay — it was a focusable control that did nothing on keyboard. It's now an honest pointer-only surface (it forwards a click coordinate to the remote browser), with the keyboard limitation documented in code. |
| Label in Name | 2.5.3 (A) | Two aria-labels adjusted so their text contains the control's visible label. |

## Regression guard

Adds a small **Biome GritQL plugin** — `biome-plugins/icon-button-aria-label.grit` — that **fails CI on any icon-only `<Button>` (size `icon`/`icon-sm`/`icon-lg`) with no accessible name**. This is the single most common gap this PR fixes, and Biome's built-in a11y rules can't detect it (they can't reason about an element's computed accessible name).

The rule is deliberately precise — it does **not** flag buttons named via `aria-label`, `aria-labelledby`, `title`, a visually-hidden `sr-only` text child, `asChild` delegation, or buttons whose content is visible text. Verified: **0 false positives** across the frontend, and it correctly fails on a fresh unlabeled icon button. It runs inside the existing `biome ci` step, so **no workflow changes** were needed. (Also corrected a stale `biome.json` `$schema` URL, 2.3.7 → 2.4.6.)

## Verification

- `pnpm type-check` ✓
- `pnpm biome ci` (including the new plugin) ✓
- `pnpm knip` ✓
- Full frontend vitest suite: **2543 passing**. Three test files were updated to locate buttons by their new accessible names (previously they matched an empty name — the bug this PR fixes), which makes those assertions stricter, not weaker.

## Not covered here (recommended for the manual accessibility review)

These require assistive-technology / in-browser testing rather than static changes:

- Screen-reader reading-order and announcement *quality* (beyond the live regions added here).
- 400% reflow / resize behavior in a real browser (WCAG 1.4.10 / 1.4.4).
- `prefers-reduced-motion` handling — the app has essentially no `motion-reduce:` guards today. Not an A/AA failure (spinners are essential; 2.3.3 is AAA), but a reasonable follow-up.
- Full keyboard control of the embedded live browser preview (would require forwarding key events to the remote session — a separate feature).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>