### PR TITLE
ci: retry flaky vitest suites in CI and bound job runtimes

### DIFF
--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -602,6 +602,9 @@ jobs:
     # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Normal runs are 2.3-6.1 min (Jul 2026 sample) even with Playwright's
+    # in-job retries; 15 minutes means the dev server or a runner is hung.
+    timeout-minutes: 15
     permissions:
       contents: read
     defaults:

--- a/platform/backend/vitest.config.ts
+++ b/platform/backend/vitest.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from "vitest/config";
 const isCI = process.env.CI === "true";
 
 /**
- * Partition test files by whether they use Vitest module mocking.
+ * Partition test files by whether they mutate worker-shared runtime state.
  *
  * `vi.mock`/`vi.doMock` registrations live in the worker's shared module/mock
  * registry, which Vitest does NOT reset between files when `isolate: false`
@@ -16,13 +16,22 @@ const isCI = process.env.CI === "true";
  * while everything else can share each worker's module cache and skip
  * re-importing the whole backend graph per file (~6s/file saved).
  *
+ * The same applies to files touching the module registry or global/env state
+ * directly: `vi.resetModules()` + dynamic re-import in a shared worker can
+ * hand back another file's cached module instance instead of a fresh one
+ * (seen as an order-dependent "runtime is not enabled" flake in
+ * skill-sandbox-runtime-service.test.ts), and `vi.stubEnv`/`vi.stubGlobal`
+ * values read at module-import time are captured by modules that later files
+ * in the same worker then reuse.
+ *
  * Routing is computed from file CONTENT at config-load time, so a new test
  * that adds `vi.mock` is automatically placed in the isolated project — no
  * manual list to maintain.
  */
 function partitionTestFiles(): { mocked: string[]; clean: string[] } {
   const root = path.resolve(__dirname, "./src");
-  const usesModuleMocks = /\bvi\.(mock|doMock|unmock|doUnmock|hoisted)\(/;
+  const needsIsolation =
+    /\bvi\.(mock|doMock|unmock|doUnmock|hoisted|resetModules|stubEnv|stubGlobal)\(/;
   const mocked: string[] = [];
   const clean: string[] = [];
 
@@ -33,7 +42,7 @@ function partitionTestFiles(): { mocked: string[]; clean: string[] } {
     if (!entry.isFile() || !entry.name.endsWith(".test.ts")) continue;
     const absolute = path.join(entry.parentPath, entry.name);
     const relative = `./${path.relative(__dirname, absolute)}`;
-    if (usesModuleMocks.test(readFileSync(absolute, "utf-8"))) {
+    if (needsIsolation.test(readFileSync(absolute, "utf-8"))) {
       mocked.push(relative);
     } else {
       clean.push(relative);
@@ -133,6 +142,14 @@ export default defineConfig({
       // Shuffle test files to balance load across workers
       shuffle: true,
     },
+
+    // CI-only in-job retry: one intermittent test failure otherwise fails the
+    // whole shard, which fails the merge-queue entry and restarts every entry
+    // stacked behind it. Retried-then-passed tests stay visible — Vitest
+    // auto-enables its github-actions reporter in CI, which lists them as
+    // flaky ("passed on retry N out of M") in the job's step summary. Local
+    // runs keep retry: 0 so flakes fail loudly during development.
+    retry: isCI ? 2 : 0,
 
     // Increase test timeout for database operations
     testTimeout: 30000,


### PR DESCRIPTION
## Why

Since heavy test suites moved to merge-queue-only (#6615), a single flaky unit test is expensive: it fails the whole queue entry (~600+ vcpu-min of compute per attempt), dequeues the PR, and restarts every entry stacked behind it. On 2026-07-20, 46 of 66 merge-queue entries failed, dominated by flaky suites — Backend Unit Tests shard 3/4 (still failing repeatedly on the morning of 2026-07-21), Frontend Integration (MSW), and AI Labs Rust.

The two dominant backend flakes (the `manager.test.ts` mock-implementation leak under shuffle, and the llm-provider-api-keys knowledge-settings tests) were already fixed on main (#6736, #6671). This PR is insurance against the *next* instance of that class, plus one latent order-dependence fix found during the investigation.

## What

### 1. CI-only vitest retry (backend)

`platform/backend/vitest.config.ts` now sets `retry: isCI ? 2 : 0`. Both vitest projects (`clean` shared-worker and `mocked` isolated) inherit it via `extends: true`; it composes with the forks pool unchanged.

**Masking trade-off, and why flakes stay visible:** retries stop one intermittent failure from burning a queue entry, but they must not hide true intermittents. Vitest auto-enables its `github-actions` reporter when `GITHUB_ACTIONS=true`, and that reporter writes a dedicated **"Flaky Tests"** section into the job's step summary — file, test name, and "passed on retry N out of M". Verified locally with a probe test that fails its first attempt: the shard goes green and the step summary names the flaky test. So a retried-then-passed test is one click away in every shard's summary, not silent. Local runs keep `retry: 0` so flakes fail loudly during development.

### 2. Shared-worker partition fix (backend)

The config-load heuristic that routes test files into the fast shared-worker project only matched `vi.mock`-family calls. `skill-sandbox-runtime-service.test.ts` has no `vi.mock` but uses `vi.resetModules()` + `vi.stubEnv` + dynamic re-import to get a freshly-compiled singleton — in a shared worker the re-import can intermittently return another file's cached (disabled) instance, throwing "the skill sandbox runtime is not enabled". The heuristic now also matches `vi.resetModules` / `vi.stubEnv` / `vi.stubGlobal`, since those mutate the same worker-shared registries. This moves 26 of 532 fast-path files (~5%) into the isolated project; the affected file now routes to `[mocked]` (verified with `vitest list`) and passes.

### 3. Timeout hygiene (`on-pull-requests.yml`)

On 2026-07-19 two PR runs sat for 97 and 66 minutes across 9 jobs each before cancellation. Investigating those runs: the jobs had **no runner assigned and zero steps executed** — they were stuck *queued* (runner-pool starvation), which `timeout-minutes` does not bound (it only starts counting once a job starts). So timeouts are not a fix for that incident, but they do bound the other hang mode we have actually hit: a *running* job wedged by leaked processes (documented on the lint job, which already carries `timeout-minutes: 20` for exactly that).

Audit of the heavy jobs against observed merge-queue durations (Jul 20-21 sample, ~20 runs):

| Job | Observed | Timeout |
|---|---|---|
| Backend Unit Tests shards | 2.8–5.5 min | 15 (existing, kept — ≈3× p95) |
| Platform Lint and Unit Tests | 1.5–2.8 min | 20 (existing, kept — justified comment re leaked runner processes) |
| Platform Rust Checks | 1.9–2.8 min | 15 (existing, kept) |
| AI Labs Rust Checks | 1.6–2.0 min | 15 (existing, kept) |
| **Frontend Integration Tests (MSW)** | 2.3–6.1 min | **none → 15 (added)** |

The MSW job was the only heavy job with no timeout at all (6h GitHub default).

## Deliberately not touched

- **Frontend Integration (MSW) retries:** the suite is Playwright, not vitest, and has had `retries: IS_CI ? 2 : 0` since its creation. Its 2026-07-20 failure burst was one spec (`skills-import.spec.ts` manual GitHub import) failing all three attempts in run after run — a real breakage in that window, not something more retries would absorb. Nothing to add.
- **Rust suites (AI Labs ×33 burst):** those failures were ~1-minute-duration deterministic failures in a bounded evening window, all green since. Retries there would mean adding nextest — separate investigation first.

## Validation

- Scoped backend runs under `CI=true` for both projects (mocked: virtual-api-key routes 37 tests; clean/moved files: 66 tests) — green.
- Probe test proving retry engages in CI, fails locally with `retry: 0`, and appears in the flaky step-summary section (probe not committed).
- `pnpm lint` + `pnpm type-check` in `platform/backend` — clean.
- Workflow YAML parses.
- `run-unit-tests` label on this PR runs the heavy suites with the new config.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>