### PR TITLE
feat: pre-populate demo apps for orgs without apps

### DIFF
--- a/platform/backend/src/database/seed.test.ts
+++ b/platform/backend/src/database/seed.test.ts
@@ -1,4 +1,5 @@
 import {
+  ADMIN_ROLE_NAME,
   ARCHESTRA_TOOL_PREFIX,
   BUILT_IN_AGENT_IDS,
   BUILT_IN_AGENT_NAMES,
@@ -6,20 +7,32 @@ import {
   CONTEXT_COMPACTION_SYSTEM_PROMPT,
   POLICY_CONFIG_SYSTEM_PROMPT,
 } from "@archestra/shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { afterEach } from "vitest";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import config from "@/config";
 import db, { schema } from "@/database";
-import { OrganizationModel, SkillFileModel, SkillModel } from "@/models";
+import {
+  AppModel,
+  AppVersionModel,
+  OrganizationModel,
+  SkillFileModel,
+  SkillModel,
+} from "@/models";
 import AgentModel from "@/models/agent";
+import { DEFAULT_APPS } from "@/services/apps/default-apps";
 import {
   BUILT_IN_SKILLS,
   builtInSkillSourceRef,
   builtInSkillVersion,
 } from "@/skills/built-in-skills";
 import { describe, expect, test } from "@/test";
-import { decideEnvSeed, syncBuiltInAgents, syncBuiltInSkills } from "./seed";
+import {
+  decideEnvSeed,
+  seedDefaultAppsForPristineOrgs,
+  syncBuiltInAgents,
+  syncBuiltInSkills,
+} from "./seed";
 
 const [BASE_SKILL] = BUILT_IN_SKILLS;
 
@@ -502,5 +515,134 @@ describe("decideEnvSeed", () => {
       kind: "create",
       persistedBaseUrl: null,
     });
+  });
+});
+
+describe("seedDefaultAppsForPristineOrgs", () => {
+  test("seeds the default apps into an org that never had one", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const admin = await makeUser();
+    await makeMember(admin.id, org.id, { role: ADMIN_ROLE_NAME });
+
+    await seedDefaultAppsForPristineOrgs();
+
+    const apps = await db
+      .select()
+      .from(schema.appsTable)
+      .where(eq(schema.appsTable.organizationId, org.id));
+    expect(apps).toHaveLength(DEFAULT_APPS.length);
+    expect(new Set(apps.map((app) => app.name))).toEqual(
+      new Set(DEFAULT_APPS.map((definition) => definition.name)),
+    );
+    for (const app of apps) {
+      expect(app.authorId).toBe(admin.id);
+      expect(app.mcpServerId).not.toBeNull();
+      expect(app.templateId).toMatch(/^default-app:/);
+    }
+
+    // Version 1 carries the shipped HTML and the backing is org-scoped.
+    const [taskTracker] = apps.filter(
+      (app) => app.name === "Demo Task Tracker",
+    );
+    const loaded = await AppModel.findById(taskTracker.id);
+    expect(loaded?.scope).toBe("org");
+    const version = await AppVersionModel.findByAppAndVersion(
+      taskTracker.id,
+      1,
+    );
+    expect(version?.html).toContain("<!DOCTYPE html>");
+  });
+
+  test("is idempotent across restarts", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const admin = await makeUser();
+    await makeMember(admin.id, org.id, { role: ADMIN_ROLE_NAME });
+
+    await seedDefaultAppsForPristineOrgs();
+    await seedDefaultAppsForPristineOrgs();
+
+    const apps = await db
+      .select()
+      .from(schema.appsTable)
+      .where(eq(schema.appsTable.organizationId, org.id));
+    expect(apps).toHaveLength(DEFAULT_APPS.length);
+  });
+
+  test("leaves an org with an existing app untouched", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeApp,
+  }) => {
+    const org = await makeOrganization();
+    const admin = await makeUser();
+    await makeMember(admin.id, org.id, { role: ADMIN_ROLE_NAME });
+    const existing = await makeApp({
+      organizationId: org.id,
+      authorId: admin.id,
+    });
+
+    await seedDefaultAppsForPristineOrgs();
+
+    const apps = await db
+      .select()
+      .from(schema.appsTable)
+      .where(eq(schema.appsTable.organizationId, org.id));
+    expect(apps.map((app) => app.id)).toEqual([existing.id]);
+  });
+
+  test("does not resurrect demos into an org whose apps were all deleted", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeApp,
+  }) => {
+    const org = await makeOrganization();
+    const admin = await makeUser();
+    await makeMember(admin.id, org.id, { role: ADMIN_ROLE_NAME });
+    const existing = await makeApp({
+      organizationId: org.id,
+      authorId: admin.id,
+    });
+    await AppModel.delete(existing.id);
+
+    await seedDefaultAppsForPristineOrgs();
+
+    const active = await db
+      .select()
+      .from(schema.appsTable)
+      .where(
+        and(
+          eq(schema.appsTable.organizationId, org.id),
+          isNull(schema.appsTable.deletedAt),
+        ),
+      );
+    expect(active).toHaveLength(0);
+  });
+
+  test("skips an org with no admin member", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const member = await makeUser();
+    await makeMember(member.id, org.id);
+
+    await seedDefaultAppsForPristineOrgs();
+
+    const apps = await db
+      .select()
+      .from(schema.appsTable)
+      .where(eq(schema.appsTable.organizationId, org.id));
+    expect(apps).toHaveLength(0);
   });
 });

