### PR TITLE
fix(k8s): full-replace managed custom policies so stale selectors self-heal

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -3776,6 +3776,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
   type CustomPolicyObject = {
     metadata?: {
       name?: string;
+      resourceVersion?: string;
       labels?: Record<string, string>;
       annotations?: Record<string, string>;
       finalizers?: string[];
@@ -3936,6 +3937,20 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
             name,
             applyJsonMergePatch(existing, body) as CustomPolicyObject,
           );
+          return {};
+        },
+      ),
+      getNamespacedCustomObject: vi.fn(async ({ name }: { name: string }) => {
+        const existing = policies.get(name);
+        if (!existing) throw { statusCode: 404 };
+        return structuredClone(existing);
+      }),
+      replaceNamespacedCustomObject: vi.fn(
+        async ({ name, body }: { name: string; body: CustomPolicyObject }) => {
+          if (!policies.has(name)) throw { statusCode: 404 };
+          // Full replace: store the body wholesale, so keys absent from it
+          // (a stale selector label) are dropped — unlike merge-patch.
+          policies.set(name, structuredClone(body));
           return {};
         },
       ),
@@ -4443,9 +4458,10 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     }).applyK8sNetworkPolicy();
 
     expect([...policies.keys()]).toEqual([policyName]);
-    expect(customObjectsApi.patchNamespacedCustomObject).toHaveBeenCalledTimes(
-      1,
-    );
+    expect(
+      customObjectsApi.replaceNamespacedCustomObject,
+    ).toHaveBeenCalledTimes(1);
+    expect(customObjectsApi.patchNamespacedCustomObject).not.toHaveBeenCalled();
     expect(customObjectsApi.deleteNamespacedCustomObject).toHaveBeenCalledWith({
       group: "networking.k8s.aws",
       version: "v1alpha1",
@@ -4525,9 +4541,10 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     }).applyK8sNetworkPolicy();
 
     expect([...policies.keys()]).toEqual([policyName]);
-    expect(customObjectsApi.patchNamespacedCustomObject).toHaveBeenCalledTimes(
-      1,
-    );
+    expect(
+      customObjectsApi.replaceNamespacedCustomObject,
+    ).toHaveBeenCalledTimes(1);
+    expect(customObjectsApi.patchNamespacedCustomObject).not.toHaveBeenCalled();
     expect(customObjectsApi.deleteNamespacedCustomObject).toHaveBeenCalledWith({
       group: "cilium.io",
       version: "v2",
@@ -4611,9 +4628,10 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     expect(networkingApi.replaceNamespacedNetworkPolicy).toHaveBeenCalledTimes(
       1,
     );
-    expect(customObjectsApi.patchNamespacedCustomObject).toHaveBeenCalledTimes(
-      1,
-    );
+    expect(
+      customObjectsApi.replaceNamespacedCustomObject,
+    ).toHaveBeenCalledTimes(1);
+    expect(customObjectsApi.patchNamespacedCustomObject).not.toHaveBeenCalled();
     expect(networkingApi.deleteNamespacedNetworkPolicy).toHaveBeenCalledWith({
       name: "mcp-egress-generated-stale-k8s",
       namespace: "default",
@@ -4849,6 +4867,67 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
       namespace: "default",
     });
     expect([...kubernetesPolicies.keys()]).not.toContain(POLICY_NAME);
+  });
+
+  test("full-replaces a custom policy on conflict, stripping a stale selector label a merge-patch would keep", async () => {
+    const staleAnp: CustomPolicyObject = {
+      metadata: {
+        name: POLICY_NAME,
+        resourceVersion: "42",
+        finalizers: ["some-controller/finalizer"],
+      },
+      spec: {
+        podSelector: {
+          matchLabels: {
+            app: "mcp-server",
+            "mcp-server-id": "test-server-id",
+            // A stale per-install label the full replace must strip.
+            "mcp-server-name": "stale-name",
+          },
+        },
+        policyTypes: ["Egress"],
+        egress: [],
+      },
+    };
+    const { api: networkingApi } = makeStatefulNetworkingApi();
+    const { api: customObjectsApi, policies } = makeStatefulCustomObjectsApi({
+      resource: {
+        group: "networking.k8s.aws",
+        version: "v1alpha1",
+        plural: "applicationnetworkpolicies",
+      },
+      initialPolicies: [staleAnp],
+    });
+
+    await makeNetworkPolicyDeployment({
+      networkingApi,
+      customObjectsApi,
+      effectiveNetworkPolicy: makeNetworkPolicy({ egressMode: "unrestricted" }),
+      networkPolicyCapabilities: AWS_CAPS,
+    }).applyK8sNetworkPolicy();
+
+    const selector = (
+      policies.get(POLICY_NAME)?.spec as
+        | { podSelector?: { matchLabels?: Record<string, string> } }
+        | undefined
+    )?.podSelector?.matchLabels;
+    // The full replace dropped the stale mcp-server-name a merge-patch would keep.
+    expect(selector).toEqual({
+      app: "mcp-server",
+      "mcp-server-id": "test-server-id",
+    });
+    expect(customObjectsApi.patchNamespacedCustomObject).not.toHaveBeenCalled();
+    // The replace carried the live resourceVersion + finalizers.
+    expect(customObjectsApi.replaceNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          metadata: expect.objectContaining({
+            resourceVersion: "42",
+            finalizers: ["some-controller/finalizer"],
+          }),
+        }),
+      }),
+    );
   });
 
   test("emits a restricted CIDR-only allow-list as an ApplicationNetworkPolicy on AWS", async () => {

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -4930,6 +4930,47 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     );
   });
 
