### PR TITLE
feat(guardrails): deep-link to tool policy editor on blocked external tool calls

### DIFF
--- a/platform/backend/src/archestra-mcp-server/run-tool.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.ts
@@ -7,10 +7,8 @@ import {
 } from "@archestra/shared";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import {
-  evaluateSingleMcpToolInvocationPolicy,
-  policyBlockToToolError,
-} from "@/guardrails/tool-invocation";
+import { evaluateSingleMcpToolInvocationPolicy } from "@/guardrails/tool-invocation";
+import { buildPolicyBlockedToolResult } from "@/guardrails/tool-policy-link";
 import logger from "@/logging";
 import { ConversationEnabledToolModel } from "@/models";
 import { agentToolExclusionsService } from "@/services/agent-tool-exclusions";
@@ -456,12 +454,16 @@ async function dispatchTool({
   });
   if (policyBlock) {
     // Attach the structured policy_denied error (in _meta + structuredContent)
-    // so clients parse the block without scraping the prose.
+    // so clients parse the block without scraping the prose. A caller who can
+    // edit guardrails also gets a deep link to this tool's policy editor.
+    const { error, text } = await buildPolicyBlockedToolResult({
+      policyBlock,
+      userId: context.userId,
+      organizationId: context.organizationId,
+      textPrefix: "Error: ",
+    });
     return appendEnvelopeRepairNote(
-      structuredToolErrorResult({
-        error: policyBlockToToolError(policyBlock),
-        text: `Error: ${policyBlock.refusalMessage}`,
-      }),
+      structuredToolErrorResult({ error, text }),
       repairedParams,
     );
   }

