### PR TITLE
fix: LLM proxy + frontend request-error resilience

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.test.ts
@@ -556,3 +556,77 @@ describe("Bedrock reasoningContent message blocks (issue #3406)", () => {
     expect(commandInput.messages?.[1]?.content?.[0]).toEqual(reasoningBlock);
   });
 });
+
+describe("Bedrock sampling-param fallback", () => {
+  function makeDeprecatedTemperatureError(): Error {
+    const message = JSON.stringify({
+      message:
+        "The model returned the following errors: `temperature` is deprecated for this model.",
+    });
+    const error = new Error(message) as Error & {
+      statusCode: number;
+      responseBody: string;
+    };
+    error.statusCode = 400;
+    error.responseBody = message;
+    return error;
+  }
+
+  const okResponse = {
+    $metadata: { requestId: "req_1" },
+    output: { message: { role: "assistant", content: [{ text: "ok" }] } },
+    stopReason: "end_turn",
+    usage: { inputTokens: 1, outputTokens: 1 },
+  };
+
+  test("retries without temperature when the model rejects it, keeping other params", async () => {
+    const request = createConverseRequest({
+      inferenceConfig: { temperature: 0.7, topP: 0.9, maxTokens: 100 },
+    });
+    const seenInferenceConfigs: Array<unknown> = [];
+    const client = {
+      converse: async (_modelId: string, input: Record<string, unknown>) => {
+        seenInferenceConfigs.push(input.inferenceConfig);
+        if (seenInferenceConfigs.length === 1) {
+          throw makeDeprecatedTemperatureError();
+        }
+        return okResponse;
+      },
+    };
+
+    const response = await bedrockAdapterFactory.execute(client, request);
+
+    // Retried exactly once; the first attempt sent temperature, the retry
+    // dropped only temperature and preserved topP + maxTokens.
+    expect(seenInferenceConfigs).toHaveLength(2);
+    expect(seenInferenceConfigs[0]).toEqual({
+      temperature: 0.7,
+      topP: 0.9,
+      maxTokens: 100,
+    });
+    expect(seenInferenceConfigs[1]).toEqual({ topP: 0.9, maxTokens: 100 });
+    expect(response.output?.message?.content?.[0]).toEqual({ text: "ok" });
+  });
+
+  test("does not retry on unrelated validation errors", async () => {
+    const request = createConverseRequest({
+      inferenceConfig: { temperature: 0.7 },
+    });
+    let calls = 0;
+    const client = {
+      converse: async () => {
+        calls++;
+        const error = new Error(
+          "Input is too long for requested model.",
+        ) as Error & { statusCode: number };
+        error.statusCode = 400;
+        throw error;
+      },
+    };
+
+    await expect(
+      bedrockAdapterFactory.execute(client, request),
+    ).rejects.toThrow("Input is too long for requested model.");
+    expect(calls).toBe(1);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -1661,6 +1661,100 @@ export function getCommandInput(request: BedrockRequest): BedrockCommandInput {
 }
 
 // =============================================================================
+// HELPER: Sampling-parameter fallback
+// =============================================================================
+
+/**
+ * Some Bedrock-hosted models (reasoning models in particular) reject sampling
+ * params instead of ignoring them, returning a ValidationException such as
+ * "`temperature` is deprecated for this model." Rather than maintain a brittle
+ * per-model allowlist of which params each model accepts, we detect the
+ * rejection, strip the offending param(s), and retry the request once.
+ *
+ * Maps the wire-level name a provider may use in its error message back to the
+ * corresponding `inferenceConfig` key.
+ */
+const SAMPLING_PARAM_ALIASES: Record<string, "temperature" | "topP"> = {
+  temperature: "temperature",
+  top_p: "topP",
+  topp: "topP",
+};
+
+/**
+ * Inspect an upstream error and return which sampling params it is rejecting.
+ * Only matches "deprecated / not supported" style validation errors so
+ * unrelated failures fall through untouched.
+ */
+function detectUnsupportedSamplingParams(
+  error: unknown,
+): Array<"temperature" | "topP"> {
+  if (!error || typeof error !== "object") return [];
+  const { message, responseBody } = error as {
+    message?: string;
+    responseBody?: string;
+  };
+  const text = `${message ?? ""} ${responseBody ?? ""}`.toLowerCase();
+  if (
+    !/deprecated|not supported|unsupported|does not support|isn't supported|not allowed/.test(
+      text,
+    )
+  ) {
+    return [];
+  }
+  const affected = new Set<"temperature" | "topP">();
+  for (const [alias, key] of Object.entries(SAMPLING_PARAM_ALIASES)) {
+    if (text.includes(alias)) affected.add(key);
+  }
+  return [...affected];
+}
+
+/**
+ * Return a copy of the command input with the given sampling params removed,
+ * dropping `inferenceConfig` entirely once it's empty. Returns null when none
+ * of the params were actually set (so there's nothing worth retrying).
+ */
+function stripSamplingParams(
+  commandInput: BedrockCommandInput,
+  params: Array<"temperature" | "topP">,
+): BedrockCommandInput | null {
+  const inferenceConfig = commandInput.inferenceConfig;
+  if (!inferenceConfig) return null;
+  const present = params.filter((p) => inferenceConfig[p] !== undefined);
+  if (present.length === 0) return null;
+  const next = { ...inferenceConfig };
+  for (const p of present) delete next[p];
+  return {
+    ...commandInput,
+    inferenceConfig: Object.keys(next).length > 0 ? next : undefined,
+  };
+}
+
+/**
+ * Run a Bedrock request and, if it fails solely because the model rejects a
+ * sampling param (temperature/topP), strip that param and retry exactly once.
+ * The retry only runs on an already-failing request, so it adds no latency to
+ * the happy path.
+ */
+async function withSamplingParamFallback<T>(
+  commandInput: BedrockCommandInput,
+  run: (input: BedrockCommandInput) => Promise<T>,
+): Promise<T> {
+  try {
+    return await run(commandInput);
+  } catch (error) {
+    const unsupported = detectUnsupportedSamplingParams(error);
+    if (unsupported.length === 0) throw error;
+    const retryInput = stripSamplingParams(commandInput, unsupported);
+    if (!retryInput) throw error;
+    logger.warn(
+      { modelId: commandInput.modelId, strippedParams: unsupported },
+      "[BedrockAdapter] model rejected sampling param(s); retrying without them",
+    );
+    return run(retryInput);
+  }
+}
+
+// =============================================================================
 // ADAPTER FACTORY
 // =============================================================================
 
@@ -1764,10 +1858,10 @@ export const bedrockAdapterFactory: LLMProvider<
     const { commandInput, toolNameMapping } =
       buildBedrockCommandContext(request);
 
-    // Use fetch-based client.converse()
-    const response = await bedrockClient.converse(
-      request.modelId,
-      commandInput,
+    // Use fetch-based client.converse(), retrying without sampling params the
+    // model rejects (e.g. "`temperature` is deprecated for this model.").
+    const response = await withSamplingParamFallback(commandInput, (input) =>
+      bedrockClient.converse(request.modelId, input),
     );
 
     // Convert response to our internal format with decoded tool names
@@ -1834,8 +1928,12 @@ export const bedrockAdapterFactory: LLMProvider<
     const bedrockClient = client as BedrockClient;
     const { commandInput } = buildBedrockCommandContext(request);
 
-    // Use fetch-based client.converseStream() - returns events with __rawBytes already set
-    return bedrockClient.converseStream(request.modelId, commandInput);
+    // Use fetch-based client.converseStream() - returns events with __rawBytes
+    // already set. Retry without sampling params the model rejects (e.g.
+    // "`temperature` is deprecated for this model.").
+    return withSamplingParamFallback(commandInput, (input) =>
+      bedrockClient.converseStream(request.modelId, input),
+    );
   },
 
   extractInternalCode(error: unknown): ArchestraInternalErrorCode | undefined {

--- a/platform/frontend/src/instrumentation.test.ts
+++ b/platform/frontend/src/instrumentation.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureRequestError = vi.fn();
+
+vi.mock("@sentry/nextjs", () => ({
+  captureRequestError: (...args: unknown[]) => captureRequestError(...args),
+}));
+
+describe("onRequestError filtering", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    captureRequestError.mockClear();
+    process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN =
+      "https://example.ingest.test";
+  });
+
+  async function loadHook() {
+    const mod = await import("./instrumentation");
+    return mod.onRequestError;
+  }
+
+  it("does not report the benign 'destination stream closed early' abort", async () => {
+    const onRequestError = await loadHook();
+
+    await onRequestError(
+      new Error("The destination stream closed early."),
+      {} as never,
+      {} as never,
+    );
+
+    expect(captureRequestError).not.toHaveBeenCalled();
+  });
+
+  it("reports genuine request errors", async () => {
+    const onRequestError = await loadHook();
+    const error = new Error("Cannot read properties of undefined");
+
+    await onRequestError(error, {} as never, {} as never);
+
+    expect(captureRequestError).toHaveBeenCalledTimes(1);
+    expect(captureRequestError).toHaveBeenCalledWith(error, {}, {});
+  });
+
+  it("skips reporting entirely when no DSN is configured", async () => {
+    process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN = "";
+    const onRequestError = await loadHook();
+
+    await onRequestError(
+      new Error("Cannot read properties of undefined"),
+      {} as never,
+      {} as never,
+    );
+
+    expect(captureRequestError).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/instrumentation.ts
+++ b/platform/frontend/src/instrumentation.ts
@@ -4,6 +4,27 @@ const MSW_ENABLED =
 const ERROR_REPORTING_DSN =
   process.env.NEXT_PUBLIC_ARCHESTRA_SENTRY_FRONTEND_DSN || "";
 
+/**
+ * Request errors that are benign client disconnects rather than server faults,
+ * so reporting them only adds noise. Next.js throws "The destination stream
+ * closed early." when the client aborts an in-flight render/RSC prefetch (e.g.
+ * navigating away before it finishes). Matched by message substring because
+ * Next throws a plain Error with no stable error code.
+ */
+const IGNORED_REQUEST_ERROR_MESSAGES = ["The destination stream closed early."];
+
+function isIgnorableRequestError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  return IGNORED_REQUEST_ERROR_MESSAGES.some((ignored) =>
+    message.includes(ignored),
+  );
+}
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     if (ERROR_REPORTING_DSN) {
@@ -24,6 +45,7 @@ export async function register() {
 export const onRequestError: typeof import("@sentry/nextjs").captureRequestError =
   async (...args) => {
     if (!ERROR_REPORTING_DSN) return;
+    if (isIgnorableRequestError(args[0])) return;
 
     const { captureRequestError } = await import("@sentry/nextjs");
     return captureRequestError(...args);


### PR DESCRIPTION
## What

Two independent resilience/noise fixes for the highest-frequency production error signals in the LLM proxy and the frontend.

### 1. Retry Bedrock requests without sampling params the model rejects
Some Bedrock-hosted models (reasoning models in particular) **reject** `temperature`/`topP` with a `ValidationException` — e.g. `` `temperature` is deprecated for this model.`` — instead of ignoring them, which fails the whole request. Today the adapter forwards whatever the client sent with no per-model handling.

- Detect that specific "deprecated / not supported" rejection, strip the offending sampling param(s), and **retry the request exactly once**.
- No brittle per-model allowlist, and **no latency on the happy path** — the retry only runs on an already-failing request.
- Params the model *didn't* complain about are preserved; covers both the non-streaming (`converse`) and streaming (`converseStream`) paths.

### 2. Stop reporting benign client-disconnect request errors (frontend)
Next.js throws `The destination stream closed early.` when a client aborts an in-flight render / RSC prefetch (e.g. navigating away before it finishes). That's a client disconnect, not a server fault — it was the single most frequent frontend server-error signal, purely as noise.

- Filter it out in the `onRequestError` instrumentation hook via a small, easily-extended list of ignorable request-error messages.

## Why
Both were among the most frequently recurring errors in production observability. The remaining high-volume signals were traced to transient infrastructure (RDS DNS resolution blips, already retried) or upstream/config conditions (provider rate limits, billing, credential misconfig), which aren't addressed here.

## Testing
- `backend`: new tests assert the Bedrock retry drops only the rejected param and preserves the rest, and that unrelated validation errors are **not** retried. Full `bedrock.test.ts` suite green (19).
- `frontend`: new tests assert the benign abort is filtered, genuine errors are still reported, and reporting is skipped when no DSN is configured (3).
- `pnpm type-check` (backend + frontend) and `biome check` on changed files: clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>