### PR TITLE
fix(ci): unbreak merge-queue jobs broken on main

### DIFF
--- a/ai-labs/runner/src/config/toml_util.rs
+++ b/ai-labs/runner/src/config/toml_util.rs
@@ -25,17 +25,11 @@ pub fn parse_toml_file(path: &std::path::Path) -> TomlResult<TomlTable> {
 }
 
 pub fn parse_toml_text(text: &str, path: &std::path::Path) -> TomlResult<TomlTable> {
-    match text.parse::<toml::Value>() {
-        Ok(toml::Value::Table(t)) => Ok(t),
-        Ok(_) => Err(TomlError::new(
-            format!("{}", path.display()),
-            "TOML root must be a table",
-        )),
-        Err(e) => Err(TomlError::new(
-            format!("{}", path.display()),
-            format!("cannot parse TOML: {e}"),
-        )),
-    }
+    // Parse as a document table, not `toml::Value`: since toml 1.x,
+    // `Value::from_str` parses a single value expression, so feeding it a
+    // document fails with "unexpected content, expected nothing".
+    text.parse::<TomlTable>()
+        .map_err(|e| TomlError::new(format!("{}", path.display()), format!("cannot parse TOML: {e}")))
 }
 
 pub fn req_str(value: &TomlTable, key: &str, ctx: &str) -> TomlResult<String> {

--- a/platform/frontend/src/mocks/handlers.ts
+++ b/platform/frontend/src/mocks/handlers.ts
@@ -212,6 +212,9 @@ export const handlers: HttpHandler[] = [
   // LLM provider API keys (plain array — not paginated)
   ...getJson("/api/llm-provider-api-keys", llmProviderApiKeysSeed),
   ...getJson("/api/llm-provider-api-keys/available", []),
+  // Deep-linkable detail dialogs refetch the opened key by id; keep this after
+  // "/available" so that route isn't swallowed by ":id".
+  ...getJson("/api/llm-provider-api-keys/:id", makeLlmProviderApiKey()),
   ...postJson("/api/llm-provider-api-keys", makeLlmProviderApiKey()),
   ...patchJson("/api/llm-provider-api-keys/:id", makeLlmProviderApiKey()),
   ...deleteJson("/api/llm-provider-api-keys/:id"),

--- a/platform/frontend/tests-integration/llm-provider-api-keys.spec.ts
+++ b/platform/frontend/tests-integration/llm-provider-api-keys.spec.ts
@@ -44,8 +44,14 @@ test.describe("LLM Provider API Keys", () => {
 
     await expect(llmKeysPage.rowFor(KEY_NAME)).toBeVisible();
 
-    // Update flow — stage the PATCH and the post-update list refetch.
+    // Update flow — stage the PATCH, the deep-link dialog's by-id refetch,
+    // and the post-update list refetch.
     const updated = { ...created, name: UPDATED_NAME };
+    await mswControl.use({
+      method: "get",
+      url: "/api/llm-provider-api-keys/:id",
+      body: created,
+    });
     await mswControl.use({
       method: "patch",
       url: "/api/llm-provider-api-keys/:id",


### PR DESCRIPTION
## What

Every merge-queue run currently fails on the same two jobs, kicking every queued PR (e.g. #6705, #6702, #6697). Both jobs are path-filtered out of most PRs' own runs, so the breakage sat latent on main and only surfaces in the merge group, where all jobs run.

### AI Labs Rust Checks — broken by the toml 0.8 → 1.1.2 bump (#6464)

In toml 1.x, `Value::from_str` parses a single TOML *value* expression instead of a whole document, so `parse_toml_text`'s `text.parse::<toml::Value>()` fails on the first key of any config file with `cannot parse TOML: … unexpected content, expected nothing`. 15 `archestra_bench` tests fail.

Fix: parse into the document table type (`text.parse::<TomlTable>()`), which has document semantics on both 0.8 and 1.x. The now-unreachable "TOML root must be a table" arm goes away (a parsed document root is always a table). `cargo test -p archestra_bench --lib`: 163/163 pass (was 148/163); `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

### Frontend Integration Tests (MSW) — broken by deep-linkable detail dialogs (#6656)

The LLM key edit dialog now refetches its key via `GET /api/llm-provider-api-keys/:id`, which no MSW handler covered — the coverage-gap guard fails the `Admin can create, update, and delete an API key` spec (4 escaped requests, client + SSR).

Fix: add the default by-id handler in `src/mocks/handlers.ts` (placed after `/available` so that route isn't swallowed by `:id`), and stage the by-id response in the spec's update flow so the dialog renders the real key. The spec passes in chromium locally (3/3).

### Not addressed: Backend Unit Tests shard 3 (`manager.test.ts` cleanupOrphanedDeployments)

Failed in one queue run only and passes locally against main (62/62) — looks like a flake, not a deterministic blocker. Left alone; worth watching if it recurs.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>