### PR TITLE
test(backend): run vitest with the forks pool to stop the flaky V8 JIT-page crash

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -553,19 +553,11 @@ jobs:
             pnpm exec turbo build --filter="@backend^..."
           }
 
-      # --no-memory-protection-keys: V8's PKU-backed JIT-page tracking
-      # (ThreadIsolation) intermittently dies with a fatal
-      # "Check failed: jit_page.has_value()" when WASM (PGlite) runs across
-      # vitest worker threads. The hardware feature only exists on these
-      # Linux runners' CPUs — dev machines never hit it. PKU is a
-      # defense-in-depth hardening for JIT pages, not a correctness feature,
-      # so disabling it for the test run is safe. NODE_OPTIONS disallows the
-      # flag, hence invoking the vitest entry through node directly.
       - name: Run backend unit tests (shard ${{ matrix.shard }} of 4)
         working-directory: ./platform/backend
         env:
           SHARD: ${{ matrix.shard }}
-        run: node --no-memory-protection-keys node_modules/vitest/vitest.mjs run --shard="${SHARD}/4"
+        run: pnpm exec vitest run --shard="${SHARD}/4"
 
   # Stable-named gate over the shard matrix so branch protection / merge queue
   # can require a single check ("Backend Unit Tests") regardless of shard count.

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -92,18 +92,36 @@ export default defineConfig({
      * - beforeEach: truncates tables (fast) instead of recreating DB
      */
 
-    // Use threads pool - faster than forks for Node.js tests
-    pool: "threads",
+    // Forks (child processes), not threads. PGlite is a WASM module; running
+    // it across worker threads sharing one process-global V8 JIT-page registry
+    // intermittently aborts the whole process with a fatal
+    // "Check failed: jit_page.has_value()" (and its sibling on unregister).
+    // Forks give each worker its own V8, so the registry can't be raced.
+    pool: "forks",
 
     // Auto-restore vi.stubGlobal/vi.stubEnv after every test. Without this, a
     // stub left behind by one test file poisons later files sharing the worker.
     unstubGlobals: true,
     unstubEnvs: true,
 
-    // Vitest defaults to one worker per core, which pins the whole machine
-    // during a full-suite run. Locally, leave a couple of cores free for the
-    // human; CI runners keep the default (all cores).
-    ...(isCI ? {} : { maxWorkers: Math.max(4, os.availableParallelism() - 2) }),
+    // Bound the fork count by BOTH cores and memory. CPU half: mirror the
+    // frontend config's "50%" convention locally (leaves half the box for the
+    // human); CI runs all cores because the memory cap below is the real limit
+    // there. Memory half: with the forks pool each worker loads the full module
+    // graph + its own PGlite (WASM) independently — ~3 GB RSS per fork, not
+    // shared like the threads pool's single address space — so cap at ~5 GB/fork
+    // or a shard OOM-kills the runner (cgroup OOM aborts a worker abruptly, not
+    // with a clean Vitest error). Yields 12 forks on the 16-vCPU / 64-GB CI
+    // runner, and half-cores (memory permitting) locally. The memory cap trusts
+    // os.totalmem() to report real available RAM — valid on the bare-VM CI
+    // runner, but it would over-report (and stop protecting) inside a
+    // cgroup-limited container.
+    maxWorkers: Math.min(
+      isCI
+        ? os.availableParallelism()
+        : Math.max(1, Math.floor(os.availableParallelism() * 0.5)),
+      Math.max(1, Math.floor(os.totalmem() / (5 * 1024 ** 3))),
+    ),
 
     // Increase concurrency on CI for faster test execution
     maxConcurrency: isCI ? 12 : 6,

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -96,7 +96,10 @@ export default defineConfig({
     // it across worker threads sharing one process-global V8 JIT-page registry
     // intermittently aborts the whole process with a fatal
     // "Check failed: jit_page.has_value()" (and its sibling on unregister).
-    // Forks give each worker its own V8, so the registry can't be raced.
+    // Forks give each worker its own V8, so the registry can't be raced. This
+    // is Vitest's default pool, recommended for native modules that misbehave
+    // across threads (https://vitest.dev/config/pool); pinned explicitly so a
+    // switch back to threads for speed can't silently reintroduce the crash.
     pool: "forks",
 
     // Auto-restore vi.stubGlobal/vi.stubEnv after every test. Without this, a

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -104,18 +104,17 @@ export default defineConfig({
     unstubGlobals: true,
     unstubEnvs: true,
 
-    // Bound the fork count by BOTH cores and memory. CPU half: mirror the
-    // frontend config's "50%" convention locally (leaves half the box for the
-    // human); CI runs all cores because the memory cap below is the real limit
-    // there. Memory half: with the forks pool each worker loads the full module
-    // graph + its own PGlite (WASM) independently — ~3 GB RSS per fork, not
-    // shared like the threads pool's single address space — so cap at ~5 GB/fork
-    // or a shard OOM-kills the runner (cgroup OOM aborts a worker abruptly, not
-    // with a clean Vitest error). Yields 12 forks on the 16-vCPU / 64-GB CI
-    // runner, and half-cores (memory permitting) locally. The memory cap trusts
-    // os.totalmem() to report real available RAM — valid on the bare-VM CI
-    // runner, but it would over-report (and stop protecting) inside a
-    // cgroup-limited container.
+    // Bound the fork count by BOTH cores and memory. CPU half: 50% of cores
+    // locally (leaves the other half for the human); CI runs all cores because
+    // the memory cap below is the real limit there. Memory half: with the forks
+    // pool each worker loads the full module graph + its own PGlite (WASM)
+    // independently — up to ~3 GB RSS per fork, not shared like the threads
+    // pool's single address space — so cap at ~5 GB/fork or a shard OOM-kills
+    // the runner (cgroup OOM aborts a worker abruptly, not with a clean Vitest
+    // error). Yields 12 forks on the 16-vCPU / 64-GB CI runner, and half-cores
+    // (memory permitting) locally. The memory cap trusts os.totalmem() to report
+    // real available RAM — valid on the bare-VM CI runner, but it would
+    // over-report (and stop protecting) inside a cgroup-limited container.
     maxWorkers: Math.min(
       isCI
         ? os.availableParallelism()


### PR DESCRIPTION
Backend unit-test shards intermittently abort with a fatal V8 assertion — `Check failed: jit_page.has_value()` (and its sibling on unregister), exit 133 / SIGTRAP, core dumped — on roughly 17% of first attempts, then pass on re-run. The suite runs PGlite (a WASM in-process Postgres) in every test file under `pool: "threads"`, so all workers are threads in one process sharing a single process-global V8 JIT-page registry. Concurrent WASM code allocation across those threads races that registry and takes down the whole process, failing the shard.

Switching to `pool: "forks"` gives each worker its own process and its own V8, so the shared registry that was being raced no longer exists. This is Vitest's own default pool — it moved away from threads for exactly this class of native/WASM crash.

Forks don't share an address space, so each worker loads the module graph plus its own PGlite independently (~3 GB RSS per fork) rather than sharing one. `maxWorkers` is therefore bounded by memory as well as cores — `min(50%-of-cores locally / all-cores on CI, ⌊total RAM / 5 GB⌋)` — so a shard cannot OOM the runner: 12 forks on the 16-vCPU / 64-GB CI runner, half-cores locally. A single test process no longer approaches a memory ceiling the way the shared threads process did.

Also removes `--no-memory-protection-keys` from the shard step. It was added to suppress this crash but never could: V8 allocates the JIT-page registry whether or not PKU protection is enabled, so the assertion still fired. Removing it restores that JIT-page hardening on the runners, which is safe now that forks eliminate the shared-registry race the flag was working around.
