### PR TITLE
feat(mcp): list auto-mode agents in the MCP server "Used by N agents" tooltip

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -201735,6 +201735,25 @@
                           "additionalProperties": false
                         }
                       },
+                      "autoModeAgents": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
                       "secretStorageType": {
                         "type": "string",
                         "enum": [
@@ -202322,6 +202341,25 @@
                         "additionalProperties": false
                       }
                     },
+                    "autoModeAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
                     "secretStorageType": {
                       "type": "string",
                       "enum": [
@@ -202809,6 +202847,25 @@
                       "additionalProperties": false
                     },
                     "assignedAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "autoModeAgents": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -203623,6 +203680,25 @@
                       "additionalProperties": false
                     },
                     "assignedAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "autoModeAgents": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -205065,6 +205141,25 @@
                       "additionalProperties": false
                     },
                     "assignedAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "autoModeAgents": {
                       "type": "array",
                       "items": {
                         "type": "object",

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -121,6 +121,48 @@ class AgentModel {
       .orderBy(desc(schema.agentsTable.createdAt), desc(schema.agentsTable.id));
   }
 
+  /**
+   * Auto-mode agents (accessAllTools = true) grouped by organization. These
+   * agents have implicit access to every tool, so they can reach every MCP
+   * server without an explicit tool assignment. They are therefore surfaced
+   * separately from `assignedAgents` (e.g. below a divider in the server card
+   * "Used by N agents" tooltip). Batched by organization to avoid an N+1 when
+   * decorating a list of servers.
+   */
+  static async getAutoModeAgentDetailsByOrganizations(
+    organizationIds: string[],
+  ): Promise<Map<string, Array<{ id: string; name: string }>>> {
+    const agentsByOrg = new Map<string, Array<{ id: string; name: string }>>();
+    for (const organizationId of organizationIds) {
+      agentsByOrg.set(organizationId, []);
+    }
+    if (organizationIds.length === 0) {
+      return agentsByOrg;
+    }
+
+    const rows = await db
+      .select({
+        organizationId: schema.agentsTable.organizationId,
+        id: schema.agentsTable.id,
+        name: schema.agentsTable.name,
+      })
+      .from(schema.agentsTable)
+      .where(
+        and(
+          inArray(schema.agentsTable.organizationId, organizationIds),
+          eq(schema.agentsTable.accessAllTools, true),
+          notDeleted(schema.agentsTable),
+        ),
+      )
+      .orderBy(asc(schema.agentsTable.name), asc(schema.agentsTable.id));
+
+    for (const { organizationId, id, name } of rows) {
+      agentsByOrg.get(organizationId)?.push({ id, name });
+    }
+
+    return agentsByOrg;
+  }
+
   static async activeNameExistsInOrganization(params: {
     name: string;
     organizationId: string;

--- a/platform/backend/src/models/mcp-server.test.ts
+++ b/platform/backend/src/models/mcp-server.test.ts
@@ -132,6 +132,47 @@ describe("McpServerModel", () => {
       );
     });
 
+    test("decorates servers with the org's auto-mode agents only when an organizationId is passed", async ({
+      makeOrganization,
+      makeAgent,
+      makeMcpServer,
+    }) => {
+      const org = await makeOrganization();
+      const autoAgent = await makeAgent({
+        organizationId: org.id,
+        name: "Auto Agent",
+        accessAllTools: true,
+      });
+      // A custom-tools agent (explicit assignments) is NOT an auto-mode agent.
+      await makeAgent({
+        organizationId: org.id,
+        name: "Custom Agent",
+        accessAllTools: false,
+      });
+      const server = await makeMcpServer();
+
+      // findAll with the viewing org → the auto-mode agent is surfaced.
+      const withOrg = await McpServerModel.findAll(undefined, true, org.id);
+      const found = mustExist(withOrg.find((s) => s.id === server.id));
+      expect(found.autoModeAgents).toEqual([
+        { id: autoAgent.id, name: "Auto Agent" },
+      ]);
+
+      // findById with the viewing org → same decoration.
+      const single = mustExist(
+        await McpServerModel.findById(server.id, undefined, true, org.id),
+      );
+      expect(single.autoModeAgents).toEqual([
+        { id: autoAgent.id, name: "Auto Agent" },
+      ]);
+
+      // Opt-in: without an org the decoration is skipped (stays empty), so
+      // existing callers are unaffected.
+      const withoutOrg = await McpServerModel.findAll(undefined, true);
+      const foundNoOrg = mustExist(withoutOrg.find((s) => s.id === server.id));
+      expect(foundNoOrg.autoModeAgents).toEqual([]);
+    });
+
     test("returns servers with no users correctly", async ({
       makeMcpServer,
     }) => {

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -27,6 +27,7 @@ import type {
 } from "@/types";
 import { externalAppLabel } from "@/utils/external-app-label";
 import { toolRequiresInputs } from "@/utils/tool-inputs";
+import AgentModel from "./agent";
 import AgentToolModel from "./agent-tool";
 import InternalMcpCatalogModel from "./internal-mcp-catalog";
 import McpCatalogTeamModel from "./mcp-catalog-team";
@@ -274,6 +275,7 @@ class McpServerModel {
   static async findAll(
     userId?: string,
     isMcpServerAdmin?: boolean,
+    organizationId?: string,
   ): Promise<McpServer[]> {
     // Single query with LEFT JOINs for all related data including assigned users,
     // eliminating the consecutive DB query for user details.
@@ -395,14 +397,27 @@ class McpServerModel {
       }
     }
 
+    const servers = Array.from(serversMap.values());
     const assignedAgentsByServer =
       await AgentToolModel.getAssignedAgentDetailsForMcpServers([
         ...serversMap.keys(),
       ]);
+    // Auto-mode agents belong to the viewing org and can reach every server, so
+    // the same set decorates each one. Skipped when the caller omits an org
+    // (e.g. background/admin sweeps that do not render the registry card).
+    let autoModeAgents: Array<{ id: string; name: string }> = [];
+    if (organizationId) {
+      const autoModeAgentsByOrg =
+        await AgentModel.getAutoModeAgentDetailsByOrganizations([
+          organizationId,
+        ]);
+      autoModeAgents = autoModeAgentsByOrg.get(organizationId) ?? [];
+    }
 
-    return Array.from(serversMap.values()).map((server) => ({
+    return servers.map((server) => ({
       ...server,
       assignedAgents: assignedAgentsByServer.get(server.id) ?? [],
+      autoModeAgents,
     }));
   }
 
@@ -877,6 +892,7 @@ class McpServerModel {
     id: string,
     userId?: string,
     isMcpServerAdmin?: boolean,
+    organizationId?: string,
   ): Promise<McpServer | null> {
     // Check access control for non-MCP server admins
     if (userId && !isMcpServerAdmin) {
@@ -923,6 +939,14 @@ class McpServerModel {
       McpServerUserModel.getUserDetailsForMcpServer(id),
       AgentToolModel.getAssignedAgentDetailsForMcpServers([id]),
     ]);
+    let autoModeAgents: Array<{ id: string; name: string }> = [];
+    if (organizationId) {
+      const autoModeAgentsByOrg =
+        await AgentModel.getAutoModeAgentDetailsByOrganizations([
+          organizationId,
+        ]);
+      autoModeAgents = autoModeAgentsByOrg.get(organizationId) ?? [];
+    }
 
     // Build teamDetails from the joined team data
     const teamDetails = result.server.teamId
@@ -948,6 +972,7 @@ class McpServerModel {
       teamDetails,
       secretStorageType,
       assignedAgents: assignedAgentsByServer.get(id) ?? [],
+      autoModeAgents,
     };
   }
 

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -84,7 +84,11 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         { mcpServerInstallation: ["admin"] },
         headers,
       );
-      let allServers = await McpServerModel.findAll(user.id, isMcpServerAdmin);
+      let allServers = await McpServerModel.findAll(
+        user.id,
+        isMcpServerAdmin,
+        organizationId,
+      );
 
       // serverType:"app" backings are managed on the Apps surface, not listed as
       // MCP servers — keep them out of the user-facing server list (and its
@@ -127,7 +131,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         response: constructResponseSchema(SelectMcpServerSchema),
       },
     },
-    async ({ params: { id }, user, headers }, reply) => {
+    async ({ params: { id }, user, headers, organizationId }, reply) => {
       const { success: isMcpServerAdmin } = await hasPermission(
         { mcpServerInstallation: ["admin"] },
         headers,
@@ -136,6 +140,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         id,
         user.id,
         isMcpServerAdmin,
+        organizationId,
       );
 
       if (!server) {

--- a/platform/backend/src/types/mcp-server.ts
+++ b/platform/backend/src/types/mcp-server.ts
@@ -59,6 +59,20 @@ export const SelectMcpServerSchema = createSelectSchema(
       }),
     )
     .optional(),
+  /**
+   * Auto-mode agents (implicit access to all tools) in this server's
+   * organization. They reach every server without an explicit tool assignment,
+   * so they are listed separately from `assignedAgents` — the same org-wide set
+   * appears on every server.
+   */
+  autoModeAgents: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+      }),
+    )
+    .optional(),
   localInstallationStatus: LocalMcpServerInstallationStatusSchema,
   secretStorageType: SecretStorageTypeSchema.optional(),
 });

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-server-card.tsx
@@ -283,6 +283,30 @@ export function McpServerCard({
     return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
   })();
 
