### PR TITLE
fix(docker): upgrade curl to 8.20.0-r0 in platform + mcp base images

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -320,6 +320,12 @@ COPY docker/certs/aws-rds-global-bundle.pem /tmp/aws-rds-ca.pem
 COPY docker/certs/gcloud-sql-global.pem /tmp/gcloud-sql-ca.pem
 
 RUN apk --no-cache upgrade && \
+    # CVE-2026-6276, CVE-2026-5773: curl/libcurl vulnerabilities (HIGH) fixed in 8.20.0-r0.
+    # The pinned node:24-alpine3.23 base ships curl 8.19.0-r0. The bare `apk upgrade` above
+    # would pick up the fix, but this RUN layer is Docker-cached on its instruction text and
+    # never re-ran against the newer index — pin curl/libcurl explicitly so the fixed version
+    # is guaranteed (and adding this line busts the stale cache).
+    apk add --no-cache --upgrade "curl>=8.20.0-r0" "libcurl>=8.20.0-r0" && \
     # Install PostgreSQL 17, pgvector, supervisord, and git.
     # The skill-marketplace clone endpoint needs the git CLI (materialize.ts) and
     # git-http-backend, the smart-HTTP CGI — which Alpine ships in git-daemon, not git.

--- a/platform/mcp_server_docker_image/Dockerfile
+++ b/platform/mcp_server_docker_image/Dockerfile
@@ -96,10 +96,13 @@ RUN apk add --no-cache \
    # CVE-2026-22184: zlib vulnerability fixed in 1.3.2-r0
    # CVE-2026-32767: expat XML parser vulnerability
    # CVE-2026-40200 (musl 1.2.5-r23) is covered by the pinned base image digest
+   # CVE-2026-6276, CVE-2026-5773: curl/libcurl vulnerabilities (HIGH) fixed in 8.20.0-r0.
+   # The base image ships 8.19.0-r0; the explicit `apk add curl` above installs it, so
+   # curl/libcurl must be listed here to be upgraded to the fixed version.
    # Go runtime is copied from the golang:1.25.11-alpine image below to pick up the
    # Go stdlib HIGH CVEs fixed in 1.25.10 (CVE-2026-42499/39836/39820/33814/33811) and
    # 1.25.11 (CVE-2026-42504) that Alpine's apk index has not yet shipped.
-   apk upgrade --no-cache nodejs bind openssl zlib expat
+   apk upgrade --no-cache nodejs bind openssl zlib expat curl libcurl
 
 # Go toolchain sourced from upstream Alpine-based image (Alpine apk currently ships go-1.25.9-r0)
 COPY --from=go-bin /usr/local/go /usr/local/go


### PR DESCRIPTION
## What

Fixes the two failing **Docker Image Scanning** jobs (Platform + MCP Server Base) by upgrading `curl`/`libcurl` to the patched **8.20.0-r0**.

Both images ship `curl 8.19.0-r0` from the Alpine 3.23 base, which Docker Scout flags as **HIGH**:

| CVE | Package | Fixed in |
| --- | --- | --- |
| CVE-2026-6276 | curl / libcurl | 8.20.0-r0 |
| CVE-2026-5773 | curl / libcurl | 8.20.0-r0 |

## Why the scans were failing

- **Platform image** (`platform/Dockerfile`) — the final stage already runs a bare `apk --no-cache upgrade`, which *should* pick up the fix. But that `RUN` layer is Docker-cached on its instruction text, so it never re-ran against the newer apk index carrying 8.20.0-r0.
- **MCP Server Base** (`platform/mcp_server_docker_image/Dockerfile`) — `curl` is installed via an explicit `apk add`, but was missing from the subsequent `apk upgrade nodejs bind openssl zlib expat` list, so it stayed at 8.19.0-r0.

## The fix

- **Platform**: add an explicit `apk add --no-cache --upgrade "curl>=8.20.0-r0" "libcurl>=8.20.0-r0"`. This guarantees the fixed version *and* busts the stale cache layer.
- **MCP base**: add `curl libcurl` to the existing `apk upgrade` list.

`curl 8.20.0-r0` and `libcurl 8.20.0-r0` are present in the Alpine 3.23 `main` repo (verified against the live `APKINDEX`), so the `>=` pins are satisfiable and won't break the build.

## Testing

The full image builds + re-scans run in the merge queue via the `Docker Image Scanning` workflow.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>