### PR TITLE
fix(interactions): tolerate an unrecognized stored auth method on list/detail reads

### DIFF
--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -42,6 +42,7 @@ import type {
 } from "@/types";
 import {
   InteractionAuthMethodSchema,
+  normalizeInteractionAuthMethod,
   normalizeInteractionResponse,
 } from "@/types";
 import { trackBackgroundWork } from "@/utils/background-work";
@@ -494,6 +495,9 @@ class InteractionModel {
           interaction.type,
           interaction.response,
         ),
+        // Coerce an out-of-enum stored authMethod to null so one legacy row
+        // can't 500 the whole list (the read schema validates it strictly).
+        authMethod: normalizeInteractionAuthMethod(interaction.authMethod),
         // computeRequestType must run on the reconstructed (full) request — it
         // inspects messages.length and the first/last message content.
         requestType: computeRequestType(
@@ -608,6 +612,9 @@ class InteractionModel {
         interaction.type,
         interaction.response,
       ),
+      // Coerce an out-of-enum stored authMethod to null so a legacy row can't
+      // 500 the detail route (the read schema validates it strictly).
+      authMethod: normalizeInteractionAuthMethod(interaction.authMethod),
       chatErrors: await findChatErrorsForSessionId(interaction.sessionId),
     } as Interaction;
   }

--- a/platform/backend/src/routes/interaction.test.ts
+++ b/platform/backend/src/routes/interaction.test.ts
@@ -589,7 +589,7 @@ describe("interaction routes", () => {
     // sessions route survived (it already tolerates it).
     await db
       .update(schema.interactionsTable)
-      .set({ authMethod: "idp_jwt" as never })
+      .set({ authMethod: "legacy_removed_method" as never })
       .where(eq(schema.interactionsTable.id, created.id));
 
     const list = await app.inject({

--- a/platform/backend/src/routes/interaction.test.ts
+++ b/platform/backend/src/routes/interaction.test.ts
@@ -4,6 +4,8 @@ import {
   CLAUDE_CLIENT_ID,
   CLAUDE_DESKTOP_CLIENT_ID,
 } from "@archestra/shared";
+import { eq } from "drizzle-orm";
+import db, { schema } from "@/database";
 import ConversationModel from "@/models/conversation";
 import ConversationChatErrorModel from "@/models/conversation-chat-error";
 import InteractionModel from "@/models/interaction";
@@ -553,5 +555,63 @@ describe("interaction routes", () => {
     expect(response.statusCode).toBe(200);
     expect(response.json().data).toHaveLength(2);
     expect(response.json().pagination.total).toBe(4);
+  });
+
+  test("serializes an interaction whose stored authMethod is out of enum", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({
+      organizationId,
+      authorId: currentUser.id,
+      scope: "org",
+    });
+    const created = await InteractionModel.create({
+      profileId: agent.id,
+      sessionId: "auth-method-session",
+      request: {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+      response: {
+        id: "r",
+        object: "chat.completion",
+        created: Date.now(),
+        model: "gpt-4",
+        choices: [],
+      } as unknown as InteractionResponse,
+      type: "openai:chatCompletions",
+    });
+
+    // A legacy row (or a writer whose value predates an enum addition) can hold
+    // an auth_method outside InteractionAuthMethodSchema. Written directly since
+    // the model's insert type only permits current enum members. Before the read
+    // path coerced it, this row 500-ed the list and detail routes while the
+    // sessions route survived (it already tolerates it).
+    await db
+      .update(schema.interactionsTable)
+      .set({ authMethod: "idp_jwt" as never })
+      .where(eq(schema.interactionsTable.id, created.id));
+
+    const list = await app.inject({
+      method: "GET",
+      url: "/api/interactions?limit=10&offset=0",
+    });
+    expect(list.statusCode).toBe(200);
+    expect(list.json().data).toHaveLength(1);
+    // The unrecognized value serializes as null rather than 500-ing.
+    expect(list.json().data[0].authMethod).toBeNull();
+
+    const detail = await app.inject({
+      method: "GET",
+      url: `/api/interactions/${created.id}`,
+    });
+    expect(detail.statusCode).toBe(200);
+    expect(detail.json().authMethod).toBeNull();
+
+    const sessions = await app.inject({
+      method: "GET",
+      url: "/api/interactions/sessions?limit=10&offset=0",
+    });
+    expect(sessions.statusCode).toBe(200);
   });
 });

--- a/platform/backend/src/types/interaction.ts
+++ b/platform/backend/src/types/interaction.ts
@@ -473,6 +473,25 @@ export function normalizeInteractionResponse(
     : { error: "Malformed stored interaction response" };
 }
 
+/**
+ * Coerce a stored `authMethod` that is not a member of
+ * `InteractionAuthMethodSchema` to null on read. Older rows (and any writer
+ * whose value predates an enum addition) can hold an out-of-enum string; without
+ * this, one such row 500s the entire GET /api/interactions list and the detail
+ * route, because the read schema validates `authMethod` strictly with no
+ * fallback. The sessions endpoint already applies the equivalent tolerance via
+ * `parseInteractionAuthMethods`; this brings the list/detail read path in line.
+ */
+export function normalizeInteractionAuthMethod(
+  authMethod: string | null | undefined,
+): InteractionAuthMethod | null {
+  if (authMethod == null) {
+    return null;
+  }
+  const parsed = InteractionAuthMethodSchema.safeParse(authMethod);
+  return parsed.success ? parsed.data : null;
+}
+
 export const InsertInteractionSchema = createInsertSchema(
   schema.interactionsTable,
   {


### PR DESCRIPTION
## Problem

`GET /api/interactions` (list) and `GET /api/interactions/:id` (detail) can return HTTP 500 "Response doesn't match the schema". Each row is serialized through the interactions read schema, whose `authMethod` is validated strictly against a fixed enum with no read-side tolerance. A stored `auth_method` value outside that enum — a legacy row, or one written before an enum value was renamed/removed — makes response serialization throw, which **500s the entire list** (and the detail route), not just the one row.

The smoking gun: the sibling `GET /api/interactions/sessions` route does **not** 500 on the same row, because it already tolerates unrecognized auth methods (it `safeParse`-filters them). This change brings the list/detail read paths in line with that existing behavior.

## Fix

Coerce an unrecognized stored `authMethod` to `null` on read, at the model layer — mirroring the existing `normalizeInteractionResponse` hardening:

- Added `normalizeInteractionAuthMethod()` (returns the value if it's a current enum member, else `null`).
- Applied it in `InteractionModel.findAllPaginated` and `findById`.
- **Writes stay strict** — the insert path is unchanged, so the OpenAPI spec and generated client are untouched (no codegen, no migration).

`null` is chosen to match the `/sessions` route's existing "drop the unrecognized value" behavior. This is defensive against any out-of-enum value (legacy rows or future drift); it does not hide a *current* auth method — current writers to the interactions table only produce enum-valid values (the MCP-gateway auth methods are a separate enum for a separate table).

## Tests

`routes/interaction.test.ts`: store an interaction whose `auth_method` is outside the enum, then assert list, detail, **and** sessions all return 200 and the value serializes as `null`.

- `vitest` (route + model) → 79 pass · `biome` clean · `tsc --noEmit` exit 0 · `knip` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>