### PR TITLE
fix: make Apps panel reachable on mobile chat

### DIFF
--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -50,6 +50,7 @@ import {
   usePlaywrightSetupRequired,
 } from "@/components/chat/playwright-install-dialog";
 import {
+  AppsPanelContent,
   type RightPanelTab,
   RightSidePanel,
 } from "@/components/chat/right-side-panel";
@@ -325,7 +326,7 @@ export function ChatPageContent({
   const cannotCreateDueToNoTeams =
     !isAgentAdmin && (!teams || teams.length === 0);
 
-  const _isMobile = useIsMobile();
+  const isMobile = useIsMobile();
 
   // State for browser panel. Restored per-conversation by the conversation-load
   // effect below (a fresh /chat with no conversation has no saved state).
@@ -2529,6 +2530,7 @@ export function ChatPageContent({
             scheduledRun,
             isArtifactOpen,
             isBrowserVisible: isBrowserPanelVisible,
+            isAppsVisible: isAppsTabOpen,
             showBrowserButton,
             isPlaywrightSetupVisible,
             onClose: closeRightPanel,
@@ -2580,6 +2582,14 @@ export function ChatPageContent({
                           handleInitialNavigateComplete
                         }
                       />
+                    </div>
+                  )}
+                  {/* Gated on isMobile (not just CSS) so the app iframe only
+                      ever mounts once — the desktop panel below unmounts on
+                      mobile the same way. */}
+                  {activeRightTab === "apps" && isMobile && (
+                    <div className="flex-1 min-h-0 overflow-hidden">
+                      <AppsPanelContent agentId={browserToolsAgentId} />
                     </div>
                   )}
                 </div>
@@ -2955,24 +2965,28 @@ export function ChatPageContent({
             </div>
           </div>
 
-          {/* Right-side panel - desktop only */}
-          <div className="hidden md:flex h-full min-h-0">
-            <RightSidePanel
-              isOpen={isRightPanelOpen}
-              activeTab={activeRightTab}
-              onClose={closeRightPanel}
-              canShowBrowser={showBrowserButton && !isPlaywrightSetupVisible}
-              scheduledRun={scheduledRun}
-              artifact={conversation?.artifact}
-              projectId={conversation?.projectId}
-              conversationId={conversationId}
-              agentId={browserToolsAgentId}
-              onCreateConversationWithUrl={handleCreateConversationWithUrl}
-              isCreatingConversation={createConversationMutation.isPending}
-              initialNavigateUrl={pendingBrowserUrl}
-              onInitialNavigateComplete={handleInitialNavigateComplete}
-            />
-          </div>
+          {/* Right-side panel - desktop only. Unmounted (not just CSS-hidden)
+              on mobile so its Apps tab never hosts a second, invisible copy of
+              the app iframe alongside the inline mobile panel above. */}
+          {!isMobile && (
+            <div className="hidden md:flex h-full min-h-0">
+              <RightSidePanel
+                isOpen={isRightPanelOpen}
+                activeTab={activeRightTab}
+                onClose={closeRightPanel}
+                canShowBrowser={showBrowserButton && !isPlaywrightSetupVisible}
+                scheduledRun={scheduledRun}
+                artifact={conversation?.artifact}
+                projectId={conversation?.projectId}
+                conversationId={conversationId}
+                agentId={browserToolsAgentId}
+                onCreateConversationWithUrl={handleCreateConversationWithUrl}
+                isCreatingConversation={createConversationMutation.isPending}
+                initialNavigateUrl={pendingBrowserUrl}
+                onInitialNavigateComplete={handleInitialNavigateComplete}
+              />
+            </div>
+          )}
         </div>
 
         <CustomServerRequestDialog

--- a/platform/frontend/src/components/chat/conversation-header.test.tsx
+++ b/platform/frontend/src/components/chat/conversation-header.test.tsx
@@ -26,6 +26,7 @@ function makePanel(overrides: Partial<Panel> = {}): Panel {
     scheduledRun: null,
     isArtifactOpen: false,
     isBrowserVisible: false,
+    isAppsVisible: false,
     showBrowserButton: true,
     isPlaywrightSetupVisible: false,
     onClose: vi.fn(),
@@ -141,5 +142,33 @@ describe("ConversationHeader — top-bar tab strip", () => {
   it("renders the Runs tab when the chat is a scheduled run", () => {
     renderHeader({ scheduledRun: { triggerId: "t1", runId: null } });
     expect(screen.getByRole("tab", { name: "Runs" })).toBeInTheDocument();
+  });
+});
+
+describe("ConversationHeader — mobile overflow menu", () => {
+  it("offers Show Apps and opens the apps tab", async () => {
+    const user = userEvent.setup();
+    const panel = renderHeader({ isOpen: false });
+
+    await user.click(screen.getByRole("button", { name: "More options" }));
+    await user.click(screen.getByRole("menuitem", { name: "Show Apps" }));
+
+    expect(panel.onOpenTab).toHaveBeenCalledWith("apps");
+    expect(panel.onClose).not.toHaveBeenCalled();
+  });
+
+  it("offers Hide Apps while the apps tab is showing and closes the panel", async () => {
+    const user = userEvent.setup();
+    const panel = renderHeader({
+      isOpen: true,
+      activeTab: "apps",
+      isAppsVisible: true,
+    });
+
+    await user.click(screen.getByRole("button", { name: "More options" }));
+    await user.click(screen.getByRole("menuitem", { name: "Hide Apps" }));
+
+    expect(panel.onClose).toHaveBeenCalledTimes(1);
+    expect(panel.onOpenTab).not.toHaveBeenCalled();
   });
 });

--- a/platform/frontend/src/components/chat/conversation-header.tsx
+++ b/platform/frontend/src/components/chat/conversation-header.tsx
@@ -43,6 +43,7 @@ interface PanelControls {
   scheduledRun: { triggerId: string; runId: string | null } | null;
   isArtifactOpen: boolean;
   isBrowserVisible: boolean;
+  isAppsVisible: boolean;
   showBrowserButton: boolean;
   isPlaywrightSetupVisible: boolean;
   onClose: () => void;
@@ -325,6 +326,18 @@ export function ConversationHeader({
                   {panel.isBrowserVisible ? "Hide Browser" : "Show Browser"}
                 </DropdownMenuItem>
               )}
+              <DropdownMenuItem
+                onSelect={() => {
+                  if (panel.isAppsVisible) {
+                    panel.onClose();
+                  } else {
+                    panel.onOpenTab("apps");
+                  }
+                }}
+              >
+                <AppWindow className="h-4 w-4" />
+                {panel.isAppsVisible ? "Hide Apps" : "Show Apps"}
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/platform/frontend/src/components/chat/right-side-panel.tsx
+++ b/platform/frontend/src/components/chat/right-side-panel.tsx
@@ -59,24 +59,12 @@ export function RightSidePanel({
   initialNavigateUrl,
   onInitialNavigateComplete,
 }: RightSidePanelProps) {
-  const { apps, setPortalTarget, setSettingsOpen } = useApps();
-  const portalDivRef = useRef<HTMLDivElement | null>(null);
+  const { setSettingsOpen } = useApps();
 
   let resolvedTab: RightPanelTab = activeTab;
   if (resolvedTab === "browser" && !canShowBrowser) resolvedTab = "files";
   // The Runs tab only exists for scheduled-run chats; fall back otherwise.
   if (resolvedTab === "runs" && !scheduledRun) resolvedTab = "files";
-
-  // Activate the portal target only while the Apps tab is showing — when the
-  // user switches to artifact/browser or closes the panel, the app falls back
-  // to inline rendering in the chat.
-  useEffect(() => {
-    const shouldHostApp = isOpen && resolvedTab === "apps";
-    setPortalTarget(shouldHostApp ? portalDivRef.current : null);
-    return () => {
-      setPortalTarget(null);
-    };
-  }, [isOpen, resolvedTab, setPortalTarget]);
 
   // Collapsing the panel drops the owned-app settings form so it reopens on the
   // live app, not the form. The tab strip (in the header) now drives collapse,
@@ -127,25 +115,46 @@ export function RightSidePanel({
         )}
         {/* Apps tab content: renders the open app directly (no portal). The
             app-switcher lives in the hosted card's header (see McpAppCard). */}
-        {resolvedTab === "apps" && (
-          <div className="flex flex-col h-full">
-            <div ref={portalDivRef} className="flex-1 min-h-0 relative">
-              {apps.length === 0 ? (
-                <div className="absolute inset-0 flex flex-col items-center justify-center text-center text-xs text-muted-foreground px-6">
-                  <AppWindow className="h-6 w-6 mb-2 opacity-50" />
-                  <p className="font-medium">No Apps in this chat</p>
-                  <p className="mt-1">
-                    Apps from tool calls in this conversation will appear here.
-                  </p>
-                </div>
-              ) : (
-                <PanelAppHost agentId={agentId} />
-              )}
-            </div>
-          </div>
-        )}
+        {resolvedTab === "apps" && <AppsPanelContent agentId={agentId} />}
       </div>
     </ResizableRightPanel>
+  );
+}
+
+/**
+ * The Apps tab content: the hosted app (or the no-apps empty state). Shared by
+ * the desktop right panel and the chat page's inline mobile panel. While
+ * mounted it registers as the apps portal target, which collapses inline app
+ * renders in the chat and switches pill clicks to select-the-hosted-app mode —
+ * so mount it only while the Apps tab is actually showing.
+ */
+export function AppsPanelContent({ agentId }: { agentId?: string }) {
+  const { apps, setPortalTarget } = useApps();
+  const portalDivRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setPortalTarget(portalDivRef.current);
+    return () => {
+      setPortalTarget(null);
+    };
+  }, [setPortalTarget]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div ref={portalDivRef} className="flex-1 min-h-0 relative">
+        {apps.length === 0 ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center text-center text-xs text-muted-foreground px-6">
+            <AppWindow className="h-6 w-6 mb-2 opacity-50" />
+            <p className="font-medium">No Apps in this chat</p>
+            <p className="mt-1">
+              Apps from tool calls in this conversation will appear here.
+            </p>
+          </div>
+        ) : (
+          <PanelAppHost agentId={agentId} />
+        )}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
The chat page's mobile branch rendered inline panels only for Files and Browser, and the mobile 3-dot menu had no Apps entry — an app opened in the sidebar was unreachable on mobile (blank screen when the Apps tab auto-opened).

- Extract the Apps tab content into `AppsPanelContent` and reuse it as the single app host on both surfaces.
- Add an apps case to the mobile inline panel and a Show/Hide Apps item to the mobile overflow menu.
- Gate the mobile inline panel and desktop right panel on `useIsMobile()` so the app iframe mounts exactly once (the CSS-hidden desktop panel would otherwise host a second invisible copy and duplicate the app's on-load tool calls).

T-601

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>