### PR TITLE
fix(test): stop cleanupOrphanedDeployments flaking under sequence.shuffle

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -2039,6 +2039,14 @@ describe("McpServerRuntimeManager.backfillRegcredTeamLabels", () => {
 describe("McpServerRuntimeManager.cleanupOrphanedDeployments", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call history but NOT implementations. Other describe
+    // blocks install a persistent InternalMcpCatalogModel.findById via
+    // mockResolvedValue (e.g. a multitenant catalog with no `name`), which under
+    // sequence.shuffle can survive into these tests and make the mocked
+    // constructDeploymentName throw — swallowed by cleanupOrphanedDeployments'
+    // try/catch, so nothing is deleted and the assertions flake. Restore the
+    // clean default (findById resolves undefined) so these tests are hermetic.
+    vi.mocked(InternalMcpCatalogModel.findById).mockReset();
   });
 
   async function createManagerWithMockK8s(params: {


### PR DESCRIPTION
## Why

`Backend Unit Tests (shard 3/4)` flakes in the merge queue on
`manager.test.ts > McpServerRuntimeManager.cleanupOrphanedDeployments > deletes legacy name-derived deployments for existing servers`
(`expected "vi.fn()" to be called once, but got 0 times`). It has ejected unrelated PRs from the queue (surfaced while landing #6719).

## Root cause

The suite runs with `sequence.shuffle: true`. The block's `beforeEach` calls `vi.clearAllMocks()`, which resets **call history but not implementations**. Other describe blocks install a *persistent* `InternalMcpCatalogModel.findById` via `mockResolvedValue(...)` — including a **multitenant catalog with no `name`** (the `reinstallSharedDeployment` block).

When shuffle orders one of those before the "deletes legacy" test, the leaked implementation survives into it. The mocked `constructDeploymentName` then runs `catalogItem.name.replaceAll(...)` on `undefined` and throws; `cleanupOrphanedDeployments` swallows it in its `try/catch`, so `deleteNamespacedDeployment` is never called and the assertion fails. (The other leaked catalogs are single-tenant, so they compute the right name and don't trip it — which is why it's intermittent.)

## Fix

Reset `InternalMcpCatalogModel.findById` in the block's `beforeEach` so these tests are hermetic regardless of shuffle order. The cleanup tests never set `findById` themselves — they rely on the clean default (`undefined`) — so this only removes leaked state.

## Verification

- Before: the file flaked ~1 in 5 fresh-seed runs.
- After: the previously-failing seed `1784584899390` passes 62/62, and **16/16** fresh-seed runs are green.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>