### PR TITLE
fix(mcp-catalog): don't fail catalog listing when one secret can't resolve

### DIFF
--- a/platform/backend/src/models/internal-mcp-catalog.secret-expansion.test.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.secret-expansion.test.ts
@@ -1,0 +1,40 @@
+import { vi } from "vitest";
+import { secretManager } from "@/secrets-manager";
+import { expect, test } from "@/test";
+import InternalMcpCatalogModel from "./internal-mcp-catalog";
+import SecretModel from "./secret";
+
+// Spying on the (real) secrets-manager instance keeps this file free of module
+// mocks, so it runs in the fast "clean" vitest project.
+test("catalog secret expansion degrades gracefully when a single secret fails to resolve", async ({
+  makeOrganization,
+  makeInternalMcpCatalog,
+}) => {
+  const org = await makeOrganization();
+  const secret = await SecretModel.create({
+    name: `expand-fail-${crypto.randomUUID().slice(0, 8)}`,
+    secret: { API_KEY: "shh" },
+  });
+  const catalog = await makeInternalMcpCatalog({
+    organizationId: org.id,
+    localConfigSecretId: secret.id,
+  });
+
+  const getSecretSpy = vi
+    .spyOn(secretManager(), "getSecret")
+    .mockRejectedValue(new Error("secrets backend unavailable"));
+
+  // Before the fix, one rejected getSecret rejected the whole Promise.all in
+  // expandSecrets and 5xx-ed the catalog tools listing. The listing must now
+  // resolve, simply leaving the unresolvable secret unpopulated.
+  const result = await InternalMcpCatalogModel.findById(catalog.id, {
+    expandSecrets: true,
+  });
+
+  // The failing secret was actually reached (the resolve path ran) ...
+  expect(getSecretSpy).toHaveBeenCalledWith(secret.id);
+  // ... yet the read succeeded instead of throwing.
+  expect(result?.id).toBe(catalog.id);
+
+  getSecretSpy.mockRestore();
+});

--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -11,6 +11,7 @@ import {
   sql,
 } from "drizzle-orm";
 import db, { schema } from "@/database";
+import logger from "@/logging";
 import { secretManager } from "@/secrets-manager";
 import {
   type CatalogItemApprovalStatus,
@@ -901,7 +902,21 @@ class InternalMcpCatalogModel {
     const resolvedSecretPromises = nonByosSecretIds.map((id) =>
       secretManager()
         .getSecret(id)
-        .then((secret) => [id, secret] as const),
+        .then((secret) => [id, secret] as const)
+        .catch((error): readonly [string, null] => {
+          // A single secret failing to resolve (a transient secrets-manager
+          // error, a stale reference, a permission issue) must not fail the
+          // whole catalog listing. Treat it as unresolved — the enrichment
+          // below already tolerates a missing secret via optional chaining — so
+          // read paths (list / findById) degrade gracefully instead of 5xx-ing.
+          // Runtime flows that require real values use
+          // expandSecretsAndAlwaysResolveValues(), which still propagates errors.
+          logger.error(
+            { err: error, secretId: id },
+            "[InternalMcpCatalog] failed to resolve secret during catalog expansion; continuing without it",
+          );
+          return [id, null] as const;
+        }),
     );
     const resolvedSecretEntries = await Promise.all(resolvedSecretPromises);
     const resolvedSecretMap = new Map(


### PR DESCRIPTION
## Problem

`GET /api/internal_mcp_catalog/:id/tools` (and the catalog list endpoints) can return a full 5xx with:

> Error: An error occurred while accessing secrets. Please try again later or contact your administrator.

`InternalMcpCatalogModel.expandSecrets()` resolves every referenced secret through `secretManager().getSecret()` inside a single `Promise.all`. If **any one** secret fails to resolve — a transient secrets-backend error, a permission issue, or a stale reference — the whole batch rejects, so the entire listing fails, even for catalog items whose secrets resolved fine.

## Fix

The enrichment step that follows already tolerates an *unresolved* secret — it optional-chains and simply skips populating a value when one is absent. So the fix is to catch resolution failures **per secret** and treat a failure as unresolved:

- One secret failing no longer rejects the batch; the read path (list / `findById`) degrades gracefully and returns the item with that secret left unpopulated.
- The failure is logged with the secret id for diagnosis.
- **Runtime flows are unchanged:** paths that require real secret values (OAuth, MCP server startup) go through `expandSecretsAndAlwaysResolveValues()`, which still propagates errors and is not touched here. Only the read/listing expansion degrades gracefully.

## Tests

New `models/internal-mcp-catalog.secret-expansion.test.ts`: creates a catalog item referencing a secret whose `getSecret()` rejects, then asserts `findById(..., { expandSecrets: true })` still resolves and returns the item. A spy confirms the failing secret was actually reached (so the test genuinely exercises the resolve path, not an early return). Spies the real secrets-manager instance (no module mocks → fast `clean` vitest project).

- `vitest run …secret-expansion.test.ts` → 1/1 pass
- `biome check` clean, `tsc --noEmit` exit 0

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>