### PR TITLE
fix(apps): don't register an MCP App when its UI resource can't be read

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.app-readability.integration.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.app-readability.integration.test.ts
@@ -1,0 +1,221 @@
+/**
+ * REAL end-to-end verification (no mocks) for the "don't register an MCP App
+ * whose UI resource can't be read" fix.
+ *
+ * Spins up an actual streamable-HTTP MCP server and drives the REAL
+ * `buildArchestraToolOutput` (the run_tool enrichment path) with the REAL
+ * `mcpClient` against it — no mocked stand-in for the resource read.
+ *
+ *  - broken server (returns -32601 Method not found on resources/read, mimicking
+ *    a third-party server like Atlassian Cloud that declares a `ui://` resource
+ *    in tool _meta but never serves it) -> the tool result is plain text, NO
+ *    `_meta.ui.resourceUri`, so chat registers no app (no pill, no auto-opened
+ *    panel).
+ *  - working server (serves the resource) -> `_meta.ui.resourceUri` is kept, so
+ *    the gate discriminates on the real read rather than blanket-dropping.
+ *
+ * No `vi.mock` in this file on purpose: it runs against the real mcpClient.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { Server as McpSdkServer } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  ErrorCode,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  McpError,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { buildArchestraToolOutput } from "@/clients/chat-tool-builder";
+import { expect, test } from "@/test";
+
+const UI_RESOURCE_URI = "ui://brokenapp/app.html";
+
+const RUN_TOOL_RESPONSE = {
+  content: [{ type: "text" as const, text: "ran" }],
+  structuredContent: { ok: true },
+  _meta: { extra: 1 },
+};
+
+/** A real streamable-HTTP MCP server; `serveResource` toggles whether
+ * resources/read succeeds or returns -32601 (like a server that advertises a
+ * ui:// resource it doesn't actually serve). */
+async function startMcpHttpServer(serveResource: boolean): Promise<{
+  url: string;
+  close: () => Promise<void>;
+}> {
+  const httpServer = http.createServer(async (req, res) => {
+    try {
+      // Reject the client's optional standalone SSE stream (GET) so no
+      // long-lived connection lingers in the shared test worker; the SDK client
+      // treats 405 as "no server-initiated stream" and proceeds over POST.
+      if (req.method !== "POST") {
+        res.writeHead(405).end();
+        return;
+      }
+      // Stateless: fresh server + transport per request.
+      const server = new McpSdkServer(
+        { name: "test-app-server", version: "1.0.0" },
+        { capabilities: { tools: {}, resources: {} } },
+      );
+      server.setRequestHandler(ListToolsRequestSchema, async () => ({
+        tools: [],
+      }));
+      server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+        resources: [],
+      }));
+      server.setRequestHandler(ReadResourceRequestSchema, async (r) => {
+        if (!serveResource) {
+          throw new McpError(ErrorCode.MethodNotFound, "Method not found");
+        }
+        return {
+          contents: [
+            {
+              uri: r.params.uri,
+              mimeType: "text/html",
+              text: "<html><body>real app</body></html>",
+            },
+          ],
+        };
+      });
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+      });
+      res.on("close", () => {
+        void transport.close();
+        void server.close();
+      });
+      await server.connect(transport);
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      await transport.handleRequest(
+        req,
+        res,
+        body ? JSON.parse(body) : undefined,
+      );
+    } catch {
+      if (!res.headersSent) res.writeHead(500).end();
+    }
+  });
+
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const { port } = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/mcp`,
+    close: () => new Promise<void>((r) => httpServer.close(() => r())),
+  };
+}
+
+test("REAL: drops the UI resource when the upstream returns -32601 on resources/read", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  makeInternalMcpCatalog,
+  makeMcpServer,
+  makeTool,
+  makeAgentTool,
+}) => {
+  const server = await startMcpHttpServer(/* serveResource */ false);
+  try {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      serverType: "remote",
+      serverUrl: server.url,
+      requiresAuth: false,
+    });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+    const tool = await makeTool({
+      name: "brokenapp__show",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: UI_RESOURCE_URI } } },
+    });
+    await makeAgentTool(agent.id, tool.id);
+
+    const result = await buildArchestraToolOutput({
+      response: RUN_TOOL_RESPONSE,
+      toolName: "archestra__run_tool",
+      toolArguments: { tool_name: "brokenapp__show", tool_args: {} },
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
+      tokenAuth: {
+        tokenId: "integration-test-token",
+        teamId: null,
+        isOrganizationToken: false,
+        isUserToken: true,
+        organizationId: org.id,
+        userId: user.id,
+      },
+    });
+
+    // Dropped -> plain text, no MCP App registered.
+    expect(result).toBe("ran");
+  } finally {
+    await server.close();
+  }
+});
+
+test("REAL: keeps the UI resource when the upstream actually serves it", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  makeInternalMcpCatalog,
+  makeMcpServer,
+  makeTool,
+  makeAgentTool,
+}) => {
+  const server = await startMcpHttpServer(/* serveResource */ true);
+  try {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      serverType: "remote",
+      serverUrl: server.url,
+      requiresAuth: false,
+    });
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+    const tool = await makeTool({
+      name: "brokenapp__show",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: UI_RESOURCE_URI } } },
+    });
+    await makeAgentTool(agent.id, tool.id);
+
+    const result = await buildArchestraToolOutput({
+      response: RUN_TOOL_RESPONSE,
+      toolName: "archestra__run_tool",
+      toolArguments: { tool_name: "brokenapp__show", tool_args: {} },
+      agentId: agent.id,
+      userId: user.id,
+      organizationId: org.id,
+      tokenAuth: {
+        tokenId: "integration-test-token",
+        teamId: null,
+        isOrganizationToken: false,
+        isUserToken: true,
+        organizationId: org.id,
+        userId: user.id,
+      },
+    });
+
+    // Genuinely serveable -> the resource is still attached (control).
+    expect(result).toMatchObject({
+      content: "ran",
+      _meta: { ui: { resourceUri: UI_RESOURCE_URI } },
+    });
+  } finally {
+    await server.close();
+  }
+});

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -48,6 +48,11 @@ vi.mock("@/clients/mcp-client", () => ({
   default: {
     executeToolCallForOwner: vi.fn(),
     resolveUiAppInstallIdForCaller: vi.fn().mockResolvedValue(null),
+    // Enrichment gates attaching a tool's ui:// resource on it being readable;
+    // default to a successful read so UI-resource attachment tests are unaffected.
+    readResource: vi.fn().mockResolvedValue({
+      contents: [{ uri: "ui://x", text: "<html></html>" }],
+    }),
   },
 }));
 
@@ -65,6 +70,10 @@ beforeEach(() => {
   vi.mocked(mcpClient.executeToolCallForOwner).mockReset();
   vi.mocked(mcpClient.resolveUiAppInstallIdForCaller).mockReset();
   vi.mocked(mcpClient.resolveUiAppInstallIdForCaller).mockResolvedValue(null);
+  vi.mocked(mcpClient.readResource).mockReset();
+  vi.mocked(mcpClient.readResource).mockResolvedValue({
+    contents: [{ uri: "ui://x", text: "<html></html>" }],
+  });
   vi.mocked(resolveSessionExternalIdpToken).mockResolvedValue(null);
   vi.mocked(StreamableHTTPClientTransport).mockClear();
 });
@@ -2197,6 +2206,41 @@ describe("buildArchestraToolOutput", () => {
       },
       structuredContent: { checkpoint: "abc" },
     });
+  });
+
+  test("does not attach the UI resource when its upstream resource can't be read", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    const agent = await makeAgent();
+    const catalog = await makeInternalMcpCatalog();
+    const targetTool = await makeTool({
+      name: "excalidraw__create_view",
+      catalogId: catalog.id,
+      meta: { _meta: { ui: { resourceUri: "ui://excalidraw/mcp-app.html" } } },
+    });
+    await makeAgentTool(agent.id, targetTool.id);
+    // The upstream server advertises the ui:// resource but doesn't serve it
+    // (e.g. resources/read -> -32601 Method not found). The app must NOT register
+    // — no `_meta.ui` — so chat renders a plain tool call instead of an empty
+    // pill and an auto-opened, blank right panel.
+    vi.mocked(mcpClient.readResource).mockRejectedValue(
+      new Error("MCP error -32601: Method not found"),
+    );
+
+    const result = await buildArchestraToolOutput({
+      response: archestraResponse,
+      toolName: "archestra__run_tool",
+      toolArguments: {
+        tool_name: "excalidraw__create_view",
+        tool_args: { elements: "[]" },
+      },
+      agentId: agent.id,
+    });
+
+    expect(result).toBe("Diagram displayed!");
   });
 
   test("does not attach the UI resource when the target tool is not assigned to the agent", async ({

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -608,6 +608,15 @@ export async function buildArchestraToolOutput(params: {
       "Failed to fetch dispatched tool definition meta",
     );
   }
+  // Drop the resource when its upstream server can't actually serve it (e.g.
+  // -32601), so the dispatch falls through to the plain-result handling below
+  // instead of registering an app that renders nothing. See uiResourceIsReadable.
+  if (
+    resourceUri &&
+    !(await uiResourceIsReadable({ uri: resourceUri, agentId, tokenAuth }))
+  ) {
+    resourceUri = undefined;
+  }
   if (!resourceUri) {
     // A dispatched third-party tool with no MCP-App UI. If it returned a
     // structured Archestra error (e.g. the expired-auth re-auth payload),
@@ -915,20 +924,24 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<{
     }
   }
 
+  // Caller auth for install resolution (own→team→org), reused below to verify a
+  // declared UI resource is readable with the exact same scoping the execution used.
+  const tokenAuthContext = mcpGwToken
+    ? {
+        tokenId: mcpGwToken.tokenId,
+        teamId: mcpGwToken.teamId,
+        isOrganizationToken: mcpGwToken.isOrganizationToken,
+        organizationId,
+        userId,
+      }
+    : undefined;
+
   let result: Awaited<ReturnType<typeof mcpClient.executeToolCallForOwner>>;
   try {
     result = await mcpClient.executeToolCallForOwner(
       toolCall,
       agentOwner(agentId),
-      mcpGwToken
-        ? {
-            tokenId: mcpGwToken.tokenId,
-            teamId: mcpGwToken.teamId,
-            isOrganizationToken: mcpGwToken.isOrganizationToken,
-            organizationId,
-            userId,
-          }
-        : undefined,
+      tokenAuthContext,
       {
         ...(availableTool ? { availableTool } : {}),
         // mcp-client scopes per-conversation sessions by this key; in UI chat it
@@ -1077,6 +1090,27 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<{
     );
   }
 
+  // A tool definition can declare a `ui://` MCP App resource its upstream server
+  // never actually serves (e.g. resources/read → -32601 Method not found).
+  // Keeping it would register an app that renders nothing — an empty pill and an
+  // auto-opened, blank right panel — so drop the declared resource when it can't
+  // be read, letting the tool render as a plain call. An embedded inline resource
+  // (below) is self-contained and re-synthesizes the ui after this check.
+  const declaredUiResourceUri = toolDefinitionMeta?.ui?.resourceUri;
+  if (
+    declaredUiResourceUri &&
+    toolDefinitionMeta?.ui &&
+    !(await uiResourceIsReadable({
+      uri: declaredUiResourceUri,
+      agentId,
+      tokenAuth: tokenAuthContext,
+    }))
+  ) {
+    const { resourceUri: _unreadable, ...uiWithoutResource } =
+      toolDefinitionMeta.ui;
+    toolDefinitionMeta = { ...toolDefinitionMeta, ui: uiWithoutResource };
+  }
+
   // Check for embedded resources (type: "resource" content items with UI resources)
   // MCP servers can return UI resources inline in tool results as an alternative to
   // declaring _meta.ui.resourceUri in tool definitions. Both patterns are standard MCP.
