### PR TITLE
fix(apps): handle terminal UI states

### DIFF
--- a/platform/frontend/src/app/a/[appId]/page.client.test.tsx
+++ b/platform/frontend/src/app/a/[appId]/page.client.test.tsx
@@ -1,0 +1,166 @@
+import { archestraApiClient, type archestraApiTypes } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { toast } from "sonner";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import AppRunPage from "./page.client";
+
+const API_ORIGIN = "http://localhost:9000";
+const APP_ID = "app-1";
+const APP_URL = `${API_ORIGIN}/api/apps/${APP_ID}`;
+const app = {
+  id: APP_ID,
+  organizationId: "org-1",
+  authorId: "user-1",
+  name: "Test App",
+  description: null,
+  templateId: null,
+  mcpServerId: "server-1",
+  spec: null,
+  latestVersion: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  deletedAt: null,
+  scope: "personal",
+  environmentId: null,
+  teams: [],
+} satisfies archestraApiTypes.GetAppResponses["200"];
+
+const server = setupServer();
+
+vi.mock("sonner");
+
+vi.mock("@/components/mcp-app/mcp-app-view", () => ({
+  McpAppRuntime: () => <div data-testid="app-frame" />,
+}));
+
+vi.mock("@/components/mcp-app/use-app-runtime-controls", () => ({
+  useAppRuntimeControls: () => ({
+    displayMode: "inline",
+    setDisplayMode: vi.fn(),
+    reloadNonce: 0,
+    resourceState: "ready",
+    setResourceState: vi.fn(),
+  }),
+}));
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  archestraApiClient.setConfig({ baseUrl: API_ORIGIN });
+  server.use(http.get(APP_URL, () => HttpResponse.json(app)));
+});
+
+afterEach(() => server.resetHandlers());
+
+afterAll(() => {
+  server.close();
+  archestraApiClient.setConfig({ baseUrl: "" });
+});
+
+describe("AppRunPage", () => {
+  it("retries an initial query failure", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(APP_URL, () => {
+        attempts += 1;
+        return attempts === 1
+          ? apiError("api_internal_server_error", 500)
+          : HttpResponse.json(app);
+      }),
+    );
+
+    renderPage();
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    expect(toast.error).not.toHaveBeenCalled();
+    fireEvent.click(retry);
+
+    expect(await screen.findByTestId("app-frame")).toBeInTheDocument();
+    expect(attempts).toBe(2);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps a successful not-found response as unavailable", async () => {
+    server.use(http.get(APP_URL, () => apiError("api_not_found_error", 404)));
+
+    renderPage();
+
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+    expect(screen.queryByTestId("app-frame")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps cached app content mounted when a refetch fails", async () => {
+    let requests = 0;
+    server.use(
+      http.get(APP_URL, () => {
+        requests += 1;
+        return apiError("api_internal_server_error", 500);
+      }),
+    );
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["apps", APP_ID], app);
+
+    renderPage(queryClient);
+
+    expect(await screen.findByTestId("app-frame")).toBeInTheDocument();
+    await act(() =>
+      queryClient.invalidateQueries({ queryKey: ["apps", APP_ID] }),
+    );
+    await waitFor(() =>
+      expect(queryClient.getQueryState(["apps", APP_ID])).toMatchObject({
+        status: "error",
+        fetchStatus: "idle",
+      }),
+    );
+    expect(requests).toBe(1);
+    expect(screen.getByTestId("app-frame")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});
+
+function renderPage(queryClient = createQueryClient()): QueryClient {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AppRunPage appId={APP_ID} />
+    </QueryClientProvider>,
+  );
+  return queryClient;
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
+  });
+}
+
+function apiError(type: string, status: number) {
+  return HttpResponse.json(
+    { error: { message: "Request failed", type } },
+    { status },
+  );
+}

--- a/platform/frontend/src/app/a/[appId]/page.client.tsx
+++ b/platform/frontend/src/app/a/[appId]/page.client.tsx
@@ -2,24 +2,40 @@
 
 import { useEffect } from "react";
 import { AppFrame } from "@/components/mcp-app/app-frame";