--- a/platform/backend/src/database/seed.ts
+++ b/platform/backend/src/database/seed.ts
@@ -20,7 +20,7 @@ import {
   SupportedProviders,
   testMcpServerCommand,
 } from "@archestra/shared";
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import config, {
   getProviderConfiguredBaseUrl,
@@ -31,6 +31,7 @@ import logger from "@/logging";
 import {
   AgentExcludedToolModel,
   AgentModel,
+  AppModel,
   InternalMcpCatalogModel,
   LlmProviderApiKeyModel,
   McpHttpSessionModel,
@@ -44,6 +45,8 @@ import {
   UserModel,
 } from "@/models";
 import { secretManager } from "@/secrets-manager";
+import { createAppBacking } from "@/services/apps/app-mcp-backing";
+import { DEFAULT_APPS, loadDefaultAppHtml } from "@/services/apps/default-apps";
 import { modelSyncService } from "@/services/model-sync";
 import {
   BUILT_IN_SKILLS,
@@ -887,6 +890,103 @@ async function enableSkillToolsForExistingOrgs(): Promise<void> {
   }
 }
 
+/**
+ * Pre-populate the demo apps into every organization that has never had an
+ * app, so the Apps page opens with working examples instead of an empty state.
+ *
+ * "Never had an app" deliberately includes soft-deleted rows: an org where
+ * someone created and then deleted apps has made a choice, and startup must
+ * not resurrect demo content there. Runs on every startup, so an org created
+ * mid-flight is picked up on the next boot, and a partial failure only skips
+ * the app that failed.
+ *
+ * @public — exported for testability
+ */
+export async function seedDefaultAppsForPristineOrgs(): Promise<void> {
+  const organizations = await db
+    .select({ id: schema.organizationsTable.id })
+    .from(schema.organizationsTable);
+
+  for (const org of organizations) {
+    try {
+      const [existingApp] = await db
+        .select({ id: schema.appsTable.id })
+        .from(schema.appsTable)
+        .where(eq(schema.appsTable.organizationId, org.id))
+        .limit(1);
+      if (existingApp) continue;
+
+      // Seeded apps need an author (backing rows and the launch-tool
+      // auto-assign are keyed on a user): the org's earliest admin.
+      const [admin] = await db
+        .select({ userId: schema.membersTable.userId })
+        .from(schema.membersTable)
+        .where(
+          and(
+            eq(schema.membersTable.organizationId, org.id),
+            eq(schema.membersTable.role, ADMIN_ROLE_NAME),
+          ),
+        )
+        .orderBy(asc(schema.membersTable.createdAt))
+        .limit(1);
+      if (!admin) continue;
+
+      let created = 0;
+      for (const definition of DEFAULT_APPS) {
+        try {
+          const app = await AppModel.create({
+            app: {
+              organizationId: org.id,
+              authorId: admin.userId,
+              name: definition.name,
+              description: definition.description,
+              templateId: definition.templateId,
+            },
+            payload: {
+              html: loadDefaultAppHtml(definition),
+              uiPermissions: null,
+            },
+          });
+          try {
+            // Org scope so every member sees the demos, mirroring built-in
+            // skills. An app must never exist without its backing — on
+            // backing failure remove the app row (same invariant as the
+            // create route).
+            await createAppBacking({
+              app,
+              scope: "org",
+              environmentId: null,
+              userId: admin.userId,
+              organizationId: org.id,
+              teamIds: [],
+            });
+          } catch (backingError) {
+            await AppModel.purge(app.id);
+            throw backingError;
+          }
+          created++;
+        } catch (error) {
+          logger.error(
+            { err: error, organizationId: org.id, app: definition.name },
+            "Failed to seed default app",
+          );
+        }
+      }
+      if (created > 0) {
+        logger.info(
+          { organizationId: org.id, count: created },
+          "Seeded default apps for organization",
+        );
+      }
+    } catch (error) {
+      logger.error(
+        { err: error, organizationId: org.id },
+        "Failed to seed default apps for organization",
+      );
+    }
+  }
+}
+
 export async function seedRequiredStartingData(): Promise<void> {
   ensureEncryptionKeyAvailable();
   await migrateSecretsToEncrypted();
@@ -907,6 +1007,7 @@ export async function seedRequiredStartingData(): Promise<void> {
   // Ensure all existing members have a personal MCP gateway
   await ensureExistingUsersHavePersonalMcpGateways();
   await ensureExistingUsersHavePersonalLlmProxies();
+  await seedDefaultAppsForPristineOrgs();
   // Clean up orphaned MCP HTTP sessions (older than 24h)
   await McpHttpSessionModel.deleteExpired();
 }

--- a/platform/backend/src/services/apps/default-apps.ts
+++ b/platform/backend/src/services/apps/default-apps.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import config from "@/config";
+
+/**
+ * Demo MCP Apps seeded into organizations that have never had an app, so the
+ * Apps page demonstrates what apps can do instead of starting empty (see
+ * `seedDefaultAppsForPristineOrgs` in `database/seed.ts`). Each app's HTML is
+ * a plain committed document under `src/static/default-apps/` (the static dir
+ * the build already copies to dist) — not a TS template literal, so authors
+ * can edit real HTML and backslashes/backticks survive verbatim.
+ *
+ * Identity is the `templateId` provenance marker stored on the app row. Seeded
+ * apps are ordinary apps in every other way: org-scoped, fully editable, and
+ * deletable — a deleted one is never resurrected because seeding only targets
+ * orgs with no app rows at all (soft-deleted included).
+ */
+interface DefaultAppDefinition {
+  /** Stable provenance marker stored in `apps.template_id`; never reuse. */
+  templateId: string;
+  name: string;
+  description: string;
+  /** Filename under the backend static dir's `default-apps/`. */
+  htmlFile: string;
+}
+
+export const DEFAULT_APPS: readonly DefaultAppDefinition[] = [
+  {
+    templateId: "default-app:demo-task-tracker",
+    name: "Demo Task Tracker",
+    description:
+      "A simple task tracker demo app that uses Archestra's persistent shared data layer. Features a cinematic intro loader and lets colleagues collaborate on tasks together.",
+    htmlFile: "demo-task-tracker.html",
+  },
+  {
+    templateId: "default-app:demo-multiplayer-video-game",
+    name: "Demo Multiplayer Video Game",
+    description:
+      "An 8-bit styled 2D top-down multiplayer shooter with a randomly generated map, built as a mini app in Archestra. Uses Archestra's shared data layer for multiplayer state and persistent storage so it can be shared with colleagues and played together.",
+    htmlFile: "demo-multiplayer-video-game.html",
+  },
+  {
+    templateId: "default-app:demo-data-analysis-tool",
+    name: "Demo Data Analysis Tool",
+    description:
+      "A stylish graph viewer with timeframe selectors and a cinematic intro loader, built as a mini app in Archestra using the shared data layer for persistent, multiplayer-friendly storage.",
+    htmlFile: "demo-data-analysis-tool.html",
+  },
+  {
+    templateId: "default-app:demo-3d-object-viewer",
+    name: "Demo 3D Object Viewer",
+    description:
+      "A stylish 3D object viewer that displays a randomly generated complex 3D shape you can rotate, with a cinematic fade-in/fade-out intro loader. Built as a mini app in Archestra.",
+    htmlFile: "demo-3d-object-viewer.html",
+  },
+];
+
+/**
+ * Read a default app's HTML from the backend static dir (same dir the sandbox
+ * proxy is served from, so it resolves in src under tsx/vitest and in dist in
+ * a production build).
+ */
+export function loadDefaultAppHtml(app: DefaultAppDefinition): string {
+  const file = path.join(
+    path.dirname(config.mcpSandbox.filePath),
+    "default-apps",
+    app.htmlFile,
+  );
+  try {
+    return readFileSync(file, "utf-8");
+  } catch (err) {
+    throw new Error(
+      `Default app HTML "${app.htmlFile}" not found at ${file}. The file is committed under src/static/default-apps and copied to dist by the build. Cause: ${String(err)}`,
+    );
+  }
+}

--- a/platform/backend/src/static/default-apps/demo-3d-object-viewer.html
+++ b/platform/backend/src/static/default-apps/demo-3d-object-viewer.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo 3D Object Viewer</title>
+  <style>
+    html, body {
+      margin: 0; padding: 0; height: 100%; overflow: hidden;
+      background: #000; color: #fff; font-family: var(--font-sans, system-ui, sans-serif);
+    }
+    #scene { position: fixed; inset: 0; width: 100%; height: 100%; display: block; touch-action: none; cursor: grab; }
+    #scene:active { cursor: grabbing; }
+
+    /* Intro loader overlay */
+    #intro {
+      position: fixed; inset: 0; z-index: 50;
+      background: #000; color: #fff;
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      text-align: center; padding: 2rem; box-sizing: border-box;
+      transition: opacity 1.2s ease;
+    }
+    #intro.hide { opacity: 0; pointer-events: none; }
+    .intro-lines { max-width: 34rem; min-height: 4.5rem; display: flex; align-items: center; justify-content: center; }
+    .intro-line {
+      position: absolute; opacity: 0;
+      font-size: 1.5rem; line-height: 1.5; font-weight: 300;
+      letter-spacing: 0.02em;
+      transition: opacity 1s ease;
+    }
+    .intro-line.show { opacity: 1; }
+    .intro-dot {
+      margin-top: 3rem; width: 8px; height: 8px; border-radius: 50%;
+      background: #fff; opacity: 0.4;
+      animation: pulse 1.4s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.15; transform: scale(0.8); }
+      50% { opacity: 0.9; transform: scale(1.3); }
+    }
+
+    /* HUD controls */
+    #hud {
+      position: fixed; left: 0; right: 0; bottom: 0; z-index: 20;
+      display: flex; gap: 0.75rem; justify-content: center; align-items: center;
+      padding: 1rem; box-sizing: border-box;
+      opacity: 0; transition: opacity 0.8s ease;
+    }
+    #hud.show { opacity: 1; }
+    .hud-btn {
+      background: rgba(255,255,255,0.08); color: #fff;
+      border: 1px solid rgba(255,255,255,0.25);
+      padding: 0.6rem 1.1rem; border-radius: 999px;
+      font-size: 0.9rem; cursor: pointer; backdrop-filter: blur(8px);
+      transition: background 0.2s ease, border-color 0.2s ease;
+    }
+    .hud-btn:hover { background: rgba(255,255,255,0.18); border-color: rgba(255,255,255,0.5); }
+    #title {
+      position: fixed; top: 0; left: 0; z-index: 20;
+      padding: 1.25rem 1.5rem;
+      opacity: 0; transition: opacity 0.8s ease;
+    }
+    #title.show { opacity: 1; }
+    #title h1 { margin: 0; font-size: 1.1rem; font-weight: 400; letter-spacing: 0.03em; }
+    #title p { margin: 0.2rem 0 0; font-size: 0.8rem; color: rgba(255,255,255,0.5); }
+  </style>
+</head>
+<body>
+  <canvas id="scene"></canvas>
+
+  <div id="title">
+    <h1>Demo 3D Object Viewer</h1>
+    <p>Drag to rotate · scroll to zoom</p>
+  </div>
+
+  <div id="hud">
+    <button class="hud-btn" id="btn-new">Generate new object</button>
+    <button class="hud-btn" id="btn-spin">Pause spin</button>
+  </div>
+
+  <div id="intro">
+    <div class="intro-lines" id="intro-lines"></div>
+    <div class="intro-dot"></div>
+  </div>
+
+  <script type="module">
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+
+    /* ---------- Intro sequence ---------- */
+    const introLines = [
+      'This app was built as a mini app in Archestra',
+      "It's using Archestra's data layer for persistent storage",
+      'It can be shared with colleagues and used together',
+      'Try creating apps yourself'
+    ];
+    const linesEl = document.getElementById('intro-lines');
+    const lineNodes = introLines.map(t => {
+      const d = document.createElement('div');
+      d.className = 'intro-line';
+      d.textContent = t;
+      linesEl.appendChild(d);
+      return d;
+    });
+
+    function runIntro() {
+      return new Promise(resolve => {
+        let i = 0;
+        const showNext = () => {
+          if (i >= lineNodes.length) {
+            const intro = document.getElementById('intro');
+            intro.classList.add('hide');
+            setTimeout(resolve, 1300);
+            return;
+          }
+          const node = lineNodes[i];
+          node.classList.add('show');
+          setTimeout(() => {
+            node.classList.remove('show');
+            setTimeout(() => { i++; showNext(); }, 1000);
+          }, 2200);
+        };
+        setTimeout(showNext, 500);
+      });
+    }
+
+    /* ---------- Three.js scene ---------- */
+    const canvas = document.getElementById('scene');
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x000000);
+
+    const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+    camera.position.set(0, 0, 6);
+
+    const key = new THREE.DirectionalLight(0xffffff, 2.2);
+    key.position.set(4, 6, 5);
+    scene.add(key);
+    const rim = new THREE.DirectionalLight(0x88aaff, 1.4);
+    rim.position.set(-5, -2, -4);
+    scene.add(rim);
+    scene.add(new THREE.AmbientLight(0x404040, 1.2));
+
+    let objectGroup = null;
+
+    // deterministic PRNG from a numeric seed
+    function mulberry32(a) {
+      return function () {
+        a |= 0; a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    function buildObject(seed) {
+      const rand = mulberry32(seed);
+      const group = new THREE.Group();
+
+      const hue = rand();
+      const geometries = [
+        () => new THREE.IcosahedronGeometry(1, 1),
+        () => new THREE.TorusKnotGeometry(0.7, 0.26, 128, 24, 2 + Math.floor(rand()*4), 3 + Math.floor(rand()*4)),
+        () => new THREE.OctahedronGeometry(1.1, 2),
+        () => new THREE.DodecahedronGeometry(1.05, 0),
+        () => new THREE.TorusGeometry(0.9, 0.32, 24, 96)
+      ];
+      const pick = geometries[Math.floor(rand() * geometries.length)];
+      const coreGeo = pick();
+
+      const coreMat = new THREE.MeshStandardMaterial({
+        color: new THREE.Color().setHSL(hue, 0.65, 0.55),
+        metalness: 0.6, roughness: 0.25, flatShading: rand() > 0.5
+      });
+      const core = new THREE.Mesh(coreGeo, coreMat);
+      group.add(core);
+
+      // wireframe shell
+      const shell = new THREE.Mesh(
+        coreGeo.clone(),
+        new THREE.MeshBasicMaterial({
+          color: new THREE.Color().setHSL((hue + 0.5) % 1, 0.8, 0.7),
+          wireframe: true, transparent: true, opacity: 0.25
+        })
+      );
+      shell.scale.setScalar(1.25);
+      group.add(shell);
+
+      // orbiting satellites
+      const count = 6 + Math.floor(rand() * 10);
+      const satGeo = new THREE.IcosahedronGeometry(0.12, 0);
+      for (let i = 0; i < count; i++) {
+        const mat = new THREE.MeshStandardMaterial({
+          color: new THREE.Color().setHSL((hue + rand() * 0.3) % 1, 0.7, 0.6),
+          metalness: 0.5, roughness: 0.3
+        });
+        const s = new THREE.Mesh(satGeo, mat);
+        const r = 1.6 + rand() * 1.2;
+        const theta = rand() * Math.PI * 2;
+        const phi = Math.acos(2 * rand() - 1);
+        s.position.set(
+          r * Math.sin(phi) * Math.cos(theta),
+          r * Math.sin(phi) * Math.sin(theta),
+          r * Math.cos(phi)
+        );
+        s.scale.setScalar(0.6 + rand() * 1.6);
+        group.add(s);
+      }
+      return group;
+    }
+
+    function setObject(seed) {
+      if (objectGroup) scene.remove(objectGroup);
+      objectGroup = buildObject(seed);
+      scene.add(objectGroup);
+    }
+
+    /* ---------- Interaction: rotate + zoom ---------- */
+    let dragging = false, px = 0, py = 0;
+    let rotY = 0.4, rotX = 0.2, velY = 0, velX = 0;
+    let autoSpin = true;
+
+    canvas.addEventListener('pointerdown', e => {
+      dragging = true; px = e.clientX; py = e.clientY;
+      canvas.setPointerCapture(e.pointerId);
+    });
+    canvas.addEventListener('pointermove', e => {
+      if (!dragging) return;
+      const dx = e.clientX - px, dy = e.clientY - py;
+      px = e.clientX; py = e.clientY;
+      rotY += dx * 0.008; rotX += dy * 0.008;
+      velY = dx * 0.008; velX = dy * 0.008;
+    });
+    const endDrag = () => { dragging = false; };
+    canvas.addEventListener('pointerup', endDrag);
+    canvas.addEventListener('pointercancel', endDrag);
+    canvas.addEventListener('wheel', e => {
+      e.preventDefault();
+      camera.position.z = Math.min(12, Math.max(3, camera.position.z + e.deltaY * 0.01));
+    }, { passive: false });
+
+    function resize() {
+      const w = window.innerWidth, h = window.innerHeight;
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    function animate() {
+      requestAnimationFrame(animate);
+      if (!dragging) {
+        velY *= 0.95; velX *= 0.95;
+        rotY += velY; rotX += velX;
+        if (autoSpin) rotY += 0.003;
+      }
+      rotX = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, rotX));
+      if (objectGroup) {
+        objectGroup.rotation.y = rotY;
+        objectGroup.rotation.x = rotX;
+        objectGroup.children.forEach((c, i) => {
+          if (i > 1) { c.rotation.y += 0.01 + i * 0.001; }
+        });
+      }
+      renderer.render(scene, camera);
+    }
+    animate();
+
+    /* ---------- Persistent storage of the current seed (shared) ---------- */
+    async function loadOrCreateSeed() {
+      try {
+        await archestra.ready;
+        const entry = await archestra.storage.shared.get('current-seed');
+        if (entry && typeof entry.value === 'number') return entry.value;
+        const seed = Math.floor(Math.random() * 1e9);
+        await archestra.storage.shared.set('current-seed', seed);
+        return seed;
+      } catch (e) {
+        return Math.floor(Math.random() * 1e9);
+      }
+    }
+    async function saveSeed(seed) {
+      try { await archestra.storage.shared.set('current-seed', seed); } catch (e) {}
+    }
+
+    /* ---------- Wire up HUD ---------- */
+    document.getElementById('btn-new').addEventListener('click', async () => {
+      const seed = Math.floor(Math.random() * 1e9);
+      setObject(seed);
+      saveSeed(seed);
+    });
+    const spinBtn = document.getElementById('btn-spin');
+    spinBtn.addEventListener('click', () => {
+      autoSpin = !autoSpin;
+      spinBtn.textContent = autoSpin ? 'Pause spin' : 'Resume spin';
+    });
+
+    /* ---------- Boot ---------- */
+    (async () => {
+      const seed = await loadOrCreateSeed();
+      setObject(seed);
+      await runIntro();
+      document.getElementById('title').classList.add('show');
+      document.getElementById('hud').classList.add('show');
+    })();
+  </script>
+</body>
+</html>

--- a/platform/backend/src/static/default-apps/demo-data-analysis-tool.html
+++ b/platform/backend/src/static/default-apps/demo-data-analysis-tool.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo Data Analysis Tool</title>
+  <style>
+    :root {
+      --bg: #060607;
+      --panel: #0f1012;
+      --panel-2: #16181b;
+      --border: #24272c;
+      --text: #e9edf1;
+      --muted: #8b929c;
+      --accent: #5b9dff;
+      --accent-2: #7bffcf;
+      --up: #35d29a;
+      --down: #ff6b6b;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100dvh;
+      overflow-x: hidden;
+    }
+
+    /* ---------- Intro loader ---------- */
+    #intro {
+      position: fixed; inset: 0; z-index: 50;
+      background: #000;
+      display: flex; align-items: center; justify-content: center;
+      text-align: center; padding: 2rem;
+      transition: opacity 1s ease;
+    }
+    #intro.hide { opacity: 0; pointer-events: none; }
+    #intro-text {
+      color: #fff;
+      font-size: clamp(1.3rem, 4vw, 2.4rem);
+      font-weight: 300;
+      letter-spacing: 0.01em;
+      line-height: 1.4;
+      max-width: 42rem;
+      opacity: 0;
+      transform: translateY(6px);
+      transition: opacity 0.9s ease, transform 0.9s ease;
+    }
+    #intro-text.in { opacity: 1; transform: translateY(0); }
+    #intro-text strong { font-weight: 600; }
+    #skip {
+      position: fixed; bottom: 1.5rem; right: 1.5rem; z-index: 51;
+      background: transparent; border: 1px solid rgba(255,255,255,0.25);
+      color: rgba(255,255,255,0.7); font-size: 0.8rem;
+      padding: 0.4rem 0.9rem; border-radius: 999px; cursor: pointer;
+      transition: opacity 0.4s ease, color 0.2s, border-color 0.2s;
+    }
+    #skip:hover { color: #fff; border-color: rgba(255,255,255,0.6); }
+
+    /* ---------- Main app ---------- */
+    #app { opacity: 0; transition: opacity 1s ease; padding: 1.5rem clamp(1rem, 4vw, 3rem) 3rem; max-width: 1080px; margin: 0 auto; }
+    #app.show { opacity: 1; }
+
+    header.head { display: flex; align-items: center; gap: 0.9rem; margin-bottom: 1.75rem; }
+    .brand-mark { width: 34px; height: 34px; border-radius: 9px; flex: none; box-shadow: 0 6px 18px rgba(0,0,0,0.5); }
+    .head h1 { font-size: 1.35rem; margin: 0; font-weight: 600; }
+    .head p { margin: 0.15rem 0 0; color: var(--muted); font-size: 0.85rem; }
+
+    .metrics { display: flex; gap: 0.6rem; flex-wrap: wrap; margin-bottom: 1.25rem; }
+    .metric-btn {
+      background: var(--panel); border: 1px solid var(--border); color: var(--muted);
+      padding: 0.55rem 1rem; border-radius: 10px; cursor: pointer; font-size: 0.85rem;
+      display: flex; align-items: center; gap: 0.5rem; transition: all 0.2s;
+    }
+    .metric-btn .dot { width: 9px; height: 9px; border-radius: 50%; }
+    .metric-btn:hover { border-color: #3a3f47; color: var(--text); }
+    .metric-btn.active { background: var(--panel-2); color: var(--text); border-color: var(--accent); }
+
+    .card {
+      background: var(--panel); border: 1px solid var(--border);
+      border-radius: 16px; padding: 1.5rem; margin-bottom: 1.25rem;
+    }
+
+    .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+    .stat { background: var(--panel-2); border: 1px solid var(--border); border-radius: 12px; padding: 1rem 1.1rem; }
+    .stat .label { color: var(--muted); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; }
+    .stat .value { font-size: 1.5rem; font-weight: 600; margin-top: 0.35rem; font-variant-numeric: tabular-nums; }
+    .stat .value.up { color: var(--up); }
+    .stat .value.down { color: var(--down); }
+
+    .chart-head { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 0.5rem; flex-wrap: wrap; gap: 0.75rem; }
+    .chart-title { font-size: 0.95rem; color: var(--muted); }
+    .chart-title b { color: var(--text); font-size: 1.05rem; display: block; margin-top: 0.15rem; }
+
+    .timeframes { display: flex; gap: 0.3rem; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 0.25rem; }
+    .tf-btn { background: transparent; border: none; color: var(--muted); padding: 0.35rem 0.7rem; border-radius: 7px; cursor: pointer; font-size: 0.78rem; font-weight: 500; transition: all 0.18s; }
+    .tf-btn:hover { color: var(--text); }
+    .tf-btn.active { background: var(--accent); color: #04122b; }
+
+    .chart-wrap { position: relative; width: 100%; height: 320px; }
+    svg.chart { width: 100%; height: 100%; display: block; overflow: visible; }
+    .grid-line { stroke: var(--border); stroke-width: 1; }
+    .area-path { transition: opacity 0.3s; }
+    .line-path { fill: none; stroke-width: 2.5; stroke-linejoin: round; stroke-linecap: round; }
+    .hover-dot { r: 5; }
+    .axis-label { fill: var(--muted); font-size: 0.68rem; }
+    .tooltip {
+      position: absolute; pointer-events: none; background: #000; border: 1px solid var(--border);
+      border-radius: 8px; padding: 0.4rem 0.65rem; font-size: 0.78rem; opacity: 0;
+      transition: opacity 0.15s; transform: translate(-50%, -120%); white-space: nowrap;
+    }
+    .tooltip .t-val { font-weight: 600; font-variant-numeric: tabular-nums; }
+    .tooltip .t-date { color: var(--muted); font-size: 0.68rem; }
+
+    .footer-note { display: flex; align-items: center; gap: 0.5rem; color: var(--muted); font-size: 0.78rem; margin-top: 0.5rem; }
+    .live-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent-2); box-shadow: 0 0 8px var(--accent-2); }
+  </style>
+</head>
+<body>
+  <div id="intro">
+    <div id="intro-text"></div>
+  </div>
+  <button id="skip" type="button">Skip intro</button>
+
+  <main id="app">
+    <header class="head">
+      <svg class="brand-mark" viewBox="0 0 994 953" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <rect width="993.958" height="952.543" rx="204.92" fill="black"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M390.871 664.818C427.68 664.818 460.629 641.985 473.553 607.519L565.238 363.026C586.887 305.296 544.211 243.715 482.556 243.715C445.747 243.715 412.798 266.548 399.874 301.014L308.189 545.507C286.54 603.237 329.216 664.818 390.871 664.818Z" fill="white"/>
+        <ellipse cx="638.487" cy="577.095" rx="87.7298" ry="81.1501" fill="white"/>
+      </svg>
+      <div>
+        <h1>Demo Data Analysis Tool</h1>
+        <p>Time-series explorer &middot; built in Archestra</p>
+      </div>
+    </header>
+
+    <div class="metrics" id="metrics"></div>
+
+    <div class="stats" id="stats"></div>
+
+    <div class="card">
+      <div class="chart-head">
+        <div class="chart-title">Selected metric<b id="chart-metric-name">—</b></div>
+        <div class="timeframes" id="timeframes"></div>
+      </div>
+      <div class="chart-wrap">
+        <svg class="chart" id="chart" preserveAspectRatio="none"></svg>
+        <div class="tooltip" id="tooltip"></div>
+      </div>
+      <div class="footer-note"><span class="live-dot"></span><span id="sync-note">Selections sync via Archestra's shared data layer</span></div>
+    </div>
+  </main>
+
+  <script>
+  (function () {
+    // ---------- Intro sequence ----------
+    const introEl = document.getElementById('intro');
+    const introText = document.getElementById('intro-text');
+    const skipBtn = document.getElementById('skip');
+    const appEl = document.getElementById('app');
+
+    const messages = [
+      'This app was built as a <strong>mini app in Archestra</strong>.',
+      "It uses Archestra's <strong>data layer</strong> for persistent storage.",
+      'It can be <strong>shared with colleagues</strong> and used together.',
+      'Try <strong>creating apps</strong> yourself.'
+    ];
+
+    let introTimers = [];
+    let introDone = false;
+
+    function clearIntroTimers() { introTimers.forEach(clearTimeout); introTimers = []; }
+
+    function finishIntro() {
+      if (introDone) return;
+      introDone = true;
+      clearIntroTimers();
+      introEl.classList.add('hide');
+      skipBtn.style.opacity = '0';
+      appEl.classList.add('show');
+      setTimeout(() => { introEl.style.display = 'none'; skipBtn.style.display = 'none'; }, 1100);
+    }
+
+    function runIntro() {
+      const IN = 900, HOLD = 1500, OUT = 900;
+      let t = 400;
+      messages.forEach((msg) => {
+        introTimers.push(setTimeout(() => { introText.innerHTML = msg; introText.classList.add('in'); }, t));
+        t += IN + HOLD;
+        introTimers.push(setTimeout(() => { introText.classList.remove('in'); }, t));
+        t += OUT;
+      });
+      introTimers.push(setTimeout(finishIntro, t + 300));
+    }
+
+    skipBtn.addEventListener('click', finishIntro);
+    runIntro();
+
+    // ---------- Demo data ----------
+    const METRICS = [
+      { id: 'revenue', name: 'Revenue', unit: '$', color: '#5b9dff', base: 48000, vol: 0.9, seed: 11 },
+      { id: 'active_users', name: 'Active Users', unit: '', color: '#7bffcf', base: 12400, vol: 1.1, seed: 29 },
+      { id: 'latency', name: 'Latency', unit: 'ms', color: '#ffb454', base: 180, vol: 0.7, seed: 47 },
+      { id: 'conversion', name: 'Conversion', unit: '%', color: '#c58bff', base: 3.2, vol: 0.6, seed: 63 }
+    ];
+    const TIMEFRAMES = [
+      { id: '1D', points: 24, stepMs: 3600e3, fmt: 'time' },
+      { id: '1W', points: 7, stepMs: 86400e3, fmt: 'day' },
+      { id: '1M', points: 30, stepMs: 86400e3, fmt: 'date' },
+      { id: '3M', points: 90, stepMs: 86400e3, fmt: 'date' },
+      { id: '1Y', points: 52, stepMs: 7*86400e3, fmt: 'date' },
+      { id: 'ALL', points: 120, stepMs: 30*86400e3, fmt: 'month' }
+    ];
+
+    function mulberry32(a) {
+      return function () {
+        a |= 0; a = a + 0x6D2B79F5 | 0;
+        let t = Math.imul(a ^ a >>> 15, 1 | a);
+        t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+        return ((t ^ t >>> 14) >>> 0) / 4294967296;
+      };
+    }
+
+    function buildSeries(metric, tf) {
+      const rnd = mulberry32(metric.seed * 1000 + tf.points);
+      const now = Date.now();
+      const pts = [];
+      let val = metric.base;
+      let trend = (rnd() - 0.45) * metric.base * 0.004;
+      for (let i = tf.points - 1; i >= 0; i--) {
+        const noise = (rnd() - 0.5) * metric.base * 0.03 * metric.vol;
+        trend += (rnd() - 0.5) * metric.base * 0.0008;
+        val = Math.max(metric.base * 0.3, val + trend + noise);
+        pts.push({ t: now - i * tf.stepMs, v: val });
+      }
+      return pts;
+    }
+
+    function fmtNum(metric, v) {
+      if (metric.unit === '$') return '$' + Math.round(v).toLocaleString();
+      if (metric.unit === '%') return v.toFixed(2) + '%';
+      if (metric.unit === 'ms') return Math.round(v) + ' ms';
+      return Math.round(v).toLocaleString();
+    }
+
+    function fmtDate(ms, fmt) {
+      const d = new Date(ms);
+      if (fmt === 'time') return d.getHours() + ':00';
+      if (fmt === 'day') return d.toLocaleDateString(undefined, { weekday: 'short' });
+      if (fmt === 'month') return d.toLocaleDateString(undefined, { month: 'short', year: '2-digit' });
+      return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    }
+
+    // ---------- State ----------
+    let state = { metric: 'revenue', timeframe: '1M' };
+    let current = { series: [], metric: null, tf: null };
+
+    const metricsEl = document.getElementById('metrics');
+    const tfEl = document.getElementById('timeframes');
+    const statsEl = document.getElementById('stats');
+    const chart = document.getElementById('chart');
+    const tooltip = document.getElementById('tooltip');
+    const metricNameEl = document.getElementById('chart-metric-name');
+    const syncNote = document.getElementById('sync-note');
+
+    function renderControls() {
+      metricsEl.innerHTML = '';
+      METRICS.forEach(m => {
+        const b = document.createElement('button');
+        b.className = 'metric-btn' + (m.id === state.metric ? ' active' : '');
+        b.innerHTML = '<span class="dot" style="background:' + m.color + '"></span>' + m.name;
+        b.onclick = () => { state.metric = m.id; persist(); render(); };
+        metricsEl.appendChild(b);
+      });
+      tfEl.innerHTML = '';
+      TIMEFRAMES.forEach(tf => {
+        const b = document.createElement('button');
+        b.className = 'tf-btn' + (tf.id === state.timeframe ? ' active' : '');
+        b.textContent = tf.id;
+        b.onclick = () => { state.timeframe = tf.id; persist(); render(); };
+        tfEl.appendChild(b);
+      });
+    }
+
+    function renderStats() {
+      const s = current.series, m = current.metric;
+      const first = s[0].v, last = s[s.length - 1].v;
+      const change = ((last - first) / first) * 100;
+      const hi = Math.max(...s.map(p => p.v));
+      const lo = Math.min(...s.map(p => p.v));
+      const dirClass = change >= 0 ? 'up' : 'down';
+      const sign = change >= 0 ? '+' : '';
+      statsEl.innerHTML =
+        stat('Current', fmtNum(m, last)) +
+        stat('Change', sign + change.toFixed(2) + '%', dirClass) +
+        stat('High', fmtNum(m, hi)) +
+        stat('Low', fmtNum(m, lo));
+    }
+    function stat(label, value, cls) {
+      return '<div class="stat"><div class="label">' + label + '</div><div class="value ' + (cls||'') + '">' + value + '</div></div>';
+    }
+
+    const W = 1000, H = 320, PAD_L = 8, PAD_R = 8, PAD_T = 18, PAD_B = 26;
+
+    function renderChart() {
+      const s = current.series, m = current.metric, tf = current.tf;
+      const vals = s.map(p => p.v);
+      let min = Math.min(...vals), max = Math.max(...vals);
+      const span = (max - min) || 1; min -= span * 0.12; max += span * 0.12;
+      const iw = W - PAD_L - PAD_R, ih = H - PAD_T - PAD_B;
+      const x = i => PAD_L + (i / (s.length - 1)) * iw;
+      const y = v => PAD_T + (1 - (v - min) / (max - min)) * ih;
+
+      let grid = '';
+      const rows = 4;
+      for (let r = 0; r <= rows; r++) {
+        const gy = PAD_T + (r / rows) * ih;
+        const gv = max - (r / rows) * (max - min);
+        grid += '<line class="grid-line" x1="' + PAD_L + '" y1="' + gy + '" x2="' + (W - PAD_R) + '" y2="' + gy + '"/>';
+        grid += '<text class="axis-label" x="' + (W - PAD_R) + '" y="' + (gy - 4) + '" text-anchor="end">' + fmtNum(m, gv) + '</text>';
+      }
+
+      const linePts = s.map((p, i) => x(i) + ',' + y(p.v));
+      const linePath = 'M' + linePts.join(' L');
+      const areaPath = linePath + ' L' + x(s.length - 1) + ',' + (PAD_T + ih) + ' L' + x(0) + ',' + (PAD_T + ih) + ' Z';
+
+      const labelIdx = [];
+      const ticks = Math.min(6, s.length);
+      for (let i = 0; i < ticks; i++) labelIdx.push(Math.round(i * (s.length - 1) / (ticks - 1)));
+      let xlabels = '';
+      labelIdx.forEach(i => {
+        xlabels += '<text class="axis-label" x="' + x(i) + '" y="' + (H - 6) + '" text-anchor="middle">' + fmtDate(s[i].t, tf.fmt) + '</text>';
+      });
+
+      const gid = 'grad-' + m.id;
+      chart.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
+      chart.innerHTML =
+        '<defs><linearGradient id="' + gid + '" x1="0" y1="0" x2="0" y2="1">' +
+          '<stop offset="0%" stop-color="' + m.color + '" stop-opacity="0.35"/>' +
+          '<stop offset="100%" stop-color="' + m.color + '" stop-opacity="0"/>' +
+        '</linearGradient></defs>' +
+        grid +
+        '<path class="area-path" d="' + areaPath + '" fill="url(#' + gid + ')"/>' +
+        '<path class="line-path" d="' + linePath + '" stroke="' + m.color + '"/>' +
+        xlabels +
+        '<circle class="hover-dot" id="hdot" fill="' + m.color + '" opacity="0"/>' +
+        '<rect id="hitbox" x="0" y="0" width="' + W + '" height="' + H + '" fill="transparent"/>';
+
+      const hdot = document.getElementById('hdot');
+      const hitbox = document.getElementById('hitbox');
+      hitbox.addEventListener('mousemove', ev => {
+        const rect = chart.getBoundingClientRect();
+        const px = (ev.clientX - rect.left) / rect.width * W;
+        let idx = Math.round((px - PAD_L) / iw * (s.length - 1));
+        idx = Math.max(0, Math.min(s.length - 1, idx));
+        const p = s[idx];
+        hdot.setAttribute('cx', x(idx)); hdot.setAttribute('cy', y(p.v)); hdot.setAttribute('opacity', '1');
+        const scrX = rect.left + (x(idx) / W) * rect.width;
+        const scrY = rect.top + (y(p.v) / H) * rect.height;
+        const wrapRect = chart.parentElement.getBoundingClientRect();
+        tooltip.style.left = (scrX - wrapRect.left) + 'px';
+        tooltip.style.top = (scrY - wrapRect.top) + 'px';
+        tooltip.innerHTML = '<div class="t-val">' + fmtNum(m, p.v) + '</div><div class="t-date">' + fmtDate(p.t, tf.fmt) + '</div>';
+        tooltip.style.opacity = '1';
+      });
+      hitbox.addEventListener('mouseleave', () => { hdot.setAttribute('opacity', '0'); tooltip.style.opacity = '0'; });
+    }
+
+    function render() {
+      const m = METRICS.find(x => x.id === state.metric) || METRICS[0];
+      const tf = TIMEFRAMES.find(x => x.id === state.timeframe) || TIMEFRAMES[2];
+      current.metric = m; current.tf = tf; current.series = buildSeries(m, tf);
+      metricNameEl.textContent = m.name + '  ·  ' + tf.id;
+      renderControls();
+      renderStats();
+      renderChart();
+    }
+
+    // ---------- Persistence via Archestra data layer ----------
+    const STORAGE_KEY = 'view_state';
+    let ready = false;
+
+    async function persist() {
+      if (!ready) return;
+      try {
+        await archestra.storage.shared.set(STORAGE_KEY, { metric: state.metric, timeframe: state.timeframe, by: archestra.user && archestra.user.name });
+      } catch (e) { /* non-fatal for the demo */ }
+    }
+
+    async function init() {
+      render();
+      try {
+        await archestra.ready;
+        ready = true;
+        const entry = await archestra.storage.shared.get(STORAGE_KEY);
+        if (entry && entry.value) {
+          if (entry.value.metric) state.metric = entry.value.metric;
+          if (entry.value.timeframe) state.timeframe = entry.value.timeframe;
+          render();
+          if (entry.value.by && archestra.user && entry.value.by !== archestra.user.name) {
+            syncNote.textContent = 'Last changed by ' + entry.value.by + ' · synced via Archestra';
+          }
+        }
+      } catch (e) {
+        syncNote.textContent = 'Demo data · storage unavailable in this preview';
+      }
+    }
+
+    init();
+  })();
+  </script>
+</body>
+</html>

