### PR TITLE
fix: surface API key creation validation errors

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -53386,13 +53386,14 @@
                 "properties": {
                   "name": {
                     "nullable": true,
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 32
                   },
                   "expiresIn": {
                     "nullable": true,
                     "type": "integer",
-                    "exclusiveMinimum": true,
-                    "maximum": 9007199254740991
+                    "minimum": 86400,
+                    "maximum": 31536000
                   }
                 },
                 "additionalProperties": false

--- a/platform/backend/src/auth/better-auth.ts
+++ b/platform/backend/src/auth/better-auth.ts
@@ -1,5 +1,8 @@
 // This file contains Enterprise regions licensed under LICENSE_ENTERPRISE.
 import {
+  API_KEY_MAX_EXPIRATION_DAYS,
+  API_KEY_MAX_NAME_LENGTH,
+  API_KEY_MIN_EXPIRATION_DAYS,
   ARCHESTRA_TOKEN_PREFIX,
   AUTO_PROVISIONED_INVITATION_STATUS,
   DEFAULT_APP_NAME,
@@ -180,6 +183,14 @@ export const auth = betterAuth({
       },
       rateLimit: {
         enabled: false,
+      },
+      // Pin the plugin's validation limits so they match the constraints the
+      // API schema and the frontend form advertise, regardless of plugin
+      // default changes.
+      maximumNameLength: API_KEY_MAX_NAME_LENGTH,
+      keyExpiration: {
+        minExpiresIn: API_KEY_MIN_EXPIRATION_DAYS,
+        maxExpiresIn: API_KEY_MAX_EXPIRATION_DAYS,
       },
       permissions: {
         /**

--- a/platform/backend/src/routes/api-key.test.ts
+++ b/platform/backend/src/routes/api-key.test.ts
@@ -58,7 +58,7 @@ describe("api key routes", () => {
       url: "/api/api-keys",
       payload: {
         name: "CLI Key",
-        expiresIn: 3600,
+        expiresIn: 30 * 24 * 60 * 60,
       },
     });
 
@@ -69,6 +69,86 @@ describe("api key routes", () => {
         type: "api_validation_error",
       },
     });
+  });
+
+  test("surfaces known better-auth validation errors on create", async () => {
+    createApiKeyMock.mockRejectedValue(
+      Object.assign(new Error("The expiresIn is smaller"), {
+        statusCode: 400,
+        body: {
+          code: "EXPIRES_IN_IS_TOO_SMALL",
+          message:
+            "The expiresIn is smaller than the predefined minimum value.",
+        },
+      }),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/api-keys",
+      payload: {
+        name: "CLI Key",
+        expiresIn: 30 * 24 * 60 * 60,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: {
+        message: "Expiration must be at least 1 day from now",
+        type: "api_validation_error",
+      },
+    });
+  });
+
+  test("rejects an expiration under 1 day before calling better-auth", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/api-keys",
+      payload: {
+        name: "CLI Key",
+        expiresIn: 3600,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain(
+      "Expiration must be at least 1 day from now",
+    );
+    expect(createApiKeyMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects an expiration over 365 days before calling better-auth", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/api-keys",
+      payload: {
+        name: "CLI Key",
+        expiresIn: 366 * 24 * 60 * 60,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain(
+      "Expiration cannot be more than 365 days from now",
+    );
+    expect(createApiKeyMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects a name over 32 characters before calling better-auth", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/api-keys",
+      payload: {
+        name: "a".repeat(33),
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain(
+      "Name must be at most 32 characters",
+    );
+    expect(createApiKeyMock).not.toHaveBeenCalled();
   });
 
   test("lists the authenticated user's API keys only", async () => {
@@ -202,7 +282,7 @@ describe("api key routes", () => {
       url: "/api/api-keys",
       payload: {
         name: "CLI Key",
-        expiresIn: 3600,
+        expiresIn: 86400,
       },
     });
 
@@ -252,7 +332,7 @@ describe("api key routes", () => {
       url: "/api/api-keys",
       payload: {
         name: null,
-        expiresIn: 3600,
+        expiresIn: 86400,
       },
     });
 
@@ -260,7 +340,7 @@ describe("api key routes", () => {
     expect(createApiKeyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         body: {
-          expiresIn: 3600,
+          expiresIn: 86400,
         },
       }),
     );

--- a/platform/backend/src/routes/api-key.ts
+++ b/platform/backend/src/routes/api-key.ts
@@ -1,4 +1,9 @@
-import { RouteId } from "@archestra/shared";
+import {
+  API_KEY_MAX_EXPIRATION_DAYS,
+  API_KEY_MAX_NAME_LENGTH,
+  API_KEY_MIN_EXPIRATION_DAYS,
+  RouteId,
+} from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { auth as betterAuth } from "@/auth/better-auth";
 import ApiKeyModel from "@/models/api-key";
@@ -119,6 +124,18 @@ export default apiKeyRoutes;
 
 // === Internal helpers
 
+/**
+ * Better Auth api-key validation error codes mapped to user-facing messages.
+ * Codes not listed here keep the generic fallback so arbitrary upstream
+ * internals are never exposed.
+ */
+const KNOWN_VALIDATION_ERROR_MESSAGES: Record<string, string> = {
+  EXPIRES_IN_IS_TOO_SMALL: `Expiration must be at least ${API_KEY_MIN_EXPIRATION_DAYS} day from now`,
+  EXPIRES_IN_IS_TOO_LARGE: `Expiration cannot be more than ${API_KEY_MAX_EXPIRATION_DAYS} days from now`,
+  INVALID_NAME_LENGTH: `Name must be at most ${API_KEY_MAX_NAME_LENGTH} characters`,
+  NAME_REQUIRED: "API key name is required",
+};
+
 function toApiError(
   error: unknown,
   params: { fallbackStatusCode: number; fallbackMessage: string },
@@ -128,13 +145,21 @@ function toApiError(
   }
 
   const statusCode = getStatusCode(error, params.fallbackStatusCode);
-  const message = getApiKeyErrorMessage(statusCode, params.fallbackMessage);
-
-  if (error instanceof Error) {
-    return new ApiError(statusCode, message);
-  }
+  const message =
+    getKnownValidationErrorMessage(error) ??
+    getApiKeyErrorMessage(statusCode, params.fallbackMessage);
 
   return new ApiError(statusCode, message);
+}
+
+function getKnownValidationErrorMessage(error: unknown): string | null {
+  const body = (error as { body?: { code?: unknown } }).body;
+  const code = body?.code;
+  if (typeof code !== "string") {
+    return null;
+  }
+
+  return KNOWN_VALIDATION_ERROR_MESSAGES[code] ?? null;
 }
 
 function getStatusCode(error: unknown, fallbackStatusCode: number): number {

--- a/platform/backend/src/types/api-key.ts
+++ b/platform/backend/src/types/api-key.ts
@@ -1,9 +1,15 @@
-import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import {
+  API_KEY_MAX_EXPIRATION_DAYS,
+  API_KEY_MAX_NAME_LENGTH,
+  API_KEY_MIN_EXPIRATION_DAYS,
+} from "@archestra/shared";
+import { createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 import { schema } from "@/database";
 
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
 export const SelectApiKeySchema = createSelectSchema(schema.apikeysTable);
-export const InsertApiKeySchema = createInsertSchema(schema.apikeysTable);
 
 export const ApiKeyPermissionsSchema = z.record(
   z.string(),
@@ -30,11 +36,29 @@ export const ApiKeyWithValueResponseSchema = ApiKeyResponseSchema.extend({
   key: z.string(),
 });
 
-export const CreateApiKeyBodySchema = InsertApiKeySchema.pick({
-  name: true,
-})
-  .extend({
-    expiresIn: z.number().int().positive().nullable().optional(),
+export const CreateApiKeyBodySchema = z
+  .object({
+    name: z
+      .string()
+      .max(
+        API_KEY_MAX_NAME_LENGTH,
+        `Name must be at most ${API_KEY_MAX_NAME_LENGTH} characters`,
+      )
+      .nullable()
+      .optional(),
+    expiresIn: z
+      .number()
+      .int()
+      .min(
+        API_KEY_MIN_EXPIRATION_DAYS * SECONDS_PER_DAY,
+        `Expiration must be at least ${API_KEY_MIN_EXPIRATION_DAYS} day from now`,
+      )
+      .max(
+        API_KEY_MAX_EXPIRATION_DAYS * SECONDS_PER_DAY,
+        `Expiration cannot be more than ${API_KEY_MAX_EXPIRATION_DAYS} days from now`,
+      )
+      .nullable()
+      .optional(),
   })
   .strict();
 

--- a/platform/frontend/src/app/settings/api-keys/page.tsx
+++ b/platform/frontend/src/app/settings/api-keys/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { API_KEY_MAX_NAME_LENGTH } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
 import { KeyRound, Plus, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -34,7 +35,11 @@ import {
   formatRelativeTimeFromNow,
 } from "@/lib/utils/date-time";
 import { useSetSettingsAction } from "../layout";
-import { shouldSkipCreateApiKeySubmit } from "./page.utils";
+import {
+  getApiKeyExpirationError,
+  isApiKeyExpirationDateDisabled,
+  shouldSkipCreateApiKeySubmit,
+} from "./page.utils";
 
 type CreateApiKeyFormValues = {
   name: string;
@@ -177,6 +182,15 @@ export default function ApiKeysSettingsPage() {
       return;
     }
 
+    const expirationError = getApiKeyExpirationError(values.expiresAt);
+    if (expirationError) {
+      form.setError("expiresAt", {
+        type: "validate",
+        message: expirationError,
+      });
+      return;
+    }
+
     hasSubmittedCreateDialogRef.current = true;
     const expiresIn = values.expiresAt
       ? Math.max(
@@ -292,19 +306,41 @@ export default function ApiKeysSettingsPage() {
                   <Input
                     id="name"
                     placeholder="CI token"
-                    {...form.register("name")}
+                    aria-invalid={!!form.formState.errors.name}
+                    {...form.register("name", {
+                      maxLength: {
+                        value: API_KEY_MAX_NAME_LENGTH,
+                        message: `Name must be at most ${API_KEY_MAX_NAME_LENGTH} characters.`,
+                      },
+                    })}
                   />
+                  {form.formState.errors.name?.message && (
+                    <p className="text-xs text-destructive">
+                      {form.formState.errors.name.message}
+                    </p>
+                  )}
                 </div>
-                <ExpirationDateTimeField
-                  value={form.watch("expiresAt")}
-                  onChange={(value) => form.setValue("expiresAt", value)}
-                  noExpirationText="Key will never expire"
-                  formatExpiration={(value) =>
-                    value
-                      ? formatDate({ date: new Date(value).toISOString() })
-                      : ""
-                  }
-                />
+                <div className="space-y-2">
+                  <ExpirationDateTimeField
+                    value={form.watch("expiresAt")}
+                    onChange={(value) => {
+                      form.clearErrors("expiresAt");
+                      form.setValue("expiresAt", value);
+                    }}
+                    disabledDate={isApiKeyExpirationDateDisabled}
+                    noExpirationText="Key will never expire"
+                    formatExpiration={(value) =>
+                      value
+                        ? formatDate({ date: new Date(value).toISOString() })
+                        : ""
+                    }
+                  />
+                  {form.formState.errors.expiresAt?.message && (
+                    <p className="text-xs text-destructive">
+                      {form.formState.errors.expiresAt.message}
+                    </p>
+                  )}
+                </div>
               </>
             )}
           </div>

--- a/platform/frontend/src/app/settings/api-keys/page.utils.test.ts
+++ b/platform/frontend/src/app/settings/api-keys/page.utils.test.ts
@@ -1,6 +1,59 @@
 import { ARCHESTRA_TOKEN_PREFIX } from "@archestra/shared";
 import { describe, expect, it } from "vitest";
-import { shouldSkipCreateApiKeySubmit } from "./page.utils";
+import {
+  getApiKeyExpirationError,
+  isApiKeyExpirationDateDisabled,
+  shouldSkipCreateApiKeySubmit,
+} from "./page.utils";
+
+const NOW = new Date("2026-07-18T12:00:00Z");
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+describe("getApiKeyExpirationError", () => {
+  it("allows no expiration", () => {
+    expect(getApiKeyExpirationError(null, NOW)).toBeNull();
+  });
+
+  it("rejects an expiration under 1 day from now", () => {
+    expect(
+      getApiKeyExpirationError(new Date(NOW.getTime() + 3 * HOUR_MS), NOW),
+    ).toMatch(/at least 1 day/);
+  });
+
+  it("rejects an expiration more than 365 days from now", () => {
+    expect(
+      getApiKeyExpirationError(new Date(NOW.getTime() + 366 * DAY_MS), NOW),
+    ).toMatch(/more than 365 days/);
+  });
+
+  it("allows an expiration within the valid range", () => {
+    expect(
+      getApiKeyExpirationError(new Date(NOW.getTime() + 30 * DAY_MS), NOW),
+    ).toBeNull();
+  });
+});
+
+describe("isApiKeyExpirationDateDisabled", () => {
+  it("disables today when no time today is at least 1 day out", () => {
+    expect(isApiKeyExpirationDateDisabled(new Date(NOW), NOW)).toBe(true);
+  });
+
+  it("keeps tomorrow enabled because late times are valid", () => {
+    expect(
+      isApiKeyExpirationDateDisabled(new Date(NOW.getTime() + DAY_MS), NOW),
+    ).toBe(false);
+  });
+
+  it("disables days past the 365 day maximum", () => {
+    expect(
+      isApiKeyExpirationDateDisabled(
+        new Date(NOW.getTime() + 367 * DAY_MS),
+        NOW,
+      ),
+    ).toBe(true);
+  });
+});
 
 describe("shouldSkipCreateApiKeySubmit", () => {
   it("allows submission for a fresh dialog state", () => {

--- a/platform/frontend/src/app/settings/api-keys/page.utils.ts
+++ b/platform/frontend/src/app/settings/api-keys/page.utils.ts
@@ -1,3 +1,59 @@
+import {
+  API_KEY_MAX_EXPIRATION_DAYS,
+  API_KEY_MIN_EXPIRATION_DAYS,
+} from "@archestra/shared";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Better Auth rejects API key expirations under 1 day or over 365 days out.
+ * Returns a user-facing error for an invalid expiration, or null when valid.
+ */
+export function getApiKeyExpirationError(
+  expiresAt: Date | null,
+  now: Date = new Date(),
+): string | null {
+  if (!expiresAt) {
+    return null;
+  }
+
+  const msFromNow = expiresAt.getTime() - now.getTime();
+  if (msFromNow < API_KEY_MIN_EXPIRATION_DAYS * MS_PER_DAY) {
+    return `Expiration must be at least ${API_KEY_MIN_EXPIRATION_DAYS} day from now.`;
+  }
+  if (msFromNow > API_KEY_MAX_EXPIRATION_DAYS * MS_PER_DAY) {
+    return `Expiration cannot be more than ${API_KEY_MAX_EXPIRATION_DAYS} days from now.`;
+  }
+
+  return null;
+}
+
+/**
+ * Disables calendar days that cannot contain any valid expiration time:
+ * days that end before the minimum expiration and days that start after
+ * the maximum.
+ */
+export function isApiKeyExpirationDateDisabled(
+  date: Date,
+  now: Date = new Date(),
+): boolean {
+  const endOfDay = new Date(date);
+  endOfDay.setHours(23, 59, 59, 999);
+  if (
+    endOfDay.getTime() - now.getTime() <
+    API_KEY_MIN_EXPIRATION_DAYS * MS_PER_DAY
+  ) {
+    return true;
+  }
+
+  const startOfDay = new Date(date);
+  startOfDay.setHours(0, 0, 0, 0);
+  return (
+    startOfDay.getTime() - now.getTime() >
+    API_KEY_MAX_EXPIRATION_DAYS * MS_PER_DAY
+  );
+}
+
 export function shouldSkipCreateApiKeySubmit(params: {
   hasSubmittedForCurrentDialogOpen: boolean;
   isCreatePending: boolean;

--- a/platform/frontend/src/components/expiration-date-time-field.tsx
+++ b/platform/frontend/src/components/expiration-date-time-field.tsx
@@ -11,6 +11,7 @@ export function ExpirationDateTimeField({
   placeholder = "No expiration",
   noExpirationText = "Will never expire",
   formatExpiration,
+  disabledDate = isPastDate,
 }: {
   value: Date | null;
   onChange: (value: Date | null) => void;
@@ -18,6 +19,7 @@ export function ExpirationDateTimeField({
   placeholder?: string;
   noExpirationText?: string;
   formatExpiration: (value: Date | string | null) => string;
+  disabledDate?: (date: Date) => boolean;
 }) {
   return (
     <div className="space-y-2">
@@ -31,11 +33,7 @@ export function ExpirationDateTimeField({
         <DateTimePicker
           value={value ?? undefined}
           onChange={(date) => onChange(date ?? null)}
-          disabledDate={(date) => {
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
-            return date < today;
-          }}
+          disabledDate={disabledDate}
           placeholder={placeholder}
           className="flex-1"
         />
@@ -55,4 +53,10 @@ export function ExpirationDateTimeField({
       </p>
     </div>
   );
+}
+
+function isPastDate(date: Date): boolean {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return date < today;
 }

--- a/platform/shared/consts.ts
+++ b/platform/shared/consts.ts
@@ -23,6 +23,15 @@ export const ALL_ARCHESTRA_TOKEN_PREFIXES = [
   ...LEGACY_ARCHESTRA_TOKEN_PREFIXES,
 ] as const;
 
+/**
+ * Constraints enforced by the Better Auth api-key plugin on API key creation.
+ * Pinned explicitly in the backend plugin config and mirrored in the frontend
+ * create-API-key form validation so limits and error copy cannot drift.
+ */
+export const API_KEY_MIN_EXPIRATION_DAYS = 1;
+export const API_KEY_MAX_EXPIRATION_DAYS = 365;
+export const API_KEY_MAX_NAME_LENGTH = 32;
+
 export const DEFAULT_ADMIN_EMAIL = "admin@example.com";
 export const DEFAULT_ADMIN_PASSWORD = "password";
 


### PR DESCRIPTION
Fixes #6617

Creating an API key with an invalid expiration or name failed with a generic "Failed to create API key" — the BetterAuth reason was swallowed and the picker allowed invalid values.

- Map known BetterAuth api-key error codes (expiration too small/large, name length) to clear messages; unknown upstream errors keep the generic fallback.
- Validate `expiresIn` (1–365 days) and `name` (max 32 chars) in the request schema, with shared constants pinned in the BetterAuth plugin config so limits can't drift.
- Client-side: the expiration picker disables days that can't hold a valid time, and the form shows inline errors for invalid expiration/name.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>