### PR TITLE
feat(baton): reduce the consumer surface of baton-core

### DIFF
--- a/ai-labs/baton/baton-authority-model-design.md
+++ b/ai-labs/baton/baton-authority-model-design.md
@@ -305,10 +305,15 @@ Built as slices S5–S8 on this branch; 126 lib tests; external (Codex) + intern
 
 ### Build 3 — Endorse as relabel + robustness visibility (D3, done)
 Converted to §4-style slices S9–S12 on this branch. Ratified encoding choices:
-**OQ1** resolves to a *sibling* `TransitionKind::EndorseValue { source, delta }`
-beside the shipped `TransformValue` (merging both into one `Relabel { via }` is a
-behavior-preserving churn across the plan/apply/enumeration/tests for no semantic
-gain; shared minting lives in `turn.rs`/`value.rs` regardless). **`ExitKind`
+**OQ1** originally resolved to a *sibling* `TransitionKind::EndorseValue { source, delta }`
+beside the shipped `TransformValue` (merging both judged behavior-preserving churn
+for no semantic gain; shared minting lives in `turn.rs`/`value.rs` regardless).
+*Superseded 2026-07-14 (maintainer-ratified, surface-reduction branch):* the two
+variants merged into `Derive { source, justification: Content(..) | Fiat { .. } }` —
+the justification split materializes the "shared mint-and-substitute, different
+voucher" ontology in the type. Behavior (routing, byte rules, `ExitKind` ranking,
+audit wording) is unchanged; the serialized plan tag shape did change, accepted
+while plans have no out-of-process consumer. **`ExitKind`
 ordering:** Endorse is the top/max variant (`Sanitize < Constrain < Accept <
 WaiverOrAcknowledge < Endorse`) — taint erasure is the priciest elevation, so a
 composite route's decisive category is its Endorse step. **Canonical remedy

--- a/ai-labs/baton/baton-core/CLAUDE.md
+++ b/ai-labs/baton/baton-core/CLAUDE.md
@@ -92,7 +92,8 @@ observable; preserve it (there is a typed-order test).
   runtime-capability sets are not modeled); a **transient waiver** changes no
   stored state — a check-transient lift (`waiving` a prior effect, standing in
   for a confirmation, excluding a control dep) plus an audit record. A
-  **fiat relabel** (`EndorseValue`), by contrast, mints a *durable* value like a
+  **fiat relabel** (`TransitionKind::Derive` with `Justification::Fiat`, the
+  Endorse), by contrast, mints a *durable* value like a
   transform: an authority raises `source`'s label with the raise helpers
   (`raised_to`/`admitting`, never `combine`), and a new value carries the raised
   label under `Provenance::Endorsed` — the source is untouched. So raising trust

--- a/ai-labs/baton/baton-core/examples/demo.rs
+++ b/ai-labs/baton/baton-core/examples/demo.rs
@@ -105,7 +105,15 @@ fn main() {
     println!("5. apply the transform step: a REGISTERED redactor derives a new value; the raw one keeps its label.");
     let transform_plan = plans
         .iter()
-        .find(|p| matches!(&p.steps.first().kind, baton_core::TransitionKind::TransformValue { .. }))
+        .find(|p| {
+            matches!(
+                &p.steps.first().kind,
+                baton_core::TransitionKind::Derive {
+                    justification: baton_core::Justification::Content(_),
+                    ..
+                }
+            )
+        })
         .expect("a transform plan was enumerated");
     let capability = engine.mint_step(&trajectory, transform_plan.id, 0).unwrap();
     // The transform clears the trust breach, but the send still grows the

--- a/ai-labs/baton/baton-core/examples/external_auditor.rs
+++ b/ai-labs/baton/baton-core/examples/external_auditor.rs
@@ -15,9 +15,9 @@ use std::collections::BTreeSet;
 
 use baton_core::{
     ArgumentName, ArgumentSchema, ArgumentTree, Audience, AudienceRule, Authority, AuthorityMandate, AuthorityMode,
-    AuthorityName, Blocked, Decision, Effect, Effects, OpaqueValue, PolicyEngine, ProposedGrant, Requirements, Ruling,
-    Speaker, StepOutcome, ToolContract, ToolName, ToolRequest, Trajectory, TrajectoryView, Trust, UserId, ValueId,
-    ValueLabel, Violation,
+    AuthorityName, Decision, Effect, Effects, OpaqueValue, PolicyEngine, ProposedGrant, Pursuit, Requirements, Ruling,
+    Speaker, ToolContract, ToolName, ToolRequest, Trajectory, TrajectoryView, Trust, UserId, ValueId, ValueLabel,
+    Violation,
 };
 
 /// The internal finance team with access to the invoicing system.
@@ -112,12 +112,19 @@ fn main() {
     );
 
     // E-mail the report to the auditor: an audience breach and the first egress,
-    // both cleared by the mandated finance approver.
+    // both cleared by the mandated finance approver as `pursue` walks the plan.
     let send = email(&mut trajectory, report, AUDITOR);
     print!("  email → {AUDITOR}: ");
-    match declassify_to_permit(&engine, &mut trajectory, send) {
-        Ok(()) => println!("PERMITTED (finance approver endorsed the auditor and accepted the egress)"),
-        Err(reason) => println!("BLOCKED — {reason}"),
+    match engine.pursue(&mut trajectory, send, 8) {
+        Pursuit::Permitted(token) => {
+            let (_canonical, receipt) = trajectory.release(token).unwrap();
+            trajectory
+                .record_output(receipt, OpaqueValue::new("message-id: 1"))
+                .unwrap();
+            println!("PERMITTED (finance approver endorsed the auditor and accepted the egress)");
+        }
+        Pursuit::Terminal(block) => println!("BLOCKED — {}", block.reason),
+        other => println!("BLOCKED — {other:?}"),
     }
 
     println!("\naudit trail:");
@@ -140,33 +147,4 @@ fn email(trajectory: &mut Trajectory, report: ValueId, recipient: &str) -> ToolR
         ArgumentTree::object([("to", to), ("body", report)]),
         [],
     )
-}
-
-/// Drive a blocked-but-remediable send through its first plan, letting the
-/// inline authorities rule, until it permits (then dispatch) or blocks.
-fn declassify_to_permit(
-    engine: &PolicyEngine,
-    trajectory: &mut Trajectory,
-    request: ToolRequest,
-) -> Result<(), String> {
-    let mut decision = engine.evaluate(trajectory, request);
-    loop {
-        match decision {
-            Decision::Permitted(token) => {
-                let (_canonical, receipt) = trajectory.release(token).unwrap();
-                trajectory
-                    .record_output(receipt, OpaqueValue::new("message-id: 1"))
-                    .unwrap();
-                return Ok(());
-            }
-            Decision::Blocked(Blocked::Terminal(block)) => return Err(block.reason.to_string()),
-            Decision::Blocked(Blocked::Remediable { plans, .. }) => {
-                let capability = engine.mint_step(trajectory, plans.first().id, 0).unwrap();
-                decision = match engine.apply_step(trajectory, capability).unwrap() {
-                    StepOutcome::Advanced(next) => next,
-                    other => return Err(format!("unexpected step outcome: {other:?}")),
-                };
-            }
-        }
-    }
 }

--- a/ai-labs/baton/baton-core/examples/external_auditor.rs
+++ b/ai-labs/baton/baton-core/examples/external_auditor.rs
@@ -14,10 +14,9 @@
 use std::collections::BTreeSet;
 
 use baton_core::{
-    ArgumentName, ArgumentSchema, ArgumentTree, Audience, AudienceRule, Authority, AuthorityMandate, AuthorityMode,
-    AuthorityName, Decision, Effect, Effects, OpaqueValue, PolicyEngine, ProposedGrant, Pursuit, Requirements, Ruling,
-    Speaker, ToolContract, ToolName, ToolRequest, Trajectory, TrajectoryView, Trust, UserId, ValueId, ValueLabel,
-    Violation,
+    ArgumentTree, Authority, AuthorityMandate, AuthorityMode, AuthorityName, Decision, OpaqueValue, PolicyEngine,
+    ProposedGrant, Pursuit, Ruling, Speaker, ToolContract, ToolName, ToolRequest, Trajectory, TrajectoryView, UserId,
+    ValueId, ValueLabel, Violation,
 };
 
 /// The internal finance team with access to the invoicing system.
