### PR TITLE
fix(chatops): cancel in-flight runs when a thread is muted

### DIFF
--- a/docs/pages/platform-ms-teams.md
+++ b/docs/pages/platform-ms-teams.md
@@ -3,7 +3,7 @@ title: MS Teams
 category: Agents
 order: 7
 description: Connect Archestra agents to Microsoft Teams channels
-lastUpdated: 2026-06-12
+lastUpdated: 2026-07-12
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -44,7 +44,7 @@ The bot responds with an **Adaptive Card dropdown** to select which agent handle
 
 In channels the bot stays silent until it is @mentioned. Once mentioned in a thread, it keeps replying to every message in that thread without further mentions. Starting a new thread needs a fresh mention. Direct messages and group chats always get a reply, no mention required.
 
-To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again. As a reminder, the bot adds a short hint about this to its first reply in each thread.
+To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again. Muting also cancels any reply the bot is already working on, so a late answer never lands after you ask for quiet. As a reminder, the bot adds a short hint about this to its first reply in each thread.
 
 ### Commands
 

--- a/docs/pages/platform-slack.md
+++ b/docs/pages/platform-slack.md
@@ -3,7 +3,7 @@ title: Slack
 category: Agents
 order: 6
 description: Connect Archestra agents to Slack channels
-lastUpdated: 2026-02-23
+lastUpdated: 2026-07-12
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -54,7 +54,7 @@ The bot responds with a list of options to choose which agent will handle messag
 
 In channels the bot stays silent until it is @mentioned. Once mentioned in a thread, it keeps replying to every message in that thread without further mentions. Starting a new thread needs a fresh mention. Direct messages always get a reply, no mention required.
 
-To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again. As a reminder, the bot adds a short hint about this to its first reply in each thread.
+To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again. Muting also cancels any reply the bot is already working on, so a late answer never lands after you ask for quiet. As a reminder, the bot adds a short hint about this to its first reply in each thread.
 
 ### Commands
 

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -94,9 +94,15 @@ export class A2AManager {
       chatOpsBindingId?: string;
       chatOpsThreadId?: string;
     };
+    /**
+     * Cancellation signal forwarded into the agent run. Used by chatops so a
+     * muted thread aborts its in-flight model requests instead of letting them
+     * finish and post a now-unwanted reply.
+     */
+    abortSignal?: AbortSignal;
   }): Promise<A2AProtocolSendMessageResponse> {
     try {
-      const { actor, agentId, request, systemParams } = params;
+      const { actor, agentId, request, systemParams, abortSignal } = params;
 
       const [a2aUser, agent] = await Promise.all([
         actor.kind === "user" && actor.id !== "system"
@@ -278,6 +284,7 @@ export class A2AManager {
             originalUiMessages: contextUiMessages,
             chatOpsBindingId: systemParams?.chatOpsBindingId,
             chatOpsThreadId: systemParams?.chatOpsThreadId,
+            abortSignal,
           });
         },
       });

--- a/platform/backend/src/agents/chatops/channel-activation.test.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.test.ts
@@ -11,13 +11,16 @@ const setSpy = vi.spyOn(cacheManager, "set");
 import {
   claimThreadMuteHint,
   clearChannelThreadActive,
+  getThreadMuteMarker,
   isChannelThreadActive,
   isMuteReaction,
   isThreadMuteCommand,
   markChannelThreadActive,
   mightBeAddressedMuteCommand,
+  muteChannelThread,
   resolveChannelGateAction,
 } from "./channel-activation";
+import { chatOpsRunRegistry } from "./chatops-run-registry";
 import {
   buildThreadMutedNotice,
   CHATOPS_CHANNEL_AUTO_REPLY,
@@ -107,6 +110,65 @@ describe("channel-activation (sticky channel auto-reply)", () => {
     expect(await clearChannelThreadActive(TEAMS)).toBe(true);
     // Second clear (e.g. a redelivered event) is a no-op transition.
     expect(await clearChannelThreadActive(TEAMS)).toBe(false);
+  });
+});
+
+describe("muteChannelThread (mute side-effects)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns the active→muted transition, like clearChannelThreadActive", async () => {
+    await markChannelThreadActive(TEAMS);
+    expect(await muteChannelThread(TEAMS)).toBe(true);
+    expect(await isChannelThreadActive(TEAMS)).toBe(false);
+    // A repeat mute (redelivered event) is a no-op transition.
+    expect(await muteChannelThread(TEAMS)).toBe(false);
+  });
+
+  test("records a mute marker so in-flight runs can detect the mute", async () => {
+    expect(await getThreadMuteMarker(TEAMS)).toBeNull();
+
+    await muteChannelThread(TEAMS);
+
+    expect(await getThreadMuteMarker(TEAMS)).not.toBeNull();
+  });
+
+  test("rewrites the marker with a fresh token on every mute", async () => {
+    await muteChannelThread(TEAMS);
+    const first = await getThreadMuteMarker(TEAMS);
+
+    await muteChannelThread(TEAMS);
+    const second = await getThreadMuteMarker(TEAMS);
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    // A different token each time is what lets a run tell "muted since I
+    // started" apart from a stale marker left by an earlier mute.
+    expect(second).not.toBe(first);
+  });
+
+  test("aborts in-flight runs registered for the thread", async () => {
+    const run = chatOpsRunRegistry.register(TEAMS);
+    expect(run.signal.aborted).toBe(false);
+
+    await muteChannelThread(TEAMS);
+
+    expect(run.signal.aborted).toBe(true);
+    run.unregister();
+  });
+
+  test("the marker is scoped per (provider, channel, thread)", async () => {
+    await muteChannelThread(TEAMS);
+
+    // Same channel, different thread — its own marker is still unset.
+    expect(
+      await getThreadMuteMarker({ ...TEAMS, threadId: "other-thread" }),
+    ).toBeNull();
+    // Different provider, same ids — isolated too.
+    expect(
+      await getThreadMuteMarker({ ...TEAMS, provider: "slack" }),
+    ).toBeNull();
   });
 });
 

