### PR TITLE
feat(analytics): report instance entity counts with heartbeat

### DIFF
--- a/platform/backend/src/models/index.ts
+++ b/platform/backend/src/models/index.ts
@@ -38,6 +38,7 @@ export { default as EnvironmentDefaultUserLimitModel } from "./environment-defau
 export { default as FileModel, FileNameExistsError } from "./file";
 export { default as GithubAppConfigModel } from "./github-app-config";
 export { default as HookFileModel } from "./hook-file";
+export { default as InstanceUsageModel } from "./instance-usage";
 export { default as InteractionModel } from "./interaction";
 export { default as InternalMcpCatalogModel } from "./internal-mcp-catalog";
 export { default as InvitationModel } from "./invitation";

--- a/platform/backend/src/models/instance-usage.test.ts
+++ b/platform/backend/src/models/instance-usage.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@/test";
+import AgentModel from "./agent";
+import InstanceUsageModel from "./instance-usage";
+import LlmProviderApiKeyModel from "./llm-provider-api-key";
+
+test("counts entities across the instance", async ({
+  makeOrganization,
+  makeUser,
+  makeTeam,
+  makeAgent,
+  makeMcpServer,
+}) => {
+  const organization = await makeOrganization();
+  const before = await InstanceUsageModel.getEntityCounts();
+
+  const user = await makeUser();
+  await makeTeam(organization.id, user.id);
+  await makeAgent({
+    organizationId: organization.id,
+    agentType: "mcp_gateway",
+  });
+  await makeAgent({ organizationId: organization.id, agentType: "llm_proxy" });
+  await makeAgent({
+    organizationId: organization.id,
+    agentType: "agent",
+    systemPrompt: "You are a test agent",
+  });
+  await makeMcpServer();
+  // Two keys for the same provider count as one connected provider.
+  for (const name of ["first", "second"]) {
+    await LlmProviderApiKeyModel.create({
+      organizationId: organization.id,
+      name,
+      provider: "anthropic",
+      scope: "org",
+    });
+  }
+
+  const after = await InstanceUsageModel.getEntityCounts();
+
+  expect(after.users - before.users).toBe(1);
+  expect(after.teams - before.teams).toBe(1);
+  expect(after.mcpGateways - before.mcpGateways).toBe(1);
+  expect(after.llmProxies - before.llmProxies).toBe(1);
+  expect(after.agents - before.agents).toBe(1);
+  expect(after.mcpServers - before.mcpServers).toBe(1);
+  expect(after.llmProviders - before.llmProviders).toBe(1);
+});
+
+test("excludes soft-deleted agents", async ({
+  makeOrganization,
+  makeAgent,
+}) => {
+  const organization = await makeOrganization();
+  const agent = await makeAgent({
+    organizationId: organization.id,
+    agentType: "mcp_gateway",
+  });
+  const before = await InstanceUsageModel.getEntityCounts();
+
+  await AgentModel.delete(agent.id);
+
+  const after = await InstanceUsageModel.getEntityCounts();
+  expect(before.mcpGateways - after.mcpGateways).toBe(1);
+});

