### PR TITLE
feat(knowledge): merge Knowledge and Connectors into one tabbed page

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -346,19 +346,9 @@ const contentNavGroups: NavGroup[] = [
     items: [
       {
         title: "Knowledge",
-        url: "/knowledge/knowledge-bases",
+        url: "/knowledge/connectors",
         icon: Database,
-        customIsActive: (pathname: string) =>
-          pathname.startsWith("/knowledge") &&
-          !pathname.startsWith("/knowledge/connectors"),
-        subItems: [
-          {
-            title: "Connectors",
-            url: "/knowledge/connectors",
-            customIsActive: (pathname: string) =>
-              pathname.startsWith("/knowledge/connectors"),
-          },
-        ],
+        customIsActive: (pathname: string) => pathname.startsWith("/knowledge"),
       },
       {
         title: "Logs",

--- a/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.test.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.test.tsx
@@ -12,6 +12,8 @@ vi.mock("@/lib/knowledge/knowledge-base.query", () => ({
 
 vi.mock("@/lib/auth/auth.query");
 
+vi.mock("@/lib/config/config.query");
+
 vi.mock("next/navigation");
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -19,6 +21,7 @@ import {
   useHasPermissions,
   useMissingPermissions,
 } from "@/lib/auth/auth.query";
+import { useSmallTeamTier } from "@/lib/config/config.query";
 import { KnowledgePageLayout } from "./knowledge-page-layout";
 
 function renderLayout(isPending = false) {
@@ -126,6 +129,23 @@ describe("KnowledgePageLayout", () => {
         name: /Create Knowledge Base/,
       });
       expect(createButton).not.toBeDisabled();
+    });
+  });
+
+  describe("small team tier banner", () => {
+    it("renders the tier banner in the shared layout so every tab shows it", () => {
+      vi.mocked(useSmallTeamTier).mockReturnValue({
+        communicate: true,
+        smallTeam: true,
+        envFlag: false,
+        userCount: 5,
+        threshold: 30,
+      } as ReturnType<typeof useSmallTeamTier>);
+      renderLayout();
+
+      expect(
+        screen.getByText(/within the free tier for teams under 30 users/),
+      ).toBeInTheDocument();
     });
   });
 

--- a/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.test.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.test.tsx
@@ -129,6 +129,27 @@ describe("KnowledgePageLayout", () => {
     });
   });
 
+  describe("tabs", () => {
+    it("renders Connectors and Knowledge Bases tabs linking to their routes", () => {
+      renderLayout();
+
+      for (const link of screen.getAllByRole("link", { name: "Connectors" })) {
+        expect(link).toHaveAttribute("href", "/knowledge/connectors");
+      }
+      for (const link of screen.getAllByRole("link", {
+        name: "Knowledge Bases",
+      })) {
+        expect(link).toHaveAttribute("href", "/knowledge/knowledge-bases");
+      }
+      expect(
+        screen.getAllByRole("link", { name: "Connectors" }).length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getAllByRole("link", { name: "Knowledge Bases" }).length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
   describe("loading state", () => {
     it("shows loading spinner when isPending is true", () => {
       renderLayout(true);

--- a/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.tsx
@@ -4,6 +4,7 @@ import type { Permissions } from "@archestra/shared";
 import { Plus } from "lucide-react";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { PageLayout } from "@/components/page-layout";
+import { SmallTeamTierBanner } from "@/components/small-team-tier-banner";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { useIsKnowledgeBaseConfigured } from "@/lib/knowledge/knowledge-base.query";
 import { EmbeddingRequiredPlaceholder } from "./embedding-required-placeholder";
@@ -44,6 +45,7 @@ export function KnowledgePageLayout({
           </PermissionButton>
         }
       >
+        <SmallTeamTierBanner featureName="Knowledge" />
         {!isKnowledgeBaseConfigured ? (
           <EmbeddingRequiredPlaceholder />
         ) : (

--- a/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.tsx
+++ b/platform/frontend/src/app/knowledge/_parts/knowledge-page-layout.tsx
@@ -32,6 +32,7 @@ export function KnowledgePageLayout({
       <PageLayout
         title={title}
         description={description}
+        tabs={KNOWLEDGE_TABS}
         actionButton={
           <PermissionButton
             permissions={createPermissions}
@@ -52,3 +53,11 @@ export function KnowledgePageLayout({
     </LoadingWrapper>
   );
 }
+
+// Connectors come first: they are the prerequisite (a knowledge base is empty
+// until a connector syncs data), so they are also the landing tab (see the
+// bare /knowledge redirect page).
+const KNOWLEDGE_TABS = [
+  { label: "Connectors", href: "/knowledge/connectors" },
+  { label: "Knowledge Bases", href: "/knowledge/knowledge-bases" },
+];

--- a/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/page.client.tsx
@@ -23,7 +23,6 @@ import { ConnectorStatusBadge } from "@/app/knowledge/knowledge-bases/_parts/con
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
-import { SmallTeamTierBanner } from "@/components/small-team-tier-banner";
 import { StandardDialog } from "@/components/standard-dialog";
 import {
   type TableRowAction,
@@ -221,7 +220,6 @@ function KnowledgeBasesList() {
       onCreateClick={() => setIsCreateDialogOpen(true)}
       isPending={isPending && !knowledgeBases}
     >
-      <SmallTeamTierBanner featureName="Knowledge Base with access control" />
       <div>
         <div className="mb-6 flex flex-col gap-2">
           <div className="flex items-center gap-4">

--- a/platform/frontend/src/app/knowledge/page.tsx
+++ b/platform/frontend/src/app/knowledge/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+/**
+ * Bare /knowledge lands on Connectors, the landing tab of the Knowledge
+ * tab set (see KNOWLEDGE_TABS in _parts/knowledge-page-layout.tsx).
+ * Client-side like /credentials: a server-side redirect() here streams a
+ * NEXT_REDIRECT payload that crashes the client router in this Next version.
+ */
+export default function KnowledgeIndexPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace("/knowledge/connectors");
+  }, [router]);
+
+  return null;
+}

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -820,7 +820,7 @@ function KnowledgeSettingsContent() {
 export default function KnowledgeSettingsPage() {
   return (
     <ErrorBoundary>
-      <SmallTeamTierBanner featureName="Knowledge Base with access control" />
+      <SmallTeamTierBanner featureName="Knowledge" />
       <KnowledgeSettingsContent />
     </ErrorBoundary>
   );

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -59,6 +59,9 @@ import { SkillEditorDialog } from "./_parts/skill-editor-dialog";
 
 type SkillItem = archestraApiTypes.GetSkillsResponses["200"]["data"][number];
 
+const SKILLS_DESCRIPTION =
+  "Skills teach your agents reusable expertise — a SKILL.md instruction set plus optional resource files, loaded on demand and invocable in chat as slash commands.";
+
 export default function SkillsPage() {
   return (
     <div className="h-full w-full">
@@ -304,7 +307,7 @@ function SkillsList() {
 
   if (isSkillsLoadError) {
     return (
-      <PageLayout title="Skills" description="">
+      <PageLayout title="Skills" description={SKILLS_DESCRIPTION}>
         <QueryLoadError
           title="Couldn't load your skills"
           onRetry={() => refetchSkills()}
@@ -320,7 +323,7 @@ function SkillsList() {
     >
       <PageLayout
         title="Skills"
-        description=""
+        description={SKILLS_DESCRIPTION}
         actionButton={
           !showEmptyState && (
             <PermissionButton permissions={{ skill: ["create"] }} asChild>

--- a/platform/frontend/src/components/small-team-tier-banner.tsx
+++ b/platform/frontend/src/components/small-team-tier-banner.tsx
@@ -26,14 +26,11 @@ export function SmallTeamTierBanner({ featureName }: SmallTeamTierBannerProps) {
   const pricingUrl = getDocsUrl(DocsPage.PlatformPricingModel);
   const enabled = tier.smallTeam || tier.envFlag;
   const userWord = tier.userCount === 1 ? "user" : "users";
-  // The tier is "free for < threshold users", so the free tier supports
-  // threshold - 1 users (e.g. threshold 30 → "29-user free tier").
-  const freeTierMax = tier.threshold - 1;
 
   return (
     <div className="mb-6 rounded-md border border-border/60 bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
       <p className="leading-relaxed">
-        {bannerCopy({ tier, featureName, enabled, userWord, freeTierMax })}{" "}
+        {bannerCopy({ tier, featureName, enabled, userWord })}{" "}
         <a
           href={`mailto:${SALES_EMAIL}`}
           className="text-foreground underline decoration-dotted underline-offset-4 hover:decoration-solid"
@@ -54,25 +51,27 @@ export function SmallTeamTierBanner({ featureName }: SmallTeamTierBannerProps) {
   );
 }
 
+// The tier is "free for teams under <threshold> users" (strict comparison on
+// the backend), so the copy phrases it the way the pricing model does instead
+// of naming a max user count.
 function bannerCopy({
   tier,
   featureName,
   enabled,
   userWord,
-  freeTierMax,
 }: {
   tier: NonNullable<ReturnType<typeof useSmallTeamTier>>;
   featureName: string | undefined;
   enabled: boolean;
   userWord: string;
-  freeTierMax: number;
 }): string {
+  const freeTier = `the free tier for teams under ${tier.threshold} users`;
   if (featureName) {
     return enabled
-      ? `${featureName} is an enterprise feature, enabled for this instance because you have ${tier.userCount} ${userWord} (within the ${freeTierMax}-user free tier).`
-      : `${featureName} is an enterprise feature. Your instance has ${tier.userCount} ${userWord}, above the ${freeTierMax}-user free tier, so it is disabled until a license is activated.`;
+      ? `${featureName} is an enterprise feature, enabled for this instance because you have ${tier.userCount} ${userWord} (within ${freeTier}).`
+      : `${featureName} is an enterprise feature. Your instance has ${tier.userCount} ${userWord}, which exceeds ${freeTier}, so it is disabled until a license is activated.`;
   }
   return enabled
-    ? `Your instance has ${tier.userCount} ${userWord} — within the ${freeTierMax}-user free tier. Enterprise features (RBAC, SSO, Knowledge Base with access control) are included.`
-    : `Your instance has ${tier.userCount} ${userWord} — above the ${freeTierMax}-user free tier. Enterprise features (RBAC, SSO, Knowledge Base with access control) are disabled until a license is activated.`;
+    ? `Your instance has ${tier.userCount} ${userWord} — within ${freeTier}. Enterprise features (RBAC, SSO, Knowledge Base with access control) are included.`
+    : `Your instance has ${tier.userCount} ${userWord} — exceeding ${freeTier}. Enterprise features (RBAC, SSO, Knowledge Base with access control) are disabled until a license is activated.`;
 }


### PR DESCRIPTION
## What

**Merge the Knowledge / Connectors sidebar entries into a single tabbed page.** The nav previously had a "Knowledge" entry (→ `/knowledge/knowledge-bases`) with a nested "Connectors" sub-item (→ `/knowledge/connectors`). Now there is one "Knowledge" entry whose page has route-linked tabs — **Connectors** (landing tab) and **Knowledge Bases** — using the same `PageLayout` tabs pattern as `/credentials` and Logs.

Also in this PR:
- **Add a header description to the `/skills` page**, which previously rendered an empty one.
- **Small-team tier banner fixes**: show it on both Knowledge tabs (previously Knowledge Bases only), phrase the free tier as "for teams under 30 users" (matching the pricing model) instead of a computed "29-user free tier", and shorten the feature name to "Knowledge".

## Why

- Better discoverability: one nav destination for the whole knowledge feature; you can create either a knowledge base or a connector from one place.
- Connectors is the landing tab because connectors are the prerequisite — a knowledge base is empty until a connector syncs data — and day-to-day sync-health checks start there.
- Connectors stay a first-class tab (rather than being fully nested under KBs) because the KB ↔ connector relationship is many-to-many, connectors can exist unassigned, and agents can attach to connectors directly.

## How

- `knowledge-page-layout.tsx` — the shared shell both list pages already render now passes `tabs` to `PageLayout` and renders the `SmallTeamTierBanner`. The connector detail page doesn't use this shell, so it stays tab-free with its existing back-links.
- `sidebar.tsx` — single "Knowledge" item → `/knowledge/connectors`, active for all `/knowledge/*` paths; nested sub-item removed. Both routes are gated by the same `knowledgeSource:read` permission, so nav gating is unchanged.
- `knowledge/page.tsx` (new) — bare `/knowledge` client-side-redirects to the landing tab. A server-side `redirect()` here streams a `NEXT_REDIRECT` payload that crashes the client router in the current Next canary ("Rendered more hooks than during the previous render"), so this mirrors the proven `/credentials/page.tsx` pattern.
- `small-team-tier-banner.tsx` — copy now says "the free tier for teams under ${threshold} users" (backend check is strict `userCount < 30`), dropping the `threshold - 1` math that produced "29-user free tier".
- `skills/page.client.tsx` — `SKILLS_DESCRIPTION` const wired into both `PageLayout` usages (main + error state).

## Testing

- Unit tests added pinning the two tabs and their hrefs, and the tier banner rendering in the shared layout (`knowledge-page-layout.test.tsx`); lint, type-check, and the knowledge/settings-knowledge/skills test suites pass.
- Verified in the running app: `/knowledge` lands on Connectors, tab switching works both ways, sidebar shows a single active Knowledge entry, the tier banner renders on both tabs with the new wording, existing deep links (`/knowledge/knowledge-bases`, `/knowledge/connectors`) still resolve, `/skills` renders the new description.

## Docs

No docs changes needed: no docs page describes the old nested nav, both URLs/titles are unchanged, and `platform-adding-knowledge-connectors.md` file-path references are untouched.