--- a/platform/backend/src/agents/chatops/channel-activation.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.ts
@@ -16,8 +16,10 @@
  * activation so the bot goes quiet until it is @mentioned again.
  */
 
+import { randomUUID } from "node:crypto";
 import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
 import type { ChatOpsProviderType } from "@/types/chatops";
+import { chatOpsRunRegistry } from "./chatops-run-registry";
 import { CHATOPS_CHANNEL_AUTO_REPLY } from "./constants";
 
 /** Mark a channel thread active so the bot keeps replying without a mention. */
@@ -49,6 +51,9 @@ export async function isChannelThreadActive(params: {
  * it). Callers post the "muted" confirmation ONLY on a true active→muted
  * transition, so redelivered events and double-clicks don't spam the thread and
  * a no-op mute (already muted / never active) stays silent.
+ *
+ * @public — the primitive muteChannelThread builds on; also exercised directly
+ * in channel-activation.test.ts (knip --production can't see the test consumer).
  */
 export async function clearChannelThreadActive(params: {
   provider: ChatOpsProviderType;
@@ -56,6 +61,53 @@ export async function clearChannelThreadActive(params: {
   threadId: string;
 }): Promise<boolean> {
   return await cacheManager.delete(activationKey(params));
+}
+
+/**
+ * Mute a channel thread — the single side-effecting entry point both providers
+ * use when a user asks the bot to be quiet (a mute command, a mute reaction, or
+ * a "Mute this thread" button). It does three things, in order:
+ *
+ *  1. Records a fresh mute marker in the distributed cache. Every in-flight
+ *     agent run re-reads this marker before posting and drops its reply if it
+ *     changed since the run began (see getThreadMuteMarker) — so a mute is never
+ *     followed by a late answer, even for a run executing on another pod.
+ *  2. Aborts in-flight runs for this thread on THIS pod, stopping their model
+ *     requests immediately instead of letting them finish unseen.
+ *  3. Drops the sticky auto-reply activation, so future un-mentioned messages
+ *     stay quiet.
+ *
+ * Returns whether the thread was active (i.e. whether this actually muted it),
+ * so callers post the "muted" confirmation ONLY on a true active→muted
+ * transition, exactly like clearChannelThreadActive.
+ */
+export async function muteChannelThread(params: {
+  provider: ChatOpsProviderType;
+  channelId: string;
+  threadId: string;
+}): Promise<boolean> {
+  await recordThreadMute(params);
+  chatOpsRunRegistry.cancelThread(params);
+  return await clearChannelThreadActive(params);
+}
+
+/**
+ * Read the current mute marker for a channel thread, or null if none is set.
+ *
+ * The marker is an opaque token rewritten on every mute (see muteChannelThread).
+ * Callers capture it when a run starts and compare it just before replying: a
+ * non-null value that differs from the captured one means the thread was muted
+ * mid-run, so the reply must be suppressed. Comparing the shared token (never a
+ * local clock) makes this correct across pods without clock-skew assumptions,
+ * and a null current value is never treated as a mute, so a lapsed marker can't
+ * cause a spurious suppression.
+ */
+export async function getThreadMuteMarker(params: {
+  provider: ChatOpsProviderType;
+  channelId: string;
+  threadId: string;
+}): Promise<string | null> {
+  return (await cacheManager.get<string>(muteMarkerKey(params))) ?? null;
 }
 
 /**
@@ -205,6 +257,39 @@ function muteHintKey(params: {
       : CacheKey.TeamsThreadMuteHint;
   return `${prefix}-${params.channelId}::${params.threadId}`;
 }
+
+/** Write a fresh mute token so in-flight runs observe the thread was just muted. */
+async function recordThreadMute(params: {
+  provider: ChatOpsProviderType;
+  channelId: string;
+  threadId: string;
+}): Promise<void> {
+  await cacheManager.set(
+    muteMarkerKey(params),
+    randomUUID(),
+    THREAD_MUTE_MARKER_TTL_MS,
+  );
+}
+
+function muteMarkerKey(params: {
+  provider: ChatOpsProviderType;
+  channelId: string;
+  threadId: string;
+}): AllowedCacheKey {
+  const prefix =
+    params.provider === "slack"
+      ? CacheKey.SlackThreadMuteMarker
+      : CacheKey.TeamsThreadMuteMarker;
+  return `${prefix}-${params.channelId}::${params.threadId}`;
+}
+
+/**
+ * How long a mute marker lives. Only needs to outlast the longest single agent
+ * turn so a run started before a mute still observes the marker when it replies;
+ * correctness never depends on the exact value (a lapsed marker reads as null,
+ * which is treated as "not muted"), so a generous window is safe.
+ */
+const THREAD_MUTE_MARKER_TTL_MS = CHATOPS_CHANNEL_AUTO_REPLY.ACTIVE_TTL_MS;
 
 /**
  * Whole-message phrases that mute the bot in a channel thread. Kept short and

--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -4,6 +4,10 @@ import { vi } from "vitest";
 // distributed cache, which isn't started in this suite). The `mock`-prefixed
 // name is referenced lazily inside the factory so it survives vi.mock hoisting.
 const mockClaimThreadMuteHint = vi.fn();
+// Drives the "was the thread muted mid-run?" check without a live distributed
+// cache: defaults to null (no mute) so unrelated tests reply normally; the mute
+// tests override it to simulate a marker moving while a run is in flight.
+const mockGetThreadMuteMarker = vi.fn().mockResolvedValue(null);
 vi.mock("./channel-activation", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./channel-activation")>();
   return {
@@ -11,6 +15,9 @@ vi.mock("./channel-activation", async (importOriginal) => {
     claimThreadMuteHint: (
       ...args: Parameters<typeof actual.claimThreadMuteHint>
     ) => mockClaimThreadMuteHint(...args),
+    getThreadMuteMarker: (
+      ...args: Parameters<typeof actual.getThreadMuteMarker>
+    ) => mockGetThreadMuteMarker(...args),
   };
 });
 
@@ -43,6 +50,7 @@ import {
   ChatOpsManager,
   matchesAgentName,
 } from "./chatops-manager";
+import { chatOpsRunRegistry } from "./chatops-run-registry";
 import {
   CHATOPS_ATTACHMENT_LIMITS,
   CHATOPS_NO_REPLY_SENTINEL,
@@ -583,6 +591,221 @@ describe("ChatOpsManager security validation", () => {
         expect.objectContaining({
           text: expect.stringContaining("Sorry, I encountered an error"),
         }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Muting a thread cancels its in-flight runs: a message already being
+  // processed when the user mutes must NOT post its (now-unwanted) answer.
+  // ===========================================================================
+
+  describe("mute cancels an in-flight run", () => {
+    beforeEach(() => {
+      // Default: no mute during the run. Individual tests override per call.
+      mockGetThreadMuteMarker.mockReset().mockResolvedValue(null);
+    });
+
+    const agentResult = () => ({
+      text: "Agent response",
+      messageId: "test-message-id",
+      finishReason: "stop",
+      responseUiMessage: {
+        id: "test-message-id",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "Agent response" }],
+      },
+    });
+
+    async function setupBoundAgent(fx: {
+      makeUser: (overrides?: { email: string }) => Promise<{ id: string }>;
+      makeOrganization: () => Promise<{ id: string }>;
+      makeTeam: (orgId: string, userId: string) => Promise<{ id: string }>;
+      makeTeamMember: (teamId: string, userId: string) => Promise<unknown>;
+      makeInternalAgent: (overrides: {
+        organizationId: string;
+        teams: string[];
+      }) => Promise<{ id: string; name: string }>;
+    }) {
+      const user = await fx.makeUser({ email: "mute@example.com" });
+      const org = await fx.makeOrganization();
+      const team = await fx.makeTeam(org.id, user.id);
+      await fx.makeTeamMember(team.id, user.id);
+      const agent = await fx.makeInternalAgent({
+        organizationId: org.id,
+        teams: [team.id],
+      });
+      await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+      await ChatOpsChannelBindingModel.create({
+        organizationId: org.id,
+        provider: "ms-teams",
+        channelId: "test-channel-id",
+        workspaceId: "test-workspace-id",
+        agentId: agent.id,
+      });
+
+      const sendReplySpy = vi.fn().mockResolvedValue("reply-id");
+      const mockProvider = createMockProvider({
+        getUserEmail: async () => "mute@example.com",
+        sendReply: sendReplySpy,
+      });
+      return {
+        manager: makeManagerWith(mockProvider),
+        mockProvider,
+        sendReplySpy,
+      };
+    }
+
+    // createMockMessage has no threadId, so the run is keyed on the channel id.
+    const threadKey = {
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      threadId: "test-channel-id",
+    } as const;
+
+    test("drops the reply when the thread is muted while the run is in flight (cross-pod marker moved)", async ({
+      makeUser,
+      makeOrganization,
+      makeTeam,
+      makeTeamMember,
+      makeInternalAgent,
+    }) => {
+      vi.spyOn(a2aExecutor, "executeA2AMessage").mockResolvedValue(
+        agentResult(),
+      );
+      // The run starts with no mute marker, but by the time it goes to reply the
+      // marker has moved — a mute landed mid-run (here, on another pod).
+      mockGetThreadMuteMarker
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce("muted-token");
+
+      const { manager, mockProvider, sendReplySpy } = await setupBoundAgent({
+        makeUser,
+        makeOrganization,
+        makeTeam,
+        makeTeamMember,
+        makeInternalAgent,
+      });
+
+      const result = await manager.processMessage({
+        message: createMockMessage(),
+        provider: mockProvider,
+      });
+
+      // Reported as a deliberate no-reply, and nothing was posted to the thread.
+      expect(result.success).toBe(true);
+      expect(result.agentResponse).toBe("");
+      expect(sendReplySpy).not.toHaveBeenCalled();
+    });
+
+    test("aborts the run and stays silent when the thread is muted on this pod", async ({
+      makeUser,
+      makeOrganization,
+      makeTeam,
+      makeTeamMember,
+      makeInternalAgent,
+    }) => {
+      // Simulate the mute landing on this pod mid-run: abort the registered run
+      // (as muteChannelThread → chatOpsRunRegistry.cancelThread would) while the
+      // model call is "executing", then let it resolve.
+      const executeSpy = vi
+        .spyOn(a2aExecutor, "executeA2AMessage")
+        .mockImplementation(async () => {
+          chatOpsRunRegistry.cancelThread(threadKey);
+          return agentResult();
+        });
+
+      const { manager, mockProvider, sendReplySpy } = await setupBoundAgent({
+        makeUser,
+        makeOrganization,
+        makeTeam,
+        makeTeamMember,
+        makeInternalAgent,
+      });
+
+      const result = await manager.processMessage({
+        message: createMockMessage(),
+        provider: mockProvider,
+      });
+
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+      expect(result.agentResponse).toBe("");
+      // Neither the answer nor an "aborted" error reaches the muted thread.
+      expect(sendReplySpy).not.toHaveBeenCalled();
+    });
+
+    test("stays silent when the mute aborts the run during the auto-retry leg", async ({
+      makeUser,
+      makeOrganization,
+      makeTeam,
+      makeTeamMember,
+      makeInternalAgent,
+    }) => {
+      // First attempt fails transiently (triggering the one auto-retry); the
+      // mute then lands during the retry and aborts it. The abort must not be
+      // posted as an error reply.
+      const executeSpy = vi
+        .spyOn(a2aExecutor, "executeA2AMessage")
+        .mockRejectedValueOnce(
+          new ProviderError({
+            code: ChatErrorCode.EmptyResponse,
+            message: ChatErrorMessages[ChatErrorCode.EmptyResponse],
+            isRetryable: true,
+          }),
+        )
+        .mockImplementationOnce(async () => {
+          chatOpsRunRegistry.cancelThread(threadKey);
+          throw new Error("aborted");
+        });
+
+      const { manager, mockProvider, sendReplySpy } = await setupBoundAgent({
+        makeUser,
+        makeOrganization,
+        makeTeam,
+        makeTeamMember,
+        makeInternalAgent,
+      });
+
+      const result = await manager.processMessage({
+        message: createMockMessage(),
+        provider: mockProvider,
+      });
+
+      expect(executeSpy).toHaveBeenCalledTimes(2);
+      expect(result.success).toBe(true);
+      expect(result.agentResponse).toBe("");
+      expect(sendReplySpy).not.toHaveBeenCalled();
+    });
+
+    test("replies normally when no mute occurs during the run", async ({
+      makeUser,
+      makeOrganization,
+      makeTeam,
+      makeTeamMember,
+      makeInternalAgent,
+    }) => {
+      vi.spyOn(a2aExecutor, "executeA2AMessage").mockResolvedValue(
+        agentResult(),
+      );
+
+      const { manager, mockProvider, sendReplySpy } = await setupBoundAgent({
+        makeUser,
+        makeOrganization,
+        makeTeam,
+        makeTeamMember,
+        makeInternalAgent,
+      });
+
+      const result = await manager.processMessage({
+        message: createMockMessage(),
+        provider: mockProvider,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.agentResponse).toBe("Agent response");
+      expect(sendReplySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "Agent response" }),
       );
     });
   });

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -54,7 +54,8 @@ import {
   ensureProvisionedUser,
   isSsoConfigured,
 } from "./auto-provision";
-import { claimThreadMuteHint } from "./channel-activation";
+import { claimThreadMuteHint, getThreadMuteMarker } from "./channel-activation";
+import { chatOpsRunRegistry } from "./chatops-run-registry";
 import {
   CHATOPS_ATTACHMENT_LIMITS,
   CHATOPS_CHANNEL_DISCOVERY,
@@ -1595,6 +1596,21 @@ export class ChatOpsManager {
         .catch(() => {});
     }
 
+    // Register this run so muting the thread can abort it mid-flight, and record
+    // the thread's mute marker now: if it changes before we reply, the thread
+    // was muted while we were working and the reply must be dropped (see
+    // muteChannelThread / getThreadMuteMarker). The abort stops this pod's model
+    // request; the marker is the cross-pod guarantee that no reply is posted
+    // after a mute even when the run executed on a different pod than the mute.
+    const threadKey = {
+      provider: provider.providerId,
+      channelId: message.channelId,
+      threadId: message.threadId ?? message.channelId,
+    };
+    const { signal: abortSignal, unregister } =
+      chatOpsRunRegistry.register(threadKey);
+    const muteMarkerAtStart = await getThreadMuteMarker(threadKey);
+
     try {
       const executeParams = {
         agent,
@@ -1603,11 +1619,22 @@ export class ChatOpsManager {
         provider,
         fullMessage,
         userId,
+        abortSignal,
       };
       let execution: Awaited<ReturnType<ChatOpsManager["executeMessage"]>>;
       try {
         execution = await this.executeMessage(executeParams);
       } catch (error) {
+        // The thread was muted mid-run: we aborted this run on purpose, so stay
+        // silent rather than posting the abort as an error. The marker check
+        // below also covers a run aborted on another pod (no local signal).
+        if (abortSignal.aborted) {
+          return await this.suppressMutedReply({
+            provider,
+            message,
+            threadKey,
+          });
+        }
         // Web chat surfaces transient provider failures as a retry button;
         // chatops has no interactive affordance, so one automatic retry
         // stands in for it. The retry re-runs the whole agent turn, exactly
@@ -1627,6 +1654,17 @@ export class ChatOpsManager {
       }
       const { result, responseAgent } = execution;
 
+      // Drop the reply if the thread was muted while the run was in flight —
+      // whether we aborted it here (abortSignal) or it ran to completion on
+      // another pod (the marker moved). Muting means "be quiet now", so an
+      // answer that lands after it would defeat the request.
+      if (
+        abortSignal.aborted ||
+        (await this.threadMutedSinceStart(threadKey, muteMarkerAtStart))
+      ) {
+        return await this.suppressMutedReply({ provider, message, threadKey });
+      }
+
       return await this.replyByMessageExecutionResult({
         agent: responseAgent,
         message,
@@ -1635,6 +1673,13 @@ export class ChatOpsManager {
         result,
       });
     } catch (error) {
+      // A mute that aborted the run mid-flight (e.g. during the retry leg above)
+      // surfaces here as a throw — stay silent rather than posting it as an
+      // error, since the user just asked the bot to be quiet.
+      if (abortSignal.aborted) {
+        return await this.suppressMutedReply({ provider, message, threadKey });
+      }
+
       logger.error(
         { messageId: message.messageId, error: errorMessage(error) },
         "[ChatOps] Failed to execute A2A message",
@@ -1655,7 +1700,59 @@ export class ChatOpsManager {
       }
 
       return { success: false, error: errorMessage(error) };
+    } finally {
+      unregister();
     }
+  }
+
+  /**
+   * Whether the thread was muted after this run started, by comparing the mute
+   * marker captured at the start against the current one. A non-null current
+   * marker that differs from the captured value means a mute landed mid-run; a
+   * null current value (lapsed marker) is never treated as a mute, so it can't
+   * cause a spurious suppression.
+   */
+  private async threadMutedSinceStart(
+    threadKey: {
+      provider: ChatOpsProviderType;
+      channelId: string;
+      threadId: string;
+    },
+    muteMarkerAtStart: string | null,
+  ): Promise<boolean> {
+    const current = await getThreadMuteMarker(threadKey);
+    return current !== null && current !== muteMarkerAtStart;
+  }
+
+  /**
+   * Silently drop the reply for a run whose thread was muted mid-flight: clear
+   * the lingering "typing…" indicator and report success with no response (same
+   * shape as the agent deliberately staying quiet), so nothing is posted to the
+   * now-muted thread.
+   */
+  private async suppressMutedReply(params: {
+    provider: ChatOpsProvider;
+    message: IncomingChatMessage;
+    threadKey: {
+      provider: ChatOpsProviderType;
+      channelId: string;
+      threadId: string;
+    };
+  }): Promise<ChatOpsProcessingResult> {
+    const { provider, message, threadKey } = params;
+    logger.info(
+      {
+        messageId: message.messageId,
+        provider: threadKey.provider,
+        channelId: threadKey.channelId,
+        threadId: threadKey.threadId,
+      },
+      "[ChatOps] Thread muted during execution — dropping reply",
+    );
+    await provider
+      .clearTypingStatus?.(message.channelId, message.threadId ?? "")
+      ?.catch(() => {});
+    return { success: true, agentResponse: "" };
   }
 
   /**
@@ -1989,11 +2086,21 @@ export class ChatOpsManager {
     provider: ChatOpsProvider;
     fullMessage: string;
     userId: string;
+    /** Aborts the agent run when the thread is muted mid-flight. */
+    abortSignal?: AbortSignal;
   }): Promise<{
     result: A2AProtocolSendMessageResponse;
     responseAgent: { id: string; name: string };
   }> {
-    const { agent, binding, message, provider, fullMessage, userId } = params;
+    const {
+      agent,
+      binding,
+      message,
+      provider,
+      fullMessage,
+      userId,
+      abortSignal,
+    } = params;
 
     // Use thread ID (or channel ID for non-threaded messages) as session ID
     // so all messages in the same thread are grouped together in logs
@@ -2030,6 +2137,7 @@ export class ChatOpsManager {
       agentId: agent.id,
       request,
       systemParams,
+      abortSignal,
     });
 
     // If swap_agent/swap_to_default_agent created a thread-level override
@@ -2083,6 +2191,7 @@ export class ChatOpsManager {
           agentId: swappedAgent.id,
           request,
           systemParams,
+          abortSignal,
         });
 
         return {

--- a/platform/backend/src/agents/chatops/chatops-run-registry.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-run-registry.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+import { chatOpsRunRegistry } from "./chatops-run-registry";
+
+const SLACK_THREAD = {
+  provider: "slack",
+  channelId: "C123",
+  threadId: "1700000000.0001",
+} as const;
+
+describe("chatOpsRunRegistry", () => {
+  test("cancelThread aborts every run registered for the thread", () => {
+    const a = chatOpsRunRegistry.register(SLACK_THREAD);
+    const b = chatOpsRunRegistry.register(SLACK_THREAD);
+
+    expect(a.signal.aborted).toBe(false);
+    expect(b.signal.aborted).toBe(false);
+
+    const aborted = chatOpsRunRegistry.cancelThread(SLACK_THREAD);
+
+    expect(aborted).toBe(2);
+    expect(a.signal.aborted).toBe(true);
+    expect(b.signal.aborted).toBe(true);
+
+    a.unregister();
+    b.unregister();
+  });
+
+  test("cancelThread only touches the matching thread", () => {
+    const target = chatOpsRunRegistry.register(SLACK_THREAD);
+    const other = chatOpsRunRegistry.register({
+      ...SLACK_THREAD,
+      threadId: "1700000000.9999",
+    });
+
+    chatOpsRunRegistry.cancelThread(SLACK_THREAD);
+
+    expect(target.signal.aborted).toBe(true);
+    expect(other.signal.aborted).toBe(false);
+
+    target.unregister();
+    other.unregister();
+  });
+
+  test("the same thread key across providers is isolated", () => {
+    const slack = chatOpsRunRegistry.register(SLACK_THREAD);
+    const teams = chatOpsRunRegistry.register({
+      ...SLACK_THREAD,
+      provider: "ms-teams",
+    });
+
+    chatOpsRunRegistry.cancelThread(SLACK_THREAD);
+
+    expect(slack.signal.aborted).toBe(true);
+    expect(teams.signal.aborted).toBe(false);
+
+    slack.unregister();
+    teams.unregister();
+  });
+
+  test("an unregistered run is no longer cancellable", () => {
+    const run = chatOpsRunRegistry.register(SLACK_THREAD);
+    run.unregister();
+
+    expect(chatOpsRunRegistry.cancelThread(SLACK_THREAD)).toBe(0);
+    expect(run.signal.aborted).toBe(false);
+  });
+
+  test("cancelThread with no runs registered is a no-op", () => {
+    expect(
+      chatOpsRunRegistry.cancelThread({
+        provider: "slack",
+        channelId: "C-empty",
+        threadId: "never-ran",
+      }),
+    ).toBe(0);
+  });
+
+  test("cancelThread does not double-count an already-aborted run", () => {
+    const run = chatOpsRunRegistry.register(SLACK_THREAD);
+
+    expect(chatOpsRunRegistry.cancelThread(SLACK_THREAD)).toBe(1);
+    // A second mute of the same thread finds the run already aborted.
+    expect(chatOpsRunRegistry.cancelThread(SLACK_THREAD)).toBe(0);
+
+    run.unregister();
+  });
+});

--- a/platform/backend/src/agents/chatops/chatops-run-registry.ts
+++ b/platform/backend/src/agents/chatops/chatops-run-registry.ts
@@ -1,0 +1,120 @@
+/**
+ * In-memory registry of in-flight chatops agent runs, keyed by channel thread.
+ *
+ * ChatOps messages are processed fire-and-forget and fully concurrently: a user
+ * can send several messages in a thread, each spinning up its own (potentially
+ * long) agent turn, before deciding to mute the bot. Muting only dropped the
+ * sticky auto-reply for FUTURE messages — the already-running turns kept going
+ * and still posted their replies, so the user got answers after asking for
+ * silence.
+ *
+ * This registry lets a mute abort those runs. Each turn registers an
+ * AbortController for its thread; muting the thread aborts every controller
+ * registered for it, so their model requests stop instead of running to
+ * completion. The signal is threaded down into the agent execution (see
+ * `A2AManager.sendMessage` → `executeA2AMessage`), which passes it to the AI SDK
+ * `streamText` call.
+ *
+ * Scope: this is a per-process registry, so it cancels the compute of runs
+ * executing on the SAME pod that received the mute — the whole story for
+ * single-pod deployments and for Slack socket-mode (one pod owns the socket, so
+ * a thread's messages and its mute land together). For multi-pod webhook
+ * deployments a mute may land on a different pod than a given run; the durable
+ * cross-pod guarantee that no reply is posted after a mute is provided
+ * separately by the distributed mute marker (see `channel-activation.ts`), which
+ * every pod consults before replying. This registry is the compute-saving
+ * fast-path; the marker is the correctness backstop.
+ */
+
+import logger from "@/logging";
+import type { ChatOpsProviderType } from "@/types/chatops";
+
+interface ChatOpsThreadKey {
+  provider: ChatOpsProviderType;
+  channelId: string;
+  /**
+   * Thread root identifier. Callers that lack one (direct messages, which can't
+   * be muted anyway) pass the channel id, matching how runs are keyed — so a DM
+   * run is registered under a key a mute can never target.
+   */
+  threadId: string;
+}
+
+class ChatOpsRunRegistry {
+  private readonly runs = new Map<string, Set<AbortController>>();
+
+  /**
+   * Register an in-flight run for a thread. Returns the run's abort signal (to
+   * thread into the agent execution) and an `unregister` callback the caller
+   * MUST invoke in a `finally` once the run settles, so the controller is not
+   * retained after it completes.
+   */
+  register(key: ChatOpsThreadKey): {
+    signal: AbortSignal;
+    unregister: () => void;
+  } {
+    const cacheKey = this.threadCacheKey(key);
+    const controller = new AbortController();
+
+    let controllers = this.runs.get(cacheKey);
+    if (!controllers) {
+      controllers = new Set();
+      this.runs.set(cacheKey, controllers);
+    }
+    controllers.add(controller);
+
+    return {
+      signal: controller.signal,
+      unregister: () => {
+        const set = this.runs.get(cacheKey);
+        if (!set) {
+          return;
+        }
+        set.delete(controller);
+        if (set.size === 0) {
+          this.runs.delete(cacheKey);
+        }
+      },
+    };
+  }
+
+  /**
+   * Abort every in-flight run registered for a thread on this process. Returns
+   * how many runs were aborted (0 when none were running here). Safe to call for
+   * a thread with no local runs.
+   */
+  cancelThread(key: ChatOpsThreadKey): number {
+    const controllers = this.runs.get(this.threadCacheKey(key));
+    if (!controllers || controllers.size === 0) {
+      return 0;
+    }
+
+    let aborted = 0;
+    for (const controller of controllers) {
+      if (!controller.signal.aborted) {
+        controller.abort();
+        aborted += 1;
+      }
+    }
+
+    if (aborted > 0) {
+      logger.info(
+        {
+          provider: key.provider,
+          channelId: key.channelId,
+          threadId: key.threadId,
+          aborted,
+        },
+        "[ChatOps] Cancelled in-flight runs after thread was muted",
+      );
+    }
+
+    return aborted;
+  }
+
+  private threadCacheKey(key: ChatOpsThreadKey): string {
+    return `${key.provider}::${key.channelId}::${key.threadId}`;
+  }
+}
+
+export const chatOpsRunRegistry = new ChatOpsRunRegistry();

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -46,12 +46,12 @@ import {
   isSsoConfigured,
 } from "./auto-provision";
 import {
-  clearChannelThreadActive,
   isChannelThreadActive,
   isMuteReaction,
   isThreadMuteCommand,
   markChannelThreadActive,
   mightBeAddressedMuteCommand,
+  muteChannelThread,
   resolveChannelGateAction,
 } from "./channel-activation";
 import {
@@ -1460,7 +1460,7 @@ class SlackProvider implements ChatOpsProvider {
     channelId: string,
     threadTs: string,
   ): Promise<void> {
-    const wasActive = await clearChannelThreadActive({
+    const wasActive = await muteChannelThread({
       provider: this.providerId,
       channelId,
       threadId: threadTs,

--- a/platform/backend/src/cache-manager.ts
+++ b/platform/backend/src/cache-manager.ts
@@ -59,6 +59,10 @@ export const CacheKey = {
   TeamsThreadMuteHint: "teams-thread-mute-hint",
   /** Slack channel threads that already got the one-time "you can mute me" hint */
   SlackThreadMuteHint: "slack-thread-mute-hint",
+  /** Latest mute token per MS Teams channel thread (cross-pod in-flight reply suppression) */
+  TeamsThreadMuteMarker: "teams-thread-mute-marker",
+  /** Latest mute token per Slack channel thread (cross-pod in-flight reply suppression) */
+  SlackThreadMuteMarker: "slack-thread-mute-marker",
   /** Telegram approval-button payloads (callback_data is capped at 64 bytes) */
   TelegramApprovalCallback: "chatops-telegram-approval",
   /** One-shot codes linking a Telegram chat to a signed-in user */

--- a/platform/backend/src/routes/chatops.ts
+++ b/platform/backend/src/routes/chatops.ts
@@ -16,11 +16,11 @@ import {
   isSsoConfigured,
 } from "@/agents/chatops/auto-provision";
 import {
-  clearChannelThreadActive,
   isChannelThreadActive,
   isThreadMuteCommand,
   markChannelThreadActive,
   mightBeAddressedMuteCommand,
+  muteChannelThread,
   resolveChannelGateAction,
 } from "@/agents/chatops/channel-activation";
 import { chatOpsManager } from "@/agents/chatops/chatops-manager";
@@ -2086,7 +2086,7 @@ async function muteTeamsThreadAndNotify(
   context: TurnContext,
   activation: { provider: "ms-teams"; channelId: string; threadId: string },
 ): Promise<void> {
-  if (await clearChannelThreadActive(activation)) {
+  if (await muteChannelThread(activation)) {
     await context.sendActivity(buildThreadMutedNotice());
   }
 }


### PR DESCRIPTION
## Problem

Silencing a ChatOps channel thread — a `mute` command, a 🔇/🤫 reaction, or the mute button — only dropped the sticky auto-reply for **future** messages. Any message already being processed kept running and still posted its answer. So if a user fired off a few messages and then asked the bot to be quiet, they still got replies landing after the silence request. There was no way to cancel in-flight model requests.

## Fix

Muting now cancels the runs already in flight for that thread, for both Slack and MS Teams. Two layers:

1. **In-process run registry** (`chatops-run-registry.ts`) — a per-process map of in-flight runs keyed by `(provider, channelId, threadId)`. Each turn registers an `AbortController`; muting aborts every controller for the thread, so the model request stops instead of running to completion. The signal is threaded through `A2AManager.sendMessage` → `executeA2AMessage` → the AI SDK `streamText` call (which already accepted an `abortSignal`). This is the whole story for single-pod deployments and Slack socket-mode (one pod owns the socket, so a thread's messages and its mute land together).

2. **Distributed mute marker** (`channel-activation.ts`) — the correctness backstop for multi-pod webhook deployments, where a mute may land on a different pod than a given run. `muteChannelThread` writes a fresh token in the shared cache on every mute. A run captures the token when it starts and re-reads it just before replying; if it moved, the thread was muted mid-run and the reply is dropped. Comparing the **shared token** (never a local clock) makes it clock-skew-free, and a lapsed marker reads as "not muted" so it can't cause a spurious suppression.

An aborted run stays silent rather than posting its abort as an error reply — including when the abort lands during the one automatic retry leg.

Both provider mute funnels (`muteThreadAndNotify` / `muteTeamsThreadAndNotify`) now route through a single `muteChannelThread`, which records the marker, aborts local runs, and clears the sticky activation in one place.

## Behavior

- `A` and `B` are running when the user mutes → both are aborted (same pod) and neither reply is posted.
- A run finishing on another pod after the mute → the marker moved, so the reply is suppressed.
- No mute → unchanged: the bot replies normally.

## Tests

- `chatops-run-registry.test.ts` — register/cancel/scope/idempotency of the registry.
- `channel-activation.test.ts` — `muteChannelThread` records/rotates the marker, aborts registered runs, and stays scoped per `(provider, channel, thread)`.
- `chatops-manager.test.ts` — manager-level suppression: local abort, cross-pod marker move, retry-leg abort, and the normal no-mute reply.

Full chatops + a2a suites pass (468 tests); type-check, knip, and biome clean.

## Docs

Slack and MS Teams pages now note that muting also cancels a reply already in progress.

## Notes

- No DB migration: the two new cache keys are runtime key prefixes, not schema.
- Cross-pod compute is only *stopped* on the pod that receives the mute; a run on another pod finishes its model call but its reply is suppressed by the marker. Stopping remote compute would need a NOTIFY broadcast — deliberately out of scope here.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>