### PR TITLE
fix(llm-proxy): proactively stream long Anthropic requests instead of capping them

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -803,23 +803,25 @@ describe("AnthropicStreamAdapter policy refusal terminal", () => {
 });
 
 describe("anthropicAdapterFactory.execute", () => {
-  // The SDK refuses non-streaming requests whose max_tokens implies a >10 min
-  // completion ("Streaming is required for operations that may take longer
-  // than 10 minutes") unless the client carries an explicit timeout. Claude
-  // Code sends max_tokens=32000 non-streaming; the proxy must forward it,
-  // not 500.
-  test("forwards large non-streaming max_tokens instead of tripping the SDK guard", async () => {
+  // Claude Code sends large max_tokens (e.g. 32000) non-streaming. Such a
+  // request would exceed the SDK's ~10-minute non-streaming limit, so — rather
+  // than attempt it non-streaming (which the client's explicit timeout would
+  // cap) — the proxy serves it over the streaming Messages API and returns the
+  // accumulated final Message. The result is forwarded, never 500-ed. Uses the
+  // real client so the real routing decision runs; only the stream transport is
+  // stubbed.
+  test("serves a large-max_tokens request over the streaming API and forwards the result", async () => {
     const client = anthropicAdapterFactory.createClient("test-key", {
       source: "api",
     }) as AnthropicProvider;
 
-    // Stub the transport: the guard under test runs synchronously inside
-    // messages.create before any network I/O.
-    const post = vi
-      .spyOn(client as unknown as { post: () => unknown }, "post")
-      .mockResolvedValue(
-        createMockResponse([{ type: "text", text: "ok", citations: null }]),
-      );
+    const finalMessage = createMockResponse([
+      { type: "text", text: "ok", citations: null },
+    ]);
+    const stream = vi.spyOn(client.messages, "stream").mockReturnValue({
+      finalMessage: () => Promise.resolve(finalMessage),
+    } as unknown as ReturnType<typeof client.messages.stream>);
+    const create = vi.spyOn(client.messages, "create");
 
     const response = await anthropicAdapterFactory.execute(
       client,
@@ -829,7 +831,10 @@ describe("anthropicAdapterFactory.execute", () => {
       }),
     );
 
-    expect(post).toHaveBeenCalled();
+    // Routed to streaming (max_tokens=64000 > the ~21k non-streaming limit),
+    // never the non-streaming path.
+    expect(stream).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
     expect(response.content[0]).toMatchObject({ type: "text", text: "ok" });
   });
 });
@@ -889,40 +894,49 @@ describe("anthropicAdapterFactory balance-too-low message", () => {
   });
 });
 
