### PR TITLE
ci: switch from Blacksmith to GitHub-hosted runners

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -1,5 +1,5 @@
 name: Build Docker Image
-description: Build a Docker image using the Blacksmith builder
+description: Build a Docker image using Docker Buildx
 
 inputs:
   context:
@@ -56,6 +56,10 @@ inputs:
     default: ""
   sentry-auth-token:
     description: "Sentry auth token for source map uploads (optional)"
+    required: false
+    default: ""
+  cache-to:
+    description: "BuildKit cache export (e.g. type=gha,mode=max). Empty means read-only cache usage; only designated warming builds should export."
     required: false
     default: ""
 
@@ -122,12 +126,12 @@ runs:
         INPUT_TURBO_TEAM: ${{ inputs.turbo-team }}
         INPUT_TURBO_TOKEN: ${{ inputs.turbo-token }}
 
-    - name: Setup Blacksmith Builder
-      uses: ./.github/actions/setup-blacksmith-builder
+    - name: Setup Docker Builder
+      uses: ./.github/actions/setup-docker-builder
 
     - name: Build Docker image
       id: build
-      uses: ./.github/actions/blacksmith-build-push
+      uses: ./.github/actions/docker-build-push
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile != '' && inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}
@@ -141,3 +145,4 @@ runs:
         network: host
         build-args: ${{ inputs.version != '' && format('VERSION={0}', inputs.version) || '' }}
         secrets: ${{ steps.prepare-secrets.outputs.value }}
+        cache-to: ${{ inputs.cache-to }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,5 +1,5 @@
-name: Blacksmith Build Push
-description: Wrapper around useblacksmith/build-push-action pinned to a vetted version.
+name: Docker Build Push
+description: Wrapper around docker/build-push-action pinned to a vetted version.
 inputs:
   context:
     description: Build context.
@@ -48,6 +48,20 @@ inputs:
     description: Build secrets.
     required: false
     default: ""
+  cache-from:
+    description: >-
+      BuildKit cache sources. Defaults to the GitHub Actions cache backend so
+      builds reuse layers exported by warm-e2e-build-cache.yml (GHA cache
+      branch scoping lets PR/merge-queue builds read main's entries).
+    required: false
+    default: "type=gha"
+  cache-to:
+    description: >-
+      BuildKit cache export. Empty by default so ordinary builds only read the
+      cache; warm-e2e-build-cache.yml is the designated writer, which keeps
+      GHA cache churn bounded instead of every build re-uploading its layers.
+    required: false
+    default: ""
 outputs:
   digest:
     description: Built image digest.
@@ -57,7 +71,7 @@ runs:
   steps:
     - name: Build image
       id: build
-      uses: useblacksmith/build-push-action@cbd1f60d194a98cb3be5523b15134501eaf0fbf3 # v2.1.0
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}
@@ -71,3 +85,5 @@ runs:
         network: ${{ inputs.network }}
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.secrets }}
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}

--- a/.github/actions/github-cache/action.yml
+++ b/.github/actions/github-cache/action.yml
@@ -1,13 +1,11 @@
 name: GitHub Cache
-# Backed by useblacksmith/cache (a drop-in for actions/cache) rather than
-# actions/cache. GitHub's Actions cache has a ~10 GB per-repo LRU budget, and
-# CodeQL default setup churns ~11 GB of per-commit overlay-database caches into
-# it, evicting these entries (e2e image tarballs, Playwright browsers) within
-# minutes of them being written. Blacksmith's cache is a separate, larger
-# backend not subject to that budget, so warmed caches actually survive to the
-# hot path. All consumers run on blacksmith-* runners, which this backend
-# requires. Interface (inputs/outputs) is identical to actions/cache.
-description: Wrapper around useblacksmith/cache pinned to a vetted version.
+# Single pin point for actions/cache so every consumer uses the same vetted
+# version. Caveat: GitHub's Actions cache has a ~10 GB per-repo LRU budget,
+# and CodeQL default setup churns ~11 GB of per-commit overlay-database caches
+# into it, which can evict these entries (e2e image tarballs, Playwright
+# browsers) between the warming run and the hot path — expect occasional cold
+# restores.
+description: Wrapper around actions/cache pinned to a vetted version.
 inputs:
   path:
     description: Files, directories, and wildcard patterns to cache.
