### PR TITLE
feat(hackathon): capture and replay app audio in session recordings

### DIFF
--- a/platform/backend/src/static/archestra-app-recording-sdk.js
+++ b/platform/backend/src/static/archestra-app-recording-sdk.js
@@ -49,23 +49,30 @@
   // Events carry an absolute epoch `ts`; the host rebases them onto the
   // recording clock (same machine, same clock).
   const push = (event) => {
-    // The recording gate — with one seam: encoded video chunks may land during
-    // the post-stop drain, while the encoder flushes what it already owns.
+    // The recording gate — with one seam per encoder: encoded video/audio
+    // chunks may land during the post-stop drain, while an encoder flushes what
+    // it already owns.
     if (
       !recording &&
-      !(videoDraining && event.kind === "video-chunk")
+      !(videoDraining && event.kind === "video-chunk") &&
+      !(
+        audioDraining &&
+        (event.kind === "audio-chunk" || event.kind === "audio-config")
+      )
     ) {
       return;
     }
     event.ts = Date.now();
     // Recorded input doubles as an activity signal for the canvas sampler: an
     // event-driven draw (a click repainting a chart) follows input, not rAF.
-    // Captured output (stills, video chunks/configs) must not count, or
+    // Captured output (stills, video/audio chunks/configs) must not count, or
     // capture would self-sustain.
     if (
       event.kind !== "canvas" &&
       event.kind !== "video-chunk" &&
-      event.kind !== "video-config"
+      event.kind !== "video-config" &&
+      event.kind !== "audio-chunk" &&
+      event.kind !== "audio-config"
     ) {
       inputActivityUntil = event.ts + INPUT_ACTIVITY_MS;
     }
@@ -684,6 +691,371 @@
     });
   };
 
