### PR TITLE
feat(frontend): warn before scoping a personal agent up shares its personal credentials

### DIFF
--- a/platform/frontend/src/components/agent-dialog.test.tsx
+++ b/platform/frontend/src/components/agent-dialog.test.tsx
@@ -175,6 +175,10 @@ vi.mock("@/components/system-prompt-editor", () => ({
   SystemPromptEditor: () => null,
 }));
 
+vi.mock("@/components/share-personal-credentials-dialog", () => ({
+  SharePersonalCredentialsDialog: () => null,
+}));
+
 vi.mock("@/components/visibility-selector", () => ({
   VisibilitySelector: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -58,6 +58,7 @@ import {
   type AgentToolsEditorRef,
   type McpEnvConflict,
 } from "@/components/agent-tools-editor";
+import type { SharedPersonalPin } from "@/components/agent-tools-editor.utils";
 import { ModelSelector } from "@/components/chat/model-selector";
 import { EnvironmentSelector } from "@/components/environment-selector";
 import { ExternalDocsLink } from "@/components/external-docs-link";
@@ -66,6 +67,7 @@ import {
   formatPermissionRequirement,
   PermissionRequirementHint,
 } from "@/components/permission-requirement-hint";
+import { SharePersonalCredentialsDialog } from "@/components/share-personal-credentials-dialog";
 import { SystemPromptEditor } from "@/components/system-prompt-editor";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
@@ -708,6 +710,12 @@ export function AgentDialog({
   const agentEnvironmentName =
     environments.find((env) => env.id === environmentId)?.name ?? null;
   const [mcpEnvConflicts, setMcpEnvConflicts] = useState<McpEnvConflict[]>([]);
+  // Active tools pinned to a personal connection that would be shared with every
+  // caller once this agent is team/org scope. Reported live by the tools editor.
+  const [sharedPersonalPins, setSharedPersonalPins] = useState<
+    SharedPersonalPin[]
+  >([]);
+  const [showShareConfirm, setShowShareConfirm] = useState(false);
   const [scope, setScope] = useState<AgentScope>("personal");
   const [knowledgeBaseIds, setKnowledgeBaseIds] = useState<string[]>([]);
   const [connectorIds, setConnectorIds] = useState<string[]>([]);
@@ -879,6 +887,10 @@ export function AgentDialog({
       setPassthroughHeaders(nextValues.passthroughHeaders);
       setToolExposureMode(nextValues.toolExposureMode);
       setAccessAllTools(nextValues.accessAllTools);
+      // Clear cross-agent leftovers; the tools editor re-reports this agent's
+      // pins once its credentials load.
+      setSharedPersonalPins([]);
+      setShowShareConfirm(false);
       setAutoConfigureOnToolDiscovery(nextValues.autoConfigureOnToolDiscovery);
       setDualLlmMaxRounds(nextValues.dualLlmMaxRounds);
       if (!agentData) {
@@ -1011,7 +1023,7 @@ export function AgentDialog({
     !isAdmin && scope === "team" && assignedTeamIds.length === 0;
   const hasNoAvailableTeams = !teams || teams.length === 0;
 
-  const handleSave = useCallback(async () => {
+  const performSave = useCallback(async () => {
     const trimmedName = name.trim();
     const trimmedSystemPrompt = systemPrompt.trim();
     const parsedDualLlmMaxRounds = Number.parseInt(dualLlmMaxRounds, 10);
@@ -1265,6 +1277,45 @@ export function AgentDialog({
     toolExposureMode,
     accessAllTools,
     supportsEnvironment,
+  ]);
+
+  const handleSave = useCallback(async () => {
+    if (!name.trim()) {
+      toast.error("Name is required");
+      return;
+    }
+    if (!isAdmin && scope === "team" && assignedTeamIds.length === 0) {
+      toast.error("Please select at least one team");
+      return;
+    }
+    // Scoping a personal agent up to team/org shares any personal static pins
+    // with every caller; confirm (defaulting to resolve-at-call-time) first.
+    // Gated to the actual personal→shared transition (an already-shared agent's
+    // pins were confirmed when set) and to Custom mode (Auto resolves per caller).
+    const isScopingUpFromPersonal =
+      agent?.scope === "personal" && scope !== "personal";
+    if (isScopingUpFromPersonal && !accessAllTools) {
+      // Fail closed while the pin set is still loading — an incomplete "no
+      // personal pins" must not silently ship a shared personal credential.
+      if (agentToolsEditorRef.current?.isCredentialClassificationLoading()) {
+        toast.error("Still loading connections — try saving again.");
+        return;
+      }
+      if (sharedPersonalPins.length > 0) {
+        setShowShareConfirm(true);
+        return;
+      }
+    }
+    await performSave();
+  }, [
+    name,
+    isAdmin,
+    scope,
+    agent,
+    accessAllTools,
+    assignedTeamIds,
+    sharedPersonalPins,
+    performSave,
   ]);
 
   // Detect unsaved edits so any close path (Esc, backdrop, the X button, or the
@@ -1811,11 +1862,59 @@ export function AgentDialog({
                             agentEnvironmentId={environmentId ?? null}
                             agentEnvironmentName={agentEnvironmentName}
                             onConflictsChange={setMcpEnvConflicts}
+                            onSharedPersonalPinsChange={setSharedPersonalPins}
                             openComboboxOnMount={openToolsCombobox}
                             includeAppCatalogs={shouldOfferAppCatalogs(
                               agentType,
                             )}
                           />
+                          {agent?.scope === "personal" &&
+                            scope !== "personal" &&
+                            !accessAllTools &&
+                            sharedPersonalPins.length > 0 && (
+                              <Alert variant="warning" className="mt-3">
+                                <AlertTriangle className="h-4 w-4" />
+                                <AlertTitle>
+                                  {sharedPersonalPins.length === 1
+                                    ? "1 connection"
+                                    : `${sharedPersonalPins.length} connections`}{" "}
+                                  will be shared with everyone
+                                </AlertTitle>
+                                <AlertDescription>
+                                  <p>
+                                    Every user of this agent will connect as the
+                                    owner shown, no matter who is calling:{" "}
+                                    <span className="font-medium text-foreground">
+                                      {sharedPersonalPins
+                                        .map(
+                                          (pin) =>
+                                            `${pin.mcpName} (${pin.isCurrentUser ? "you" : pin.ownerEmail})`,
+                                        )
+                                        .join(", ")}
+                                    </span>
+                                  </p>
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="mt-2"
+                                    onClick={() =>
+                                      agentToolsEditorRef.current?.convertPersonalPinsToDynamic(
+                                        Array.from(
+                                          new Set(
+                                            sharedPersonalPins.map(
+                                              (pin) => pin.catalogId,
+                                            ),
+                                          ),
+                                        ),
+                                      )
+                                    }
+                                  >
+                                    Resolve at call time
+                                  </Button>
+                                </AlertDescription>
+                              </Alert>
+                            )}
                         </div>
                         <div className="space-y-2">
                           <p className="text-xs font-medium text-muted-foreground">
@@ -2510,6 +2609,26 @@ export function AgentDialog({
         open={guard.confirmOpen}
         onKeepEditing={guard.keepEditing}
         onDiscard={guard.discardChanges}
+      />
+      <SharePersonalCredentialsDialog
+        open={showShareConfirm}
+        pins={sharedPersonalPins.map((pin) => ({
+          mcpName: pin.mcpName,
+          ownerEmail: pin.ownerEmail,
+          isCurrentUser: pin.isCurrentUser,
+        }))}
+        onResolveDynamic={() => {
+          setShowShareConfirm(false);
+          agentToolsEditorRef.current?.convertPersonalPinsToDynamic(
+            Array.from(new Set(sharedPersonalPins.map((pin) => pin.catalogId))),
+          );
+          void performSave();
+        }}
+        onShareAsIs={() => {
+          setShowShareConfirm(false);
+          void performSave();
+        }}
+        onCancel={() => setShowShareConfirm(false)}
       />
     </>
   );

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -31,6 +31,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useInvalidateToolAssignmentQueries } from "@/lib/agent-tools.hook";
 import { useAssignTool, useUnassignTool } from "@/lib/agent-tools.query";
+import { useSession } from "@/lib/auth/auth.query";
 import { useProfileToolsWithIds } from "@/lib/chat/chat.query";
 import { useFeature } from "@/lib/config/config.query";
 import { useArchestraMcpIdentity } from "@/lib/mcp/archestra-mcp-server";
@@ -39,14 +40,19 @@ import {
   useCatalogTools,
   useInternalMcpCatalog,
 } from "@/lib/mcp/internal-mcp-catalog.query";
-import { useMcpServersGroupedByCatalog } from "@/lib/mcp/mcp-server.query";
+import {
+  useMcpServers,
+  useMcpServersGroupedByCatalog,
+} from "@/lib/mcp/mcp-server.query";
 import { useOrganization } from "@/lib/organization.query";
 import { cn } from "@/lib/utils";
 import {
   computeMcpEnvConflicts,
+  computeSharedPersonalPins,
   getCatalogAssignmentGate,
   getDefaultArchestraToolIds,
   isCatalogInEnvironment,
+  type SharedPersonalPin,
   shouldResetCredentialPin,
   sortAndFilterTools,
   sortCatalogItems,
@@ -95,6 +101,14 @@ export interface AgentToolsEditorRef {
   }) => Promise<void>;
   /** Unselect every MCP catalog flagged as not belonging to the agent's environment. */
   removeIncompatibleTools: () => void;
+  /** Switch the named catalogs' credential from a personal static pin to resolve-at-call-time. */
+  convertPersonalPinsToDynamic: (catalogIds: string[]) => void;
+  /**
+   * True while the catalog, assigned-tool, or credential queries are still
+   * loading, so the personal-pin set is incomplete. The save guard fails closed
+   * on this rather than treating an incomplete "no personal pins" as safe.
+   */
+  isCredentialClassificationLoading: () => boolean;
 }
 
 interface AgentToolsEditorProps {
@@ -127,6 +141,12 @@ interface AgentToolsEditorProps {
    * setter) to avoid effect loops.
    */
   onConflictsChange?: (conflicts: McpEnvConflict[]) => void;
+  /**
+   * Reports the active tools currently pinned to a still-resolvable personal
+   * connection — the pins that would be shared if the agent is team/org scope.
+   * Pass a referentially-stable callback (e.g. a `useState` setter).
+   */
+  onSharedPersonalPinsChange?: (pins: SharedPersonalPin[]) => void;
   /** "pills" (default): compact pills + dropdown combobox. "cards": inline grid of MCP server cards. */
   layout?: "pills" | "cards";
   /** When true, the "Add MCP server" combobox starts open. */
@@ -154,6 +174,7 @@ export const AgentToolsEditor = forwardRef<
     agentEnvironmentId,
     agentEnvironmentName,
     onConflictsChange,
+    onSharedPersonalPinsChange,
     layout = "pills",
     openComboboxOnMount,
     includeAppCatalogs,
@@ -171,6 +192,7 @@ export const AgentToolsEditor = forwardRef<
       agentEnvironmentId={agentEnvironmentId}
       agentEnvironmentName={agentEnvironmentName}
       onConflictsChange={onConflictsChange}
+      onSharedPersonalPinsChange={onSharedPersonalPinsChange}
       layout={layout}
       openComboboxOnMount={openComboboxOnMount}
       includeAppCatalogs={includeAppCatalogs}
@@ -193,6 +215,7 @@ const AgentToolsEditorContent = forwardRef<
     agentEnvironmentId = null,
     agentEnvironmentName,
     onConflictsChange,
+    onSharedPersonalPinsChange,
     layout = "pills",
     openComboboxOnMount,
     includeAppCatalogs = false,
@@ -200,6 +223,8 @@ const AgentToolsEditorContent = forwardRef<
   ref,
 ) {
   const { catalogName } = useArchestraMcpIdentity();
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
   const invalidateAllQueries = useInvalidateToolAssignmentQueries();
   const assignTool = useAssignTool();
   const unassignTool = useUnassignTool();
@@ -215,6 +240,24 @@ const AgentToolsEditorContent = forwardRef<
     assignmentScope,
     assignmentTeamIds,
   });
+  // Unfiltered accessible installs, used to classify a pin's scope/owner. Not
+  // the scope-filtered `allCredentials` above: that answers "what can be picked
+  // for this scope" and drops a personal pin whose owner isn't in the target
+  // group — but such a pin still persists on the agent and gets shared, so it
+  // must still be classified (and warned about). Scope-independent, so it does
+  // not refetch on a scope flip.
+  const { data: accessibleServers = [], isLoading: credentialsLoading } =
+    useMcpServers();
+  const accessibleServersByCatalog = useMemo(() => {
+    const map = new Map<string, typeof accessibleServers>();
+    for (const server of accessibleServers) {
+      if (!server.catalogId) continue;
+      const list = map.get(server.catalogId) ?? [];
+      list.push(server);
+      map.set(server.catalogId, list);
+    }
+    return map;
+  }, [accessibleServers]);
 
   // Fetch tool counts for all catalog items to enable sorting
   const toolCountQueries = useQueries({
@@ -241,7 +284,8 @@ const AgentToolsEditorContent = forwardRef<
   // Fetch assigned tools for this resource (only when editing an existing one).
   // Use the resource-scoped endpoint so MCP gateway members do not need the
   // broader tool-policy table permission just to edit their gateway tools.
-  const { data: assignedToolsData = [] } = useProfileToolsWithIds(agentId);
+  const { data: assignedToolsData = [], isLoading: assignedToolsLoading } =
+    useProfileToolsWithIds(agentId);
 
   // Group assigned tools by catalogId
   const assignedToolsByCatalog = useMemo(() => {
@@ -285,6 +329,14 @@ const AgentToolsEditorContent = forwardRef<
 
   // State counter to force re-renders when pendingChangesRef updates
   const [pendingVersion, setPendingVersion] = useState(0);
+
+  // Per-catalog remount counter. A bulk credential conversion writes
+  // pendingChangesRef directly, but each pill owns its credential selection in
+  // mount-time state; bumping a catalog's epoch remounts its pill so it re-seeds
+  // from the freshly-written pending change instead of showing the stale pin.
+  const [credentialEpoch, setCredentialEpoch] = useState<
+    Record<string, number>
+  >({});
 
   // Track which catalog pill should auto-open its popover after being added
   const [autoOpenCatalogId, setAutoOpenCatalogId] = useState<string | null>(
@@ -409,6 +461,73 @@ const AgentToolsEditorContent = forwardRef<
     lastReportedSelectionKeyRef.current = key;
     onSelectedToolIdsChange(effectiveSelectedToolIds);
   }, [effectiveSelectedToolIds, onSelectedToolIdsChange]);
+
+  // Each active catalog's effective credential: the pending edit when the user
+  // touched it, else the saved assignment. `pinnedServerId` is the static pin
+  // (null when it resolves at call time).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pendingVersion triggers re-computation when pendingChangesRef updates
+  const pinnedCatalogs = useMemo(() => {
+    return catalogItems.flatMap((catalog) => {
+      const pending = pendingChangesRef.current.get(catalog.id);
+      const assigned = assignedToolsByCatalog.get(catalog.id) ?? [];
+      const selectedCount = pending
+        ? pending.selectedToolIds.size
+        : assigned.length;
+      if (selectedCount === 0) return [];
+      const effectiveCred = pending
+        ? pending.credentialSourceId
+        : assigned[0]?.credentialResolutionMode === "static"
+          ? (assigned[0]?.mcpServerId ?? null)
+          : DYNAMIC_CREDENTIAL_VALUE;
+      const pinnedServerId =
+        effectiveCred && effectiveCred !== DYNAMIC_CREDENTIAL_VALUE
+          ? effectiveCred
+          : null;
+      return [
+        {
+          catalogId: catalog.id,
+          pinnedServerId,
+          resolvableServers: accessibleServersByCatalog.get(catalog.id) ?? [],
+        },
+      ];
+    });
+  }, [
+    catalogItems,
+    assignedToolsByCatalog,
+    accessibleServersByCatalog,
+    pendingVersion,
+  ]);
+
+  // The pins the dialog warns about when the agent is (being made) team/org
+  // scope: a static pin whose server is a `personal` install. A pin the user
+  // already switched back to resolve-at-call-time drops out because its
+  // effective credential is no longer a server id.
+  const sharedPersonalPins = useMemo(
+    () => computeSharedPersonalPins(pinnedCatalogs, currentUserId),
+    [pinnedCatalogs, currentUserId],
+  );
+
+  // Until the catalog, assigned-tool, and credential queries have all settled,
+  // the pin set and its scopes are incomplete — a still-loading assigned-tools
+  // query hides a pin, a still-loading credential query hides its scope. The
+  // save guard fails closed on this rather than treat an incomplete "no
+  // personal pins" as safe to share.
+  const credentialClassificationLoading =
+    isPending || assignedToolsLoading || credentialsLoading;
+
+  const lastReportedPinsKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!onSharedPersonalPinsChange) return;
+    const key = sharedPersonalPins
+      .map(
+        (p) => `${p.catalogId}:${p.mcpName}:${p.ownerEmail}:${p.isCurrentUser}`,
+      )
+      .sort()
+      .join("|");
+    if (lastReportedPinsKeyRef.current === key) return;
+    lastReportedPinsKeyRef.current = key;
+    onSharedPersonalPinsChange(sharedPersonalPins);
+  }, [sharedPersonalPins, onSharedPersonalPinsChange]);
 
   // Expose saveChanges method to parent
   useImperativeHandle(ref, () => ({
@@ -552,6 +671,38 @@ const AgentToolsEditorContent = forwardRef<
         });
       }
     },
+    convertPersonalPinsToDynamic: (catalogIds) => {
+      for (const catalogId of catalogIds) {
+        const catalog = catalogItems.find((c) => c.id === catalogId);
+        if (!catalog) continue;
+        const pending = pendingChangesRef.current.get(catalogId);
+        // Keep the tools; only swap the credential to resolve-at-call-time. An
+        // untouched pin has no pending entry, so seed the selection from the
+        // saved assignment or saveChanges would skip the catalog entirely.
+        const selectedToolIds = pending
+          ? pending.selectedToolIds
+          : new Set(
+              (assignedToolsByCatalog.get(catalogId) ?? []).map(
+                (at) => at.tool.id,
+              ),
+            );
+        registerPendingChanges(catalogId, {
+          selectedToolIds,
+          credentialSourceId: DYNAMIC_CREDENTIAL_VALUE,
+          catalogItem: catalog,
+          selectAll: false,
+          isActive: pending?.isActive ?? true,
+        });
+      }
+      setCredentialEpoch((prev) => {
+        const next = { ...prev };
+        for (const catalogId of catalogIds) {
+          next[catalogId] = (next[catalogId] ?? 0) + 1;
+        }
+        return next;
+      });
+    },
+    isCredentialClassificationLoading: () => credentialClassificationLoading,
   }));
 
   // Compute which catalog IDs are "selected" (have tools assigned or pending)
@@ -779,7 +930,7 @@ const AgentToolsEditorContent = forwardRef<
       <div className="flex flex-wrap gap-2">
         {selectedCatalogs.map((catalog) => (
           <McpServerPill
-            key={catalog.id}
+            key={`${catalog.id}:${credentialEpoch[catalog.id] ?? 0}`}
             catalogItem={catalog}
             displayName={
               catalog.id === ARCHESTRA_MCP_CATALOG_ID

--- a/platform/frontend/src/components/agent-tools-editor.utils.test.ts
+++ b/platform/frontend/src/components/agent-tools-editor.utils.test.ts
@@ -11,6 +11,7 @@ import {
 import { describe, expect, it } from "vitest";
 import {
   computeMcpEnvConflicts,
+  computeSharedPersonalPins,
   getCatalogAssignmentGate,
   getDefaultArchestraToolIds,
   isCatalogInEnvironment,
@@ -559,5 +560,131 @@ describe("computeMcpEnvConflicts", () => {
   it("skips unknown catalog ids", () => {
     const conflicts = computeMcpEnvConflicts(catalogs, ["ghost"], "prod");
     expect(conflicts).toEqual([]);
+  });
+});
+
+describe("computeSharedPersonalPins", () => {
+  const personal = {
+    id: "srv-personal",
+    scope: "personal",
+    ownerId: "user-1",
+    ownerEmail: "owner@example.com",
+    catalogName: "GitHub",
+    name: "github-personal",
+  };
+  const team = {
+    id: "srv-team",
+    scope: "team",
+    ownerId: "user-2",
+    ownerEmail: "team-owner@example.com",
+    catalogName: "Jira",
+    name: "jira-team",
+  };
+
+  it("flags a static pin to a resolvable personal connection", () => {
+    const pins = computeSharedPersonalPins(
+      [
+        {
+          catalogId: "cat-a",
+          pinnedServerId: "srv-personal",
+          resolvableServers: [personal],
+        },
+      ],
+      "user-2",
+    );
+    expect(pins).toEqual([
+      {
+        catalogId: "cat-a",
+        mcpName: "GitHub",
+        ownerEmail: "owner@example.com",
+        isCurrentUser: false,
+      },
+    ]);
+  });
+
+  it("marks the current user's own connection", () => {
+    const pins = computeSharedPersonalPins(
+      [
+        {
+          catalogId: "cat-a",
+          pinnedServerId: "srv-personal",
+          resolvableServers: [personal],
+        },
+      ],
+      "user-1",
+    );
+    expect(pins[0]?.isCurrentUser).toBe(true);
+  });
+
+  it("ignores a pin whose server is no longer resolvable (already reset / out of group)", () => {
+    const pins = computeSharedPersonalPins(
+      [
+        {
+          catalogId: "cat-a",
+          pinnedServerId: "srv-personal",
+          resolvableServers: [team],
+        },
+      ],
+      "user-1",
+    );
+    expect(pins).toEqual([]);
+  });
+
+  it("ignores team- and org-scoped pins (shared by design)", () => {
+    const pins = computeSharedPersonalPins(
+      [
+        {
+          catalogId: "cat-a",
+          pinnedServerId: "srv-team",
+          resolvableServers: [team],
+        },
+      ],
+      "user-1",
+    );
+    expect(pins).toEqual([]);
+  });
+
+  it("ignores catalogs that resolve at call time (no pin)", () => {
+    const pins = computeSharedPersonalPins(
+      [
+        {
+          catalogId: "cat-a",
+          pinnedServerId: null,
+          resolvableServers: [personal],
+        },
+      ],
+      "user-1",
+    );
+    expect(pins).toEqual([]);
+  });
+
+  it("falls back to the raw name and a placeholder owner", () => {
+    const pins = computeSharedPersonalPins(
+      [
+        {
+          catalogId: "cat-a",
+          pinnedServerId: "srv-x",
+          resolvableServers: [
+            {
+              id: "srv-x",
+              scope: "personal",
+              ownerId: null,
+              ownerEmail: null,
+              catalogName: null,
+              name: "raw-name",
+            },
+          ],
+        },
+      ],
+      "user-1",
+    );
+    expect(pins).toEqual([
+      {
+        catalogId: "cat-a",
+        mcpName: "raw-name",
+        ownerEmail: "Deleted user",
+        isCurrentUser: false,
+      },
+    ]);
   });
 });

--- a/platform/frontend/src/components/agent-tools-editor.utils.ts
+++ b/platform/frontend/src/components/agent-tools-editor.utils.ts
@@ -170,6 +170,54 @@ export function computeMcpEnvConflicts(
   return conflicts;
 }
 
+export type SharedPersonalPin = {
+  catalogId: string;
+  mcpName: string;
+  ownerEmail: string;
+  isCurrentUser: boolean;
+};
+
+/**
+ * The active tools whose effective credential is a static pin to a still-resolvable
+ * `personal`-scope connection. On a shared (team/org) agent these are exactly the
+ * pins that make every caller authenticate as one owner, so the dialog warns about
+ * them and offers to switch them to resolve-at-call-time.
+ *
+ * `pinnedServerId` is each catalog's effective credential (pending overlaid on
+ * saved), or `null` when it resolves at call time. A pin whose server is absent
+ * from `resolvableServers` is excluded: it has either already reset to dynamic or
+ * cannot resolve for the target group, so it will not be shared.
+ */
+export function computeSharedPersonalPins(
+  catalogs: {
+    catalogId: string;
+    pinnedServerId: string | null;
+    resolvableServers: readonly {
+      id: string;
+      scope: string;
+      ownerEmail?: string | null;
+      ownerId?: string | null;
+      catalogName?: string | null;
+      name: string;
+    }[];
+  }[],
+  currentUserId: string | null | undefined,
+): SharedPersonalPin[] {
+  const pins: SharedPersonalPin[] = [];
+  for (const { catalogId, pinnedServerId, resolvableServers } of catalogs) {
+    if (!pinnedServerId) continue;
+    const server = resolvableServers.find((s) => s.id === pinnedServerId);
+    if (!server || server.scope !== "personal") continue;
+    pins.push({
+      catalogId,
+      mcpName: server.catalogName ?? server.name,
+      ownerEmail: server.ownerEmail || "Deleted user",
+      isCurrentUser: !!currentUserId && server.ownerId === currentUserId,
+    });
+  }
+  return pins;
+}
+
 export function sortCatalogItems<
   T extends { id: string; name: string; serverType?: string | null },
 >(

--- a/platform/frontend/src/components/share-personal-credentials-dialog.test.tsx
+++ b/platform/frontend/src/components/share-personal-credentials-dialog.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SharePersonalCredentialsDialog } from "@/components/share-personal-credentials-dialog";
+
+// Render the shell inline (no Radix portal) so the copy and footer are directly
+// assertable.
+vi.mock("@/components/standard-dialog", () => ({
+  StandardDialog: ({
+    open,
+    title,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    title?: React.ReactNode;
+    children?: React.ReactNode;
+    footer?: React.ReactNode;
+  }) =>
+    open ? (
+      <div>
+        <div>{title}</div>
+        <div>{children}</div>
+        <div>{footer}</div>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: (e: React.MouseEvent) => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+const pins = [
+  { mcpName: "GitHub", ownerEmail: "alice@example.com", isCurrentUser: false },
+  { mcpName: "Jira", ownerEmail: "me@example.com", isCurrentUser: true },
+];
+
+describe("SharePersonalCredentialsDialog", () => {
+  it("lists every affected server with its owner (and 'you' for the caller)", () => {
+    const { container } = render(
+      <SharePersonalCredentialsDialog
+        open
+        pins={pins}
+        onResolveDynamic={vi.fn()}
+        onShareAsIs={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain("GitHub");
+    expect(container.textContent).toContain("as alice@example.com");
+    expect(container.textContent).toContain("Jira");
+    expect(container.textContent).toContain("as you");
+    expect(container.textContent).toContain("no matter who is calling");
+  });
+
+  it("wires the resolve-at-call-time (safe) action", () => {
+    const onResolveDynamic = vi.fn();
+    const onShareAsIs = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <SharePersonalCredentialsDialog
+        open
+        pins={pins}
+        onResolveDynamic={onResolveDynamic}
+        onShareAsIs={onShareAsIs}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByText("Resolve at call time"));
+    expect(onResolveDynamic).toHaveBeenCalledTimes(1);
+    expect(onShareAsIs).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("wires the share-as-is and cancel actions", () => {
+    const onResolveDynamic = vi.fn();
+    const onShareAsIs = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <SharePersonalCredentialsDialog
+        open
+        pins={pins}
+        onResolveDynamic={onResolveDynamic}
+        onShareAsIs={onShareAsIs}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByText("Share as-is"));
+    expect(onShareAsIs).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onResolveDynamic).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/components/share-personal-credentials-dialog.tsx
+++ b/platform/frontend/src/components/share-personal-credentials-dialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Users } from "lucide-react";
+import { StandardDialog } from "@/components/standard-dialog";
+import type { PersonalCredentialPin } from "@/components/static-credential-confirm-dialog";
+import { Button } from "@/components/ui/button";
+
+interface SharePersonalCredentialsDialogProps {
+  open: boolean;
+  pins: PersonalCredentialPin[];
+  /** Switch the pinned connections to resolve-at-call-time, then save (safe default). */
+  onResolveDynamic: () => void;
+  /** Keep the personal pins and share them with everyone, then save. */
+  onShareAsIs: () => void;
+  /** Dismiss without saving. */
+  onCancel: () => void;
+}
+
+const asWho = (pin: PersonalCredentialPin) =>
+  pin.isCurrentUser ? "you" : pin.ownerEmail;
+
+/**
+ * Confirms scoping an agent up (personal → team/org) while it still pins personal
+ * connections. Cancel renders first so it takes initial focus — a reflexive Enter
+ * dismisses rather than shares. "Resolve at call time" is the visually primary,
+ * recommended action; "Share as-is" is the deliberate opt-in to sharing.
+ */
+export function SharePersonalCredentialsDialog({
+  open,
+  pins,
+  onResolveDynamic,
+  onShareAsIs,
+  onCancel,
+}: SharePersonalCredentialsDialogProps) {
+  return (
+    <StandardDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+      title={
+        <div className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          <span>Share these connections with everyone?</span>
+        </div>
+      }
+      size="small"
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={(e) => {
+              e.stopPropagation();
+              onCancel();
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={(e) => {
+              e.stopPropagation();
+              onShareAsIs();
+            }}
+          >
+            Share as-is
+          </Button>
+          <Button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onResolveDynamic();
+            }}
+          >
+            Resolve at call time
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-3 text-sm text-muted-foreground">
+        <p>
+          Every user of this agent will connect as the person shown, no matter
+          who is calling:
+        </p>
+        <ul className="list-disc space-y-1 pl-5">
+          {pins.map((pin) => (
+            <li key={`${pin.mcpName}:${pin.ownerEmail}`}>
+              <span className="text-foreground font-medium">{pin.mcpName}</span>{" "}
+              as {asWho(pin)}
+            </li>
+          ))}
+        </ul>
+        <p>
+          Resolve at call time instead to let each user connect with their own
+          connection.
+        </p>
+      </div>
+    </StandardDialog>
+  );
+}


### PR DESCRIPTION
## Summary

Changing an existing **personal** agent to **team/org** scope silently shared any tool pinned to a **personal static credential**: every caller of the now-shared agent would authenticate to that MCP server as the pin's owner, using their access and rate limits — with no prompt. This closes that gap for the scope-up transition.

When a personal agent whose Custom-mode tools carry a personal static pin is scoped up, the edit dialog now:

- shows a persistent inline warning in the Tools section naming the affected servers and owners, with a one-click **Resolve at call time** that switches those pins to per-caller resolution; and
- on Save, shows a blocking **"Share these connections with everyone?"** confirmation — **Resolve at call time** (recommended) · **Share as-is** (deliberate opt-in) · **Cancel** (reverts, nothing persists).

It fires only on the actual personal→shared transition and only in Custom tools mode (Auto mode resolves every tool per caller). The sibling select-time confirmation (picking a personal credential for an already-shared agent) is unchanged; this covers the other direction — an already-pinned personal agent being scoped up.

Pins are classified from the **unfiltered** accessible-install list rather than the scope-filtered credential picker: a personal pin whose owner is not a member of the target team is hidden from the picker but still persists on the agent (scope change does not re-validate existing pins), so it must still be detected and warned about. The guard **fails closed** while the catalog, assigned-tool, or credential queries are still loading — an incomplete "no personal pins" never silently ships a shared credential.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>