### PR TITLE
fix(llm): tolerate unknown provider values in provider-keys read responses

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -183826,27 +183826,34 @@
                         "type": "string"
                       },
                       "provider": {
-                        "type": "string",
-                        "enum": [
-                          "openai",
-                          "gemini",
-                          "anthropic",
-                          "bedrock",
-                          "cohere",
-                          "cerebras",
-                          "mistral",
-                          "perplexity",
-                          "groq",
-                          "xai",
-                          "openrouter",
-                          "vllm",
-                          "ollama",
-                          "zhipuai",
-                          "deepseek",
-                          "minimax",
-                          "azure",
-                          "github-copilot",
-                          "microsoft-365-copilot"
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "openai",
+                              "gemini",
+                              "anthropic",
+                              "bedrock",
+                              "cohere",
+                              "cerebras",
+                              "mistral",
+                              "perplexity",
+                              "groq",
+                              "xai",
+                              "openrouter",
+                              "vllm",
+                              "ollama",
+                              "zhipuai",
+                              "deepseek",
+                              "minimax",
+                              "azure",
+                              "github-copilot",
+                              "microsoft-365-copilot"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
                         ]
                       },
                       "secretId": {
@@ -184721,27 +184728,34 @@
                         "type": "string"
                       },
                       "provider": {
-                        "type": "string",
-                        "enum": [
-                          "openai",
-                          "gemini",
-                          "anthropic",
-                          "bedrock",
-                          "cohere",
-                          "cerebras",
-                          "mistral",
-                          "perplexity",
-                          "groq",
-                          "xai",
-                          "openrouter",
-                          "vllm",
-                          "ollama",
-                          "zhipuai",
-                          "deepseek",
-                          "minimax",
-                          "azure",
-                          "github-copilot",
-                          "microsoft-365-copilot"
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "openai",
+                              "gemini",
+                              "anthropic",
+                              "bedrock",
+                              "cohere",
+                              "cerebras",
+                              "mistral",
+                              "perplexity",
+                              "groq",
+                              "xai",
+                              "openrouter",
+                              "vllm",
+                              "ollama",
+                              "zhipuai",
+                              "deepseek",
+                              "minimax",
+                              "azure",
+                              "github-copilot",
+                              "microsoft-365-copilot"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
                         ]
                       },
                       "secretId": {
@@ -185127,27 +185141,34 @@
                       "type": "string"
                     },
                     "provider": {
-                      "type": "string",
-                      "enum": [
-                        "openai",
-                        "gemini",
-                        "anthropic",
-                        "bedrock",
-                        "cohere",
-                        "cerebras",
-                        "mistral",
-                        "perplexity",
-                        "groq",
-                        "xai",
-                        "openrouter",
-                        "vllm",
-                        "ollama",
-                        "zhipuai",
-                        "deepseek",
-                        "minimax",
-                        "azure",
-                        "github-copilot",
-                        "microsoft-365-copilot"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "openai",
+                            "gemini",
+                            "anthropic",
+                            "bedrock",
+                            "cohere",
+                            "cerebras",
+                            "mistral",
+                            "perplexity",
+                            "groq",
+                            "xai",
+                            "openrouter",
+                            "vllm",
+                            "ollama",
+                            "zhipuai",
+                            "deepseek",
+                            "minimax",
+                            "azure",
+                            "github-copilot",
+                            "microsoft-365-copilot"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
                       ]
                     },
                     "secretId": {

--- a/platform/backend/src/routes/llm-provider-api-keys.test.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.test.ts
@@ -1,3 +1,4 @@
+import type { SupportedProvider } from "@archestra/shared";
 import { vi } from "vitest";
 import LlmProviderApiKeyModelLinkModel from "@/models/llm-provider-api-key-model";
 import ModelModel from "@/models/model";
@@ -246,6 +247,39 @@ describe("LLM Provider API Keys CRUD", () => {
 
     expect(response.statusCode).toBe(200);
     expect(Array.isArray(response.json())).toBe(true);
+  });
+
+  test("lists a stored provider value outside the known enum without a 500", async ({
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    // The provider column is free text, so a stored row can hold a value the
+    // running instance's enum doesn't list — legacy data, or (more commonly) a
+    // key created on a newer pod during a rolling deploy while an older pod,
+    // whose enum predates that provider, serves the list. The read schema must
+    // serialize such a row instead of throwing a ResponseSerializationError,
+    // which (because the list is a z.array) would 500 the entire endpoint for
+    // every key. Insert via the fixture to bypass the route's strict write-time
+    // enum validation and reproduce that stored state.
+    const unknownProvider = "acme-next-gen-provider" as SupportedProvider;
+    const secret = await makeSecret();
+    const apiKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: unknownProvider,
+      scope: "personal",
+      userId: user.id,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/llm-provider-api-keys",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const returned = response
+      .json()
+      .find((key: { id: string }) => key.id === apiKey.id);
+    expect(returned).toBeDefined();
+    expect(returned.provider).toBe("acme-next-gen-provider");
   });
 
   test("should create a personal LLM provider API key", async () => {

--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -40,7 +40,7 @@ import {
   ApiError,
   constructResponseSchema,
   type LlmProviderApiKey,
-  LlmProviderApiKeyWithScopeInfoSchema,
+  LlmProviderApiKeyWithScopeInfoResponseSchema,
   type ResourceVisibilityScope,
   ResourceVisibilityScopeSchema,
   SelectLlmProviderApiKeySchema,
@@ -170,7 +170,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
           provider: SupportedProvidersSchema.optional(),
         }),
         response: constructResponseSchema(
-          z.array(LlmProviderApiKeyWithScopeInfoSchema),
+          z.array(LlmProviderApiKeyWithScopeInfoResponseSchema),
         ),
       },
     },
@@ -214,7 +214,7 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
           includeKeyId: z.string().uuid().optional(),
         }),
         response: constructResponseSchema(
-          z.array(LlmProviderApiKeyWithScopeInfoSchema),
+          z.array(LlmProviderApiKeyWithScopeInfoResponseSchema),
         ),
       },
     },