@@ -1163,6 +1197,34 @@ function metaProvidesUiResource(
   const isUiUri = (value: unknown): boolean =>
     typeof value === "string" && value.startsWith("ui://");
   return isUiUri(meta?.ui?.resourceUri) || isUiUri(meta?.["ui/resourceUri"]);
+}
+
+/**
+ * Whether an MCP App `ui://` UI resource can actually be read from its upstream
+ * server. A tool may advertise a resource its server never implements
+ * (`resources/read` → -32601 Method not found) or otherwise can't serve;
+ * attaching such a resource to a tool result makes chat register an app that
+ * renders nothing — an empty pill plus an auto-opened, blank right panel. Both
+ * enrichment paths (executeMcpTool and buildArchestraToolOutput) gate the
+ * attachment on this, mirroring the SSE prefetch's own readability gate
+ * (tool-ui-stream). A successful read is cached, so the frontend's later render
+ * reuses it rather than re-reading.
+ */
+async function uiResourceIsReadable(params: {
+  uri: string;
+  agentId: string;
+  tokenAuth?: TokenAuthContext;
+}): Promise<boolean> {
+  try {
+    await mcpClient.readResource(params.uri, params.agentId, params.tokenAuth);
+    return true;
+  } catch (error) {
+    logger.debug(
+      { error, uri: params.uri, agentId: params.agentId },
+      "MCP App UI resource unreadable; rendering as a plain tool call",
+    );
+    return false;
+  }
 }
 
 // The resolved catalog tool nests its MCP `_meta` one level down under `meta`.


