### PR TITLE
fix(skills): slugify SKILL.md names so shared skills install as working slash commands

### DIFF
--- a/docs/pages/platform-agent-skills-sharing.md
+++ b/docs/pages/platform-agent-skills-sharing.md
@@ -3,14 +3,14 @@ title: Sharing Skills
 category: Agents
 order: 4
 description: Share Archestra skills into Claude Code, Codex CLI, Copilot CLI, and Cursor through native plugin marketplaces
-lastUpdated: 2026-06-10
+lastUpdated: 2026-07-13
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
 
 Archestra skills can be installed into your local Claude Code, Codex CLI, Copilot CLI, or Cursor IDE through each tool's native plugin marketplace. A signed share link points the client at an Archestra-hosted git repository that serves the marketplaces in parallel — Claude reads `.claude-plugin/marketplace.json`, Codex and Copilot read `.agents/plugins/marketplace.json`, Cursor reads `.cursor-plugin/marketplace.json`, and the underlying `SKILL.md` files are identical.
 
-Every shared skill is bundled into a single plugin so the user installs one thing instead of one-per-skill. The plugin name is the marketplace name (e.g. `archestra-acme-corp-skills`), and each skill lives under `skills/<slug>/` inside that plugin. Anthropic's official marketplaces follow the same one-plugin-per-toolkit convention.
+Every shared skill is bundled into a single plugin so the user installs one thing instead of one-per-skill. The plugin name is the marketplace name (e.g. `archestra-acme-corp-skills`), and each skill lives under `skills/<slug>/` inside that plugin. The slug is also written as the SKILL.md frontmatter `name`, per the Agent Skills spec, so the skill's slash command is well-formed (a skill named "Build App" installs as `/build-app`). Anthropic's official marketplaces follow the same one-plugin-per-toolkit convention.
 
 The marketplace lives at `/connection` alongside the MCP Gateway and LLM Proxy connection flows. For Claude Code, Codex, Copilot CLI, and Cursor the skills install is part of the one-command setup by default: the generated `curl | bash` command registers the marketplace automatically (a fresh share link is created when the script is fetched); the review step lists the skills and lets you deselect individual ones. Picking "Any client" keeps the manual "Install shared skills" step that snapshots every current skill into one link.
 

--- a/platform/backend/src/models/skill-share-link.test.ts
+++ b/platform/backend/src/models/skill-share-link.test.ts
@@ -5,17 +5,22 @@ import { SKILL_SHARE_LINK_TOKEN_PREFIX } from "@/models/skill-share-link";
 import { describe, expect, test } from "@/test";
 import { deriveSkillShareLinkStatus, type SkillShareLink } from "@/types";
 
