### PR TITLE
fix(connection): accept the browser origin as a setup-script endpoint

### DIFF
--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -724,13 +724,16 @@ export function parseActiveChatRunPollIntervalMs(params: {
  */
 /**
  * Raw URL sources a /connection setup baseUrl may come from: the frontend
- * origin plus every URL in `ARCHESTRA_API_BASE_URL` (the same list the
- * frontend's connection page derives its endpoint candidates from). Returned
- * unparsed; callers normalize and compare full URLs, not just hosts.
+ * origin, every URL in `ARCHESTRA_API_BASE_URL`, and the in-cluster
+ * `ARCHESTRA_INTERNAL_API_BASE_URL` (the connection page falls back to the
+ * internal URL when every external URL is hidden). Returned unparsed; callers
+ * normalize and compare full URLs, not just hosts.
  * @public — exported for testability
  */
 export const getConnectionBaseUrlSources = (): string[] => {
   const sources = [frontendBaseUrl];
+  const internalUrl = process.env.ARCHESTRA_INTERNAL_API_BASE_URL?.trim();
+  if (internalUrl) sources.push(internalUrl);
   const externalUrls = process.env.ARCHESTRA_API_BASE_URL?.trim();
   if (externalUrls) {
     for (const url of externalUrls.split(",")) {

--- a/platform/backend/src/routes/connection-setup/connection-setup.routes.ts
+++ b/platform/backend/src/routes/connection-setup/connection-setup.routes.ts
@@ -160,7 +160,7 @@ const connectionSetupRoutes: FastifyPluginAsyncZod = async (fastify) => {
         response: constructResponseSchema(CreateConnectionSetupResponseSchema),
       },
     },
-    async ({ body, organizationId, user }, reply) => {
+    async ({ body, headers, organizationId, user }, reply) => {
       const {
         clientId,
         platform,
@@ -193,7 +193,14 @@ const connectionSetupRoutes: FastifyPluginAsyncZod = async (fastify) => {
       }
 
       const organization = await OrganizationModel.getById(organizationId);
-      if (!organization || !isAllowedBaseUrl({ baseUrl, organization })) {
+      if (
+        !organization ||
+        !isAllowedBaseUrl({
+          baseUrl,
+          organization,
+          requestOrigin: headers.origin,
+        })
+      ) {
         throw new ApiError(
           400,
           "baseUrl is not an allowed connection endpoint",
@@ -765,21 +772,40 @@ async function assertSkillsBelongToOrg(params: {
  * baseUrl ends up verbatim in a script served from a public endpoint AND in
  * the copy-pasted curl one-liner, so it must EXACTLY match (normalized full
  * URL, not just host) a URL the deployment already trusts: the env-configured
- * public URLs, the admin-curated connection URLs (each optionally with the
- * /v1 suffix the connection page appends), or localhost with no path beyond
- * /v1. Host-only matching would let a crafted path smuggle shell syntax into
- * the rendered script.
+ * public/internal URLs, the admin-curated connection URLs (each optionally
+ * with the /v1 suffix the connection page appends), or — with no path beyond
+ * /v1 — localhost or the origin the browser reached the app on (the request's
+ * Origin header). The Origin match is what keeps zero-config deployments
+ * working: without ARCHESTRA_API_BASE_URL/ARCHESTRA_FRONTEND_URL the
+ * connection page derives its endpoint from window.location.origin, which no
+ * env-derived source can know. Restricting origin-level matches to the exact
+ * ""/"/v1" paths the page generates prevents a crafted path from smuggling
+ * shell syntax into the rendered script, and URL parsing confines the origin
+ * itself to the host/port charset.
  */
 function isAllowedBaseUrl(params: {
   baseUrl: string;
   organization: Organization;
+  requestOrigin: string | undefined;
 }): boolean {
   const normalized = normalizeBaseUrl(params.baseUrl);
   if (!normalized) return false;
 
-  const localHostnames = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
-  if (localHostnames.has(normalized.hostname)) {
-    return normalized.path === "" || normalized.path === "/v1";
+  if (normalized.path === "" || normalized.path === "/v1") {
+    const localHostnames = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+    if (localHostnames.has(normalized.hostname)) return true;
+
+    const requestOrigin = params.requestOrigin
+      ? normalizeBaseUrl(params.requestOrigin)
+      : null;
+    // A browser Origin header is origin-only; a path means it was forged.
+    if (
+      requestOrigin &&
+      requestOrigin.path === "" &&
+      requestOrigin.url === normalized.origin
+    ) {
+      return true;
+    }
   }
 
   const allowed = new Set<string>();
@@ -804,7 +830,7 @@ function isAllowedBaseUrl(params: {
  */
 function normalizeBaseUrl(
   raw: string,
-): { url: string; hostname: string; path: string } | null {
+): { url: string; origin: string; hostname: string; path: string } | null {
   let parsed: URL;
   try {
     parsed = new URL(raw);
@@ -818,8 +844,10 @@ function normalizeBaseUrl(
 
   const path = parsed.pathname.replace(/\/+$/, "");
   const hostname = parsed.hostname.toLowerCase();
+  const origin = `${parsed.protocol}//${parsed.host.toLowerCase()}`;
   return {
-    url: `${parsed.protocol}//${parsed.host.toLowerCase()}${path}`,
+    url: `${origin}${path}`,
+    origin,
     hostname,
     path,
   };

--- a/platform/backend/src/routes/connection-setup/create.connection-setup.route.test.ts
+++ b/platform/backend/src/routes/connection-setup/create.connection-setup.route.test.ts
@@ -157,6 +157,71 @@ describe("POST /api/connection-setups", () => {
     ).toBe(400);
   });
 
+  test("allowlist: accepts the origin the browser reached the app on (Origin header)", async ({
+    makeAgent,
+  }) => {
+    const gateway = await makeAgent({
+      organizationId,
+      agentType: "mcp_gateway",
+    });
+    const post = (baseUrl: string, origin?: string) =>
+      app.inject({
+        method: "POST",
+        url: "/api/connection-setups",
+        headers: origin ? { origin } : {},
+        payload: { clientId: "claude-code", baseUrl, mcpGatewayId: gateway.id },
+      });
+
+    // the zero-config path: the page derives its endpoint from
+    // window.location.origin, which only the request itself can vouch for
+    const origin = "https://selfhosted.example.com";
+    expect((await post(`${origin}/v1`, origin)).statusCode).toBe(200);
+    expect((await post(origin, origin)).statusCode).toBe(200);
+    const created = await post(`${origin}/v1`, origin);
+    expect(created.json().command).toContain(
+      `${origin}/api/connection-setups/script/`,
+    );
+
+    // only the exact ""/"/v1" paths are trusted at origin level
+    expect((await post(`${origin}/v1/evil`, origin)).statusCode).toBe(400);
+    // a different origin than the one the browser used never passes
+    expect(
+      (await post("https://other.example.com/v1", origin)).statusCode,
+    ).toBe(400);
+    // port counts as part of the origin
+    expect((await post(`${origin}:8443/v1`, origin)).statusCode).toBe(400);
+    // a forged Origin header carrying a path is not origin-shaped — rejected
+    expect((await post(`${origin}/app/v1`, `${origin}/app`)).statusCode).toBe(
+      400,
+    );
+    // no Origin header, no origin-level trust
+    expect((await post(`${origin}/v1`)).statusCode).toBe(400);
+  });
+
+  test("allowlist: accepts the in-cluster internal API base URL", async ({
+    makeAgent,
+  }) => {
+    vi.stubEnv(
+      "ARCHESTRA_INTERNAL_API_BASE_URL",
+      "http://archestra.default.svc:9000",
+    );
+    const gateway = await makeAgent({
+      organizationId,
+      agentType: "mcp_gateway",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/connection-setups",
+      payload: {
+        clientId: "claude-code",
+        baseUrl: "http://archestra.default.svc:9000/v1",
+        mcpGatewayId: gateway.id,
+      },
+    });
+    expect(response.statusCode).toBe(200);
+  });
+
   test("allowlist: accepts admin-curated org connection URLs incl. /v1 suffix", async ({
     makeAgent,
   }) => {


### PR DESCRIPTION
The /connection page derives its endpoint from window.location.origin whenever ARCHESTRA_API_BASE_URL is unset (the default in the Docker image and Helm chart), but the setup-script allowlist only accepted env-derived URLs, admin-curated org URLs, and localhost. On any deployment reached at a non-localhost origin without those env vars, the only endpoint the UI offers was always rejected, so every command generation failed with "baseUrl is not an allowed connection endpoint". Localhost and CI passed via the loopback carve-out, which is why this shipped green.

Fix: trust a baseUrl whose origin matches the request's Origin header, restricted to the exact ""/"/v1" paths the page generates (same shape as the loopback carve-out), so no crafted path can smuggle shell syntax into the rendered script. Also allow ARCHESTRA_INTERNAL_API_BASE_URL, the page's fallback endpoint when every external URL is hidden.

Verified that the Origin header survives the Next.js /api rewrite (its http-proxy forwards request headers; only Host is rewritten).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>