+  // ── Encoded audio capture (WebCodecs) ──
+  // The app's SOUND, mixed into one Opus stream: Web Audio graphs and
+  // <audio>/<video> playback both. Capture taps the app's OUTPUT — what it
+  // routes to the speakers — never a microphone, so it adds no new input
+  // surface to redact. The stream has no replay counterpart in this file: the
+  // player decodes and plays it host-side (and muxes it into the exported
+  // video) rather than posting it back into the frame. Where AudioEncoder /
+  // MediaStreamTrackProcessor are absent the recording simply carries no audio
+  // and the visuals are unaffected — the same fail-soft as the video→stills
+  // fallback. And a silent app spins up nothing at all: the mixer starts only
+  // once a real source appears (a graph reaches the speakers, a media element
+  // plays), so silence is never encoded.
+  const AUDIO_CODEC = "opus";
+  // 60ms Opus frames (~16 events/s) keep audio an order of magnitude below the
+  // canvas video's event count, well inside the bundle's event cap.
+  const AUDIO_FRAME_DURATION_US = 60_000;
+  const AUDIO_BITRATE = 96_000;
+  // How deep the encoder's queue may grow before frames are dropped, so a slow
+  // machine sheds audio instead of piling backlog (mirrors the video gate).
+  const AUDIO_MAX_QUEUE = 8;
+
+  const OrigAudioContext =
+    typeof window.AudioContext === "function"
+      ? window.AudioContext
+      : typeof window.webkitAudioContext === "function"
+        ? window.webkitAudioContext
+        : null;
+  /** app AudioContext → its silent MediaStreamAudioDestinationNode tap. */
+  const audioTaps = new WeakMap();
+  /** Every app AudioContext we've tapped, so a recording started later can
+   *  adopt contexts already running (a WeakMap can't be enumerated). */
+  const liveAudioContexts = new Set();
+  /** Media elements routed through Web Audio (createMediaElementSource): their
+   *  sound is already in the graph tap, so they must NOT also be captured via
+   *  captureStream, or they'd be recorded twice. */
+  const graphRoutedMediaEls = new WeakSet();
+  /** The single live mix+encode session while recording, else null. */
+  let audioCapture = null;
+  /** Holds the push gate open for the encoder's post-stop flush (see push). */
+  let audioDraining = false;
+
+  // A per-context tap: fan the graph's output into a MediaStreamDestination we
+  // can read without disturbing playback. Created lazily on the first connect
+  // to a context's speakers, and adopted into a live recording at once.
+  const tapForContext = (ctx) => {
+    let tap = audioTaps.get(ctx);
+    if (tap) return tap;
+    try {
+      tap = ctx.createMediaStreamDestination();
+    } catch {
+      return null;
+    }
+    audioTaps.set(ctx, tap);
+    liveAudioContexts.add(ctx);
+    if (recording) {
+      ensureAudioCapture();
+      if (audioCapture) bridgeStream(audioCapture, tap.stream);
+    }
+    return tap;
+  };
+
+  // Installed at SDK load, before any app code runs (the IIFE completes first).
+  // Web Audio has no observer, so every node reaching a context's destination
+  // is ALSO fanned into that context's tap — the original connect runs first,
+  // so the sound still plays; the tap is a silent parallel branch.
+  if (
+    typeof AudioNode !== "undefined" &&
+    AudioNode.prototype &&
+    typeof AudioNode.prototype.connect === "function"
+  ) {
+    const origConnect = AudioNode.prototype.connect;
+    AudioNode.prototype.connect = function (target) {
+      const result = origConnect.apply(this, arguments);
+      try {
+        if (
+          target &&
+          typeof AudioDestinationNode !== "undefined" &&
+          target instanceof AudioDestinationNode
+        ) {
+          const tap = tapForContext(target.context);
+          if (tap) origConnect.call(this, tap);
+        }
+      } catch {
+        // a tap that can't be wired just means this context isn't captured
+      }
+      return result;
+    };
+  }
+
+  // Mark elements routed through Web Audio so they aren't double-captured.
+  if (
+    OrigAudioContext &&
+    OrigAudioContext.prototype &&
+    typeof OrigAudioContext.prototype.createMediaElementSource === "function"
+  ) {
+    const origCreateMediaElementSource =
+      OrigAudioContext.prototype.createMediaElementSource;
+    OrigAudioContext.prototype.createMediaElementSource = function (el) {
+      try {
+        if (el) graphRoutedMediaEls.add(el);
+      } catch {}
+      return origCreateMediaElementSource.apply(this, arguments);
+    };
+  }
+
+  // A media element played directly (not through Web Audio) reaches the speakers
+  // on its own; captureStream is the only way to tap it. Hooked on play() so
+  // even a `new Audio(url).play()` created mid-session is captured.
+  if (
+    typeof HTMLMediaElement !== "undefined" &&
+    HTMLMediaElement.prototype &&
+    typeof HTMLMediaElement.prototype.play === "function"
+  ) {
+    const origPlay = HTMLMediaElement.prototype.play;
+    HTMLMediaElement.prototype.play = function () {
+      try {
+        if (recording) {
+          ensureAudioCapture();
+          if (audioCapture) bridgeMediaElement(audioCapture, this);
+        }
+      } catch {}
+      return origPlay.apply(this, arguments);
+    };
+  }
+
+  const anyMediaElementActive = () => {
+    try {
+      for (const el of document.querySelectorAll("audio,video")) {
+        if (!el.paused && !el.ended) return true;
+      }
+    } catch {}
+    return false;
+  };
+
+  const pushAudioConfig = (decoderConfig) => {
+    const event = {
+      kind: "audio-config",
+      codec: decoderConfig.codec || AUDIO_CODEC,
+      sampleRate:
+        decoderConfig.sampleRate ||
+        (audioCapture && audioCapture.sampleRate) ||
+        48_000,
+      numberOfChannels:
+        decoderConfig.numberOfChannels ||
+        (audioCapture && audioCapture.numberOfChannels) ||
+        2,
+    };
+    const description = decoderConfig.description;
+    if (description) {
+      // Copy out of the codec-owned buffer; the event outlives the callback.
+      event.description = new Uint8Array(
+        description instanceof ArrayBuffer
+          ? description.slice(0)
+          : description.buffer.slice(
+              description.byteOffset,
+              description.byteOffset + description.byteLength,
+            ),
+      );
+    }
+    push(event);
+  };
+
+  // Source one MediaStream (a context tap, or a media element's captureStream)
+  // into the recording mix, once.
+  const bridgeStream = (session, stream) => {
+    try {
+      if (
+        !stream ||
+        session.bridged.has(stream) ||
+        typeof stream.getAudioTracks !== "function" ||
+        stream.getAudioTracks().length === 0
+      ) {
+        return;
+      }
+      session.ctx.createMediaStreamSource(stream).connect(session.mix);
+      session.bridged.add(stream);
+    } catch {}
+  };
+
+  const bridgeMediaElement = (session, el) => {
+    try {
+      if (graphRoutedMediaEls.has(el)) return; // already tapped via Web Audio
+      const capture = el.captureStream || el.mozCaptureStream;
+      if (typeof capture !== "function") return;
+      bridgeStream(session, capture.call(el));
+    } catch {}
+  };
+
+  // Pull mixed audio off the mix track and feed the encoder, configuring it on
+  // the first frame (whose real sample-rate/channels the config then carries).
+  const runAudioReader = (session) => {
+    let reader;
+    try {
+      const track = session.dest.stream.getAudioTracks()[0];
+      if (!track) return;
+      session.processor = new MediaStreamTrackProcessor({ track });
+      reader = session.processor.readable.getReader();
+      session.reader = reader;
+    } catch {
+      return;
+    }
+    const pump = () => {
+      reader.read().then(({ done, value }) => {
+        if (done || session.stopped) {
+          if (value) {
+            try {
+              value.close();
+            } catch {}
+          }
+          return;
+        }
+        try {
+          const enc = session.encoder;
+          if (recording && enc && enc.state !== "closed" && !session.errored) {
+            if (!session.configured) {
+              session.configured = true;
+              session.sampleRate = value.sampleRate;
+              session.numberOfChannels = value.numberOfChannels;
+              enc.configure({
+                codec: AUDIO_CODEC,
+                sampleRate: value.sampleRate,
+                numberOfChannels: value.numberOfChannels,
+                bitrate: AUDIO_BITRATE,
+                opus: { frameDuration: AUDIO_FRAME_DURATION_US },
+              });
+            }
+            if (enc.encodeQueueSize < AUDIO_MAX_QUEUE) enc.encode(value);
+          }
+        } catch {
+          session.errored = true;
+        }
+        try {
+          value.close();
+        } catch {}
+        pump();
+      }, () => {});
+    };
+    pump();
+  };
+
+  // Start the mix+encode session on first real audio, and adopt every source
+  // that already exists. Idempotent: later sources just bridge into it.
+  const ensureAudioCapture = () => {
+    if (
+      audioCapture ||
+      !recording ||
+      !OrigAudioContext ||
+      typeof AudioEncoder !== "function" ||
+      typeof MediaStreamTrackProcessor !== "function"
+    ) {
+      return;
+    }
+    let session;
+    try {
+      const ctx = new OrigAudioContext();
+      const mix = ctx.createGain();
+      const dest = ctx.createMediaStreamDestination();
+      mix.connect(dest);
+      session = {
+        ctx,
+        mix,
+        dest,
+        encoder: null,
+        bridged: new WeakSet(),
+        configured: false,
+        errored: false,
+        stopped: false,
+        configSent: false,
+        reader: null,
+        processor: null,
+        sampleRate: 0,
+        numberOfChannels: 0,
+      };
+      session.encoder = new AudioEncoder({
+        output: (chunk, metadata) => {
+          try {
+            if (!session.configSent) {
+              session.configSent = true;
+              pushAudioConfig((metadata && metadata.decoderConfig) || {});
+            }
+            const bytes = new Uint8Array(chunk.byteLength);
+            chunk.copyTo(bytes);
+            push({
+              kind: "audio-chunk",
+              tsUs: Math.max(0, Math.round(chunk.timestamp || 0)),
+              bytes,
+            });
+          } catch {
+            // a dropped chunk must never break the app
+          }
+        },
+        error: () => {
+          session.errored = true;
+        },
+      });
+    } catch {
+      if (session && session.ctx) {
+        try {
+          session.ctx.close();
+        } catch {}
+      }
+      return;
+    }
+    audioCapture = session;
+    // A user gesture in the app during recording satisfies autoplay; harmless
+    // if the context is already running.
+    try {
+      session.ctx.resume();
+    } catch {}
+    for (const ctx of liveAudioContexts) {
+      const tap = audioTaps.get(ctx);
+      if (tap) bridgeStream(session, tap.stream);
+    }
+    let els;
+    try {
+      els = document.querySelectorAll("audio,video");
+    } catch {
+      els = [];
+    }
+    for (const el of els) bridgeMediaElement(session, el);
+    runAudioReader(session);
+  };
+
+  /**
+   * Flush the audio encoder after the recording gate closes so its last frames
+   * make the capture — mirrors drainVideoStreams: `audioDraining` holds the
+   * push gate open for exactly those chunks, and the buffer is flushed again
+   * once the encoder settles, inside the host's post-stop grace window.
+   */
+  const drainAudioStreams = () => {
+    const session = audioCapture;
+    audioCapture = null;
+    if (!session) return;
+    session.stopped = true;
+    try {
+      if (session.reader) session.reader.cancel().catch(() => {});
+    } catch {}
+    const finish = () => {
+      audioDraining = false;
+      flush();
+      try {
+        if (session.encoder && session.encoder.state !== "closed") {
+          session.encoder.close();
+        }
+      } catch {}
+      try {
+        session.ctx.close();
+      } catch {}
+    };
+    if (
+      session.encoder &&
+      session.encoder.state === "configured" &&
+      !session.errored
+    ) {
+      audioDraining = true;
+      try {
+        session.encoder.flush().then(finish, finish);
+      } catch {
+        finish();
+      }
+    } else {
+      finish();
+    }
+  };
+
   /**
    * Read one canvas's current pixels into an encoded-image Blob (the stills
    * fallback for browsers without WebCodecs), off the app's critical path: an
@@ -961,6 +1333,12 @@
     startDomCapture();
     sampleCanvases();
     canvasRafId = origRaf(canvasCaptureLoop);
+    // Audio only if the app already has sound — a context routed to the speakers
+    // or a media element playing. The connect/play hooks spin the mixer up later
+    // if sound starts mid-session, so a silent app records no audio stream.
+    if (liveAudioContexts.size > 0 || anyMediaElementActive()) {
+      ensureAudioCapture();
+    }
 
     listen(window, "resize", () => {
       push({
@@ -1115,6 +1493,7 @@
     sampleCanvases(true);
     recording = false;
     drainVideoStreams();
+    drainAudioStreams();
     for (const fn of teardownFns) {
       try {
         fn();

--- a/platform/frontend/src/app/app-recording-render/page.tsx
+++ b/platform/frontend/src/app/app-recording-render/page.tsx
@@ -51,7 +51,17 @@ export default function AppRecordingRenderPage() {
       const replay = await waitFor(() => window.__archestraReplay);
       await replay.seek(ms);
     };
-    window.__archestraRenderEncoderStart = startEncoder;
+    window.__archestraRenderEncoderStart = async (params) => {
+      // The renderer films pixels only; the captured sound is decoded by the
+      // player onto the export timeline and muxed here as the MP4's audio
+      // track. Best-effort — a failure just yields a silent video.
+      let audio = null;
+      try {
+        const replay = await waitFor(() => window.__archestraReplay);
+        audio = (await replay.audio?.()) ?? null;
+      } catch {}
+      await startEncoder({ ...params, audio });
+    };
     window.__archestraRenderEncodeFrame = async (jpeg, index) =>
       enqueueFrame(jpeg, index);
     window.__archestraRenderRepeatFrame = async (index) => repeatFrame(index);

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -26,6 +26,8 @@ import {
   Sparkles,
   Trash2,
   Undo2,
+  Volume2,
+  VolumeX,
   X,
 } from "lucide-react";
 import {
@@ -77,6 +79,12 @@ import {
   useIsRenderingAppRecordingVideo,
   useRenderAppRecordingVideo,
 } from "@/lib/app-session-recording/app-recording.query";
+import {
+  AudioPlaybackController,
+  buildPlaybackAudio,
+  type PlaybackAudio,
+  recordingHasAudio,
+} from "@/lib/app-session-recording/app-recording-audio";
 import {
   type RuntimeRecordingEvent,
   reviveRecordingEvents,
@@ -914,6 +922,24 @@ function PlayerSurface({
   const frameReadyRef = useRef(frameReady);
   frameReadyRef.current = frameReady;
 
+  // ── Captured audio (host-side). The recording's app sound is decoded once and
+  // scheduled against the same clock as the visuals; the offline renderer muxes
+  // it separately, so live audio is never driven while filming. Muting is the
+  // viewer's, defaulting to on (sound present) — hidden entirely when the
+  // recording captured no audio.
+  const hasAudio = useMemo(
+    () => !filming && recordingHasAudio(recording.events),
+    [filming, recording.events],
+  );
+  const [muted, setMuted] = useState(false);
+  const audioRef = useRef<AudioPlaybackController | null>(null);
+  /** Cached export-audio build, used only while filming (see the replay bridge). */
+  const renderAudioRef = useRef<Promise<PlaybackAudio | null> | null>(null);
+  const mutedRef = useRef(muted);
+  mutedRef.current = muted;
+  const playStateRef = useRef(playState);
+  playStateRef.current = playState;
+
   // A remount (version switch, restart, or seek) makes the frame not-ready
   // until its SDK reconnects. The deps ARE the remount triggers even though the
   // body only resets the flag.
