### PR TITLE
[DO NOT MERGE] fix(chat): budget Ollama output up to the context window and show the effective max output limit

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -182048,6 +182048,12 @@
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
+                          "outputLength": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -2147483648,
+                            "maximum": 2147483647
+                          },
                           "inputModalities": {
                             "nullable": true,
                             "type": "array",
@@ -182077,6 +182083,9 @@
                           "supportsToolCalling": {
                             "nullable": true,
                             "type": "boolean"
+                          },
+                          "effectiveMaxOutputTokens": {
+                            "type": "number"
                           },
                           "pricePerMillionInput": {
                             "nullable": true,
@@ -182119,9 +182128,11 @@
                         },
                         "required": [
                           "contextLength",
+                          "outputLength",
                           "inputModalities",
                           "outputModalities",
                           "supportsToolCalling",
+                          "effectiveMaxOutputTokens",
                           "pricePerMillionInput",
                           "pricePerMillionOutput",
                           "isCustomPrice",
@@ -182919,6 +182930,9 @@
                       },
                       "isFree": {
                         "type": "boolean"
+                      },
+                      "effectiveMaxOutputTokens": {
+                        "type": "number"
                       }
                     },
                     "required": [
@@ -182956,7 +182970,8 @@
                       "pricePerMillionCacheRead",
                       "pricePerMillionCacheWrite",
                       "cachePriceSource",
-                      "isFree"
+                      "isFree",
+                      "effectiveMaxOutputTokens"
                     ],
                     "additionalProperties": false
                   }

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1147,7 +1147,7 @@ Enable polling compatibility only when your database endpoint cannot keep sessio
 
 - **`ARCHESTRA_CHAT_MAX_OUTPUT_TOKENS`** - Upper bound on the output tokens an agent turn (interactive chat and A2A/headless) may generate.
   - Default: `32768`
