### PR TITLE
[DO NOT MERGE]  fix(llm-providers): honor Ollama num_ctx when syncing model context length

### DIFF
--- a/platform/backend/src/models/model.test.ts
+++ b/platform/backend/src/models/model.test.ts
@@ -324,13 +324,13 @@ describe("ModelModel", () => {
 
       expect(updated.id).toBe(initial.id);
       expect(updated.description).toBe("Updated description");
-      // contextLength, inputModalities, supportsToolCalling are NOT updated on
-      // conflict to preserve user-edited values
-      expect(updated.contextLength).toBe(128000);
+      // inputModalities, supportsToolCalling are NOT updated on conflict to
+      // preserve user-edited values
       expect(updated.inputModalities).toEqual(["text"]);
       expect(updated.supportsToolCalling).toBe(false);
-      // outputLength is not user-editable and tracks the provider cap, so a
-      // fresh synced value overwrites the previous one.
+      // contextLength and outputLength are not user-editable and track the
+      // provider limits, so a fresh synced value overwrites the previous one.
+      expect(updated.contextLength).toBe(256000);
       expect(updated.outputLength).toBe(32000);
     });
   });
@@ -455,19 +455,24 @@ describe("ModelModel", () => {
         "update-model-50",
       );
       expect(updated?.description).toBe("Updated Description 50");
-      // contextLength and supportsToolCalling are NOT updated on conflict
-      // to preserve user-edited values
-      expect(updated?.contextLength).toBe(100000);
+      // contextLength tracks the provider limit, so a fresh synced value wins
+      expect(updated?.contextLength).toBe(200000);
+      // supportsToolCalling is NOT updated on conflict to preserve
+      // user-edited values
       expect(updated?.supportsToolCalling).toBe(false);
     });
 
