### PR TITLE
fix(mcp): keep edits and surface errors when cloning a catalog item

### DIFF
--- a/platform/frontend/src/app/mcp/registry/new/page.clone.test.tsx
+++ b/platform/frontend/src/app/mcp/registry/new/page.clone.test.tsx
@@ -1,0 +1,224 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter, useSearchParams } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useEnterpriseFeature, useFeature } from "@/lib/config/config.query";
+import { useAppName } from "@/lib/hooks/use-app-name";
+import {
+  useCreateInternalMcpCatalogItem,
+  useInternalMcpCatalog,
+} from "@/lib/mcp/internal-mcp-catalog.query";
+import {
+  useDefaultEnvironment,
+  useOrganization,
+} from "@/lib/organization.query";
+import {
+  useAssignableTeams,
+  useMyTeams,
+  useTeams,
+} from "@/lib/teams/team.query";
+import NewMcpCatalogItemPage from "./page";
+
+vi.mock("next/navigation");
+
+vi.mock("@/lib/config/config.query");
+
+vi.mock("@/lib/config/config", () => ({
+  default: {
+    enterpriseFeatures: {
+      core: false,
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/auth.query");
+
+vi.mock("@/lib/organization.query");
+
+vi.mock("@/lib/environment.query", () => ({
+  useEnvironments: vi.fn(() => ({
+    data: { environments: [], defaultAssignedCatalogCount: 0 },
+  })),
+}));
+
+vi.mock("@/lib/auth/identity-provider-read.query", () => ({
+  useIdentityProviders: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock("@/lib/teams/team.query");
+
+// Keep the real error-code helpers (the page's inline-error mapping depends on
+// them matching the backend), mock only the hooks.
+vi.mock("@/lib/mcp/internal-mcp-catalog.query", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/lib/mcp/internal-mcp-catalog.query")
+    >();
+  return {
+    ...actual,
+    useInternalMcpCatalog: vi.fn(),
+    useCreateInternalMcpCatalogItem: vi.fn(),
+    useK8sImagePullSecrets: vi.fn(() => ({ data: [] })),
+  };
+});
+
+vi.mock("@/lib/secrets.query", () => ({
+  useGetSecret: vi.fn(() => ({ data: null })),
+}));
+
+vi.mock("@/lib/docs/docs", () => ({
+  getVisibleDocsUrl: vi.fn(() => "https://docs.example.com"),
+  getFrontendDocsUrl: vi.fn(() => "https://docs.example.com/mcp-auth"),
+}));
+
+vi.mock("@/lib/hooks/use-app-name");
+
+vi.mock("@/components/agent-icon-picker", () => ({
+  AgentIconPicker: () => <div data-testid="agent-icon-picker" />,
+}));
+
+vi.mock("@/components/agent-labels", () => ({
+  ProfileLabels: () => <div data-testid="profile-labels" />,
+}));
+
+vi.mock("@/components/environment-variables-form-field", () => ({
+  EnvironmentVariablesFormField: () => (
+    <div data-testid="environment-variables-form-field" />
+  ),
+}));
+
+vi.mock("@/components/visibility-selector", () => ({
+  VisibilitySelector: () => <div data-testid="visibility-selector" />,
+}));
+
+// Minimal remote catalog item the ?clone= param resolves to.
+const cloneSource = {
+  id: "clone-source-id",
+  name: "remote-src",
+  description: "A remote server",
+  icon: null,
+  serverType: "remote",
+  serverUrl: "https://api.example.com/mcp",
+  oauthConfig: null,
+  userConfig: null,
+  enterpriseManagedConfig: null,
+  localConfig: null,
+  deploymentSpecYaml: null,
+  labels: [],
+  scope: "personal",
+  teams: [],
+  environmentId: null,
+} as unknown as NonNullable<
+  ReturnType<typeof useInternalMcpCatalog>["data"]
+>[number];
+
+describe("NewMcpCatalogItemPage clone flow", () => {
+  const push = vi.fn();
+  const mutate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({ push } as unknown as ReturnType<
+      typeof useRouter
+    >);
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("clone=clone-source-id") as unknown as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+    vi.mocked(useInternalMcpCatalog).mockReturnValue({
+      data: [cloneSource],
+    } as unknown as ReturnType<typeof useInternalMcpCatalog>);
+    vi.mocked(useCreateInternalMcpCatalogItem).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateInternalMcpCatalogItem>);
+    vi.mocked(useOrganization).mockReturnValue({
+      data: { onlineMcpCatalogEnabled: false },
+      isPending: false,
+    } as unknown as ReturnType<typeof useOrganization>);
+    vi.mocked(useFeature).mockImplementation((feature: string) => {
+      if (feature === "mcpServerBaseImage") return "";
+      if (feature === "orchestratorK8sRuntime") return true;
+      if (feature === "byosEnabled") return false;
+      return undefined;
+    });
+    vi.mocked(useEnterpriseFeature).mockReturnValue(false);
+    vi.mocked(useHasPermissions).mockReturnValue({
+      data: true,
+    } as ReturnType<typeof useHasPermissions>);
+    vi.mocked(useDefaultEnvironment).mockReturnValue({
+      name: "Default",
+      namespace: null,
+      description: null,
+      networkPolicy: null,
+      restricted: false,
+    } as ReturnType<typeof useDefaultEnvironment>);
+    vi.mocked(useTeams).mockReturnValue({ data: [] } as unknown as ReturnType<
+      typeof useTeams
+    >);
+    vi.mocked(useMyTeams).mockReturnValue({ data: [] } as unknown as ReturnType<
+      typeof useMyTeams
+    >);
+    vi.mocked(useAssignableTeams).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useAssignableTeams>);
+    vi.mocked(useAppName).mockReturnValue("Archestra");
+  });
+
+  it("keeps user edits across parent re-renders instead of resetting to the clone values", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<NewMcpCatalogItemPage />);
+
+    const nameInput = await screen.findByDisplayValue("remote-src-copy");
+    await user.clear(nameInput);
+    await user.type(nameInput, "my-edited-name");
+
+    // A parent re-render (e.g. the create mutation flipping to pending) must
+    // not rebuild the pre-fill values and wipe the user's edits.
+    rerender(<NewMcpCatalogItemPage />);
+
+    expect(screen.getByDisplayValue("my-edited-name")).toBeInTheDocument();
+  });
+
+  it("submits the edited values and shows a network-policy rejection inline instead of silently dropping it", async () => {
+    mutate.mockImplementation((_data, opts) => {
+      const error = new Error(
+        "The remote MCP server host is not permitted by the environment's network egress policy.",
+      ) as Error & { internalCode?: string };
+      error.internalCode = "remote_server_url_not_allowed";
+      // TanStack Query always delivers mutation callbacks asynchronously —
+      // a synchronous call here would land before the form's post-submit
+      // baseline reset and get wiped, which real mutations never hit.
+      setTimeout(() => opts?.onError?.(error), 0);
+    });
+
+    const user = userEvent.setup();
+    render(<NewMcpCatalogItemPage />);
+
+    const nameInput = await screen.findByDisplayValue("remote-src-copy");
+    await user.clear(nameInput);
+    await user.type(nameInput, "my-edited-name");
+
+    await user.click(screen.getByRole("button", { name: "Add Server" }));
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledTimes(1);
+    });
+    expect(mutate.mock.calls[0][0]).toMatchObject({
+      name: "my-edited-name",
+      clonedFrom: "clone-source-id",
+    });
+
+    // The rejection surfaces inline on the Server URL field...
+    expect(
+      await screen.findByText(
+        "The remote MCP server host is not permitted by the environment's network egress policy.",
+      ),
+    ).toBeInTheDocument();
+    // ...the user's edits survive the failed submit, and no navigation happens.
+    expect(screen.getByDisplayValue("my-edited-name")).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/platform/frontend/src/app/mcp/registry/new/page.tsx
+++ b/platform/frontend/src/app/mcp/registry/new/page.tsx
@@ -4,7 +4,8 @@ import { MCP_CATALOG_CLONE_QUERY_PARAM } from "@archestra/shared";
 import { ArrowLeft, Copy, PencilRuler, Search } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
 import { LoadingSpinner } from "@/components/loading";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -15,6 +16,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
+  getCatalogMutationErrorCode,
+  REMOTE_SERVER_URL_NOT_ALLOWED_CODE,
   useCreateInternalMcpCatalogItem,
   useInternalMcpCatalog,
 } from "@/lib/mcp/internal-mcp-catalog.query";
@@ -50,9 +53,14 @@ export default function NewMcpCatalogItemPage() {
   const cloneSource = cloneSourceId
     ? catalogItems?.find((item) => item.id === cloneSourceId)
     : undefined;
-  const cloneValues = cloneSource
-    ? buildCloneFormValues(cloneSource)
-    : undefined;
+  // Memoized: the form resets itself whenever its `formValues` prop changes
+  // identity, so rebuilding this object on every render (e.g. the re-render
+  // from the create mutation entering its pending state) would wipe the
+  // user's edits back to the pre-filled clone values.
+  const cloneValues = useMemo(
+    () => (cloneSource ? buildCloneFormValues(cloneSource) : undefined),
+    [cloneSource],
+  );
 
   const [step, setStep] = useState<SourceSubStep>(
     cloneSourceId ? "configure" : "source",
@@ -62,18 +70,42 @@ export default function NewMcpCatalogItemPage() {
     McpCatalogFormValues | undefined
   >(undefined);
 
-  const onSubmit = async (values: McpCatalogFormValues) => {
+  const onSubmit = (
+    values: McpCatalogFormValues,
+    form: UseFormReturn<McpCatalogFormValues>,
+  ) => {
     const apiData = {
       ...transformFormToApiData(values),
       // Record clone lineage (null for a plain "Add Server").
       clonedFrom: cloneSource ? cloneSource.id : null,
     };
-    const createdItem = await createMutation.mutateAsync(apiData);
-    if (!createdItem) return;
-
-    // Continue the setup wizard on the created item: test the connection,
-    // review tools, configure guardrails.
-    router.push(`/mcp/registry/${createdItem.id}/edit?step=test`);
+    createMutation.mutate(apiData, {
+      onSuccess: (createdItem) => {
+        if (!createdItem) return;
+        // Continue the setup wizard on the created item: test the connection,
+        // review tools, configure guardrails.
+        router.push(`/mcp/registry/${createdItem.id}/edit?step=test`);
+      },
+      onError: (error) => {
+        // Network-policy rejections point at the Server URL — show them
+        // inline on that field rather than as a toast (the mutation's shared
+        // onError intentionally skips the toast for this code). Without this,
+        // e.g. binding a clone to an environment whose egress policy blocks
+        // the cloned URL failed with no feedback at all.
+        if (
+          getCatalogMutationErrorCode(error) ===
+          REMOTE_SERVER_URL_NOT_ALLOWED_CODE
+        ) {
+          form.setError("serverUrl", {
+            type: "server",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Server URL is not allowed by the environment's network policy.",
+          });
+        }
+      },
+    });
   };
 
   const handleSelectFromCatalog = (formValues: McpCatalogFormValues) => {


### PR DESCRIPTION
## Problem

Cloning an MCP server from the registry (item page → `⋯` → Clone), changing the **Name** and **Environment**, and clicking **Add Server** could appear to do nothing: no error, no navigation, and the form snapped back to the pre-filled `-copy` name and original environment. Clicking **Add Server** again then created the clone with the *unedited* values.

## Root cause — two compounding defects on the create page

1. **Silent failure.** When the selected environment's network egress policy blocks the cloned server URL, the backend rejects the create with `remote_server_url_not_allowed`. The shared mutation `onError` intentionally skips the toast for that code, expecting the caller to render it inline on the Server URL field — but only the edit dialog wired that up. `new/page.tsx` never did, so the rejection vanished with zero feedback.
2. **Edits wiped.** `new/page.tsx` rebuilt the clone pre-fill values (`buildCloneFormValues`) on every render. `McpCatalogForm` resets itself whenever its `formValues` prop changes identity, so the re-render from the create mutation entering its pending state handed the form a fresh object and the reset effect reverted the user's edits back to the `-copy` state. That's why the *second* click submitted the original values — which the original environment's policy allows, so it succeeded.

Reproduced end-to-end locally: clone a remote server, bind it to an environment whose egress policy disallows the server's host, click Add Server → silent no-op + revert, exactly as reported.

## Fix

- Memoize the clone pre-fill values on the clone source so parent re-renders can't wipe the user's edits.
- Map `remote_server_url_not_allowed` create failures onto the Server URL field inline (same treatment as the edit dialog), switching `onSubmit` to the callback-style `mutate` the edit dialog uses so the form instance is available for `setError`.

## Tests

Added `page.clone.test.tsx` rendering the real form through the create page:

- user edits survive a parent re-render instead of resetting to the clone values
- a submit that fails with `remote_server_url_not_allowed` submits the *edited* values, shows the rejection inline on the Server URL field, keeps the edits, and does not navigate

Both tests fail against the previous `page.tsx` and pass with the fix. `pnpm lint` and `pnpm type-check` clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>