### PR TITLE
test(orchestrator): fix shuffle-seed pollution in cleanupOrphanedDeployments tests

### DIFF
--- a/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.test.ts
@@ -2039,6 +2039,11 @@ describe("McpServerRuntimeManager.backfillRegcredTeamLabels", () => {
 describe("McpServerRuntimeManager.cleanupOrphanedDeployments", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call history but not implementations, so a
+    // persistent mockResolvedValue from another suite would otherwise leak in
+    // under a shuffling seed. These tests drive the catalog via localCatalogItems
+    // and expect the frozen-name path, so pin findById back to null.
+    vi.mocked(InternalMcpCatalogModel.findById).mockResolvedValue(null);
   });
 
   async function createManagerWithMockK8s(params: {


### PR DESCRIPTION
The `McpServerRuntimeManager.cleanupOrphanedDeployments` suite has no per-suite `findById` setup — it relies on `InternalMcpCatalogModel.findById` returning null so `cleanupOrphanedDeployments` takes the frozen-name path. But `vi.clearAllMocks()` in its `beforeEach` only resets call history, not implementations. Sibling suites set a persistent `mockResolvedValue` on the same mock (a multitenant catalog with no `name`), which survives `clearAllMocks`. With `sequence.shuffle` on, any seed that orders one of those suites first leaves that catalog in place: `constructDeploymentName` then calls `.replaceAll` on an undefined name and throws, the sweep's outer try/catch swallows it, and "deletes legacy name-derived deployments for existing servers" observes zero deletions instead of one — the failure seen on the merge queue.

Pinning `findById` back to null in the suite's own `beforeEach` makes it independent of shuffle order.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>