+import { QueryLoadError } from "@/components/query-load-error";
 import { useApp } from "@/lib/app.query";
 
 // Full-page standalone runtime: just the app, no Archestra chrome. The app name
 // goes to the browser tab title, like any standalone web app.
 export default function AppRunPage({ appId }: { appId: string }) {
-  const { data: app, isPending } = useApp(appId);
+  const {
+    data: app,
+    isPending,
+    isLoadingError,
+    refetch,
+  } = useApp(appId, { toastOnError: false });
 
   useEffect(() => {
     if (app?.name) document.title = app.name;
   }, [app?.name]);
 
+  if (isLoadingError) {
+    return (
+      <QueryLoadError
+        title="Couldn't load this app"
+        onRetry={() => refetch()}
+        className="h-screen"
+      />
+    );
+  }
+
   // Mount only once resolved so the runtime keys diagnostics to a concrete
   // version — AppFrame renders the bare runtime and doesn't gate on it.
   if (!app) {
     return isPending ? null : (
-      <div className="flex h-screen items-center justify-center p-8 text-center text-sm text-muted-foreground">
+      <output className="flex h-screen items-center justify-center p-8 text-center text-sm text-muted-foreground">
         This app does not exist or you do not have access to it.
-      </div>
+      </output>
     );
   }
 

--- a/platform/frontend/src/app/a/catalog/[catalogId]/page.client.test.tsx
+++ b/platform/frontend/src/app/a/catalog/[catalogId]/page.client.test.tsx
@@ -1,11 +1,34 @@
-import { render, screen } from "@testing-library/react";
+import { archestraApiClient, type archestraApiTypes } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import CatalogAppRunPage from "./page.client";
 
+const API_ORIGIN = "http://localhost:9000";
+const CATALOG_ID = "cat-1";
+const APP_URL = `${API_ORIGIN}/api/apps/external/${CATALOG_ID}`;
 const resolution = {
-  catalogId: "cat-1",
+  catalogId: CATALOG_ID,
   name: "Archestra PM",
   description: null,
   resourceUri: "ui://pm/backlog.html",
@@ -31,11 +54,19 @@ const resolution = {
   ],
   defaultMcpServerId: "srv-1",
   installs: [
-    { mcpServerId: "srv-1", scope: "org" as const, name: "Org install" },
+    {
+      mcpServerId: "srv-1",
+      scope: "org",
+      ownerId: null,
+      teamId: null,
+      name: "Org install",
+      localInstallationStatus: null,
+    },
   ],
-};
+} satisfies archestraApiTypes.GetExternalAppResponses["200"];
 
 let searchString = "";
