### PR TITLE
feat(apps): seed new MCP Apps with the organization's white-label logo

### DIFF
--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -3,7 +3,7 @@ title: MCP Apps
 category: Apps
 order: 1
 description: User-authored MCP Apps — sandboxed HTML interfaces with their own data store and tools
-lastUpdated: 2026-07-03
+lastUpdated: 2026-07-14
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -97,4 +97,4 @@ A shared (team or org) app is author-written HTML executing in a viewer's browse
 
 ## Templates
 
-A single `default` starter seeds a new app's HTML when no explicit HTML is given on create: a themed empty state that centers the app's name, a prompt-only call to action, and a short list of what an app can build on (assigned MCP tools, the per-user and shared data store, built-in AI). It leans on the injected baseline stylesheet, so it looks themed with no full theme of its own. Resolution is server-side — `POST /api/apps` (with an optional `templateId`) or `scaffold_app` seeds the starter's HTML as version 1, substituting the app's name (the id is kept as provenance). Explicit HTML always wins over the template.
+A single `default` starter seeds a new app's HTML when no explicit HTML is given on create: a themed empty state that centers the app's name, a prompt-only call to action, and a short list of what an app can build on (assigned MCP tools, the per-user and shared data store, built-in AI). It leans on the injected baseline stylesheet, so it looks themed with no full theme of its own. Resolution is server-side — `POST /api/apps` (with an optional `templateId`) or `scaffold_app` seeds the starter's HTML as version 1, substituting the app's name (the id is kept as provenance). The starter's mark follows your branding: when the organization has a logo configured in appearance settings, new apps seed with that logo instead of the Archestra mark. Explicit HTML always wins over the template.

--- a/platform/backend/src/app-templates/default.ts
+++ b/platform/backend/src/app-templates/default.ts
@@ -3,13 +3,16 @@ import type { AppTemplate } from "@/types";
 // The one opinionated starter for owned MCP Apps. Pure UI: the platform injects
 // the baseline stylesheet (theme variables, themed element defaults — all
 // light/dark aware) at render time, so this document carries no full theme. It
-// is an empty state: the Archestra mark, the app's name and a prompt-to-build
+// is an empty state: a logo mark, the app's name and a prompt-to-build
 // call to action, and three cards naming the platform capabilities an app gets
 // out of the box — so the user knows what to ask for. The `{{APP_NAME}}` token
-// is replaced (HTML-escaped) with the real app name when the app is created
-// (resolveCreateAppHtml). The inline SVGs and click handler keep it
-// self-contained — no network, so it renders under the app sandbox CSP. The SDK
-// contract a model needs to build the app up lives in the build-app skill.
+// is replaced (HTML-escaped) with the real app name and the `{{APP_LOGO}}`
+// token with the logo block — the organization's white-label logo when one is
+// configured, else the Archestra mark below — when the app is created
+// (resolveCreateAppHtml). The inline SVGs / data-URI images and click handler
+// keep it self-contained — no network, so it renders under the app sandbox CSP.
+// The SDK contract a model needs to build the app up lives in the build-app
+// skill.
 const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -37,8 +40,16 @@ const html = `<!DOCTYPE html>
       display: block; width: 80px; height: 80px; border-radius: 16px;
       box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
     }
-    .logo.press svg { animation: logo-press 0.11s ease-out; }
-    .logo.spin svg { animation: logo-spin 0.5s ease; }
+    /* A white-label logo is an arbitrary image (often a transparent PNG or a
+       wide wordmark), so it gets proportional sizing and no card treatment. */
+    .logo img { display: block; height: 80px; width: auto; max-width: 240px; object-fit: contain; }
+    .logo .logo-dark { display: none; }
+    @media (prefers-color-scheme: dark) {
+      .logo .logo-light { display: none; }
+      .logo .logo-dark { display: block; }
+    }
+    .logo.press svg, .logo.press img { animation: logo-press 0.11s ease-out; }
+    .logo.spin svg, .logo.spin img { animation: logo-spin 0.5s ease; }
     /* A mechanical key press: a quick depress, then spring back. */
     @keyframes logo-press {
       0%   { transform: translateY(0)    scale(1); }
@@ -77,13 +88,7 @@ const html = `<!DOCTYPE html>
   </style>
 </head>
 <body>
