### PR TITLE
feat(staging): move staging database to private Cloud SQL PG18

### DIFF
--- a/.github/values-staging.yaml
+++ b/.github/values-staging.yaml
@@ -145,35 +145,12 @@ archestra:
         secretName: archestra-sandbox-wildcard-tls
 
 postgresql:
-  # Staging still uses the bundled PostgreSQL chart. This is not HA, but these
-  # settings keep routine app deploys and voluntary node disruptions from
-  # bouncing the only database pod.
-  primary:
-    priorityClassName: platform-default
-    terminationGracePeriodSeconds: 120
-    pdb:
-      create: true
-      maxUnavailable: 0
-    startupProbe:
-      enabled: true
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 30
-    livenessProbe:
-      initialDelaySeconds: 60
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 12
-    readinessProbe:
-      initialDelaySeconds: 5
-      periodSeconds: 5
-      timeoutSeconds: 5
-      failureThreshold: 12
-    resources:
-      requests:
-        cpu: "1000m"
-        memory: "1Gi"
-      limits:
-        cpu: "1000m"
-        memory: "2Gi"
+  # Staging's database is Cloud SQL for PostgreSQL 18 (private IP, no public
+  # endpoint), not the bundled chart, so the database's durability no longer
+  # depends on the GKE node lifecycle — replacing a node used to take the only
+  # database pod down with it, which is what kept staging dying at random.
+  #
+  # The connection string is injected by the deploy workflow from the
+  # ARCHESTRA_STAGING_DATABASE_URL repo secret, so it is not in this file.
+  # The chart hard-fails if external_database_url is set while this is true.
+  enabled: false

--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -101,6 +101,7 @@ jobs:
           ARCHESTRA_STAGING_CHAT_ANTHROPIC_API_KEY: ${{ secrets.ARCHESTRA_STAGING_CHAT_ANTHROPIC_API_KEY }}
           ARCHESTRA_STAGING_MICROSOFT_365_COPILOT_CLIENT_ID: ${{ secrets.ARCHESTRA_STAGING_MICROSOFT_365_COPILOT_CLIENT_ID }}
           ARCHESTRA_STAGING_MICROSOFT_365_COPILOT_TENANT_ID: ${{ secrets.ARCHESTRA_STAGING_MICROSOFT_365_COPILOT_TENANT_ID }}
+          ARCHESTRA_STAGING_DATABASE_URL: ${{ secrets.ARCHESTRA_STAGING_DATABASE_URL }}
         run: |
           helm upgrade archestra-platform \
             ./platform/helm/archestra \
@@ -121,6 +122,7 @@ jobs:
             --set "archestra.env.ARCHESTRA_CHAT_ANTHROPIC_API_KEY=${ARCHESTRA_STAGING_CHAT_ANTHROPIC_API_KEY}" \
             --set "archestra.env.ARCHESTRA_MICROSOFT_365_COPILOT_CLIENT_ID=${ARCHESTRA_STAGING_MICROSOFT_365_COPILOT_CLIENT_ID}" \
             --set "archestra.env.ARCHESTRA_MICROSOFT_365_COPILOT_TENANT_ID=${ARCHESTRA_STAGING_MICROSOFT_365_COPILOT_TENANT_ID}" \
+            --set-string "postgresql.external_database_url=${ARCHESTRA_STAGING_DATABASE_URL}" \
             --values .github/values-staging.yaml \
             --atomic \
             --timeout 15m


### PR DESCRIPTION
## Why

Staging's database was the **bundled Bitnami PostgreSQL chart** — a single pod in the GKE cluster. That tied database availability to the *node* lifecycle: when a node went away, it took the only database pod with it and downed the whole environment.

That's what has been killing `frontend.archestra.dev` at random. The recent spot → on-demand node pool switch made it concrete: replacing the pool replaced every node, and staging went down with it.

## What

Staging now points at **Cloud SQL for PostgreSQL 18** (`archestra-staging-pg`):

- `db-custom-2-8192` (2 vCPU / 8 GB)
- **Private IP only** (`10.183.160.3`) — no public endpoint, reachable solely from inside the VPC via Private Services Access
- Lifecycle fully independent of GKE, so node churn no longer touches the database

The chart already supported this natively. Setting `postgresql.external_database_url` templates the URL into both the app secret and the migration-job secret and wires `ARCHESTRA_DATABASE_URL` via `secretKeyRef`. The chart *hard-fails* unless `postgresql.enabled: false` is also set, so the bundled subchart is disabled and its now-dead tuning block (probes / PDB / resources for the in-cluster pod) is removed.

The connection string is injected by the deploy workflow from a new `ARCHESTRA_STAGING_DATABASE_URL` repo secret (already set), so it never lands in the repo.

> `--set-string` rather than `--set` is required: the URL contains an `=` inside its `?sslmode=disable` query parameter.

## Data

The existing **37 GB** was cloned into the instance. Source and target are both **PostgreSQL 18.4**, so it's a like-for-like restore — no version hop, no downgrade risk. Extensions (`vector`, `pg_trgm`) are present on the target.

## Verification done before opening this PR

- `helm template` with the real secret value renders clean: the chart's fail-guard is satisfied, the bundled Postgres StatefulSet disappears, and the `database-url` in **both** rendered secrets is byte-identical to the Cloud SQL connection string (sha256-compared).
- A pod in the cluster reached the Cloud SQL private IP and authenticated successfully.

## Rollback

The bundled Postgres PVC (`data-archestra-platform-postgresql-0`, 100 Gi) uses `persistentVolumeClaimRetentionPolicy: Retain`, so **the old database stays on disk**. Reverting this PR brings the bundled Postgres back against the same volume.

## Related

Terraform for the instance (PSA range, peering, instance, database, roles) is in the `infra` repo.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>