### PR TITLE
fix(llm-proxy): give Bedrock non-OK errors a diagnosable message

### DIFF
--- a/platform/backend/src/clients/bedrock-client.test.ts
+++ b/platform/backend/src/clients/bedrock-client.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BedrockClient } from "./bedrock-client";
+
+// Stub fetch at the process boundary (no module mocks) so this file stays in
+// the fast "clean" vitest project. Re-applied per test because unstubGlobals
+// auto-reverts after each test.
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function makeClient() {
+  return new BedrockClient({
+    baseUrl: "https://bedrock.example.com",
+    region: "us-east-1",
+    // apiKey path skips SigV4 signing: signedFetch just sets a Bearer header.
+    apiKey: "test-key",
+  });
+}
+
+type ThrownError = Error & { statusCode?: number; responseBody?: string };
+
+async function catchError(promise: Promise<unknown>): Promise<ThrownError> {
+  return promise.then(
+    () => {
+      throw new Error("expected the request to reject");
+    },
+    (e) => e as ThrownError,
+  );
+}
+
+describe("BedrockClient non-OK error messages", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+  });
+
+  describe("converse", () => {
+    it("does not surface an opaque `{}` when the error body is a message-less JSON object", async () => {
+      fetchMock.mockResolvedValue(new Response("{}", { status: 400 }));
+
+      const err = await catchError(makeClient().converse("model", {}));
+
+      // The regression: `{}` used to become the Error message verbatim.
+      expect(err.message).toBe("Bedrock API error: 400");
+      expect(err.message).not.toBe("{}");
+      // The raw body is still preserved for callers that want it.
+      expect(err.statusCode).toBe(400);
+      expect(err.responseBody).toBe("{}");
+    });
+
+    it("falls back to the status when the error body is empty", async () => {
+      fetchMock.mockResolvedValue(new Response("", { status: 502 }));
+
+      const err = await catchError(makeClient().converse("model", {}));
+
+      expect(err.message).toBe("Bedrock API error: 502");
+    });
+
+    it("includes the embedded AWS message when present", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            message: "prompt is too long",
+            __type: "ValidationException",
+          }),
+          { status: 400 },
+        ),
+      );
+
+      const err = await catchError(makeClient().converse("model", {}));
+
+      expect(err.message).toBe("Bedrock API error (400): prompt is too long");
+    });
+
+    it("uses a non-JSON body verbatim as the detail", async () => {
+      fetchMock.mockResolvedValue(
+        new Response("Rate exceeded", { status: 429 }),
+      );
+
+      const err = await catchError(makeClient().converse("model", {}));
+
+      expect(err.message).toBe("Bedrock API error (429): Rate exceeded");
+    });
+  });
+
+  describe("converseStream", () => {
+    it("does not surface an opaque `{}` when the error body is a message-less JSON object", async () => {
+      fetchMock.mockResolvedValue(new Response("{}", { status: 500 }));
+
+      const err = await catchError(makeClient().converseStream("model", {}));
+
+      expect(err.message).toBe("Bedrock API error: 500");
+      expect(err.message).not.toBe("{}");
+      expect(err.statusCode).toBe(500);
+    });
+
+    it("falls back to the __type when the body has no message field", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ __type: "ThrottlingException" }), {
+          status: 429,
+        }),
+      );
+
+      const err = await catchError(makeClient().converseStream("model", {}));
+
+      expect(err.message).toBe("Bedrock API error (429): ThrottlingException");
+    });
+  });
+});

--- a/platform/backend/src/clients/bedrock-client.ts
+++ b/platform/backend/src/clients/bedrock-client.ts
@@ -95,7 +95,7 @@ export class BedrockClient {
         "[BedrockClient] converse error",
       );
       const error = new Error(
-        errorBody || `Bedrock API error: ${response.status}`,
+        buildBedrockErrorMessage(response.status, errorBody),
       );
       (error as Error & { statusCode: number }).statusCode = response.status;
       (error as Error & { responseBody: string }).responseBody = errorBody;
@@ -137,7 +137,7 @@ export class BedrockClient {
         "[BedrockClient] converseStream error",
       );
       const error = new Error(
-        errorBody || `Bedrock API error: ${response.status}`,
+        buildBedrockErrorMessage(response.status, errorBody),
       );
       (error as Error & { statusCode: number }).statusCode = response.status;
       (error as Error & { responseBody: string }).responseBody = errorBody;
