### PR TITLE
fix(k8s): reconcile MCP egress policies on runtime start

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -208,6 +208,17 @@ export class McpServerRuntimeManager {
         logger.info(`${successes.length} MCP server(s) started successfully`);
       }
 
+      // Re-assert every server's egress policy so a restart reconciles floors for
+      // already-running servers, not only newly-created ones. Without this a
+      // server whose deploy path didn't (re)apply its floor stays under the
+      // namespace deny-all baseline — no egress — until a manual policy change.
+      await this.reconcileEgressPolicies({
+        localServers,
+        localCatalogItems,
+        capabilities: networkPolicyCapabilities,
+        cache: networkPolicyResolutionCache,
+      });
+
       logger.info("MCP Server Runtime initialization complete");
       this.onRuntimeStartupSuccess();
 
@@ -253,6 +264,83 @@ export class McpServerRuntimeManager {
       this.egressBaselineByNamespace.set(namespace, ensured);
     }
     return ensured;
+  }
+
+  /**
+   * Re-assert every local MCP server's egress policy (baseline + per-pod floor /
+   * off / restricted), policy-only — no pod redeploy. Runs at the end of start()
+   * so a restart re-applies the per-pod policy to servers that were already
+   * running (or whose deploy path skipped it), instead of leaving them under the
+   * namespace deny-all baseline with no floor — no egress — until a manual policy
+   * change. Per-server failures are logged and skipped so one server can't abort
+   * the sweep.
+   */
+  private async reconcileEgressPolicies(params: {
+    localServers: McpServer[];
+    localCatalogItems: CatalogItem[];
+    capabilities: K8sNetworkPolicyCapabilities;
+    cache: NetworkPolicyResolutionCache;
+  }): Promise<void> {
+    const {
+      k8sApi,
+      k8sAppsApi,
+      k8sNetworkingApi,
+      k8sCustomObjectsApi,
+      k8sAttach,
+      k8sLog,
+      k8sExec,
+    } = this;
+    if (
+      !k8sApi ||
+      !k8sAppsApi ||
+      !k8sNetworkingApi ||
+      !k8sCustomObjectsApi ||
+      !k8sAttach ||
+      !k8sLog ||
+      !k8sExec
+    ) {
+      return;
+    }
+
+    logger.info(
+      `Reconciling egress policies for ${params.localServers.length} MCP server(s)`,
+    );
+
+    for (let i = 0; i < params.localServers.length; i++) {
+      const mcpServer = params.localServers[i];
+      const catalogItem = params.localCatalogItems[i];
+      try {
+        const namespace = await this.resolveNamespaceForCatalog(
+          catalogItem,
+          params.cache,
+        );
+        await this.ensureEgressBaseline(namespace, params.capabilities);
+        const k8sDeployment = new K8sDeployment({
+          mcpServer,
+          k8sApi,
+          k8sAppsApi,
+          k8sNetworkingApi,
+          k8sCustomObjectsApi,
+          k8sAttach,
+          k8sLog,
+          k8sExec,
+          namespace,
+          catalogItem,
+          effectiveNetworkPolicy: await this.resolveNetworkPolicyForDeployment({
+            mcpServer,
+            catalogItem,
+            cache: params.cache,
+          }),
+          networkPolicyCapabilities: params.capabilities,
+        });
+        await k8sDeployment.applyK8sNetworkPolicy();
+      } catch (err) {
+        logger.warn(
+          { err, mcpServerId: mcpServer.id },
+          "Failed to reconcile egress policy for MCP server on startup",
+        );
+      }
+    }
   }
 
   private async resolveNamespaceForCatalog(


### PR DESCRIPTION
MCP server pods are confined by an always-on namespace default-deny egress baseline plus a per-pod egress policy. The per-pod policy was applied only when a server was deployed — nothing re-asserted it for already-running servers when the backend restarts.

The consequence on a rollout: any server whose per-pod policy is not re-applied — a deploy path that skipped it, or a `startServer` failure — is left selected only by the deny-all baseline, so it has no egress and no DNS, and stays that way until someone manually edits the environment policy to force a reconcile. Servers that need egress at startup (npm/npx installs, config fetches) crashloop instead of coming up.

This adds a reconcile pass at the end of runtime `start()`: for every local MCP server it re-asserts the namespace baseline and the per-pod egress policy, policy-only (no pod redeploy), skipping and logging per-server failures so one server can't abort the sweep. A backend restart now reconciles egress for all servers, not only newly-created ones.