### PR TITLE
fix(audit): capture agent model change and label delegation mutations (#6583)

### DIFF
--- a/platform/backend/src/middleware/audit-log-registry.test.ts
+++ b/platform/backend/src/middleware/audit-log-registry.test.ts
@@ -38,6 +38,30 @@ describe("resolveAuditableRouteConfig", () => {
     expect(typeof resolved?.cfg.fetchById).toBe("function");
   });
 
+  test("agent delegations sync route resolves to agent.updated, not the unknown.* create fallback", () => {
+    // POST /api/agents/:agentId/delegations replaces an agent's delegation
+    // targets — a mutation of the agent, not a create. Without an explicit
+    // entry it recorded "Unknown create" with an empty resource (#6583).
+    const resolved = resolveAuditableRouteConfig(
+      "/api/agents/:agentId/delegations",
+    );
+    expect(resolved?.viaWalkUp).toBe(false);
+    expect(resolved?.cfg.resourceType).toBe("agent");
+    expect(resolved?.cfg.resourceIdParam).toBe("agentId");
+    expect(resolved?.cfg.action).toBe("agent.updated");
+    expect(typeof resolved?.cfg.fetchById).toBe("function");
+  });
+
+  test("agent single-delegation removal route resolves to agent.updated", () => {
+    const resolved = resolveAuditableRouteConfig(
+      "/api/agents/:agentId/delegations/:targetAgentId",
+    );
+    expect(resolved?.viaWalkUp).toBe(false);
+    expect(resolved?.cfg.resourceType).toBe("agent");
+    expect(resolved?.cfg.resourceIdParam).toBe("agentId");
+    expect(resolved?.cfg.action).toBe("agent.updated");
+  });
+
   test("skill reset route uses updated action instead of POST create fallback", () => {
     const resolved = resolveAuditableRouteConfig("/api/skills/:id/reset");
     expect(resolved?.viaWalkUp).toBe(false);

--- a/platform/backend/src/middleware/audit-log-registry.ts
+++ b/platform/backend/src/middleware/audit-log-registry.ts
@@ -145,6 +145,22 @@ export const AUDITABLE_ROUTES: Record<string, AuditableRouteConfig> = {
     resourceIdParam: "agentId",
     fetchById: (id, orgId) => AgentModel.findByIdForAudit(id, orgId),
   },
+  // Syncing (replace-all) or removing an agent's delegation targets is a
+  // mutation of the agent, not a create. Without these entries the POST/DELETE
+  // fall through to the unknown.* fallback ("Unknown create" with an empty
+  // resource, #6583). Map them to the agent so the diff shows delegationTargets.
+  "/api/agents/:agentId/delegations": {
+    resourceType: "agent",
+    resourceIdParam: "agentId",
+    action: "agent.updated",
+    fetchById: (id, orgId) => AgentModel.findByIdForAudit(id, orgId),
+  },
+  "/api/agents/:agentId/delegations/:targetAgentId": {
+    resourceType: "agent",
+    resourceIdParam: "agentId",
+    action: "agent.updated",
+    fetchById: (id, orgId) => AgentModel.findByIdForAudit(id, orgId),
+  },
 
   "/api/agent-tools/:id": {
     resourceType: "agentTool",

--- a/platform/backend/src/middleware/audit-log-snapshot.test.ts
+++ b/platform/backend/src/middleware/audit-log-snapshot.test.ts
@@ -356,6 +356,11 @@ describe("audit snapshot shape — non-redacted models", () => {
     expect(snapshot).toHaveProperty("scope", "org");
     expect(Array.isArray(snapshot?.delegationTargets)).toBe(true);
     expect(typeof snapshot?.createdAt).toBe("string");
+    // Snapshot the live model FK (+ resolved name), not the deprecated
+    // `llmModel` column — otherwise a model change diffs to nothing (#6583).
+    expect(snapshot).toHaveProperty("modelId");
+    expect(snapshot).toHaveProperty("model");
+    expect(snapshot).not.toHaveProperty("llmModel");
   });
 
   test("AgentModel.findByIdForAudit returns null for wrong org", async ({

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -2943,19 +2943,37 @@ class AgentModel {
     // Fetch relational data so audit diffs capture tool/KB/team changes —
     // not just main-table columns.  Each sub-query is lightweight (index
     // lookup by agent_id) and the parallel fetch keeps latency low.
-    const [tools, teams, labels, knowledgeBaseIds, connectorIds, delegations] =
-      await Promise.all([
-        AgentToolModel.getToolsForAgent(id),
-        AgentTeamModel.getTeamDetailsForAgent(id),
-        AgentLabelModel.getLabelsForAgent(id),
-        AgentKnowledgeBaseModel.getKnowledgeBaseIds(id),
-        AgentConnectorAssignmentModel.getConnectorIds(id),
-        AgentToolModel.getDelegationTargets(id),
-      ]);
+    const [
+      tools,
+      teams,
+      labels,
+      knowledgeBaseIds,
+      connectorIds,
+      delegations,
+      modelRows,
+    ] = await Promise.all([
+      AgentToolModel.getToolsForAgent(id),
+      AgentTeamModel.getTeamDetailsForAgent(id),
+      AgentLabelModel.getLabelsForAgent(id),
+      AgentKnowledgeBaseModel.getKnowledgeBaseIds(id),
+      AgentConnectorAssignmentModel.getConnectorIds(id),
+      AgentToolModel.getDelegationTargets(id),
+      // Resolve the human-facing model name (e.g. "gpt-4") so a model change
+      // shows "model: gpt-4 → claude-opus" rather than a bare UUID diff.
+      row.modelId
+        ? db
+            .select({ modelName: schema.modelsTable.modelId })
+            .from(schema.modelsTable)
+            .where(eq(schema.modelsTable.id, row.modelId))
+            .limit(1)
+        : Promise.resolve([]),
+    ]);
 
     const delegationTargets = [...delegations]
       .sort((a, b) => a.id.localeCompare(b.id))
       .map((d) => ({ id: d.id, name: d.name }));
+
+    const modelName = modelRows[0]?.modelName ?? null;
 
     return {
       id: row.id,
@@ -2967,7 +2985,12 @@ class AgentModel {
       systemPrompt: row.systemPrompt ?? null,
       slug: row.slug ?? null,
       isDefault: row.isDefault,
-      llmModel: row.llmModel ?? null,
+      // The agent's configured model. `modelId` (the live FK) drives diff
+      // detection; `model` is its resolved human name for a readable diff.
+      // The legacy `llmModel` text column is deprecated (never read/written), so
+      // snapshotting it hid every model change behind an empty diff (#6583).
+      modelId: row.modelId ?? null,
+      model: modelName,
       toolExposureMode: row.toolExposureMode,
       accessAllTools: row.accessAllTools,
       tools: tools.map((t) => t.name).sort(),


### PR DESCRIPTION
## Problem

Changing an agent's model produces confusing audit output:
1. The **Agent updated** event shows *"No field-level differences between the snapshots."*
2. A second **Unknown create** event is recorded (`POST /api/agents/:agentId/delegations`) with an empty resource and no tracked changes.

## Root cause & fix

**No model diff** — `AgentModel.findByIdForAudit` snapshotted the deprecated `llmModel` text column (marked `@deprecated — no longer read or written`) instead of the live `modelId` FK, so a model change never appeared in the diff. The snapshot now carries `modelId` (drives diff detection) plus the resolved human model name (`model`, e.g. `gpt-4`) for a readable *old → new* diff, and drops the dead `llmModel`.

**"Unknown create" with empty resource** — `POST` / `DELETE /api/agents/:agentId/delegations` had no `AUDITABLE_ROUTES` entry, so they fell through to the `unknown.*` fallback. They're now mapped to the `agent` resource (`resourceIdParam: agentId`, `action: agent.updated`, `fetchById: findByIdForAudit`), so a delegation change is recorded against the agent and its diff shows the `delegationTargets` change.

## Tests
- `audit-log-registry.test.ts` — the delegations sync/removal routes resolve to `agent.updated` (not the `unknown.*` fallback), with `resourceType: agent` / `resourceIdParam: agentId`.
- `audit-log-snapshot.test.ts` — the agent snapshot now carries `modelId`/`model` and no longer carries `llmModel`.

All green locally: type-check, tests (registry + snapshot + hook + agent route), biome, knip (dev + production).

## Note (out of scope)
A delegations sync that changes nothing still records an `agent.updated` event with an empty diff, because the audit hook records every mutating request. Suppressing no-diff mutation records is a broader audit-hook policy decision affecting all routes, so I've kept this PR scoped to the mislabeling and the missing model diff — happy to follow up if you'd like no-diff mutations suppressed.

Closes #6583