-  <button type="button" class="logo" aria-label="Archestra">
-    <svg width="80" height="80" viewBox="0 0 994 953" xmlns="http://www.w3.org/2000/svg">
-      <rect width="993.958" height="952.543" rx="204.92" fill="black"/>
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M390.871 664.818C427.68 664.818 460.629 641.985 473.553 607.519L565.238 363.026C586.887 305.296 544.211 243.715 482.556 243.715C445.747 243.715 412.798 266.548 399.874 301.014L308.189 545.507C286.54 603.237 329.216 664.818 390.871 664.818Z" fill="white"/>
-      <ellipse cx="638.487" cy="577.095" rx="87.7298" ry="81.1501" fill="white"/>
-    </svg>
-  </button>
+  {{APP_LOGO}}
   <div class="content">
     <div class="intro">
       <h1>{{APP_NAME}}</h1>
@@ -126,12 +131,23 @@ const html = `<!DOCTYPE html>
   </div>
   <!-- Easter egg: logo presses on click, spins every fifth one. This is starter
        decoration only — remove this script (and the .logo press/spin styles) on
-       the first real edit. -->
+       the first real edit. The null guard covers the logo-less seed (an
+       organization logo too large to inline). -->
   <script>
-    const logo=document.querySelector(".logo");let clicks=0,spinning=false;logo.addEventListener("click",()=>{if(spinning)return;const move=++clicks%5===0?"spin":"press";if(move==="spin")spinning=true;logo.classList.remove("press","spin");void logo.offsetWidth;logo.classList.add(move)});logo.addEventListener("animationend",e=>{logo.classList.remove("press","spin");if(e.animationName==="logo-spin")spinning=false});
+    const logo=document.querySelector(".logo");let clicks=0,spinning=false;logo?.addEventListener("click",()=>{if(spinning)return;const move=++clicks%5===0?"spin":"press";if(move==="spin")spinning=true;logo.classList.remove("press","spin");void logo.offsetWidth;logo.classList.add(move)});logo?.addEventListener("animationend",e=>{logo.classList.remove("press","spin");if(e.animationName==="logo-spin")spinning=false});
   </script>
 </body>
 </html>`;
