### PR TITLE
fix(audit): show agent model-change diff and stop phantom audit records

### DIFF
--- a/platform/backend/src/middleware/audit-log-hook.test.ts
+++ b/platform/backend/src/middleware/audit-log-hook.test.ts
@@ -80,6 +80,18 @@ vi.mock("./audit-log-registry", async () => {
             }
           : null,
     },
+    // Child-mutation DELETE registered with an explicit `.updated` action: the
+    // parent resource still exists after the delete, so `after` must be captured
+    // rather than forced to null like a genuine resource deletion.
+    "/api/agents/:agentId/delegations": {
+      resourceType: "agent",
+      resourceIdParam: "agentId",
+      action: "agent.updated" as const,
+      fetchById: async (id: string) =>
+        id === KNOWN_RESOURCE_ID
+          ? { id, name: "Some Agent", delegationTargets: [] }
+          : null,
+    },
     // Rotation route with explicit action — key test for action overrides.
     "/api/user-tokens/me/rotate": {
       resourceType: "userToken",
@@ -257,6 +269,12 @@ describe("registerAuditLogHook", () => {
     app.post("/api/agents/:agentId/tools/:toolId", async () => ({ ok: true }));
     app.delete("/api/agents/:agentId/tools/:toolId", async () => ({
       ok: true,
+    }));
+
+    // Child-mutation DELETE — walks up to /api/agents/:agentId/delegations
+    // (explicit agent.updated action); the agent survives the removal.
+    app.delete("/api/agents/:agentId/delegations/:targetAgentId", async () => ({
+      success: true,
     }));
 
     // Unregistered child route — walks up to /api/agents/:agentId.
@@ -460,6 +478,32 @@ describe("registerAuditLogHook", () => {
         name: "Existing Thing",
       });
       expect(rows[0].after).toBeNull();
+    });
+
+    test("semantic-update DELETE (child removal) captures after-state, not null", async () => {
+      const res = await app.inject({
+        method: "DELETE",
+        url: `/api/agents/${KNOWN_RESOURCE_ID}/delegations/00000000-0000-0000-0000-0000000000ff`,
+      });
+      expect(res.statusCode).toBe(200);
+      await settle();
+
+      const rows = await getRows();
+      expect(rows).toHaveLength(1);
+      // Explicit `.updated` action → the resource survives, so the removal must
+      // not render as a full deletion (after=null). before/after are both the
+      // agent snapshot; the diff surfaces the delegation change.
+      expect(rows[0].action).toBe("agent.updated");
+      expect(rows[0].before).toEqual({
+        id: KNOWN_RESOURCE_ID,
+        name: "Some Agent",
+        delegationTargets: [],
+      });
+      expect(rows[0].after).toEqual({
+        id: KNOWN_RESOURCE_ID,
+        name: "Some Agent",
+        delegationTargets: [],
+      });
     });
   });
 

