### PR TITLE
refactor(apps): delete dead backend symbols and unpin prose from apps tests

### DIFF
--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -39,6 +39,7 @@ import {
   EnvironmentModel,
   InternalMcpCatalogModel,
   McpServerModel,
+  ToolModel,
 } from "@/models";
 import { buildValidatedVersionPayload } from "@/services/apps/app-ui-policy";
 import { fileStore } from "@/skills-sandbox/file-store";
@@ -1892,11 +1893,12 @@ describe("scaffold_app tools param", () => {
     expect(created.isError).toBe(false);
     expect(structured(created).tools).toEqual([paperSearchName]);
 
-    const assignments = await AppToolModel.getAssignmentsForApp(
+    const assignments = await ToolModel.getMcpToolsAssignedToApp(
+      [paperSearchName],
       structured(created).id as string,
     );
     expect(assignments).toHaveLength(1);
-    expect(assignments[0].tool.name).toBe(paperSearchName);
+    expect(assignments[0].toolName).toBe(paperSearchName);
     // dynamic mode: server + credential resolve per viewing user at call time
     expect(assignments[0].credentialResolutionMode).toBe("dynamic");
     expect(assignments[0].mcpServerId).toBeNull();
@@ -1961,10 +1963,11 @@ describe("scaffold_app tools param", () => {
     const created = await scaffold({ name: "Dupes", tools: [paperSearchName] });
     expect(created.isError).toBe(false);
 
-    const assignments = await AppToolModel.getAssignmentsForApp(
+    const assignments = await ToolModel.getMcpToolsAssignedToApp(
+      [paperSearchName],
       structured(created).id as string,
     );
-    expect(assignments.map((a) => a.tool.id)).toEqual([canonical?.id]);
+    expect(assignments.map((a) => a.id)).toEqual([canonical?.id]);
   });
 
   test("an assigned duplicate wins over a newer installed one, matching search_tools", async ({
@@ -1989,12 +1992,13 @@ describe("scaffold_app tools param", () => {
 
     const created = await scaffold({ name: "Assigned", tools: [dupName] });
     expect(created.isError).toBe(false);
-    const assignments = await AppToolModel.getAssignmentsForApp(
+    const assignments = await ToolModel.getMcpToolsAssignedToApp(
+      [dupName],
       structured(created).id as string,
     );
     // The assigned (older) row wins: search_tools ranks assigned before
     // discoverable, and the app runtime executes the app-assigned row.
-    expect(assignments.map((a) => a.tool.id)).toEqual([assignedRow.id]);
+    expect(assignments.map((a) => a.id)).toEqual([assignedRow.id]);
   });
 
   test("a tool in a visible catalog with no install is assignable by name (auth is enforced at call time)", async ({
@@ -2014,10 +2018,11 @@ describe("scaffold_app tools param", () => {
 
     const created = await scaffold({ name: "Orphan", tools: [orphanName] });
     expect(created.isError).toBe(false);
-    const assignments = await AppToolModel.getAssignmentsForApp(
+    const assignments = await ToolModel.getMcpToolsAssignedToApp(
+      [orphanName],
       structured(created).id as string,
     );
-    expect(assignments.map((a) => a.tool.id)).toEqual([orphanRow.id]);
+    expect(assignments.map((a) => a.id)).toEqual([orphanRow.id]);
   });
 
   test("an unassigned, installed tool is not assignable when the agent lacks dynamic access", async ({

--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -1893,9 +1893,12 @@ describe("scaffold_app tools param", () => {
     expect(created.isError).toBe(false);
     expect(structured(created).tools).toEqual([paperSearchName]);
 
+    const appId = structured(created).id as string;
+    // Complete-set check: exactly one assignment exists on the app.
+    expect(await AppToolModel.getToolsForApp(appId)).toHaveLength(1);
     const assignments = await ToolModel.getMcpToolsAssignedToApp(
       [paperSearchName],
-      structured(created).id as string,
+      appId,
     );
     expect(assignments).toHaveLength(1);
     expect(assignments[0].toolName).toBe(paperSearchName);
@@ -1963,11 +1966,10 @@ describe("scaffold_app tools param", () => {
     const created = await scaffold({ name: "Dupes", tools: [paperSearchName] });
     expect(created.isError).toBe(false);
 
-    const assignments = await ToolModel.getMcpToolsAssignedToApp(
-      [paperSearchName],
+    const assigned = await AppToolModel.getToolsForApp(
       structured(created).id as string,
     );
-    expect(assignments.map((a) => a.id)).toEqual([canonical?.id]);
+    expect(assigned.map((t) => t.id)).toEqual([canonical?.id]);
   });
 
   test("an assigned duplicate wins over a newer installed one, matching search_tools", async ({
@@ -1992,13 +1994,12 @@ describe("scaffold_app tools param", () => {
 
     const created = await scaffold({ name: "Assigned", tools: [dupName] });
     expect(created.isError).toBe(false);
-    const assignments = await ToolModel.getMcpToolsAssignedToApp(
-      [dupName],
+    const assigned = await AppToolModel.getToolsForApp(
       structured(created).id as string,
     );
     // The assigned (older) row wins: search_tools ranks assigned before
     // discoverable, and the app runtime executes the app-assigned row.
-    expect(assignments.map((a) => a.id)).toEqual([assignedRow.id]);
+    expect(assigned.map((t) => t.id)).toEqual([assignedRow.id]);
   });
 
   test("a tool in a visible catalog with no install is assignable by name (auth is enforced at call time)", async ({
@@ -2018,11 +2019,10 @@ describe("scaffold_app tools param", () => {
 
     const created = await scaffold({ name: "Orphan", tools: [orphanName] });
     expect(created.isError).toBe(false);
-    const assignments = await ToolModel.getMcpToolsAssignedToApp(
-      [orphanName],
+    const assigned = await AppToolModel.getToolsForApp(
       structured(created).id as string,
     );
-    expect(assignments.map((a) => a.id)).toEqual([orphanRow.id]);
+    expect(assigned.map((t) => t.id)).toEqual([orphanRow.id]);
   });
 
   test("an unassigned, installed tool is not assignable when the agent lacks dynamic access", async ({

--- a/platform/backend/src/models/app-tool.ts
+++ b/platform/backend/src/models/app-tool.ts
@@ -20,30 +20,6 @@ class AppToolModel {
     return results.map((r) => r.tool);
   }
 
-  /** Full assignments (tool + resolution config) — what the app server needs to execute. */
-  static async getAssignmentsForApp(appId: string) {
-    return await db
-      .select({
-        tool: schema.toolsTable,
-        mcpServerId: schema.appToolsTable.mcpServerId,
-        credentialResolutionMode: schema.appToolsTable.credentialResolutionMode,
-      })
-      .from(schema.appToolsTable)
-      .innerJoin(
-        schema.toolsTable,
-        eq(schema.appToolsTable.toolId, schema.toolsTable.id),
-      )
-      .where(eq(schema.appToolsTable.appId, appId));
-  }
-
-  static async findToolIdsByApp(appId: string): Promise<string[]> {
-    const results = await db
-      .select({ toolId: schema.appToolsTable.toolId })
-      .from(schema.appToolsTable)
-      .where(eq(schema.appToolsTable.appId, appId));
-    return results.map((r) => r.toolId);
-  }
-
   /** Attach a tool to an app. */
   static async create(
     appId: string,

--- a/platform/backend/src/models/app-version.ts
+++ b/platform/backend/src/models/app-version.ts
@@ -76,14 +76,6 @@ class AppVersionModel {
     return version;
   }
 
-  static async findById(id: string): Promise<AppVersion | null> {
-    const [row] = await db
-      .select()
-      .from(schema.appVersionsTable)
-      .where(eq(schema.appVersionsTable.id, id));
-    return row ?? null;
-  }
-
   /** Resolve a specific `(app, version)` pair, e.g. the app's head version. */
   static async findByAppAndVersion(
     appId: string,

--- a/platform/backend/src/models/app.ts
+++ b/platform/backend/src/models/app.ts
@@ -285,16 +285,7 @@ class AppModel {
   static async update(params: {
     id: string;
     patch?: Partial<
-      Pick<
-        App,
-        | "name"
-        | "description"
-        | "scope"
-        | "templateId"
-        | "spec"
-        | "environmentId"
-        | "mcpServerId"
-      >
+      Pick<App, "name" | "description" | "scope" | "spec" | "environmentId">
     >;
     version?: VersionPayload;
     teamIds?: string[];
@@ -302,20 +293,12 @@ class AppModel {
   }): Promise<App | null> {
     const patch = params.patch ?? {};
     // App-row columns only; scope/environmentId are owned by the backing catalog.
-    const appRowPatch: Partial<
-      Pick<
-        AppRow,
-        "name" | "description" | "templateId" | "spec" | "mcpServerId"
-      >
-    > = {};
+    const appRowPatch: Partial<Pick<AppRow, "name" | "description" | "spec">> =
+      {};
     if (patch.name !== undefined) appRowPatch.name = patch.name;
     if (patch.description !== undefined)
       appRowPatch.description = patch.description;
-    if (patch.templateId !== undefined)
-      appRowPatch.templateId = patch.templateId;
     if (patch.spec !== undefined) appRowPatch.spec = patch.spec;
-    if (patch.mcpServerId !== undefined)
-      appRowPatch.mcpServerId = patch.mcpServerId;
 
     const ok = await withDbTransaction(async (tx) => {
       let app: AppRow | undefined;

--- a/platform/backend/src/routes/app/mcp-backing.app.route.test.ts
+++ b/platform/backend/src/routes/app/mcp-backing.app.route.test.ts
@@ -273,9 +273,7 @@ describe("MCP backing for apps", () => {
     expect(toolAfter.name.endsWith("__open")).toBe(true);
     // The launch tool's derived description IS refreshed on rename, so stored
     // metadata never keeps a stale (or pre-sanitization) app name.
-    expect(toolAfter.description).toBe(
-      'Open the "Renamed Dashboard" app and render its UI.',
-    );
+    expect(toolAfter.description).toContain("Renamed Dashboard");
     expect(toolAfter.description).not.toBe(toolBefore.description);
   });
 

--- a/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
@@ -146,11 +146,10 @@ describe("POST /api/apps/external/:mcpServerId/open-in-chat", () => {
     const { conversationId, mode, prompt } = res.json();
     expect(mode).toBe("prompt");
     // The opening prompt names the app (a single-UI-tool server labels as the
-    // bare server name) plus the tool, so the agent can find and call it.
-    expect(prompt).toContain("Open the Atlassian app.");
-    expect(prompt).toContain(
-      "call the createjiraissue tool on the Atlassian MCP server",
-    );
+    // bare server name), the tool, and the server, so the agent can find and
+    // call it — the exact wording is not pinned.
+    expect(prompt).toContain("Atlassian");
+    expect(prompt).toContain("createjiraissue");
 
     // No seeded render: the client sends `prompt` as the first user message,
     // which triggers the model turn.

--- a/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat-external.app.route.test.ts
@@ -146,8 +146,7 @@ describe("POST /api/apps/external/:mcpServerId/open-in-chat", () => {
     const { conversationId, mode, prompt } = res.json();
     expect(mode).toBe("prompt");
     // The opening prompt names the app (a single-UI-tool server labels as the
-    // bare server name), the tool, and the server, so the agent can find and
-    // call it — the exact wording is not pinned.
+    // bare server name) and the tool, so the agent can find and call it.
     expect(prompt).toContain("Atlassian");
     expect(prompt).toContain("createjiraissue");
 

--- a/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
@@ -88,11 +88,8 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     expect(message.role).toBe("assistant");
     const part = message.content.parts[0] as { type: string; text: string };
     expect(part.type).toBe("text");
+    // The greeting names the app; its exact wording is not pinned.
     expect(part.text).toContain(appName);
-    expect(part.text).toContain("Want to change the app? Tell me how!");
-    expect(part.text).toContain(
-      "Want to use the app? Use the UI 👉, or ask me to!",
-    );
     return part.text;
   }
 

--- a/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
+++ b/platform/backend/src/routes/app/open-in-chat.app.route.test.ts
@@ -88,7 +88,7 @@ describe("POST /api/apps/:appId/open-in-chat", () => {
     expect(message.role).toBe("assistant");
     const part = message.content.parts[0] as { type: string; text: string };
     expect(part.type).toBe("text");
-    // The greeting names the app; its exact wording is not pinned.
+    // The greeting names the app.
     expect(part.text).toContain(appName);
     return part.text;
   }

--- a/platform/backend/src/routes/app/templates.app.route.test.ts
+++ b/platform/backend/src/routes/app/templates.app.route.test.ts
@@ -44,14 +44,10 @@ describe("GET /api/app-templates", () => {
     const templates = listed.json() as Array<{ id: string; html: string }>;
     expect(templates.map((t) => t.id)).toEqual(["default"]);
 
-    // The single starter is a pure-UI empty state: its name token is resolved
-    // to a neutral default and it carries no SDK bootstrap glue — so it passes
-    // the save-time validator unchanged.
+    // The single starter is a pure-UI empty state with no SDK bootstrap glue —
+    // it passes the save-time validator unchanged. (Token resolution itself is
+    // pinned by app-templates/index.test.ts.)
     const [starter] = templates;
-    expect(starter.html).toContain("My App");
-    expect(starter.html).not.toContain("{{APP_NAME}}");
-    expect(starter.html).not.toContain("__ARCHESTRA_APP_SDK_URL__");
-    expect(starter.html).not.toContain("PostMessageTransport");
     await expect(
       buildValidatedVersionPayload({ html: starter.html }),
     ).resolves.toMatchObject({ warnings: [] });

--- a/platform/backend/src/services/apps/app-capability-context.test.ts
+++ b/platform/backend/src/services/apps/app-capability-context.test.ts
@@ -179,8 +179,7 @@ describe("buildAppCapabilityContext", () => {
       environmentId: null,
     });
 
-    // The grounding text is the canonical SDK summary, verbatim — identity, not
-    // wording, is the contract.
+    // The grounding text is the canonical SDK summary, verbatim.
     expect(context.sdkSummary).toBe(ARCHESTRA_APP_SDK_SUMMARY);
   });
 });

--- a/platform/backend/src/services/apps/app-capability-context.test.ts
+++ b/platform/backend/src/services/apps/app-capability-context.test.ts
@@ -1,3 +1,4 @@
+import { ARCHESTRA_APP_SDK_SUMMARY } from "@/archestra-mcp-server/app-authoring-guidance";
 import { resolveDynamicTool } from "@/archestra-mcp-server/dynamic-tools";
 import { EnvironmentModel } from "@/models";
 import { describe, expect, test } from "@/test";
@@ -178,8 +179,8 @@ describe("buildAppCapabilityContext", () => {
       environmentId: null,
     });
 
-    expect(context.sdkSummary.length).toBeGreaterThan(0);
-    expect(context.sdkSummary).toContain("archestra.storage");
-    expect(context.sdkSummary).toContain("archestra.tools.call");
+    // The grounding text is the canonical SDK summary, verbatim — identity, not
+    // wording, is the contract.
+    expect(context.sdkSummary).toBe(ARCHESTRA_APP_SDK_SUMMARY);
   });
 });

--- a/platform/backend/src/services/apps/app-chat-conversation.ts
+++ b/platform/backend/src/services/apps/app-chat-conversation.ts
@@ -41,8 +41,6 @@ export async function createSeededAppConversation(params: {
   appId: string;
   userId: string;
   organizationId: string;
-  /** Agent to bind the chat to; defaults to the caller's default chat agent. */
-  agentId?: string;
 }): Promise<{ conversationId: string }> {
   const { appId, userId, organizationId } = params;
 
@@ -70,7 +68,6 @@ export async function createSeededAppConversation(params: {
   return seedConversationWithRender({
     userId,
     organizationId,
-    agentId: params.agentId,
     title: app.name,
     part: {
       type: "dynamic-tool",
@@ -118,8 +115,6 @@ export async function createSeededExternalAppConversation(params: {
   resourceUri: string;
   userId: string;
   organizationId: string;
-  /** Agent to bind the chat to; defaults to the caller's default chat agent. */
-  agentId?: string;
 }): Promise<ExternalAppOpenResult> {
   const { mcpServerId, resourceUri, userId, organizationId } = params;
 
@@ -141,7 +136,6 @@ export async function createSeededExternalAppConversation(params: {
     const { conversationId } = await createAppChatConversation({
       userId,
       organizationId,
-      agentId: params.agentId,
       title: label,
     });
     return {
@@ -157,7 +151,6 @@ export async function createSeededExternalAppConversation(params: {
   const { conversationId } = await seedConversationWithRender({
     userId,
     organizationId,
-    agentId: params.agentId,
     title: label,
     part: {
       type: "dynamic-tool",
@@ -189,14 +182,11 @@ export async function createSeededExternalAppConversation(params: {
 async function createAppChatConversation(params: {
   userId: string;
   organizationId: string;
-  agentId?: string;
   title: string;
 }): Promise<{ conversationId: string }> {
   const { userId, organizationId, title } = params;
 
-  const agentId =
-    params.agentId ??
-    (await resolveDefaultChatAgentId({ userId, organizationId }));
+  const agentId = await resolveDefaultChatAgentId({ userId, organizationId });
   const agent = await AgentModel.findById(agentId);
   if (!agent || agent.organizationId !== organizationId) {
     throw new ApiError(404, "Agent not found");
@@ -237,17 +227,15 @@ async function createAppChatConversation(params: {
 async function seedConversationWithRender(params: {
   userId: string;
   organizationId: string;
-  agentId?: string;
   title: string;
   part: UIMessage["parts"][number];
   greeting?: string;
 }): Promise<{ conversationId: string }> {
-  const { userId, organizationId, agentId, title, part, greeting } = params;
+  const { userId, organizationId, title, part, greeting } = params;
 
   const { conversationId } = await createAppChatConversation({
     userId,
     organizationId,
-    agentId,
     title,
   });
 

--- a/platform/backend/src/services/apps/app-tool-runtime-gate.test.ts
+++ b/platform/backend/src/services/apps/app-tool-runtime-gate.test.ts
@@ -11,6 +11,7 @@ import {
   TOOL_SCAFFOLD_APP_SHORT_NAME,
   TOOL_VALIDATE_APP_SHORT_NAME,
 } from "@archestra/shared";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import EnvironmentModel from "@/models/environment";
 import { expect, test } from "@/test";
 import { gateAppToolCall } from "./app-tool-runtime-gate";
@@ -275,6 +276,12 @@ test("enforces a block_always policy on the target (runtime gap fix)", async ({
       treatRequireApprovalAsBlock,
     });
     expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      // The reason attributes the block to the gateway brand and names the
+      // blocked tool, so the app knows the tool itself did not fail.
+      expect(decision.reason).toContain(toolName);
+      expect(decision.reason).toContain(archestraMcpBranding.catalogName);
+    }
   }
 });
 

--- a/platform/backend/src/services/apps/app-tool-runtime-gate.test.ts
+++ b/platform/backend/src/services/apps/app-tool-runtime-gate.test.ts
@@ -275,13 +275,6 @@ test("enforces a block_always policy on the target (runtime gap fix)", async ({
       treatRequireApprovalAsBlock,
     });
     expect(decision.allowed).toBe(false);
-    if (!decision.allowed) {
-      // Attribute the guardrail to Archestra so the app (and whoever reads the
-      // error) knows the gateway blocked the call, not the tool.
-      expect(decision.reason).toContain(
-        "a security guardrail enforced by Archestra, not by the tool itself",
-      );
-    }
   }
 });
 

--- a/platform/backend/src/types/app-diagnostics.ts
+++ b/platform/backend/src/types/app-diagnostics.ts
@@ -18,6 +18,3 @@ export type AppRenderDiagnosticEntry = z.infer<
 /** Per-app entry cap and per-message truncation, shared store/read side. */
 export const APP_RENDER_DIAGNOSTICS_MAX_ENTRIES = 20;
 export const APP_RENDER_DIAGNOSTIC_MESSAGE_MAX_LENGTH = 500;
-
-/** What `get_app_diagnostics` reports for the calling user's latest render. */
-export type AppRenderStatus = "no_render_observed" | "clean" | "errors";

--- a/platform/backend/src/types/app.ts
+++ b/platform/backend/src/types/app.ts
@@ -140,7 +140,6 @@ export const AppListItemSchema = z.discriminatedUnion("source", [
   ExternalAppListItemSchema,
 ]);
 export type AppListItem = z.infer<typeof AppListItemSchema>;
-export type ExternalAppListItem = z.infer<typeof ExternalAppListItemSchema>;
 
 /** One of the caller's accessible installs of an external app's catalog. */
 export const ExternalAppInstallSchema = z.object({
@@ -151,7 +150,6 @@ export const ExternalAppInstallSchema = z.object({
   name: z.string(),
   localInstallationStatus: z.string().nullable(),
 });
-export type ExternalAppInstall = z.infer<typeof ExternalAppInstallSchema>;
 
 /** One UI-providing resource of an external app's catalog (a server may have several). */
 export const ExternalAppResourceSchema = z.object({
@@ -163,7 +161,6 @@ export const ExternalAppResourceSchema = z.object({
   // open-in-chat handoff instead of rendering the resource with no input.
   requiresInput: z.boolean(),
 });
-export type ExternalAppResource = z.infer<typeof ExternalAppResourceSchema>;
 
 /**
  * Run-page resolution for an external app: the catalog's UI resources plus the
@@ -215,29 +212,12 @@ export const SelectAppVersionSchema = createSelectSchema(
     spec: AppSpecSchema.nullable(),
   },
 );
-export const InsertAppVersionSchema = createInsertSchema(
-  schema.appVersionsTable,
-  {
-    uiPermissions: AppUiPermissionsSchema.nullable().optional(),
-    spec: AppSpecSchema.nullable().optional(),
-  },
-).omit({ id: true, createdAt: true });
-
 export const SelectAppToolSchema = createSelectSchema(schema.appToolsTable, {
   credentialResolutionMode: CredentialResolutionModeSchema,
 });
 export const InsertAppToolSchema = createInsertSchema(schema.appToolsTable, {
   credentialResolutionMode: CredentialResolutionModeSchema.optional(),
 }).omit({ id: true, createdAt: true, updatedAt: true });
-
-export const SelectAppDataSchema = createSelectSchema(schema.appDataTable);
-export const InsertAppDataSchema = createInsertSchema(schema.appDataTable).omit(
-  {
-    id: true,
-    createdAt: true,
-    updatedAt: true,
-  },
-);
 
 export const SelectAppRenderDiagnosticsSchema = createSelectSchema(
   schema.appRenderDiagnosticsTable,
@@ -350,11 +330,8 @@ export { AppSpecSchema } from "./app-spec";
 export type App = z.infer<typeof SelectAppSchema>;
 export type InsertApp = z.infer<typeof InsertAppSchema>;
 export type AppVersion = z.infer<typeof SelectAppVersionSchema>;
-export type InsertAppVersion = z.infer<typeof InsertAppVersionSchema>;
 export type AppTool = z.infer<typeof SelectAppToolSchema>;
 export type InsertAppTool = z.infer<typeof InsertAppToolSchema>;
-export type AppData = z.infer<typeof SelectAppDataSchema>;
-export type InsertAppData = z.infer<typeof InsertAppDataSchema>;
 export type CreateApp = z.infer<typeof CreateAppSchema>;
 export type UpdateApp = z.infer<typeof UpdateAppSchema>;
 export type AppTemplate = z.infer<typeof AppTemplateSchema>;


### PR DESCRIPTION
Behavior-preserving dead-code deletion in the backend apps feature, plus test-assertion cleanup.

**Deletions** (all with zero callers, verified by repo-wide grep + git history — dead since the feature's birth commit #5437 unless noted):
- `AppVersionModel.findById`, `AppToolModel.findToolIdsByApp`, `AppToolModel.getAssignmentsForApp` (test-only; those tests now use the live runtime reader `ToolModel.getMcpToolsAssignedToApp` plus unfiltered complete-set asserts)
- Unused type exports in `types/app.ts` (`InsertAppVersionSchema`, `SelectAppDataSchema`, `InsertAppDataSchema`, and 6 inferred type aliases) and `AppRenderStatus`
- Never-passed `templateId`/`mcpServerId` patch keys on `AppModel.update` (unreachable branches; `setMcpServerId` is the live path)
- Never-supplied `agentId` override threading in `app-chat-conversation` (all callers use the default-agent fallback)

**Test cleanup**: prose-pinning assertions rewritten to pin behavior (names/data present, identity with the canonical SDK summary constant, gate attribution via the branding constant) instead of exact LLM/user-facing sentences.

Validation: backend vitest (690 files / 11,695 tests), type-check, biome, knip dev+production — all green. Adversarially reviewed to convergence (2 rounds, external + internal).

https://claude.ai/code/session_01WHh4HT7ftnPvVYeUsCcAgR

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>