### PR TITLE
fix(mcp-gateway): stop the chat client's GET SSE reconnect storm

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.loopback-fetch.integration.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.loopback-fetch.integration.test.ts
@@ -6,37 +6,38 @@
  * standalone GET SSE stream after `initialized`. The real gateway answers that
  * GET with finite discovery JSON (`200`), which the SDK reads as an empty SSE
  * stream and reconnects roughly once per second — each GET running DB-backed
- * profile/auth work. `loopbackGatewayFetch` short-circuits the SDK's GET to a
- * `405` in the client's own fetch, so the SDK stops polling and no GET ever
- * reaches the network.
+ * profile/auth work. The transport built by `createLoopbackGatewayTransport`
+ * injects a fetch that short-circuits the SDK's GET to a `405`, so the SDK
+ * stops polling and no GET ever reaches the network.
  *
- * This spins up a real stateless streamable-HTTP MCP server (like the gateway)
- * that would happily answer GET with `200` JSON, connects the REAL SDK client
- * through the production `loopbackGatewayFetch`, and asserts the server observes
- * zero GET requests while a POST-based `tools/list` still succeeds (proving the
- * Bearer-carrying POST path passes through untouched).
+ * This drives the REAL production transport factory against a real stateless
+ * streamable-HTTP MCP server (like the gateway) that would happily answer GET
+ * with `200` JSON, and asserts the server observes zero GET requests while a
+ * POST-based `tools/list` still succeeds AND still carries the Bearer token
+ * (proving the JSON-RPC POST path passes through the custom fetch untouched).
  *
  * No `vi.mock` on purpose: it runs against a real client, transport, and server.
  */
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Server as McpSdkServer } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { expect, test } from "vitest";
-import { loopbackGatewayFetch } from "@/clients/chat-mcp-client";
+import { createLoopbackGatewayTransport } from "@/clients/chat-mcp-client";
 
 /** A real stateless streamable-HTTP MCP server that mirrors the gateway: POST
  * carries JSON-RPC, and GET is answered with a `200` JSON body (the exact shape
- * that makes the SDK loop). It records how many GET requests actually arrive. */
+ * that makes the SDK loop). Records GET arrivals and the last POST's bearer. */
 async function startGatewayLikeServer(): Promise<{
   url: string;
   getRequestCount: () => number;
+  lastPostAuthorization: () => string | undefined;
   close: () => Promise<void>;
 }> {
   let getRequests = 0;
+  let lastPostAuth: string | undefined;
   const httpServer = http.createServer(async (req, res) => {
     try {
       if (req.method === "GET") {
@@ -46,6 +47,7 @@ async function startGatewayLikeServer(): Promise<{
         res.writeHead(200, { "content-type": "application/json" }).end("{}");
         return;
       }
+      lastPostAuth = req.headers.authorization;
       const server = new McpSdkServer(
         { name: "gateway-like", version: "1.0.0" },
         { capabilities: { tools: {} } },
@@ -81,39 +83,33 @@ async function startGatewayLikeServer(): Promise<{
   return {
     url: `http://127.0.0.1:${port}/mcp`,
     getRequestCount: () => getRequests,
+    lastPostAuthorization: () => lastPostAuth,
     close: () => new Promise<void>((r) => httpServer.close(() => r())),
   };
 }
 
-test("REAL: loopbackGatewayFetch stops the SDK GET SSE poll while POST still works", async () => {
+test("REAL: the loopback transport stops the SDK GET SSE poll while the POST path still carries the bearer", async () => {
   const server = await startGatewayLikeServer();
   const client = new Client({ name: "loopback-fetch-test", version: "1.0.0" });
   try {
-    const transport = new StreamableHTTPClientTransport(new URL(server.url), {
-      fetch: loopbackGatewayFetch,
-      requestInit: {
-        headers: new Headers({ Authorization: "Bearer test-token" }),
-      },
-    });
+    // Drive the exact production transport construction.
+    const transport = createLoopbackGatewayTransport(server.url, "test-token");
 
     await client.connect(transport);
-    // POST path must still work end-to-end through the custom fetch.
+    // POST path must still work end-to-end through the custom fetch...
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name)).toEqual(["ping"]);
+    // ...and still carry the Bearer token the transport was built with.
+    expect(server.lastPostAuthorization()).toBe("Bearer test-token");
 
     // Give any floating GET SSE reconnect attempt time to fire against the
-    // network. With the fix it is answered 405 in-process and never arrives.
+    // network. The SDK's first standalone GET is issued immediately after the
+    // `initialized` 202 (no backoff), so without the fix it would already have
+    // arrived; with the fix it is answered 405 in-process and never reaches us.
     await new Promise((r) => setTimeout(r, 300));
     expect(server.getRequestCount()).toBe(0);
   } finally {
     await client.close();
     await server.close();
   }
-});
-
-test("REAL: loopbackGatewayFetch answers a bare GET with 405 and never touches the network", async () => {
-  const response = await loopbackGatewayFetch("http://127.0.0.1:1/v1/mcp/x", {
-    method: "GET",
-  });
-  expect(response.status).toBe(405);
 });

--- a/platform/backend/src/clients/chat-mcp-client.loopback-fetch.integration.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.loopback-fetch.integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * REAL end-to-end verification (no mocks) that the chat MCP client no longer
+ * drives the recurring GET SSE poll against the loopback gateway.
+ *
+ * Background: the MCP SDK's `StreamableHTTPClientTransport` opens an optional
+ * standalone GET SSE stream after `initialized`. The real gateway answers that
+ * GET with finite discovery JSON (`200`), which the SDK reads as an empty SSE
+ * stream and reconnects roughly once per second — each GET running DB-backed
+ * profile/auth work. `loopbackGatewayFetch` short-circuits the SDK's GET to a
+ * `405` in the client's own fetch, so the SDK stops polling and no GET ever
+ * reaches the network.
+ *
+ * This spins up a real stateless streamable-HTTP MCP server (like the gateway)
+ * that would happily answer GET with `200` JSON, connects the REAL SDK client
+ * through the production `loopbackGatewayFetch`, and asserts the server observes
+ * zero GET requests while a POST-based `tools/list` still succeeds (proving the
+ * Bearer-carrying POST path passes through untouched).
+ *
+ * No `vi.mock` on purpose: it runs against a real client, transport, and server.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Server as McpSdkServer } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { expect, test } from "vitest";
+import { loopbackGatewayFetch } from "@/clients/chat-mcp-client";
+
+/** A real stateless streamable-HTTP MCP server that mirrors the gateway: POST
+ * carries JSON-RPC, and GET is answered with a `200` JSON body (the exact shape
+ * that makes the SDK loop). It records how many GET requests actually arrive. */
+async function startGatewayLikeServer(): Promise<{
+  url: string;
+  getRequestCount: () => number;
+  close: () => Promise<void>;
+}> {
+  let getRequests = 0;
+  const httpServer = http.createServer(async (req, res) => {
+    try {
+      if (req.method === "GET") {
+        getRequests += 1;
+        // Mimic the discovery route: finite JSON, not SSE. A client that does
+        // NOT short-circuit its GET would receive this and reconnect forever.
+        res.writeHead(200, { "content-type": "application/json" }).end("{}");
+        return;
+      }
+      const server = new McpSdkServer(
+        { name: "gateway-like", version: "1.0.0" },
+        { capabilities: { tools: {} } },
+      );
+      server.setRequestHandler(ListToolsRequestSchema, async () => ({
+        tools: [{ name: "ping", inputSchema: { type: "object" } }],
+      }));
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      res.on("close", () => {
+        void transport.close();
+        void server.close();
+      });
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      await server.connect(transport);
+      await transport.handleRequest(
+        req,
+        res,
+        body ? JSON.parse(body) : undefined,
+      );
+    } catch {
+      if (!res.headersSent) res.writeHead(500).end();
+    }
+  });
+
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const { port } = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/mcp`,
+    getRequestCount: () => getRequests,
+    close: () => new Promise<void>((r) => httpServer.close(() => r())),
+  };
+}
+
+test("REAL: loopbackGatewayFetch stops the SDK GET SSE poll while POST still works", async () => {
+  const server = await startGatewayLikeServer();
+  const client = new Client({ name: "loopback-fetch-test", version: "1.0.0" });
+  try {
+    const transport = new StreamableHTTPClientTransport(new URL(server.url), {
+      fetch: loopbackGatewayFetch,
+      requestInit: {
+        headers: new Headers({ Authorization: "Bearer test-token" }),
+      },
+    });
+
+    await client.connect(transport);
+    // POST path must still work end-to-end through the custom fetch.
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["ping"]);
+
+    // Give any floating GET SSE reconnect attempt time to fire against the
+    // network. With the fix it is answered 405 in-process and never arrives.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(server.getRequestCount()).toBe(0);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("REAL: loopbackGatewayFetch answers a bare GET with 405 and never touches the network", async () => {
+  const response = await loopbackGatewayFetch("http://127.0.0.1:1/v1/mcp/x", {
+    method: "GET",
+  });
+  expect(response.status).toBe(405);
+});

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -12,6 +12,7 @@ import type {
 } from "@modelcontextprotocol/ext-apps";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { Tool } from "ai";
 import { archestraMcpBranding, getAgentTools } from "@/archestra-mcp-server";
 import { CacheKey, LRUCacheManager } from "@/cache-manager";
@@ -46,6 +47,34 @@ import { buildMcpClientInfo } from "@/utils/mcp-client-info";
  * Derives from the configured API port to work in multi-pod deployments.
  */
 const MCP_GATEWAY_BASE_URL = `http://localhost:${config.api.port}/v1/mcp`;
+
+/**
+ * Custom fetch for the loopback MCP Gateway transport.
+ *
+ * The MCP SDK opens an optional standalone GET SSE stream (per spec) to receive
+ * server-initiated messages. Our gateway runs stateless (`enableJsonResponse`,
+ * no session id) and never pushes on that stream. Worse, the gateway's GET route
+ * answers the SDK's poll with finite discovery JSON (`200`), which the SDK reads
+ * as an empty SSE stream and immediately reconnects — ~once per second per
+ * client, each GET running DB-backed profile and auth work. Under many cached
+ * clients this alone can saturate the connection pool.
+ *
+ * Answering the GET with `405` tells the SDK the server offers no GET SSE stream,
+ * so it stops polling (the SDK treats 405 as an expected, terminal response).
+ * Doing it in the client's fetch — rather than the shared route — keeps the
+ * public JSON discovery route unchanged. POST/DELETE, the only requests carrying
+ * real JSON-RPC and the Bearer token, pass through to the network unchanged.
+ *
+ * @public — exercised by chat-mcp-client.loopback-fetch integration test
+ */
+export const loopbackGatewayFetch: FetchLike = (url, init) => {
+  if ((init?.method ?? "GET").toUpperCase() === "GET") {
+    return Promise.resolve(
+      new Response(null, { status: 405, statusText: "Method Not Allowed" }),
+    );
+  }
+  return fetch(url, init);
+};
 
 /**
  * Raised when the agent's MCP tool set could not be fetched (no gateway token,
@@ -580,6 +609,7 @@ export async function getChatMcpClient(
     const transport = new StreamableHTTPClientTransport(
       new URL(mcpGatewayUrl),
       {
+        fetch: loopbackGatewayFetch,
         requestInit: {
           headers: new Headers({
             Authorization: `Bearer ${authToken}`,

--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -49,25 +49,51 @@ import { buildMcpClientInfo } from "@/utils/mcp-client-info";
 const MCP_GATEWAY_BASE_URL = `http://localhost:${config.api.port}/v1/mcp`;
 
 /**
+ * Build the MCP client transport for the loopback gateway.
+ *
+ * Shared by `getChatMcpClient` and the loopback-fetch integration test so the
+ * test drives the exact production construction — most importantly the
+ * `loopbackGatewayFetch` wiring below, which is the whole fix.
+ *
+ * @public — used by getChatMcpClient and the loopback-fetch integration test
+ */
+export function createLoopbackGatewayTransport(
+  mcpGatewayUrl: string,
+  authToken: string,
+): StreamableHTTPClientTransport {
+  return new StreamableHTTPClientTransport(new URL(mcpGatewayUrl), {
+    fetch: loopbackGatewayFetch,
+    requestInit: {
+      headers: new Headers({
+        Authorization: `Bearer ${authToken}`,
+        Accept: "application/json, text/event-stream",
+      }),
+    },
+  });
+}
+
+/**
  * Custom fetch for the loopback MCP Gateway transport.
  *
  * The MCP SDK opens an optional standalone GET SSE stream (per spec) to receive
  * server-initiated messages. Our gateway runs stateless (`enableJsonResponse`,
- * no session id) and never pushes on that stream. Worse, the gateway's GET route
- * answers the SDK's poll with finite discovery JSON (`200`), which the SDK reads
- * as an empty SSE stream and immediately reconnects — ~once per second per
- * client, each GET running DB-backed profile and auth work. Under many cached
- * clients this alone can saturate the connection pool.
+ * no session id) and never pushes on that stream, and its transport is built
+ * without an `authProvider`, so the standalone GET SSE stream is the only GET
+ * the SDK issues. Worse, the gateway's GET route answers that poll with finite
+ * discovery JSON (`200`), which the SDK reads as an empty SSE stream and
+ * immediately reconnects — ~once per second per client, each GET running
+ * DB-backed profile and auth work. Under many cached clients this alone can
+ * saturate the connection pool.
  *
  * Answering the GET with `405` tells the SDK the server offers no GET SSE stream,
  * so it stops polling (the SDK treats 405 as an expected, terminal response).
  * Doing it in the client's fetch — rather than the shared route — keeps the
  * public JSON discovery route unchanged. POST/DELETE, the only requests carrying
  * real JSON-RPC and the Bearer token, pass through to the network unchanged.
- *
- * @public — exercised by chat-mcp-client.loopback-fetch integration test
+ * (If an `authProvider` is ever added here, OAuth metadata is fetched with GET
+ * too, so this would need to key on the request URL rather than the method.)
  */
-export const loopbackGatewayFetch: FetchLike = (url, init) => {
+const loopbackGatewayFetch: FetchLike = (url, init) => {
   if ((init?.method ?? "GET").toUpperCase() === "GET") {
     return Promise.resolve(
       new Response(null, { status: 405, statusText: "Method Not Allowed" }),
@@ -606,18 +632,7 @@ export async function getChatMcpClient(
 
   const connectWithToken = async (authToken: string) => {
     // Create StreamableHTTP transport with profile token authentication
-    const transport = new StreamableHTTPClientTransport(
-      new URL(mcpGatewayUrl),
-      {
-        fetch: loopbackGatewayFetch,
-        requestInit: {
-          headers: new Headers({
-            Authorization: `Bearer ${authToken}`,
-            Accept: "application/json, text/event-stream",
-          }),
-        },
-      },
-    );
+    const transport = createLoopbackGatewayTransport(mcpGatewayUrl, authToken);
 
     const capabilities: ClientCapabilitiesWithExtensions = {
       roots: { listChanged: true },


### PR DESCRIPTION
## Problem

The chat MCP client points `StreamableHTTPClientTransport` at the loopback gateway. After `initialized`, the SDK opens an optional standalone GET SSE stream. The gateway's GET route answers with finite discovery JSON (`200`), which the SDK consumes as an empty SSE stream and reconnects **~once per second per cached client** — each GET running DB-backed profile and auth work (`resolveIdFromIdOrSlug` + `validateMCPGatewayToken`). Under many cached clients this alone can saturate the 50-connection pg pool; the vast majority of pool-checkout timeouts landed on `GET /v1/mcp/:profileId`.

## Fix

Inject a `fetch` into the client's transport that answers the SDK's `GET` with `405` — per the MCP spec, the terminal "server offers no GET SSE stream" signal, after which the SDK stops polling (`streamableHttp.js:100-103`). Done in the client's fetch (via a shared `createLoopbackGatewayTransport` factory), **not** the shared route, so the public JSON discovery route is unchanged. `POST`/`DELETE` — the only requests carrying real JSON-RPC and the Bearer token — pass through untouched.

The gateway runs stateless (`sessionIdGenerator: undefined`, `enableJsonResponse: true`) and never pushes server-initiated messages on that stream, so no functionality is lost.

## Test

A real, mock-free integration test drives the production transport factory against a live stateless streamable-HTTP MCP server that would answer GET with `200` JSON (the shape that makes the SDK loop). It asserts the server observes **zero GET requests** while a POST-based `tools/list` succeeds and still carries the Bearer token. Removing the fetch injection makes the test fail.

## Scope

This addresses the reconnect storm at its source. Two related gaps are intentionally out of scope: MCP client lifecycle ownership (orphaned clients linger until idle-TTL/LRU eviction — idle, no DB load after this change) and the benchmark runner's lack of a backend-health circuit-breaker.

https://claude.ai/code/session_011ioELrLZbUzymU5D24a3Cv

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>