### PR TITLE
perf(chat): repair trailing-garbage tool JSON deterministically before model re-ask

### DIFF
--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -168,7 +168,10 @@ import {
   detectSandboxCommand,
   runSandboxCommandTurn,
 } from "./sandbox-command-turn";
-import { repairHarmonyToolName } from "./tool-call-repair";
+import {
+  repairHarmonyToolName,
+  repairMalformedToolInput,
+} from "./tool-call-repair";
 import { createToolUiStartTransform } from "./tool-ui-stream";
 import { sendGatedUiMessageStreamResponse } from "./ui-stream-response";
 
@@ -1040,6 +1043,23 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     }
 
                     if (InvalidToolInputError.isInstance(error)) {
+                      // Cheap, deterministic first: models often tack a stray
+                      // token (an extra closing brace, trailing prose) onto
+                      // otherwise-valid tool JSON. Recover the first complete
+                      // JSON value with no extra model round-trip, and only fall
+                      // back to the model re-ask below when that can't safely
+                      // repair it.
+                      const deterministicInput = repairMalformedToolInput(
+                        toolCall.input,
+                      );
+                      if (deterministicInput !== null) {
+                        logger.info(
+                          { conversationId, toolName: toolCall.toolName },
+                          "Repaired malformed tool-call arguments without a model re-ask",
+                        );
+                        return { ...toolCall, input: deterministicInput };
+                      }
+
                       try {
                         const schema = await inputSchema({
                           toolName: toolCall.toolName,

--- a/platform/backend/src/routes/chat/tool-call-repair.test.ts
+++ b/platform/backend/src/routes/chat/tool-call-repair.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { repairHarmonyToolName } from "./tool-call-repair";
+import {
+  repairHarmonyToolName,
+  repairMalformedToolInput,
+} from "./tool-call-repair";
 
 const AVAILABLE = [
   "archestra__run_command",
@@ -91,5 +94,51 @@ describe("repairHarmonyToolName", () => {
         AVAILABLE,
       ),
     ).toBe("archestra__run_command");
+  });
+});
+
+describe("repairMalformedToolInput", () => {
+  test("returns valid JSON unchanged", () => {
+    const input = '{"path":"/a","count":2}';
+    expect(repairMalformedToolInput(input)).toBe(input);
+  });
+
+  test("drops a stray trailing brace on a new line", () => {
+    const repaired = repairMalformedToolInput('{"path":"/a"}\n}');
+    expect(repaired).toBe('{"path":"/a"}');
+    expect(JSON.parse(repaired as string)).toEqual({ path: "/a" });
+  });
+
+  test("drops trailing prose after a complete object", () => {
+    expect(repairMalformedToolInput('{"a":1} here you go!')).toBe('{"a":1}');
+  });
+
+  test("recovers an object whose string values contain braces and escaped quotes, then trailing garbage", () => {
+    // Mirrors the real failure: a large text field full of `}` and `\"`, with a
+    // duplicated closing brace appended by the model.
+    const intended = {
+      path: "/home/sandbox/app.html",
+      source: { type: "text", text: 'body { color: red; } and a "quote"' },
+    };
+    const malformed = `${JSON.stringify(intended)}\n}`;
+    const repaired = repairMalformedToolInput(malformed);
+    expect(repaired).not.toBeNull();
+    expect(JSON.parse(repaired as string)).toEqual(intended);
+  });
+
+  test("recovers a top-level array with trailing garbage", () => {
+    expect(repairMalformedToolInput("[1,2,3]]")).toBe("[1,2,3]");
+  });
+
+  test("returns null for an unterminated string (not safely recoverable)", () => {
+    expect(repairMalformedToolInput('{"a":"no close')).toBeNull();
+  });
+
+  test("returns null for a missing closing brace", () => {
+    expect(repairMalformedToolInput('{"a":1')).toBeNull();
+  });
+
+  test("returns null when there is no JSON value at all", () => {
+    expect(repairMalformedToolInput("just some text")).toBeNull();
   });
 });

--- a/platform/backend/src/routes/chat/tool-call-repair.ts
+++ b/platform/backend/src/routes/chat/tool-call-repair.ts
@@ -40,3 +40,80 @@ export function repairHarmonyToolName(
   }
   return null;
 }
