### PR TITLE
refactor(frontend): simplify shared-credential confirm dialog copy

### DIFF
--- a/platform/e2e-tests/utils/tool-assignments.ts
+++ b/platform/e2e-tests/utils/tool-assignments.ts
@@ -45,17 +45,17 @@ export async function saveOpenProfileDialog(page: Page): Promise<void> {
 }
 
 /**
- * Pinning a personal-scope connection to a shared (team/org) agent or gateway
- * prompts a confirmation ("Pin every user to a personal account?") because every
- * caller would then authenticate as that one owner. Confirm it so the pin
- * applies; non-personal connections and personal-scope targets don't prompt.
- * Returns whether a confirmation was handled.
+ * Choosing a personal-scope connection for a shared (team/org) agent or gateway
+ * prompts a confirmation ("Use this connection for everyone?") because every
+ * caller would then connect as that one owner. Confirm it so the choice applies;
+ * non-personal connections and personal-scope targets don't prompt. Returns
+ * whether a confirmation was handled.
  */
 async function confirmPersonalCredentialPinIfPrompted(
   page: Page,
 ): Promise<boolean> {
   const confirmButton = page
-    .getByRole("button", { name: /^Pin to .+$/ })
+    .getByRole("button", { name: /^Use th(is|ese) connections?$/ })
     .first();
   if (await confirmButton.isVisible({ timeout: 1500 }).catch(() => false)) {
     // Force past the actionability wait: the dialog's entrance animation keeps

--- a/platform/frontend/src/components/static-credential-confirm-dialog.test.tsx
+++ b/platform/frontend/src/components/static-credential-confirm-dialog.test.tsx
@@ -2,10 +2,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { StaticCredentialConfirmDialog } from "@/components/static-credential-confirm-dialog";
 
-vi.mock("@/lib/hooks/use-app-name", () => ({
-  useAppName: () => "Archestra",
-}));
-
 // Render the shell inline (no Radix portal) so the copy and footer are directly
 // assertable.
 vi.mock("@/components/standard-dialog", () => ({
@@ -59,14 +55,15 @@ describe("StaticCredentialConfirmDialog", () => {
         onCancel={vi.fn()}
       />,
     );
-    expect(container.textContent).toContain("Everyone who uses this agent");
-    expect(container.textContent).toContain("member@example.com's connection");
-    expect(
-      screen.getByText("Pin to member@example.com's connection"),
-    ).toBeInTheDocument();
+    expect(container.textContent).toContain("Every user of this agent");
+    expect(container.textContent).toContain("connect to");
+    expect(container.textContent).toContain("as member@example.com");
+    expect(container.textContent).toContain("no matter who is calling");
+    expect(container.textContent).toContain("member@example.com's access");
+    expect(screen.getByText("Use this connection")).toBeInTheDocument();
   });
 
-  it("agent context uses 'your' wording for the caller's own connection", () => {
+  it("agent context uses 'you' / 'your' wording for the caller's own connection", () => {
     const { container } = render(
       <StaticCredentialConfirmDialog
         open
@@ -81,12 +78,14 @@ describe("StaticCredentialConfirmDialog", () => {
         onCancel={vi.fn()}
       />,
     );
-    expect(container.textContent).toContain("through your connection");
-    expect(container.textContent).toContain("comes from you");
-    expect(screen.getByText("Pin to your connection")).toBeInTheDocument();
+    expect(container.textContent).toContain("Every user of this agent");
+    expect(container.textContent).toContain("connect to");
+    expect(container.textContent).toContain("as you");
+    expect(container.textContent).toContain("your access");
+    expect(screen.getByText("Use this connection")).toBeInTheDocument();
   });
 
-  it("server context describes the default connection and labels the action", () => {
+  it("server context describes the default connection", () => {
     const { container } = render(
       <StaticCredentialConfirmDialog
         open
@@ -102,15 +101,14 @@ describe("StaticCredentialConfirmDialog", () => {
         onCancel={vi.fn()}
       />,
     );
-    expect(container.textContent).toContain("connects as");
+    expect(container.textContent).toContain("Every agent that resolves");
+    expect(container.textContent).toContain("at call time will connect as");
     expect(container.textContent).toContain("member@example.com");
-    expect(
-      screen.getByText("Use member@example.com's account"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Use this connection")).toBeInTheDocument();
   });
 
-  it("server context uses 'you' / 'Use your account' for the caller's own connection", () => {
-    render(
+  it("server context uses 'you' for the caller's own connection", () => {
+    const { container } = render(
       <StaticCredentialConfirmDialog
         open
         context="server"
@@ -125,7 +123,8 @@ describe("StaticCredentialConfirmDialog", () => {
         onCancel={vi.fn()}
       />,
     );
-    expect(screen.getByText("Use your account")).toBeInTheDocument();
+    expect(container.textContent).toContain("will connect as you");
+    expect(container.textContent).toContain("your access");
   });
 
   it("wires the confirm and cancel actions", () => {
@@ -141,7 +140,7 @@ describe("StaticCredentialConfirmDialog", () => {
     );
     fireEvent.click(screen.getByText("Cancel"));
     expect(onCancel).toHaveBeenCalledTimes(1);
-    fireEvent.click(screen.getByText("Pin to e@x.com's connection"));
+    fireEvent.click(screen.getByText("Use this connection"));
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
@@ -158,9 +157,9 @@ describe("StaticCredentialConfirmDialog", () => {
       />,
     );
     expect(container.textContent).toContain("ServerA");
-    expect(container.textContent).toContain("a@x.com");
+    expect(container.textContent).toContain("as a@x.com");
     expect(container.textContent).toContain("ServerB");
     expect(container.textContent).toContain("as you");
-    expect(screen.getByText("Pin anyway")).toBeInTheDocument();
+    expect(screen.getByText("Use these connections")).toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/static-credential-confirm-dialog.tsx
+++ b/platform/frontend/src/components/static-credential-confirm-dialog.tsx
@@ -3,12 +3,11 @@
 import { Users } from "lucide-react";
 import { StandardDialog } from "@/components/standard-dialog";
 import { Button } from "@/components/ui/button";
-import { useAppName } from "@/lib/hooks/use-app-name";
 
 export interface PersonalCredentialPin {
   mcpName: string;
   ownerEmail: string;
-  /** The pinned connection belongs to the person doing the pinning. */
+  /** The chosen connection belongs to the person making the change. */
   isCurrentUser: boolean;
 }
 
@@ -18,12 +17,17 @@ interface StaticCredentialConfirmDialogProps {
   onConfirm: () => void;
   onCancel: () => void;
   /**
-   * "agent" (default): pinning a connection to one agent's tools. "server": the
-   * server's default credential, which applies to every agent that resolves it
-   * at call time.
+   * "agent" (default): a connection chosen for one agent's tools. "server": the
+   * server's default connection, used by every agent that resolves it at call
+   * time.
    */
   context?: "agent" | "server";
 }
+
+const asWho = (pin: PersonalCredentialPin) =>
+  pin.isCurrentUser ? "you" : pin.ownerEmail;
+const possessiveWho = (pin: PersonalCredentialPin) =>
+  pin.isCurrentUser ? "your" : `${pin.ownerEmail}'s`;
 
 export function StaticCredentialConfirmDialog({
   open,
@@ -32,18 +36,7 @@ export function StaticCredentialConfirmDialog({
   onCancel,
   context = "agent",
 }: StaticCredentialConfirmDialogProps) {
-  const appName = useAppName();
   const single = pins.length === 1 ? pins[0] : null;
-
-  const confirmLabel = single
-    ? context === "server"
-      ? single.isCurrentUser
-        ? "Use your account"
-        : `Use ${single.ownerEmail}'s account`
-      : single.isCurrentUser
-        ? "Pin to your connection"
-        : `Pin to ${single.ownerEmail}'s connection`
-    : "Pin anyway";
 
   // A plain (non-form) dialog: this renders inside a modal's own form, and a
   // nested submit would bubble through the React portal to that form and
@@ -58,7 +51,11 @@ export function StaticCredentialConfirmDialog({
       title={
         <div className="flex items-center gap-2">
           <Users className="h-5 w-5" />
-          <span>Pin every user to a personal account?</span>
+          <span>
+            {single
+              ? "Use this connection for everyone?"
+              : "Use these connections for everyone?"}
+          </span>
         </div>
       }
       size="small"
@@ -81,7 +78,7 @@ export function StaticCredentialConfirmDialog({
               onConfirm();
             }}
           >
-            {confirmLabel}
+            {single ? "Use this connection" : "Use these connections"}
           </Button>
         </>
       }
@@ -89,72 +86,38 @@ export function StaticCredentialConfirmDialog({
       {single ? (
         <p className="text-sm text-muted-foreground">
           {context === "server" ? (
-            single.isCurrentUser ? (
-              <>
-                Set as the default, every agent that resolves{" "}
-                <span className="text-foreground font-medium">
-                  {single.mcpName}
-                </span>{" "}
-                at call time connects as{" "}
-                <span className="text-foreground font-medium">you</span> — every
-                caller's request comes from you, with your access, against your
-                rate limits, and under your name.
-              </>
-            ) : (
-              <>
-                Set as the default, every agent that resolves{" "}
-                <span className="text-foreground font-medium">
-                  {single.mcpName}
-                </span>{" "}
-                at call time connects as{" "}
-                <span className="text-foreground font-medium">
-                  {single.ownerEmail}
-                </span>{" "}
-                — every caller's request comes from {single.ownerEmail}, with
-                their access, against their rate limits, and under their name.
-              </>
-            )
-          ) : single.isCurrentUser ? (
             <>
-              Everyone who uses this agent will call{" "}
+              Every agent that resolves{" "}
               <span className="text-foreground font-medium">
                 {single.mcpName}
               </span>{" "}
-              through <span className="text-foreground font-medium">your</span>{" "}
-              connection. To{" "}
+              at call time will connect as{" "}
               <span className="text-foreground font-medium">
-                {single.mcpName}
+                {asWho(single)}
               </span>
-              , every request comes from you — with your access, against your
-              rate limits, and under your name.
+              , no matter who is calling — using {possessiveWho(single)} access
+              and rate limits.
             </>
           ) : (
             <>
-              Everyone who uses this agent will call{" "}
+              Every user of this agent will connect to{" "}
               <span className="text-foreground font-medium">
                 {single.mcpName}
               </span>{" "}
-              through{" "}
+              as{" "}
               <span className="text-foreground font-medium">
-                {single.ownerEmail}
+                {asWho(single)}
               </span>
-              's connection. To{" "}
-              <span className="text-foreground font-medium">
-                {single.mcpName}
-              </span>
-              , every request comes from {single.ownerEmail} — with their
-              access, against their rate limits, and under their name.
+              , no matter who is calling — using {possessiveWho(single)} access
+              and rate limits.
             </>
-          )}{" "}
-          {appName}'s own tool-call log still records who actually ran each
-          call.
+          )}
         </p>
       ) : (
         <div className="space-y-3 text-sm text-muted-foreground">
           <p>
-            Sharing this agent pins its tools to personal connections. Everyone
-            who uses it will call each server as that one owner — with their
-            access, rate limits, and name:
+            Every user of this agent will connect to these servers as the person
+            shown, no matter who is calling:
           </p>
           <ul className="list-disc space-y-1 pl-5">
             {pins.map((pin) => (
@@ -162,14 +125,10 @@ export function StaticCredentialConfirmDialog({
                 <span className="text-foreground font-medium">
                   {pin.mcpName}
                 </span>{" "}
-                as {pin.isCurrentUser ? "you" : pin.ownerEmail}
+                as {asWho(pin)}
               </li>
             ))}
           </ul>
-          <p>
-            {appName}'s own tool-call log still records who actually ran each
-            call.
-          </p>
         </div>
       )}
     </StandardDialog>


### PR DESCRIPTION
## Summary

The confirmation shown before a **personal** MCP connection gets used by a **shared** (team/org) agent introduced its own vocabulary — "Pin", "personal account" — which read like a new product concept rather than the shared-identity warning it is. This rewrites the copy to reuse the app's existing phrasing (the server default-credential selector already says "Agents connect as {X}, no matter who is calling"), so the same idea reads the same way everywhere.

User-visible change:

- **Title:** "Pin every user to a personal account?" → "Use this connection for everyone?"
- **Confirm button:** "Pin to {email}'s connection" / "Pin anyway" → "Use this connection" / "Use these connections". The owner is still named, in the body sentence.
- **Body:** now reads "Every user of this agent will connect to **{server}** as **{owner}**, no matter who is calling — using {owner}'s access and rate limits." (with you/your variants when it's the current user). The server-default variant and the multi-server list use the same phrasing.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>