### PR TITLE
fix(chat): stalled-response warning no longer fires during long tool executions

### DIFF
--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -460,6 +460,154 @@ describe("ChatProvider retries", () => {
     });
   });
 
+  it("counts heartbeats as response progress while a tool call awaits output", async () => {
+    // While a tool executes server-side the stream is intentionally silent
+    // apart from heartbeats. Those heartbeats must keep the response-progress
+    // window fresh, or the "upstream provider may have stalled" warning fires
+    // for any tool run longer than the idle threshold.
+    const latestSessionRef: { current: ChatSessionSnapshot } = {
+      current: undefined,
+    };
+    const messages: UIMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "run the tool" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "archestra__run_command",
+            toolCallId: "tool-call-1",
+            state: "input-available",
+            input: {},
+          } as unknown as UIMessage["parts"][number],
+        ],
+      },
+    ];
+    mocks.useChat.mockImplementation((options) => {
+      chatOptions = options;
+      return {
+        addToolApprovalResponse: mocks.addToolApprovalResponse,
+        addToolResult: mocks.addToolResult,
+        clearError: mocks.clearError,
+        error: undefined,
+        messages,
+        regenerate: mocks.regenerate,
+        resumeStream: mocks.resumeStream,
+        sendMessage: mocks.sendMessage,
+        setMessages: mocks.setMessages,
+        status: "streaming",
+        stop: mocks.stop,
+      };
+    });
+
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+        <CaptureChatSession
+          onSession={(session) => {
+            latestSessionRef.current = session;
+          }}
+        />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(latestSessionRef.current).toBeDefined());
+    const initialProgressSequence =
+      latestSessionRef.current?.responseProgressSequence ?? 0;
+
+    act(() => {
+      chatOptions?.onData?.({
+        type: "data-heartbeat",
+        data: { timestamp: Date.now() },
+      });
+    });
+
+    await waitFor(() => {
+      expect(latestSessionRef.current?.responseProgressSequence).toBe(
+        initialProgressSequence + 1,
+      );
+    });
+  });
+
+  it("keeps heartbeats transport-only once the pending tool call has output", async () => {
+    // Output arrived and the provider is generating again: silence is now a
+    // potential upstream stall, so heartbeats must not refresh the
+    // response-progress window.
+    const latestSessionRef: { current: ChatSessionSnapshot } = {
+      current: undefined,
+    };
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "archestra__run_command",
+            toolCallId: "tool-call-1",
+            state: "output-available",
+            input: {},
+            output: { ok: true },
+          } as unknown as UIMessage["parts"][number],
+        ],
+      },
+    ];
+    mocks.useChat.mockImplementation((options) => {
+      chatOptions = options;
+      return {
+        addToolApprovalResponse: mocks.addToolApprovalResponse,
+        addToolResult: mocks.addToolResult,
+        clearError: mocks.clearError,
+        error: undefined,
+        messages,
+        regenerate: mocks.regenerate,
+        resumeStream: mocks.resumeStream,
+        sendMessage: mocks.sendMessage,
+        setMessages: mocks.setMessages,
+        status: "streaming",
+        stop: mocks.stop,
+      };
+    });
+
+    render(
+      <ChatProvider>
+        <RegisterChatSession />
+        <CaptureChatSession
+          onSession={(session) => {
+            latestSessionRef.current = session;
+          }}
+        />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(latestSessionRef.current).toBeDefined());
+    const initialTransportSequence =
+      latestSessionRef.current?.transportActivitySequence ?? 0;
+    const initialProgressSequence =
+      latestSessionRef.current?.responseProgressSequence ?? 0;
+
+    act(() => {
+      chatOptions?.onData?.({
+        type: "data-heartbeat",
+        data: { timestamp: Date.now() },
+      });
+    });
+
+    await waitFor(() => {
+      expect(latestSessionRef.current?.transportActivitySequence).toBe(
+        initialTransportSequence + 1,
+      );
+    });
+    expect(latestSessionRef.current?.responseProgressSequence).toBe(
+      initialProgressSequence,
+    );
+  });
+
   it("updates live context token estimate from usage and compaction data", async () => {
     const latestSessionRef: { current: ChatSessionSnapshot } = {
       current: undefined,

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -94,6 +94,23 @@ function shouldResumeActiveRun(messages: UIMessage[]): boolean {
   return messages.at(-1)?.role === "user";
 }
 
+// True while the trailing assistant message has a tool call whose input is
+// complete but whose output hasn't arrived — i.e. a tool is executing (or a
+// client-side tool awaits its result). "input-streaming" is excluded: there
+// the provider is still emitting deltas, so silence IS an upstream stall.
+function awaitingToolOutput(messages: UIMessage[]): boolean {
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role !== "assistant") {
+    return false;
+  }
+  return lastMessage.parts.some(
+    (part) =>
+      (part.type === "dynamic-tool" || part.type.startsWith("tool-")) &&
+      "state" in part &&
+      part.state === "input-available",
+  );
+}
+
 interface ChatSession {
   conversationId: string;
   messages: UIMessage[];
@@ -545,6 +562,11 @@ function ChatSessionHook({
   // resumed stream ends and immediately when there is nothing to resume.
   const [resumeSettled, setResumeSettled] = useState(!shouldResume);
 
+  // Latest SDK messages for callbacks defined inside the useChat config (like
+  // onData), which close over the config object before `messages` exists.
+  // Assigned every render right after useChat returns.
+  const latestMessagesRef = useRef<UIMessage[]>(initialMessages);
+
   const {
     messages,
     sendMessage,
@@ -853,9 +875,18 @@ function ChatSessionHook({
     },
     onData: (dataPart) => {
       // A transient heartbeat proves the browser-to-backend stream is alive,
-      // but not that the upstream provider is making response progress.
+      // but not, in general, that the upstream provider is making response
+      // progress. The exception is while a tool call is executing (input
+      // complete, output pending): the stream is intentionally silent — the
+      // backend sends heartbeats precisely to cover long-running tool
+      // executions and subagent calls — so the heartbeat counts as progress,
+      // not as a stalled upstream provider.
       if (dataPart.type === "data-heartbeat") {
-        recordTransportActivity();
+        if (awaitingToolOutput(latestMessagesRef.current)) {
+          recordResponseProgress();
+        } else {
+          recordTransportActivity();
+        }
       } else {
         recordResponseProgress();
       }
@@ -951,6 +982,8 @@ function ChatSessionHook({
         messages: msgs,
       }),
   } as Parameters<typeof useChat>[0]);
+
+  latestMessagesRef.current = messages;
 
   // Text and tool-call deltas update the SDK's raw message list. Track that
   // progress independently from displayedMessages, which can intentionally be


### PR DESCRIPTION
## Problem

The chat stream-timeout banner ("No response progress has been received for the last 40 seconds. The upstream provider may still be processing or may have stalled…") appears during long-running tool executions, even though the backend is sending heartbeats every 5 seconds and the turn is progressing normally. The warning then disappears on its own once the tool finishes.

## Root cause

The backend emits a `data-heartbeat` every 5s explicitly to cover long-running tool executions / subagent calls (`backend/src/routes/chat/routes.ts`). The frontend, however, counted heartbeats only toward the **transport** activity window, never the **response-progress** window (`onData` in `global-chat.context.tsx`). Response progress is otherwise only bumped by stream message updates — so while a server-side tool call runs (no deltas arriving), the progress window goes idle after 40s and `StreamTimeoutWarning` shows its "upstream provider may have stalled" variant. False positive: the silence is a tool executing, not a stalled provider.

## Fix

While the trailing assistant message has a tool part in state `input-available` (input complete, output pending — i.e. a tool is executing, a subagent is running, or a client-side tool awaits its result), a heartbeat now counts as response progress.

Deliberately unchanged:
- `input-streaming` is excluded — there the provider is actively emitting deltas, so silence *is* a potential upstream stall and the warning should still fire.
- Once tool output arrives and generation resumes, heartbeats go back to transport-only, so genuine mid-generation stalls still warn.
- The transport-idle variant of the warning (heartbeats themselves stop → likely LB timeout) is untouched.

## Testing

- Added two tests in `global-chat.context.test.tsx`: heartbeats bump response progress while a tool call awaits output, and stay transport-only once the tool has output.
- Existing `stream-timeout-warning.test.tsx` and chat context suites pass (36 tests).
- `biome check` + `tsc --noEmit` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>