### PR TITLE
fix(a2a): default a missing attachment content type in buildUserContent

### DIFF
--- a/platform/backend/src/agents/a2a-executor.test.ts
+++ b/platform/backend/src/agents/a2a-executor.test.ts
@@ -270,6 +270,30 @@ describe("buildUserContent", () => {
     expect(note).not.toBe("");
   });
 
+  test("defaults a missing content type instead of crashing the classifier", async () => {
+    // An attachment can reach buildUserContent without a content type if an
+    // upstream ingestion path's `as string` cast is ever exercised with an
+    // undefined value. It must be normalized to a safe default rather than throw
+    // on the `image/` prefix check (or produce a `data:undefined;...` URL).
+    const attachments: A2AAttachment[] = [
+      {
+        contentType: undefined as unknown as string,
+        contentBase64: "QUJD",
+        name: "mystery.bin",
+      },
+    ];
+
+    const { content } = await buildUserContent(
+      "Inspect",
+      attachments,
+      // Make the defaulted octet-stream readable so the normalized attachment is
+      // kept and its resolved mediaType is observable.
+      geminiOpts(new Set(["application/octet-stream"])),
+    );
+
+    expect(fileMediaTypes(content)).toContain("application/octet-stream");
+  });
+
   test("filters out tiny image attachments below MIN_IMAGE_ATTACHMENT_SIZE", async () => {
     // ~988 decoded bytes (below the 2KB threshold), like broken inline refs.
     const tinyBase64 = "A".repeat(1317);

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -731,7 +731,16 @@ export async function buildUserContent(
     stageAttachments?: StageAttachmentsFn;
   },
 ): Promise<{ content: UserContent | null; note: string }> {
-  const allAttachments = attachments ?? [];
+  // `A2AAttachment.contentType` is typed non-optional, but every value
+  // originates from an external source (A2A protocol parts, chat-platform or
+  // email uploads) and stays populated only because each ingestion path defaults
+  // it — the A2A path in particular narrows an optional SDK `mediaType` through
+  // an `as string` cast behind a co-located filter. Default a missing content
+  // type once here so a slip at any of those sites can't crash the image/mime
+  // classification below or emit a `data:undefined;base64,...` URL further down.
+  const allAttachments = (attachments ?? []).map((att) =>
+    att.contentType ? att : { ...att, contentType: "application/octet-stream" },
+  );
   // A sandbox is usable iff the caller supplied a stager; deriving it here (vs a
   // separate flag) makes the "available but unstageable" state unrepresentable.
   const sandboxAvailable = opts.stageAttachments !== undefined;


### PR DESCRIPTION
## What

`buildUserContent` (the A2A/agent attachment pipeline) classifies each attachment by its `contentType` — the `image/` prefix check, the mime rejection policy, the inline-vs-stage decision, and the `data:<contentType>;base64,...` URL it hands to the provider all read that field.

`A2AAttachment.contentType` is typed non-optional (`string`), but every value originates from an **external** source — A2A protocol message parts, and chat-platform / email uploads. It stays populated today only because each of the five ingestion paths independently remembers to default or filter it. The A2A path in particular narrows an optional SDK `mediaType` to `string` through an `as string` cast that is sound only because of a co-located `mediaType !== undefined` filter.

That makes the invariant fragile: if that filter is ever weakened, or a sixth ingestion path forgets to default, a missing content type would reach `buildUserContent` and throw a `TypeError` on `.startsWith("image/")` (or emit a `data:undefined;base64,...` URL), crashing agent execution.

## Change

Normalize a missing content type to `application/octet-stream` **once**, at the top of `buildUserContent`, before any downstream use. This centralizes the invariant at the single consumption point instead of relying on every current and future producer, and protects every downstream read at once.

This is defensive hardening, not a fix for a reproduced crash — I traced all five construction paths and each currently guarantees a string. It closes the one genuine type-hole (the `as string` cast) so the classifier can't be crashed by a producer-side slip.

## Test

Adds a regression test: an attachment whose `contentType` is `undefined` is normalized to `application/octet-stream` (kept and observable as a file part) rather than throwing on the prefix check.

## Checks

- `tsc --noEmit`: clean
- Biome: clean
- knip (dev + production): clean
- `a2a-executor.test.ts`: 36 passed (35 baseline + 1 new)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>