### PR TITLE
fix(chat): mount model selector dialog content only while open

### DIFF
--- a/platform/frontend/src/app/chat/prompt-input-tools.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Typing-performance contract for the chat composer (GH #4256): a keystroke
+ * updates the PromptInputProvider text state and rerenders PromptInputContent,
+ * but the memoized footer toolbar (ChatPromptInputTools) must not rerender —
+ * it hosts the model selector, which is expensive with many models.
+ *
+ * Unlike prompt-input.test.tsx, this file keeps the real ai-elements
+ * prompt-input module (provider, controller context, textarea) so a keystroke
+ * exercises the real context-update path, and counts renders of the toolbar's
+ * children to pin that the memo holds.
+ */
+import { E2eTestId } from "@archestra/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { renderCounts } = vi.hoisted(() => ({
+  renderCounts: { modelSelector: 0, apiKeySelector: 0 },
+}));
+
+// Used by Radix and the toolbar-collapse hook; jsdom reports 0 widths, so the
+// toolbar stays in its full (expanded) layout, which renders the selectors.
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as typeof ResizeObserver;
+
+// For the useIsMobile hook used by the real PromptInputTextarea
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Render-counting stubs for the toolbar's expensive children. If the toolbar
+// memo breaks (an unstable prop at the call site, or a dropped memo), these
+// rerender on every keystroke and the counts move.
+vi.mock("@/components/chat/model-selector", () => ({
+  ModelSelector: () => {
+    renderCounts.modelSelector++;
+    return <div data-testid="model-selector" />;
+  },
+  providerToLogoProvider: {},
+}));
+
+vi.mock("@/components/chat/llm-provider-api-key-selector", () => ({
+  LlmProviderApiKeySelector: () => {
+    renderCounts.apiKeySelector++;
+    return <div data-testid="api-key-selector" />;
+  },
+}));
+
+vi.mock("@/lib/agent.query", () => ({
+  useProfile: () => ({ data: null, isLoading: false, error: null }),
+}));
+
+vi.mock("@/lib/chat/chat.query", () => ({
+  useConversation: () => ({ data: null }),
+  useToggleHooksDebug: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/lib/chat/chat-placeholder.hook", () => ({
+  useChatPlaceholder: () => ({
+    placeholder: "placeholder",
+    isAnimating: false,
+  }),
+}));
+
+vi.mock("@/lib/skills/skill.query", () => ({
+  useSkillsPaginated: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock("@/lib/organization.query");
+vi.mock("@/lib/auth/auth.query");
+vi.mock("@/lib/config/config.query");
+
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useOrganization } from "@/lib/organization.query";
+import ArchestraPromptInput from "./prompt-input";
+
+describe("chat composer typing performance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    renderCounts.modelSelector = 0;
+    renderCounts.apiKeySelector = 0;
+    localStorage.clear();
+    vi.mocked(useOrganization).mockReturnValue({
+      data: null,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useOrganization>);
+    // Provider settings visible (so the toolbar renders both selectors),
+    // everything else off (so the agent picker stays out of the tree).
+    vi.mocked(useHasPermissions).mockImplementation(
+      (permissions) =>
+        ({
+          data: "chatProviderSettings" in permissions,
+          isPending: false,
+          isLoading: false,
+        }) as ReturnType<typeof useHasPermissions>,
+    );
+  });
+
+  it("does not rerender the footer toolbar selectors on prompt keystrokes", () => {
+    render(
+      <ArchestraPromptInput
+        onSubmit={vi.fn()}
+        status="ready"
+        selectedModel="gpt-4"
+        onModelChange={vi.fn()}
+        agentId="agent-1"
+        conversationId="conv-1"
+        isPlaywrightSetupVisible={false}
+      />,
+    );
+
+    const textarea = screen.getByTestId(E2eTestId.ChatPromptTextarea);
+    expect(screen.getByTestId("model-selector")).toBeInTheDocument();
+    expect(screen.getByTestId("api-key-selector")).toBeInTheDocument();
+
+    const modelSelectorRendersAfterMount = renderCounts.modelSelector;
+    const apiKeySelectorRendersAfterMount = renderCounts.apiKeySelector;
+
+    fireEvent.change(textarea, { target: { value: "h" } });
+    fireEvent.change(textarea, { target: { value: "he" } });
+    fireEvent.change(textarea, { target: { value: "hello" } });
+
+    // The keystrokes really went through the provider round-trip: the
+    // textarea is controlled by the provider-owned text state.
+    expect(textarea).toHaveValue("hello");
+
+    expect(renderCounts.modelSelector).toBe(modelSelectorRendersAfterMount);
+    expect(renderCounts.apiKeySelector).toBe(apiKeySelectorRendersAfterMount);
+  });
+});

