### PR TITLE
fix(k8s): key MCP per-pod egress policy selector on stable labels

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -3832,6 +3832,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
       supportsHttpMethods: boolean;
       message: string | null;
     };
+    multitenant?: boolean;
   }): K8sDeployment {
     return new K8sDeployment({
       mcpServer: makeNetworkPolicyTestServer(),
@@ -3843,7 +3844,12 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
       k8sLog: {} as Log,
       k8sExec: {} as Exec,
       namespace: "default",
-      catalogItem: null,
+      catalogItem: params.multitenant
+        ? ({
+            multitenant: true,
+            name: "test-catalog",
+          } as unknown as import("@/types").InternalMcpCatalog)
+        : null,
       effectiveNetworkPolicy: params.effectiveNetworkPolicy,
       networkPolicyCapabilities: params.networkPolicyCapabilities,
     });
@@ -4768,6 +4774,41 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     const policy = policies.get(POLICY_NAME);
     expect(policy?.spec?.policyTypes).toEqual(["Egress"]);
     expect(policy?.spec?.egress).toEqual(PLAIN_FLOOR_EGRESS);
+  });
+
+  test("per-pod policy selector keys on app + mcp-server-id only, never the per-install name", async () => {
+    const { api, policies } = makeStatefulNetworkingApi();
+    await makeNetworkPolicyDeployment({
+      networkingApi: api,
+      effectiveNetworkPolicy: makeNetworkPolicy({ egressMode: "unrestricted" }),
+      networkPolicyCapabilities: PLAIN_CAPS,
+    }).applyK8sNetworkPolicy();
+
+    const selector = policies.get(POLICY_NAME)?.spec?.podSelector?.matchLabels;
+    expect(selector).toEqual({
+      app: "mcp-server",
+      "mcp-server-id": "test-server-id",
+    });
+    // mcp-server-name is per-install; including it in the AND-semantics selector
+    // makes a multitenant policy select zero pods.
+    expect(selector).not.toHaveProperty("mcp-server-name");
+  });
+
+  test("multitenant per-pod policy selects on the catalog-stable id, matching the shared pod", async () => {
+    const { api, policies } = makeStatefulNetworkingApi();
+    await makeNetworkPolicyDeployment({
+      networkingApi: api,
+      effectiveNetworkPolicy: makeNetworkPolicy({ egressMode: "unrestricted" }),
+      networkPolicyCapabilities: PLAIN_CAPS,
+      multitenant: true,
+    }).applyK8sNetworkPolicy();
+
+    const selector = [...policies.values()][0]?.spec?.podSelector?.matchLabels;
+    expect(selector).toEqual({
+      app: "mcp-server",
+      "mcp-server-id": "test-catalog-id",
+    });
+    expect(selector).not.toHaveProperty("mcp-server-name");
   });
 
   test("applies the SSRF floor for a built-in (null) policy — the case the union bug silently opened", async () => {

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -504,7 +504,7 @@ export default class K8sDeployment {
       policyName,
       buildManagedNetworkPolicy({
         name: policyName,
-        podSelectorLabels: this.getSystemLabels(),
+        podSelectorLabels: this.getPodSelectorLabels(),
         effectivePolicy,
       }),
     );
@@ -557,7 +557,7 @@ export default class K8sDeployment {
         policyName,
         body: buildUnrestrictedFloorAwsApplicationNetworkPolicy({
           name: policyName,
-          podSelectorLabels: this.getSystemLabels(),
+          podSelectorLabels: this.getPodSelectorLabels(),
           labels,
           clusterDnsIps,
         }),
@@ -578,7 +578,7 @@ export default class K8sDeployment {
       policyName,
       buildUnrestrictedFloorPolicy({
         name: policyName,
-        podSelectorLabels: this.getSystemLabels(),
+        podSelectorLabels: this.getPodSelectorLabels(),
         labels,
         clusterDnsIps,
       }),
@@ -655,7 +655,7 @@ export default class K8sDeployment {
       policyName,
       body: buildManagedCiliumNetworkPolicy({
         name: policyName,
-        podSelectorLabels: this.getSystemLabels(),
+        podSelectorLabels: this.getPodSelectorLabels(),
         effectivePolicy,
       }),
     });
@@ -670,7 +670,7 @@ export default class K8sDeployment {
       policyName,
       body: buildManagedGkeFqdnNetworkPolicy({
         name: policyName,
-        podSelectorLabels: this.getSystemLabels(),
+        podSelectorLabels: this.getPodSelectorLabels(),
         effectivePolicy,
       }),
     });
@@ -699,7 +699,7 @@ export default class K8sDeployment {
       policyName,
       body: buildManagedAwsApplicationNetworkPolicy({
         name: policyName,
-        podSelectorLabels: this.getSystemLabels(),
+        podSelectorLabels: this.getPodSelectorLabels(),
         effectivePolicy,
         clusterDnsIps,
       }),
@@ -1161,7 +1161,7 @@ export default class K8sDeployment {
   }): boolean {
     if (!params.policyName) return false;
     if (!hasManagedNetworkPolicyLabels(params.metadataLabels)) return false;
-    if (!policyTargetsPodLabels(params.spec, this.getSystemLabels())) {
+    if (!policyTargetsPodLabels(params.spec, this.getPodSelectorLabels())) {
       return false;
     }
     return !params.keepPolicy || params.policyName !== params.desiredPolicyName;
@@ -1574,6 +1574,22 @@ export default class K8sDeployment {
       app: "mcp-server",
       "mcp-server-id": this.getPodSelectorServerId(),
       "mcp-server-name": this.mcpServer.name,
+    });
+  }
+
+  /**
+   * Labels the per-pod NetworkPolicy (and Service) selector keys on: `app` plus
+   * the catalog-stable `mcp-server-id` (see getPodSelectorServerId). It excludes
+   * `mcp-server-name`: for a multitenant catalog the shared pod is labeled with
+   * one install's name while the policy may be reconciled by another install, so
+   * an AND-semantics selector keyed on the name would match zero pods — the pod
+   * then falls through to the namespace deny-all baseline and gets no egress
+   * (DNS included). `mcp-server-id` alone uniquely identifies the server.
+   */
+  private getPodSelectorLabels(): Record<string, string> {
+    return sanitizeMetadataLabels({
+      app: "mcp-server",
+      "mcp-server-id": this.getPodSelectorServerId(),
     });
   }
 


### PR DESCRIPTION
Multitenant MCP servers (one shared pod across installs) got **zero egress** — crashlooping on `getaddrinfo EAI_AGAIN <host>` for every destination, DNS included.

Root cause: the per-pod egress `NetworkPolicy`'s `podSelector.matchLabels` included `mcp-server-name`, whose value for a multitenant catalog is a per-install-derived string. The shared pod is labeled with one install's name while the policy is reconciled by another install, so with `matchLabels` AND-semantics the policy selected **zero pods**. The pod then matched only the namespace-wide deny-all baseline (`mcp-server-egress-baseline`) and lost all egress — including reaching CoreDNS. `app` and `mcp-server-id` matched; only `mcp-server-name` diverged. Single-tenant servers were unaffected (their name is per-install but the pod and policy are the same install).

The fix keys the per-pod policy `podSelector` on stable, guaranteed-matching labels only — `app` + the catalog-stable `mcp-server-id` (`getPodSelectorServerId`), the same identity the Service selector already uses. `mcp-server-id` uniquely identifies the server; `mcp-server-name` stays as a pod/policy metadata label, just not in the selector. Applies to every builder that takes the pod selector (floor, AWS ANP, Cilium, GKE-FQDN, managed) and the managed-policy cleanup check.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>