@@ -1392,6 +1418,49 @@ function PlayerSurface({
     );
   }, [playState, frameReady]);
 
+  // Decode the captured audio onto the current playback timeline (idle
+  // compression + cuts baked in) and hold a controller. Rebuilt whenever the
+  // playback identity changes — an edit retimes where audio lands — and torn
+  // down on unmount/filming. Best-effort: a browser that can't decode just
+  // plays silent.
+  useEffect(() => {
+    if (!hasAudio) return;
+    let cancelled = false;
+    let controller: AudioPlaybackController | null = null;
+    void buildPlaybackAudio({
+      events: recording.events,
+      cuts: recording.edits?.cuts ?? [],
+      durationMs: playback.duration,
+      toPlaybackMs: playback.toPlaybackMs,
+    }).then((audio) => {
+      if (cancelled || !audio) return;
+      controller = new AudioPlaybackController(audio);
+      controller.setMuted(mutedRef.current);
+      audioRef.current = controller;
+      controller.sync(
+        clockRef.current,
+        playStateRef.current === "playing" && frameReadyRef.current,
+      );
+    });
+    return () => {
+      cancelled = true;
+      controller?.dispose();
+      audioRef.current = null;
+    };
+  }, [hasAudio, recording, playback]);
+
+  // Keep the audio reconciled with the clock: one call handles play, pause, and
+  // seek (a large jump restarts; smooth advance is left to free-run in step).
+  // Driven by displayClock — the throttled mirror updates each tick and jumps on
+  // a seek, both well inside the controller's drift tolerance.
+  useEffect(() => {
+    audioRef.current?.sync(displayClock, playState === "playing" && frameReady);
+  }, [displayClock, playState, frameReady]);
+
+  useEffect(() => {
+    audioRef.current?.setMuted(muted);
+  }, [muted]);
+
   useEffect(() => {
     // Hold the clock until the current app frame's SDK has connected, so events
     // aren't posted into a frame that can't yet receive them.
@@ -1597,11 +1666,27 @@ function PlayerSurface({
         seekTo(ms);
         await settled();
       },
+      // The renderer can't hear the sandboxed frame, so the captured audio is
+      // decoded onto the export timeline here and muxed into the MP4 separately
+      // (the video is filmed frame by frame with playback paused). Built once,
+      // then reused if the renderer asks again.
+      audio: () => {
+        if (!renderAudioRef.current) {
+          renderAudioRef.current = buildPlaybackAudio({
+            events: recording.events,
+            cuts: recording.edits?.cuts ?? [],
+            durationMs: playback.duration,
+            toPlaybackMs: playback.toPlaybackMs,
+          }).catch(() => null);
+        }
+        return renderAudioRef.current;
+      },
     };
     return () => {
       window.__archestraReplay = undefined;
+      renderAudioRef.current = null;
     };
-  }, [filming, duration, seekTo, events]);
+  }, [filming, duration, seekTo, events, recording, playback]);
 
   // The single timeline runs on the FULL (uncut) session; a click there seeks
   // the cut playback to the same moment (a click inside a removed stretch
