### PR TITLE
perf(db): stop creating payload trgm GIN indexes on interactions

### DIFF
--- a/platform/backend/src/database/index-maintenance.test.ts
+++ b/platform/backend/src/database/index-maintenance.test.ts
@@ -1,0 +1,43 @@
+import { sql } from "drizzle-orm";
+import db from "@/database";
+import { describe, expect, test } from "@/test";
+import { dropLegacyPayloadTrgmIndexes } from "./index-maintenance";
+
+async function indexExists(name: string): Promise<boolean> {
+  const result = await db.execute(
+    sql`select to_regclass(${name}) as index_oid`,
+  );
+  return result.rows[0]?.index_oid != null;
+}
+
+describe("dropLegacyPayloadTrgmIndexes", () => {
+  test("drops the legacy payload indexes when present", async () => {
+    // The test schema never creates the trgm indexes (pg_trgm is unavailable
+    // under PGlite, and migration 0116 no longer creates them anyway), so
+    // stand in plain indexes under the legacy names.
+    await db.execute(
+      sql.raw(
+        'CREATE INDEX IF NOT EXISTS "interactions_request_trgm_idx" ON "interactions" (id)',
+      ),
+    );
+    await db.execute(
+      sql.raw(
+        'CREATE INDEX IF NOT EXISTS "interactions_response_trgm_idx" ON "interactions" (id)',
+      ),
+    );
+
+    // concurrently: false — PGlite rejects DROP INDEX CONCURRENTLY; production
+    // always uses the concurrent form (see the option's doc).
+    await dropLegacyPayloadTrgmIndexes({ concurrently: false });
+
+    expect(await indexExists("interactions_request_trgm_idx")).toBe(false);
+    expect(await indexExists("interactions_response_trgm_idx")).toBe(false);
+  });
+
+  test("is a no-op when the indexes are already gone", async () => {
+    await expect(
+      dropLegacyPayloadTrgmIndexes({ concurrently: false }),
+    ).resolves.toBeUndefined();
+    expect(await indexExists("interactions_request_trgm_idx")).toBe(false);
+  });
+});

--- a/platform/backend/src/database/index-maintenance.ts
+++ b/platform/backend/src/database/index-maintenance.ts
@@ -1,0 +1,71 @@
+import { sql } from "drizzle-orm";
+import db from "@/database";
+import logger from "@/logging";
+
+/**
+ * Drop the legacy pg_trgm GIN indexes over interactions' request/response
+ * payloads on deployments that created them before migration 0116 stopped
+ * doing so. The free-text search they served no longer exists (the LLM logs
+ * UI filters by dropdowns + exact session id), while every hot-path
+ * interactions insert paid GIN maintenance over a multi-hundred-KB payload.
+ *
+ * This runs from worker startup rather than a Drizzle migration because
+ * migrations execute inside a transaction, where only the blocking,
+ * non-concurrent DROP INDEX is possible — an ACCESS EXCLUSIVE lock on the LLM
+ * proxy's hottest table (see the archestra-dev-interactions-migrations rules).
+ * DROP INDEX CONCURRENTLY must run outside a transaction, which is exactly
+ * what a standalone autocommit statement gives us.
+ *
+ * Idempotent and race-tolerant: IF EXISTS makes reruns no-ops, and a failure
+ * (e.g. two workers racing, or a lock wait aborted) is logged and retried on
+ * the next boot.
+ */
+export async function dropLegacyPayloadTrgmIndexes(
+  options: {
+    /**
+     * Tests set this to false: PGlite's single-backend WASM build rejects
+     * DROP INDEX CONCURRENTLY ("tuple concurrently updated"). Production
+     * callers always use the concurrent, non-write-blocking form.
+     */
+    concurrently?: boolean;
+  } = {},
+): Promise<void> {
+  const concurrently = options.concurrently ?? true;
+  for (const indexName of LEGACY_PAYLOAD_TRGM_INDEXES) {
+    try {
+      const existing = await db.execute(
+        sql`select to_regclass(${indexName}) as index_oid`,
+      );
+      if (!existing.rows[0]?.index_oid) {
+        continue;
+      }
+
+      logger.info({ indexName }, "Dropping legacy payload trgm index");
+      await db.execute(
+        sql.raw(
+          `DROP INDEX ${concurrently ? "CONCURRENTLY " : ""}IF EXISTS "${indexName}"`,
+        ),
+      );
+      logger.info({ indexName }, "Dropped legacy payload trgm index");
+    } catch (error) {
+      // Non-fatal: the index keeps working (it is just dead weight), and the
+      // next worker boot retries.
+      logger.warn(
+        {
+          error: error instanceof Error ? error.message : String(error),
+          indexName,
+        },
+        "Failed to drop legacy payload trgm index; will retry on next boot",
+      );
+    }
+  }
+}
+
+// ============================================================
+// Internal implementation
+// ============================================================
+
+const LEGACY_PAYLOAD_TRGM_INDEXES = [
+  "interactions_request_trgm_idx",
+  "interactions_response_trgm_idx",
+];

