### PR TITLE
fix(agents): assign discovered tools without a caller-resolvable install

### DIFF
--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -44,8 +44,10 @@ import { useOrganization } from "@/lib/organization.query";
 import { cn } from "@/lib/utils";
 import {
   computeMcpEnvConflicts,
+  getCatalogAssignmentGate,
   getDefaultArchestraToolIds,
   isCatalogInEnvironment,
+  shouldResetCredentialPin,
   sortAndFilterTools,
   sortCatalogItems,
 } from "./agent-tools-editor.utils";
@@ -661,13 +663,16 @@ const AgentToolsEditorContent = forwardRef<
         ? pending.selectedToolIds.size
         : (assignedToolsByCatalog.get(catalog.id)?.length ?? 0);
       const totalCount = toolCountByCatalog.get(catalog.id) ?? 0;
-      const hasNoTools = totalCount === 0;
-      const hasNoCredentials =
-        !isCredentialLessCatalogType(catalog.serverType) &&
-        !allCredentials?.[catalog.id]?.length;
-      const isEnvIncompatible =
-        environmentScopingEnabled && !isEnvCompatible(catalog);
-      const isDisabled = hasNoTools || hasNoCredentials || isEnvIncompatible;
+      const hasResolvableInstall =
+        isCredentialLessCatalogType(catalog.serverType) ||
+        !!allCredentials?.[catalog.id]?.length;
+      const gate = getCatalogAssignmentGate({
+        hasDiscoveredTools: totalCount > 0,
+        hasResolvableInstall,
+        isEnvIncompatible:
+          environmentScopingEnabled && !isEnvCompatible(catalog),
+        environmentName: agentEnvironmentName,
+      });
       const displayName =
         catalog.id === ARCHESTRA_MCP_CATALOG_ID ? catalogName : catalog.name;
       return {
@@ -682,23 +687,15 @@ const AgentToolsEditorContent = forwardRef<
             size={16}
           />
         ),
-        badge: isDisabled
+        badge: gate.disabled
           ? undefined
