### PR TITLE
fix(deps): bump mcp SDK to 1.28.1 to clear 3 HIGH CVEs

### DIFF
--- a/platform/mcp_server_docker_image/pyproject.toml
+++ b/platform/mcp_server_docker_image/pyproject.toml
@@ -3,7 +3,9 @@ name = "archestra-mcp-server-python-deps"
 version = "0.1.0"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-  "mcp[cli]>=1.2.0",
+  # mcp <= 1.27.1: CVE-2026-52869 (auth bypass), CVE-2026-52870 (missing authorization)
+  # mcp < 1.28.1: CVE-2026-59950 (missing WebSocket origin validation)
+  "mcp[cli]>=1.28.1",
   "httpx",
   "fastapi",
   # starlette <= 1.0.0: CVE-2026-48710 (BadHost host-header path confusion)

--- a/platform/mcp_server_docker_image/requirements.lock
+++ b/platform/mcp_server_docker_image/requirements.lock
@@ -348,9 +348,9 @@ markdown-it-py==4.0.0 \
     --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \
     --hash=sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
     # via rich
-mcp==1.26.0 \
-    --hash=sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca \
-    --hash=sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66
+mcp==1.28.1 \
+    --hash=sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df \
+    --hash=sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683
     # via archestra-mcp-server-python-deps (pyproject.toml)
 mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \


### PR DESCRIPTION
The `mcp-server-base` image — the base every MCP server pod runs on — ships the Python `mcp` SDK at `1.26.0`, which Docker Scout now flags for three HIGH advisories. Because the vulnerable version is baked into the image, this fails the "Docker Image Scanning (MCP Server Base)" check for every PR entering the merge queue, not just one branch.

Bumps `mcp[cli]` to `>=1.28.1` (regenerating the locked manifest), clearing all three:

- **CVE-2026-59950** — missing Origin validation in the WebSocket transport (CVSS 7.6). Fixed in `1.28.1`.
- **CVE-2026-52870** — missing authorization (CVSS 7.6). Fixed in `1.27.2`.
- **CVE-2026-52869** — authorization bypass through a user-controlled key (CVSS 7.1). Fixed in `1.27.2`.

`1.28.1` is the highest floor and clears all three at once. It is the current PyPI release (published 2026-06-26) and pulls the same transitive tree as `1.26.0`, so the lock diff is limited to the `mcp` entry. Verified locally by building the image's `python-builder` stage: `uv pip sync --require-hashes` installs `mcp==1.28.1` cleanly and every other CVE-pinned floor still holds.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>