### PR TITLE
feat(chat): group sidebar recents into per-day date sections

### DIFF
--- a/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
@@ -4,7 +4,7 @@ import {
 } from "@archestra/shared";
 import { render, screen } from "@testing-library/react";
 import { format, subDays } from "date-fns";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock ResizeObserver used by Radix UI components
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
@@ -253,6 +253,10 @@ import { useFeature } from "@/lib/config/config.query";
 import { ChatSidebarSection } from "./chat-sidebar-section";
 
 beforeEach(() => {
+  // Pin the clock (midday, local time) so date-bucket labels are deterministic
+  // — no flakes when a run crosses midnight or a DST transition.
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(2026, 6 /* July */, 16, 12));
   vi.mocked(useRouter).mockReturnValue({
     push: mockRouterPush,
   } as unknown as ReturnType<typeof useRouter>);
@@ -264,6 +268,10 @@ beforeEach(() => {
     data: true,
   } as ReturnType<typeof useHasPermissions>);
   vi.mocked(useFeature).mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 function makeConv(
@@ -283,9 +291,9 @@ function makeConv(
   };
 }
 
-/** ISO timestamp n days before now (0 = today, 1 = always the previous calendar day). */
+/** ISO timestamp n calendar days before now (0 = today, 1 = yesterday). */
 function daysAgo(n: number) {
-  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+  return subDays(new Date(), n).toISOString();
 }
 
 describe("ChatSidebarSection", () => {

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.test.tsx
@@ -3,6 +3,7 @@ import {
   getChatItemUnreadIndicatorTestId,
 } from "@archestra/shared";
 import { render, screen } from "@testing-library/react";
+import { format, subDays } from "date-fns";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock ResizeObserver used by Radix UI components
@@ -268,16 +269,23 @@ beforeEach(() => {
 function makeConv(
   id: string,
   title: string,
-  opts?: { pinnedAt?: string; updatedAt?: string },
+  opts?: { pinnedAt?: string; updatedAt?: string; lastMessageAt?: string },
 ) {
+  const updatedAt = opts?.updatedAt ?? new Date().toISOString();
   return {
     id,
     title,
     pinnedAt: opts?.pinnedAt ?? null,
-    updatedAt: opts?.updatedAt ?? new Date().toISOString(),
+    updatedAt,
+    lastMessageAt: opts?.lastMessageAt ?? updatedAt,
     messages: [],
     agent: { id: "agent-1", name: "Test Agent" },
   };
+}
+
+/** ISO timestamp n days before now (0 = today, 1 = always the previous calendar day). */
+function daysAgo(n: number) {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
 }
 
 describe("ChatSidebarSection", () => {
@@ -344,9 +352,10 @@ describe("ChatSidebarSection", () => {
 
     render(<ChatSidebarSection fadeIn={fadeIn} />);
 
-    // Section labels
+    // Section labels: recents render under a date bucket, not "Recents"
+    // (2026-01-02 is long past, so it lands in "Older").
     expect(screen.getByText("Pinned")).toBeInTheDocument();
-    expect(screen.getByText("Recents")).toBeInTheDocument();
+    expect(screen.getByText("Older")).toBeInTheDocument();
 
     // Pinned chats are not capped by the recents budget — all 3 show...
     expect(screen.getByText("Pinned One")).toBeInTheDocument();
@@ -383,7 +392,7 @@ describe("ChatSidebarSection", () => {
     expect(screen.queryByText("More")).not.toBeInTheDocument();
   });
 
-  it("does not render a Recents section or 'More' when all chats are pinned", () => {
+  it("does not render date sections or 'More' when all chats are pinned", () => {
     mockConversations = [
       makeConv("c1", "Pinned A", {
         pinnedAt: "2026-01-05T00:00:00Z",
@@ -401,9 +410,57 @@ describe("ChatSidebarSection", () => {
     expect(screen.getByText("Pinned A")).toBeInTheDocument();
     expect(screen.getByText("Pinned B")).toBeInTheDocument();
 
-    // No unpinned chats → no Recents section and no dangling "More".
-    expect(screen.queryByText("Recents")).not.toBeInTheDocument();
+    // No unpinned chats → no date sections and no dangling "More".
+    expect(screen.queryByText("Today")).not.toBeInTheDocument();
+    expect(screen.queryByText("Older")).not.toBeInTheDocument();
     expect(screen.queryByText("More")).not.toBeInTheDocument();
+  });
+
+  it("groups recents into per-day date sections by lastMessageAt", () => {
+    mockConversations = [
+      makeConv("c1", "Today Chat", { lastMessageAt: daysAgo(0) }),
+      makeConv("c2", "Yesterday Chat", { lastMessageAt: daysAgo(1) }),
+      makeConv("c3", "This Week Chat", { lastMessageAt: daysAgo(3) }),
+      makeConv("c4", "Old Chat", { lastMessageAt: daysAgo(30) }),
+    ];
+
+    render(<ChatSidebarSection slots={4} fadeIn={fadeIn} />);
+
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    // Days 2-6 back get their own "Jul 14"-style section.
+    expect(
+      screen.getByText(format(subDays(new Date(), 3), "MMM d")),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Older")).toBeInTheDocument();
+
+    expect(screen.getByText("Today Chat")).toBeInTheDocument();
+    expect(screen.getByText("Yesterday Chat")).toBeInTheDocument();
+    expect(screen.getByText("This Week Chat")).toBeInTheDocument();
+    expect(screen.getByText("Old Chat")).toBeInTheDocument();
+
+    // All 4 fit the slot budget, so no "More".
+    expect(screen.queryByText("More")).not.toBeInTheDocument();
+  });
+
+  it("only renders date sections for non-empty buckets and keeps 'More' in the last one", () => {
+    mockConversations = [
+      makeConv("c1", "Today One", { lastMessageAt: daysAgo(0) }),
+      makeConv("c2", "Today Two", { lastMessageAt: daysAgo(0) }),
+      makeConv("c3", "Today Three", { lastMessageAt: daysAgo(0) }),
+      makeConv("c4", "Today Four", { lastMessageAt: daysAgo(0) }),
+    ];
+
+    render(<ChatSidebarSection fadeIn={fadeIn} />);
+
+    // Only the "Today" bucket has visible chats (default 3 slots).
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.queryByText("Yesterday")).not.toBeInTheDocument();
+    expect(screen.queryByText("Older")).not.toBeInTheDocument();
+
+    // 4th chat falls behind the slot budget → "More" affordance.
+    expect(screen.queryByText("Today Four")).not.toBeInTheDocument();
+    expect(screen.getByText("More")).toBeInTheDocument();
   });
 
   it("does not show 'More' when total conversations fit in slots", () => {

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -73,6 +73,7 @@ import {
   getConversationShareTooltip,
 } from "@/lib/chat/chat-utils";
 import { useGlobalChat } from "@/lib/chat/global-chat.context";
+import { groupConversationsByDay } from "@/lib/chat/group-conversations-by-date";
 import { buildPinnedSidebarItems } from "@/lib/chat/pinned-sidebar-items";
 import type { Once } from "@/lib/hooks/use-once";
 import { canCreateProjectFromChat } from "@/lib/projects/can-create-project-from-chat";
@@ -703,6 +704,13 @@ export function ChatSidebarSection({
   const subClass = flat ? "mx-0 border-l-0 px-0" : "mx-0 ml-3.5 px-0 pl-2.5";
   const showMore = recentUnpinnedChats.length > slots;
 
+  // The list arrives sorted by lastMessageAt desc, so grouping the visible
+  // slice by the same timestamp yields contiguous date sections.
+  const recentChatGroups = groupConversationsByDay(
+    recentUnpinnedChats.slice(0, slots),
+    (c) => c.lastMessageAt,
+  );
+
   return (
     <>
       {isLoading ? (
@@ -730,33 +738,32 @@ export function ChatSidebarSection({
             </SidebarGroup>
           )}
 
-          {recentUnpinnedChats.length > 0 && (
-            <SidebarGroup className="pt-0">
-              <SidebarGroupLabel>Recents</SidebarGroupLabel>
+          {recentChatGroups.map((group, groupIndex) => (
+            <SidebarGroup key={group.label} className="pt-0">
+              <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
                   <SidebarMenuItem>
                     <SidebarMenuSub className={subClass}>
-                      {recentUnpinnedChats
-                        .slice(0, slots)
-                        .map((conv) => renderConversationItem(conv))}
-                      {showMore && (
-                        <SidebarMenuSubItem>
-                          <SidebarMenuSubButton
-                            className="cursor-pointer text-sidebar-foreground/70"
-                            onClick={openConversationSearch}
-                          >
-                            <MoreHorizontal />
-                            <span>More</span>
-                          </SidebarMenuSubButton>
-                        </SidebarMenuSubItem>
-                      )}
+                      {group.chats.map((conv) => renderConversationItem(conv))}
+                      {showMore &&
+                        groupIndex === recentChatGroups.length - 1 && (
+                          <SidebarMenuSubItem>
+                            <SidebarMenuSubButton
+                              className="cursor-pointer text-sidebar-foreground/70"
+                              onClick={openConversationSearch}
+                            >
+                              <MoreHorizontal />
+                              <span>More</span>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        )}
                     </SidebarMenuSub>
                   </SidebarMenuItem>
                 </SidebarMenu>
               </SidebarGroupContent>
             </SidebarGroup>
-          )}
+          ))}
         </ChatListFadeIn>
       )}
 

--- a/platform/frontend/src/components/conversation-search-palette.test.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.test.tsx
@@ -153,12 +153,14 @@ describe("ConversationSearchPalette", () => {
           id: "conv-1",
           title: "First conversation",
           updatedAt: new Date().toISOString(),
+          lastMessageAt: new Date().toISOString(),
           messages: [],
         },
         {
           id: "conv-2",
           title: "Second conversation",
           updatedAt: new Date().toISOString(),
+          lastMessageAt: new Date().toISOString(),
           messages: [],
         },
       ],
@@ -189,6 +191,40 @@ describe("ConversationSearchPalette", () => {
 
     expect(screen.getByText("First conversation")).toBeInTheDocument();
     expect(screen.getByText("Second conversation")).toBeInTheDocument();
+  });
+
+  it("shows a date bucket label on each row instead of date group headings", () => {
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    // Both mock conversations have lastMessageAt = now → one "Today" label per
+    // row. With date headings there would be a single "Today" for the group.
+    expect(screen.getAllByText("Today")).toHaveLength(2);
+    expect(screen.queryByText("Previous 7 Days")).not.toBeInTheDocument();
+    expect(screen.queryByText("Previous 30 Days")).not.toBeInTheDocument();
+  });
+
+  it("keeps the Pinned heading for pinned conversations", () => {
+    mockUseConversations.mockReturnValue({
+      data: [
+        {
+          id: "conv-1",
+          title: "Pinned conversation",
+          updatedAt: new Date().toISOString(),
+          lastMessageAt: new Date().toISOString(),
+          pinnedAt: new Date().toISOString(),
+          messages: [],
+        },
+      ],
+      isLoading: false,
+      isFetching: false,
+    });
+
+    render(<ConversationSearchPalette {...defaultProps} />);
+
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+    expect(screen.getByText("Pinned conversation")).toBeInTheDocument();
+    // Pinned rows show their date bucket too.
+    expect(screen.getByText("Today")).toBeInTheDocument();
   });
 
   it("routes Connect to the connection page", () => {

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -415,9 +415,9 @@ export function ConversationSearchPalette({
 
   const renderConversationItem = (
     conv: (typeof conversations)[number],
-    showPinIcon = false,
-    dateLabel?: string,
+    opts?: { showPinIcon?: boolean; dateLabel?: string },
   ) => {
+    const { showPinIcon = false, dateLabel } = opts ?? {};
     const isSearchActive = debouncedSearch.trim().length > 0;
     const displayTitle = getConversationDisplayTitle(conv.title, conv.messages);
     const preview = isSearchActive
@@ -574,22 +574,19 @@ export function ConversationSearchPalette({
                 {browseConversations.pinned.length > 0 && (
                   <CommandGroup heading="Pinned">
                     {browseConversations.pinned.map((conv) =>
-                      renderConversationItem(
-                        conv,
-                        true,
-                        getDateBucketLabel(conv.lastMessageAt),
-                      ),
+                      renderConversationItem(conv, {
+                        showPinIcon: true,
+                        dateLabel: getDateBucketLabel(conv.lastMessageAt),
+                      }),
                     )}
                   </CommandGroup>
                 )}
                 {browseConversations.unpinned.length > 0 && (
                   <CommandGroup>
                     {browseConversations.unpinned.map((conv) =>
-                      renderConversationItem(
-                        conv,
-                        false,
-                        getDateBucketLabel(conv.lastMessageAt),
-                      ),
+                      renderConversationItem(conv, {
+                        dateLabel: getDateBucketLabel(conv.lastMessageAt),
+                      }),
                     )}
                   </CommandGroup>
                 )}

--- a/platform/frontend/src/components/conversation-search-palette.tsx
+++ b/platform/frontend/src/components/conversation-search-palette.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useDebounce } from "@uidotdev/usehooks";
-import { isToday, isWithinInterval, isYesterday, subDays } from "date-fns";
 import {
   Bot,
   Cable,
@@ -54,6 +53,7 @@ import {
   getConversationDisplayTitle,
   getConversationShareTooltip,
 } from "@/lib/chat/chat-utils";
+import { getDateBucketLabel } from "@/lib/chat/group-conversations-by-date";
 import { usePlatform } from "@/lib/hooks/use-platform";
 
 /**
@@ -77,39 +77,6 @@ function extractTextFromMessages(
     }
   }
   return textParts.join(" ");
-}
-
-/** Groups conversations into time-based buckets for organized display */
-function groupConversationsByDate<
-  T extends { updatedAt: string | Date; pinnedAt?: string | Date | null },
->(conversations: T[]) {
-  const pinned: T[] = [];
-  const today: T[] = [];
-  const yesterday: T[] = [];
-  const previous7Days: T[] = [];
-  const older: T[] = [];
-
-  const now = new Date();
-  const sevenDaysAgo = subDays(now, 7);
-
-  for (const conv of conversations) {
-    if (conv.pinnedAt) {
-      pinned.push(conv);
-      continue;
-    }
-    const updatedAt = new Date(conv.updatedAt);
-    if (isToday(updatedAt)) {
-      today.push(conv);
-    } else if (isYesterday(updatedAt)) {
-      yesterday.push(conv);
-    } else if (isWithinInterval(updatedAt, { start: sevenDaysAgo, end: now })) {
-      previous7Days.push(conv);
-    } else {
-      older.push(conv);
-    }
-  }
-
-  return { pinned, today, yesterday, previous7Days, older };
 }
 
 // Product navigation items matching sidebar names
@@ -251,11 +218,14 @@ export function ConversationSearchPalette({
   const isTyping = searchQuery !== debouncedSearch;
   const isSearchingAndFetching = isSearching && (isTyping || isFetching);
 
-  const groupedConversations = useMemo(() => {
+  const browseConversations = useMemo(() => {
     if (debouncedSearch.trim()) {
       return null;
     }
-    return groupConversationsByDate(conversations);
+    return {
+      pinned: conversations.filter((c) => c.pinnedAt),
+      unpinned: conversations.filter((c) => !c.pinnedAt),
+    };
   }, [conversations, debouncedSearch]);
 
   // Reset state on every open/close transition.
@@ -446,6 +416,7 @@ export function ConversationSearchPalette({
   const renderConversationItem = (
     conv: (typeof conversations)[number],
     showPinIcon = false,
+    dateLabel?: string,
   ) => {
     const isSearchActive = debouncedSearch.trim().length > 0;
     const displayTitle = getConversationDisplayTitle(conv.title, conv.messages);
@@ -479,6 +450,11 @@ export function ConversationSearchPalette({
           <span className="text-sm flex-1 min-w-0 break-words leading-snug line-clamp-2">
             {displayTitle}
           </span>
+          {dateLabel && !isPending && (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {dateLabel}
+            </span>
+          )}
           {isPending && (
             <Badge
               variant="destructive"
@@ -593,40 +569,27 @@ export function ConversationSearchPalette({
                   {conversations.map((conv) => renderConversationItem(conv))}
                 </CommandGroup>
               )
-            ) : groupedConversations ? (
+            ) : browseConversations ? (
               <>
-                {groupedConversations.pinned.length > 0 && (
+                {browseConversations.pinned.length > 0 && (
                   <CommandGroup heading="Pinned">
-                    {groupedConversations.pinned.map((conv) =>
-                      renderConversationItem(conv, true),
+                    {browseConversations.pinned.map((conv) =>
+                      renderConversationItem(
+                        conv,
+                        true,
+                        getDateBucketLabel(conv.lastMessageAt),
+                      ),
                     )}
                   </CommandGroup>
                 )}
-                {groupedConversations.today.length > 0 && (
-                  <CommandGroup heading="Today">
-                    {groupedConversations.today.map((conv) =>
-                      renderConversationItem(conv),
-                    )}
-                  </CommandGroup>
-                )}
-                {groupedConversations.yesterday.length > 0 && (
-                  <CommandGroup heading="Yesterday">
-                    {groupedConversations.yesterday.map((conv) =>
-                      renderConversationItem(conv),
-                    )}
-                  </CommandGroup>
-                )}
-                {groupedConversations.previous7Days.length > 0 && (
-                  <CommandGroup heading="Previous 7 Days">
-                    {groupedConversations.previous7Days.map((conv) =>
-                      renderConversationItem(conv),
-                    )}
-                  </CommandGroup>
-                )}
-                {groupedConversations.older.length > 0 && (
-                  <CommandGroup heading="Previous 30 Days">
-                    {groupedConversations.older.map((conv) =>
-                      renderConversationItem(conv),
+                {browseConversations.unpinned.length > 0 && (
+                  <CommandGroup>
+                    {browseConversations.unpinned.map((conv) =>
+                      renderConversationItem(
+                        conv,
+                        false,
+                        getDateBucketLabel(conv.lastMessageAt),
+                      ),
                     )}
                   </CommandGroup>
                 )}

--- a/platform/frontend/src/lib/chat/group-conversations-by-date.test.ts
+++ b/platform/frontend/src/lib/chat/group-conversations-by-date.test.ts
@@ -34,6 +34,10 @@ describe("getDateBucketLabel", () => {
     expect(getDateBucketLabel(new Date(2026, 0, 1))).toBe("Older");
   });
 
+  it("labels future dates (clock skew) as Today, not Older", () => {
+    expect(getDateBucketLabel(at(17, 0))).toBe("Today");
+  });
+
   it("falls back to Older for invalid dates instead of throwing", () => {
     expect(getDateBucketLabel("not-a-date")).toBe("Older");
   });

--- a/platform/frontend/src/lib/chat/group-conversations-by-date.test.ts
+++ b/platform/frontend/src/lib/chat/group-conversations-by-date.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getDateBucketLabel,
+  groupConversationsByDay,
+} from "@/lib/chat/group-conversations-by-date";
+
+// date-fns buckets by LOCAL calendar days, so fixtures use local-time Date
+// constructors (never UTC ISO strings) to stay timezone-independent.
+const at = (day: number, hour: number) =>
+  new Date(2026, 6 /* July */, day, hour);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(at(16, 12));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("getDateBucketLabel", () => {
+  it("labels today and yesterday by name", () => {
+    expect(getDateBucketLabel(at(16, 8))).toBe("Today");
+    expect(getDateBucketLabel(at(15, 23))).toBe("Yesterday");
+  });
+
+  it("labels the rest of the last week with the day date", () => {
+    expect(getDateBucketLabel(at(14, 12))).toBe("Jul 14");
+    expect(getDateBucketLabel(at(10, 0))).toBe("Jul 10");
+  });
+
+  it("labels anything before the last week as Older", () => {
+    expect(getDateBucketLabel(at(9, 23))).toBe("Older");
+    expect(getDateBucketLabel(new Date(2026, 0, 1))).toBe("Older");
+  });
+
+  it("falls back to Older for invalid dates instead of throwing", () => {
+    expect(getDateBucketLabel("not-a-date")).toBe("Older");
+  });
+
+  it("accepts Date and string timestamps interchangeably", () => {
+    expect(getDateBucketLabel(at(16, 8).toISOString())).toBe("Today");
+  });
+});
+
+describe("groupConversationsByDay", () => {
+  const conv = (id: string, lastMessageAt: Date) => ({ id, lastMessageAt });
+
+  it("returns ordered per-day groups following input order", () => {
+    const result = groupConversationsByDay(
+      [
+        conv("t1", at(16, 10)),
+        conv("t2", at(16, 8)),
+        conv("y1", at(15, 12)),
+        conv("d14", at(14, 12)),
+        conv("d12", at(12, 12)),
+        conv("o1", at(1, 12)),
+        conv("o2", new Date(2026, 0, 1)),
+      ],
+      (c) => c.lastMessageAt,
+    );
+
+    expect(result.map((g) => [g.label, g.chats.map((c) => c.id)])).toEqual([
+      ["Today", ["t1", "t2"]],
+      ["Yesterday", ["y1"]],
+      ["Jul 14", ["d14"]],
+      ["Jul 12", ["d12"]],
+      ["Older", ["o1", "o2"]],
+    ]);
+  });
+
+  it("omits empty buckets", () => {
+    const result = groupConversationsByDay(
+      [conv("t1", at(16, 10)), conv("o1", at(1, 12))],
+      (c) => c.lastMessageAt,
+    );
+
+    expect(result.map((g) => g.label)).toEqual(["Today", "Older"]);
+  });
+
+  it("returns an empty array for an empty list", () => {
+    expect(groupConversationsByDay([], () => new Date())).toEqual([]);
+  });
+});

--- a/platform/frontend/src/lib/chat/group-conversations-by-date.ts
+++ b/platform/frontend/src/lib/chat/group-conversations-by-date.ts
@@ -1,0 +1,50 @@
+import {
+  differenceInCalendarDays,
+  format,
+  isToday,
+  isYesterday,
+} from "date-fns";
+
+/**
+ * Human label for a chat's date bucket: "Today", "Yesterday", a "Jul 14"-style
+ * day label for the rest of the last week, or "Older".
+ */
+export function getDateBucketLabel(value: string | Date): string {
+  const date = new Date(value);
+  if (isToday(date)) {
+    return "Today";
+  }
+  if (isYesterday(date)) {
+    return "Yesterday";
+  }
+  // NaN (invalid date) and future dates fail this check and fall to "Older",
+  // which also keeps `format` away from Invalid Date (it throws).
+  const days = differenceInCalendarDays(new Date(), date);
+  if (days >= 2 && days <= 6) {
+    return format(date, "MMM d");
+  }
+  return "Older";
+}
+
+/**
+ * Groups conversations into ordered per-day buckets for sectioned display.
+ * Expects the input sorted by the same timestamp `getDate` returns (the API
+ * sorts by lastMessageAt desc), so bucket order follows input order. Pure and
+ * generic so it can be unit-tested independent of the React tree.
+ */
+export function groupConversationsByDay<T>(
+  conversations: T[],
+  getDate: (conversation: T) => string | Date,
+): Array<{ label: string; chats: T[] }> {
+  const groups = new Map<string, T[]>();
+  for (const conv of conversations) {
+    const label = getDateBucketLabel(getDate(conv));
+    const chats = groups.get(label);
+    if (chats) {
+      chats.push(conv);
+    } else {
+      groups.set(label, [conv]);
+    }
+  }
+  return Array.from(groups, ([label, chats]) => ({ label, chats }));
+}

--- a/platform/frontend/src/lib/chat/group-conversations-by-date.ts
+++ b/platform/frontend/src/lib/chat/group-conversations-by-date.ts
@@ -17,9 +17,14 @@ export function getDateBucketLabel(value: string | Date): string {
   if (isYesterday(date)) {
     return "Yesterday";
   }
-  // NaN (invalid date) and future dates fail this check and fall to "Older",
-  // which also keeps `format` away from Invalid Date (it throws).
   const days = differenceInCalendarDays(new Date(), date);
+  // A future calendar day only happens on client/server clock skew across
+  // local midnight — the chat is effectively brand new, so call it "Today".
+  if (days < 0) {
+    return "Today";
+  }
+  // NaN (invalid date) fails both checks and falls to "Older", which also
+  // keeps `format` away from Invalid Date (it throws).
   if (days >= 2 && days <= 6) {
     return format(date, "MMM d");
   }


### PR DESCRIPTION
## What

- The chat sidebar's flat "Recents" section is now split into per-day date sections ("Today", "Yesterday", a "Jul 14"-style label for days 2–6 back, and "Older"), grouped by `lastMessageAt`. Pinned chats and the "More" affordance behave as before.
- The conversation search palette drops its "Today / Yesterday / Previous 7 Days / Previous 30 Days" group headings; each row instead shows its date bucket as a small right-aligned label, and pinned rows keep the "Pinned" heading.
- The bucketing logic lives in a new shared, pure helper (`group-conversations-by-date.ts`) with its own unit tests, replacing the palette's local `groupConversationsByDate`.

## Why

Date context was inconsistent between the sidebar (none) and the search palette (coarse buckets based on `updatedAt`). Grouping by last message activity makes it easier to find a recent conversation at a glance.

## Testing

- `pnpm vitest run` on the three touched test files — 44 tests pass, including new coverage for per-day grouping, empty-bucket skipping, "More" placement, and the palette's per-row date labels.
- `pnpm type-check` and `pnpm biome check` on the touched files — clean.