@@ -2276,6 +2361,33 @@ function PlayerSurface({
               playButton
             );
           })()}
+          {/* Mute toggle — only when the recording captured sound. Sound is on
+              by default so the demo replays as it happened; this is the way to
+              silence it. */}
+          {hasAudio && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="-mb-0.5 size-9 rounded-md text-muted-foreground hover:text-foreground"
+                  aria-label={muted ? "Unmute" : "Mute"}
+                  aria-pressed={muted}
+                  onClick={() => setMuted((value) => !value)}
+                >
+                  {muted ? (
+                    <VolumeX className="h-4 w-4" />
+                  ) : (
+                    <Volume2 className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                {muted ? "Unmute" : "Mute"}
+              </TooltipContent>
+            </Tooltip>
+          )}
           {/* No fixed-width reserve: tabular-nums keeps the readout stable,
               and a sized box would pad one side and break the row's even
               gap rhythm. */}

--- a/platform/frontend/src/lib/app-session-recording/app-recording-audio.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-recording-audio.ts
@@ -1,0 +1,367 @@
+import { normalizeCuts } from "@archestra/shared";
+import type { RuntimeRecordingEvent } from "./app-recording-binary";
+
+// WebCodecs audio types aren't in the project's TS lib (and its `types`
+// allowlist keeps @types/* out), so the minimal surface we use is declared here
+// and the constructors are read off globalThis. AudioContext/AudioBuffer/… are
+// standard lib.dom and used directly.
+interface DecodedAudioFrame {
+  readonly sampleRate: number;
+  readonly numberOfChannels: number;
+  readonly numberOfFrames: number;
+  readonly timestamp: number;
+  copyTo(
+    destination: Float32Array,
+    options: { planeIndex: number; format: string },
+  ): void;
+  close(): void;
+}
+interface AudioDecoderLike {
+  configure(config: {
+    codec: string;
+    sampleRate: number;
+    numberOfChannels: number;
+    // Uint8Array rather than the real BufferSource: our data is always a plain
+    // Uint8Array, and pinning to that (instead of lib.dom's ArrayBuffer-generic
+    // BufferSource) avoids an ArrayBufferLike/ArrayBuffer mismatch at call sites
+    // that never construct a SharedArrayBuffer-backed view in the first place.
+    description?: Uint8Array;
+  }): void;
+  decode(chunk: unknown): void;
+  flush(): Promise<void>;
+  close(): void;
+}
+type AudioDecoderCtor = new (init: {
+  output: (frame: DecodedAudioFrame) => void;
+  error: (error: unknown) => void;
+}) => AudioDecoderLike;
+type EncodedAudioChunkCtor = new (init: {
+  type: string;
+  timestamp: number;
+  data: Uint8Array;
+}) => unknown;
+
+const AudioDecoderClass = (
+  globalThis as unknown as { AudioDecoder?: AudioDecoderCtor }
+).AudioDecoder;
+const EncodedAudioChunkClass = (
+  globalThis as unknown as { EncodedAudioChunk?: EncodedAudioChunkCtor }
+).EncodedAudioChunk;
+
+/**
+ * Host-side audio for a recording — decode once, play everywhere.
+ *
+ * The recorder captures the app's sound as one Opus stream (`audio-config` +
+ * `audio-chunk` events). Unlike the visual streams, audio is NOT posted back
+ * into the sandboxed app frame on replay: the app iframe can't autoplay, and
+ * the exporter can't hear it anyway. Instead this module decodes the captured
+ * Opus in the player's own document into one PCM buffer laid out on the
+ * COMPRESSED/cut playback timeline, so the exact same decode drives both live
+ * replay (an {@link AudioPlaybackController}) and the offline video export (the
+ * PCM handed to the MP4 encoder as an AAC track).
+ */
+
+/** Decoded audio laid out on the playback timeline: planar, silence-filled. */
+export interface PlaybackAudio {
+  sampleRate: number;
+  numberOfChannels: number;
+  /** Frames per channel — the whole playback duration. */
+  length: number;
+  /** One Float32Array per channel, aligned to the compressed playback clock. */
+  channelData: Float32Array[];
+}
+
+type RuntimeAudioConfig = Extract<
+  RuntimeRecordingEvent,
+  { kind: "audio-config" }
+>;
+type RuntimeAudioChunk = Extract<
+  RuntimeRecordingEvent,
+  { kind: "audio-chunk" }
+>;
+
+/** Whether a recording carries any captured audio at all. */
+export function recordingHasAudio(
+  events: readonly RuntimeRecordingEvent[],
+): boolean {
+  return events.some(
+    (event) => event.kind === "audio-config" || event.kind === "audio-chunk",
+  );
+}
+
+/**
+ * Decode the recording's Opus into PCM positioned on the playback timeline.
+ *
+ * Chunks carry their raw recording time `t`; each decoded frame is written at
+ * `toPlaybackMs(t)` (the compressed clock the player and export both run on),
+ * and frames inside a cut are dropped so a cut range plays silent rather than
+ * bursting the removed audio at the collapse instant — the audio counterpart of
+ * how the transcript drops cut messages. Returns null when the recording has no
+ * audio or the browser can't decode it (WebCodecs absent) — callers stay silent.
+ */
+export async function buildPlaybackAudio(params: {
+  events: readonly RuntimeRecordingEvent[];
+  cuts: readonly { fromMs: number; toMs: number }[];
+  /** The compressed playback duration (buildPlayback().duration). */
+  durationMs: number;
+  toPlaybackMs: (rawMs: number) => number;
+}): Promise<PlaybackAudio | null> {
+  const { events, cuts, durationMs, toPlaybackMs } = params;
+  if (!AudioDecoderClass || !EncodedAudioChunkClass) return null;
+  const config = events.find(
+    (event): event is RuntimeAudioConfig => event.kind === "audio-config",
+  );
+  const chunks = events
+    .filter((event): event is RuntimeAudioChunk => event.kind === "audio-chunk")
+    .sort((a, b) => a.tsUs - b.tsUs);
+  if (!config || chunks.length === 0) return null;
+
+  const merged = normalizeCuts(cuts.map((cut) => ({ ...cut })));
+  const inCut = (t: number) =>
+    merged.some((cut) => cut.fromMs < t && t < cut.toMs);
+
+  const frames = await decodeChunks(config, chunks);
+  if (!frames || frames.length === 0) return null;
+
+  const sampleRate = frames[0].sampleRate || config.sampleRate;
+  const numberOfChannels =
+    frames[0].numberOfChannels || config.numberOfChannels;
+  const length = Math.max(1, Math.ceil((durationMs / 1000) * sampleRate));
+  const channelData: Float32Array[] = [];
+  for (let c = 0; c < numberOfChannels; c++) {
+    channelData.push(new Float32Array(length));
+  }
+
+  // Opus decodes one frame per chunk in order, so index pairing recovers each
+  // frame's raw time; a length mismatch (unexpected) falls back to the encoder
+  // timestamp map, and anything still unresolved is skipped rather than
+  // misplaced.
+  const paired = frames.length === chunks.length;
+  const rawTByTs = new Map<number, number>();
+  if (!paired) for (const chunk of chunks) rawTByTs.set(chunk.tsUs, chunk.t);
+
+  for (let index = 0; index < frames.length; index++) {
+    const frame = frames[index];
+    try {
+      const rawT = paired
+        ? chunks[index].t
+        : rawTByTs.get(Math.round(frame.timestamp));
+      if (rawT === undefined || inCut(rawT)) continue;
+      const startSample = Math.round((toPlaybackMs(rawT) / 1000) * sampleRate);
+      const frameLen = frame.numberOfFrames;
+      const scratch = new Float32Array(frameLen);
+      for (let c = 0; c < numberOfChannels; c++) {
+        try {
+          frame.copyTo(scratch, { planeIndex: c, format: "f32-planar" });
+        } catch {
+          continue;
+        }
+        const dest = channelData[c];
+        for (let i = 0; i < frameLen; i++) {
+          const at = startSample + i;
+          if (at >= 0 && at < length) dest[at] = scratch[i];
+        }
+      }
+    } finally {
+      frame.close();
+    }
+  }
+  return { sampleRate, numberOfChannels, length, channelData };
+}
+
+/**
+ * How far the audio may drift from the clock before {@link
+ * AudioPlaybackController.sync} restarts it. Comfortably above the clock's
+ * ~100ms display cadence, so smooth playback never restarts (which would
+ * stutter) while a seek — a large jump — always resyncs.
+ */
+const AUDIO_SYNC_DRIFT_MS = 250;
+
+/**
+ * Live audio for the player: one prebuilt {@link PlaybackAudio} buffer scheduled
+ * against the host clock. Follows play/pause/seek by (re)starting a
+ * `AudioBufferSourceNode` at the clock offset; both the clock and the buffer run
+ * on the compressed timeline at real speed, so they stay in step without
+ * per-frame correction.
+ */
+export class AudioPlaybackController {
+  private readonly audio: PlaybackAudio;
+  private ctx: AudioContext | null = null;
+  private buffer: AudioBuffer | null = null;
+  private gain: GainNode | null = null;
+  private source: AudioBufferSourceNode | null = null;
+  private muted = false;
+  private playing = false;
+  /** ctx.currentTime when the live source started, for drift estimation. */
+  private startedAtCtxTime: number | null = null;
+  private startedOffsetMs = 0;
+
+  constructor(audio: PlaybackAudio) {
+    this.audio = audio;
+  }
+
+  /**
+   * Reconcile audio with the host clock in one call, from a single effect:
+   * pause when the clock isn't running, start when it is, and restart only on a
+   * real jump (a seek) — smooth advance stays within {@link
+   * AUDIO_SYNC_DRIFT_MS} and is left alone so the buffer free-runs in step.
+   */
+  sync(offsetMs: number, playing: boolean) {
+    if (!playing) {
+      this.pause();
+      return;
+    }
+    const expected = this.expectedOffsetMs();
+    if (
+      expected === null ||
+      Math.abs(expected - offsetMs) > AUDIO_SYNC_DRIFT_MS
+    ) {
+      this.play(offsetMs);
+    }
+  }
+
+  /** (Re)start playback at the given playback-clock offset. */
+  play(offsetMs: number) {
+    this.ensure();
+    if (!this.ctx || !this.buffer || !this.gain) return;
+    this.stopSource();
+    this.playing = true;
+    // A user gesture (opening the player, pressing play, toggling mute) is what
+    // reaches here, so resuming a suspended context is allowed.
+    void this.ctx.resume().catch(() => {});
+    const offsetSec = Math.max(0, offsetMs / 1000);
+    if (offsetSec >= this.buffer.duration) return;
+    const source = this.ctx.createBufferSource();
+    source.buffer = this.buffer;
+    source.connect(this.gain);
+    try {
+      source.start(0, offsetSec);
+    } catch {
+      return;
+    }
+    this.source = source;
+    this.startedAtCtxTime = this.ctx.currentTime;
+    this.startedOffsetMs = offsetMs;
+  }
+
+  pause() {
+    this.playing = false;
+    this.startedAtCtxTime = null;
+    this.stopSource();
+  }
+
+  setMuted(muted: boolean) {
+    this.muted = muted;
+    if (this.gain) this.gain.gain.value = muted ? 0 : 1;
+  }
+
+  dispose() {
+    this.stopSource();
+    try {
+      void this.ctx?.close();
+    } catch {}
+    this.ctx = null;
+    this.buffer = null;
+    this.gain = null;
+  }
+
+  /** The offset the live source has reached, or null when not playing. */
+  private expectedOffsetMs(): number | null {
+    if (!this.playing || !this.ctx || this.startedAtCtxTime === null) {
+      return null;
+    }
+    return (
+      this.startedOffsetMs +
+      (this.ctx.currentTime - this.startedAtCtxTime) * 1000
+    );
+  }
+
+  private ensure() {
+    if (this.ctx) return;
+    try {
+      const ctx = new AudioContext();
+      const gain = ctx.createGain();
+      gain.gain.value = this.muted ? 0 : 1;
+      gain.connect(ctx.destination);
+      const buffer = ctx.createBuffer(
+        this.audio.numberOfChannels,
+        this.audio.length,
+        this.audio.sampleRate,
+      );
+      for (let c = 0; c < this.audio.numberOfChannels; c++) {
+        // Our Float32Arrays are always plain `new Float32Array(length)` —
+        // ArrayBuffer-backed, never a SharedArrayBuffer view — so the cast past
+        // lib.dom's ArrayBuffer-generic typing is safe.
+        buffer.copyToChannel(
+          this.audio.channelData[c] as Float32Array<ArrayBuffer>,
+          c,
+        );
+      }
+      this.ctx = ctx;
+      this.gain = gain;
+      this.buffer = buffer;
+    } catch {
+      this.ctx = null;
+    }
+  }
+
+  private stopSource() {
+    if (!this.source) return;
+    try {
+      this.source.onended = null;
+      this.source.stop();
+    } catch {}
+    try {
+      this.source.disconnect();
+    } catch {}
+    this.source = null;
+  }
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/** Decode every Opus chunk to ordered PCM frames; null on decoder failure. */
+async function decodeChunks(
+  config: RuntimeAudioConfig,
+  chunks: RuntimeAudioChunk[],
+): Promise<DecodedAudioFrame[] | null> {
+  if (!AudioDecoderClass || !EncodedAudioChunkClass) return null;
+  const frames: DecodedAudioFrame[] = [];
+  let decoder: AudioDecoderLike | null = null;
+  try {
+    decoder = new AudioDecoderClass({
+      output: (frame) => frames.push(frame),
+      error: () => {},
+    });
+    decoder.configure({
+      codec: config.codec,
+      sampleRate: config.sampleRate,
+      numberOfChannels: config.numberOfChannels,
+      ...(config.description ? { description: config.description } : {}),
+    });
+    for (const chunk of chunks) {
+      decoder.decode(
+        new EncodedAudioChunkClass({
+          type: "key",
+          timestamp: chunk.tsUs,
+          data: chunk.bytes,
+        }),
+      );
+    }
+    await decoder.flush();
+  } catch {
+    for (const frame of frames) {
+      try {
+        frame.close();
+      } catch {}
+    }
+    return null;
+  } finally {
+    try {
+      decoder?.close();
+    } catch {}
+  }
+  return frames;
+}

--- a/platform/frontend/src/lib/app-session-recording/app-recording-binary.test.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-recording-binary.test.ts
@@ -57,6 +57,32 @@ describe("recording event binary conversion", () => {
     expect(revived[1]).not.toHaveProperty("data");
   });
 
+  it("round-trips audio chunks and configs as raw bytes", async () => {
+    const bytes = Uint8Array.from({ length: 180 }, (_, i) => (i * 5) % 256);
+    const description = new Uint8Array([1, 1, 56, 1, 0]);
+    const runtime = [
+      {
+        kind: "audio-config",
+        t: 0,
+        codec: "opus",
+        sampleRate: 48_000,
+        numberOfChannels: 2,
+        description,
+      },
+      { kind: "audio-chunk", t: 12, tsUs: 12_000, bytes },
+    ];
+    const stored = await serializeRecordingEvents(runtime);
+    expect(typeof stored[0].description).toBe("string");
+    expect(typeof stored[1].data).toBe("string");
+    expect(stored[1]).not.toHaveProperty("bytes");
+    const revived = reviveRecordingEvents(stored as unknown as StoredEvents);
+    expect((revived[0] as { description: Uint8Array }).description).toEqual(
+      description,
+    );
+    expect((revived[1] as { bytes: Uint8Array }).bytes).toEqual(bytes);
+    expect(revived[1]).not.toHaveProperty("data");
+  });
+
   it("passes non-binary events through and tolerates legacy stored stills", async () => {
     const pointer = { kind: "pointer", t: 1, type: "click", x: 1, y: 2 };
     const legacy = {

--- a/platform/frontend/src/lib/app-session-recording/app-recording-binary.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-recording-binary.ts
@@ -18,6 +18,8 @@ type StoredEvent = AppRecordingBundle["recording"]["events"][number];
 type StoredCanvasFrame = Extract<StoredEvent, { kind: "canvas" }>;
 type StoredVideoConfig = Extract<StoredEvent, { kind: "video-config" }>;
 type StoredVideoChunk = Extract<StoredEvent, { kind: "video-chunk" }>;
+type StoredAudioConfig = Extract<StoredEvent, { kind: "audio-config" }>;
+type StoredAudioChunk = Extract<StoredEvent, { kind: "audio-chunk" }>;
 
 /** A canvas still with its pixels as an encoded-image Blob (WebP fallback). */
 export type RuntimeCanvasFrame = Omit<StoredCanvasFrame, "data"> & {
@@ -31,15 +33,29 @@ export type RuntimeVideoConfig = Omit<StoredVideoConfig, "description"> & {
 export type RuntimeVideoChunk = Omit<StoredVideoChunk, "data"> & {
   bytes: Uint8Array;
 };
+/** The audio stream config with its codec extradata as raw bytes. */
+export type RuntimeAudioConfig = Omit<StoredAudioConfig, "description"> & {
+  description?: Uint8Array;
+};
+/** An encoded audio chunk with its payload as raw bytes. */
+export type RuntimeAudioChunk = Omit<StoredAudioChunk, "data"> & {
+  bytes: Uint8Array;
+};
 
 export type RuntimeRecordingEvent =
   | Exclude<
       StoredEvent,
-      StoredCanvasFrame | StoredVideoConfig | StoredVideoChunk
+      | StoredCanvasFrame
+      | StoredVideoConfig
+      | StoredVideoChunk
+      | StoredAudioConfig
+      | StoredAudioChunk
     >
   | RuntimeCanvasFrame
   | RuntimeVideoConfig
-  | RuntimeVideoChunk;
+  | RuntimeVideoChunk
+  | RuntimeAudioConfig
+  | RuntimeAudioChunk;
 
 /**
  * Stored → runtime, once at bundle-open time. Synchronous: base64 decode is
@@ -59,6 +75,16 @@ export function reviveRecordingEvents(
       return { ...rest, bytes: base64ToBytes(data) };
     }
     if (event.kind === "video-config") {
+      const { description, ...rest } = event;
+      return description === undefined
+        ? rest
+        : { ...rest, description: base64ToBytes(description) };
+    }
+    if (event.kind === "audio-chunk") {
+      const { data, ...rest } = event;
+      return { ...rest, bytes: base64ToBytes(data) };
+    }
+    if (event.kind === "audio-config") {
       const { description, ...rest } = event;
       return description === undefined
         ? rest
@@ -92,6 +118,16 @@ export async function serializeRecordingEvents(
       }
       if (
         event.kind === "video-config" &&
+        event.description instanceof Uint8Array
+      ) {
+        return { ...event, description: bytesToBase64(event.description) };
+      }
+      if (event.kind === "audio-chunk" && event.bytes instanceof Uint8Array) {
+        const { bytes, ...rest } = event;
+        return { ...rest, data: bytesToBase64(bytes) };
+      }
+      if (
+        event.kind === "audio-config" &&
         event.description instanceof Uint8Array
       ) {
         return { ...event, description: bytesToBase64(event.description) };

--- a/platform/frontend/src/lib/app-session-recording/app-recording-store.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-recording-store.ts
@@ -336,6 +336,9 @@ declare global {
       ready(): Promise<void>;
       durationMs(): number;
       seek(ms: number): Promise<void>;
+      /** The recording's captured audio, decoded onto the export timeline, for
+       *  the renderer to mux as the MP4's audio track. Null when silent. */
+      audio(): Promise<import("./app-recording-audio").PlaybackAudio | null>;
     };
     __archestraRenderSeed(bundle: unknown): Promise<void>;
     __archestraRenderReady(): Promise<number>;

--- a/platform/frontend/src/lib/app-session-recording/app-recording-video-encoder.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-recording-video-encoder.ts
@@ -1,10 +1,13 @@
 import {
+  AudioSample,
+  AudioSampleSource,
   BufferTarget,
   Mp4OutputFormat,
   Output,
   VideoSample,
   VideoSampleSource,
 } from "mediabunny";
+import type { PlaybackAudio } from "./app-recording-audio";
 
 /**
  * Encodes rendered frames into an MP4, inside the browser that rendered them.
@@ -43,6 +46,10 @@ class VideoEncoderSession {
     /** Region to crop out of each JPEG. Absent when frames arrive pre-cropped
      * (the legacy capture path clips at the compositor). */
     crop?: { x: number; y: number; width: number; height: number };
+    /** The recording's captured sound, decoded onto the export timeline. Muxed
+     * as an AAC track so the video carries the original audio. Absent/null when
+     * the recording was silent. */
+    audio?: PlaybackAudio | null;
   }): Promise<void> {
     // One page renders one video. Silently replacing a live session would
     // finalize the newcomer and abandon the first render's output and source,
@@ -59,10 +66,30 @@ class VideoEncoderSession {
       bitrate: exportBitrate(params),
     });
     output.addVideoTrack(source, { frameRate: params.fps });
+    // AAC for MP4 (the same compatibility reason as H.264 above — Slides,
+    // Keynote, QuickTime). All tracks must be added before start(); a codec the
+    // render browser can't encode just drops the audio rather than the whole
+    // export.
+    let audioSource: AudioSampleSource | null = null;
+    if (params.audio && params.audio.channelData.length > 0) {
+      try {
+        audioSource = new AudioSampleSource({
+          codec: "aac",
+          bitrate: AUDIO_EXPORT_BITRATE,
+        });
+        output.addAudioTrack(audioSource);
+      } catch {
+        audioSource = null;
+      }
+    }
     await output.start();
+    if (audioSource && params.audio) {
+      await feedAudioTrack(audioSource, params.audio);
+    }
     this.active = {
       output,
       source,
+      audioSource,
       fps: params.fps,
       crop: params.crop ?? null,
       chain: Promise.resolve(),
@@ -125,6 +152,7 @@ class VideoEncoderSession {
     active.lastBitmap = null;
     if (active.failure) throw active.failure;
     active.source.close();
+    active.audioSource?.close();
     await active.output.finalize();
     const buffer = (active.output.target as BufferTarget).buffer;
     if (!buffer) throw new Error("The encoder produced no video.");
@@ -156,6 +184,7 @@ export const startEncoder = (
         height: number;
         fps: number;
         crop?: { x: number; y: number; width: number; height: number };
+        audio?: PlaybackAudio | null;
       }
     | number,
   height?: number,
@@ -200,6 +229,48 @@ export const finishEncoder = (): Promise<string> => encoder.finish();
 /** Where a legacy renderer's never-drained queue is absorbed instead. */
 const LEGACY_SELF_DRAIN_DEPTH = 24;
 
+/** AAC bitrate for the exported audio track — transparent for demo sound. */
+const AUDIO_EXPORT_BITRATE = 128_000;
+/** One second of PCM per muxed AudioSample: coarse enough to be cheap, fine
+ *  enough that the encoder starts emitting early. */
+const AUDIO_EXPORT_CHUNK_SEC = 1;
+
+/**
+ * Feed the whole decoded audio track into the muxer as one-second AudioSamples
+ * on the shared 0-based seconds timeline (the same clock the video's index/fps
+ * timestamps sit on), so audio and video line up without any fps conversion.
+ * The PCM is planar Float32; each sample carries all channels for its slice.
+ */
+async function feedAudioTrack(
+  source: AudioSampleSource,
+  audio: PlaybackAudio,
+): Promise<void> {
+  const { channelData, numberOfChannels, sampleRate, length } = audio;
+  const framesPerChunk = Math.max(
+    1,
+    Math.round(sampleRate * AUDIO_EXPORT_CHUNK_SEC),
+  );
+  for (let start = 0; start < length; start += framesPerChunk) {
+    const frames = Math.min(framesPerChunk, length - start);
+    const planar = new Float32Array(frames * numberOfChannels);
+    for (let c = 0; c < numberOfChannels; c++) {
+      planar.set(channelData[c].subarray(start, start + frames), c * frames);
+    }
+    const sample = new AudioSample({
+      data: planar,
+      format: "f32-planar",
+      numberOfChannels,
+      sampleRate,
+      timestamp: start / sampleRate,
+    });
+    try {
+      await source.add(sample);
+    } finally {
+      sample.close();
+    }
+  }
+}
+
 /**
  * Export bits scale with the region. mediabunny's QUALITY_HIGH preset
  * resolved to ~1.3 Mbps for a ~1.5MP frame — fine for the mostly-static chat
@@ -228,6 +299,8 @@ function exportBitrate(params: {
 interface EncoderSession {
   output: Output;
   source: VideoSampleSource;
+  /** The muxed audio track's source, or null when the recording was silent. */
+  audioSource: AudioSampleSource | null;
   fps: number;
   crop: { x: number; y: number; width: number; height: number } | null;
   /** Serializes decode+encode in index order (the muxer needs monotonic

--- a/platform/shared/app-recording.test.ts
+++ b/platform/shared/app-recording.test.ts
@@ -199,6 +199,39 @@ describe("validateRecordingBundle", () => {
     expect(validateRecordingBundle(edited).ok).toBe(true);
   });
 
+  it("accepts captured audio events (config + chunk)", () => {
+    const withAudio = bundle();
+    withAudio.recording = {
+      ...withAudio.recording,
+      events: [
+        ...withAudio.recording.events,
+        {
+          kind: "audio-config",
+          t: 0,
+          codec: "opus",
+          sampleRate: 48_000,
+          numberOfChannels: 2,
+          description: "AQE4AQA=",
+        },
+        { kind: "audio-chunk", t: 100, tsUs: 100_000, data: "AAECAwQ=" },
+      ],
+    };
+    expect(validateRecordingBundle(withAudio).ok).toBe(true);
+  });
+
+  it("rejects a malformed audio event", () => {
+    const badAudio = bundle();
+    badAudio.recording = {
+      ...badAudio.recording,
+      events: [
+        ...badAudio.recording.events,
+        // Missing the required sampleRate/numberOfChannels.
+        { kind: "audio-config", t: 0, codec: "opus" } as never,
+      ],
+    };
+    expect(validateRecordingBundle(badAudio).ok).toBe(false);
+  });
+
   it("rejects unknown chat-edit keys", () => {
     const smuggled = bundle({
       edits: {

--- a/platform/shared/app-recording.ts
+++ b/platform/shared/app-recording.ts
@@ -225,6 +225,47 @@ const VideoChunkEventSchema = z
   .strict();
 
 /**
+ * Opens (or reopens) the recording's single mixed audio stream: the codec and
+ * sample format a decoder needs before it can take chunks. The recorder mixes
+ * every app audio source — Web Audio graphs and `<audio>`/`<video>` playback —
+ * into one Opus stream, so unlike video there is no per-canvas `sel`; there is
+ * exactly one audio stream per recording. Replayed as the decoder-reset point:
+ * a seek re-feeds this config, then the chunks from the seek point.
+ *
+ * Stored (JSON) form; `description` is base64 codec extradata (Opus carries its
+ * channel/pre-skip config here). In memory the bytes flow raw — base64 exists
+ * only in the bundle at rest.
+ */
+const AudioConfigEventSchema = z
+  .object({
+    kind: z.literal("audio-config"),
+    t: EventTimeSchema,
+    codec: z.string().max(64),
+    sampleRate: z.number().int().positive(),
+    numberOfChannels: z.number().int().positive().max(8),
+    description: z.string().max(65_536).optional(),
+  })
+  .strict();
+
+/**
+ * One encoded audio chunk of the recording's mixed stream. `tsUs` is the
+ * encoder's microsecond timestamp (monotonic within the stream); `data` is the
+ * chunk's bytes, base64 in this stored form only. Opus frames are all
+ * independently decodable, so — unlike video — there is no key/delta split.
+ *
+ * The `data` cap matches the video chunk's: a corruption backstop far above any
+ * real Opus frame (which run to a few kilobytes), not a rate control.
+ */
+const AudioChunkEventSchema = z
+  .object({
+    kind: z.literal("audio-chunk"),
+    t: EventTimeSchema,
+    tsUs: z.number().int().min(0),
+    data: z.string().max(2_000_000),
+  })
+  .strict();
+
+/**
  * One DOM change: an element's markup after it changed, or one attribute.
  *
  * Replay applies these rather than re-running the app, so what the viewer sees
@@ -253,6 +294,8 @@ export const AppRecordingEventSchema = z.discriminatedUnion("kind", [
   CanvasFrameEventSchema,
   VideoConfigEventSchema,
   VideoChunkEventSchema,
+  AudioConfigEventSchema,
+  AudioChunkEventSchema,
   DomMutationEventSchema,
 ]);
 export type AppRecordingEvent = z.infer<typeof AppRecordingEventSchema>;


### PR DESCRIPTION
## Summary
- Adds `audio-config`/`audio-chunk` events to the recording contract (mirrors the existing video-config/video-chunk shape; one mixed Opus stream per recording).
- SDK captures app sound during recording — Web Audio graphs (via an `AudioNode.prototype.connect` patch fanning playback into a per-context `MediaStreamDestination`) and `<audio>`/`<video>` element playback (via `captureStream`), mixed into one Opus stream via WebCodecs. Starts only once real sound appears; drains on stop like the video encoders.
- Player decodes the captured Opus onto the compressed/cut playback timeline and schedules it against the clock; on by default with a mute toggle in the transport bar, hidden when a recording has no audio.
- Offline video export mixes the same decoded PCM into the exported MP4 as an AAC track (the renderer films pixels only and can't hear the sandboxed app, so audio is decoded host-side and muxed separately on the same 0-based-seconds timeline as the video).

## Test plan
- [x] `pnpm type-check` clean on `shared` and `frontend`
- [x] `pnpm biome check` clean on all touched files
- [x] `node --check` on the SDK static file
- [x] Existing + new unit tests pass (497 shared, 127 frontend, incl. new audio schema + binary round-trip cases)
- [ ] Manual: record an app with sound, confirm audio plays in the player (mute toggle works, stays in sync across seeks/cuts) and the exported MP4 has an audible in-sync track — WebCodecs audio needs a real browser, not exercisable in CI/headless

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>