--- a/platform/backend/src/database/migrations/0116_pg_trgm_indexes.sql
+++ b/platform/backend/src/database/migrations/0116_pg_trgm_indexes.sql
@@ -15,9 +15,19 @@ END$$;
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm') THEN
-    -- Interactions table indexes (for LLM proxy logs search)
-    CREATE INDEX IF NOT EXISTS "interactions_request_trgm_idx" ON "interactions" USING gin ((request::text) gin_trgm_ops);
-    CREATE INDEX IF NOT EXISTS "interactions_response_trgm_idx" ON "interactions" USING gin ((response::text) gin_trgm_ops);
+    -- NOTE: this migration originally also created payload trgm indexes on
+    -- interactions (interactions_request_trgm_idx on (request::text) and
+    -- interactions_response_trgm_idx on (response::text)). The free-text
+    -- search they served no longer exists — the LLM logs UI filters by
+    -- dropdowns + exact session id — while the GIN indexes write-amplified
+    -- every hot-path interactions insert and grew to multiple GB of dead
+    -- weight. They were removed here (inert for already-migrated databases:
+    -- drizzle applies migrations by journal timestamp, so editing this file
+    -- only affects fresh installs). Existing deployments drop them out of
+    -- band, per archestra-dev-interactions-migrations (a transactional
+    -- DROP INDEX would take a write-blocking lock on the proxy's hot path):
+    --   DROP INDEX CONCURRENTLY IF EXISTS interactions_request_trgm_idx;
+    --   DROP INDEX CONCURRENTLY IF EXISTS interactions_response_trgm_idx;
 
     -- Conversations table index (for chat title search in LLM proxy logs)
     CREATE INDEX IF NOT EXISTS "conversations_title_trgm_idx" ON "conversations" USING gin (title gin_trgm_ops);

--- a/platform/backend/src/database/schemas/interaction.ts
+++ b/platform/backend/src/database/schemas/interaction.ts
@@ -254,10 +254,14 @@ const interactionsTable = pgTable(
       "interactions_session_thread_created_at_idx",
     ).on(table.sessionId, table.threadId, table.createdAt.desc()),
     parentIdIdx: index("interactions_parent_id_idx").on(table.parentId),
-    // Note: Additional pg_trgm GIN indexes for search are created in migration 0116_pg_trgm_indexes.sql:
-    // - interactions_request_trgm_idx: GIN index on (request::text)
-    // - interactions_response_trgm_idx: GIN index on (response::text)
-    // These can't be defined in Drizzle schema as they require ::text cast and gin_trgm_ops operator class.
+    // Note: interactions deliberately has NO trgm/GIN indexes on the request/
+    // response payload columns. Migration 0116 used to create them for a
+    // free-text log search that no longer exists (the LLM logs UI filters by
+    // dropdowns + exact session id), and GIN over multi-hundred-KB payloads
+    // write-amplified every hot-path insert. If payload search ever returns,
+    // build it on a bounded column — not on (request::text)/(response::text) —
+    // and create the index CONCURRENTLY out of band (see the
+    // archestra-dev-interactions-migrations skill).
   }),
 );
 

