### PR TITLE
fix(frontend): Fixed Revoke confirmation dialog persisting after revo…

### DIFF
--- a/platform/frontend/src/app/connection/skills-marketplace-step.test.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.test.tsx
@@ -13,9 +13,10 @@ function renderWithClient(ui: ReactElement) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
+  const result = render(
     <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
   );
+  return { ...result, queryClient };
 }
 
 const {
@@ -331,8 +332,54 @@ describe("SkillsMarketplaceStep", () => {
       screen.getByTestId("skills-marketplace-confirm-revoke"),
     );
 
-    await waitFor(() =>
-      expect(revokeLinkMock).toHaveBeenCalledWith(ACTIVE_LINK.id),
+    await waitFor(() => {
+      expect(revokeLinkMock).toHaveBeenCalledWith(ACTIVE_LINK.id);
+      expect(
+        screen.queryByText(/Revoke and block all existing clones/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("returns to create panel after revoking the link", async () => {
+    let activeLinks: (typeof ACTIVE_LINK)[] = [ACTIVE_LINK];
+    listLinksMock.mockImplementation(() => ({
+      data: { links: activeLinks },
+      isPending: false,
+    }));
+
+    const { rerender, queryClient } = renderWithClient(
+      <SkillsMarketplaceStep client={anyClient} />,
     );
+
+    revokeLinkMock.mockImplementation(async (id: string) => {
+      activeLinks = activeLinks.filter((l) => l.id !== id);
+      return { success: true };
+    });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /^Revoke$/i }),
+    );
+
+    expect(
+      screen.getByText(/Revoke and block all existing clones/i),
+    ).toBeVisible();
+
+    await userEvent.click(
+      screen.getByTestId("skills-marketplace-confirm-revoke"),
+    );
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <SkillsMarketplaceStep client={anyClient} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(revokeLinkMock).toHaveBeenCalledWith(ACTIVE_LINK.id);
+      expect(
+        screen.queryByText(/Revoke and block all existing clones/i),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("skills-marketplace-create")).toBeVisible();
+    });
   });
 });

--- a/platform/frontend/src/app/connection/skills-marketplace-step.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.tsx
@@ -203,7 +203,7 @@ function ExistingLinkPanel({
   link: SkillShareLink | null;
   totalSkills: number;
   revealed: RevealedClone | null;
-  onReveal: (revealed: RevealedClone) => void;
+  onReveal: (revealed: RevealedClone | null) => void;
 }) {
   const revokeShare = useRevokeSkillShareLink();
   const rotateShare = useRotateSkillShareLink();
@@ -232,7 +232,8 @@ function ExistingLinkPanel({
     if (!link) return;
     await revokeShare.mutateAsync(link.id);
     setConfirmRevoke(false);
-  }, [revokeShare, link]);
+    onReveal(null);
+  }, [revokeShare, link, onReveal]);
 
   const linkSkillCount = link?.skills.length ?? totalSkills;
   const stale = link !== null && linkSkillCount !== totalSkills;
@@ -276,17 +277,7 @@ function ExistingLinkPanel({
                 : "Refresh to reveal URL"}
           </Button>
         )}
-        {link && !confirmRevoke ? (
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => setConfirmRevoke(true)}
-            className="text-destructive hover:text-destructive"
-          >
-            <Trash2 className="mr-2 h-4 w-4" />
-            Revoke
-          </Button>
-        ) : (
+        {confirmRevoke ? (
           <div className="flex items-center gap-2">
             <span className="text-sm text-muted-foreground">
               Revoke and block all existing clones?
@@ -309,7 +300,17 @@ function ExistingLinkPanel({
               {revokeShare.isPending ? "Revoking…" : "Confirm revoke"}
             </Button>
           </div>
-        )}
+        ) : link ? (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setConfirmRevoke(true)}
+            className="text-destructive hover:text-destructive"
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Revoke
+          </Button>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
# Fix: Revoke confirmation dialog persists after revoking a marketplace share link

Fixes #6569

## Problem

After revoking a marketplace share link via the Connect flow, the "Revoke and block all existing clones?" confirmation panel remains on screen. The user cannot dismiss it without navigating away and back.

## Root cause

The conditional rendering logic in `ExistingLinkPanel` used `link && !confirmRevoke` to decide between showing the Revoke button or the confirmation panel:

```tsx
{link && !confirmRevoke ? <RevokeButton /> : <ConfirmationPanel />}
```

After a successful revoke, `link` becomes `null` (the active link no longer exists), so the condition always falls through to the confirmation panel — regardless of the `confirmRevoke` state.

## Fix

Reversed the ternary so `confirmRevoke` is checked first:

```tsx
{confirmRevoke ? <ConfirmationPanel /> : link ? <RevokeButton /> : null}
```

This ensures the confirmation panel only renders when `confirmRevoke` is `true`, and after revoking (when `link` is `null` and `confirmRevoke` is reset to `false`), nothing renders — returning the user to the Create panel on next re-render.

Additionally, `onReveal(null)` is called after a successful revoke to clear the `revealed` state, handling the edge case where a user creates a link (revealing the URL) and immediately revokes it.

## Changes

- `platform/frontend/src/app/connection/skills-marketplace-step.tsx`
  - Reversed ternary condition to prioritize `confirmRevoke` over `link`
  - Added `onReveal(null)` in `handleRevoke` to clear revealed state
  - Widened `onReveal` prop type to accept `null`

- `platform/frontend/src/app/connection/skills-marketplace-step.test.tsx`
  - Updated existing revoke test to assert confirmation panel disappears
  - Added regression test verifying the UI returns to the Create panel after revoke

## Test plan

- All 11 tests in `skills-marketplace-step.test.tsx` pass
- Manual verification: Create marketplace link → Revoke → Confirm → UI returns to Create panel


## Screenshot / Recording

### Before

https://github.com/user-attachments/assets/65a28900-c2d4-4e3c-9234-2a7e9c702189

### After

https://github.com/user-attachments/assets/9722c5db-ff22-4672-91a9-5cc6401292b3


 
