### PR TITLE
chore(bench): run GPT-5.6 Luna

### DIFF
--- a/.github/bench/job.yaml
+++ b/.github/bench/job.yaml
@@ -63,7 +63,7 @@ spec:
             - name: BENCH_ENVS
               value: "basic"
             - name: BENCH_LANES
-              value: "glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-54-nano,gpt-54-mini,mimo-25,qwen36-35b-a3b,qwen36-27b"
+              value: "glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-56-luna,mimo-25,qwen36-35b-a3b,qwen36-27b"
             # Dagger runner host is resolved from the live staging Deployment by CI.
             # Setting it also turns on the code sandbox (gated on the host's presence).
             - name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST

--- a/ai-labs/lanes.toml
+++ b/ai-labs/lanes.toml
@@ -52,14 +52,9 @@ provider = "openrouter"
 model = "minimax/minimax-m3"
 
 [[lane]]
-name = "gpt-54-nano"
+name = "gpt-56-luna"
 provider = "openrouter"
-model = "openai/gpt-5.4-nano"
-
-[[lane]]
-name = "gpt-54-mini"
-provider = "openrouter"
-model = "openai/gpt-5.4-mini"
+model = "openai/gpt-5.6-luna"
 
 [[lane]]
 name = "claude-haiku-45"


### PR DESCRIPTION
## Summary
- replace the GPT-5.4 Nano and Mini benchmark lanes with GPT-5.6 Luna
- run the CI benchmark once for the consolidated Luna lane

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test -p archestra_bench --test integration

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>