### PR TITLE
chore(observability): reduce non-actionable error-tracking noise

### DIFF
--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -49,6 +49,26 @@ describe("isTransientDbError", () => {
     ).toBe(true);
   });
 
+  test("detects ENOTFOUND (DNS name did not resolve)", () => {
+    expect(
+      isTransientDbError(
+        new Error("getaddrinfo ENOTFOUND db.example.internal"),
+      ),
+    ).toBe(true);
+  });
+
+  test("detects ENOTFOUND wrapped as a DrizzleQueryError cause", () => {
+    const pgError = Object.assign(
+      new Error("getaddrinfo ENOTFOUND postgresql.archestra-dev"),
+      { code: "ENOTFOUND" },
+    );
+    const drizzleError = new Error(
+      'Failed query: select "id" from "agents" where "slug" = $1',
+      { cause: pgError },
+    );
+    expect(isTransientDbError(drizzleError)).toBe(true);
+  });
+
   test("detects 'Connection terminated'", () => {
     expect(isTransientDbError(new Error("Connection terminated"))).toBe(true);
   });
@@ -142,6 +162,9 @@ describe("getTransientDbErrorCode", () => {
     expect(
       getTransientDbErrorCode(new Error("getaddrinfo EAI_AGAIN db.internal")),
     ).toBe("EAI_AGAIN");
+    expect(
+      getTransientDbErrorCode(new Error("getaddrinfo ENOTFOUND db.internal")),
+    ).toBe("ENOTFOUND");
   });
 
   test("maps message patterns to low-cardinality codes", () => {

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -62,8 +62,12 @@ const TRANSIENT_ERROR_PATTERNS: ReadonlyArray<{
   { pattern: "ECONNRESET", code: "ECONNRESET" },
   { pattern: "EPIPE", code: "EPIPE" },
   { pattern: "ETIMEDOUT", code: "ETIMEDOUT" },
-  // Temporary DNS resolution failure (getaddrinfo). By definition retryable.
+  // DNS resolution failures (getaddrinfo). EAI_AGAIN is an explicitly
+  // temporary lookup failure; ENOTFOUND is a name that did not resolve,
+  // which is transient when a database host briefly stops resolving during
+  // a restart or failover (common with in-cluster service DNS).
   { pattern: "EAI_AGAIN", code: "EAI_AGAIN" },
+  { pattern: "ENOTFOUND", code: "ENOTFOUND" },
   { pattern: "Connection terminated", code: "connection_terminated" },
   {
     pattern: "timeout exceeded when trying to connect",

--- a/platform/backend/src/observability/sentry.test.ts
+++ b/platform/backend/src/observability/sentry.test.ts
@@ -1,0 +1,128 @@
+import { ArchestraInternalErrorCode } from "@archestra/shared";
+import type { ErrorEvent, EventHint } from "@sentry/core";
+import { describe, expect, test } from "@/test";
+import { ApiError, SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
+import { buildRawProviderError, filterErrorEvent } from "./sentry";
+
+function makeEvent(): ErrorEvent {
+  return {} as ErrorEvent;
+}
+
+function hintFor(error: unknown): EventHint {
+  return { originalException: error } as EventHint;
+}
+
+describe("buildRawProviderError", () => {
+  test("attaches the upstream status code to the error", () => {
+    const error = buildRawProviderError({
+      statusCode: 429,
+      errorMessage: "rate limit exceeded",
+    });
+    expect((error as Error & { statusCode?: number }).statusCode).toBe(429);
+    expect(error.message).toBe("rate limit exceeded");
+    expect(error.name).toBe("RawProviderError");
+  });
+
+  test("leaves statusCode unset when the upstream status is unknown", () => {
+    const error = buildRawProviderError({
+      statusCode: undefined,
+      errorMessage: "unknown provider failure",
+    });
+    expect("statusCode" in error).toBe(false);
+  });
+});
+
+describe("filterErrorEvent", () => {
+  test("drops an upstream provider client error (4xx)", () => {
+    // 429 rate limit, 401 invalid credentials, 403 provider block — all
+    // reflect the request/config, not a bug in our code.
+    for (const statusCode of [400, 401, 403, 429]) {
+      const error = buildRawProviderError({
+        statusCode,
+        errorMessage: `provider ${statusCode}`,
+      });
+      expect(filterErrorEvent(makeEvent(), hintFor(error))).toBeNull();
+    }
+  });
+
+  test("keeps an upstream provider server error (5xx)", () => {
+    for (const statusCode of [500, 502, 503]) {
+      const error = buildRawProviderError({
+        statusCode,
+        errorMessage: `provider ${statusCode}`,
+      });
+      const event = makeEvent();
+      expect(filterErrorEvent(event, hintFor(error))).toBe(event);
+    }
+  });
+
+  test("keeps a provider error with no status code", () => {
+    const error = buildRawProviderError({
+      statusCode: undefined,
+      errorMessage: "provider failure",
+    });
+    const event = makeEvent();
+    expect(filterErrorEvent(event, hintFor(error))).toBe(event);
+  });
+
+  test("drops ApiError instances with a 4xx status code", () => {
+    expect(
+      filterErrorEvent(makeEvent(), hintFor(new ApiError(404, "not found"))),
+    ).toBeNull();
+  });
+
+  test("keeps ApiError instances with a 5xx status code", () => {
+    const event = makeEvent();
+    expect(filterErrorEvent(event, hintFor(new ApiError(500, "boom")))).toBe(
+      event,
+    );
+  });
+
+  test("groups transient DB connectivity failures by root cause", () => {
+    // A DNS lookup failure the ORM wrapped per-query: fingerprint by the
+    // root cause so an outage groups into one issue, not one per statement.
+    const dbError = new Error(
+      'Failed query: select "id" from "agents" where "slug" = $1',
+      { cause: new Error("getaddrinfo ENOTFOUND postgresql.archestra-dev") },
+    );
+    const event = makeEvent();
+    const result = filterErrorEvent(event, hintFor(dbError));
+    expect(result).toBe(event);
+    expect(result?.fingerprint).toEqual(["db-transient", "ENOTFOUND"]);
+    expect(result?.tags?.error_type).toBe("db_transient");
+    expect(result?.tags?.db_error_code).toBe("ENOTFOUND");
+  });
+
+  test("groups secrets-backend outages by the root condition", () => {
+    const error = new ApiError(
+      503,
+      "secrets manager unavailable",
+      SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+    );
+    const event = makeEvent();
+    const result = filterErrorEvent(event, hintFor(error));
+    expect(result).toBe(event);
+    expect(result?.fingerprint).toEqual([
+      SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+    ]);
+  });
+
+  test("drops handled upstream-empty-response conditions", () => {
+    const error = new ApiError(
+      500,
+      "provider streamed an empty completion",
+      ArchestraInternalErrorCode.UpstreamEmptyResponse,
+    );
+    expect(filterErrorEvent(makeEvent(), hintFor(error))).toBeNull();
+  });
+
+  test("keeps a genuine server-side bug (generic 500)", () => {
+    const event = makeEvent();
+    expect(
+      filterErrorEvent(
+        event,
+        hintFor(new Error("undefined is not a function")),
+      ),
+    ).toBe(event);
+  });
+});

--- a/platform/backend/src/observability/sentry.ts
+++ b/platform/backend/src/observability/sentry.ts
@@ -30,6 +30,27 @@ const {
   },
 } = config;
 
+/**
+ * Build the Error object reported for a raw upstream-provider failure.
+ *
+ * The upstream HTTP status is attached to the Error so the {@link filterErrorEvent}
+ * 4xx filter drops expected provider CLIENT errors (rate limits, invalid
+ * credentials, provider-side content blocks) as noise, while genuine provider
+ * 5xx failures still report.
+ * @public — exported for testability
+ */
+export function buildRawProviderError(params: {
+  statusCode: number | undefined;
+  errorMessage: string;
+}): Error {
+  const error = new Error(params.errorMessage);
+  error.name = "RawProviderError";
+  if (params.statusCode !== undefined) {
+    (error as Error & { statusCode?: number }).statusCode = params.statusCode;
+  }
+  return error;
+}
+
 export function captureRawProviderErrorInSentry(params: {
   provider: string;
   statusCode: number | undefined;
@@ -39,8 +60,10 @@ export function captureRawProviderErrorInSentry(params: {
   errorType: string | undefined;
   rawErrorJson: string;
 }): void {
-  const error = new Error(params.errorMessage);
-  error.name = "RawProviderError";
+  const error = buildRawProviderError({
+    statusCode: params.statusCode,
+    errorMessage: params.errorMessage,
+  });
 
   Sentry.captureException(error, {
     level: "error",
@@ -65,6 +88,87 @@ export function captureRawProviderErrorInSentry(params: {
       rawErrorJson: params.rawErrorJson,
     },
   });
+}
+
+/**
+ * Decide whether an error event should be reported and normalize its
+ * fingerprint/tags for known classes of non-bug failures. Returns null to
+ * drop the event.
+ *
+ * Filters out expected client errors (4xx) — not found, validation errors,
+ * upstream provider client errors, etc. — which don't indicate bugs and
+ * would just create noise. Also groups availability incidents (transient DB
+ * connectivity, secrets-backend outages) by root cause so one outage becomes
+ * one issue instead of one issue per in-flight query/route.
+ *
+ * https://docs.sentry.io/platforms/javascript/configuration/filtering/
+ * @public — exported for testability
+ */
+export function filterErrorEvent(
+  event: ErrorEvent,
+  hint: EventHint,
+): ErrorEvent | null {
+  const error = hint.originalException;
+
+  // Transient database connectivity failures (DNS lookup, connection
+  // refused during a database restart, pool connect timeouts) get
+  // wrapped per-query by the ORM, which fragments one availability
+  // incident into an issue per SQL statement. Fingerprint them by root
+  // cause instead so each outage groups into a single issue.
+  const transientDbErrorCode = getTransientDbErrorCode(error);
+  if (transientDbErrorCode) {
+    event.fingerprint = ["db-transient", transientDbErrorCode];
+    event.tags = {
+      ...event.tags,
+      error_type: "db_transient",
+      db_error_code: transientDbErrorCode,
+    };
+  }
+
+  // A secrets-backend (e.g. Vault) outage fails every route that touches
+  // secrets, fragmenting one incident into an issue per endpoint and per
+  // upstream error message. Group by the root condition instead, same as
+  // the transient-DB handling above.
+  if (
+    error instanceof ApiError &&
+    error.internalCode === SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE
+  ) {
+    event.fingerprint = [SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE];
+    event.tags = {
+      ...event.tags,
+      error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+    };
+  }
+
+  // Filter out ApiError instances with 4xx status codes
+  if (error instanceof ApiError) {
+    if (error.statusCode >= 400 && error.statusCode < 500) {
+      return null;
+    }
+    // Known-transient upstream conditions (e.g. the provider streamed an
+    // empty completion) are handled: the client receives a retryable 503.
+    // They indicate provider flakiness, not a bug, so don't report them.
+    if (
+      error.internalCode === ArchestraInternalErrorCode.UpstreamEmptyResponse
+    ) {
+      return null;
+    }
+  }
+
+  // Also check for statusCode property on generic errors (e.g., from Fastify
+  // or an upstream provider error built by buildRawProviderError)
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number" &&
+    error.statusCode >= 400 &&
+    error.statusCode < 500
+  ) {
+    return null;
+  }
+
+  return event;
 }
 
 /**
@@ -144,76 +248,7 @@ const initSentry = async (): Promise<void> => {
      */
     skipOpenTelemetrySetup: true,
 
-    /**
-     * Filter out expected client errors (4xx) from being sent to Sentry.
-     * These are expected application errors (not found, validation errors, etc.)
-     * that don't indicate bugs and would just create noise in Sentry.
-     *
-     * https://docs.sentry.io/platforms/javascript/configuration/filtering/
-     */
-    beforeSend(event: ErrorEvent, hint: EventHint): ErrorEvent | null {
-      const error = hint.originalException;
-
-      // Transient database connectivity failures (DNS lookup, connection
-      // refused during a database restart, pool connect timeouts) get
-      // wrapped per-query by the ORM, which fragments one availability
-      // incident into an issue per SQL statement. Fingerprint them by root
-      // cause instead so each outage groups into a single issue.
-      const transientDbErrorCode = getTransientDbErrorCode(error);
-      if (transientDbErrorCode) {
-        event.fingerprint = ["db-transient", transientDbErrorCode];
-        event.tags = {
-          ...event.tags,
-          error_type: "db_transient",
-          db_error_code: transientDbErrorCode,
-        };
-      }
-
-      // A secrets-backend (e.g. Vault) outage fails every route that touches
-      // secrets, fragmenting one incident into an issue per endpoint and per
-      // upstream error message. Group by the root condition instead, same as
-      // the transient-DB handling above.
-      if (
-        error instanceof ApiError &&
-        error.internalCode === SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE
-      ) {
-        event.fingerprint = [SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE];
-        event.tags = {
-          ...event.tags,
-          error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
-        };
-      }
-
-      // Filter out ApiError instances with 4xx status codes
-      if (error instanceof ApiError) {
-        if (error.statusCode >= 400 && error.statusCode < 500) {
-          return null;
-        }
-        // Known-transient upstream conditions (e.g. the provider streamed an
-        // empty completion) are handled: the client receives a retryable 503.
-        // They indicate provider flakiness, not a bug, so don't report them.
-        if (
-          error.internalCode ===
-          ArchestraInternalErrorCode.UpstreamEmptyResponse
-        ) {
-          return null;
-        }
-      }
-
-      // Also check for statusCode property on generic errors (e.g., from Fastify)
-      if (
-        error &&
-        typeof error === "object" &&
-        "statusCode" in error &&
-        typeof error.statusCode === "number" &&
-        error.statusCode >= 400 &&
-        error.statusCode < 500
-      ) {
-        return null;
-      }
-
-      return event;
-    },
+    beforeSend: filterErrorEvent,
 
     // https://docs.sentry.io/platforms/javascript/configuration/options/#tracesSampler
     tracesSampler: ({


### PR DESCRIPTION
## Summary

The backend reports server errors to error tracking, but a large share of what lands there is non-actionable and buries real bugs. This filters/groups two classes of failures that are **not** bugs in our code, without suppressing genuine 5xx.

## Item A — upstream provider CLIENT errors (4xx) no longer captured

`captureRawProviderErrorInSentry` built a plain `Error` from an upstream provider failure but attached no status code to it. The error filter already drops errors whose `statusCode` is 4xx (expected client errors), but because the constructed error carried no `statusCode`, provider client-errors — rate limits (429), invalid credentials (401), provider content blocks (403) — slipped through and were reported as exceptions.

Fix: extract `buildRawProviderError(...)` which attaches the upstream status to the constructed `Error` (only when defined), so the existing 4xx filter drops provider client-errors while provider 5xx still report. The inline event filter is also extracted into a named `filterErrorEvent(event, hint)` so its drop/keep contract is directly unit-testable; the filtering logic itself is unchanged.

## Item B — transient DB connectivity (`ENOTFOUND`) mis-captured as fragmented 500s

The transient-DB classifier (`getTransientDbErrorCode`) walks the `.cause` chain and already recognizes `EAI_AGAIN`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, connection-terminated, and pool connect timeouts — but it did **not** recognize `ENOTFOUND` (a database host that briefly stops resolving during a restart or failover; common with in-cluster service DNS). That gap meant retry-exhausted DNS failures fell through to the generic handler and were captured as 500 "unhandled_error", fragmenting one availability incident into a separate issue per in-flight SQL statement.

Fix: add `ENOTFOUND` to the transient patterns (one line, same message-match style as its siblings). Retry-exhausted transient DB errors now classify as transient → returned as a retryable 503 → grouped as one issue by root cause. Only genuinely-transient DNS/socket connectivity signatures are added; real query errors (constraint violations, syntax errors) are untouched and still surface as 500.

## Item C — skipped (follow-up)

Expected user-side failures — remote MCP server connection failures ("Failed to connect to MCP server", "Session not found", "Invalid Host header") and user MCP container CrashLoopBackOff — are also non-actionable. These are thrown across many sites (`clients/mcp-client.ts`, `k8s/mcp-server-runtime/*`, `routes/mcp-server.ts`) with varied propagation paths to the error handler and inconsistent status codes; a clean, conservative filter would require tracing each path individually. Deferred to a dedicated follow-up rather than over-reaching in this PR.

## Tests

- `retry.test.ts`: `ENOTFOUND` recognized both directly and when wrapped as a query error's `.cause`; still returns the stable `ENOTFOUND` code.
- `sentry.test.ts` (new): provider 4xx dropped / provider 5xx kept / no-status-code kept; `ApiError` 4xx dropped and 5xx kept; transient-DB and secrets-outage grouping (fingerprint + tags); handled upstream-empty-response dropped; a genuine server-side bug (generic 500) still reports.

## Verification

- `npx vitest run src/database/retry.test.ts src/observability/sentry.test.ts` → 58 passed
- `biome check` → clean
- `npx tsc --noEmit -p tsconfig.json` → exit 0
- `pnpm knip` (dev + production) → clean

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>