-describe("anthropicAdapterFactory.execute - long request streaming fallback", () => {
+describe("anthropicAdapterFactory.execute - long-request routing", () => {
   const messages = [
     { role: "user", content: "hi" },
   ] as Anthropic.Types.MessagesRequest["messages"];
 
-  // The SDK throws this client-side (before any network call) when a
-  // non-streaming request's max_tokens implies a >10-minute completion.
-  const longRequestError = new Error(
-    "Streaming is required for operations that may take longer than 10 minutes. See https://github.com/anthropics/anthropic-sdk-typescript#long-requests for more details",
-  );
-
-  test("returns the non-streaming response when create() succeeds", async () => {
+  test("routes to non-streaming create() when the request fits the non-streaming limit", async () => {
     const response = createMockResponse([{ type: "text", text: "ok" }]);
     const create = vi.fn().mockResolvedValue(response);
     const stream = vi.fn();
-    const client = { messages: { create, stream } };
+    // The SDK guard returns a timeout (does not throw) → request fits.
+    const calculateNonstreamingTimeout = vi.fn().mockReturnValue(600000);
+    const client = {
+      calculateNonstreamingTimeout,
+      messages: { create, stream },
+    };
 
     const result = await anthropicAdapterFactory.execute(
       client,
-      createMockRequest(messages),
+      createMockRequest(messages, { max_tokens: 1024 }),
     );
 
     expect(result).toBe(response);
     expect(create).toHaveBeenCalledTimes(1);
-    // The happy path must not touch the streaming helper.
     expect(stream).not.toHaveBeenCalled();
+    // The routing decision is keyed on the request's own max_tokens.
+    expect(calculateNonstreamingTimeout).toHaveBeenCalledWith(1024);
   });
 
-  test("falls back to the streaming API when the SDK rejects the request as too long", async () => {
+  test("routes to the streaming API and returns the final message when the request is too long for non-streaming", async () => {
     const response = createMockResponse([{ type: "text", text: "done" }]);
-    const create = vi.fn().mockRejectedValue(longRequestError);
+    const create = vi.fn();
     const finalMessage = vi.fn().mockResolvedValue(response);
     const stream = vi.fn().mockReturnValue({ finalMessage });
-    const client = { messages: { create, stream } };
+    // The SDK guard throws → max_tokens implies a >10-minute completion.
+    const calculateNonstreamingTimeout = vi.fn(() => {
+      throw new Error(
+        "Streaming is required for operations that may take longer than 10 minutes",
+      );
+    });
+    const client = {
+      calculateNonstreamingTimeout,
+      messages: { create, stream },
+    };
 
     const result = await anthropicAdapterFactory.execute(
       client,
@@ -931,19 +945,9 @@ describe("anthropicAdapterFactory.execute - long request streaming fallback", ()
 
     // Same shape a non-streaming create() would have returned.
     expect(result).toBe(response);
-    expect(create).toHaveBeenCalledTimes(1);
     expect(stream).toHaveBeenCalledTimes(1);
     expect(finalMessage).toHaveBeenCalledTimes(1);
-  });
-
-  test("rethrows unrelated errors without falling back to streaming", async () => {
-    const create = vi.fn().mockRejectedValue(new Error("overloaded_error"));
-    const stream = vi.fn();
-    const client = { messages: { create, stream } };
-
-    await expect(
-      anthropicAdapterFactory.execute(client, createMockRequest(messages)),
-    ).rejects.toThrow("overloaded_error");
-    expect(stream).not.toHaveBeenCalled();
+    // The non-streaming path is skipped entirely for long requests.
+    expect(create).not.toHaveBeenCalled();
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -888,3 +888,62 @@ describe("anthropicAdapterFactory balance-too-low message", () => {
     );
   });
 });
+
+describe("anthropicAdapterFactory.execute - long request streaming fallback", () => {
+  const messages = [
+    { role: "user", content: "hi" },
+  ] as Anthropic.Types.MessagesRequest["messages"];
+
+  // The SDK throws this client-side (before any network call) when a
+  // non-streaming request's max_tokens implies a >10-minute completion.
+  const longRequestError = new Error(
+    "Streaming is required for operations that may take longer than 10 minutes. See https://github.com/anthropics/anthropic-sdk-typescript#long-requests for more details",
+  );
+
+  test("returns the non-streaming response when create() succeeds", async () => {
+    const response = createMockResponse([{ type: "text", text: "ok" }]);
+    const create = vi.fn().mockResolvedValue(response);
+    const stream = vi.fn();
+    const client = { messages: { create, stream } };
+
+    const result = await anthropicAdapterFactory.execute(
+      client,
+      createMockRequest(messages),
+    );
+
+    expect(result).toBe(response);
+    expect(create).toHaveBeenCalledTimes(1);
+    // The happy path must not touch the streaming helper.
+    expect(stream).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the streaming API when the SDK rejects the request as too long", async () => {
+    const response = createMockResponse([{ type: "text", text: "done" }]);
+    const create = vi.fn().mockRejectedValue(longRequestError);
+    const finalMessage = vi.fn().mockResolvedValue(response);
+    const stream = vi.fn().mockReturnValue({ finalMessage });
+    const client = { messages: { create, stream } };
+
+    const result = await anthropicAdapterFactory.execute(
+      client,
+      createMockRequest(messages, { max_tokens: 64000 }),
+    );
+
+    // Same shape a non-streaming create() would have returned.
+    expect(result).toBe(response);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(stream).toHaveBeenCalledTimes(1);
+    expect(finalMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("rethrows unrelated errors without falling back to streaming", async () => {
+    const create = vi.fn().mockRejectedValue(new Error("overloaded_error"));
+    const stream = vi.fn();
+    const client = { messages: { create, stream } };
+
+    await expect(
+      anthropicAdapterFactory.execute(client, createMockRequest(messages)),
+    ).rejects.toThrow("overloaded_error");
+    expect(stream).not.toHaveBeenCalled();
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1297,8 +1297,9 @@ export const anthropicAdapterFactory: LLMProvider<
       // still return a non-streaming *result*, Anthropic's recommended pattern
       // is to consume the streaming Messages API and hand back the accumulated
       // final Message — identical in shape to a non-streaming response, but over
-      // a connection that keeps producing events. See "Long requests":
-      // https://github.com/anthropics/anthropic-sdk-typescript#long-requests
+      // a connection that keeps producing events. This exact
+      // stream(...).finalMessage() pattern is documented under "Long requests":
+      // https://platform.claude.com/docs/en/api/errors#long-requests
       return anthropicClient.messages
         .stream(
           params as unknown as AnthropicProvider.Messages.MessageStreamParams,
@@ -1360,7 +1361,7 @@ export const anthropicAdapterFactory: LLMProvider<
  * non-streaming call's `max_tokens` implies a completion that could exceed 10
  * minutes. Matched by message so `execute` can transparently retry the request
  * over the streaming API and return the accumulated final Message. See:
- * https://github.com/anthropics/anthropic-sdk-typescript#long-requests
+ * https://platform.claude.com/docs/en/api/errors#long-requests
  */
 function isNonStreamingTooLongError(error: unknown): boolean {
   return (

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1283,10 +1283,28 @@ export const anthropicAdapterFactory: LLMProvider<
     request: AnthropicRequest,
   ): Promise<AnthropicResponse> {
     const anthropicClient = client as AnthropicProvider;
-    return anthropicClient.messages.create({
+    const params = {
       ...request,
       stream: false,
-    } as AnthropicProvider.Messages.MessageCreateParamsNonStreaming);
+    } as AnthropicProvider.Messages.MessageCreateParamsNonStreaming;
+    try {
+      return await anthropicClient.messages.create(params);
+    } catch (error) {
+      if (!isNonStreamingTooLongError(error)) throw error;
+      // The SDK refuses a non-streaming request whose `max_tokens` implies a
+      // completion that could exceed 10 minutes, because a single long-lived
+      // response can be dropped by networks that close idle connections. To
+      // still return a non-streaming *result*, Anthropic's recommended pattern
+      // is to consume the streaming Messages API and hand back the accumulated
+      // final Message — identical in shape to a non-streaming response, but over
+      // a connection that keeps producing events. See "Long requests":
+      // https://github.com/anthropics/anthropic-sdk-typescript#long-requests
+      return anthropicClient.messages
+        .stream(
+          params as unknown as AnthropicProvider.Messages.MessageStreamParams,
+        )
+        .finalMessage();
+    }
   },
 
   async executeStream(
@@ -1336,6 +1354,22 @@ export const anthropicAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+/**
+ * The Anthropic SDK throws this client-side (before any request is sent) when a
+ * non-streaming call's `max_tokens` implies a completion that could exceed 10
+ * minutes. Matched by message so `execute` can transparently retry the request
+ * over the streaming API and return the accumulated final Message. See:
+ * https://github.com/anthropics/anthropic-sdk-typescript#long-requests
+ */
+function isNonStreamingTooLongError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(
+      "Streaming is required for operations that may take longer than 10 minutes",
+    )
+  );
+}
 
 /** The SDK nests the provider body as `error.error.{type,message}`. */
 function isAnthropicBalanceTooLow(error: unknown): boolean {

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1287,25 +1287,25 @@ export const anthropicAdapterFactory: LLMProvider<
       ...request,
       stream: false,
     } as AnthropicProvider.Messages.MessageCreateParamsNonStreaming;
-    try {
-      return await anthropicClient.messages.create(params);
-    } catch (error) {
-      if (!isNonStreamingTooLongError(error)) throw error;
-      // The SDK refuses a non-streaming request whose `max_tokens` implies a
-      // completion that could exceed 10 minutes, because a single long-lived
-      // response can be dropped by networks that close idle connections. To
-      // still return a non-streaming *result*, Anthropic's recommended pattern
-      // is to consume the streaming Messages API and hand back the accumulated
-      // final Message — identical in shape to a non-streaming response, but over
-      // a connection that keeps producing events. This exact
-      // stream(...).finalMessage() pattern is documented under "Long requests":
-      // https://platform.claude.com/docs/en/api/errors#long-requests
+
+    // A non-streaming request whose `max_tokens` implies a completion that could
+    // exceed ~10 minutes can't be served reliably: our client is built with an
+    // explicit timeout, so the SDK skips its own "streaming required" guard and
+    // instead sends the request and lets it hit that timeout, and networks may
+    // drop the idle connection before the single response arrives. The SSE body
+    // of a *streaming* request is not bounded by the client timeout (only its
+    // initial connection is), so — per Anthropic's guidance — consume such
+    // requests over the streaming Messages API and return the accumulated final
+    // Message, which is identical in shape to a non-streaming response.
+    // https://platform.claude.com/docs/en/api/errors#long-requests
+    if (exceedsNonStreamingLimit(anthropicClient, request.max_tokens)) {
       return anthropicClient.messages
         .stream(
           params as unknown as AnthropicProvider.Messages.MessageStreamParams,
         )
         .finalMessage();
     }
+    return anthropicClient.messages.create(params);
   },
 
   async executeStream(
@@ -1357,19 +1357,24 @@ export const anthropicAdapterFactory: LLMProvider<
 };
 
 /**
- * The Anthropic SDK throws this client-side (before any request is sent) when a
- * non-streaming call's `max_tokens` implies a completion that could exceed 10
- * minutes. Matched by message so `execute` can transparently retry the request
- * over the streaming API and return the accumulated final Message. See:
+ * Whether a non-streaming request with this `max_tokens` would exceed the SDK's
+ * ~10-minute non-streaming limit (i.e. should be served over the streaming API
+ * instead). Delegates to the SDK's own estimate — which throws exactly when
+ * streaming is required — so the threshold stays in sync with the SDK rather
+ * than being duplicated here. `maxNonstreamingTokens` is left unset so only the
+ * general 10-minute estimate applies, not any per-model cap.
  * https://platform.claude.com/docs/en/api/errors#long-requests
  */
-function isNonStreamingTooLongError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    error.message.includes(
-      "Streaming is required for operations that may take longer than 10 minutes",
-    )
-  );
+function exceedsNonStreamingLimit(
+  client: AnthropicProvider,
+  maxTokens: number,
+): boolean {
+  try {
+    client.calculateNonstreamingTimeout(maxTokens);
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 /** The SDK nests the provider body as `error.error.{type,message}`. */

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -1369,6 +1369,11 @@ function exceedsNonStreamingLimit(
   client: AnthropicProvider,
   maxTokens: number,
 ): boolean {
+  // Defensive: a real AnthropicProvider always exposes this, but partial/mock
+  // clients may not. If we can't obtain the estimate, don't force streaming.
+  if (typeof client.calculateNonstreamingTimeout !== "function") {
+    return false;
+  }
   try {
     client.calculateNonstreamingTimeout(maxTokens);
     return false;


### PR DESCRIPTION
## Problem

On the Anthropic proxy path (`POST /v1/anthropic/:agentId/v1/messages`), a request with a large `max_tokens` (e.g. Claude Code sends 32000) can't be served reliably non-streaming:

- The SDK's own guard (`calculateNonstreamingTimeout`) is meant to reject such requests with *"Streaming is required for operations that may take longer than 10 minutes"* — but it **only runs when the client has no explicit `timeout`**. Our `createClient` sets `timeout: ANTHROPIC_CLIENT_TIMEOUT_MS` (10 min) on every client, so the guard never fires.
- With the guard suppressed, the request is attempted **non-streaming** and capped at that 10-minute timeout. A genuinely long generation hits the cap and fails; a request that finishes under 10 min only works by luck.

> A first version of this PR tried to *catch* the "streaming required" error and fall back to streaming — but that catch was **dead code**, because the explicit client timeout means the error is never thrown (verified empirically). This rework replaces it.

## Fix

Route proactively in `execute()`: decide up front whether the request would exceed the non-streaming limit, and if so serve it over the streaming Messages API, returning the accumulated final `Message` (identical in shape to a non-streaming response).

- **Routing uses the SDK's own estimate** — `calculateNonstreamingTimeout(max_tokens)` throws exactly when streaming is required — so the threshold stays in sync with the SDK instead of being hardcoded.
- **Streaming genuinely supports long requests:** a streaming request's SSE body is **not** bounded by the client timeout (the SDK clears the timeout once response headers arrive); only the initial connection is. So `stream(...).finalMessage()` can run past 10 minutes, which the non-streaming path cannot.
- Short requests take the non-streaming path unchanged — no added latency or behavior change for ordinary traffic.

This follows Anthropic's guidance directly: https://platform.claude.com/docs/en/api/errors#long-requests (TCP keep-alive is handled by the SDK automatically; Message Batches is an alternative that doesn't fit a synchronous proxy).

## Verification

**Real Anthropic API (local), calling the actual `execute()`:**

| max_tokens | routed | result |
|---|---|---|
| 64 | non-streaming (`create=1, stream=0`) | `"PONG"`, `stop_reason=end_turn`, `output_tokens=6` |
| 40000 | streaming (`stream=1`) | `"PONG"`, `stop_reason=end_turn`, `output_tokens=6` |

Both return a complete, well-formed assistant `Message`, and routing splits exactly at the SDK's ~21k-token threshold.

**Unit tests** (`adapters/anthropic.test.ts`, fake client, no network → fast `clean` project):
- fits the non-streaming limit → `create()` used, `stream` not called, routing keyed on the request's `max_tokens`.
- too long for non-streaming → `stream().finalMessage()` used, `create` not called, result forwarded.
- The pre-existing large-`max_tokens` test (which encoded the old "forward non-streaming" behavior) is updated to expect the streaming route via the real client.

`vitest run` → 23/23 pass · `biome check` clean · `tsc --noEmit` exit 0.