+  // Auto-mode agents (implicit access to all tools) can reach this server
+  // without an explicit assignment. The set is org-wide, so the same list rides
+  // on every install of this catalog item — dedupe across them.
+  const autoModeAgents = (() => {
+    const byId = new Map<string, { id: string; name: string }>();
+    for (const server of allServersForCatalog) {
+      for (const agent of server.autoModeAgents ?? []) {
+        byId.set(agent.id, agent);
+      }
+    }
+    return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+  })();
+
+  // An auto-mode agent may also carry an explicit assignment to this server
+  // (a legacy pin, or "Auto except some"), which would otherwise list it in
+  // both sections. An explicit assignment is the more specific fact, so show it
+  // once — under assigned tools — and drop it from the auto-mode list. The
+  // badge counts the distinct agents across both sections.
+  const assignedAgentIds = new Set(assignedAgents.map((agent) => agent.id));
+  const autoModeOnlyAgents = autoModeAgents.filter(
+    (agent) => !assignedAgentIds.has(agent.id),
+  );
+  const totalAgentCount = assignedAgents.length + autoModeOnlyAgents.length;
+
   // The most recent personal install for this catalog item, if any.
   const uninstallInstalls: UninstallServerInstall[] = (() => {
     const install = personalServersForCatalog
@@ -558,7 +582,7 @@ export function McpServerCard({
   const hasCompactInfoContent =
     showAuthorAvatar ||
     toolsCount > 0 ||
-    assignedAgents.length > 0 ||
+    totalAgentCount > 0 ||
     (variant === "local" && deploymentServerIds.length > 0) ||
     (!isBuiltinVariant &&
       (connectionAvatars.length > 0 ||
@@ -600,7 +624,7 @@ export function McpServerCard({
           <div className="h-4 w-px bg-border" />
         </>
       )}
-      {assignedAgents.length > 0 && (
+      {totalAgentCount > 0 && (
         <>
           <TooltipProvider>
             <Tooltip>
@@ -608,24 +632,48 @@ export function McpServerCard({
                 <div className="flex items-center gap-1 cursor-help">
                   <Bot className="h-3.5 w-3.5" />
                   <span data-testid={`${E2eTestId.McpServerAgentsCount}`}>
-                    {assignedAgents.length}
+                    {totalAgentCount}
                   </span>
                 </div>
               </TooltipTrigger>
               <TooltipContent>
-                <p className="font-medium">
-                  Used by {assignedAgents.length}{" "}
-                  {assignedAgents.length === 1 ? "agent" : "agents"} (assigned
-                  tools)
-                </p>
-                <div className="mt-1 space-y-0.5">
-                  {assignedAgents.slice(0, 8).map((agent) => (
-                    <div key={agent.id}>{agent.name}</div>
-                  ))}
-                  {assignedAgents.length > 8 && (
-                    <div>+{assignedAgents.length - 8} more</div>
-                  )}
-                </div>
+                {assignedAgents.length > 0 && (
+                  <>
+                    <p className="font-medium">
+                      Used by {assignedAgents.length}{" "}
+                      {assignedAgents.length === 1 ? "agent" : "agents"}{" "}
+                      (assigned tools)
+                    </p>
+                    <div className="mt-1 space-y-0.5">
+                      {assignedAgents.slice(0, 8).map((agent) => (
+                        <div key={agent.id}>{agent.name}</div>
+                      ))}
+                      {assignedAgents.length > 8 && (
+                        <div>+{assignedAgents.length - 8} more</div>
+                      )}
+                    </div>
+                  </>
+                )}
+                {assignedAgents.length > 0 && autoModeOnlyAgents.length > 0 && (
+                  <div className="my-1.5 h-px bg-border" />
+                )}
+                {autoModeOnlyAgents.length > 0 && (
+                  <>
+                    <p className="font-medium">
+                      {autoModeOnlyAgents.length} auto-mode{" "}
+                      {autoModeOnlyAgents.length === 1 ? "agent" : "agents"}{" "}
+                      (access all tools)
+                    </p>
+                    <div className="mt-1 space-y-0.5">
+                      {autoModeOnlyAgents.slice(0, 8).map((agent) => (
+                        <div key={agent.id}>{agent.name}</div>
+                      ))}
+                      {autoModeOnlyAgents.length > 8 && (
+                        <div>+{autoModeOnlyAgents.length - 8} more</div>
+                      )}
+                    </div>
+                  </>
+                )}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -52483,6 +52483,10 @@ export type GetMcpServersResponses = {
             id: string;
             name: string;
         }>;
+        autoModeAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
         secretStorageType?: 'vault' | 'external_vault' | 'database' | 'none';
     }>;
 };
@@ -52622,6 +52626,10 @@ export type InstallMcpServerResponses = {
             createdAt: string;
         } | null;
         assignedAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
+        autoModeAgents?: Array<{
             id: string;
             name: string;
         }>;
@@ -52833,6 +52841,10 @@ export type GetMcpServerResponses = {
             id: string;
             name: string;
         }>;
+        autoModeAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
         secretStorageType?: 'vault' | 'external_vault' | 'database' | 'none';
     };
 };
@@ -52963,6 +52975,10 @@ export type ReauthenticateMcpServerResponses = {
             createdAt: string;
         } | null;
         assignedAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
+        autoModeAgents?: Array<{
             id: string;
             name: string;
         }>;
@@ -53368,6 +53384,10 @@ export type ReinstallMcpServerResponses = {
             createdAt: string;
         } | null;
         assignedAgents?: Array<{
+            id: string;
+            name: string;
+        }>;
+        autoModeAgents?: Array<{
             id: string;
             name: string;
         }>;


### PR DESCRIPTION
## What

The MCP registry server card shows a **"Used by N agents (assigned tools)"** tooltip that only listed agents with explicitly assigned tools. Agents in **Auto tool mode** (implicit access to all tools) were omitted, so the count understated who can actually reach the server.

This adds those auto-mode agents to the tooltip, **below a divider**, and fixes the count.

## Changes

**Backend**
- `AgentModel.getAutoModeAgentDetailsByOrganizations()` — auto-mode agents (`accessAllTools = true`), batched per organization.
- `McpServerModel.findAll` / `findById` take an optional `organizationId` and decorate each server with `autoModeAgents` (the viewing org's set — auto-mode agents reach every server, so the same set rides on each). Opt-in, so other callers are unaffected.
- `GET /api/mcp_server` and `GET /api/mcp_server/:id` pass `request.organizationId`.
- `assignedAgents` is intentionally left as-is — the uninstall dialog uses it for impact warnings.

**Frontend**
- Server card renders a second section under a divider: **"N auto-mode agents (access all tools)"**.
- An agent that is both auto-mode **and** explicitly assigned is shown **once**, under assigned tools (the more specific fact); the badge counts distinct agents across both sections.

## Testing

- New model test in `mcp-server.test.ts` covering `findAll`/`findById` decoration with and without an org, and that custom vs auto agents are classified correctly.
- `type-check`, `lint`, and the full `mcp-server` model + route suites (115 tests) pass.
- Verified in-browser on a dev stack: `/mcp/registry` tooltip shows the divided sections and the correct distinct count.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>