-  - Each turn already requests the model's real output ceiling instead of the provider/SDK default that truncated large tool-call payloads and final submission turns. This variable caps that request for cost control: the turn uses `min(this value, the model's real output ceiling)`, and unsynced models fall back to `8192`.
+  - Each turn already requests the model's real output ceiling instead of the provider/SDK default that truncated large tool-call payloads and final submission turns. This variable caps that request for cost control: the turn uses `min(this value, the model's real output ceiling)`. Models without a known output ceiling fall back to `8192` — except Ollama models, which fall back to their context window (Ollama itself does not cap output). The effective value per model is shown in the Max output column on the Models page.
   - Lower it to constrain spend; raise it for models whose useful outputs exceed 32768 tokens.
 
 ### MCP Apps Sandbox

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -425,7 +425,9 @@ export async function executeA2AMessage(
       // inject a small default max (e.g. Anthropic's ~4096) truncated large
       // tool-call payloads.
       maxOutputTokens: resolveAgentMaxOutputTokens({
+        provider,
         outputLength: modelRow?.outputLength ?? null,
+        contextLength: modelRow?.contextLength ?? null,
         ceiling: config.chat.maxOutputTokensCeiling,
       }),
       // Per-step context guard: cap oversized tool results and keep the

--- a/platform/backend/src/agents/agent-output-budget.test.ts
+++ b/platform/backend/src/agents/agent-output-budget.test.ts
@@ -8,40 +8,138 @@ describe("resolveAgentMaxOutputTokens", () => {
   const ceiling = 32768;
 
   test("uses the model's real output ceiling when it fits under the ceiling", () => {
-    expect(resolveAgentMaxOutputTokens({ outputLength: 8192, ceiling })).toBe(
-      8192,
-    );
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "anthropic",
+        outputLength: 8192,
+        contextLength: null,
+        ceiling,
+      }),
+    ).toBe(8192);
   });
 
   test("clamps a large real ceiling down to the operator ceiling", () => {
-    expect(resolveAgentMaxOutputTokens({ outputLength: 64000, ceiling })).toBe(
-      32768,
-    );
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "anthropic",
+        outputLength: 64000,
+        contextLength: null,
+        ceiling,
+      }),
+    ).toBe(32768);
   });
 
   test("keeps a small legacy cap (4096) intact", () => {
-    expect(resolveAgentMaxOutputTokens({ outputLength: 4096, ceiling })).toBe(
-      4096,
-    );
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "anthropic",
+        outputLength: 4096,
+        contextLength: null,
+        ceiling,
+      }),
+    ).toBe(4096);
   });
 
   test("falls back to the unknown-model budget when outputLength is null", () => {
-    expect(resolveAgentMaxOutputTokens({ outputLength: null, ceiling })).toBe(
-      UNKNOWN_MODEL_OUTPUT_TOKENS,
-    );
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "anthropic",
+        outputLength: null,
+        contextLength: null,
+        ceiling,
+      }),
+    ).toBe(UNKNOWN_MODEL_OUTPUT_TOKENS);
   });
 
   test("treats invalid outputLength as unknown", () => {
     for (const bad of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
-      expect(resolveAgentMaxOutputTokens({ outputLength: bad, ceiling })).toBe(
-        UNKNOWN_MODEL_OUTPUT_TOKENS,
-      );
+      expect(
+        resolveAgentMaxOutputTokens({
+          provider: "anthropic",
+          outputLength: bad,
+          contextLength: null,
+          ceiling,
+        }),
+      ).toBe(UNKNOWN_MODEL_OUTPUT_TOKENS);
     }
   });
 
   test("a lower operator ceiling also caps the unknown-model fallback", () => {
     expect(
-      resolveAgentMaxOutputTokens({ outputLength: null, ceiling: 4096 }),
+      resolveAgentMaxOutputTokens({
+        provider: "anthropic",
+        outputLength: null,
+        contextLength: null,
+        ceiling: 4096,
+      }),
     ).toBe(4096);
+  });
+
+  test("ollama with unknown output falls back to the context window, clamped by the ceiling", () => {
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "ollama",
+        outputLength: null,
+        contextLength: 131072,
+        ceiling,
+      }),
+    ).toBe(32768);
+  });
+
+  test("ollama context window below the unknown-model budget is the honest cap", () => {
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "ollama",
+        outputLength: null,
+        contextLength: 4096,
+        ceiling,
+      }),
+    ).toBe(4096);
+  });
+
+  test("ollama without a context window keeps the unknown-model budget", () => {
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "ollama",
+        outputLength: null,
+        contextLength: null,
+        ceiling,
+      }),
+    ).toBe(UNKNOWN_MODEL_OUTPUT_TOKENS);
+  });
+
+  test("ollama with a real output ceiling ignores the context-window fallback", () => {
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "ollama",
+        outputLength: 16000,
+        contextLength: 131072,
+        ceiling,
+      }),
+    ).toBe(16000);
+  });
+
+  test("the context-window fallback is ollama-only", () => {
+    expect(
+      resolveAgentMaxOutputTokens({
+        provider: "anthropic",
+        outputLength: null,
+        contextLength: 200000,
+        ceiling,
+      }),
+    ).toBe(UNKNOWN_MODEL_OUTPUT_TOKENS);
+  });
+
+  test("ollama treats an invalid context window as unknown", () => {
+    for (const bad of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(
+        resolveAgentMaxOutputTokens({
+          provider: "ollama",
+          outputLength: null,
+          contextLength: bad,
+          ceiling,
+        }),
+      ).toBe(UNKNOWN_MODEL_OUTPUT_TOKENS);
+    }
   });
 });

--- a/platform/backend/src/agents/agent-output-budget.ts
+++ b/platform/backend/src/agents/agent-output-budget.ts
@@ -1,3 +1,4 @@
+import type { SupportedProvider } from "@archestra/shared";
 import { sanitizeOutputLimit } from "@/clients/models-dev-client";
 
 /**
@@ -9,15 +10,28 @@ const UNKNOWN_MODEL_OUTPUT_TOKENS = 8192;
 
 /**
  * Resolve `maxOutputTokens` for an agent turn: the model's real output ceiling
- * (or {@link UNKNOWN_MODEL_OUTPUT_TOKENS} when it is unknown/invalid), clamped by
- * the operator ceiling. The result never exceeds the model's real cap, so a small
- * model never receives an over-budget request from a known ceiling.
+ * (or a fallback when it is unknown/invalid), clamped by the operator ceiling.
+ * The result never exceeds the model's real cap, so a small model never
+ * receives an over-budget request from a known ceiling.
+ *
+ * The unknown-model fallback is provider-dependent: Ollama never caps output on
+ * its own (`num_predict` defaults to generate-until-the-context-is-full), so the
+ * context window is the honest ceiling for a local model missing from the
+ * catalog — a hardcoded budget would truncate long generations mid-stream.
+ * Hosted providers reject `max_tokens` above the model's real cap, so they keep
+ * the conservative {@link UNKNOWN_MODEL_OUTPUT_TOKENS} budget.
  */
 export function resolveAgentMaxOutputTokens(params: {
+  provider: SupportedProvider | null;
   outputLength: number | null;
+  contextLength: number | null;
   ceiling: number;
 }): number {
-  const base =
-    sanitizeOutputLimit(params.outputLength) ?? UNKNOWN_MODEL_OUTPUT_TOKENS;
+  const fallback =
+    params.provider === "ollama"
+      ? (sanitizeOutputLimit(params.contextLength) ??
+        UNKNOWN_MODEL_OUTPUT_TOKENS)
+      : UNKNOWN_MODEL_OUTPUT_TOKENS;
+  const base = sanitizeOutputLimit(params.outputLength) ?? fallback;
   return Math.min(params.ceiling, base);
 }