@@ -32,7 +30,7 @@ runs:
   steps:
     - name: Cache
       id: cache
-      uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.0.2
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}

--- a/.github/actions/setup-blacksmith-builder/action.yml
+++ b/.github/actions/setup-blacksmith-builder/action.yml
@@ -1,7 +1,0 @@
-name: Setup Blacksmith Builder
-description: Wrapper around useblacksmith/setup-docker-builder pinned to a vetted version.
-runs:
-  using: composite
-  steps:
-    - name: Setup Blacksmith Builder
-      uses: useblacksmith/setup-docker-builder@ac083cc84672d01c60d5e8561d0a939b697de542 # v1.7.0

--- a/.github/actions/setup-docker-builder/action.yml
+++ b/.github/actions/setup-docker-builder/action.yml
@@ -1,0 +1,7 @@
+name: Setup Docker Builder
+description: Wrapper around docker/setup-buildx-action pinned to a vetted version.
+runs:
+  using: composite
+  steps:
+    - name: Setup Docker Builder
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # checkout
       id-token: write # Workload Identity Federation + GKE credentials
@@ -42,7 +42,7 @@ jobs:
 
       # docker-container driver — the default docker driver cannot export the registry build cache.
       - name: Set up Docker builder
-        uses: ./.github/actions/setup-blacksmith-builder
+        uses: ./.github/actions/setup-docker-builder
 
       - name: Authenticate to Google Artifact Registry
         uses: ./.github/actions/auth-to-gar

--- a/.github/workflows/build-base-mcp-server-docker-image.yml
+++ b/.github/workflows/build-base-mcp-server-docker-image.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   python-mcp-lockfile-check:
     name: MCP Python Lockfile Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./platform

--- a/.github/workflows/build-native-multi-arch-image.yml
+++ b/.github/workflows/build-native-multi-arch-image.yml
@@ -83,7 +83,7 @@ jobs:
   build-image:
     name: Build ${{ inputs.image_name }} (${{ matrix.os_and_arch }})
     # Pick the runner matching the arch.
-    runs-on: ${{ matrix.os_and_arch == 'linux/arm64' && 'blacksmith-16vcpu-ubuntu-2404-arm' || 'blacksmith-16vcpu-ubuntu-2404' }}
+    runs-on: ${{ matrix.os_and_arch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       # Build both arches, or amd64 only when amd64_only is set.
@@ -150,7 +150,7 @@ jobs:
   merge-manifests:
     name: Create multi-arch manifest
     if: ${{ inputs.push_image }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs:
       - build-image
     permissions:
@@ -170,8 +170,8 @@ jobs:
           pattern: ${{ inputs.image_name }}-digests-*
           merge-multiple: true
 
-      - name: Setup Blacksmith Builder
-        uses: ./.github/actions/setup-blacksmith-builder
+      - name: Setup Docker Builder
+        uses: ./.github/actions/setup-docker-builder
 
       - name: Authenticate to Google Artifact Registry
         if: ${{ inputs.auth_provider == 'gar' }}

--- a/.github/workflows/build-sandbox-base-docker-image.yml
+++ b/.github/workflows/build-sandbox-base-docker-image.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   sandbox-base-lockfile-check:
     name: Sandbox Base Python Lockfile Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./platform

--- a/.github/workflows/claude-coreteam-mentions-shared.yml
+++ b/.github/workflows/claude-coreteam-mentions-shared.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
       contents: write # Required for Claude to push follow-up commits when explicitly instructed.

--- a/.github/workflows/claude-coreteam-review-shared.yml
+++ b/.github/workflows/claude-coreteam-review-shared.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   pr-review:
     name: PR Review
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository and inspect the PR diff.

--- a/.github/workflows/claude-coreteam-review.yml
+++ b/.github/workflows/claude-coreteam-review.yml
@@ -23,7 +23,7 @@ jobs:
     if: |
       !contains(github.event.pull_request.title, '[WIP]') &&
       !github.event.pull_request.draft
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions: {}
     outputs:
       pr_author: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/clear-github-actions-cache.yml
+++ b/.github/workflows/clear-github-actions-cache.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   clear-cache:
     name: Clear GitHub Actions Cache
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       actions: write # Required to list and delete Actions caches.
       contents: read # Required to checkout the repository for local workflow context.

--- a/.github/workflows/deploy-dev-platform-images.yml
+++ b/.github/workflows/deploy-dev-platform-images.yml
@@ -33,7 +33,7 @@ jobs:
   resolve-previous-platform-image:
     name: Resolve previous platform image
     if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.label.name == 'deploy-dev-platform-images' && github.event.pull_request.head.repo.fork != true) }}
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # Required to resolve the currently deployed platform image from staging.
       id-token: write # Required for Workload Identity Federation and GKE credential retrieval.

