### PR TITLE
fix(chat): make seeded owned-app chats work on Bedrock

### DIFF
--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.test.ts
@@ -215,3 +215,54 @@ describe("prepareMessagesForProvider — tool-call id sanitization", () => {
     expect(extractToolCallId(messages)).toBe("functions.search:0");
   });
 });
+
+describe("prepareMessagesForProvider — bedrock empty-content padding", () => {
+  const NO_CONTENT = "(no content)";
+
+  function hasNoContentPlaceholder(message: ChatMessage): boolean {
+    return Boolean(
+      message.parts?.some((p) => p.type === "text" && p.text === NO_CONTENT),
+    );
+  }
+
+  it("does not pad an assistant message whose only part is a dynamic-tool (e.g. the render_app seed)", () => {
+    // The owned-app render_app seed is a single `dynamic-tool` part. It is real
+    // provider-visible content (a tool_use block), so Bedrock must not treat the
+    // message as empty and append a bogus "(no content)" text part.
+    const [message] = prepareMessagesForProvider({
+      messages: [
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "dynamic-tool",
+              toolName: "archestra__render_app",
+              toolCallId: "call_render_1",
+              state: "output-available",
+              input: { appId: "402e041f-a78c-40a0-b8b3-a14d91633fce" },
+              output: { content: [{ type: "text", text: "app rendered" }] },
+            },
+          ],
+        },
+      ] as unknown as ChatMessage[],
+      provider: "bedrock",
+    });
+
+    expect(hasNoContentPlaceholder(message)).toBe(false);
+    expect(message.parts).toHaveLength(1);
+    expect(message.parts?.[0]?.type).toBe("dynamic-tool");
+  });
+
+  it("still pads a genuinely empty assistant message with a placeholder", () => {
+    // Regression guard: the dynamic-tool fix must not disable the workaround for
+    // an assistant turn that really has no provider-visible content.
+    const [message] = prepareMessagesForProvider({
+      messages: [
+        { role: "assistant", parts: [{ type: "text", text: "" }] },
+      ] as unknown as ChatMessage[],
+      provider: "bedrock",
+    });
+
+    expect(hasNoContentPlaceholder(message)).toBe(true);
+  });
+});

--- a/platform/backend/src/routes/chat/normalization/prepare-for-provider.ts
+++ b/platform/backend/src/routes/chat/normalization/prepare-for-provider.ts
@@ -408,7 +408,13 @@ function producesBedrockContentBlock(part: ChatMessagePart): boolean {
       | undefined;
     return Boolean(bedrock?.signature || bedrock?.redactedData);
   }
-  if (part.type.startsWith("tool-")) {
+  // `dynamic-tool` is the shape MCP tools (and the seeded `render_app` app
+  // render) deserialize to; it is a real content-producing tool part, exactly
+  // as the sibling `isToolPart` in normalize-chat-messages.ts treats it. Without
+  // this, an assistant message whose only part is a `dynamic-tool` (e.g. the
+  // owned-app render_app seed) is judged empty and padded with a bogus
+  // "(no content)" text block.
+  if (part.type === "dynamic-tool" || part.type.startsWith("tool-")) {
     return part.state !== "input-streaming";
   }
   return false;

--- a/platform/backend/src/routes/chat/prepare-model-messages.test.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.test.ts
@@ -593,7 +593,7 @@ test("gemini: render_app-seeded history gets a leading user turn so contents don
   expect(JSON.stringify(toolCall?.input)).toContain(RENDER_APP_APP_ID);
 });
 
