### PR TITLE
ci: run heavy test suites only in the merge queue

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -6,6 +6,11 @@ on:
       - opened
       - synchronize
       - reopened
+      # labeled: adding the "run-unit-tests" label triggers a run immediately
+      # (see the merge-queue-only guard comment below). The per-PR concurrency
+      # group cancels the superseded run, so the label-event re-run of the
+      # lint/policy jobs is cheap noise, not a duplicate.
+      - labeled
   # Required checks must also run on merge_group when merge queue is enabled,
   # otherwise the queue waits for PR-only statuses that never appear on the
   # temporary merge-group SHA.
@@ -227,33 +232,42 @@ jobs:
       - name: Skip dependency review for merge queue
         run: echo "Dependency Review only has PR diff context; PR run already validated dependencies before merge queue."
 
-  # Fast feedback on every PR push: lint + typecheck + unit tests.
-  # Full E2E runs in the separate "Platform E2E Tests" workflow on merge queue
-  # or on-demand via the "run-e2e" PR label.
+  # Fast feedback on every PR push: lint + typecheck + codegen validation
+  # (platform-lint-and-unit-tests). The heavy test suites — backend unit test
+  # shards, frontend integration tests, and both Rust checks — are
+  # merge-queue-only, mirroring the E2E model in platform-e2e-tests.yml
+  # (which runs on merge queue or on-demand via the "run-e2e" PR label).
   #
-  # bot-pr-guard: the expensive jobs below skip on automated bot PRs.
-  # release-please (archestra-ci[bot]) force-rewrites its PR branch on every
-  # merge to main — re-running the full suite dozens of times a day — and the
-  # contributor-onboarding bot (archestra-contributor-pr-bot[bot]) opens
-  # one-line docs PRs that auto-merge in seconds. Neither can surface real
-  # failures, and the merge queue re-runs all required checks for real on
-  # merge_group anyway. A job that skips under its own name still satisfies
-  # its required status check (see the required-check note in
-  # platform-e2e-tests.yml), so no placeholder twins are needed — a
-  # same-named twin would mask real failures on merge_group. The guard only
-  # bites on pull_request events: on merge_group, github.event.pull_request
-  # is null and the first clause short-circuits, so queue validation runs
-  # unchanged.
+  # merge-queue-only guard: the heavy test jobs below carry
+  #   github.event_name != 'pull_request' ||
+  #     contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
+  # On plain PR pushes the jobs skip UNDER THEIR OWN NAMES — GitHub treats a
+  # skipped check run as satisfying a required status check (see the
+  # required-check note in platform-e2e-tests.yml), so the "Backend Unit
+  # Tests" / "Platform Rust Checks" required contexts stay green without
+  # running. NEVER add same-named placeholder twin jobs: a skipped twin also
+  # reports on merge_group and would satisfy the required check even when the
+  # real job FAILS. On merge_group, github.event_name != 'pull_request' is
+  # true, so the queue always validates for real — a red shard blocks the
+  # merge. Add the "run-unit-tests" label to a PR to run the suites on its
+  # pushes (the `labeled` trigger above picks the label up immediately).
   #
-  # EXCEPTION: platform-lint-and-unit-tests must still run on release-please
-  # PRs — it auto-commits the regenerated docs/openapi.json version bump onto
-  # the release branch ("chore: update docs/openapi.json version for
-  # release"). Without that commit the merge_group codegen check fails and
-  # the release cannot merge, so that job only skips the contributor bot.
+  # This guard subsumes the old bot-pr-guard on these jobs: bot PRs
+  # (release-please / contributor-onboarding) never carry the label, so they
+  # skip like every other unlabeled PR.
+  #
+  # EXCEPTION: platform-lint-and-unit-tests stays on every PR push for fast
+  # typecheck/codegen signal, and must still run on release-please PRs — it
+  # auto-commits the regenerated docs/openapi.json version bump onto the
+  # release branch ("chore: update docs/openapi.json version for release").
+  # Without that commit the merge_group codegen check fails and the release
+  # cannot merge, so that job only skips the contributor-onboarding bot
+  # (archestra-contributor-pr-bot[bot]), whose one-line auto-merged docs PRs
+  # cannot surface real failures.
   platform-lint-and-unit-tests:
     name: Platform Lint and Unit Tests
-    # bot-pr-guard (see above): contributor bot only — release-please PRs
-    # need this job's codegen auto-commit.
+    # bot guard (see the EXCEPTION note above): contributor bot only —
+    # release-please PRs need this job's codegen auto-commit.
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     # Backstop: every check here finishes in well under 10m, but leaked
@@ -419,8 +433,8 @@ jobs:
   # operates on the committed lockfile.
   platform-rust-checks:
     name: Platform Rust Checks
-    # bot-pr-guard (see comment above platform-lint-and-unit-tests)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
+    # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
@@ -462,8 +476,8 @@ jobs:
 
   ai-labs-rust-checks:
     name: AI Labs Rust Checks
-    # bot-pr-guard (see comment above platform-lint-and-unit-tests)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
+    # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
@@ -502,8 +516,8 @@ jobs:
   # takes the suite off the workflow's critical path.
   backend-unit-tests:
     name: Backend Unit Tests (shard ${{ matrix.shard }}/4)