--- a/platform/backend/src/guardrails/tool-invocation.ts
+++ b/platform/backend/src/guardrails/tool-invocation.ts
@@ -47,6 +47,7 @@ export interface PolicyEnforcementContext {
  */
 export function policyBlockToToolError(
   policyBlock: PolicyBlockResult,
+  policyUrl?: string,
 ): PolicyDeniedMcpToolError {
   return buildPolicyDeniedMcpToolError({
     toolName: policyBlock.blockedToolName,
@@ -54,6 +55,7 @@ export function policyBlockToToolError(
     input: policyBlock.toolInput,
     reason: policyBlock.reason,
     message: policyBlock.contentMessage,
+    policyUrl,
   });
 }
 

--- a/platform/backend/src/guardrails/tool-policy-link.test.ts
+++ b/platform/backend/src/guardrails/tool-policy-link.test.ts
@@ -1,0 +1,120 @@
+import config from "@/config";
+import { expect, test } from "@/test";
+import type { PolicyBlockResult } from "./tool-invocation";
+import { buildPolicyBlockedToolResult } from "./tool-policy-link";
+
+const TOOL_ID = "11111111-1111-4111-8111-111111111111";
+const TOOL_NAME = "server__do_thing";
+
+function makePolicyBlock(
+  overrides: Partial<PolicyBlockResult> = {},
+): PolicyBlockResult {
+  return {
+    refusalMessage: "REFUSAL PROSE",
+    contentMessage: "CONTENT PROSE",
+    reason: "not allowed",
+    blockedToolName: TOOL_NAME,
+    blockedToolId: TOOL_ID,
+    toolInput: { foo: "bar" },
+    allToolCallNames: [TOOL_NAME],
+    ...overrides,
+  };
+}
+
+test("includes a permission-gated deep link for a caller who can edit guardrails", async ({
+  makeUser,
+  makeOrganization,
+  makeMember,
+}) => {
+  const org = await makeOrganization();
+  const admin = await makeUser();
+  await makeMember(admin.id, org.id, { role: "admin" });
+
+  const { error, text } = await buildPolicyBlockedToolResult({
+    policyBlock: makePolicyBlock(),
+    userId: admin.id,
+    organizationId: org.id,
+  });
+
+  expect(error.policyUrl).toBeDefined();
+  const url = new URL(error.policyUrl as string);
+  expect(url.origin).toBe(new URL(config.frontendBaseUrl).origin);
+  expect(url.pathname).toBe("/mcp/tool-guardrails");
+  expect(url.searchParams.get("toolId")).toBe(TOOL_ID);
+  expect(url.searchParams.get("toolName")).toBe(TOOL_NAME);
+
+  // The prose the external client renders carries the link too.
+  expect(text).toContain("REFUSAL PROSE");
+  expect(text).toContain(error.policyUrl as string);
+});
+
+test("omits the deep link for a caller who cannot edit guardrails", async ({
+  makeUser,
+  makeOrganization,
+  makeMember,
+}) => {
+  const org = await makeOrganization();
+  const member = await makeUser();
+  await makeMember(member.id, org.id, { role: "member" });
+
+  const { error, text } = await buildPolicyBlockedToolResult({
+    policyBlock: makePolicyBlock(),
+    userId: member.id,
+    organizationId: org.id,
+  });
+
+  expect(error.policyUrl).toBeUndefined();
+  expect(text).toBe("REFUSAL PROSE");
+  expect(text).not.toContain("/mcp/tool-guardrails");
+});
+
+test("omits the deep link when there is no acting user (e.g. org token)", async ({
+  makeOrganization,
+}) => {
+  const org = await makeOrganization();
+
+  const { error } = await buildPolicyBlockedToolResult({
+    policyBlock: makePolicyBlock(),
+    userId: undefined,
+    organizationId: org.id,
+  });
+
+  expect(error.policyUrl).toBeUndefined();
+});
+
+test("omits the deep link when the blocked tool row is unknown", async ({
+  makeUser,
+  makeOrganization,
+  makeMember,
+}) => {
+  const org = await makeOrganization();
+  const admin = await makeUser();
+  await makeMember(admin.id, org.id, { role: "admin" });
+
+  const { error } = await buildPolicyBlockedToolResult({
+    policyBlock: makePolicyBlock({ blockedToolId: undefined }),
+    userId: admin.id,
+    organizationId: org.id,
+  });
+
+  expect(error.policyUrl).toBeUndefined();
+});
+
+test("applies the text prefix for the run_tool surface", async ({
+  makeUser,
+  makeOrganization,
+  makeMember,
+}) => {
+  const org = await makeOrganization();
+  const member = await makeUser();
+  await makeMember(member.id, org.id, { role: "member" });
+
+  const { text } = await buildPolicyBlockedToolResult({
+    policyBlock: makePolicyBlock(),
+    userId: member.id,
+    organizationId: org.id,
+    textPrefix: "Error: ",
+  });
+
+  expect(text).toBe("Error: REFUSAL PROSE");
+});

--- a/platform/backend/src/guardrails/tool-policy-link.ts
+++ b/platform/backend/src/guardrails/tool-policy-link.ts
@@ -1,0 +1,97 @@
+import type { PolicyDeniedMcpToolError } from "@archestra/shared";
+import { userHasPermission } from "@/auth/utils";
+import config from "@/config";
+import logger from "@/logging";
+import {
+  type PolicyBlockResult,
+  policyBlockToToolError,
+} from "./tool-invocation";
+
+// ===================================================================
+// Public API
+// ===================================================================
+
+/**
+ * Turn a policy block into the `{ error, text }` an external-client tool result
+ * carries. When the blocked caller is a known user who holds `toolPolicy:update`
+ * and the blocked tool row is identifiable, both the structured error and the
+ * prose gain a deep link to that tool's guardrail editor so the client can offer
+ * "view/modify this guardrail". Callers without edit rights (or org/service
+ * tokens with no user identity) get the block unchanged — never a link they'd
+ * only hit a 403 behind.
+ *
+ * `textPrefix` is prepended to the prose (the gateway sends the refusal as-is;
+ * run_tool prefixes it with "Error: ").
+ */
+export async function buildPolicyBlockedToolResult(params: {
+  policyBlock: PolicyBlockResult;
+  userId?: string;
+  organizationId?: string;
+  textPrefix?: string;
+}): Promise<{ error: PolicyDeniedMcpToolError; text: string }> {
+  const policyUrl = await resolveToolPolicyEditUrl({
+    toolId: params.policyBlock.blockedToolId,
+    toolName: params.policyBlock.blockedToolName,
+    userId: params.userId,
+    organizationId: params.organizationId,
+  });
+
+  const prefix = params.textPrefix ?? "";
+  const urlLine = policyUrl
+    ? `\n\nYou have permission to review or update this guardrail here: ${policyUrl}`
+    : "";
+
+  return {
+    error: policyBlockToToolError(params.policyBlock, policyUrl ?? undefined),
+    text: `${prefix}${params.policyBlock.refusalMessage}${urlLine}`,
+  };
+}
+
+// ===================================================================
+// Internal helpers
+// ===================================================================
+
+/**
+ * Deep link to a tool's guardrail editor, gated on the caller holding
+ * `toolPolicy:update`. Returns null (fail-closed) unless we can identify both
+ * the tool row and an acting user who can edit it.
+ */
+async function resolveToolPolicyEditUrl(params: {
+  toolId?: string;
+  toolName?: string;
+  userId?: string;
+  organizationId?: string;
+}): Promise<string | null> {
+  const { toolId, toolName, userId, organizationId } = params;
+  if (!toolId || !userId || !organizationId) {
+    return null;
+  }
+
+  let canEdit = false;
+  try {
+    canEdit = await userHasPermission(
+      userId,
+      organizationId,
+      "toolPolicy",
+      "update",
+    );
+  } catch (err) {
+    logger.info(
+      { err },
+      "Failed to resolve tool policy edit permission for deep link",
+    );
+    return null;
+  }
+
+  if (!canEdit) {
+    return null;
+  }
+
+  const url = new URL("/mcp/tool-guardrails", config.frontendBaseUrl);
+  url.searchParams.set("toolId", toolId);
+  // Name is only for the editor's title; the id is what resolves the tool.
+  if (toolName) {
+    url.searchParams.set("toolName", toolName);
+  }
+  return url.toString();
+}

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -46,10 +46,8 @@ import { userHasPermission } from "@/auth/utils";
 import { LRUCacheManager } from "@/cache-manager";
 import mcpClient, { type TokenAuthContext } from "@/clients/mcp-client";
 import config from "@/config";
-import {
-  evaluateSingleMcpToolInvocationPolicy,
-  policyBlockToToolError,
-} from "@/guardrails/tool-invocation";
+import { evaluateSingleMcpToolInvocationPolicy } from "@/guardrails/tool-invocation";
+import { buildPolicyBlockedToolResult } from "@/guardrails/tool-policy-link";
 import logger from "@/logging";
 import {
   AgentConnectorAssignmentModel,
@@ -542,11 +540,15 @@ export async function createAgentServer(
         if (policyBlock) {
           // Carry the machine-readable policy_denied error alongside the prose
           // (in _meta + structuredContent) so MCP clients render the block
-          // structurally instead of scraping the refusal text.
-          const blockedResult = structuredToolErrorResult({
-            error: policyBlockToToolError(policyBlock),
-            text: policyBlock.refusalMessage,
+          // structurally instead of scraping the refusal text. When the caller
+          // can edit guardrails, both gain a deep link to this tool's policy
+          // editor so the external client can offer to review/modify it.
+          const { error, text } = await buildPolicyBlockedToolResult({
+            policyBlock,
+            userId: tokenAuth?.userId,
+            organizationId: tokenAuth?.organizationId,
           });
+          const blockedResult = structuredToolErrorResult({ error, text });
 
           // Blocked calls are still tool calls: report metrics and persist them
           // (isError) so they show up in the MCP gateway logs and dashboards

--- a/platform/frontend/src/app/mcp/tool-guardrails/page.client.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/page.client.tsx
@@ -2,8 +2,10 @@
 
 import type { archestraApiTypes } from "@archestra/shared";
 import { useQueryClient } from "@tanstack/react-query";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
+import { EditPolicyDialog } from "@/components/chat/edit-policy-dialog";
 import {
   prefetchOperators,
   prefetchToolInvocationPolicies,
@@ -39,8 +41,16 @@ export function ToolGuardrailsClient({
 
 function ToolsList({ initialData }: { initialData?: ToolsInitialData }) {
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [selectedToolForDialog, setSelectedToolForDialog] =
     useState<ToolWithAssignmentsData | null>(null);
+
+  // Deep link from an external-client guardrail block: `?toolId=<id>` opens
+  // that tool's policy editor directly (name is only for the dialog title).
+  const deepLinkToolId = searchParams.get("toolId");
+  const deepLinkToolName = searchParams.get("toolName") ?? "";
 
   // Sync selected tool with cache updates
   useEffect(() => {
@@ -81,6 +91,18 @@ function ToolsList({ initialData }: { initialData?: ToolsInitialData }) {
         onOpenChange={(open: boolean) =>
           !open && setSelectedToolForDialog(null)
         }
+      />
+
+      <EditPolicyDialog
+        open={!!deepLinkToolId}
+        onOpenChange={(open: boolean) => {
+          // Closing clears the deep-link params so the dialog does not reopen.
+          if (!open) {
+            router.replace(pathname);
+          }
+        }}
+        toolId={deepLinkToolId ?? undefined}
+        toolName={deepLinkToolName}
       />
     </div>
   );

--- a/platform/frontend/src/components/chat/edit-policy-dialog.tsx
+++ b/platform/frontend/src/components/chat/edit-policy-dialog.tsx
@@ -14,7 +14,10 @@ interface EditPolicyDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   toolName: string;
-  profileId: string;
+  // The agent whose blocked call opened this dialog. Only used by the
+  // name-based fallback lookup below, so it is optional: the tool-guardrails
+  // deep link opens the dialog with a toolId and no agent context.
+  profileId?: string;
   // The blocked tool's row id, when the backend supplied it. Resolves the tool
   // directly (works for All-mode tools with no agent_tools assignment); absent
   // for denials persisted before the id was carried, which fall back to the
@@ -46,7 +49,7 @@ export function EditPolicyDialog({
     pagination: {
       limit: 50,
     },
-    enabled: canUpdateToolPolicy === true && !toolId,
+    enabled: canUpdateToolPolicy === true && !toolId && !!profileId,
   });
 
   const tool =

--- a/platform/shared/mcp-tool-error.ts
+++ b/platform/shared/mcp-tool-error.ts
@@ -82,6 +82,12 @@ export const PolicyDeniedMcpToolErrorSchema = z
     input: z.record(z.string(), z.unknown()),
     reason: z.string(),
     reasonType: PolicyDeniedReasonTypeSchema.optional(),
+    // Deep link to this tool's guardrail editor, included only when the blocked
+    // caller both is a known user and holds toolPolicy:update — so a client can
+    // offer "view/modify this guardrail" without dangling a link that 403s.
+    // Absent for callers without edit rights and for denials persisted before
+    // this field existed.
+    policyUrl: z.string().url().optional(),
   })
   .strict();
 
@@ -149,6 +155,7 @@ export function buildPolicyDeniedMcpToolError(params: {
   input: Record<string, unknown>;
   reason: string;
   message: string;
+  policyUrl?: string;
 }): PolicyDeniedMcpToolError {
   return {
     type: "policy_denied",
@@ -158,6 +165,7 @@ export function buildPolicyDeniedMcpToolError(params: {
     input: params.input,
     reason: params.reason,
     reasonType: classifyPolicyDeniedReason(params.reason),
+    policyUrl: params.policyUrl,
   };
 }
 


### PR DESCRIPTION
## What

When the **MCP Gateway** (`tools/call`) or **run_tool** blocks a tool call, external MCP clients only saw the refusal prose with no way to act on it. Now, when the blocked caller is a known user who holds `toolPolicy:update`, the block carries a **permission-gated deep link** to that tool's guardrail editor so the client can offer "view/modify this guardrail".

The link is:
- attached to the structured `policy_denied` error as `policyUrl`, and
- appended to the refusal text (so clients that only surface text still see it).

Callers **without** edit rights — including org/service tokens with no user identity — get the block **unchanged**. We fail closed, so we never dangle a link that would just 403.

## How

- **shared** (`mcp-tool-error.ts`): optional `policyUrl` on `PolicyDeniedMcpToolErrorSchema` + builder.
- **backend** (`guardrails/tool-policy-link.ts`, new): `buildPolicyBlockedToolResult` resolves the deep link (`/mcp/tool-guardrails?toolId=<id>`) gated on `userHasPermission(..., "toolPolicy", "update")`, fail-closed on missing tool id / user / permission, and augments the `{ error, text }`. Wired into both external-client block sites (`mcp-gateway.utils.ts`, `run-tool.ts`).
- **frontend** (`tool-guardrails/page.client.tsx`): reads `?toolId` and auto-opens that tool's policy editor by reusing `EditPolicyDialog` (its `profileId` is now optional since the deep link has no agent context). Closing clears the query param.

## Testing

- New behavior test `tool-policy-link.test.ts`: URL present for an admin (can edit), absent for a member (read-only), absent with no acting user, absent when the tool id is unknown, and the `run_tool` text prefix.
- Existing suites still green: `mcp-gateway.utils.test.ts` (87), `run-tool.test.ts` (73), shared `mcp-tool-error.test.ts` (18), frontend `edit-policy-dialog.test.tsx` (4).
- `pnpm type-check`, `pnpm lint`, `pnpm knip` (dev + production) all pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>