### PR TITLE
fix: dismiss revoke confirmation after revoking a marketplace share link

### DIFF
--- a/platform/frontend/src/app/connection/skills-marketplace-step.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.tsx
@@ -114,6 +114,7 @@ function SkillsMarketplaceBody({ client }: { client: ConnectClient }) {
         totalSkills={totalSkills ?? 0}
         revealed={revealed}
         onReveal={setRevealed}
+        onRevoked={() => setRevealed(null)}
       />
     );
   }
@@ -197,6 +198,7 @@ function ExistingLinkPanel({
   totalSkills,
   revealed,
   onReveal,
+  onRevoked,
 }: {
   client: ConnectClient;
   /** May be null in the brief window between create-mutation and list refetch. */
@@ -204,6 +206,7 @@ function ExistingLinkPanel({
   totalSkills: number;
   revealed: RevealedClone | null;
   onReveal: (revealed: RevealedClone) => void;
+  onRevoked: () => void;
 }) {
   const revokeShare = useRevokeSkillShareLink();
   const rotateShare = useRotateSkillShareLink();
@@ -232,7 +235,10 @@ function ExistingLinkPanel({
     if (!link) return;
     await revokeShare.mutateAsync(link.id);
     setConfirmRevoke(false);
-  }, [revokeShare, link]);
+    // drop the revealed clone URL so the parent falls back to the create
+    // panel once the list refetch confirms no active link remains.
+    onRevoked();
+  }, [revokeShare, link, onRevoked]);
 
   const linkSkillCount = link?.skills.length ?? totalSkills;
   const stale = link !== null && linkSkillCount !== totalSkills;
@@ -259,8 +265,8 @@ function ExistingLinkPanel({
 
       <SecurityNote />
 
-      <div className="flex flex-wrap items-center gap-2 border-t pt-4">
-        {link && (
+      {link && (
+        <div className="flex flex-wrap items-center gap-2 border-t pt-4">
           <Button
             type="button"
             variant="outline"
@@ -275,42 +281,42 @@ function ExistingLinkPanel({
                 ? "Refresh link"
                 : "Refresh to reveal URL"}
           </Button>
-        )}
-        {link && !confirmRevoke ? (
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => setConfirmRevoke(true)}
-            className="text-destructive hover:text-destructive"
-          >
-            <Trash2 className="mr-2 h-4 w-4" />
-            Revoke
-          </Button>
-        ) : (
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">
-              Revoke and block all existing clones?
-            </span>
+          {!confirmRevoke ? (
             <Button
               type="button"
               variant="ghost"
-              onClick={() => setConfirmRevoke(false)}
-              disabled={revokeShare.isPending}
+              onClick={() => setConfirmRevoke(true)}
+              className="text-destructive hover:text-destructive"
             >
-              Cancel
+              <Trash2 className="mr-2 h-4 w-4" />
+              Revoke
             </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={handleRevoke}
-              disabled={revokeShare.isPending}
-              data-testid="skills-marketplace-confirm-revoke"
-            >
-              {revokeShare.isPending ? "Revoking…" : "Confirm revoke"}
-            </Button>
-          </div>
-        )}
-      </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">
+                Revoke and block all existing clones?
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setConfirmRevoke(false)}
+                disabled={revokeShare.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={handleRevoke}
+                disabled={revokeShare.isPending}
+                data-testid="skills-marketplace-confirm-revoke"
+              >
+                {revokeShare.isPending ? "Revoking…" : "Confirm revoke"}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/platform/frontend/tests-integration/skills-share.spec.ts
+++ b/platform/frontend/tests-integration/skills-share.spec.ts
@@ -139,9 +139,63 @@ test.describe("Skills marketplace share step", () => {
       page.getByText("Revoke and block all existing clones?"),
     ).toBeVisible();
 
+    // after the DELETE the list refetch no longer returns the link — the real
+    // backend filters revoked links out
+    await mswControl.use({
+      method: "get",
+      url: "/api/skill-share-links",
+      body: { links: [] },
+    });
+
     await page.getByTestId("skills-marketplace-confirm-revoke").click();
     // the mutation's success toast confirms the DELETE round trip completed
     await expect(page.getByText("Share link revoked")).toBeVisible();
+
+    // the confirmation panel must dismiss and the UI return to the initial
+    // create state instead of lingering with no way out
+    await expect(
+      page.getByText("Revoke and block all existing clones?"),
+    ).toBeHidden();
+    await expect(page.getByTestId("skills-marketplace-create")).toBeVisible();
+  });
+
+  test("revoking a freshly created link returns to the create state", async ({
+    page,
+    mswControl,
+  }) => {
+    await page.goto(STEP_URL);
+    await expect(page.getByTestId("skills-marketplace-create")).toBeVisible();
+
+    // after create the invalidated list refetch returns the created link,
+    // like the real backend; install the override before the mutation fires
+    await mswControl.use({
+      method: "get",
+      url: "/api/skill-share-links",
+      body: { links: [makeShareLinkCreateResult("created0").link] },
+    });
+
+    await page.getByTestId("skills-marketplace-create").click();
+    await expect(
+      page.getByTestId("skills-marketplace-snippets-generic"),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Revoke", exact: true }).click();
+
+    // the revoked link disappears from the next list refetch
+    await mswControl.use({
+      method: "get",
+      url: "/api/skill-share-links",
+      body: { links: [] },
+    });
+
+    await page.getByTestId("skills-marketplace-confirm-revoke").click();
+
+    // the confirmation panel must not persist after the link is revoked
+    // (regression: it lingered with no way to dismiss it)
+    await expect(
+      page.getByText("Revoke and block all existing clones?"),
+    ).toBeHidden();
+    await expect(page.getByTestId("skills-marketplace-create")).toBeVisible();
   });
 
   test("a link covering fewer skills than the org now has shows the stale notice", async ({


### PR DESCRIPTION
Fixes #6569

After revoking, the `revealed` clone-URL state kept `ExistingLinkPanel` mounted with a null link, and the action-row ternary rendered the confirmation panel whenever the link was null — with no way to dismiss it.

- Clear `revealed` on successful revoke so the UI falls back to the create panel once the refetch confirms no active link
- Render the rotate/revoke action row only when a link exists, so the confirmation panel can never show without one
- Integration test for the create → revoke → confirm repro

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>