-    # bot-pr-guard (see comment above platform-lint-and-unit-tests)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
+    # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     # A full local suite run is ~4 min on comparable hardware; a shard is a
     # quarter of that plus setup. 15 minutes means something is hung.
@@ -565,11 +579,11 @@ jobs:
     name: Backend Unit Tests
     runs-on: blacksmith-2vcpu-ubuntu-2404
     # always() so the gate still runs (and turns red) when a shard fails,
-    # ANDed with the bot-pr-guard (see comment above
-    # platform-lint-and-unit-tests): when the shards skip on a bot PR, the
-    # gate must skip too — with plain always() it would run and fail on the
-    # shards' "skipped" result.
-    if: always() && (github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'))
+    # ANDed with the merge-queue-only guard (see comment above
+    # platform-lint-and-unit-tests): when the shards skip on an unlabeled PR
+    # push, the gate must skip too — with plain always() it would run and
+    # fail on the shards' "skipped" result.
+    if: always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests'))
     needs: [backend-unit-tests]
     permissions: {}
     steps:
@@ -585,8 +599,8 @@ jobs:
 
   frontend-integration-tests:
     name: Frontend Integration Tests (MSW)
-    # bot-pr-guard (see comment above platform-lint-and-unit-tests)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'archestra-ci[bot]' && github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]')
+    # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read


### PR DESCRIPTION
## What

Moves the four heavy test suites in `on-pull-requests.yml` off plain PR pushes. They now run for real only in the merge queue (`merge_group`) — or on a PR's pushes when the `run-unit-tests` label is present.

**Moved to merge-queue-only:**
- Backend Unit Tests (all 4 shards) + the "Backend Unit Tests" fan-in gate
- Frontend Integration Tests (MSW)
- Platform Rust Checks
- AI Labs Rust Checks

**Unchanged on every PR push:**
- Platform Lint and Unit Tests (fast typecheck/codegen signal; release-please PRs depend on its codegen auto-commit)
- All cheap policy checks: License Compliance, Supply Chain Policy, Docs Image Policy, Docs Link Check, Migration Kit Checks, Dependency Review, Release Freeze Check, Helm Chart Linting and Tests

## Why

Measured today, the four 16vcpu Backend Unit Test shards alone are ~48% of total CI compute, and the frontend integration + two Rust checks add ~2.6k vcpu-min/day. Every PR paid the full suite twice: once per push, again per merge-queue attempt. The merge queue re-validates every required check for real before anything lands, so the per-push run is redundant spend for most PRs.

## Mechanics

Same model the repo already uses for e2e (see the header comment in `platform-e2e-tests.yml`):

- Each moved job carries a job-level guard:
  ```
  if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
  ```
- On plain PR pushes the jobs **skip under their own names**. GitHub treats a skipped check run as satisfying a required status check, so the required "Backend Unit Tests" and "Platform Rust Checks" contexts stay satisfied. No placeholder twin jobs — a skipped twin would also report on `merge_group` and could mask a real failure there.
- On `merge_group`, `github.event_name != 'pull_request'` is true, so the queue always runs the suites for real; a red shard fails the gate (`always()` + explicit needs-result check) and blocks the merge.
- The "Backend Unit Tests" gate keeps its `always()` + result-check structure, ANDed with the same guard: it skips exactly when the shards skip, and still turns red on any shard failure when they run.

**Bot guards:** the moved jobs previously skipped on release-please / contributor-bot PRs via author checks. The new guard fully subsumes those for `pull_request` events — bot PRs never carry the `run-unit-tests` label, so they skip like every other unlabeled PR. The bot-author clauses were removed from the four moved jobs only. `platform-lint-and-unit-tests` keeps its contributor-bot guard untouched.

**`labeled` trigger:** added to `on: pull_request: types` so adding the label triggers a run immediately (mirrors `platform-e2e-tests.yml`). The per-PR concurrency group (`cancel-in-progress: true`) cancels the superseded run, so the label-event re-run of lint/policy jobs is cheap noise, not a duplicate. Side effect: any label added to a PR now retriggers this workflow (and cancels its in-flight run) — same trade the e2e workflow already accepted.

## Using the label

Add `run-unit-tests` to a PR to run the heavy suites on that PR's pushes — useful when iterating on test-heavy changes and you want per-push signal instead of finding out at queue time.

## Trade-off

Test failures on unlabeled PRs surface at merge-queue time instead of per push. This is the same accepted model as `run-e2e`: the queue is the real gate, and the label is the escape hatch for PRs that want early signal.

## Validation

- YAML parses (`ruby -ryaml`).
- Required-check inventory confirmed via `gh api repos/archestra-ai/archestra/rules/branches/main`: of the moved jobs, "Backend Unit Tests" (the gate name) and "Platform Rust Checks" are required; both still produce a (skipped) check run on plain PR pushes because the gating is job-level `if` only — no workflow-level event/path filtering.
- This PR's own runs: first run without the label shows the moved jobs SKIPPED with lint + policy green; then the `run-unit-tests` label was added to confirm the suites run and pass on a labeled PR (results in comments/checks below).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>