+
+/**
+ * Best-effort, dependency-free repair for malformed tool-call argument JSON.
+ *
+ * Models sometimes emit otherwise-valid tool arguments with a stray trailing
+ * token — an extra closing brace on a new line, trailing prose, a duplicated
+ * value — which makes a strict `JSON.parse` reject the whole payload (e.g.
+ * "Unexpected non-whitespace character after JSON"). In that case the intended
+ * object is fully recoverable: it is the first complete, balanced JSON value in
+ * the string, and everything after it is garbage.
+ *
+ * Returns a valid JSON string when the input already parses, or when the first
+ * complete JSON value can be isolated and parses cleanly. Returns null when the
+ * input can't be safely recovered this way (an unterminated string, a missing
+ * brace, no JSON at all), leaving the caller to fall back to a heavier repair.
+ */
+export function repairMalformedToolInput(input: string): string | null {
+  if (isParseableJson(input)) {
+    return input;
+  }
+  const candidate = extractFirstJsonValue(input);
+  if (candidate === null || candidate === input) {
+    return null;
+  }
+  return isParseableJson(candidate) ? candidate : null;
+}
+
+function isParseableJson(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scan from the first `{`/`[` and return the substring spanning the first
+ * balanced, complete JSON value. String literals (and their escapes) are
+ * tracked so structural characters inside string values don't affect nesting
+ * depth. Returns null when no balanced value is found before the string ends.
+ */
+function extractFirstJsonValue(text: string): string | null {
+  const start = text.search(/[{[]/);
+  if (start === -1) {
+    return null;
+  }
+  const open = text[start];
+  const close = open === "{" ? "}" : "]";
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === open) {
+      depth++;
+    } else if (char === close) {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Context

The chat agent loop already repairs malformed tool-call argument JSON: on an `InvalidToolInputError`, `experimental_repairToolCall` re-asks the model (via `generateObject`) to re-emit valid JSON (added in #6024). That works and is the correct fallback — but it spends a **full extra LLM round-trip on every malformed input**, and those repair calls are noisy enough that #6201 had to exclude them from bench anomaly detection.

The most common malformation doesn't need a model at all: the model appends a **stray token** — an extra closing brace on a new line, trailing prose — to otherwise-valid arguments (`Unexpected non-whitespace character after JSON at position N`). The intended object is fully recoverable: it's the first complete, balanced JSON value in the string, and everything after it is garbage.

> Note: this is an **optimization, not a bug fix** — the underlying failure was already mitigated by the #6024 model re-ask (the observed occurrences stopped when it landed). This makes the common case free/instant and cuts repair LLM calls.

## Change

Add a cheap, dependency-free pre-pass `repairMalformedToolInput` (in the existing `tool-call-repair.ts`) to the `InvalidToolInputError` branch:

- Isolates the first complete, **balanced** JSON value, tracking string literals and escapes so `}`/`]` inside string values don't skew nesting depth (critical — the real payloads are HTML/CSS/JS full of braces).
- Returns it when it parses cleanly → the tool call is repaired **inline, no LLM call**.
- Returns `null` for anything it can't safely recover (unterminated string, missing brace, no JSON) → the **existing model re-ask runs exactly as before**.

So it strictly improves the common trailing-garbage case and is a no-op everywhere else. The AI SDK re-validates the repaired input against the tool schema after the hook returns, so a recovered-but-schema-invalid value fails the same as today.

## Tests

`tool-call-repair.test.ts` gains cases for: valid passthrough, stray trailing brace, trailing prose, a **nested object whose string values contain braces + escaped quotes followed by a duplicate closing brace** (mirrors the real failure), a top-level array with trailing garbage, and the three unrecoverable cases (all `null`). Plain vitest, no mocks → fast `clean` project.

- `vitest run …tool-call-repair.test.ts` → 18/18 pass (8 new)
- `biome check` clean, `tsc --noEmit` exit 0

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>