### PR TITLE
fix: drop header sidebar triggers, restore centered logo

### DIFF
--- a/platform/frontend/src/app/_parts/sidebar.tsx
+++ b/platform/frontend/src/app/_parts/sidebar.tsx
@@ -56,7 +56,6 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
-  SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
 import { useIsAuthenticated } from "@/lib/auth/auth.hook";
@@ -666,11 +665,10 @@ export function AppSidebar() {
   return (
     <Sidebar collapsible="icon">
       <SidebarHeader className="pt-4 group-data-[collapsible=icon]:pt-2 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:gap-1">
-        <div className="flex items-center justify-between gap-2 group-data-[collapsible=icon]:hidden">
+        <div className="group-data-[collapsible=icon]:hidden">
           <SidebarPrefetchLink href="/chat" className="block min-w-0">
             <AppLogo />
           </SidebarPrefetchLink>
-          <SidebarTrigger className="shrink-0 text-muted-foreground hover:text-foreground" />
         </div>
         <SidebarPrefetchLink
           href="/chat"
@@ -678,7 +676,6 @@ export function AppSidebar() {
         >
           <img src={appIconLogo} alt="Logo" className="size-7" />
         </SidebarPrefetchLink>
-        <SidebarTrigger className="hidden text-muted-foreground hover:text-foreground group-data-[collapsible=icon]:flex" />
         {isAuthenticated && permissionMap && (
           <SidebarModeToggle
             mode={sidebarMode}


### PR DESCRIPTION
#6677 added SidebarTrigger burgers to the sidebar header (expanded + collapsed rail). That duplicated the edge pill on desktop and, via the flex justify-between wrapper, left-aligned the logo that relies on a full-width parent to center itself.

Removes both header triggers and restores the block wrapper; the edge pill (with its #6677 visibility restyle) is again the sole desktop collapse control, and the logo is centered.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>