--- a/platform/backend/src/models/instance-usage.ts
+++ b/platform/backend/src/models/instance-usage.ts
@@ -1,0 +1,74 @@
+import { count, countDistinct } from "drizzle-orm";
+import db, { schema } from "@/database";
+import { notDeleted } from "@/database/schemas/soft-deletable-table";
+import type { AgentType, InstanceEntityCounts } from "@/types";
+
+class InstanceUsageModel {
+  /**
+   * Instance-wide entity counts reported with analytics heartbeats.
+   */
+  static async getEntityCounts(): Promise<InstanceEntityCounts> {
+    const [
+      [users],
+      [teams],
+      agentRows,
+      [llmProviders],
+      [virtualApiKeys],
+      [mcpServers],
+      [conversations],
+      [skills],
+      [apps],
+      [knowledgeBases],
+    ] = await Promise.all([
+      db.select({ total: count() }).from(schema.usersTable),
+      db.select({ total: count() }).from(schema.teamsTable),
+      db
+        .select({ agentType: schema.agentsTable.agentType, total: count() })
+        .from(schema.agentsTable)
+        .where(notDeleted(schema.agentsTable))
+        .groupBy(schema.agentsTable.agentType),
+      db
+        .select({
+          total: countDistinct(schema.llmProviderApiKeysTable.provider),
+        })
+        .from(schema.llmProviderApiKeysTable),
+      db.select({ total: count() }).from(schema.virtualApiKeysTable),
+      db.select({ total: count() }).from(schema.mcpServersTable),
+      db.select({ total: count() }).from(schema.conversationsTable),
+      db.select({ total: count() }).from(schema.skillsTable),
+      db
+        .select({ total: count() })
+        .from(schema.appsTable)
+        .where(notDeleted(schema.appsTable)),
+      db.select({ total: count() }).from(schema.knowledgeBasesTable),
+    ]);
+
+    const agentCountsByType: Record<AgentType, number> = {
+      profile: 0,
+      mcp_gateway: 0,
+      llm_proxy: 0,
+      agent: 0,
+    };
+    for (const row of agentRows) {
+      agentCountsByType[row.agentType] = row.total;
+    }
+
+    return {
+      users: users?.total ?? 0,
+      teams: teams?.total ?? 0,
+      agents: agentCountsByType.agent,
+      profiles: agentCountsByType.profile,
+      mcpGateways: agentCountsByType.mcp_gateway,
+      llmProxies: agentCountsByType.llm_proxy,
+      llmProviders: llmProviders?.total ?? 0,
+      virtualApiKeys: virtualApiKeys?.total ?? 0,
+      mcpServers: mcpServers?.total ?? 0,
+      conversations: conversations?.total ?? 0,
+      skills: skills?.total ?? 0,
+      apps: apps?.total ?? 0,
+      knowledgeBases: knowledgeBases?.total ?? 0,
+    };
+  }
+}
+
+export default InstanceUsageModel;

--- a/platform/backend/src/services/instance-analytics.test.ts
+++ b/platform/backend/src/services/instance-analytics.test.ts
@@ -1,5 +1,5 @@
 import config from "@/config";
-import { OrganizationModel } from "@/models";
+import { InstanceUsageModel, OrganizationModel } from "@/models";
 import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
 import type { OrganizationAnalyticsState } from "@/types";
 import { instanceAnalyticsService } from "./instance-analytics";
@@ -81,6 +81,19 @@ describe("instanceAnalyticsService", () => {
           app_version: "1.2.3",
           instance_id: state.analyticsInstanceId,
           source: "backend",
+          user_count: 0,
+          team_count: 0,
+          agent_count: 0,
+          profile_count: 0,
+          mcp_gateway_count: 0,
+          llm_proxy_count: 0,
+          llm_provider_count: 0,
+          virtual_api_key_count: 0,
+          mcp_server_count: 0,
+          conversation_count: 0,
+          skill_count: 0,
+          app_count: 0,
+          knowledge_base_count: 0,
         },
       }),
     ]);