--- a/platform/frontend/src/components/chat/model-selector.test.tsx
+++ b/platform/frontend/src/components/chat/model-selector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ModelSelector } from "./model-selector";
@@ -20,23 +20,56 @@ vi.mock("@/lib/llm-models.query", () => ({
 }));
 
 // The dropdown internals are Radix-based and irrelevant to the branches under
-// test; render only the trigger so assertions target the visible button text.
+// test. The root mock exposes a toggle button wired to onOpenChange so tests
+// can flip the component's open state, and structural wrappers render their
+// children so the gating tests can observe what is mounted.
 vi.mock("@/components/ai-elements/model-selector", () => ({
-  ModelSelector: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
+  ModelSelector: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        data-testid="dialog-toggle"
+        onClick={() => onOpenChange?.(!open)}
+      />
+      {children}
+    </div>
   ),
   ModelSelectorTrigger: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
-  ModelSelectorContent: () => null,
-  ModelSelectorList: () => null,
+  ModelSelectorContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="dialog-content">{children}</div>
+  ),
+  ModelSelectorList: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
   ModelSelectorEmpty: () => null,
-  ModelSelectorGroup: () => null,
-  ModelSelectorItem: () => null,
+  ModelSelectorGroup: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ModelSelectorItem: ({ children }: { children: ReactNode }) => (
+    <div data-testid="model-option">{children}</div>
+  ),
   ModelSelectorInput: () => null,
   ModelSelectorLogo: () => null,
   ModelSelectorName: ({ children }: { children: ReactNode }) => (
     <span>{children}</span>
+  ),
+}));
+
+// The dialog body renders a DialogClose, which requires a real Radix Dialog
+// ancestor — mocked away above, so stub it.
+vi.mock("@/components/ui/dialog", () => ({
+  DialogClose: ({ children }: { children?: ReactNode }) => (
+    <button type="button">{children}</button>
   ),
 }));
 
