### PR TITLE
fix(frontend): make copy buttons work on insecure (plain-HTTP) origins

### DIFF
--- a/platform/frontend/src/app/connection/connect-command-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.tsx
@@ -28,6 +28,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { WizardStep } from "@/components/wizard-step";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   type CreateConnectionSetupBody,
   type CreateConnectionSetupResult,
@@ -817,7 +818,7 @@ function CommandLine({
   const [copied, setCopied] = useState(false);
   const onCopy = useCallback(async () => {
     if (!command) return;
-    await navigator.clipboard.writeText(command);
+    await copyToClipboard(command);
     setCopied(true);
     toast.success("Copied to clipboard");
     setTimeout(() => setCopied(false), 1600);

--- a/platform/frontend/src/app/connection/proxy-client-instructions.tsx
+++ b/platform/frontend/src/app/connection/proxy-client-instructions.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   useCreateConnectionPassthroughKey,
   useCreateConnectionVirtualKey,
@@ -920,7 +921,7 @@ function FieldRow({
 function FieldCopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
   const onCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(value);
+    await copyToClipboard(value);
     setCopied(true);
     setTimeout(() => setCopied(false), 1600);
   }, [value]);

--- a/platform/frontend/src/app/connection/terminal-block.tsx
+++ b/platform/frontend/src/app/connection/terminal-block.tsx
@@ -3,6 +3,7 @@
 import { Check, Copy } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { copyToClipboard } from "@/lib/clipboard";
 
 interface TerminalBlockProps {
   /** Raw code to render and copy. */
@@ -13,7 +14,7 @@ export function TerminalBlock({ code }: TerminalBlockProps) {
   const [copied, setCopied] = useState(false);
 
   const onCopy = async () => {
-    await navigator.clipboard.writeText(code);
+    await copyToClipboard(code);
     setCopied(true);
     toast.success("Copied to clipboard");
     setTimeout(() => setCopied(false), 1600);

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-exec-terminal.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-exec-terminal.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { copyToClipboard } from "@/lib/clipboard";
 import websocketService from "@/lib/websocket/websocket";
 
 type ConnectionStatus =
@@ -217,7 +218,7 @@ export function McpExecTerminal({ serverId, isActive }: McpExecTerminalProps) {
   const handleCopyCommand = useCallback(async () => {
     if (!command) return;
     try {
-      await navigator.clipboard.writeText(command);
+      await copyToClipboard(command);
       setCommandCopied(true);
       toast.success("Command copied to clipboard");
       setTimeout(() => setCommandCopied(false), 2000);

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
@@ -39,6 +39,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { copyToClipboard } from "@/lib/clipboard";
 import { useAnimatedDots } from "@/lib/hooks/use-animated-dots";
 import websocketService from "@/lib/websocket/websocket";
 import {
@@ -396,7 +397,7 @@ export function McpLogsContent({
 
   const handleCopyLogs = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(streamedLogs);
+      await copyToClipboard(streamedLogs);
       setCopied(true);
       toast.success("Logs copied to clipboard");
       setTimeout(() => setCopied(false), 2000);
@@ -407,7 +408,7 @@ export function McpLogsContent({
 
   const handleCopyCommand = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(command);
+      await copyToClipboard(command);
       setCommandCopied(true);
       toast.success("Command copied to clipboard");
       setTimeout(() => setCommandCopied(false), 2000);

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -24,7 +24,6 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import {
   Avatar,
@@ -32,7 +31,6 @@ import {
   AvatarGroup,
   AvatarGroupCount,
 } from "@/components/ui/avatar";
-
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -53,6 +51,7 @@ import {
 import { TruncatedTooltip } from "@/components/ui/truncated-tooltip";
 import { LOCAL_MCP_DISABLED_MESSAGE } from "@/consts";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { copyToClipboard } from "@/lib/clipboard";
 import { useFeature } from "@/lib/config/config.query";
 import { useEnvironments } from "@/lib/environment.query";
 import { useReinstallInternalMcpCatalogItem } from "@/lib/mcp/internal-mcp-catalog.query";
@@ -791,7 +790,7 @@ export function McpServerCard({
   const isInstallAdmin = !!isMcpServerInstallAdmin;
 
   const copyApprovalLink = () => {
-    void navigator.clipboard.writeText(
+    void copyToClipboard(
       `${window.location.origin}/mcp/registry/${item.id}/edit`,
     );
     toast.success("Link copied — share it with an admin to approve this image");

--- a/platform/frontend/src/app/settings/account/_components/two-factor-card.tsx
+++ b/platform/frontend/src/app/settings/account/_components/two-factor-card.tsx
@@ -27,6 +27,7 @@ import {
   useDisableTwoFactorMutation,
   useEnableTwoFactorMutation,
 } from "@/lib/auth/two-factor.query";
+import { copyToClipboard } from "@/lib/clipboard";
 
 const PasswordFormSchema = z.object({
   password: z.string().min(1, "Password is required"),
@@ -197,7 +198,7 @@ function BackupCodesDialog({
 }) {
   async function copyBackupCodes() {
     if (!result) return;
-    await navigator.clipboard.writeText(result.backupCodes.join("\n"));
+    await copyToClipboard(result.backupCodes.join("\n"));
     toast.success("Backup codes copied to clipboard");
   }
 

--- a/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
@@ -37,6 +37,7 @@ import { PermissionButton } from "@/components/ui/permission-button";
 import { RoleSelect } from "@/components/ui/role-select";
 import { Switch } from "@/components/ui/switch";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   type ServiceAccountToken,
   useCreateServiceAccountToken,
@@ -272,7 +273,7 @@ export default function ServiceAccountDetailPage({
   const copyCreatedToken = async () => {
     if (!createdToken) return;
 
-    await navigator.clipboard.writeText(createdToken);
+    await copyToClipboard(createdToken);
   };
 
   const closeCreatedTokenDialog = () => setCreatedToken(null);

--- a/platform/frontend/src/app/settings/users/page.client.tsx
+++ b/platform/frontend/src/app/settings/users/page.client.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/components/ui/select";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import { copyToClipboard } from "@/lib/clipboard";
 import { useDisableInvitations } from "@/lib/config/config.query";
 import {
   useCanImpersonate,
@@ -351,7 +352,7 @@ function MembersTab({
                   onClick: async () => {
                     if (!member.invitationId) return;
                     const link = `${window.location.origin}/auth/sign-up-with-invitation?invitationId=${member.invitationId}&email=${encodeURIComponent(member.email)}`;
-                    await navigator.clipboard.writeText(link);
+                    await copyToClipboard(link);
                   },
                 },
                 {

--- a/platform/frontend/src/components/ai-elements/code-block.tsx
+++ b/platform/frontend/src/components/ai-elements/code-block.tsx
@@ -15,6 +15,7 @@ import {
   oneLight,
 } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 
 type CodeBlockContextType = {
@@ -112,14 +113,9 @@ export const CodeBlockCopyButton = ({
   const [isCopied, setIsCopied] = useState(false);
   const { code } = useContext(CodeBlockContext);
 
-  const copyToClipboard = async () => {
-    if (typeof window === "undefined" || !navigator.clipboard.writeText) {
-      onError?.(new Error("Clipboard API not available"));
-      return;
-    }
-
+  const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(code);
+      await copyToClipboard(code);
       setIsCopied(true);
       onCopy?.();
       setTimeout(() => setIsCopied(false), timeout);
@@ -134,7 +130,7 @@ export const CodeBlockCopyButton = ({
     <Button
       aria-label={isCopied ? "Copied!" : "Copy to clipboard"}
       className={cn("shrink-0", className)}
-      onClick={copyToClipboard}
+      onClick={handleCopy}
       size="icon"
       variant="ghost"
       {...props}

--- a/platform/frontend/src/components/chat/conversation-artifact.tsx
+++ b/platform/frontend/src/components/chat/conversation-artifact.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ai-elements/code-block";
 import { Button } from "@/components/ui/button";
 import { printMarkdownElementAsPdf } from "@/lib/chat/print-markdown";
+import { copyToClipboard } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 
 const MermaidDiagram = dynamic(
@@ -197,7 +198,7 @@ export function ConversationArtifactPanel({
       return;
     }
     try {
-      await navigator.clipboard.writeText(artifact);
+      await copyToClipboard(artifact);
       toast.success("Artifact copied to clipboard");
     } catch (_error) {
       toast.error("Failed to copy artifact");

--- a/platform/frontend/src/components/chat/conversation-files-panel.tsx
+++ b/platform/frontend/src/components/chat/conversation-files-panel.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/chat/conversation-files";
 import { printMarkdownElementAsPdf } from "@/lib/chat/print-markdown";
 import { useFileDeletion } from "@/lib/chat/use-file-deletion";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   useProject,
   useUploadProjectFiles,
@@ -445,7 +446,7 @@ function ArtifactRowActions({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(content);
+      await copyToClipboard(content);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/collapsible";
 import { useHasPermissions } from "@/lib/auth/auth.query";
 import type { ModelSource } from "@/lib/chat/use-chat-preferences";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   formatOriginalError,
   mapClientError,
@@ -131,7 +132,7 @@ export function InlineChatError({
     }
 
     try {
-      await navigator.clipboard.writeText(lines.join("\n"));
+      await copyToClipboard(lines.join("\n"));
       toast.success(
         slimChatErrorUi ? "Error details copied" : "Debug info copied",
       );

--- a/platform/frontend/src/components/chat/message-actions.tsx
+++ b/platform/frontend/src/components/chat/message-actions.tsx
@@ -14,6 +14,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { copyToClipboard } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 
 export function MessageActions({
@@ -41,7 +42,7 @@ export function MessageActions({
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(textToCopy);
+    await copyToClipboard(textToCopy);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/platform/frontend/src/components/chat/model-selector.tsx
+++ b/platform/frontend/src/components/chat/model-selector.tsx
@@ -53,6 +53,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { resolveAutoSelectedModel } from "@/lib/chat/use-chat-preferences";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   type LlmModel,
   type ModelCapabilities,
@@ -328,7 +329,7 @@ function CopyModelIdButton({ modelId }: { modelId: string }) {
       e.stopPropagation();
       e.preventDefault();
       try {
-        await navigator.clipboard.writeText(modelId);
+        await copyToClipboard(modelId);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       } catch {

--- a/platform/frontend/src/components/chat/share-conversation-dialog.tsx
+++ b/platform/frontend/src/components/chat/share-conversation-dialog.tsx
@@ -22,6 +22,7 @@ import {
   useShareConversation,
   useUnshareConversation,
 } from "@/lib/chat/chat-share.query";
+import { copyToClipboard } from "@/lib/clipboard";
 import { useOrganizationMembers } from "@/lib/organization.query";
 import { useTeams } from "@/lib/teams/team.query";
 
@@ -184,7 +185,7 @@ export function ShareConversationDialog({
     }
 
     setHasSavedVisibleShare(true);
-    await navigator.clipboard.writeText(shareLink);
+    await copyToClipboard(shareLink);
     toast.success("Chat visibility updated and share link copied");
   }, [
     conversationId,

--- a/platform/frontend/src/components/copy-button.tsx
+++ b/platform/frontend/src/components/copy-button.tsx
@@ -3,6 +3,7 @@
 import { Check, Copy } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 
 export function CopyButton({
   text,
@@ -25,25 +26,11 @@ export function CopyButton({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (_error) {
-      // Fallback for older browsers
-      const textArea = document.createElement("textarea");
-      textArea.value = text;
-      textArea.style.position = "fixed";
-      textArea.style.left = "-999999px";
-      document.body.appendChild(textArea);
-      textArea.select();
-      try {
-        document.execCommand("copy");
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      } catch (err) {
-        console.error("Failed to copy:", err);
-      }
-      document.body.removeChild(textArea);
+    } catch (err) {
+      console.error("Failed to copy:", err);
     }
   };
 

--- a/platform/frontend/src/components/copyable-code.tsx
+++ b/platform/frontend/src/components/copyable-code.tsx
@@ -4,6 +4,7 @@ import { Check, Copy } from "lucide-react";
 import { type ReactNode, useCallback, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 
 interface CopyableCodeProps {
@@ -29,7 +30,7 @@ export function CopyableCode({
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(value);
+    await copyToClipboard(value);
     setCopied(true);
     toast.success(toastMessage);
     setTimeout(() => setCopied(false), 2000);

--- a/platform/frontend/src/components/github-copilot-sign-in.tsx
+++ b/platform/frontend/src/components/github-copilot-sign-in.tsx
@@ -3,6 +3,7 @@
 import { Check, Copy, Github, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   type GithubCopilotDeviceStart,
   usePollGithubCopilotDeviceFlow,
@@ -114,7 +115,7 @@ export function GithubCopilotSignIn({
   // fastest path to a paste.
   const copyCodeAndOpen = async (deviceFlow: GithubCopilotDeviceStart) => {
     try {
-      await navigator.clipboard.writeText(deviceFlow.userCode);
+      await copyToClipboard(deviceFlow.userCode);
       markCopied();
     } catch {
       // clipboard blocked (permissions/focus) — the visible code + copy button
@@ -155,7 +156,7 @@ export function GithubCopilotSignIn({
             aria-label="Copy code"
             onClick={async () => {
               try {
-                await navigator.clipboard.writeText(flow.userCode);
+                await copyToClipboard(flow.userCode);
                 markCopied();
               } catch {
                 // clipboard blocked — code stays visible to copy manually

--- a/platform/frontend/src/components/invite-by-link-card.tsx
+++ b/platform/frontend/src/components/invite-by-link-card.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PermissionButton } from "@/components/ui/permission-button";
 import { RoleSelect } from "@/components/ui/role-select";
+import { copyToClipboard } from "@/lib/clipboard";
 import { useCreateInvitation } from "@/lib/organization.query";
 
 interface InviteByLinkCardProps {
@@ -55,7 +56,7 @@ function InviteByLinkCardContent({
   const handleCopyLink = useCallback(async () => {
     if (!invitationLink) return;
 
-    await navigator.clipboard.writeText(invitationLink);
+    await copyToClipboard(invitationLink);
     setIsCopied(true);
     toast.success("Link copied", {
       description: "Invitation link copied to clipboard",

--- a/platform/frontend/src/components/microsoft-365-copilot-sign-in.tsx
+++ b/platform/frontend/src/components/microsoft-365-copilot-sign-in.tsx
@@ -3,6 +3,7 @@
 import { Check, Copy, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   type Microsoft365CopilotDeviceStart,
   usePollMicrosoft365CopilotDeviceFlow,
@@ -119,7 +120,7 @@ export function Microsoft365CopilotSignIn({
     deviceFlow: Microsoft365CopilotDeviceStart,
   ) => {
     try {
-      await navigator.clipboard.writeText(deviceFlow.userCode);
+      await copyToClipboard(deviceFlow.userCode);
       markCopied();
     } catch {
       // clipboard blocked (permissions/focus) — the visible code + copy button
@@ -160,7 +161,7 @@ export function Microsoft365CopilotSignIn({
             aria-label="Copy code"
             onClick={async () => {
               try {
-                await navigator.clipboard.writeText(flow.userCode);
+                await copyToClipboard(flow.userCode);
                 markCopied();
               } catch {
                 // clipboard blocked — code stays visible to copy manually

--- a/platform/frontend/src/components/openai-codex-sign-in.tsx
+++ b/platform/frontend/src/components/openai-codex-sign-in.tsx
@@ -3,6 +3,7 @@
 import { Check, Copy, Info, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   type OpenaiCodexDeviceStart,
   usePollOpenaiCodexDeviceFlow,
@@ -127,7 +128,7 @@ export function OpenaiCodexSignIn({
   // document focused for the clipboard write.
   const copyCodeAndOpen = async (deviceFlow: OpenaiCodexDeviceStart) => {
     try {
-      await navigator.clipboard.writeText(deviceFlow.userCode);
+      await copyToClipboard(deviceFlow.userCode);
       markCopied();
     } catch {
       // clipboard blocked (permissions/focus) — the visible code + copy button
@@ -185,7 +186,7 @@ export function OpenaiCodexSignIn({
               aria-label="Copy code"
               onClick={async () => {
                 try {
-                  await navigator.clipboard.writeText(flow.userCode);
+                  await copyToClipboard(flow.userCode);
                   markCopied();
                 } catch {
                   // clipboard blocked — code stays visible to copy manually

--- a/platform/frontend/src/components/secret-copy-button.tsx
+++ b/platform/frontend/src/components/secret-copy-button.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { copyToClipboard } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 
 /**
@@ -60,7 +61,7 @@ export function SecretCopyButton({
   const handleCopyPlaceholder = async () => {
     if (disabled) return;
     try {
-      await navigator.clipboard.writeText(placeholderText);
+      await copyToClipboard(placeholderText);
       flashCopied();
       toast.success("Copied with placeholder token");
     } catch {
@@ -77,7 +78,7 @@ export function SecretCopyButton({
       // The fetch failed and already surfaced an error; don't copy the mask
       // under a success toast.
       if (text === null) return;
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       flashCopied();
       toast.success("Copied with real token");
     } catch {

--- a/platform/frontend/src/components/teams/team-management-dialog.tsx
+++ b/platform/frontend/src/components/teams/team-management-dialog.tsx
@@ -38,6 +38,7 @@ import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { UserSearchableSelect } from "@/components/user-searchable-select";
 import { useHasPermissions } from "@/lib/auth/auth.query";
+import { copyToClipboard } from "@/lib/clipboard";
 import config from "@/lib/config/config";
 import { useFeature } from "@/lib/config/config.query";
 import { useMembersPaginated } from "@/lib/member.query";
@@ -719,7 +720,7 @@ function TokenSection({ token }: { token?: TeamToken }) {
     },
     onSuccess: async (value) => {
       if (!value) return;
-      await navigator.clipboard.writeText(value);
+      await copyToClipboard(value);
       setDisplayedValue(value);
       setShowValue(true);
       setConfirmRotate(false);
@@ -747,7 +748,7 @@ function TokenSection({ token }: { token?: TeamToken }) {
 
   const handleCopy = async () => {
     if (!displayedValue) return;
-    await navigator.clipboard.writeText(displayedValue);
+    await copyToClipboard(displayedValue);
     setCopied(true);
     toast.success("Token copied to clipboard");
     setTimeout(() => setCopied(false), 2000);

--- a/platform/frontend/src/components/tokens/platform-token-manager-dialog.tsx
+++ b/platform/frontend/src/components/tokens/platform-token-manager-dialog.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { DialogBody, DialogStickyFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { copyToClipboard } from "@/lib/clipboard";
 import { formatRelativeTimeFromNow } from "@/lib/utils/date-time";
 
 export interface ManagedPlatformToken {
@@ -62,7 +63,7 @@ export function PlatformTokenManagerDialog({
   const handleCopy = async () => {
     if (!displayedValue) return;
 
-    await navigator.clipboard.writeText(displayedValue);
+    await copyToClipboard(displayedValue);
     setCopied(true);
     toast.success("Token copied to clipboard");
     setTimeout(() => setCopied(false), 2000);
@@ -77,7 +78,7 @@ export function PlatformTokenManagerDialog({
     const value = await rotateToken();
     if (!value) return;
 
-    await navigator.clipboard.writeText(value);
+    await copyToClipboard(value);
     toast.success("Token rotated and copied to clipboard");
     setDisplayedValue(value);
     setShowValue(true);

--- a/platform/frontend/src/lib/clipboard.test.ts
+++ b/platform/frontend/src/lib/clipboard.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "./clipboard";
+
+const originalClipboard = navigator.clipboard;
+const originalExecCommand = document.execCommand;
+
+function setNavigatorClipboard(value: Clipboard | undefined) {
+  Object.defineProperty(window.navigator, "clipboard", {
+    value,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  setNavigatorClipboard(originalClipboard);
+  document.execCommand = originalExecCommand;
+  vi.restoreAllMocks();
+});
+
+describe("copyToClipboard", () => {
+  it("uses the async Clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setNavigatorClipboard({ writeText } as unknown as Clipboard);
+    document.execCommand = vi.fn();
+
+    await copyToClipboard("hello");
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(document.execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand when navigator.clipboard is unavailable (insecure context)", async () => {
+    setNavigatorClipboard(undefined);
+    let copiedText: string | undefined;
+    document.execCommand = vi.fn((command: string) => {
+      if (command === "copy") {
+        copiedText = document.querySelector("textarea")?.value;
+        return true;
+      }
+      return false;
+    });
+
+    await copyToClipboard("http://example.com/invite?id=123");
+
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(copiedText).toBe("http://example.com/invite?id=123");
+    // The helper textarea must not be left in the DOM
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("falls back to execCommand when the Clipboard API rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("NotAllowedError"));
+    setNavigatorClipboard({ writeText } as unknown as Clipboard);
+    document.execCommand = vi.fn(() => true);
+
+    await copyToClipboard("hello");
+
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("rejects and cleans up when no copy mechanism works", async () => {
+    setNavigatorClipboard(undefined);
+    document.execCommand = vi.fn(() => false);
+
+    await expect(copyToClipboard("hello")).rejects.toThrow();
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});

--- a/platform/frontend/src/lib/clipboard.ts
+++ b/platform/frontend/src/lib/clipboard.ts
@@ -1,0 +1,43 @@
+/**
+ * Copies text to the user's clipboard.
+ *
+ * `navigator.clipboard` only exists in secure contexts (HTTPS or localhost),
+ * so deployments reached over plain HTTP (e.g. `http://<host>:3000`) don't get
+ * the async Clipboard API at all. In that case — or when the Clipboard API
+ * rejects (e.g. permission denied) — fall back to the legacy hidden-textarea +
+ * `document.execCommand("copy")` approach, which still works there.
+ *
+ * Rejects if the text could not be copied by either mechanism.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Fall through to the legacy fallback
+    }
+  }
+  legacyCopyToClipboard(text);
+}
+
+// === Internal helpers ===
+
+function legacyCopyToClipboard(text: string) {
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  // Keep the textarea invisible without affecting layout or scroll position
+  textArea.style.position = "fixed";
+  textArea.style.left = "-9999px";
+  textArea.style.top = "0";
+  textArea.setAttribute("readonly", "");
+  document.body.appendChild(textArea);
+  textArea.select();
+  try {
+    if (!document.execCommand("copy")) {
+      throw new Error("Copying to the clipboard is not supported here");
+    }
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}


### PR DESCRIPTION
## Problem

A user reported that **no Copy button copies anything** (invite-link dialog, share-conversation dialog, copy-message in chat, …) on v1.3.8 in Chrome.

Root cause: their instance is reached via `http://<host>:3002` — a non-secure origin. Browsers only expose `navigator.clipboard` in secure contexts (HTTPS or `localhost`), so on plain-HTTP deployments it is `undefined` and every handler doing `await navigator.clipboard.writeText(...)` throws:

```
TypeError: Cannot read properties of undefined (reading 'writeText')
```

Nothing is copied and the user gets no feedback. This is also why it wasn't reproducible locally — on `localhost` (or any HTTPS deployment) the Clipboard API is present.

Reproduced by clicking **Copy Link** in the Invite User dialog with the app served on a LAN-IP http origin: the exact exception above fires from `InviteByLinkCardContent.handleCopyLink`.

## Fix

- New shared helper `frontend/src/lib/clipboard.ts` — `copyToClipboard(text)`:
  - uses `navigator.clipboard.writeText` when available;
  - falls back to the legacy hidden-textarea + `document.execCommand("copy")` approach (which still works in insecure contexts) when the API is missing or rejects;
  - rejects if neither mechanism works, so callers' error paths still fire.
- Migrated **all 33 direct `navigator.clipboard.writeText` call sites (25 files)** to the helper, including the reported ones (invite-by-link card, users page invitation table, share-conversation dialog, chat message actions) and the two components that had their own partial fallbacks (`copy-button.tsx`, `ai-elements/code-block.tsx`).

## Testing

- New unit tests `frontend/src/lib/clipboard.test.ts`: Clipboard-API path, fallback when `navigator.clipboard` is undefined, fallback when the API rejects, rejection + DOM cleanup when nothing works.
- Existing copy-related suites still pass (`curl-example-section`, `mcp-client-instructions`, `audit-log-detail-dialog`).
- `pnpm lint`, `pnpm type-check`, `pnpm knip` all clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>