### PR TITLE
fix: handle upstream LLM overloads

### DIFF
--- a/platform/backend/src/observability/error-tracking-policy.test.ts
+++ b/platform/backend/src/observability/error-tracking-policy.test.ts
@@ -41,8 +41,8 @@ describe("classifyErrorForTracking", () => {
     }
   });
 
-  test("drops 502/504 ApiErrors as upstream failures", () => {
-    for (const statusCode of [502, 504]) {
+  test("drops 502/504/529 ApiErrors as upstream failures", () => {
+    for (const statusCode of [502, 504, 529]) {
       expect(
         classifyErrorForTracking(new ApiError(statusCode, "upstream")).report,
       ).toBe(false);
@@ -54,6 +54,15 @@ describe("classifyErrorForTracking", () => {
       500,
       "provider streamed an empty completion",
       ArchestraInternalErrorCode.UpstreamEmptyResponse,
+    );
+    expect(classifyErrorForTracking(error).report).toBe(false);
+  });
+
+  test("drops the handled provider-overload condition", () => {
+    const error = new ApiError(
+      503,
+      "The server is currently overloaded",
+      ArchestraInternalErrorCode.ProviderOverloaded,
     );
     expect(classifyErrorForTracking(error).report).toBe(false);
   });

--- a/platform/backend/src/observability/error-tracking-policy.ts
+++ b/platform/backend/src/observability/error-tracking-policy.ts
@@ -89,14 +89,21 @@ function isNonActionableError(error: unknown): boolean {
   if (error instanceof ApiError) {
     // 4xx client errors (not found, validation, upstream client errors).
     if (error.statusCode >= 400 && error.statusCode < 500) return true;
-    // Handled transient upstream condition (empty completion → retryable 503).
+    // Handled transient upstream conditions.
     if (
-      error.internalCode === ArchestraInternalErrorCode.UpstreamEmptyResponse
+      error.internalCode === ArchestraInternalErrorCode.UpstreamEmptyResponse ||
+      error.internalCode === ArchestraInternalErrorCode.ProviderOverloaded
     ) {
       return true;
     }
-    // 502/504 report an upstream's failure, not a crash of ours.
-    if (error.statusCode === 502 || error.statusCode === 504) return true;
+    // Upstream gateway failures and Anthropic overloads.
+    if (
+      error.statusCode === 502 ||
+      error.statusCode === 504 ||
+      error.statusCode === 529
+    ) {
+      return true;
+    }
     return false;
   }
 

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -1656,6 +1656,19 @@ describe("mapProviderError - Fallback behavior", () => {
     expect(mockSentryCaptureException).not.toHaveBeenCalled();
   });
 
+  it("should map a mid-stream provider overload to a retryable server error", () => {
+    const error = {
+      message: "The provider is overloaded",
+      type: "api_error",
+      internal_code: ArchestraInternalErrorCode.ProviderOverloaded,
+    };
+    const result = mapProviderError(error, "anthropic");
+
+    expect(result.code).toBe(ChatErrorCode.ServerError);
+    expect(result.isRetryable).toBe(true);
+    expect(mockSentryCaptureException).not.toHaveBeenCalled();
+  });
+
   it("should map a pre-stream upstream empty response 503 to a retryable empty-response card", () => {
     // The other delivery shape: detection before headers commit arrives as an
     // HTTP 503 whose body carries the normalized internal code.

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -350,7 +350,8 @@ function extractArchestraInternalCode(
       code === ArchestraInternalErrorCode.ContextLengthExceeded ||
       code === ArchestraInternalErrorCode.ProviderInsufficientBalance ||
       code === ArchestraInternalErrorCode.UpstreamEmptyResponse ||
-      code === ArchestraInternalErrorCode.UpstreamTimeout
+      code === ArchestraInternalErrorCode.UpstreamTimeout ||
+      code === ArchestraInternalErrorCode.ProviderOverloaded
     ) {
       return code;
     }
@@ -1810,6 +1811,9 @@ export function mapProviderError(
     // Mid-stream HTTP status is already committed as 200, so the normalized
     // code preserves the upstream 504 semantics and retryability.
     errorCode = ChatErrorCode.NetworkError;
+  } else if (normalizedCode === ArchestraInternalErrorCode.ProviderOverloaded) {
+    // Mid-stream overloads have no usable HTTP status.
+    errorCode = ChatErrorCode.ServerError;
   }
   const usageLimitError = extractUsageLimitError(responseBody);
   // An Archestra usage-limit block arrives over the proxy envelope as an HTTP

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -512,7 +512,12 @@ describe("shouldForwardAnthropicBeta", () => {
 describe("handleError", () => {
   function makeReply(headersSent: boolean) {
     const writes: string[] = [];
+    const headers: Record<string, string> = {};
     const reply = {
+      header: (name: string, value: string) => {
+        headers[name] = value;
+        return reply;
+      },
       raw: {
         headersSent,
         write: (chunk: string) => {
@@ -522,7 +527,7 @@ describe("handleError", () => {
         end: () => {},
       },
     } as unknown as FastifyReply;
-    return { reply, writes };
+    return { reply, writes, headers };
   }
 
   const extractMessage = (error: unknown) =>
@@ -646,6 +651,122 @@ describe("handleError", () => {
     // No connection/timeout signal → stays a 500 and remains captured.
     expect(throwStatusFor(new TypeError("cannot read x of undefined"))).toBe(
       500,
+    );
+  });
+
+  function makeStreamedOverloadError(headers?: Headers) {
+    const body = {
+      type: "error",
+      error: { type: "overloaded_error", message: "Overloaded" },
+    };
+    return Object.assign(new Error(JSON.stringify(body)), {
+      error: body,
+      headers,
+    });
+  }
+
+  function throwErrorFor(error: unknown, reply: FastifyReply): ApiError {
+    try {
+      handleError(error, reply, extractMessage, true, () => undefined);
+    } catch (thrown) {
+      return thrown as ApiError;
+    }
+    throw new Error("handleError did not throw");
+  }
+
+  test("classifies a streamed Anthropic overload as 529 with the normalized code", () => {
+    const { reply } = makeReply(false);
+    const thrown = throwErrorFor(makeStreamedOverloadError(), reply);
+
+    expect(thrown.statusCode).toBe(529);
+    expect(thrown.internalCode).toBe(
+      ArchestraInternalErrorCode.ProviderOverloaded,
+    );
+  });
+
+  test("classifies generic overload wording without a status as 503", () => {
+    const thrown = throwErrorFor(
+      Object.assign(
+        new Error("The server is currently overloaded, please retry"),
+        { error: { message: "Overloaded" } },
+      ),
+      makeReply(false).reply,
+    );
+
+    expect(thrown.statusCode).toBe(503);
+    expect(thrown.internalCode).toBe(
+      ArchestraInternalErrorCode.ProviderOverloaded,
+    );
+  });
+
+  test("does not reclassify an internal error containing overload wording", () => {
+    const thrown = throwErrorFor(
+      new Error("Internal worker overloaded"),
+      makeReply(false).reply,
+    );
+
+    expect(thrown.statusCode).toBe(500);
+    expect(thrown.internalCode).toBeUndefined();
+  });
+
+  test("keeps an explicit upstream 529 and tags it as overloaded", () => {
+    const thrown = throwErrorFor(
+      Object.assign(new Error("Overloaded"), { status: 529 }),
+      makeReply(false).reply,
+    );
+
+    expect(thrown.statusCode).toBe(529);
+    expect(thrown.internalCode).toBe(
+      ArchestraInternalErrorCode.ProviderOverloaded,
+    );
+  });
+
+  test("does not tag an explicit 503 without overload wording", () => {
+    const thrown = throwErrorFor(
+      Object.assign(new Error("Service Unavailable"), { status: 503 }),
+      makeReply(false).reply,
+    );
+
+    expect(thrown.statusCode).toBe(503);
+    expect(thrown.internalCode).toBeUndefined();
+  });
+
+  test("forwards the upstream Retry-After header before headers commit", () => {
+    const { reply, headers } = makeReply(false);
+    const error = makeStreamedOverloadError(
+      new Headers({ "retry-after": "30" }),
+    );
+
+    expect(throwErrorFor(error, reply).statusCode).toBe(529);
+    expect(headers["retry-after"]).toBe("30");
+  });
+
+  test("drops a Retry-After value that is neither seconds nor a date", () => {
+    const { reply, headers } = makeReply(false);
+    const error = Object.assign(new Error("rate limited"), {
+      status: 429,
+      headers: { "retry-after": "soon\u0000ish" },
+    });
+
+    expect(throwErrorFor(error, reply).statusCode).toBe(429);
+    expect(headers["retry-after"]).toBeUndefined();
+  });
+
+  test("surfaces the overload code in the mid-stream SSE error event", () => {
+    const { reply, writes } = makeReply(true);
+
+    handleError(
+      makeStreamedOverloadError(),
+      reply,
+      extractMessage,
+      true,
+      () => undefined,
+    );
+
+    expect(writes).toHaveLength(1);
+    const payload = JSON.parse(writes[0].replace(/^event: error\ndata: /, ""));
+    expect(payload.error.internal_code).toBe(
+      ArchestraInternalErrorCode.ProviderOverloaded,
     );
   });
 });

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -7,7 +7,7 @@
 
 import {
   ApiError,
-  type ArchestraInternalErrorCode,
+  ArchestraInternalErrorCode,
   type InteractionSource,
   type SupportedProvider,
   type SupportedProviderDiscriminator,
@@ -369,13 +369,7 @@ export function handleError(
     }
   }
 
-  // A connection failure or timeout reaching the upstream provider carries no
-  // HTTP status (the request never got a response), so it would otherwise fall
-  // through as a generic 500 and be captured as a server exception. That's the
-  // upstream's/network's failure, not ours — reclassify it as a gateway error
-  // (504 timeout, 502 connection) so the central error handler logs it but keeps
-  // it out of error tracking (it already excludes 502/504), while the client
-  // still sees a retryable 5xx.
+  // Some SDK transport and streaming failures do not carry an HTTP status.
   if (!hasExplicitStatus) {
     const upstreamStatus = classifyTransientUpstreamError(error);
     if (upstreamStatus !== undefined) {
@@ -383,13 +377,28 @@ export function handleError(
     }
   }
 
+  // The internal code preserves overload semantics after streaming starts.
+  const isUpstreamOverload =
+    statusCode === 529 ||
+    (statusCode === 503 &&
+      !(error instanceof ApiError) &&
+      classifyUpstreamOverload(error) !== undefined);
+
   const errorMessage = extractErrorMessage(error);
-  // Prefer the adapter's classification, but fall back to a code already
-  // carried by an ApiError (e.g. the adapter threw one tagged with
-  // upstream_empty_response) so re-wrapping below doesn't drop it.
   const internalCode =
     extractInternalCode(error) ??
-    (error instanceof ApiError ? error.internalCode : undefined);
+    (error instanceof ApiError ? error.internalCode : undefined) ??
+    (isUpstreamOverload
+      ? ArchestraInternalErrorCode.ProviderOverloaded
+      : undefined);
+
+  // Headers cannot be changed after streaming starts.
+  if (!reply.raw.headersSent) {
+    const retryAfter = extractRetryAfterHeader(error);
+    if (retryAfter !== undefined) {
+      reply.header("retry-after", retryAfter);
+    }
+  }
 
   // If headers already sent (mid-stream error), write error to stream.
   // Clients (like AI SDK) detect errors via HTTP status code, but we can't change
@@ -426,19 +435,15 @@ export function handleError(
 }
 
 /**
- * When an LLM SDK call fails to reach the upstream provider — a dropped/refused
- * connection or a timeout, both with no HTTP status — classify it as an upstream
- * gateway failure: 504 for a timeout, 502 for any other connection failure.
- * Returns undefined for anything that isn't a recognizable connection failure so
- * genuine 500s (our own bugs) are left alone.
- *
- * Matches the OpenAI/Anthropic SDK `APIConnectionError` ("Connection error.") and
- * `APIConnectionTimeoutError` ("Request timed out."), plus the underlying Node
- * `fetch`/libuv/undici errno codes those wrap (via the shared network-error
- * vocabulary), across providers.
+ * Classify status-less SDK transport and overload errors as upstream failures.
  */
-function classifyTransientUpstreamError(error: unknown): 502 | 504 | undefined {
+function classifyTransientUpstreamError(
+  error: unknown,
+): 502 | 503 | 504 | 529 | undefined {
   if (!(error instanceof Error)) return undefined;
+
+  const overloadStatus = classifyUpstreamOverload(error);
+  if (overloadStatus !== undefined) return overloadStatus;
 
   const { name, message } = error;
   const codes = collectErrorCodes(error);
@@ -458,6 +463,74 @@ function classifyTransientUpstreamError(error: unknown): 502 | 504 | undefined {
     codes.some(isConnectionErrno);
   if (isConnectionFailure) return 502;
 
+  return undefined;
+}
+
+/**
+ * Anthropic's `overloaded_error` maps to 529; other provider overloads map to
+ * 503. Message matching is limited to SDK-like errors so internal failures are
+ * not reclassified.
+ */
+function classifyUpstreamOverload(error: unknown): 503 | 529 | undefined {
+  if (!(error instanceof Error)) return undefined;
+
+  if (
+    nestedProviderErrorType(error) === "overloaded_error" ||
+    /\boverloaded_error\b/.test(error.message)
+  ) {
+    return 529;
+  }
+  const hasProviderErrorShape =
+    "error" in error ||
+    "headers" in error ||
+    "status" in error ||
+    "statusCode" in error;
+  if (hasProviderErrorShape && /\boverloaded\b/i.test(error.message)) {
+    return 503;
+  }
+
+  return undefined;
+}
+
+/**
+ * Read a provider error type from the SDK's direct or nested error body.
+ */
+function nestedProviderErrorType(error: Error): string | undefined {
+  const body = (error as Error & { error?: unknown }).error;
+  const inner =
+    body && typeof body === "object"
+      ? (body as { error?: unknown }).error
+      : undefined;
+  for (const candidate of [inner, body]) {
+    if (candidate && typeof candidate === "object") {
+      const type = (candidate as { type?: unknown }).type;
+      if (typeof type === "string" && type !== "error") return type;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Read a valid Retry-After value from current or legacy SDK error headers.
+ */
+function extractRetryAfterHeader(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const headers = (error as Error & { headers?: unknown }).headers;
+
+  let value: unknown;
+  if (headers instanceof Headers) {
+    value = headers.get("retry-after");
+  } else if (headers && typeof headers === "object") {
+    const record = headers as Record<string, unknown>;
+    value = record["retry-after"] ?? record["Retry-After"];
+  }
+  if (typeof value !== "string") return undefined;
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  if (/^\d+$/.test(trimmed) || Number.isFinite(Date.parse(trimmed))) {
+    return trimmed;
+  }
   return undefined;
 }
 

--- a/platform/shared/chat-error.ts
+++ b/platform/shared/chat-error.ts
@@ -41,6 +41,10 @@ export const ArchestraInternalErrorCode = {
    * Archestra's inactivity deadline elapsed. Transient and safe to retry.
    */
   UpstreamTimeout: "upstream_timeout",
+  /**
+   * The upstream provider declared a transient overload (HTTP 503/529).
+   */
+  ProviderOverloaded: "provider_overloaded",
 } as const;
 
 export type ArchestraInternalErrorCode =

--- a/platform/shared/types.ts
+++ b/platform/shared/types.ts
@@ -67,7 +67,9 @@ export class ApiError extends Error {
       case 413:
         this.type = "api_payload_too_large_error";
         break;
+      // Anthropic uses 529 for the same transient condition as 503.
       case 503:
+      case 529:
         this.type = "api_service_unavailable_error";
         break;
       default:


### PR DESCRIPTION
Return provider overloads as 503/529, forward valid Retry-After headers, and preserve retryability for streaming chat errors.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>