@@ -67,6 +100,7 @@ function setQuery(overrides: Partial<QueryShape>) {
 
 const model = (over: Record<string, unknown> = {}) => ({
   dbId: "m1",
+  id: "gpt-4o",
   displayName: "GPT-4o",
   provider: "openai",
   isBest: true,
@@ -173,6 +207,28 @@ describe("ModelSelector coverage matrix", () => {
       variant: "default",
     });
     expect(onModelChange).not.toHaveBeenCalled();
+  });
+
+  // The option tree is expensive with many models, and the toolbar rerenders
+  // on unrelated state changes; a closed selector must not build the dialog
+  // content at all (chat prompt typing froze when it did).
+  it("does not mount the dialog option tree while closed", () => {
+    setQuery({ modelsByProvider: { openai: [model()] } });
+    renderSelector({ selectedModel: "m1", variant: "default" });
+    expect(screen.queryByTestId("dialog-content")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("model-option")).not.toBeInTheDocument();
+  });
+
+  it("mounts the option tree when opened and unmounts it again on close", () => {
+    setQuery({ modelsByProvider: { openai: [model()] } });
+    renderSelector({ selectedModel: "m1", variant: "default" });
+
+    fireEvent.click(screen.getByTestId("dialog-toggle"));
+    expect(screen.getByTestId("dialog-content")).toBeInTheDocument();
+    expect(screen.getAllByTestId("model-option").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByTestId("dialog-toggle"));
+    expect(screen.queryByTestId("dialog-content")).not.toBeInTheDocument();
   });
 
   it("keeps the pinned model and shows the fallback name when auto-select is suppressed", () => {

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -550,14 +550,9 @@ export const ModelSelector = memo(function ModelSelector({
       enabled,
     });
   const [open, setOpen] = useState(false);
-  const [filters, setFilters] = useState<ModelFilters>(INITIAL_FILTERS);
 
   const handleOpenChange = (newOpen: boolean) => {
     setOpen(newOpen);
-    // Reset filters when closing the dialog
-    if (!newOpen) {
-      setFilters(INITIAL_FILTERS);
-    }
     onOpenChangeProp?.(newOpen);
   };
 
@@ -565,60 +560,6 @@ export const ModelSelector = memo(function ModelSelector({
   const availableProviders = useMemo(() => {
     return Object.keys(modelsByProvider) as SupportedProvider[];
   }, [modelsByProvider]);
-
-  // Calculate which modalities are available across all models
-  const availableModalities = useMemo(() => {
-    const modalities = new Set<FilterableModality>();
-    for (const provider of availableProviders) {
-      for (const model of modelsByProvider[provider] ?? []) {
-        const inputMods = model.capabilities?.inputModalities ?? [];
-        for (const mod of inputMods) {
-          if (mod !== "text") {
-            modalities.add(mod as FilterableModality);
-          }
-        }
-      }
-    }
-    return modalities;
-  }, [availableProviders, modelsByProvider]);
-
-  // Check if any filters are active
-  const hasActiveFilters = filters.modalities.size > 0 || filters.toolCalling;
-
-  // Filter models by provider based on active filters
-  const filteredModelsByProvider = useMemo(() => {
-    if (!hasActiveFilters) {
-      return modelsByProvider;
-    }
-
-    const filtered: Partial<Record<SupportedProvider, LlmModel[]>> = {};
-    for (const provider of availableProviders) {
-      const models = modelsByProvider[provider] ?? [];
-      const matchingModels = models.filter((model) =>
-        modelMatchesFilters(model, filters),
-      );
-      if (matchingModels.length > 0) {
-        filtered[provider] = matchingModels;
-      }
-    }
-    return filtered;
-  }, [modelsByProvider, availableProviders, filters, hasActiveFilters]);
-
-  // Get filtered providers (only those with matching models)
-  const filteredProviders = useMemo(() => {
-    return Object.keys(filteredModelsByProvider) as SupportedProvider[];
-  }, [filteredModelsByProvider]);
-
-  // Sort once per data change rather than on every render inside the JSX map.
-  const sortedModelsByProvider = useMemo(() => {
-    const sorted: Partial<Record<SupportedProvider, LlmModel[]>> = {};
-    for (const provider of filteredProviders) {
-      sorted[provider] = [...(filteredModelsByProvider[provider] ?? [])].sort(
-        compareLlmModels,
-      );
-    }
-    return sorted;
-  }, [filteredModelsByProvider, filteredProviders]);
 
   // Find the provider for a given model
   const getProviderForModel = (model: string): SupportedProvider | null => {
@@ -803,130 +744,232 @@ export const ModelSelector = memo(function ModelSelector({
             </PromptInputButton>
           )}
         </ModelSelectorTrigger>
-        <ModelSelectorContent
-          title="Select Model"
-          onCloseAutoFocus={(e) => e.preventDefault()}
-          showCloseButton={false}
-        >
-          <ModelFiltersBar
-            filters={filters}
-            onFiltersChange={setFilters}
-            availableModalities={availableModalities}
-          />
-          <ModelSelectorInput placeholder="Search models..." autoFocus />
-          <ModelSelectorList>
-            <ModelSelectorEmpty>
-              {hasActiveFilters
-                ? "No models match the selected filters."
-                : "No models found."}
-            </ModelSelectorEmpty>
-
-            {/* Option to unselect model */}
-            {onClear && (
-              <ModelSelectorGroup heading="">
-                <ModelSelectorItem
-                  value="__none__"
-                  onSelect={() => {
-                    handleOpenChange(false);
-                    onClear();
-                  }}
-                >
-                  <ModelSelectorName>
-                    Best available model (resolved at runtime)
-                  </ModelSelectorName>
-                  {!selectedModel && <CheckIcon className="ml-auto size-4" />}
-                </ModelSelectorItem>
-              </ModelSelectorGroup>
-            )}
-
-            {/* Show current model if not in available list */}
-            {!isModelAvailable && selectedModel && (
-              <ModelSelectorGroup heading="Current (API key missing)">
-                <ModelSelectorItem
-                  disabled
-                  value={selectedModel}
-                  className="text-yellow-600"
-                >
-                  {selectedModelLogo && (
-                    <ModelSelectorLogo provider={selectedModelLogo} />
-                  )}
-                  <ModelSelectorName>{selectedModel}</ModelSelectorName>
-                  <CheckIcon className="ml-auto size-4" />
-                </ModelSelectorItem>
-              </ModelSelectorGroup>
-            )}
-
-            {filteredProviders.map((provider) => (
-              <ModelSelectorGroup
-                key={provider}
-                heading={providerDisplayNames[provider]}
-              >
-                {(sortedModelsByProvider[provider] ?? []).map((model) => {
-                  // Use provider:modelId format for unique keys/values
-                  // This prevents issues when different providers have models with the same ID
-                  const modelValue = createModelValue(provider, model.dbId);
-                  return (
-                    <ModelSelectorItem
-                      key={modelValue}
-                      value={modelValue}
-                      // value is provider:dbId (a UUID) for stable selection,
-                      // so search must match human-readable terms via keywords
-                      keywords={[
-                        model.displayName,
-                        model.id,
-                        providerDisplayNames[provider],
-                      ]}
-                      onSelect={() => handleSelectModel(modelValue)}
-                      className="group"
-                    >
-                      <ModelSelectorLogo
-                        provider={providerToLogoProvider[provider]}
-                      />
-                      <ModelSelectorName>
-                        {model.displayName}{" "}
-                        <span className="text-xs text-muted-foreground font-mono">
-                          ({model.id})
-                        </span>
-                        <CopyModelIdButton modelId={model.id} />
-                      </ModelSelectorName>
-                      {model.isFree && <FreeModelBadge />}
-                      {model.requiresUserConnection && !model.isConnected && (
-                        <ConnectAccountBadge />
-                      )}
-                      {isOpenRouterLatestAlias(provider, model.id) && (
-                        <LatestModelBadge />
-                      )}
-                      {provider === "gemini" &&
-                        isLegacyGeminiModel(model.id) && <OldModelBadge />}
-                      <div className="ml-auto flex items-center gap-2">
-                        <ModelCapabilityBadges
-                          capabilities={model.capabilities}
-                        />
-                        <ContextLengthIndicator
-                          contextLength={model.capabilities?.contextLength}
-                        />
-                        <PricingIndicator
-                          pricePerMillionInput={
-                            model.capabilities?.pricePerMillionInput
-                          }
-                          pricePerMillionOutput={
-                            model.capabilities?.pricePerMillionOutput
-                          }
-                        />
-                        {selectedModel === model.dbId ? (
-                          <CheckIcon className="size-4" />
-                        ) : (
-                          <div className="size-4" />
-                        )}
-                      </div>
-                    </ModelSelectorItem>
-                  );
-                })}
-              </ModelSelectorGroup>
-            ))}
-          </ModelSelectorList>
-        </ModelSelectorContent>
+        {/* The option tree is expensive to build with many models, so it is
+            only mounted while the dialog is open — a closed selector must not
+            rebuild it on every toolbar rerender. Unmounting on close also
+            resets the capability filters. */}
+        {open && (
+          <ModelSelectorContent
+            title="Select Model"
+            onCloseAutoFocus={(e) => e.preventDefault()}
+            showCloseButton={false}
+          >
+            <ModelSelectorDialogBody
+              modelsByProvider={modelsByProvider}
+              availableProviders={availableProviders}
+              selectedModel={selectedModel}
+              selectedModelLogo={selectedModelLogo}
+              isModelAvailable={isModelAvailable}
+              onClear={onClear}
+              onSelectModel={handleSelectModel}
+              onClose={() => handleOpenChange(false)}
+            />
+          </ModelSelectorContent>
+        )}
       </ModelSelectorRoot>
     </div>
   );
 });
+
+/**
+ * Body of the model selector dialog: capability filter bar, search input, and
+ * the provider-grouped option tree. Mounted only while the dialog is open, so
+ * the (potentially large) option tree is never built for a closed selector.
+ * Filter state lives here and resets naturally when the dialog closes.
+ */
+function ModelSelectorDialogBody({
+  modelsByProvider,
+  availableProviders,
+  selectedModel,
+  selectedModelLogo,
+  isModelAvailable,
+  onClear,
+  onSelectModel,
+  onClose,
+}: {
+  modelsByProvider: Record<SupportedProvider, LlmModel[]>;
+  availableProviders: SupportedProvider[];
+  selectedModel: string;
+  selectedModelLogo: string | null;
+  isModelAvailable: boolean;
+  onClear?: () => void;
+  onSelectModel: (modelValue: string) => void;
+  onClose: () => void;
+}) {
+  const [filters, setFilters] = useState<ModelFilters>(INITIAL_FILTERS);
+
+  // Calculate which modalities are available across all models
+  const availableModalities = useMemo(() => {
+    const modalities = new Set<FilterableModality>();
+    for (const provider of availableProviders) {
+      for (const model of modelsByProvider[provider] ?? []) {
+        const inputMods = model.capabilities?.inputModalities ?? [];
+        for (const mod of inputMods) {
+          if (mod !== "text") {
+            modalities.add(mod as FilterableModality);
+          }
+        }
+      }
+    }
+    return modalities;
+  }, [availableProviders, modelsByProvider]);
+
+  // Check if any filters are active
+  const hasActiveFilters = filters.modalities.size > 0 || filters.toolCalling;
+
+  // Filter models by provider based on active filters
+  const filteredModelsByProvider = useMemo(() => {
+    if (!hasActiveFilters) {
+      return modelsByProvider;
+    }
+
+    const filtered: Partial<Record<SupportedProvider, LlmModel[]>> = {};
+    for (const provider of availableProviders) {
+      const models = modelsByProvider[provider] ?? [];
+      const matchingModels = models.filter((model) =>
+        modelMatchesFilters(model, filters),
+      );
+      if (matchingModels.length > 0) {
+        filtered[provider] = matchingModels;
+      }
+    }
+    return filtered;
+  }, [modelsByProvider, availableProviders, filters, hasActiveFilters]);
+
+  // Get filtered providers (only those with matching models)
+  const filteredProviders = useMemo(() => {
+    return Object.keys(filteredModelsByProvider) as SupportedProvider[];
+  }, [filteredModelsByProvider]);
+
+  // Sort once per data change rather than on every render inside the JSX map.
+  const sortedModelsByProvider = useMemo(() => {
+    const sorted: Partial<Record<SupportedProvider, LlmModel[]>> = {};
+    for (const provider of filteredProviders) {
+      sorted[provider] = [...(filteredModelsByProvider[provider] ?? [])].sort(
+        compareLlmModels,
+      );
+    }
+    return sorted;
+  }, [filteredModelsByProvider, filteredProviders]);
+
+  return (
+    <>
+      <ModelFiltersBar
+        filters={filters}
+        onFiltersChange={setFilters}
+        availableModalities={availableModalities}
+      />
+      <ModelSelectorInput placeholder="Search models..." autoFocus />
+      <ModelSelectorList>
+        <ModelSelectorEmpty>
+          {hasActiveFilters
+            ? "No models match the selected filters."
+            : "No models found."}
+        </ModelSelectorEmpty>
+
+        {/* Option to unselect model */}
+        {onClear && (
+          <ModelSelectorGroup heading="">
+            <ModelSelectorItem
+              value="__none__"
+              onSelect={() => {
+                onClose();
+                onClear();
+              }}
+            >
+              <ModelSelectorName>
+                Best available model (resolved at runtime)
+              </ModelSelectorName>
+              {!selectedModel && <CheckIcon className="ml-auto size-4" />}
+            </ModelSelectorItem>
+          </ModelSelectorGroup>
+        )}
+
+        {/* Show current model if not in available list */}
+        {!isModelAvailable && selectedModel && (
+          <ModelSelectorGroup heading="Current (API key missing)">
+            <ModelSelectorItem
+              disabled
+              value={selectedModel}
+              className="text-yellow-600"
+            >
+              {selectedModelLogo && (
+                <ModelSelectorLogo provider={selectedModelLogo} />
+              )}
+              <ModelSelectorName>{selectedModel}</ModelSelectorName>
+              <CheckIcon className="ml-auto size-4" />
+            </ModelSelectorItem>
+          </ModelSelectorGroup>
+        )}
+
+        {filteredProviders.map((provider) => (
+          <ModelSelectorGroup
+            key={provider}
+            heading={providerDisplayNames[provider]}
+          >
+            {(sortedModelsByProvider[provider] ?? []).map((model) => {
+              // Use provider:modelId format for unique keys/values
+              // This prevents issues when different providers have models with the same ID
+              const modelValue = createModelValue(provider, model.dbId);
+              return (
+                <ModelSelectorItem
+                  key={modelValue}
+                  value={modelValue}
+                  // value is provider:dbId (a UUID) for stable selection,
+                  // so search must match human-readable terms via keywords
+                  keywords={[
+                    model.displayName,
+                    model.id,
+                    providerDisplayNames[provider],
+                  ]}
+                  onSelect={() => onSelectModel(modelValue)}
+                  className="group"
+                >
+                  <ModelSelectorLogo
+                    provider={providerToLogoProvider[provider]}
+                  />
+                  <ModelSelectorName>
+                    {model.displayName}{" "}
+                    <span className="text-xs text-muted-foreground font-mono">
+                      ({model.id})
+                    </span>
+                    <CopyModelIdButton modelId={model.id} />
+                  </ModelSelectorName>
+                  {model.isFree && <FreeModelBadge />}
+                  {model.requiresUserConnection && !model.isConnected && (
+                    <ConnectAccountBadge />
+                  )}
+                  {isOpenRouterLatestAlias(provider, model.id) && (
+                    <LatestModelBadge />
+                  )}
+                  {provider === "gemini" && isLegacyGeminiModel(model.id) && (
+                    <OldModelBadge />
+                  )}
+                  <div className="ml-auto flex items-center gap-2">
+                    <ModelCapabilityBadges capabilities={model.capabilities} />
+                    <ContextLengthIndicator
+                      contextLength={model.capabilities?.contextLength}
+                    />
+                    <PricingIndicator
+                      pricePerMillionInput={
+                        model.capabilities?.pricePerMillionInput
+                      }
+                      pricePerMillionOutput={
+                        model.capabilities?.pricePerMillionOutput
+                      }
+                    />
+                    {selectedModel === model.dbId ? (
+                      <CheckIcon className="size-4" />
+                    ) : (
+                      <div className="size-4" />
+                    )}
+                  </div>
+                </ModelSelectorItem>
+              );
+            })}
+          </ModelSelectorGroup>
+        ))}
+      </ModelSelectorList>
+    </>
+  );
+}


### PR DESCRIPTION
Closes #4256.

ModelSelector rebuilt the full model dialog option tree on every rerender even while closed, which is expensive with many models. The dialog body (capability filters + provider-grouped option tree) is now an internal component mounted only while the selector is open; filter state lives there and resets on close by unmounting.

Also adds tests pinning the closed-state gating and that prompt keystrokes do not rerender the memoized footer toolbar (fails if the memo or prop stability regresses).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>