--- a/.github/workflows/docker-image-scanning.yml
+++ b/.github/workflows/docker-image-scanning.yml
@@ -46,14 +46,14 @@ jobs:
       matrix:
         include:
           - name: Platform
-            runner: blacksmith-16vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             context: ./platform
             dockerfile: ./platform/Dockerfile
             local-tag-prefix: archestra-platform
             use-build-action: true
             scan-exit-code: "true"
           - name: MCP Server Base
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             context: ./platform/mcp_server_docker_image
             dockerfile: ./platform/mcp_server_docker_image/Dockerfile
             local-tag-prefix: mcp-server-base
@@ -83,13 +83,13 @@ jobs:
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}
 
-      - name: Setup Blacksmith Builder
+      - name: Setup Docker Builder
         if: ${{ !matrix.use-build-action }}
-        uses: ./.github/actions/setup-blacksmith-builder
+        uses: ./.github/actions/setup-docker-builder
 
       - name: Build MCP server base image
         if: ${{ !matrix.use-build-action }}
-        uses: ./.github/actions/blacksmith-build-push
+        uses: ./.github/actions/docker-build-push
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/good-first-issue-welcome.yml
+++ b/.github/workflows/good-first-issue-welcome.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   welcome-new-contributor:
     name: Welcome New Contributor
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: github.event.label.name == 'good first issue'
     permissions:
       issues: write # Required to post the welcome comment on the labeled issue.

--- a/.github/workflows/on-commits-to-main.yml
+++ b/.github/workflows/on-commits-to-main.yml
@@ -47,7 +47,7 @@ jobs:
 
   deploy-to-staging:
     name: Deploy to staging
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [deploy-dev-platform-images]
     # cancel-in-progress MUST stay false here: cancelling `helm upgrade`
     # mid-flight has previously left the release wedged in pending-upgrade.

--- a/.github/workflows/on-pull-requests.yml
+++ b/.github/workflows/on-pull-requests.yml
@@ -27,7 +27,7 @@ jobs:
     name: Release Freeze Check
     # Always run so it can be a required status check - passes immediately for
     # non-release-please PRs and merge queue runs.
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # Required to inspect the repository context for release-please PRs.
       pull-requests: write # Required to request changes on frozen release PRs.
@@ -90,7 +90,7 @@ jobs:
 
   license-compliance-check:
     name: License Compliance Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     defaults:
@@ -131,7 +131,7 @@ jobs:
 
   supply-chain-policy:
     name: Supply Chain Policy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -148,7 +148,7 @@ jobs:
 
   docs-image-policy:
     name: Docs Image Policy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -163,7 +163,7 @@ jobs:
 
   docs-links:
     name: Docs Link Check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -178,7 +178,7 @@ jobs:
 
   migration-kit-checks:
     name: Migration Kit Checks
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -199,7 +199,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # Required for dependency-review-action to read the PR dependency graph via the API.
       pull-requests: write # Required for dependency-review-action PR comments.
@@ -226,7 +226,7 @@ jobs:
   dependency-review-merge-group:
     name: Dependency Review
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions: {}
     steps:
       - name: Skip dependency review for merge queue
@@ -269,7 +269,7 @@ jobs:
     # bot guard (see the EXCEPTION note above): contributor bot only —
     # release-please PRs need this job's codegen auto-commit.
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'archestra-contributor-pr-bot[bot]'
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # Backstop: every check here finishes in well under 10m, but leaked
     # test-runner processes (vitest fork workers / esbuild) occasionally orphan
     # and hold the step's log pipe open, leaving a *finished* job hanging until
