### PR TITLE
fix(chat): suppress empty "Thinking…" reasoning accordions

### DIFF
--- a/platform/frontend/src/components/ai-elements/reasoning.test.tsx
+++ b/platform/frontend/src/components/ai-elements/reasoning.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { Reasoning, ReasoningTrigger } from "./reasoning";
 
 describe("Reasoning trigger label", () => {
@@ -22,5 +22,30 @@ describe("Reasoning trigger label", () => {
     );
 
     expect(screen.getByText("Thinking...")).toBeInTheDocument();
+  });
+
+  it("switches to the measured duration once streaming ends", () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(
+        <Reasoning isStreaming>
+          <ReasoningTrigger />
+        </Reasoning>,
+      );
+      expect(screen.getByText("Thinking...")).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      rerender(
+        <Reasoning isStreaming={false}>
+          <ReasoningTrigger />
+        </Reasoning>,
+      );
+
+      expect(screen.getByText(/Thought for 3 seconds/)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/platform/frontend/src/components/ai-elements/reasoning.test.tsx
+++ b/platform/frontend/src/components/ai-elements/reasoning.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Reasoning, ReasoningTrigger } from "./reasoning";
+
+describe("Reasoning trigger label", () => {
+  it("does not stay pinned on 'Thinking…' for a non-streaming block with no duration", () => {
+    render(
+      <Reasoning>
+        <ReasoningTrigger />
+      </Reasoning>,
+    );
+
+    expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
+    expect(screen.getByText(/Thought for/)).toBeInTheDocument();
+  });
+
+  it("shows 'Thinking…' while the block is streaming", () => {
+    render(
+      <Reasoning isStreaming>
+        <ReasoningTrigger />
+      </Reasoning>,
+    );
+
+    expect(screen.getByText("Thinking...")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/ai-elements/reasoning.tsx
+++ b/platform/frontend/src/components/ai-elements/reasoning.tsx
@@ -16,7 +16,10 @@ type ReasoningContextValue = {
   isStreaming: boolean;
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
-  duration: number;
+  // Undefined until a live block measures its own duration (or a caller passes
+  // one); a persisted block never has it. `getThinkingMessage` distinguishes the
+  // two, so the type must admit undefined.
+  duration: number | undefined;
 };
 
 const ReasoningContext = createContext<ReasoningContextValue | null>(null);
@@ -58,7 +61,12 @@ export const Reasoning = memo(
     });
     const [duration, setDuration] = useControllableState({
       prop: durationProp,
-      defaultProp: 0,
+      // Undefined, not 0: a reasoning block that never streamed (a persisted
+      // conversation reopened, or a surface that passes no `isStreaming`) has no
+      // measured duration and must read "Thought for a few seconds", not stay
+      // pinned on "Thinking…". A live block still gets a real duration from the
+      // streaming-end effect below.
+      defaultProp: undefined,
     });
 
     const [hasAutoClosed, setHasAutoClosed] = useState(false);

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -31,8 +31,16 @@ vi.mock("@/components/ai-elements/message", () => ({
 }));
 
 vi.mock("@/components/ai-elements/reasoning", () => ({
-  Reasoning: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="reasoning">{children}</div>
+  Reasoning: ({
+    children,
+    isStreaming,
+  }: {
+    children: React.ReactNode;
+    isStreaming?: boolean;
+  }) => (
+    <div data-testid="reasoning" data-streaming={String(Boolean(isStreaming))}>
+      {children}
+    </div>
   ),
   ReasoningContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -332,6 +340,58 @@ describe("ChatMessages", () => {
 
     expect(screen.getAllByTestId("reasoning")).toHaveLength(1);
     expect(screen.getByText("weighing the options")).toBeInTheDocument();
+  });
+
+  it("marks the last reasoning part of the last message as streaming", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "reasoning", text: "earlier thought" }],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [{ type: "reasoning", text: "current thought" }],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="streaming"
+      />,
+    );
+
+    const accordions = screen.getAllByTestId("reasoning");
+    expect(accordions).toHaveLength(2);
+    // Only the last part of the last message streams; earlier blocks are done.
+    expect(accordions[0]).toHaveAttribute("data-streaming", "false");
+    expect(accordions[1]).toHaveAttribute("data-streaming", "true");
+  });
+
+  it("marks no reasoning as streaming once the response is ready", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "reasoning", text: "settled thought" }],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.getByTestId("reasoning")).toHaveAttribute(
+      "data-streaming",
+      "false",
+    );
   });
 
   it("keeps the loading logo visible for the whole streaming response", () => {

--- a/platform/frontend/src/components/chat/chat-messages.test.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.test.tsx
@@ -32,7 +32,7 @@ vi.mock("@/components/ai-elements/message", () => ({
 
 vi.mock("@/components/ai-elements/reasoning", () => ({
   Reasoning: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+    <div data-testid="reasoning">{children}</div>
   ),
   ReasoningContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -283,6 +283,55 @@ describe("ChatMessages", () => {
     );
 
     expect(screen.getByText("Switched to GitHub Agent")).toBeInTheDocument();
+  });
+
+  it("does not render an accordion for an empty reasoning part", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "reasoning", text: "" },
+          { type: "reasoning", text: "   " },
+          { type: "text", text: "the answer" },
+        ],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.queryByTestId("reasoning")).not.toBeInTheDocument();
+    expect(screen.getByText("the answer")).toBeInTheDocument();
+  });
+
+  it("renders an accordion only for reasoning parts with real text", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "reasoning", text: "" },
+          { type: "reasoning", text: "weighing the options" },
+        ],
+      },
+    ] as UIMessage[];
+
+    render(
+      <ChatMessages
+        conversationId="conv-1"
+        messages={messages}
+        status="ready"
+      />,
+    );
+
+    expect(screen.getAllByTestId("reasoning")).toHaveLength(1);
+    expect(screen.getByText("weighing the options")).toBeInTheDocument();
   });
 
   it("keeps the loading logo visible for the whole streaming response", () => {

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -111,6 +111,7 @@ import {
   hasTextPart,
   identifyCompactToolGroups,
   isBlankAssistantTextPart,
+  isBlankReasoningPart,
   resolveRunToolTargetName,
   type SubagentChildEntry,
 } from "./chat-messages.utils";
@@ -999,13 +1000,28 @@ export function ChatMessages({
                         );
                       }
 
-                      case "reasoning":
+                      case "reasoning": {
+                        // Redacted/signature-only thinking blocks arrive as
+                        // empty reasoning parts (kept for provider replay); they
+                        // must not render as empty "Thinking…" accordions.
+                        if (isBlankReasoningPart(part)) {
+                          return null;
+                        }
+                        const isStreamingThisReasoning =
+                          status === "streaming" &&
+                          idx === messages.length - 1 &&
+                          i === message.parts.length - 1;
                         return (
-                          <Reasoning key={partKey} className="w-full">
+                          <Reasoning
+                            key={partKey}
+                            className="w-full"
+                            isStreaming={isStreamingThisReasoning}
+                          >
                             <ReasoningTrigger />
                             <ReasoningContent>{part.text}</ReasoningContent>
                           </Reasoning>
                         );
+                      }
 
                       case "file": {
                         // User file attachments are normally rendered inside EditableUserMessage

--- a/platform/frontend/src/components/chat/chat-messages.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.test.ts
@@ -14,6 +14,7 @@ import {
   hasTextPart,
   identifyCompactToolGroups,
   isBlankAssistantTextPart,
+  isBlankReasoningPart,
   mcpToolLabel,
 } from "./chat-messages.utils";
 
@@ -1242,5 +1243,32 @@ describe("isBlankAssistantTextPart", () => {
         "assistant",
       ),
     ).toBe(false);
+  });
+});
+
+describe("isBlankReasoningPart", () => {
+  const reasoningPart = (text?: string) => ({ type: "reasoning", text });
+
+  it.each([
+    "",
+    " ",
+    "   ",
+    "\n\n",
+    "\t",
+    "\n  \t ",
+  ])("suppresses a reasoning part with no readable text %j", (text) => {
+    expect(isBlankReasoningPart(reasoningPart(text))).toBe(true);
+  });
+
+  it("suppresses a reasoning part with undefined text (redacted thinking)", () => {
+    expect(isBlankReasoningPart(reasoningPart(undefined))).toBe(true);
+  });
+
+  it("keeps a reasoning part that has real content", () => {
+    expect(isBlankReasoningPart(reasoningPart("  because X  "))).toBe(false);
+  });
+
+  it("ignores non-reasoning parts", () => {
+    expect(isBlankReasoningPart({ type: "text", text: "" })).toBe(false);
   });
 });