+
+// The default mark for the `{{APP_LOGO}}` slot, used when the organization has
+// no white-label logo configured.
+export const defaultTemplateLogoHtml = `<button type="button" class="logo" aria-label="Archestra">
+    <svg width="80" height="80" viewBox="0 0 994 953" xmlns="http://www.w3.org/2000/svg">
+      <rect width="993.958" height="952.543" rx="204.92" fill="black"/>
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M390.871 664.818C427.68 664.818 460.629 641.985 473.553 607.519L565.238 363.026C586.887 305.296 544.211 243.715 482.556 243.715C445.747 243.715 412.798 266.548 399.874 301.014L308.189 545.507C286.54 603.237 329.216 664.818 390.871 664.818Z" fill="white"/>
+      <ellipse cx="638.487" cy="577.095" rx="87.7298" ry="81.1501" fill="white"/>
+    </svg>
+  </button>`;
 
 export const defaultTemplate: AppTemplate = {
   id: "default",

--- a/platform/backend/src/app-templates/index.test.ts
+++ b/platform/backend/src/app-templates/index.test.ts
@@ -1,36 +1,137 @@
-import { describe, expect, test } from "vitest";
-import { resolveCreateAppHtml } from "./index";
+import OrganizationModel from "@/models/organization";
+import { describe, expect, test } from "@/test";
+import { getAppTemplates, resolveCreateAppHtml } from "./index";
+
+const PNG_LOGO =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg==";
+const PNG_LOGO_DARK =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADklEQVR42mNk+M9QDwADgQF/e5IkGQAAAABJRU5ErkJggg==";
+// A marker unique to the default Archestra mark's SVG.
+const ARCHESTRA_MARK = 'viewBox="0 0 994 953"';
 
 describe("resolveCreateAppHtml", () => {
-  test("injects the app name into the seeded default template", () => {
-    const { html, seededFromTemplate } = resolveCreateAppHtml({
+  test("injects the app name into the seeded default template", async () => {
+    const { html, seededFromTemplate } = await resolveCreateAppHtml({
       name: "Sales Dashboard",
     });
     expect(seededFromTemplate).toBe(true);
     expect(html).toContain("<title>Sales Dashboard</title>");
     expect(html).toContain("<h1>Sales Dashboard</h1>");
     expect(html).not.toContain("{{APP_NAME}}");
+    expect(html).not.toContain("{{APP_LOGO}}");
   });
 
-  test("HTML-escapes a name with special characters", () => {
-    const { html } = resolveCreateAppHtml({ name: "Tom & Jerry <v2>" });
+  test("HTML-escapes a name with special characters", async () => {
+    const { html } = await resolveCreateAppHtml({ name: "Tom & Jerry <v2>" });
     expect(html).toContain("Tom &amp; Jerry &lt;v2&gt;");
     expect(html).not.toContain("Tom & Jerry <v2>");
   });
 
-  test("falls back to a neutral name when none is given", () => {
-    const { html } = resolveCreateAppHtml({});
+  test("falls back to a neutral name when none is given", async () => {
+    const { html } = await resolveCreateAppHtml({});
     expect(html).toContain("<h1>My App</h1>");
     expect(html).not.toContain("{{APP_NAME}}");
   });
 
-  test("explicit html wins and is not templated", () => {
+  test("explicit html wins and is not templated", async () => {
     const explicit = "<html><head></head><body>{{APP_NAME}}</body></html>";
-    const { html, seededFromTemplate } = resolveCreateAppHtml({
+    const { html, seededFromTemplate } = await resolveCreateAppHtml({
       html: explicit,
       name: "Ignored",
     });
     expect(seededFromTemplate).toBe(false);
     expect(html).toBe(explicit);
+  });
+
+  test("seeds the Archestra mark when no white-label logo is configured", async ({
+    makeOrganization,
+  }) => {
+    await makeOrganization();
+    const { html } = await resolveCreateAppHtml({ name: "My App" });
+    expect(html).toContain(ARCHESTRA_MARK);
+    expect(html).toContain('aria-label="Archestra"');
+    expect(html).not.toContain("<img");
+  });
+
+  test("seeds the organization's icon logo instead of the Archestra mark", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    await OrganizationModel.patch(org.id, {
+      iconLogo: PNG_LOGO,
+      appName: "Acme Portal",
+    });
+    const { html } = await resolveCreateAppHtml({ name: "My App" });
+    expect(html).toContain(`<img src="${PNG_LOGO}"`);
+    expect(html).toContain('aria-label="Acme Portal"');
+    expect(html).not.toContain(ARCHESTRA_MARK);
+    expect(html).not.toContain("{{APP_LOGO}}");
+  });
+
+  test("emits light and dark images when a dark variant is configured", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    await OrganizationModel.patch(org.id, {
+      iconLogo: PNG_LOGO,
+      iconLogoDark: PNG_LOGO_DARK,
+    });
+    const { html } = await resolveCreateAppHtml({ name: "My App" });
+    expect(html).toContain(`<img class="logo-light" src="${PNG_LOGO}"`);
+    expect(html).toContain(`<img class="logo-dark" src="${PNG_LOGO_DARK}"`);
+  });
+
+  test("falls back to the full logo when no icon logo is configured", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    await OrganizationModel.patch(org.id, { logo: PNG_LOGO });
+    const { html } = await resolveCreateAppHtml({ name: "My App" });
+    expect(html).toContain(`<img src="${PNG_LOGO}"`);
+    expect(html).not.toContain(ARCHESTRA_MARK);
+  });
+
+  test("uses the dark variant for both themes when it is the only one configured", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    await OrganizationModel.patch(org.id, { iconLogoDark: PNG_LOGO_DARK });
+    const { html } = await resolveCreateAppHtml({ name: "My App" });
+    expect(html).toContain(`<img src="${PNG_LOGO_DARK}"`);
+    expect(html).not.toContain('class="logo-dark"');
+    expect(html).not.toContain(ARCHESTRA_MARK);
+  });
+
+  test("seeds without a logo when the configured logo would exceed the app HTML limit", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const hugeLogo = `data:image/png;base64,${"A".repeat(600 * 1024)}`;
+    await OrganizationModel.patch(org.id, { iconLogo: hugeLogo });
+    const { html } = await resolveCreateAppHtml({ name: "My App" });
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain(ARCHESTRA_MARK);
+    expect(html).not.toContain("{{APP_LOGO}}");
+    expect(html).toContain("<h1>My App</h1>");
+  });
+});
+
+describe("getAppTemplates", () => {
+  test("resolves both tokens in the preview html", async () => {
+    const [template] = await getAppTemplates();
+    expect(template.html).toContain("<h1>My App</h1>");
+    expect(template.html).toContain(ARCHESTRA_MARK);
+    expect(template.html).not.toContain("{{APP_NAME}}");
+    expect(template.html).not.toContain("{{APP_LOGO}}");
+  });
+
+  test("previews the white-label logo when configured", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    await OrganizationModel.patch(org.id, { iconLogo: PNG_LOGO });
+    const [template] = await getAppTemplates();
+    expect(template.html).toContain(`<img src="${PNG_LOGO}"`);
+    expect(template.html).not.toContain(ARCHESTRA_MARK);
   });
 });

--- a/platform/backend/src/app-templates/index.ts
+++ b/platform/backend/src/app-templates/index.ts
@@ -1,5 +1,7 @@
-import type { AppTemplate } from "@/types";
-import { defaultTemplate } from "./default";
+import OrganizationModel from "@/models/organization";
+import type { AppearanceSettings, AppTemplate } from "@/types";
+import { APP_HTML_MAX_BYTES } from "@/types";
+import { defaultTemplate, defaultTemplateLogoHtml } from "./default";
 
 // The single opinionated starter surfaced by GET /api/app-templates and seeded
 // by the create paths. Its id is stored on the app row as provenance.
@@ -8,12 +10,14 @@ const APP_TEMPLATES: readonly AppTemplate[] = [defaultTemplate];
 /** Provenance recorded on an app row seeded from the default template. */
 export const DEFAULT_APP_TEMPLATE_ID = defaultTemplate.id;
 
-export function getAppTemplates(): AppTemplate[] {
+export async function getAppTemplates(): Promise<AppTemplate[]> {
   // Surface a presentable preview: resolve the name token to a neutral default
-  // so no raw `{{APP_NAME}}` leaks to GET /api/app-templates or the save-gate.
+  // and the logo token to the effective branding, so no raw `{{APP_NAME}}` /
+  // `{{APP_LOGO}}` leaks to GET /api/app-templates or the save-gate.
+  const logoHtml = await resolveTemplateLogoHtml();
   return APP_TEMPLATES.map((t) => ({
     ...t,
-    html: applyAppName(t.html, "My App"),
+    html: renderTemplateHtml(t.html, { name: "My App", logoHtml }),
   }));
 }
 
@@ -21,26 +25,92 @@ export function getAppTemplates(): AppTemplate[] {
  * Resolve the initial HTML for a new app. Explicit `html` always wins
  * (`templateId` is then provenance only); otherwise the single default template
  * seeds the first version, with `name` substituted into its `{{APP_NAME}}`
- * token. Shared by REST `POST /api/apps` and the `scaffold_app` tool (which
- * always omits html). Update paths never re-template an existing app.
+ * token and the `{{APP_LOGO}}` token resolved to the organization's
+ * white-label logo when one is configured (the Archestra mark otherwise).
+ * Shared by REST `POST /api/apps` and the `scaffold_app` tool (which always
+ * omits html). Update paths never re-template an existing app.
  */
-export function resolveCreateAppHtml(input: { html?: string; name?: string }): {
+export async function resolveCreateAppHtml(input: {
+  html?: string;
+  name?: string;
+}): Promise<{
   html: string;
   seededFromTemplate: boolean;
-} {
+}> {
   if (input.html !== undefined) {
     return { html: input.html, seededFromTemplate: false };
   }
+  const name = input.name ?? "My App";
+  const logoHtml = await resolveTemplateLogoHtml();
   return {
-    html: applyAppName(defaultTemplate.html, input.name ?? "My App"),
+    html: renderTemplateHtml(defaultTemplate.html, { name, logoHtml }),
     seededFromTemplate: true,
   };
 }
 
-// Substitute the `{{APP_NAME}}` token with an HTML-escaped name so names with
-// special characters render as text and can't break the markup or validation.
-function applyAppName(html: string, name: string): string {
-  return html.replaceAll("{{APP_NAME}}", escapeHtml(name));
+// Substitute the `{{APP_NAME}}` token with an HTML-escaped name — so names
+// with special characters render as text and can't break the markup or
+// validation — and the `{{APP_LOGO}}` token with the (already-safe) logo block.
+// A configured logo can be up to 2 MB decoded, so its data URI may push the
+// document past the app HTML limit. Rather than fail the create (or fall back
+// to the Archestra mark on a white-labeled instance), render without a logo
+// block.
+function renderTemplateHtml(
+  template: string,
+  tokens: { name: string; logoHtml: string },
+): string {
+  const html = applyTemplateTokens(template, tokens);
+  if (Buffer.byteLength(html, "utf8") <= APP_HTML_MAX_BYTES) return html;
+  return applyTemplateTokens(template, { ...tokens, logoHtml: "" });
+}
+
+function applyTemplateTokens(
+  html: string,
+  tokens: { name: string; logoHtml: string },
+): string {
+  return html
+    .replaceAll("{{APP_NAME}}", escapeHtml(tokens.name))
+    .replaceAll("{{APP_LOGO}}", tokens.logoHtml);
+}
+
+// The `{{APP_LOGO}}` block: the organization's white-label logo when one is
+// configured, else the default Archestra mark. Logos are validated data URIs
+// (see the appearance-settings schemas), so they render inline under the app
+// sandbox CSP (`img-src` always allows `data:`) with no network fetch.
+async function resolveTemplateLogoHtml(): Promise<string> {
+  const appearance = await OrganizationModel.getAppearanceSettings();
+  const logo = resolveWhiteLabelLogo(appearance);
+  if (!logo) return defaultTemplateLogoHtml;
+  const label = appearance.appName ?? "Logo";
+  // With a dark variant, both images are emitted and the template's
+  // `prefers-color-scheme` rules toggle between them; otherwise the single
+  // image serves both themes.
+  const images = logo.dark
+    ? `<img class="logo-light" src="${escapeHtml(logo.light)}" alt="" />
+    <img class="logo-dark" src="${escapeHtml(logo.dark)}" alt="" />`
+    : `<img src="${escapeHtml(logo.light)}" alt="" />`;
+  return `<button type="button" class="logo" aria-label="${escapeHtml(label)}">
+    ${images}
+  </button>`;
+}
+
+// Pick the branding pair for the template's square-ish mark slot: the icon
+// logos when any is set (they are square by design), the full logos otherwise.
+// Variants never mix across pairs; a missing side falls back to the other so a
+// single configured image serves both themes.
+function resolveWhiteLabelLogo(
+  appearance: AppearanceSettings,
+): { light: string; dark: string | null } | null {
+  const preferIcon = Boolean(appearance.iconLogo ?? appearance.iconLogoDark);
+  const lightVariant = preferIcon ? appearance.iconLogo : appearance.logo;
+  const darkVariant = preferIcon
+    ? appearance.iconLogoDark
+    : appearance.logoDark;
+  const light = lightVariant ?? darkVariant;
+  if (!light) return null;
+  const dark =
+    lightVariant && darkVariant !== lightVariant ? darkVariant : null;
+  return { light, dark: dark ?? null };
 }
 
 function escapeHtml(value: string): string {

--- a/platform/backend/src/archestra-mcp-server/apps.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.ts
@@ -407,7 +407,7 @@ const registry = defineArchestraTools([
           resourceTeamIds: [],
         });
         // Scaffold always seeds the single default template.
-        const resolved = resolveCreateAppHtml({ name: args.name });
+        const resolved = await resolveCreateAppHtml({ name: args.name });
         const validated = await buildValidatedVersionPayload({
           html: resolved.html,
           uiPermissions: args.uiPermissions,

--- a/platform/backend/src/routes/app/app.routes.ts
+++ b/platform/backend/src/routes/app/app.routes.ts
@@ -252,7 +252,7 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
       },
     },
     async (_request, reply) => {
-      return reply.send(getAppTemplates());
+      return reply.send(await getAppTemplates());
     },
   );
 
@@ -288,7 +288,7 @@ const appRoutes: FastifyPluginAsyncZod = async (fastify) => {
         organizationId,
         environmentId: body.environmentId ?? null,
       });
-      const { html, seededFromTemplate } = resolveCreateAppHtml({
+      const { html, seededFromTemplate } = await resolveCreateAppHtml({
         html: body.html,
         name: body.name,
       });

--- a/platform/backend/src/services/apps/app-ui-policy.test.ts
+++ b/platform/backend/src/services/apps/app-ui-policy.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, test } from "vitest";
 import { getAppTemplates } from "@/app-templates";
+import OrganizationModel from "@/models/organization";
+import { describe, expect, test } from "@/test";
 import { APP_HTML_MAX_BYTES } from "@/types/app";
 import {
   APP_PLATFORM_CSP,
@@ -325,20 +326,37 @@ describe("validateAppHtmlStatic", () => {
 });
 
 describe("starter templates pass the save gate", () => {
-  test.each(
-    getAppTemplates().map((t) => [t.id, t.html] as const),
-  )("%s validates with no warnings (vars resolve against the base sheet)", async (_id, html) => {
-    const { warnings } = await buildValidatedVersionPayload({ html });
-    expect(warnings).toEqual([]);
+  test("every template validates with no warnings (vars resolve against the base sheet)", async () => {
+    for (const { id, html } of await getAppTemplates()) {
+      const { warnings } = await buildValidatedVersionPayload({ html });
+      expect(warnings, `${id} should validate with no warnings`).toEqual([]);
+    }
   });
 
-  test("every CSS variable a template references is defined in the base sheet", () => {
+  test("a template seeded with a white-label logo still validates cleanly", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    await OrganizationModel.patch(org.id, {
+      iconLogo:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg==",
+    });
+    for (const { id, html } of await getAppTemplates()) {
+      expect(html, `${id} should embed the configured logo`).toContain(
+        '<img src="data:image/png;base64,',
+      );
+      const { warnings } = await buildValidatedVersionPayload({ html });
+      expect(warnings, `${id} should validate with no warnings`).toEqual([]);
+    }
+  });
+
+  test("every CSS variable a template references is defined in the base sheet", async () => {
     const baseCss = readFileSync(
       join(__dirname, "../../static/archestra-app-base.css"),
       "utf-8",
     );
     const defined = new Set(baseCss.match(/--[\w-]+(?=\s*:)/g) ?? []);
-    for (const { id, html } of getAppTemplates()) {
+    for (const { id, html } of await getAppTemplates()) {
       for (const ref of html.match(/var\(\s*(--[\w-]+)/g) ?? []) {
         const name = ref.replace(/var\(\s*/, "");
         expect(defined, `${id} references undefined ${name}`).toContain(name);


### PR DESCRIPTION
## Problem

The default MCP App starter template hardcodes the Archestra logomark as an inline SVG. Every new app seeds with it, and apps built up from the starter often carry that mark into their final design — so on white-labeled instances, apps end up showing the Archestra logo instead of the organization's own branding.

## Change

- The starter template's logo block is now an `{{APP_LOGO}}` token, resolved server-side at create time (`POST /api/apps` and the `scaffold_app` tool) alongside `{{APP_NAME}}`.
- When the organization has a white-label logo configured in appearance settings, the seeded HTML embeds it as data-URI `<img>`s — the icon logo pair is preferred (square, matches the mark slot), the full logo pair is the fallback, and dark variants toggle via the template's `prefers-color-scheme` rules. Data URIs render under the app sandbox CSP (`img-src` always allows `data:`) with no network fetch.
- Without a configured logo, behavior is unchanged: the Archestra mark.
- Logos can be up to 2 MB decoded while app HTML is capped at 512 KB, so if embedding would exceed the limit the app seeds without a logo block rather than failing the create or reverting to the Archestra mark.
- `GET /api/app-templates` previews resolve the same way, so the preview matches what a create would seed.
- Docs: noted the branding behavior in the Templates section of `platform-apps.md`.

## Tests

- `app-templates/index.test.ts`: white-label seeding (icon logo, full-logo fallback, dark variants, dark-only config, oversize fallback, template previews) plus the pre-existing name/explicit-html cases.
- `app-ui-policy.test.ts`: the save gate now also validates a template seeded with a configured logo.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>