### PR TITLE
chore(baton): kagent demo polish — teardown script + drop redundant user block

### DIFF
--- a/ai-labs/baton/demo/kagent/README.md
+++ b/ai-labs/baton/demo/kagent/README.md
@@ -48,6 +48,12 @@ exists. Per-turn decisions:
 kubectl -n kagent logs deploy/ops-agent -c baton-proxy
 ```
 
+Tear it all down (deletes the kind cluster; `--image` also drops the built image):
+
+```sh
+./teardown.sh
+```
+
 ## Files
 
 - `policy.toml` — the proxy's contracts (mounted into the sidecar as a ConfigMap).
@@ -56,4 +62,5 @@ kubectl -n kagent logs deploy/ops-agent -c baton-proxy
 - `manifests/agent.yaml` — the `ModelConfig` and the `Agent`, whose
   `deployment.extraContainers` runs the baton-proxy sidecar.
 - `run-demo.sh` / `invoke-agent.sh` — one-command runner and the A2A invoke helper.
+- `teardown.sh` — delete the kind cluster (and, with `--image`, the built image).
 - `NOTES.md` — the verified kagent wiring facts (chart version, CRD fields, tool names).

--- a/ai-labs/baton/demo/kagent/policy.toml
+++ b/ai-labs/baton/demo/kagent/policy.toml
@@ -7,10 +7,10 @@
 
 upstream_base_url = "https://openrouter.ai/api/v1"
 
-[contracts.user]
-id = "operator"
-# The operator's request is trusted (default), so a clean investigation that
-# never touches suspicious content can still reach the guarded sinks.
+# The user's turns default to trusted, so a clean investigation reaches the
+# guarded sinks; the injection blocks them by tainting the flow suspicious. Add
+# a `[contracts.user]` block only to change that (e.g. `trust = "suspicious"`
+# for a public-facing agent) or to use audience rules.
 
 # --- Injection vector: pod logs are third-party text. --------------------------
 [[contracts.tool]]

--- a/ai-labs/baton/demo/kagent/teardown.sh
+++ b/ai-labs/baton/demo/kagent/teardown.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Tear down the kagent + baton-proxy demo.
+#
+# Deletes the kind cluster (which removes kagent, the agent, the fixture, and
+# all secrets/configmaps in one shot). Pass --image to also remove the locally
+# built proxy image.
+#
+# Prereqs: kind, docker (only if using --image).
+set -euo pipefail
+
+CLUSTER=baton-poc
+IMAGE=baton-proxy:poc
+
+remove_image=false
+[[ "${1:-}" == "--image" ]] && remove_image=true
+
+if kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+  echo "▸ deleting kind cluster $CLUSTER"
+  kind delete cluster --name "$CLUSTER"
+else
+  echo "▸ no kind cluster named $CLUSTER — nothing to delete"
+fi
+
+if [[ "$remove_image" == true ]]; then
+  echo "▸ removing image $IMAGE"
+  docker image rm "$IMAGE" 2>/dev/null || echo "  (image not present)"
+fi
+
+echo "done"


### PR DESCRIPTION
Follow-up to #6586 (merged), two small kagent-demo touchups:

- **`teardown.sh`** — deletes the `baton-poc` kind cluster (and, with `--image`, the built image). Documented in the demo README next to `run-demo.sh`.
- **Drop the `[contracts.user]` block** from `policy.toml` — `id = "operator"` was never referenced (no contract uses an audience rule) and the trust it set is already the default, so it was dead config. Behavior is identical; a one-line note keeps the trusted-by-default fact visible.