### PR TITLE
fix(mcp-registry): render ForbiddenPage for users without registry read access

### DIFF
--- a/platform/frontend/src/app/mcp/registry/page.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/page.test.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getServerApiHeadersMock,
+  getInternalMcpCatalogMock,
+  getMcpServersMock,
+} = vi.hoisted(() => ({
+  getServerApiHeadersMock: vi.fn(),
+  getInternalMcpCatalogMock: vi.fn(),
+  getMcpServersMock: vi.fn(),
+}));
+const { serverCanAccessPageMock } = vi.hoisted(() => ({
+  serverCanAccessPageMock: vi.fn(),
+}));
+
+vi.mock("@archestra/shared", () => ({
+  archestraApiSdk: {
+    getInternalMcpCatalog: getInternalMcpCatalogMock,
+    getMcpServers: getMcpServersMock,
+  },
+}));
+
+vi.mock("@/lib/utils/server", () => ({
+  getServerApiHeaders: getServerApiHeadersMock,
+}));
+
+vi.mock("@/lib/auth/auth.server", () => ({
+  serverCanAccessPage: serverCanAccessPageMock,
+}));
+
+vi.mock("./page.client", () => ({
+  default: ({ initialData }: { initialData: unknown }) => (
+    <div data-testid="mcp-registry-page">{JSON.stringify(initialData)}</div>
+  ),
+}));
+
+vi.mock("@/components/error-fallback", () => ({
+  ServerErrorFallback: ({ error }: { error: Error }) => (
+    <div data-testid="server-error-fallback">{error.message}</div>
+  ),
+}));
+
+import McpRegistryPage from "./page";
+
+describe("McpRegistryPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServerApiHeadersMock.mockResolvedValue({});
+    serverCanAccessPageMock.mockResolvedValue(true);
+  });
+
+  it("renders the forbidden page before fetching data when access is denied", async () => {
+    serverCanAccessPageMock.mockResolvedValue(false);
+
+    render(await McpRegistryPage());
+
+    expect(
+      screen.getByText("You don't have permission to access this page."),
+    ).toBeInTheDocument();
+    expect(getInternalMcpCatalogMock).not.toHaveBeenCalled();
+    expect(getMcpServersMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the page client when data loads successfully", async () => {
+    getInternalMcpCatalogMock.mockResolvedValue({ data: [] });
+    getMcpServersMock.mockResolvedValue({ data: [] });
+
+    render(await McpRegistryPage());
+
+    expect(screen.getByTestId("mcp-registry-page")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/page.tsx
+++ b/platform/frontend/src/app/mcp/registry/page.tsx
@@ -4,7 +4,9 @@ import {
   type ErrorExtended,
 } from "@archestra/shared";
 
+import { ForbiddenPage } from "@/app/_parts/forbidden-page";
 import { ServerErrorFallback } from "@/components/error-fallback";
+import { serverCanAccessPage } from "@/lib/auth/auth.server";
 import { handleApiError } from "@/lib/utils";
 import { getServerApiHeaders } from "@/lib/utils/server";
 import McpRegistryClient from "./page.client";
@@ -21,6 +23,10 @@ export default async function McpRegistryPage() {
   };
 
   try {
+    if (!(await serverCanAccessPage("/mcp/registry"))) {
+      return <ForbiddenPage />;
+    }
+
     const headers = await getServerApiHeaders();
     const [catalogResponse, serversResponse] = await Promise.all([
       archestraApiSdk.getInternalMcpCatalog({ headers }),


### PR DESCRIPTION
## What

The MCP registry page (`/mcp/registry`) fetched catalog/server data during SSR **without** the server-side page-access gate that its sibling resource pages already use (`agents`, `llm/proxies`, `mcp/gateways`).

`/mcp/registry` requires `mcpRegistry: ["read"]` (see `shared/access-control.ts`), but the page never checked it server-side. A user lacking that permission got an **empty registry** — the non-2xx response was swallowed into the default `[]` — instead of the standard `ForbiddenPage` the other resource pages render. That ungated SSR fetch was also the source of the reported access-denied noise.

## Change

Add the same guard the sibling pages use, before the data fetch:

```ts
if (!(await serverCanAccessPage("/mcp/registry"))) {
  return <ForbiddenPage />;
}
```

Now an unauthorized request renders the standard `ForbiddenPage` and skips the data fetch, consistent with the other resource pages. No behavior change for authorized users.

## Tests

Added `frontend/src/app/mcp/registry/page.test.tsx` (mirrors the existing `mcp/gateways/page.test.tsx`):
- renders `ForbiddenPage` and does **not** fetch when access is denied
- renders the page client when data loads successfully

## Checks

- `pnpm type-check` — pass
- `pnpm --filter @frontend lint` — pass
- new test file — pass

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>