+const server = setupServer();
 
 vi.mock("next/link", () => ({
   default: ({ children, ...props }: { children: ReactNode }) => (
@@ -44,11 +75,7 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("next/navigation");
-
-vi.mock("@/lib/app.query", () => ({
-  useExternalApp: () => ({ data: resolution, isPending: false }),
-  useOpenExternalAppInChat: () => ({ mutateAsync: vi.fn() }),
-}));
+vi.mock("sonner");
 
 vi.mock("@/components/mcp-app/app-frame", () => ({
   AppFrame: ({ resourceUri }: { resourceUri: string }) => (
@@ -56,7 +83,12 @@ vi.mock("@/components/mcp-app/app-frame", () => ({
   ),
 }));
 
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
 beforeEach(() => {
+  vi.clearAllMocks();
+  archestraApiClient.setConfig({ baseUrl: API_ORIGIN });
+  server.use(http.get(APP_URL, () => HttpResponse.json(resolution)));
   vi.mocked(useRouter).mockReturnValue({
     replace: vi.fn(),
     push: vi.fn(),
@@ -71,41 +103,135 @@ beforeEach(() => {
 
 afterEach(() => {
   searchString = "";
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+  archestraApiClient.setConfig({ baseUrl: "" });
 });
 
 describe("CatalogAppRunPage", () => {
-  it("renders the resource named by ?resource= and labels the header", () => {
+  it("renders the resource named by ?resource= and labels the header", async () => {
     searchString = "resource=ui://pm/board.html";
-    render(<CatalogAppRunPage catalogId="cat-1" />);
+    renderPage();
 
-    expect(screen.getByTestId("app-frame")).toHaveAttribute(
+    expect(await screen.findByTestId("app-frame")).toHaveAttribute(
       "data-resource",
       "ui://pm/board.html",
     );
     expect(screen.getByText("Archestra PM / show_board")).toBeInTheDocument();
   });
 
-  it("falls back to the default resource when ?resource= is absent or unknown", () => {
+  it("falls back to the default resource when ?resource= is absent or unknown", async () => {
     searchString = "resource=ui://pm/does-not-exist.html";
-    render(<CatalogAppRunPage catalogId="cat-1" />);
+    renderPage();
 
-    expect(screen.getByTestId("app-frame")).toHaveAttribute(
+    expect(await screen.findByTestId("app-frame")).toHaveAttribute(
       "data-resource",
       "ui://pm/backlog.html",
     );
   });
 
-  it("offers an open-in-chat handoff instead of a bare render when the tool needs inputs", () => {
+  it("offers an open-in-chat handoff instead of a bare render when the tool needs inputs", async () => {
     searchString = "resource=ui://pm/task.html";
-    render(<CatalogAppRunPage catalogId="cat-1" />);
+    renderPage();
 
     // A deep link to a prompt-mode app must not mount a broken app.
+    expect(
+      await screen.findByRole("button", { name: /open in chat/i }),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("app-frame")).not.toBeInTheDocument();
     expect(
       screen.getByText(/needs a few inputs before it can render/i),
     ).toBeInTheDocument();
+  });
+
+  it("retries an initial query failure", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(APP_URL, () => {
+        attempts += 1;
+        return attempts === 1
+          ? apiError("api_internal_server_error", 500)
+          : HttpResponse.json(resolution);
+      }),
+    );
+
+    renderPage();
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    expect(toast.error).not.toHaveBeenCalled();
+    fireEvent.click(retry);
+
+    expect(await screen.findByTestId("app-frame")).toBeInTheDocument();
+    expect(attempts).toBe(2);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps a successful not-found response as unavailable", async () => {
+    server.use(http.get(APP_URL, () => apiError("api_not_found_error", 404)));
+
+    renderPage();
+
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+    expect(screen.queryByTestId("app-frame")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /open in chat/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps cached app content mounted when a refetch fails", async () => {
+    let requests = 0;
+    server.use(
+      http.get(APP_URL, () => {
+        requests += 1;
+        return apiError("api_internal_server_error", 500);
+      }),
+    );
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["apps", "external", CATALOG_ID], resolution);
+
+    renderPage(queryClient);
+
+    expect(await screen.findByTestId("app-frame")).toBeInTheDocument();
+    await act(() =>
+      queryClient.invalidateQueries({
+        queryKey: ["apps", "external", CATALOG_ID],
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryState(["apps", "external", CATALOG_ID]),
+      ).toMatchObject({ status: "error", fetchStatus: "idle" }),
+    );
+    expect(requests).toBe(1);
+    expect(screen.getByTestId("app-frame")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });
+
+function renderPage(queryClient = createQueryClient()): QueryClient {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CatalogAppRunPage catalogId={CATALOG_ID} />
+    </QueryClientProvider>,
+  );
+  return queryClient;
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
+  });
+}
+
+function apiError(type: string, status: number) {
+  return HttpResponse.json(
+    { error: { message: "Request failed", type } },
+    { status },
+  );
+}

--- a/platform/frontend/src/app/a/catalog/[catalogId]/page.client.tsx
+++ b/platform/frontend/src/app/a/catalog/[catalogId]/page.client.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { AppFrame } from "@/components/mcp-app/app-frame";
+import { QueryLoadError } from "@/components/query-load-error";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -43,7 +44,10 @@ export default function CatalogAppRunPage({
   const searchParams = useSearchParams();
   const requestedInstall = searchParams.get("install");
   const requestedResource = searchParams.get("resource");
-  const { data, isPending } = useExternalApp(catalogId);
+  const { data, isPending, isLoadingError, refetch } = useExternalApp(
+    catalogId,
+    { toastOnError: false },
+  );
 
   const installs = data?.installs ?? [];
   const activeInstallId =
@@ -75,12 +79,22 @@ export default function CatalogAppRunPage({
     }
   }, [isPending, data, activeInstallId, router]);
 
+  if (isLoadingError) {
+    return (
+      <QueryLoadError
+        title="Couldn't load this app"
+        onRetry={() => refetch()}
+        className="h-screen"
+      />
+    );
+  }
+
   if (!isPending && !data) {
     return (
       <div className="flex h-screen flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-sm text-muted-foreground">
+        <output className="text-sm text-muted-foreground">
           This app does not exist or you do not have access to it.
-        </p>
+        </output>
         <Button asChild variant="outline" size="sm">
           <Link href="/apps">
             <ArrowLeft className="h-4 w-4" />

--- a/platform/frontend/src/app/apps/_parts/app-delete-dialog.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-delete-dialog.tsx
@@ -58,9 +58,9 @@ export function AppDeleteDialog({
         >
           <div className="flex flex-col gap-3 px-4 pb-4">
             <DialogDescription>
-              Are you sure you want to delete &quot;{app.name}&quot;? This
-              permanently removes the app and its version history and cannot be
-              undone.
+              Are you sure you want to delete &quot;{app.name}&quot;? The app
+              will no longer be available, and this cannot be undone in the UI.
+              Its app record and version history may be retained.
             </DialogDescription>
           </div>
           <DialogStickyFooter className="mt-0 border-t-0 shadow-none">

--- a/platform/frontend/src/app/apps/_parts/app-tools-editor.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-editor.tsx
@@ -73,7 +73,7 @@ export function AppToolsEditor({
   selectedToolIds?: Set<string>;
   onSelectionChange?: (next: Set<string>) => void;
 }) {
-  const { data: app } = useApp(appId);
+  const { data: app } = useApp(environmentId === undefined ? appId : null);
   const { data: assigned, isPending } = useAppTools(appId);
   const { data: catalogs = [] } = useInternalMcpCatalog();
   const { data: canEdit } = useHasPermissions({ app: ["update"] });

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mock heavy dependencies before module import ─────────────────────────────
 
@@ -82,6 +82,8 @@ vi.mock("@/components/mcp-app/app-settings-form", () => ({
 
 // ── Import component under test after mocks ───────────────────────────────────
 
+import { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { McpAppRuntime } from "@/components/mcp-app/mcp-app-view";
 import { useApp } from "@/lib/app.query";
 import {
   clearAllAppDiagnostics,
@@ -1197,6 +1199,257 @@ describe("McpAppSection owned-app panel chrome", () => {
       screen.getByRole("button", { name: /^settings$/i }),
     ).toBeInTheDocument();
   });
+});
+
+describe("McpAppRuntime auth banner recovery", () => {
+  const AUTH_URL = "http://localhost:3000/mcp/registry?install=cat_test";
+  type CapturedBridge = {
+    oncalltool: ((params: { name: string }) => Promise<unknown>) | null;
+  };
+  type PendingToolCall = {
+    toolName: string;
+    respond: (result: unknown) => void;
+    reject: (error: unknown) => void;
+  };
+
+  let bridges: CapturedBridge[];
+  let pendingToolCalls: PendingToolCall[];
+  let restoreFetch: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bridges = [];
+    pendingToolCalls = [];
+
+    (AppBridge as ReturnType<typeof vi.fn>).mockImplementation(function (
+      this: Record<string, unknown>,
+    ) {
+      this.onrequestdisplaymode = null;
+      this.onopenlink = null;
+      this.oncalltool = null;
+      this.onreadresource = null;
+      this.onlistresources = null;
+      this.onlistresourcetemplates = null;
+      this.onlistprompts = null;
+      this.onloggingmessage = null;
+      this.onmessage = null;
+      this.onsizechange = null;
+      this.oninitialized = null;
+      this.onsandboxready = null;
+      this.connect = vi.fn().mockResolvedValue(undefined);
+      this.sendSandboxResourceReady = vi.fn().mockResolvedValue(undefined);
+      this.sendToolInput = vi.fn().mockResolvedValue(undefined);
+      this.sendToolInputPartial = vi.fn().mockResolvedValue(undefined);
+      this.sendToolResult = vi.fn().mockResolvedValue(undefined);
+      this.setHostContext = vi.fn();
+      this.teardownResource = vi.fn().mockResolvedValue(undefined);
+      bridges.push(this as CapturedBridge);
+    });
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_input, init) => {
+        if (typeof init?.body !== "string") {
+          throw new Error("Expected a JSON-RPC request body");
+        }
+        const request = JSON.parse(init.body) as {
+          id: number;
+          params: { name: string };
+        };
+        return new Promise<Response>((resolve, reject) => {
+          pendingToolCalls.push({
+            toolName: request.params.name,
+            respond: (result) =>
+              resolve(
+                Response.json({ jsonrpc: "2.0", id: request.id, result }),
+              ),
+            reject,
+          });
+        });
+      });
+    restoreFetch = () => fetchSpy.mockRestore();
+  });
+
+  afterEach(() => restoreFetch());
+
+  it("clears a same-tool auth refusal after a newer success", async () => {
+    const bridge = await renderRuntime();
+    const authCall = callTool(bridge, "search");
+    await settleToolCall(0, authRequiredResult(), authCall);
+    expect(screen.getByRole("link")).toHaveAttribute("href", AUTH_URL);
+
+    const success = successfulResult();
+    const successCall = callTool(bridge, "search");
+    const outcome = await settleToolCall(1, success, successCall);
+
+    expect(outcome).toStrictEqual(success);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("keeps a refusal through ordinary errors and other-tool successes", async () => {
+    const bridge = await renderRuntime();
+    const authCall = callTool(bridge, "search");
+    await settleToolCall(0, authRequiredResult(), authCall);
+
+    const errorCall = callTool(bridge, "search");
+    await settleToolCall(1, ordinaryErrorResult(), errorCall);
+    expect(screen.getByRole("link")).toHaveAttribute("href", AUTH_URL);
+
+    const otherSuccess = callTool(bridge, "other");
+    await settleToolCall(2, successfulResult(), otherSuccess);
+    expect(screen.getByRole("link")).toHaveAttribute("href", AUTH_URL);
+  });
+
+  it("does not let newer ordinary failures suppress older auth refusals", async () => {
+    const user = userEvent.setup();
+    const bridge = await renderRuntime();
+
+    const olderAuth = callTool(bridge, "search");
+    const newerError = callTool(bridge, "search");
+    await settleToolCall(1, ordinaryErrorResult(), newerError);
+    await settleToolCall(0, authRequiredResult(), olderAuth);
+    expect(screen.getByRole("link")).toHaveAttribute("href", AUTH_URL);
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    const secondOlderAuth = callTool(bridge, "search");
+    const newerRejected = callTool(bridge, "search");
+    const requestError = new Error("Request failed");
+    expect(await rejectToolCall(3, requestError, newerRejected)).toBe(
+      requestError,
+    );
+    await settleToolCall(2, authRequiredResult(), secondOlderAuth);
+    expect(screen.getByRole("link")).toHaveAttribute("href", AUTH_URL);
+  });
+
+  it("refreshes identical-refusal ordering without replacing the banner", async () => {
+    const bridge = await renderRuntime();
+    const firstAuth = callTool(bridge, "search");
+    await settleToolCall(0, authRequiredResult(), firstAuth);
+    const firstLink = screen.getByRole("link");
+
+    const olderSuccess = callTool(bridge, "search");
+    const newerRepeatedAuth = callTool(bridge, "search");
+    await settleToolCall(2, authRequiredResult(), newerRepeatedAuth);
+    expect(screen.getByRole("link")).toBe(firstLink);
+    expect(screen.getAllByRole("link")).toHaveLength(1);
+
+    await settleToolCall(1, successfulResult(), olderSuccess);
+    expect(screen.getByRole("link")).toBe(firstLink);
+  });
+
+  it("orders both out-of-order completion directions by call generation", async () => {
+    const bridge = await renderRuntime();
+
+    const olderAuth = callTool(bridge, "search");
+    const newerSuccess = callTool(bridge, "search");
+    await settleToolCall(1, successfulResult(), newerSuccess);
+    await settleToolCall(0, authRequiredResult(), olderAuth);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+
+    const olderSuccess = callTool(bridge, "search");
+    const newerAuth = callTool(bridge, "search");
+    await settleToolCall(3, authRequiredResult(), newerAuth);
+    await settleToolCall(2, successfulResult(), olderSuccess);
+    expect(screen.getByRole("link")).toHaveAttribute("href", AUTH_URL);
+  });
+
+  it("ignores a late settlement from a replaced bridge", async () => {
+    const rendered = render(runtimeNode("app-1"));
+    await vi.waitFor(() => expect(bridges).toHaveLength(1));
+    const staleCall = callTool(bridges[0], "search");
+
+    rendered.rerender(runtimeNode("app-2"));
+    await vi.waitFor(() => expect(bridges).toHaveLength(2));
+    const staleResult = authRequiredResult();
+    const outcome = await settleToolCall(0, staleResult, staleCall);
+
+    expect(outcome).toStrictEqual(staleResult);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  async function renderRuntime(): Promise<CapturedBridge> {
+    render(runtimeNode("app-1"));
+    await vi.waitFor(() => expect(bridges).toHaveLength(1));
+    return bridges[0];
+  }
+
+  function runtimeNode(appId: string) {
+    return (
+      <McpAppRuntime
+        toolResourceUri="ui://test/app"
+        endpoint={{ kind: "app", appId }}
+        displayMode="inline"
+        onDisplayModeChange={vi.fn()}
+        onSizeChange={vi.fn()}
+        onResourceStateChange={vi.fn()}
+        preloadedResource={preloadedResource}
+      />
+    );
+  }
+
+  function callTool(bridge: CapturedBridge, name: string): Promise<unknown> {
+    if (!bridge.oncalltool)
+      throw new Error("Bridge tool callback not installed");
+    return bridge.oncalltool({ name });
+  }
+
+  async function settleToolCall(
+    index: number,
+    result: unknown,
+    call: Promise<unknown>,
+  ): Promise<unknown> {
+    let outcome: unknown;
+    await act(async () => {
+      pendingToolCalls[index].respond(result);
+      outcome = await call;
+    });
+    return outcome;
+  }
+
+  async function rejectToolCall(
+    index: number,
+    error: unknown,
+    call: Promise<unknown>,
+  ): Promise<unknown> {
+    let rejection: unknown;
+    await act(async () => {
+      pendingToolCalls[index].reject(error);
+      try {
+        await call;
+      } catch (caught) {
+        rejection = caught;
+      }
+    });
+    return rejection;
+  }
+
+  function authRequiredResult() {
+    return {
+      isError: true,
+      content: [{ type: "text", text: "Authentication required" }],
+      _meta: {
+        archestraError: {
+          type: "auth_required",
+          message: "Authentication required",
+          catalogName: "Test catalog",
+          catalogId: "cat_test",
+          action: "install_mcp_credentials",
+          actionUrl: AUTH_URL,
+        },
+      },
+    };
+  }
+
+  function successfulResult() {
+    return { content: [{ type: "text", text: "ok" }] };
+  }
+
+  function ordinaryErrorResult() {
+    return {
+      isError: true,
+      content: [{ type: "text", text: "Tool failed" }],
+    };
+  }
 });
 
 describe("McpAppSection error handling", () => {

--- a/platform/frontend/src/components/mcp-app/app-frame.tsx
+++ b/platform/frontend/src/components/mcp-app/app-frame.tsx
@@ -46,7 +46,7 @@ export function AppFrame({
   } = useAppRuntimeControls();
 
   const appId = endpoint.kind === "app" ? endpoint.appId : null;
-  const { data: app } = useApp(appId);
+  const { data: app } = useApp(appId, { toastOnError: false });
   const resolvedResourceUri = appId
     ? getArchestraAppResourceUri(appId)
     : resourceUri;

--- a/platform/frontend/src/components/mcp-app/app-settings-dialog.test.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-dialog.test.tsx
@@ -1,0 +1,258 @@
+import {
+  archestraApiClient,
+  type archestraApiTypes,
+  type Permissions,
+} from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { authQueryKeys } from "@/lib/auth/auth.query";
+import { adminPermissionsSeed, sessionSeed } from "@/mocks/data/auth";
+import { organizationSeed, teamsSeed } from "@/mocks/data/organization";
+import { AppSettingsDialog } from "./app-settings-dialog";
+
+const API_ORIGIN = "http://localhost:9000";
+const APP_ID = "app-1";
+const APP_URL = `${API_ORIGIN}/api/apps/${APP_ID}`;
+const APP_TOOLS_URL = `${APP_URL}/tools`;
+const app = {
+  id: APP_ID,
+  organizationId: "org-1",
+  authorId: "user-1",
+  name: "Test App",
+  description: null,
+  templateId: null,
+  mcpServerId: "server-1",
+  spec: null,
+  latestVersion: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  deletedAt: null,
+  scope: "personal",
+  environmentId: null,
+  teams: [],
+} satisfies archestraApiTypes.GetAppResponses["200"];
+const userPermissions = {
+  ...adminPermissionsSeed,
+  app: ["read", "update", "admin", "team-admin"],
+} satisfies Permissions;
+
+const server = setupServer(
+  http.get(`${API_ORIGIN}/api/teams`, () => HttpResponse.json(teamsSeed)),
+  http.get(`${API_ORIGIN}/api/environments`, () =>
+    HttpResponse.json({ environments: [], defaultAssignedCatalogCount: 0 }),
+  ),
+  http.get(`${API_ORIGIN}/api/organization`, () =>
+    HttpResponse.json(organizationSeed),
+  ),
+  http.get(`${API_ORIGIN}/api/internal_mcp_catalog`, () =>
+    HttpResponse.json([]),
+  ),
+);
+
+vi.mock("sonner");
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  archestraApiClient.setConfig({ baseUrl: API_ORIGIN });
+  server.use(
+    http.get(APP_URL, () => HttpResponse.json(app)),
+    http.get(APP_TOOLS_URL, () => HttpResponse.json([])),
+  );
+});
+
+afterEach(() => server.resetHandlers());
+
+afterAll(() => {
+  server.close();
+  archestraApiClient.setConfig({ baseUrl: "" });
+});
+
+describe("AppSettingsDialog", () => {
+  it("shows a pending state until the app resolves", async () => {
+    let releaseRequest = () => {};
+    const blocked = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+    server.use(
+      http.get(APP_URL, async () => {
+        await blocked;
+        return HttpResponse.json(app);
+      }),
+    );
+
+    renderDialog();
+
+    expect(
+      await screen.findByRole("status", { name: "Loading app settings" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+
+    await act(async () => releaseRequest());
+    expect(
+      await screen.findByRole("textbox", { name: "Name" }),
+    ).toBeInTheDocument();
+  });
+
+  it("retries an initial query failure without showing Save", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(APP_URL, () => {
+        attempts += 1;
+        return attempts === 1
+          ? apiError("api_internal_server_error", 500)
+          : HttpResponse.json(app);
+      }),
+    );
+
+    renderDialog();
+    const retry = await screen.findByRole("button", { name: "Retry" });
+
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(toast.error).not.toHaveBeenCalled();
+    fireEvent.click(retry);
+
+    expect(
+      await screen.findByRole("textbox", { name: "Name" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled(),
+    );
+    expect(attempts).toBe(2);
+  });
+
+  it("shows an unavailable terminal state without Save after not-found", async () => {
+    server.use(http.get(APP_URL, () => apiError("api_not_found_error", 404)));
+
+    renderDialog();
+
+    expect(
+      await screen.findByRole("status", { name: "App settings unavailable" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: "Name" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+  });
+
+  it("keeps cached settings usable when a refetch fails", async () => {
+    let requests = 0;
+    server.use(
+      http.get(APP_URL, () => {
+        requests += 1;
+        return apiError("api_internal_server_error", 500);
+      }),
+    );
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["apps", APP_ID], app);
+
+    renderDialog(queryClient);
+    expect(
+      await screen.findByRole("textbox", { name: "Name" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled(),
+    );
+
+    await act(() =>
+      queryClient.invalidateQueries({ queryKey: ["apps", APP_ID] }),
+    );
+    await waitFor(() =>
+      expect(queryClient.getQueryState(["apps", APP_ID])).toMatchObject({
+        status: "error",
+        fetchStatus: "idle",
+      }),
+    );
+
+    expect(requests).toBe(1);
+    expect(screen.getByRole("textbox", { name: "Name" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("closes on Cancel and remounts a fresh form when reopened", async () => {
+    renderControlledDialog();
+    const nameInput = await screen.findByRole("textbox", { name: "Name" });
+    fireEvent.change(nameInput, { target: { value: "Unsaved name" } });
+    expect(nameInput).toHaveValue("Unsaved name");
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(await screen.findByRole("textbox", { name: "Name" })).toHaveValue(
+      app.name,
+    );
+  });
+});
+
+function renderDialog(queryClient = createQueryClient()): void {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AppSettingsDialog appId={APP_ID} open onOpenChange={vi.fn()} />
+    </QueryClientProvider>,
+  );
+}
+
+function renderControlledDialog(): void {
+  function Harness() {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        {!open ? (
+          <button type="button" onClick={() => setOpen(true)}>
+            Open settings
+          </button>
+        ) : null}
+        <AppSettingsDialog appId={APP_ID} open={open} onOpenChange={setOpen} />
+      </>
+    );
+  }
+
+  const queryClient = createQueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Harness />
+    </QueryClientProvider>,
+  );
+}
+
+function createQueryClient(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
+  });
+  queryClient.setQueryData(authQueryKeys.session(), sessionSeed);
+  queryClient.setQueryData(authQueryKeys.userPermissions(), userPermissions);
+  return queryClient;
+}
+
+function apiError(type: string, status: number) {
+  return HttpResponse.json(
+    { error: { message: "Request failed", type } },
+    { status },
+  );
+}

--- a/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { LoadingSpinner } from "@/components/loading";
 import { AppSettingsForm } from "@/components/mcp-app/app-settings-form";
+import { QueryLoadError } from "@/components/query-load-error";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -34,7 +35,12 @@ export function AppSettingsDialog({
 }) {
   // Only fetch while open; the content unmounts on close, so reopening remounts
   // the form fresh from the (cached) app.
-  const { data: app } = useApp(open ? appId : null);
+  const {
+    data: app,
+    isPending,
+    isLoadingError,
+    refetch,
+  } = useApp(open ? appId : null, { toastOnError: false });
   const [status, setStatus] = useState({ saving: false, disabled: false });
 
   return (
@@ -43,7 +49,20 @@ export function AppSettingsDialog({
         <DialogHeader className="px-4 py-4">
           <DialogTitle>App settings</DialogTitle>
         </DialogHeader>
-        {app ? (
+        {isPending ? (
+          <output
+            aria-label="Loading app settings"
+            className="flex min-h-40 flex-1 items-center justify-center"
+          >
+            <LoadingSpinner />
+          </output>
+        ) : isLoadingError ? (
+          <QueryLoadError
+            title="Couldn't load app settings"
+            onRetry={() => refetch()}
+            className="min-h-40 flex-1"
+          />
+        ) : app ? (
           <AppSettingsForm
             app={app}
             formId={APP_SETTINGS_FORM_ID}
@@ -51,9 +70,12 @@ export function AppSettingsDialog({
             onStatusChange={setStatus}
           />
         ) : (
-          <div className="flex min-h-40 flex-1 items-center justify-center">
-            <LoadingSpinner />
-          </div>
+          <output
+            aria-label="App settings unavailable"
+            className="flex min-h-40 flex-1 items-center justify-center text-sm text-muted-foreground"
+          >
+            App settings are unavailable.
+          </output>
         )}
         <DialogFooter className="px-4 py-3">
           <Button
@@ -63,13 +85,15 @@ export function AppSettingsDialog({
           >
             Cancel
           </Button>
-          <Button
-            type="submit"
-            form={APP_SETTINGS_FORM_ID}
-            disabled={!app || status.disabled}
-          >
-            {status.saving ? "Saving…" : "Save"}
-          </Button>
+          {app ? (
+            <Button
+              type="submit"
+              form={APP_SETTINGS_FORM_ID}
+              disabled={status.disabled}
+            >
+              {status.saving ? "Saving…" : "Save"}
+            </Button>
+          ) : null}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -143,6 +143,7 @@ export const McpAppRuntime = function McpAppRuntime({
   // host-side connect banner above the iframe (see McpAppAuthBanner).
   const [toolCallAuthError, setToolCallAuthError] =
     useState<McpAppToolCallAuthError | null>(null);
+  const dismissToolCallAuthErrorRef = useRef<() => void>(() => {});
 
   // Stable identity for the bridge-creation effect — re-run when the endpoint or
   // resource changes, never on unrelated re-renders. The effect derives its
@@ -388,20 +389,53 @@ export const McpAppRuntime = function McpAppRuntime({
     // connect banner OUTSIDE the iframe — the app may only print the error
     // text, and the sandbox blocks popups so an in-app link couldn't open.
     // A fresh render (endpoint/resource/reload change) starts with no banner.
+    let nextToolCallGeneration = 0;
+    const latestAuthoritativeGenerationByTool = new Map<string, number>();
+    let activeAuthError: ActiveMcpAppToolCallAuthError | null = null;
+    dismissToolCallAuthErrorRef.current = () => {
+      activeAuthError = null;
+      setToolCallAuthError(null);
+    };
     setToolCallAuthError(null);
     const proxyToolCall = async (params: {
       name: string;
       arguments?: unknown;
     }) => {
+      const generation = ++nextToolCallGeneration;
       const result = await mcpProxy("tools/call", params);
+      if (cancelled) return result;
+
       const authState = resolveMcpAppToolCallAuthState(result);
       if (authState) {
-        const next = { toolName: params.name, authState };
+        const latestGeneration =
+          latestAuthoritativeGenerationByTool.get(params.name) ?? 0;
+        if (generation < latestGeneration) return result;
+
+        latestAuthoritativeGenerationByTool.set(params.name, generation);
+        if (activeAuthError && generation < activeAuthError.generation) {
+          return result;
+        }
+
+        const next = { toolName: params.name, authState, generation };
+        activeAuthError = next;
         // Keep the previous object when the same refusal repeats (an app retry
         // loop) so the banner doesn't re-render on every failed call.
         setToolCallAuthError((prev) =>
           prev && isSameToolCallAuthError(prev, next) ? prev : next,
         );
+      } else if (isSuccessfulMcpToolCallResult(result)) {
+        const latestGeneration =
+          latestAuthoritativeGenerationByTool.get(params.name) ?? 0;
+        if (generation < latestGeneration) return result;
+
+        latestAuthoritativeGenerationByTool.set(params.name, generation);
+        if (
+          activeAuthError?.toolName === params.name &&
+          generation > activeAuthError.generation
+        ) {
+          activeAuthError = null;
+          setToolCallAuthError(null);
+        }
       }
       return result;
     };
@@ -691,7 +725,7 @@ export const McpAppRuntime = function McpAppRuntime({
         <McpAppAuthBanner
           toolName={toolCallAuthError.toolName}
           authState={toolCallAuthError.authState}
-          onDismiss={() => setToolCallAuthError(null)}
+          onDismiss={() => dismissToolCallAuthErrorRef.current()}
         />
       )}
       {loadError && (
@@ -762,6 +796,10 @@ type McpAppToolCallAuthError = {
   authState: ConnectableAuthState;
 };
 
+type ActiveMcpAppToolCallAuthError = McpAppToolCallAuthError & {
+  generation: number;
+};
+
 /** Same auth refusal (tool + kind + action URL): the banner needn't update. */
 function isSameToolCallAuthError(
   a: McpAppToolCallAuthError,
@@ -774,6 +812,14 @@ function isSameToolCallAuthError(
     a.authState.kind === b.authState.kind &&
     urlOf(a.authState) === urlOf(b.authState)
   );
+}
+
+function isSuccessfulMcpToolCallResult(
+  result: unknown,
+): result is McpCallToolResult {
+  if (typeof result !== "object" || result === null) return false;
+  const candidate = result as { content?: unknown; isError?: unknown };
+  return Array.isArray(candidate.content) && candidate.isError !== true;
 }
 
 const SANDBOX_PROXY_READY = "ui/notifications/sandbox-proxy-ready";

--- a/platform/frontend/src/lib/app.query.ts
+++ b/platform/frontend/src/lib/app.query.ts
@@ -24,6 +24,7 @@ const {
 
 type AppsQuery = NonNullable<archestraApiTypes.GetAppsData["query"]>;
 type AppsParams = Pick<AppsQuery, "limit" | "offset" | "search">;
+type AppDetailQueryOptions = { toastOnError?: boolean };
 
 // ===== Query hooks =====
 
@@ -46,7 +47,11 @@ export function useApps(
 
 // Resolves an external UI-providing app by catalog id: its UI resource plus the
 // caller's accessible installs and default install for the run-page selector.
-export function useExternalApp(catalogId: string | null) {
+export function useExternalApp(
+  catalogId: string | null,
+  options?: AppDetailQueryOptions,
+) {
+  const toastOnError = options?.toastOnError;
   return useQuery({
     queryKey: ["apps", "external", catalogId],
     enabled: !!catalogId,
@@ -54,13 +59,14 @@ export function useExternalApp(catalogId: string | null) {
       const { data, error } = await getExternalApp({
         path: { catalogId: catalogId as string },
       });
-      throwOnApiError(error, { allowNotFound: true });
+      throwOnApiError(error, { allowNotFound: true, toastOnError });
       return data ?? null;
     },
   });
 }
 
-export function useApp(appId: string | null) {
+export function useApp(appId: string | null, options?: AppDetailQueryOptions) {
+  const toastOnError = options?.toastOnError;
   return useQuery({
     queryKey: ["apps", appId],
     enabled: !!appId,
@@ -68,7 +74,7 @@ export function useApp(appId: string | null) {
       const { data, error } = await getApp({
         path: { appId: appId as string },
       });
-      throwOnApiError(error, { allowNotFound: true });
+      throwOnApiError(error, { allowNotFound: true, toastOnError });
       return data ?? null;
     },
   });


### PR DESCRIPTION
## Summary

- distinguish retryable standalone load failures from unavailable Apps
- render terminal settings states and recover auth banners after the current same-tool request succeeds
- align deletion copy with retained audit and version history

## Follow-ups

sweep-key: platform/frontend/src/app/apps/_parts/app-delete-dialog.tsx:59-63:delete-copy-misstates-retention

sweep-key: platform/frontend/src/components/mcp-app/app-settings-dialog.tsx:35-57:terminal-load-state-spins-forever

sweep-key: platform/frontend/src/components/mcp-app/mcp-app-view.tsx:396-405:auth-banner-persists-after-success

sweep-key: platform/frontend/src/app/a/[appId]/page.client.tsx:9-23:query-errors-misreported-as-unavailable

## Validation

- 52 targeted frontend Vitest tests
- frontend type-check, Biome CI, and Knip

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>