### PR TITLE
feat(agents): show the "Accessible to" column to non-admins instead of the scope badge

### DIFF
--- a/platform/frontend/src/app/agents/page.client.tsx
+++ b/platform/frontend/src/app/agents/page.client.tsx
@@ -308,7 +308,6 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
         return (
           <AgentNameCell
             name={agent.name}
-            scope={agent.scope}
             builtIn={agent.builtIn ?? undefined}
             description={agent.description}
             labels={agent.labels}
@@ -316,24 +315,21 @@ function Agents({ initialData }: { initialData?: AgentsInitialData }) {
         );
       },
     },
-    ...(isAgentAdmin
-      ? [
-          {
-            id: "team",
-            header: "Accessible to",
-            enableSorting: false,
-            cell: ({ row }: { row: { original: AgentData } }) => (
-              <ResourceVisibilityBadge
-                scope={row.original.scope}
-                teams={row.original.teams}
-                authorId={row.original.authorId}
-                authorName={row.original.authorName}
-                currentUserId={currentUserId}
-              />
-            ),
-          } satisfies ColumnDef<AgentData>,
-        ]
-      : []),
+    {
+      id: "team",
+      header: "Accessible to",
+      enableSorting: false,
+      cell: ({ row }) => (
+        <ResourceVisibilityBadge
+          scope={row.original.scope}
+          teams={row.original.teams}
+          authorId={row.original.authorId}
+          authorName={row.original.authorName}
+          currentUserId={currentUserId}
+          showSelfAsMe
+        />
+      ),
+    },
     {
       id: "actions",
       header: "Actions",

--- a/platform/frontend/src/app/llm/proxies/page.client.tsx
+++ b/platform/frontend/src/app/llm/proxies/page.client.tsx
@@ -271,7 +271,6 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
         return (
           <AgentNameCell
             name={agent.name}
-            scope={agent.scope}
             description={agent.description}
             extraBadges={
               agent.agentType === "profile" ? (
@@ -298,24 +297,21 @@ function LlmProxies({ initialData }: { initialData?: LlmProxiesInitialData }) {
         );
       },
     },
-    ...(isAdmin
-      ? [
-          {
-            id: "team",
-            header: "Accessible to",
-            enableSorting: false,
-            cell: ({ row }: { row: { original: ProxyData } }) => (
-              <ResourceVisibilityBadge
-                scope={row.original.scope}
-                teams={row.original.teams}
-                authorId={row.original.authorId}
-                authorName={row.original.authorName}
-                currentUserId={currentUserId}
-              />
-            ),
-          } satisfies ColumnDef<ProxyData>,
-        ]
-      : []),
+    {
+      id: "team",
+      header: "Accessible to",
+      enableSorting: false,
+      cell: ({ row }) => (
+        <ResourceVisibilityBadge
+          scope={row.original.scope}
+          teams={row.original.teams}
+          authorId={row.original.authorId}
+          authorName={row.original.authorName}
+          currentUserId={currentUserId}
+          showSelfAsMe
+        />
+      ),
+    },
     {
       id: "actions",
       header: "Actions",

--- a/platform/frontend/src/app/mcp/gateways/page.client.tsx
+++ b/platform/frontend/src/app/mcp/gateways/page.client.tsx
@@ -294,7 +294,6 @@ function McpGateways({
         return (
           <AgentNameCell
             name={agent.name}
-            scope={agent.scope}
             description={agent.description}
             extraBadges={
               agent.agentType === "profile" ? (
@@ -388,24 +387,21 @@ function McpGateways({
         );
       },
     },
-    ...(isAdmin
-      ? [
-          {
-            id: "team",
-            header: "Accessible to",
-            enableSorting: false,
-            cell: ({ row }: { row: { original: GatewayData } }) => (
-              <ResourceVisibilityBadge
-                scope={row.original.scope}
-                teams={row.original.teams}
-                authorId={row.original.authorId}
-                authorName={row.original.authorName}
-                currentUserId={currentUserId}
-              />
-            ),
-          } satisfies ColumnDef<GatewayData>,
-        ]
-      : []),
+    {
+      id: "team",
+      header: "Accessible to",
+      enableSorting: false,
+      cell: ({ row }) => (
+        <ResourceVisibilityBadge
+          scope={row.original.scope}
+          teams={row.original.teams}
+          authorId={row.original.authorId}
+          authorName={row.original.authorName}
+          currentUserId={currentUserId}
+          showSelfAsMe
+        />
+      ),
+    },
     {
       id: "actions",
       header: "Actions",

--- a/platform/frontend/src/components/agent-name-cell.test.tsx
+++ b/platform/frontend/src/components/agent-name-cell.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentNameCell } from "./agent-name-cell";
+
+describe("AgentNameCell", () => {
+  it("renders no visibility chip — visibility lives in the Accessible-to column", () => {
+    render(<AgentNameCell name="My Agent" />);
+
+    expect(screen.getByText("My Agent")).toBeInTheDocument();
+    expect(screen.queryByText("Personal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Team")).not.toBeInTheDocument();
+    expect(screen.queryByText("Organization")).not.toBeInTheDocument();
+  });
+
+  it("keeps the Built-in badge for built-in agents", () => {
+    render(<AgentNameCell name="Built-in Agent" builtIn />);
+
+    expect(screen.getByText("Built-in")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/agent-name-cell.tsx
+++ b/platform/frontend/src/components/agent-name-cell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { AgentScope, archestraApiTypes } from "@archestra/shared";
+import type { archestraApiTypes } from "@archestra/shared";
 import type { ReactNode } from "react";
 import { AgentBadge } from "@/components/agent-badge";
 import { LabelTags } from "@/components/label-tags";
@@ -12,20 +12,18 @@ const MAX_NAME_LENGTH = 20;
 
 export function AgentNameCell({
   name,
-  scope,
   builtIn = false,
   description,
   labels,
   extraBadges,
 }: {
   name: string;
-  scope: AgentScope;
   builtIn?: boolean;
   description?: string | null;
   labels?: AgentLabels;
   extraBadges?: ReactNode;
 }) {
-  const hasMetadata = !!extraBadges || !!labels?.length || builtIn || !!scope;
+  const hasMetadata = !!extraBadges || !!labels?.length || builtIn;
   const displayName = truncateName(name);
 
   return (
@@ -37,7 +35,7 @@ export function AgentNameCell({
           </span>
           {hasMetadata && (
             <>
-              <AgentBadge type={builtIn ? "builtIn" : scope} />
+              {builtIn && <AgentBadge type="builtIn" />}
               {extraBadges}
               {labels && labels.length > 0 && <LabelTags labels={labels} />}
             </>


### PR DESCRIPTION
## What

The "Accessible to" column in the agents, LLM proxies, and MCP gateways tables is now shown to all users, not just admins. The redundant scope badge next to the agent name is removed (only the Built-in badge remains), and the visibility badge shows "Me" for the user's own personal resources via the new `showSelfAsMe` flag.

## Why

Non-admin users had no way to see who an agent is shared with — the scope badge only showed a raw scope label and disappeared for non-admins along with the column. One consistent column for everyone is clearer than two competing indicators.

## Testing

- Added a unit test for `AgentNameCell` pinning that no visibility chip renders in the name cell and the Built-in badge is kept (`pnpm vitest run` — 2 passed)
- `pnpm type-check` on the frontend workspace passes