@@ -435,7 +435,7 @@ jobs:
     name: Platform Rust Checks
     # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -478,7 +478,7 @@ jobs:
     name: AI Labs Rust Checks
     # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -518,7 +518,7 @@ jobs:
     name: Backend Unit Tests (shard ${{ matrix.shard }}/4)
     # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # A full local suite run is ~4 min on comparable hardware; a shard is a
     # quarter of that plus setup. 15 minutes means something is hung.
     timeout-minutes: 15
@@ -577,7 +577,7 @@ jobs:
   # can require a single check ("Backend Unit Tests") regardless of shard count.
   backend-unit-tests-gate:
     name: Backend Unit Tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # always() so the gate still runs (and turns red) when a shard fails,
     # ANDed with the merge-queue-only guard (see comment above
     # platform-lint-and-unit-tests): when the shards skip on an unlabeled PR
@@ -601,7 +601,7 @@ jobs:
     name: Frontend Integration Tests (MSW)
     # merge-queue-only guard (see comment above platform-lint-and-unit-tests)
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-unit-tests')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     defaults:
@@ -667,7 +667,7 @@ jobs:
 
   helm-chart-linting-and-tests:
     name: Helm Chart Linting and Tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # Required to checkout the repository and lint/package the Helm chart.
     defaults:

--- a/.github/workflows/platform-e2e-tests.yml
+++ b/.github/workflows/platform-e2e-tests.yml
@@ -88,7 +88,7 @@ jobs:
       matrix:
         include:
           - name: Platform
-            runner: blacksmith-16vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             context: ./platform
             dockerfile: ""
             artifact-name: platform-docker-image
@@ -96,7 +96,7 @@ jobs:
             local-tag-prefix: archestra-platform
             use-build-action: true
           - name: MCP Server Base
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             context: ./platform/mcp_server_docker_image
             dockerfile: ./platform/mcp_server_docker_image/Dockerfile
             artifact-name: mcp-server-base-docker-image
@@ -219,11 +219,11 @@ jobs:
       # Slim variant for the K8s e2e job: the same image minus the ~352MB
       # Dagger engine tar that only the quickstart job uses. Every layer is already in
       # the builder cache from the full build above, so this push takes
-      # seconds. (blacksmith-build-push directly: the builder is already set
+      # seconds. (docker-build-push directly: the builder is already set
       # up from the full build.)
       - name: Build slim Platform image (K8s job, no Dagger engine tar) and push
         if: ${{ matrix.use-build-action && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && steps.platform-reuse.outputs.reuse != 'true' }}
-        uses: ./.github/actions/blacksmith-build-push
+        uses: ./.github/actions/docker-build-push
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/Dockerfile
@@ -278,13 +278,13 @@ jobs:
 
       # The builder is only needed for an actual build; the reuse check above
       # talks straight to the registry. Fork PRs always build.
-      - name: Setup Blacksmith Builder
+      - name: Setup Docker Builder
         if: ${{ !matrix.use-build-action && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) || steps.mcp-base-reuse.outputs.reuse != 'true') }}
-        uses: ./.github/actions/setup-blacksmith-builder
+        uses: ./.github/actions/setup-docker-builder
 
       - name: Build MCP server base image
         if: ${{ !matrix.use-build-action && steps.mcp-base-reuse.outputs.reuse != 'true' }}
-        uses: ./.github/actions/blacksmith-build-push
+        uses: ./.github/actions/docker-build-push
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -325,7 +325,7 @@ jobs:
   # build, and then polls the registry for the pushed image up to
   # image-pull-timeout-seconds (900s). That overlap is a win when the build
   # succeeds, but when it FAILS the K8s job would otherwise burn the full ~15-min
-  # poll deadline on an 8vcpu runner for an image that will never arrive. The
+  # poll deadline on a runner for an image that will never arrive. The
   # merge is already blocked by the failed required "Build ... Image" check, so
   # cancelling the run here only reclaims that wasted runner time — it changes no
   # merge outcome. (The lite and quickstart jobs already fast-fail: they `needs`
