### PR TITLE
fix(llm-providers): classify key-validation failures instead of blaming the key

### DIFF
--- a/platform/backend/src/routes/llm-provider-api-keys.test.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.test.ts
@@ -712,6 +712,196 @@ describe("LLM Provider API Keys CRUD", () => {
     );
   });
 
+  test("uses the provider display name in keyless connection errors", async () => {
+    mockTestProviderApiKey.mockRejectedValueOnce(new Error("fetch failed"));
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "vLLM Local",
+        provider: "vllm",
+        scope: "personal",
+        baseUrl: "http://192.168.1.50:8000/v1",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain(
+      "Failed to connect to vLLM: fetch failed",
+    );
+  });
+
+  test("reports a network problem (not an invalid key) when the provider is unreachable", async () => {
+    mockTestProviderApiKey.mockRejectedValueOnce(new Error("fetch failed"));
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Unreachable Anthropic",
+        provider: "anthropic",
+        apiKey: "sk-ant-unreachable-test",
+        scope: "personal",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const message = response.json().error.message;
+    // The configured default URL is env-dependent, so assert its presence in
+    // the label without pinning the value.
+    expect(message).toMatch(
+      /^Could not reach Anthropic \(\S+\) to validate the API key: fetch failed/,
+    );
+    expect(message).not.toContain("Invalid API key");
+  });
+
+  test("reports an invalid key (not a connection failure) when the provider rejects it", async () => {
+    mockTestProviderApiKey.mockRejectedValueOnce(
+      new Error("Failed to fetch Anthropic models: 401"),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Rejected Anthropic",
+        provider: "anthropic",
+        apiKey: "sk-ant-rejected-test",
+        scope: "personal",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const message = response.json().error.message;
+    expect(message).toBe(
+      "Invalid API key: Failed to fetch Anthropic models: 401",
+    );
+    expect(message).not.toContain("Could not reach");
+  });
+
+  test("keeps the Docker localhost hint on keyed-provider connection failures", async () => {
+    mockTestProviderApiKey.mockRejectedValueOnce(new Error("fetch failed"));
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Local OpenAI-compatible",
+        provider: "openai",
+        apiKey: "sk-local-test",
+        scope: "personal",
+        baseUrl: "http://localhost:8080/v1",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const message = response.json().error.message;
+    expect(message).toContain(
+      "Could not reach OpenAI (http://localhost:8080/v1)",
+    );
+    expect(message).toContain("http://host.docker.internal:8080/v1");
+  });
+
+  test("falls back to the invalid-key error when the validation message has no HTTP status", async () => {
+    mockTestProviderApiKey.mockRejectedValueOnce(
+      new Error("Models list is empty"),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Empty Models Anthropic",
+        provider: "anthropic",
+        apiKey: "sk-ant-empty-models-test",
+        scope: "personal",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toBe(
+      "Invalid API key: Models list is empty",
+    );
+  });
+
+  test("points at the base URL (not the key or a temporary issue) on a 404 validation response", async () => {
+    mockTestProviderApiKey.mockRejectedValueOnce(
+      new Error("Failed to fetch Anthropic models: 404"),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Wrong Path Anthropic",
+        provider: "anthropic",
+        apiKey: "sk-ant-wrong-path-test",
+        scope: "personal",
+        baseUrl: "https://anthropic.example.com/extra",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const message = response.json().error.message;
+    expect(message).toContain(
+      "Anthropic (https://anthropic.example.com/extra) returned an error while validating the API key: Failed to fetch Anthropic models: 404",
+    );
+    expect(message).toContain("verify it");
+    expect(message).not.toContain("temporary provider issue");
+    expect(message).not.toContain("Invalid API key");
+  });
+
+  test("treats a non-JSON response body as a wrong endpoint, not an invalid key", async () => {
+    mockTestProviderApiKey.mockRejectedValueOnce(
+      new Error("Unexpected token '<', \"<html>\" is not valid JSON"),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "HTML Anthropic",
+        provider: "anthropic",
+        apiKey: "sk-ant-html-test",
+        scope: "personal",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const message = response.json().error.message;
+    expect(message).toContain("returned an error while validating the API key");
+    expect(message).toContain("does not look like the provider's API");
+    expect(message).not.toContain("Invalid API key");
+  });
+
+  test("reports a provider-side error (not an invalid key) on a 429/5xx validation response", async () => {
+    mockTestProviderApiKey.mockRejectedValueOnce(
+      new Error("Failed to fetch Anthropic models: 429"),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/llm-provider-api-keys",
+      payload: {
+        name: "Throttled Anthropic",
+        provider: "anthropic",
+        apiKey: "sk-ant-throttled-test",
+        scope: "personal",
+        baseUrl: "https://anthropic.example.com",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const message = response.json().error.message;
+    expect(message).toContain(
+      "Anthropic (https://anthropic.example.com) returned an error while validating the API key: Failed to fetch Anthropic models: 429",
+    );
+    expect(message).toContain("temporary provider issue");
+    expect(message).not.toContain("Invalid API key");
+    expect(message).not.toContain("Could not reach");
+  });
+
   test("treats an empty Ollama model list as a reachable server (keyless create succeeds)", async () => {
     mockTestProviderApiKey.mockRejectedValueOnce(
       new Error("Models list is empty"),

--- a/platform/backend/src/routes/llm-provider-api-keys.ts
+++ b/platform/backend/src/routes/llm-provider-api-keys.ts
@@ -1,12 +1,12 @@
 import type { IncomingHttpHeaders } from "node:http";
 import {
   isProviderApiKeyOptional,
+  providerDisplayNames,
   RouteId,
   type SupportedProvider,
   SupportedProvidersSchema,
 } from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
-import { capitalize } from "lodash-es";
 import { z } from "zod";
 import { hasPermission, userHasPermission } from "@/auth";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
@@ -16,7 +16,7 @@ import {
   encodeBedrockSigV4Marker,
 } from "@/clients/bedrock-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
-import config from "@/config";
+import { getProviderConfiguredBaseUrl } from "@/config";
 import logger from "@/logging";
 import {
   LlmOauthClientModel,
@@ -50,7 +50,10 @@ import {
   type SelectSecret,
 } from "@/types";
 import { isUniqueConstraintError } from "@/utils/db";
-import { dockerLocalhostConnectionHint } from "@/utils/docker-localhost-hint";
+import {
+  dockerLocalhostConnectionHint,
+  isConnectionFailureMessage,
+} from "@/utils/docker-localhost-hint";
 
 async function testApiKeyOrThrow(
   provider: SupportedProvider,
@@ -62,15 +65,56 @@ async function testApiKeyOrThrow(
     await testProviderApiKey(provider, apiKey, baseUrl, extraHeaders);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const hint = dockerLocalhostConnectionHint({
-      baseUrl: effectiveBaseUrlForHint(provider, baseUrl),
-      errorMessage: message,
-    });
-    throw new ApiError(
-      400,
-      `Invalid API key: Failed to connect to ${capitalize(provider)}: ${message}${hint ? ` ${hint}` : ""}`,
-    );
+    // Name the URL actually tested: a base-URL override (user- or
+    // env-configured, e.g. the e2e WireMock) silently redirects validation
+    // away from the real provider, and the message is the only place that
+    // misconfiguration can surface.
+    const testedUrl = effectiveBaseUrlForHint(provider, baseUrl);
+    const providerName = providerDisplayNames[provider];
+    const providerLabel = testedUrl
+      ? `${providerName} (${testedUrl})`
+      : providerName;
+    // A connection failure means the key was never checked — surface it as a
+    // network problem, not a credentials problem.
+    if (isConnectionFailureMessage(message)) {
+      const hint = dockerLocalhostConnectionHint({
+        baseUrl: testedUrl,
+        errorMessage: message,
+      });
+      throw new ApiError(
+        400,
+        `Could not reach ${providerLabel} to validate the API key: ${message}. Check the server's outbound network connectivity.${hint ? ` ${hint}` : ""}`,
+      );
+    }
+    const providerSideSuffix = providerSideErrorSuffix(message);
+    if (providerSideSuffix) {
+      throw new ApiError(
+        400,
+        `${providerLabel} returned an error while validating the API key: ${message}. ${providerSideSuffix}`,
+      );
+    }
+    throw new ApiError(400, `Invalid API key: ${message}`);
   }
+}
+
+/**
+ * Classifies a failure where the tested endpoint responded but the credential
+ * wasn't the problem, returning the guidance to append (null = treat as a
+ * rejected credential). Model fetchers throw `Failed to fetch <provider>
+ * models: <status>` for non-2xx responses; 400/401/403 on a plain models-list
+ * read means the credential was rejected (Gemini uses 400 for invalid keys).
+ * A 404 or a non-JSON body means the URL isn't the provider's API; other
+ * statuses — 429, 5xx — are provider-side trouble.
+ */
+function providerSideErrorSuffix(message: string): string | null {
+  const status = message.match(/: (\d{3})$/)?.[1];
+  if (status === "404" || /not valid JSON|Unexpected token/i.test(message)) {
+    return "The endpoint does not look like the provider's API — if a custom base URL is configured, verify it.";
+  }
+  if (status && !["400", "401", "403"].includes(status)) {
+    return "This may be a temporary provider issue (e.g. rate limiting or an outage).";
+  }
+  return null;
 }
 
 /**
@@ -96,25 +140,23 @@ async function testKeylessConnectivityOrThrow(
     });
     throw new ApiError(
       400,
-      `Failed to connect to ${capitalize(provider)}: ${message}${hint ? ` ${hint}` : ""}`,
+      `Failed to connect to ${providerDisplayNames[provider]}: ${message}${hint ? ` ${hint}` : ""}`,
     );
   }
 }
 
 /**
  * The base URL connectivity is actually tested against: an explicit override if
- * present, otherwise the provider's configured default. Needed so the Docker
- * hint fires when an Ollama key is created with no Base URL (the default points
- * at localhost).
+ * present, otherwise the provider's configured default. Needed so validation
+ * errors name the URL they hit and so the Docker hint fires when a key is
+ * created with no Base URL but a loopback default (e.g. Ollama).
  */
 function effectiveBaseUrlForHint(
   provider: SupportedProvider,
   baseUrl: string | null | undefined,
 ): string | null {
   if (baseUrl) return baseUrl;
-  if (provider === "ollama") return config.llm.ollama.baseUrl ?? null;
-  if (provider === "vllm") return config.llm.vllm.baseUrl ?? null;
-  return null;
+  return getProviderConfiguredBaseUrl(provider) ?? null;
 }
 
 async function testKeylessAzureEntraOrThrow(

--- a/platform/backend/src/utils/docker-localhost-hint.test.ts
+++ b/platform/backend/src/utils/docker-localhost-hint.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, test } from "vitest";
-import { dockerLocalhostConnectionHint } from "./docker-localhost-hint";
+import {
+  dockerLocalhostConnectionHint,
+  isConnectionFailureMessage,
+} from "./docker-localhost-hint";
+
+describe("isConnectionFailureMessage", () => {
+  test.each([
+    "fetch failed",
+    "connect ECONNREFUSED 127.0.0.1:443",
+  ])("is true for the TCP-level failure %j", (message) => {
+    expect(isConnectionFailureMessage(message)).toBe(true);
+  });
+
+  test.each([
+    "Failed to fetch Anthropic models: 401",
+    "Models list is empty",
+  ])("is false for the provider response %j", (message) => {
+    expect(isConnectionFailureMessage(message)).toBe(false);
+  });
+});
 
 describe("dockerLocalhostConnectionHint", () => {
   test("suggests host.docker.internal for a localhost URL on a connection failure", () => {

--- a/platform/backend/src/utils/docker-localhost-hint.ts
+++ b/platform/backend/src/utils/docker-localhost-hint.ts
@@ -1,19 +1,14 @@
 import { isLoopbackRedirectUri } from "@/utils/network";
 
 /**
- * Substrings that appear in Node's `fetch` errors when a TCP connection cannot
- * be established (as opposed to an HTTP error response). `fetch failed` is the
- * generic wrapper message; the others are the underlying libuv codes that may
- * surface depending on the platform and Node version.
+ * True when an error message indicates a TCP-level connection failure (as
+ * opposed to an HTTP error response the provider actually sent back).
  */
-const CONNECTION_ERROR_MARKERS = [
-  "fetch failed",
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "ETIMEDOUT",
-  "ENOTFOUND",
-  "EHOSTUNREACH",
-];
+export function isConnectionFailureMessage(errorMessage: string): boolean {
+  return CONNECTION_ERROR_MARKERS.some((marker) =>
+    errorMessage.includes(marker),
+  );
+}
 
 /**
  * When connecting to a self-hosted provider (e.g. Ollama) fails and the base
@@ -30,10 +25,7 @@ export function dockerLocalhostConnectionHint(params: {
   const { baseUrl, errorMessage } = params;
   if (!baseUrl) return null;
 
-  const looksLikeConnectionFailure = CONNECTION_ERROR_MARKERS.some((marker) =>
-    errorMessage.includes(marker),
-  );
-  if (!looksLikeConnectionFailure) return null;
+  if (!isConnectionFailureMessage(errorMessage)) return null;
 
   if (!isLoopbackRedirectUri(baseUrl)) return null;
 
@@ -48,3 +40,18 @@ export function dockerLocalhostConnectionHint(params: {
 
   return `If this server is running in Docker, "localhost" points at the container itself, not your host machine — try using ${suggestedUrl} instead.`;
 }
+
+/**
+ * Substrings that appear in Node's `fetch` errors when a TCP connection cannot
+ * be established (as opposed to an HTTP error response). `fetch failed` is the
+ * generic wrapper message; the others are the underlying libuv codes that may
+ * surface depending on the platform and Node version.
+ */
+const CONNECTION_ERROR_MARKERS = [
+  "fetch failed",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EHOSTUNREACH",
+];


### PR DESCRIPTION
## Summary

Adding an LLM provider API key reported every validation failure as `Invalid API key: Failed to connect to <Provider>: <err>` — a dead network, a base URL pointing at the wrong server, and a genuinely rejected credential were indistinguishable. In practice this hid a real misconfiguration: with `ARCHESTRA_ANTHROPIC_BASE_URL` env-pointed at the e2e WireMock, a valid Anthropic key failed with a message that blamed the key.

`testApiKeyOrThrow` now separates the failure classes, and each message names the URL it actually tested (user-supplied base URL or the configured provider default):

- TCP-level failure (`fetch failed`, `ECONNREFUSED`, …) → `Could not reach Anthropic (https://api.anthropic.com) to validate the API key: …` — the key was never checked, so the message no longer calls it invalid. The Docker `host.docker.internal` hint still applies for loopback URLs.
- 404 or a non-JSON body → `… returned an error while validating the API key: … The endpoint does not look like the provider's API — if a custom base URL is configured, verify it.`
- 429/5xx → `… This may be a temporary provider issue (e.g. rate limiting or an outage).`
- 400/401/403 → `Invalid API key: …` (400 stays in this bucket because Gemini returns 400 for invalid keys).

Classification parses the `Failed to fetch <provider> models: <status>` shape all model fetchers throw; messages without a trailing status keep the invalid-key default, so unrecognized errors behave as before. The connection-failure markers were already maintained for the Docker hint in `docker-localhost-hint.ts` and are now exported (`isConnectionFailureMessage`) instead of duplicated.

Provider names in these messages now come from the shared `providerDisplayNames` map (`OpenAI`, `vLLM`) instead of `lodash capitalize` (`Openai`, `Vllm`).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>