### PR TITLE
docs(ai-labs): add baton-core audience examples

### DIFF
--- a/ai-labs/baton/baton-core/examples/external_auditor.rs
+++ b/ai-labs/baton/baton-core/examples/external_auditor.rs
@@ -1,0 +1,125 @@
+//! Read this quarter's invoices from the internal system (readable only by the
+//! finance team), then e-mail the report to an *external auditor* who is **not**
+//! a reader of that data. The send is legitimate, but it crosses the audience
+//! boundary — so baton routes it to a sign-off that *declassifies* it and leaves
+//! an audit record, rather than letting it egress silently.
+//!
+//! Contrast with `recording_to_task`, where the boundary crossing (to the whole
+//! public) should be *refused*. Same `AudienceExceeds` breach; opposite ruling —
+//! because here an authority is mandated to vouch the auditor in.
+//!
+//! Run once with the invoices' audience *specified* (internal-only) and once
+//! left *Unknown*.
+//!
+//! Run with `cargo run --example external_auditor`.
+
+use baton_core::{
+    Audience, AudienceRule, Authority, AuthorityName, Decision, Effect, Effects, Grant, Label, PolicyEngine,
+    Requirements, Ruling, Speaker, ToolContract, ToolName, ToolRequest, Trajectory, Trust, UnknownPolicy, UserId,
+    Violation,
+};
+
+/// The internal finance team with access to the invoicing system.
+const ALICE: &str = "alice@archestra.ai";
+const BOB: &str = "bob@archestra.ai";
+/// The external auditor — a different org, and *not* a reader of the invoices.
+const AUDITOR: &str = "alex@finance-audit.com";
+
+fn u(id: &str) -> UserId {
+    UserId::new(id)
+}
+
+/// Signs off sending financial data to the known external auditor — and nothing
+/// else. Its mandate vouches in exactly `AUDITOR`, so it can declassify a send
+/// to that address but is not competent to wave data to anyone else.
+struct FinanceApprover;
+
+impl Authority for FinanceApprover {
+    fn rule(&self, needed: &Grant, _: &ToolRequest, _: &Label, _: &[Violation]) -> Option<(AuthorityName, Ruling)> {
+        let mandate = Grant {
+            audience: Some([u(AUDITOR)].into_iter().collect()),
+            ..Grant::empty()
+        };
+        mandate.covers(needed).then(|| {
+            (
+                AuthorityName::new("finance-approver"),
+                Ruling::Approve {
+                    reason: "approved sending financials to the external auditor".to_owned(),
+                },
+            )
+        })
+    }
+}
+
+/// List the invoices (wearing `invoices` as their audience), then e-mail the
+/// report to the auditor, and print the decision plus any audit record.
+fn run(invoices: Audience, policy: UnknownPolicy) {
+    let mut engine = PolicyEngine::new(FinanceApprover, policy);
+    engine
+        .register(ToolContract {
+            name: ToolName::new("invoices.list"),
+            requires: Requirements::default(),
+            output_label: Label {
+                audience: invoices,
+                trust: Trust::TRUSTED,
+                ..Label::identity()
+            },
+        })
+        .unwrap();
+    engine
+        .register(ToolContract {
+            name: ToolName::new("email.send"),
+            requires: Requirements {
+                audience: AudienceRule::RecipientsWithinContext,
+                ..Requirements::default()
+            },
+            output_label: Label {
+                effects: Effects::declared([Effect::Egress]),
+                ..Label::identity()
+            },
+        })
+        .unwrap();
+
+    let mut trajectory = Trajectory::new();
+    trajectory.push_message(
+        Label::identity(),
+        Speaker::user(u(ALICE)),
+        "Pull this quarter's invoices, summarize them, and send the report to our external auditor.",
+    );
+    let Decision::Permitted(permit) = engine.evaluate(&trajectory, &ToolRequest::new(ToolName::new("invoices.list")))
+    else {
+        unreachable!("the read-only invoice list has no requirements");
+    };
+    trajectory
+        .record_result(permit, "<47 invoices totaling $1.2M>")
+        .unwrap();
+
+    let request = ToolRequest::exposing(ToolName::new("email.send"), [u(AUDITOR)]);
+    print!(
+        "  audience {}  (policy {policy:?})  email → {AUDITOR}: ",
+        trajectory.context_label().audience
+    );
+    match engine.evaluate(&trajectory, &request) {
+        Decision::Permitted(permit) => {
+            println!("PERMITTED");
+            for entry in &permit.result_label().audit {
+                println!("      {entry}");
+            }
+        }
+        Decision::Blocked { reason, .. } => println!("BLOCKED — {reason}"),
+    }
+}
+
+fn main() {
+    println!("invoices are internal-only ({{{ALICE}, {BOB}}}); the auditor {AUDITOR} is outside the audience:");
+    run(Audience::readers([u(ALICE), u(BOB)]), UnknownPolicy::Escalate);
+
+    println!("\nif the invoices' audience is UNKNOWN, the outcome is the UnknownPolicy's:");
+    for policy in [
+        UnknownPolicy::Deny,
+        UnknownPolicy::Escalate,
+        UnknownPolicy::AllowWithAudit,
+    ] {
+        run(Audience::UNKNOWN, policy);
+    }
+}