@@ -149,6 +162,50 @@ describe("instanceAnalyticsService", () => {
       instanceAnalyticsService.stop();
       vi.useRealTimers();
     }
+  });
+
+  test("reports current entity counts in the heartbeat", async ({
+    makeOrganization,
+    makeUser,
+    makeAgent,
+  }) => {
+    const organization = await makeOrganization();
+    await makeUser();
+    await makeAgent({
+      organizationId: organization.id,
+      agentType: "mcp_gateway",
+    });
+
+    await instanceAnalyticsService.start();
+
+    const heartbeat = capturedBodies().find(
+      (body) => body.event === "instance_heartbeat",
+    );
+    expect(heartbeat?.properties).toMatchObject({
+      user_count: 1,
+      mcp_gateway_count: 1,
+      team_count: 0,
+    });
+  });
+
+  test("still sends the heartbeat when counting entities fails", async ({
+    makeOrganization,
+  }) => {
+    await makeOrganization();
+    vi.spyOn(InstanceUsageModel, "getEntityCounts").mockRejectedValue(
+      new Error("counting broke"),
+    );
+
+    await instanceAnalyticsService.start();
+
+    expect(capturedEventNames()).toEqual([
+      "instance_started",
+      "instance_heartbeat",
+    ]);
+    const heartbeat = capturedBodies().find(
+      (body) => body.event === "instance_heartbeat",
+    );
+    expect(heartbeat?.properties).not.toHaveProperty("user_count");
   });
 
   test("does nothing when analytics is disabled", async () => {

--- a/platform/backend/src/services/instance-analytics.ts
+++ b/platform/backend/src/services/instance-analytics.ts
@@ -1,6 +1,7 @@
 import config from "@/config";
 import logger from "@/logging";
-import { OrganizationModel } from "@/models";
+import { InstanceUsageModel, OrganizationModel } from "@/models";
+import type { InstanceEntityCounts } from "@/types";
 
 const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000;
 const CAPTURE_TIMEOUT_MS = 10_000;
@@ -82,17 +83,37 @@ class InstanceAnalyticsService {
       analyticsConfig,
       event: INSTANCE_HEARTBEAT_EVENT,
       distinctId: state.analyticsInstanceId,
+      extraProperties: await this.collectEntityCountProperties(),
     });
+  }
+
+  // Best effort: a failed count query must not cost us the heartbeat itself.
+  private async collectEntityCountProperties(): Promise<
+    Record<string, number>
+  > {
+    try {
+      return getEntityCountProperties(
+        await InstanceUsageModel.getEntityCounts(),
+      );
+    } catch (error) {
+      logger.warn(
+        { err: error },
+        "Failed to collect instance entity counts for analytics heartbeat",
+      );
+      return {};
+    }
   }
 
   private async capture({
     analyticsConfig,
     event,
     distinctId,
+    extraProperties,
   }: {
     analyticsConfig: InstanceAnalyticsConfig;
     event: string;
     distinctId: string;
+    extraProperties?: Record<string, number>;
   }): Promise<void> {
     const response = await this.getFetch()(getCaptureUrl(analyticsConfig), {
       method: "POST",
@@ -108,6 +129,7 @@ class InstanceAnalyticsService {
           app_version: this.options.appVersion ?? config.api.version,
           instance_id: distinctId,
           source: "backend",
+          ...extraProperties,
           $groups: {
             instance: distinctId,
           },
@@ -139,4 +161,24 @@ export const instanceAnalyticsService = new InstanceAnalyticsService();
 
 function getCaptureUrl(analyticsConfig: InstanceAnalyticsConfig): string {
   return new URL("/capture/", analyticsConfig.posthog.host).toString();
+}
+
+function getEntityCountProperties(
+  counts: InstanceEntityCounts,
+): Record<string, number> {
+  return {
+    user_count: counts.users,
+    team_count: counts.teams,
+    agent_count: counts.agents,
+    profile_count: counts.profiles,
+    mcp_gateway_count: counts.mcpGateways,
+    llm_proxy_count: counts.llmProxies,
+    llm_provider_count: counts.llmProviders,
+    virtual_api_key_count: counts.virtualApiKeys,
+    mcp_server_count: counts.mcpServers,
+    conversation_count: counts.conversations,
+    skill_count: counts.skills,
+    app_count: counts.apps,
+    knowledge_base_count: counts.knowledgeBases,
+  };
 }

--- a/platform/backend/src/types/index.ts
+++ b/platform/backend/src/types/index.ts
@@ -36,6 +36,7 @@ export * from "./github-app-config";
 export * from "./hook";
 export * from "./identity-provider";
 export * from "./incoming-email";
+export * from "./instance-usage";
 export * from "./interaction";
 export * from "./interaction-guardrails";
 export * from "./invitation";

--- a/platform/backend/src/types/instance-usage.ts
+++ b/platform/backend/src/types/instance-usage.ts
@@ -1,0 +1,23 @@
+/**
+ * Instance-wide entity counts reported with analytics heartbeats.
+ */
+export type InstanceEntityCounts = {
+  users: number;
+  teams: number;
+  /** Internal agents (agentType = 'agent'). */
+  agents: number;
+  /** Legacy profiles (agentType = 'profile'). */
+  profiles: number;
+  /** MCP gateways (agentType = 'mcp_gateway'). */
+  mcpGateways: number;
+  /** LLM proxies (agentType = 'llm_proxy'). */
+  llmProxies: number;
+  /** Distinct LLM providers with at least one configured API key. */
+  llmProviders: number;
+  virtualApiKeys: number;
+  mcpServers: number;
+  conversations: number;
+  skills: number;
+  apps: number;
+  knowledgeBases: number;
+};


### PR DESCRIPTION
Adds instance-wide aggregate entity counts (users, teams, agents by type, LLM providers, virtual API keys, MCP servers, conversations, skills, apps, knowledge bases) to the hourly PostHog `instance_heartbeat` event.

Counting is best-effort: a failed count query logs a warning and the heartbeat is still sent without counts.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>