@@ -58,29 +57,12 @@ fn finance_approver() -> Authority {
 fn build_engine() -> PolicyEngine {
     let mut engine = PolicyEngine::new();
     engine
-        .register(ToolContract {
-            name: ToolName::new("invoices.list"),
-            requires: Requirements::default(),
-            output_label: ValueLabel {
-                audience: Audience::readers([u(ALICE), u(BOB)]),
-                trust: Trust::TRUSTED,
-            },
-            effects: Effects::none(),
-            arguments: ArgumentSchema::opaque(),
-        })
+        .register(ToolContract::source(
+            "invoices.list",
+            ValueLabel::trusted_readers([u(ALICE), u(BOB)]),
+        ))
         .unwrap();
-    engine
-        .register(ToolContract {
-            name: ToolName::new("email.send"),
-            requires: Requirements {
-                audience: AudienceRule::RecipientsWithinContext,
-                ..Requirements::default()
-            },
-            output_label: ValueLabel::identity(),
-            effects: Effects::declared([Effect::Egress]),
-            arguments: ArgumentSchema::with_recipients(ArgumentName::new("to")),
-        })
-        .unwrap();
+    engine.register(ToolContract::egress_sink("email.send", "to")).unwrap();
     engine.register_authority(finance_approver()).unwrap();
     engine
 }

--- a/ai-labs/baton/baton-core/examples/external_auditor.rs
+++ b/ai-labs/baton/baton-core/examples/external_auditor.rs
@@ -11,7 +11,7 @@
 //!
 //! Run with `cargo run --example external_auditor`.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use baton_core::{
     ArgumentName, ArgumentSchema, ArgumentTree, Audience, AudienceRule, Authority, AuthorityMandate, AuthorityMode,
@@ -95,11 +95,7 @@ fn main() {
     );
 
     // Read the invoices; the output wears the finance team's audience.
-    let list = ToolRequest::new(
-        ToolName::new("invoices.list"),
-        ArgumentTree::Object(BTreeMap::new()),
-        BTreeSet::new(),
-    );
+    let list = ToolRequest::new(ToolName::new("invoices.list"), ArgumentTree::empty(), []);
     let report = match engine.evaluate(&mut trajectory, list) {
         Decision::Permitted(token) => {
             let (_canonical, receipt) = trajectory.release(token).unwrap();
@@ -141,11 +137,8 @@ fn email(trajectory: &mut Trajectory, report: ValueId, recipient: &str) -> ToolR
     );
     ToolRequest::new(
         ToolName::new("email.send"),
-        ArgumentTree::Object(BTreeMap::from([
-            (ArgumentName::new("to"), ArgumentTree::Value(to)),
-            (ArgumentName::new("body"), ArgumentTree::Value(report)),
-        ])),
-        BTreeSet::new(),
+        ArgumentTree::object([("to", to), ("body", report)]),
+        [],
     )
 }
 

--- a/ai-labs/baton/baton-core/examples/external_auditor.rs
+++ b/ai-labs/baton/baton-core/examples/external_auditor.rs
@@ -11,12 +11,9 @@
 //!
 //! Run with `cargo run --example external_auditor`.
 
-use std::collections::BTreeSet;
-
 use baton_core::{
-    ArgumentTree, Authority, AuthorityMandate, AuthorityMode, AuthorityName, Decision, OpaqueValue, PolicyEngine,
-    ProposedGrant, Pursuit, Ruling, Speaker, ToolContract, ToolName, ToolRequest, Trajectory, TrajectoryView, UserId,
-    ValueId, ValueLabel, Violation,
+    ArgumentTree, Authority, AuthorityMandate, Decision, OpaqueValue, PolicyEngine, ProposedGrant, Pursuit, Ruling,
+    Speaker, ToolContract, ToolName, ToolRequest, Trajectory, TrajectoryView, UserId, ValueId, ValueLabel, Violation,
 };
 
 /// The internal finance team with access to the invoicing system.
@@ -39,19 +36,11 @@ fn approve_auditor(_: &ProposedGrant, _: &[Violation], _: &TrajectoryView<'_>) -
 }
 
 fn finance_approver() -> Authority {
-    Authority {
-        name: AuthorityName::new("finance-approver"),
-        mandate: AuthorityMandate {
-            trust: None,
-            audience: Some(BTreeSet::from([u(AUDITOR)])),
-            waive_prior_effects: false,
-            confirms: false,
-            acknowledge_unknown: false,
-            may_release_control: false,
-            acquire_effects: true,
-        },
-        mode: AuthorityMode::Inline(approve_auditor),
-    }
+    Authority::inline(
+        "finance-approver",
+        AuthorityMandate::none().vouch_audience([u(AUDITOR)]).acquire_effects(),
+        approve_auditor,
+    )
 }
 
 fn build_engine() -> PolicyEngine {

--- a/ai-labs/baton/baton-core/examples/recording_to_task.rs
+++ b/ai-labs/baton/baton-core/examples/recording_to_task.rs
@@ -11,9 +11,8 @@
 //! Run with `cargo run --example recording_to_task`.
 
 use baton_core::{
-    ArgumentName, ArgumentSchema, ArgumentTree, Audience, AudienceRule, Blocked, Decision, Effect, Effects,
-    OpaqueValue, PolicyEngine, Requirements, Speaker, ToolContract, ToolName, ToolRequest, Trajectory, Trust, UserId,
-    ValueId, ValueLabel,
+    ArgumentTree, Blocked, Decision, OpaqueValue, PolicyEngine, Speaker, ToolContract, ToolName, ToolRequest,
+    Trajectory, UserId, ValueId, ValueLabel,
 };
 
 /// The internal team who may read the recording.
@@ -30,28 +29,13 @@ fn u(id: &str) -> UserId {
 fn build_engine() -> PolicyEngine {
     let mut engine = PolicyEngine::new();
     engine
-        .register(ToolContract {
-            name: ToolName::new("grain.fetch"),
-            requires: Requirements::default(),
-            output_label: ValueLabel {
-                audience: Audience::readers([u(ALICE), u(BOB)]),
-                trust: Trust::TRUSTED,
-            },
-            effects: Effects::none(),
-            arguments: ArgumentSchema::opaque(),
-        })
+        .register(ToolContract::source(
+            "grain.fetch",
+            ValueLabel::trusted_readers([u(ALICE), u(BOB)]),
+        ))
         .unwrap();
     engine
-        .register(ToolContract {
-            name: ToolName::new("github.open_issue"),
-            requires: Requirements {
-                audience: AudienceRule::RecipientsWithinContext,
-                ..Requirements::default()
-            },
-            output_label: ValueLabel::identity(),
-            effects: Effects::declared([Effect::Egress]),
-            arguments: ArgumentSchema::with_recipients(ArgumentName::new("to")),
-        })
+        .register(ToolContract::egress_sink("github.open_issue", "to"))
         .unwrap();
     engine
 }

--- a/ai-labs/baton/baton-core/examples/recording_to_task.rs
+++ b/ai-labs/baton/baton-core/examples/recording_to_task.rs
@@ -10,8 +10,6 @@
 //!
 //! Run with `cargo run --example recording_to_task`.
 
-use std::collections::{BTreeMap, BTreeSet};
-
 use baton_core::{
     ArgumentName, ArgumentSchema, ArgumentTree, Audience, AudienceRule, Blocked, Decision, Effect, Effects,
     OpaqueValue, PolicyEngine, Requirements, Speaker, ToolContract, ToolName, ToolRequest, Trajectory, Trust, UserId,
@@ -68,11 +66,7 @@ fn main() {
     );
 
     // Fetch the recording; the output wears the internal team's audience.
-    let fetch = ToolRequest::new(
-        ToolName::new("grain.fetch"),
-        ArgumentTree::Object(BTreeMap::new()),
-        BTreeSet::new(),
-    );
+    let fetch = ToolRequest::new(ToolName::new("grain.fetch"), ArgumentTree::empty(), []);
     let recording = match engine.evaluate(&mut trajectory, fetch) {
         Decision::Permitted(token) => {
             let (_canonical, receipt) = trajectory.release(token).unwrap();
@@ -120,10 +114,7 @@ fn open_issue(trajectory: &mut Trajectory, recording: ValueId, recipient: &str) 
     );
     ToolRequest::new(
         ToolName::new("github.open_issue"),
-        ArgumentTree::Object(BTreeMap::from([
-            (ArgumentName::new("to"), ArgumentTree::Value(to)),
-            (ArgumentName::new("body"), ArgumentTree::Value(recording)),
-        ])),
-        BTreeSet::new(),
+        ArgumentTree::object([("to", to), ("body", recording)]),
+        [],
     )
 }

--- a/ai-labs/baton/baton-core/src/approval.rs
+++ b/ai-labs/baton/baton-core/src/approval.rs
@@ -182,7 +182,7 @@ pub enum AuthorityMode {
 }
 
 /// A grant step awaiting an external authority's ruling. Issued by the engine
-/// when an `ApplyWaiver`, `AcceptGrowth`, or `EndorseValue` step names an
+/// when an `ApplyWaiver`, `AcceptGrowth`, or fiat `Derive` (Endorse) step names an
 /// external authority; consumed by
 /// [`crate::engine::PolicyEngine::apply_approval`], which dispatches on the
 /// grant variant.

--- a/ai-labs/baton/baton-core/src/approval.rs
+++ b/ai-labs/baton/baton-core/src/approval.rs
@@ -148,6 +148,27 @@ pub struct Authority {
     pub mode: AuthorityMode,
 }
 
+impl Authority {
+    /// An in-process authority deciding synchronously through `rule`.
+    pub fn inline(name: impl Into<String>, mandate: AuthorityMandate, rule: AuthorityFn) -> Self {
+        Self {
+            name: AuthorityName::new(name),
+            mandate,
+            mode: AuthorityMode::Inline(rule),
+        }
+    }
+
+    /// An out-of-process authority whose rulings re-enter through
+    /// [`crate::engine::PolicyEngine::apply_approval`].
+    pub fn external(name: impl Into<String>, mandate: AuthorityMandate) -> Self {
+        Self {
+            name: AuthorityName::new(name),
+            mandate,
+            mode: AuthorityMode::External,
+        }
+    }
+}
+
 /// How an [`Authority`] rules. Inline authorities are consulted before
 /// external ones during routing (a deterministic answer beats a round-trip to
 /// a human).

--- a/ai-labs/baton/baton-core/src/engine/application.rs
+++ b/ai-labs/baton/baton-core/src/engine/application.rs
@@ -6,7 +6,7 @@ use crate::approval::{AncestrySnapshot, AuthorityMode, PendingApproval, Ruling, 
 use crate::audit::{AuditEvent, AuthorityName};
 use crate::contract::{Fixability, Violation};
 use crate::dimension::Effects;
-use crate::plan::TransitionKind;
+use crate::plan::{Justification, TransitionKind};
 use crate::request::ToolRequest;
 use crate::revision::{ActionId, PlanId, ValueId};
 use crate::transition::{ActionTransition, ProposedGrant, TransientWaiver};
@@ -158,7 +158,10 @@ impl PolicyEngine {
         }
 
         match spec.kind.clone() {
-            TransitionKind::TransformValue { source, transformer } => {
+            TransitionKind::Derive {
+                source,
+                justification: Justification::Content(transformer),
+            } => {
                 let registered = self
                     .transformers
                     .iter()
@@ -282,7 +285,10 @@ impl PolicyEngine {
                     },
                 )
             }
-            TransitionKind::EndorseValue { source, delta, targets } => {
+            TransitionKind::Derive {
+                source,
+                justification: Justification::Fiat { delta, targets },
+            } => {
                 let grant = ProposedGrant::Endorse {
                     source,
                     delta: delta.clone(),

--- a/ai-labs/baton/baton-core/src/engine/capability.rs
+++ b/ai-labs/baton/baton-core/src/engine/capability.rs
@@ -40,9 +40,9 @@ pub struct ToolContract {
 }
 
 impl ToolContract {
-    /// A pure read: no requirements, no effects, opaque arguments. An
-    /// argument-free call's output wears exactly `output_label`; arguments,
-    /// when present, fold in and can only worsen it.
+    /// A pure read: no requirements, no effects, opaque arguments. A
+    /// dependency-free call's output wears exactly `output_label`; argument
+    /// and control dependencies fold in and can only worsen it.
     pub fn source(name: impl Into<String>, output_label: ValueLabel) -> Self {
         Self {
             name: ToolName::new(name),

--- a/ai-labs/baton/baton-core/src/engine/capability.rs
+++ b/ai-labs/baton/baton-core/src/engine/capability.rs
@@ -40,8 +40,9 @@ pub struct ToolContract {
 }
 
 impl ToolContract {
-    /// A pure read: no requirements, no effects, opaque arguments — the tool
-    /// only introduces data, wearing `output_label`.
+    /// A pure read: no requirements, no effects, opaque arguments. An
+    /// argument-free call's output wears exactly `output_label`; arguments,
+    /// when present, fold in and can only worsen it.
     pub fn source(name: impl Into<String>, output_label: ValueLabel) -> Self {
         Self {
             name: ToolName::new(name),

--- a/ai-labs/baton/baton-core/src/engine/capability.rs
+++ b/ai-labs/baton/baton-core/src/engine/capability.rs
@@ -6,10 +6,10 @@ use serde::Serialize;
 use crate::ToolName;
 use crate::approval::PendingApproval;
 use crate::audit::AuthorityName;
-use crate::contract::{Requirements, Violation};
-use crate::dimension::Effects;
+use crate::contract::{AudienceRule, Requirements, Violation};
+use crate::dimension::{Effect, Effects};
 use crate::plan::{NonEmptyVec, RemedyPlan};
-use crate::request::ArgumentSchema;
+use crate::request::{ArgumentName, ArgumentSchema};
 use crate::revision::{ActionId, PlanId, Revision, ValueId};
 use crate::turn::TrajectoryId;
 use crate::value::ValueLabel;
@@ -37,6 +37,36 @@ pub struct ToolContract {
     /// past when dispatch begins.
     pub effects: Effects,
     pub arguments: ArgumentSchema,
+}
+
+impl ToolContract {
+    /// A pure read: no requirements, no effects, opaque arguments — the tool
+    /// only introduces data, wearing `output_label`.
+    pub fn source(name: impl Into<String>, output_label: ValueLabel) -> Self {
+        Self {
+            name: ToolName::new(name),
+            requires: Requirements::default(),
+            output_label,
+            effects: Effects::none(),
+            arguments: ArgumentSchema::opaque(),
+        }
+    }
+
+    /// An egress sink: recipients are read from the top-level argument
+    /// `recipients_arg` and must lie within the flow's audience; one dispatch
+    /// proposes an `Egress` effect. The output wears the identity label.
+    pub fn egress_sink(name: impl Into<String>, recipients_arg: impl Into<String>) -> Self {
+        Self {
+            name: ToolName::new(name),
+            requires: Requirements {
+                audience: AudienceRule::RecipientsWithinContext,
+                ..Requirements::default()
+            },
+            output_label: ValueLabel::identity(),
+            effects: Effects::declared([Effect::Egress]),
+            arguments: ArgumentSchema::with_recipients(ArgumentName::new(recipients_arg)),
+        }
+    }
 }
 
 /// Proof that the engine authorized one tool call — the only way to append a

--- a/ai-labs/baton/baton-core/src/engine/mod.rs
+++ b/ai-labs/baton/baton-core/src/engine/mod.rs
@@ -40,6 +40,7 @@ mod application;
 mod capability;
 mod evaluation;
 mod planning;
+mod pursue;
 
 #[cfg(test)]
 mod tests;
@@ -50,6 +51,7 @@ pub use capability::{
     RejectedToken, ResponseDecision, ResponsePolicy, StepCapability, StepOutcome, StepRefused, TerminalBlock,
     ToolContract,
 };
+pub use pursue::{Pursuit, StallCause};
 
 /// Identity of one engine configuration, unique within the process. Plans,
 /// step capabilities, and pending approvals bind to it: registries are the

--- a/ai-labs/baton/baton-core/src/engine/planning.rs
+++ b/ai-labs/baton/baton-core/src/engine/planning.rs
@@ -4,7 +4,7 @@ use crate::ToolName;
 use crate::approval::{Authority, AuthorityMode};
 use crate::contract::{Fixability, Requirements, Unprovable, Verdict, Violation};
 use crate::dimension::{Effects, KnownTrust};
-use crate::plan::{ExitKind, NonEmptyVec, Posture, TransitionKind, TransitionSpec};
+use crate::plan::{ExitKind, Justification, NonEmptyVec, Posture, TransitionKind, TransitionSpec};
 use crate::request::ToolRequest;
 use crate::revision::ValueId;
 use crate::transition::{ActionTransition, EndorseDelta, ProposedGrant, RegisteredTransformer, TransientWaiver};
@@ -128,9 +128,9 @@ impl PolicyEngine {
                         postcondition: Posture {
                             remaining: sim.violations(None),
                         },
-                        kind: TransitionKind::TransformValue {
+                        kind: TransitionKind::Derive {
                             source: *leaf,
-                            transformer: transformer.descriptor.transformer.clone(),
+                            justification: Justification::Content(transformer.descriptor.transformer.clone()),
                         },
                     });
                 }
@@ -192,10 +192,9 @@ impl PolicyEngine {
                             postcondition: Posture {
                                 remaining: remaining.clone(),
                             },
-                            kind: TransitionKind::EndorseValue {
+                            kind: TransitionKind::Derive {
                                 source: leaf,
-                                delta,
-                                targets,
+                                justification: Justification::Fiat { delta, targets },
                             },
                         });
                     }
@@ -317,10 +316,12 @@ impl PolicyEngine {
                 postcondition: Posture {
                     remaining: remaining.clone(),
                 },
-                kind: TransitionKind::EndorseValue {
+                kind: TransitionKind::Derive {
                     source: *leaf,
-                    delta: delta.clone(),
-                    targets: targets.clone(),
+                    justification: Justification::Fiat {
+                        delta: delta.clone(),
+                        targets: targets.clone(),
+                    },
                 },
             });
         }

--- a/ai-labs/baton/baton-core/src/engine/pursue.rs
+++ b/ai-labs/baton/baton-core/src/engine/pursue.rs
@@ -1,0 +1,117 @@
+//! Drive one requested flow to a settled outcome: evaluate, then walk the
+//! engine's first remedy plan step by step until the flow permits, blocks
+//! terminally, needs an external ruling, or stalls.
+//!
+//! This is the common consumer loop, centralized. It encodes exactly one
+//! policy — **the first enumerated plan, one step at a time** — so callers
+//! wanting a different plan choice (shortest, least-authority) or an
+//! auto-approval loop keep driving [`PolicyEngine::mint_step`] /
+//! [`PolicyEngine::apply_step`] themselves.
+//!
+//! Two-phase dispatch is untouched: a permitted pursuit hands back the
+//! [`ExecutionToken`], and only [`crate::turn::Trajectory::release`] renders
+//! the canonical request and commits effects.
+
+use tracing::debug;
+
+use super::PolicyEngine;
+use super::capability::{Blocked, Decision, ExecutionToken, StepOutcome, StepRefused, TerminalBlock};
+use crate::approval::PendingApproval;
+use crate::audit::TransitionFailure;
+use crate::contract::Violation;
+use crate::request::ToolRequest;
+use crate::turn::Trajectory;
+
+/// How a pursuit settled. Terminal and stalled pursuits leave no pending
+/// action behind; a `NeedsApproval` pursuit deliberately keeps the slot —
+/// the held [`PendingApproval`] re-enters through
+/// [`PolicyEngine::apply_approval`], which requires that same action.
+#[derive(Debug, PartialEq, Eq)]
+#[must_use = "a dropped Pursuit loses the execution token or the pending approval"]
+pub enum Pursuit {
+    /// The flow is authorized; release the token to dispatch.
+    Permitted(ExecutionToken),
+    /// Nothing can clear the flow.
+    Terminal(TerminalBlock),
+    /// A step routed to an external authority; the pending action is kept so
+    /// the ruling can re-enter.
+    NeedsApproval(PendingApproval),
+    /// The walk could not settle the flow; the pending action was abandoned
+    /// so the trajectory is free for the next proposal.
+    Stalled {
+        /// The violations of the round that stalled.
+        violations: Vec<Violation>,
+        cause: StallCause,
+    },
+}
+
+/// Why a pursuit stalled.
+#[derive(Debug, PartialEq, Eq)]
+pub enum StallCause {
+    /// `max_steps` remedy steps were applied without settling.
+    BoundExhausted,
+    /// A step could not be minted or applied against the current state.
+    Refused(StepRefused),
+    /// A step's transition failed (audited; no state changed beyond the record).
+    Failed(TransitionFailure),
+}
+
+impl PolicyEngine {
+    /// Evaluate `request` and walk the first remedy plan until the flow
+    /// permits, blocks terminally, defers to an external authority, or
+    /// stalls — applying at most `max_steps` steps. The bound is checked
+    /// before each step, never after: a permit produced by the final
+    /// allowed step is still returned.
+    pub fn pursue(&self, trajectory: &mut Trajectory, request: ToolRequest, max_steps: usize) -> Pursuit {
+        let mut decision = self.evaluate(trajectory, request);
+        let mut steps = 0;
+        loop {
+            let (violations, plans) = match decision {
+                Decision::Permitted(token) => return Pursuit::Permitted(token),
+                Decision::Blocked(Blocked::Terminal(block)) => return Pursuit::Terminal(block),
+                Decision::Blocked(Blocked::Remediable { violations, plans }) => (violations, plans),
+            };
+            if steps >= max_steps {
+                debug!(steps, "pursuit stalled: step bound exhausted");
+                trajectory.abandon_pending();
+                return Pursuit::Stalled {
+                    violations,
+                    cause: StallCause::BoundExhausted,
+                };
+            }
+            steps += 1;
+            let plan = plans.first().id;
+            let capability = match self.mint_step(trajectory, plan, 0) {
+                Ok(capability) => capability,
+                Err(refused) => {
+                    debug!(%plan, "pursuit stalled: step refused at mint");
+                    trajectory.abandon_pending();
+                    return Pursuit::Stalled {
+                        violations,
+                        cause: StallCause::Refused(refused),
+                    };
+                }
+            };
+            match self.apply_step(trajectory, capability) {
+                Ok(StepOutcome::Advanced(next)) => decision = next,
+                Ok(StepOutcome::NeedsApproval(pending)) => return Pursuit::NeedsApproval(pending),
+                Ok(StepOutcome::Failed(failure)) => {
+                    debug!(%plan, "pursuit stalled: transition failed");
+                    trajectory.abandon_pending();
+                    return Pursuit::Stalled {
+                        violations,
+                        cause: StallCause::Failed(failure),
+                    };
+                }
+                Err(refused) => {
+                    debug!(%plan, "pursuit stalled: step refused at apply");
+                    trajectory.abandon_pending();
+                    return Pursuit::Stalled {
+                        violations,
+                        cause: StallCause::Refused(refused),
+                    };
+                }
+            }
+        }
+    }
+}

--- a/ai-labs/baton/baton-core/src/engine/pursue.rs
+++ b/ai-labs/baton/baton-core/src/engine/pursue.rs
@@ -22,16 +22,18 @@ use crate::contract::Violation;
 use crate::request::ToolRequest;
 use crate::turn::Trajectory;
 
-/// How a pursuit settled. Terminal and stalled pursuits leave no pending
-/// action behind; a `NeedsApproval` pursuit deliberately keeps the slot —
-/// the held [`PendingApproval`] re-enters through
-/// [`PolicyEngine::apply_approval`], which requires that same action.
+/// How a pursuit settled. A stalled pursuit leaves no pending action behind;
+/// a `NeedsApproval` pursuit deliberately keeps the slot — the held
+/// [`PendingApproval`] re-enters through [`PolicyEngine::apply_approval`],
+/// which requires that same action.
 #[derive(Debug, PartialEq, Eq)]
 #[must_use = "a dropped Pursuit loses the execution token or the pending approval"]
 pub enum Pursuit {
     /// The flow is authorized; release the token to dispatch.
     Permitted(ExecutionToken),
-    /// Nothing can clear the flow.
+    /// Nothing can clear the flow. The engine cleared this request's pending
+    /// slot — except `ActionAlreadyPending`, which refuses a *different*
+    /// proposal precisely without touching the action already in flight.
     Terminal(TerminalBlock),
     /// A step routed to an external authority; the pending action is kept so
     /// the ruling can re-enter.

--- a/ai-labs/baton/baton-core/src/engine/pursue.rs
+++ b/ai-labs/baton/baton-core/src/engine/pursue.rs
@@ -32,8 +32,9 @@ pub enum Pursuit {
     /// The flow is authorized; release the token to dispatch.
     Permitted(ExecutionToken),
     /// Nothing can clear the flow. The engine cleared this request's pending
-    /// slot — except `ActionAlreadyPending`, which refuses a *different*
-    /// proposal precisely without touching the action already in flight.
+    /// slot — except `ActionAlreadyPending`, which refuses while another
+    /// action (or this one's released dispatch) is still in flight, precisely
+    /// without touching it.
     Terminal(TerminalBlock),
     /// A step routed to an external authority; the pending action is kept so
     /// the ruling can re-enter.

--- a/ai-labs/baton/baton-core/src/engine/tests.rs
+++ b/ai-labs/baton/baton-core/src/engine/tests.rs
@@ -62,18 +62,9 @@ fn dispatch(trajectory: &mut Trajectory, token: ExecutionToken, body: &str) -> R
 /// for effect-axis tests that must genuinely acquire the growth (walk the
 /// Accept) rather than pre-seed a downhill past.
 fn walk_to_permit(engine: &PolicyEngine, trajectory: &mut Trajectory, request: ToolRequest) -> ExecutionToken {
-    let mut decision = engine.evaluate(trajectory, request);
-    loop {
-        match decision {
-            Decision::Permitted(token) => break token,
-            Decision::Blocked(Blocked::Remediable { plans, .. }) => {
-                decision = match apply_first_step(engine, trajectory, plans.first().id) {
-                    StepOutcome::Advanced(decision) => decision,
-                    other => panic!("unexpected step outcome: {other:?}"),
-                };
-            }
-            other => panic!("expected to reach a permit, got {other:?}"),
-        }
+    match engine.pursue(trajectory, request, 16) {
+        Pursuit::Permitted(token) => token,
+        other => panic!("expected to reach a permit, got {other:?}"),
     }
 }
 
@@ -532,6 +523,86 @@ fn canonical_request_renders_the_checked_tree() {
     let (canonical, receipt) = trajectory.release(token).unwrap();
     assert_eq!(canonical.rendered, r#"{"body":"the doc","to":"bob"}"#);
     trajectory.record_output(receipt, OpaqueValue::new("sent")).unwrap();
+}
+
+/// The bound is checked before a step, never after: with exactly enough
+/// budget for the one Accept step, the resulting permit is still returned.
+#[test]
+fn pursue_returns_a_permit_produced_by_the_final_allowed_step() {
+    let mut engine = engine_with([egress_tool()]);
+    engine.register_authority(inline_acquirer()).unwrap();
+    let mut trajectory = Trajectory::new();
+    let body = ingress(&mut trajectory, &["alice"], Trust::TRUSTED, "ping");
+    let Pursuit::Permitted(token) = engine.pursue(&mut trajectory, ping_request(body), 1) else {
+        panic!("the final allowed step's permit must be returned");
+    };
+    dispatch(&mut trajectory, token, "pong").unwrap();
+}
+
+/// A permitted pursuit authorizes but commits nothing: effects land at
+/// release, not while walking — the two-phase boundary is untouched.
+#[test]
+fn pursue_permit_commits_nothing_before_release() {
+    let mut engine = engine_with([egress_tool()]);
+    engine.register_authority(inline_acquirer()).unwrap();
+    let mut trajectory = Trajectory::new();
+    let body = ingress(&mut trajectory, &["alice"], Trust::TRUSTED, "ping");
+    let Pursuit::Permitted(token) = engine.pursue(&mut trajectory, ping_request(body), 8) else {
+        panic!("expected a permit");
+    };
+    assert_eq!(trajectory.state().past_effects(), &Effects::none());
+    let (_, receipt) = trajectory.release(token).unwrap();
+    assert_eq!(trajectory.state().past_effects(), &Effects::declared([Effect::Egress]));
+    trajectory.record_output(receipt, OpaqueValue::new("pong")).unwrap();
+}
+
+/// A stalled pursuit abandons the pending action: the trajectory stays free
+/// for the next proposal instead of refusing it as already-pending.
+#[test]
+fn pursue_stall_abandons_the_pending_action() {
+    let mut engine = engine_with([egress_tool()]);
+    engine.register_authority(inline_acquirer()).unwrap();
+    let mut trajectory = Trajectory::new();
+    let body = ingress(&mut trajectory, &["alice"], Trust::TRUSTED, "ping");
+    let Pursuit::Stalled { violations, cause } = engine.pursue(&mut trajectory, ping_request(body), 0) else {
+        panic!("a zero bound must stall a remediable flow");
+    };
+    assert_eq!(cause, StallCause::BoundExhausted);
+    assert!(!violations.is_empty());
+    assert!(trajectory.pending_action().is_none());
+    let Pursuit::Permitted(token) = engine.pursue(&mut trajectory, ping_request(body), 8) else {
+        panic!("the trajectory must be free after a stall");
+    };
+    dispatch(&mut trajectory, token, "pong").unwrap();
+}
+
+/// A pursuit deferring to an external authority keeps the pending action, so
+/// the held approval can re-enter through `apply_approval`.
+#[test]
+fn pursue_keeps_the_slot_for_an_external_ruling() {
+    let mut engine = engine_with([egress_tool()]);
+    engine
+        .register_authority(external_authority("effect-approver", acquirer_mandate()))
+        .unwrap();
+    let mut trajectory = Trajectory::new();
+    let body = ingress(&mut trajectory, &["alice"], Trust::TRUSTED, "ping");
+    let Pursuit::NeedsApproval(pending) = engine.pursue(&mut trajectory, ping_request(body), 8) else {
+        panic!("the external acquirer should defer");
+    };
+    assert!(trajectory.pending_action().is_some());
+    let Decision::Permitted(token) = engine
+        .apply_approval(
+            &mut trajectory,
+            pending,
+            crate::approval::Ruling::Approve {
+                reason: "acquired".to_owned(),
+            },
+        )
+        .unwrap()
+    else {
+        panic!("the approval should permit");
+    };
+    dispatch(&mut trajectory, token, "pong").unwrap();
 }
 
 #[test]

--- a/ai-labs/baton/baton-core/src/engine/tests.rs
+++ b/ai-labs/baton/baton-core/src/engine/tests.rs
@@ -605,6 +605,48 @@ fn pursue_keeps_the_slot_for_an_external_ruling() {
     dispatch(&mut trajectory, token, "pong").unwrap();
 }
 
+/// A `source`-registered tool is a pure read whose recorded output wears the
+/// declared label after the admission fold.
+#[test]
+fn source_contract_output_wears_the_declared_label() {
+    let internal = || ValueLabel::trusted_readers([user("alice"), user("bob")]);
+    let engine = engine_with([ToolContract::source("invoices.list", internal())]);
+    let mut trajectory = Trajectory::new();
+    let request = ToolRequest::new(ToolName::new("invoices.list"), ArgumentTree::empty(), []);
+    let Decision::Permitted(token) = engine.evaluate(&mut trajectory, request) else {
+        panic!("a pure read must permit");
+    };
+    let id = dispatch(&mut trajectory, token, "47 invoices").unwrap();
+    assert_eq!(trajectory.value(id).unwrap().label(), &internal());
+}
+
+/// An `egress_sink`-registered tool reads recipients from the named argument
+/// (walking the Accept for its declared egress), and blocks structurally when
+/// the recipients argument is missing.
+#[test]
+fn egress_sink_contract_resolves_recipients_and_blocks_undeclared() {
+    let mut engine = engine_with([ToolContract::egress_sink("email.send", "to")]);
+    engine.register_authority(inline_acquirer()).unwrap();
+    let mut trajectory = Trajectory::new();
+
+    let body = ingress(&mut trajectory, &["bob"], Trust::TRUSTED, "doc");
+    let request = email_request(&mut trajectory, body, "bob");
+    let token = walk_to_permit(&engine, &mut trajectory, request);
+    dispatch(&mut trajectory, token, "sent").unwrap();
+    assert_eq!(trajectory.state().past_effects(), &Effects::declared([Effect::Egress]));
+
+    let body = ingress(&mut trajectory, &["bob"], Trust::TRUSTED, "doc two");
+    let bare = ToolRequest::new(ToolName::new("email.send"), ArgumentTree::object([("body", body)]), []);
+    let Decision::Blocked(Blocked::Terminal(block)) = engine.evaluate(&mut trajectory, bare) else {
+        panic!("an egress sink with no recipients argument must block terminally");
+    };
+    assert!(
+        block
+            .violations
+            .contains(&Violation::Breach(crate::contract::Breach::UndeclaredRecipients))
+    );
+}
+
 #[test]
 fn object_built_request_checks_and_renders_like_the_literal_tree() {
     let engine = engine_with([email_contract()]);

--- a/ai-labs/baton/baton-core/src/engine/tests.rs
+++ b/ai-labs/baton/baton-core/src/engine/tests.rs
@@ -576,6 +576,39 @@ fn pursue_stall_abandons_the_pending_action() {
     dispatch(&mut trajectory, token, "pong").unwrap();
 }
 
+/// Pursuing a different proposal while an action is in flight is refused
+/// terminally WITHOUT touching the in-flight action: its token still
+/// releases — the one terminal where clearing the slot would be a bug.
+#[test]
+fn pursue_of_a_different_proposal_leaves_the_inflight_action_untouched() {
+    let engine = engine_with([email_contract()]);
+    let mut trajectory = Trajectory::new();
+    trajectory.seed_committed_effects(Effects::declared([Effect::Egress]));
+    let body = ingress(&mut trajectory, &["alice", "bob"], Trust::TRUSTED, "doc");
+    let to_bob = identity_ingress(&mut trajectory, "bob");
+    let to_alice = identity_ingress(&mut trajectory, "alice");
+    let first = ToolRequest::new(
+        ToolName::new("email.send"),
+        ArgumentTree::object([("to", to_bob), ("body", body)]),
+        [],
+    );
+    let second = ToolRequest::new(
+        ToolName::new("email.send"),
+        ArgumentTree::object([("to", to_alice), ("body", body)]),
+        [],
+    );
+
+    let Decision::Permitted(token) = engine.evaluate(&mut trajectory, first) else {
+        panic!("expected a permit");
+    };
+    let Pursuit::Terminal(block) = engine.pursue(&mut trajectory, second, 8) else {
+        panic!("a different proposal while one is pending must refuse terminally");
+    };
+    assert!(matches!(block.reason, BlockReason::ActionAlreadyPending { .. }));
+    assert!(trajectory.pending_action().is_some());
+    dispatch(&mut trajectory, token, "sent").unwrap();
+}
+
 /// A pursuit deferring to an external authority keeps the pending action, so
 /// the held approval can re-enter through `apply_approval`.
 #[test]

--- a/ai-labs/baton/baton-core/src/engine/tests.rs
+++ b/ai-labs/baton/baton-core/src/engine/tests.rs
@@ -605,6 +605,46 @@ fn pursue_keeps_the_slot_for_an_external_ruling() {
     dispatch(&mut trajectory, token, "pong").unwrap();
 }
 
+/// A combinator-built inline authority routes and rules end-to-end: vouching
+/// carol in (Endorse) and acquiring the egress (Accept) walk the flow to a
+/// genuine permit — the combinators grant real, sufficient competence.
+#[test]
+fn combinator_built_inline_authority_endorses_to_a_permit() {
+    let mut engine = engine_with([email_contract()]);
+    engine
+        .register_authority(Authority::inline(
+            "approver",
+            crate::transition::AuthorityMandate::none()
+                .vouch_audience([user("carol")])
+                .acquire_effects(),
+            approve_all,
+        ))
+        .unwrap();
+    let mut trajectory = Trajectory::new();
+    let body = ingress(&mut trajectory, &["alice"], Trust::TRUSTED, "doc");
+    let request = email_request(&mut trajectory, body, "carol");
+    let token = walk_to_permit(&engine, &mut trajectory, request);
+    dispatch(&mut trajectory, token, "sent").unwrap();
+}
+
+/// A combinator-built external authority defers, and the pursuit names it.
+#[test]
+fn combinator_built_external_authority_defers_naming_it() {
+    let mut engine = engine_with([egress_tool()]);
+    engine
+        .register_authority(Authority::external(
+            "effect-approver",
+            crate::transition::AuthorityMandate::none().acquire_effects(),
+        ))
+        .unwrap();
+    let mut trajectory = Trajectory::new();
+    let body = ingress(&mut trajectory, &["alice"], Trust::TRUSTED, "ping");
+    let Pursuit::NeedsApproval(pending) = engine.pursue(&mut trajectory, ping_request(body), 8) else {
+        panic!("the external acquirer should defer");
+    };
+    assert_eq!(pending.authority(), &AuthorityName::new("effect-approver"));
+}
+
 /// A `source`-registered tool is a pure read whose recorded output wears the
 /// declared label after the admission fold.
 #[test]

--- a/ai-labs/baton/baton-core/src/engine/tests.rs
+++ b/ai-labs/baton/baton-core/src/engine/tests.rs
@@ -535,6 +535,30 @@ fn canonical_request_renders_the_checked_tree() {
 }
 
 #[test]
+fn object_built_request_checks_and_renders_like_the_literal_tree() {
+    let engine = engine_with([email_contract()]);
+    let mut trajectory = Trajectory::new();
+    trajectory.seed_committed_effects(Effects::declared([Effect::Egress]));
+    let body = ingress(&mut trajectory, &["alice", "bob"], Trust::TRUSTED, "the doc");
+    let to = identity_ingress(&mut trajectory, "bob");
+    // `object` + leaf coercion + iterator control set: duplicates dedup into
+    // the same mandatory set a literal `BTreeSet` would carry.
+    let request = ToolRequest::new(
+        ToolName::new("email.send"),
+        ArgumentTree::object([("to", to), ("body", body)]),
+        [body, body],
+    );
+    assert_eq!(request.control, BTreeSet::from([body]));
+
+    let Decision::Permitted(token) = engine.evaluate(&mut trajectory, request) else {
+        panic!("expected permit");
+    };
+    let (canonical, receipt) = trajectory.release(token).unwrap();
+    assert_eq!(canonical.rendered, r#"{"body":"the doc","to":"bob"}"#);
+    trajectory.record_output(receipt, OpaqueValue::new("sent")).unwrap();
+}
+
+#[test]
 fn stale_receipt_is_rejected_after_any_mutation() {
     let engine = engine_with([email_contract()]);
     let mut trajectory = Trajectory::new();

--- a/ai-labs/baton/baton-core/src/engine/tests.rs
+++ b/ai-labs/baton/baton-core/src/engine/tests.rs
@@ -8,7 +8,7 @@ use crate::approval::{AuthorityMode, Ruling, TrajectoryView};
 use crate::audit::{AuditEvent, AuthorityName};
 use crate::contract::{Requirements, Unprovable, Violation};
 use crate::dimension::{Audience, Effect, Effects, KnownTrust, Trust, UserId};
-use crate::plan::{ExitKind, NonEmptyVec, Posture, RemedyPlan, TransitionKind, TransitionSpec};
+use crate::plan::{ExitKind, Justification, NonEmptyVec, Posture, RemedyPlan, TransitionKind, TransitionSpec};
 use crate::request::{ArgumentName, ArgumentSchema, ArgumentTree, ResponseRequest, ToolRequest};
 use crate::revision::{PlanId, ValueId};
 use crate::turn::{Speaker, Trajectory};
@@ -313,7 +313,7 @@ fn unknown_trust_routes_as_an_endorse() {
     // the sink's requirement.
     assert!(matches!(
         &plans.first().steps.first().kind,
-        TransitionKind::EndorseValue { source, delta, .. }
+        TransitionKind::Derive { source, justification: Justification::Fiat { delta, .. } }
             if *source == doc && delta.trust == Some(KnownTrust::Trusted)
     ));
     // ...routed to the trust-competent external human.
@@ -1058,7 +1058,7 @@ fn tainted_payload_plans_a_transform() {
         .expect("single-step transform plan");
     assert!(matches!(
         &transform_plan.steps.first().kind,
-        TransitionKind::TransformValue { source, .. } if *source == raw
+        TransitionKind::Derive { source, justification: Justification::Content(_) } if *source == raw
     ));
     assert!(transform_plan.final_postcondition.is_clean());
     // Plans are stored on the trajectory, bound to its current revision,
@@ -1085,7 +1085,7 @@ fn audience_breach_plans_an_endorse() {
     assert_eq!(endorse.steps.len(), 1);
     assert!(matches!(
         &endorse.steps.first().kind,
-        TransitionKind::EndorseValue { source, delta, .. }
+        TransitionKind::Derive { source, justification: Justification::Fiat { delta, .. } }
             if *source == doc && delta.audience.as_ref().is_some_and(|r| r.contains(&user("charlie")))
     ));
     // Routing is live at application: the endorse step defers to the
@@ -1135,7 +1135,10 @@ fn a_multi_source_audience_breach_endorses_every_contributing_leaf() {
         .steps
         .iter()
         .filter_map(|s| match &s.kind {
-            TransitionKind::EndorseValue { source, .. } => Some(*source),
+            TransitionKind::Derive {
+                source,
+                justification: Justification::Fiat { .. },
+            } => Some(*source),
             _ => None,
         })
         .collect();
@@ -1189,7 +1192,7 @@ fn a_granted_endorse_durably_relabels_the_source_and_permits() {
     let plans = remediable(&engine, &mut trajectory, request);
     let endorse_plan = plans
         .iter()
-        .find(|p| matches!(&p.steps.first().kind, TransitionKind::EndorseValue { source, .. } if *source == doc))
+        .find(|p| matches!(&p.steps.first().kind, TransitionKind::Derive { source, justification: Justification::Fiat { .. } } if *source == doc))
         .expect("an endorse plan for the doc");
     let StepOutcome::NeedsApproval(pending) = apply_first_step(&engine, &mut trajectory, endorse_plan.id) else {
         panic!("expected the external human to be consulted");
@@ -1284,7 +1287,7 @@ fn a_denied_endorse_is_terminal_and_mints_no_value() {
     let plans = remediable(&engine, &mut trajectory, request);
     let endorse_plan = plans
         .iter()
-        .find(|p| matches!(&p.steps.first().kind, TransitionKind::EndorseValue { source, .. } if *source == doc))
+        .find(|p| matches!(&p.steps.first().kind, TransitionKind::Derive { source, justification: Justification::Fiat { .. } } if *source == doc))
         .expect("an endorse plan for the doc");
     let values_before = trajectory.store().len();
     let StepOutcome::NeedsApproval(pending) = apply_first_step(&engine, &mut trajectory, endorse_plan.id) else {
@@ -1446,7 +1449,7 @@ fn control_release_and_endorse_compose_for_a_mixed_audience_breach() {
         let endorses_charlie = plan.steps.iter().any(|step| {
             matches!(
                 &step.kind,
-                TransitionKind::EndorseValue { source, delta, .. }
+                TransitionKind::Derive { source, justification: Justification::Fiat { delta, .. } }
                     if *source == body && delta.audience.as_ref().is_some_and(|r| r.contains(&user("charlie")))
             )
         });
@@ -1677,7 +1680,16 @@ fn transform_step_applies_and_flow_permits() {
     let plans = remediable(&engine, &mut trajectory, request);
     let plan = plans
         .iter()
-        .find(|p| p.steps.len() == 1 && matches!(&p.steps.first().kind, TransitionKind::TransformValue { .. }))
+        .find(|p| {
+            p.steps.len() == 1
+                && matches!(
+                    &p.steps.first().kind,
+                    TransitionKind::Derive {
+                        justification: Justification::Content(_),
+                        ..
+                    }
+                )
+        })
         .expect("transform plan");
 
     let outcome = apply_first_step(&engine, &mut trajectory, plan.id);
@@ -1715,7 +1727,10 @@ fn rule_approved_endorse_permits_inline() {
     let plans = remediable(&engine, &mut trajectory, request);
     assert!(matches!(
         &plans.first().steps.first().kind,
-        TransitionKind::EndorseValue { .. }
+        TransitionKind::Derive {
+            justification: Justification::Fiat { .. },
+            ..
+        }
     ));
     let outcome = apply_first_step(&engine, &mut trajectory, plans.first().id);
     let StepOutcome::Advanced(Decision::Permitted(_token)) = outcome else {
@@ -2214,9 +2229,9 @@ fn plan_steps(kinds: Vec<TransitionKind>) -> NonEmptyVec<TransitionSpec> {
 /// composite is categorized by that step, not its first.
 #[test]
 fn exit_kind_is_the_decisive_step() {
-    let transform = TransitionKind::TransformValue {
+    let transform = TransitionKind::Derive {
         source: ValueId::new(0),
-        transformer: tref("s"),
+        justification: Justification::Content(tref("s")),
     };
     let constrain = TransitionKind::ConstrainAction { transition: tref("c") };
     let accept = TransitionKind::AcceptGrowth {
@@ -2259,9 +2274,9 @@ fn cap_fairness_keeps_one_route_per_category() {
     let mut pool: Vec<(NonEmptyVec<TransitionSpec>, Posture)> = Vec::new();
     for i in 0..6u64 {
         pool.push((
-            plan_steps(vec![TransitionKind::TransformValue {
+            plan_steps(vec![TransitionKind::Derive {
                 source: ValueId::new(i),
-                transformer: tref("s"),
+                justification: Justification::Content(tref("s")),
             }]),
             clean.clone(),
         ));
@@ -2423,9 +2438,15 @@ fn constrain_then_accept_covers_only_the_residual_growth() {
 /// The discriminant of a step's kind, for asserting the order steps ran.
 fn step_label(kind: &TransitionKind) -> &'static str {
     match kind {
-        TransitionKind::TransformValue { .. } => "sanitize",
+        TransitionKind::Derive {
+            justification: Justification::Content(_),
+            ..
+        } => "sanitize",
         TransitionKind::ConstrainAction { .. } => "constrain",
-        TransitionKind::EndorseValue { .. } => "endorse",
+        TransitionKind::Derive {
+            justification: Justification::Fiat { .. },
+            ..
+        } => "endorse",
         TransitionKind::AcceptGrowth { .. } => "accept",
         TransitionKind::ApplyWaiver { .. } => "waiver",
     }
@@ -2523,7 +2544,10 @@ fn full_composition_reduces_then_authorizes_the_irreducible_residual() {
         .steps
         .iter()
         .find_map(|s| match &s.kind {
-            TransitionKind::EndorseValue { delta, .. } => Some(delta),
+            TransitionKind::Derive {
+                justification: Justification::Fiat { delta, .. },
+                ..
+            } => Some(delta),
             _ => None,
         })
         .expect("an endorse step");
@@ -2969,7 +2993,15 @@ fn multi_step_composition_transform_then_waiver() {
     // ...and application goes step by step, re-planning in between.
     let transform_plan = plans
         .iter()
-        .find(|p| matches!(&p.steps.first().kind, TransitionKind::TransformValue { .. }))
+        .find(|p| {
+            matches!(
+                &p.steps.first().kind,
+                TransitionKind::Derive {
+                    justification: Justification::Content(_),
+                    ..
+                }
+            )
+        })
         .expect("plan starting with a transform");
     let StepOutcome::Advanced(Decision::Blocked(Blocked::Remediable { plans, violations })) =
         apply_first_step(&engine, &mut trajectory, transform_plan.id)
@@ -3669,7 +3701,7 @@ fn rescue_composes_endorse_then_release_for_a_masked_flow() {
     let steps = &plans.first().steps;
     assert!(matches!(
         &steps.first().kind,
-        TransitionKind::EndorseValue { source, delta, targets }
+        TransitionKind::Derive { source, justification: Justification::Fiat { delta, targets } }
             if *source == body
                 && delta.trust == Some(KnownTrust::Suspicious)
                 && *targets == vec![Violation::Unprovable(Unprovable::TrustUnknown)]
@@ -4051,7 +4083,7 @@ fn rescue_does_not_over_endorse_re_masked_leaves() {
     assert_eq!(steps.len(), 2);
     assert!(matches!(
         &steps.first().kind,
-        TransitionKind::EndorseValue { source, .. } if *source == first
+        TransitionKind::Derive { source, justification: Justification::Fiat { .. } } if *source == first
     ));
     assert!(matches!(
         &steps.get(1).unwrap().kind,
@@ -4113,14 +4145,14 @@ fn rescue_endorse_targets_shrink_per_peel() {
     let steps = &plans.first().steps;
     assert!(matches!(
         &steps.first().kind,
-        TransitionKind::EndorseValue { source, targets, .. }
+        TransitionKind::Derive { source, justification: Justification::Fiat { targets, .. } }
             if *source == first
                 && targets.iter().any(|v| matches!(v, Violation::Unprovable(Unprovable::TrustUnknown)))
                 && targets.iter().any(|v| matches!(v, Violation::Breach(crate::contract::Breach::AudienceExceeds { .. })))
     ));
     assert!(matches!(
         &steps.get(1).unwrap().kind,
-        TransitionKind::EndorseValue { source, targets, .. }
+        TransitionKind::Derive { source, justification: Justification::Fiat { targets, .. } }
             if *source == second
                 && *targets == vec![Violation::Breach(crate::contract::Breach::AudienceExceeds {
                     outside: BTreeSet::from([user("bob")]),

--- a/ai-labs/baton/baton-core/src/lib.rs
+++ b/ai-labs/baton/baton-core/src/lib.rs
@@ -110,7 +110,7 @@ pub use approval::{
 pub use audit::{AuthorityName, TransitionFailure};
 pub use contract::{AttentionRule, AudienceRule};
 pub use engine::{BlockReason, ResponseDecision, ResponsePolicy, StepCapability, StepOutcome, StepRefused};
-pub use plan::{ExitKind, NonEmptyVec, RemedyPlan, TransitionKind};
+pub use plan::{ExitKind, Justification, NonEmptyVec, RemedyPlan, TransitionKind};
 pub use revision::PlanId;
 pub use transition::{
     ActionTransition, AuthorityMandate, DuplicateRegistration, EndorseDelta, LabelPredicate, ProposedGrant,

--- a/ai-labs/baton/baton-core/src/lib.rs
+++ b/ai-labs/baton/baton-core/src/lib.rs
@@ -93,8 +93,8 @@ impl fmt::Display for ToolName {
 pub use contract::{Requirements, Violation};
 pub use dimension::{Audience, Effect, Effects, KnownTrust, Trust, UserId};
 pub use engine::{
-    Blocked, CanonicalRequest, Decision, DispatchReceipt, DuplicateContract, ExecutionToken, PolicyEngine,
-    RejectedToken, TerminalBlock, ToolContract,
+    Blocked, CanonicalRequest, Decision, DispatchReceipt, DuplicateContract, ExecutionToken, PolicyEngine, Pursuit,
+    RejectedToken, StallCause, TerminalBlock, ToolContract,
 };
 pub use request::{ArgumentName, ArgumentSchema, ArgumentTree, ResponseRequest, ToolRequest};
 pub use revision::{Revision, ValueId};

--- a/ai-labs/baton/baton-core/src/plan.rs
+++ b/ai-labs/baton/baton-core/src/plan.rs
@@ -74,9 +74,20 @@ impl<'a, T> IntoIterator for &'a NonEmptyVec<T> {
 /// bound check and appends audit history.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum TransitionKind {
-    TransformValue {
+    /// Admit a derived value in `source`'s argument slot. Both justifications
+    /// mint a new value and substitute it into the flow; they differ in who
+    /// vouches for the new label (see [`Justification`]).
+    ///
+    /// A plan is a *prediction*: when a fiat step is predicted after a
+    /// content step in the same plan, `source` is the pre-transform leaf id
+    /// (the shared `SimFlow` swaps a leaf's label in place without
+    /// re-id-ing), but at application the transform mints a new id and
+    /// re-enumeration resolves the fiat step against the transformed
+    /// descendant. Revision-binding forces that re-enumeration, so a stale
+    /// downstream `source` is never applied.
+    Derive {
         source: ValueId,
-        transformer: TransformerRef,
+        justification: Justification,
     },
     ConstrainAction {
         transition: TransformerRef,
@@ -91,18 +102,20 @@ pub enum TransitionKind {
     AcceptGrowth {
         effects: Effects,
     },
-    /// An authority durably raises `source`'s label by `delta` (Endorse). Like
-    /// a transform it mints a derived value and substitutes it into the flow;
-    /// unlike one the raise is authority-justified, not content-justified.
-    ///
-    /// A plan is a *prediction*: when this step is predicted after a Transform in
-    /// the same plan, `source` is the pre-transform leaf id (the shared `SimFlow`
-    /// swaps a leaf's label in place without re-id-ing), but at application the
-    /// transform mints a new id and re-enumeration resolves the Endorse against
-    /// the transformed descendant. Revision-binding forces that re-enumeration, so
-    /// a stale downstream `source` is never applied.
-    EndorseValue {
-        source: ValueId,
+}
+
+/// Who vouches for a derived value's label. The two justifications share the
+/// mint-and-substitute machinery but answer to different registries: content
+/// to the transformer registry (never routed to an authority), fiat to a
+/// competent authority's mandate (always routed).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum Justification {
+    /// Content-justified: a registered transformer derives new bytes under
+    /// its declared output label.
+    Content(TransformerRef),
+    /// Authority fiat (Endorse): the same bytes, the label durably raised by
+    /// `delta` — taint erased by mandate, not by content.
+    Fiat {
         delta: EndorseDelta,
         /// The violations this endorse asks the authority to clear, as the
         /// authority should see them. For an ordinary enumerated step this is
@@ -140,11 +153,17 @@ pub enum ExitKind {
 impl ExitKind {
     fn of_step(kind: &TransitionKind) -> Self {
         match kind {
-            TransitionKind::TransformValue { .. } => Self::Sanitize,
+            TransitionKind::Derive {
+                justification: Justification::Content(_),
+                ..
+            } => Self::Sanitize,
             TransitionKind::ConstrainAction { .. } => Self::Constrain,
             TransitionKind::AcceptGrowth { .. } => Self::Accept,
             TransitionKind::ApplyWaiver { .. } => Self::WaiverOrAcknowledge,
-            TransitionKind::EndorseValue { .. } => Self::Endorse,
+            TransitionKind::Derive {
+                justification: Justification::Fiat { .. },
+                ..
+            } => Self::Endorse,
         }
     }
 

--- a/ai-labs/baton/baton-core/src/request.rs
+++ b/ai-labs/baton/baton-core/src/request.rs
@@ -335,7 +335,7 @@ impl PendingAction {
         self.state = ActionState::Released;
     }
 
-    /// A `TransformValue` step replaced `from` with the derived `to` in the
+    /// A content-justified `Derive` step replaced `from` with the derived `to` in the
     /// current argument tree. The original proposal is untouched — it is the
     /// identity basis, never dispatched.
     pub(crate) fn substitute_argument(&mut self, from: ValueId, to: ValueId) {

--- a/ai-labs/baton/baton-core/src/request.rs
+++ b/ai-labs/baton/baton-core/src/request.rs
@@ -50,12 +50,52 @@ impl fmt::Display for ArgumentName {
     }
 }
 
+impl From<&str> for ArgumentName {
+    fn from(name: &str) -> Self {
+        Self::new(name)
+    }
+}
+
+impl From<String> for ArgumentName {
+    fn from(name: String) -> Self {
+        Self::new(name)
+    }
+}
+
 /// The executable argument structure: every leaf is a stored value.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum ArgumentTree<T> {
     Value(T),
     List(Vec<ArgumentTree<T>>),
     Object(BTreeMap<ArgumentName, ArgumentTree<T>>),
+}
+
+impl<T> From<T> for ArgumentTree<T> {
+    fn from(leaf: T) -> Self {
+        Self::Value(leaf)
+    }
+}
+
+impl<T> ArgumentTree<T> {
+    /// The empty argument object — a no-argument invocation.
+    pub fn empty() -> Self {
+        Self::Object(BTreeMap::new())
+    }
+
+    /// An object node from `(name, subtree)` pairs. Leaves coerce, so
+    /// `ArgumentTree::object([("to", to), ("body", report)])` reads plainly.
+    pub fn object<N, V>(fields: impl IntoIterator<Item = (N, V)>) -> Self
+    where
+        N: Into<ArgumentName>,
+        V: Into<Self>,
+    {
+        Self::Object(
+            fields
+                .into_iter()
+                .map(|(name, value)| (name.into(), value.into()))
+                .collect(),
+        )
+    }
 }
 
 impl<T: Copy + Ord> ArgumentTree<T> {
@@ -198,11 +238,11 @@ pub struct ToolRequest {
 }
 
 impl ToolRequest {
-    pub fn new(tool: ToolName, arguments: ArgumentTree<ValueId>, control: BTreeSet<ValueId>) -> Self {
+    pub fn new(tool: ToolName, arguments: ArgumentTree<ValueId>, control: impl IntoIterator<Item = ValueId>) -> Self {
         Self {
             tool,
             arguments,
-            control,
+            control: control.into_iter().collect(),
         }
     }
 }

--- a/ai-labs/baton/baton-core/src/transition.rs
+++ b/ai-labs/baton/baton-core/src/transition.rs
@@ -168,8 +168,59 @@ pub struct AuthorityMandate {
 
 impl AuthorityMandate {
     /// The identity mandate: competent for nothing but the empty ask.
+    /// Powers are granted one combinator at a time, so a mandate reads as
+    /// exactly what it may do.
     pub fn none() -> Self {
         Self::default()
+    }
+
+    /// Competent to endorse flow trust up to `ceiling`.
+    #[must_use]
+    pub fn endorse_trust(mut self, ceiling: KnownTrust) -> Self {
+        self.trust = Some(ceiling);
+        self
+    }
+
+    /// Competent to vouch exactly `readers` into a flow audience.
+    #[must_use]
+    pub fn vouch_audience(mut self, readers: impl IntoIterator<Item = UserId>) -> Self {
+        self.audience = Some(readers.into_iter().collect());
+        self
+    }
+
+    /// Competent to waive an already-committed prior effect for one check.
+    #[must_use]
+    pub fn waive_prior_effects(mut self) -> Self {
+        self.waive_prior_effects = true;
+        self
+    }
+
+    /// Competent to stand in for a user confirmation.
+    #[must_use]
+    pub fn confirms(mut self) -> Self {
+        self.confirms = true;
+        self
+    }
+
+    /// Competent to acknowledge unprovable facts.
+    #[must_use]
+    pub fn acknowledge_unknown(mut self) -> Self {
+        self.acknowledge_unknown = true;
+        self
+    }
+
+    /// Competent to release a control dependency for one flow.
+    #[must_use]
+    pub fn release_control(mut self) -> Self {
+        self.may_release_control = true;
+        self
+    }
+
+    /// Competent to acquire a new effect for one action.
+    #[must_use]
+    pub fn acquire_effects(mut self) -> Self {
+        self.acquire_effects = true;
+        self
     }
 
     /// Is this mandate competent for `grant`? Endorse dimensions compare by

--- a/ai-labs/baton/baton-core/src/transition.rs
+++ b/ai-labs/baton/baton-core/src/transition.rs
@@ -216,7 +216,9 @@ impl AuthorityMandate {
         self
     }
 
-    /// Competent to acquire a new effect for one action.
+    /// Competent to acquire a new effect for one action. A global capability:
+    /// `covers` does not scope it to particular effects, so an acquirer may
+    /// accept *any* surface growth its routing reaches, not just one kind.
     #[must_use]
     pub fn acquire_effects(mut self) -> Self {
         self.acquire_effects = true;
@@ -508,6 +510,62 @@ mod tests {
             wrong_tool.narrows(&pending("shell.run", Effects::UNKNOWN)),
             Err(TransitionFailure::PreconditionMismatch)
         );
+    }
+
+    /// Each builder combinator grants exactly its named power, verified
+    /// through `covers` on a grant demanding that power alone.
+    #[test]
+    fn combinators_grant_exactly_their_named_power() {
+        let endorse_trust_grant = ProposedGrant::Endorse {
+            source: ValueId::new(0),
+            delta: EndorseDelta {
+                trust: Some(KnownTrust::Trusted),
+                audience: None,
+            },
+        };
+        assert!(!AuthorityMandate::none().covers(&endorse_trust_grant));
+        assert!(
+            AuthorityMandate::none()
+                .endorse_trust(KnownTrust::Trusted)
+                .covers(&endorse_trust_grant)
+        );
+        // A ceiling below the asked raise does not cover it.
+        assert!(
+            !AuthorityMandate::none()
+                .endorse_trust(KnownTrust::Suspicious)
+                .covers(&endorse_trust_grant)
+        );
+
+        let waive = |waiver| ProposedGrant::Waive {
+            waiver,
+            acknowledged: Vec::new(),
+        };
+        let prior = waive(TransientWaiver {
+            prior_effects: Some(std::collections::BTreeSet::from([Effect::Egress])),
+            ..TransientWaiver::empty()
+        });
+        assert!(!AuthorityMandate::none().covers(&prior));
+        assert!(AuthorityMandate::none().waive_prior_effects().covers(&prior));
+
+        let confirm = waive(TransientWaiver {
+            confirms: true,
+            ..TransientWaiver::empty()
+        });
+        assert!(!AuthorityMandate::none().covers(&confirm));
+        assert!(AuthorityMandate::none().confirms().covers(&confirm));
+
+        let release = waive(TransientWaiver {
+            control_release: std::collections::BTreeSet::from([ValueId::new(0)]),
+            ..TransientWaiver::empty()
+        });
+        assert!(!AuthorityMandate::none().covers(&release));
+        assert!(AuthorityMandate::none().release_control().covers(&release));
+
+        let ack = ProposedGrant::Acknowledge {
+            facts: vec![Unprovable::EffectsUnknown],
+        };
+        assert!(!AuthorityMandate::none().covers(&ack));
+        assert!(AuthorityMandate::none().acknowledge_unknown().covers(&ack));
     }
 
     #[test]

--- a/ai-labs/baton/baton-core/src/transition.rs
+++ b/ai-labs/baton/baton-core/src/transition.rs
@@ -512,60 +512,86 @@ mod tests {
         );
     }
 
-    /// Each builder combinator grants exactly its named power, verified
-    /// through `covers` on a grant demanding that power alone.
+    /// Each builder combinator grants exactly its named power: the mandate it
+    /// builds covers the grant demanding that power and none of the grants
+    /// demanding another (the full covers matrix is diagonal).
     #[test]
-    fn combinators_grant_exactly_their_named_power() {
-        let endorse_trust_grant = ProposedGrant::Endorse {
+    fn combinators_grant_their_named_power_and_nothing_else() {
+        let endorse = |delta| ProposedGrant::Endorse {
             source: ValueId::new(0),
-            delta: EndorseDelta {
-                trust: Some(KnownTrust::Trusted),
-                audience: None,
-            },
+            delta,
         };
-        assert!(!AuthorityMandate::none().covers(&endorse_trust_grant));
-        assert!(
-            AuthorityMandate::none()
-                .endorse_trust(KnownTrust::Trusted)
-                .covers(&endorse_trust_grant)
-        );
-        // A ceiling below the asked raise does not cover it.
-        assert!(
-            !AuthorityMandate::none()
-                .endorse_trust(KnownTrust::Suspicious)
-                .covers(&endorse_trust_grant)
-        );
-
         let waive = |waiver| ProposedGrant::Waive {
             waiver,
             acknowledged: Vec::new(),
         };
-        let prior = waive(TransientWaiver {
-            prior_effects: Some(std::collections::BTreeSet::from([Effect::Egress])),
-            ..TransientWaiver::empty()
-        });
-        assert!(!AuthorityMandate::none().covers(&prior));
-        assert!(AuthorityMandate::none().waive_prior_effects().covers(&prior));
-
-        let confirm = waive(TransientWaiver {
-            confirms: true,
-            ..TransientWaiver::empty()
-        });
-        assert!(!AuthorityMandate::none().covers(&confirm));
-        assert!(AuthorityMandate::none().confirms().covers(&confirm));
-
-        let release = waive(TransientWaiver {
-            control_release: std::collections::BTreeSet::from([ValueId::new(0)]),
-            ..TransientWaiver::empty()
-        });
-        assert!(!AuthorityMandate::none().covers(&release));
-        assert!(AuthorityMandate::none().release_control().covers(&release));
-
-        let ack = ProposedGrant::Acknowledge {
-            facts: vec![Unprovable::EffectsUnknown],
-        };
-        assert!(!AuthorityMandate::none().covers(&ack));
-        assert!(AuthorityMandate::none().acknowledge_unknown().covers(&ack));
+        let cases: Vec<(AuthorityMandate, ProposedGrant)> = vec![
+            (
+                AuthorityMandate::none().endorse_trust(KnownTrust::Trusted),
+                endorse(EndorseDelta {
+                    trust: Some(KnownTrust::Trusted),
+                    audience: None,
+                }),
+            ),
+            (
+                AuthorityMandate::none().vouch_audience([UserId::new("bob")]),
+                endorse(EndorseDelta {
+                    trust: None,
+                    audience: Some(std::collections::BTreeSet::from([UserId::new("bob")])),
+                }),
+            ),
+            (
+                AuthorityMandate::none().waive_prior_effects(),
+                waive(TransientWaiver {
+                    prior_effects: Some(std::collections::BTreeSet::from([Effect::Egress])),
+                    ..TransientWaiver::empty()
+                }),
+            ),
+            (
+                AuthorityMandate::none().confirms(),
+                waive(TransientWaiver {
+                    confirms: true,
+                    ..TransientWaiver::empty()
+                }),
+            ),
+            (
+                AuthorityMandate::none().release_control(),
+                waive(TransientWaiver {
+                    control_release: std::collections::BTreeSet::from([ValueId::new(0)]),
+                    ..TransientWaiver::empty()
+                }),
+            ),
+            (
+                AuthorityMandate::none().acknowledge_unknown(),
+                ProposedGrant::Acknowledge {
+                    facts: vec![Unprovable::EffectsUnknown],
+                },
+            ),
+            (
+                AuthorityMandate::none().acquire_effects(),
+                ProposedGrant::Accept {
+                    effects: Effects::declared([Effect::Egress]),
+                },
+            ),
+        ];
+        for (i, (mandate, _)) in cases.iter().enumerate() {
+            for (j, (_, grant)) in cases.iter().enumerate() {
+                assert_eq!(mandate.covers(grant), i == j, "mandate {i} vs grant {j}");
+            }
+        }
+        // The identity mandate covers none of them, and a trust ceiling below
+        // the asked raise does not cover it.
+        for (_, grant) in &cases {
+            assert!(!AuthorityMandate::none().covers(grant));
+        }
+        assert!(
+            !AuthorityMandate::none()
+                .endorse_trust(KnownTrust::Suspicious)
+                .covers(&endorse(EndorseDelta {
+                    trust: Some(KnownTrust::Trusted),
+                    audience: None,
+                }))
+        );
     }
 
     #[test]

--- a/ai-labs/baton/baton-core/src/turn.rs
+++ b/ai-labs/baton/baton-core/src/turn.rs
@@ -443,7 +443,7 @@ impl Trajectory {
         self.advance();
     }
 
-    /// Apply a validated `TransformValue` step as one transaction: admit the
+    /// Apply a validated content-justified `Derive` step as one transaction: admit the
     /// derived value under the declared output label, substitute it into the
     /// pending action's current argument tree, and audit the transition. The
     /// source keeps its own label and its slot in the immutable original
@@ -483,7 +483,7 @@ impl Trajectory {
         derived
     }
 
-    /// Audit a failed `TransformValue` step: an event, no derived value, and
+    /// Audit a failed content-justified `Derive` step: an event, no derived value, and
     /// a revision advance that stales every sibling capability and plan.
     pub(crate) fn fail_transform(
         &mut self,
@@ -548,7 +548,7 @@ impl Trajectory {
         self.advance();
     }
 
-    /// Apply a granted `EndorseValue` step as one transaction: admit a new
+    /// Apply a granted fiat `Derive` (Endorse) step as one transaction: admit a new
     /// value carrying `source`'s bytes under the authority-`raised` label,
     /// substitute it into the pending action's current argument tree, and audit
     /// the authority. The bytes are unchanged (a no-op relabel); the source

--- a/ai-labs/baton/baton-core/src/value.rs
+++ b/ai-labs/baton/baton-core/src/value.rs
@@ -24,7 +24,7 @@ use serde::Serialize;
 use tracing::trace;
 
 use crate::audit::AuthorityName;
-use crate::dimension::{Audience, Trust};
+use crate::dimension::{Audience, Trust, UserId};
 use crate::revision::{ActionId, TransitionId, TurnId, ValueId};
 use crate::transition::EndorseDelta;
 
@@ -61,6 +61,15 @@ impl ValueLabel {
     pub fn identity() -> Self {
         Self {
             audience: Audience::PUBLIC,
+            trust: Trust::TRUSTED,
+        }
+    }
+
+    /// Trusted data readable by exactly `readers` — the everyday label for an
+    /// internal system's output.
+    pub fn trusted_readers(readers: impl IntoIterator<Item = UserId>) -> Self {
+        Self {
+            audience: Audience::readers(readers),
             trust: Trust::TRUSTED,
         }
     }

--- a/ai-labs/baton/baton-dojo/src/policy.rs
+++ b/ai-labs/baton/baton-dojo/src/policy.rs
@@ -267,12 +267,9 @@ impl BatonGateBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use baton_core::{
-        Audience, AudienceRule, Authority, AuthorityMandate, AuthorityMode, AuthorityName, Effect, Effects,
-        ProposedGrant, Requirements, Ruling, ToolContract, ToolName, TrajectoryView, Trust, UserId, ValueLabel,
-        Violation,
+        Audience, AudienceRule, Authority, AuthorityMandate, Effect, Effects, ProposedGrant, Requirements, Ruling,
+        ToolContract, ToolName, TrajectoryView, Trust, UserId, ValueLabel, Violation,
     };
     use serde_json::json;
 
@@ -321,20 +318,14 @@ mod tests {
     }
 
     /// Vouches in exactly the auditor and accepts the resulting first egress.
+    fn auditor_mandate() -> AuthorityMandate {
+        AuthorityMandate::none()
+            .vouch_audience([UserId::new(AUDITOR)])
+            .acquire_effects()
+    }
+
     fn auditor_authority() -> Authority {
-        Authority {
-            name: AuthorityName::new("finance-approver"),
-            mandate: AuthorityMandate {
-                trust: None,
-                audience: Some(BTreeSet::from([UserId::new(AUDITOR)])),
-                waive_prior_effects: false,
-                confirms: false,
-                acknowledge_unknown: false,
-                may_release_control: false,
-                acquire_effects: true,
-            },
-            mode: AuthorityMode::Inline(approve),
-        }
+        Authority::inline("finance-approver", auditor_mandate(), approve)
     }
 
     fn auditor_gate() -> BatonGate {
@@ -380,19 +371,7 @@ mod tests {
     /// reaches its grant step blocks with `NeedsApproval` rather than permitting.
     fn external_auditor_gate() -> BatonGate {
         BatonGate::builder()
-            .authority(Authority {
-                name: AuthorityName::new("finance-approver"),
-                mandate: AuthorityMandate {
-                    trust: None,
-                    audience: Some(BTreeSet::from([UserId::new(AUDITOR)])),
-                    waive_prior_effects: false,
-                    confirms: false,
-                    acknowledge_unknown: false,
-                    may_release_control: false,
-                    acquire_effects: true,
-                },
-                mode: AuthorityMode::External,
-            })
+            .authority(Authority::external("finance-approver", auditor_mandate()))
             .contract(read_contract("list_invoices"))
             .contract(sink_contract("send_email"))
             .recipients_for("send_email", |a| {

--- a/ai-labs/baton/baton-dojo/src/policy.rs
+++ b/ai-labs/baton/baton-dojo/src/policy.rs
@@ -30,9 +30,9 @@
 use std::collections::HashMap;
 
 use baton_core::{
-    ArgumentName, ArgumentSchema, ArgumentTree, AttentionRule, Authority, Blocked, Decision, ExecutionToken,
-    OpaqueValue, PolicyEngine, Speaker, StepOutcome, ToolContract, ToolName, ToolRequest, Trajectory, UserId, ValueId,
-    ValueLabel, Violation,
+    ArgumentName, ArgumentSchema, ArgumentTree, AttentionRule, Authority, ExecutionToken, OpaqueValue, PolicyEngine,
+    Pursuit, Speaker, StallCause, ToolContract, ToolName, ToolRequest, Trajectory, UserId, ValueId, ValueLabel,
+    Violation,
 };
 
 use crate::error::DojoError;
@@ -96,65 +96,39 @@ impl BatonGate {
     /// then call [`commit`](BatonGate::commit).
     pub(crate) fn check(&mut self, tool: &str, args: &serde_json::Value) -> GateVerdict {
         let request = self.build_request(tool, args);
-        let mut decision = self.engine.evaluate(&mut self.trajectory, request);
-        // Each iteration applies one remedy step, resolving at least one
-        // violation; a plan needs at most one Endorse per audience-failing
-        // context leaf, plus an Accept and a waiver. Bound the walk on the
-        // context, not a fixed count, so a longer run still converges. The
-        // bound is a fail-closed backstop, not the expected path.
+        // A plan needs at most one Endorse per audience-failing context leaf,
+        // plus an Accept and a waiver. Bound the walk on the context, not a
+        // fixed count, so a longer run still converges; the bound is a
+        // fail-closed backstop, not the expected path.
         let max_steps = self.context.len() + 8;
-        let mut steps = 0;
-        loop {
-            match decision {
-                Decision::Permitted(token) => {
-                    self.pending = Some(token);
-                    return GateVerdict::Allow;
-                }
-                // The engine already cleared the pending slot on a terminal block.
-                Decision::Blocked(Blocked::Terminal(block)) => {
-                    return GateVerdict::Block {
-                        reason: block.reason.to_string(),
-                    };
-                }
-                Decision::Blocked(Blocked::Remediable { violations, plans }) => {
-                    // Guard the *next* step, so a permit produced by the last
-                    // allowed step is still inspected above before the bound bites.
-                    if steps >= max_steps {
-                        return self.block("remedy did not converge within the step bound".to_owned());
-                    }
-                    steps += 1;
-                    let plan = plans.first().id;
-                    let capability = match self.engine.mint_step(&self.trajectory, plan, 0) {
-                        Ok(capability) => capability,
-                        Err(_) => return self.block(block_reason(&violations)),
-                    };
-                    match self.engine.apply_step(&mut self.trajectory, capability) {
-                        Ok(StepOutcome::Advanced(next)) => decision = next,
-                        // Inline authorities resolve synchronously; a needs-approval
-                        // means only an out-of-process authority could clear it,
-                        // which this in-process gate cannot answer — fail closed.
-                        Ok(StepOutcome::NeedsApproval(pending)) => {
-                            return self.block(format!("needs external ruling from {}", pending.authority()));
-                        }
-                        // A precondition no longer held or a transformer failed:
-                        // audited, revision advanced, nothing changed — fail closed.
-                        Ok(StepOutcome::Failed(failure)) => {
-                            return self.block(format!("remedy step failed: {failure:?}"));
-                        }
-                        Err(refused) => return self.block(format!("policy step refused: {refused:?}")),
-                    }
-                }
+        match self.engine.pursue(&mut self.trajectory, request, max_steps) {
+            Pursuit::Permitted(token) => {
+                self.pending = Some(token);
+                GateVerdict::Allow
             }
+            // The engine already cleared the pending slot on a terminal block.
+            Pursuit::Terminal(block) => GateVerdict::Block {
+                reason: block.reason.to_string(),
+            },
+            // Inline authorities resolve synchronously; a needs-approval means
+            // only an out-of-process authority could clear it, which this
+            // in-process gate cannot answer — fail closed, discarding the
+            // approval and freeing the slot the pursuit deliberately kept.
+            Pursuit::NeedsApproval(pending) => {
+                let reason = format!("needs external ruling from {}", pending.authority());
+                drop(pending);
+                self.trajectory.abandon_pending();
+                GateVerdict::Block { reason }
+            }
+            // A stalled pursuit already abandoned the pending action.
+            Pursuit::Stalled { violations, cause } => GateVerdict::Block {
+                reason: match cause {
+                    StallCause::BoundExhausted => "remedy did not converge within the step bound".to_owned(),
+                    StallCause::Refused(_) => block_reason(&violations),
+                    StallCause::Failed(failure) => format!("remedy step failed: {failure:?}"),
+                },
+            },
         }
-    }
-
-    /// Fail closed on a remedy the walk could not complete: abandon any pending
-    /// action the partial walk left behind (a remediable block keeps the slot;
-    /// leaving it would refuse every later call with `ActionAlreadyPending`),
-    /// then report the block. Harmless when nothing is pending.
-    fn block(&mut self, reason: String) -> GateVerdict {
-        self.trajectory.abandon_pending();
-        GateVerdict::Block { reason }
     }
 
     /// Fold an executed call's result into the trajectory, consuming the stashed

--- a/ai-labs/baton/baton-dojo/src/policy.rs
+++ b/ai-labs/baton/baton-dojo/src/policy.rs
@@ -106,7 +106,9 @@ impl BatonGate {
                 self.pending = Some(token);
                 GateVerdict::Allow
             }
-            // The engine already cleared the pending slot on a terminal block.
+            // The engine cleared this request's slot on a terminal block —
+            // except ActionAlreadyPending, which deliberately leaves the
+            // in-flight action (and its stashed token) untouched.
             Pursuit::Terminal(block) => GateVerdict::Block {
                 reason: block.reason.to_string(),
             },
@@ -124,7 +126,9 @@ impl BatonGate {
             Pursuit::Stalled { violations, cause } => GateVerdict::Block {
                 reason: match cause {
                     StallCause::BoundExhausted => "remedy did not converge within the step bound".to_owned(),
-                    StallCause::Refused(_) => block_reason(&violations),
+                    StallCause::Refused(refused) => {
+                        format!("policy step refused: {refused:?}; {}", block_reason(&violations))
+                    }
                     StallCause::Failed(failure) => format!("remedy step failed: {failure:?}"),
                 },
             },
@@ -391,7 +395,7 @@ mod tests {
         allow(gate.check("list_invoices", &json!({})));
         gate.commit("<invoices>").unwrap();
         // The remediable walk reaches an external grant it cannot resolve
-        // in-process and blocks, leaving a pending action behind.
+        // in-process and blocks, discarding the approval and freeing the slot.
         assert!(matches!(
             gate.check("send_email", &json!({ "to": AUDITOR })),
             GateVerdict::Block { .. }

--- a/ai-labs/baton/baton-dojo/src/policy.rs
+++ b/ai-labs/baton/baton-dojo/src/policy.rs
@@ -27,7 +27,7 @@
 //! without control-release competence can clear it). Acceptable for a benchmark
 //! substrate; a faithful gate needs the model's real argument provenance.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::HashMap;
 
 use baton_core::{
     ArgumentName, ArgumentSchema, ArgumentTree, AttentionRule, Authority, Blocked, Decision, ExecutionToken,
@@ -184,7 +184,7 @@ impl BatonGate {
     /// be released). Recipients (if any) sit under the recipient key.
     fn build_request(&mut self, tool: &str, args: &serde_json::Value) -> ToolRequest {
         let body: Vec<ArgumentTree<ValueId>> = self.context.iter().copied().map(ArgumentTree::Value).collect();
-        let mut fields = BTreeMap::from([(ArgumentName::new(BODY_ARG), ArgumentTree::List(body))]);
+        let mut fields = vec![(ArgumentName::new(BODY_ARG), ArgumentTree::List(body))];
         if let Some(recipients) = self.recipients.get(tool).map(|extract| extract(args)) {
             let leaves = recipients
                 .into_iter()
@@ -197,9 +197,9 @@ impl BatonGate {
                     ArgumentTree::Value(id)
                 })
                 .collect();
-            fields.insert(ArgumentName::new(RECIPIENT_ARG), ArgumentTree::List(leaves));
+            fields.push((ArgumentName::new(RECIPIENT_ARG), ArgumentTree::List(leaves)));
         }
-        ToolRequest::new(ToolName::new(tool), ArgumentTree::Object(fields), BTreeSet::new())
+        ToolRequest::new(ToolName::new(tool), ArgumentTree::object(fields), [])
     }
 }
 
@@ -293,6 +293,8 @@ impl BatonGateBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use baton_core::{
         Audience, AudienceRule, Authority, AuthorityMandate, AuthorityMode, AuthorityName, Effect, Effects,
         ProposedGrant, Requirements, Ruling, ToolContract, ToolName, TrajectoryView, Trust, UserId, ValueLabel,

--- a/ai-labs/baton/baton-dojo/src/policy.rs
+++ b/ai-labs/baton/baton-dojo/src/policy.rs
@@ -95,6 +95,14 @@ impl BatonGate {
     /// On a permit the token is stashed and the caller must execute the tool and
     /// then call [`commit`](BatonGate::commit).
     pub(crate) fn check(&mut self, tool: &str, args: &serde_json::Value) -> GateVerdict {
+        // Refuse before touching the trajectory: building a request ingresses
+        // recipient values, which advances the revision and would stale the
+        // stashed token — the previous permit must be committed first.
+        if self.pending.is_some() {
+            return GateVerdict::Block {
+                reason: "a permitted call is awaiting commit".to_owned(),
+            };
+        }
         let request = self.build_request(tool, args);
         // A plan needs at most one Endorse per audience-failing context leaf,
         // plus an Accept and a waiver. Bound the walk on the context, not a
@@ -106,9 +114,7 @@ impl BatonGate {
                 self.pending = Some(token);
                 GateVerdict::Allow
             }
-            // The engine cleared this request's slot on a terminal block —
-            // except ActionAlreadyPending, which deliberately leaves the
-            // in-flight action (and its stashed token) untouched.
+            // The engine cleared this request's slot on a terminal block.
             Pursuit::Terminal(block) => GateVerdict::Block {
                 reason: block.reason.to_string(),
             },
@@ -386,6 +392,21 @@ mod tests {
             })
             .build()
             .unwrap()
+    }
+
+    #[test]
+    fn a_check_before_commit_blocks_without_staling_the_stashed_token() {
+        let mut gate = auditor_gate();
+        gate.begin("email the report to the auditor");
+        allow(gate.check("list_invoices", &json!({})));
+        // A second check — on the recipient-bearing tool — is refused before
+        // recipient ingress can advance the revision, so the stashed permit
+        // still commits.
+        assert!(matches!(
+            gate.check("send_email", &json!({ "to": AUDITOR })),
+            GateVerdict::Block { .. }
+        ));
+        gate.commit("<invoices>").unwrap();
     }
 
     #[test]

--- a/ai-labs/baton/baton-dojo/src/scenarios/auditor_email.rs
+++ b/ai-labs/baton/baton-dojo/src/scenarios/auditor_email.rs
@@ -8,8 +8,8 @@
 use std::collections::BTreeSet;
 
 use baton_core::{
-    ArgumentSchema, Audience, AudienceRule, Authority, AuthorityMandate, AuthorityMode, AuthorityName, Effect, Effects,
-    ProposedGrant, Requirements, Ruling, ToolContract, ToolName, TrajectoryView, Trust, UserId, ValueLabel, Violation,
+    ArgumentSchema, AudienceRule, Authority, AuthorityMandate, AuthorityMode, AuthorityName, Effect, Effects,
+    ProposedGrant, Requirements, Ruling, ToolContract, ToolName, TrajectoryView, UserId, ValueLabel, Violation,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -93,16 +93,10 @@ fn seed() -> Invoices {
 fn gate() -> Result<BatonGate, DojoError> {
     BatonGate::builder()
         .authority(finance_approver())
-        .contract(ToolContract {
-            name: ToolName::new("list_invoices"),
-            requires: Requirements::default(),
-            output_label: ValueLabel {
-                audience: Audience::readers([UserId::new(ALICE), UserId::new(BOB)]),
-                trust: Trust::TRUSTED,
-            },
-            effects: Effects::none(),
-            arguments: ArgumentSchema::opaque(),
-        })
+        .contract(ToolContract::source(
+            "list_invoices",
+            ValueLabel::trusted_readers([UserId::new(ALICE), UserId::new(BOB)]),
+        ))
         .contract(ToolContract {
             name: ToolName::new("send_email"),
             requires: Requirements {

--- a/ai-labs/baton/baton-dojo/src/scenarios/auditor_email.rs
+++ b/ai-labs/baton/baton-dojo/src/scenarios/auditor_email.rs
@@ -5,11 +5,9 @@
 //! cost. Utility-only — there is no attacker; it measures whether baton lets the
 //! legitimate, authorized flow through.
 
-use std::collections::BTreeSet;
-
 use baton_core::{
-    ArgumentSchema, AudienceRule, Authority, AuthorityMandate, AuthorityMode, AuthorityName, Effect, Effects,
-    ProposedGrant, Requirements, Ruling, ToolContract, ToolName, TrajectoryView, UserId, ValueLabel, Violation,
+    ArgumentSchema, AudienceRule, Authority, AuthorityMandate, Effect, Effects, ProposedGrant, Requirements, Ruling,
+    ToolContract, ToolName, TrajectoryView, UserId, ValueLabel, Violation,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -57,19 +55,13 @@ fn approve_auditor(_: &ProposedGrant, _: &[Violation], _: &TrajectoryView<'_>) -
 /// Vouches in exactly the external auditor (audience) and accepts the resulting
 /// first egress (`acquire_effects`); competent for nothing else.
 fn finance_approver() -> Authority {
-    Authority {
-        name: AuthorityName::new("finance-approver"),
-        mandate: AuthorityMandate {
-            trust: None,
-            audience: Some(BTreeSet::from([UserId::new(AUDITOR)])),
-            waive_prior_effects: false,
-            confirms: false,
-            acknowledge_unknown: false,
-            may_release_control: false,
-            acquire_effects: true,
-        },
-        mode: AuthorityMode::Inline(approve_auditor),
-    }
+    Authority::inline(
+        "finance-approver",
+        AuthorityMandate::none()
+            .vouch_audience([UserId::new(AUDITOR)])
+            .acquire_effects(),
+        approve_auditor,
+    )
 }
 
 fn seed() -> Invoices {

--- a/ai-labs/baton/baton-dojo/src/scenarios/recording_bug_filing.rs
+++ b/ai-labs/baton/baton-dojo/src/scenarios/recording_bug_filing.rs
@@ -7,8 +7,7 @@
 //! so nothing leaks but the bug isn't filed either.
 
 use baton_core::{
-    ArgumentSchema, Audience, AudienceRule, Effect, Effects, Requirements, ToolContract, ToolName, Trust, UserId,
-    ValueLabel,
+    ArgumentSchema, AudienceRule, Effect, Effects, Requirements, ToolContract, ToolName, UserId, ValueLabel,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -59,16 +58,10 @@ fn gate() -> Result<BatonGate, DojoError> {
     // No authority is registered: the gate is fully fail-closed, so the public
     // issue's audience breach is terminal — nothing declassifies it.
     BatonGate::builder()
-        .contract(ToolContract {
-            name: ToolName::new("fetch_recording"),
-            requires: Requirements::default(),
-            output_label: ValueLabel {
-                audience: Audience::readers([UserId::new(ALICE), UserId::new(BOB)]),
-                trust: Trust::TRUSTED,
-            },
-            effects: Effects::none(),
-            arguments: ArgumentSchema::opaque(),
-        })
+        .contract(ToolContract::source(
+            "fetch_recording",
+            ValueLabel::trusted_readers([UserId::new(ALICE), UserId::new(BOB)]),
+        ))
         .contract(ToolContract {
             name: ToolName::new("open_issue"),
             requires: Requirements {


### PR DESCRIPTION
Shrinks what a baton-core consumer writes for the four recurring chores, with no change to check, grant, or routing semantics.

- **`PolicyEngine::pursue`** — one first-plan walk helper (`Pursuit`: Permitted / Terminal / NeedsApproval / Stalled) replacing the hand-written mint/apply loops in the example, the test helper, and the baton-dojo gate. Stall abandons the pending action; NeedsApproval keeps it for `apply_approval` re-entry; the bound is checked before a step so a final-step permit is returned.
- **Contract role constructors** — `ToolContract::source(name, label)`, `ToolContract::egress_sink(name, recipients_arg)`, `ValueLabel::trusted_readers([...])`.
- **Mandate/authority constructors** — `AuthorityMandate::none().vouch_audience([...]).acquire_effects()` combinators (fail-closed by construction; covers-matrix tested) and `Authority::inline/external`.
- **Request-building helpers** — `ArgumentTree::object([("to", to), ("body", report)])`, `ArgumentTree::empty()`, leaf coercion via `From`, and `ToolRequest::new` taking `impl IntoIterator` control (non-breaking).
- **`TransitionKind::Derive { source, justification: Content | Fiat }`** — TransformValue/EndorseValue merged; routing, byte rules, `ExitKind` ranking, and audit wording keyed off the justification and unchanged (design doc OQ1 note updated).
- baton-dojo gate hardening that fell out of review: `check` while a permit awaits commit is refused before recipient ingress can stale the stashed token.

`demo.rs` and `scenarios.rs` deliberately keep their explicit walk loops (they encode different plan-selection/approval policies). The Acknowledge/Waive grant merge was attempted and dropped: the covering tests pin `Waive{empty}` as covered-by-all while `Acknowledge{}` requires the capability — the standalone variant is the typed plug for an acknowledge-laundering hole, not a redundancy.

Validation: `cargo fmt --check`, `clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (167 core + 6 dojo tests), all four examples verdict-identical.

https://claude.ai/code/session_01QwHQcZG5kbAd7B6RyTB9MU

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>