### PR TITLE
fix(connection): remove escape sequences from connection scripts

### DIFF
--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -166,33 +166,74 @@ async function runClaudeSettingsMerge(params: {
 }
 
 /**
- * Runs the real `cli` helper (lifted out of a rendered script) the way
- * `curl | bash` runs it: bash reads the script from a pipe, so every command it
- * starts inherits that pipe on stdin unless `cli` redirects it. Returns what the
- * invoked command actually read.
+ * A python pty driver that reproduces the exact `curl | bash` shape inside a
+ * terminal: bash reads the script from a pipe (so its stdin is NOT a tty, and
+ * every command inherits that pipe), while its stdout IS a real tty. The driver
+ * also answers terminal probes the way an emulator would, so any probe reply
+ * that leaks would show up in the captured output.
  */
-async function runCliWithScriptOnStdin(archStdin: string): Promise<string> {
-  const helpers = renderSetupScript(fullContext("claude-code"))
+const PTY_DRIVER = `import os, pty, select, sys, time, re
+script_path = sys.argv[1]
+r, w = os.pipe()
+os.write(w, b"FROM-THE-CURL-PIPE\\n" * 20); os.close(w)
+pid, master = os.forkpty()
+if pid == 0:
+    os.dup2(r, 0)                      # stdin = the download pipe (curl | bash)
+    os.execvp("bash", ["bash", script_path])
+    os._exit(1)
+out = b""; end = time.time() + 20
+while time.time() < end:
+    rr, _, _ = select.select([master], [], [], 0.3)
+    if rr:
+        try: d = os.read(master, 65536)
+        except OSError: break
+        if not d: break
+        out += d
+        reply = b""
+        if b"\\x1b]11;?" in d: reply += b"\\x1b]11;rgb:1e1e/1e1e/1e1e\\x1b\\\\"
+        if re.search(rb"\\x1b\\[c", d): reply += b"\\x1b[?1;2c"
+        if reply: os.write(master, reply)
+    if os.waitpid(pid, os.WNOHANG)[0] != 0:
+        time.sleep(0.3)
+        rr, _, _ = select.select([master], [], [], 0.3)
+        if rr:
+            try: out += os.read(master, 65536)
+            except OSError: pass
+        break
+try: os.kill(pid, 9)
+except Exception: pass
+sys.stdout.write(out.decode("latin1"))`;
+
+/** The rendered helper block (color + terminal guard + `say`/`cli`/… helpers). */
+function helperBlock(): string {
+  return renderSetupScript(fullContext("claude-code"))
     .split("set -euo pipefail\n\n")[1]
     .split("\n\ncat <<'ARCHESTRA_BANNER'")[0];
+}
+
+/**
+ * Runs arbitrary bash under {@link PTY_DRIVER} — i.e. as `curl | bash` would,
+ * with the download pipe on stdin and a live tty on stdout, and an emulator that
+ * answers terminal probes. Returns everything the terminal saw (escape bytes
+ * shown as `^[`).
+ */
+async function runBashInTerminal(script: string): Promise<string> {
   const dir = await mkdtemp(path.join(tmpdir(), "archestra-cli-"));
   try {
-    const file = path.join(dir, "setup.sh");
-    await writeFile(
-      file,
-      `set -euo pipefail\n${helpers}\nARCH_STDIN=${archStdin}\ncli cat\n`,
-      "utf8",
-    );
-    const { stdout } = await execFileAsync("bash", [
-      "-c",
-      `printf '%s\\n' 'FROM-THE-CURL-PIPE' | bash "$1"`,
-      "bash",
-      file,
-    ]);
-    return stdout;
+    const scriptFile = path.join(dir, "run.sh");
+    const driver = path.join(dir, "pty.py");
+    await writeFile(scriptFile, script, "utf8");
+    await writeFile(driver, PTY_DRIVER, "utf8");
+    const { stdout } = await execFileAsync("python3", [driver, scriptFile]);
+    return stdout.replaceAll("\x1b", "^[");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+}
+
+/** Runs `body` after the real rendered helper block. */
+function runInTerminal(body: string): Promise<string> {
+  return runBashInTerminal(`set -euo pipefail\n${helperBlock()}\n${body}\n`);
 }
 
 const ALL_CLIENTS = ["claude-code", "codex", "copilot-cli", "cursor"] as const;
@@ -218,22 +259,20 @@ describe("renderSetupScript", () => {
       expect(script).toContain(SKILLS.marketplaceName);
     });
 
-    test(`${clientId}: client CLIs are never left on the curl pipe`, () => {
+    test(`${clientId}: client CLIs never drive the terminal directly`, () => {
       const script = renderSetupScript(fullContext(clientId));
-      // `curl | bash` puts the download pipe on stdin, and every command the
-      // script starts inherits it. A client CLI probes the terminal for its
-      // theme/capabilities by writing to stdout, but it can only silence the
-      // echo and read the reply back when stdin is a tty — so on the pipe the
-      // terminal's replies ("rgb:1e1e/1e1e/1e1e", "^[[?1;2c") echo into this
-      // script's output, and the CLI could read the script itself as input.
-      // Every invocation goes through `cli`, which redirects stdin.
-      const onThePipe = script
+      // A client CLI renders a full-screen TUI when its stdout is a tty: it
+      // probes the terminal (replies echo in as "rgb:1e1e/1e1e/1e1e" / "^[[?1;2c")
+      // and positions text with absolute cursor moves that assume it owns the
+      // screen, cascading every line to the right under `curl | bash`. Every
+      // invocation must go through `cli`, which detaches stdout from the tty.
+      const bareInvocations = script
         .split("\n")
         .map((line) => line.trim())
         .filter((line) =>
           /^(?:if\s+!\s+|!\s+)?(?:claude|codex|copilot)\s/.test(line),
         );
-      expect(onThePipe).toEqual([]);
+      expect(bareInvocations).toEqual([]);
     });
 
     test(`${clientId}: sections are omitted when not selected`, async () => {
@@ -253,33 +292,86 @@ describe("renderSetupScript", () => {
     });
   }
 
-  test("bash: `cli` keeps the piped-in script off a command's stdin", async () => {
-    // No terminal to hand over (CI, or any non-interactive run): the command
-    // gets EOF — never the rest of this script.
-    expect(await runCliWithScriptOnStdin("/dev/null")).toBe("");
+  test("bash: `cli` detaches a command's stdout from the terminal", async () => {
+    // Control + subject in one run. At script level stdout is a real tty (the
+    // pty harness is faithful), so the control prints TTY-AT-SCRIPT. Through
+    // `cli` the same probe sees a pipe, so it prints PIPE-VIA-CLI — that non-tty
+    // stdout is what stops a client CLI probing the terminal or positioning text
+    // with absolute cursor moves. `cat` reads stdin and gets EOF from /dev/null,
+    // so the download pipe ("FROM-THE-CURL-PIPE") is never read as input.
+    const probe = `[ -t 1 ] && echo TTY-AT-SCRIPT
+cli sh -c '[ -t 1 ] && echo TTY-VIA-CLI || echo PIPE-VIA-CLI; cat'`;
+    const out = await runInTerminal(probe);
+    expect(out).toContain("TTY-AT-SCRIPT");
+    expect(out).toContain("PIPE-VIA-CLI");
+    expect(out).not.toContain("TTY-VIA-CLI");
+    expect(out).not.toContain("FROM-THE-CURL-PIPE");
   });
 
-  test("bash: `cli` gives a command the terminal, not the download pipe", async () => {
-    // Stand-in for /dev/tty. A real terminal is what lets a client CLI turn the
-    // echo off and consume its own probe replies, so they stop leaking into the
-    // output as stray "rgb:1e1e/1e1e/1e1e" / "^[[?1;2c" text. /dev/null alone
-    // would not do: the probe is keyed on stdout, so it still fires and echoes.
-    const dir = await mkdtemp(path.join(tmpdir(), "archestra-tty-"));
-    try {
-      const fakeTty = path.join(dir, "tty");
-      await writeFile(fakeTty, "FROM-THE-TERMINAL\n", "utf8");
-      expect(await runCliWithScriptOnStdin(fakeTty)).toBe(
-        "FROM-THE-TERMINAL\n",
-      );
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
+  test("bash: `cli` leaks no terminal probe replies into the output", async () => {
+    // Model a client CLI faithfully: it probes the terminal only when stdout is
+    // a tty. Run bare (stdout = tty) it fires the probe and the harness's reply
+    // echoes in as stray "rgb:1e1e/1e1e/1e1e" / "^[[?1;2c" text — the reported
+    // bug. Through `cli` (stdout = pipe) the tty check fails, so nothing probes
+    // and nothing leaks.
+    const probe = `if [ -t 1 ]; then printf '\\033]11;?\\033[c'; fi; sleep 0.5`;
+
+    const bare = await runInTerminal(`sh -c ${JSON.stringify(probe)}`);
+    expect(bare).toContain("1e1e/1e1e/1e1e"); // harness answers, bare leaks
+
+    const wrapped = await runInTerminal(`cli sh -c ${JSON.stringify(probe)}`);
+    expect(wrapped).not.toContain("1e1e/1e1e/1e1e");
+    expect(wrapped).not.toContain("^[[?1;2c");
+  });
+
+  test("bash: `cli` surfaces the command's failure through pipefail", async () => {
+    // `cli` pipes stdout through cat; without `set -o pipefail` the pipeline
+    // would mask a CLI failure behind cat's success, so `if ! cli ...` guards
+    // (e.g. the skills-install fallback) would never fire.
+    const out = await runInTerminal(
+      `if ! cli sh -c 'exit 7'; then echo FAILURE-SEEN; fi`,
+    );
+    expect(out).toContain("FAILURE-SEEN");
+  });
+
+  test("bash: the script leaves the terminal's line discipline sane", async () => {
+    // Regression: a CLI that grabbed the terminal (raw mode) leaves newline
+    // translation (onlcr) off, so every line staircases to the right — including
+    // a plain banner printed before any CLI runs. The helper block guards both
+    // ends: it resets the terminal on entry (healing a terminal a *previous* run
+    // wedged) and, via an EXIT trap, restores it on exit (so a CLI that wedges it
+    // *mid-run* never leaves it broken for the next command).
+    const state = (label: string) =>
+      `printf '${label}:'; stty -a </dev/tty | grep -o -- '-\\?onlcr' | head -1`;
+
+    // Sanity: the harness really can wedge the terminal (nothing heals it here).
+    const wedged = await runBashInTerminal(
+      `stty -onlcr </dev/tty\n${state("BARE")}\n`,
+    );
+    expect(wedged).toContain("BARE:-onlcr");
+
+    // Start wedged (inherited). Inside a subshell running the helper block, entry
+    // reset should have healed it (ENTRY); then re-wedge to mimic a CLI grabbing
+    // the terminal mid-run; after the subshell exits its trap should heal it
+    // again (AFTER). Both points must read `onlcr`, isolating the two guards.
+    const helpers = helperBlock();
+    const out = await runBashInTerminal(
+      `stty -onlcr </dev/tty\n(\nset -euo pipefail\n${helpers}\n${state("ENTRY")}\nstty -onlcr </dev/tty\n)\n${state("AFTER")}\n`,
+    );
+    expect(out).toContain("ENTRY:onlcr"); // entry reset healed the inherited wedge
+    expect(out).toContain("AFTER:onlcr"); // exit trap healed the mid-run wedge
   });
 
   test("claude-code: registers gateway idempotently and merges settings.json", () => {
     const script = renderSetupScript(fullContext("claude-code"));
-    // The real terminal is preferred over /dev/null when there is one.
-    expect(script).toContain("ARCH_STDIN=/dev/tty");
+    // The terminal is reset on entry and on exit so a raw-mode-wedged terminal
+    // is healed and never handed back broken.
+    expect(script).toContain("stty sane </dev/tty");
+    expect(script).toContain(
+      "trap 'stty sane </dev/tty 2>/dev/null || true' EXIT",
+    );
+    // Client CLIs run detached from the tty so they print plain linear text.
+    expect(script).toContain('cli() { "$@" </dev/null 2>&1 | cat; }');
     expect(script).toContain(
       "cli claude mcp remove 'prod_gateway' >/dev/null 2>&1 || true",
     );

--- a/platform/backend/src/services/connection-setup-script.ts
+++ b/platform/backend/src/services/connection-setup-script.ts
@@ -201,11 +201,26 @@ function sanitizeAppName(appName: string): string {
  * section headers, `ok` a success, `warn`/`err` advisory and failure lines
  * (err goes to stderr so `curl -f | bash` surfaces it).
  *
- * `cli` runs an external client CLI with a usable stdin — see the comment it
- * carries into the script. Every `claude`/`codex`/`copilot` invocation must go
- * through it, except ones already fed by a pipe (they own their stdin).
+ * `cli` runs an external client CLI with its stdout/stderr detached from the
+ * terminal — see the comment it carries into the script. Every
+ * `claude`/`codex`/`copilot` invocation must go through it, except ones already
+ * fed by a pipe (they own their stdin).
+ *
+ * The leading block normalizes the terminal's line discipline: a child that put
+ * the terminal in raw mode on an earlier run can leave it wedged (output no
+ * longer returns to column 0 and every line marches right), so we reset it up
+ * front and restore it on exit — the script both survives a wedged terminal and
+ * never hands one back.
  */
-const SCRIPT_HELPERS = `if [ -t 1 ] && [ -z "\${NO_COLOR:-}" ]; then
+const SCRIPT_HELPERS = `# If stdout is a terminal, make sure its line discipline is sane: a CLI that
+# grabbed it (raw mode) on a previous run can leave newline handling off, which
+# staircases every following line to the right. Reset on entry so this run reads
+# cleanly, and on exit so the shell gets a usable terminal back.
+if [ -t 1 ] && command -v stty >/dev/null 2>&1 && { : </dev/tty; } 2>/dev/null; then
+  stty sane </dev/tty 2>/dev/null || true
+  trap 'stty sane </dev/tty 2>/dev/null || true' EXIT
+fi
+if [ -t 1 ] && [ -z "\${NO_COLOR:-}" ]; then
   ARCH_C_RESET=$'\\033[0m'; ARCH_C_HEAD=$'\\033[1;36m'; ARCH_C_OK=$'\\033[1;32m'
   ARCH_C_WARN=$'\\033[1;33m'; ARCH_C_ERR=$'\\033[1;31m'
 else
@@ -216,16 +231,17 @@ ok()   { printf '%s==>%s %s\\n' "$ARCH_C_OK" "$ARCH_C_RESET" "$1"; }
 warn() { printf '%swarning:%s %s\\n' "$ARCH_C_WARN" "$ARCH_C_RESET" "$1"; }
 err()  { printf '%serror:%s %s\\n' "$ARCH_C_ERR" "$ARCH_C_RESET" "$1" >&2; }
 
-# This script is piped into bash, so its stdin is the download pipe rather than
-# the terminal, and every command it starts inherits that. A CLI that probes the
-# terminal for its theme or capabilities writes the query to stdout but needs a
-# tty on stdin to switch the echo off and read the answer back; handed a pipe it
-# can do neither, so the terminal's answers echo into this output as stray text
-# like "rgb:1e1e/1e1e/1e1e" and "^[[?1;2c". Run those CLIs against the real
-# terminal when there is one — /dev/null is not enough, the probe is keyed on
-# stdout and would still echo — and never let them read this script as input.
-if (exec </dev/tty) 2>/dev/null; then ARCH_STDIN=/dev/tty; else ARCH_STDIN=/dev/null; fi
-cli() { "$@" <"$ARCH_STDIN"; }`;
+# Run a client CLI (claude/codex/copilot) so it prints plain text instead of
+# driving the terminal. Those CLIs render a full-screen TUI whenever stdout is a
+# tty: they probe the terminal for its theme/capabilities and position output
+# with absolute cursor moves, both of which assume they own the screen. Under
+# "curl | bash" they don't — this script is already writing to it — so the probe
+# replies echo in as stray text ("rgb:1e1e/1e1e/1e1e", "^[[?1;2c") and the
+# cursor moves land at the wrong column, cascading every following line to the
+# right. Piping stdout+stderr through cat makes stdout a pipe, not a tty, so each
+# CLI falls back to linear plain-text output; </dev/null keeps them off this
+# script's own stdin (the download pipe). pipefail preserves their exit status.
+cli() { "$@" </dev/null 2>&1 | cat; }`;
 
 function header(ctx: SetupScriptContext): string {
   const label = CLIENT_LABELS[ctx.clientId];


### PR DESCRIPTION


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>