### PR TITLE
fix(mcp-logs): attribute app-owned tool calls to their app instead of "Deleted MCP Gateway"

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -201490,6 +201490,10 @@
                           "userName": {
                             "nullable": true,
                             "type": "string"
+                          },
+                          "appName": {
+                            "nullable": true,
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -201504,7 +201508,8 @@
                           "userId",
                           "authMethod",
                           "createdAt",
-                          "userName"
+                          "userName",
+                          "appName"
                         ],
                         "additionalProperties": false
                       }
@@ -201901,6 +201906,10 @@
                     "userName": {
                       "nullable": true,
                       "type": "string"
+                    },
+                    "appName": {
+                      "nullable": true,
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -201915,7 +201924,8 @@
                     "userId",
                     "authMethod",
                     "createdAt",
-                    "userName"
+                    "userName",
+                    "appName"
                   ],
                   "additionalProperties": false
                 }

--- a/platform/backend/src/models/mcp-tool-call.test.ts
+++ b/platform/backend/src/models/mcp-tool-call.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "@/test";
 import AgentModel from "./agent";
+import AppModel from "./app";
 import McpToolCallModel from "./mcp-tool-call";
 
 describe("McpToolCallModel", () => {
@@ -769,6 +770,99 @@ describe("McpToolCallModel", () => {
 
       expect(existingAgentCall).toBeDefined();
       expect(existingAgentCall?.agentId).toBe(agentToKeep.id);
+    });
+  });
+
+  describe("app-owned tool calls", () => {
+    test("findAllPaginated and findById return the owning app's name", async ({
+      makeAdmin,
+      makeApp,
+    }) => {
+      const admin = await makeAdmin();
+      const app = await makeApp({ name: "My Dashboard App" });
+
+      const created = await McpToolCallModel.create({
+        ownerType: "app",
+        appId: app.id,
+        mcpServerName: "app-server",
+        method: "tools/call",
+        toolCall: { id: "test-id", name: "app_data_get", arguments: {} },
+        toolResult: { isError: false, content: "Success" },
+      });
+
+      const toolCalls = await McpToolCallModel.findAllPaginated(
+        { limit: 100, offset: 0 },
+        undefined,
+        admin.id,
+        true,
+      );
+
+      expect(toolCalls.data).toHaveLength(1);
+      expect(toolCalls.data[0].ownerType).toBe("app");
+      expect(toolCalls.data[0].agentId).toBeNull();
+      expect(toolCalls.data[0].appId).toBe(app.id);
+      expect(toolCalls.data[0].appName).toBe("My Dashboard App");
+
+      const found = await McpToolCallModel.findById(created.id, admin.id, true);
+      expect(found?.appName).toBe("My Dashboard App");
+      expect(found?.ownerType).toBe("app");
+    });
+
+    test("tool call is preserved with null appId/appName when the app is deleted", async ({
+      makeAdmin,
+      makeApp,
+    }) => {
+      const admin = await makeAdmin();
+      const app = await makeApp({ name: "App To Delete" });
+
+      const created = await McpToolCallModel.create({
+        ownerType: "app",
+        appId: app.id,
+        mcpServerName: "app-server",
+        method: "tools/call",
+        toolCall: { id: "test-id", name: "app_data_set", arguments: {} },
+        toolResult: { isError: false, content: "Success" },
+      });
+
+      await AppModel.delete(app.id);
+
+      const found = await McpToolCallModel.findById(created.id, admin.id, true);
+      expect(found).toBeDefined();
+      expect(found?.ownerType).toBe("app");
+      expect(found?.appId).toBeNull();
+      expect(found?.appName).toBeNull();
+      expect(found?.agentId).toBeNull();
+    });
+
+    test("agent-owned tool calls have a null appName", async ({
+      makeAdmin,
+    }) => {
+      const admin = await makeAdmin();
+
+      await McpToolCallModel.create({
+        agentId,
+        mcpServerName: "agent-server",
+        method: "tools/call",
+        toolCall: { id: "test-id", name: "someTool", arguments: {} },
+        toolResult: { isError: false, content: "Success" },
+      });
+
+      const toolCalls = await McpToolCallModel.findAllPaginated(
+        { limit: 100, offset: 0 },
+        undefined,
+        admin.id,
+        true,
+      );
+      expect(toolCalls.data).toHaveLength(1);
+      expect(toolCalls.data[0].appName).toBeNull();
+
+      const agentScoped =
+        await McpToolCallModel.getAllMcpToolCallsForAgentPaginated(agentId, {
+          limit: 100,
+          offset: 0,
+        });
+      expect(agentScoped.data).toHaveLength(1);
+      expect(agentScoped.data[0].appName).toBeNull();
     });
   });
 });

