### PR TITLE
fix(ci): unbreak merge queue (rmcp 2.2 Content rename + skills-import checkbox role)

### DIFF
--- a/ai-labs/runner/src/fixture_mcp.rs
+++ b/ai-labs/runner/src/fixture_mcp.rs
@@ -22,7 +22,7 @@ use std::net::SocketAddr;
 
 use axum::Router;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, Implementation, ListToolsResult, PaginatedRequestParams,
+    CallToolRequestParams, CallToolResult, ContentBlock, Implementation, ListToolsResult, PaginatedRequestParams,
     ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
@@ -360,7 +360,7 @@ fn contracts() -> Vec<JsonValue> {
 }
 
 fn text(s: impl Into<String>) -> CallToolResult {
-    CallToolResult::success(vec![Content::text(s.into())])
+    CallToolResult::success(vec![ContentBlock::text(s.into())])
 }
 
 fn string_prop(description: &str) -> JsonValue {

--- a/ai-labs/runner/src/mcp_server.rs
+++ b/ai-labs/runner/src/mcp_server.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use axum::Router;
 use jsonschema::{Draft, Validator};
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, Implementation, ListToolsResult, PaginatedRequestParams,
+    CallToolRequestParams, CallToolResult, ContentBlock, Implementation, ListToolsResult, PaginatedRequestParams,
     ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
@@ -357,7 +357,7 @@ fn retryable_rejection(errors: &[String], result_schema: &JsonValue) -> String {
 }
 
 fn text_result(text: impl Into<String>) -> CallToolResult {
-    CallToolResult::success(vec![Content::text(text)])
+    CallToolResult::success(vec![ContentBlock::text(text)])
 }
 
 fn schema_errors(validator: &Validator, result: &JsonValue) -> Vec<String> {

--- a/platform/frontend/tests-integration/skills-import.spec.ts
+++ b/platform/frontend/tests-integration/skills-import.spec.ts
@@ -150,10 +150,10 @@ test.describe("Skills import", () => {
     await expect(selectDialog).toBeVisible();
     await expect(selectDialog).toContainText("2 of 2 selected");
     await expect(
-      selectDialog.getByRole("button", { name: "Deselect Alpha skill" }),
+      selectDialog.getByRole("checkbox", { name: "Deselect Alpha skill" }),
     ).toBeVisible();
     await expect(
-      selectDialog.getByRole("button", { name: "Deselect Beta skill" }),
+      selectDialog.getByRole("checkbox", { name: "Deselect Beta skill" }),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Why

Two independent breakages already on `main` are failing **every** PR in the merge queue — proven across #6715, #6717, #6501, #6714 — because neither suite runs on ordinary PR pushes, only in `merge_group`. This clears both so the queue can move.

### 1. AI Labs Rust Checks
`deps: bump rmcp from 1.7.0 to 2.2.0` (#6463) renamed `rmcp::model::Content` → `ContentBlock`. `ai-labs/runner` still imported the old name in two files. Updated the imports and the two `Content::text` call sites.

`cargo check` / `clippy --all-targets -D warnings` / `fmt --check` all clean on the ai-labs workspace.

### 2. Frontend Integration Tests (MSW)
`feat(skills): recurring GitHub sync…` (#6713) changed the per-skill toggle in `import-skills-dialog.tsx` from a `<button>` to a Radix `<Checkbox>` (ARIA role `button` → `checkbox`), keeping the `aria-label`, but did not update `skills-import.spec.ts`, which still queried `getByRole("button", { name: "Deselect … skill" })`. Switched the two assertions to the `checkbox` role.

## Scope
6 lines across 3 files. No behavior change — a Rust import rename and a test-selector correction.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>