+  test("retries the custom-policy replace on a resourceVersion conflict (409) between GET and PUT", async () => {
+    const existingAnp: CustomPolicyObject = {
+      metadata: { name: POLICY_NAME, resourceVersion: "1" },
+      spec: {
+        podSelector: {
+          matchLabels: { app: "mcp-server", "mcp-server-id": "test-server-id" },
+        },
+        policyTypes: ["Egress"],
+        egress: [],
+      },
+    };
+    const { api: networkingApi } = makeStatefulNetworkingApi();
+    const { api: customObjectsApi, policies } = makeStatefulCustomObjectsApi({
+      resource: {
+        group: "networking.k8s.aws",
+        version: "v1alpha1",
+        plural: "applicationnetworkpolicies",
+      },
+      initialPolicies: [existingAnp],
+    });
+    // First PUT loses the resourceVersion race (a controller bumped it); the
+    // retry re-reads and succeeds.
+    (
+      customObjectsApi.replaceNamespacedCustomObject as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce({ statusCode: 409 });
+
+    await makeNetworkPolicyDeployment({
+      networkingApi,
+      customObjectsApi,
+      effectiveNetworkPolicy: makeNetworkPolicy({ egressMode: "unrestricted" }),
+      networkPolicyCapabilities: AWS_CAPS,
+    }).applyK8sNetworkPolicy();
+
+    // Re-read then re-PUT on the conflict — 2 GETs, 2 replaces, no throw.
+    expect(customObjectsApi.getNamespacedCustomObject).toHaveBeenCalledTimes(2);
+    expect(
+      customObjectsApi.replaceNamespacedCustomObject,
+    ).toHaveBeenCalledTimes(2);
+    expect(policies.get(POLICY_NAME)?.spec).toBeDefined();
+  });
+
   test("emits a restricted CIDR-only allow-list as an ApplicationNetworkPolicy on AWS", async () => {
     const { api: networkingApi } = makeStatefulNetworkingApi();
     const { api: customObjectsApi, policies: anpPolicies } =

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -709,10 +709,11 @@ export default class K8sDeployment {
   /**
    * Create or update a managed custom policy object.
    *
-   * Updates use a JSON merge patch instead of a PUT: custom resources reject
-   * a PUT without metadata.resourceVersion (so policies created by older
-   * releases would never be corrected in place), and a merge patch also
-   * preserves controller-owned metadata such as finalizers.
+   * Updates read the live object and PUT a full replace (carrying its
+   * resourceVersion, required by CRDs, and any controller-owned finalizers)
+   * rather than a JSON merge patch: merge patch recurses into nested objects and
+   * cannot delete a key absent from the body, so a stale selector label from an
+   * older release would survive and keep the policy from selecting its pod.
    */
   private async upsertManagedCustomPolicy(params: {
     resource: ManagedCustomPolicyResource;
@@ -744,17 +745,27 @@ export default class K8sDeployment {
           throw createError;
         }
 
-        await k8sCustomObjectsApi.patchNamespacedCustomObject(
-          {
-            group,
-            version,
-            namespace: this.namespace,
-            plural,
-            name: params.policyName,
-            body: params.body,
-          },
-          setHeaderOptions("Content-Type", PatchStrategy.MergePatch),
-        );
+        // Full replace, not merge-patch: a JSON Merge Patch recurses into
+        // podSelector.matchLabels and cannot delete a key absent from the body,
+        // so a stale selector label (e.g. a pre-fix mcp-server-name) would survive
+        // and keep the policy from selecting its pod. A blind PUT is rejected
+        // without a resourceVersion, so read the live object and carry its
+        // resourceVersion (and any controller-owned finalizers) into the body.
+        const existing = await k8sCustomObjectsApi.getNamespacedCustomObject({
+          group,
+          version,
+          namespace: this.namespace,
+          plural,
+          name: params.policyName,
+        });
+        await k8sCustomObjectsApi.replaceNamespacedCustomObject({
+          group,
+          version,
+          namespace: this.namespace,
+          plural,
+          name: params.policyName,
+          body: bodyWithPreservedMetadata(params.body, existing),
+        });
         logger.info(
           {
             mcpServerId: this.mcpServer.id,
@@ -3991,6 +4002,35 @@ function listCustomObjectItems(response: unknown): Array<{
       spec?: unknown;
     } => Boolean(item) && typeof item === "object",
   );
+}
+
+/**
+ * Carry the live object's resourceVersion (a CRD replace/PUT is rejected 422
+ * without it) and any controller-owned finalizers into the replacement body, so
+ * a full replace satisfies optimistic concurrency and doesn't strip finalizers.
+ */
+function bodyWithPreservedMetadata(
+  body: Record<string, unknown>,
+  existing: unknown,
+): Record<string, unknown> {
+  const existingMetadata =
+    existing && typeof existing === "object" && "metadata" in existing
+      ? ((existing as { metadata?: unknown }).metadata as
+          | { resourceVersion?: string; finalizers?: string[] }
+          | undefined)
+      : undefined;
+  const bodyMetadata =
+    (body.metadata as Record<string, unknown> | undefined) ?? {};
+  return {
+    ...body,
+    metadata: {
+      ...bodyMetadata,
+      resourceVersion: existingMetadata?.resourceVersion,
+      ...(existingMetadata?.finalizers
+        ? { finalizers: existingMetadata.finalizers }
+        : {}),
+    },
+  };
 }
 
 function policyTargetsPodLabels(

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -751,21 +751,37 @@ export default class K8sDeployment {
         // and keep the policy from selecting its pod. A blind PUT is rejected
         // without a resourceVersion, so read the live object and carry its
         // resourceVersion (and any controller-owned finalizers) into the body.
-        const existing = await k8sCustomObjectsApi.getNamespacedCustomObject({
-          group,
-          version,
-          namespace: this.namespace,
-          plural,
-          name: params.policyName,
-        });
-        await k8sCustomObjectsApi.replaceNamespacedCustomObject({
-          group,
-          version,
-          namespace: this.namespace,
-          plural,
-          name: params.policyName,
-          body: bodyWithPreservedMetadata(params.body, existing),
-        });
+        // Retry the read-modify-write on a 409: the policy's own CRD controller
+        // (AWS VPC CNI, Cilium operator) can bump resourceVersion by writing
+        // finalizers/status between the GET and the PUT.
+        for (let attempt = 1; ; attempt++) {
+          const existing = await k8sCustomObjectsApi.getNamespacedCustomObject({
+            group,
+            version,
+            namespace: this.namespace,
+            plural,
+            name: params.policyName,
+          });
+          try {
+            await k8sCustomObjectsApi.replaceNamespacedCustomObject({
+              group,
+              version,
+              namespace: this.namespace,
+              plural,
+              name: params.policyName,
+              body: bodyWithPreservedMetadata(params.body, existing),
+            });
+            break;
+          } catch (replaceError: unknown) {
+            if (
+              isK8sConflictError(replaceError) &&
+              attempt < CUSTOM_POLICY_REPLACE_MAX_ATTEMPTS
+            ) {
+              continue;
+            }
+            throw replaceError;
+          }
+        }
         logger.info(
           {
             mcpServerId: this.mcpServer.id,
@@ -4003,6 +4019,10 @@ function listCustomObjectItems(response: unknown): Array<{
     } => Boolean(item) && typeof item === "object",
   );
 }
+
+// Bounded optimistic-concurrency retries for the custom-policy read-modify-write
+// replace: a CRD controller can bump resourceVersion between the GET and the PUT.
+const CUSTOM_POLICY_REPLACE_MAX_ATTEMPTS = 4;
 
 /**
  * Carry the live object's resourceVersion (a CRD replace/PUT is rejected 422


### PR DESCRIPTION
Follow-up to the multitenant per-pod selector fix. That fix corrected the selector for **new** policies and self-healed existing **plain `NetworkPolicy`** ones (they're updated via `replaceNamespacedNetworkPolicy` — a full replace). But managed **custom-policy CRDs** — Cilium, GKE-FQDN, AWS `ApplicationNetworkPolicy` — were updated with a JSON Merge Patch (RFC 7396), which recurses into `podSelector.matchLabels` and cannot delete a key that's absent from the patch body. So an already-broken policy carrying a stale per-install `mcp-server-name` selector label would **never self-heal** on those providers: the policy keeps selecting zero pods and the pod gets no egress until it's manually recreated.

The custom-policy update path now reads the live object and issues a full replace (`replaceNamespacedCustomObject`, a PUT), carrying the live `metadata.resourceVersion` (a CRD PUT is rejected `422` without it) and any controller-owned `finalizers`, so the whole `spec` is overwritten and stale selector keys are dropped — matching how plain `NetworkPolicy` already behaves.

This does not affect plain-`NetworkPolicy` clusters (e.g. Calico), which already self-heal; it closes the gap for Cilium / GKE-Dataplane-V2 / AWS-VPC-CNI clusters that carry pre-existing broken multitenant policies.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>