-          : assignedCount > 0
-            ? `${assignedCount}/${totalCount}`
-            : `${totalCount} tools`,
-        disabled: isDisabled,
-        disabledReason: isEnvIncompatible
-          ? `Not in ${
-              agentEnvironmentName
-                ? `the "${agentEnvironmentName}" environment`
-                : "the Default environment"
-            }`
-          : hasNoTools
-            ? "Not installed"
-            : hasNoCredentials
-              ? "Not installed"
-              : undefined,
+          : gate.unavailable
+            ? "Not connected"
+            : assignedCount > 0
+              ? `${assignedCount}/${totalCount}`
+              : `${totalCount} tools`,
+        disabled: gate.disabled,
+        disabledReason: gate.disabledReason,
       };
     });
   }, [
@@ -745,11 +742,15 @@ const AgentToolsEditorContent = forwardRef<
             ? pending.selectedToolIds.size
             : (assignedToolsByCatalog.get(catalog.id)?.length ?? 0);
           const totalCount = toolCountByCatalog.get(catalog.id) ?? 0;
-          const hasNoTools = totalCount === 0;
-          const hasNoCredentials =
-            !isCredentialLessCatalogType(catalog.serverType) &&
-            !allCredentials?.[catalog.id]?.length;
-          const isDisabled = hasNoTools || hasNoCredentials;
+          // The cards layout is not environment-scoped (McpServerCard has no
+          // reason slot), so tool discovery is the only assignability gate here.
+          const gate = getCatalogAssignmentGate({
+            hasDiscoveredTools: totalCount > 0,
+            hasResolvableInstall:
+              isCredentialLessCatalogType(catalog.serverType) ||
+              !!allCredentials?.[catalog.id]?.length,
+            isEnvIncompatible: false,
+          });
 
           return (
             <McpServerCard
@@ -761,7 +762,8 @@ const AgentToolsEditorContent = forwardRef<
                   : catalog.name
               }
               isSelected={isSelected}
-              isDisabled={isDisabled}
+              isDisabled={gate.disabled}
+              unavailable={gate.unavailable}
               assignedCount={assignedCount}
               totalCount={totalCount}
               onToggle={() => handleCatalogToggle(catalog.id)}
@@ -819,6 +821,7 @@ function McpServerCard({
   displayName,
   isSelected,
   isDisabled,
+  unavailable,
   assignedCount,
   totalCount,
   onToggle,
@@ -827,6 +830,7 @@ function McpServerCard({
   displayName: string;
   isSelected: boolean;
   isDisabled: boolean;
+  unavailable: boolean;
   assignedCount: number;
   totalCount: number;
   onToggle: () => void;
@@ -848,9 +852,11 @@ function McpServerCard({
       <span className="text-[10px] text-muted-foreground">
         {isDisabled
           ? "Not installed"
-          : isSelected
-            ? `${assignedCount}/${totalCount} tools`
-            : `${totalCount} tools`}
+          : unavailable
+            ? "Not connected"
+            : isSelected
+              ? `${assignedCount}/${totalCount} tools`
+              : `${totalCount} tools`}
       </span>
     </button>
   );
@@ -955,25 +961,19 @@ function McpServerPill({
   }, [currentAssignedToolIdsKey]);
 
   useEffect(() => {
-    // Wait until credentials load so a valid static pin isn't reset to
-    // dynamic while the list is still empty.
-    if (!credentials) {
-      return;
-    }
-
-    if (selectedCredential === DYNAMIC_CREDENTIAL_VALUE) {
-      return;
-    }
-
     if (
-      selectedCredential &&
-      mcpServers.some((server) => server.id === selectedCredential)
+      shouldResetCredentialPin({
+        credentialsLoaded: !!credentials,
+        selectionIsDynamic: selectedCredential === DYNAMIC_CREDENTIAL_VALUE,
+        pinnedServerId:
+          selectedCredential && selectedCredential !== DYNAMIC_CREDENTIAL_VALUE
+            ? selectedCredential
+            : null,
+        resolvableServerIds: mcpServers.map((server) => server.id),
+      })
     ) {
-      return;
+      setSelectedCredential(DYNAMIC_CREDENTIAL_VALUE);
     }
-
-    // Unset or stale selection — fall back to resolve-at-call-time.
-    setSelectedCredential(DYNAMIC_CREDENTIAL_VALUE);
   }, [credentials, mcpServers, selectedCredential]);
 
   // Auto-select all tools when selectAll flag is set and tools finish loading.
@@ -1013,15 +1013,6 @@ function McpServerPill({
     return false;
   }, [selectedToolIds, currentAssignedToolIds]);
 
-  // Don't show MCP server if no credentials are available (except for builtin
-  // servers and in-process Apps, which need neither an install nor credentials)
-  if (
-    !isCredentialLessCatalogType(catalogItem.serverType) &&
-    mcpServers.length === 0
-  ) {
-    return null;
-  }
-
   const assignedCount = assignedTools.length;
   const totalCount = allTools.length;
   const displayedCount = hasPendingChanges
@@ -1029,13 +1020,14 @@ function McpServerPill({
     : assignedCount;
   const isEmpty = displayedCount === 0;
 
-  // Show credential selector for non-builtin, non-App, non-Playwright servers
-  // that have credentials available
+  // Show the connection selector for non-builtin, non-App, non-Playwright
+  // servers. It always offers resolve-at-call-time, so a server with no
+  // connection that resolves for the caller still shows it — that is how the
+  // dynamic per-caller resolution (and any pinned-but-unavailable connection)
+  // stays visible for an assignment made without a local install.
   const isPlaywright = isPlaywrightCatalogItem(catalogItem.id);
   const showCredentialSelector =
-    !isCredentialLessCatalogType(catalogItem.serverType) &&
-    !isPlaywright &&
-    mcpServers.length > 0;
+    !isCredentialLessCatalogType(catalogItem.serverType) && !isPlaywright;
   return (
     <McpServerPillShell
       icon={

--- a/platform/frontend/src/components/agent-tools-editor.utils.test.ts
+++ b/platform/frontend/src/components/agent-tools-editor.utils.test.ts
@@ -11,13 +11,122 @@ import {
 import { describe, expect, it } from "vitest";
 import {
   computeMcpEnvConflicts,
+  getCatalogAssignmentGate,
   getDefaultArchestraToolIds,
   isCatalogInEnvironment,
+  shouldResetCredentialPin,
   sortAndFilterTools,
   sortCatalogItems,
 } from "./agent-tools-editor.utils";
 
 const OTHER_CATALOG_ID = "other-catalog-id";
+
+describe("getCatalogAssignmentGate", () => {
+  // Install state does not gate assignment: a catalog item with discovered
+  // tools but no install the caller can resolve stays assignable (as a dynamic
+  // assignment) and is surfaced as unavailable.
+  it("keeps a catalog with discovered tools but no resolvable install assignable", () => {
+    const gate = getCatalogAssignmentGate({
+      hasDiscoveredTools: true,
+      hasResolvableInstall: false,
+      isEnvIncompatible: false,
+    });
+
+    expect(gate.disabled).toBe(false);
+    expect(gate.disabledReason).toBeUndefined();
+    expect(gate.unavailable).toBe(true);
+  });
+
+  it("keeps a fully-installed catalog assignable and available", () => {
+    const gate = getCatalogAssignmentGate({
+      hasDiscoveredTools: true,
+      hasResolvableInstall: true,
+      isEnvIncompatible: false,
+    });
+
+    expect(gate.disabled).toBe(false);
+    expect(gate.unavailable).toBe(false);
+  });
+
+  it("refuses a catalog with no discovered tool — nothing to assign", () => {
+    const gate = getCatalogAssignmentGate({
+      hasDiscoveredTools: false,
+      hasResolvableInstall: true,
+      isEnvIncompatible: false,
+    });
+
+    expect(gate.disabled).toBe(true);
+    expect(gate.disabledReason).toBe("Not installed");
+    expect(gate.unavailable).toBe(false);
+  });
+
+  it("refuses an environment-incompatible catalog with a named-environment reason", () => {
+    const gate = getCatalogAssignmentGate({
+      hasDiscoveredTools: true,
+      hasResolvableInstall: false,
+      isEnvIncompatible: true,
+      environmentName: "Staging",
+    });
+
+    expect(gate.disabled).toBe(true);
+    expect(gate.disabledReason).toBe('Not in the "Staging" environment');
+  });
+
+  it("refuses an environment-incompatible catalog in the Default environment", () => {
+    const gate = getCatalogAssignmentGate({
+      hasDiscoveredTools: true,
+      hasResolvableInstall: true,
+      isEnvIncompatible: true,
+    });
+
+    expect(gate.disabled).toBe(true);
+    expect(gate.disabledReason).toBe("Not in the Default environment");
+  });
+});
+
+describe("shouldResetCredentialPin", () => {
+  const base = {
+    credentialsLoaded: true,
+    selectionIsDynamic: false,
+    pinnedServerId: "srv-1",
+    resolvableServerIds: ["srv-2", "srv-3"],
+  };
+
+  it("resets a stale pin absent from a non-empty resolvable set", () => {
+    expect(shouldResetCredentialPin(base)).toBe(true);
+  });
+
+  // Regression: an assignment persists independently of install state. When no
+  // connection resolves for the caller, preserve the pin instead of coercing it
+  // to dynamic — coercing would silently rewrite the pin on the next save.
+  it("preserves the pin when no connection resolves for the caller", () => {
+    expect(shouldResetCredentialPin({ ...base, resolvableServerIds: [] })).toBe(
+      false,
+    );
+  });
+
+  it("keeps a pin that still resolves", () => {
+    expect(shouldResetCredentialPin({ ...base, pinnedServerId: "srv-2" })).toBe(
+      false,
+    );
+  });
+
+  it("does nothing for a dynamic selection", () => {
+    expect(
+      shouldResetCredentialPin({
+        ...base,
+        selectionIsDynamic: true,
+        pinnedServerId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("waits until credentials have loaded", () => {
+    expect(
+      shouldResetCredentialPin({ ...base, credentialsLoaded: false }),
+    ).toBe(false);
+  });
+});
 
 function makeCatalog(id: string, name: string) {
   return { id, name };

--- a/platform/frontend/src/components/agent-tools-editor.utils.ts
+++ b/platform/frontend/src/components/agent-tools-editor.utils.ts
@@ -77,6 +77,78 @@ export function isCatalogInEnvironment(
 }
 
 /**
+ * Whether a catalog item may be assigned to an agent in the tools picker, and
+ * how it should read when it is.
+ *
+ * A catalog item is assignable when it has at least one **discovered** tool; an
+ * install the assigning caller can resolve is NOT required. A discovered tool
+ * with no resolvable install stays assignable as a dynamic assignment — its
+ * connection resolved per caller at call time — and is surfaced as `unavailable`,
+ * prompting install/reconnect when invoked. A catalog item with no discovered
+ * tool has nothing to assign. Environment incompatibility is a separate,
+ * orthogonal gate.
+ */
+export function getCatalogAssignmentGate(params: {
+  hasDiscoveredTools: boolean;
+  hasResolvableInstall: boolean;
+  isEnvIncompatible: boolean;
+  environmentName?: string | null;
+}): { disabled: boolean; disabledReason?: string; unavailable: boolean } {
+  const { hasDiscoveredTools, hasResolvableInstall, isEnvIncompatible } =
+    params;
+
+  if (isEnvIncompatible) {
+    return {
+      disabled: true,
+      unavailable: false,
+      disabledReason: `Not in ${
+        params.environmentName
+          ? `the "${params.environmentName}" environment`
+          : "the Default environment"
+      }`,
+    };
+  }
+
+  if (!hasDiscoveredTools) {
+    return {
+      disabled: true,
+      unavailable: false,
+      disabledReason: "Not installed",
+    };
+  }
+
+  return { disabled: false, unavailable: !hasResolvableInstall };
+}
+
+/**
+ * Whether the tools picker should drop a per-server credential pin back to
+ * resolve-at-call-time.
+ *
+ * Only a genuinely stale pin — one absent from a non-empty set of connections
+ * that resolve for the caller — is reset. When no connection resolves at all,
+ * the pin is preserved: the assignment persists independently of install state,
+ * so coercing it here would register a pending change and silently rewrite the
+ * pin to dynamic on the next save. A dynamic/unset selection has nothing to
+ * reset.
+ */
+export function shouldResetCredentialPin(params: {
+  credentialsLoaded: boolean;
+  selectionIsDynamic: boolean;
+  pinnedServerId: string | null;
+  resolvableServerIds: readonly string[];
+}): boolean {
+  const { credentialsLoaded, selectionIsDynamic, pinnedServerId } = params;
+
+  if (!credentialsLoaded || selectionIsDynamic || pinnedServerId === null) {
+    return false;
+  }
+  if (params.resolvableServerIds.includes(pinnedServerId)) {
+    return false;
+  }
+  return params.resolvableServerIds.length > 0;
+}
+
+/**
  * The selected catalogs that don't belong to the agent's environment (builtins
  * are always compatible). Drives the save-blocking conflict alert. Unknown
  * catalog ids are skipped.

--- a/platform/frontend/src/components/token-select.tsx
+++ b/platform/frontend/src/components/token-select.tsx
@@ -130,7 +130,7 @@ export function TokenSelect({
             <span>Resolve at call time</span>
           </div>
         </SelectItem>
-        {mcpServers.length > 0 && (
+        {mcpServers.length > 0 ? (
           <>
             {organizationCredentials.length > 0 && (
               <>
@@ -187,6 +187,15 @@ export function TokenSelect({
                 ))}
               </>
             )}
+          </>
+        ) : (
+          <>
+            <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
+              Static
+            </div>
+            <div className="px-2 pb-2 text-xs text-muted-foreground">
+              No saved credentials for this server.
+            </div>
           </>
         )}
       </SelectContent>


### PR DESCRIPTION
## Summary

The Custom-mode agent tools picker refused to assign an MCP server's tools whenever the assigning user had no connection that resolves for them in scope — the server was disabled and labeled "Not installed" — even when the server had discovered tools. This contradicted the runtime, which already resolves such tools per caller at call time, so a server another user had installed (or an org-visible catalog entry with no personal install) could never be wired onto a personal agent.

A server with at least one **discovered** tool is now assignable regardless of the caller's install state. Such an assignment is created as a **dynamic** (resolve-at-call-time) assignment — the connection is resolved per caller when a tool runs, prompting install/reconnect if none exists. In the picker the server now shows a "Not connected" badge instead of being disabled; its pill's "Connect on behalf of" selector stays visible and, when the caller has no static credentials, shows a "Static — No saved credentials for this server." state alongside "Resolve at call time". Only a server with **zero** discovered tools stays unassignable.

To keep the newly-rendered pill from corrupting data, an existing static credential pin that no longer resolves in the current scope is now preserved rather than silently rewritten to dynamic on the next save.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>