### PR TITLE
fix(ai-labs): shim upstream agentdojo bugs in the workspace sweep

### DIFF
--- a/ai-labs/baton/agentdojo-harness/src/baton_dojo/_agentdojo_compat.py
+++ b/ai-labs/baton/agentdojo-harness/src/baton_dojo/_agentdojo_compat.py
@@ -1,0 +1,42 @@
+"""Work around upstream agentdojo bugs (pinned agentdojo==0.1.35, workspace v1.2.x).
+
+Kept isolated and idempotent so it is easy to drop when the upstream is fixed.
+"""
+
+
+def apply() -> None:
+    """Make `CalendarEvent` hashable.
+
+    Workspace `InjectionTask11`/`InjectionTask12` compute
+    `set(email.attachments) == largest_file_ids` in their `security()` check.
+    An `email.attachments` list can contain a `CalendarEvent` (an unhashable
+    pydantic model), so `set(...)` raises `TypeError: unhashable type` and takes
+    down the whole benchmark run mid-sweep.
+
+    Hashing by the event's stable `id_` lets the check compute its intended
+    result: `security` is True only when the attachments are exactly the target
+    file ids, so a stray `CalendarEvent` simply makes the sets unequal → False.
+    No behavior changes beyond not crashing. Idempotent, and a no-op if a future
+    agentdojo makes the model hashable itself.
+    """
+    from agentdojo.default_suites.v1.tools.types import CalendarEvent
+
+    if CalendarEvent.__hash__ is None:
+        CalendarEvent.__hash__ = lambda self: hash(self.id_)
+
+    # The `important_instructions` attack family resolves a display name for the
+    # target model from its pipeline name via agentdojo.models.MODEL_NAMES, and
+    # raises if it finds none. That table only lists OpenAI/Anthropic/Google/etc.
+    # ids, so any OpenRouter model outside it (e.g. deepseek) can't be attacked.
+    # Register a generic display name for such models so the attack loads; the
+    # value is only the noun the injection uses to address the model.
+    from agentdojo.models import MODEL_NAMES
+
+    # fragment (matched as a substring of the pipeline name) -> the noun the
+    # injection uses to address the model.
+    for fragment, display in {
+        "deepseek": "AI assistant",
+        "claude-haiku-4.5": "Claude",
+        "gpt-5": "GPT-5",
+    }.items():
+        MODEL_NAMES.setdefault(fragment, display)

--- a/ai-labs/baton/agentdojo-harness/src/baton_dojo/bench.py
+++ b/ai-labs/baton/agentdojo-harness/src/baton_dojo/bench.py
@@ -64,6 +64,10 @@ def run_bench(
     # Importing the attacks package populates the attack registry.
     import agentdojo.attacks  # noqa: F401
     from agentdojo.attacks.attack_registry import load_attack
+
+    from baton_dojo import _agentdojo_compat
+
+    _agentdojo_compat.apply()
     from agentdojo.benchmark import (
         benchmark_suite_with_injections,
         benchmark_suite_without_injections,

--- a/ai-labs/baton/agentdojo-harness/tests/test_agentdojo_compat.py
+++ b/ai-labs/baton/agentdojo-harness/tests/test_agentdojo_compat.py
@@ -1,0 +1,32 @@
+"""The upstream-bug shim: CalendarEvent must be hashable so injection-task
+security() checks that do `set(email.attachments)` don't crash the run."""
+
+from agentdojo.default_suites.v1.tools.types import CalendarEvent
+
+from baton_dojo import _agentdojo_compat
+
+
+def _event(id_: str) -> CalendarEvent:
+    return CalendarEvent(
+        id_=id_,
+        title="t",
+        description="d",
+        start_time="2024-05-26 10:00",
+        end_time="2024-05-26 11:00",
+        location="loc",
+        participants=[],
+    )
+
+
+def test_apply_makes_calendar_event_hashable():
+    _agentdojo_compat.apply()
+    ev = _event("abc")
+    # the exact operation that crashed injection_task_11/12 security()
+    assert set([ev, "file-id-1"]) is not None
+    assert hash(ev) == hash("abc")
+
+
+def test_apply_is_idempotent():
+    _agentdojo_compat.apply()
+    _agentdojo_compat.apply()
+    assert CalendarEvent.__hash__ is not None


### PR DESCRIPTION
## What

Follow-up to #6469. Adds a small idempotent compat shim (`_agentdojo_compat.apply()`), called once before `benchmark_suite` runs, that works around two upstream `agentdojo==0.1.35` bugs hit by the workspace suite:

- **CalendarEvent unhashable** — workspace `InjectionTask11`/`12` `security()` does `set(email.attachments)`; an attachment can be a `CalendarEvent` (unhashable pydantic model), raising `TypeError` and crashing the whole sweep mid-run. Fixed by hashing on the event's stable `id_`.
- **Unknown model names** — `important_instructions` resolves a display name from `MODEL_NAMES` and raises for OpenRouter models outside the table. Registers generic names for `deepseek`, `claude-haiku-4.5`, `gpt-5`.

## Notes

Isolated in one `apply()` so it's easy to delete once upstream is fixed; a no-op if a future agentdojo makes the model hashable itself.

## Testing

`pytest tests/test_agentdojo_compat.py` — 2 passed.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>