--- a/platform/backend/src/models/mcp-tool-call.ts
+++ b/platform/backend/src/models/mcp-tool-call.ts
@@ -111,6 +111,8 @@ class McpToolCallModel {
           ...getTableColumns(schema.mcpToolCallsTable),
           userName: schema.usersTable.name,
           agentDeletedAt: schema.agentsTable.deletedAt,
+          appName: schema.appsTable.name,
+          appDeletedAt: schema.appsTable.deletedAt,
         })
         .from(schema.mcpToolCallsTable)
         .leftJoin(
@@ -120,6 +122,10 @@ class McpToolCallModel {
         .leftJoin(
           schema.agentsTable,
           eq(schema.mcpToolCallsTable.agentId, schema.agentsTable.id),
+        )
+        .leftJoin(
+          schema.appsTable,
+          eq(schema.mcpToolCallsTable.appId, schema.appsTable.id),
         )
         .where(whereClause)
         .orderBy(orderByClause)
@@ -169,6 +175,8 @@ class McpToolCallModel {
         ...getTableColumns(schema.mcpToolCallsTable),
         userName: schema.usersTable.name,
         agentDeletedAt: schema.agentsTable.deletedAt,
+        appName: schema.appsTable.name,
+        appDeletedAt: schema.appsTable.deletedAt,
       })
       .from(schema.mcpToolCallsTable)
       .leftJoin(
@@ -178,6 +186,10 @@ class McpToolCallModel {
       .leftJoin(
         schema.agentsTable,
         eq(schema.mcpToolCallsTable.agentId, schema.agentsTable.id),
+      )
+      .leftJoin(
+        schema.appsTable,
+        eq(schema.mcpToolCallsTable.appId, schema.appsTable.id),
       )
       .where(eq(schema.mcpToolCallsTable.id, id));
 
@@ -270,6 +282,9 @@ class McpToolCallModel {
         .select({
           ...getTableColumns(schema.mcpToolCallsTable),
           userName: schema.usersTable.name,
+          // Agent-scoped rows are never app-owned; select the column anyway so
+          // rows satisfy the McpToolCall contract (appName is non-optional).
+          appName: sql<string | null>`null`,
         })
         .from(schema.mcpToolCallsTable)
         .leftJoin(
@@ -352,16 +367,23 @@ class McpToolCallModel {
 export default McpToolCallModel;
 
 function toVisibleMcpToolCall(
-  row: McpToolCall & { agentDeletedAt?: Date | null },
+  row: McpToolCall & {
+    agentDeletedAt?: Date | null;
+    appDeletedAt?: Date | null;
+  },
 ): McpToolCall {
-  const { agentDeletedAt: _agentDeletedAt, ...toolCall } = row;
+  const {
+    agentDeletedAt: _agentDeletedAt,
+    appDeletedAt: _appDeletedAt,
+    ...toolCall
+  } = row;
 
-  if (row.agentDeletedAt) {
-    return {
-      ...toolCall,
-      agentId: null,
-    };
-  }
-
-  return toolCall;
+  return {
+    ...toolCall,
+    // Null out references to soft-deleted owners so consumers can't resolve
+    // them; ownerType still tells which kind of owner made the call.
+    agentId: row.agentDeletedAt ? null : toolCall.agentId,
+    appId: row.appDeletedAt ? null : toolCall.appId,
+    appName: row.appDeletedAt ? null : toolCall.appName,
+  };
 }

--- a/platform/backend/src/types/mcp-tool-call.ts
+++ b/platform/backend/src/types/mcp-tool-call.ts
@@ -35,6 +35,9 @@ export const SelectMcpToolCallSchema = createSelectSchema(
   },
 ).extend({
   userName: z.string().nullable(),
+  // Name of the owning app for app-owned calls; null for agent-owned calls
+  // or when the app was deleted.
+  appName: z.string().nullable(),
 });
 
 /**

--- a/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
@@ -142,14 +142,22 @@ function McpToolCallDetail({
             </>
           }
         >
-          <MetadataItem label="MCP Gateway">
-            <div className="font-semibold">
-              {agent?.name ??
-                (mcpToolCall.agentId === null
-                  ? "Deleted MCP Gateway"
-                  : "Unknown")}
-            </div>
-          </MetadataItem>
+          {mcpToolCall.ownerType === "app" ? (
+            <MetadataItem label="App">
+              <div className="font-semibold">
+                {mcpToolCall.appName ?? "Deleted App"}
+              </div>
+            </MetadataItem>
+          ) : (
+            <MetadataItem label="MCP Gateway">
+              <div className="font-semibold">
+                {agent?.name ??
+                  (mcpToolCall.agentId === null
+                    ? "Deleted MCP Gateway"
+                    : "Unknown")}
+              </div>
+            </MetadataItem>
+          )}
           <MetadataItem label="MCP Server">
             <div className="font-mono">{mcpToolCall.mcpServerName}</div>
           </MetadataItem>

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -249,28 +249,21 @@ function McpToolCallsTable({
     },
     {
       id: "agent",
-      accessorFn: (row) => {
-        const agent = agents?.find((a) => a.id === row.agentId);
-        return (
-          agent?.name ??
-          (row.agentId === null ? "Deleted MCP Gateway" : "Unknown")
-        );
-      },
+      accessorFn: (row) => getGatewayDisplayName(row, agents),
       header: "MCP Gateway",
-      cell: ({ row }) => {
-        const agent = agents?.find((a) => a.id === row.original.agentId);
-        return (
+      cell: ({ row }) => (
+        <div className="flex items-center gap-1.5">
           <TruncatedText
-            message={
-              agent?.name ??
-              (row.original.agentId === null
-                ? "Deleted MCP Gateway"
-                : "Unknown")
-            }
+            message={getGatewayDisplayName(row.original, agents)}
             maxLength={30}
           />
-        );
-      },
+          {row.original.ownerType === "app" && (
+            <Badge variant="outline" className="text-xs whitespace-nowrap">
+              App
+            </Badge>
+          )}
+        </div>
+      ),
     },
     {
       id: "user",
@@ -494,5 +487,20 @@ function McpToolCallsTable({
         }}
       />
     </div>
+  );
+}
+
+function getGatewayDisplayName(
+  row: Pick<McpToolCallData, "ownerType" | "agentId" | "appName">,
+  agents: archestraApiTypes.GetAllAgentsResponses["200"] | undefined,
+) {
+  // App-owned calls have no agent by design — attribute them to the app
+  // instead of falling through to the deleted-gateway label.
+  if (row.ownerType === "app") {
+    return row.appName ?? "Deleted App";
+  }
+  const agent = agents?.find((a) => a.id === row.agentId);
+  return (
+    agent?.name ?? (row.agentId === null ? "Deleted MCP Gateway" : "Unknown")
   );
 }

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -52429,6 +52429,7 @@ export type GetMcpToolCallsResponses = {
             authMethod: 'oauth' | 'user_token' | 'org_token' | 'team_token' | 'external_idp' | 'session';
             createdAt: string;
             userName: string | null;
+            appName: string | null;
         }>;
         pagination: {
             currentPage: number;
@@ -52543,6 +52544,7 @@ export type GetMcpToolCallResponses = {
         authMethod: 'oauth' | 'user_token' | 'org_token' | 'team_token' | 'external_idp' | 'session';
         createdAt: string;
         userName: string | null;
+        appName: string | null;
     };
 };
 


### PR DESCRIPTION
## Problem

Tool calls made by Apps (`window.archestra.tools.call`, executed server-side with the viewing user's session) are logged with a null `agentId` by design — they carry `ownerType: "app"` and an `appId` instead. The MCP Gateway logs page, however, only knows one meaning for a null `agentId`: a deleted agent. As a result, **every** app-owned tool call rendered as "Deleted MCP Gateway" in the logs list and detail pages, which reads like data corruption and hides which app actually made the call.

## Fix

**Backend**
- `McpToolCallModel.findAllPaginated` / `findById` now left-join `apps` and return an `appName` on each log row.
- Soft-deleted apps are handled the same way as soft-deleted agents: `appId`/`appName` are nulled on the visible row while `ownerType` still says which kind of owner made the call.
- `SelectMcpToolCallSchema` gains `appName: string | null` (OpenAPI spec + generated client regenerated).

**Frontend**
- The logs list "MCP Gateway" column and the detail page now branch on `ownerType === "app"`: they show the app's name (with an `App` badge in the list) and fall back to "Deleted App" when the app itself was deleted, instead of the deleted-gateway label. Agent-owned rows behave exactly as before.

## Tests

- New model tests: app-owned rows return the owning app's name from both list and detail queries; deleting the app preserves the row with nulled `appId`/`appName` and `ownerType: "app"`; agent-owned rows (including the agent-scoped query) carry `appName: null` so response serialization stays valid.
- Existing deleted-agent behavior is unchanged and still covered by the pre-existing tests.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>