### PR TITLE
fix(mcp-catalog-form): support JSON array format in Arguments field

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1415,16 +1415,20 @@ export function McpCatalogForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Arguments (one per line)
+                          Arguments
                           <ReinstallHint show={isArgumentsDirty} />
                         </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={`/path/to/server.js\n--verbose`}
+                            placeholder={`/path/to/server.js\n--verbose\n\nor as JSON:\n["/path/to/server.js", "--verbose"]`}
                             className="font-mono min-h-20"
                             {...field}
                           />
                         </FormControl>
+                        <FormDescription>
+                          One argument per line, or a JSON array of strings
+                          (e.g. from a catalog entry).
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.utils.ts
@@ -12,6 +12,33 @@ import type { McpCatalogFormValues } from "./mcp-catalog-form.types";
 type McpCatalogApiData =
   archestraApiTypes.CreateInternalMcpCatalogItemData["body"];
 
+// Parses the Arguments textarea input into an array of strings.
+// Supports both formats:
+//   - one argument per line (the traditional format)
+//   - a JSON array of strings, e.g. ["-y", "@modelcontextprotocol/server"]
+export function parseArgumentsInput(input: string): string[] {
+  const trimmed = input.trim();
+
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (
+        Array.isArray(parsed) &&
+        parsed.every((item) => typeof item === "string")
+      ) {
+        return parsed.map((arg) => arg.trim()).filter((arg) => arg.length > 0);
+      }
+    } catch {
+      // Not valid JSON - fall through to line-based parsing
+    }
+  }
+
+  return trimmed
+    .split("\n")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
 // Transform function to convert form values to API format
 export function transformFormToApiData(
   values: McpCatalogFormValues,
@@ -34,12 +61,9 @@ export function transformFormToApiData(
 
   // Handle local configuration
   if (values.serverType === "local" && values.localConfig) {
-    // Parse arguments string into array
+    // Parse arguments string into array (supports one-per-line or JSON array format)
     const argumentsArray = values.localConfig.arguments
-      ? values.localConfig.arguments
-          .split("\n")
-          .map((arg) => arg.trim())
-          .filter((arg) => arg.length > 0)
+      ? parseArgumentsInput(values.localConfig.arguments)
       : [];
 
     data.localConfig = {


### PR DESCRIPTION
Closes #3859

Args field now takes JSON arrays too, not just one-per-line. Most catalogs paste args as JSON so this was annoying before.