@@ -334,7 +334,7 @@ jobs:
     name: Cancel E2E on build failure
     needs: [platform-e2e-build]
     if: ${{ failure() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       actions: write # Required to cancel this workflow run.
@@ -353,14 +353,12 @@ jobs:
   # servers, and the Vault K8s-auth boot. Everything else runs in the lite
   # job below against the container harness.
   #
-  # One 8vcpu environment, no sharding: every extra shard pays the full
-  # ~4min environment setup again to split a few minutes of tests, and bigger
+  # One environment, no sharding: every extra shard pays the full ~4min
+  # environment setup again to split a few minutes of tests, and bigger
   # runners don't speed the tests up either (the serial spec groups set the
-  # floor). 8vcpu is enough because the job is wait-bound, not compute-bound:
-  # setup blocks on image pulls and pod readiness probes, and the tests are
-  # API-bound Playwright specs. 16vcpu was sized for the old full-suite
-  # sharded runs, and measurements showed 16 vs 32 vcpu made no difference
-  # to test time. The required check is "Merge E2E Test Reports", not this job.
+  # floor) — the job is wait-bound, not compute-bound: setup blocks on image
+  # pulls and pod readiness probes, and the tests are API-bound Playwright
+  # specs. The required check is "Merge E2E Test Reports", not this job.
   platform-e2e-k8s-tests:
     name: Platform E2E Tests (K8s)
     # Deliberately NO `needs: [platform-e2e-build]`: this job starts alongside
@@ -373,7 +371,7 @@ jobs:
     # instead of being skipped — the merge is still blocked either way by the
     # required "Build ... Image" checks.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # Observed worst-case wall-clock is ~10 min (setup + tests); 30 caps a
     # hung run instead of letting it burn a runner for the GitHub default.
     timeout-minutes: 30
@@ -546,7 +544,7 @@ jobs:
     name: Platform E2E Tests (Lite)
     needs: [platform-e2e-build]
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository and read test assets.
@@ -649,7 +647,7 @@ jobs:
     name: Platform E2E Tests (Quickstart)
     needs: [platform-e2e-build]
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository and read test assets.
@@ -904,7 +902,7 @@ jobs:
     # gate; the event guard keeps it running on merge_group / on-demand runs but
     # reporting skipped (and thus satisfying the ruleset) on ordinary PR pushes.
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     # No permissions needed: this job only inspects `needs.*.result`.
     permissions: {}
@@ -947,7 +945,7 @@ jobs:
         platform-quickstart-e2e-tests,
       ]
     if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || github.event.label.name == 'run-e2e') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read # Required to checkout the repository and merge Playwright reports.

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-pr-title:
     name: PR Title Linter
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # Required to checkout the repository and read commitlint config.
       pull-requests: read # Required by lint-pr-title to read PR metadata.

--- a/.github/workflows/publish-platform-helm-chart.yml
+++ b/.github/workflows/publish-platform-helm-chart.yml
@@ -33,7 +33,7 @@ jobs:
   # https://medium.com/google-cloud/ci-gitops-with-helm-github-actions-google-artifact-registry-and-config-sync-b48604191fda
   publish-platform-helm-chart:
     name: Publish platform Helm chart
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # Required to package the chart from the checked-out repository.
       id-token: write # Required for Workload Identity Federation.

--- a/.github/workflows/random-issue-pr-assignee.yml
+++ b/.github/workflows/random-issue-pr-assignee.yml
@@ -32,7 +32,7 @@ jobs:
   assign-issue:
     name: Assign Issues
     if: github.event_name == 'issues' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       issues: write # Required to assign issues.
 
@@ -108,7 +108,7 @@ jobs:
   request-recent-pr-reviewers:
     name: Request Recent PR Reviewers
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write # Required to read PR metadata and request reviewers.
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   release-please:
     name: Release Please
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # Required to update manifests and release metadata in the repository.
       pull-requests: write # Required for release-please PR creation and updates.
