### PR TITLE
fix(backend): stop the dev-watch server from orphaning itself across rebuilds

### DIFF
--- a/platform/backend/tsdown.config.ts
+++ b/platform/backend/tsdown.config.ts
@@ -8,104 +8,113 @@ import { defineConfig, type UserConfig } from "tsdown";
 /** Max time to wait for the server process to exit gracefully before force killing */
 const PROCESS_EXIT_TIMEOUT_MS = 5000;
 
-/** Delay after SIGKILL to allow the process to fully terminate */
+/** Grace period after SIGKILL so stopServer still resolves if no exit event arrives */
 const POST_KILL_DELAY_MS = 100;
 
 /** Delay after process exit to ensure OS releases the ports */
 const PORT_RELEASE_DELAY_MS = 250;
 
-/**
- * Track the current server process so we can properly terminate it before starting a new one.
- * This prevents EADDRINUSE errors by ensuring the old process fully exits before the new one starts.
- */
 let currentServerProcess: ChildProcess | null = null;
 
 /**
- * Wait for the current server process to exit, with a timeout.
- * Returns a promise that resolves when the process exits or times out.
+ * Serializes server restarts. tsdown does not await onSuccess and debounces
+ * rebuilds with a bare setTimeout, so a burst of saves can invoke the handler
+ * re-entrantly. Chaining every invocation through one queue keeps kill→spawn
+ * atomic, so a later rebuild can never overwrite currentServerProcess while an
+ * earlier restart is mid-flight and orphan a server that keeps holding 9000/9050.
  */