@@ -359,4 +359,46 @@ function encodeEventStreamMessage(
     },
     body: bodyBytes,
   });
+}
+
+/**
+ * Build the message for an error thrown from a non-OK Bedrock response.
+ *
+ * The raw response body is only used when it carries a human-readable detail.
+ * An empty body, a whitespace-only body, or a message-less JSON object such as
+ * `{}` would otherwise become the Error's message verbatim, producing an opaque
+ * `Error: {}` that hides the HTTP status. In those cases we fall back to the
+ * status code so the failure is always identifiable. The full raw body is still
+ * preserved on the thrown error's `responseBody` property for callers that need
+ * it.
+ */
+function buildBedrockErrorMessage(status: number, errorBody: string): string {
+  const detail = extractBedrockErrorDetail(errorBody);
+  return detail
+    ? `Bedrock API error (${status}): ${detail}`
+    : `Bedrock API error: ${status}`;
+}
+
+/**
+ * Pull a human-readable detail out of a Bedrock error body, or `undefined` when
+ * the body carries nothing useful. AWS returns JSON payloads shaped like
+ * `{"message": "...", "__type": "..."}`; an empty body or a field-less object
+ * (e.g. `{}`) yields `undefined` so the caller falls back to the HTTP status.
+ */
+function extractBedrockErrorDetail(errorBody: string): string | undefined {
+  const trimmed = errorBody.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object") {
+      const { message, Message, __type } = parsed as Record<string, unknown>;
+      const detail = message ?? Message ?? __type;
+      return typeof detail === "string" && detail.trim() ? detail : undefined;
+    }
+    // A JSON primitive (string/number/boolean) is itself the detail.
+    return String(parsed);
+  } catch {
+    // Not JSON — the raw text is the most useful signal we have.
+    return trimmed;
+  }
 }


### PR DESCRIPTION
## Problem

On the Bedrock proxy path (`POST /v1/bedrock/:agentId/model/:modelId/converse`), a failed upstream request could surface as an opaque `Error: {}` — no HTTP status, nothing actionable for triage.

Root cause is in `BedrockClient`: when a `converse` / `converse-stream` response is not OK, the thrown Error's message was built as `errorBody || \`Bedrock API error: \${status}\``. Bedrock can return a non-OK response whose body is a **message-less JSON object** (e.g. `{}`). That string is truthy, so it became the Error message verbatim, discarding the status code and yielding `Error: {}`.

## Fix

Route both throw sites through a small message builder (`buildBedrockErrorMessage`):

- Uses the body only when it carries a human-readable detail — an embedded AWS `message` / `__type`, or non-JSON text.
- Otherwise falls back to `Bedrock API error: <status>`, so the failure is always identifiable.
- The full raw body is still preserved on the error's `responseBody` property (unchanged), and `statusCode` is untouched — so downstream error handling/persistence behaves exactly as before, just with a meaningful message.

Both `converse` and `converseStream` had the identical latent pattern; both are fixed.

## Behavior

| upstream body | old `Error.message` | new `Error.message` |
|---|---|---|
| `{}` | `{}` | `Bedrock API error: 400` |
| `""` (empty) | `Bedrock API error: 502` | `Bedrock API error: 502` |
| `{"message":"prompt is too long"}` | `{"message":"prompt is too long"}` | `Bedrock API error (400): prompt is too long` |
| `Rate exceeded` (non-JSON) | `Rate exceeded` | `Bedrock API error (429): Rate exceeded` |
| `{"__type":"ThrottlingException"}` | `{"__type":"ThrottlingException"}` | `Bedrock API error (429): ThrottlingException` |

## Tests

New `backend/src/clients/bedrock-client.test.ts` pins the thrown message across message-less `{}`, empty, embedded-message, non-JSON, and `__type`-only bodies for both `converse` and `converseStream`, and asserts `statusCode` / `responseBody` are still populated. Stubs `fetch` at the boundary (no module mocks, so it runs in the fast `clean` vitest project).

- `vitest run src/clients/bedrock-client.test.ts` → 6/6 pass
- `biome check` clean, `tsc --noEmit` exit 0

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>