@@ -600,7 +600,9 @@ const llmProviderApiKeyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         params: z.object({
           id: z.string().uuid(),
         }),
-        response: constructResponseSchema(LlmProviderApiKeyWithScopeInfoSchema),
+        response: constructResponseSchema(
+          LlmProviderApiKeyWithScopeInfoResponseSchema,
+        ),
       },
     },
     async ({ params, organizationId, user }, reply) => {

--- a/platform/backend/src/types/llm-provider-api-key.ts
+++ b/platform/backend/src/types/llm-provider-api-key.ts
@@ -77,3 +77,26 @@ export const LlmProviderApiKeyWithScopeInfoSchema =
 export type LlmProviderApiKeyWithScopeInfo = z.infer<
   typeof LlmProviderApiKeyWithScopeInfoSchema
 >;
+
+/**
+ * Response-only variant of {@link LlmProviderApiKeyWithScopeInfoSchema} for the
+ * read endpoints (list / available / get), which serialize whatever is stored.
+ *
+ * The `provider` column is unconstrained `text` (only compile-time typed as
+ * SupportedProvider), so a stored row can hold a value the running instance's
+ * enum doesn't list — e.g. a key created on a newer pod during a rolling deploy,
+ * read back by an older pod whose enum predates that provider. A strict enum in
+ * the response schema would make Fastify serialization throw on that one row
+ * and, because the list response is a `z.array(...)` (all-or-nothing), 500 the
+ * entire endpoint. The union keeps the known providers declared while accepting
+ * any other string.
+ *
+ * This tolerance lives ONLY on the wire schema so the domain types
+ * (`LlmProviderApiKey`, `LlmProviderApiKeyWithScopeInfo`) stay strictly
+ * `SupportedProvider` for backend logic; writes remain validated by the
+ * Insert/Update schemas and the route request bodies.
+ */
+export const LlmProviderApiKeyWithScopeInfoResponseSchema =
+  LlmProviderApiKeyWithScopeInfoSchema.extend({
+    provider: SupportedProvidersSchema.or(z.string()),
+  });

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -6,12 +6,14 @@ import {
   formatSecretStorageType,
   isProviderApiKeyOptional,
   type ResourceVisibilityScope,
+  type SupportedProvider,
 } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
   AlertTriangle,
   Building2,
   CheckCircle2,
+  Key,
   Loader2,
   Pencil,
   Plus,
@@ -116,7 +118,7 @@ export default function ApiKeysPage() {
     provider:
       providerFilter === "all"
         ? undefined
-        : (providerFilter as LlmProviderApiKeyResponse["provider"]),
+        : (providerFilter as SupportedProvider),
     enabled: apiKeyQueriesEnabled,
   });
   const { data: organization } = useOrganization();
