### PR TITLE
chore(knowledge-base): Cleanup auto-sync permissions connector creden…

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -90,6 +90,18 @@ Supported connectors: **GitHub**, **Confluence**, and **Jira**. Support for Goog
 
 **Manual user assignment.** When an account's email stays hidden, assign it to an Archestra user from the Users tab.
 
+#### Atlassian Organization Admin API Key
+
+An organization admin API key reads managed accounts' emails through the Atlassian admin APIs. Add it to a Jira or Confluence connector, and permission sync resolves members whose profile email visibility is not **"Anyone"**.
+
+Create the key in [Atlassian administration](https://admin.atlassian.com) under **Settings → API keys**:
+
+1. Select **Create API key** and name it.
+2. Leave the key **without scopes**. Permission sync calls the classic admin APIs, which scopes do not cover.
+3. Copy the key into the connector's **Organization admin API key** field.
+
+The API token stays required. Atlassian does not accept admin API keys on the Jira and Confluence APIs.
+
 ## Supported Connectors
 
 Archestra ships with these built-in connector types.
@@ -100,7 +112,7 @@ Sync issues and discussions from Atlassian Jira.
 
 **Indexed:** issue descriptions, comments, and metadata from Jira Cloud or Server.
 
-**Authentication:** an Atlassian account email and an [API token](https://id.atlassian.com/manage-profile/security/api-tokens). For auto-sync permissions on Cloud, also add an [organization admin API key](https://support.atlassian.com/organization-administration/docs/manage-an-organization-with-the-admin-apis/) in the **Organization admin API key** field — it lets permission sync read managed accounts' hidden emails. Create the key without scopes. The API token is still required: Atlassian does not accept admin API keys on the Jira or Confluence APIs.
+**Authentication:** an Atlassian account email and an [API token](https://id.atlassian.com/manage-profile/security/api-tokens). For auto-sync permissions on Cloud, also add an [organization admin API key](#atlassian-organization-admin-api-key).
 
 | Field                   | Description                                                        |
 | ----------------------- | ------------------------------------------------------------------ |
@@ -117,7 +129,7 @@ Sync wiki pages from Atlassian Confluence.
 
 **Indexed:** pages from Confluence Cloud or Server.
 
-**Authentication:** the same Atlassian email and API token used for Jira, with the same optional organization admin API key for auto-sync permissions.
+**Authentication:** the same Atlassian email and API token used for Jira, with the same optional [organization admin API key](#atlassian-organization-admin-api-key) for auto-sync permissions.
 
 | Field          | Description                                                                   |
 | -------------- | ----------------------------------------------------------------------------- |

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-dialog-config.tsx
@@ -7,6 +7,7 @@ import {
 } from "@archestra/shared";
 import type { ReactNode } from "react";
 import type { UseFormReturn } from "react-hook-form";
+import { ExternalDocsLink } from "@/components/external-docs-link";
 import {
   FormControl,
   FormDescription,
@@ -342,25 +343,55 @@ export function connectorSupportsAdminApiKey(type: ConnectorType): boolean {
 }
 
 /**
+ * Description of the admin API key field, shared by the create and edit
+ * dialogs (each appends its own trailing sentence). Says why the key exists —
+ * the email join permission sync needs — and links to the docs for the
+ * how-to (creating a scopeless key in Atlassian administration).
+ */
+export function AdminApiKeyDescription({ type }: { type: ConnectorType }) {
+  const label = getConnectorTypeLabel(type);
+  return (
+    <>
+      Permissions auto-sync needs {label} user emails to work. Add a {label}{" "}
+      organization admin API key or set every {label} user&apos;s profile
+      visibility to &quot;Anyone&quot; to let this connector read {label} user
+      emails.{" "}
+      <ExternalDocsLink
+        href={getFrontendDocsUrl(
+          DocsPage.PlatformKnowledge,
+          ATLASSIAN_ADMIN_API_KEY_DOC_ANCHOR,
+        )}
+        className="underline"
+        showIcon={false}
+      >
+        Learn more
+      </ExternalDocsLink>
+      .
+    </>
+  );
+}
+
+/**
  * What the credential must be able to see for auto-sync permissions to
  * resolve members to users (the email join). Shown under the credential field
  * when Auto-sync permissions is selected: each source hides emails behind a
  * specific, non-obvious visibility rule, and a credential without it produces
- * a snapshot full of unresolvable members.
+ * a snapshot full of unresolvable members. Atlassian says this on its admin
+ * API key field instead, since that field is where the fix lives.
  */
 export function getPermissionSyncCredentialNote(
   type: ConnectorType,
 ): string | null {
   switch (type) {
-    case "jira":
-    case "confluence":
-      return "Auto-sync permissions matches members by email, and Atlassian Cloud only returns another user's email when that user's profile email visibility is set to \"Anyone\" — admin roles on this API token do not unlock hidden emails. Add an organization admin API key below so permission sync can resolve managed accounts' emails through the Atlassian admin APIs.";
     case "github":
       return "Auto-sync permissions matches members by their public GitHub profile email. No token scope reveals a private email, so members without a public profile email are recorded but stay unresolvable.";
     default:
       return null;
   }
 }
+
+const ATLASSIAN_ADMIN_API_KEY_DOC_ANCHOR =
+  "atlassian-organization-admin-api-key";
 // SPDX-SnippetEnd
 
 export function getConnectorUrlConfig(

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
@@ -41,6 +41,7 @@ import { Input } from "@/components/ui/input";
 import { SecretInput, SecretTextarea } from "@/components/ui/secret-input";
 import { useCreateConnector } from "@/lib/knowledge/connector.query";
 import {
+  AdminApiKeyDescription,
   CONNECTOR_OPTIONS,
   ConnectorAdvancedConfigFields,
   ConnectorInlineConfigFields,
@@ -218,6 +219,8 @@ export function CreateConnectorDialog({
     mode: "create",
     authMethod,
   });
+  const permissionSyncCredentialNote =
+    getPermissionSyncCredentialNote(connectorType);
 
   useLayoutEffect(() => {
     if (open && step === "select") {
@@ -452,11 +455,12 @@ export function CreateConnectorDialog({
                           )}
                         </FormControl>
                         {apiTokenHelpText}
-                        {visibility === "auto-sync-permissions" && (
-                          <FormDescription>
-                            {getPermissionSyncCredentialNote(connectorType)}
-                          </FormDescription>
-                        )}
+                        {visibility === "auto-sync-permissions" &&
+                          permissionSyncCredentialNote && (
+                            <FormDescription>
+                              {permissionSyncCredentialNote}
+                            </FormDescription>
+                          )}
                         <FormMessage />
                       </FormItem>
                     )}
@@ -480,13 +484,7 @@ export function CreateConnectorDialog({
                             />
                           </FormControl>
                           <FormDescription>
-                            Lets permission sync resolve managed accounts&apos;
-                            hidden emails through the Atlassian admin APIs.
-                            Create a key <em>without scopes</em> in Atlassian
-                            administration under Settings → API keys. The API
-                            token above is still required — Atlassian does not
-                            accept admin API keys on the Jira/Confluence APIs
-                            themselves.
+                            <AdminApiKeyDescription type={connectorType} />
                           </FormDescription>
                           <FormMessage />
                         </FormItem>

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/edit-connector-dialog.tsx
@@ -31,6 +31,7 @@ import { SecretInput, SecretTextarea } from "@/components/ui/secret-input";
 import { Switch } from "@/components/ui/switch";
 import { useUpdateConnector } from "@/lib/knowledge/connector.query";
 import {
+  AdminApiKeyDescription,
   ConnectorAdvancedConfigFields,
   ConnectorInlineConfigFields,
   connectorNeedsEmail,
@@ -387,10 +388,8 @@ export function EditConnectorDialog({
                       />
                     </FormControl>
                     <FormDescription>
-                      Lets permission sync resolve managed accounts&apos; hidden
-                      emails through the Atlassian admin APIs. Create a key{" "}
-                      <em>without scopes</em> in Atlassian administration under
-                      Settings → API keys. Leave empty to keep the existing key.
+                      <AdminApiKeyDescription type={connectorType} /> Leave
+                      empty to keep the existing key.
                     </FormDescription>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION
…tials input fields note texts

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>