### PR TITLE
fix(chatops): Telegram group behavior — privacy-mode truth in docs, full participation when privacy is off

### DIFF
--- a/docs/pages/platform-telegram.md
+++ b/docs/pages/platform-telegram.md
@@ -44,9 +44,12 @@ Every message in a DM gets a reply. On first contact the bot asks which agent sh
 
 ### Group chats
 
-Add the bot to a group. It replies when addressed: an `@botname` mention, a reply to one of its messages, or a `/command`.
+Add the bot to a group. The bot's Group Privacy setting in BotFather decides what it hears:
 
-One Telegram quirk matters here: bots have Group Privacy on by default, and with it on Telegram delivers only `/commands` and replies — plain `@botname` mentions never reach the bot. For group use, disable Group Privacy for the bot in BotFather, then remove and re-add the bot to the group (Telegram caches the setting). Making the bot a group admin also works, and additionally lets the agent observe all group messages.
+- **Privacy on** (Telegram's default): the bot only receives `/commands` and replies to its own messages — plain `@botname` mentions never reach it.
+- **Privacy off** (or the bot is a group admin): the bot hears every message. The agent joins the conversation — it answers mentions and replies always, answers other messages when they're for it, and stays silent when people are clearly talking to each other.
+
+For group use, disable Group Privacy, then remove and re-add the bot to the group — Telegram caches the setting per membership.
 
 In supergroups with Topics enabled, each forum topic is a separate conversation for the agent.
 

--- a/docs/pages/platform-telegram.md
+++ b/docs/pages/platform-telegram.md
@@ -44,13 +44,9 @@ Every message in a DM gets a reply. On first contact the bot asks which agent sh
 
 ### Group chats
 
-Add the bot to a group. It replies when addressed:
+Add the bot to a group. It replies when addressed: an `@botname` mention, a reply to one of its messages, or a `/command`.
 
-- `@botname` mention
-- a reply to one of its messages
-- a `/command`
-
-By default Telegram's privacy mode means the bot only receives these messages anyway. To let an agent observe all group messages (and decide when to chime in), disable Group Privacy for the bot in BotFather, then remove and re-add the bot to the group — Telegram caches the setting.
+One Telegram quirk matters here: bots have Group Privacy on by default, and with it on Telegram delivers only `/commands` and replies — plain `@botname` mentions never reach the bot. For group use, disable Group Privacy for the bot in BotFather, then remove and re-add the bot to the group (Telegram caches the setting). Making the bot a group admin also works, and additionally lets the agent observe all group messages.
 
 In supergroups with Topics enabled, each forum topic is a separate conversation for the agent.
 
@@ -93,8 +89,8 @@ Photos and documents sent to the bot are downloaded and passed to the agent, sub
 - Check the integration is enabled and the token is valid (the status shows "configured")
 - Make sure your Telegram account is linked — send `/start` to the bot to check
 
-**Bot not responding in a group**
-- Address it explicitly (@mention, reply, or command), or disable Group Privacy in BotFather and re-add the bot to the group
+**Bot not responding to @mentions in a group**
+- Group Privacy is on (the default): Telegram only delivers `/commands` and replies to the bot's messages. Send `/select-agent` to confirm the bot is alive, then disable Group Privacy in BotFather and remove and re-add the bot to the group
 
 **"This Telegram account isn't linked" reply**
 - Send `/start` to the bot and follow the sign-in link it replies with

--- a/platform/backend/src/agents/chatops/telegram-provider.test.ts
+++ b/platform/backend/src/agents/chatops/telegram-provider.test.ts
@@ -145,15 +145,21 @@ describe("parseWebhookNotification", () => {
     ).toBeNull();
   });
 