--- a/platform/backend/src/models/model.ts
+++ b/platform/backend/src/models/model.ts
@@ -12,6 +12,8 @@ import {
   or,
   sql,
 } from "drizzle-orm";
+import { resolveAgentMaxOutputTokens } from "@/agents/agent-output-budget";
+import config from "@/config";
 import db, { schema, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import type {
@@ -815,9 +817,16 @@ class ModelModel {
     if (!model) {
       return {
         contextLength: null,
+        outputLength: null,
         inputModalities: null,
         outputModalities: null,
         supportsToolCalling: null,
+        effectiveMaxOutputTokens: resolveAgentMaxOutputTokens({
+          provider: null,
+          outputLength: null,
+          contextLength: null,
+          ceiling: config.chat.maxOutputTokensCeiling,
+        }),
         pricePerMillionInput: null,
         pricePerMillionOutput: null,
         isCustomPrice: false,
@@ -832,9 +841,16 @@ class ModelModel {
 
     return {
       contextLength: model.contextLength,
+      outputLength: model.outputLength,
       inputModalities: model.inputModalities,
       outputModalities: model.outputModalities,
       supportsToolCalling: model.supportsToolCalling,
+      effectiveMaxOutputTokens: resolveAgentMaxOutputTokens({
+        provider: model.provider,
+        outputLength: model.outputLength,
+        contextLength: model.contextLength,
+        ceiling: config.chat.maxOutputTokensCeiling,
+      }),
       pricePerMillionInput: pricing.pricePerMillionInput,
       pricePerMillionOutput: pricing.pricePerMillionOutput,
       isCustomPrice: pricing.source === "custom",

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -1206,7 +1206,9 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 // (e.g. Anthropic's ~4096) truncated large tool-call payloads
                 // and final submission turns.
                 streamTextConfig.maxOutputTokens = resolveAgentMaxOutputTokens({
+                  provider,
                   outputLength: modelRow?.outputLength ?? null,
+                  contextLength: modelRow?.contextLength ?? null,
                   ceiling: config.chat.maxOutputTokensCeiling,
                 });
 

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -713,6 +713,51 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(mockStreamText.mock.calls[0]?.[0].maxOutputTokens).toBe(8192);
   });
 
+  test("falls back to the context window for an ollama model without a published output limit", async ({
+    makeConversation,
+  }) => {
+    // Catalog-unknown Ollama models sync with outputLength=null but a real
+    // contextLength; Ollama itself never caps output, so the turn must budget
+    // up to the context window (clamped by the ceiling), not the 8192 default.
+    const ollamaModel = await ModelModel.create({
+      externalId: "ollama/qwen3-coder:30b",
+      provider: "ollama",
+      modelId: "qwen3-coder:30b",
+      description: "Local Ollama model",
+      contextLength: 131072,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+    const ollamaConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: ollamaModel.id,
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: ollamaConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+    expect(mockStreamText.mock.calls[0]?.[0].maxOutputTokens).toBe(32768);
+  });
+
   test("omits temperature from streamText when none is provided", async () => {
     mockStreamText.mockClear();
 

--- a/platform/backend/src/routes/llm-provider-models.test.ts
+++ b/platform/backend/src/routes/llm-provider-models.test.ts
@@ -359,6 +359,86 @@ describe("chat model routes", () => {
     ]);
   });
 
+  test("GET /api/llm-models reports the effective max output tokens per model", async ({
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    // Ollama models without a published output limit budget up to the context
+    // window; other providers keep the unknown-model default; a published
+    // limit is used as-is (all clamped by the operator ceiling, default 32768).
+    const ollamaModel = await ModelModel.create({
+      externalId: "ollama/qwen3-coder:30b",
+      provider: "ollama",
+      modelId: "qwen3-coder:30b",
+      description: "Local Ollama model",
+      contextLength: 131072,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+    const knownLimitModel = await ModelModel.create({
+      externalId: "anthropic/claude-test",
+      provider: "anthropic",
+      modelId: "claude-test",
+      description: "Model with a published output limit",
+      contextLength: 200000,
+      outputLength: 16000,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+    const unknownModel = await ModelModel.create({
+      externalId: "openai/mystery-model",
+      provider: "openai",
+      modelId: "mystery-model",
+      description: "Model with no known limits",
+      contextLength: null,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+
+    // Models only appear in the response when linked to a visible API key.
+    for (const model of [ollamaModel, knownLimitModel, unknownModel]) {
+      const secret = await makeSecret({ secret: { apiKey: "test-key" } });
+      const apiKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+        provider: model.provider,
+        scope: "personal",
+        userId: user.id,
+      });
+      await LlmProviderApiKeyModelLinkModel.syncModelsForApiKey(
+        apiKey.id,
+        [{ id: model.id, modelId: model.modelId }],
+        model.provider,
+      );
+    }
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/llm-models",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const rows: { id: string; effectiveMaxOutputTokens: number }[] =
+      response.json();
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    expect(byId.get(ollamaModel.id)?.effectiveMaxOutputTokens).toBe(32768);
+    expect(byId.get(knownLimitModel.id)?.effectiveMaxOutputTokens).toBe(16000);
+    expect(byId.get(unknownModel.id)?.effectiveMaxOutputTokens).toBe(8192);
+  });
+
   test("syncModelsForVisibleApiKeys syncs visible keys and preserves baseUrl", async ({
     makeSecret,
   }) => {

--- a/platform/backend/src/routes/llm-provider-models.ts
+++ b/platform/backend/src/routes/llm-provider-models.ts
@@ -665,5 +665,6 @@ function toModelWithApiKeysResponse(params: {
     pricePerMillionCacheWrite: pricing.pricePerMillionCacheWrite,
     cachePriceSource: pricing.cachePriceSource,
     isFree: isFreeModel(model),
+    effectiveMaxOutputTokens: pricing.effectiveMaxOutputTokens,
   };
 }

--- a/platform/backend/src/types/model.ts
+++ b/platform/backend/src/types/model.ts
@@ -101,10 +101,13 @@ export type PriceSource = z.infer<typeof PriceSourceSchema>;
  */
 export const ModelCapabilitiesSchema = SelectModelSchema.pick({
   contextLength: true,
+  outputLength: true,
   inputModalities: true,
   outputModalities: true,
   supportsToolCalling: true,
 }).extend({
+  /** Effective per-turn output-token budget the platform requests: min of the operator ceiling and the model's cap (or its fallback when the cap is unknown) */
+  effectiveMaxOutputTokens: z.number(),
   /** Price per million tokens for input (computed from per-token price) */
   pricePerMillionInput: z.string().nullable(),
   /** Price per million tokens for output (computed from per-token price) */
@@ -262,5 +265,7 @@ export const ModelWithApiKeysSchema = SelectModelSchema.extend({
   cachePriceSource: PriceSourceSchema.nullable(),
   /** True when the provider charges nothing for this model (both raw prices are zero). */
   isFree: z.boolean(),
+  /** Effective per-turn output-token budget the platform requests: min of the operator ceiling and the model's cap (or its fallback when the cap is unknown) */
+  effectiveMaxOutputTokens: z.number(),
 });
 export type ModelWithApiKeys = z.infer<typeof ModelWithApiKeysSchema>;

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -321,6 +321,44 @@ export default function ModelsPage() {
         },
       },
       {
+        id: "maxOutput",
+        size: 110,
+        header: "Max output",
+        cell: ({ row }) => {
+          // The Context column already shows the unknown-capabilities badge.
+          if (hasUnknownCapabilities(row.original)) return null;
+          const { outputLength, effectiveMaxOutputTokens, provider } =
+            row.original;
+          if (outputLength !== null) {
+            return (
+              <span className="text-sm">
+                {formatContextLength(outputLength)}
+              </span>
+            );
+          }
+          return (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="text-sm text-muted-foreground">
+                    ~{formatContextLength(effectiveMaxOutputTokens)}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  <p>
+                    This model does not publish an output-token limit. Shown is
+                    the effective per-turn budget requested for it
+                    {provider === "ollama"
+                      ? ", capped by the model's context window and the server output-token ceiling."
+                      : ", the unknown-model default capped by the server output-token ceiling."}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          );
+        },
+      },
+      {
         id: "actions",
         header: "Actions",
         cell: ({ row }) => (
@@ -672,6 +710,24 @@ function EditModelDialog({
             <p className="text-sm font-mono text-muted-foreground">
               {model.modelId}
             </p>
+          </div>
+
+          {/* Read-only: Token limits */}
+          <div className="space-y-1">
+            <span className="text-sm font-medium">Token limits</span>
+            <p className="text-sm text-muted-foreground">
+              Context window: {formatContextLength(model.contextLength ?? null)}
+              {" · "}Max output:{" "}
+              {model.outputLength !== null
+                ? formatContextLength(model.outputLength)
+                : `~${formatContextLength(model.effectiveMaxOutputTokens)} (estimated)`}
+            </p>
+            {model.outputLength === null && (
+              <p className="text-xs text-muted-foreground">
+                The model doesn't publish an output limit; this is the effective
+                per-turn budget that will be requested.
+              </p>
+            )}
           </div>
 
           {/* Pricing */}

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -47337,9 +47337,11 @@ export type GetLlmModelsResponses = {
         createdAt?: string;
         capabilities?: {
             contextLength: number | null;
+            outputLength: number | null;
             inputModalities: Array<'text' | 'image' | 'audio' | 'video' | 'pdf'> | null;
             outputModalities: Array<'text' | 'image' | 'audio'> | null;
             supportsToolCalling: boolean | null;
+            effectiveMaxOutputTokens: number;
             pricePerMillionInput: string | null;
             pricePerMillionOutput: string | null;
             isCustomPrice: boolean;
@@ -47561,6 +47563,7 @@ export type GetModelsWithApiKeysResponses = {
         pricePerMillionCacheWrite: string | null;
         cachePriceSource: 'custom' | 'models_dev' | 'derived_multiplier' | 'default';
         isFree: boolean;
+        effectiveMaxOutputTokens: number;
     }>;
 };
 


### PR DESCRIPTION
## What

- Catalog-unknown Ollama models (`output_length` NULL) now request `max_tokens = min(ceiling, context window)` instead of the hardcoded 8192 unknown-model budget. Other providers keep the 8192 fallback.
- The models API returns a server-computed `effectiveMaxOutputTokens`; the Models page shows it as a new "Max output" column (muted `~value` + tooltip when estimated) and the edit dialog gets a read-only "Token limits" block.
- Docs: the `ARCHESTRA_CHAT_MAX_OUTPUT_TOKENS` section documents the Ollama fallback.

## Why

Local Ollama tags (e.g. `qwen3.6:27b-q8_0`) never match the models.dev catalog, so every request silently carried `max_tokens: 8192` regardless of the model's capability, truncating long generations mid-stream (app creation via `edit_app` was the reported casualty). Ollama itself never caps output — `num_predict` defaults to generate-until-the-context-is-full — so the context window is the honest budget. The effective limit was also displayed nowhere, so diagnosing the truncation required digging in the `interactions` table.

## How

`resolveAgentMaxOutputTokens` gains `provider` and `contextLength` params and owns the fallback policy; both call sites (chat stream route, A2A executor) pass the model row through. The fallback is Ollama-only because hosted providers reject `max_tokens` above the model's real cap. `ModelModel.toCapabilities` computes `effectiveMaxOutputTokens` with the same function, so the frontend never duplicates the min() logic.

## Testing

- Unit: extended `agent-output-budget.test.ts` (context-window fallback, ollama-only scope, invalid-value handling, ceiling clamp).
- Integration: new `stream-route.test.ts` case (ollama row, `outputLength` NULL, 131072 context → `maxOutputTokens` 32768) and `llm-provider-models.test.ts` case pinning `effectiveMaxOutputTokens` for ollama/known-limit/unknown models.
- Full backend suite (11650 tests), `pnpm lint`, `pnpm type-check`, backend + frontend `knip` all green; `pnpm codegen` output committed.