--- a/platform/frontend/src/components/chat/chat-messages.utils.ts
+++ b/platform/frontend/src/components/chat/chat-messages.utils.ts
@@ -107,6 +107,23 @@ export function isBlankAssistantTextPart(
   return role === "assistant" && part.type === "text" && !part.text.trim();
 }
 
+/**
+ * Anthropic `redacted_thinking` blocks (encrypted, no visible text) and
+ * signature-only `thinking` blocks arrive as `reasoning` parts with empty text.
+ * They are load-bearing — the thinking signature must be replayed to the
+ * provider on the next turn — so they are persisted and reload verbatim, but
+ * rendered they show as empty "Thinking…" accordions. Suppress those; a
+ * reasoning part only renders when it carries readable text. Structurally typed
+ * so both the live-chat (`UIMessage`) and read-only (`PartialUIMessage`) part
+ * shapes qualify.
+ */
+export function isBlankReasoningPart(part: {
+  type: string;
+  text?: string;
+}): boolean {
+  return part.type === "reasoning" && !part.text?.trim();
+}
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 

--- a/platform/frontend/src/components/message-thread.test.tsx
+++ b/platform/frontend/src/components/message-thread.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/components/ai-elements/message", () => ({
 
 vi.mock("@/components/ai-elements/reasoning", () => ({
   Reasoning: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+    <div data-testid="reasoning">{children}</div>
   ),
   ReasoningContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -148,6 +148,27 @@ describe("MessageThread", () => {
 
     expect(screen.getAllByTestId("message-bubble")).toHaveLength(1);
     expect(screen.getByText("All done.")).toBeInTheDocument();
+  });
+
+  it("does not render an accordion for empty reasoning parts", () => {
+    const messages: PartialUIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "reasoning", text: "" },
+          { type: "reasoning", text: "  " },
+          { type: "reasoning", text: "actual reasoning" },
+          { type: "text", text: "the answer" },
+        ],
+      },
+    ];
+
+    render(<MessageThread messages={messages} />);
+
+    expect(screen.getAllByTestId("reasoning")).toHaveLength(1);
+    expect(screen.getByText("actual reasoning")).toBeInTheDocument();
+    expect(screen.getByText("the answer")).toBeInTheDocument();
   });
 
   it("renders persisted chat errors between messages by timestamp", () => {

--- a/platform/frontend/src/components/message-thread.tsx
+++ b/platform/frontend/src/components/message-thread.tsx
@@ -44,6 +44,7 @@ import {
   ToolInput,
   ToolOutput,
 } from "@/components/ai-elements/tool";
+import { isBlankReasoningPart } from "@/components/chat/chat-messages.utils";
 import { InlineChatError } from "@/components/chat/inline-chat-error";
 import {
   hasKnowledgeBaseToolCall,
@@ -553,6 +554,12 @@ const MessageThread = ({
                             );
                           }
                           case "reasoning":
+                            // Empty reasoning parts (redacted/signature-only
+                            // thinking, kept for provider replay) must not render
+                            // as empty "Thinking…" accordions.
+                            if (isBlankReasoningPart(part)) {
+                              return null;
+                            }
                             return (
                               <Reasoning
                                 key={partKey}


### PR DESCRIPTION
## Problem

In the web chat / interaction UI, assistant reasoning renders as collapsible "Thinking…" accordions. Anthropic `redacted_thinking` and signature-only `thinking` blocks arrive as `reasoning` parts with **empty text**. On reload they rendered as many stacked **empty** accordions, and expanding one showed nothing. Separately, the label stayed pinned on "Thinking…" permanently (never "Thought for N seconds").

## Why display-only

The empty reasoning parts are load-bearing: the thinking signature must be replayed to the provider on the next turn, so they are persisted and reload verbatim. Deleting them upstream would break the conversation. The fix is therefore at the render layer.

## Change

- Add `isBlankReasoningPart` (mirrors the existing `isBlankAssistantTextPart` blank-text guard).
- Skip rendering a reasoning accordion when its text is blank, on both surfaces: live chat (`chat-messages.tsx`) and read-only/logs (`message-thread.tsx`).
- Wire `isStreaming` into the live-chat reasoning render.
- Default the reasoning `duration` to `undefined` instead of `0`, so a non-streaming block reads "Thought for a few seconds" instead of a permanent "Thinking…".

## Tests

- `isBlankReasoningPart` unit tests.
- Empty reasoning renders no accordion; non-blank still renders (both surfaces).
- `isStreaming` wiring picks the last reasoning part of the last streaming message.
- Streaming→ready duration measurement produces a measured label.

`pnpm type-check`, Biome, and vitest (136 tests) pass.

https://claude.ai/code/session_01CpsbbbncmFGgkX3gvV5HTD

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>