### PR TITLE
feat(observability): emit llm_request_duration_seconds for Bedrock

### DIFF
--- a/platform/backend/src/observability/metrics/llm.test.ts
+++ b/platform/backend/src/observability/metrics/llm.test.ts
@@ -36,6 +36,7 @@ import {
   reportLLMCacheCost,
   reportLLMCost,
   reportLLMTokens,
+  reportRequestDuration,
   reportTimeToFirstToken,
   reportTokensPerSecond,
 } from "./llm";
@@ -981,6 +982,80 @@ describe("reportTokensPerSecond", () => {
         model: "claude-3",
       },
       value: 20,
+      exemplarLabels: expect.any(Object),
+    });
+  });
+});
+
+describe("reportRequestDuration", () => {
+  let testAgent: Agent;
+
+  beforeEach(async ({ makeAgent }) => {
+    vi.clearAllMocks();
+    testAgent = await makeAgent();
+    initializeMetrics([]);
+  });
+
+  test("records duration with a success status code", () => {
+    reportRequestDuration(
+      "bedrock",
+      testAgent,
+      "claude-sonnet",
+      1.5,
+      "200",
+      "api",
+    );
+
+    expect(histogramObserve).toHaveBeenCalledWith({
+      labels: {
+        provider: "bedrock",
+        agent_id: testAgent.id,
+        agent_name: testAgent.name,
+        agent_type: testAgent.agentType,
+        source: "api",
+        model: "claude-sonnet",
+        status_code: "200",
+      },
+      value: 1.5,
+      exemplarLabels: expect.any(Object),
+    });
+  });
+
+  test("records duration with an error status code", () => {
+    reportRequestDuration(
+      "bedrock",
+      testAgent,
+      "claude-sonnet",
+      0.2,
+      "400",
+      "chat",
+    );
+
+    expect(histogramObserve).toHaveBeenCalledWith({
+      labels: {
+        provider: "bedrock",
+        agent_id: testAgent.id,
+        agent_name: testAgent.name,
+        agent_type: testAgent.agentType,
+        source: "chat",
+        model: "claude-sonnet",
+        status_code: "400",
+      },
+      value: 0.2,
+      exemplarLabels: expect.any(Object),
+    });
+  });
+
+  test("falls back to unknown model label", () => {
+    reportRequestDuration("bedrock", testAgent, "unknown", 3, "0", "api");
+
+    expect(histogramObserve).toHaveBeenCalledWith({
+      labels: expect.objectContaining({
+        provider: "bedrock",
+        model: "unknown",
+        status_code: "0",
+      }),
+      value: 3,
       exemplarLabels: expect.any(Object),
     });
   });

--- a/platform/backend/src/observability/metrics/llm.ts
+++ b/platform/backend/src/observability/metrics/llm.ts
@@ -527,6 +527,48 @@ export function reportTokensPerSecond(
 }
 
 /**
+ * Records the `llm_request_duration_seconds` histogram for a single request.
+ *
+ * Most providers instrument duration inside their transport wrapper
+ * (fetch-based providers via getObservableFetch, Gemini via getObservableGenAI),
+ * so they must NOT call this or the observation would be double-counted. It
+ * exists for providers whose transport can't self-instrument — notably Bedrock,
+ * which uses a custom SigV4 client that has no access to the profile/source
+ * needed for metric labels. For those, the LLM proxy handler records duration
+ * on the provider's behalf (gated by `LLMProvider.recordRequestDurationInHandler`).
+ * @param provider The LLM provider
+ * @param profile The Archestra profile
+ * @param model The model name
+ * @param durationSeconds Request duration in seconds
+ * @param statusCode HTTP-like status code label ("200" on success, upstream
+ *   status or "0" on error) — mirrors getObservableFetch's status labeling
+ * @param source Interaction source (e.g. "api", "chat", "knowledge:embedding")
+ */
+export function reportRequestDuration(
+  provider: SupportedProvider,
+  profile: Agent,
+  model: string,
+  durationSeconds: number,
+  statusCode: string,
+  source: InteractionSource,
+): void {
+  if (!llmRequestDuration) {
+    logger.warn("LLM metrics not initialized, skipping duration reporting");
+    return;
+  }
+  llmRequestDuration.observe({
+    labels: buildMetricLabels(
+      profile,
+      { provider, status_code: statusCode },
+      model,
+      source,
+    ),
+    value: durationSeconds,
+    exemplarLabels: getExemplarLabels(),
+  });
+}
+
+/**
  * Returns a fetch wrapped in observability. Use it as OpenAI or Anthropic provider custom fetch implementation.
  * @param provider The LLM provider
  * @param profile The Archestra profile

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -1767,6 +1767,10 @@ export const bedrockAdapterFactory: LLMProvider<
 > = {
   provider: "bedrock",
   interactionType: "bedrock:converse",
+  // Bedrock's custom SigV4 client (BedrockClient) can't self-instrument the
+  // request-duration metric the way fetch/Gemini transports do, so the LLM
+  // proxy handler records `llm_request_duration_seconds` on its behalf.
+  recordRequestDurationInHandler: true,
 
   createRequestAdapter(
     request: BedrockRequest,

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -97,12 +97,14 @@ import { metrics } from "@/observability";
 import {
   anthropicAdapterFactory,
   azureAdapterFactory,
+  bedrockAdapterFactory,
   geminiAdapterFactory,
   openaiAdapterFactory,
 } from "./adapters";
 import { virtualKeyRateLimiter } from "./llm-proxy-auth";
 import anthropicProxyRoutes from "./routes/anthropic";
 import azureProxyRoutes from "./routes/azure";
+import bedrockProxyRoutes from "./routes/bedrock";
 import geminiProxyRoutes from "./routes/gemini";
 import githubCopilotProxyRoutes from "./routes/github-copilot";
 import openAiProxyRoutes from "./routes/openai";
@@ -646,6 +648,116 @@ describe("LLM Proxy Handler Prometheus Metrics", () => {
             model: "gemini-2.5-pro",
             agent_id: testAgent.id,
             agent_name: testAgent.name,
+          }),
+          value: expect.any(Number),
+        }),
+      );
+    });
+  });
+
+  // Bedrock uses a custom SigV4 client instead of getObservableFetch, so unlike
+  // fetch-based providers it can't self-instrument llm_request_duration_seconds.
+  // The handler records it on Bedrock's behalf; these tests pin that behavior.
+  // The duration histogram is the only LLM metric carrying a `status_code`
+  // label, which is what distinguishes it from TTFT/tokens-per-second here.
+  describe("Bedrock", () => {
+    const BEDROCK_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    beforeEach(async () => {
+      await app.register(bedrockProxyRoutes);
+
+      vi.spyOn(bedrockAdapterFactory, "createClient").mockReturnValue({
+        converse: async () => ({
+          $metadata: { requestId: "req_bedrock_test" },
+          output: {
+            message: { role: "assistant", content: [{ text: "Hi there" }] },
+          },
+          stopReason: "end_turn",
+          usage: { inputTokens: 12, outputTokens: 10 },
+        }),
+        converseStream: async () =>
+          (async function* () {
+            yield { messageStart: { role: "assistant" } };
+            yield {
+              contentBlockDelta: {
+                contentBlockIndex: 0,
+                delta: { text: "Hi there" },
+              },
+            };
+            yield { contentBlockStop: { contentBlockIndex: 0 } };
+            yield { messageStop: { stopReason: "end_turn" } };
+            yield {
+              metadata: { usage: { inputTokens: 12, outputTokens: 10 } },
+            };
+          })(),
+      } as never);
+
+      await ModelModel.upsert({
+        externalId: `bedrock/${BEDROCK_MODEL}`,
+        provider: "bedrock",
+        modelId: BEDROCK_MODEL,
+        inputModalities: null,
+        outputModalities: null,
+        customPricePerMillionInput: "3.00",
+        customPricePerMillionOutput: "15.00",
+        lastSyncedAt: new Date(),
+      });
+    });
+
+    test("streaming request records the request-duration metric", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/bedrock/${testAgent.id}/converse-stream`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+        },
+        payload: {
+          modelId: BEDROCK_MODEL,
+          messages: [{ role: "user", content: [{ text: "Hello!" }] }],
+        },
+      });
+
+      expect(response.statusCode, response.body).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(histogramObserve).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labels: expect.objectContaining({
+            provider: "bedrock",
+            model: BEDROCK_MODEL,
+            agent_id: testAgent.id,
+            status_code: "200",
+          }),
+          value: expect.any(Number),
+        }),
+      );
+    });
+
+    test("non-streaming request records the request-duration metric", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/bedrock/${testAgent.id}/converse`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+        },
+        payload: {
+          modelId: BEDROCK_MODEL,
+          messages: [{ role: "user", content: [{ text: "Hello!" }] }],
+        },
+      });
+
+      expect(response.statusCode, response.body).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(histogramObserve).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labels: expect.objectContaining({
+            provider: "bedrock",
+            model: BEDROCK_MODEL,
+            agent_id: testAgent.id,
+            status_code: "200",
           }),
           value: expect.any(Number),
         }),

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -1115,6 +1115,10 @@ async function handleStreaming<
   const streamStartTime = Date.now();
   let firstChunkTime: number | undefined;
   let streamCompleted = false;
+  // Providers whose transport can't self-instrument duration (Bedrock) rely on
+  // us to record llm_request_duration_seconds. Guard against a second (error-path)
+  // observation once the stream has been established.
+  let requestDurationRecorded = false;
   const streamedEventIndices = new Set<number>();
   // Once a blocking tool is encountered, buffer all subsequent tool call chunks
   // to prevent streaming data for tools that appear after a blocked tool.
@@ -1150,6 +1154,22 @@ async function handleStreaming<
       user: toSpanUserInfo(resolvedUser),
       callback: async (llmSpan) => {
         const stream = await provider.executeStream(client, request);
+
+        // Record request duration at stream establishment for providers whose
+        // transport can't self-instrument it (Bedrock). This mirrors
+        // getObservableFetch/getObservableGenAI, which observe duration when the
+        // response/stream is established rather than when it finishes streaming.
+        if (provider.recordRequestDurationInHandler) {
+          metrics.llm.reportRequestDuration(
+            providerName,
+            agent,
+            actualModel,
+            (Date.now() - streamStartTime) / 1000,
+            "200",
+            source,
+          );
+          requestDurationRecorded = true;
+        }
 
         // Process chunks
         // Per-tool buffer/stream decisions: only "Allow always" tools stream immediately.
@@ -1414,6 +1434,22 @@ async function handleStreaming<
     streamCompleted = true;
     return reply;
   } catch (error) {
+    // If the stream never established (e.g. a provider 400 rejecting the
+    // request), record the duration here for providers we instrument in the
+    // handler. A mid-stream error is not double-recorded: establishment already
+    // set the flag, matching the "duration = time to establishment" semantics.
+    if (provider.recordRequestDurationInHandler && !requestDurationRecorded) {
+      metrics.llm.reportRequestDuration(
+        providerName,
+        agent,
+        actualModel,
+        (Date.now() - streamStartTime) / 1000,
+        extractDurationStatusCode(error),
+        source,
+      );
+      requestDurationRecorded = true;
+    }
+
     // The finally-block persist below is gated on usage, so a stream that
     // fails before any usage arrives (e.g. a provider 400 rejecting the
     // request) would otherwise leave no trace in LLM logs / session history.
@@ -1609,6 +1645,7 @@ async function handleNonStreaming<
   } = ctx;
 
   const providerName = provider.provider;
+  const requestStartTime = Date.now();
 
   logger.debug(
     { model: actualModel },
@@ -1637,7 +1674,35 @@ async function handleNonStreaming<
     parentContext,
     user: toSpanUserInfo(resolvedUser),
     callback: async (llmSpan) => {
-      const result = await provider.execute(client, request);
+      // Record request duration for providers we instrument in the handler
+      // (Bedrock). getObservableFetch covers the fetch-based providers, so those
+      // must not double-report here — the flag gates that.
+      let result: TResponse;
+      try {
+        result = await provider.execute(client, request);
+      } catch (error) {
+        if (provider.recordRequestDurationInHandler) {
+          metrics.llm.reportRequestDuration(
+            providerName,
+            agent,
+            actualModel,
+            (Date.now() - requestStartTime) / 1000,
+            extractDurationStatusCode(error),
+            source,
+          );
+        }
+        throw error;
+      }
+      if (provider.recordRequestDurationInHandler) {
+        metrics.llm.reportRequestDuration(
+          providerName,
+          agent,
+          actualModel,
+          (Date.now() - requestStartTime) / 1000,
+          "200",
+          source,
+        );
+      }
       const adapter = provider.createResponseAdapter(result);
 
       // Set response attributes on span per OTEL GenAI semconv. Correct zero-input
@@ -2002,4 +2067,15 @@ function headerNamePeek(
     result[k] = typeof v === "string" && v.length > 0 ? v[0] : "";
   }
   return result;
+}
+
+/**
+ * Derive a status_code label for the request-duration metric from a thrown
+ * provider error. Bedrock's client attaches `statusCode` to its errors; when
+ * absent (network failure before a response) we fall back to "0", matching how
+ * getObservableFetch labels network errors.
+ */
+function extractDurationStatusCode(error: unknown): string {
+  const statusCode = (error as { statusCode?: number } | null)?.statusCode;
+  return typeof statusCode === "number" ? String(statusCode) : "0";
 }

--- a/platform/backend/src/types/llm-provider.ts
+++ b/platform/backend/src/types/llm-provider.ts
@@ -367,6 +367,16 @@ export interface LLMProvider<TRequest, TResponse, TMessages, TChunk, THeaders> {
   /** Interaction type for database storage */
   readonly interactionType: SupportedProviderDiscriminator;
 
+  /**
+   * When true, the LLM proxy handler records the `llm_request_duration_seconds`
+   * metric for this provider. Leave unset for providers whose transport already
+   * self-instruments duration (fetch-based providers via getObservableFetch,
+   * Gemini via getObservableGenAI) to avoid double-counting. Bedrock sets this
+   * because its custom SigV4 client has no access to the profile/source labels
+   * the metric needs, so the handler records duration on its behalf.
+   */
+  readonly recordRequestDurationInHandler?: boolean;
+
   // ---------------------------------------------------------------------------
   // Adapter Creation
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Bedrock provider silently emitted **no** `llm_request_duration_seconds` metric. Every other provider records this histogram in its transport layer — fetch-based providers via `getObservableFetch`, Gemini via `getObservableGenAI` — but Bedrock uses a custom SigV4 client (`BedrockClient`) that bypasses both, and that transport has no access to the profile/source/model needed for the metric labels. The result: Bedrock requests were invisible to any duration-derived analytics (e.g. **Hours Automated** / **Cost Avoided**).

This wires Bedrock into the same histogram everything else already uses.

## Approach

Duration is the one LLM metric recorded at the transport layer; TTFT, tokens, tokens/sec, and cost are already reported centrally in `llm-proxy-handler.ts` for **all** providers (Bedrock included). So the fix is targeted:

- **New exported helper** `reportRequestDuration()` in `observability/metrics/llm.ts` — observes the existing `llm_request_duration_seconds` histogram with the standard labels + `status_code` (mirrors the direct-observe pattern already used by `reportKbLlmCall`).
- **New opt-in flag** `LLMProvider.recordRequestDurationInHandler?: boolean`. Providers whose transport self-instruments duration (fetch providers, Gemini) leave it unset to avoid double-counting; Bedrock sets it because its client can't self-instrument.
- **Handler records on the provider's behalf** when the flag is set:
  - **Streaming** — at stream establishment (consistent with `getObservableFetch`/`getObservableGenAI`, which observe when the response/stream is established, not when it finishes), with an error-path fallback guarded so a mid-stream error doesn't double-record.
  - **Non-streaming** — after `provider.execute()` resolves, plus an error path.
- **Status code** — `"200"` on success; on error, Bedrock's client attaches `statusCode`, falling back to `"0"` for pre-response network failures (matching `getObservableFetch`).

No new metric, no new env var — this fills a silent gap in an existing, already-documented metric.

## Tests

- Unit tests for `reportRequestDuration` (success / error status codes, unknown-model fallback).
- Handler integration tests that drive **streaming** and **non-streaming** Bedrock requests through the real proxy (stubbed `createClient`) and assert the duration histogram is observed with a `status_code` label — the label that uniquely distinguishes duration from TTFT/tokens-per-second.

`pnpm type-check`, `pnpm knip` (dev + production), Biome, and the affected test files all pass.

## Docs

No change needed. `docs/pages/platform-observability.md` already documents `llm_request_duration_seconds` generically ("by provider, model, agent_id, …, and status code"); this fills a silent per-provider gap rather than changing the metric's contract. (The provider-adding guide's metrics section documents only the fetch-extractor path and could later mention the `recordRequestDurationInHandler` seam for custom-transport providers — orthogonal and pre-existing.)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>