--- a/platform/backend/src/middleware/audit-log-hook.ts
+++ b/platform/backend/src/middleware/audit-log-hook.ts
@@ -97,6 +97,7 @@ export function registerAuditLogHook(fastify: FastifyInstanceWithZod): void {
           ? request.auditAfter
           : await resolveAfterState({
               method: request.method,
+              action,
               id,
               organizationId: request.organizationId,
               cfg,
@@ -382,14 +383,19 @@ function extractIp(request: {
 
 async function resolveAfterState(params: {
   method: string;
+  action: AuditEventName;
   id: string | null;
   organizationId: string;
   cfg: AuditableRouteConfig | undefined;
   routeParams?: Record<string, unknown>;
 }): Promise<Record<string, unknown> | null> {
-  const { method, id, organizationId, cfg, routeParams } = params;
+  const { method, action, id, organizationId, cfg, routeParams } = params;
 
-  if (method === "DELETE") return null;
+  // A genuine resource deletion has no post-state. But a DELETE registered with
+  // a non-delete action (e.g. removing one delegation → agent.updated) leaves
+  // the resource alive, so its after-state must be captured — otherwise the row
+  // renders as a full teardown instead of the child-level diff.
+  if (method === "DELETE" && action.endsWith(".deleted")) return null;
   if (!cfg?.fetchById || !id) return null;
 
   return cfg.fetchById(id, organizationId, routeParams).catch((err) => {

--- a/platform/backend/src/middleware/audit-log-registry.test.ts
+++ b/platform/backend/src/middleware/audit-log-registry.test.ts
@@ -58,6 +58,34 @@ describe("resolveAuditableRouteConfig", () => {
     expect(typeof resolved?.cfg.fetchById).toBe("function");
   });
 
+  test("delegations sync route is registered so its POST is not dropped as a walk-up", () => {
+    // POST /api/agents/:agentId/delegations is unregistered → walks up to
+    // /api/agents/:agentId → the hook discards POST walk-ups → the record falls
+    // to the unknown.created fallback with a null resourceType. Registering it
+    // directly pins the correct agent.updated semantics.
+    const resolved = resolveAuditableRouteConfig(
+      "/api/agents/:agentId/delegations",
+    );
+    expect(resolved?.viaWalkUp).toBe(false);
+    expect(resolved?.cfg.resourceType).toBe("agent");
+    expect(resolved?.cfg.action).toBe("agent.updated");
+    expect(resolved?.cfg.resourceIdParam).toBe("agentId");
+    expect(typeof resolved?.cfg.fetchById).toBe("function");
+  });
+
+  test("single-delegation DELETE inherits agent.updated, not agent.deleted", () => {
+    // DELETE /api/agents/:agentId/delegations/:targetAgentId walks up. A DELETE
+    // walk-up is NOT suppressed, so without the explicit /delegations entry it
+    // would inherit /api/agents/:agentId and derive agent.deleted — mislabeling
+    // the removal of one delegation as deleting the whole agent.
+    const resolved = resolveAuditableRouteConfig(
+      "/api/agents/:agentId/delegations/:targetAgentId",
+    );
+    expect(resolved?.viaWalkUp).toBe(true);
+    expect(resolved?.cfg.action).toBe("agent.updated");
+    expect(resolved?.cfg.resourceType).toBe("agent");
+  });
+
   test("walk-up match returns viaWalkUp=true with the parent config", () => {
     // /api/mcp_server/:id/some-subroute is not registered; walks up to /api/mcp_server/:id
     const resolved = resolveAuditableRouteConfig(

--- a/platform/backend/src/middleware/audit-log-registry.ts
+++ b/platform/backend/src/middleware/audit-log-registry.ts
@@ -146,6 +146,17 @@ export const AUDITABLE_ROUTES: Record<string, AuditableRouteConfig> = {
     fetchById: (id, orgId) => AgentModel.findByIdForAudit(id, orgId),
   },
 
+  // Syncing/removing delegation targets mutates the agent's subagent surface.
+  // Registered explicitly so the POST sync isn't dropped as a walk-up (which
+  // falls to unknown.created with a null resourceType) and the single-target
+  // DELETE inherits agent.updated instead of deriving agent.deleted.
+  "/api/agents/:agentId/delegations": {
+    resourceType: "agent",
+    resourceIdParam: "agentId",
+    action: "agent.updated",
+    fetchById: (id, orgId) => AgentModel.findByIdForAudit(id, orgId),
+  },
+
   "/api/agent-tools/:id": {
     resourceType: "agentTool",
     fetchById: (id, orgId) => AgentToolModel.findByIdForAudit(id, orgId),

--- a/platform/backend/src/middleware/audit-log-snapshot.test.ts
+++ b/platform/backend/src/middleware/audit-log-snapshot.test.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import db, { schema } from "@/database";
 import AgentModel from "@/models/agent";
+import AgentExcludedSubagentModel from "@/models/agent-excluded-subagent";
 import AgentToolModel from "@/models/agent-tool";
 import ApiKeyModel from "@/models/api-key";
 import InternalMcpCatalogModel from "@/models/internal-mcp-catalog";
@@ -398,6 +399,34 @@ describe("audit snapshot shape — non-redacted models", () => {
     expect(snapshot).toHaveProperty("model", "google/gemini-2.5-pro");
     expect(snapshot).toHaveProperty("llmProvider", "gemini");
     expect(snapshot).not.toHaveProperty("llmModel");
+  });
+
+  test("AgentModel.findByIdForAudit captures accessAllSubagents and excluded subagent ids so a subagent-permission change diffs", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const parent = await AgentModel.create({
+      name: "Parent Agent",
+      organizationId: org.id,
+      scope: "org",
+      agentType: "agent",
+      teams: [],
+      knowledgeBaseIds: [],
+    });
+    const excluded = await AgentModel.create({
+      name: "Excluded Subagent",
+      organizationId: org.id,
+      scope: "org",
+      agentType: "agent",
+      teams: [],
+      knowledgeBaseIds: [],
+    });
+    await AgentExcludedSubagentModel.replaceForAgent(parent.id, [excluded.id]);
+
+    const snapshot = await AgentModel.findByIdForAudit(parent.id, org.id);
+
+    expect(snapshot).toHaveProperty("accessAllSubagents");
+    expect(snapshot).toHaveProperty("excludedSubagentIds", [excluded.id]);
   });
 
   test("AgentModel.findByIdForAudit returns null model/provider when the agent has no model configured", async ({

--- a/platform/backend/src/middleware/audit-log-snapshot.test.ts
+++ b/platform/backend/src/middleware/audit-log-snapshot.test.ts
@@ -399,6 +399,69 @@ describe("audit snapshot shape — non-redacted models", () => {
     expect(snapshot).toHaveProperty("model", "google/gemini-2.5-pro");
     expect(snapshot).toHaveProperty("llmProvider", "gemini");
     expect(snapshot).not.toHaveProperty("llmModel");
+    // A redacted key identity (id/name/scope) so a swap between two
+    // same-provider keys still diffs — never any secret material.
+    expect(snapshot?.llmApiKey).toEqual({
+      id: key.id,
+      name: "Gemini Key",
+      scope: "org",
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("secretId");
+  });
+
+  test("AgentModel.findByIdForAudit diffs a swap between two same-provider keys", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const model = await ModelModel.create({
+      externalId: "google/gemini-2.5-pro",
+      provider: "gemini",
+      modelId: "gemini-2.5-pro",
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+    });
+    const [keyA] = await db
+      .insert(schema.llmProviderApiKeysTable)
+      .values({
+        organizationId: org.id,
+        name: "Gemini Key A",
+        provider: "gemini",
+        scope: "org",
+        baseUrl: null,
+      })
+      .returning();
+    const [keyB] = await db
+      .insert(schema.llmProviderApiKeysTable)
+      .values({
+        organizationId: org.id,
+        name: "Gemini Key B",
+        provider: "gemini",
+        scope: "org",
+        baseUrl: null,
+      })
+      .returning();
+    const agent = await AgentModel.create({
+      name: "Key Swap Agent",
+      organizationId: org.id,
+      scope: "org",
+      teams: [],
+      knowledgeBaseIds: [],
+      modelId: model.id,
+      llmApiKeyId: keyA.id,
+    });
+
+    const before = await AgentModel.findByIdForAudit(agent.id, org.id);
+    await AgentModel.update(agent.id, { llmApiKeyId: keyB.id });
+    const after = await AgentModel.findByIdForAudit(agent.id, org.id);
+
+    // llmProvider is identical (same provider), so the diff must come from the
+    // key identity — otherwise the swap would be invisible in the audit log.
+    expect(before?.llmProvider).toBe(after?.llmProvider);
+    expect(before?.llmApiKey).not.toEqual(after?.llmApiKey);
+    expect(after?.llmApiKey).toMatchObject({
+      id: keyB.id,
+      name: "Gemini Key B",
+    });
   });
 
   test("AgentModel.findByIdForAudit captures accessAllSubagents and excluded subagent ids so a subagent-permission change diffs", async ({

--- a/platform/backend/src/middleware/audit-log-snapshot.test.ts
+++ b/platform/backend/src/middleware/audit-log-snapshot.test.ts
@@ -7,6 +7,7 @@ import InternalMcpCatalogModel from "@/models/internal-mcp-catalog";
 import KnowledgeBaseModel from "@/models/knowledge-base";
 import LlmProviderApiKeyModel from "@/models/llm-provider-api-key";
 import McpServerModel from "@/models/mcp-server";
+import ModelModel from "@/models/model";
 import ScheduleTriggerModel from "@/models/schedule-trigger";
 import SkillModel from "@/models/skill";
 import TeamModel from "@/models/team";
@@ -356,6 +357,65 @@ describe("audit snapshot shape — non-redacted models", () => {
     expect(snapshot).toHaveProperty("scope", "org");
     expect(Array.isArray(snapshot?.delegationTargets)).toBe(true);
     expect(typeof snapshot?.createdAt).toBe("string");
+  });
+
+  test("AgentModel.findByIdForAudit captures the resolved model and provider, not the dead llmModel column", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const model = await ModelModel.create({
+      externalId: "google/gemini-2.5-pro",
+      provider: "gemini",
+      modelId: "gemini-2.5-pro",
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+    });
+    const [key] = await db
+      .insert(schema.llmProviderApiKeysTable)
+      .values({
+        organizationId: org.id,
+        name: "Gemini Key",
+        provider: "gemini",
+        scope: "org",
+        baseUrl: null,
+      })
+      .returning();
+    const agent = await AgentModel.create({
+      name: "Model Audit Agent",
+      organizationId: org.id,
+      scope: "org",
+      teams: [],
+      knowledgeBaseIds: [],
+      modelId: model.id,
+      llmApiKeyId: key.id,
+    });
+
+    const snapshot = await AgentModel.findByIdForAudit(agent.id, org.id);
+
+    // The audit diff must surface the model that actually changed as a
+    // human-readable identity, plus the LLM provider — the deprecated
+    // llmModel column (always null) must not be in the snapshot.
+    expect(snapshot).toHaveProperty("model", "google/gemini-2.5-pro");
+    expect(snapshot).toHaveProperty("llmProvider", "gemini");
+    expect(snapshot).not.toHaveProperty("llmModel");
+  });
+
+  test("AgentModel.findByIdForAudit returns null model/provider when the agent has no model configured", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await AgentModel.create({
+      name: "No Model Agent",
+      organizationId: org.id,
+      scope: "org",
+      teams: [],
+      knowledgeBaseIds: [],
+    });
+
+    const snapshot = await AgentModel.findByIdForAudit(agent.id, org.id);
+
+    expect(snapshot).toHaveProperty("model", null);
+    expect(snapshot).toHaveProperty("llmProvider", null);
   });
 
   test("AgentModel.findByIdForAudit returns null for wrong org", async ({

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -3114,11 +3114,18 @@ class AgentModel {
             .where(eq(schema.modelsTable.id, row.modelId))
             .limit(1)
         : Promise.resolve([]),
-      // The model and its API key are set as a pair; capture the key's provider
-      // so an LLM-config change is legible without exposing key material.
+      // The model and its API key are set as a pair; capture a redacted key
+      // identity (id/name/scope + provider) so an LLM-config change is legible
+      // and a swap between two same-provider keys still diffs — without ever
+      // touching key material (secretId is excluded).
       row.llmApiKeyId
         ? db
-            .select({ provider: schema.llmProviderApiKeysTable.provider })
+            .select({
+              id: schema.llmProviderApiKeysTable.id,
+              name: schema.llmProviderApiKeysTable.name,
+              scope: schema.llmProviderApiKeysTable.scope,
+              provider: schema.llmProviderApiKeysTable.provider,
+            })
             .from(schema.llmProviderApiKeysTable)
             .where(eq(schema.llmProviderApiKeysTable.id, row.llmApiKeyId))
             .limit(1)
@@ -3141,6 +3148,13 @@ class AgentModel {
       isDefault: row.isDefault,
       model: modelRows[0]?.externalId ?? null,
       llmProvider: keyRows[0]?.provider ?? null,
+      llmApiKey: keyRows[0]
+        ? {
+            id: keyRows[0].id,
+            name: keyRows[0].name,
+            scope: keyRows[0].scope,
+          }
+        : null,
       toolExposureMode: row.toolExposureMode,
       accessAllTools: row.accessAllTools,
       accessAllSubagents: row.accessAllSubagents,

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -57,6 +57,7 @@ import type {
 import { isUniqueConstraintError } from "@/utils/db";
 import { isUuid } from "@/utils/uuid";
 import AgentConnectorAssignmentModel from "./agent-connector-assignment";
+import AgentExcludedSubagentModel from "./agent-excluded-subagent";
 import AgentExcludedToolModel from "./agent-excluded-tool";
 import AgentKnowledgeBaseModel from "./agent-knowledge-base";
 import AgentLabelModel from "./agent-label";
@@ -3092,6 +3093,7 @@ class AgentModel {
       knowledgeBaseIds,
       connectorIds,
       delegations,
+      excludedSubagentIds,
       modelRows,
       keyRows,
     ] = await Promise.all([
@@ -3101,6 +3103,7 @@ class AgentModel {
       AgentKnowledgeBaseModel.getKnowledgeBaseIds(id),
       AgentConnectorAssignmentModel.getConnectorIds(id),
       AgentToolModel.getDelegationTargets(id),
+      AgentExcludedSubagentModel.findTargetAgentIdsByAgent(id),
       // Resolve the live modelId FK to its human-readable identity so a model
       // change surfaces as a real diff — the legacy llmModel text column is
       // deprecated (never written) and would always read null.
@@ -3140,12 +3143,14 @@ class AgentModel {
       llmProvider: keyRows[0]?.provider ?? null,
       toolExposureMode: row.toolExposureMode,
       accessAllTools: row.accessAllTools,
+      accessAllSubagents: row.accessAllSubagents,
       tools: tools.map((t) => t.name).sort(),
       knowledgeBaseIds: [...knowledgeBaseIds].sort(),
       connectorIds: [...connectorIds].sort(),
       teams: teams.map((t) => t.name).sort(),
       labels: labels.sort(),
       delegationTargets,
+      excludedSubagentIds: [...excludedSubagentIds].sort(),
       deletedAt: row.deletedAt?.toISOString() ?? null,
       createdAt: row.createdAt.toISOString(),
     };

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -3085,15 +3085,42 @@ class AgentModel {
     // Fetch relational data so audit diffs capture tool/KB/team changes —
     // not just main-table columns.  Each sub-query is lightweight (index
     // lookup by agent_id) and the parallel fetch keeps latency low.
-    const [tools, teams, labels, knowledgeBaseIds, connectorIds, delegations] =
-      await Promise.all([
-        AgentToolModel.getToolsForAgent(id),
-        AgentTeamModel.getTeamDetailsForAgent(id),
-        AgentLabelModel.getLabelsForAgent(id),
-        AgentKnowledgeBaseModel.getKnowledgeBaseIds(id),
-        AgentConnectorAssignmentModel.getConnectorIds(id),
-        AgentToolModel.getDelegationTargets(id),
-      ]);
+    const [
+      tools,
+      teams,
+      labels,
+      knowledgeBaseIds,
+      connectorIds,
+      delegations,
+      modelRows,
+      keyRows,
+    ] = await Promise.all([
+      AgentToolModel.getToolsForAgent(id),
+      AgentTeamModel.getTeamDetailsForAgent(id),
+      AgentLabelModel.getLabelsForAgent(id),
+      AgentKnowledgeBaseModel.getKnowledgeBaseIds(id),
+      AgentConnectorAssignmentModel.getConnectorIds(id),
+      AgentToolModel.getDelegationTargets(id),
+      // Resolve the live modelId FK to its human-readable identity so a model
+      // change surfaces as a real diff — the legacy llmModel text column is
+      // deprecated (never written) and would always read null.
+      row.modelId
+        ? db
+            .select({ externalId: schema.modelsTable.externalId })
+            .from(schema.modelsTable)
+            .where(eq(schema.modelsTable.id, row.modelId))
+            .limit(1)
+        : Promise.resolve([]),
+      // The model and its API key are set as a pair; capture the key's provider
+      // so an LLM-config change is legible without exposing key material.
+      row.llmApiKeyId
+        ? db
+            .select({ provider: schema.llmProviderApiKeysTable.provider })
+            .from(schema.llmProviderApiKeysTable)
+            .where(eq(schema.llmProviderApiKeysTable.id, row.llmApiKeyId))
+            .limit(1)
+        : Promise.resolve([]),
+    ]);
 
     const delegationTargets = [...delegations]
       .sort((a, b) => a.id.localeCompare(b.id))
@@ -3109,7 +3136,8 @@ class AgentModel {
       systemPrompt: row.systemPrompt ?? null,
       slug: row.slug ?? null,
       isDefault: row.isDefault,
-      llmModel: row.llmModel ?? null,
+      model: modelRows[0]?.externalId ?? null,
+      llmProvider: keyRows[0]?.provider ?? null,
       toolExposureMode: row.toolExposureMode,
       accessAllTools: row.accessAllTools,
       tools: tools.map((t) => t.name).sort(),

--- a/platform/frontend/src/components/agent-dialog.test.tsx
+++ b/platform/frontend/src/components/agent-dialog.test.tsx
@@ -429,6 +429,10 @@ const targetAgent = {
 describe("AgentDialog delegation state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks wipes call data but keeps implementations; re-assert the
+    // fast (immediate) tool-editor save so the save flow isn't gated on the
+    // hoisted 50ms default, which makes the save-path assertions flaky.
+    pendingSaveChanges.mockResolvedValue(undefined);
     vi.mocked(useHasPermissions).mockImplementation(
       () => ({ data: true }) as unknown as ReturnType<typeof useHasPermissions>,
     );
@@ -438,6 +442,87 @@ describe("AgentDialog delegation state", () => {
       data: [targetAgent],
       isFetched: true,
     });
+  });
+
+  it("skips the delegation and subagent-exclusion syncs when neither set changed on save", async () => {
+    const user = userEvent.setup();
+    const syncDelegations = vi
+      .fn()
+      .mockResolvedValue({ added: [], removed: [] });
+    const syncExclusions = vi.fn().mockResolvedValue(undefined);
+    const updateAgent = vi.fn().mockResolvedValue(baseAgent);
+    useSyncAgentDelegationsMock.mockReturnValue({
+      mutateAsync: syncDelegations,
+      isPending: false,
+    });
+    useUpdateAgentSubagentExclusionsMock.mockReturnValue({
+      mutateAsync: syncExclusions,
+      isPending: false,
+    });
+    useUpdateProfileMock.mockReturnValue({
+      mutateAsync: updateAgent,
+      isPending: false,
+    });
+    const onOpenChange = vi.fn();
+
+    render(
+      <AgentDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        agentType="agent"
+        agent={baseAgent}
+      />,
+    );
+
+    await screen.findByText("Subagents (1)");
+    await user.click(screen.getByRole("button", { name: /update/i }));
+
+    // The save must complete (reaches the success close) and persist the agent —
+    // proving the handler ran through the sync block, not that it bailed early.
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(updateAgent).toHaveBeenCalled();
+    // No delegation/exclusion changes → no redundant sync writes (each of which
+    // would produce a spurious no-op agent.updated audit record).
+    expect(syncDelegations).not.toHaveBeenCalled();
+    expect(syncExclusions).not.toHaveBeenCalled();
+  });
+
+  it("syncs delegations when a subagent is removed before save", async () => {
+    const user = userEvent.setup();
+    const syncDelegations = vi
+      .fn()
+      .mockResolvedValue({ added: [], removed: [] });
+    const updateAgent = vi.fn().mockResolvedValue(baseAgent);
+    useSyncAgentDelegationsMock.mockReturnValue({
+      mutateAsync: syncDelegations,
+      isPending: false,
+    });
+    useUpdateProfileMock.mockReturnValue({
+      mutateAsync: updateAgent,
+      isPending: false,
+    });
+
+    render(
+      <AgentDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        agentType="agent"
+        agent={baseAgent}
+      />,
+    );
+
+    await screen.findByText("Subagents (1)");
+    await user.click(screen.getByRole("button", { name: /remove agent/i }));
+    await user.click(screen.getByRole("button", { name: /update/i }));
+
+    await waitFor(
+      () =>
+        expect(syncDelegations).toHaveBeenCalledWith({
+          agentId: baseAgent.id,
+          targetAgentIds: [],
+        }),
+      { timeout: 3000 },
+    );
   });
 
   it("keeps selected subagents when fresh agent data refetches", async () => {

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -1284,27 +1284,33 @@ export function AgentDialog({
         }
       }
 
-      // Sync delegations (skip for built-in agents)
+      // Sync delegations only when the target set actually changed (skip for
+      // built-in agents). Re-sending the unchanged set on every save produced a
+      // spurious no-op agent.updated audit record.
       if (
         !isBuiltIn &&
         savedAgentId &&
-        selectedDelegationTargetIds.length > 0
+        hasUnsavedChanges(
+          [...currentDelegations.map((d) => d.id)].sort(),
+          [...selectedDelegationTargetIds].sort(),
+        )
       ) {
         await syncDelegations.mutateAsync({
           agentId: savedAgentId,
           targetAgentIds: selectedDelegationTargetIds,
         });
-      } else if (savedAgentId && agent && currentDelegations.length > 0) {
-        // Clear delegations if none selected but there were some before
-        await syncDelegations.mutateAsync({
-          agentId: savedAgentId,
-          targetAgentIds: [],
-        });
       }
 
-      // Persist the Auto-mode disabled-subagents set (full replace; inert in
-      // Custom mode, so it is safe to always write). Skipped for built-ins.
-      if (!isBuiltIn && savedAgentId) {
+      // Persist the Auto-mode disabled-subagents set only when it changed (same
+      // no-op-audit reasoning as delegations). Skipped for built-ins.
+      if (
+        !isBuiltIn &&
+        savedAgentId &&
+        hasUnsavedChanges(
+          [...(currentSubagentExclusions?.excludedSubagentIds ?? [])].sort(),
+          [...disabledSubagentIds].sort(),
+        )
+      ) {
         await syncSubagentExclusions.mutateAsync({
           agentId: savedAgentId,
           exclusions: { excludedSubagentIds: disabledSubagentIds },
@@ -1346,7 +1352,8 @@ export function AgentDialog({
     builtInAgentName,
     showSecurity,
     selectedDelegationTargetIds,
-    currentDelegations.length,
+    currentDelegations,
+    currentSubagentExclusions,
     disabledSubagentIds,
     updateAgent,
     createAgent,


### PR DESCRIPTION
Closes #6583

Changing an agent's model produced a confusing audit trail: an `Agent updated` record whose diff read "No field-level differences," plus a second `Unknown create` record with an empty resource and no tracked changes. Neither told an auditor what actually changed.

The audit snapshot captured the deprecated `llmModel` text column — superseded by the `modelId` FK and never written — so the field that a model change actually mutates was absent from both before/after snapshots. The snapshot now resolves `modelId` to the model's human identity (e.g. `google/gemini-2.5-pro`) and `llmApiKeyId` to its provider, so a model change shows `model: A → B`.

The delegation-sync route (`POST /api/agents/:agentId/delegations`) was never registered for audit, so it fell through to the `unknown.created` fallback with a null resource type; the single-target `DELETE` derived `agent.deleted`, labelling the removal of one subagent as the deletion of the whole agent. Registering the route as `agent.updated` fixes both. Because a `DELETE` carrying a non-`.deleted` action leaves the parent alive, the audit hook now captures its after-state rather than forcing `after=null` — so removing one delegation renders as a `delegationTargets` diff instead of a full teardown.

The agent-edit dialog re-sent the delegation and subagent-exclusion sync calls on every save regardless of whether those sets changed, each generating its own no-diff `agent.updated` record. Both are now gated on an actual set change, so a model-only save produces exactly one `agent.updated` carrying the model diff.

The snapshot also omitted several fields whose changes therefore diffed empty: `accessAllSubagents` and the excluded-subagent set (a subagent-permission change read as "no differences"), and the LLM key identity (a swap between two keys of the same provider was invisible because only the provider name was recorded). The snapshot now carries `accessAllSubagents`, `excludedSubagentIds`, and a redacted key identity (`id`/`name`/`scope`, never key material), so those changes surface in the diff.