@@ -275,7 +275,7 @@ jobs:
     # Un-drafts the GitHub release and triggers the website deploy only after ALL artifacts
     # (MCP server image, sandbox base image, platform Docker image, Helm chart) are published.
     if: ${{ always() && needs.release-please.outputs.platform_should_publish == 'true' && (github.event_name != 'workflow_dispatch' || inputs.finalize_github_release) && (needs.build-and-push-mcp-server-docker-image.result == 'success' || needs.build-and-push-mcp-server-docker-image.result == 'skipped') && (needs.build-and-push-sandbox-base-docker-image.result == 'success' || needs.build-and-push-sandbox-base-docker-image.result == 'skipped') && (needs.build-and-push-platform-docker-image-to-dockerhub.result == 'success' || needs.build-and-push-platform-docker-image-to-dockerhub.result == 'skipped') && (needs.publish-platform-helm-chart.result == 'success' || needs.publish-platform-helm-chart.result == 'skipped') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs:
       - release-please
       - build-and-push-mcp-server-docker-image
@@ -342,7 +342,7 @@ jobs:
       - publish-platform-helm-chart
       - publish-github-release
     if: ${{ always() && needs.release-please.outputs.platform_should_publish == 'true' && contains(needs.*.result, 'failure') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions: {}
     steps:
       - name: Post failure alert to Slack

--- a/.github/workflows/toggle-release-freeze.yml
+++ b/.github/workflows/toggle-release-freeze.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   toggle-release-freeze:
     name: Toggle Release Freeze
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   trigger-website-deploy:
     name: Trigger Website Vercel Deploy
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Trigger Vercel Deploy Hook
         env:

--- a/.github/workflows/warm-e2e-build-cache.yml
+++ b/.github/workflows/warm-e2e-build-cache.yml
@@ -1,21 +1,24 @@
 name: Warm E2E Build Cache
 
-# The platform image build swings ~85s (warm) to ~226s (cold) purely on how hot
-# the BuildKit layer cache is. Merge-queue entries run on ephemeral
-# gh-readonly-queue/* refs and land on whichever Blacksmith runner is free, so
-# they routinely hit a cold/evicted layer cache and pay the full ~226s on the
-# merge-queue critical path (the build gates every e2e shard).
+# The platform image build cost swings heavily on how hot the BuildKit layer
+# cache is. GitHub-hosted runners are ephemeral — every job starts with an
+# empty local layer cache — so builds only reuse layers through the GitHub
+# Actions cache backend (cache-from: type=gha, the docker-build-push default).
 #
-# This job rebuilds the platform image from main on a schedule so the EXPENSIVE,
+# This job rebuilds the platform image from main on a schedule and is the
+# DESIGNATED WRITER of that cache (cache-to: type=gha,mode=max): the EXPENSIVE,
 # rarely-changing base layers — the go-builder toolchain, `pnpm install`
-# node_modules, the dagger-engine assets — stay hot in the Blacksmith layer
-# cache and the Turborepo remote cache. Even when a queue entry changes app
-# source, only the cheap top layers rebuild; the heavy base is reused. That is
-# the difference between the ~85s and ~226s paths.
+# node_modules, the dagger-engine assets — stay warm in the GHA cache and the
+# Turborepo remote cache. GHA cache branch scoping lets PR and merge-queue
+# builds (gh-readonly-queue/* refs) read main's entries, so even when a queue
+# entry changes app source, only the cheap top layers rebuild.
 #
-# It deliberately does NOT push (push: false, load: false): the only product is a
-# warm cache, not an image. It runs on the same runner class as the real build
-# (blacksmith-16vcpu-ubuntu-2404) so it shares that pool's sticky-disk cache.
+# Ordinary builds deliberately do not export cache (cache-to stays empty):
+# one mode=max export per warming run keeps churn in the ~10 GB per-repo GHA
+# cache budget bounded, instead of every build re-uploading its layers.
+#
+# It deliberately does NOT push (push: false, load: false): the only product is
+# a warm cache, not an image.
 #
 # Mirrors the trigger shape of warm-e2e-image-caches.yml: daily before European
 # hours, plus an immediate re-warm on push to main when a base-layer input
@@ -37,8 +40,8 @@ on:
       - "platform/Dockerfile"
       - "platform/pnpm-lock.yaml"
       - ".github/actions/build-docker-image/action.yml"
-      - ".github/actions/blacksmith-build-push/action.yml"
-      - ".github/actions/setup-blacksmith-builder/action.yml"
+      - ".github/actions/docker-build-push/action.yml"
+      - ".github/actions/setup-docker-builder/action.yml"
       - ".github/workflows/warm-e2e-build-cache.yml"
 
 permissions: {}
@@ -50,9 +53,7 @@ concurrency:
 jobs:
   warm-build-cache:
     name: Warm E2E Build Cache
-    # Same runner class as platform-e2e-tests.yml's Build Platform Image leg so
-    # this warms the layer cache on the pool the merge queue actually builds on.
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read # Checkout only. No id-token: this build never pushes.
@@ -67,7 +68,9 @@ jobs:
       # build (platform-e2e-tests.yml), but push: false / load: false — the run
       # exists solely to populate the BuildKit layer cache and Turborepo remote
       # cache. provenance: false matches the e2e build so the cached layers line
-      # up byte-for-byte with what the queue produces.
+      # up byte-for-byte with what the queue produces. cache-to mode=max exports
+      # ALL stages (not just the final image), which is what keeps the heavy
+      # intermediate build stages warm for everyone else.
       - name: Warm platform image build cache
         uses: ./.github/actions/build-docker-image
         with:
@@ -75,5 +78,6 @@ jobs:
           push: "false"
           load: "false"
           provenance: "false"
+          cache-to: type=gha,mode=max
           turbo-team: ${{ secrets.TURBOREPO_REMOTE_CACHING_TEAM }}
           turbo-token: ${{ secrets.TURBOREPO_REMOTE_CACHING_TOKEN }}

--- a/.github/workflows/warm-e2e-image-caches.yml
+++ b/.github/workflows/warm-e2e-image-caches.yml
@@ -39,7 +39,7 @@ jobs:
     name: Warm E2E Image Caches
     # Same arch as the e2e runners (X64) so ${{ runner.arch }} in the keys
     # matches; a small runner suffices — this job only pulls and saves.
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read


### PR DESCRIPTION
## What

Moves all CI off Blacksmith onto GitHub-hosted runners.

- **Runner labels** (27 workflows): every `blacksmith-{2,4,8,16}vcpu-ubuntu-2404` → `ubuntu-24.04`; `blacksmith-16vcpu-ubuntu-2404-arm` → `ubuntu-24.04-arm` (free for public repos).
- **Wrapper actions** renamed and repointed to upstream, same pin-by-SHA convention:
  - `setup-blacksmith-builder` → `setup-docker-builder` (`docker/setup-buildx-action` v4.2.0)
  - `blacksmith-build-push` → `docker-build-push` (`docker/build-push-action` v7.3.0)
  - `github-cache` now wraps `actions/cache` v6.1.0 instead of `useblacksmith/cache` (identical interface)
- **Layer caching**: Blacksmith's sticky disks are gone, so `docker-build-push` defaults to reading the GHA BuildKit cache (`cache-from: type=gha`), and `warm-e2e-build-cache.yml` becomes the single designated writer (`cache-to: type=gha,mode=max`). PR/merge-queue builds read main's cache via GHA branch scoping; ordinary builds don't export, keeping churn in the 10 GB per-repo budget bounded.

## Caveats to be aware of

- **Slower builds**: the 8/16-vCPU Blacksmith jobs (platform image build, e2e legs, multi-arch native builds) now run on 4-vCPU standard runners. If that hurts the merge-queue critical path, GitHub larger runners can be configured org-side and the labels swapped in.
- **Cache eviction**: as documented in `github-cache/action.yml`, CodeQL churns ~11 GB into the 10 GB Actions cache LRU, so warmed entries (image tarballs, Playwright browsers, and now BuildKit layers) can be evicted before the hot path — expect occasional cold builds/restores.
- The MCP server base image build reads `type=gha` but has no warming writer (Blacksmith cached it implicitly); it's a small image, but a follow-up could add it to the warm workflow if it shows up in timings.

## Verification

- All 26 changed YAML files parse.
- Every input passed to the pinned `docker/build-push-action` and `actions/cache` SHAs was checked against those versions' `action.yml` (including `network`, `provenance`, `secrets`, `cache-from`/`cache-to`).
- No `blacksmith`/`useblacksmith` references remain anywhere in `.github/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>