### PR TITLE
fix: cut three production error-tracking signals (loopback crash, title-gen race, upstream connection noise)

### DIFF
--- a/platform/backend/src/knowledge-base/embedding-clients/index.ts
+++ b/platform/backend/src/knowledge-base/embedding-clients/index.ts
@@ -2,6 +2,7 @@ import type {
   SupportedProvider,
   SupportedProviderDiscriminator,
 } from "@archestra/shared";
+import { isConnectionErrno, isTimeoutErrno } from "@/utils/network-errors";
 import { AzureEmbeddingError, callAzureEmbedding } from "./azure";
 import { callGeminiEmbedding, GeminiEmbeddingError } from "./gemini";
 import { callOpenAIEmbedding, OpenAIEmbeddingError } from "./openai";
@@ -10,18 +11,6 @@ import type { EmbeddingApiResponse, EmbeddingInput } from "./types";
 export type { EmbeddingApiResponse, EmbeddingInput };
 /** @public — re-exported for testability */
 export { AzureEmbeddingError, GeminiEmbeddingError, OpenAIEmbeddingError };
-
-const RETRYABLE_NETWORK_ERROR_CODES = new Set([
-  "ECONNABORTED",
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "EHOSTUNREACH",
-  "ENETDOWN",
-  "ENETRESET",
-  "ENETUNREACH",
-  "ENOTFOUND",
-  "ETIMEDOUT",
-]);
 
 /**
  * Provider-agnostic embedding call.
@@ -80,10 +69,11 @@ export function isRetryableEmbeddingError(error: unknown): boolean {
   ) {
     return error.status === 429 || error.status >= 500;
   }
-  // Network-level errors (ECONNRESET, ETIMEDOUT, etc.)
+  // Network-level errors (ECONNRESET, ETIMEDOUT, etc.) — a dropped/refused
+  // connection or a timeout is transient and worth retrying.
   if (error instanceof Error && "code" in error) {
     const code = (error as Error & { code?: string }).code;
-    return typeof code === "string" && RETRYABLE_NETWORK_ERROR_CODES.has(code);
+    return isConnectionErrno(code) || isTimeoutErrno(code);
   }
   return false;
 }

--- a/platform/backend/src/routes/chat/generate-title.route.test.ts
+++ b/platform/backend/src/routes/chat/generate-title.route.test.ts
@@ -3,6 +3,7 @@ import { generateText } from "ai";
 import { eq } from "drizzle-orm";
 import { vi } from "vitest";
 import db, { schema } from "@/database";
+import ConversationModel from "@/models/conversation";
 import MessageModel from "@/models/message";
 import ModelModel from "@/models/model";
 import { getSecretValueForLlmProviderApiKey } from "@/secrets-manager";
@@ -182,6 +183,53 @@ describe("POST /api/chat/conversations/:id/generate-title", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json().title).toBe("Friendly greeting");
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 200 (not 500) when the conversation is deleted mid-generation", async ({
+    makeAgent,
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    // Title generation is a slow async LLM call; the user can delete the
+    // conversation before the generated title is written back. That benign race
+    // used to raise a 500 ("Failed to update conversation with title") which was
+    // captured as a server exception — it must now fall through gracefully.
+    const agent = await makeAgent({
+      organizationId,
+      authorId: currentUser.id,
+      scope: "personal",
+    });
+    const conversation = await makeConversationWithExchange(agent.id);
+
+    const secret = await makeSecret({ secret: { apiKey: "sk-ant-test" } });
+    const apiKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: "anthropic",
+      scope: "org",
+      name: "Anthropic",
+    });
+    const model = await makeModelRow("anthropic", "claude-sonnet-5");
+    await setOrganizationDefaultLlm(model.id, apiKey.id);
+
+    // Delete the conversation from inside the mocked generation, reproducing a
+    // concurrent delete landing while the title LLM call is in flight — right
+    // before the route writes the title back.
+    mockGenerateText.mockImplementation(async () => {
+      await ConversationModel.delete(
+        conversation.id,
+        currentUser.id,
+        organizationId,
+      );
+      return { text: "A title" } as Awaited<ReturnType<typeof generateText>>;
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/chat/conversations/${conversation.id}/generate-title`,
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
     expect(mockGenerateText).toHaveBeenCalledTimes(1);
   });
 });

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -2781,7 +2781,16 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
       );
 
       if (!updatedConversation) {
-        throw new ApiError(500, "Failed to update conversation with title");
+        // No row matched id + user + org, even though findById succeeded at the
+        // start of this handler — the conversation was deleted during the async
+        // title generation (a slow LLM call). That's a benign race, not a server
+        // fault: title generation is best-effort, so fall through gracefully like
+        // the other skip branches above instead of raising a 500.
+        logger.info(
+          { conversationId: id },
+          "Skipping title update - conversation no longer exists (deleted during generation)",
+        );
+        return reply.send(conversation);
       }
 
       return reply.send(updatedConversation);

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -593,4 +593,59 @@ describe("handleError", () => {
     );
     expect(payload.error.message).toBe("empty upstream response");
   });
+
+  // Transient upstream connection failures carry no HTTP status, so they used to
+  // fall through as a generic 500 and get captured as a server exception. They're
+  // reclassified to 502/504 so the central handler keeps them out of error
+  // tracking (it already excludes 502/504) while the client still sees a 5xx.
+  function throwStatusFor(error: unknown): number | undefined {
+    const { reply } = makeReply(false);
+    try {
+      handleError(error, reply, extractMessage, false, () => undefined);
+    } catch (thrown) {
+      return (thrown as ApiError).statusCode;
+    }
+    return undefined;
+  }
+
+  test("classifies an SDK connection error as 502", () => {
+    // OpenAI/Anthropic SDK APIConnectionError message, no HTTP status.
+    expect(throwStatusFor(new Error("Connection error."))).toBe(502);
+  });
+
+  test("classifies an SDK request timeout as 504", () => {
+    // OpenAI/Anthropic SDK APIConnectionTimeoutError message, no HTTP status.
+    expect(throwStatusFor(new Error("Request timed out."))).toBe(504);
+  });
+
+  test("classifies a wrapped network errno cause as an upstream gateway error", () => {
+    const connReset = Object.assign(new Error("fetch failed"), {
+      cause: Object.assign(new Error("read ECONNRESET"), {
+        code: "ECONNRESET",
+      }),
+    });
+    expect(throwStatusFor(connReset)).toBe(502);
+
+    const timedOut = Object.assign(new Error("fetch failed"), {
+      cause: Object.assign(new Error("connect ETIMEDOUT"), {
+        code: "ETIMEDOUT",
+      }),
+    });
+    expect(throwStatusFor(timedOut)).toBe(504);
+  });
+
+  test("leaves an error that carries an explicit HTTP status untouched", () => {
+    // A real upstream 500 response must not be reclassified away from capture.
+    expect(throwStatusFor(new ApiError(500, "Connection error."))).toBe(500);
+    expect(
+      throwStatusFor(Object.assign(new Error("boom"), { status: 500 })),
+    ).toBe(500);
+  });
+
+  test("leaves a generic internal error as a 500", () => {
+    // No connection/timeout signal → stays a 500 and remains captured.
+    expect(throwStatusFor(new TypeError("cannot read x of undefined"))).toBe(
+      500,
+    );
+  });
 });

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -33,6 +33,11 @@ import type {
   UnsafeContextBoundary,
   UsageView,
 } from "@/types";
+import {
+  collectErrorCodes,
+  isConnectionErrno,
+  isTimeoutErrno,
+} from "@/utils/network-errors";
 import * as utils from "./utils";
 import { estimateToolTokens } from "./utils/cost-optimization";
 import type { SessionSource } from "./utils/headers/session-id";
@@ -421,32 +426,6 @@ export function handleError(
 }
 
 /**
- * Network errno codes (libuv + undici) for a connection to the upstream provider
- * that failed or was dropped before an HTTP response arrived.
- */
-const UPSTREAM_CONNECTION_ERRNOS = new Set([
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "ECONNABORTED",
-  "ENOTFOUND",
-  "EAI_AGAIN",
-  "EHOSTUNREACH",
-  "ENETUNREACH",
-  "ENETDOWN",
-  "EPIPE",
-  "UND_ERR_SOCKET",
-]);
-
-/** Network errno codes for a connection that specifically *timed out*. */
-const UPSTREAM_TIMEOUT_ERRNOS = new Set([
-  "ETIMEDOUT",
-  "ESOCKETTIMEDOUT",
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_HEADERS_TIMEOUT",
-  "UND_ERR_BODY_TIMEOUT",
-]);
-
-/**
  * When an LLM SDK call fails to reach the upstream provider — a dropped/refused
  * connection or a timeout, both with no HTTP status — classify it as an upstream
  * gateway failure: 504 for a timeout, 502 for any other connection failure.
@@ -455,7 +434,8 @@ const UPSTREAM_TIMEOUT_ERRNOS = new Set([
  *
  * Matches the OpenAI/Anthropic SDK `APIConnectionError` ("Connection error.") and
  * `APIConnectionTimeoutError` ("Request timed out."), plus the underlying Node
- * `fetch`/libuv/undici errno codes those wrap, across providers.
+ * `fetch`/libuv/undici errno codes those wrap (via the shared network-error
+ * vocabulary), across providers.
  */
 function classifyTransientUpstreamError(error: unknown): 502 | 504 | undefined {
   if (!(error instanceof Error)) return undefined;
@@ -466,7 +446,7 @@ function classifyTransientUpstreamError(error: unknown): 502 | 504 | undefined {
   const isTimeout =
     name === "APIConnectionTimeoutError" ||
     /timed out|timeout/i.test(message) ||
-    codes.some((code) => UPSTREAM_TIMEOUT_ERRNOS.has(code));
+    codes.some(isTimeoutErrno);
   if (isTimeout) return 504;
 
   const isConnectionFailure =
@@ -475,25 +455,10 @@ function classifyTransientUpstreamError(error: unknown): 502 | 504 | undefined {
     /fetch failed|socket hang up|network error|connection (?:reset|refused|closed|aborted)|terminated/i.test(
       message,
     ) ||
-    codes.some((code) => UPSTREAM_CONNECTION_ERRNOS.has(code));
+    codes.some(isConnectionErrno);
   if (isConnectionFailure) return 502;
 
   return undefined;
-}
-
-/**
- * Gather candidate errno strings from an error and its `cause` chain — Node's
- * `fetch` wraps the real libuv error as `cause`, sometimes a level or two deep.
- */
-function collectErrorCodes(error: Error): string[] {
-  const codes: string[] = [];
-  let current: unknown = error;
-  for (let depth = 0; depth < 3 && current instanceof Error; depth++) {
-    const code = (current as Error & { code?: unknown }).code;
-    if (typeof code === "string") codes.push(code);
-    current = (current as Error & { cause?: unknown }).cause;
-  }
-  return codes;
 }
 
 /**

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -349,6 +349,7 @@ export function handleError(
   // Extract status code from error, checking multiple common property names
   // and ensuring the value is a valid number (not undefined/null)
   let statusCode: number = 500;
+  let hasExplicitStatus = false;
   if (error instanceof Error) {
     const errorObj = error as Error & {
       status?: number;
@@ -356,8 +357,24 @@ export function handleError(
     };
     if (typeof errorObj.status === "number") {
       statusCode = errorObj.status;
+      hasExplicitStatus = true;
     } else if (typeof errorObj.statusCode === "number") {
       statusCode = errorObj.statusCode;
+      hasExplicitStatus = true;
+    }
+  }
+
+  // A connection failure or timeout reaching the upstream provider carries no
+  // HTTP status (the request never got a response), so it would otherwise fall
+  // through as a generic 500 and be captured as a server exception. That's the
+  // upstream's/network's failure, not ours — reclassify it as a gateway error
+  // (504 timeout, 502 connection) so the central error handler logs it but keeps
+  // it out of error tracking (it already excludes 502/504), while the client
+  // still sees a retryable 5xx.
+  if (!hasExplicitStatus) {
+    const upstreamStatus = classifyTransientUpstreamError(error);
+    if (upstreamStatus !== undefined) {
+      statusCode = upstreamStatus;
     }
   }
 
@@ -401,6 +418,82 @@ export function handleError(
   // Headers not sent yet - throw ApiError to let central handler return proper status code
   // This matches V1 handler behavior and ensures clients receive correct HTTP status
   throw new ApiError(statusCode, errorMessage, internalCode);
+}
+
+/**
+ * Network errno codes (libuv + undici) for a connection to the upstream provider
+ * that failed or was dropped before an HTTP response arrived.
+ */
+const UPSTREAM_CONNECTION_ERRNOS = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ECONNABORTED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EPIPE",
+  "UND_ERR_SOCKET",
+]);
+
+/** Network errno codes for a connection that specifically *timed out*. */
+const UPSTREAM_TIMEOUT_ERRNOS = new Set([
+  "ETIMEDOUT",
+  "ESOCKETTIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+
+/**
+ * When an LLM SDK call fails to reach the upstream provider — a dropped/refused
+ * connection or a timeout, both with no HTTP status — classify it as an upstream
+ * gateway failure: 504 for a timeout, 502 for any other connection failure.
+ * Returns undefined for anything that isn't a recognizable connection failure so
+ * genuine 500s (our own bugs) are left alone.
+ *
+ * Matches the OpenAI/Anthropic SDK `APIConnectionError` ("Connection error.") and
+ * `APIConnectionTimeoutError` ("Request timed out."), plus the underlying Node
+ * `fetch`/libuv/undici errno codes those wrap, across providers.
+ */
+function classifyTransientUpstreamError(error: unknown): 502 | 504 | undefined {
+  if (!(error instanceof Error)) return undefined;
+
+  const { name, message } = error;
+  const codes = collectErrorCodes(error);
+
+  const isTimeout =
+    name === "APIConnectionTimeoutError" ||
+    /timed out|timeout/i.test(message) ||
+    codes.some((code) => UPSTREAM_TIMEOUT_ERRNOS.has(code));
+  if (isTimeout) return 504;
+
+  const isConnectionFailure =
+    name === "APIConnectionError" ||
+    /^connection error\.?$/i.test(message) ||
+    /fetch failed|socket hang up|network error|connection (?:reset|refused|closed|aborted)|terminated/i.test(
+      message,
+    ) ||
+    codes.some((code) => UPSTREAM_CONNECTION_ERRNOS.has(code));
+  if (isConnectionFailure) return 502;
+
+  return undefined;
+}
+
+/**
+ * Gather candidate errno strings from an error and its `cause` chain — Node's
+ * `fetch` wraps the real libuv error as `cause`, sometimes a level or two deep.
+ */
+function collectErrorCodes(error: Error): string[] {
+  const codes: string[] = [];
+  let current: unknown = error;
+  for (let depth = 0; depth < 3 && current instanceof Error; depth++) {
+    const code = (current as Error & { code?: unknown }).code;
+    if (typeof code === "string") codes.push(code);
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return codes;
 }
 
 /**

--- a/platform/backend/src/utils/network-errors.test.ts
+++ b/platform/backend/src/utils/network-errors.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import {
+  collectErrorCodes,
+  isConnectionErrno,
+  isTimeoutErrno,
+} from "./network-errors";
+
+describe("isConnectionErrno", () => {
+  test("returns true for connection-failure codes", () => {
+    expect(isConnectionErrno("ECONNREFUSED")).toBe(true);
+    expect(isConnectionErrno("ECONNRESET")).toBe(true);
+    expect(isConnectionErrno("ENOTFOUND")).toBe(true);
+    expect(isConnectionErrno("EAI_AGAIN")).toBe(true);
+    expect(isConnectionErrno("UND_ERR_SOCKET")).toBe(true);
+  });
+
+  test("returns false for timeout codes and unknowns", () => {
+    expect(isConnectionErrno("ETIMEDOUT")).toBe(false);
+    expect(isConnectionErrno("EPERM")).toBe(false);
+  });
+
+  test("returns false for a missing code", () => {
+    expect(isConnectionErrno(undefined)).toBe(false);
+    expect(isConnectionErrno(null)).toBe(false);
+  });
+});
+
+describe("isTimeoutErrno", () => {
+  test("returns true for timeout codes", () => {
+    expect(isTimeoutErrno("ETIMEDOUT")).toBe(true);
+    expect(isTimeoutErrno("ESOCKETTIMEDOUT")).toBe(true);
+    expect(isTimeoutErrno("UND_ERR_HEADERS_TIMEOUT")).toBe(true);
+  });
+
+  test("returns false for connection-failure codes and unknowns", () => {
+    expect(isTimeoutErrno("ECONNRESET")).toBe(false);
+    expect(isTimeoutErrno("nope")).toBe(false);
+  });
+
+  test("returns false for a missing code", () => {
+    expect(isTimeoutErrno(undefined)).toBe(false);
+    expect(isTimeoutErrno(null)).toBe(false);
+  });
+});
+
+describe("collectErrorCodes", () => {
+  test("returns the code of a single error", () => {
+    const err = Object.assign(new Error("boom"), { code: "ECONNRESET" });
+    expect(collectErrorCodes(err)).toEqual(["ECONNRESET"]);
+  });
+
+  test("walks the cause chain (fetch wraps the real errno as cause)", () => {
+    const err = Object.assign(new Error("fetch failed"), {
+      cause: Object.assign(new Error("read ECONNRESET"), {
+        code: "ECONNRESET",
+      }),
+    });
+    expect(collectErrorCodes(err)).toEqual(["ECONNRESET"]);
+  });
+
+  test("collects codes at multiple levels of the cause chain", () => {
+    const err = Object.assign(new Error("outer"), {
+      code: "OUTER",
+      cause: Object.assign(new Error("inner"), { code: "ETIMEDOUT" }),
+    });
+    expect(collectErrorCodes(err)).toEqual(["OUTER", "ETIMEDOUT"]);
+  });
+
+  test("stops at maxDepth, guarding against circular causes", () => {
+    const a = new Error("a") as Error & { code?: string; cause?: unknown };
+    const b = new Error("b") as Error & { code?: string; cause?: unknown };
+    a.code = "A";
+    b.code = "B";
+    a.cause = b;
+    b.cause = a; // circular
+    // Default maxDepth is 3 levels: a, b, a — three codes, no infinite loop.
+    expect(collectErrorCodes(a)).toEqual(["A", "B", "A"]);
+  });
+
+  test("returns an empty array for a non-error or code-less error", () => {
+    expect(collectErrorCodes("not an error")).toEqual([]);
+    expect(collectErrorCodes(new Error("no code"))).toEqual([]);
+  });
+});

--- a/platform/backend/src/utils/network-errors.ts
+++ b/platform/backend/src/utils/network-errors.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared vocabulary for classifying low-level network failures by their errno
+ * code — the codes libuv (Node's `fetch`, sockets) and undici surface when a
+ * connection cannot be established, is dropped, or times out before any HTTP
+ * response arrives.
+ *
+ * Consumers ask different questions of these (retryable? connection vs timeout?),
+ * so this module owns only the vocabulary and a cause-chain code collector; each
+ * caller composes its own domain predicate on top. It deliberately does NOT own
+ * database transience — Postgres SQLSTATE codes and pool-specific message
+ * patterns live in `database/retry.ts`, a different concern with different codes.
+ */
+
+/** Whether a code names a connection failure (dropped / refused / unreachable). */
+export function isConnectionErrno(code: string | null | undefined): boolean {
+  return typeof code === "string" && CONNECTION_ERRNOS.has(code);
+}
+
+/** Whether a code names a connection that specifically *timed out*. */
+export function isTimeoutErrno(code: string | null | undefined): boolean {
+  return typeof code === "string" && TIMEOUT_ERRNOS.has(code);
+}
+
+/**
+ * Gather candidate errno strings from an error and its `cause` chain — Node's
+ * `fetch` wraps the real libuv error as `cause`, sometimes a level or two deep.
+ * Bounded by `maxDepth` to guard against circular `cause` references.
+ */
+export function collectErrorCodes(error: unknown, maxDepth = 3): string[] {
+  const codes: string[] = [];
+  let current: unknown = error;
+  for (let depth = 0; depth < maxDepth && current instanceof Error; depth++) {
+    const code = (current as Error & { code?: unknown }).code;
+    if (typeof code === "string") codes.push(code);
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return codes;
+}
+
+// === Internal vocabulary ===
+
+/** Errno codes for a connection that failed or was dropped (not a timeout). */
+const CONNECTION_ERRNOS: ReadonlySet<string> = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ECONNABORTED",
+  "ENOTFOUND",
+  "EAI_AGAIN", // transient DNS resolution failure
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "ENETRESET",
+  "EPIPE",
+  "UND_ERR_SOCKET",
+]);
+
+/** Errno codes for a connection that specifically *timed out*. */
+const TIMEOUT_ERRNOS: ReadonlySet<string> = new Set([
+  "ETIMEDOUT",
+  "ESOCKETTIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);

--- a/platform/backend/src/utils/network.test.ts
+++ b/platform/backend/src/utils/network.test.ts
@@ -59,6 +59,14 @@ describe("isLoopbackAddress", () => {
     expect(isLoopbackAddress("not-an-ip")).toBe(false);
     expect(isLoopbackAddress("127.0.0")).toBe(false);
   });
+
+  // Fastify types request.ip as string but it can be undefined at runtime
+  // (socket with no remote address, empty X-Forwarded-For under trustProxy).
+  // An unknown origin must be treated as non-loopback, not throw.
+  test("returns false for undefined or null", () => {
+    expect(isLoopbackAddress(undefined)).toBe(false);
+    expect(isLoopbackAddress(null)).toBe(false);
+  });
 });
 
 describe("isLoopbackRedirectUri", () => {

--- a/platform/backend/src/utils/network.ts
+++ b/platform/backend/src/utils/network.ts
@@ -8,8 +8,14 @@ import ipaddr from "ipaddr.js";
  *  - IPv4 loopback range `127.0.0.0/8`  (any `127.x.x.x`)
  *  - IPv6 loopback `::1`
  *  - IPv4-mapped IPv6 loopback `::ffff:127.x.x.x`
+ *
+ * Accepts a possibly-missing value: Fastify types `request.ip` as `string` but
+ * it can be `undefined` at runtime (e.g. a socket with no remote address, or an
+ * empty `X-Forwarded-For` under `trustProxy`). An unknown origin is treated as
+ * non-loopback — the secure default — rather than throwing on `.startsWith`.
  */
-export function isLoopbackAddress(ip: string): boolean {
+export function isLoopbackAddress(ip: string | null | undefined): boolean {
+  if (typeof ip !== "string") return false;
   if (ip === "::1") return true;
 
   // Handle IPv4-mapped IPv6 (e.g. "::ffff:127.0.0.1")


### PR DESCRIPTION
## What

Fixes three recurring production error signals, all traced from error tracking. Each is either a crash or noise from an upstream/transient condition being reported as a server fault. In the spirit of #6418 and #6506, these cut the remaining high-frequency noise (and one real crash), plus a small follow-on refactor to centralize the network-errno vocabulary the fixes introduced.

### 1. `TypeError: Cannot read properties of undefined (reading 'startsWith')`
`isLoopbackAddress(ip)` is called with `request.ip` from the LLM proxy. Fastify types `request.ip` as `string`, but at runtime it can be `undefined` (a socket with no remote address, or an empty `X-Forwarded-For` under `trustProxy`). The helper then threw on `.startsWith`, 500-ing the request.

Treat a non-string IP as **non-loopback** (the secure default — an unknown origin is never trusted as loopback) rather than throwing. Centralized in the helper so all six call sites are covered.

### 2. `Error: Failed to update conversation with title`
The generate-title handler fetches the conversation, makes a slow async LLM call, then writes the title back. If the conversation is deleted during that window, `ConversationModel.update` matches no row and returns `null` — which raised a 500 that was captured as a server exception.

That's a benign race, not a server fault. Title generation is best-effort, so it now falls through gracefully like the handler's other skip branches instead of throwing.

### 3. `Error: Connection error.` / `Request timed out.`
A connection failure or timeout reaching the upstream provider (SDK `APIConnectionError` / `APIConnectionTimeoutError`, or the libuv/undici errno codes they wrap) carries **no** HTTP status, so `handleError` defaulted it to 500 and the central handler captured it as a server exception.

These are the upstream's/network's failure, not ours. They're now reclassified as gateway errors (**504** timeout, **502** connection) so the central handler logs them but keeps them out of error tracking — it already excludes 502/504. The client still sees the same retryable `ServerError` card (any `statusCode >= 500` maps to it), so no UX change.

### 4. Refactor: centralize the network-errno vocabulary
Fix #3's classifier and the existing embedding retry check each hand-rolled their own set of libuv/undici errno strings (and the LLM proxy also its own cause-chain walker). Extracted a shared `utils/network-errors` module that owns the vocabulary plus `isConnectionErrno` / `isTimeoutErrno` predicates and `collectErrorCodes(error)` (the cause-chain walker). Both consumers now compose from it; the raw sets stay module-private so callers can't diverge on membership again.

Deliberately **not** folded in:
- `database/retry.ts` — Postgres SQLSTATE codes + pool-specific message patterns, a different domain with different matching.
- `utils/docker-localhost-hint.ts` — matches on message substrings, not `error.code`.

`isRetryableEmbeddingError` now retries on a slightly larger but strictly-safe superset (EAI_AGAIN, EPIPE, undici socket/timeout errors) — all genuinely transient.

## Why

All three were among the current highest-frequency error-tracking signals. Two were pure noise from upstream/transient conditions; one (#1) was a real crash on the LLM proxy path.

## Testing

- `isLoopbackAddress` returns `false` for `undefined`/`null`.
- generate-title returns 200 (not 500) when the conversation is deleted mid-generation.
- `handleError` classifies SDK connection errors → 502, timeouts → 504, wrapped `cause` errno chains correctly, and leaves errors with an explicit HTTP status and generic internal errors as 500.
- New `network-errors` unit tests: connection vs timeout predicates, cause-chain collection (incl. circular-cause bound). Existing embedding tests still pass.
- `pnpm type-check`, backend `pnpm knip` (dev + production), and Biome all clean.
