### PR TITLE
fix: Action Buttons in sub-menu for Tables are displaying behind the title row in-chat view and also in full screen mode

### DIFF
--- a/platform/frontend/src/app/globals.css
+++ b/platform/frontend/src/app/globals.css
@@ -171,6 +171,16 @@
   [data-streamdown="inline-code"] {
     background-color: var(--accent) !important;
   }
+  /* Keep table action dropdowns above Streamdown's sticky table headers.
+     This covers both inline tables and the fullscreen portal. */
+  :is(
+    [data-streamdown="table-wrapper"],
+    [data-streamdown="table-fullscreen"]
+  )
+    .relative
+    > .absolute {
+    z-index: 20 !important;
+  }
   /* Override Tailwind's font-sans to use our dynamic CSS variable */
   .font-sans {
     font-family: var(--font-sans) !important;


### PR DESCRIPTION


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>