### PR TITLE
feat(mcp): confirm before pinning a personal MCP connection for a shared agent

### DIFF
--- a/platform/e2e-tests/tests/static-credentials-management.spec.ts
+++ b/platform/e2e-tests/tests/static-credentials-management.spec.ts
@@ -24,6 +24,7 @@ import {
   openGatewayCatalogToolAssignment,
   openManageCredentialsDialog,
   saveOpenProfileDialog,
+  selectCredentialOption,
   settleRegistryAfterInstall,
   verifyToolCallResultViaApi,
   waitForMcpServerAbsent,
@@ -192,16 +193,12 @@ test.describe("Custom Self-hosted MCP Server - installation and static credentia
         await expect(visibleStaticCredentials).toHaveLength(
           expectedAssignableCredentials.length,
         );
-        // Force the click: the credential option list re-renders when the
-        // dropdown opens, detaching the node mid-click. Same DOM-detach race
-        // assignCatalogCredentialToGateway already handles this way.
-        await page
-          .getByRole("option", {
+        await selectCredentialOption(
+          page,
+          page.getByRole("option", {
             name: expectedAssignableCredentials[0] ?? "",
-          })
-          .click({ force: true });
-        await page.keyboard.press("Escape");
-        await page.waitForTimeout(200);
+          }),
+        );
         await saveOpenProfileDialog(page);
 
         // Revoke the admin's own (personal) credential, then close dialog.

--- a/platform/e2e-tests/utils/tool-assignments.ts
+++ b/platform/e2e-tests/utils/tool-assignments.ts
@@ -44,6 +44,46 @@ export async function saveOpenProfileDialog(page: Page): Promise<void> {
   await page.waitForLoadState("domcontentloaded");
 }
 
+/**
+ * Pinning a personal-scope connection to a shared (team/org) agent or gateway
+ * prompts a confirmation ("Pin every user to a personal account?") because every
+ * caller would then authenticate as that one owner. Confirm it so the pin
+ * applies; non-personal connections and personal-scope targets don't prompt.
+ * Returns whether a confirmation was handled.
+ */
+export async function confirmPersonalCredentialPinIfPrompted(
+  page: Page,
+): Promise<boolean> {
+  const confirmButton = page
+    .getByRole("button", { name: /^Pin to .+$/ })
+    .first();
+  if (await confirmButton.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await confirmButton.click();
+    await expect(confirmButton).toBeHidden({ timeout: 5000 });
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Select a static credential in the open assignment dialog: click the option,
+ * confirm the personal-pin dialog if it appears, otherwise close the still-open
+ * dropdown. Applying the pin (confirm) leaves the edit dialog open for saving,
+ * so a trailing Escape only runs when no confirmation was shown.
+ */
+export async function selectCredentialOption(
+  page: Page,
+  credentialOption: ReturnType<Page["getByRole"]>,
+): Promise<void> {
+  // DOM-detach guard: the option list re-renders as the dropdown opens.
+  await credentialOption.click({ force: true });
+  const confirmed = await confirmPersonalCredentialPinIfPrompted(page);
+  if (!confirmed) {
+    await page.keyboard.press("Escape");
+  }
+  await page.waitForTimeout(200);
+}
+
 export async function assignCatalogCredentialToGateway(params: {
   page: Page;
   catalogItemName: string;
@@ -59,11 +99,7 @@ export async function assignCatalogCredentialToGateway(params: {
     name: params.credentialName,
   });
   await expect(credentialOption).toBeVisible({ timeout: 10_000 });
-  // Same DOM-detach issue as the visibleTokenSelect click above — the
-  // capability row re-renders briefly when the credential dropdown opens.
-  await credentialOption.click({ force: true });
-  await params.page.keyboard.press("Escape");
-  await params.page.waitForTimeout(200);
+  await selectCredentialOption(params.page, credentialOption);
   await saveOpenProfileDialog(params.page);
 }
 

--- a/platform/e2e-tests/utils/tool-assignments.ts
+++ b/platform/e2e-tests/utils/tool-assignments.ts
@@ -58,7 +58,9 @@ async function confirmPersonalCredentialPinIfPrompted(
     .getByRole("button", { name: /^Pin to .+$/ })
     .first();
   if (await confirmButton.isVisible({ timeout: 1500 }).catch(() => false)) {
-    await confirmButton.click();
+    // Force past the actionability wait: the dialog's entrance animation keeps
+    // the button from being "stable" long enough for a normal click to land.
+    await confirmButton.click({ force: true });
     await expect(confirmButton).toBeHidden({ timeout: 5000 });
     return true;
   }

--- a/platform/e2e-tests/utils/tool-assignments.ts
+++ b/platform/e2e-tests/utils/tool-assignments.ts
@@ -51,7 +51,7 @@ export async function saveOpenProfileDialog(page: Page): Promise<void> {
  * applies; non-personal connections and personal-scope targets don't prompt.
  * Returns whether a confirmation was handled.
  */
-export async function confirmPersonalCredentialPinIfPrompted(
+async function confirmPersonalCredentialPinIfPrompted(
   page: Page,
 ): Promise<boolean> {
   const confirmButton = page

--- a/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
@@ -22,6 +22,7 @@ import {
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ExternalDocsLink } from "@/components/external-docs-link";
+import { StaticCredentialConfirmDialog } from "@/components/static-credential-confirm-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -843,11 +844,50 @@ function AgentConnectionsSection({
 }) {
   const { canModify } = useCanModifyCatalogItem(item);
   const updateMutation = useUpdateInternalMcpCatalogItem();
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
   const pinnedId = item.dynamicConnectionMcpServerId ?? null;
   const pinnedConnection = pinnedId
     ? connections.find((connection) => connection.id === pinnedId)
     : undefined;
   const pinRemoved = Boolean(pinnedId) && !pinnedConnection;
+
+  const [pendingPersonalDefault, setPendingPersonalDefault] = useState<{
+    id: string;
+    mcpName: string;
+    ownerEmail: string;
+    isCurrentUser: boolean;
+  } | null>(null);
+
+  const applyDefault = (value: string | null) =>
+    updateMutation.mutate({
+      id: item.id,
+      data: { dynamicConnectionMcpServerId: value },
+    });
+
+  // Making a personal connection the default authenticates every call-time
+  // resolution as that one owner; confirm before applying. Org/team accounts
+  // and "on behalf of the user" are shared by design and apply immediately.
+  const handleSelectDefault = (value: string) => {
+    if (value === ON_BEHALF_OF_VALUE) {
+      applyDefault(null);
+      return;
+    }
+    const connection = connections.find((c) => c.id === value);
+    const scope = connection
+      ? (connection.scope ?? (connection.teamId ? "team" : "personal"))
+      : undefined;
+    if (connection && scope === "personal") {
+      setPendingPersonalDefault({
+        id: value,
+        mcpName: connection.catalogName ?? item.name,
+        ownerEmail: connection.ownerEmail || "Deleted user",
+        isCurrentUser: !!currentUserId && connection.ownerId === currentUserId,
+      });
+      return;
+    }
+    applyDefault(value);
+  };
 
   const connectionLabel = (connection: (typeof connections)[number]) => {
     const scope = connection.scope ?? (connection.teamId ? "team" : "personal");
@@ -858,92 +898,108 @@ function AgentConnectionsSection({
   };
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
-      <div className="max-w-xl space-y-1">
-        <h4 className="text-sm font-medium">Default credential</h4>
-        <p className="text-sm text-muted-foreground">
-          {!pinnedId ? (
-            <>
-              Agents connect on behalf of whoever is calling — each person uses
-              their own connection if they have one, otherwise a team or
-              organization connection they can access. Applies in Auto mode and
-              to Custom tool assignments that resolve at call time.
-            </>
-          ) : pinRemoved ? (
-            <>
-              The selected connection was removed. Agents connect on behalf of
-              whoever is calling until you choose another one.
-            </>
-          ) : (
-            <>
-              Agents connect as{" "}
-              <span className="font-medium text-foreground">
-                {pinnedConnection ? connectionLabel(pinnedConnection) : ""}
-              </span>
-              , no matter who is calling. Applies in Auto mode and to Custom
-              tool assignments that resolve at call time.
-            </>
-          )}{" "}
-          <ExternalDocsLink
-            href={getDocsUrl(
-              DocsPage.McpAuthentication,
-              "resolve-at-call-time",
-            )}
-            className="underline"
-            showIcon={false}
-          >
-            Learn more
-          </ExternalDocsLink>
-        </p>
-      </div>
-      <Select
-        value={pinRemoved ? "" : (pinnedId ?? ON_BEHALF_OF_VALUE)}
-        disabled={!canModify || updateMutation.isPending}
-        onValueChange={(value) =>
-          updateMutation.mutate({
-            id: item.id,
-            data: {
-              dynamicConnectionMcpServerId:
-                value === ON_BEHALF_OF_VALUE ? null : value,
-            },
-          })
-        }
-      >
-        <SelectTrigger className="w-[260px]">
-          <SelectValue placeholder="Connection removed" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem
-            value={ON_BEHALF_OF_VALUE}
-            className="cursor-pointer"
-            description="Everyone connects their own account."
-          >
-            <div className="flex items-center gap-1.5">
-              <Zap className="h-3.5! w-3.5! text-amber-500" />
-              <span>On behalf of the user</span>
-            </div>
-          </SelectItem>
-          {connections.length > 0 && (
-            <>
-              <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
-                Always use one account
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+        <div className="max-w-xl space-y-1">
+          <h4 className="text-sm font-medium">Default credential</h4>
+          <p className="text-sm text-muted-foreground">
+            {!pinnedId ? (
+              <>
+                Agents connect on behalf of whoever is calling — each person
+                uses their own connection if they have one, otherwise a team or
+                organization connection they can access. Applies in Auto mode
+                and to Custom tool assignments that resolve at call time.
+              </>
+            ) : pinRemoved ? (
+              <>
+                The selected connection was removed. Agents connect on behalf of
+                whoever is calling until you choose another one.
+              </>
+            ) : (
+              <>
+                Agents connect as{" "}
+                <span className="font-medium text-foreground">
+                  {pinnedConnection ? connectionLabel(pinnedConnection) : ""}
+                </span>
+                , no matter who is calling. Applies in Auto mode and to Custom
+                tool assignments that resolve at call time.
+              </>
+            )}{" "}
+            <ExternalDocsLink
+              href={getDocsUrl(
+                DocsPage.McpAuthentication,
+                "resolve-at-call-time",
+              )}
+              className="underline"
+              showIcon={false}
+            >
+              Learn more
+            </ExternalDocsLink>
+          </p>
+        </div>
+        <Select
+          value={pinRemoved ? "" : (pinnedId ?? ON_BEHALF_OF_VALUE)}
+          disabled={!canModify || updateMutation.isPending}
+          onValueChange={handleSelectDefault}
+        >
+          <SelectTrigger className="w-[320px]">
+            <SelectValue placeholder="Connection removed" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              value={ON_BEHALF_OF_VALUE}
+              className="cursor-pointer"
+              description="Everyone connects their own account."
+            >
+              <div className="flex items-center gap-1.5">
+                <Zap className="h-3.5! w-3.5! text-amber-500" />
+                <span>On behalf of the user (Recommended)</span>
               </div>
-              {connections.map((connection) => (
-                <SelectItem
-                  key={connection.id}
-                  value={connection.id}
-                  className="cursor-pointer"
-                >
-                  <div className="flex items-center gap-1.5">
-                    <KeyRound className="h-3.5! w-3.5! text-muted-foreground" />
-                    <span>{connectionLabel(connection)}</span>
-                  </div>
-                </SelectItem>
-              ))}
-            </>
-          )}
-        </SelectContent>
-      </Select>
-    </div>
+            </SelectItem>
+            {connections.length > 0 && (
+              <>
+                <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
+                  Always use one account
+                </div>
+                {connections.map((connection) => (
+                  <SelectItem
+                    key={connection.id}
+                    value={connection.id}
+                    className="cursor-pointer"
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <KeyRound className="h-3.5! w-3.5! text-muted-foreground" />
+                      <span>{connectionLabel(connection)}</span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </>
+            )}
+          </SelectContent>
+        </Select>
+      </div>
+      <StaticCredentialConfirmDialog
+        open={pendingPersonalDefault !== null}
+        context="server"
+        pins={
+          pendingPersonalDefault
+            ? [
+                {
+                  mcpName: pendingPersonalDefault.mcpName,
+                  ownerEmail: pendingPersonalDefault.ownerEmail,
+                  isCurrentUser: pendingPersonalDefault.isCurrentUser,
+                },
+              ]
+            : []
+        }
+        onConfirm={() => {
+          if (pendingPersonalDefault) {
+            applyDefault(pendingPersonalDefault.id);
+          }
+          setPendingPersonalDefault(null);
+        }}
+        onCancel={() => setPendingPersonalDefault(null)}
+      />
+    </>
   );
 }

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -1055,15 +1055,11 @@ function McpServerPill({
       {showCredentialSelector && (
         <div className="p-4 border-b space-y-2 shrink-0">
           <Label className="text-sm font-medium">Connect on behalf of</Label>
-          <p className="text-xs text-muted-foreground">
-            By default, credentials resolve at call time per the server's
-            default credential setting. Pin a specific connection to always use
-            it for these tools instead.
-          </p>
           <TokenSelect
             catalogId={catalogItem.id}
             assignmentScope={assignmentScope}
             assignmentTeamIds={assignmentTeamIds}
+            agentScope={assignmentScope}
             value={selectedCredential}
             onValueChange={setSelectedCredential}
             shouldSetDefaultValue={false}

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -464,6 +464,7 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
               <ConfigureToolView
                 agentId={editingAgent.id}
                 agentName={editingAgent.name}
+                agentScope={(editingAgent.scope as AgentScope) ?? "personal"}
                 catalog={selectedCatalog}
                 onBack={() => setDialogView(configureToolFrom)}
                 onDone={() => setDialogView("settings")}
@@ -1423,12 +1424,14 @@ function AddToolView({
 function ConfigureToolView({
   agentId,
   agentName,
+  agentScope,
   catalog,
   onBack,
   onDone,
 }: {
   agentId: string;
   agentName: string;
+  agentScope: AgentScope;
   catalog: CatalogItem;
   onBack: () => void;
   onDone: () => void;
@@ -1574,6 +1577,7 @@ function ConfigureToolView({
             </Label>
             <TokenSelect
               catalogId={catalog.id}
+              agentScope={agentScope}
               value={credential}
               onValueChange={setCredential}
               shouldSetDefaultValue={false}

--- a/platform/frontend/src/components/static-credential-confirm-dialog.test.tsx
+++ b/platform/frontend/src/components/static-credential-confirm-dialog.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { StaticCredentialConfirmDialog } from "@/components/static-credential-confirm-dialog";
+
+vi.mock("@/lib/hooks/use-app-name", () => ({
+  useAppName: () => "Archestra",
+}));
+
+// Render the shell inline (no Radix portal) so the copy and footer are directly
+// assertable.
+vi.mock("@/components/standard-dialog", () => ({
+  StandardDialog: ({
+    open,
+    title,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    title?: React.ReactNode;
+    children?: React.ReactNode;
+    footer?: React.ReactNode;
+  }) =>
+    open ? (
+      <div>
+        <div>{title}</div>
+        <div>{children}</div>
+        <div>{footer}</div>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: (e: React.MouseEvent) => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+describe("StaticCredentialConfirmDialog", () => {
+  it("agent context names another user's connection", () => {
+    const { container } = render(
+      <StaticCredentialConfirmDialog
+        open
+        pins={[
+          {
+            mcpName: "Everything",
+            ownerEmail: "member@example.com",
+            isCurrentUser: false,
+          },
+        ]}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain("Everyone who uses this agent");
+    expect(container.textContent).toContain("member@example.com's connection");
+    expect(
+      screen.getByText("Pin to member@example.com's connection"),
+    ).toBeInTheDocument();
+  });
+
+  it("agent context uses 'your' wording for the caller's own connection", () => {
+    const { container } = render(
+      <StaticCredentialConfirmDialog
+        open
+        pins={[
+          {
+            mcpName: "Everything",
+            ownerEmail: "me@example.com",
+            isCurrentUser: true,
+          },
+        ]}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain("through your connection");
+    expect(container.textContent).toContain("comes from you");
+    expect(screen.getByText("Pin to your connection")).toBeInTheDocument();
+  });
+
+  it("server context describes the default connection and labels the action", () => {
+    const { container } = render(
+      <StaticCredentialConfirmDialog
+        open
+        context="server"
+        pins={[
+          {
+            mcpName: "Everything",
+            ownerEmail: "member@example.com",
+            isCurrentUser: false,
+          },
+        ]}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain("connects as");
+    expect(container.textContent).toContain("member@example.com");
+    expect(
+      screen.getByText("Use member@example.com's account"),
+    ).toBeInTheDocument();
+  });
+
+  it("server context uses 'you' / 'Use your account' for the caller's own connection", () => {
+    render(
+      <StaticCredentialConfirmDialog
+        open
+        context="server"
+        pins={[
+          {
+            mcpName: "Everything",
+            ownerEmail: "me@example.com",
+            isCurrentUser: true,
+          },
+        ]}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Use your account")).toBeInTheDocument();
+  });
+
+  it("wires the confirm and cancel actions", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <StaticCredentialConfirmDialog
+        open
+        pins={[{ mcpName: "X", ownerEmail: "e@x.com", isCurrentUser: false }]}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText("Pin to e@x.com's connection"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists every pin when more than one is affected", () => {
+    const { container } = render(
+      <StaticCredentialConfirmDialog
+        open
+        pins={[
+          { mcpName: "ServerA", ownerEmail: "a@x.com", isCurrentUser: false },
+          { mcpName: "ServerB", ownerEmail: "b@x.com", isCurrentUser: true },
+        ]}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain("ServerA");
+    expect(container.textContent).toContain("a@x.com");
+    expect(container.textContent).toContain("ServerB");
+    expect(container.textContent).toContain("as you");
+    expect(screen.getByText("Pin anyway")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/static-credential-confirm-dialog.tsx
+++ b/platform/frontend/src/components/static-credential-confirm-dialog.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { Users } from "lucide-react";
+import { StandardDialog } from "@/components/standard-dialog";
+import { Button } from "@/components/ui/button";
+import { useAppName } from "@/lib/hooks/use-app-name";
+
+export interface PersonalCredentialPin {
+  mcpName: string;
+  ownerEmail: string;
+  /** The pinned connection belongs to the person doing the pinning. */
+  isCurrentUser: boolean;
+}
+
+interface StaticCredentialConfirmDialogProps {
+  open: boolean;
+  pins: PersonalCredentialPin[];
+  onConfirm: () => void;
+  onCancel: () => void;
+  /**
+   * "agent" (default): pinning a connection to one agent's tools. "server": the
+   * server's default credential, which applies to every agent that resolves it
+   * at call time.
+   */
+  context?: "agent" | "server";
+}
+
+export function StaticCredentialConfirmDialog({
+  open,
+  pins,
+  onConfirm,
+  onCancel,
+  context = "agent",
+}: StaticCredentialConfirmDialogProps) {
+  const appName = useAppName();
+  const single = pins.length === 1 ? pins[0] : null;
+
+  const confirmLabel = single
+    ? context === "server"
+      ? single.isCurrentUser
+        ? "Use your account"
+        : `Use ${single.ownerEmail}'s account`
+      : single.isCurrentUser
+        ? "Pin to your connection"
+        : `Pin to ${single.ownerEmail}'s connection`
+    : "Pin anyway";
+
+  // A plain (non-form) dialog: this renders inside a modal's own form, and a
+  // nested submit would bubble through the React portal to that form and
+  // save/close the whole modal. `type="button"` + stopPropagation keep the
+  // confirm contained. Cancel comes first so it takes initial focus.
+  return (
+    <StandardDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+      title={
+        <div className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          <span>Pin every user to a personal account?</span>
+        </div>
+      }
+      size="small"
+      footer={
+        <>
+          <Button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onCancel();
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={(e) => {
+              e.stopPropagation();
+              onConfirm();
+            }}
+          >
+            {confirmLabel}
+          </Button>
+        </>
+      }
+    >
+      {single ? (
+        <p className="text-sm text-muted-foreground">
+          {context === "server" ? (
+            single.isCurrentUser ? (
+              <>
+                Set as the default, every agent that resolves{" "}
+                <span className="text-foreground font-medium">
+                  {single.mcpName}
+                </span>{" "}
+                at call time connects as{" "}
+                <span className="text-foreground font-medium">you</span> — every
+                caller's request comes from you, with your access, against your
+                rate limits, and under your name.
+              </>
+            ) : (
+              <>
+                Set as the default, every agent that resolves{" "}
+                <span className="text-foreground font-medium">
+                  {single.mcpName}
+                </span>{" "}
+                at call time connects as{" "}
+                <span className="text-foreground font-medium">
+                  {single.ownerEmail}
+                </span>{" "}
+                — every caller's request comes from {single.ownerEmail}, with
+                their access, against their rate limits, and under their name.
+              </>
+            )
+          ) : single.isCurrentUser ? (
+            <>
+              Everyone who uses this agent will call{" "}
+              <span className="text-foreground font-medium">
+                {single.mcpName}
+              </span>{" "}
+              through <span className="text-foreground font-medium">your</span>{" "}
+              connection. To{" "}
+              <span className="text-foreground font-medium">
+                {single.mcpName}
+              </span>
+              , every request comes from you — with your access, against your
+              rate limits, and under your name.
+            </>
+          ) : (
+            <>
+              Everyone who uses this agent will call{" "}
+              <span className="text-foreground font-medium">
+                {single.mcpName}
+              </span>{" "}
+              through{" "}
+              <span className="text-foreground font-medium">
+                {single.ownerEmail}
+              </span>
+              's connection. To{" "}
+              <span className="text-foreground font-medium">
+                {single.mcpName}
+              </span>
+              , every request comes from {single.ownerEmail} — with their
+              access, against their rate limits, and under their name.
+            </>
+          )}{" "}
+          {appName}'s own tool-call log still records who actually ran each
+          call.
+        </p>
+      ) : (
+        <div className="space-y-3 text-sm text-muted-foreground">
+          <p>
+            Sharing this agent pins its tools to personal connections. Everyone
+            who uses it will call each server as that one owner — with their
+            access, rate limits, and name:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            {pins.map((pin) => (
+              <li key={`${pin.mcpName}:${pin.ownerEmail}`}>
+                <span className="text-foreground font-medium">
+                  {pin.mcpName}
+                </span>{" "}
+                as {pin.isCurrentUser ? "you" : pin.ownerEmail}
+              </li>
+            ))}
+          </ul>
+          <p>
+            {appName}'s own tool-call log still records who actually ran each
+            call.
+          </p>
+        </div>
+      )}
+    </StandardDialog>
+  );
+}

--- a/platform/frontend/src/components/token-select.test.tsx
+++ b/platform/frontend/src/components/token-select.test.tsx
@@ -1,13 +1,20 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DYNAMIC_CREDENTIAL_VALUE,
   TokenSelect,
 } from "@/components/token-select";
 
-const { useMcpServersGroupedByCatalogMock } = vi.hoisted(() => ({
-  useMcpServersGroupedByCatalogMock: vi.fn(),
-}));
+const { useMcpServersGroupedByCatalogMock, selectState, confirmDialogSpy } =
+  vi.hoisted(() => ({
+    useMcpServersGroupedByCatalogMock: vi.fn(),
+    // Captures the mocked Select's onValueChange so a SelectItem "click" can
+    // drive it (the real Radix Select can't be exercised in jsdom).
+    selectState: {
+      onValueChange: undefined as ((v: string) => void) | undefined,
+    },
+    confirmDialogSpy: vi.fn(),
+  }));
 
 vi.mock("@/lib/mcp/mcp-server.query", () => ({
   useMcpServersGroupedByCatalog: useMcpServersGroupedByCatalogMock,
@@ -16,13 +23,34 @@ vi.mock("@/lib/mcp/mcp-server.query", () => ({
 // TokenSelect reads the current user to label the selector's own connection in
 // the personal-pin confirmation.
 vi.mock("@/lib/auth/auth.query", () => ({
-  useSession: () => ({ data: undefined }),
+  useSession: () => ({ data: { user: { id: "current-user" } } }),
 }));
 
-// The confirmation dialog is exercised via e2e/QA; stub it here so its own
-// hooks (app name, dialog portal) don't pull a QueryClient into this unit test.
+// Stub the confirm dialog: record its props and, when open, expose confirm /
+// cancel buttons so the selection gate can be driven without the real dialog.
 vi.mock("@/components/static-credential-confirm-dialog", () => ({
-  StaticCredentialConfirmDialog: () => null,
+  StaticCredentialConfirmDialog: (props: {
+    open: boolean;
+    pins: Array<{
+      mcpName: string;
+      ownerEmail: string;
+      isCurrentUser: boolean;
+    }>;
+    onConfirm: () => void;
+    onCancel: () => void;
+  }) => {
+    confirmDialogSpy(props);
+    return props.open ? (
+      <div data-testid="confirm-dialog">
+        <button type="button" onClick={props.onConfirm}>
+          confirm-pin
+        </button>
+        <button type="button" onClick={props.onCancel}>
+          cancel-pin
+        </button>
+      </div>
+    ) : null;
+  },
 }));
 
 vi.mock("@/lib/utils", () => ({
@@ -39,9 +67,16 @@ vi.mock("@/components/divider", () => ({
 }));
 
 vi.mock("@/components/ui/select", () => ({
-  Select: ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  Select: ({
+    children,
+    onValueChange,
+  }: {
+    children?: React.ReactNode;
+    onValueChange?: (v: string) => void;
+  }) => {
+    selectState.onValueChange = onValueChange;
+    return <div>{children}</div>;
+  },
   SelectTrigger: ({ children }: { children?: React.ReactNode }) => (
     <button type="button">{children}</button>
   ),
@@ -53,29 +88,65 @@ vi.mock("@/components/ui/select", () => ({
   ),
   SelectItem: ({
     children,
+    value,
     description,
   }: {
     children?: React.ReactNode;
+    value?: string;
     description?: React.ReactNode;
   }) => (
-    <div>
+    <button
+      type="button"
+      onClick={() => value != null && selectState.onValueChange?.(value)}
+    >
       <div>{children}</div>
       {description ? <div>{description}</div> : null}
-    </div>
+    </button>
   ),
 }));
 
+const personalCred = {
+  id: "user-cred",
+  ownerEmail: "member@example.com",
+  ownerId: "other-user",
+  scope: "personal",
+  catalogName: "Everything",
+  name: "Everything",
+  teamDetails: null,
+};
+const ownPersonalCred = {
+  id: "own-cred",
+  ownerEmail: "me@example.com",
+  ownerId: "current-user",
+  scope: "personal",
+  catalogName: "Everything",
+  name: "Everything",
+  teamDetails: null,
+};
+const orgCred = {
+  id: "org-cred",
+  ownerEmail: "admin@example.com",
+  ownerId: "admin-user",
+  scope: "org",
+  catalogName: "Everything",
+  name: "Everything",
+  teamDetails: null,
+};
+
+const lastPins = () =>
+  confirmDialogSpy.mock.calls.at(-1)?.[0]?.pins as
+    | Array<{ mcpName: string; ownerEmail: string; isCurrentUser: boolean }>
+    | undefined;
+
 describe("TokenSelect", () => {
+  beforeEach(() => {
+    confirmDialogSpy.mockClear();
+    selectState.onValueChange = undefined;
+  });
+
   it("defaults to resolve-at-call-time even when static credentials exist", () => {
     useMcpServersGroupedByCatalogMock.mockReturnValue({
-      "catalog-1": [
-        {
-          id: "user-credential",
-          ownerEmail: "member@example.com",
-          scope: "personal",
-          teamDetails: null,
-        },
-      ],
+      "catalog-1": [personalCred],
     });
     const onValueChange = vi.fn();
 
@@ -141,5 +212,122 @@ describe("TokenSelect", () => {
     expect(screen.getByText("Static - User Credentials")).toBeInTheDocument();
     expect(screen.getByText("member@example.com")).toBeInTheDocument();
     expect(screen.getByText("Owned by member@example.com")).toBeInTheDocument();
+  });
+
+  it("confirms before applying a personal credential on a shared agent, and applies it on confirm", () => {
+    useMcpServersGroupedByCatalogMock.mockReturnValue({
+      "catalog-1": [personalCred],
+    });
+    const onValueChange = vi.fn();
+
+    render(
+      <TokenSelect
+        value={DYNAMIC_CREDENTIAL_VALUE}
+        onValueChange={onValueChange}
+        catalogId="catalog-1"
+        shouldSetDefaultValue={false}
+        agentScope="org"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("member@example.com"));
+
+    // Gated: selection not applied yet, dialog shown with the right pin.
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("confirm-dialog")).toBeInTheDocument();
+    expect(lastPins()).toEqual([
+      {
+        mcpName: "Everything",
+        ownerEmail: "member@example.com",
+        isCurrentUser: false,
+      },
+    ]);
+
+    fireEvent.click(screen.getByText("confirm-pin"));
+    expect(onValueChange).toHaveBeenCalledWith("user-cred");
+  });
+
+  it("does not apply the personal credential when the confirmation is cancelled", () => {
+    useMcpServersGroupedByCatalogMock.mockReturnValue({
+      "catalog-1": [personalCred],
+    });
+    const onValueChange = vi.fn();
+
+    render(
+      <TokenSelect
+        value={DYNAMIC_CREDENTIAL_VALUE}
+        onValueChange={onValueChange}
+        catalogId="catalog-1"
+        shouldSetDefaultValue={false}
+        agentScope="org"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("member@example.com"));
+    fireEvent.click(screen.getByText("cancel-pin"));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+  });
+
+  it("marks the selector's own connection as the current user in the confirmation", () => {
+    useMcpServersGroupedByCatalogMock.mockReturnValue({
+      "catalog-1": [ownPersonalCred],
+    });
+
+    render(
+      <TokenSelect
+        value={DYNAMIC_CREDENTIAL_VALUE}
+        onValueChange={vi.fn()}
+        catalogId="catalog-1"
+        shouldSetDefaultValue={false}
+        agentScope="team"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("me@example.com"));
+    expect(lastPins()?.[0]?.isCurrentUser).toBe(true);
+  });
+
+  it("applies a personal credential without confirmation on a personal-scope agent", () => {
+    useMcpServersGroupedByCatalogMock.mockReturnValue({
+      "catalog-1": [personalCred],
+    });
+    const onValueChange = vi.fn();
+
+    render(
+      <TokenSelect
+        value={DYNAMIC_CREDENTIAL_VALUE}
+        onValueChange={onValueChange}
+        catalogId="catalog-1"
+        shouldSetDefaultValue={false}
+        agentScope="personal"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("member@example.com"));
+    expect(onValueChange).toHaveBeenCalledWith("user-cred");
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+  });
+
+  it("applies an org/team credential on a shared agent without confirmation", () => {
+    useMcpServersGroupedByCatalogMock.mockReturnValue({
+      "catalog-1": [orgCred],
+    });
+    const onValueChange = vi.fn();
+
+    render(
+      <TokenSelect
+        value={DYNAMIC_CREDENTIAL_VALUE}
+        onValueChange={onValueChange}
+        catalogId="catalog-1"
+        shouldSetDefaultValue={false}
+        agentScope="org"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Organization"));
+    expect(onValueChange).toHaveBeenCalledWith("org-cred");
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/token-select.test.tsx
+++ b/platform/frontend/src/components/token-select.test.tsx
@@ -13,6 +13,18 @@ vi.mock("@/lib/mcp/mcp-server.query", () => ({
   useMcpServersGroupedByCatalog: useMcpServersGroupedByCatalogMock,
 }));
 
+// TokenSelect reads the current user to label the selector's own connection in
+// the personal-pin confirmation.
+vi.mock("@/lib/auth/auth.query", () => ({
+  useSession: () => ({ data: undefined }),
+}));
+
+// The confirmation dialog is exercised via e2e/QA; stub it here so its own
+// hooks (app name, dialog portal) don't pull a QueryClient into this unit test.
+vi.mock("@/components/static-credential-confirm-dialog", () => ({
+  StaticCredentialConfirmDialog: () => null,
+}));
+
 vi.mock("@/lib/utils", () => ({
   cn: (...classes: Array<string | false | null | undefined>) =>
     classes.filter(Boolean).join(" "),

--- a/platform/frontend/src/components/token-select.tsx
+++ b/platform/frontend/src/components/token-select.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { type AgentScope, E2eTestId } from "@archestra/shared";
-import { Zap } from "lucide-react";
-import { useEffect } from "react";
+import { RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
 import {
   Select,
   SelectContent,
@@ -10,10 +10,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useSession } from "@/lib/auth/auth.query";
 import { useMcpServersGroupedByCatalog } from "@/lib/mcp/mcp-server.query";
 import { cn } from "@/lib/utils";
 import Divider from "./divider";
 import { LoadingSpinner } from "./loading";
+import { StaticCredentialConfirmDialog } from "./static-credential-confirm-dialog";
 
 // Special value for dynamic team credential option
 export const DYNAMIC_CREDENTIAL_VALUE = "__dynamic__";
@@ -29,6 +31,13 @@ interface TokenSelectProps {
   assignmentTeamIds?: string[];
   shouldSetDefaultValue: boolean;
   prefersEnterpriseManaged?: boolean;
+  /**
+   * Scope of the agent this credential is assigned to. Picking a personal-scope
+   * connection for a shared (team/org) agent makes every caller authenticate as
+   * that one owner, so it is confirmed on selection. A personal agent is
+   * single-user and skips the confirmation. Unknown scope falls to the safe side.
+   */
+  agentScope?: AgentScope;
 }
 
 /**
@@ -47,7 +56,11 @@ export function TokenSelect({
   assignmentTeamIds,
   shouldSetDefaultValue,
   prefersEnterpriseManaged = false,
+  agentScope,
 }: TokenSelectProps) {
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
+
   const groupedCredentials = useMcpServersGroupedByCatalog({
     catalogId,
     assignmentScope,
@@ -84,6 +97,34 @@ export function TokenSelect({
     }
   }, []);
 
+  const [pendingPersonalPin, setPendingPersonalPin] = useState<{
+    id: string;
+    mcpName: string;
+    ownerEmail: string;
+    isCurrentUser: boolean;
+  } | null>(null);
+
+  // A personal connection pinned to a shared agent authenticates every caller
+  // as that one owner; confirm the pick before applying it. A personal agent is
+  // single-user, so it skips the gate; unknown scope falls to the safe side.
+  const isSharedAgent = agentScope !== "personal";
+
+  const handleSelect = (newValue: string | null) => {
+    if (isSharedAgent && newValue && newValue !== DYNAMIC_CREDENTIAL_VALUE) {
+      const server = mcpServers.find((s) => s.id === newValue);
+      if (server?.scope === "personal") {
+        setPendingPersonalPin({
+          id: server.id,
+          mcpName: server.catalogName ?? server.name,
+          ownerEmail: server.ownerEmail || "Deleted user",
+          isCurrentUser: !!currentUserId && server.ownerId === currentUserId,
+        });
+        return;
+      }
+    }
+    onValueChange(newValue);
+  };
+
   if (isLoading) {
     return <LoadingSpinner className="w-3 h-3 inline-block ml-2" />;
   }
@@ -97,108 +138,131 @@ export function TokenSelect({
   }
 
   return (
-    <Select
-      value={value ?? ""}
-      onValueChange={onValueChange}
-      disabled={disabled || isLoading}
-    >
-      <SelectTrigger
-        className={cn(
-          "h-fit! w-fit! bg-transparent! border-none! shadow-none! ring-0! outline-none! focus:ring-0! focus:outline-none! focus:border-none! p-0! text-xs font-normal",
-          className,
-        )}
-        size="sm"
-        data-testid={E2eTestId.TokenSelect}
+    <>
+      <Select
+        value={value ?? ""}
+        onValueChange={handleSelect}
+        disabled={disabled || isLoading}
       >
-        <SelectValue placeholder="Select connection..." />
-      </SelectTrigger>
-      <SelectContent>
-        <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
-          Dynamic
-        </div>
-        <SelectItem
-          value={DYNAMIC_CREDENTIAL_VALUE}
-          className="cursor-pointer"
-          description={
-            prefersEnterpriseManaged
-              ? "Ask your identity provider for a runtime credential for this server."
-              : "Follow the server's default credential setting — the caller's own connection, unless the server always uses one account."
-          }
+        <SelectTrigger
+          className={cn(
+            "h-fit! w-fit! bg-transparent! border-none! shadow-none! ring-0! outline-none! focus:ring-0! focus:outline-none! focus:border-none! p-0! text-xs font-normal",
+            className,
+          )}
+          size="sm"
+          data-testid={E2eTestId.TokenSelect}
         >
-          <div className="flex items-center gap-1">
-            <Zap className="h-3! w-3! text-amber-500" />
-            <span>Resolve at call time</span>
+          <SelectValue placeholder="Select connection..." />
+        </SelectTrigger>
+        <SelectContent>
+          <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
+            Dynamic
           </div>
-        </SelectItem>
-        {mcpServers.length > 0 ? (
-          <>
-            {organizationCredentials.length > 0 && (
-              <>
-                <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
-                  Static - Organization Credentials
-                </div>
-                {organizationCredentials.map((server) => (
-                  <SelectItem
-                    key={server.id}
-                    value={server.id}
-                    className="cursor-pointer"
-                    data-testid={E2eTestId.StaticCredentialToUse}
-                    description="Available to the organization"
-                  >
-                    Organization
-                  </SelectItem>
-                ))}
-              </>
-            )}
-            <Divider className="my-2" />
-            {teamCredentials.length > 0 && (
-              <>
-                <div className="px-2 pt-1 pb-1 text-xs text-muted-foreground">
-                  Static - Team Credentials
-                </div>
-                {teamCredentials.map((server) => (
-                  <SelectItem
-                    key={server.id}
-                    value={server.id}
-                    className="cursor-pointer"
-                    data-testid={E2eTestId.StaticCredentialToUse}
-                    description={`Shared with team ${server.teamDetails?.name ?? "Unknown team"}`}
-                  >
-                    {server.teamDetails?.name ?? "Unknown team"}
-                  </SelectItem>
-                ))}
-              </>
-            )}
-            {userCredentials.length > 0 && (
-              <>
-                <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
-                  Static - User Credentials
-                </div>
-                {userCredentials.map((server) => (
-                  <SelectItem
-                    key={server.id}
-                    value={server.id}
-                    className="cursor-pointer"
-                    data-testid={E2eTestId.StaticCredentialToUse}
-                    description={`Owned by ${server.ownerEmail || "Deleted user"}`}
-                  >
-                    {server.ownerEmail || "Deleted user"}
-                  </SelectItem>
-                ))}
-              </>
-            )}
-          </>
-        ) : (
-          <>
-            <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
-              Static
+          <SelectItem
+            value={DYNAMIC_CREDENTIAL_VALUE}
+            className="cursor-pointer"
+            description={
+              prefersEnterpriseManaged
+                ? "Ask your identity provider for a runtime credential for this server."
+                : "Follow the server's default credential setting — the caller's own connection, unless the server always uses one account."
+            }
+          >
+            <div className="flex items-center gap-1">
+              <RefreshCw className="h-3! w-3! text-muted-foreground" />
+              <span>Resolve at call time (Recommended)</span>
             </div>
-            <div className="px-2 pb-2 text-xs text-muted-foreground">
-              No saved credentials for this server.
-            </div>
-          </>
-        )}
-      </SelectContent>
-    </Select>
+          </SelectItem>
+          {mcpServers.length > 0 ? (
+            <>
+              {organizationCredentials.length > 0 && (
+                <>
+                  <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
+                    Static - Organization Credentials
+                  </div>
+                  {organizationCredentials.map((server) => (
+                    <SelectItem
+                      key={server.id}
+                      value={server.id}
+                      className="cursor-pointer"
+                      data-testid={E2eTestId.StaticCredentialToUse}
+                      description="Available to the organization"
+                    >
+                      Organization
+                    </SelectItem>
+                  ))}
+                </>
+              )}
+              <Divider className="my-2" />
+              {teamCredentials.length > 0 && (
+                <>
+                  <div className="px-2 pt-1 pb-1 text-xs text-muted-foreground">
+                    Static - Team Credentials
+                  </div>
+                  {teamCredentials.map((server) => (
+                    <SelectItem
+                      key={server.id}
+                      value={server.id}
+                      className="cursor-pointer"
+                      data-testid={E2eTestId.StaticCredentialToUse}
+                      description={`Shared with team ${server.teamDetails?.name ?? "Unknown team"}`}
+                    >
+                      {server.teamDetails?.name ?? "Unknown team"}
+                    </SelectItem>
+                  ))}
+                </>
+              )}
+              {userCredentials.length > 0 && (
+                <>
+                  <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
+                    Static - User Credentials
+                  </div>
+                  {userCredentials.map((server) => (
+                    <SelectItem
+                      key={server.id}
+                      value={server.id}
+                      className="cursor-pointer"
+                      data-testid={E2eTestId.StaticCredentialToUse}
+                      description={`Owned by ${server.ownerEmail || "Deleted user"}`}
+                    >
+                      {server.ownerEmail || "Deleted user"}
+                    </SelectItem>
+                  ))}
+                </>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="px-2 pt-2 pb-1 text-xs text-muted-foreground">
+                Static
+              </div>
+              <div className="px-2 pb-2 text-xs text-muted-foreground">
+                No saved credentials for this server.
+              </div>
+            </>
+          )}
+        </SelectContent>
+      </Select>
+      <StaticCredentialConfirmDialog
+        open={pendingPersonalPin !== null}
+        pins={
+          pendingPersonalPin
+            ? [
+                {
+                  mcpName: pendingPersonalPin.mcpName,
+                  ownerEmail: pendingPersonalPin.ownerEmail,
+                  isCurrentUser: pendingPersonalPin.isCurrentUser,
+                },
+              ]
+            : []
+        }
+        onConfirm={() => {
+          if (pendingPersonalPin) {
+            onValueChange(pendingPersonalPin.id);
+          }
+          setPendingPersonalPin(null);
+        }}
+        onCancel={() => setPendingPersonalPin(null)}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Selecting a **personal-scope** MCP connection for a **shared** (team/org) agent makes *every* caller of that agent authenticate to the MCP server as that one owner — their access, their rate limits, their identity at the server. Nothing marked that moment, so a shared agent (or a shared server default) could be bound to one person's personal account silently.

This adds a confirmation the instant such a connection is selected, before it takes effect, on the surfaces where it can happen:

- **Agent editor and chat setup** — choosing a personal connection as a tool's static credential (`TokenSelect`).
- **MCP registry → Default credential** — designating a personal connection as the server's default call-time connection (`dynamicConnectionMcpServerId`).

The dialog names the backing server and the owning user, and says "your connection" when it is the selector's own. Organization/team connections (shared by design), "on behalf of the user", and resolve-at-call-time apply with no prompt. Cancel reverts the selection; nothing persists until confirm.

Because the guard lives in the shared credential selector, both the agent editor and chat setup are covered by one component. The registry's "Default credential" control is a separate immediate-save selector and gets the same confirmation with server-context wording.

Alongside the guard: the resolve-at-call-time option now uses a neutral refresh icon and reads "Resolve at call time (Recommended)" (matching "On behalf of the user (Recommended)" on the server default), the now-redundant helper paragraph above the selector is removed, and the default-credential selector is widened to fit its label.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>