-test("non-gemini: render_app-seeded history keeps the assistant tool-call first (no leading user turn injected)", async ({
+test("openai: render_app-seeded history keeps the assistant tool-call first (openai accepts an assistant-first turn, so no leading user turn is injected)", async ({
   makeAgent,
   makeConversation,
 }) => {
@@ -610,6 +610,70 @@ test("non-gemini: render_app-seeded history keeps the assistant tool-call first 
   });
 
   expect(modelMessages[0]?.role).toBe("assistant");
+});
+
+test("bedrock: render_app-seeded history gets a leading user turn so the assistant tool_use isn't rejected", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  // Real owned-app seed shape: render_app assistant tool-call, a separate
+  // greeting assistant message, then the user's first prompt.
+  const messages: ChatMessage[] = [
+    {
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "archestra__render_app",
+          toolCallId: "call_render_1",
+          state: "output-available",
+          input: { appId: RENDER_APP_APP_ID },
+          output: { content: [{ type: "text", text: "app rendered" }] },
+        },
+      ],
+    },
+    { role: "assistant", parts: [{ type: "text", text: "Here's the app." }] },
+    { role: "user", parts: [{ type: "text", text: "can I ask you things?" }] },
+  ] as unknown as ChatMessage[];
+
+  const { modelMessages } = await __test.buildModelMessagesForProvider({
+    messages,
+    provider: "bedrock",
+    conversationId: conversation.id,
+    sandboxAvailable: false,
+  });
+
+  // Bedrock's Converse API rejects a history that opens with an assistant
+  // tool_use ("`tool_use` ids were found without `tool_result` blocks
+  // immediately after"). Pin the full well-formed order: a leading user turn,
+  // the seed's tool-call immediately paired with its tool-result, the greeting,
+  // then the real prompt.
+  expect(modelMessages.map((message) => message.role)).toEqual([
+    "user",
+    "assistant",
+    "tool",
+    "assistant",
+    "user",
+  ]);
+
+  // The render_app seed is preserved (its result carries the app id app tools
+  // need), and the tool-call assistant message is NOT polluted with a bogus
+  // "(no content)" placeholder.
+  const toolCall = firstToolCall(modelMessages);
+  expect(toolCall?.toolName).toBe("archestra__render_app");
+  expect(JSON.stringify(toolCall?.input)).toContain(RENDER_APP_APP_ID);
+  const toolCallMessage = modelMessages[1];
+  expect(Array.isArray(toolCallMessage.content)).toBe(true);
+  expect(
+    (toolCallMessage.content as { type: string; text?: string }[]).some(
+      (part) => part.type === "text" && part.text === "(no content)",
+    ),
+  ).toBe(false);
 });
 
 test("gemini: a normal user-first history is left unchanged (no synthetic turn added)", async ({

--- a/platform/backend/src/routes/chat/prepare-model-messages.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.ts
@@ -213,27 +213,33 @@ async function buildModelMessagesForProvider(params: {
   );
 
   return {
-    modelMessages:
-      params.provider === "gemini"
-        ? ensureGeminiLeadingUserTurn(nonEmpty)
-        : nonEmpty,
+    modelMessages: PROVIDERS_REQUIRING_LEADING_USER_TURN.has(params.provider)
+      ? ensureLeadingUserTurn(nonEmpty)
+      : nonEmpty,
     preparedMessages: providerPreparedMessages,
   };
 }
 
 // Owned-app chats are seeded with a synthetic `render_app` assistant tool-call
 // as the conversation's first message (see app-chat-conversation.ts), so their
-// history opens with an assistant turn. Gemini maps that to a `contents[0]` of
-// role `model` carrying a `functionCall`, and rejects it with 400 "function
-// call turn comes immediately after a user turn or after a function response
-// turn" — Gemini requires the first turn to be from the user. Prepend a minimal
-// user turn (after any leading system messages, which Gemini lifts into
-// `systemInstruction`) so the required leading user turn is present without
-// dropping the seed, whose tool result carries the app id the app tools need.
-// Gemini-only: other providers accept a leading assistant/tool turn.
-const GEMINI_LEADING_USER_TURN_TEXT = "Continue.";
+// history opens with an assistant turn. Some providers require the first turn to
+// be from the user and reject that seeded shape:
+// - `gemini` maps it to a `contents[0]` of role `model` carrying a
+//   `functionCall` and 400s with "function call turn comes immediately after a
+//   user turn or after a function response turn".
+// - `bedrock` (Anthropic models via the Converse API) rejects it with
+//   "`tool_use` ids were found without `tool_result` blocks immediately after"
+//   — its Converse→messages mapping requires a leading user turn even though
+//   native Anthropic and OpenAI accept the assistant-first seed unchanged.
+// Prepend a minimal user turn (after any leading system messages, which these
+// providers lift out of the message list) so the required leading user turn is
+// present without dropping the seed, whose tool result carries the app id the
+// app tools need to edit the bound app.
+const PROVIDERS_REQUIRING_LEADING_USER_TURN: ReadonlySet<SupportedProvider> =
+  new Set(["gemini", "bedrock"]);
+const LEADING_USER_TURN_TEXT = "Continue.";
 
-function ensureGeminiLeadingUserTurn(messages: ModelMessage[]): ModelMessage[] {
+function ensureLeadingUserTurn(messages: ModelMessage[]): ModelMessage[] {
   const firstContentIndex = messages.findIndex(
     (message) => message.role !== "system",
   );
@@ -243,7 +249,7 @@ function ensureGeminiLeadingUserTurn(messages: ModelMessage[]): ModelMessage[] {
 
   const leadingUserTurn: ModelMessage = {
     role: "user",
-    content: [{ type: "text", text: GEMINI_LEADING_USER_TURN_TEXT }],
+    content: [{ type: "text", text: LEADING_USER_TURN_TEXT }],
   };
   return [
     ...messages.slice(0, firstContentIndex),


### PR DESCRIPTION
## Problem

Opening an **owned MCP App in chat** and then messaging its agent fails on **Amazon Bedrock**. The agent turn errors out immediately with:

> The model returned the following errors: `messages.1`: `tool_use` ids were found without `tool_result` blocks immediately after: `<id>`. Each `tool_use` block must have a corresponding `tool_result` block in the next message.

The user can still edit the app from the main (model-first) chat — only the app-specific, seeded chat breaks.

## Root cause

An owned-app chat is **seeded** with a synthetic `render_app` assistant tool-call as the conversation's *first* message (see `app-chat-conversation.ts`), so the history opens with an **assistant** turn rather than a user turn.

- Native Anthropic and OpenAI accept an assistant-first turn (verified against the live Anthropic Messages API — the exact seeded shape returns `200`).
- **Bedrock's Converse API does not.** Its Converse→messages mapping requires the conversation to begin with a user turn, and the seeded assistant `tool_use` is rejected with the pairing error above.

We already had a fix for exactly this class of problem — `ensureGeminiLeadingUserTurn` prepends a minimal user turn so the seeded history is well-formed — but it was gated to **Gemini only**, on the (now-falsified) assumption that "other providers accept a leading assistant/tool turn." Gemini and Bedrock both reject an assistant-first seed; they just surface different errors.

A second, related defect compounds it on Bedrock: `producesBedrockContentBlock` only matched `part.type.startsWith("tool-")`, missing `dynamic-tool` — the shape `render_app` and all MCP tools deserialize to. As a result the render_app assistant message (whose only part is a `dynamic-tool`) was judged empty and padded with a bogus `"(no content)"` text block.

## Fix

1. Generalize the Gemini-only leading-user-turn prepend into a provider set (`gemini`, `bedrock`) and apply it there. Only triggers when the history opens with an assistant turn (i.e. seeded app chats) — normal user-first chats are untouched, and native Anthropic/OpenAI keep their assistant-first seed unchanged.
2. Recognize `dynamic-tool` as content-producing in `producesBedrockContentBlock`, mirroring `isToolPart` in `normalize-chat-messages.ts`, so the render_app message is no longer padded with `"(no content)"`.

After the fix the Bedrock Converse request is canonical: `user("Continue.") → assistant(tool_use) → user(tool_result) → assistant(greeting) → user(prompt)` — verified end-to-end (captured the real serialized Converse body, and confirmed the equivalent shape returns `200` from the live Anthropic API).

## Tests

- `bedrock: render_app-seeded history gets a leading user turn …` — pins the well-formed order `["user","assistant","tool","assistant","user"]`, that the seed's app id is preserved, and that the tool-call message carries no `"(no content)"` placeholder.
- `producesBedrockContentBlock` no longer pads a `dynamic-tool`-only assistant message, while a genuinely empty assistant message still gets the placeholder (regression guard).
- The Gemini test is unchanged; the OpenAI test now documents that OpenAI accepts an assistant-first seed (no injection).

All 755 chat tests pass; type-check and lint clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>