-const waitForProcessExit = (
-  proc: ChildProcess,
-  timeoutMs = PROCESS_EXIT_TIMEOUT_MS,
-): Promise<void> => {
+let restartQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Terminate a server process and resolve once it has exited. Always resolves
+ * (via the exit event, or a bounded SIGKILL fallback) so a hung or already-dead
+ * child can never wedge restartQueue and strand the dev server.
+ */
+const stopServer = (proc: ChildProcess): Promise<void> => {
   return new Promise((resolve) => {
-    // If process already exited, resolve immediately
-    if (proc.exitCode !== null || proc.killed) {
+    // A child is already gone once exitCode (normal exit) OR signalCode (signal
+    // death, e.g. an OOM SIGKILL) is set. Node leaves exitCode null for a
+    // signal-terminated child, so checking exitCode alone would miss those and
+    // wait on an `exit` event that has already fired — hanging forever.
+    if (proc.exitCode !== null || proc.signalCode !== null) {
       resolve();
       return;
     }
-
-    const timeout = setTimeout(() => {
-      // Force kill if still running after timeout
-      if (proc.exitCode === null && !proc.killed) {
-        console.log("Server process did not exit in time, force killing...");
+    const forceKill = setTimeout(() => {
+      if (proc.exitCode === null && proc.signalCode === null) {
+        console.log("Server did not exit after SIGTERM, sending SIGKILL...");
         proc.kill("SIGKILL");
       }
-      // Give it a moment to die
+      // Resolve even if the exit event never arrives, so the queue can't wedge.
       setTimeout(resolve, POST_KILL_DELAY_MS);
-    }, timeoutMs);
-
+    }, PROCESS_EXIT_TIMEOUT_MS);
     proc.once("exit", () => {
-      clearTimeout(timeout);
+      clearTimeout(forceKill);
       resolve();
     });
+    proc.kill("SIGTERM");
   });
 };
 
 /**
- * Properly manage server process lifecycle.
- * Before starting a new server, we terminate and wait for the old one to fully exit.
- * This prevents EADDRINUSE errors on the metrics port (9050) and main port (9000).
+ * Restart the dev server: stop the previous one, wait for its ports to release,
+ * then spawn the freshly built server. Runs one-at-a-time via restartQueue.
  *
  * Set DEBUG=1 to enable Node.js inspector (e.g., DEBUG=1 pnpm dev)
  *
  * @see https://tsdown.dev/advanced/hooks
  */
-const onSuccessHandler: UserConfig["onSuccess"] = async () => {
-  // Kill and wait for the previous server to fully exit before starting a new one
-  if (currentServerProcess && currentServerProcess.exitCode === null) {
-    console.log("Stopping previous server...");
-    currentServerProcess.kill("SIGTERM");
-    await waitForProcessExit(currentServerProcess);
-
-    // Add a small delay to ensure OS releases the ports (EADDRINUSE prevention)
-    await new Promise((resolve) => setTimeout(resolve, PORT_RELEASE_DELAY_MS));
-
-    console.log("Previous server stopped");
-  }
-
-  const args = ["--enable-source-maps"];
-
-  if (process.env.DEBUG) {
-    args.push("--inspect");
-  }
-
-  args.push("dist/server.mjs");
-
-  // Use process.execPath (absolute path to Node.js binary) instead of "node" string
-  // for cross-platform compatibility. On Windows, spawn("node", ...) can fail if
-  // Node.js isn't in PATH or PATH resolution behaves differently. Using the absolute
-  // path bypasses PATH resolution entirely.
-  // Note: We intentionally avoid shell: true to prevent orphaned processes on Windows
-  // (shell creates cmd.exe as parent, making kill() ineffective on the actual server).
-  currentServerProcess = spawn(process.execPath, args, {
-    stdio: "inherit",
-  });
-
-  currentServerProcess.on("error", (err) => {
-    console.error("Server process error:", err);
-  });
-
-  currentServerProcess.on("exit", (code, signal) => {
-    if (signal) {
-      console.log(`Server process terminated by signal: ${signal}`);
-    } else if (code !== 0) {
-      console.error(`Server process exited with code: ${code}`);
+const onSuccessHandler: UserConfig["onSuccess"] = (_config, signal) => {
+  restartQueue = restartQueue.then(async () => {
+    if (currentServerProcess) {
+      console.log("Stopping previous server...");
+      await stopServer(currentServerProcess);
+      currentServerProcess = null;
+      // Give the OS a moment to release the listen sockets before rebinding.
+      await new Promise((resolve) =>
+        setTimeout(resolve, PORT_RELEASE_DELAY_MS),
+      );
     }
+
+    // tsdown aborts this build's signal when a newer rebuild starts; don't spawn
+    // a superseded server (the next queued restart owns the current build).
+    if (signal.aborted) {
+      return;
+    }
+
+    const args = ["--enable-source-maps"];
+
+    if (process.env.DEBUG) {
+      args.push("--inspect");
+    }
+
+    args.push("dist/server.mjs");
+
+    // Use process.execPath (absolute path to Node.js binary) instead of "node" string
+    // for cross-platform compatibility. On Windows, spawn("node", ...) can fail if
+    // Node.js isn't in PATH or PATH resolution behaves differently. Using the absolute
+    // path bypasses PATH resolution entirely.
+    // Note: We intentionally avoid shell: true to prevent orphaned processes on Windows
+    // (shell creates cmd.exe as parent, making kill() ineffective on the actual server).
+    const child = spawn(process.execPath, args, {
+      stdio: "inherit",
+    });
+    currentServerProcess = child;
+
+    child.on("error", (err) => {
+      console.error("Server process error:", err);
+    });
+
+    child.on("exit", (code, exitSignal) => {
+      if (exitSignal) {
+        console.log(`Server process terminated by signal: ${exitSignal}`);
+      } else if (code !== 0) {
+        console.error(`Server process exited with code: ${code}`);
+      }
+    });
   });
 
-  // Return immediately so tsdown can continue watching for changes
-  // The server runs in the background
+  return restartQueue;
 };
 
 export default defineConfig((options: UserConfig) => {

--- a/platform/backend/tsdown.config.ts
+++ b/platform/backend/tsdown.config.ts
@@ -26,6 +26,15 @@ let currentServerProcess: ChildProcess | null = null;
 let restartQueue: Promise<void> = Promise.resolve();
 
 /**
+ * Id of the most recent restart request. A queued restart only spawns while it
+ * is still the latest, so a burst of rebuilds collapses to a single spawn.
+ * tsdown calls onSuccess only for a build that succeeded, so a failed
+ * superseding build never bumps this — the last good build still spawns and the
+ * server is never left stranded down.
+ */
+let latestRestartId = 0;
+
+/**
  * Terminate a server process and resolve once it has exited. Always resolves
  * (via the exit event, or a bounded SIGKILL fallback) so a hung or already-dead
  * child can never wedge restartQueue and strand the dev server.
@@ -64,55 +73,69 @@ const stopServer = (proc: ChildProcess): Promise<void> => {
  *
  * @see https://tsdown.dev/advanced/hooks
  */
-const onSuccessHandler: UserConfig["onSuccess"] = (_config, signal) => {
-  restartQueue = restartQueue.then(async () => {
-    if (currentServerProcess) {
-      console.log("Stopping previous server...");
-      await stopServer(currentServerProcess);
-      currentServerProcess = null;
-      // Give the OS a moment to release the listen sockets before rebinding.
-      await new Promise((resolve) =>
-        setTimeout(resolve, PORT_RELEASE_DELAY_MS),
-      );
-    }
-
-    // tsdown aborts this build's signal when a newer rebuild starts; don't spawn
-    // a superseded server (the next queued restart owns the current build).
-    if (signal.aborted) {
-      return;
-    }
-
-    const args = ["--enable-source-maps"];
-
-    if (process.env.DEBUG) {
-      args.push("--inspect");
-    }
-
-    args.push("dist/server.mjs");
-
-    // Use process.execPath (absolute path to Node.js binary) instead of "node" string
-    // for cross-platform compatibility. On Windows, spawn("node", ...) can fail if
-    // Node.js isn't in PATH or PATH resolution behaves differently. Using the absolute
-    // path bypasses PATH resolution entirely.
-    // Note: We intentionally avoid shell: true to prevent orphaned processes on Windows
-    // (shell creates cmd.exe as parent, making kill() ineffective on the actual server).
-    const child = spawn(process.execPath, args, {
-      stdio: "inherit",
-    });
-    currentServerProcess = child;
-
-    child.on("error", (err) => {
-      console.error("Server process error:", err);
-    });
-
-    child.on("exit", (code, exitSignal) => {
-      if (exitSignal) {
-        console.log(`Server process terminated by signal: ${exitSignal}`);
-      } else if (code !== 0) {
-        console.error(`Server process exited with code: ${code}`);
+const onSuccessHandler: UserConfig["onSuccess"] = () => {
+  const restartId = ++latestRestartId;
+  restartQueue = restartQueue
+    .then(async () => {
+      // A newer build already queued its own restart: leave the running server
+      // up and let that restart own the swap. Skipping the kill keeps the old
+      // server serving until the winning build is ready to spawn.
+      if (restartId !== latestRestartId) {
+        return;
       }
+
+      if (currentServerProcess) {
+        console.log("Stopping previous server...");
+        await stopServer(currentServerProcess);
+        currentServerProcess = null;
+        // Give the OS a moment to release the listen sockets before rebinding.
+        await new Promise((resolve) =>
+          setTimeout(resolve, PORT_RELEASE_DELAY_MS),
+        );
+      }
+
+      // Re-check: a newer build may have landed while we were stopping the old
+      // server. Don't spawn a stale build over it.
+      if (restartId !== latestRestartId) {
+        return;
+      }
+
+      const args = ["--enable-source-maps"];
+
+      if (process.env.DEBUG) {
+        args.push("--inspect");
+      }
+
+      args.push("dist/server.mjs");
+
+      // Use process.execPath (absolute path to Node.js binary) instead of "node" string
+      // for cross-platform compatibility. On Windows, spawn("node", ...) can fail if
+      // Node.js isn't in PATH or PATH resolution behaves differently. Using the absolute
+      // path bypasses PATH resolution entirely.
+      // Note: We intentionally avoid shell: true to prevent orphaned processes on Windows
+      // (shell creates cmd.exe as parent, making kill() ineffective on the actual server).
+      const child = spawn(process.execPath, args, {
+        stdio: "inherit",
+      });
+      currentServerProcess = child;
+
+      child.on("error", (err) => {
+        console.error("Server process error:", err);
+      });
+
+      child.on("exit", (code, exitSignal) => {
+        if (exitSignal) {
+          console.log(`Server process terminated by signal: ${exitSignal}`);
+        } else if (code !== 0) {
+          console.error(`Server process exited with code: ${code}`);
+        }
+      });
+    })
+    .catch((error) => {
+      // A rejected restartQueue would skip every future rebuild's restart and
+      // strand the server, so a failed restart must not poison the chain.
+      console.error("Dev server restart failed:", error);
     });
-  });
 
   return restartQueue;
 };

--- a/platform/backend/tsdown.config.ts
+++ b/platform/backend/tsdown.config.ts
@@ -14,25 +14,46 @@ const POST_KILL_DELAY_MS = 100;
 /** Delay after process exit to ensure OS releases the ports */
 const PORT_RELEASE_DELAY_MS = 250;
 
-let currentServerProcess: ChildProcess | null = null;
+type DevServerState = {
+  /** The running server child, or null when none is up. */
+  current: ChildProcess | null;
+  /**
+   * Serializes restarts. tsdown does not await onSuccess and debounces rebuilds
+   * with a bare setTimeout, so a burst of saves can invoke the handler
+   * re-entrantly. Chaining every invocation through one queue keeps kill→spawn
+   * atomic, so a later rebuild can never overwrite `current` while an earlier
+   * restart is mid-flight and orphan a server that keeps holding 9000/9050.
+   */
+  restartQueue: Promise<void>;
+  /**
+   * Id of the most recent restart request. A queued restart only spawns while it
+   * is still the latest, so a burst of rebuilds collapses to a single spawn.
+   * tsdown calls onSuccess only for a build that succeeded, so a failed
+   * superseding build never bumps this — the last good build still spawns and
+   * the server is never left stranded down.
+   */
+  latestRestartId: number;
+};
 
 /**
- * Serializes server restarts. tsdown does not await onSuccess and debounces
- * rebuilds with a bare setTimeout, so a burst of saves can invoke the handler
- * re-entrantly. Chaining every invocation through one queue keeps kill→spawn
- * atomic, so a later rebuild can never overwrite currentServerProcess while an
- * earlier restart is mid-flight and orphan a server that keeps holding 9000/9050.
+ * Restart state is kept on globalThis so it survives a tsdown config self-reload:
+ * editing this file, tsconfig, or package.json makes tsdown clear the require
+ * cache and load a fresh copy of this module in the same process. A module-local
+ * handle would be lost on reload — orphaning the running server, then hitting
+ * EADDRINUSE on the next spawn. The process-global handle lets the reloaded
+ * module find and replace the server it inherited.
  */
-let restartQueue: Promise<void> = Promise.resolve();
-
-/**
- * Id of the most recent restart request. A queued restart only spawns while it
- * is still the latest, so a burst of rebuilds collapses to a single spawn.
- * tsdown calls onSuccess only for a build that succeeded, so a failed
- * superseding build never bumps this — the last good build still spawns and the
- * server is never left stranded down.
- */
-let latestRestartId = 0;
+const globalStore = globalThis as typeof globalThis & {
+  __archestraDevServer__?: DevServerState;
+};
+if (!globalStore.__archestraDevServer__) {
+  globalStore.__archestraDevServer__ = {
+    current: null,
+    restartQueue: Promise.resolve(),
+    latestRestartId: 0,
+  };
+}
+const devServer = globalStore.__archestraDevServer__;
 
 /**
  * Terminate a server process and resolve once it has exited. Always resolves
@@ -74,20 +95,20 @@ const stopServer = (proc: ChildProcess): Promise<void> => {
  * @see https://tsdown.dev/advanced/hooks
  */
 const onSuccessHandler: UserConfig["onSuccess"] = () => {
-  const restartId = ++latestRestartId;
-  restartQueue = restartQueue
+  const restartId = ++devServer.latestRestartId;
+  devServer.restartQueue = devServer.restartQueue
     .then(async () => {
       // A newer build already queued its own restart: leave the running server
       // up and let that restart own the swap. Skipping the kill keeps the old
       // server serving until the winning build is ready to spawn.
-      if (restartId !== latestRestartId) {
+      if (restartId !== devServer.latestRestartId) {
         return;
       }
 
-      if (currentServerProcess) {
+      if (devServer.current) {
         console.log("Stopping previous server...");
-        await stopServer(currentServerProcess);
-        currentServerProcess = null;
+        await stopServer(devServer.current);
+        devServer.current = null;
         // Give the OS a moment to release the listen sockets before rebinding.
         await new Promise((resolve) =>
           setTimeout(resolve, PORT_RELEASE_DELAY_MS),
@@ -96,7 +117,7 @@ const onSuccessHandler: UserConfig["onSuccess"] = () => {
 
       // Re-check: a newer build may have landed while we were stopping the old
       // server. Don't spawn a stale build over it.
-      if (restartId !== latestRestartId) {
+      if (restartId !== devServer.latestRestartId) {
         return;
       }
 
@@ -117,7 +138,7 @@ const onSuccessHandler: UserConfig["onSuccess"] = () => {
       const child = spawn(process.execPath, args, {
         stdio: "inherit",
       });
-      currentServerProcess = child;
+      devServer.current = child;
 
       child.on("error", (err) => {
         console.error("Server process error:", err);
@@ -137,7 +158,7 @@ const onSuccessHandler: UserConfig["onSuccess"] = () => {
       console.error("Dev server restart failed:", error);
     });
 
-  return restartQueue;
+  return devServer.restartQueue;
 };
 
 export default defineConfig((options: UserConfig) => {

--- a/platform/backend/tsdown.config.ts
+++ b/platform/backend/tsdown.config.ts
@@ -33,6 +33,13 @@ type DevServerState = {
    * the server is never left stranded down.
    */
   latestRestartId: number;
+  /**
+   * Bumped once per module load. A config self-reload (editing this file /
+   * tsconfig / package.json) loads a fresh module and runs rmSync(dist), so a
+   * restart still queued under the older generation must bail before it stops
+   * the server or spawns against the wiped dist — the fresh module owns it.
+   */
+  generation: number;
 };
 
 /**
@@ -51,9 +58,14 @@ if (!globalStore.__archestraDevServer__) {
     current: null,
     restartQueue: Promise.resolve(),
     latestRestartId: 0,
+    generation: 0,
   };
 }
 const devServer = globalStore.__archestraDevServer__;
+
+// Identify this module load; a later config self-reload gets a higher generation.
+devServer.generation += 1;
+const configGeneration = devServer.generation;
 
 /**
  * Terminate a server process and resolve once it has exited. Always resolves
@@ -98,10 +110,14 @@ const onSuccessHandler: UserConfig["onSuccess"] = () => {
   const restartId = ++devServer.latestRestartId;
   devServer.restartQueue = devServer.restartQueue
     .then(async () => {
-      // A newer build already queued its own restart: leave the running server
-      // up and let that restart own the swap. Skipping the kill keeps the old
-      // server serving until the winning build is ready to spawn.
-      if (restartId !== devServer.latestRestartId) {
+      // Skip if a newer build already queued its own restart, or a config
+      // self-reload superseded this module. Either way, leave the running server
+      // up and let the winner own the swap — the old server keeps serving until
+      // the winning build is ready to spawn.
+      if (
+        restartId !== devServer.latestRestartId ||
+        configGeneration !== devServer.generation
+      ) {
         return;
       }
 
@@ -115,9 +131,13 @@ const onSuccessHandler: UserConfig["onSuccess"] = () => {
         );
       }
 
-      // Re-check: a newer build may have landed while we were stopping the old
-      // server. Don't spawn a stale build over it.
-      if (restartId !== devServer.latestRestartId) {
+      // Re-check: a newer build or a config reload may have landed while we were
+      // stopping the old server. Don't spawn a stale build (or one whose dist the
+      // reload wiped) over it.
+      if (
+        restartId !== devServer.latestRestartId ||
+        configGeneration !== devServer.generation
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Summary

During a long local dev session the backend could end up with a stale or duplicate `node dist/server.mjs`: code changes silently stopped taking effect, and orphaned servers accumulated. The tsdown watch-mode `onSuccess` handler tracked the running server in a module-local handle and respawned as soon as it had *sent* SIGTERM. But a server that catches SIGTERM closes its listen sockets first and exits last, so the new server grabbed the freed ports while the half-dead old one lived on, and rapid or config-triggered rebuilds could lose the handle entirely.

This reworks the respawn lifecycle so exactly one server runs and it always reflects the latest successful build:

- Wait for the real `exit` event (with a bounded SIGKILL fallback) before rebinding, and treat `signalCode` as exited so a child that dies by signal (e.g. an OOM SIGKILL) can't hang the restart queue forever.
- Serialize restarts through one queue and coalesce a burst of rebuilds to a single spawn, keyed on a per-invocation id. Because tsdown fires `onSuccess` only for a build that succeeded, a superseding build that fails to compile no longer strands the last good build down.
- Keep the restart state on `globalThis` and stamp each module load with a generation, so a tsdown config self-reload — editing `tsdown.config.ts`, `tsconfig`, or `package.json` wipes `dist` and loads a fresh copy of this module — inherits the running-server handle and replaces it, instead of orphaning it and hitting EADDRINUSE on the next spawn.

Net effect: rebuilds during local development leave a single server bound to 9000/9050 that serves the latest code, with no accumulating orphans.

Known limitation: if a restart stops the running server exactly as a config reload lands and the new config then fails to build, the dev server stays down until the config builds again. This is inherent to a single-port, kill-before-spawn model while the config is actively broken.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>