### PR TITLE
fix(archestra-mcp): attribute created agents/gateways/proxies to the calling user

### DIFF
--- a/platform/backend/src/archestra-mcp-server/agent-resources.ts
+++ b/platform/backend/src/archestra-mcp-server/agent-resources.ts
@@ -318,10 +318,7 @@ export async function handleCreateResource<
       if (args.icon) createParams.icon = args.icon;
     }
 
-    const created = await AgentModel.create(
-      createParams,
-      scope === "personal" ? context.userId : undefined,
-    );
+    const created = await AgentModel.create(createParams, context.userId);
 
     const toolAssignmentResults =
       targetAgentType === "agent" && (args.toolAssignments?.length ?? 0) > 0

--- a/platform/backend/src/archestra-mcp-server/agents.test.ts
+++ b/platform/backend/src/archestra-mcp-server/agents.test.ts
@@ -51,6 +51,23 @@ describe("agent tool execution", () => {
     expect((result.content[0] as any).text).toContain("New Test Agent");
   });
 
+  test("create_agent attributes the calling user as author for org-scoped agents", async () => {
+    const result = await executeArchestraTool(
+      `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}create_agent`,
+      { name: "Org Scoped Agent", scope: "org" },
+      mockContext,
+    );
+    expect(result.isError).toBe(false);
+
+    const created = await AgentModel.findById(
+      extractCreatedId(result),
+      mockContext.userId,
+      true,
+    );
+    expect(created?.scope).toBe("org");
+    expect(created?.authorId).toBe(mockContext.userId);
+  });
+
   test("create_agent persists toolExposureMode", async () => {
     const result = await executeArchestraTool(
       `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}create_agent`,

--- a/platform/backend/src/archestra-mcp-server/llm-proxies.test.ts
+++ b/platform/backend/src/archestra-mcp-server/llm-proxies.test.ts
@@ -40,6 +40,24 @@ describe("llm proxy tool execution", () => {
     );
   });
 
+  test("create_llm_proxy attributes the calling user as author", async () => {
+    const result = await executeArchestraTool(
+      `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}create_llm_proxy`,
+      { name: "Attributed LLM Proxy" },
+      mockContext,
+    );
+
+    expect(result.isError).toBe(false);
+
+    const created = await AgentModel.findById(
+      extractCreatedId(result),
+      mockContext.userId,
+      true,
+    );
+    expect(created?.scope).toBe("org");
+    expect(created?.authorId).toBe(mockContext.userId);
+  });
+
   test("edit_llm_proxy updates an llm proxy successfully", async ({
     makeAgent,
   }) => {
@@ -80,3 +98,18 @@ describe("llm proxy tool execution", () => {
     );
   });
 });
+
+function extractCreatedId(
+  result: Awaited<ReturnType<typeof executeArchestraTool>>,
+) {
+  const createdId = ((result.content[0] as any).text as string)
+    .split("\n")
+    .find((line) => line.startsWith("ID: "))
+    ?.replace("ID: ", "");
+
+  if (!createdId) {
+    throw new Error("Expected created resource id in tool output");
+  }
+
+  return createdId;
+}

--- a/platform/backend/src/archestra-mcp-server/mcp-gateways.test.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-gateways.test.ts
@@ -40,6 +40,24 @@ describe("mcp gateway tool execution", () => {
     );
   });
 
+  test("create_mcp_gateway attributes the calling user as author", async () => {
+    const result = await executeArchestraTool(
+      `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}create_mcp_gateway`,
+      { name: "Attributed Gateway" },
+      mockContext,
+    );
+
+    expect(result.isError).toBe(false);
+
+    const created = await AgentModel.findById(
+      extractCreatedId(result),
+      mockContext.userId,
+      true,
+    );
+    expect(created?.scope).toBe("org");
+    expect(created?.authorId).toBe(mockContext.userId);
+  });
+
   test("create_mcp_gateway assigns knowledge bases and connectors", async ({
     makeKnowledgeBase,
     makeKnowledgeBaseConnector,


### PR DESCRIPTION
## Problem

When a model/agent creates entities through the built-in Archestra MCP tools (`create_agent`, `create_mcp_gateway`, `create_llm_proxy`), the created entity is not attributed to the user who invoked the tool. The UI then falls back to showing the white-label app name ("Archestra") as the creator.

## Root cause

The shared create handler (`handleCreateResource` in `backend/src/archestra-mcp-server/agent-resources.ts`) only forwarded `context.userId` as the author **when `scope === "personal"`**:

```ts
const created = await AgentModel.create(
  createParams,
  scope === "personal" ? context.userId : undefined,
);
```

`create_mcp_gateway` and `create_llm_proxy` default to `org` scope (and `create_agent` can be org/team-scoped), so those rows were inserted with `authorId = NULL` → `authorName = null` → the frontend's `authorName ?? appName` fallback rendered the app name.

The calling user *is* available on the context: the MCP Gateway resolves the Bearer token to a user and passes `userId` into `executeArchestraTool`. The REST create endpoint (`routes/agent.ts`) already passes `user.id` unconditionally — this was the lone outlier (every other built-in create handler, e.g. apps/skills/teams/mcp-servers, already sets `context.userId` unconditionally).

## Fix

Pass `context.userId` unconditionally, matching the REST endpoint. `AgentModel.create` already guards with `...(authorId && { authorId })`, so org/team tokens that carry no user still yield a NULL author as before.

## Tests

Added regression tests in each affected tool suite asserting `authorId` equals the calling user for non-personal-scope creations (org-scoped gateway/llm-proxy defaults, and explicit `scope: "org"` for agents). Verified each fails without the fix.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>