### PR TITLE
perf(llm-proxy): resolve lean GatewayAgent on the hot path + pool saturation metrics

### DIFF
--- a/platform/backend/src/database/index.ts
+++ b/platform/backend/src/database/index.ts
@@ -117,6 +117,30 @@ export async function isDatabaseHealthy(): Promise<boolean> {
 }
 
 /**
+ * Live connection-pool counters for observability. `waitingCount` is the
+ * number of queries queued for a free client — a sustained non-zero value
+ * means the pool max is the bottleneck (checkout queueing is otherwise
+ * invisible: individual query spans stay fast while requests stall).
+ * Returns null before the pool is initialized.
+ */
+export function getPoolStats(): {
+  totalCount: number;
+  idleCount: number;
+  waitingCount: number;
+  maxSize: number;
+} | null {
+  if (!pool) {
+    return null;
+  }
+  return {
+    totalCount: pool.totalCount,
+    idleCount: pool.idleCount,
+    waitingCount: pool.waitingCount,
+    maxSize: config.database.poolMax,
+  };
+}
+
+/**
  * Default export to use a Proxy to defer access until after database initialization.
  */
 export default new Proxy({} as ReturnType<typeof getDb>, {

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -1899,6 +1899,36 @@ class AgentModel {
   }
 
   /**
+   * Lean counterpart of {@link getDefaultProfile} for the LLM proxy hot path:
+   * the raw agents row plus labels, like {@link findGatewayAgentById}. The
+   * proxy resolves the default profile on every request that omits an agent id
+   * in the URL, and it only reads scalar config (org, agent type,
+   * considerContextUntrusted, identity provider) and trace/metric labels — the
+   * tools join and team/knowledge/connector hydration of the full method are
+   * unused there.
+   */
+  static async getDefaultGatewayProfile(): Promise<GatewayAgent | null> {
+    const [agent] = await db
+      .select()
+      .from(schema.agentsTable)
+      .where(
+        and(
+          eq(schema.agentsTable.isDefault, true),
+          eq(schema.agentsTable.agentType, "profile"),
+          notDeleted(schema.agentsTable),
+        ),
+      )
+      .limit(1);
+
+    if (!agent) {
+      return null;
+    }
+
+    const labels = await AgentLabelModel.getLabelsForAgent(agent.id);
+    return { ...agent, labels };
+  }
+
+  /**
    * Minimal agent lookup for opening a conversation: the SAME access gate as
    * {@link findById}, but selecting only the LLM-selection fields that path uses
    * (`llmApiKeyId`, `modelId`). Skips the tool join and the

--- a/platform/backend/src/observability/index.ts
+++ b/platform/backend/src/observability/index.ts
@@ -19,6 +19,7 @@ export async function initializeObservabilityMetrics(params?: {
     metrics.agentExecution.initializeAgentExecutionMetrics(labelKeys);
   }
 
+  metrics.database.initializeDatabaseMetrics();
   metrics.rag.initializeRagMetrics();
   metrics.sandbox.initializeSandboxMetrics();
   metrics.scheduleTrigger.initializeScheduleTriggerMetrics();

--- a/platform/backend/src/observability/metrics/agent-execution.ts
+++ b/platform/backend/src/observability/metrics/agent-execution.ts
@@ -8,7 +8,7 @@
 
 import client from "prom-client";
 import logger from "@/logging";
-import type { Agent } from "@/types";
+import type { GatewayAgent } from "@/types";
 import { sanitizeLabelKey } from "./utils";
 
 let agentExecutionsTotal: client.Counter<string>;
@@ -61,7 +61,7 @@ export function initializeAgentExecutionMetrics(labelKeys: string[]): void {
  */
 export function reportAgentExecution(params: {
   executionId: string;
-  profile: Agent;
+  profile: GatewayAgent;
   externalAgentId?: string;
 }): void {
   if (!agentExecutionsTotal) {

--- a/platform/backend/src/observability/metrics/database.test.ts
+++ b/platform/backend/src/observability/metrics/database.test.ts
@@ -1,0 +1,43 @@
+import client from "prom-client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
+
+describe("database pool metrics", () => {
+  beforeEach(() => {
+    client.register.clear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    client.register.clear();
+    vi.resetModules();
+  });
+
+  test("reports live pool counters and the configured max at scrape time", async () => {
+    const { initializeDatabaseMetrics } = await import("./database");
+
+    initializeDatabaseMetrics(() => ({
+      totalCount: 7,
+      idleCount: 4,
+      waitingCount: 2,
+      maxSize: 20,
+    }));
+
+    const metrics = await client.register.metrics();
+    expect(metrics).toContain('database_pool_connections{state="total"} 7');
+    expect(metrics).toContain('database_pool_connections{state="idle"} 4');
+    expect(metrics).toContain('database_pool_connections{state="waiting"} 2');
+    expect(metrics).toContain("database_pool_size_limit 20");
+  });
+
+  test("emits no per-state samples before the pool is initialized", async () => {
+    const { initializeDatabaseMetrics } = await import("./database");
+
+    initializeDatabaseMetrics(() => null);
+
+    const metrics = await client.register.metrics();
+    expect(metrics).not.toContain("database_pool_connections{state=");
+    // A label-less prom-client gauge always carries a default 0 sample; it
+    // stays 0 until the pool exists.
+    expect(metrics).toContain("database_pool_size_limit 0");
+  });
+});

--- a/platform/backend/src/observability/metrics/database.ts
+++ b/platform/backend/src/observability/metrics/database.ts
@@ -1,0 +1,55 @@
+import client from "prom-client";
+import { getPoolStats } from "@/database";
+import logger from "@/logging";
+
+type PoolStatsProvider = () => ReturnType<typeof getPoolStats>;
+
+/**
+ * Initialize database connection-pool metrics.
+ *
+ * The pool is sampled at scrape time via the gauge `collect()` callback rather
+ * than on a timer, so the series always reflects the live pool state.
+ * `database_pool_connections{state="waiting"}` is the load-bearing series:
+ * queries queued for a free client are otherwise invisible — individual query
+ * spans stay fast while requests stall in checkout.
+ */
+export function initializeDatabaseMetrics(
+  // Injectable for tests; production callers use the live pool counters.
+  statsProvider: PoolStatsProvider = getPoolStats,
+): void {
+  if (initialized) return;
+
+  // The gauges are fully self-driving via collect(); no handles are kept
+  // because nothing records to them outside scrape time.
+  new client.Gauge({
+    name: "database_pool_connections",
+    help: "Live pg pool connection counts (total = open clients, idle = unused open clients, waiting = queries queued for a free client)",
+    labelNames: ["state"],
+    collect() {
+      const stats = statsProvider();
+      if (!stats) return;
+      this.set({ state: "total" }, stats.totalCount);
+      this.set({ state: "idle" }, stats.idleCount);
+      this.set({ state: "waiting" }, stats.waitingCount);
+    },
+  });
+
+  new client.Gauge({
+    name: "database_pool_size_limit",
+    help: "Configured pg pool max size per Node process (ARCHESTRA_DATABASE_POOL_MAX)",
+    collect() {
+      const stats = statsProvider();
+      if (!stats) return;
+      this.set(stats.maxSize);
+    },
+  });
+
+  initialized = true;
+  logger.info("Database pool metrics initialized");
+}
+
+// ============================================================
+// Internal implementation
+// ============================================================
+
+let initialized = false;

--- a/platform/backend/src/observability/metrics/index.ts
+++ b/platform/backend/src/observability/metrics/index.ts
@@ -1,6 +1,7 @@
 export * as agentExecution from "./agent-execution";
 export * as audit from "./audit";
 export * as chat from "./chat";
+export * as database from "./database";
 export * as llm from "./llm";
 export * as mcp from "./mcp";
 export * as rag from "./rag";

--- a/platform/backend/src/observability/metrics/llm.ts
+++ b/platform/backend/src/observability/metrics/llm.ts
@@ -23,7 +23,7 @@ import { getUsageTokens as getGeminiUsage } from "@/routes/proxy/adapters/gemini
 import { getUsageTokens as getMinimaxUsage } from "@/routes/proxy/adapters/minimax";
 import { getUsageTokens as getOpenAIUsage } from "@/routes/proxy/adapters/openai";
 import { getUsageTokens as getZhipuaiUsage } from "@/routes/proxy/adapters/zhipuai";
-import type { Agent } from "@/types";
+import type { GatewayAgent } from "@/types";
 import { getExemplarLabels, sanitizeLabelKey } from "./utils";
 
 type UsageExtractor =
@@ -272,7 +272,7 @@ export function initializeMetrics(labelKeys: string[]): void {
  * @param source Interaction source (e.g. "api", "chat", "knowledge:embedding")
  */
 function buildMetricLabels(
-  profile: Agent,
+  profile: GatewayAgent,
   additionalLabels: Record<string, string>,
   model: string | undefined,
   source: InteractionSource,
@@ -309,7 +309,7 @@ function buildMetricLabels(
  */
 export function reportLLMTokens(
   provider: SupportedProvider,
-  profile: Agent,
+  profile: GatewayAgent,
   usage: {
     input?: number;
     output?: number;
@@ -381,7 +381,7 @@ export function reportLLMTokens(
  */
 export function reportBlockedTools(
   provider: SupportedProvider,
-  profile: Agent,
+  profile: GatewayAgent,
   count: number,
   model: string,
   source: InteractionSource,
@@ -409,7 +409,7 @@ export function reportBlockedTools(
  */
 export function reportLLMCost(
   provider: SupportedProvider,
-  profile: Agent,
+  profile: GatewayAgent,
   model: string,
   cost: number | null | undefined,
   source: InteractionSource,
@@ -447,7 +447,7 @@ export function reportLLMCost(
  */
 export function reportLLMCacheCost(
   provider: SupportedProvider,
-  profile: Agent,
+  profile: GatewayAgent,
   model: string,
   cache: { cacheCost?: number | null; cacheReadSavings?: number | null },
   source: InteractionSource,
@@ -484,7 +484,7 @@ export function reportLLMCacheCost(
  */
 export function reportTimeToFirstToken(
   provider: SupportedProvider,
-  profile: Agent,
+  profile: GatewayAgent,
   model: string,
   ttftSeconds: number,
   source: InteractionSource,
@@ -517,7 +517,7 @@ export function reportTimeToFirstToken(
  */
 export function reportTokensPerSecond(
   provider: SupportedProvider,
-  profile: Agent,
+  profile: GatewayAgent,
   model: string,
   outputTokens: number,
   durationSeconds: number,
@@ -559,7 +559,7 @@ export function reportTokensPerSecond(
  */
 export function reportRequestDuration(
   provider: SupportedProvider,
-  profile: Agent,
+  profile: GatewayAgent,
   model: string,
   durationSeconds: number,
   statusCode: string,
@@ -589,7 +589,7 @@ export function reportRequestDuration(
  */
 export function getObservableFetch(
   provider: SupportedProvider,
-  profile: Agent,
+  profile: GatewayAgent,
   source: InteractionSource,
 ): Fetch {
   return async function observableFetch(
@@ -731,7 +731,7 @@ export function getObservableFetch(
  */
 export function getObservableGenAI(
   genAI: GoogleGenAI,
-  profile: Agent,
+  profile: GatewayAgent,
   source: InteractionSource,
 ) {
   const originalGenerateContent = genAI.models.generateContent;
@@ -936,7 +936,7 @@ function extractGeminiModel(arg: unknown): string | undefined {
 function observeGeminiError(
   error: unknown,
   startTime: number,
-  profile: Agent,
+  profile: GatewayAgent,
   model: string | undefined,
   source: InteractionSource,
 ): void {

--- a/platform/backend/src/observability/tracing/llm.ts
+++ b/platform/backend/src/observability/tracing/llm.ts
@@ -10,7 +10,11 @@ import {
 import config from "@/config";
 import logger from "@/logging";
 import { SESSION_ID_KEY } from "@/observability/request-context";
-import type { Agent, GenAiOperationName, InteractionAuthMethod } from "@/types";
+import type {
+  GatewayAgent,
+  GenAiOperationName,
+  InteractionAuthMethod,
+} from "@/types";
 import {
   ATTR_ARCHESTRA_APP_ID,
   ATTR_ARCHESTRA_APP_NAME,
@@ -70,7 +74,7 @@ export async function startActiveLlmSpan<T>(params: {
   provider: SupportedProvider;
   model: string;
   stream: boolean;
-  agent?: Agent;
+  agent?: GatewayAgent;
   teams?: SpanTeamInfo[];
   userTeams?: SpanTeamInfo[];
   sessionId?: string | null;

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@archestra/shared";
 import type { FastifyRequest } from "fastify";
 import { vi } from "vitest";
-import { VirtualApiKeyModel } from "@/models";
+import { AgentLabelModel, AgentModel, VirtualApiKeyModel } from "@/models";
 import { describe, expect, test } from "@/test";
 import { ApiError } from "@/types";
 import {
@@ -55,6 +55,37 @@ describe("resolveAgent", () => {
   });
 
   test("throws 400 when no agentId and no default profile", async () => {
+    await expect(resolveAgent(undefined)).rejects.toThrow(
+      "Please specify an LLMProxy ID in the URL path.",
+    );
+  });
+
+  // The proxy resolves a lean GatewayAgent (agents row + labels): labels feed
+  // metric/span label values, so they must survive the lean lookup.
+  test("resolved agent carries its labels", async ({ makeAgent }) => {
+    const agent = await makeAgent();
+    await AgentLabelModel.syncAgentLabels(agent.id, [
+      { key: "environment", value: "production", keyId: "", valueId: "" },
+    ]);
+
+    const result = await resolveAgent(agent.id);
+    expect(result.labels).toEqual([
+      expect.objectContaining({ key: "environment", value: "production" }),
+    ]);
+  });
+
+  test("does not resolve a soft-deleted default profile", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const profile = await makeAgent({
+      organizationId: org.id,
+      agentType: "profile",
+      isDefault: true,
+    });
+    await AgentModel.delete(profile.id);
+
     await expect(resolveAgent(undefined)).rejects.toThrow(
       "Please specify an LLMProxy ID in the URL path.",
     );

--- a/platform/backend/src/routes/proxy/llm-proxy-auth.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-auth.ts
@@ -31,7 +31,11 @@ import {
   credentialRequiresPerUserScope,
   perUserCredentialLabel,
 } from "@/services/openai-codex-credentials";
-import { type Agent, ApiError, type ResourceVisibilityScope } from "@/types";
+import {
+  ApiError,
+  type GatewayAgent,
+  type ResourceVisibilityScope,
+} from "@/types";
 import { resolveProviderApiKey } from "@/utils/llm-api-key-resolution";
 import { isLoopbackAddress } from "@/utils/network";
 
@@ -44,16 +48,16 @@ import { isLoopbackAddress } from "@/utils/network";
  */
 export async function resolveAgent(
   agentId: string | undefined,
-): Promise<Agent> {
+): Promise<GatewayAgent> {
   if (agentId) {
-    const agent = await AgentModel.findById(agentId);
+    const agent = await AgentModel.findGatewayAgentById(agentId);
     if (!agent) {
       throw new ApiError(404, `Agent with ID ${agentId} not found`);
     }
     return agent;
   }
 
-  const defaultProfile = await AgentModel.getDefaultProfile();
+  const defaultProfile = await AgentModel.getDefaultGatewayProfile();
   if (!defaultProfile) {
     throw new ApiError(400, "Please specify an LLMProxy ID in the URL path.");
   }
@@ -212,7 +216,7 @@ export async function validateVirtualApiKey(
  */
 export async function validatePassthroughVirtualKey(params: {
   tokenValue: string;
-  agent: Agent;
+  agent: GatewayAgent;
 }): Promise<PassthroughVirtualKeyResult> {
   const { tokenValue, agent } = params;
 
@@ -302,7 +306,7 @@ export type LlmOAuthAccessTokenValidationResult = {
 export async function validateLlmOAuthAccessToken(params: {
   tokenValue: string;
   expectedProvider: string;
-  agent: Agent;
+  agent: GatewayAgent;
 }): Promise<LlmOAuthAccessTokenValidationResult | null> {
   const accessToken = await OAuthAccessTokenModel.getByTokenHash(
     OAuthAccessTokenModel.hashTokenForLookup(params.tokenValue),
@@ -359,7 +363,7 @@ export interface JwksAuthResult {
  */
 export async function attemptJwksAuth(
   request: FastifyRequest,
-  resolvedAgent: Agent,
+  resolvedAgent: GatewayAgent,
   providerName: string,
 ): Promise<JwksAuthResult | null> {
   if (!resolvedAgent.identityProviderId) return null;
@@ -538,7 +542,7 @@ export const virtualKeyRateLimiter = new VirtualKeyRateLimiter(cacheManager);
 async function validateClientCredentialsLlmOAuthAccessToken(params: {
   clientId: string;
   expectedProvider: string;
-  agent: Agent;
+  agent: GatewayAgent;
 }): Promise<LlmOAuthAccessTokenValidationResult> {
   const oauthClient = await LlmOauthClientModel.findByClientId(params.clientId);
   if (!oauthClient) {
@@ -615,7 +619,7 @@ async function validateUserLlmOAuthAccessToken(params: {
   userId: string;
   clientId: string;
   expectedProvider: string;
-  agent: Agent;
+  agent: GatewayAgent;
 }): Promise<LlmOAuthAccessTokenValidationResult> {
   const member = await MemberModel.getFirstMembershipForUser(params.userId);
   if (!member || member.organizationId !== params.agent.organizationId) {

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -58,9 +58,9 @@ import {
   type SpanTeamInfo,
 } from "@/observability/tracing";
 import {
-  type Agent,
   ApiError,
   type DualLlmAnalysis,
+  type GatewayAgent,
   type InteractionAuthMethod,
   type InteractionRequest,
   type LLMProvider,
@@ -117,7 +117,7 @@ const toolPolicyCache = new LRUCacheManager<boolean>({
  * for maintainability and readability.
  */
 export interface LLMProxyContext<TRequest> {
-  agent: Agent;
+  agent: GatewayAgent;
   originalRequest: TRequest;
   baselineModel: string;
   actualModel: string;

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -22,9 +22,9 @@ import { SESSION_ID_KEY } from "@/observability/request-context";
 import type { SpanTeamInfo, SpanUserInfo } from "@/observability/tracing";
 import { getTokenizer } from "@/tokenizers";
 import type {
-  Agent,
   CommonMcpToolDefinition,
   DualLlmAnalysis,
+  GatewayAgent,
   InsertInteraction,
   InteractionAuthMethod,
   InteractionRequest,
@@ -216,7 +216,7 @@ export function applyInputTokenFallback(params: {
  * Pure function — callers handle `InteractionModel.create()` and error handling.
  */
 export function buildInteractionRecord(params: {
-  agent: Agent;
+  agent: GatewayAgent;
   externalAgentId?: string;
   authMethod?: InteractionAuthMethod;
   billingMode: BillingMode;
@@ -297,7 +297,7 @@ export function buildInteractionRecord(params: {
 export function recordBlockedToolCallMetrics(params: {
   allToolCallNames: string[];
   reason: string;
-  agent: Agent;
+  agent: GatewayAgent;
   teams?: SpanTeamInfo[];
   userTeams?: SpanTeamInfo[];
   sessionId?: string | null;

--- a/platform/backend/src/routes/proxy/routes/model-router.test.ts
+++ b/platform/backend/src/routes/proxy/routes/model-router.test.ts
@@ -1811,11 +1811,16 @@ describe("model router proxy routes", () => {
     expect(anthropicAdapterFactory.createClient).toHaveBeenCalledOnce();
     expect(anthropicAdapterFactory.createClient).toHaveBeenCalledWith(
       "test-anthropic-key",
-      // The proxy re-fetches the agent, so the object passed downstream carries
-      // the server-resolved LLM metadata (resolvedLlmProvider, etc.) that the
-      // freshly-created object doesn't — objectContaining tolerates those.
+      // The proxy resolves a lean GatewayAgent (agents row + labels, no
+      // tools/teams hydration), so assert the identity fields adapters and
+      // observability actually consume rather than the full fixture object.
       expect.objectContaining({
-        agent: expect.objectContaining(agent),
+        agent: expect.objectContaining({
+          id: agent.id,
+          name: agent.name,
+          organizationId: agent.organizationId,
+          agentType: agent.agentType,
+        }),
       }),
     );
     expect(response.json()).toMatchObject({

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.ts
@@ -15,12 +15,12 @@ import {
   type Tokenizer,
 } from "@/tokenizers";
 import type {
-  Agent,
   Anthropic,
   Cerebras,
   Cohere,
   CommonMcpToolDefinition,
   DeepSeek,
+  GatewayAgent,
   Gemini,
   GithubCopilot,
   Groq,
@@ -85,7 +85,7 @@ export function estimateToolTokens(
 export async function getOptimizedModel<
   Provider extends keyof ProviderMessages,
 >(
-  agent: Agent,
+  agent: GatewayAgent,
   messages: ProviderMessages[Provider],
   provider: Provider,
   hasTools: boolean,

--- a/platform/backend/src/types/llm-provider.ts
+++ b/platform/backend/src/types/llm-provider.ts
@@ -35,7 +35,7 @@ import type {
   SupportedProviderDiscriminator,
 } from "@archestra/shared";
 
-import type { Agent } from "./agent";
+import type { GatewayAgent } from "./agent";
 
 /**
  * GenAI operation names for tracing span names.
@@ -59,7 +59,7 @@ export interface CreateClientOptions {
   /** Base URL override for the provider API */
   baseUrl?: string;
   /** Agent for observability metrics (request duration, tokens) */
-  agent?: Agent;
+  agent?: GatewayAgent;
   /** Default headers to include with every request */
   defaultHeaders?: Record<string, string>;
   /** Interaction source for observability metrics (e.g. "api", "chat", "knowledge:embedding") */


### PR DESCRIPTION
## Problem

`resolveAgent` in the LLM proxy ran the full `AgentModel.findById` on **every proxied LLM request** (8,790/day on staging): a 3-table join (`agents × agent_tools × tools`) plus ~6 hydration queries (teams, labels, knowledge-base ids, connector ids, author names, suggested prompts, resolved LLM). The proxy path reads none of that — a field-by-field trace shows it consumes only `id`, `name`, `organizationId`, `agentType`, `considerContextUntrusted`, `identityProviderId`, and `labels` (teams for policy/spans are re-fetched separately via `AgentTeamModel.getTeamLabelInfoForAgent`; tools come from the request body). The MCP gateway was already optimized with a lean `findGatewayAgentById` for exactly this reason — the proxy never got the same treatment.

Separately, pool checkout queueing was **unobservable**: when all pooled connections are busy, requests silently queue (up to the 10s connect timeout) while individual query spans still look fast. On staging (pool max 8) this showed up as trivial indexed selects with p95 ~370ms and Sentry "Slow DB Query" issues on the sub-millisecond auth lookup.

## Changes

- `resolveAgent` now uses `findGatewayAgentById`, and a new lean `AgentModel.getDefaultGatewayProfile` for the no-agent-id fallback (the old default-profile path did the identical heavy join + hydration, so the win would otherwise vanish for URL-without-id callers).
- Narrowed `Agent` → `GatewayAgent` on the signatures that carry the resolved agent: `LLMProxyContext.agent`, `CreateClientOptions.agent`, `metrics.llm.*`/`reportAgentExecution` `profile`, `startActiveLlmSpan` `agent`, proxy auth helpers, `getOptimizedModel`. A full `Agent` still satisfies these structurally, so non-proxy callers are unaffected.
- New `database_pool_connections{state="total"|"idle"|"waiting"}` and `database_pool_size_limit` gauges (`observability/metrics/database.ts`), sampled at scrape time via `collect()` from a new `getPoolStats()` accessor. `state="waiting"` is the load-bearing series — sustained non-zero means the pool max is the bottleneck.

Deliberately **not** included: response caching for agent resolution. `considerContextUntrusted`/`identityProviderId` change security behavior, and the lean query alone removes ~8 of 9 queries without any invalidation risk.

## Testing

- New: `resolveAgent` carries labels through the lean lookup; soft-deleted default profile is not resolved; pool gauges report live counters / stay empty pre-init (`database.test.ts`).
- Updated: model-router `createClient` assertion now pins the lean identity fields the adapters actually consume.
- Full `src/routes/proxy` + `src/models/agent.test.ts` + `src/observability/metrics` suites pass (1,100 tests); `tsc`, biome, and `pnpm knip` (dev+production) clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>