-async function seedSkill(params: { organizationId: string; name: string }) {
+async function seedSkill(params: {
+  organizationId: string;
+  name: string;
+  authorId?: string | null;
+  scope?: "personal" | "org";
+}) {
   const skill = await SkillModel.createWithFiles({
     skill: {
       organizationId: params.organizationId,
-      authorId: null,
+      authorId: params.authorId ?? null,
       name: params.name,
       description: `${params.name} description`,
       content: `# ${params.name}`,
       metadata: {},
       sourceType: "manual",
-      scope: "org",
+      scope: params.scope ?? "org",
     },
     files: [],
   });
@@ -121,6 +126,40 @@ describe("SkillShareLinkModel.validate", () => {
     const result = await SkillShareLinkModel.validate({ rawToken });
     expect(result).not.toBeNull();
     expect(result?.skills.map((s) => s.id)).toEqual([skill.id]);
+  });
+
+  test("orders same-named skills deterministically by id", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const authorA = await makeUser();
+    const authorB = await makeUser();
+    await makeMember(user.id, org.id);
+    const a = await seedSkill({
+      organizationId: org.id,
+      name: "Duplicate Name",
+      authorId: authorA.id,
+      scope: "personal",
+    });
+    const b = await seedSkill({
+      organizationId: org.id,
+      name: "Duplicate Name",
+      authorId: authorB.id,
+      scope: "personal",
+    });
+
+    const { rawToken } = await SkillShareLinkModel.create({
+      organizationId: org.id,
+      createdByUserId: user.id,
+      skillIds: [a.id, b.id],
+      marketplaceName: "org-12345678-skills",
+    });
+
+    const result = await SkillShareLinkModel.validate({ rawToken });
+    expect(result?.skills.map((s) => s.id)).toEqual([a.id, b.id].sort());
   });
 
   test("returns null for an unknown token", async () => {

--- a/platform/backend/src/models/skill-share-link.ts
+++ b/platform/backend/src/models/skill-share-link.ts
@@ -273,7 +273,7 @@ async function loadSkillsForLinks(
       eq(schema.skillShareLinkSkillsTable.skillId, schema.skillsTable.id),
     )
     .where(inArray(schema.skillShareLinkSkillsTable.shareLinkId, linkIds))
-    .orderBy(schema.skillsTable.name);
+    .orderBy(schema.skillsTable.name, schema.skillsTable.id);
 
   for (const row of rows) {
     const list = map.get(row.shareLinkId);

--- a/platform/backend/src/routes/skill-marketplace-public.test.ts
+++ b/platform/backend/src/routes/skill-marketplace-public.test.ts
@@ -280,7 +280,7 @@ describe.skipIf(!GIT_HTTP_BACKEND_AVAILABLE)(
         path.join(target, "plugins/org-test-skills/skills/clone-me/SKILL.md"),
         "utf8",
       );
-      expect(skillMd).toContain("name: Clone Me");
+      expect(skillMd).toContain("name: clone-me");
       expect(skillMd).toContain("# Clone Me");
     }, 30_000);
   },

--- a/platform/backend/src/skills/marketplace/layout.test.ts
+++ b/platform/backend/src/skills/marketplace/layout.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { parseSkillManifest } from "@/skills/parser";
 import type { SkillFile } from "@/types";
 import { computeLayout, type MaterializeSkillInput } from "./layout";
 
@@ -14,7 +15,10 @@ function makeResourceFile(path: string): SkillFile {
   };
 }
 
-function makeSkill(files: SkillFile[]): MaterializeSkillInput {
+function makeSkill(
+  files: SkillFile[],
+  overrides: Partial<MaterializeSkillInput> = {},
+): MaterializeSkillInput {
   return {
     id: "11111111-2222-3333-4444-555555555555",
     name: "PDF Helper",
@@ -27,6 +31,7 @@ function makeSkill(files: SkillFile[]): MaterializeSkillInput {
     metadata: {},
     updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     files,
+    ...overrides,
   };
 }
 
@@ -106,5 +111,46 @@ describe("computeLayout", () => {
     // materialize.ts re-splits stored paths, so a backslash ".." segment must
     // be rejected too, not just POSIX "../".
     expect(files.some((f) => /evil\.md$/.test(f.path))).toBe(false);
+  });
+
+  test("every SKILL.md frontmatter name equals its directory, matches the Agent Skills spec, and is unique", () => {
+    const files = computeLayout({
+      linkId: "aaaaaaaa-1111-2222-3333-444444444444",
+      marketplaceName: "org-abcd1234-skills",
+      ownerName: "Acme Corp",
+      displayName: "Acme Skills",
+      skills: [
+        makeSkill([], { id: "a1", name: "Archestra Platform Operations" }),
+        makeSkill([], { id: "a2", name: "Build App" }),
+        makeSkill([], { id: "a3", name: "PDF Helper" }),
+        // collides with the previous slug → disambiguated with -2
+        makeSkill([], { id: "a4", name: "PDF HELPER" }),
+        // slugifies to empty → id-derived fallback
+        makeSkill([], {
+          id: "eeeeeeee-1111-2222-3333-444444444444",
+          name: "🎉🎉",
+        }),
+        // longer than the spec's 64-char cap
+        makeSkill([], { id: "a5", name: "x".repeat(80) }),
+      ],
+    });
+
+    const skillMds = files.filter((f) =>
+      /^plugins\/[^/]+\/skills\/[^/]+\/SKILL\.md$/.test(f.path),
+    );
+    expect(skillMds).toHaveLength(6);
+
+    const seen = new Set<string>();
+    for (const file of skillMds) {
+      const dir = file.path.split("/").at(-2);
+      const parsed = parseSkillManifest(file.content);
+      // clients derive the slash command from the frontmatter name, and the
+      // Agent Skills spec requires it to equal the directory name
+      expect(parsed.name).toBe(dir);
+      expect(parsed.name).toMatch(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/);
+      expect(parsed.name.length).toBeLessThanOrEqual(64);
+      seen.add(parsed.name);
+    }
+    expect(seen.size).toBe(skillMds.length);
   });
 });