--- a/platform/backend/src/static/default-apps/demo-multiplayer-video-game.html
+++ b/platform/backend/src/static/default-apps/demo-multiplayer-video-game.html
@@ -1,0 +1,465 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Demo Multiplayer Video Game</title>
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; background: #000; overflow: hidden; }
+  body {
+    font-family: 'Press Start 2P', monospace; color: #fff;
+    display: flex; align-items: center; justify-content: center;
+    -webkit-font-smoothing: none; image-rendering: pixelated; user-select: none;
+  }
+  #intro { position: fixed; inset: 0; background: #000; z-index: 50; display: flex; align-items: center; justify-content: center; text-align: center; }
+  #intro .line { position: absolute; opacity: 0; color: #fff; font-size: clamp(12px, 2.6vw, 22px); line-height: 1.9; max-width: 80%; letter-spacing: 1px; transition: opacity 0.9s ease; }
+  #intro .line.show { opacity: 1; }
+  #intro #skipBtn { position: fixed; bottom: 28px; right: 28px; font-size: 10px; padding: 10px 16px; z-index: 51; }
+  #intro .cursor { animation: blink 1s steps(1) infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+  #title { position: fixed; inset: 0; background: #000; z-index: 40; display: none; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 28px; opacity: 0; transition: opacity 0.8s ease; }
+  #title h1 { margin: 0; font-size: clamp(16px, 4.5vw, 42px); color: #7fff5a; text-shadow: 4px 4px 0 #044a04; line-height: 1.4; }
+  #title p { margin: 0; font-size: clamp(9px, 1.8vw, 13px); color: #9fe89f; line-height: 1.8; }
+  .field { display: flex; flex-direction: column; gap: 10px; align-items: center; }
+  #nameInput { font-family: inherit; font-size: 12px; text-align: center; color: #fff; background: #111; border: 3px solid #7fff5a; padding: 10px 12px; width: 240px; outline: none; }
+  .pxbtn { font-family: inherit; font-size: 13px; color: #000; background: #7fff5a; border: none; padding: 14px 22px; cursor: pointer; box-shadow: 4px 4px 0 #044a04; transition: transform .05s; }
+  .pxbtn:active { transform: translate(4px,4px); box-shadow: none; }
+  .hint { font-size: 8px; color: #567; line-height: 1.9; }
+  #game { position: fixed; inset: 0; display: none; }
+  canvas { display: block; width: 100%; height: 100%; image-rendering: pixelated; background: #0a1a0a; }
+  #hud { position: fixed; top: 10px; left: 10px; z-index: 10; font-size: 10px; line-height: 1.8; text-shadow: 2px 2px 0 #000; pointer-events: none; }
+  #hud .hp-wrap { width: 160px; height: 14px; border: 2px solid #fff; background:#300; margin-top:4px; }
+  #hud .hp-bar { height: 100%; background: #ff4b4b; width: 100%; transition: width .15s; }
+  #net { font-size: 8px; color: #567; margin-top: 4px; }
+  #players { position: fixed; top: 10px; right: 10px; z-index: 10; text-align: right; font-size: 9px; line-height: 2; text-shadow: 2px 2px 0 #000; }
+  #players b { color: #7fff5a; }
+  #respawn { position: fixed; inset: 0; z-index: 20; display: none; align-items: center; justify-content: center; flex-direction: column; gap: 20px; background: rgba(0,0,0,.72); text-align:center; }
+  #respawn h2 { color:#ff4b4b; font-size: clamp(16px,4vw,32px); text-shadow: 4px 4px 0 #400; }
+  .scan { position: fixed; inset: 0; z-index: 30; pointer-events: none; background: repeating-linear-gradient(0deg, rgba(0,0,0,0) 0 2px, rgba(0,0,0,.18) 2px 4px); mix-blend-mode: multiply; }
+</style>
+</head>
+<body>
+
+<div id="intro"><div class="line" id="introLine"></div><button type="button" class="pxbtn" id="skipBtn">SKIP ⏭</button></div>
+
+<div id="title">
+  <h1>DEMO<br>MULTIPLAYER<br>SHOOTER</h1>
+  <p>An 8-bit arena you can share &amp; play together</p>
+  <div class="field">
+    <input id="nameInput" maxlength="12" placeholder="ENTER NAME" />
+    <button class="pxbtn" id="startBtn">▶ ENTER ARENA</button>
+  </div>
+  <div class="hint">MOVE: WASD / ARROWS &nbsp;•&nbsp; AIM: MOUSE &nbsp;•&nbsp; SHOOT: CLICK / SPACE<br>Open this same app on another machine to join the fight.</div>
+</div>
+
+<div id="game"><canvas id="cv"></canvas></div>
+<div id="hud"></div>
+<div id="players"></div>
+<div id="respawn"><h2>YOU DIED</h2><button class="pxbtn" id="respawnBtn">RESPAWN</button></div>
+<div class="scan"></div>
+
+<script>
+// ============ INTRO LOADER ============
+const introEl = document.getElementById('intro');
+const introLine = document.getElementById('introLine');
+const titleEl = document.getElementById('title');
+const lines = [
+  "Built as a mini app in Archestra",
+  "Using Archestra's data layer for\nreal-time multiplayer & persistent storage",
+  "Share it with your colleagues\nand play together",
+  "Try creating apps yourself"
+];
+function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;'); }
+function runIntro(){
+  let i = 0;
+  (function next(){
+    if (i >= lines.length){ setTimeout(showTitle, 400); return; }
+    introLine.innerHTML = esc(lines[i]).replace(/\n/g,'<br>') + ' <span class="cursor">_</span>';
+    introLine.classList.add('show');
+    setTimeout(()=> introLine.classList.remove('show'), 2100);
+    setTimeout(()=>{ i++; next(); }, 3200);
+  })();
+}
+function showTitle(){
+  if(introEl.dataset.done) return;   // guard against double-fire (timer + skip)
+  introEl.dataset.done = '1';
+  introEl.style.opacity = '0';
+  setTimeout(()=>{ introEl.style.display='none'; titleEl.style.display='flex'; requestAnimationFrame(()=> titleEl.style.opacity='1'); }, 800);
+}
+document.getElementById('skipBtn').addEventListener('click', showTitle);
+setTimeout(runIntro, 500);
+
+// ============ CONSTANTS ============
+const TILE = 40, COLS = 40, ROWS = 30;
+const WORLD_W = TILE*COLS, WORLD_H = TILE*ROWS;
+const PLAYER_R = 12, BULLET_R = 4, SPEED = 3.4, BULLET_SPEED = 7, MAX_HP = 100;
+const SYNC_MS = 120;          // one get+set of the world table per this interval
+const LIVE_MS = 5000;         // drop a player if WE haven't seen their seq change in this long
+const SHOT_COOLDOWN = 220;
+const SHOT_LIFETIME = 1500;
+const MAX_SHOTS = 40;         // rolling cap on the shared shots list
+
+// ============ STATE ============
+const MY_ID = crypto.randomUUID();   // one identity per open session
+let me = null;                        // my player row (authoritative locally)
+let map = null, seed = 0;
+// The multiplayer TABLE, kept in memory and mirrored to shared storage key 'world'.
+// players: id -> { name, x, y, aim, hp, dead, kills, color, seq }
+let players = {};
+let shots = [];                       // shared rolling shot list [{id,owner,x,y,vx,vy,born}]
+let worldRev = undefined;             // last revision we read/wrote for 'world'
+const lastSeq = {};                   // id -> last seq we observed (remote liveness)
+const lastSeenLocal = {};             // id -> reader-local time seq last changed
+let mySeq = 0;
+let pendingShots = [];                // shots fired since last sync, to append to the shared table
+let pendingHits = [];                 // damage events I dealt this tick: {id,target,by,dmg}
+const appliedHits = new Set();        // hit-event ids I've already applied to my own HP
+const seenShots = new Set();          // shot ids we've already spawned locally for hit-detection
+let dbg = '';                          // last sync debug summary (shown under HUD)
+let syncing = false;                   // guard against overlapping syncs
+
+const keys = {};
+let mouse = { x: 0, y: 0 };
+let stats = { kills: 0, deaths: 0, best: 0 };
+let lastShot = 0;
+let netOk = false;
+
+const cv = document.getElementById('cv');
+const ctx = cv.getContext('2d');
+function resize(){ cv.width = window.innerWidth; cv.height = window.innerHeight; }
+window.addEventListener('resize', resize); resize();
+
+// ============ MAP ============
+function mulberry32(a){ return function(){ a|=0; a=a+0x6D2B79F5|0; let t=Math.imul(a^a>>>15,1|a); t=t+Math.imul(t^t>>>7,61|t)^t; return ((t^t>>>14)>>>0)/4294967296; }; }
+function buildMap(s){
+  const rnd = mulberry32(s), m = [];
+  for(let y=0;y<ROWS;y++){ const row=[]; for(let x=0;x<COLS;x++){
+    let wall = (x===0||y===0||x===COLS-1||y===ROWS-1);
+    if(!wall && rnd()<0.10) wall = true;
+    row.push(wall?1:0);
+  } m.push(row); }
+  for(let k=0;k<14;k++){
+    const rx=1+Math.floor(rnd()*(COLS-8)), ry=1+Math.floor(rnd()*(ROWS-8));
+    const rw=3+Math.floor(rnd()*5), rh=3+Math.floor(rnd()*5);
+    for(let y=ry;y<Math.min(ROWS-1,ry+rh);y++) for(let x=rx;x<Math.min(COLS-1,rx+rw);x++) m[y][x]=0;
+  }
+  return m;
+}
+function tileAt(px,py){ const c=Math.floor(px/TILE), r=Math.floor(py/TILE); if(r<0||c<0||r>=ROWS||c>=COLS) return 1; return map[r][c]; }
+function blocked(px,py){ return [[px-PLAYER_R,py-PLAYER_R],[px+PLAYER_R,py-PLAYER_R],[px-PLAYER_R,py+PLAYER_R],[px+PLAYER_R,py+PLAYER_R]].some(p=>tileAt(p[0],p[1])===1); }
+function findSpawn(rnd){
+  for(let i=0;i<500;i++){ const x=(1+Math.floor(rnd()*(COLS-2)))*TILE+TILE/2, y=(1+Math.floor(rnd()*(ROWS-2)))*TILE+TILE/2; if(tileAt(x,y)===0 && !blocked(x,y)) return {x,y}; }
+  return {x:WORLD_W/2,y:WORLD_H/2};
+}
+const COLORS = ['#7fff5a','#5ab8ff','#ff5ad0','#ffd15a','#ff5a5a','#b45aff','#5affd1'];
+function colorFor(id){ let h=0; for(const c of id) h=(h*31+c.charCodeAt(0))>>>0; return COLORS[h%COLORS.length]; }
+
+// ============ PERSISTENT STATS ============
+async function loadStats(){ try { const e = await archestra.storage.user.get('stats'); if(e&&e.value) stats = Object.assign(stats, e.value); } catch(_){} }
+async function saveStats(){ try { await archestra.storage.user.set('stats', stats); } catch(_){} }
+
+// ============ THE SHARED WORLD TABLE ============
+// One key, 'world', holds everything: { seed, players{}, shots[] }. Every client
+// reads it, merges in only its OWN player row + any new shots it fired, and writes
+// it back under optimistic concurrency. On conflict we re-read and retry once, so
+// concurrent writers never clobber each other's rows.
+function myRow(){
+  return { name: me.name, x: Math.round(me.x), y: Math.round(me.y), aim: +me.aim.toFixed(2), hp: me.hp, dead: !!me.dead, kills: me.kills, color: me.color, seq: ++mySeq };
+}
+
+async function syncWorld(){
+  if(!me) return;
+  if(syncing) return;                 // never overlap two syncs (they'd conflict with each other)
+  syncing = true;
+  try {
+    // Retry generously with jittered backoff so two clients writing on the same
+    // cadence desync and both land their row, instead of starving each other.
+    for(let attempt=0; attempt<6; attempt++){
+      let entry;
+      try { entry = await archestra.storage.shared.get('world'); }
+      catch(_){ netOk=false; dbg='get failed'; return; }
+
+      const world = (entry && entry.value) ? entry.value : { seed, players:{}, shots:[] };
+      worldRev = entry ? entry.revision : undefined;
+
+      // adopt the shared seed if one exists and differs from ours
+      if(typeof world.seed === 'number' && world.seed !== seed){
+        seed = world.seed; map = buildMap(seed);
+        const sp = findSpawn(mulberry32(seed ^ (Date.now()&0xffff)));
+        if(!me.placed){ me.x=sp.x; me.y=sp.y; me.placed=true; }
+      } else if(typeof world.seed !== 'number'){ world.seed = seed; }
+
+      // pull EVERYONE else's rows into our in-memory table (optimistic view)
+      const incoming = world.players || {};
+      const now = Date.now();
+      const merged = {};
+      for(const id in incoming){
+        if(id === MY_ID) continue;
+        const r = incoming[id];
+        if(!r) continue;
+        if(lastSeq[id] !== r.seq){ lastSeq[id] = r.seq; lastSeenLocal[id] = now; }
+        if(lastSeenLocal[id] === undefined) lastSeenLocal[id] = now;
+        if(now - lastSeenLocal[id] < LIVE_MS) merged[id] = r;   // still alive by OUR clock
+      }
+      merged[MY_ID] = myRow();     // write our own authoritative row
+      players = merged;            // paint optimistically from this immediately
+
+      // merge shots: keep fresh shared shots + append ones we just fired
+      const freshShared = (world.shots||[]).filter(s => now - (s.born||0) < SHOT_LIFETIME + 800);
+      const mineNew = pendingShots; pendingShots = [];
+      let allShots = freshShared.concat(mineNew);
+      if(allShots.length > MAX_SHOTS) allShots = allShots.slice(-MAX_SHOTS);
+      shots = allShots;
+      for(const s of allShots){ if(!seenShots.has(s.id)){ seenShots.add(s.id); } }
+
+      // merge HIT EVENTS. Apply them AFTER computing myRow so our own HP change
+      // from an incoming hit publishes in the SAME write — otherwise the drop
+      // would only appear on the next sync and others would briefly see stale HP.
+      const incomingHits = (world.hits||[]).filter(h => now - (h.t||0) < 4000);
+      let hpChanged = false;
+      for(const h of incomingHits){
+        if(h.kill){
+          if(h.killer === MY_ID && !appliedHits.has(h.id)){
+            appliedHits.add(h.id);
+            me.kills++; stats.kills++; stats.best=Math.max(stats.best,me.kills); saveStats();
+          }
+          continue;
+        }
+        if(h.target === MY_ID && !appliedHits.has(h.id)){
+          appliedHits.add(h.id);
+          if(!me.dead){ takeDamage(h.dmg||20, h.by); hpChanged = true; }
+        }
+      }
+      // If my HP/kills/dead changed while processing hits, refresh my published row.
+      if(hpChanged || merged[MY_ID].kills !== me.kills || merged[MY_ID].dead !== !!me.dead){
+        merged[MY_ID] = myRow(); players = merged;
+      }
+      const mineHits = pendingHits; pendingHits = [];
+      for(const h of mineHits){ appliedHits.add(h.id); }   // never apply my own events to myself
+      let allHits = incomingHits.concat(mineHits);
+      if(allHits.length > MAX_SHOTS) allHits = allHits.slice(-MAX_SHOTS);
+
+      const out = { seed, players: merged, shots: allShots, hits: allHits };
+      try {
+        const res = await archestra.storage.shared.set('world', out, worldRev!==undefined ? { ifRevision: worldRev } : undefined);
+        worldRev = res.revision; netOk = true;
+        dbg = 'rows:'+Object.keys(merged).length+' rev:'+res.revision;
+        return;
+      } catch(err){
+        if(err && err.code === 'conflict'){
+          // Someone wrote between our get and set. Re-queue our shots+hits and
+          // retry after a short randomized delay so we don't collide again.
+          pendingShots = mineNew.concat(pendingShots);
+          pendingHits = mineHits.concat(pendingHits);
+          await new Promise(r=> setTimeout(r, 15 + Math.random()*40));
+          continue;
+        }
+        netOk = false; dbg = 'set err:'+((err&&err.code)||'?'); return;
+      }
+    }
+    dbg = 'conflict x6';   // gave up this tick; next tick tries again
+  } finally { syncing = false; }
+}
+
+// ============ HUD / LIST ============
+function renderPlayerList(){
+  const list = Object.entries(players).map(([id,r])=> Object.assign({id}, r));
+  list.sort((a,b)=> (b.kills||0)-(a.kills||0));
+  document.getElementById('players').innerHTML =
+    '<b>PLAYERS (' + list.length + ')</b><br>' +
+    list.map(p=>{ const c = p.color||colorFor(p.id); const meMark = p.id===MY_ID ? ' \u25c0' : '';
+      return '<span style="color:'+c+'">'+esc(p.name||'???')+'</span> '+(p.kills||0)+(p.dead?' \u2620':'')+meMark; }).join('<br>');
+}
+function updateHud(){
+  if(!me) return;
+  const pct = Math.max(0, me.hp)/MAX_HP*100;
+  document.getElementById('hud').innerHTML =
+    esc(me.name)+'<br>KILLS '+me.kills+'  DEATHS '+stats.deaths+'  BEST '+stats.best+
+    '<div class="hp-wrap"><div class="hp-bar" style="width:'+pct+'%"></div></div>'+
+    '<div id="net">'+(netOk?'\u25cf online':'\u25cb offline')+'  '+esc(dbg)+'</div>';
+}
+
+// ============ INPUT ============
+window.addEventListener('keydown', e=>{ keys[e.key.toLowerCase()]=true; if(e.key===' '){ e.preventDefault(); shoot(); } });
+window.addEventListener('keyup', e=>{ keys[e.key.toLowerCase()]=false; });
+cv.addEventListener('mousemove', e=>{ mouse.x=e.clientX; mouse.y=e.clientY; });
+cv.addEventListener('mousedown', ()=> shoot());
+
+function camera(){
+  let cx = me.x - cv.width/2, cy = me.y - cv.height/2;
+  cx = Math.max(0, Math.min(WORLD_W - cv.width, cx));
+  cy = Math.max(0, Math.min(WORLD_H - cv.height, cy));
+  if(WORLD_W < cv.width) cx = (WORLD_W - cv.width)/2;
+  if(WORLD_H < cv.height) cy = (WORLD_H - cv.height)/2;
+  return {cx, cy};
+}
+
+function shoot(){
+  if(!me || me.dead) return;
+  const now = Date.now();
+  if(now - lastShot < SHOT_COOLDOWN) return;
+  lastShot = now;
+  const b = { id: crypto.randomUUID(), owner: MY_ID, x: me.x, y: me.y, vx: Math.cos(me.aim)*BULLET_SPEED, vy: Math.sin(me.aim)*BULLET_SPEED, born: now };
+  seenShots.add(b.id);
+  shots.push(b);          // paint immediately (optimistic)
+  pendingShots.push(b);   // queue for the next world write
+}
+
+// ============ SIMULATION ============
+function step(){
+  if(!me) return;
+  const {cx, cy} = camera();
+  me.aim = Math.atan2((mouse.y+cy)-me.y, (mouse.x+cx)-me.x);
+
+  if(!me.dead){
+    let dx=0, dy=0;
+    if(keys['w']||keys['arrowup']) dy-=1;
+    if(keys['s']||keys['arrowdown']) dy+=1;
+    if(keys['a']||keys['arrowleft']) dx-=1;
+    if(keys['d']||keys['arrowright']) dx+=1;
+    if(dx||dy){ const l=Math.hypot(dx,dy); dx/=l; dy/=l;
+      const nx=me.x+dx*SPEED, ny=me.y+dy*SPEED;
+      if(!blocked(nx, me.y)) me.x=nx;
+      if(!blocked(me.x, ny)) me.y=ny;
+    }
+  }
+
+  const now = Date.now();
+  // advance all shots by their velocity every frame (position stored is the origin,
+  // we integrate from born time so all clients agree on where a shot is)
+  for(const s of shots){ s._age = now - (s.born||now); }
+  // cull dead shots locally
+  shots = shots.filter(s => (now - (s.born||now)) < SHOT_LIFETIME);
+
+  // collisions: my shots vs other players; others' shots vs me
+  if(!me.dead){
+    for(const s of shots){
+      const age = now - (s.born||now);
+      const bx = s.x + s.vx*(age/16.67), by = s.y + s.vy*(age/16.67);
+      if(tileAt(bx,by)===1){ s.born = 0; continue; } // hit wall -> mark expired
+      if(s.owner === MY_ID){
+        for(const id in players){ if(id===MY_ID) continue; const o=players[id]; if(o.dead) continue;
+          if(Math.hypot(o.x-bx, o.y-by) < PLAYER_R+BULLET_R){ dealHit(id); s.born=0; break; } }
+      } else {
+        if(!s._hitMe && Math.hypot(me.x-bx, me.y-by) < PLAYER_R+BULLET_R+2){ s._hitMe=true; /* damage arrives via shared hit events, not applied locally */ }
+      }
+    }
+  }
+}
+
+let hitCd = {};
+// I hit another player: emit a shared damage event they will apply to their own
+// HP. I don't change their HP directly — each player owns their own hp row.
+// Do NOT call syncWorld() here: it is re-entrancy-guarded and the periodic sync
+// (every SYNC_MS) picks up pendingHits on its own. Calling it re-entrantly was
+// silently dropped and raced the pendingHits swap.
+function dealHit(id){
+  if(hitCd[id] && Date.now()-hitCd[id]<220) return;
+  hitCd[id]=Date.now();
+  const ev = { id: crypto.randomUUID(), target: id, by: MY_ID, dmg: 20, t: Date.now() };
+  pendingHits.push(ev);
+  appliedHits.add(ev.id);            // never apply my own hit to myself
+}
+// Each distinct damage EVENT is applied at most once (deduped by appliedHits in
+// the caller), so no time-based throttle here — that could swallow real hits.
+function takeDamage(d, byId){
+  if(byId) me.lastHitBy = byId;      // always record attacker, even for the fatal blow
+  me.hp -= d;
+  if(me.hp<=0 && !me.dead) die();
+}
+function die(){
+  me.dead=true; me.hp=0; stats.deaths++; saveStats();
+  // Credit the kill to whoever last damaged me, via a shared kill-credit event.
+  // Just queue it; the periodic sync publishes pendingHits. (die() is called
+  // from inside a sync, where a nested syncWorld() would be a no-op anyway.)
+  if(me.lastHitBy){ pendingHits.push({ id: crypto.randomUUID(), kill: true, killer: me.lastHitBy, victim: MY_ID, t: Date.now() }); }
+  document.getElementById('respawn').style.display='flex';
+}
+function doRespawn(){ const sp=findSpawn(mulberry32(seed^Date.now())); me.x=sp.x; me.y=sp.y; me.hp=MAX_HP; me.dead=false; me.lastHitBy=null; document.getElementById('respawn').style.display='none'; syncWorld(); }
+document.getElementById('respawnBtn').addEventListener('click', doRespawn);
+
+// ============ RENDER ============
+function drawTile(x,y,t){
+  if(t===1){ ctx.fillStyle='#3a2f24'; ctx.fillRect(x,y,TILE,TILE);
+    ctx.fillStyle='#5a4a38'; ctx.fillRect(x+3,y+3,TILE-6,TILE-6);
+    ctx.fillStyle='#2a2016'; ctx.fillRect(x+3,y+TILE-8,TILE-6,5);
+  } else { ctx.fillStyle=((x/TILE+y/TILE)%2===0)?'#143014':'#1b3d1b'; ctx.fillRect(x,y,TILE,TILE); }
+}
+function drawPlayer(px,py,color,aim,name,hp,dead){
+  ctx.save(); ctx.translate(px,py);
+  if(dead) ctx.globalAlpha=0.4;
+  ctx.fillStyle=color; ctx.fillRect(-PLAYER_R,-PLAYER_R,PLAYER_R*2,PLAYER_R*2);
+  ctx.fillStyle='rgba(0,0,0,.35)'; ctx.fillRect(-PLAYER_R,PLAYER_R-4,PLAYER_R*2,4);
+  ctx.strokeStyle='#fff'; ctx.lineWidth=4;
+  ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(Math.cos(aim)*(PLAYER_R+10),Math.sin(aim)*(PLAYER_R+10)); ctx.stroke();
+  ctx.restore();
+  ctx.globalAlpha=1; ctx.font='8px "Press Start 2P", monospace'; ctx.textAlign='center';
+  ctx.fillStyle='#000'; ctx.fillText(name, px+1, py-PLAYER_R-9);
+  ctx.fillStyle='#fff'; ctx.fillText(name, px, py-PLAYER_R-10);
+  const w=PLAYER_R*2; ctx.fillStyle='#300'; ctx.fillRect(px-PLAYER_R,py-PLAYER_R-6,w,3);
+  ctx.fillStyle='#ff4b4b'; ctx.fillRect(px-PLAYER_R,py-PLAYER_R-6,w*Math.max(0,hp)/MAX_HP,3);
+}
+function render(){
+  requestAnimationFrame(render);
+  if(!me || !map) return;
+  const {cx,cy}=camera();
+  ctx.setTransform(1,0,0,1,0,0); ctx.clearRect(0,0,cv.width,cv.height);
+  ctx.save(); ctx.translate(-cx,-cy);
+  const c0=Math.max(0,Math.floor(cx/TILE)), c1=Math.min(COLS-1,Math.ceil((cx+cv.width)/TILE));
+  const r0=Math.max(0,Math.floor(cy/TILE)), r1=Math.min(ROWS-1,Math.ceil((cy+cv.height)/TILE));
+  for(let r=r0;r<=r1;r++) for(let c=c0;c<=c1;c++) drawTile(c*TILE,r*TILE,map[r][c]);
+  const now=Date.now();
+  for(const s of shots){ const age=now-(s.born||now); if(age<0||age>SHOT_LIFETIME) continue;
+    const bx=s.x+s.vx*(age/16.67), by=s.y+s.vy*(age/16.67);
+    ctx.fillStyle = s.owner===MY_ID ? '#fff' : '#ffef8a';
+    ctx.fillRect(bx-BULLET_R,by-BULLET_R,BULLET_R*2,BULLET_R*2);
+  }
+  // paint EVERY player from the table (optimistic), including me
+  for(const id in players){ if(id===MY_ID) continue; const o=players[id]; drawPlayer(o.x,o.y,o.color||colorFor(id),o.aim||0,o.name||'???',o.hp||0,o.dead); }
+  drawPlayer(me.x,me.y,me.color,me.aim,me.name,me.hp,me.dead);
+  ctx.restore();
+  updateHud();
+}
+
+// ============ START ============
+let started = false;
+async function startGame(name){
+  if(started) return; started = true;
+  document.getElementById('title').style.display='none';
+  document.getElementById('game').style.display='block';
+  resize();
+
+  seed = seed || (Math.floor(Math.random()*2e9)||12345);
+  map = buildMap(seed);
+  const sp0 = findSpawn(mulberry32(seed ^ (Date.now()&0xffff)));
+  me = { id: MY_ID, name, x: sp0.x, y: sp0.y, aim: 0, hp: MAX_HP, dead: false, kills: 0, color: colorFor(MY_ID), placed: true };
+
+  render();
+  setInterval(step, 16);
+  setInterval(()=>renderPlayerList(), 500);
+
+  try {
+    await archestra.ready;
+    if((!name || name==='PLAYER') && archestra.user && archestra.user.name) me.name = archestra.user.name.slice(0,12).toUpperCase();
+    await loadStats();
+    await syncWorld();                 // first exchange: adopt shared seed, publish our row
+    setInterval(syncWorld, SYNC_MS);   // ONE get+set per tick keeps the whole table in sync
+    window.addEventListener('beforeunload', async ()=>{
+      // remove our row so we drop out of everyone's table promptly
+      try { const e = await archestra.storage.shared.get('world'); if(e&&e.value&&e.value.players){ delete e.value.players[MY_ID]; await archestra.storage.shared.set('world', e.value, {ifRevision:e.revision}); } } catch(_){}
+    });
+  } catch(err){ console.warn('Data layer unavailable, running locally:', err); netOk=false; }
+}
+
+document.getElementById('startBtn').addEventListener('click', ()=>{
+  const val = document.getElementById('nameInput').value.trim();
+  const name = (val || (window.archestra&&archestra.user&&archestra.user.name) || 'PLAYER').slice(0,12).toUpperCase();
+  startGame(name);
+});
+document.getElementById('nameInput').addEventListener('keydown', e=>{ if(e.key==='Enter') document.getElementById('startBtn').click(); });
+(async ()=>{ try{ await archestra.ready; const n=archestra.user&&archestra.user.name; if(n) document.getElementById('nameInput').value = n.slice(0,12); }catch(_){} })();
+</script>
+</body>
+</html>

--- a/platform/backend/src/static/default-apps/demo-task-tracker.html
+++ b/platform/backend/src/static/default-apps/demo-task-tracker.html
@@ -1,0 +1,405 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo Task Tracker</title>
+  <style>
+    :root { --tt-fade: 700ms; }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100dvh; }
+
+    /* ---------- Intro loader ---------- */
+    #intro {
+      position: fixed; inset: 0; z-index: 1000;
+      background: #000; color: #fff;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      text-align: center; padding: 2rem;
+      font-family: var(--font-sans, system-ui, sans-serif);
+      transition: opacity var(--tt-fade) ease;
+    }
+    #intro.hide { opacity: 0; pointer-events: none; }
+    #intro .intro-logo { width: 72px; height: 72px; border-radius: 16px; margin-bottom: 1.75rem; opacity: 0; animation: introIn 900ms ease forwards; }
+    #intro .lines { max-width: 34rem; display: flex; flex-direction: column; gap: 1.1rem; }
+    #intro .line { opacity: 0; font-size: 1.15rem; line-height: 1.5; animation: introIn 900ms ease forwards; }
+    #intro .line.title { font-size: 1.9rem; font-weight: 600; letter-spacing: -0.01em; }
+    #intro .line.muted { color: #b9b9b9; font-size: 1.02rem; }
+    #intro .skip {
+      position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%);
+      background: transparent; color: #fff; border: 1px solid rgba(255,255,255,0.35);
+      border-radius: 999px; padding: 0.5rem 1.4rem; font-size: 0.9rem; cursor: pointer;
+      opacity: 0; animation: skipIn 900ms ease forwards; animation-delay: 900ms;
+      transition: background 150ms ease, border-color 150ms ease;
+      font-family: inherit;
+    }
+    #intro .skip:hover { background: rgba(255,255,255,0.12); border-color: rgba(255,255,255,0.6); }
+    @keyframes introIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+    /* Skip keeps its horizontal centering (translateX(-50%)) inside the animated transform. */
+    @keyframes skipIn { from { opacity: 0; transform: translateX(-50%) translateY(10px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }
+
+    /* ---------- App ---------- */
+    #app { opacity: 0; transition: opacity var(--tt-fade) ease; max-width: 620px; margin: 0 auto; padding: 3rem 1.5rem 4rem; font-family: var(--font-sans, system-ui, sans-serif); }
+    #app.show { opacity: 1; }
+
+    .hero { text-align: center; margin-bottom: 2rem; }
+    .hero .badge {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+      font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--color-text-secondary); border: 1px solid var(--color-border-primary, #e2e2e2);
+      padding: 0.25rem 0.7rem; border-radius: 999px; margin-bottom: 0.9rem;
+    }
+    .hero .badge svg { width: 13px; height: 13px; }
+    .hero h1 { margin: 0 0 0.4rem; font-size: 1.9rem; letter-spacing: -0.02em; }
+    .hero p { margin: 0; color: var(--color-text-secondary); font-size: 0.95rem; }
+
+    .panel {
+      border: 1px solid var(--color-border-primary, #e6e6e6);
+      border-radius: 16px; padding: 1.1rem; margin-bottom: 1.5rem;
+      background: var(--color-background-secondary, rgba(127,127,127,0.05));
+    }
+    .add-row { display: flex; gap: 0.6rem; }
+    .add-row .arch-input, .add-row input { flex: 1; height: 44px; font-size: 1rem; }
+    .add-row .arch-btn, .add-row button { height: 44px; padding: 0 1.3rem; font-weight: 600; white-space: nowrap; }
+
+    .toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.9rem; gap: 0.75rem; }
+    .stats { font-size: 0.85rem; color: var(--color-text-secondary); }
+    .progress { flex: 1; height: 6px; border-radius: 999px; background: var(--color-border-primary, #e6e6e6); overflow: hidden; max-width: 180px; }
+    .progress > span { display: block; height: 100%; width: 0; background: var(--color-accent, #4f7cff); transition: width 300ms ease; }
+
+    ul.tasks { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+    li.task {
+      display: flex; align-items: center; gap: 0.85rem; padding: 0.85rem 1rem;
+      border: 1px solid var(--color-border-primary, #e6e6e6); border-radius: 12px;
+      background: var(--color-background-primary, #fff);
+      transition: transform 120ms ease, box-shadow 120ms ease, opacity 200ms ease;
+      animation: taskIn 240ms ease;
+    }
+    @keyframes taskIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+    li.task:hover { box-shadow: 0 4px 14px rgba(0,0,0,0.07); }
+    li.task .check { flex: none; width: 20px; height: 20px; cursor: pointer; accent-color: var(--color-accent, #4f7cff); }
+    li.task .label { flex: 1; text-align: left; word-break: break-word; font-size: 0.98rem; }
+    li.task.done { opacity: 0.65; }
+    li.task.done .label { text-decoration: line-through; color: var(--color-text-secondary); }
+    li.task .meta { font-size: 0.72rem; color: var(--color-text-secondary); flex: none; }
+    li.task .del { flex: none; background: transparent; border: 0; color: var(--color-text-secondary); cursor: pointer; font-size: 1.25rem; line-height: 1; padding: 0.15rem 0.45rem; border-radius: 8px; }
+    li.task .del:hover { color: #e5484d; background: rgba(229,72,77,0.12); }
+
+    .empty { text-align: center; color: var(--color-text-secondary); padding: 2.5rem 0; font-size: 0.95rem; }
+    .empty .big { font-size: 1.8rem; display: block; margin-bottom: 0.5rem; opacity: 0.5; }
+
+    #toast {
+      position: fixed; bottom: 1.5rem; left: 50%; transform: translateX(-50%) translateY(150%);
+      background: #e5484d; color: #fff; padding: 0.7rem 1.2rem; border-radius: 10px;
+      font-size: 0.9rem; box-shadow: 0 8px 24px rgba(0,0,0,0.2); z-index: 500;
+      transition: transform 260ms ease; max-width: 90vw; text-align: center;
+    }
+    #toast.show { transform: translateX(-50%) translateY(0); }
+
+    /* ---------- Diagnostics panel ---------- */
+    #diag {
+      margin-top: 1.5rem; border: 1px solid #e5484d; border-radius: 12px;
+      background: rgba(229,72,77,0.06); overflow: hidden;
+    }
+    #diag[hidden] { display: none; }
+    #diag .diag-head {
+      display: flex; align-items: center; gap: 0.5rem; padding: 0.8rem 1rem;
+      font-weight: 600; color: #e5484d; font-size: 0.9rem;
+    }
+    #diag .diag-head svg { width: 16px; height: 16px; flex: none; }
+    #diag .diag-body { padding: 0 1rem 1rem; }
+    #diag pre {
+      margin: 0; padding: 0.8rem; background: #0e0e0e; color: #f2f2f2;
+      border-radius: 8px; font-family: var(--font-mono, ui-monospace, monospace);
+      font-size: 0.78rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word;
+      max-height: 340px; overflow: auto;
+    }
+    #diag .diag-actions { margin-top: 0.7rem; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+    #diag .diag-actions button {
+      font-size: 0.82rem; padding: 0.4rem 0.9rem; border-radius: 8px;
+      border: 1px solid var(--color-border-primary, #ccc); background: transparent;
+      cursor: pointer; color: var(--color-text-primary, inherit); font-family: inherit;
+    }
+    #diag .diag-actions button:hover { background: rgba(127,127,127,0.12); }
+  </style>
+</head>
+<body>
+  <!-- Intro loader -->
+  <div id="intro">
+    <svg class="intro-logo" viewBox="0 0 994 953" xmlns="http://www.w3.org/2000/svg">
+      <rect width="993.958" height="952.543" rx="204.92" fill="#111"/>
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M390.871 664.818C427.68 664.818 460.629 641.985 473.553 607.519L565.238 363.026C586.887 305.296 544.211 243.715 482.556 243.715C445.747 243.715 412.798 266.548 399.874 301.014L308.189 545.507C286.54 603.237 329.216 664.818 390.871 664.818Z" fill="white"/>
+      <ellipse cx="638.487" cy="577.095" rx="87.7298" ry="81.1501" fill="white"/>
+    </svg>
+    <div class="lines">
+      <div class="line title" style="animation-delay:150ms">Demo Task Tracker</div>
+      <div class="line" style="animation-delay:400ms">Built as a mini app in Archestra.</div>
+      <div class="line muted" style="animation-delay:650ms">It uses Archestra's data layer for persistent storage.</div>
+      <div class="line muted" style="animation-delay:900ms">Share it with colleagues and use it together!</div>
+      <div class="line muted" style="animation-delay:1150ms">Try creating apps yourself.</div>
+    </div>
+    <button class="skip" type="button" id="skipBtn">Skip &rarr;</button>
+  </div>
+
+  <!-- App -->
+  <main id="app">
+    <div class="hero">
+      <span class="badge">
+        <svg viewBox="0 0 994 953" xmlns="http://www.w3.org/2000/svg"><rect width="993.958" height="952.543" rx="204.92" fill="currentColor"/></svg>
+        Archestra mini app
+      </span>
+      <h1>Task Tracker</h1>
+      <p>A shared list saved in Archestra&rsquo;s data layer &mdash; everyone sees the same tasks.</p>
+    </div>
+
+    <div class="panel">
+      <div class="add-row">
+        <input id="taskInput" class="arch-input" type="text" placeholder="What needs doing?" autocomplete="off" />
+        <button id="addBtn" class="arch-btn arch-btn--primary" type="button">Add task</button>
+      </div>
+    </div>
+
+    <div class="toolbar">
+      <span class="stats" id="statLine">Loading&hellip;</span>
+      <div class="progress"><span id="progressBar"></span></div>
+    </div>
+
+    <ul class="tasks" id="taskList"></ul>
+    <div class="empty" id="emptyState" hidden><span class="big">&#10003;</span>No tasks yet &mdash; add your first one above.</div>
+  </main>
+
+  <div id="toast"></div>
+
+  <section id="diag" hidden>
+    <div class="diag-head">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      Storage diagnostics
+    </div>
+    <div class="diag-body">
+      <pre id="diagLog"></pre>
+      <div class="diag-actions">
+        <button type="button" id="diagRetry">Retry connection</button>
+        <button type="button" id="diagCopy">Copy details</button>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    (function () {
+      // ----- Intro loader (bound immediately, no SDK dependency) -----
+      const intro = document.getElementById('intro');
+      const app = document.getElementById('app');
+      let dismissed = false;
+      function dismissIntro() {
+        if (dismissed) return;
+        dismissed = true;
+        intro.classList.add('hide');
+        app.classList.add('show');
+        setTimeout(() => { intro.style.display = 'none'; }, 750);
+        const input = document.getElementById('taskInput');
+        if (input) input.focus();
+      }
+      document.getElementById('skipBtn').addEventListener('click', dismissIntro);
+      setTimeout(dismissIntro, 5200);
+
+      // ----- Elements -----
+      const listEl = document.getElementById('taskList');
+      const emptyEl = document.getElementById('emptyState');
+      const statEl = document.getElementById('statLine');
+      const barEl = document.getElementById('progressBar');
+      const input = document.getElementById('taskInput');
+      const addBtn = document.getElementById('addBtn');
+      const toastEl = document.getElementById('toast');
+
+      let store = null, me = { id: 'anon', name: 'Someone' }, ready = false;
+      let toastTimer;
+
+      // ----- Diagnostics: surface the FULL traceback of any storage failure in-app -----
+      const diagEl = document.getElementById('diag');
+      const diagLog = document.getElementById('diagLog');
+      const diagLines = [];
+      function fmtErr(err) {
+        if (err == null) return String(err);
+        if (typeof err === 'string') return err;
+        const parts = [];
+        if (err.name || err.message) parts.push((err.name || 'Error') + ': ' + (err.message || ''));
+        if (err.code) parts.push('code: ' + err.code);
+        if (err.url) parts.push('url: ' + err.url);
+        if (err.stack) parts.push('\n' + err.stack);
+        try {
+          const extra = {};
+          for (const k of Object.keys(err)) { if (!['name','message','stack','code','url'].includes(k)) extra[k] = err[k]; }
+          if (Object.keys(extra).length) parts.push('detail: ' + JSON.stringify(extra));
+        } catch (_) {}
+        if (!parts.length) { try { return JSON.stringify(err); } catch (_) { return String(err); } }
+        return parts.join('\n');
+      }
+      function diag(label, err) {
+        const stamp = new Date().toISOString();
+        const block = '[' + stamp + '] ' + label + (err !== undefined ? '\n' + fmtErr(err) : '');
+        diagLines.push(block);
+        diagLog.textContent = diagLines.join('\n\n');
+        diagEl.hidden = false;
+        console.error(label, err);
+      }
+      window.addEventListener('error', e => diag('Uncaught error', e.error || e.message));
+      window.addEventListener('unhandledrejection', e => diag('Unhandled promise rejection', e.reason));
+
+      document.getElementById('diagRetry').addEventListener('click', () => { diag('Retrying storage connection\u2026'); connectStorage(); });
+      document.getElementById('diagCopy').addEventListener('click', async () => {
+        try { await navigator.clipboard.writeText(diagLog.textContent); toast('Diagnostics copied.'); }
+        catch (_) { toast('Copy failed \u2014 select the text manually.'); }
+      });
+      function toast(msg) {
+        toastEl.textContent = msg;
+        toastEl.classList.add('show');
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => toastEl.classList.remove('show'), 3200);
+      }
+      function esc(s) {
+        return String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+      }
+
+      async function loadTasks() {
+        const entries = await store.list();
+        return entries
+          .filter(e => e.key.startsWith('task:') && e.value && typeof e.value === 'object')
+          .map(e => ({ key: e.key, revision: e.revision, ...e.value }))
+          .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+      }
+
+      function render(tasks) {
+        listEl.innerHTML = '';
+        if (!tasks.length) {
+          emptyEl.hidden = false;
+          statEl.textContent = 'No tasks';
+          barEl.style.width = '0%';
+          return;
+        }
+        emptyEl.hidden = true;
+        const done = tasks.filter(t => t.done).length;
+        statEl.textContent = done + ' of ' + tasks.length + ' done';
+        barEl.style.width = Math.round((done / tasks.length) * 100) + '%';
+        for (const t of tasks) {
+          const li = document.createElement('li');
+          li.className = 'task' + (t.done ? ' done' : '');
+          li.innerHTML =
+            '<input type="checkbox" class="check"' + (t.done ? ' checked' : '') + ' />' +
+            '<span class="label">' + esc(t.text) + '</span>' +
+            '<span class="meta">' + esc(t.by || '') + '</span>' +
+            '<button class="del" type="button" aria-label="Delete">&times;</button>';
+          li.querySelector('.check').addEventListener('change', () => toggleTask(t));
+          li.querySelector('.del').addEventListener('click', () => deleteTask(t));
+          listEl.appendChild(li);
+        }
+      }
+
+      async function refresh() {
+        if (!ready) return;
+        try { render(await loadTasks()); }
+        catch (e) { toast('Could not load tasks.'); diag('store.list() failed while loading tasks', e); }
+      }
+
+      async function addTask() {
+        const text = input.value.trim();
+        if (!text) { input.focus(); return; }
+        if (!ready) { toast('Still connecting to storage&hellip; try again in a moment.'); return; }
+        input.value = '';
+        addBtn.disabled = true;
+        const key = 'task:' + crypto.randomUUID();
+        try {
+          await store.set(key, { text, done: false, by: me.name, createdAt: Date.now() });
+          await refresh();
+        } catch (e) {
+          input.value = text;
+          toast('Could not save the task. Please try again.');
+          diag('store.set() failed while adding task "' + text + '"', e);
+        } finally {
+          addBtn.disabled = false;
+          input.focus();
+        }
+      }
+
+      async function toggleTask(t) {
+        try {
+          await store.set(t.key, { text: t.text, done: !t.done, by: t.by, createdAt: t.createdAt }, { ifRevision: t.revision });
+        } catch (e) { diag('store.set() failed while toggling task ' + t.key, e); }
+        await refresh();
+      }
+
+      async function deleteTask(t) {
+        try { await store.delete(t.key); } catch (e) { toast('Could not delete the task.'); diag('store.delete() failed for ' + t.key, e); }
+        await refresh();
+      }
+
+      // Bind interaction handlers IMMEDIATELY so clicks never no-op while the SDK loads.
+      addBtn.addEventListener('click', addTask);
+      input.addEventListener('keydown', e => { if (e.key === 'Enter') addTask(); });
+
+      // Connect to storage once the SDK is ready. Each step is checked and logged
+      // so a failure shows exactly where it broke, with the full traceback.
+      let pollTimer = null;
+
+      // Per the SDK contract window.archestra is present SYNCHRONOUSLY and you
+      // await archestra.ready. We still poll briefly as a safety net for hosts that
+      // attach it a tick late, and we report a full snapshot so a genuine absence is diagnosable.
+      function sdkSnapshot() {
+        try {
+          const a = window.archestra;
+          return 'typeof window.archestra=' + (typeof a) +
+            '; truthy=' + (!!a) +
+            (a ? '; keys=[' + Object.keys(a).join(', ') + ']; hasReady=' + ('ready' in a) : '') +
+            '; inIframe=' + (window.top !== window.self) +
+            '; readyState=' + document.readyState;
+        } catch (e) { return 'snapshot error: ' + (e && e.message); }
+      }
+
+      function waitForSdk(timeoutMs) {
+        return new Promise((resolve, reject) => {
+          if (window.archestra) return resolve(window.archestra);
+          const started = Date.now();
+          const iv = setInterval(() => {
+            if (window.archestra) { clearInterval(iv); resolve(window.archestra); }
+            else if (Date.now() - started > timeoutMs) {
+              clearInterval(iv);
+              reject(new Error('window.archestra was not injected within ' + timeoutMs + 'ms.\nSnapshot: ' + sdkSnapshot()));
+            }
+          }, 50);
+        });
+      }
+
+      async function connectStorage() {
+        try {
+          diag('Locating the Archestra SDK\u2026 ' + sdkSnapshot());
+          const sdk = await waitForSdk(15000);
+          diag('SDK object found; awaiting sdk.ready\u2026 (ready is a ' + (typeof sdk.ready) + ')');
+          await sdk.ready;
+          me = sdk.user || me;
+          diag('SDK ready. Viewer: ' + (me && me.name ? me.name + ' (' + me.id + ')' : 'unknown') +
+            '. storage=' + (typeof sdk.storage) + ', shared=' + (sdk.storage ? typeof sdk.storage.shared : 'n/a'));
+          if (!sdk.storage || !sdk.storage.shared) {
+            throw new Error('sdk.storage.shared is unavailable. SDK keys: [' + Object.keys(sdk).join(', ') + ']');
+          }
+          store = sdk.storage.shared;
+          const probe = await store.list();
+          diag('Connected to shared storage. list() returned ' + (Array.isArray(probe) ? probe.length + ' entries.' : 'a non-array value: ' + JSON.stringify(probe)));
+          ready = true;
+          diagEl.hidden = true;
+          diagLines.length = 0;
+          statEl.textContent = 'Loading\u2026';
+          await refresh();
+          if (!pollTimer) pollTimer = setInterval(refresh, 5000);
+        } catch (e) {
+          ready = false;
+          statEl.textContent = 'Storage unavailable';
+          toast('Could not connect to Archestra storage \u2014 see diagnostics below.');
+          diag('Storage connection failed', e);
+        }
+      }
+
+      // Start after full load so a late-attached SDK is already present.
+      if (document.readyState === 'complete') connectStorage();
+      else window.addEventListener('load', connectStorage);
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
On startup, seed 4 org-scoped demo apps (Demo Task Tracker, Demo Multiplayer Video Game, Demo Data Analysis Tool, Demo 3D Object Viewer) into every organization that has never had an app, authored by the org's earliest admin.

- Orgs with any app row — including soft-deleted — are left untouched, so deleting the demos never resurrects them.
- App HTML ships as plain files under `backend/src/static/default-apps/` (already copied to dist by the build) and each app is created through the normal `AppModel.create` + `createAppBacking` path, so seeded apps are ordinary editable/deletable apps.
- Provenance recorded via `templateId: default-app:<slug>`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>