### PR TITLE
fix(mcp-base): bump click to fix CVE-2026-7246

### DIFF
--- a/platform/mcp_server_docker_image/pyproject.toml
+++ b/platform/mcp_server_docker_image/pyproject.toml
@@ -22,4 +22,6 @@ dependencies = [
   "pyjwt>=2.13.0",
   # cryptography < 48.0.1: GHSA-537c-gmf6-5ccf (out-of-bounds read)
   "cryptography>=48.0.1",
+  # click < 8.3.3: CVE-2026-7246 (pulled in via typer and uvicorn)
+  "click>=8.3.3",
 ]

--- a/platform/mcp_server_docker_image/requirements.lock
+++ b/platform/mcp_server_docker_image/requirements.lock
@@ -248,10 +248,11 @@ charset-normalizer==3.4.6 \
     --hash=sha256:f98059e4fcd3e3e4e2d632b7cf81c2faae96c43c60b569e9c621468082f1d104 \
     --hash=sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659
     # via requests
-click==8.3.1 \
-    --hash=sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a \
-    --hash=sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
+click==8.4.2 \
+    --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
     # via
+    #   archestra-mcp-server-python-deps (pyproject.toml)
     #   typer
     #   uvicorn
 cryptography==49.0.0 \


### PR DESCRIPTION
## What

Docker Scout's `Docker Image Scanning (MCP Server Base)` job fails with 1 HIGH CVE:

```
0C  1H  0M  0L  click 8.3.1  (pkg:pypi/click@8.3.1)
```

- **CVE-2026-7246** / GHSA-47fr-3ffg-hgmw — fixed in `click >= 8.3.3`
- `click` is pulled into the MCP server base image transitively via `typer` and `uvicorn`.

## Change

- Add a transitive constraint `click>=8.3.3` to `mcp_server_docker_image/pyproject.toml` (following the existing CVE-pin comment convention).
- Regenerate `requirements.lock` via `make -C mcp_server_docker_image update-python-lockfile`; uv resolves `click` to **8.4.2** (published 2026-06-24, ~19 days old, comfortably past the 7-day release-age practice).

Only `click` changed in the lockfile.

## Verification

- `uv pip compile` regenerated a valid hashed lock; `click==8.4.2` (> 8.3.3) clears the CVE.
- Failing run: https://github.com/archestra-ai/archestra/actions/runs/29272796931/job/86894407917

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>