-    test("updates outputLength to the freshly synced cap, keeping it only when the sync omits it", async () => {
-      const base = (modelId: string, outputLength: number | null) => ({
+    test("updates contextLength/outputLength to the freshly synced limits, keeping them only when the sync omits them", async () => {
+      const base = (
+        modelId: string,
+        outputLength: number | null,
+        contextLength: number | null,
+      ) => ({
         externalId: `openai/${modelId}`,
         provider: "openai" as const,
         modelId,
         description: modelId,
-        contextLength: 128000,
+        contextLength,
         outputLength,
         inputModalities: ["text" as const],
         outputModalities: ["text" as const],
@@ -478,14 +483,14 @@ describe("ModelModel", () => {
       });
 
       await ModelModel.bulkUpsert([
-        base("cap-lowered", 64000),
-        base("cap-null", null),
-        base("cap-cleared", 16384),
+        base("cap-lowered", 64000, 128000),
+        base("cap-null", null, null),
+        base("cap-cleared", 16384, 32000),
       ]);
       await ModelModel.bulkUpsert([
-        base("cap-lowered", 4096), // provider corrected the cap downward
-        base("cap-null", 8192), // backfills the previously-null cap
-        base("cap-cleared", null), // sync omits it → last known value kept
+        base("cap-lowered", 4096, 8192), // provider corrected the limits downward
+        base("cap-null", 8192, 40960), // backfills the previously-null limits
+        base("cap-cleared", null, null), // sync omits them → last known values kept
       ]);
 
       const lowered = await ModelModel.findByProviderAndModelId(
@@ -501,8 +506,11 @@ describe("ModelModel", () => {
         "cap-cleared",
       );
       expect(lowered?.outputLength).toBe(4096);
+      expect(lowered?.contextLength).toBe(8192);
       expect(filled?.outputLength).toBe(8192);
+      expect(filled?.contextLength).toBe(40960);
       expect(cleared?.outputLength).toBe(16384);
+      expect(cleared?.contextLength).toBe(32000);
     });
 
     test("preserves manual embedding dimension overrides on non-full sync", async () => {

--- a/platform/backend/src/models/model.ts
+++ b/platform/backend/src/models/model.ts
@@ -304,11 +304,12 @@ class ModelModel {
         set: {
           externalId: data.externalId,
           description: data.description,
-          contextLength: sql`COALESCE(${schema.modelsTable.contextLength}, excluded.context_length)`,
-          // Unlike the other capability fields, outputLength has no admin editor
-          // and is used as an output-token safety cap, so prefer the freshly
-          // synced value (keeping the last known value only when the sync omits it)
-          // — a lowered provider cap must propagate, not be pinned forever.
+          // Unlike the other capability fields, contextLength and outputLength
+          // have no admin editor and drive context/output safety limits, so
+          // prefer the freshly synced value (keeping the last known value only
+          // when the sync omits it) — a lowered provider limit must propagate,
+          // not be pinned forever.
+          contextLength: sql`COALESCE(excluded.context_length, ${schema.modelsTable.contextLength})`,
           outputLength: sql`COALESCE(excluded.output_length, ${schema.modelsTable.outputLength})`,
           inputModalities: sql`COALESCE(${schema.modelsTable.inputModalities}, excluded.input_modalities)`,
           outputModalities: sql`COALESCE(${schema.modelsTable.outputModalities}, excluded.output_modalities)`,
@@ -377,9 +378,10 @@ class ModelModel {
             set: {
               externalId: sql`excluded.external_id`,
               description: sql`excluded.description`,
-              contextLength: sql`COALESCE(${schema.modelsTable.contextLength}, excluded.context_length)`,
-              // See upsert(): outputLength prefers the fresh synced value so a
-              // lowered provider cap propagates instead of being pinned forever.
+              // See upsert(): contextLength/outputLength prefer the fresh synced
+              // value so a lowered provider limit propagates instead of being
+              // pinned forever.
+              contextLength: sql`COALESCE(excluded.context_length, ${schema.modelsTable.contextLength})`,
               outputLength: sql`COALESCE(excluded.output_length, ${schema.modelsTable.outputLength})`,
               inputModalities: sql`COALESCE(${schema.modelsTable.inputModalities}, excluded.input_modalities)`,
               outputModalities: sql`COALESCE(${schema.modelsTable.outputModalities}, excluded.output_modalities)`,

--- a/platform/backend/src/routes/chat/model-fetchers/ollama.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.test.ts
@@ -179,6 +179,19 @@ describe("fetchOllamaModels", () => {
     expect(model.capabilities?.contextLength).toBe(8192);
   });
 
+  test("ignores a non-integer num_ctx (would break the integer DB column)", async () => {
+    listBody = { data: [{ id: "weird" }] };
+    showByModel.weird = {
+      body: {
+        capabilities: ["completion"],
+        model_info: { "llama.context_length": 262144 },
+        parameters: "num_ctx 8192.5",
+      },
+    };
+    const [model] = await fetchOllamaModels("k");
+    expect(model.capabilities?.contextLength).toBe(262144);
+  });
+
   test("uses num_ctx as contextLength when model_info reports none", async () => {
     listBody = { data: [{ id: "bare" }] };
     showByModel.bare = {

--- a/platform/backend/src/routes/chat/model-fetchers/ollama.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.test.ts
@@ -153,6 +153,41 @@ describe("fetchOllamaModels", () => {
     expect(model.id).toBe("llama3");
   });
 
+  test("caps contextLength with a configured num_ctx below the architectural value", async () => {
+    listBody = { data: [{ id: "qwen3-8k" }] };
+    showByModel["qwen3-8k"] = {
+      body: {
+        capabilities: ["completion"],
+        model_info: { "qwen3.context_length": 262144 },
+        parameters: "num_ctx 8192",
+      },
+    };
+    const [model] = await fetchOllamaModels("k");
+    expect(model.capabilities?.contextLength).toBe(8192);
+  });
+
+  test("keeps the architectural contextLength when num_ctx is larger", async () => {
+    listBody = { data: [{ id: "small" }] };
+    showByModel.small = {
+      body: {
+        capabilities: ["completion"],
+        model_info: { "llama.context_length": 8192 },
+        parameters: "num_ctx 16384",
+      },
+    };
+    const [model] = await fetchOllamaModels("k");
+    expect(model.capabilities?.contextLength).toBe(8192);
+  });
+
+  test("uses num_ctx as contextLength when model_info reports none", async () => {
+    listBody = { data: [{ id: "bare" }] };
+    showByModel.bare = {
+      body: { capabilities: ["completion"], parameters: "num_ctx 4096" },
+    };
+    const [model] = await fetchOllamaModels("k");
+    expect(model.capabilities?.contextLength).toBe(4096);
+  });
+
   test("parses default parameters, coalescing repeated keys and keeping quoted values as strings", async () => {
     listBody = { data: [{ id: "llama3" }] };
     showByModel.llama3 = {

--- a/platform/backend/src/routes/chat/model-fetchers/ollama.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.ts
@@ -155,7 +155,7 @@ function toFetchedCapabilities(
   // display, compaction, and overflow checks operate on the real window.
   const numCtx = defaultParameters?.num_ctx;
   const configuredContextLength =
-    typeof numCtx === "number" && Number.isFinite(numCtx) && numCtx > 0
+    typeof numCtx === "number" && Number.isInteger(numCtx) && numCtx > 0
       ? numCtx
       : undefined;
   const contextLength =

--- a/platform/backend/src/routes/chat/model-fetchers/ollama.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/ollama.ts
@@ -143,9 +143,26 @@ async function fetchOllamaShow(params: {
 function toFetchedCapabilities(
   show: OllamaShowResponse,
 ): FetchedModelCapabilities {
-  const contextLength =
-    readModelInfoNumber(show.model_info, ".context_length") ?? null;
+  const architecturalContextLength = readModelInfoNumber(
+    show.model_info,
+    ".context_length",
+  );
   const defaultParameters = parseOllamaParameters(show.parameters);
+
+  // The architectural context length is the model's theoretical maximum; the
+  // effective input window is the configured `num_ctx` (from a Modelfile),
+  // beyond which Ollama silently truncates the prompt. Cap with it so context
+  // display, compaction, and overflow checks operate on the real window.
+  const numCtx = defaultParameters?.num_ctx;
+  const configuredContextLength =
+    typeof numCtx === "number" && Number.isFinite(numCtx) && numCtx > 0
+      ? numCtx
+      : undefined;
+  const contextLength =
+    architecturalContextLength !== undefined &&
+    configuredContextLength !== undefined
+      ? Math.min(architecturalContextLength, configuredContextLength)
+      : (architecturalContextLength ?? configuredContextLength ?? null);
 
   // `capabilities` distinguishes embedding models from generative ones. Tri-state:
   // - embedding model with a reported dimension -> the number (authoritative).


### PR DESCRIPTION
## What

- The Ollama model fetcher now caps the synced `contextLength` with the model's configured `num_ctx` (from a Modelfile): `min(architectural, num_ctx)`, or `num_ctx` alone when `model_info` reports no context length.
- Model upsert (`upsert`/`bulkUpsert`) now lets a freshly synced `contextLength` overwrite the stored one (same precedence as `outputLength`), so corrected values propagate to already-synced rows; a sync that omits the value still keeps the last known one.

## Why

Archestra stored the architectural context window (e.g. 262K) while Ollama silently truncates prompts at the configured `num_ctx` (e.g. 8K). The context badge, context ring, auto-compaction, and overflow checks all operated on the wrong window, so models lost their prompt beginning with no signal and failed confusingly. `contextLength` has no admin editor, so the old keep-existing conflict rule only pinned stale values.

## Testing

- Unit: new fetcher cases (num_ctx below/above architectural, num_ctx-only) and updated upsert precedence tests — 65/65 pass, plus model-sync suite 16/16.
- `pnpm type-check` and Biome clean on changed files.
- Manual: ran the fetcher against a live Ollama 0.32.0 with a `num_ctx 8192` Modelfile variant of qwen3:4b — it now resolves 8192 (was 262144); the base model still resolves its architectural 262144.