### PR TITLE
fix: highlight links in skill sync panel, rename Chat button

### DIFF
--- a/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
@@ -1005,7 +1005,7 @@ function GithubSyncPanel({
   const authLabel = skill.githubPatId ? (
     <Link
       href="/settings/github"
-      className="max-w-44 min-w-0 truncate underline-offset-4 hover:underline"
+      className="max-w-44 min-w-0 truncate underline underline-offset-4 hover:text-primary"
       title="Manage saved tokens in Settings → GitHub"
     >
       {patName ? `saved token “${patName}”` : "a saved token"}
@@ -1031,7 +1031,7 @@ function GithubSyncPanel({
             href={`https://github.com/${sourceRepo}${skill.githubSyncRef ? `/tree/${skill.githubSyncRef}` : ""}`}
             target="_blank"
             rel="noreferrer"
-            className="min-w-0 truncate font-mono underline-offset-4 hover:underline"
+            className="min-w-0 truncate font-mono underline underline-offset-4 hover:text-primary"
             title="Open on GitHub"
           >
             {sourceRepo}
@@ -1104,7 +1104,7 @@ function GithubSyncPanel({
         {" · "}Content is read-only here —{" "}
         <button
           type="button"
-          className="cursor-pointer font-medium text-foreground underline-offset-4 hover:underline"
+          className="cursor-pointer font-medium text-foreground underline underline-offset-2 hover:text-primary"
           onClick={() => setConfirmingDisconnect(true)}
           disabled={updateGithubSync.isPending}
         >
@@ -1144,7 +1144,7 @@ function ChatWithSkillButton({ skillId }: { skillId: string | null }) {
     >
       <Link href={`/chat/new?skill_id=${skillId}`}>
         <MessageSquare className="h-4 w-4" />
-        Chat
+        Chat with a skill
       </Link>
     </PermissionButton>
   );


### PR DESCRIPTION
- GitHub sync panel in the skill editor: repo, saved-token, and "stop syncing" links now have persistent underlines (hover-only before), so they're visibly clickable. Smaller underline offset on "stop syncing" — the truncated text-xs line clipped offset-4.
- Renamed the editor footer button "Chat" to "Chat with a skill".

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>