### PR TITLE
fix(chat): stop rapid submits from racing the direct-send path and losing messages

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1213,22 +1213,28 @@ export function ChatPageContent({
 
   const syncPersistedMessageMetadata = useCallback(
     (persistedMessages: UIMessage[]) => {
-      if (!chatSession?.messages || !setMessages) {
+      if (!setMessages) {
         return;
       }
 
-      const mergedMessages = mergePersistedMessageMetadata({
-        liveMessages: chatSession.messages,
-        persistedMessages,
-      });
-
-      if (mergedMessages === chatSession.messages) {
-        return;
-      }
-
-      setMessages(mergedMessages);
+      // Merge against the SDK's CURRENT thread via the functional updater — NOT
+      // the `chatSession.messages` session snapshot, which trails the live SDK
+      // thread by a render (it is published through a post-render sync effect;
+      // see ChatSessionHook). During rapid queue drain that snapshot can be
+      // missing the just-sent user message; folding a stale, shorter snapshot
+      // and writing it back here would shrink the SDK thread and drop that
+      // in-flight user message, while the ongoing stream only re-adds the
+      // assistant reply — the user bubble then vanishes until a reload (the
+      // backend persisted it fine). mergePersistedMessageMetadata returns the
+      // same array reference when nothing changed, so React bails out.
+      setMessages((current) =>
+        mergePersistedMessageMetadata({
+          liveMessages: current,
+          persistedMessages,
+        }),
+      );
     },
-    [chatSession?.messages, setMessages],
+    [setMessages],
   );
 
   useEffect(() => {

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -118,6 +118,7 @@ import {
   useForkConversation,
   useForkSharedConversation,
 } from "@/lib/chat/chat-share.query";
+import { classifyChatSubmitAction } from "@/lib/chat/chat-submit-action";
 import {
   applyFeedbackToMessages,
   conversationStorageKeys,
@@ -1039,6 +1040,31 @@ export function ChatPageContent({
   const setMessages = chatSession?.setMessages;
   const stop = chatSession?.stop;
 
+  // `status` here is read from the shared session map, which each
+  // ChatSessionHook updates a render behind the real SDK status (via a
+  // post-render sync effect + notifySessionUpdate). Right after handleSubmit
+  // fires a direct send, the SDK is already busy but this `status` can still
+  // read "ready" for a tick or two. Without a synchronous guard, rapid
+  // follow-up submits take the direct-send path again and race each other
+  // inside the single useChat instance — every message reaches the model, but
+  // the concurrent sends clobber each other's optimistic user bubble, so most
+  // never render. This latch makes only the first submit of a turn direct-send;
+  // the rest enqueue and drain in order. Only meaningful with queueing on,
+  // which is the sole path able to absorb the extra submits.
+  const directSendPendingRef = useRef(false);
+  // The real SDK status leaving "ready" means the direct send has landed and
+  // this `status` snapshot will now gate follow-ups on its own; a conversation
+  // switch retargets everything. Either way the latch has done its job.
+  useEffect(() => {
+    if (status !== "ready") {
+      directSendPendingRef.current = false;
+    }
+  }, [status]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on conversation switch — the body writes a ref, so conversationId is a trigger, not a read
+  useEffect(() => {
+    directSendPendingRef.current = false;
+  }, [conversationId]);
+
   // Thumbs feedback on assistant messages: optimistic apply + rollback against
   // the originating session's setter, captured here so a conversation switch
   // mid-request cannot retarget the rollback (or the invalidation, which the
@@ -1611,17 +1637,12 @@ export function ChatPageContent({
   ) => {
     e.preventDefault();
     if (isPlaywrightSetupVisible) return;
-    if (status === "submitted" || status === "streaming") {
-      // With queueing on, a submit while a response is in-flight queues the
-      // message; the conversation's ChatSessionHook sends it once the turn
-      // settles. (Stopping is the submit button's onClick, not a form
-      // submit.) With queueing off, the submit button doubles as Stop.
-      if (!isMessageQueueEnabled || !conversationId) {
-        handleStopStreaming();
-        // Throw to keep the textarea and draft intact — see onSubmit
-        // contract in ArchestraPromptInputProps.
-        throw new Error("stop-not-submit");
-      }
+
+    // Enqueue this submission instead of sending it now (throws on inputs that
+    // can't be queued, keeping the composer intact per the onSubmit contract).
+    // Only reached when queueing is on and a conversation exists.
+    const enqueueSubmission = () => {
+      if (!conversationId) return;
       if (message.files && message.files.length > 0) {
         toast.error(
           "Attachments can't be queued. Wait for the current response to finish, then send.",
@@ -1644,7 +1665,29 @@ export function ChatPageContent({
         agentId: conversation?.agentId ?? undefined,
         messageLength: message.text?.length ?? 0,
       });
+    };
+
+    const queueEnabled = isMessageQueueEnabled && !!conversationId;
+    const submitAction = classifyChatSubmitAction({
+      status,
+      queueEnabled,
+      directSendPending: directSendPendingRef.current,
+    });
+
+    if (submitAction === "stop") {
+      // Queueing off: the submit button doubles as Stop while a turn streams.
+      // (Stopping is the submit button's onClick, not a form submit.) Throw to
+      // keep the textarea and draft intact — see onSubmit contract in
+      // ArchestraPromptInputProps.
+      handleStopStreaming();
+      throw new Error("stop-not-submit");
+    }
+
+    if (submitAction === "queue") {
+      // Streaming (or a direct send is still settling): queue the message; the
+      // conversation's ChatSessionHook sends it once the turn settles.
       // Returning normally clears the textarea and draft, like a send.
+      enqueueSubmission();
       return;
     }
 
@@ -1727,6 +1770,14 @@ export function ChatPageContent({
         ...(appDiagnostics.length > 0 ? { appDiagnostics } : {}),
       },
     });
+    // Mark the turn as in flight synchronously so follow-up submits queue
+    // instead of racing this send while the page's `status` catches up. Cleared
+    // by the status/conversation effects above. Only latch when queueing can
+    // absorb the overflow; otherwise leave the pre-existing (queue-off)
+    // behavior untouched.
+    if (queueEnabled) {
+      directSendPendingRef.current = true;
+    }
 
     trackEvent("message_sent", {
       conversationId,

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -1,6 +1,7 @@
-import { E2eTestId } from "@archestra/shared";
+import { type ChatSkillMetadata, E2eTestId } from "@archestra/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { chatMessageQueue } from "@/lib/chat/chat-message-queue";
 import { NEW_CHAT_DRAFT_STORAGE_KEY } from "@/lib/chat/chat-utils";
 
 const {
@@ -17,7 +18,7 @@ const {
   mockTextInputSetInput: vi.fn(),
   mockTextInputClear: vi.fn(),
   mockControllerState: { value: "", files: [] as { url: string }[] },
-  mockFeatureState: { chatSecretScanEnabled: false },
+  mockFeatureState: { chatSecretScanEnabled: false, betaEnabled: false },
   mockProfileState: {
     agent: null as { sandboxAvailable: boolean } | null,
   },
@@ -289,11 +290,15 @@ describe("ArchestraPromptInput", () => {
       isPending: false,
       isLoading: false,
     } as ReturnType<typeof useHasPermissions>);
-    vi.mocked(useFeature).mockImplementation((flag) =>
-      flag === "chatSecretScanEnabled"
-        ? mockFeatureState.chatSecretScanEnabled
-        : undefined,
-    );
+    vi.mocked(useFeature).mockImplementation((flag) => {
+      if (flag === "chatSecretScanEnabled") {
+        return mockFeatureState.chatSecretScanEnabled;
+      }
+      if (flag === "betaEnabled") {
+        return mockFeatureState.betaEnabled;
+      }
+      return undefined;
+    });
     mockUseChatPlaceholder.mockReturnValue({
       placeholder: "Animated placeholder",
       isAnimating: true,
@@ -305,11 +310,25 @@ describe("ArchestraPromptInput", () => {
     mockControllerState.value = "";
     mockControllerState.files = [];
     mockFeatureState.chatSecretScanEnabled = false;
+    mockFeatureState.betaEnabled = false;
     mockProfileState.agent = null;
     localStorage.clear();
   });
 
   describe("File Upload Button", () => {
+    // The composer renders more than one tooltip now (the submit button carries
+    // a keyboard-shortcut tooltip too), so scope file-upload assertions to the
+    // tooltip whose content matches.
+    const getFileUploadTooltip = (text: string): HTMLElement => {
+      const tooltip = screen
+        .getAllByTestId("tooltip-content")
+        .find((element) => element.textContent?.includes(text));
+      if (!tooltip) {
+        throw new Error(`No tooltip content matching "${text}"`);
+      }
+      return tooltip;
+    };
+
     it("should render enabled file upload button when allowFileUploads is true and model supports files", () => {
       render(
         <ArchestraPromptInput
@@ -366,7 +385,7 @@ describe("ArchestraPromptInput", () => {
       expect(disabledButton).toBeInTheDocument();
 
       // Tooltip should show message about model not supporting files
-      const tooltip = screen.getByTestId("tooltip-content");
+      const tooltip = getFileUploadTooltip("does not support file uploads");
       expect(tooltip).toHaveTextContent(
         "This model does not support file uploads",
       );
@@ -386,9 +405,7 @@ describe("ArchestraPromptInput", () => {
       ).toBeInTheDocument();
       // Enabled state shows the supported-types tooltip rather than the
       // disabled "does not support file uploads" message.
-      expect(screen.getByTestId("tooltip-content")).toHaveTextContent(
-        "Supports:",
-      );
+      expect(getFileUploadTooltip("Supports:")).toHaveTextContent("Supports:");
     });
 
     it("should show settings link in tooltip for admins when file uploads disabled", () => {
@@ -408,7 +425,7 @@ describe("ArchestraPromptInput", () => {
       );
 
       // Tooltip should show "Enable in settings" link for admins
-      const tooltip = screen.getByTestId("tooltip-content");
+      const tooltip = getFileUploadTooltip("File uploads are disabled");
       expect(tooltip).toHaveTextContent("File uploads are disabled.");
       expect(tooltip).toHaveTextContent("Enable in settings");
       expect(screen.getByRole("link")).toHaveAttribute(
@@ -438,7 +455,9 @@ describe("ArchestraPromptInput", () => {
       );
 
       // Tooltip should show message about admin for non-admins
-      const tooltip = screen.getByTestId("tooltip-content");
+      const tooltip = getFileUploadTooltip(
+        "File uploads are disabled by your administrator",
+      );
       expect(tooltip).toHaveTextContent(
         "File uploads are disabled by your administrator",
       );
@@ -938,6 +957,127 @@ describe("ArchestraPromptInput", () => {
 
       expect(onSubmit).toHaveBeenCalledTimes(1);
       expect(localStorage.getItem(draftKey)).toBeNull();
+    });
+  });
+
+  describe("queue keyboard shortcuts", () => {
+    it("pops the most recently queued message into the composer on ArrowUp when empty", () => {
+      mockFeatureState.betaEnabled = true;
+      const conversationId = "conv-arrowup-pop";
+      chatMessageQueue.clear(conversationId);
+      chatMessageQueue.enqueue(conversationId, { text: "first queued" });
+      chatMessageQueue.enqueue(conversationId, { text: "second queued" });
+      mockControllerState.value = "";
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          conversationId={conversationId}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getByTestId(E2eTestId.ChatPromptTextarea), {
+        key: "ArrowUp",
+      });
+
+      // The newest queued message loads into the composer...
+      expect(mockTextInputSetInput).toHaveBeenCalledWith("second queued");
+      // ...and is removed from the queue, leaving the older one behind.
+      expect(chatMessageQueue.get(conversationId).map((m) => m.text)).toEqual([
+        "first queued",
+      ]);
+
+      chatMessageQueue.clear(conversationId);
+    });
+
+    it("prefixes a queued skill command when popping it back", () => {
+      mockFeatureState.betaEnabled = true;
+      const conversationId = "conv-arrowup-skill";
+      chatMessageQueue.clear(conversationId);
+      chatMessageQueue.enqueue(conversationId, {
+        text: "do the thing",
+        skill: { name: "helper" } as ChatSkillMetadata,
+      });
+      mockControllerState.value = "";
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          conversationId={conversationId}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getByTestId(E2eTestId.ChatPromptTextarea), {
+        key: "ArrowUp",
+      });
+
+      expect(mockTextInputSetInput).toHaveBeenCalledWith(
+        "/helper do the thing",
+      );
+      chatMessageQueue.clear(conversationId);
+    });
+
+    it("leaves the queue alone on ArrowUp when the composer already has text", () => {
+      mockFeatureState.betaEnabled = true;
+      const conversationId = "conv-arrowup-nonempty";
+      chatMessageQueue.clear(conversationId);
+      chatMessageQueue.enqueue(conversationId, { text: "queued" });
+      mockControllerState.value = "typing";
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          conversationId={conversationId}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getByTestId(E2eTestId.ChatPromptTextarea), {
+        key: "ArrowUp",
+      });
+
+      // ArrowUp is ignored while typing: the queue is untouched and the typed
+      // text is never replaced by a queued message.
+      expect(mockTextInputSetInput).not.toHaveBeenCalledWith("queued");
+      expect(chatMessageQueue.get(conversationId)).toHaveLength(1);
+      chatMessageQueue.clear(conversationId);
+    });
+
+    it("stops the in-flight response on Escape", () => {
+      const onStop = vi.fn();
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          status="streaming"
+          onStop={onStop}
+          conversationId="conv-escape-stop"
+        />,
+      );
+
+      fireEvent.keyDown(screen.getByTestId(E2eTestId.ChatPromptTextarea), {
+        key: "Escape",
+      });
+
+      expect(onStop).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not stop on Escape when no response is in flight", () => {
+      const onStop = vi.fn();
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          status="ready"
+          onStop={onStop}
+          conversationId="conv-escape-idle"
+        />,
+      );
+
+      fireEvent.keyDown(screen.getByTestId(E2eTestId.ChatPromptTextarea), {
+        key: "Escape",
+      });
+
+      expect(onStop).not.toHaveBeenCalled();
     });
   });
 });

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -50,6 +50,12 @@ import {
 } from "@/components/ai-elements/queue";
 import { PlaywrightInstallInline } from "@/components/chat/playwright-install-dialog";
 import { SensitiveDataConfirmDialog } from "@/components/chat/sensitive-data-confirm-dialog";
+import { Kbd } from "@/components/ui/kbd";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useProfile } from "@/lib/agent.query";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import { useConversation, useToggleHooksDebug } from "@/lib/chat/chat.query";
@@ -465,53 +471,6 @@ const PromptInputContent = ({
     [controller.textInput, runCompactCommand, runDebugCommand, textareaRef],
   );
 
-  const handleTextareaKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (!isSlashCommandOpen || visibleSlashCommands.length === 0) {
-        return;
-      }
-
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setActiveCommandIndex(
-          (current) => (current + 1) % visibleSlashCommands.length,
-        );
-        return;
-      }
-
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setActiveCommandIndex(
-          (current) =>
-            (current - 1 + visibleSlashCommands.length) %
-            visibleSlashCommands.length,
-        );
-        return;
-      }
-
-      if (event.key === "Enter" && !event.shiftKey) {
-        event.preventDefault();
-        const command = visibleSlashCommands[selectedCommandIndex];
-        if (command) {
-          selectSlashCommand(command);
-        }
-        return;
-      }
-
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setDismissedSlashCommandValue(controller.textInput.value);
-      }
-    },
-    [
-      controller.textInput.value,
-      isSlashCommandOpen,
-      selectSlashCommand,
-      selectedCommandIndex,
-      visibleSlashCommands,
-    ],
-  );
-
   const sensitiveDataDetectionEnabled =
     useFeature("chatSecretScanEnabled") ?? false;
   const [sensitiveDataDialogOpen, setSensitiveDataDialogOpen] = useState(false);
@@ -677,6 +636,102 @@ const PromptInputContent = ({
   // order) by the conversation's chat session once each turn settles.
   const queuedMessages = useConversationMessageQueue(
     isMessageQueueEnabled ? conversationId : undefined,
+  );
+
+  // Composer keyboard shortcuts layered on top of the primitive textarea:
+  //   • Esc — stop the in-flight response (mirrors the Stop button).
+  //   • ArrowUp on an empty composer — pop the most recently queued message
+  //     back into the input to edit / resend (like shell history recall).
+  // Both defer to the slash-command menu when it is open: Esc dismisses that
+  // menu and ArrowUp navigates it (handled further down).
+  const handleTextareaKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (
+        event.key === "Escape" &&
+        !isSlashCommandOpen &&
+        isResponseInFlight &&
+        onStop
+      ) {
+        event.preventDefault();
+        onStop();
+        return;
+      }
+
+      if (
+        event.key === "ArrowUp" &&
+        !isSlashCommandOpen &&
+        isMessageQueueEnabled &&
+        conversationId &&
+        controller.textInput.value === "" &&
+        queuedMessages.length > 0
+      ) {
+        event.preventDefault();
+        const mostRecent = queuedMessages[queuedMessages.length - 1];
+        if (mostRecent) {
+          chatMessageQueue.remove(conversationId, mostRecent.id);
+          const restored = `${
+            mostRecent.skill ? `/${mostRecent.skill.name} ` : ""
+          }${mostRecent.text}`;
+          controller.textInput.setInput(restored);
+          // Caret to the end so the user can append / edit immediately.
+          requestAnimationFrame(() => {
+            const element = textareaRef.current;
+            element?.focus();
+            element?.setSelectionRange(restored.length, restored.length);
+          });
+        }
+        return;
+      }
+
+      if (!isSlashCommandOpen || visibleSlashCommands.length === 0) {
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveCommandIndex(
+          (current) => (current + 1) % visibleSlashCommands.length,
+        );
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveCommandIndex(
+          (current) =>
+            (current - 1 + visibleSlashCommands.length) %
+            visibleSlashCommands.length,
+        );
+        return;
+      }
+
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        const command = visibleSlashCommands[selectedCommandIndex];
+        if (command) {
+          selectSlashCommand(command);
+        }
+        return;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setDismissedSlashCommandValue(controller.textInput.value);
+      }
+    },
+    [
+      conversationId,
+      controller.textInput,
+      isMessageQueueEnabled,
+      isResponseInFlight,
+      isSlashCommandOpen,
+      onStop,
+      queuedMessages,
+      selectSlashCommand,
+      selectedCommandIndex,
+      textareaRef,
+      visibleSlashCommands,
+    ],
   );
 
   return (
@@ -861,22 +916,38 @@ const PromptInputContent = ({
               textareaRef={textareaRef}
               onTranscriptionChange={handleTranscriptionChange}
             />
-            <PromptInputSubmit
-              className="!h-8"
-              status={submitStatus}
-              disabled={submitDisabled || isContextCompacting}
-              onClick={(event) => {
-                // While a response is in-flight the button shows Stop; a
-                // click stops the stream instead of submitting the form
-                // (which would queue the typed text — see onStop docs). With
-                // queueing off, the click falls through to the form submit,
-                // whose handler stops the stream (the pre-queue behavior).
-                if (isMessageQueueEnabled && onStop && isResponseInFlight) {
-                  event.preventDefault();
-                  onStop();
-                }
-              }}
-            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <PromptInputSubmit
+                  className="!h-8"
+                  status={submitStatus}
+                  disabled={submitDisabled || isContextCompacting}
+                  onClick={(event) => {
+                    // While a response is in-flight the button shows Stop; a
+                    // click stops the stream instead of submitting the form
+                    // (which would queue the typed text — see onStop docs).
+                    // With queueing off, the click falls through to the form
+                    // submit, whose handler stops the stream (pre-queue
+                    // behavior).
+                    if (isMessageQueueEnabled && onStop && isResponseInFlight) {
+                      event.preventDefault();
+                      onStop();
+                    }
+                  }}
+                />
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {isResponseInFlight && onStop ? (
+                  <span className="flex items-center gap-1.5">
+                    Stop <Kbd>Esc</Kbd>
+                  </span>
+                ) : (
+                  <span className="flex items-center gap-1.5">
+                    Send <Kbd>Enter</Kbd>
+                  </span>
+                )}
+              </TooltipContent>
+            </Tooltip>
           </div>
         </PromptInputFooter>
       </PromptInput>

--- a/platform/frontend/src/components/ui/kbd.tsx
+++ b/platform/frontend/src/components/ui/kbd.tsx
@@ -1,0 +1,20 @@
+import type { ComponentProps } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * A single keycap for rendering a keyboard shortcut — inside a tooltip, a
+ * command-palette footer, etc. Use one <Kbd> per key so multi-key shortcuts
+ * read as separate caps: `<Kbd>⌘</Kbd><Kbd>K</Kbd>`. Shared so every shortcut
+ * hint in the app renders with the same styling.
+ */
+export function Kbd({ className, ...props }: ComponentProps<"kbd">) {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex h-5 min-w-[20px] items-center justify-center rounded border border-border/50 bg-muted px-1.5 font-sans text-[10px] font-medium text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/platform/frontend/src/components/ui/sidebar.tsx
+++ b/platform/frontend/src/components/ui/sidebar.tsx
@@ -13,6 +13,7 @@ import * as React from "react";
 import { OnboardingDot } from "@/components/onboarding-dot";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Kbd } from "@/components/ui/kbd";
 import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
@@ -301,16 +302,16 @@ function SidebarTrigger({
       </TooltipTrigger>
       <TooltipContent side="right">
         {isCollapsed ? (
-          <span>
+          <span className="flex items-center gap-1.5">
             Toggle Sidebar{" "}
-            <kbd className="ml-1 rounded border bg-muted px-1 py-0.5 text-[11px] font-mono">
+            <Kbd>
               {modLabel} + {SHORTCUT_SIDEBAR.label}
-            </kbd>
+            </Kbd>
           </span>
         ) : (
-          <span className="text-[11px] font-mono">
+          <Kbd>
             {modLabel} + {SHORTCUT_SIDEBAR.label}
-          </span>
+          </Kbd>
         )}
       </TooltipContent>
     </Tooltip>
@@ -389,9 +390,9 @@ function SidebarCircleToggle({
         </button>
       </TooltipTrigger>
       <TooltipContent side="right">
-        <span className="text-[11px] font-mono">
+        <Kbd>
           {modLabel} + {SHORTCUT_SIDEBAR.label}
-        </span>
+        </Kbd>
       </TooltipContent>
     </Tooltip>
   );

--- a/platform/frontend/src/lib/chat/chat-submit-action.test.ts
+++ b/platform/frontend/src/lib/chat/chat-submit-action.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { classifyChatSubmitAction } from "@/lib/chat/chat-submit-action";
+
+describe("classifyChatSubmitAction", () => {
+  it("sends when idle with an empty pipeline", () => {
+    expect(
+      classifyChatSubmitAction({
+        status: "ready",
+        queueEnabled: true,
+        directSendPending: false,
+      }),
+    ).toBe("send");
+  });
+
+  it("queues a submit made while a turn is streaming", () => {
+    for (const status of ["submitted", "streaming"]) {
+      expect(
+        classifyChatSubmitAction({
+          status,
+          queueEnabled: true,
+          directSendPending: false,
+        }),
+      ).toBe("queue");
+    }
+  });
+
+  it("stops instead of queueing when queueing is off and a turn is streaming", () => {
+    for (const status of ["submitted", "streaming"]) {
+      expect(
+        classifyChatSubmitAction({
+          status,
+          queueEnabled: false,
+          directSendPending: false,
+        }),
+      ).toBe("stop");
+    }
+  });
+
+  // The regression: after a direct send fires, the page's `status` still reads
+  // "ready" for a render or two. A follow-up submit in that window must queue,
+  // not start a second racing direct send (which reaches the model but clobbers
+  // the first send's optimistic message so it never renders).
+  it("queues a follow-up while a direct send is still settling (status lag)", () => {
+    expect(
+      classifyChatSubmitAction({
+        status: "ready",
+        queueEnabled: true,
+        directSendPending: true,
+      }),
+    ).toBe("queue");
+  });
+
+  it("does not treat a settling direct send as reason to queue when queueing is off", () => {
+    // With queueing off there is nowhere to queue; the direct-send latch is
+    // only ever set when queueing is on, but guard the classification anyway.
+    expect(
+      classifyChatSubmitAction({
+        status: "ready",
+        queueEnabled: false,
+        directSendPending: true,
+      }),
+    ).toBe("send");
+  });
+});

--- a/platform/frontend/src/lib/chat/chat-submit-action.ts
+++ b/platform/frontend/src/lib/chat/chat-submit-action.ts
@@ -1,0 +1,40 @@
+// Decides what a chat composer submit should do, given the current send state.
+// Extracted from the chat page's handleSubmit so the routing contract can be
+// unit-tested in isolation (the page component itself is too large to exercise
+// this branch reliably).
+//
+// The subtlety this encodes: the `status` the page reads is a snapshot from the
+// shared session map, which lags the real AI SDK status by a render. Right
+// after a direct send fires, the turn is already in flight but `status` can
+// still read "ready" for a tick or two. `directSendPending` carries that fact
+// synchronously so follow-up submits queue instead of starting a second,
+// racing direct send (concurrent sends reach the model but clobber each other's
+// optimistic message, so most never render).
+
+export type ChatSubmitAction = "queue" | "stop" | "send";
+
+export function classifyChatSubmitAction(params: {
+  /** AI SDK useChat status snapshot as seen by the page. */
+  status: string;
+  /** Message queueing is on (beta) AND a conversation exists to queue into. */
+  queueEnabled: boolean;
+  /** A direct send fired but the page's `status` hasn't caught up yet. */
+  directSendPending: boolean;
+}): ChatSubmitAction {
+  const { status, queueEnabled, directSendPending } = params;
+  const isStreaming = status === "submitted" || status === "streaming";
+
+  if (isStreaming) {
+    // Submitting mid-turn queues the message with queueing on; without it, the
+    // submit button doubles as Stop.
+    return queueEnabled ? "queue" : "stop";
+  }
+
+  // Status reads idle, but a direct send we just issued is still settling — the
+  // turn is live, so queue the follow-up rather than race it.
+  if (queueEnabled && directSendPending) {
+    return "queue";
+  }
+
+  return "send";
+}

--- a/platform/frontend/src/lib/chat/chat-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.test.ts
@@ -305,7 +305,9 @@ describe("mergePersistedMessageMetadata", () => {
       "live-assistant-2",
     ]);
     // the unpersisted in-flight user turn keeps its text
-    expect(mergedMessages[2]?.parts).toEqual([{ type: "text", text: "second" }]);
+    expect(mergedMessages[2]?.parts).toEqual([
+      { type: "text", text: "second" },
+    ]);
   });
 
   it("returns the original array when no metadata changes are needed", () => {

--- a/platform/frontend/src/lib/chat/chat-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-utils.test.ts
@@ -251,6 +251,63 @@ describe("mergePersistedMessageMetadata", () => {
     });
   });
 
+  // Regression: during rapid queue drain the persisted snapshot trails the live
+  // thread, so the just-sent user turn (and its streaming reply) are not in it
+  // yet. The merge must keep every live message — it feeds setMessages, so
+  // dropping the unpersisted tail here would erase the in-flight user bubble
+  // from the thread until a reload.
+  it("preserves the in-flight tail when the live thread is longer than persisted", () => {
+    const liveMessages = [
+      {
+        id: "live-user-1",
+        role: "user",
+        parts: [{ type: "text", text: "first" }],
+      },
+      {
+        id: "live-assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "reply" }],
+      },
+      // in-flight turn the backend has not persisted yet
+      {
+        id: "live-user-2",
+        role: "user",
+        parts: [{ type: "text", text: "second" }],
+      },
+      {
+        id: "live-assistant-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "streaming…" }],
+      },
+    ] as UIMessage[];
+    const persistedMessages = [
+      {
+        id: "db-user-1",
+        role: "user",
+        parts: [{ type: "text", text: "first" }],
+      },
+      {
+        id: "db-assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "reply" }],
+      },
+    ] as UIMessage[];
+
+    const mergedMessages = mergePersistedMessageMetadata({
+      liveMessages,
+      persistedMessages,
+    });
+
+    expect(mergedMessages.map((message) => message.id)).toEqual([
+      "live-user-1",
+      "live-assistant-1",
+      "live-user-2",
+      "live-assistant-2",
+    ]);
+    // the unpersisted in-flight user turn keeps its text
+    expect(mergedMessages[2]?.parts).toEqual([{ type: "text", text: "second" }]);
+  });
+
   it("returns the original array when no metadata changes are needed", () => {
     const liveMessages = [
       {


### PR DESCRIPTION
Fixes queued chat messages being sent to the model but not rendered, plus a few composer keyboard-UX touches for the message queue.

## Bug fix 1 — rapid submits race the direct-send path (`handleSubmit`)

`handleSubmit` decides *enqueue vs. direct-send* from `status`, read out of the shared session map. Each `ChatSessionHook` updates that map only in a post-render `useEffect` → `notifySessionUpdate()`, so the page's `status` trails the real AI SDK status by a full React round-trip. Right after a direct `sendMessage` fires, the SDK is busy but the page can still read `"ready"` for a tick or two — so rapid follow-up submits take the direct-send path again and race each other inside the single `useChat` instance. Each POSTs to the model, but the concurrent sends clobber each other's optimistic user bubble, so most never render.

**Fix:** a synchronous `directSendPendingRef` latch — only the first submit of a turn direct-sends; follow-ups enqueue and drain in order until `status` catches up. Routing extracted into a pure, unit-tested `classifyChatSubmitAction` helper.

## Bug fix 2 — persisted-metadata sync shrinks the SDK thread (`syncPersistedMessageMetadata`)

The one that survived fix 1: messages drain to the model, the assistant answers, but the **user bubbles don't render until you refresh**. `syncPersistedMessageMetadata` merged persisted metadata against the lagged `chatSession.messages` session snapshot and wrote it back with `setMessages`. During rapid drain that snapshot is missing the just-sent user turn, so the write **shrinks the SDK thread and drops the in-flight user message**; the ongoing stream only re-adds the assistant reply. **Fix:** merge against the SDK's current thread via the functional `setMessages` updater, so it can never shrink from a stale snapshot.

## UX — composer keyboard shortcuts

- **ArrowUp** on an empty composer pops the most recently queued message back into the input (removing it from the queue) to edit / re-send — shell-history-style recall.
- **Esc** while a response is in flight stops the stream (mirrors the Stop button; defers to the slash-command menu when open).
- The submit button now shows a **keyboard-shortcut tooltip**: `Enter` when it will send, `Esc` when it will stop.
- Added a shared `<Kbd>` keycap component (`components/ui/kbd.tsx`) for the hints and retrofitted the sidebar's inline `<kbd>`/mono spans onto it for consistent styling.

## Testing

- `classifyChatSubmitAction` unit tests (status-lag regression); `mergePersistedMessageMetadata` regression test (preserves the unpersisted in-flight tail).
- New composer tests: ArrowUp recall (incl. skill-prefix reconstruction + empty-composer guard) and Esc-to-stop; file-upload tooltip tests scoped now that the composer renders more than one tooltip.
- `pnpm type-check` + `pnpm lint` + `pnpm knip` clean; full frontend suite green (2642 tests).
- The sub-100ms timing races themselves aren't covered by e2e (non-deterministic in Playwright); the load-bearing decision/merge contracts are pinned at the unit level. Worth a manual pass of the fill-queue → stop → rapid-type flow in a running env.
