### PR TITLE
feat(mcp): confirm personal connection pin for personal agents too

### DIFF
--- a/platform/e2e-tests/utils/tool-assignments.ts
+++ b/platform/e2e-tests/utils/tool-assignments.ts
@@ -45,11 +45,10 @@ export async function saveOpenProfileDialog(page: Page): Promise<void> {
 }
 
 /**
- * Choosing a personal-scope connection for a shared (team/org) agent or gateway
- * prompts a confirmation ("Use this connection for everyone?") because every
- * caller would then connect as that one owner. Confirm it so the choice applies;
- * non-personal connections and personal-scope targets don't prompt. Returns
- * whether a confirmation was handled.
+ * Choosing a personal-scope connection prompts a confirmation ("Use this
+ * connection for everyone?") because every caller of the tool would then connect
+ * as that one owner. Confirm it so the choice applies; non-personal connections
+ * don't prompt. Returns whether a confirmation was handled.
  */
 async function confirmPersonalCredentialPinIfPrompted(
   page: Page,

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -1210,7 +1210,6 @@ function McpServerPill({
             catalogId={catalogItem.id}
             assignmentScope={assignmentScope}
             assignmentTeamIds={assignmentTeamIds}
-            agentScope={assignmentScope}
             value={selectedCredential}
             onValueChange={setSelectedCredential}
             shouldSetDefaultValue={false}

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -464,7 +464,6 @@ export const InitialAgentSelector = memo(function InitialAgentSelector({
               <ConfigureToolView
                 agentId={editingAgent.id}
                 agentName={editingAgent.name}
-                agentScope={(editingAgent.scope as AgentScope) ?? "personal"}
                 catalog={selectedCatalog}
                 onBack={() => setDialogView(configureToolFrom)}
                 onDone={() => setDialogView("settings")}
@@ -1424,14 +1423,12 @@ function AddToolView({
 function ConfigureToolView({
   agentId,
   agentName,
-  agentScope,
   catalog,
   onBack,
   onDone,
 }: {
   agentId: string;
   agentName: string;
-  agentScope: AgentScope;
   catalog: CatalogItem;
   onBack: () => void;
   onDone: () => void;
@@ -1577,7 +1574,6 @@ function ConfigureToolView({
             </Label>
             <TokenSelect
               catalogId={catalog.id}
-              agentScope={agentScope}
               value={credential}
               onValueChange={setCredential}
               shouldSetDefaultValue={false}

--- a/platform/frontend/src/components/token-select.test.tsx
+++ b/platform/frontend/src/components/token-select.test.tsx
@@ -214,7 +214,7 @@ describe("TokenSelect", () => {
     expect(screen.getByText("Owned by member@example.com")).toBeInTheDocument();
   });
 
-  it("confirms before applying a personal credential on a shared agent, and applies it on confirm", () => {
+  it("confirms before applying a personal credential, and applies it on confirm", () => {
     useMcpServersGroupedByCatalogMock.mockReturnValue({
       "catalog-1": [personalCred],
     });
@@ -226,7 +226,6 @@ describe("TokenSelect", () => {
         onValueChange={onValueChange}
         catalogId="catalog-1"
         shouldSetDefaultValue={false}
-        agentScope="org"
       />,
     );
 
@@ -259,7 +258,6 @@ describe("TokenSelect", () => {
         onValueChange={onValueChange}
         catalogId="catalog-1"
         shouldSetDefaultValue={false}
-        agentScope="org"
       />,
     );
 
@@ -281,7 +279,6 @@ describe("TokenSelect", () => {
         onValueChange={vi.fn()}
         catalogId="catalog-1"
         shouldSetDefaultValue={false}
-        agentScope="team"
       />,
     );
 
@@ -289,9 +286,9 @@ describe("TokenSelect", () => {
     expect(lastPins()?.[0]?.isCurrentUser).toBe(true);
   });
 
-  it("applies a personal credential without confirmation on a personal-scope agent", () => {
+  it("confirms before applying the selector's own personal credential", () => {
     useMcpServersGroupedByCatalogMock.mockReturnValue({
-      "catalog-1": [personalCred],
+      "catalog-1": [ownPersonalCred],
     });
     const onValueChange = vi.fn();
 
@@ -301,16 +298,15 @@ describe("TokenSelect", () => {
         onValueChange={onValueChange}
         catalogId="catalog-1"
         shouldSetDefaultValue={false}
-        agentScope="personal"
       />,
     );
 
-    fireEvent.click(screen.getByText("member@example.com"));
-    expect(onValueChange).toHaveBeenCalledWith("user-cred");
-    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("me@example.com"));
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("confirm-dialog")).toBeInTheDocument();
   });
 
-  it("applies an org/team credential on a shared agent without confirmation", () => {
+  it("applies an org/team credential without confirmation", () => {
     useMcpServersGroupedByCatalogMock.mockReturnValue({
       "catalog-1": [orgCred],
     });
@@ -322,7 +318,6 @@ describe("TokenSelect", () => {
         onValueChange={onValueChange}
         catalogId="catalog-1"
         shouldSetDefaultValue={false}
-        agentScope="org"
       />,
     );
 

--- a/platform/frontend/src/components/token-select.tsx
+++ b/platform/frontend/src/components/token-select.tsx
@@ -31,13 +31,6 @@ interface TokenSelectProps {
   assignmentTeamIds?: string[];
   shouldSetDefaultValue: boolean;
   prefersEnterpriseManaged?: boolean;
-  /**
-   * Scope of the agent this credential is assigned to. Picking a personal-scope
-   * connection for a shared (team/org) agent makes every caller authenticate as
-   * that one owner, so it is confirmed on selection. A personal agent is
-   * single-user and skips the confirmation. Unknown scope falls to the safe side.
-   */
-  agentScope?: AgentScope;
 }
 
 /**
@@ -56,7 +49,6 @@ export function TokenSelect({
   assignmentTeamIds,
   shouldSetDefaultValue,
   prefersEnterpriseManaged = false,
-  agentScope,
 }: TokenSelectProps) {
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
@@ -104,13 +96,11 @@ export function TokenSelect({
     isCurrentUser: boolean;
   } | null>(null);
 
-  // A personal connection pinned to a shared agent authenticates every caller
-  // as that one owner; confirm the pick before applying it. A personal agent is
-  // single-user, so it skips the gate; unknown scope falls to the safe side.
-  const isSharedAgent = agentScope !== "personal";
-
+  // Pinning a personal connection makes every caller of this tool authenticate
+  // as that one owner; confirm the pick before applying it, regardless of the
+  // agent's scope — a personal agent can still be shared later.
   const handleSelect = (newValue: string | null) => {
-    if (isSharedAgent && newValue && newValue !== DYNAMIC_CREDENTIAL_VALUE) {
+    if (newValue && newValue !== DYNAMIC_CREDENTIAL_VALUE) {
       const server = mcpServers.find((s) => s.id === newValue);
       if (server?.scope === "personal") {
         setPendingPersonalPin({


### PR DESCRIPTION
## Summary

Selecting a **personal-scope** MCP connection as a tool's static credential authenticates *every* caller of that tool to the MCP server as that one owner — their access, their rate limits, their identity at the server. [#6611](https://github.com/archestra-ai/archestra/pull/6611) added a confirmation the instant such a connection is picked, but exempted **personal-scope agents** on the reasoning that a personal agent is single-user.

That exemption leaves a gap: a personal agent can be **scoped up** to a team or org later, and at that moment its personal pin silently becomes shared with no prompt. This removes the exemption, so choosing a personal connection now confirms on selection regardless of the agent's scope. The dialog wording is unchanged ("Use this connection for everyone?" — every user connects as the owner). A personal agent can only ever pin the current user's own personal install (backend-enforced in `filterMcpServersAssignableToTarget`), so the confirmation always reads "as you / your access" there.

The `agentScope` prop that drove the exemption is now unused and is removed from `TokenSelect` and its two callers.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>