### PR TITLE
fix(mcp-catalog-form): support JSON array format in Arguments textarea

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1415,16 +1415,21 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`One per line:\n/path/to/server.js\n--verbose\n\nor paste a JSON array:\n["run", "-i", "--rm", "mcp/server"]`}
                             className="font-mono min-h-20"
                             {...field}
                           />
                         </FormControl>
+                        <FormDescription>
+                          One argument per line, or paste a JSON array (e.g.
+                          copied from an MCP catalog&apos;s{" "}
+                          <code>args</code> field).
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.test.ts
@@ -1,6 +1,7 @@
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 import {
   buildCloneFormValues,
+  parseArgumentsInput,
   transformCatalogItemToFormValues,
   transformExternalCatalogToFormValues,
   transformFormToApiData,
@@ -1096,6 +1097,69 @@ describe("team access levels", () => {
     expect(data.teams).toEqual([
       { id: "t1", level: "write" },
       { id: "t2", level: "use" },
+    ]);
+  });
+});
+
+describe("parseArgumentsInput", () => {
+  it("returns an empty array for empty input", () => {
+    expect(parseArgumentsInput("")).toEqual([]);
+    expect(parseArgumentsInput("   \n  ")).toEqual([]);
+  });
+
+  it("parses one-argument-per-line input (legacy behavior)", () => {
+    expect(parseArgumentsInput("/path/to/server.js\n--verbose")).toEqual([
+      "/path/to/server.js",
+      "--verbose",
+    ]);
+  });
+
+  it("trims whitespace and drops blank lines for plain input", () => {
+    expect(parseArgumentsInput("  --foo  \n\n  --bar  \n")).toEqual([
+      "--foo",
+      "--bar",
+    ]);
+  });
+
+  it("parses a single-line JSON array", () => {
+    expect(
+      parseArgumentsInput('["run", "-i", "--rm", "mcp/server"]'),
+    ).toEqual(["run", "-i", "--rm", "mcp/server"]);
+  });
+
+  it("parses a multi-line JSON array", () => {
+    const input = `[
+      "run",
+      "--init",
+      "--pull=always",
+      "-i",
+      "--rm"
+    ]`;
+    expect(parseArgumentsInput(input)).toEqual([
+      "run",
+      "--init",
+      "--pull=always",
+      "-i",
+      "--rm",
+    ]);
+  });
+
+  it("parses JSON array contents pasted without the surrounding brackets", () => {
+    const input = `"run",\n"-i",\n"--rm",`;
+    expect(parseArgumentsInput(input)).toEqual(["run", "-i", "--rm"]);
+  });
+
+  it("falls back to line-splitting when the input isn't valid JSON", () => {
+    // Looks JSON-ish but isn't valid (unquoted token) - should not throw,
+    // should gracefully fall back to treating it as plain lines.
+    expect(parseArgumentsInput("[not, valid, json]")).toEqual([
+      "[not, valid, json]",
+    ]);
+  });
+
+  it("falls back to line-splitting when JSON array contains non-string items", () => {
+    expect(parseArgumentsInput('["--port", 8080]')).toEqual([
+      '["--port", 8080]',
     ]);
   });
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -9,6 +9,83 @@ import {
 import { parseDockerArgsToLocalConfig } from "./docker-args-parser";
 import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 
+/**
+ * Parses the raw text entered into the "Arguments" textarea into an array
+ * of individual argument strings.
+ *
+ * Historically the textarea only supported one argument per line, but many
+ * MCP catalogs display their `args` as a JSON array (as found in a typical
+ * `mcpServers` config block), so copy-pasting one of those directly used to
+ * produce a single, malformed "argument" containing the whole JSON snippet.
+ *
+ * This now transparently supports:
+ *  - Plain one-argument-per-line text (existing behavior), e.g.
+ *      /path/to/server.js
+ *      --verbose
+ *  - A full JSON array, e.g.
+ *      ["run", "-i", "--rm", "mcp/server"]
+ *  - The *inner* contents of a JSON array (no surrounding brackets), which
+ *    is what you get pasting just the "args" lines out of a larger config:
+ *      "run",
+ *      "-i",
+ *      "--rm",
+ *
+ * Anything that isn't valid/parseable JSON falls back to the original
+ * line-splitting behavior so existing configs keep working unchanged.
+ */
+export function parseArgumentsInput(input: string): string[] {
+  const trimmed = input.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  const fromJson = tryParseJsonArgsArray(trimmed);
+  if (fromJson) {
+    return fromJson;
+  }
+
+  // Fall back to legacy one-per-line parsing
+  return trimmed
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
+function tryParseJsonArgsArray(trimmed: string): string[] | null {
+  const candidates: string[] = [];
+
+  if (trimmed.startsWith("[")) {
+    // Looks like a full JSON array already
+    candidates.push(trimmed);
+  } else {
+    // Might be the inner lines of a JSON array, pasted without brackets,
+    // e.g.:
+    //   "run",
+    //   "-i",
+    //   "--rm",
+    // Strip a trailing comma (common when copy-pasting) and wrap it.
+    const withoutTrailingComma = trimmed.replace(/,\s*$/, "");
+    candidates.push(`[${withoutTrailingComma}]`);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (
+        Array.isArray(parsed) &&
+        parsed.every((item) => typeof item === "string")
+      ) {
+        return parsed;
+      }
+    } catch {
+      // Not valid JSON - ignore and try the next candidate / fall back
+    }
+  }
+
+  return null;
+}
+
 type McpCatalogApiData =
   archestraApiTypes.CreateInternalMcpCatalogItemData["body"];
 
@@ -34,12 +111,10 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
+    // Parse arguments string into array (supports both one-per-line and
+    // JSON array formats, see parseArgumentsInput)
     const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
+      ? parseArgumentsInput(values.localConfig.arguments)
       : [];
 
     data.localConfig = {


### PR DESCRIPTION
The Arguments textarea previously only accepted one argument per
  line, but most MCP catalogs display args as a JSON array. This adds
  a parseArgumentsInput() helper that transparently detects and parses:
  - a full JSON array (single or multi-line)
  - JSON array contents pasted without surrounding brackets and falls back to the original line-splitting behavior otherwise, so existing configs are unaffected.

  Also updates the field label/placeholder to reflect the new
  behavior, and adds unit tests for the new parser.

  Fixes #3859