### PR TITLE
feat(agents): choose the clone's visibility when cloning an agent / MCP gateway / LLM proxy

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -43797,7 +43797,36 @@
         "tags": [
           "Agents"
         ],
-        "description": "Clone an agent and all its associations\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\nNone (no additional RBAC permission required)",
+        "description": "Clone an agent and all its associations. Optionally override the clone's visibility (scope/teams); by default the source's visibility is copied.\n\nAuthentication:\n\nRequired. Use an authenticated browser session or send your Archestra API key in the `Authorization` header.\n\nAuthorization:\n\nNone (no additional RBAC permission required)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "description": "Visibility of the clone. Defaults to the source agent's scope.",
+                    "type": "string",
+                    "enum": [
+                      "personal",
+                      "team",
+                      "org"
+                    ]
+                  },
+                  "teams": {
+                    "description": "Teams for a team-scoped clone. Defaults to the source agent's teams. Ignored unless the clone's scope resolves to 'team'.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "parameters": [
           {
             "schema": {

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -2831,6 +2831,10 @@ class AgentModel {
   static async cloneAgent(params: {
     sourceId: string;
     userId: string;
+    /** Visibility for the clone; defaults to copying the source's scope. */
+    scope?: AgentScope;
+    /** Teams for a team-scoped clone; defaults to the source's teams. */
+    teams?: string[];
   }): Promise<Agent> {
     const { sourceId, userId } = params;
 
@@ -2839,9 +2843,12 @@ class AgentModel {
       throw new Error("Source agent not found");
     }
 
+    const cloneScope = params.scope ?? sourceAgent.scope;
     // Omit teams if scope is not 'team' — scope takes precedence
     const cloneTeams =
-      sourceAgent.scope === "team" ? sourceAgent.teams.map((t) => t.id) : [];
+      cloneScope === "team"
+        ? (params.teams ?? sourceAgent.teams.map((t) => t.id))
+        : [];
 
     let created: Agent | null = null;
     try {
@@ -2849,7 +2856,7 @@ class AgentModel {
         {
           organizationId: sourceAgent.organizationId,
           agentType: sourceAgent.agentType,
-          scope: sourceAgent.scope,
+          scope: cloneScope,
           teams: cloneTeams,
           labels: sourceAgent.labels,
           knowledgeBaseIds: sourceAgent.knowledgeBaseIds ?? [],
@@ -2873,7 +2880,7 @@ class AgentModel {
           identityProviderId: null,
           passthroughHeaders: null,
         },
-        sourceAgent.scope === "personal" ? userId : undefined,
+        cloneScope === "personal" ? userId : undefined,
         // Copy the source's assignments verbatim below; don't let create's
         // default assignment force built-ins the source lacked onto the clone.
         { skipCreationDefaultTools: true },

--- a/platform/backend/src/routes/agent.clone.test.ts
+++ b/platform/backend/src/routes/agent.clone.test.ts
@@ -423,6 +423,219 @@ describe("clone agent route", () => {
     );
   });
 
+  test("overrides visibility to personal and clears teams", async ({
+    makeInternalAgent,
+    makeTeam,
+  }) => {
+    const team = await makeTeam(organizationId, user.id);
+    const sourceAgent = await makeInternalAgent({
+      organizationId,
+      name: "Team Agent",
+      scope: "team",
+      teams: [team.id],
+      labels: [],
+      knowledgeBaseIds: [],
+      connectorIds: [],
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/agents/${sourceAgent.id}/clone`,
+      payload: { scope: "personal" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const cloned = response.json() as Agent;
+
+    expect(cloned.scope).toBe("personal");
+    expect(cloned.teams).toEqual([]);
+    // A personal clone is owned by the user who cloned it
+    expect(cloned.authorId).toBe(user.id);
+  });
+
+  test("overrides visibility to org", async ({ makeInternalAgent }) => {
+    const sourceAgent = await makeInternalAgent({
+      organizationId,
+      name: "Personal Agent",
+      scope: "personal",
+      authorId: user.id,
+      teams: [],
+      labels: [],
+      knowledgeBaseIds: [],
+      connectorIds: [],
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/agents/${sourceAgent.id}/clone`,
+      payload: { scope: "org" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const cloned = response.json() as Agent;
+
+    expect(cloned.scope).toBe("org");
+    expect(cloned.teams).toEqual([]);
+  });
+
+  test("overrides visibility to team with explicit teams", async ({
+    makeInternalAgent,
+    makeTeam,
+  }) => {
+    const team = await makeTeam(organizationId, user.id);
+    const sourceAgent = await makeInternalAgent({
+      organizationId,
+      name: "Personal Agent",
+      scope: "personal",
+      authorId: user.id,
+      teams: [],
+      labels: [],
+      knowledgeBaseIds: [],
+      connectorIds: [],
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/agents/${sourceAgent.id}/clone`,
+      payload: { scope: "team", teams: [team.id] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const cloned = response.json() as Agent;
+
+    expect(cloned.scope).toBe("team");
+    expect(cloned.teams.map((t) => t.id)).toEqual([team.id]);
+  });
+
+  test("empty body copies the source's visibility (backward compatible)", async ({
+    makeInternalAgent,
+    makeTeam,
+  }) => {
+    const team = await makeTeam(organizationId, user.id);
+    const sourceAgent = await makeInternalAgent({
+      organizationId,
+      name: "Team Agent",
+      scope: "team",
+      teams: [team.id],
+      labels: [],
+      knowledgeBaseIds: [],
+      connectorIds: [],
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/agents/${sourceAgent.id}/clone`,
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    const cloned = response.json() as Agent;
+
+    expect(cloned.scope).toBe("team");
+    expect(cloned.teams.map((t) => t.id)).toEqual([team.id]);
+  });
+
+  test("non-admin cannot clone to org scope", async ({ makeInternalAgent }) => {
+    const sourceAgent = await makeInternalAgent({
+      organizationId,
+      name: "Personal Agent",
+      scope: "personal",
+      authorId: user.id,
+      teams: [],
+      labels: [],
+      knowledgeBaseIds: [],
+      connectorIds: [],
+    });
+
+    mockGetAgentTypePermissionChecker.mockResolvedValueOnce({
+      require: vi.fn(),
+      isAdmin: vi.fn().mockReturnValue(false),
+      isTeamAdmin: vi.fn().mockReturnValue(true),
+      hasAnyReadPermission: vi.fn().mockReturnValue(true),
+      hasAnyAdminPermission: vi.fn().mockReturnValue(false),
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/agents/${sourceAgent.id}/clone`,
+      payload: { scope: "org" },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  test("non-admin team-admin can only assign teams they are a member of", async ({
+    makeInternalAgent,
+    makeTeam,
+  }) => {
+    // User is not a member of this team
+    const team = await makeTeam(organizationId, user.id);
+    const sourceAgent = await makeInternalAgent({
+      organizationId,
+      name: "Personal Agent",
+      scope: "personal",
+      authorId: user.id,
+      teams: [],
+      labels: [],
+      knowledgeBaseIds: [],
+      connectorIds: [],
+    });
+
+    mockGetAgentTypePermissionChecker.mockResolvedValueOnce({
+      require: vi.fn(),
+      isAdmin: vi.fn().mockReturnValue(false),
+      isTeamAdmin: vi.fn().mockReturnValue(true),
+      hasAnyReadPermission: vi.fn().mockReturnValue(true),
+      hasAnyAdminPermission: vi.fn().mockReturnValue(false),
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/agents/${sourceAgent.id}/clone`,
+      payload: { scope: "team", teams: [team.id] },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  test("non-admin team-admin can clone to a team they belong to", async ({
+    makeInternalAgent,
+    makeTeam,
+    makeTeamMember,
+  }) => {
+    const team = await makeTeam(organizationId, user.id);
+    await makeTeamMember(team.id, user.id, { role: "member" });
+    const sourceAgent = await makeInternalAgent({
+      organizationId,
+      name: "Personal Agent",
+      scope: "personal",
+      authorId: user.id,
+      teams: [],
+      labels: [],
+      knowledgeBaseIds: [],
+      connectorIds: [],
+    });
+
+    mockGetAgentTypePermissionChecker.mockResolvedValueOnce({
+      require: vi.fn(),
+      isAdmin: vi.fn().mockReturnValue(false),
+      isTeamAdmin: vi.fn().mockReturnValue(true),
+      hasAnyReadPermission: vi.fn().mockReturnValue(true),
+      hasAnyAdminPermission: vi.fn().mockReturnValue(false),
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/agents/${sourceAgent.id}/clone`,
+      payload: { scope: "team", teams: [team.id] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const cloned = response.json() as Agent;
+    expect(cloned.scope).toBe("team");
+    expect(cloned.teams.map((t) => t.id)).toEqual([team.id]);
+  });
+
   test("clones all three built-in agent types", async ({
     makeInternalAgent,
   }) => {

--- a/platform/backend/src/routes/agent.ts
+++ b/platform/backend/src/routes/agent.ts
@@ -36,6 +36,7 @@ import {
   AgentToolExclusionsSchema,
   ApiError,
   BuiltInAgentConfigSchema,
+  CloneAgentBodySchema,
   constructResponseSchema,
   createSortingQuerySchema,
   DeleteObjectResponseSchema,
@@ -591,15 +592,19 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
     {
       schema: {
         operationId: RouteId.CloneAgent,
-        description: "Clone an agent and all its associations",
+        description:
+          "Clone an agent and all its associations. Optionally override the clone's visibility (scope/teams); by default the source's visibility is copied.",
         tags: ["Agents"],
         params: z.object({
           id: UuidIdSchema,
         }),
+        // Nullish so pre-existing clients that POST without a payload keep
+        // working (an empty body arrives as null)
+        body: CloneAgentBodySchema.nullish(),
         response: constructResponseSchema(SelectAgentSchema),
       },
     },
-    async ({ params: { id }, user, organizationId }, reply) => {
+    async ({ params: { id }, body, user, organizationId }, reply) => {
       // Fetch agent first to determine its type for permission checks
       const sourceAgent = await AgentModel.findById(id, user.id, true);
       if (!sourceAgent) {
@@ -645,6 +650,36 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
         userTeamIds,
         userId: user.id,
       });
+
+      // The clone is a new agent, so an explicitly requested visibility is
+      // validated like agent creation (mirrors POST /api/agents).
+      const targetScope = body?.scope ?? sourceAgent.scope;
+      const requestedTeams = body?.teams ?? [];
+      if (!checker.isAdmin(sourceAgent.agentType)) {
+        if (targetScope === "org") {
+          throw new ApiError(403, "Only admins can create org-scoped agents");
+        }
+        if (targetScope === "team" || requestedTeams.length > 0) {
+          if (!checker.isTeamAdmin(sourceAgent.agentType)) {
+            throw new ApiError(
+              403,
+              "You need team-admin permission to create team-scoped agents",
+            );
+          }
+
+          // team-admin can only assign teams they are a member of
+          const userTeamIdSet = new Set(userTeamIds);
+          const invalidTeams = requestedTeams.filter(
+            (teamId) => !userTeamIdSet.has(teamId),
+          );
+          if (invalidTeams.length > 0) {
+            throw new ApiError(
+              403,
+              "You can only assign teams you are a member of",
+            );
+          }
+        }
+      }
 
       // Validate knowledgeBaseIds if provided
       if ((sourceAgent.knowledgeBaseIds?.length ?? 0) > 0) {
@@ -694,6 +729,8 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const clonedAgent = await AgentModel.cloneAgent({
         sourceId: sourceAgent.id,
         userId: user.id,
+        scope: body?.scope,
+        teams: body?.teams,
       });
 
       return reply.send(clonedAgent);

--- a/platform/backend/src/types/agent.ts
+++ b/platform/backend/src/types/agent.ts
@@ -331,6 +331,18 @@ export const UpdateAgentSchema = UpdateAgentSchemaBase.superRefine(
   validateIncomingEmailDomain,
 );
 
+export const CloneAgentBodySchema = z.object({
+  scope: AgentScopeSchema.optional().describe(
+    "Visibility of the clone. Defaults to the source agent's scope.",
+  ),
+  teams: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Teams for a team-scoped clone. Defaults to the source agent's teams. Ignored unless the clone's scope resolves to 'team'.",
+    ),
+});
+
 export type Agent = z.infer<typeof SelectAgentSchema>;
 export type AgentAccessContext = Pick<
   Agent,

--- a/platform/frontend/src/app/agents/agent-actions.tsx
+++ b/platform/frontend/src/app/agents/agent-actions.tsx
@@ -29,7 +29,7 @@ type AgentActionsProps = {
   onView: (agent: Agent) => void;
   onDelete: (agentId: string) => void;
   onRestore: (agentId: string) => void;
-  onClone: (agentId: string) => void;
+  onClone: (agent: Agent) => void;
   onExport: (agent: Agent) => void;
   onConvertToSkill: (agent: Agent) => void;
 };
@@ -130,7 +130,7 @@ export function AgentActions({
         ? "Built-in agents cannot be cloned"
         : undefined,
       permissions: { agent: ["create"] },
-      onClick: () => onClone(agent.id),
+      onClick: () => onClone(agent),
       testId: `${E2eTestId.CloneAgentButton}-${agent.name}`,
     },
     {

--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -20,6 +20,7 @@ import {
   AgentDeletedStatusFilter,
   AgentScopeFilter,
 } from "@/components/agent-scope-filter";
+import { CloneAgentDialog } from "@/components/clone-agent-dialog";
 import {
   ConnectDialog,
   ConnectDialogSection,
@@ -37,7 +38,6 @@ import { DataTable } from "@/components/ui/data-table";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { DEFAULT_SORT_BY, DEFAULT_SORT_DIRECTION } from "@/consts";
 import {
-  useCloneAgent,
   useDeleteProfile,
   useExportAgent,
   useProfile,
@@ -201,20 +201,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
   const viewDialog = useAgentDialogUrlParam("view");
   const [deletingAgentId, setDeletingAgentId] = useState<string | null>(null);
 
-  const cloneAgent = useCloneAgent();
-
-  const handleClone = useCallback(
-    async (agentId: string) => {
-      try {
-        const cloned = await cloneAgent.mutateAsync(agentId);
-        if (cloned) {
-          // Open edit dialog for the cloned agent so user can rename immediately
-          editDialog.open(cloned as AgentData);
-        }
-      } catch (_error) {}
-    },
-    [cloneAgent, editDialog.open],
-  );
+  const [cloningAgent, setCloningAgent] = useState<AgentData | null>(null);
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const exportAgent = useExportAgent();
   const restoreAgent = useRestoreProfile();
@@ -383,7 +370,7 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
                 },
               });
             }}
-            onClone={handleClone}
+            onClone={setCloningAgent}
             onConvertToSkill={setConvertingAgent}
             onExport={(agentData) => {
               exportAgent.mutate(agentData.id, {
@@ -565,6 +552,17 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
               agent={convertingAgent}
               onOpenChange={(open) => {
                 if (!open) setConvertingAgent(null);
+              }}
+            />
+
+            <CloneAgentDialog
+              agent={cloningAgent}
+              onOpenChange={(open) => {
+                if (!open) setCloningAgent(null);
+              }}
+              onCloned={(cloned) => {
+                // Open edit dialog for the cloned agent so user can rename immediately
+                editDialog.open(cloned as AgentData);
               }}
             />
           </div>

--- a/platform/frontend/src/app/llm/proxies/llm-proxy-actions.tsx
+++ b/platform/frontend/src/app/llm/proxies/llm-proxy-actions.tsx
@@ -1,5 +1,5 @@
 import { E2eTestId } from "@archestra/shared";
-import { Pencil, Plug, RotateCcw, Trash2 } from "lucide-react";
+import { Copy, Pencil, Plug, RotateCcw, Trash2 } from "lucide-react";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { PermissionButton } from "@/components/ui/permission-button";
 import type { useProfilesPaginated } from "@/lib/agent.query";
@@ -16,6 +16,7 @@ type LlmProxyActionsProps = {
   onEdit: (agent: Proxy) => void;
   onDelete: (agentId: string) => void;
   onRestore: (agentId: string) => void;
+  onClone: (agent: Proxy) => void;
 };
 
 export function LlmProxyActions({
@@ -25,6 +26,7 @@ export function LlmProxyActions({
   onEdit,
   onDelete,
   onRestore,
+  onClone,
 }: LlmProxyActionsProps) {
   if (agent.deletedAt) {
     return (
@@ -74,6 +76,19 @@ export function LlmProxyActions({
         }}
       >
         <Pencil className="h-4 w-4" />
+      </PermissionButton>
+      <PermissionButton
+        permissions={{ llmProxy: ["create"] }}
+        aria-label="Clone"
+        variant="outline"
+        size="icon-sm"
+        data-testid={`${E2eTestId.CloneAgentButton}-${agent.name}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClone(agent);
+        }}
+      >
+        <Copy className="h-4 w-4" />
       </PermissionButton>
       <PermissionButton
         permissions={{ llmProxy: ["delete"] }}

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -15,6 +15,7 @@ import {
   AgentDeletedStatusFilter,
   AgentScopeFilter,
 } from "@/components/agent-scope-filter";
+import { CloneAgentDialog } from "@/components/clone-agent-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
@@ -198,6 +199,7 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
   );
   const editDialog = useAgentDialogUrlParam("edit");
   const [deletingProxyId, setDeletingProxyId] = useState<string | null>(null);
+  const [cloningProxy, setCloningProxy] = useState<ProxyData | null>(null);
   const restoreProxy = useRestoreProfile();
 
   const handleSortingChange = useCallback(
@@ -348,6 +350,7 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
                 },
               });
             }}
+            onClone={setCloningProxy}
           />
         );
       },
@@ -498,6 +501,17 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
                 onOpenChange={(open) => !open && setDeletingProxyId(null)}
               />
             )}
+
+            <CloneAgentDialog
+              agent={cloningProxy}
+              onOpenChange={(open) => {
+                if (!open) setCloningProxy(null);
+              }}
+              onCloned={(cloned) => {
+                // Open edit dialog for the clone so user can rename immediately
+                editDialog.open(cloned as ProxyData);
+              }}
+            />
           </div>
         </div>
       </PageLayout>

--- a/platform/frontend/src/app/mcp/gateways/mcp-gateway-actions.tsx
+++ b/platform/frontend/src/app/mcp/gateways/mcp-gateway-actions.tsx
@@ -1,5 +1,5 @@
 import { E2eTestId } from "@archestra/shared";
-import { Pencil, Plug, RotateCcw, Trash2 } from "lucide-react";
+import { Copy, Pencil, Plug, RotateCcw, Trash2 } from "lucide-react";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { PermissionButton } from "@/components/ui/permission-button";
 import type { useProfilesPaginated } from "@/lib/agent.query";
@@ -16,6 +16,7 @@ type McpGatewayActionsProps = {
   onEdit: (agent: Gateway) => void;
   onDelete: (agentId: string) => void;
   onRestore: (agentId: string) => void;
+  onClone: (agent: Gateway) => void;
 };
 
 export function McpGatewayActions({
@@ -25,6 +26,7 @@ export function McpGatewayActions({
   onEdit,
   onDelete,
   onRestore,
+  onClone,
 }: McpGatewayActionsProps) {
   if (agent.deletedAt) {
     return (
@@ -74,6 +76,19 @@ export function McpGatewayActions({
         }}
       >
         <Pencil className="h-4 w-4" />
+      </PermissionButton>
+      <PermissionButton
+        permissions={{ mcpGateway: ["create"] }}
+        aria-label="Clone"
+        variant="outline"
+        size="icon-sm"
+        data-testid={`${E2eTestId.CloneAgentButton}-${agent.name}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClone(agent);
+        }}
+      >
+        <Copy className="h-4 w-4" />
       </PermissionButton>
       <PermissionButton
         permissions={{ mcpGateway: ["delete"] }}

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -15,6 +15,7 @@ import {
   AgentDeletedStatusFilter,
   AgentScopeFilter,
 } from "@/components/agent-scope-filter";
+import { CloneAgentDialog } from "@/components/clone-agent-dialog";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
 import { ExternalDocsLink } from "@/components/external-docs-link";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
@@ -217,6 +218,9 @@ function McpGateways({
   );
   const editDialog = useAgentDialogUrlParam("edit");
   const [deletingGatewayId, setDeletingGatewayId] = useState<string | null>(
+    null,
+  );
+  const [cloningGateway, setCloningGateway] = useState<GatewayData | null>(
     null,
   );
   const restoreGateway = useRestoreProfile();
@@ -436,6 +440,7 @@ function McpGateways({
                 },
               });
             }}
+            onClone={setCloningGateway}
           />
         );
       },
@@ -626,6 +631,17 @@ function McpGateways({
                 onOpenChange={(open) => !open && setDeletingGatewayId(null)}
               />
             )}
+
+            <CloneAgentDialog
+              agent={cloningGateway}
+              onOpenChange={(open) => {
+                if (!open) setCloningGateway(null);
+              }}
+              onCloned={(cloned) => {
+                // Open edit dialog for the clone so user can rename immediately
+                editDialog.open(cloned as GatewayData);
+              }}
+            />
           </div>
         </div>
       </PageLayout>

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -412,7 +412,7 @@ function getSuccessMessage(agentType: AgentType, isUpdate: boolean): string {
   return isUpdate ? messages[agentType].update : messages[agentType].create;
 }
 
-const agentTypeDisplayName: Record<string, string> = {
+export const agentTypeDisplayName: Record<string, string> = {
   agent: "agent",
   mcp_gateway: "MCP Gateway",
   llm_proxy: "LLM Proxy",
@@ -443,7 +443,7 @@ function getScopeOptions(agentType: string) {
   ];
 }
 
-function AccessLevelSelector({
+export function AccessLevelSelector({
   scope,
   onScopeChange,
   isAdmin,

--- a/platform/frontend/src/components/clone-agent-dialog.tsx
+++ b/platform/frontend/src/components/clone-agent-dialog.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import {
+  type AgentScope,
+  type archestraApiTypes,
+  getResourceForAgentType,
+} from "@archestra/shared";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+  AccessLevelSelector,
+  agentTypeDisplayName,
+} from "@/components/agent-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogForm,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCloneAgent } from "@/lib/agent.query";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useAssignableTeams } from "@/lib/teams/team.query";
+
+type CloneSourceAgent = Pick<
+  archestraApiTypes.GetAgentsResponses["200"]["data"][number],
+  "id" | "name" | "agentType" | "scope" | "teams"
+>;
+
+type CloneAgentDialogProps = {
+  /** Agent / MCP gateway / LLM proxy to clone; null keeps the dialog closed. */
+  agent: CloneSourceAgent | null;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the newly created clone (e.g. to open its edit dialog). */
+  onCloned?: (cloned: archestraApiTypes.CloneAgentResponses["200"]) => void;
+};
+
+/**
+ * Confirms a clone and lets the user pick the copy's visibility before it is
+ * created. Defaults to the source's visibility, downgraded to "personal" when
+ * the user lacks the permission to recreate it (the clone is a new object, so
+ * the same rules as creation apply).
+ */
+export function CloneAgentDialog({
+  agent,
+  onOpenChange,
+  onCloned,
+}: CloneAgentDialogProps) {
+  const cloneAgent = useCloneAgent();
+
+  const resource = getResourceForAgentType(agent?.agentType ?? "agent");
+  const { data: canReadTeams } = useHasPermissions({ team: ["read"] });
+  const { data: isAdmin } = useHasPermissions({ [resource]: ["admin"] });
+  const { data: isTeamAdmin } = useHasPermissions({
+    [resource]: ["team-admin"],
+  });
+  // Picker offers all teams to a full resource-admin, otherwise only the teams
+  // the user belongs to (the only ones the backend lets a team-admin assign).
+  const { data: teams } = useAssignableTeams({
+    isResourceAdmin: !!isAdmin,
+    enabled: agent !== null && !!canReadTeams,
+  });
+
+  const [scope, setScope] = useState<AgentScope>("personal");
+  const [teamIds, setTeamIds] = useState<string[]>([]);
+
+  // Start from the source's visibility whenever a new agent is picked
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset only when the target changes
+  useEffect(() => {
+    if (!agent) return;
+    setScope(agent.scope);
+    setTeamIds(agent.teams.map((team) => team.id));
+  }, [agent?.id]);
+
+  // Fall back to personal when the source's visibility isn't one the user can
+  // grant to a new object (permission data resolves asynchronously)
+  useEffect(() => {
+    if (isAdmin === undefined || isTeamAdmin === undefined) return;
+    setScope((prev) => {
+      if (prev === "org" && !isAdmin) return "personal";
+      if (prev === "team" && !isAdmin && !isTeamAdmin) return "personal";
+      return prev;
+    });
+  }, [isAdmin, isTeamAdmin]);
+
+  // Drop preselected teams the user cannot assign (the backend rejects them)
+  useEffect(() => {
+    if (!teams) return;
+    const assignable = new Set(teams.map((team) => team.id));
+    setTeamIds((prev) => prev.filter((id) => assignable.has(id)));
+  }, [teams]);
+
+  const handleSubmit = async () => {
+    if (!agent) return;
+    if (!isAdmin && scope === "team" && teamIds.length === 0) {
+      toast.error("Please select at least one team");
+      return;
+    }
+    try {
+      const cloned = await cloneAgent.mutateAsync({
+        id: agent.id,
+        scope,
+        teams: scope === "team" ? teamIds : [],
+      });
+      if (cloned) {
+        onOpenChange(false);
+        onCloned?.(cloned);
+      }
+    } catch (_error) {
+      // The mutation already surfaced the API error as a toast
+    }
+  };
+
+  const displayName = agentTypeDisplayName[agent?.agentType ?? "agent"];
+
+  return (
+    <Dialog open={agent !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Clone {displayName}</DialogTitle>
+          <DialogDescription>
+            {agent
+              ? `Creates a copy of "${agent.name}" with the same configuration.`
+              : null}
+          </DialogDescription>
+        </DialogHeader>
+
+        {agent ? (
+          <DialogForm onSubmit={handleSubmit}>
+            <DialogBody>
+              <AccessLevelSelector
+                scope={scope}
+                onScopeChange={setScope}
+                isAdmin={!!isAdmin}
+                isTeamAdmin={!!isTeamAdmin}
+                canReadTeams={!!canReadTeams}
+                agentType={agent.agentType}
+                teams={teams}
+                assignedTeamIds={teamIds}
+                onTeamIdsChange={setTeamIds}
+                hasNoAvailableTeams={!teams || teams.length === 0}
+                showTeamRequired={!isAdmin && scope === "team"}
+              />
+            </DialogBody>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={cloneAgent.isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={cloneAgent.isPending}>
+                {cloneAgent.isPending && (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                )}
+                Clone
+              </Button>
+            </DialogFooter>
+          </DialogForm>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/platform/frontend/src/lib/agent.query.ts
+++ b/platform/frontend/src/lib/agent.query.ts
@@ -67,12 +67,17 @@ export function useProfiles(
   });
 }
 
+type CloneAgentArgs = {
+  id: string;
+} & NonNullable<archestraApiTypes.CloneAgentData["body"]>;
+
 export function useCloneAgent() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
+    mutationFn: async ({ id, ...body }: CloneAgentArgs) => {
       const { data: responseData, error } = await cloneAgent({
         path: { id },
+        body,
       });
       if (error) {
         handleApiError(error);

--- a/platform/shared/hey-api/clients/api/sdk.gen.ts
+++ b/platform/shared/hey-api/clients/api/sdk.gen.ts
@@ -195,7 +195,7 @@ export const updateAgent = <ThrowOnError extends boolean = false>(options: Optio
 });
 
 /**
- * Clone an agent and all its associations
+ * Clone an agent and all its associations. Optionally override the clone's visibility (scope/teams); by default the source's visibility is copied.
  *
  * Authentication:
  *
@@ -205,7 +205,14 @@ export const updateAgent = <ThrowOnError extends boolean = false>(options: Optio
  *
  * None (no additional RBAC permission required)
  */
-export const cloneAgent = <ThrowOnError extends boolean = false>(options: Options<CloneAgentData, ThrowOnError>) => (options.client ?? client).post<CloneAgentResponses, CloneAgentErrors, ThrowOnError>({ url: '/api/agents/{id}/clone', ...options });
+export const cloneAgent = <ThrowOnError extends boolean = false>(options: Options<CloneAgentData, ThrowOnError>) => (options.client ?? client).post<CloneAgentResponses, CloneAgentErrors, ThrowOnError>({
+    url: '/api/agents/{id}/clone',
+    ...options,
+    headers: {
+        'Content-Type': 'application/json',
+        ...options.headers
+    }
+});
 
 /**
  * Export an agent configuration as a portable JSON payload for cross-instance transfer

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -12616,7 +12616,16 @@ export type UpdateAgentResponses = {
 export type UpdateAgentResponse = UpdateAgentResponses[keyof UpdateAgentResponses];
 
 export type CloneAgentData = {
-    body?: never;
+    body: {
+        /**
+         * Visibility of the clone. Defaults to the source agent's scope.
+         */
+        scope?: 'personal' | 'team' | 'org';
+        /**
+         * Teams for a team-scoped clone. Defaults to the source agent's teams. Ignored unless the clone's scope resolves to 'team'.
+         */
+        teams?: Array<string>;
+    } | null;
     path: {
         id: string;
     };


### PR DESCRIPTION
## What

When cloning an agent, MCP gateway, or LLM proxy, a small dialog now asks who should be able to use the copy (Personal / Teams / Organization) before the clone is created. Previously the clone silently inherited the source's visibility — cloning an org-wide gateway instantly published the copy org-wide.

The MCP gateway and LLM proxy pages also gain a Clone row action; the clone endpoint has always supported all three agent types, but only the Agents page exposed it.

## How

**Backend**
- `POST /api/agents/:id/clone` accepts an optional `{ scope, teams }` body. An explicit choice is validated exactly like agent creation: `org` requires `<resource>:admin`, `team` requires `<resource>:team-admin`, and a team-admin can only assign teams they belong to.
- No body (or `{}`) copies the source's visibility as before — the body schema is `nullish` so pre-existing clients that POST without a payload keep working.
- `AgentModel.cloneAgent` takes optional `scope`/`teams` overrides; a clone whose final scope is `personal` is owned by the cloning user.

**Frontend**
- New shared `CloneAgentDialog` reusing the existing `AccessLevelSelector` (same permission gating and copy as the create/edit dialog). It defaults to the source's visibility and downgrades to Personal when the user can't grant the source's scope to a new object; preselected teams the user can't assign are dropped.
- Since the clone is a new object, the "shared can't go back to personal" rule from edit does not apply — an org gateway can be cloned as a personal copy.
- After cloning, the copy's edit dialog opens for an immediate rename (unchanged behavior).

## Tests

- Extended `backend/src/routes/agent.clone.test.ts` (34 tests passing): override to personal/org/team, empty-body backward compatibility, non-admin org 403, team-membership 403, and the team-admin happy path.
- No frontend component test added: the dialog is standard form wiring around the already-shared `AccessLevelSelector`, and the behavior contract (validation, defaults, backward compat) is pinned by the route tests. Flagging this as a judgment call.

`pnpm lint`, `pnpm type-check`, and backend `pnpm knip` pass. (`@archestra/shared` knip fails on `ServerWebSocketMessage`/`ServerWebSocketMessageType` on pristine `origin/main` too — pre-existing, untouched here.)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>