@@ -171,7 +173,7 @@ export default function ApiKeysPage() {
     if (isEditDialogOpen && selectedApiKey) {
       editForm.reset({
         name: selectedApiKey.name,
-        provider: selectedApiKey.provider,
+        provider: selectedApiKey.provider as SupportedProvider,
         apiKey: selectedApiKey.secretId ? LLM_PROVIDER_API_KEY_PLACEHOLDER : "",
         baseUrl: selectedApiKey.baseUrl ?? null,
         inferenceBaseUrl: selectedApiKey.inferenceBaseUrl ?? null,
@@ -308,13 +310,20 @@ export default function ApiKeysPage() {
         seen.add(apiKey.provider);
         return true;
       })
-      .map((apiKey) => {
-        const config = PROVIDER_CONFIG[apiKey.provider];
-        return {
-          value: apiKey.provider,
-          icon: config.icon,
-          name: config.name,
-        };
+      .flatMap((apiKey) => {
+        // A stored provider may not be in the known enum (see the union on the
+        // provider-keys read schema). Such providers have no icon/label config,
+        // so they're omitted from the filter dropdown; the key itself still
+        // renders in the table below with a generic-icon fallback.
+        const config = PROVIDER_CONFIG[apiKey.provider as SupportedProvider];
+        if (!config) return [];
+        return [
+          {
+            value: apiKey.provider,
+            icon: config.icon,
+            name: config.name,
+          },
+        ];
       })
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [allApiKeys]);
@@ -342,17 +351,24 @@ export default function ApiKeysPage() {
         accessorKey: "provider",
         header: "Provider",
         cell: ({ row }) => {
-          const config = PROVIDER_CONFIG[row.original.provider];
+          // Unknown providers (not in the known enum) have no icon/label config;
+          // fall back to a generic icon and the raw provider string.
+          const config =
+            PROVIDER_CONFIG[row.original.provider as SupportedProvider];
           return (
             <div className="flex items-center gap-2">
-              <Image
-                src={config.icon}
-                alt={config.name}
-                width={20}
-                height={20}
-                className="rounded dark:invert"
-              />
-              <span>{config.name}</span>
+              {config?.icon ? (
+                <Image
+                  src={config.icon}
+                  alt={config.name}
+                  width={20}
+                  height={20}
+                  className="rounded dark:invert"
+                />
+              ) : (
+                <Key className="h-5 w-5 shrink-0 text-muted-foreground" />
+              )}
+              <span>{config?.name ?? row.original.provider}</span>
             </div>
           );
         },
@@ -412,7 +428,7 @@ export default function ApiKeysPage() {
             {row.original.isSystem ||
             row.original.secretId ||
             isProviderApiKeyOptional({
-              provider: row.original.provider,
+              provider: row.original.provider as SupportedProvider,
               azureEntraIdEnabled: azureOpenAiEntraIdEnabled === true,
               anthropicWifEnabled: anthropicWifEnabled === true,
             }) ? (

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -992,7 +992,8 @@ export function AgentDialog({
         setLlmModel(bestModelId);
       } else if (currentLlmProvider !== key.provider) {
         // Only fall back to first model when switching providers (no bestModelId available)
-        const providerModels = modelsByProvider[key.provider];
+        const providerModels =
+          modelsByProvider[key.provider as SupportedProvider];
         if (providerModels?.length) {
           setLlmModel(providerModels[0].dbId);
         }

--- a/platform/frontend/src/components/chat/llm-provider-api-key-selector.tsx
+++ b/platform/frontend/src/components/chat/llm-provider-api-key-selector.tsx
@@ -189,7 +189,7 @@ export function LlmProviderApiKeySelector({
       // For existing conversations, let onProviderChange handle both the API key
       // update and model selection in a single mutation to avoid race conditions.
       if (selectedKeyProvider && onProviderChange) {
-        onProviderChange(selectedKeyProvider, keyId);
+        onProviderChange(selectedKeyProvider as SupportedProvider, keyId);
       } else {
         updateConversationMutation.mutate({
           id: conversationId,
@@ -202,7 +202,7 @@ export function LlmProviderApiKeySelector({
         onApiKeyChange(keyId);
       }
       if (selectedKeyProvider && onProviderChange) {
-        onProviderChange(selectedKeyProvider, keyId);
+        onProviderChange(selectedKeyProvider as SupportedProvider, keyId);
       }
     }
   };

--- a/platform/frontend/src/components/llm-provider-api-key-dropdown.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-dropdown.tsx
@@ -133,7 +133,9 @@ export function LlmProviderApiKeyDropdown({
             <span className="flex min-w-0 items-center gap-1.5">
               {selectedKey ? (
                 <>
-                  <ProviderIcon provider={selectedKey.provider} />
+                  <ProviderIcon
+                    provider={selectedKey.provider as SupportedProvider}
+                  />
                   <span className="truncate font-medium">
                     {selectedKey.name}
                   </span>
@@ -264,7 +266,10 @@ export function LlmProviderApiKeyDropdown({
 }
 
 function groupKeysByProvider(availableKeys: DropdownLlmProviderApiKey[]) {
-  const grouped = {} as Record<SupportedProvider, DropdownLlmProviderApiKey[]>;
+  // Keyed by the raw provider string: a stored provider may not be in the known
+  // enum, so an unknown one simply becomes its own group (rendered gracefully by
+  // ProviderGroupHeading/ProviderIcon) instead of breaking the lookup.
+  const grouped = {} as Record<string, DropdownLlmProviderApiKey[]>;
 
   for (const key of availableKeys) {
     if (!grouped[key.provider]) {

--- a/platform/frontend/src/components/virtual-key-searchable-select.tsx
+++ b/platform/frontend/src/components/virtual-key-searchable-select.tsx
@@ -1,10 +1,8 @@
 "use client";
 
+import type { SupportedProvider } from "@archestra/shared";
 import Image from "next/image";
-import {
-  type LlmProviderApiKeyResponse,
-  PROVIDER_CONFIG,
-} from "@/components/llm-provider-api-key-form";
+import { PROVIDER_CONFIG } from "@/components/llm-provider-api-key-form";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { cn } from "@/lib/utils";
 
@@ -38,10 +36,7 @@ function VirtualKeyOptionLabel({ option }: { option: VirtualKeyApiItem }) {
     <div className="flex min-w-0 items-center gap-2">
       <div className="flex shrink-0 gap-1">
         {providerApiKeys.map((pk) => {
-          const config =
-            PROVIDER_CONFIG[
-              pk.provider as LlmProviderApiKeyResponse["provider"]
-            ];
+          const config = PROVIDER_CONFIG[pk.provider as SupportedProvider];
           if (!config?.icon) return null;
           return (
             <Image
@@ -71,9 +66,7 @@ function VirtualKeySelectedValue({ option }: { option: VirtualKeyApiItem }) {
   const providerApiKeys = option.providerApiKeys ?? [];
   const firstProvider = providerApiKeys[0];
   const config = firstProvider
-    ? PROVIDER_CONFIG[
-        firstProvider.provider as LlmProviderApiKeyResponse["provider"]
-      ]
+    ? PROVIDER_CONFIG[firstProvider.provider as SupportedProvider]
     : null;
 
   return (

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -47748,7 +47748,7 @@ export type GetLlmProviderApiKeysResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot' | 'microsoft-365-copilot';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot' | 'microsoft-365-copilot' | string;
         secretId: string | null;
         scope: 'personal' | 'team' | 'org';
         userId: string | null;
@@ -47973,7 +47973,7 @@ export type GetAvailableLlmProviderApiKeysResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot' | 'microsoft-365-copilot';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot' | 'microsoft-365-copilot' | string;
         secretId: string | null;
         scope: 'personal' | 'team' | 'org';
         userId: string | null;
@@ -48166,7 +48166,7 @@ export type GetLlmProviderApiKeyResponses = {
         id: string;
         organizationId: string;
         name: string;
-        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot' | 'microsoft-365-copilot';
+        provider: 'openai' | 'gemini' | 'anthropic' | 'bedrock' | 'cohere' | 'cerebras' | 'mistral' | 'perplexity' | 'groq' | 'xai' | 'openrouter' | 'vllm' | 'ollama' | 'zhipuai' | 'deepseek' | 'minimax' | 'azure' | 'github-copilot' | 'microsoft-365-copilot' | string;
         secretId: string | null;
         scope: 'personal' | 'team' | 'org';
         userId: string | null;


### PR DESCRIPTION
## Problem

`GET /api/llm-provider-api-keys` (and the sibling `available` / `:id` read endpoints) intermittently returned **HTTP 500 "Response doesn't match the schema"**.

Root cause: the `provider` column on `llm_provider_api_keys` is an unconstrained `text` column (only compile-time typed as `SupportedProvider` — there is no DB-level enum). The read endpoints declared a **strict enum** for `provider` in their Fastify response schema. When a stored row holds a provider value the running instance's enum doesn't list — most plausibly a key created on a newer pod during a rolling deploy, then read back by a not-yet-upgraded pod whose enum predates that provider — response serialization threw a `ResponseSerializationError`. Because the list response is a `z.array(...)` (all-or-nothing), a single such row **500'd the entire endpoint** for every key, until the rollout completed.

## Fix

Add a response-only schema, `LlmProviderApiKeyWithScopeInfoResponseSchema`, whose `provider` is `SupportedProvidersSchema.or(z.string())`, and use it in the three GET read endpoints (`list`, `available`, `:id`). The union keeps the known providers **declared in OpenAPI** while accepting any other string, so one unrecognized row can no longer take down the list.

The tolerance lives **only on the wire schema**:

- **Writes stay strict** — the Insert/Update schemas and the `POST`/`PATCH` request bodies still validate `provider` against `SupportedProvidersSchema`, so no out-of-enum value can enter via the API.
- **Backend domain types are unchanged** — `LlmProviderApiKey` and `LlmProviderApiKeyWithScopeInfo` remain `SupportedProvider`, so no backend logic is affected (this is why the tolerance is a separate response schema rather than being placed on `SelectLlmProviderApiKeySchema`, which would have collapsed the domain type to `string` across the whole backend).
- **Frontend degrades gracefully** — the generated read-response `provider` type becomes `… | string`, so the provider-keys UI renders an unknown provider with a generic icon and its raw name (instead of crashing / indexing `undefined`), and buckets it into its own filter/group entry.

## Tests

Adds a backend behavior test that stores a `provider` value outside the canonical enum and asserts `GET /api/llm-provider-api-keys` returns **200** with that key present. Verified it fails (500) against the pre-fix strict schema and passes with the fix.

## Verification

- `backend` `tsc --noEmit`, `frontend` `tsc --noEmit`, and the root `type-check` (all workspaces) pass.
- Affected backend test file passes (47 tests); biome and knip clean on both workspaces.
- OpenAPI + generated API client regenerated via `pnpm codegen`.

## Follow-up (out of scope)

The generated client renders the read-response type as `'openai' | … | string`, which TypeScript collapses to bare `string` (autocomplete/assignability for the known providers is lost — handled here via the frontend fallbacks). Restoring literal-union autocomplete for this and other open-enum generated fields would require a **codegen-level `(string & {})` transform** in the hey-api pipeline — a global change to how every `anyOf[enum, string]` field is typed, which warrants its own review and is intentionally not bundled here.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>