### PR TITLE
feat(chat): GA message queueing; keep the composer usable during context compaction

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -3,7 +3,7 @@ title: Chat
 category: Agents
 order: 2
 description: Built-in Chat interface for working with agents and MCP tools
-lastUpdated: 2026-07-03
+lastUpdated: 2026-07-18
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -23,6 +23,12 @@ Type `/` in the prompt input to open available chat commands.
 - [`/compact`](#context-compaction) summarizes older conversation history to reduce context usage and help prevent hitting the selected model's context limit. The full chat history remains visible in the conversation.
 
 When the agent has the [code sandbox](./platform-code-sandbox) available, a message starting with `!` (for example `! ls attachments/`) runs the rest of the message as a shell command in the conversation's sandbox instead of asking the model. The command and its output appear in the conversation as a regular `run_command` tool call, so the agent sees the result in later turns. Output appears when the command finishes. Requires the `sandbox: execute` permission; without a sandbox, the message is sent as normal text. User-typed commands do not trigger PreToolUse/PostToolUse hooks — the user, not the model, initiated the call.
+
+### Message Queueing
+
+Press Enter while a response is streaming to queue your message. Queued messages appear above the prompt input and send in order as each turn finishes — you can keep typing without waiting. Remove a queued message with its X, or press ArrowUp on an empty prompt to pull the newest one back for editing.
+
+While a response streams, the send button becomes Stop. Clicking it (or pressing Esc) stops the response and pauses the queue; sending a new message resumes it.
 
 ### MCP Elicitation
 

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -150,7 +150,7 @@ import {
   deriveModelSource,
 } from "@/lib/chat/use-chat-preferences";
 import { useInitialChatModelState } from "@/lib/chat/use-initial-chat-model-state.hook";
-import { useConfig, useFeature } from "@/lib/config/config.query";
+import { useConfig } from "@/lib/config/config.query";
 import {
   type ConnectivityState,
   useConnectivity,
@@ -1136,9 +1136,6 @@ export function ChatPageContent({
     },
     [setMessages, conversationId, messages, setChatMessageFeedback],
   );
-  // Message queueing is beta, gated by the ARCHESTRA_BETA master switch.
-  const isMessageQueueEnabled = useFeature("betaEnabled") ?? false;
-
   // A scheduled run's transcript is persisted only when it completes, so a run
   // opened while still running seeds the live chat session empty. When the run
   // finishes, the completion effect refetches the conversation; hydrate the
@@ -1705,7 +1702,7 @@ export function ChatPageContent({
       });
     };
 
-    const queueEnabled = isMessageQueueEnabled && !!conversationId;
+    const queueEnabled = !!conversationId;
     const submitAction = classifyChatSubmitAction({
       status,
       queueEnabled,
@@ -1713,10 +1710,10 @@ export function ChatPageContent({
     });
 
     if (submitAction === "stop") {
-      // Queueing off: the submit button doubles as Stop while a turn streams.
-      // (Stopping is the submit button's onClick, not a form submit.) Throw to
-      // keep the textarea and draft intact — see onSubmit contract in
-      // ArchestraPromptInputProps.
+      // No conversation to queue into (new-chat composer): the submit button
+      // doubles as Stop while a turn streams. (Stopping is the submit button's
+      // onClick, not a form submit.) Throw to keep the textarea and draft
+      // intact — see onSubmit contract in ArchestraPromptInputProps.
       handleStopStreaming();
       throw new Error("stop-not-submit");
     }

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1346,7 +1346,9 @@ export function ChatPageContent({
     !!contextCompaction?.isCompacting || compactConversationMutation.isPending;
 
   const handleCompactConversation = useCallback(async () => {
-    if (!conversationId || isReadOnlyConversation) {
+    // The compaction guard matters now that the composer stays usable during
+    // compaction when queueing is on — a second /compact must not re-enter.
+    if (!conversationId || isReadOnlyConversation || isContextCompacting) {
       return;
     }
 
@@ -1433,6 +1435,7 @@ export function ChatPageContent({
   }, [
     compactConversationMutation,
     conversationId,
+    isContextCompacting,
     isReadOnlyConversation,
     recordContextCompaction,
     syncPersistedMessageMetadata,

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -153,8 +153,14 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
     <div>{children}</div>
   ),
   PromptInputSpeechButton: () => <button type="button">Speech</button>,
-  PromptInputSubmit: ({ status }: { status?: string }) => (
-    <button data-testid="prompt-submit" type="submit">
+  PromptInputSubmit: ({
+    status,
+    disabled,
+  }: {
+    status?: string;
+    disabled?: boolean;
+  }) => (
+    <button data-testid="prompt-submit" type="submit" disabled={disabled}>
       Submit {status ?? "unset"}
     </button>
   ),
@@ -1078,6 +1084,76 @@ describe("ArchestraPromptInput", () => {
       });
 
       expect(onStop).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("context compaction", () => {
+    // The Enter path is routed through the submit button's disabled state (the
+    // textarea refuses to requestSubmit while the button is disabled), so the
+    // button assertions below pin the keyboard contract too.
+    const getSubmitButton = (): HTMLButtonElement => {
+      const button = document.querySelector('button[type="submit"]');
+      if (!(button instanceof HTMLButtonElement)) {
+        throw new Error("submit button not found");
+      }
+      return button;
+    };
+
+    it("keeps the composer usable mid-stream when queueing can absorb the message", () => {
+      mockFeatureState.betaEnabled = true;
+      const onSubmit = vi.fn();
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          onSubmit={onSubmit}
+          status="streaming"
+          conversationId="conv-compacting-queue"
+          isContextCompacting
+        />,
+      );
+
+      expect(
+        screen.getByTestId(E2eTestId.ChatPromptTextarea),
+      ).not.toBeDisabled();
+      expect(getSubmitButton()).not.toBeDisabled();
+
+      // A submit during compaction still reaches the consumer (which queues it).
+      mockControllerState.value = "queued while compacting";
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it("locks the composer during compaction when queueing is off", () => {
+      mockFeatureState.betaEnabled = false;
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          status="streaming"
+          conversationId="conv-compacting-no-queue"
+          isContextCompacting
+        />,
+      );
+
+      expect(screen.getByTestId(E2eTestId.ChatPromptTextarea)).toBeDisabled();
+      expect(getSubmitButton()).toBeDisabled();
+    });
+
+    it("locks the composer during an idle (manual) compaction even with queueing on", () => {
+      mockFeatureState.betaEnabled = true;
+
+      render(
+        <ArchestraPromptInput
+          {...defaultProps}
+          status="ready"
+          conversationId="conv-compacting-idle"
+          isContextCompacting
+        />,
+      );
+
+      expect(screen.getByTestId(E2eTestId.ChatPromptTextarea)).toBeDisabled();
+      expect(getSubmitButton()).toBeDisabled();
     });
   });
 });

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -18,7 +18,7 @@ const {
   mockTextInputSetInput: vi.fn(),
   mockTextInputClear: vi.fn(),
   mockControllerState: { value: "", files: [] as { url: string }[] },
-  mockFeatureState: { chatSecretScanEnabled: false, betaEnabled: false },
+  mockFeatureState: { chatSecretScanEnabled: false },
   mockProfileState: {
     agent: null as { sandboxAvailable: boolean } | null,
   },
@@ -300,9 +300,6 @@ describe("ArchestraPromptInput", () => {
       if (flag === "chatSecretScanEnabled") {
         return mockFeatureState.chatSecretScanEnabled;
       }
-      if (flag === "betaEnabled") {
-        return mockFeatureState.betaEnabled;
-      }
       return undefined;
     });
     mockUseChatPlaceholder.mockReturnValue({
@@ -316,7 +313,6 @@ describe("ArchestraPromptInput", () => {
     mockControllerState.value = "";
     mockControllerState.files = [];
     mockFeatureState.chatSecretScanEnabled = false;
-    mockFeatureState.betaEnabled = false;
     mockProfileState.agent = null;
     localStorage.clear();
   });
@@ -968,7 +964,6 @@ describe("ArchestraPromptInput", () => {
 
   describe("queue keyboard shortcuts", () => {
     it("pops the most recently queued message into the composer on ArrowUp when empty", () => {
-      mockFeatureState.betaEnabled = true;
       const conversationId = "conv-arrowup-pop";
       chatMessageQueue.clear(conversationId);
       chatMessageQueue.enqueue(conversationId, { text: "first queued" });
@@ -997,7 +992,6 @@ describe("ArchestraPromptInput", () => {
     });
 
     it("prefixes a queued skill command when popping it back", () => {
-      mockFeatureState.betaEnabled = true;
       const conversationId = "conv-arrowup-skill";
       chatMessageQueue.clear(conversationId);
       chatMessageQueue.enqueue(conversationId, {
@@ -1024,7 +1018,6 @@ describe("ArchestraPromptInput", () => {
     });
 
     it("leaves the queue alone on ArrowUp when the composer already has text", () => {
-      mockFeatureState.betaEnabled = true;
       const conversationId = "conv-arrowup-nonempty";
       chatMessageQueue.clear(conversationId);
       chatMessageQueue.enqueue(conversationId, { text: "queued" });
@@ -1100,7 +1093,6 @@ describe("ArchestraPromptInput", () => {
     };
 
     it("keeps the composer usable mid-stream when queueing can absorb the message", () => {
-      mockFeatureState.betaEnabled = true;
       const onSubmit = vi.fn();
 
       render(
@@ -1124,14 +1116,11 @@ describe("ArchestraPromptInput", () => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
     });
 
-    it("locks the composer during compaction when queueing is off", () => {
-      mockFeatureState.betaEnabled = false;
-
+    it("locks the composer during compaction when there is no conversation to queue into", () => {
       render(
         <ArchestraPromptInput
           {...defaultProps}
           status="streaming"
-          conversationId="conv-compacting-no-queue"
           isContextCompacting
         />,
       );
@@ -1140,9 +1129,7 @@ describe("ArchestraPromptInput", () => {
       expect(getSubmitButton()).toBeDisabled();
     });
 
-    it("locks the composer during an idle (manual) compaction even with queueing on", () => {
-      mockFeatureState.betaEnabled = true;
-
+    it("locks the composer during an idle (manual) compaction", () => {
       render(
         <ArchestraPromptInput
           {...defaultProps}

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -620,6 +620,16 @@ const PromptInputContent = ({
   // When off, the composer behaves as before: Enter is blocked while a
   // response streams and the submit button stops via the form-submit path.
   const isMessageQueueEnabled = useFeature("betaEnabled") ?? false;
+  // Context compaction normally locks the composer, but when queueing can
+  // absorb the message (queue on, live conversation, response in flight) the
+  // composer stays usable: Enter enqueues — the session-level drain already
+  // defers to compaction — and the button keeps its Stop role. Without this,
+  // mid-turn auto-compaction silently swallows Enter and drops keyboard focus,
+  // which reads as "queueing stopped working".
+  const canComposeDuringCompaction =
+    isMessageQueueEnabled && !!conversationId && isResponseInFlight;
+  const composerLocked =
+    submitDisabled || (isContextCompacting && !canComposeDuringCompaction);
   // Messages queued while a response was in-flight; sent automatically (in
   // order) by the conversation's chat session once each turn settles.
   const queuedMessages = useConversationMessageQueue(
@@ -841,7 +851,7 @@ const PromptInputContent = ({
               ref={textareaRef}
               className="px-4"
               autoFocus
-              disabled={submitDisabled || isContextCompacting}
+              disabled={composerLocked}
               // With queueing on and a live conversation, Enter during a
               // stream submits and the submit handler queues the message.
               // Otherwise (queueing off, or the new-chat composer while the
@@ -897,7 +907,7 @@ const PromptInputContent = ({
                 <PromptInputSubmit
                   className="!h-8"
                   status={submitStatus}
-                  disabled={submitDisabled || isContextCompacting}
+                  disabled={composerLocked}
                   onClick={(event) => {
                     // While a response is in-flight the button shows Stop; a
                     // click stops the stream instead of submitting the form

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -616,25 +616,18 @@ const PromptInputContent = ({
   const submitStatus = status === "error" ? "ready" : status;
   const isResponseInFlight = status === "submitted" || status === "streaming";
 
-  // Message queueing is beta, gated by the ARCHESTRA_BETA master switch.
-  // When off, the composer behaves as before: Enter is blocked while a
-  // response streams and the submit button stops via the form-submit path.
-  const isMessageQueueEnabled = useFeature("betaEnabled") ?? false;
   // Context compaction normally locks the composer, but when queueing can
-  // absorb the message (queue on, live conversation, response in flight) the
-  // composer stays usable: Enter enqueues — the session-level drain already
-  // defers to compaction — and the button keeps its Stop role. Without this,
-  // mid-turn auto-compaction silently swallows Enter and drops keyboard focus,
-  // which reads as "queueing stopped working".
-  const canComposeDuringCompaction =
-    isMessageQueueEnabled && !!conversationId && isResponseInFlight;
+  // absorb the message (live conversation, response in flight) the composer
+  // stays usable: Enter enqueues — the session-level drain already defers to
+  // compaction — and the button keeps its Stop role. Without this, mid-turn
+  // auto-compaction silently swallows Enter and drops keyboard focus, which
+  // reads as "queueing stopped working".
+  const canComposeDuringCompaction = !!conversationId && isResponseInFlight;
   const composerLocked =
     submitDisabled || (isContextCompacting && !canComposeDuringCompaction);
   // Messages queued while a response was in-flight; sent automatically (in
   // order) by the conversation's chat session once each turn settles.
-  const queuedMessages = useConversationMessageQueue(
-    isMessageQueueEnabled ? conversationId : undefined,
-  );
+  const queuedMessages = useConversationMessageQueue(conversationId);
 
   // Composer keyboard shortcuts layered on top of the primitive textarea:
   //   • Esc — stop the in-flight response (mirrors the Stop button).
@@ -658,7 +651,6 @@ const PromptInputContent = ({
       if (
         event.key === "ArrowUp" &&
         !isSlashCommandOpen &&
-        isMessageQueueEnabled &&
         conversationId &&
         controller.textInput.value === "" &&
         queuedMessages.length > 0
@@ -720,7 +712,6 @@ const PromptInputContent = ({
     [
       conversationId,
       controller.textInput,
-      isMessageQueueEnabled,
       isResponseInFlight,
       isSlashCommandOpen,
       onStop,
@@ -734,7 +725,7 @@ const PromptInputContent = ({
 
   return (
     <div className="relative">
-      {isMessageQueueEnabled && conversationId && queuedMessages.length > 0 && (
+      {conversationId && queuedMessages.length > 0 && (
         <div
           className="mb-2 flex max-h-40 flex-col gap-1 overflow-y-auto"
           data-testid={E2eTestId.ChatMessageQueue}
@@ -852,14 +843,11 @@ const PromptInputContent = ({
               className="px-4"
               autoFocus
               disabled={composerLocked}
-              // With queueing on and a live conversation, Enter during a
-              // stream submits and the submit handler queues the message.
-              // Otherwise (queueing off, or the new-chat composer while the
-              // conversation is being created) Enter stays blocked.
-              disableEnterSubmit={
-                isResponseInFlight &&
-                (!isMessageQueueEnabled || !conversationId)
-              }
+              // In a live conversation, Enter during a stream submits and the
+              // submit handler queues the message. On the new-chat composer
+              // (no conversation to queue into yet) Enter stays blocked while
+              // the conversation is being created.
+              disableEnterSubmit={isResponseInFlight && !conversationId}
               onKeyDown={handleTextareaKeyDown}
               data-testid={E2eTestId.ChatPromptTextarea}
             />
@@ -912,10 +900,7 @@ const PromptInputContent = ({
                     // While a response is in-flight the button shows Stop; a
                     // click stops the stream instead of submitting the form
                     // (which would queue the typed text — see onStop docs).
-                    // With queueing off, the click falls through to the form
-                    // submit, whose handler stops the stream (pre-queue
-                    // behavior).
-                    if (isMessageQueueEnabled && onStop && isResponseInFlight) {
+                    if (onStop && isResponseInFlight) {
                       event.preventDefault();
                       onStop();
                     }

--- a/platform/frontend/src/lib/chat/chat-submit-action.ts
+++ b/platform/frontend/src/lib/chat/chat-submit-action.ts
@@ -16,7 +16,7 @@ export type ChatSubmitAction = "queue" | "stop" | "send";
 export function classifyChatSubmitAction(params: {
   /** AI SDK useChat status snapshot as seen by the page. */
   status: string;
-  /** Message queueing is on (beta) AND a conversation exists to queue into. */
+  /** A conversation exists to queue into (false on the new-chat composer). */
   queueEnabled: boolean;
   /** A direct send fired but the page's `status` hasn't caught up yet. */
   directSendPending: boolean;
@@ -25,8 +25,8 @@ export function classifyChatSubmitAction(params: {
   const isStreaming = status === "submitted" || status === "streaming";
 
   if (isStreaming) {
-    // Submitting mid-turn queues the message with queueing on; without it, the
-    // submit button doubles as Stop.
+    // Submitting mid-turn queues the message when there is a conversation to
+    // queue into; on the new-chat composer the submit doubles as Stop.
     return queueEnabled ? "queue" : "stop";
   }
 

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -90,7 +90,8 @@ vi.mock("@/lib/config/config", () => ({
 
 // Bespoke factory (not the canonical __mocks__ one): this file partially
 // mocks @/lib/config/config above, which the canonical mock's importActual
-// chain would break on. Beta off means message-queue draining stays inert.
+// chain would break on. (Message-queue draining stays inert here because no
+// messages are ever enqueued for the test conversations.)
 vi.mock("@/lib/config/config.query", () => ({
   useFeature: () => false,
 }));

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -74,7 +74,6 @@ import {
   hasSwapToolErrorInPart,
 } from "@/lib/chat/swap-agent.utils";
 import appConfig from "@/lib/config/config";
-import { useFeature } from "@/lib/config/config.query";
 import { useAppName } from "@/lib/hooks/use-app-name";
 
 const SESSION_CLEANUP_TIMEOUT = 10 * 60 * 1000; // 10 min
@@ -1106,14 +1105,7 @@ function ChatSessionHook({
   // as each drained turn finishes. Living here (not in the page) means queues
   // keep draining while the user is viewing another conversation, since
   // ChatSessionHook instances survive conversation switches.
-  //
-  // Queueing is beta (ARCHESTRA_BETA): with the flag off the hook is passed
-  // no conversation, the snapshot stays empty, and the drain never fires —
-  // even for queues persisted while the flag was on.
-  const isMessageQueueEnabled = useFeature("betaEnabled") ?? false;
-  const queuedMessages = useConversationMessageQueue(
-    isMessageQueueEnabled ? conversationId : undefined,
-  );
+  const queuedMessages = useConversationMessageQueue(conversationId);
   // One-at-a-time guard: taking a message re-fires this effect (the queue
   // snapshot changes) possibly before the SDK's status has left "ready"; the
   // ref blocks a second send until a status transition confirms the turn


### PR DESCRIPTION
Two changes to chat message queueing, one per commit.

## 1. Fix: keep the composer usable during context compaction

With message queueing enabled, mid-turn **auto context compaction disabled the entire composer**:

- the textarea was `disabled`, so it dropped keyboard focus and typing stopped working;
- the submit button was `disabled`, and the textarea's Enter handler refuses to `requestSubmit()` while the submit button is disabled — so **Enter was silently swallowed**: nothing queued, nothing was shown, the typed text just sat there.

On long agentic turns (many tool calls) auto-compaction kicks in regularly, so message queueing intermittently "stopped working" with no feedback — and it was invisible in reproduction attempts unless compaction happened to be running at that moment.

Queueing during compaction is safe — the session-level queue drain already defers to compaction (it only sends once the turn settles and `isCompacting` is false). The composer now stays usable whenever the queue can absorb the message (a live conversation with a response in flight): typing keeps working, **Enter enqueues**, and the button keeps its Stop role (no longer dead during compaction). The composer stays locked during an idle manual `/compact` and on the new-chat composer. `handleCompactConversation` gains a re-entry guard since `/compact` can now be typed while a compaction is running.

## 2. GA: message queueing no longer requires `ARCHESTRA_BETA`

Queueing is "GA ready" — the `isMessageQueueEnabled` / `useFeature("betaEnabled")` checks are removed from the composer, the chat page's submit routing, and the session-level queue drain. Queueing is now gated only by having a conversation to queue into:

- live conversation + response in flight → Enter queues, chips render, drain runs;
- new-chat composer (conversation still being created) → Enter stays blocked and the submit doubles as Stop, as before.

The `/api/config` `features.betaEnabled` field is untouched (the `ARCHESTRA_BETA` master switch still gates other backend features); the frontend just no longer consumes it.

Docs: `platform-chat.md` gains a **Message Queueing** section (Enter to queue, chips above the composer, ArrowUp recall, Stop/Esc pauses the queue).

## Tests

- New `context compaction` component tests pin: usable mid-stream with a conversation (submit reaches the consumer), locked with no conversation, locked during idle compaction. The `PromptInputSubmit` test mock now forwards `disabled` so button assertions are real.
- Beta-flag toggling removed from composer tests; queue tests now run against the always-on behavior.
- Full frontend suite: 318 files, 2805 tests green. `pnpm type-check`, biome, and the docs link checker all pass.