-  test("ignores group messages that don't address the bot", async () => {
+  test("forwards unaddressed group messages so the agent decides whether to reply", async () => {
+    // Only deliverable with BotFather privacy mode off (or the bot as group
+    // admin) — Telegram filters these otherwise. The manager's group framing
+    // gives the agent the no-reply sentinel for messages not meant for it.
     const provider = makeProvider();
-    expect(await provider.parseWebhookNotification(groupUpdate())).toBeNull();
-    // A bare command may target another bot in the group
-    expect(
-      await provider.parseWebhookNotification(
-        groupUpdate({ text: "/weather" }),
-      ),
-    ).toBeNull();
+    const message = await provider.parseWebhookNotification(groupUpdate());
+    expect(message).toMatchObject({
+      channelId: "-100123",
+      text: "hello",
+      metadata: { conversationType: "groupChat", botMentioned: false },
+    });
+  });
+
+  test("drops group commands aimed at another bot", async () => {
+    const provider = makeProvider();
     expect(
       await provider.parseWebhookNotification(
         groupUpdate({ text: "/weather@some_other_bot" }),

--- a/platform/backend/src/agents/chatops/telegram-provider.ts
+++ b/platform/backend/src/agents/chatops/telegram-provider.ts
@@ -142,15 +142,12 @@ class TelegramProvider implements ChatOpsProvider {
       message.reply_to_message?.from?.id != null &&
       message.reply_to_message.from.id === this.botId;
 
-    // Groups: only act when addressed — mention, reply to the bot, or a
-    // /command@thisbot. Telegram delivers every group /command to every bot,
-    // so a bare unknown command may be meant for another bot and is ignored.
-    if (
-      isGroup &&
-      !botMentioned &&
-      !isReplyToBot &&
-      !this.isCommandAddressedToBot(rawText)
-    ) {
+    // Groups: with BotFather's privacy mode on (the default) Telegram itself
+    // delivers only /commands and replies to the bot. When it's off — or the
+    // bot is a group admin — every message arrives; forward them all and let
+    // the agent's group framing decide when to stay silent, like MS Teams
+    // group chats. Only commands aimed at a different bot are dropped.
+    if (isGroup && this.isCommandForAnotherBot(rawText)) {
       return null;
     }
 
@@ -833,10 +830,10 @@ class TelegramProvider implements ChatOpsProvider {
     }
   }
 
-  private isCommandAddressedToBot(text: string): boolean {
-    if (!this.botUsername) return false;
+  private isCommandForAnotherBot(text: string): boolean {
     const match = /^\/\w+@(\w+)/.exec(text);
-    return match?.[1]?.toLowerCase() === this.botUsername.toLowerCase();
+    if (!match) return false;
+    return match[1].toLowerCase() !== this.botUsername?.toLowerCase();
   }
 
   private isBotMentioned(message: TelegramMessage): boolean {

--- a/platform/frontend/src/components/telegram-setup-dialog.tsx
+++ b/platform/frontend/src/components/telegram-setup-dialog.tsx
@@ -83,10 +83,10 @@ export function TelegramSetupDialog({
             />
           </div>
           <p className="text-xs text-muted-foreground">
-            To let the bot see regular messages in group chats, disable Group
-            Privacy for it in BotFather (Bot Settings → Group Privacy), then
-            re-add the bot to the group. With privacy on, it only receives
-            @mentions, replies, and commands.
+            For group chats, disable Group Privacy for the bot in BotFather (Bot
+            Settings → Group Privacy), then remove and re-add the bot to the
+            group. With privacy on, Telegram delivers only /commands and replies
+            to the bot — not @mentions.
           </p>
           <div className="flex justify-end">
             <Button


### PR DESCRIPTION
Follow-ups to #6494 from real-world group testing.

**Docs/UI copy correction:** with BotFather's default Group Privacy ON, Telegram delivers only `/commands` and replies to the bot's own messages — plain `@botname` mentions never reach the bot (reads as "the bot ignores the group", and the group never appears in Channels). The copy implied mentions get through; now it states the quirk and the mandatory remove/re-add after flipping the setting.

**Behavior:** with Group Privacy OFF (or the bot as group admin) Telegram delivers every message, but the provider dropped unaddressed ones. Now it forwards them all with `botMentioned=false` and the manager's existing group framing decides — reply by default, no-reply sentinel when the conversation is clearly between other people (same model as MS Teams group chats). Commands aimed at another bot are still dropped. Privacy mode effectively becomes the setting: on = respond only when addressed, off = participate in the conversation.