### PR TITLE
fix(apps): tighten fallback resource scanning

### DIFF
--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -40,7 +40,7 @@ static HEAD_OR_HTML: LazyLock<Regex> =
 // This backstops the DOM loops for tag shapes `tl` drops without treating
 // custom or namespace-like elements as native resource tags.
 static RESOURCE_TAG_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?is)<(script|link)([\x20\t\n\x0c\r/][^>]*|>)")
+    Regex::new(r"(?s)<(?i-u:(script|link))([\x20\t\n\x0c\r/][^>]*|>)")
         .expect("static resource tag fallback regex")
 });
 
@@ -51,7 +51,7 @@ static RESOURCE_TAG_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
 // entity-spliced markers) can still slip it — the render-time CSP stays the
 // real security boundary.
 static RESOURCE_ATTR_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?is)[\s/"'](src|href)\s*=\s*(?:["']([^"']*)["']|([^\s>"']+))"#)
+    Regex::new(r#"(?is)[\s/"'](?i-u:(src|href))\s*=\s*(?:["']([^"']*)["']|([^\s>"']+))"#)
         .expect("static resource attribute fallback regex")
 });
 
@@ -137,30 +137,26 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     //    matches this can add (e.g. inside HTML comments) are fail-closed.
     for tag_capture in RESOURCE_TAG_FALLBACK.captures_iter(html) {
         let tag_name = &tag_capture[1];
-        let attr_name = if tag_name.eq_ignore_ascii_case("script") {
-            "src"
-        } else {
-            "href"
-        };
-        let Some(attr_capture) = RESOURCE_ATTR_FALLBACK
-            .captures_iter(&tag_capture[2])
-            .find(|capture| capture[1].eq_ignore_ascii_case(attr_name))
-        else {
+        let Some(attr_capture) = RESOURCE_ATTR_FALLBACK.captures(&tag_capture[2]) else {
             continue;
         };
+        let attr_name = &attr_capture[1];
         let value = attr_capture
             .get(2)
             .or_else(|| attr_capture.get(3))
             .map_or("", |matched| matched.as_str());
         let normalized = normalize_resource_ref(value);
-        if tag_name.eq_ignore_ascii_case("script") {
+        if tag_name.eq_ignore_ascii_case("script") && attr_name.eq_ignore_ascii_case("src") {
             if PLATFORM_SCRIPT_SRC_MARKERS
                 .iter()
                 .any(|marker| normalized.contains(marker))
             {
                 return reject(RejectionKind::PlatformScriptSrc, value.to_string());
             }
-        } else if normalized.contains(PLATFORM_BASE_CSS_MARKER) {
+        } else if tag_name.eq_ignore_ascii_case("link")
+            && attr_name.eq_ignore_ascii_case("href")
+            && normalized.contains(PLATFORM_BASE_CSS_MARKER)
+        {
             return reject(RejectionKind::PlatformBaseCss, value.to_string());
         }
     }
@@ -425,6 +421,8 @@ mod tests {
             r#"<html><head><link-widget href="/_sandbox/archestra-app-base.css"></head></html>"#,
             r#"<html><head><script:widget src="/_sandbox/archestra-app-sdk.js"></script:widget></head></html>"#,
             "<html><head><link\u{00a0}href=\"/_sandbox/archestra-app-base.css\"></head></html>",
+            "<html><head><ſcript src=\"/_sandbox/archestra-app-sdk.js\"></ſcript></head></html>",
+            "<html><head><linK href=\"/_sandbox/archestra-app-base.css\"></head></html>",
         ];
         for html in cases {
             assert_eq!(scan_app_html(html).rejection, None, "{html}");
@@ -432,10 +430,12 @@ mod tests {
     }
 
     #[test]
-    fn fallback_uses_the_first_effective_resource_attribute() {
+    fn fallback_preserves_browser_effective_resource_attributes() {
         let cases = [
             r#"<html><head><script src="safe.js" src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#,
             r#"<html><head><link href="safe.css" href="/_sandbox/archestra-app-base.css"></head></html>"#,
+            r#"<html><head><script href="safe" data-note="src=/_sandbox/archestra-app-sdk.js"></script></head></html>"#,
+            r#"<html><head><link src="safe" data-note="href=/_sandbox/archestra-app-base.css"></head></html>"#,
         ];
         for html in cases {
             assert_eq!(scan_app_html(html).rejection, None, "{html}");

--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -112,28 +112,23 @@ pub fn scan_app_html(html: &str) -> ScanResult {
 
     // 2. Platform script self-load via <script src>, document order.
     for tag in tags().filter(|tag| exact_resource_tag_is(tag, "script")) {
-        if let Some(src) = resource_ref(tag, "src")
-            && PLATFORM_SCRIPT_SRC_MARKERS
+        if let Some(src) = resource_ref(tag, "src") {
+            let normalized = normalize_resource_ref(&src);
+            if PLATFORM_SCRIPT_SRC_MARKERS
                 .iter()
-                .any(|marker| src.contains(marker))
-        {
-            return reject(RejectionKind::PlatformScriptSrc, src);
+                .any(|marker| normalized.contains(marker))
+            {
+                return reject(RejectionKind::PlatformScriptSrc, src);
+            }
         }
     }
 
-    // 3. Platform stylesheet self-load via <link href>. Strip whitespace the
-    //    browser ignores when resolving the URL so a spliced tab/newline (or a
-    //    ZWNBSP, which JS `\s` strips but Rust's `is_whitespace` does not) can't
-    //    sneak the marker past.
+    // 3. Platform stylesheet self-load via <link href>.
     for tag in tags().filter(|tag| exact_resource_tag_is(tag, "link")) {
-        if let Some(href) = resource_ref(tag, "href") {
-            let collapsed: String = href
-                .chars()
-                .filter(|c| !c.is_whitespace() && *c != '\u{feff}')
-                .collect();
-            if collapsed.contains(PLATFORM_BASE_CSS_MARKER) {
-                return reject(RejectionKind::PlatformBaseCss, href);
-            }
+        if let Some(href) = resource_ref(tag, "href")
+            && normalize_resource_ref(&href).contains(PLATFORM_BASE_CSS_MARKER)
+        {
+            return reject(RejectionKind::PlatformBaseCss, href);
         }
     }
 
@@ -149,22 +144,18 @@ pub fn scan_app_html(html: &str) -> ScanResult {
                 .or_else(|| attr_capture.get(3))
                 .map_or("", |m| m.as_str());
             if tag_name.eq_ignore_ascii_case("script") && attr_name.eq_ignore_ascii_case("src") {
+                let normalized = normalize_resource_ref(value);
                 if PLATFORM_SCRIPT_SRC_MARKERS
                     .iter()
-                    .any(|marker| value.contains(marker))
+                    .any(|marker| normalized.contains(marker))
                 {
                     return reject(RejectionKind::PlatformScriptSrc, value.to_string());
                 }
             } else if tag_name.eq_ignore_ascii_case("link")
                 && attr_name.eq_ignore_ascii_case("href")
+                && normalize_resource_ref(value).contains(PLATFORM_BASE_CSS_MARKER)
             {
-                let collapsed: String = value
-                    .chars()
-                    .filter(|c| !c.is_whitespace() && *c != '\u{feff}')
-                    .collect();
-                if collapsed.contains(PLATFORM_BASE_CSS_MARKER) {
-                    return reject(RejectionKind::PlatformBaseCss, value.to_string());
-                }
+                return reject(RejectionKind::PlatformBaseCss, value.to_string());
             }
         }
     }
@@ -243,6 +234,13 @@ fn exact_resource_tag_is(tag: &tl::HTMLTag, expected: &str) -> bool {
         })
 }
 
+fn normalize_resource_ref(reference: &str) -> String {
+    reference
+        .chars()
+        .filter(|character| !matches!(character, '\t' | '\n' | '\r'))
+        .collect()
+}
+
 fn reject(kind: RejectionKind, offender: String) -> ScanResult {
     ScanResult {
         rejection: Some(Rejection { kind, offender }),
@@ -304,16 +302,6 @@ mod tests {
         let html = "<html><head><link href=\"/_sandbox/archestra-app-\n\tbase.css\"></head></html>";
         let rejection = scan_app_html(html).rejection.expect("should reject");
         assert_eq!(rejection.kind, RejectionKind::PlatformBaseCss);
-    }
-
-    #[test]
-    fn zwnbsp_spliced_href_is_still_caught() {
-        let html =
-            "<html><head><link href=\"/_sandbox/archestra-app-\u{feff}base.css\"></head></html>";
-        assert_eq!(
-            scan_app_html(html).rejection.expect("should reject").kind,
-            RejectionKind::PlatformBaseCss
-        );
     }
 
     #[test]
@@ -461,6 +449,47 @@ mod tests {
                 RejectionKind::PlatformBaseCss,
                 "{link}"
             );
+        }
+    }
+
+    #[test]
+    fn ignored_url_controls_cannot_splice_platform_resource_markers() {
+        for control in ["\t", "\n", "\r"] {
+            let script_ref = format!("/_sandbox/archestra-app-{control}sdk.js");
+            for html in [
+                format!(r#"<html><head><script src="{script_ref}"></script></head></html>"#),
+                format!(r#"<html><head><script /src="{script_ref}"></script></head></html>"#),
+            ] {
+                let rejection = scan_app_html(&html).rejection.expect("should reject");
+                assert_eq!(rejection.kind, RejectionKind::PlatformScriptSrc);
+                assert_eq!(rejection.offender, script_ref);
+            }
+
+            let stylesheet_ref = format!("/_sandbox/archestra-app-{control}base.css");
+            for html in [
+                format!(r#"<html><head><link href="{stylesheet_ref}"></head></html>"#),
+                format!(r#"<html><head><link /href="{stylesheet_ref}"></head></html>"#),
+            ] {
+                let rejection = scan_app_html(&html).rejection.expect("should reject");
+                assert_eq!(rejection.kind, RejectionKind::PlatformBaseCss);
+                assert_eq!(rejection.offender, stylesheet_ref);
+            }
+        }
+    }
+
+    #[test]
+    fn non_ignored_url_characters_do_not_reconstruct_platform_resource_markers() {
+        for preserved in [" ", "\u{000c}", "\u{feff}"] {
+            let script_ref = format!("/_sandbox/archestra-app-{preserved}sdk.js");
+            let stylesheet_ref = format!("/_sandbox/archestra-app-{preserved}base.css");
+            for html in [
+                format!(r#"<html><head><script src="{script_ref}"></script></head></html>"#),
+                format!(r#"<html><head><script /src="{script_ref}"></script></head></html>"#),
+                format!(r#"<html><head><link href="{stylesheet_ref}"></head></html>"#),
+                format!(r#"<html><head><link /href="{stylesheet_ref}"></head></html>"#),
+            ] {
+                assert_eq!(scan_app_html(&html).rejection, None, "{html}");
+            }
         }
     }
 

--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -36,17 +36,23 @@ const NO_DOCUMENT_ROOT_WARNING: &str = "html has no <head> or <html> element; pr
 static HEAD_OR_HTML: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)<(head|html)[\s>]").expect("static head/html probe regex"));
 
-// Raw-text src/href refs on script/link open tags, quoted (group 3) or
-// unquoted (group 4); backstops the DOM loops for tag shapes `tl` drops. The
-// attribute name must follow a whitespace/solidus/quote boundary so `data-src`
-// does not count. Deliberately regex-grade: crafted markup (decoy `src=` in
-// another attribute's value, mixed quotes, entity-spliced markers) can still
-// slip it — the render-time CSP stays the real security boundary.
-static RESOURCE_REF_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?is)<(script|link)\b[^>]*?[\s/"'](src|href)\s*=\s*(?:["']([^"']*)["']|([^\s>"']+))"#,
-    )
-    .expect("static resource ref fallback regex")
+// Exact script/link open tags with a browser-recognized tag-name boundary.
+// This backstops the DOM loops for tag shapes `tl` drops without treating
+// custom or namespace-like elements as native resource tags.
+static RESOURCE_TAG_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)<(script|link)([\x20\t\n\x0c\r/][^>]*|>)")
+        .expect("static resource tag fallback regex")
+});
+
+// A src/href ref inside the bounded opening-tag tail, quoted (group 2) or
+// unquoted (group 3). The attribute name must follow a whitespace, solidus, or
+// quote boundary so `data-src` does not count. Deliberately regex-grade:
+// crafted markup (decoy `src=` in another attribute's value, mixed quotes,
+// entity-spliced markers) can still slip it — the render-time CSP stays the
+// real security boundary.
+static RESOURCE_ATTR_FALLBACK: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?is)[\s/"'](src|href)\s*=\s*(?:["']([^"']*)["']|([^\s>"']+))"#)
+        .expect("static resource attribute fallback regex")
 });
 
 /// Why a scan disqualified the HTML. Carries the offending value so the caller
@@ -105,7 +111,7 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     }
 
     // 2. Platform script self-load via <script src>, document order.
-    for tag in tags().filter(|tag| tag_is(tag, "script")) {
+    for tag in tags().filter(|tag| exact_resource_tag_is(tag, "script")) {
         if let Some(src) = resource_ref(tag, "src")
             && PLATFORM_SCRIPT_SRC_MARKERS
                 .iter()
@@ -119,7 +125,7 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     //    browser ignores when resolving the URL so a spliced tab/newline (or a
     //    ZWNBSP, which JS `\s` strips but Rust's `is_whitespace` does not) can't
     //    sneak the marker past.
-    for tag in tags().filter(|tag| tag_is(tag, "link")) {
+    for tag in tags().filter(|tag| exact_resource_tag_is(tag, "link")) {
         if let Some(href) = resource_ref(tag, "href") {
             let collapsed: String = href
                 .chars()
@@ -134,27 +140,31 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     // 4. Lexical fallback for self-load refs in tag shapes `tl` drops
     //    entirely (`<script /src=…>`, unquoted URL values with `/`). Extra
     //    matches this can add (e.g. inside HTML comments) are fail-closed.
-    for capture in RESOURCE_REF_FALLBACK.captures_iter(html) {
-        let tag_name = &capture[1];
-        let attr_name = &capture[2];
-        let value = capture
-            .get(3)
-            .or_else(|| capture.get(4))
-            .map_or("", |m| m.as_str());
-        if tag_name.eq_ignore_ascii_case("script") && attr_name.eq_ignore_ascii_case("src") {
-            if PLATFORM_SCRIPT_SRC_MARKERS
-                .iter()
-                .any(|marker| value.contains(marker))
+    for tag_capture in RESOURCE_TAG_FALLBACK.captures_iter(html) {
+        let tag_name = &tag_capture[1];
+        for attr_capture in RESOURCE_ATTR_FALLBACK.captures_iter(&tag_capture[2]) {
+            let attr_name = &attr_capture[1];
+            let value = attr_capture
+                .get(2)
+                .or_else(|| attr_capture.get(3))
+                .map_or("", |m| m.as_str());
+            if tag_name.eq_ignore_ascii_case("script") && attr_name.eq_ignore_ascii_case("src") {
+                if PLATFORM_SCRIPT_SRC_MARKERS
+                    .iter()
+                    .any(|marker| value.contains(marker))
+                {
+                    return reject(RejectionKind::PlatformScriptSrc, value.to_string());
+                }
+            } else if tag_name.eq_ignore_ascii_case("link")
+                && attr_name.eq_ignore_ascii_case("href")
             {
-                return reject(RejectionKind::PlatformScriptSrc, value.to_string());
-            }
-        } else if tag_name.eq_ignore_ascii_case("link") && attr_name.eq_ignore_ascii_case("href") {
-            let collapsed: String = value
-                .chars()
-                .filter(|c| !c.is_whitespace() && *c != '\u{feff}')
-                .collect();
-            if collapsed.contains(PLATFORM_BASE_CSS_MARKER) {
-                return reject(RejectionKind::PlatformBaseCss, value.to_string());
+                let collapsed: String = value
+                    .chars()
+                    .filter(|c| !c.is_whitespace() && *c != '\u{feff}')
+                    .collect();
+                if collapsed.contains(PLATFORM_BASE_CSS_MARKER) {
+                    return reject(RejectionKind::PlatformBaseCss, value.to_string());
+                }
             }
         }
     }
@@ -218,6 +228,19 @@ fn attr(tag: &tl::HTMLTag, name: &str) -> Option<String> {
         .find(|(key, _)| key.eq_ignore_ascii_case(name))
         .and_then(|(_, value)| value)
         .map(|value| value.into_owned())
+}
+
+fn exact_resource_tag_is(tag: &tl::HTMLTag, expected: &str) -> bool {
+    if !tag_is(tag, expected) {
+        return false;
+    }
+    let raw = tag.raw().as_utf8_str();
+    RESOURCE_TAG_FALLBACK
+        .captures(raw.as_ref())
+        .is_some_and(|capture| {
+            capture.get(0).is_some_and(|matched| matched.start() == 0)
+                && capture[1].eq_ignore_ascii_case(expected)
+        })
 }
 
 fn reject(kind: RejectionKind, offender: String) -> ScanResult {
@@ -400,6 +423,45 @@ mod tests {
         // boundary must not read it as a real `src`.
         let html = r#"<html><head><script data-src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#;
         assert_eq!(scan_app_html(html).rejection, None);
+    }
+
+    #[test]
+    fn fallback_does_not_treat_non_native_names_as_resource_tags() {
+        let cases = [
+            r#"<html><head><script-widget src="/_sandbox/archestra-app-sdk.js"></script-widget></head></html>"#,
+            r#"<html><head><link-widget href="/_sandbox/archestra-app-base.css"></head></html>"#,
+            r#"<html><head><script:widget src="/_sandbox/archestra-app-sdk.js"></script:widget></head></html>"#,
+            "<html><head><link\u{00a0}href=\"/_sandbox/archestra-app-base.css\"></head></html>",
+        ];
+        for html in cases {
+            assert_eq!(scan_app_html(html).rejection, None, "{html}");
+        }
+    }
+
+    #[test]
+    fn native_resource_tags_accept_only_html_tag_name_boundaries() {
+        for boundary in [" ", "\t", "\n", "\u{000c}", "\r", "/"] {
+            let script = format!(
+                "<html><head><script{boundary}src=/_sandbox/archestra-app-sdk.js></script></head></html>"
+            );
+            assert_eq!(
+                scan_app_html(&script)
+                    .rejection
+                    .expect("should reject")
+                    .kind,
+                RejectionKind::PlatformScriptSrc,
+                "{script}"
+            );
+
+            let link = format!(
+                "<html><head><link{boundary}href=/_sandbox/archestra-app-base.css></head></html>"
+            );
+            assert_eq!(
+                scan_app_html(&link).rejection.expect("should reject").kind,
+                RejectionKind::PlatformBaseCss,
+                "{link}"
+            );
+        }
     }
 
     #[test]

--- a/platform/archestra-rs/app-runtime-core/src/app_html.rs
+++ b/platform/archestra-rs/app-runtime-core/src/app_html.rs
@@ -137,26 +137,31 @@ pub fn scan_app_html(html: &str) -> ScanResult {
     //    matches this can add (e.g. inside HTML comments) are fail-closed.
     for tag_capture in RESOURCE_TAG_FALLBACK.captures_iter(html) {
         let tag_name = &tag_capture[1];
-        for attr_capture in RESOURCE_ATTR_FALLBACK.captures_iter(&tag_capture[2]) {
-            let attr_name = &attr_capture[1];
-            let value = attr_capture
-                .get(2)
-                .or_else(|| attr_capture.get(3))
-                .map_or("", |m| m.as_str());
-            if tag_name.eq_ignore_ascii_case("script") && attr_name.eq_ignore_ascii_case("src") {
-                let normalized = normalize_resource_ref(value);
-                if PLATFORM_SCRIPT_SRC_MARKERS
-                    .iter()
-                    .any(|marker| normalized.contains(marker))
-                {
-                    return reject(RejectionKind::PlatformScriptSrc, value.to_string());
-                }
-            } else if tag_name.eq_ignore_ascii_case("link")
-                && attr_name.eq_ignore_ascii_case("href")
-                && normalize_resource_ref(value).contains(PLATFORM_BASE_CSS_MARKER)
+        let attr_name = if tag_name.eq_ignore_ascii_case("script") {
+            "src"
+        } else {
+            "href"
+        };
+        let Some(attr_capture) = RESOURCE_ATTR_FALLBACK
+            .captures_iter(&tag_capture[2])
+            .find(|capture| capture[1].eq_ignore_ascii_case(attr_name))
+        else {
+            continue;
+        };
+        let value = attr_capture
+            .get(2)
+            .or_else(|| attr_capture.get(3))
+            .map_or("", |matched| matched.as_str());
+        let normalized = normalize_resource_ref(value);
+        if tag_name.eq_ignore_ascii_case("script") {
+            if PLATFORM_SCRIPT_SRC_MARKERS
+                .iter()
+                .any(|marker| normalized.contains(marker))
             {
-                return reject(RejectionKind::PlatformBaseCss, value.to_string());
+                return reject(RejectionKind::PlatformScriptSrc, value.to_string());
             }
+        } else if normalized.contains(PLATFORM_BASE_CSS_MARKER) {
+            return reject(RejectionKind::PlatformBaseCss, value.to_string());
         }
     }
 
@@ -420,6 +425,17 @@ mod tests {
             r#"<html><head><link-widget href="/_sandbox/archestra-app-base.css"></head></html>"#,
             r#"<html><head><script:widget src="/_sandbox/archestra-app-sdk.js"></script:widget></head></html>"#,
             "<html><head><link\u{00a0}href=\"/_sandbox/archestra-app-base.css\"></head></html>",
+        ];
+        for html in cases {
+            assert_eq!(scan_app_html(html).rejection, None, "{html}");
+        }
+    }
+
+    #[test]
+    fn fallback_uses_the_first_effective_resource_attribute() {
+        let cases = [
+            r#"<html><head><script src="safe.js" src="/_sandbox/archestra-app-sdk.js"></script></head></html>"#,
+            r#"<html><head><link href="safe.css" href="/_sandbox/archestra-app-base.css"></head></html>"#,
         ];
         for html in cases {
             assert_eq!(scan_app_html(html).rejection, None, "{html}");

--- a/platform/backend/src/services/apps/app-ui-policy.test.ts
+++ b/platform/backend/src/services/apps/app-ui-policy.test.ts
@@ -106,7 +106,7 @@ describe("buildValidatedVersionPayload", () => {
   test("a whitespace-spliced href cannot slip the self-link past", async () => {
     await expect(
       buildValidatedVersionPayload({
-        html: '<html><head><link rel="stylesheet" href="/_sandbox/archestra-app-\n base.css"></head><body/></html>',
+        html: '<html><head><link rel="stylesheet" href="/_sandbox/archestra-app-\n\tbase.css"></head><body/></html>',
       }),
     ).rejects.toThrow(/must not load the platform stylesheet/);
   });


### PR DESCRIPTION
## Summary

- require exact HTML tag boundaries when fallback-scanning script and link resources
- normalize only browser-ignored TAB, LF, and CR characters before resource marker checks
- preserve browser-effective duplicate/decoy attributes and inert custom, namespace-like, and Unicode-folded element names

## Follow-ups

sweep-key: platform/archestra-rs/app-runtime-core/src/app_html.rs:45-49:custom-elements-match-resource-fallback

sweep-key: platform/archestra-rs/app-runtime-core/src/app_html.rs:107-149:script-src-whitespace-marker-bypass

## Validation

- targeted app-runtime-core tests
- cargo fmt check, cargo check, clippy with warnings denied, and cargo test
- rebuilt NAPI addon and backend App UI policy tests