--- a/ai-labs/baton/baton-core/examples/recording_to_task.rs
+++ b/ai-labs/baton/baton-core/examples/recording_to_task.rs
@@ -1,0 +1,118 @@
+//! Fetch a Grain recording, then open an issue on a *public* GitHub repo. The
+//! recording is readable only by the internal team; a public issue egresses to
+//! `world` — a sentinel recipient for the public (there is no e-mail for
+//! "everyone"; see `insights.md`). Run once with the recording's audience
+//! *specified* and once left *Unknown*, to see where the audience label alone
+//! stops the leak and where it falls to the `UnknownPolicy`.
+//!
+//! The authority declines every escalation (fail closed), so a PERMITTED means
+//! the audience label cleared the sink on its own — except under
+//! `AllowWithAudit`, where the policy audits an Unknown through (the `(audited)`
+//! row).
+//!
+//! Run with `cargo run --example recording_to_task`.
+
+use baton_core::{
+    Audience, AudienceRule, Authority, AuthorityName, Decision, Effect, Effects, Grant, Label, PolicyEngine,
+    Requirements, Ruling, Speaker, ToolContract, ToolName, ToolRequest, Trajectory, Trust, UnknownPolicy, UserId,
+    Violation,
+};
+
+/// The internal team who may read the recording.
+const ALICE: &str = "alice@archestra.ai";
+const BOB: &str = "bob@archestra.ai";
+/// Sentinel recipient standing for the public readership of an open issue — not
+/// a real address (the public has no e-mail); see `insights.md`.
+const WORLD: &str = "world";
+
+fn u(id: &str) -> UserId {
+    UserId::new(id)
+}
+
+/// Declines every escalation (fail closed): no permit ever comes from a waiver.
+struct DeclineAll;
+
+impl Authority for DeclineAll {
+    fn rule(&self, _: &Grant, _: &ToolRequest, _: &Label, _: &[Violation]) -> Option<(AuthorityName, Ruling)> {
+        Some((
+            AuthorityName::new("decline-all"),
+            Ruling::Deny {
+                reason: "no waiver".to_owned(),
+            },
+        ))
+    }
+}
+
+/// Fetch the recording (wearing `recording` as its audience), then open a public
+/// issue that egresses to `world`, and print whether the label cleared the sink
+/// under `policy`.
+fn run(recording: Audience, policy: UnknownPolicy) {
+    let mut engine = PolicyEngine::new(DeclineAll, policy);
+    engine
+        .register(ToolContract {
+            name: ToolName::new("grain.fetch"),
+            requires: Requirements::default(),
+            output_label: Label {
+                audience: recording,
+                trust: Trust::TRUSTED,
+                ..Label::identity()
+            },
+        })
+        .unwrap();
+    engine
+        .register(ToolContract {
+            name: ToolName::new("github.open_issue"),
+            requires: Requirements {
+                audience: AudienceRule::RecipientsWithinContext,
+                ..Requirements::default()
+            },
+            output_label: Label {
+                effects: Effects::declared([Effect::Egress]),
+                ..Label::identity()
+            },
+        })
+        .unwrap();
+
+    let mut trajectory = Trajectory::new();
+    trajectory.push_message(
+        Label::identity(),
+        Speaker::user(u(ALICE)),
+        "Skim the latest customer call and open a bug for the crash they hit.",
+    );
+    let Decision::Permitted(permit) = engine.evaluate(&trajectory, &ToolRequest::new(ToolName::new("grain.fetch")))
+    else {
+        unreachable!("the read-only recording fetch has no requirements");
+    };
+    trajectory
+        .record_result(permit, "<transcript: names the customer's staging host>")
+        .unwrap();
+
+    let request = ToolRequest::exposing(ToolName::new("github.open_issue"), [u(WORLD)]);
+    print!(
+        "  audience {}  (policy {policy:?})  open public issue → {WORLD}: ",
+        trajectory.context_label().audience
+    );
+    match engine.evaluate(&trajectory, &request) {
+        Decision::Permitted(permit) => {
+            println!("PERMITTED");
+            for entry in &permit.result_label().audit {
+                println!("      {entry}");
+            }
+        }
+        Decision::Blocked { reason, .. } => println!("BLOCKED — {reason}"),
+    }
+}
+
+fn main() {
+    println!("recording audience SPECIFIED → the leak is a provable breach:");
+    run(Audience::readers([u(ALICE), u(BOB)]), UnknownPolicy::Escalate);
+
+    println!("\nrecording audience UNKNOWN → the outcome is the UnknownPolicy's:");
+    for policy in [
+        UnknownPolicy::Deny,
+        UnknownPolicy::Escalate,
+        UnknownPolicy::AllowWithAudit,
+    ] {
+        run(Audience::UNKNOWN, policy);
+    }
+}


### PR DESCRIPTION
## What

Two runnable `baton-core` examples exercising the **Audience** dimension end to end:

- **`recording_to_task`** — fetch an internal Grain recording, then open an issue on a *public* GitHub repo. The leak is caught as `AudienceExceeds` (a provable breach) when the recording's audience is specified, or `AudienceUnknown` when it's left unlabeled.
- **`external_auditor`** — list internal-only invoices, then e-mail the report to an *external auditor* outside the audience. A mandated approver (`FinanceApprover`) declassifies the send and records it — the opposite ruling from the public-issue case, same `AudienceExceeds` breach.

Each example sweeps *specified* vs *Unknown* audience across the three `UnknownPolicy` settings (`Deny` / `Escalate` / `AllowWithAudit`).

## Notes

- Additive only: two new files under `baton-core/examples/`. No library or dependency changes.
- Same standalone shape as `demo.rs`; each is `cargo run --example <name>`.

## Testing

```
cd ai-labs/baton/baton-core
cargo run --example recording_to_task
cargo run --example external_auditor
cargo fmt --check && cargo clippy --examples
```

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>