--- a/platform/backend/src/skills/marketplace/layout.test.ts
+++ b/platform/backend/src/skills/marketplace/layout.test.ts
@@ -113,6 +113,31 @@ describe("computeLayout", () => {
     expect(files.some((f) => /evil\.md$/.test(f.path))).toBe(false);
   });
 
+  test("preserves the display name in metadata, letting an author-provided displayName win", () => {
+    const files = computeLayout({
+      linkId: "aaaaaaaa-1111-2222-3333-444444444444",
+      marketplaceName: "org-abcd1234-skills",
+      ownerName: "Acme Corp",
+      displayName: "Acme Skills",
+      skills: [
+        makeSkill([], { id: "a1", name: "PDF Helper" }),
+        makeSkill([], {
+          id: "a2",
+          name: "Build App",
+          metadata: { displayName: "Custom Label" },
+        }),
+      ],
+    });
+
+    const byDir = new Map(
+      files
+        .filter((f) => f.path.endsWith("/SKILL.md"))
+        .map((f) => [f.path.split("/").at(-2), parseSkillManifest(f.content)]),
+    );
+    expect(byDir.get("pdf-helper")?.metadata.displayName).toBe("PDF Helper");
+    expect(byDir.get("build-app")?.metadata.displayName).toBe("Custom Label");
+  });
+
   test("every SKILL.md frontmatter name equals its directory, matches the Agent Skills spec, and is unique", () => {
     const files = computeLayout({
       linkId: "aaaaaaaa-1111-2222-3333-444444444444",
@@ -144,10 +169,8 @@ describe("computeLayout", () => {
     for (const file of skillMds) {
       const dir = file.path.split("/").at(-2);
       const parsed = parseSkillManifest(file.content);
-      // clients derive the slash command from the frontmatter name, and the
-      // Agent Skills spec requires it to equal the directory name
       expect(parsed.name).toBe(dir);
-      expect(parsed.name).toMatch(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/);
+      expect(parsed.name).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
       expect(parsed.name.length).toBeLessThanOrEqual(64);
       seen.add(parsed.name);
     }

--- a/platform/backend/src/skills/marketplace/layout.ts
+++ b/platform/backend/src/skills/marketplace/layout.ts
@@ -171,9 +171,7 @@ function buildSkillMarkdown(
   if (skill.compatibility) frontmatter.compatibility = skill.compatibility;
   if (skill.allowedTools) frontmatter["allowed-tools"] = skill.allowedTools;
   if (skill.templated) frontmatter.templated = true;
-  if (skill.metadata && Object.keys(skill.metadata).length > 0) {
-    frontmatter.metadata = skill.metadata;
-  }
+  frontmatter.metadata = { displayName: skill.name, ...skill.metadata };
 
   const yamlBody = dumpYaml(frontmatter, {
     sortKeys: false,

--- a/platform/backend/src/skills/marketplace/layout.ts
+++ b/platform/backend/src/skills/marketplace/layout.ts
@@ -122,7 +122,7 @@ export function computeLayout(req: MaterializeRequest): RevisionPayloadFile[] {
     const skillRoot = `${pluginRoot}/skills/${slug}`;
     const skillMd = textFile(
       `${skillRoot}/SKILL.md`,
-      buildSkillMarkdown(skill),
+      buildSkillMarkdown(skill, slug),
     );
     files.push(skillMd);
     seenLowerPaths.add(skillMd.path.toLowerCase());
@@ -156,9 +156,15 @@ function jsonStringify(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 
-function buildSkillMarkdown(skill: MaterializeSkillInput): string {
+function buildSkillMarkdown(
+  skill: MaterializeSkillInput,
+  slug: string,
+): string {
+  // The Agent Skills spec requires frontmatter `name` to be a kebab slug that
+  // equals the parent directory name — clients derive the slash command from
+  // it, so the display name (which may contain spaces) must not leak here.
   const frontmatter: Record<string, unknown> = {
-    name: skill.name,
+    name: slug,
     description: skill.description,
   };
   if (skill.license) frontmatter.license = skill.license;

--- a/platform/backend/src/skills/marketplace/manifest.test.ts
+++ b/platform/backend/src/skills/marketplace/manifest.test.ts
@@ -95,6 +95,30 @@ describe("resolveMarketplaceSkills", () => {
     expect(skill.slug).toBe("skill-abcdef12");
   });
 
+  test("caps slugs at 64 characters and trims a trailing hyphen at the cut", () => {
+    const [long] = resolveMarketplaceSkills([
+      makeSkill({ name: "x".repeat(80) }),
+    ]);
+    expect(long.slug).toBe("x".repeat(64));
+
+    // the cut lands on the separator hyphen, which must not survive
+    const [cutOnHyphen] = resolveMarketplaceSkills([
+      makeSkill({ name: `${"a".repeat(63)} b` }),
+    ]);
+    expect(cutOnHyphen.slug).toBe("a".repeat(63));
+  });
+
+  test("collision suffixes stay within the 64-char cap", () => {
+    const resolved = resolveMarketplaceSkills([
+      makeSkill({ id: "a", name: "x".repeat(70) }),
+      makeSkill({ id: "b", name: "x".repeat(70) }),
+    ]);
+    expect(resolved.map((s) => s.slug)).toEqual([
+      "x".repeat(64),
+      `${"x".repeat(62)}-2`,
+    ]);
+  });
+
   test("preserves input order", () => {
     const skills = [
       makeSkill({ id: "b", name: "Beta" }),

--- a/platform/backend/src/skills/marketplace/manifest.ts
+++ b/platform/backend/src/skills/marketplace/manifest.ts
@@ -115,7 +115,8 @@ export function resolveMarketplaceSkills(
     let slug = base;
     let counter = 2;
     while (used.has(slug)) {
-      slug = `${base}-${counter}`;
+      const suffix = `-${counter}`;
+      slug = `${truncateSlug(base, MAX_SKILL_SLUG_LENGTH - suffix.length)}${suffix}`;
       counter += 1;
     }
     used.add(slug);
@@ -130,15 +131,18 @@ export function resolveMarketplaceSkills(
 }
 
 /**
- * Version for the single bundle plugin. Derived from the sorted set of skill
- * (id, updatedAt) pairs so two replicas materializing the same input agree on
- * the same value, and editing any skill bumps the version exactly once.
+ * Version for the single bundle plugin. Derived from the layout format
+ * version plus the sorted set of skill (id, updatedAt) pairs so two replicas
+ * materializing the same input agree on the same value, and editing any skill
+ * (or changing the layout format) bumps the version exactly once.
  * @public — exported for testability
  */
 export function resolveBundleVersion(skills: MarketplaceSkillInput[]): string {
   if (skills.length === 0) return "0.0.0+empty";
   const sorted = [...skills].sort((a, b) => a.id.localeCompare(b.id));
   const h = createHash("sha256");
+  h.update(LAYOUT_FORMAT_VERSION);
+  h.update("\0");
   for (const s of sorted) {
     h.update(s.id);
     h.update("\0");
@@ -225,7 +229,7 @@ interface SimpleManifestParams {
 }
 
 function baseSlug(skill: MarketplaceSkillInput): string {
-  const slugged = urlSlugify(skill.name);
+  const slugged = truncateSlug(urlSlugify(skill.name), MAX_SKILL_SLUG_LENGTH);
   if (slugged) return slugged;
   // Names that slugify to empty (e.g. all punctuation or non-ASCII) still
   // need a stable slug; fall back to a prefix of the skill id.
@@ -234,6 +238,21 @@ function baseSlug(skill: MarketplaceSkillInput): string {
     .slice(0, 8)
     .toLowerCase()}`;
 }
+
+// The Agent Skills spec caps skill names (and therefore directory slugs,
+// which must equal the frontmatter name) at 64 characters.
+const MAX_SKILL_SLUG_LENGTH = 64;
+
+function truncateSlug(slug: string, max: number): string {
+  return slug.slice(0, max).replace(/-+$/g, "");
+}
+
+/**
+ * Salt for {@link resolveBundleVersion}. Bump when the materialized layout
+ * output changes shape without any skill edit, so already-installed clients
+ * see a new plugin version and re-sync.
+ */
+const LAYOUT_FORMAT_VERSION = "2";
 
 function bundleDescription(skillCount: number, sourceLabel: string): string {
   const noun = skillCount === 1 ? "skill" : "skills";

--- a/platform/backend/src/skills/marketplace/materialize.test.ts
+++ b/platform/backend/src/skills/marketplace/materialize.test.ts
@@ -229,11 +229,14 @@ describe("MarketplaceMaterializer", () => {
       "utf8",
     );
     const parsed = parseSkillManifest(raw);
-    expect(parsed.name).toBe("PDF Helper");
+    expect(parsed.name).toBe("pdf-helper");
     expect(parsed.description).toBe("Helps with PDFs");
     expect(parsed.license).toBe("MIT");
     expect(parsed.compatibility).toBe("claude>=1.0");
-    expect(parsed.metadata).toEqual({ author: "Acme", version: "2.0" });
+    expect(parsed.metadata).toEqual({
+      author: "Acme",
+      version: "2.0",
+    });
     expect(parsed.content).toBe("# PDF Helper\n\nDoes the thing.");
   });
 
@@ -265,7 +268,7 @@ describe("MarketplaceMaterializer", () => {
       ),
       "utf8",
     );
-    expect(skillMd).toContain("name: PDF Helper");
+    expect(skillMd).toContain("name: pdf-helper");
     expect(skillMd).not.toContain("attacker-controlled content");
   });
 
@@ -297,7 +300,7 @@ describe("MarketplaceMaterializer", () => {
       ),
       "utf8",
     );
-    expect(skillMd).toContain("name: PDF Helper");
+    expect(skillMd).toContain("name: pdf-helper");
     await expect(
       fs.access(
         path.join(

--- a/platform/backend/src/skills/marketplace/materialize.test.ts
+++ b/platform/backend/src/skills/marketplace/materialize.test.ts
@@ -234,6 +234,7 @@ describe("MarketplaceMaterializer", () => {
     expect(parsed.license).toBe("MIT");
     expect(parsed.compatibility).toBe("claude>=1.0");
     expect(parsed.metadata).toEqual({
+      displayName: "PDF Helper",
       author: "Acme",
       version: "2.0",
     });


### PR DESCRIPTION
Fixes #6537

Four changes, all in the skill marketplace pipeline.

### 1. Slug as the SKILL.md frontmatter name

**Problem:** skills with spaces in their name install into Claude Code as broken slash commands: "Build App" becomes `/Build App`. The materializer wrote the raw display name into the frontmatter, but the [Agent Skills spec](https://agentskills.io/specification) requires kebab-case with name equal to the directory, and clients derive the slash command from it.

**Fix:** `buildSkillMarkdown` writes the directory slug as `name`.

**Tests:** new invariant test in `layout.test.ts` (name equals directory, spec format, unique, fits in 64 chars); pinned assertions updated.

### 2. Cap slugs at 64 chars

**Problem:** the slug now doubles as the name, which the spec caps at 64 chars, and skill names have no length limit in the DB.

**Fix:** truncate the base slug to 64 and keep collision suffixes (`-2`) under the cap.

**Tests:** new `manifest.test.ts` cases for the cap and capped suffixes.

### 3. Salt the bundle version

**Problem:** this PR changes SKILL.md bytes without touching any skill's `updatedAt`, and clients skip plugins whose version didn't change, so installed marketplaces would never pick up the fix.

**Fix:** `resolveBundleVersion` also hashes a layout format version; broken entries become `/build-app` on the next `claude plugin marketplace update`.

**Tests:** none new, the existing version tests pass unchanged.

### 4. Corner-case hardening from review

**Problem:** slug suffixes were assigned in `ORDER BY name` order with no tiebreak, so two same-named skills (legal across authors) could swap `-2` suffixes between materializations with no version change, silently rebinding slash commands. Also, the invariant test regex allowed the consecutive hyphens the spec forbids, and the display name appeared nowhere in the materialized repo, so re-imports degraded "PDF Helper" to `pdf-helper`.

**Fix:** order link skills by `(name, id)`; tighten the regex; write the display name as `metadata.displayName`, with an author-provided key winning.

**Tests:** same-name ordering pinned in `skill-share-link.test.ts`; displayName round-trip and precedence in `layout.test.ts` and `materialize.test.ts`.

---

On purpose, no DB slug column or authoring-time validation: the skill name is a display name (white-label branding rewrites it per org), and the platform already slugifies at the consumption edge.
