### PR TITLE
fix(apps): show an exit-fullscreen button for panel-hosted apps

### DIFF
--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -378,6 +378,78 @@ describe("McpAppContainer (via McpAppSection)", () => {
       screen.queryByRole("button", { name: /exit fullscreen/i }),
     ).not.toBeInTheDocument();
   });
+
+  it("shows an exit-fullscreen button in the panel top bar when the app goes fullscreen", async () => {
+    // Regression: the panel surface renders no hover overlay, so when a
+    // panel-hosted app requested fullscreen via the SDK there was no way back
+    // out (Escape is swallowed by iframe focus) short of reloading the page.
+    const user = userEvent.setup();
+
+    const { AppBridge } = await import(
+      "@modelcontextprotocol/ext-apps/app-bridge"
+    );
+    // biome-ignore lint/suspicious/noExplicitAny: accessing mock internals
+    const bridgeInstances: any[] = [];
+    (AppBridge as ReturnType<typeof vi.fn>).mockImplementation(function (
+      this: Record<string, unknown>,
+    ) {
+      this.onrequestdisplaymode = null as
+        | null
+        | ((args: { mode: string }) => Promise<{ mode: string }>);
+      this.onopenlink = null;
+      this.oncalltool = null;
+      this.onreadresource = null;
+      this.onlistresources = null;
+      this.onlistresourcetemplates = null;
+      this.onlistprompts = null;
+      this.onloggingmessage = null;
+      this.onmessage = null;
+      this.onsizechange = null;
+      this.oninitialized = null;
+      this.onsandboxready = null;
+      this.connect = vi.fn().mockReturnValue(Promise.resolve());
+      this.sendSandboxResourceReady = vi
+        .fn()
+        .mockReturnValue(Promise.resolve());
+      this.sendToolInput = vi.fn().mockReturnValue(Promise.resolve());
+      this.sendToolInputPartial = vi.fn().mockReturnValue(Promise.resolve());
+      this.sendToolResult = vi.fn().mockReturnValue(Promise.resolve());
+      this.setHostContext = vi.fn();
+      this.teardownResource = vi.fn().mockReturnValue(Promise.resolve());
+      bridgeInstances.push(this);
+    });
+
+    await act(async () => {
+      render(
+        <McpAppSection
+          {...defaultProps}
+          surface="panel"
+          preloadedResource={preloadedResource}
+        />,
+      );
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /exit fullscreen/i }),
+    ).not.toBeInTheDocument();
+
+    const bridge = bridgeInstances[0];
+    await act(async () => {
+      await bridge.onrequestdisplaymode({ mode: "fullscreen" });
+    });
+
+    const exitButton = screen.getByRole("button", {
+      name: /exit fullscreen/i,
+    });
+
+    await act(async () => {
+      await user.click(exitButton);
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /exit fullscreen/i }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("McpAppContainer inline height (via McpAppSection)", () => {

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -467,6 +467,13 @@ export function McpAppEntryContent({
           {isOwnedInPanel ? (
             <McpAppSettingsButton onClick={() => setSettingsOpen(true)} />
           ) : null}
+          {/* Apps can request fullscreen from the panel too (via the SDK); the
+              bar is the only chrome there, so it must carry the way back out.
+              Escape alone doesn't cut it — focus usually sits inside the
+              iframe, where the host never sees the keydown. */}
+          {displayMode === "fullscreen" ? (
+            <McpAppFullscreenExitButton onClick={toggleFullscreen} size="bar" />
+          ) : null}
         </>
       }
     />

--- a/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-chrome.tsx
@@ -116,14 +116,17 @@ export function McpAppSettingsButton({ onClick }: { onClick: () => void }) {
 
 export function McpAppFullscreenExitButton({
   onClick,
+  size = "sm",
 }: {
   onClick: () => void;
+  size?: McpAppButtonSize;
 }) {
   return (
     <McpAppIconButton
       icon={Minimize2}
       label="Exit fullscreen"
       onClick={onClick}
+      size={size}
     />
   );
 }


### PR DESCRIPTION
## Problem

Opening a pinned app from the sidebar seeds a chat that auto-opens the app in the chat's right panel. If the app then requests fullscreen via the MCP UI SDK (`requestDisplayMode`), the card goes fixed-fullscreen with **no way back out short of reloading the page**:

- The exit-fullscreen hover overlay is only rendered on the **inline** chat surface — the panel surface passes `overlay={undefined}`.
- The panel top bar (refresh / name / open-in-tab / settings) carried no exit control.
- The Escape fallback in `McpAppCard` listens on the host `window`, but after clicking the app's own fullscreen button, focus sits **inside the iframe**, so the host never sees the keydown.

## Fix

Render `McpAppFullscreenExitButton` in the panel top bar while `displayMode === "fullscreen"` (the top bar stays visible in fullscreen), with a new `size="bar"` variant so it lines up with the other 32px header buttons.

## Testing

- Added a regression test: a panel-surface app that requests fullscreen through the bridge now shows the exit button; clicking it returns to the panel and the button unmounts.
- `pnpm vitest run` on affected suites (47 passed), `pnpm type-check`, `pnpm lint` all clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>