### PR TITLE
chore(observability): stop capturing upstream 502/504 failures in the exception sink

### DIFF
--- a/platform/backend/src/observability/sentry.test.ts
+++ b/platform/backend/src/observability/sentry.test.ts
@@ -78,6 +78,27 @@ describe("filterErrorEvent", () => {
     );
   });
 
+  test("drops upstream-gateway failures surfaced as 502/504 ApiErrors", () => {
+    // 502/504 mean a user-configured provider or an external/self-hosted MCP
+    // server failed (unreachable, misconfigured, timed out) — not our code.
+    // Mirror the request-error handler's exclusion so both sinks agree.
+    for (const statusCode of [502, 504]) {
+      expect(
+        filterErrorEvent(
+          makeEvent(),
+          hintFor(new ApiError(statusCode, `upstream ${statusCode}`)),
+        ),
+      ).toBeNull();
+    }
+  });
+
+  test("keeps a 503 ApiError, which signals our own overload/outage", () => {
+    const event = makeEvent();
+    expect(filterErrorEvent(event, hintFor(new ApiError(503, "busy")))).toBe(
+      event,
+    );
+  });
+
   test("groups transient DB connectivity failures by root cause", () => {
     // A DNS lookup failure the ORM wrapped per-query: fingerprint by the
     // root cause so an outage groups into one issue, not one per statement.

--- a/platform/backend/src/observability/sentry.ts
+++ b/platform/backend/src/observability/sentry.ts
@@ -153,6 +153,13 @@ export function filterErrorEvent(
     ) {
       return null;
     }
+    // 502/504 report an upstream's failure — a user-configured provider or an
+    // external/self-hosted MCP server that is unreachable, misconfigured, or
+    // timed out — not a crash of ours. The request-error handler already keeps
+    // these out of exception tracking; mirror that here so the two sinks agree.
+    if (error.statusCode === 502 || error.statusCode === 504) {
+      return null;
+    }
   }
 
   // Also check for statusCode property on generic errors (e.g., from Fastify


### PR DESCRIPTION
## What

Errors we surface with a **502** or **504** status report a failure of something *upstream* — a user-configured LLM provider, an external provider token exchange, or an external / self-hosted MCP server that is unreachable, misconfigured, or timed out (for example, probing an MCP server that isn't running). These are operational / configuration conditions on the other side of the boundary, **not crashes of our own code** — our own faults surface as `500`.

The request-error handler already keeps 502/504 out of exception tracking (with the rationale that they "report an upstream's failure … not a crash of ours"). The shared error filter that feeds the other exception sink did **not** have the equivalent exclusion, so the same upstream failures showed up there as noise — the largest contributor being MCP-server-inspection failures when a user's server can't be reached.

## Change

Mirror the existing 502/504 exclusion in the shared error filter, so both exception sinks apply the same policy.

Scoped deliberately to avoid over-suppression:
- Only `ApiError` instances with status `502`/`504` are dropped. Every place we emit those codes is an upstream-failure mapping (provider token exchange, MCP inspect, LLM provider), never an our-code bug.
- Genuine server-side bugs surface as `500` (and `503` for our own overload/outage) and **still report**.
- Upstream provider `5xx` captured via the raw-provider-error path are **generic** errors (not `ApiError`) and are untouched — they still report for diagnostics.
- No message-substring matching and no blanket status suppression.

## Test

Adds cases to the error-filter test: `ApiError` 502/504 are dropped; a `503` `ApiError` is kept (contrast case proving our-side failures still report). Existing coverage that keeps provider 5xx via the raw-provider path remains green.

## Checks

- `tsc --noEmit`: clean
- Biome: clean
- knip (dev + production): clean
- error-filter tests: 13 passed (11 baseline + 2 new)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>