### PR TITLE
refactor(observability): share one error-tracking noise policy across both sinks

### DIFF
--- a/platform/backend/src/observability/error-tracking-policy.test.ts
+++ b/platform/backend/src/observability/error-tracking-policy.test.ts
@@ -1,0 +1,115 @@
+import { ArchestraInternalErrorCode } from "@archestra/shared";
+import { describe, expect, test } from "@/test";
+import { ApiError, SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
+import { classifyErrorForTracking } from "./error-tracking-policy";
+
+/** A generic Error whose `.name` marks it as an MCP-connectivity failure. */
+function namedError(name: string, message = "boom"): Error {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+}
+
+/** A generic Error carrying an HTTP `statusCode` property. */
+function statusError(statusCode: number): Error & { statusCode: number } {
+  return Object.assign(new Error(`status ${statusCode}`), { statusCode });
+}
+
+describe("classifyErrorForTracking", () => {
+  test("reports a genuine server-side bug (generic 500) without grouping", () => {
+    const decision = classifyErrorForTracking(
+      new Error("undefined is not a function"),
+    );
+    expect(decision.report).toBe(true);
+    expect(decision.fingerprint).toBeUndefined();
+  });
+
+  test("reports our own 5xx ApiErrors (500, 503)", () => {
+    for (const statusCode of [500, 503]) {
+      expect(
+        classifyErrorForTracking(new ApiError(statusCode, "boom")).report,
+      ).toBe(true);
+    }
+  });
+
+  test("drops 4xx ApiErrors as expected client errors", () => {
+    for (const statusCode of [400, 401, 403, 404, 429]) {
+      expect(
+        classifyErrorForTracking(new ApiError(statusCode, "client error"))
+          .report,
+      ).toBe(false);
+    }
+  });
+
+  test("drops 502/504 ApiErrors as upstream failures", () => {
+    for (const statusCode of [502, 504]) {
+      expect(
+        classifyErrorForTracking(new ApiError(statusCode, "upstream")).report,
+      ).toBe(false);
+    }
+  });
+
+  test("drops the handled upstream-empty-response condition", () => {
+    const error = new ApiError(
+      500,
+      "provider streamed an empty completion",
+      ArchestraInternalErrorCode.UpstreamEmptyResponse,
+    );
+    expect(classifyErrorForTracking(error).report).toBe(false);
+  });
+
+  test("drops a generic error carrying a 4xx client status", () => {
+    for (const statusCode of [400, 404, 429]) {
+      expect(classifyErrorForTracking(statusError(statusCode)).report).toBe(
+        false,
+      );
+    }
+  });
+
+  test("keeps a generic error carrying a 5xx status", () => {
+    // Unlike ApiError 502/504 (our upstream-gateway mapping, dropped), a
+    // generic 5xx is a provider's own server error surfaced via the
+    // raw-provider-error path — a diagnostic signal we keep reporting.
+    for (const statusCode of [500, 502, 503, 504]) {
+      expect(classifyErrorForTracking(statusError(statusCode)).report).toBe(
+        true,
+      );
+    }
+  });
+
+  test("drops MCP-server-unreachable errors by name", () => {
+    for (const name of [
+      "McpServerNotReadyError",
+      "McpServerConnectionTimeoutError",
+    ]) {
+      expect(classifyErrorForTracking(namedError(name)).report).toBe(false);
+    }
+  });
+
+  test("groups transient DB connectivity failures by root cause", () => {
+    const dbError = new Error(
+      'Failed query: select "id" from "agents" where "slug" = $1',
+      { cause: new Error("connect ECONNREFUSED 10.0.0.1:5432") },
+    );
+    const decision = classifyErrorForTracking(dbError);
+    expect(decision.report).toBe(true);
+    expect(decision.fingerprint).toEqual(["db-transient", "ECONNREFUSED"]);
+    expect(decision.tags).toMatchObject({
+      error_type: "db_transient",
+      db_error_code: "ECONNREFUSED",
+    });
+  });
+
+  test("groups secrets-backend outages by the root condition", () => {
+    const error = new ApiError(
+      503,
+      "secrets manager unavailable",
+      SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+    );
+    const decision = classifyErrorForTracking(error);
+    expect(decision.report).toBe(true);
+    expect(decision.fingerprint).toEqual([
+      SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+    ]);
+  });
+});

--- a/platform/backend/src/observability/error-tracking-policy.ts
+++ b/platform/backend/src/observability/error-tracking-policy.ts
@@ -1,0 +1,119 @@
+import { ArchestraInternalErrorCode } from "@archestra/shared";
+import { getTransientDbErrorCode } from "@/database/retry";
+import { ApiError, SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
+
+/**
+ * Sink-agnostic policy for what backend errors reach our exception trackers,
+ * shared by every capture path (the Sentry `beforeSend` filter and the
+ * PostHog request-error / unhandled-rejection capture funnels) so the two
+ * sinks agree and the rules live in one place.
+ *
+ * Two kinds of non-bug failure are handled:
+ *
+ *   - Expected client/upstream errors (4xx, upstream 502/504, a user's MCP
+ *     server that is unreachable or not ready, handled empty-completions) are
+ *     dropped — they reflect the request, the caller's config, or an external
+ *     dependency, not a crash of ours, and would only create noise.
+ *   - Availability incidents (transient DB connectivity, a secrets-backend
+ *     outage) are kept but assigned a stable fingerprint so one outage groups
+ *     into a single issue instead of fragmenting per in-flight query/route.
+ */
+interface ErrorTrackingDecision {
+  /** When false, the error is expected noise — skip both exception sinks. */
+  report: boolean;
+  /**
+   * Stable grouping key for an availability incident. Applied by each sink in
+   * its own shape (Sentry `event.fingerprint`, PostHog `$exception_fingerprint`
+   * joined with "/").
+   */
+  fingerprint?: string[];
+  /** Tags/properties describing the grouping, merged into the sink's payload. */
+  tags?: Record<string, string>;
+}
+
+export function classifyErrorForTracking(
+  error: unknown,
+): ErrorTrackingDecision {
+  // Availability incidents: report once, grouped by root cause.
+  //
+  // Transient database connectivity failures (DNS lookup, connection refused
+  // during a restart, pool connect timeouts) get wrapped per-query by the ORM,
+  // which otherwise fragments one incident into an issue per SQL statement.
+  const transientDbErrorCode = getTransientDbErrorCode(error);
+  if (transientDbErrorCode) {
+    return {
+      report: true,
+      fingerprint: ["db-transient", transientDbErrorCode],
+      tags: { error_type: "db_transient", db_error_code: transientDbErrorCode },
+    };
+  }
+
+  // A secrets-backend (e.g. Vault) outage fails every route that reads secrets,
+  // fragmenting one incident into an issue per endpoint and upstream message.
+  if (
+    error instanceof ApiError &&
+    error.internalCode === SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE
+  ) {
+    return {
+      report: true,
+      fingerprint: [SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE],
+      tags: { error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE },
+    };
+  }
+
+  if (isNonActionableError(error)) {
+    return { report: false };
+  }
+
+  return { report: true };
+}
+
+// === Internal helpers ===
+
+/**
+ * Error `name`s for a user's MCP server being unreachable or not yet running —
+ * an operational/config condition on the caller's side, not a bug of ours.
+ * Matched by name to avoid importing the client error classes into the
+ * observability layer.
+ */
+const MCP_UNREACHABLE_ERROR_NAMES = new Set([
+  "McpServerNotReadyError",
+  "McpServerConnectionTimeoutError",
+]);
+
+function isNonActionableError(error: unknown): boolean {
+  if (error instanceof Error && MCP_UNREACHABLE_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+
+  if (error instanceof ApiError) {
+    // 4xx client errors (not found, validation, upstream client errors).
+    if (error.statusCode >= 400 && error.statusCode < 500) return true;
+    // Handled transient upstream condition (empty completion → retryable 503).
+    if (
+      error.internalCode === ArchestraInternalErrorCode.UpstreamEmptyResponse
+    ) {
+      return true;
+    }
+    // 502/504 report an upstream's failure, not a crash of ours.
+    if (error.statusCode === 502 || error.statusCode === 504) return true;
+    return false;
+  }
+
+  // Generic errors carrying a 4xx HTTP status (Fastify typed errors, or an
+  // upstream provider CLIENT error built with an attached statusCode) are
+  // expected client errors. Unlike ApiError, a generic 5xx is left to report:
+  // a provider's own 5xx (surfaced via the raw-provider-error path) is a
+  // diagnostic signal, not one of our upstream-gateway mappings.
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof (error as { statusCode?: unknown }).statusCode === "number"
+  ) {
+    const statusCode = (error as { statusCode: number }).statusCode;
+    if (statusCode >= 400 && statusCode < 500) return true;
+  }
+
+  return false;
+}

--- a/platform/backend/src/observability/sentry.test.ts
+++ b/platform/backend/src/observability/sentry.test.ts
@@ -99,6 +99,13 @@ describe("filterErrorEvent", () => {
     );
   });
 
+  test("drops MCP-server-unreachable errors surfaced by the shared policy", () => {
+    const notReady = Object.assign(new Error("server not running yet"), {
+      name: "McpServerNotReadyError",
+    });
+    expect(filterErrorEvent(makeEvent(), hintFor(notReady))).toBeNull();
+  });
+
   test("groups transient DB connectivity failures by root cause", () => {
     // A DNS lookup failure the ORM wrapped per-query: fingerprint by the
     // root cause so an outage groups into one issue, not one per statement.

--- a/platform/backend/src/observability/sentry.ts
+++ b/platform/backend/src/observability/sentry.ts
@@ -1,4 +1,3 @@
-import { ArchestraInternalErrorCode } from "@archestra/shared";
 import type {
   ErrorEvent,
   EventHint,
@@ -7,9 +6,8 @@ import type {
 } from "@sentry/core";
 import * as Sentry from "@sentry/node";
 import config from "@/config";
-import { getTransientDbErrorCode } from "@/database/retry";
 import logger from "@/logging";
-import { ApiError, SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
+import { classifyErrorForTracking } from "./error-tracking-policy";
 import {
   isNoiseRoute,
   isNoisyMcpGatewayGetRoute,
@@ -91,15 +89,10 @@ export function captureRawProviderErrorInSentry(params: {
 }
 
 /**
- * Decide whether an error event should be reported and normalize its
- * fingerprint/tags for known classes of non-bug failures. Returns null to
- * drop the event.
- *
- * Filters out expected client errors (4xx) — not found, validation errors,
- * upstream provider client errors, etc. — which don't indicate bugs and
- * would just create noise. Also groups availability incidents (transient DB
- * connectivity, secrets-backend outages) by root cause so one outage becomes
- * one issue instead of one issue per in-flight query/route.
+ * Sentry `beforeSend` filter. Delegates the drop/keep-and-group decision to the
+ * sink-agnostic {@link classifyErrorForTracking} policy (shared with the PostHog
+ * capture path), then applies the result in Sentry's shape: return null to drop,
+ * or set the event's fingerprint/tags to group an availability incident.
  *
  * https://docs.sentry.io/platforms/javascript/configuration/filtering/
  * @public — exported for testability
@@ -108,73 +101,16 @@ export function filterErrorEvent(
   event: ErrorEvent,
   hint: EventHint,
 ): ErrorEvent | null {
-  const error = hint.originalException;
-
-  // Transient database connectivity failures (DNS lookup, connection
-  // refused during a database restart, pool connect timeouts) get
-  // wrapped per-query by the ORM, which fragments one availability
-  // incident into an issue per SQL statement. Fingerprint them by root
-  // cause instead so each outage groups into a single issue.
-  const transientDbErrorCode = getTransientDbErrorCode(error);
-  if (transientDbErrorCode) {
-    event.fingerprint = ["db-transient", transientDbErrorCode];
-    event.tags = {
-      ...event.tags,
-      error_type: "db_transient",
-      db_error_code: transientDbErrorCode,
-    };
-  }
-
-  // A secrets-backend (e.g. Vault) outage fails every route that touches
-  // secrets, fragmenting one incident into an issue per endpoint and per
-  // upstream error message. Group by the root condition instead, same as
-  // the transient-DB handling above.
-  if (
-    error instanceof ApiError &&
-    error.internalCode === SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE
-  ) {
-    event.fingerprint = [SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE];
-    event.tags = {
-      ...event.tags,
-      error_type: SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
-    };
-  }
-
-  // Filter out ApiError instances with 4xx status codes
-  if (error instanceof ApiError) {
-    if (error.statusCode >= 400 && error.statusCode < 500) {
-      return null;
-    }
-    // Known-transient upstream conditions (e.g. the provider streamed an
-    // empty completion) are handled: the client receives a retryable 503.
-    // They indicate provider flakiness, not a bug, so don't report them.
-    if (
-      error.internalCode === ArchestraInternalErrorCode.UpstreamEmptyResponse
-    ) {
-      return null;
-    }
-    // 502/504 report an upstream's failure — a user-configured provider or an
-    // external/self-hosted MCP server that is unreachable, misconfigured, or
-    // timed out — not a crash of ours. The request-error handler already keeps
-    // these out of exception tracking; mirror that here so the two sinks agree.
-    if (error.statusCode === 502 || error.statusCode === 504) {
-      return null;
-    }
-  }
-
-  // Also check for statusCode property on generic errors (e.g., from Fastify
-  // or an upstream provider error built by buildRawProviderError)
-  if (
-    error &&
-    typeof error === "object" &&
-    "statusCode" in error &&
-    typeof error.statusCode === "number" &&
-    error.statusCode >= 400 &&
-    error.statusCode < 500
-  ) {
+  const decision = classifyErrorForTracking(hint.originalException);
+  if (!decision.report) {
     return null;
   }
-
+  if (decision.fingerprint) {
+    event.fingerprint = decision.fingerprint;
+  }
+  if (decision.tags) {
+    event.tags = { ...event.tags, ...decision.tags };
+  }
   return event;
 }
 

--- a/platform/backend/src/server.test.ts
+++ b/platform/backend/src/server.test.ts
@@ -122,6 +122,36 @@ describe("createFastifyInstance", () => {
       captureSpy.mockRestore();
     });
 
+    test("skips MCP-server-unreachable errors on the PostHog sink too", async () => {
+      const { posthogErrorTrackingService } = await import(
+        "@/services/error-tracking"
+      );
+      const captureSpy = vi.spyOn(
+        posthogErrorTrackingService,
+        "captureException",
+      );
+
+      const app = createFastifyInstance();
+      // A user's MCP server being unreachable is an operational/config
+      // condition, not a bug: the shared tracking policy drops it, so the
+      // PostHog capture funnel skips it just as the Sentry filter does.
+      app.get("/test-mcp-unreachable", async () => {
+        throw Object.assign(new Error("MCP server is not running yet"), {
+          name: "McpServerNotReadyError",
+        });
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/test-mcp-unreachable",
+      });
+
+      expect(response.statusCode).toBe(500);
+      expect(captureSpy).not.toHaveBeenCalled();
+
+      captureSpy.mockRestore();
+    });
+
     test("maps transient database connectivity errors to a retryable 503 with root-cause grouping", async () => {
       const { posthogErrorTrackingService } = await import(
         "@/services/error-tracking"

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -68,6 +68,7 @@ import { initAuditRegistry } from "@/middleware/audit-log-registry";
 import OrganizationModel from "@/models/organization";
 import { ngrokTunnelManager } from "@/ngrok-tunnel-manager";
 import { initializeObservabilityMetrics } from "@/observability";
+import { classifyErrorForTracking } from "@/observability/error-tracking-policy";
 import { enrichOpenApiWithRbac } from "@/openapi/enrich-openapi-with-rbac";
 import { activeChatRunService } from "@/services/active-chat-run";
 import {
@@ -95,7 +96,6 @@ import {
   OpenAi,
   Openrouter,
   Perplexity,
-  SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
   Vllm,
   Xai,
   Zhipuai,
@@ -377,6 +377,14 @@ function captureServerException(
   error: unknown,
   extraProperties?: Record<string, unknown>,
 ): void {
+  // Same drop/keep-and-group policy the Sentry filter uses, so the two sinks
+  // agree: expected client/upstream errors are skipped, and availability
+  // incidents (transient DB, secrets-backend outage) get a stable fingerprint.
+  const decision = classifyErrorForTracking(error);
+  if (!decision.report) {
+    return;
+  }
+
   const { distinctId, sessionId } = getPostHogTraceContext(request);
   posthogErrorTrackingService.captureException({
     error,
@@ -391,6 +399,10 @@ function captureServerException(
       // deployment hit the error, used by the PostHog Slack alert template.
       hostname: request.host,
       reqId: request.id,
+      ...(decision.fingerprint && {
+        $exception_fingerprint: decision.fingerprint.join("/"),
+      }),
+      ...decision.tags,
       ...extraProperties,
     },
   });
@@ -584,7 +596,6 @@ export const createFastifyInstance = () =>
           error_type: "db_unavailable",
           db_error_code: transientDbErrorCode,
           status_code: 503,
-          $exception_fingerprint: `db-transient/${transientDbErrorCode}`,
         });
 
         return reply.status(503).send({
@@ -607,23 +618,14 @@ export const createFastifyInstance = () =>
 
         if (statusCode >= 500) {
           this.log.error(logPayload, "HTTP 50x request error occurred");
-          // 502/504 report an upstream's failure (a user-configured provider
-          // or external server), not a crash of ours — log them, but keep
-          // them out of exception tracking.
-          if (statusCode !== 502 && statusCode !== 504) {
-            captureServerException(request, error, {
-              error_type: "api_error",
-              status_code: statusCode,
-              ...(internalCode && { internal_code: internalCode }),
-              // A secrets-backend outage fails every route that reads
-              // secrets — group by the root condition, not per endpoint.
-              ...(internalCode ===
-                SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE && {
-                $exception_fingerprint:
-                  SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
-              }),
-            });
-          }
+          // Capture is centrally filtered and grouped by
+          // classifyErrorForTracking: 502/504 upstream failures are dropped as
+          // noise, and a secrets-backend outage is grouped by root cause.
+          captureServerException(request, error, {
+            error_type: "api_error",
+            status_code: statusCode,
+            ...(internalCode && { internal_code: internalCode }),
+          });
         } else if (statusCode >= 400) {
           this.log.info(logPayload, "HTTP 40x request error occurred");
         } else {
@@ -1585,9 +1587,22 @@ const startWorker = async () => {
 // This handler logs those leaks and keeps the server alive.
 process.on("unhandledRejection", (reason) => {
   logger.error({ err: reason }, "Unhandled promise rejection");
+  // Apply the shared tracking policy on this non-request capture path too, so a
+  // rejected transient-DB query groups by root cause and expected client/
+  // upstream errors are skipped, matching the request-error handler.
+  const decision = classifyErrorForTracking(reason);
+  if (!decision.report) {
+    return;
+  }
   posthogErrorTrackingService.captureException({
     error: reason,
-    properties: { error_type: "unhandled_rejection" },
+    properties: {
+      ...(decision.fingerprint && {
+        $exception_fingerprint: decision.fingerprint.join("/"),
+      }),
+      ...decision.tags,
+      error_type: "unhandled_rejection",
+    },
   });
 });
 


### PR DESCRIPTION
## Why

The rules for which backend errors reach exception tracking lived in **two** places:

- inline in the Sentry `beforeSend` filter (`filterErrorEvent`), and
- again — only partially — spread across the Fastify request-error handler branches that feed the PostHog sink (`captureServerException`).

So the two sinks disagreed. The Sentry filter dropped a class of expected client/upstream errors, but the PostHog path did not apply the same rules on every branch — most notably the generic `unhandled_error` and unhandled-rejection paths. The observed result: PostHog still carried operational noise Sentry already filtered, and **fragmented one availability incident into an issue per SQL statement** (a transient `ECONNREFUSED`/DNS failure leaking in unclassified, instead of grouping under `db-transient`).

## What

Extract a single **sink-agnostic** policy, `classifyErrorForTracking(error)`, and have both sinks delegate to it:

- **Sentry** — `filterErrorEvent` now just applies the policy result (return `null` to drop; set `event.fingerprint`/tags to group).
- **PostHog** — `captureServerException` and the `unhandledRejection` handler consult the same policy, so **every** capture path drops the same noise and groups the same incidents.

The policy owns two kinds of non-bug failure:

- **Drop** (expected, not our crash): 4xx client errors; our own **502/504** upstream-gateway mappings; a user's MCP server that is **unreachable / not ready** (matched by the `McpServerNotReadyError` / `McpServerConnectionTimeoutError` names); handled empty-completions.
- **Keep but group** (availability incident, one issue not N): transient DB connectivity (`getTransientDbErrorCode`, fingerprint `db-transient/<code>`); secrets-backend outage.

## Scoping / safety

- **No over-suppression.** Only reliably-signalled errors are dropped — status code, `internalCode`, or error class. A provider's **own** generic 5xx (surfaced via the raw-provider-error path) is **kept** on both sinks (it's a diagnostic signal, unlike our `ApiError` 502/504 gateway mapping — a real semantic distinction, covered by a test). Genuine server bugs (generic 500) still report.
- **No behavior regression.** The request handler still returns the same HTTP statuses; PostHog keeps its existing per-branch property labels (e.g. `error_type: "db_unavailable"`) — only the drop/group decision and fingerprint are now centralized. Existing 502/504-exclusion and `db-transient/<code>` tests are unchanged and green.
- The one Sentry behavior delta: it now **also** drops MCP-unreachable errors (previously only PostHog-relevant), which is desirable.

## Not addressed here (deliberately)

The loudest remaining PostHog items are **message-only** — a provider rate-limit that the proxy's `handleError` couldn't map to a status (so it becomes a generic 500, not a 429), a K8s `CrashLoopBackOff` string, upstream model messages. They carry no reliable status/class signal, so filtering them safely needs **status/class tagging at the throw site**, not a filter — a follow-up, not message-substring matching.

## Tests

- New `error-tracking-policy.test.ts` — the full classify matrix (drop 4xx / 502-504 ApiError / MCP-unreachable / upstream-empty; keep our 5xx and provider generic 5xx; group transient-DB and secrets-outage).
- `sentry.test.ts` — added MCP-unreachable drop via the delegation.
- `server.test.ts` — added a case asserting an MCP-unreachable error is skipped on the **PostHog** sink; existing 502/504-exclusion and `db-transient` grouping tests remain green.

## Checks
- `tsc --noEmit`: clean
- Biome: clean
- knip (dev + production): clean
- observability + server + error-tracking service tests: 180 passed

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>