### PR TITLE
feat(mcp-registry): surface which agents use an MCP server

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -196659,6 +196659,25 @@
                         ],
                         "additionalProperties": false
                       },
+                      "assignedAgents": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
                       "secretStorageType": {
                         "type": "string",
                         "enum": [
@@ -197222,6 +197241,25 @@
                       ],
                       "additionalProperties": false
                     },
+                    "assignedAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
                     "secretStorageType": {
                       "type": "string",
                       "enum": [
@@ -197702,6 +197740,25 @@
                         "createdAt"
                       ],
                       "additionalProperties": false
+                    },
+                    "assignedAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
                     },
                     "secretStorageType": {
                       "type": "string",
@@ -198492,6 +198549,25 @@
                         "createdAt"
                       ],
                       "additionalProperties": false
+                    },
+                    "assignedAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
                     },
                     "secretStorageType": {
                       "type": "string",
@@ -199910,6 +199986,25 @@
                         "createdAt"
                       ],
                       "additionalProperties": false
+                    },
+                    "assignedAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
                     },
                     "secretStorageType": {
                       "type": "string",

--- a/docs/pages/platform-private-registry.md
+++ b/docs/pages/platform-private-registry.md
@@ -3,7 +3,7 @@ title: Private MCP Registry
 category: MCP
 order: 2
 description: Managing your organization's MCP servers in a private registry
-lastUpdated: 2026-07-06
+lastUpdated: 2026-07-15
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -86,6 +86,8 @@ See [Environments](/docs/platform-environments) for the full isolation model and
 The registry does not expose tools to clients by itself. After a server is installed, Archestra discovers the tools exposed by that installed connection. Those tools become usable after they are assigned to an Agent or MCP Gateway.
 
 For external MCP clients, create or edit an [MCP Gateway](/docs/platform-mcp-gateway), assign tools from installed registry entries (or use Automatic tool assignment mode to derive them from labels), then connect the client to the gateway endpoint. For built-in Archestra agents, assign the same tools from the agent's tool configuration.
+
+Each registry card shows which agents and gateways have tools assigned from the server. The uninstall dialog lists them too, so you can see who is affected before removing a connection. The count covers explicit assignments only — Automatic tool assignment mode is not included.
 
 ## Refreshing Tools
 

--- a/platform/backend/src/models/agent-tool.test.ts
+++ b/platform/backend/src/models/agent-tool.test.ts
@@ -133,6 +133,102 @@ describe("AgentToolModel delegation queries", () => {
   });
 });
 