### PR DESCRIPTION
## Problem

Follow-up to #6487 (graceful degradation for unloadable MCP Apps). That fix stopped the red **"Failed to load app"** card in the chat stream, but the **right-side Apps panel still auto-opened** and showed a blank *"This app rendered nothing to display"* (plus an empty app pill) whenever a tool advertised a `ui://` MCP App resource its upstream server doesn't actually serve (`resources/read` → `-32601 Method not found`).

### Why the panel still opened

The chat registers an app for any tool whose **persisted result** carries `_meta.ui.resourceUri` (`deriveAppsFromMessages`). The right panel auto-opens once that registry is non-empty (`chat/page.tsx`), independent of whether the resource ever loads. The previous fix only degraded the inline *render*; the app was still registered, so the panel + pill remained.

The SSE early-hint path (`tool-ui-stream.ts`) is already gated on a successful prefetch read — the persisted result `_meta` was the one ungated source.

## Fix

Gate **both** result-enrichment paths on the UI resource actually being readable before attaching `_meta.ui.resourceUri`:

- `executeMcpTool` — direct tool calls
- `buildArchestraToolOutput` — `run_tool` dispatches

via a shared `uiResourceIsReadable` helper (`mcpClient.readResource`, using the same caller-auth scoping the execution uses, so install resolution matches). When the read fails, the resource is dropped and the tool renders as a **plain tool call** — no pill, no card, no auto-opened panel. This mirrors the SSE prefetch's own readability gate, and a successful read is cached so the frontend's later render reuses it rather than re-reading.

Tools without a `ui://` resource are unaffected (the gate short-circuits). An embedded *inline* resource in the result is self-contained and still renders (the direct-path gate runs before that synthesis).

## Tests

- New test in `chat-mcp-client.test.ts`: a `run_tool` dispatch whose UI resource read fails (`-32601`) attaches no `_meta.ui` and returns the plain result. Existing attach tests keep passing (the mocked `readResource` resolves by default).
- Backend `type-check`, biome lint, and the full `chat-mcp-client.test.ts` suite (87 tests) pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>