### PR TITLE
fix: Remove Star history section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,6 @@ Thank you for continuously making **Archestra** better — you're awesome 🫶
   <img src="https://contrib.rocks/image?repo=archestra-ai/archestra" alt="Contributors" />
 </a>
 
-## Star history
-
-<a href="https://star-history.com/#archestra-ai/archestra&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=archestra-ai/archestra&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=archestra-ai/archestra&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=archestra-ai/archestra&type=Date" />
-  </picture>
-</a>
-
 ---
 
 <div align="center">


### PR DESCRIPTION
Removed the Star history section from the README.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>