### PR TITLE
chore(chat): show chat support links in the mobile header bar

### DIFF
--- a/platform/frontend/src/app/_parts/app-shell.tsx
+++ b/platform/frontend/src/app/_parts/app-shell.tsx
@@ -3,6 +3,7 @@
 import { APP_RECORDING_RENDER_ROUTE } from "@archestra/shared";
 import type { Permissions } from "@archestra/shared/permission.types";
 import { usePathname } from "next/navigation";
+import { MOBILE_HEADER_ACTIONS_CONTAINER_ID } from "@/components/chat/chat-help-link";
 import { ConnectivityStatusBar } from "@/components/connectivity-status-bar";
 import { ConversationSearchProvider } from "@/components/conversation-search-provider";
 import { FeedbackPopupDialog } from "@/components/feedback-popup-dialog";
@@ -152,7 +153,7 @@ export function AppShell({ children }: AppShellProps) {
               <header className="h-14 border-b border-border flex md:hidden items-center justify-between px-6 bg-card/50 backdrop-blur supports-backdrop-filter:bg-card/50">
                 <NavAwareSidebarTrigger />
                 <div
-                  id="mobile-header-actions"
+                  id={MOBILE_HEADER_ACTIONS_CONTAINER_ID}
                   className="flex items-center gap-2"
                 />
               </header>

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -38,7 +38,10 @@ import {
 import { ButtonWithTooltip } from "@/components/button-with-tooltip";
 import { AppsProvider } from "@/components/chat/apps-context";
 import { BrowserPanel } from "@/components/chat/browser-panel";
-import { ChatLinkButton } from "@/components/chat/chat-help-link";
+import {
+  ChatLinkButton,
+  MobileHeaderChatLinks,
+} from "@/components/chat/chat-help-link";
 import { ChatMessages } from "@/components/chat/chat-messages";
 import {
   collectBrowserToolCallIds,
@@ -2858,6 +2861,11 @@ export function ChatPageContent({
                         }
                       }}
                     >
+                      {/* On mobile the splash buttons would overlap the logo,
+                          so the links move into the app shell's header bar. */}
+                      <MobileHeaderChatLinks
+                        links={organization?.chatLinks ?? []}
+                      />
                       {((organization?.chatLinks?.length ?? 0) > 0 ||
                         organization?.onboardingWizard) && (
                         <div className="absolute top-4 right-4 z-10 flex flex-wrap justify-end gap-2 max-w-[min(100%,36rem)]">
@@ -2866,6 +2874,7 @@ export function ChatPageContent({
                               key={`link-${link.label}-${link.url}`}
                               url={link.url}
                               label={link.label}
+                              className="hidden md:inline-flex"
                             />
                           ))}
                           {organization?.onboardingWizard && (

--- a/platform/frontend/src/components/chat/chat-help-link.test.tsx
+++ b/platform/frontend/src/components/chat/chat-help-link.test.tsx
@@ -1,6 +1,28 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { ChatLinkButton } from "./chat-help-link";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ChatLinkButton,
+  MOBILE_HEADER_ACTIONS_CONTAINER_ID,
+  MobileHeaderChatLinks,
+} from "./chat-help-link";
+
+// Pass-through dropdown mock so the collapsed menu's items are assertable
+// without driving Radix portals in jsdom.
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
 
 describe("ChatLinkButton", () => {
   it("renders nothing when no URL is configured", () => {
@@ -29,5 +51,62 @@ describe("ChatLinkButton", () => {
     expect(
       screen.getByRole("link", { name: /Docs & Support/i }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("MobileHeaderChatLinks", () => {
+  function renderWithHeaderSlot(ui: ReactNode) {
+    const slot = document.createElement("div");
+    slot.id = MOBILE_HEADER_ACTIONS_CONTAINER_ID;
+    document.body.appendChild(slot);
+    const result = render(ui);
+    return {
+      ...result,
+      slot,
+      cleanupSlot: () => slot.remove(),
+    };
+  }
+
+  it("renders nothing when there are no links with a URL", () => {
+    const { slot, cleanupSlot } = renderWithHeaderSlot(
+      <MobileHeaderChatLinks links={[{ label: "Broken", url: null }]} />,
+    );
+
+    expect(slot).toBeEmptyDOMElement();
+    cleanupSlot();
+  });
+
+  it("portals a single link into the header slot as a direct button", () => {
+    const { slot, cleanupSlot } = renderWithHeaderSlot(
+      <MobileHeaderChatLinks
+        links={[{ label: "Help Channel", url: "https://help.example.com" }]}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /Help Channel/i });
+    expect(slot.contains(link)).toBe(true);
+    expect(link).toHaveAttribute("href", "https://help.example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    cleanupSlot();
+  });
+
+  it("collapses multiple links into a help menu in the header slot", () => {
+    const { slot, cleanupSlot } = renderWithHeaderSlot(
+      <MobileHeaderChatLinks
+        links={[
+          { label: "Help Channel", url: "https://help.example.com" },
+          { label: "Docs", url: "https://docs.example.com" },
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Help and support/i });
+    expect(slot.contains(trigger)).toBe(true);
+
+    const helpLink = screen.getByRole("link", { name: /Help Channel/i });
+    const docsLink = screen.getByRole("link", { name: /Docs/i });
+    expect(helpLink).toHaveAttribute("href", "https://help.example.com");
+    expect(docsLink).toHaveAttribute("href", "https://docs.example.com");
+    cleanupSlot();
   });
 });

--- a/platform/frontend/src/components/chat/chat-help-link.tsx
+++ b/platform/frontend/src/components/chat/chat-help-link.tsx
@@ -1,23 +1,96 @@
 import { CircleHelp, ExternalLink } from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+// The app shell's mobile-only header exposes this container so pages can
+// portal actions into the header bar next to the sidebar trigger.
+export const MOBILE_HEADER_ACTIONS_CONTAINER_ID = "mobile-header-actions";
 
 interface ChatLinkButtonProps {
   label?: string | null | undefined;
   url: string | null | undefined;
+  className?: string;
 }
 
-export function ChatLinkButton({ label, url }: ChatLinkButtonProps) {
+export function ChatLinkButton({ label, url, className }: ChatLinkButtonProps) {
   if (!url) {
     return null;
   }
 
   return (
-    <Button asChild variant="outline" size="sm" className="gap-2">
+    <Button
+      asChild
+      variant="outline"
+      size="sm"
+      className={cn("gap-2", className)}
+    >
       <a href={url} target="_blank" rel="noopener noreferrer">
         <CircleHelp className="h-4 w-4" />
         {label?.trim() || "Open Link"}
         <ExternalLink className="h-3.5 w-3.5" />
       </a>
     </Button>
+  );
+}
+
+// Chat links rendered into the app shell's mobile header bar (hidden on
+// desktop, where the splash shows the full buttons instead). A single link
+// renders as the regular button; multiple links collapse into one help icon
+// that opens a menu, since the header bar has no room for several buttons.
+export function MobileHeaderChatLinks({
+  links,
+}: {
+  links: ChatLinkButtonProps[];
+}) {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setContainer(document.getElementById(MOBILE_HEADER_ACTIONS_CONTAINER_ID));
+  }, []);
+
+  const validLinks = links.filter((link) => !!link.url);
+  if (!container || validLinks.length === 0) {
+    return null;
+  }
+
+  if (validLinks.length === 1) {
+    return createPortal(
+      <ChatLinkButton label={validLinks[0].label} url={validLinks[0].url} />,
+      container,
+    );
+  }
+
+  return createPortal(
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon-sm" aria-label="Help and support">
+          <CircleHelp className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {validLinks.map((link) => (
+          <DropdownMenuItem key={`link-${link.label}-${link.url}`} asChild>
+            <a
+              href={link.url ?? undefined}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <CircleHelp className="h-4 w-4" />
+              {link.label?.trim() || "Open Link"}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>,
+    container,
   );
 }


### PR DESCRIPTION
## What

On mobile, the admin-configured chat support links (e.g. a "Help Channel" button) rendered absolutely over the New Chat splash, overlapping the logo/title. They now show nicely in the mobile header bar (the bar with the sidebar/hamburger trigger) instead:

- **One configured link** → the regular link button renders in the header bar.
- **More than one link** (up to 3 are allowed) → they collapse into a single help icon that opens a dropdown menu when tapped, since the header has no room for several buttons.

Desktop behavior is unchanged — the splash still shows the full buttons top-right, and the header-bar variant is hidden at `md+` (the header itself is `md:hidden`).

## How

- The app shell's mobile header already exposed an (unused) `#mobile-header-actions` slot next to the sidebar trigger; `MobileHeaderChatLinks` portals the links into it, mounted only on the New Chat splash (parity with the existing desktop-only placement). The slot id is now a shared exported constant.
- The splash's inline `ChatLinkButton`s get `hidden md:inline-flex` (new optional `className` prop) so they disappear on mobile. The onboarding wizard button is untouched.
- Unit tests cover the empty/single/multiple-link behaviors of the new component.