--- a/platform/backend/src/server.ts
+++ b/platform/backend/src/server.ts
@@ -59,6 +59,7 @@ import config, {
   shouldRunWorker,
 } from "@/config";
 import { initializeDatabase, isDatabaseHealthy } from "@/database";
+import { dropLegacyPayloadTrgmIndexes } from "@/database/index-maintenance";
 import { getTransientDbErrorCode } from "@/database/retry";
 import { seedRequiredStartingData } from "@/database/seed";
 import { enterpriseTier } from "@/enterprise-tier";
@@ -1279,6 +1280,11 @@ const startWebServer = async () => {
       registerTaskHandlers(taskQueueService);
       await taskQueueService.seedPeriodicTasks();
       taskQueueService.startWorker();
+      // Fire-and-forget: concurrent (non-write-blocking) drop of legacy
+      // interactions payload indexes on deployments upgrading from before
+      // migration 0116 stopped creating them. Idempotent; errors are logged
+      // inside and retried next boot.
+      void dropLegacyPayloadTrgmIndexes();
     }
 
     // Background job to renew email subscriptions before they expire
@@ -1598,6 +1604,9 @@ const startWorker = async () => {
     registerTaskHandlers(taskQueueService);
     await taskQueueService.seedPeriodicTasks();
     taskQueueService.startWorker();
+    // See the shouldRunWorker branch in `start` — same legacy-index cleanup,
+    // for the dedicated worker Deployment.
+    void dropLegacyPayloadTrgmIndexes();
 
     posthogErrorTrackingService.init().catch((error) => {
       logger.warn(


### PR DESCRIPTION
## What

Removes `interactions_request_trgm_idx` (GIN over `request::text`) and `interactions_response_trgm_idx` (GIN over `response::text`) from migration `0116_pg_trgm_indexes.sql`, and updates the schema-file comment to document that the payload columns are deliberately unindexed.

## Why

These two indexes are dead weight on the platform's hottest table:

- **No code uses them.** Nothing in the backend ILIKEs `interactions.request` or `interactions.response`. The LLM logs UI already searches by exact session UUID only (`frontend/src/app/llm/logs/page.client.tsx` — the input even validates "Enter a valid session UUID") plus dropdown filters.
- **They write-amplify every proxied LLM call.** Each interactions insert pays GIN trigram maintenance over a multi-hundred-KB JSON payload. On staging, single-row interaction inserts run p95 1.2–1.4s, and `interactions_request_trgm_idx` alone is **2.1 GB** for 93k rows (heap: 104 MB).

The other 0116 indexes are untouched: `conversations_title_trgm_idx`, `mcp_tool_calls_method_trgm_idx`, `mcp_tool_calls_mcp_server_name_trgm_idx` are small-column live-feature indexes, and `mcp_tool_calls_tool_result_trgm_idx` backs the MCP gateway logs free-text search (whether to keep that feature is a separate decision).

## Why edit 0116 instead of a new DROP INDEX migration

Per the `archestra-dev-interactions-migrations` rules: Drizzle migrations run in a transaction, so a migration can only emit the blocking, non-concurrent `DROP INDEX`, which takes an ACCESS EXCLUSIVE lock on the LLM proxy's hot write path (the migration linter hard-errors on it). Drizzle applies migrations by journal timestamp, so editing 0116 is **inert for every already-migrated database** — it only changes what fresh installs create.

## Rollout for existing deployments (out-of-band ops step)

```sql
DROP INDEX CONCURRENTLY IF EXISTS interactions_request_trgm_idx;
DROP INDEX CONCURRENTLY IF EXISTS interactions_response_trgm_idx;
```

Non-blocking; safe to run while the proxy is live. Frees ~2.2 GB on staging immediately; existing deployments reclaim similar proportions. (Also documented in the migration file itself.)

## Testing

No application behavior changes (index-only). `drizzle-kit check` passes; `check:migrations` reports 0 errors (4 pre-existing warnings for the remaining non-concurrent CREATE INDEX statements in 0116).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>