### PR TITLE
fix(llm-proxy): make reject-mode 400 self-diagnosing for misconfigured base URLs

### DIFF
--- a/platform/backend/src/routes/proxy/routes/proxy-prehandler.test.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-prehandler.test.ts
@@ -346,8 +346,38 @@ describe("createProxyPreHandler", () => {
       expect(response.statusCode).toBe(400);
       const body = JSON.parse(response.body);
       expect(body.error.message).toContain("/chat/completions and /models");
+      // The message must name the offending request and the expected base
+      // URL, so a misconfigured client sees the cause in its own error body.
+      expect(body.error.message).toContain("POST /v1/github-copilot/responses");
+      expect(body.error.message).toContain(
+        '"/v1/github-copilot" or "/v1/github-copilot/<llm-proxy-id>"',
+      );
       // The preHandler must short-circuit before http-proxy's handler runs:
       // a forwarded request would relay the caller's raw token upstream.
+      expect(upstreamHits).toBe(0);
+    });
+
+    test("rejectUnhandledPaths: names the stray base-URL segment for a supported endpoint", async () => {
+      await setupProxy({
+        apiPrefix: "/v1/github-copilot",
+        endpointSuffix: "/chat/completions",
+        providerName: "GitHubCopilot",
+        rejectUnhandledPaths: true,
+      });
+
+      // A base URL misconfigured with a trailing "/v1" makes OpenAI-compatible
+      // clients request /v1/github-copilot/v1/models — /models itself is
+      // supported, so the error must point at the base URL, not the endpoint.
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/github-copilot/v1/models",
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body.error.type).toBe("invalid_request_error");
+      expect(body.error.message).toContain("GET /v1/github-copilot/v1/models");
+      expect(body.error.message).toContain('no trailing "/v1"');
       expect(upstreamHits).toBe(0);
     });
 

--- a/platform/backend/src/routes/proxy/routes/proxy-prehandler.ts
+++ b/platform/backend/src/routes/proxy/routes/proxy-prehandler.ts
@@ -71,9 +71,18 @@ export function createProxyPreHandler(params: {
         { method: request.method, url: request.url, action: "reject" },
         `${providerName} proxy preHandler: rejecting unsupported endpoint`,
       );
+      // OpenAI-compatible clients (e.g. VS Code Copilot BYOK) build this path
+      // from a configured base URL, so a stray suffix like "/v1" or a bad
+      // LLM proxy id lands here even though the endpoint itself is supported.
+      // Echo the offending path and the expected base-URL shape so the
+      // misconfiguration is visible in the client, not only in server logs.
       reply.code(400).send({
         error: {
-          message: `${providerName} only supports the /chat/completions and /models endpoints`,
+          message:
+            `${providerName} only supports the /chat/completions and /models endpoints; ` +
+            `got ${request.method} ${urlPath}. The configured base URL must be exactly ` +
+            `"${apiPrefix}" or "${apiPrefix}/<llm-proxy-id>" with no extra path segments ` +
+            `(e.g. no trailing "/v1") — the client appends the endpoint path itself.`,
           type: "invalid_request_error",
         },
       });


### PR DESCRIPTION
## Why

A community user doing a VS Code Copilot BYOK POC hit the `GitHubCopilot only supports the /chat/completions and /models endpoints` 400 and concluded the endpoint was missing. The real problem was the configured base URL: OpenAI-compatible clients append `/models` and `/chat/completions` to whatever base is configured, so a stray trailing `/v1` (or a malformed LLM proxy id) lands in the reject-mode catch-all even though the endpoint itself is supported. The generic message points at the wrong thing.

## What

- The `rejectUnhandledPaths` 400 (GitHub Copilot and Microsoft 365 Copilot prefixes) now echoes the offending `METHOD /path` and the expected base-URL shape (`<prefix>` or `<prefix>/<llm-proxy-id>`, no extra segments such as a trailing `/v1`), so the misconfiguration is visible in the client's own error body instead of only in server logs.
- Pinned the new message in the existing reject test and added a test for the stray-`/v1` base URL case (`GET /v1/github-copilot/v1/models`).

## Validation

- `npx vitest run src/routes/proxy/routes/proxy-prehandler.test.ts` — 15 passed
- `npx vitest run src/routes/proxy/routes/provider-matrix.test.ts src/routes/proxy/routes/proxy-model-listing.test.ts` — 122 passed, 7 pre-existing skips
- `tsc --noEmit` and `biome check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>