+describe("AgentToolModel.getAssignedAgentDetailsForMcpServers", () => {
+  test("returns distinct agents assigned tools from each server's catalog, sorted by name", async ({
+    makeAgent,
+    makeTool,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog();
+    const server = await makeMcpServer({ catalogId: catalog.id });
+    const toolA = await makeTool({ catalogId: catalog.id });
+    const toolB = await makeTool({ catalogId: catalog.id });
+
+    const agentZed = await makeAgent({ name: "Zed Agent" });
+    const agentAda = await makeAgent({ name: "Ada Agent" });
+    // Two assignments for the same agent must collapse to one entry
+    await makeAgentTool(agentZed.id, toolA.id);
+    await makeAgentTool(agentZed.id, toolB.id);
+    await makeAgentTool(agentAda.id, toolA.id);
+
+    const result = await AgentToolModel.getAssignedAgentDetailsForMcpServers([
+      server.id,
+    ]);
+
+    expect(result.get(server.id)).toEqual([
+      { id: agentAda.id, name: "Ada Agent" },
+      { id: agentZed.id, name: "Zed Agent" },
+    ]);
+  });
+
+  test("counts pinned assignments only toward the pinned install; unpinned toward every install of the catalog", async ({
+    makeAgent,
+    makeTool,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog();
+    const serverOne = await makeMcpServer({ catalogId: catalog.id });
+    const serverTwo = await makeMcpServer({ catalogId: catalog.id });
+    const tool = await makeTool({ catalogId: catalog.id });
+
+    const pinnedAgent = await makeAgent({ name: "Pinned Agent" });
+    const dynamicAgent = await makeAgent({ name: "Dynamic Agent" });
+    await makeAgentTool(pinnedAgent.id, tool.id, {
+      mcpServerId: serverOne.id,
+    });
+    await makeAgentTool(dynamicAgent.id, tool.id);
+
+    const result = await AgentToolModel.getAssignedAgentDetailsForMcpServers([
+      serverOne.id,
+      serverTwo.id,
+    ]);
+
+    expect(result.get(serverOne.id)).toEqual([
+      { id: dynamicAgent.id, name: "Dynamic Agent" },
+      { id: pinnedAgent.id, name: "Pinned Agent" },
+    ]);
+    expect(result.get(serverTwo.id)).toEqual([
+      { id: dynamicAgent.id, name: "Dynamic Agent" },
+    ]);
+  });
+
+  test("excludes soft-deleted agents and returns empty arrays for unused servers", async ({
+    makeAgent,
+    makeTool,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog();
+    const server = await makeMcpServer({ catalogId: catalog.id });
+    const unusedServer = await makeMcpServer();
+    const tool = await makeTool({ catalogId: catalog.id });
+
+    const agent = await makeAgent();
+    await makeAgentTool(agent.id, tool.id);
+    await AgentModel.delete(agent.id);
+
+    const result = await AgentToolModel.getAssignedAgentDetailsForMcpServers([
+      server.id,
+      unusedServer.id,
+    ]);
+
+    expect(result.get(server.id)).toEqual([]);
+    expect(result.get(unusedServer.id)).toEqual([]);
+  });
+
+  test("returns an empty map for empty input", async () => {
+    const result = await AgentToolModel.getAssignedAgentDetailsForMcpServers(
+      [],
+    );
+    expect(result.size).toBe(0);
+  });
+});
+
 describe("AgentToolModel.findAll", () => {
   test("excludes assignments for soft-deleted agents", async ({
     makeAgent,

--- a/platform/backend/src/models/agent-tool.ts
+++ b/platform/backend/src/models/agent-tool.ts
@@ -465,6 +465,66 @@ class AgentToolModel {
     return [...new Set(results.map((r) => r.toolId))];
   }
 
+  /**
+   * Get the distinct agents that have tools explicitly assigned from each of
+   * the given MCP servers, in one query to avoid N+1.
+   *
+   * An assignment counts toward a server when it is statically pinned to that
+   * server (`agent_tools.mcp_server_id`), or when it is unpinned (dynamic
+   * credential resolution) and the tool belongs to the server's catalog — a
+   * dynamic assignment can resolve to any install of the catalog at call time.
+   */
+  static async getAssignedAgentDetailsForMcpServers(
+    mcpServerIds: string[],
+  ): Promise<Map<string, Array<{ id: string; name: string }>>> {
+    const agentsMap = new Map<string, Array<{ id: string; name: string }>>();
+    for (const mcpServerId of mcpServerIds) {
+      agentsMap.set(mcpServerId, []);
+    }
+    if (mcpServerIds.length === 0) {
+      return agentsMap;
+    }
+
+    const assignments = await db
+      .selectDistinct({
+        mcpServerId: schema.mcpServersTable.id,
+        agentId: schema.agentsTable.id,
+        agentName: schema.agentsTable.name,
+      })
+      .from(schema.agentToolsTable)
+      .innerJoin(
+        schema.toolsTable,
+        eq(schema.agentToolsTable.toolId, schema.toolsTable.id),
+      )
+      .innerJoin(
+        schema.agentsTable,
+        eq(schema.agentToolsTable.agentId, schema.agentsTable.id),
+      )
+      .innerJoin(
+        schema.mcpServersTable,
+        or(
+          eq(schema.agentToolsTable.mcpServerId, schema.mcpServersTable.id),
+          and(
+            isNull(schema.agentToolsTable.mcpServerId),
+            eq(schema.toolsTable.catalogId, schema.mcpServersTable.catalogId),
+          ),
+        ),
+      )
+      .where(
+        and(
+          inArray(schema.mcpServersTable.id, mcpServerIds),
+          notDeleted(schema.agentsTable),
+        ),
+      )
+      .orderBy(asc(schema.agentsTable.name), asc(schema.agentsTable.id));
+
+    for (const { mcpServerId, agentId, agentName } of assignments) {
+      agentsMap.get(mcpServerId)?.push({ id: agentId, name: agentName });
+    }
+
+    return agentsMap;
+  }
+
   static async getToolsForAgent(agentId: string) {
     const results = await db
       .select({ tool: schema.toolsTable })

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -26,6 +26,7 @@ import type {
 } from "@/types";
 import { externalAppLabel } from "@/utils/external-app-label";
 import { toolRequiresInputs } from "@/utils/tool-inputs";
+import AgentToolModel from "./agent-tool";
 import InternalMcpCatalogModel from "./internal-mcp-catalog";
 import McpCatalogTeamModel from "./mcp-catalog-team";
 import McpHttpSessionModel from "./mcp-http-session";
@@ -365,7 +366,15 @@ class McpServerModel {
       }
     }
 
-    return Array.from(serversMap.values());
+    const assignedAgentsByServer =
+      await AgentToolModel.getAssignedAgentDetailsForMcpServers([
+        ...serversMap.keys(),
+      ]);
+
+    return Array.from(serversMap.values()).map((server) => ({
+      ...server,
+      assignedAgents: assignedAgentsByServer.get(server.id) ?? [],
+    }));
   }
 
   /**
@@ -828,7 +837,10 @@ class McpServerModel {
       return null;
     }
 
-    const userDetails = await McpServerUserModel.getUserDetailsForMcpServer(id);
+    const [userDetails, assignedAgentsByServer] = await Promise.all([
+      McpServerUserModel.getUserDetailsForMcpServer(id),
+      AgentToolModel.getAssignedAgentDetailsForMcpServers([id]),
+    ]);
 
     // Build teamDetails from the joined team data
     const teamDetails = result.server.teamId
@@ -853,6 +865,7 @@ class McpServerModel {
       userDetails,
       teamDetails,
       secretStorageType,
+      assignedAgents: assignedAgentsByServer.get(id) ?? [],
     };
   }
 

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -3875,6 +3875,40 @@ describe("mcp server core route coverage", () => {
     await app.close();
   });
 
+  describe("GET /api/mcp_server", () => {
+    test("lists the agents using each server via explicit tool assignments", async ({
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeTool,
+      makeAgent,
+      makeAgentTool,
+    }) => {
+      const catalog = await makeInternalMcpCatalog({
+        organizationId,
+        serverType: "local",
+      });
+      const server = await makeMcpServer({
+        ownerId: user.id,
+        catalogId: catalog.id,
+      });
+      const tool = await makeTool({ catalogId: catalog.id });
+      const agent = await makeAgent({ name: "Server Consumer" });
+      await makeAgentTool(agent.id, tool.id);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/mcp_server",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const servers = response.json();
+      const returned = servers.find((s: { id: string }) => s.id === server.id);
+      expect(returned.assignedAgents).toEqual([
+        { id: agent.id, name: "Server Consumer" },
+      ]);
+    });
+  });
+
   describe("GET /api/mcp_server/:id", () => {
     test("returns an MCP server the caller can access", async ({
       makeInternalMcpCatalog,
@@ -3896,6 +3930,7 @@ describe("mcp server core route coverage", () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json().id).toBe(server.id);
+      expect(response.json().assignedAgents).toEqual([]);
     });
 
     test("returns 404 for an unknown id", async () => {

--- a/platform/backend/src/types/mcp-server.ts
+++ b/platform/backend/src/types/mcp-server.ts
@@ -47,6 +47,18 @@ export const SelectMcpServerSchema = createSelectSchema(
     })
     .nullable()
     .optional(),
+  /**
+   * Agents (profiles / MCP gateways) with tools explicitly assigned from this
+   * server — statically pinned to it, or unpinned on a tool of its catalog.
+   */
+  assignedAgents: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+      }),
+    )
+    .optional(),
   localInstallationStatus: LocalMcpServerInstallationStatusSchema,
   secretStorageType: SecretStorageTypeSchema.optional(),
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "@archestra/shared";
 import {
   AlertTriangle,
+  Bot,
   Copy,
   FileSearch,
   Globe,
@@ -271,6 +272,18 @@ export function McpServerCard({
   const hasPersonalConnection =
     personalServersForCatalog.length > 0 || !!personalServer;
 
+  // Distinct agents with tools explicitly assigned from any install of this
+  // catalog item — the audience affected if those installs go away.
+  const assignedAgents = (() => {
+    const byId = new Map<string, { id: string; name: string }>();
+    for (const server of allServersForCatalog) {
+      for (const agent of server.assignedAgents ?? []) {
+        byId.set(agent.id, agent);
+      }
+    }
+    return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+  })();
+
   // The most recent personal install for this catalog item, if any.
   const uninstallInstalls: UninstallServerInstall[] = (() => {
     const install = personalServersForCatalog
@@ -279,7 +292,14 @@ export function McpServerCard({
         (a, b) =>
           new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
       )[0];
-    return install ? [{ server: { id: install.id, name: install.name } }] : [];
+    return install
+      ? [
+          {
+            server: { id: install.id, name: install.name },
+            assignedAgents: install.assignedAgents ?? [],
+          },
+        ]
+      : [];
   })();
 
   const handleUninstallClick = () => {
@@ -539,6 +559,7 @@ export function McpServerCard({
   const hasCompactInfoContent =
     showAuthorAvatar ||
     toolsCount > 0 ||
+    assignedAgents.length > 0 ||
     (variant === "local" && deploymentServerIds.length > 0) ||
     (!isBuiltinVariant &&
       (connectionAvatars.length > 0 ||
@@ -577,6 +598,38 @@ export function McpServerCard({
               {toolsCount}
             </span>
           </div>
+          <div className="h-4 w-px bg-border" />
+        </>
+      )}
+      {assignedAgents.length > 0 && (
+        <>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="flex items-center gap-1 cursor-help">
+                  <Bot className="h-3.5 w-3.5" />
+                  <span data-testid={`${E2eTestId.McpServerAgentsCount}`}>
+                    {assignedAgents.length}
+                  </span>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="font-medium">
+                  Used by {assignedAgents.length}{" "}
+                  {assignedAgents.length === 1 ? "agent" : "agents"} (assigned
+                  tools)
+                </p>
+                <div className="mt-1 space-y-0.5">
+                  {assignedAgents.slice(0, 8).map((agent) => (
+                    <div key={agent.id}>{agent.name}</div>
+                  ))}
+                  {assignedAgents.length > 8 && (
+                    <div>+{assignedAgents.length - 8} more</div>
+                  )}
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <div className="h-4 w-px bg-border" />
         </>
       )}

--- a/platform/frontend/src/app/mcp/registry/_parts/uninstall-server-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/uninstall-server-dialog.tsx
@@ -14,6 +14,8 @@ import { useDeleteMcpServer } from "@/lib/mcp/mcp-server.query";
 
 export interface UninstallServerInstall {
   server: { id: string; name: string };
+  /** Agents with tools explicitly assigned from this install. */
+  assignedAgents?: Array<{ id: string; name: string }>;
 }
 
 interface UninstallServerDialogProps {
@@ -34,6 +36,7 @@ export function UninstallServerDialog({
   const uninstallMutation = useDeleteMcpServer();
 
   const server = installs[0]?.server ?? null;
+  const assignedAgents = installs[0]?.assignedAgents ?? [];
 
   const handleConfirm = async () => {
     if (!server) return;
@@ -89,6 +92,19 @@ export function UninstallServerDialog({
         >
           <div className="flex flex-col gap-3 px-4 pb-4">
             <DialogDescription>{description}</DialogDescription>
+            {!isCancelingInstallation && assignedAgents.length > 0 && (
+              <div className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-sm">
+                <p className="font-medium text-amber-600 dark:text-amber-500">
+                  Used by {assignedAgents.length}{" "}
+                  {assignedAgents.length === 1 ? "agent" : "agents"}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {assignedAgents.map((agent) => agent.name).join(", ")}{" "}
+                  {assignedAgents.length === 1 ? "has" : "have"} tools assigned
+                  from this server and may lose access to them.
+                </p>
+              </div>
+            )}
           </div>
           <DialogStickyFooter className="mt-0 border-t-0 shadow-none">
             <Button type="button" variant="outline" onClick={() => onClose()}>

--- a/platform/shared/e2e-test-ids.ts
+++ b/platform/shared/e2e-test-ids.ts
@@ -39,6 +39,7 @@ export const E2eTestId = {
   McpServerCard: "mcp-server-card",
   McpServerSettingsButton: "mcp-server-settings-button",
   McpServerToolsCount: "mcp-server-tools-count",
+  McpServerAgentsCount: "mcp-server-agents-count",
   McpToolsDialog: "mcp-tools-dialog",
   TokenSelect: "token-select",
   ProfileTokenManagerTeamsSelect: "profile-token-manager-teams-select",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -51115,6 +51115,10 @@ export type GetMcpServersResponses = {
             name: string;
             createdAt: string;
         } | null;
+        assignedAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
         secretStorageType?: 'vault' | 'external_vault' | 'database' | 'none';
     }>;
 };
@@ -51252,6 +51256,10 @@ export type InstallMcpServerResponses = {
             name: string;
             createdAt: string;
         } | null;
+        assignedAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
         secretStorageType?: 'vault' | 'external_vault' | 'database' | 'none';
     };
 };
@@ -51455,6 +51463,10 @@ export type GetMcpServerResponses = {
             name: string;
             createdAt: string;
         } | null;
+        assignedAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
         secretStorageType?: 'vault' | 'external_vault' | 'database' | 'none';
     };
 };
@@ -51583,6 +51595,10 @@ export type ReauthenticateMcpServerResponses = {
             name: string;
             createdAt: string;
         } | null;
+        assignedAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
         secretStorageType?: 'vault' | 'external_vault' | 'database' | 'none';
     };
 };
@@ -51983,6 +51999,10 @@ export type ReinstallMcpServerResponses = {
             name: string;
             createdAt: string;
         } | null;
+        assignedAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
         secretStorageType?: 'vault' | 'external_vault' | 'database' | 'none';
     };
 };


### PR DESCRIPTION
## What

Adds visibility into which Agents / MCP Gateways are using an MCP server, via their explicit tool assignments.

Today there is no way to see this: when a server's tools are unassigned (e.g. the server is deleted and recreated), there's no record of which agents were using it to re-assign the tools afterwards.

## How

**Backend**
- New `AgentToolModel.getAssignedAgentDetailsForMcpServers(mcpServerIds)` batch method (single query, no N+1): the distinct, non-deleted agents with `agent_tools` rows for each server. An assignment statically pinned to an install (`agent_tools.mcp_server_id`) counts only toward that install; an unpinned (resolve-at-call-time) assignment counts toward every install of the tool's catalog, since it can resolve to any of them.
- `GET /api/mcp_server` and `GET /api/mcp_server/:id` now include `assignedAgents: Array<{ id, name }>` (additive, optional field on `SelectMcpServerSchema`; OpenAPI + generated client regenerated).

**Frontend**
- Registry card: a used-by-agents count next to the tools count, with the agent names in a tooltip (deduped across all installs of the catalog item).
- Uninstall dialog: warns which agents have tools assigned from the install being removed.

**Docs**
- Short note in the private registry page; explicitly states the rollup covers explicit assignments only (automatic tool assignment mode is not reflected).

## Notes

- This intentionally shows **explicit assignments only** — with automatic tool/knowledge-source usage there is no static assignment to surface.
- Pre-existing on `main` and unrelated: `shared` knip flags unused types in `shared/websocket.ts`.

## Tests

- Model tests: pinned vs. dynamic assignment attribution across sibling installs, dedupe across tools, soft-deleted agents excluded, empty input.
- Route tests: `GET /api/mcp_server` returns the assigned agents; detail response carries the field.
- Validated: `pnpm type-check`, `pnpm lint`, backend `pnpm knip` (dev+production), frontend knip, and the touched backend test files (173 tests passing).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>