### PR TITLE
fix: make sidebar collapse toggle more visible

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -56,6 +56,7 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
@@ -665,10 +666,11 @@ export function AppSidebar() {
   return (
     <Sidebar collapsible="icon">
       <SidebarHeader className="pt-4 group-data-[collapsible=icon]:pt-2 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:gap-1">
-        <div className="group-data-[collapsible=icon]:hidden">
+        <div className="flex items-center justify-between gap-2 group-data-[collapsible=icon]:hidden">
           <SidebarPrefetchLink href="/chat" className="block min-w-0">
             <AppLogo />
           </SidebarPrefetchLink>
+          <SidebarTrigger className="shrink-0 text-muted-foreground hover:text-foreground" />
         </div>
         <SidebarPrefetchLink
           href="/chat"
@@ -676,6 +678,7 @@ export function AppSidebar() {
         >
           <img src={appIconLogo} alt="Logo" className="size-7" />
         </SidebarPrefetchLink>
+        <SidebarTrigger className="hidden text-muted-foreground hover:text-foreground group-data-[collapsible=icon]:flex" />
         {isAuthenticated && permissionMap && (
           <SidebarModeToggle
             mode={sidebarMode}

--- a/platform/frontend/src/components/ui/sidebar.tsx
+++ b/platform/frontend/src/components/ui/sidebar.tsx
@@ -354,9 +354,16 @@ function SidebarCircleToggle({
           className={cn(
             "group/circle-toggle hidden md:flex items-center justify-center",
             "fixed top-1/2 z-30 h-10 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full",
-            "bg-background border cursor-pointer",
-            "transition-[left,background-color] duration-200 ease-in-out",
-            "hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-1",
+            "border shadow-sm cursor-pointer text-muted-foreground",
+            // Offset fill while collapsed so the expand affordance stands out;
+            // mixed opaquely so the sidebar border doesn't show through, with a
+            // stronger mix on dark themes where a subtle one vanishes on black.
+            // Blend with the background when the sidebar is already open.
+            isCollapsed
+              ? "bg-[color-mix(in_oklab,var(--muted-foreground)_20%,var(--background))] dark:bg-[color-mix(in_oklab,var(--muted-foreground)_40%,var(--background))] text-foreground"
+              : "bg-background",
+            "transition-[left,background-color,color] duration-200 ease-in-out",
+            "hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-1",
             className,
           )}
           {...props}


### PR DESCRIPTION
Desktop users had no visible collapse affordance: the only control was a 14px edge pill. Adds the standard SidebarTrigger to the sidebar header (next to the logo when expanded, under the icon logo in the collapsed rail) and gives the edge pill an opaque offset fill while collapsed (lighter mix on light themes, stronger on dark) so the expand affordance is noticeable.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>