### PR TITLE
fix(projects): hide Schedules section for roles without scheduledTask:read

### DIFF
--- a/platform/frontend/src/app/projects/[id]/project-schedules-section.test.tsx
+++ b/platform/frontend/src/app/projects/[id]/project-schedules-section.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth/auth.query");
+
+vi.mock("next/navigation");
+
+vi.mock("@/lib/schedule-trigger.query", () => ({
+  useScheduleTriggers: vi.fn(),
+  useScheduleTrigger: vi.fn(),
+  useScheduleTriggerRuns: vi.fn(),
+  useCreateScheduleTrigger: vi.fn(),
+  useUpdateScheduleTrigger: vi.fn(),
+  useDeleteScheduleTrigger: vi.fn(),
+  useEnableScheduleTrigger: vi.fn(),
+  useDisableScheduleTrigger: vi.fn(),
+  useRunScheduleTriggerNow: vi.fn(),
+}));
+
+vi.mock("@/lib/agent.query", () => ({
+  useProfiles: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock("@/lib/hooks/use-dialog-url-param", () => ({
+  useDialogUrlParam: vi.fn(() => ({
+    entity: null,
+    open: vi.fn(),
+    close: vi.fn(),
+  })),
+}));
+
+vi.mock("@/components/scheduled-tasks/use-resolve-run-chat", () => ({
+  useResolveRunChat: vi.fn(() => ({ resolve: vi.fn(), isResolving: false })),
+}));
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
+import {
+  type ScheduleTrigger,
+  useDeleteScheduleTrigger,
+  useDisableScheduleTrigger,
+  useEnableScheduleTrigger,
+  useRunScheduleTriggerNow,
+  useScheduleTrigger,
+  useScheduleTriggerRuns,
+  useScheduleTriggers,
+} from "@/lib/schedule-trigger.query";
+import { ProjectSchedulesSection } from "./project-schedules-section";
+
+const SCHEDULE: ScheduleTrigger = {
+  id: "trigger-1",
+  organizationId: "org-1",
+  name: "Weekly summary",
+  agentId: "agent-1",
+  projectId: "project-1",
+  messageTemplate: "Summarize the week",
+  cronExpression: "0 9 * * 1",
+  timezone: "UTC",
+  enabled: true,
+  actorUserId: "user-1",
+  lastExecutedAt: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  agent: { id: "agent-1", name: "Reporter", agentType: "agent" },
+};
+
+/** Maps a permission check to its mocked result, e.g. `{ read: true, create: false }`. */
+function mockSchedulePermissions(granted: {
+  read?: boolean;
+  create?: boolean;
+}) {
+  vi.mocked(useHasPermissions).mockImplementation((permissions) => {
+    const actions = permissions.scheduledTask ?? [];
+    const allGranted = actions.every(
+      (action) => granted[action as keyof typeof granted] === true,
+    );
+    return {
+      data: allGranted,
+      isPending: false,
+    } as ReturnType<typeof useHasPermissions>;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useSession).mockReturnValue({
+    data: { user: { id: "user-1" } },
+  } as ReturnType<typeof useSession>);
+  vi.mocked(useRouter).mockReturnValue({
+    push: vi.fn(),
+  } as unknown as ReturnType<typeof useRouter>);
+  vi.mocked(useSearchParams).mockReturnValue(
+    new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
+  );
+  vi.mocked(useScheduleTriggers).mockReturnValue({
+    data: { data: [] },
+  } as unknown as ReturnType<typeof useScheduleTriggers>);
+  vi.mocked(useScheduleTrigger).mockReturnValue({
+    data: null,
+  } as unknown as ReturnType<typeof useScheduleTrigger>);
+  vi.mocked(useScheduleTriggerRuns).mockReturnValue({
+    data: { data: [] },
+  } as unknown as ReturnType<typeof useScheduleTriggerRuns>);
+  const idleMutation = { mutate: vi.fn(), isPending: false };
+  vi.mocked(useDeleteScheduleTrigger).mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useDeleteScheduleTrigger>,
+  );
+  vi.mocked(useDisableScheduleTrigger).mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useDisableScheduleTrigger>,
+  );
+  vi.mocked(useEnableScheduleTrigger).mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useEnableScheduleTrigger>,
+  );
+  vi.mocked(useRunScheduleTriggerNow).mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useRunScheduleTriggerNow>,
+  );
+});
+
+describe("ProjectSchedulesSection without scheduledTask:read", () => {
+  beforeEach(() => {
+    mockSchedulePermissions({ read: false });
+  });
+
+  it("renders nothing", () => {
+    render(<ProjectSchedulesSection projectId="project-1" />);
+
+    expect(screen.queryByText("Schedules")).not.toBeInTheDocument();
+  });
+
+  it("never mounts the schedule-triggers query", () => {
+    render(<ProjectSchedulesSection projectId="project-1" />);
+
+    expect(useScheduleTriggers).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProjectSchedulesSection with scheduledTask:read only", () => {
+  beforeEach(() => {
+    mockSchedulePermissions({ read: true, create: false });
+  });
+
+  it("renders the section", () => {
+    render(<ProjectSchedulesSection projectId="project-1" />);
+
+    expect(screen.getByText("Schedules")).toBeInTheDocument();
+  });
+
+  it("hides the New schedule button without scheduledTask:create", () => {
+    render(<ProjectSchedulesSection projectId="project-1" canCreate />);
+
+    expect(
+      screen.queryByRole("button", { name: /new schedule/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("ProjectSchedulesSection with scheduledTask read+create", () => {
+  beforeEach(() => {
+    mockSchedulePermissions({ read: true, create: true });
+  });
+
+  it("shows the New schedule button when the caller allows creating", () => {
+    render(<ProjectSchedulesSection projectId="project-1" canCreate />);
+
+    expect(
+      screen.getByRole("button", { name: /new schedule/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the New schedule button when the caller disallows creating", () => {
+    render(<ProjectSchedulesSection projectId="project-1" canCreate={false} />);
+
+    expect(
+      screen.queryByRole("button", { name: /new schedule/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no schedules", () => {
+    render(<ProjectSchedulesSection projectId="project-1" />);
+
+    expect(screen.getByText(/no schedules yet/i)).toBeInTheDocument();
+  });
+
+  it("lists existing schedules", () => {
+    vi.mocked(useScheduleTriggers).mockReturnValue({
+      data: { data: [SCHEDULE] },
+    } as unknown as ReturnType<typeof useScheduleTriggers>);
+
+    render(<ProjectSchedulesSection projectId="project-1" />);
+
+    expect(screen.getByText("Weekly summary")).toBeInTheDocument();
+    expect(screen.getByText("Reporter")).toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/app/projects/[id]/project-schedules-section.tsx
+++ b/platform/frontend/src/app/projects/[id]/project-schedules-section.tsx
@@ -73,7 +73,33 @@ export function ProjectSchedulesSection({
   projectId: string;
   canCreate?: boolean;
 }) {
+  // Without scheduledTask:read the schedules query can only 403 (and it polls,
+  // so it would toast the permission error forever). Hide the section and
+  // never mount the query for roles that can't see schedules.
+  const { data: canReadSchedules } = useHasPermissions({
+    scheduledTask: ["read"],
+  });
+  if (canReadSchedules !== true) return null;
+
+  return (
+    <ProjectSchedulesSectionContent
+      projectId={projectId}
+      canCreate={canCreate}
+    />
+  );
+}
+
+function ProjectSchedulesSectionContent({
+  projectId,
+  canCreate,
+}: {
+  projectId: string;
+  canCreate: boolean;
+}) {
   const { data } = useScheduleTriggers({ projectId, refetchInterval: 10000 });
+  const { data: canCreateSchedules } = useHasPermissions({
+    scheduledTask: ["create"],
+  });
   const [createOpen, setCreateOpen] = useState(false);
   const searchParams = useSearchParams();
   const scheduleId = searchParams.get("schedule");
@@ -94,7 +120,7 @@ export function ProjectSchedulesSection({
         <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
           Schedules
         </h2>
-        {canCreate && (
+        {canCreate && canCreateSchedules === true && (
           <Button
             variant="outline"
             size="sm"

--- a/platform/frontend/src/lib/utils/api.test.ts
+++ b/platform/frontend/src/lib/utils/api.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner");
 
-import { getApiErrorMessage, throwOnApiError } from "./api";
+import { getApiErrorMessage, handleApiError, throwOnApiError } from "./api";
 
 describe("throwOnApiError", () => {
   beforeEach(() => {
@@ -51,6 +51,41 @@ describe("throwOnApiError", () => {
         { allowNotFound: true, toastOnError: false },
       ),
     ).toThrow();
+  });
+});
+
+describe("handleApiError toast dedupe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keys the toast by its message so repeated identical errors collapse", () => {
+    const error = {
+      error: {
+        message: "You don't have permission to get schedule triggers.",
+        type: "api_authorization_error",
+      },
+    };
+
+    handleApiError(error);
+    handleApiError(error);
+
+    expect(toast.error).toHaveBeenCalledTimes(2);
+    const [firstMessage, firstOptions] = vi.mocked(toast.error).mock.calls[0];
+    const [secondMessage, secondOptions] = vi.mocked(toast.error).mock.calls[1];
+    expect(firstOptions?.id).toBe(firstMessage);
+    expect(secondOptions?.id).toBe(secondMessage);
+    expect(firstOptions?.id).toBe(secondOptions?.id);
+  });
+
+  it("keeps distinct messages as distinct toasts", () => {
+    handleApiError({ error: { message: "first failure" } });
+    handleApiError({ error: { message: "second failure" } });
+
+    const ids = vi
+      .mocked(toast.error)
+      .mock.calls.map(([, options]) => options?.id);
+    expect(new Set(ids).size).toBe(2);
   });
 });
 

--- a/platform/frontend/src/lib/utils/api.ts
+++ b/platform/frontend/src/lib/utils/api.ts
@@ -85,7 +85,10 @@ export function handleApiError(error: ApiSdkError) {
   if (typeof window !== "undefined") {
     // Errors stay long enough to read and copy; the close button dismisses early.
     // The toast shows the humanized message; Sentry keeps the raw error.
-    toast.error(getApiErrorMessage(error), { duration: 12000 });
+    // Keyed by message so a repeating failure (retries, several queries hitting
+    // the same missing permission) refreshes one toast instead of stacking.
+    const message = getApiErrorMessage(error);
+    toast.error(message, { duration: 12000, id: message });
   }
 
   void import("@sentry/nextjs")


### PR DESCRIPTION
## Summary

Roles without `scheduledTask:read` (custom RBAC roles that grant project/chat access but no scheduled-task permissions) hit an endless stream of "Missing permission: scheduledTask:read" error toasts on every project page: the Schedules section mounted unconditionally and its schedule-triggers query polls on a 10-second interval, so a request that can only 403 re-fired — and re-toasted — forever.

The section now renders only for roles with `scheduledTask:read`, and the query never mounts without it, so no forbidden request is issued at all (same gate idiom the section's agent picker already uses). The "New schedule" button additionally requires `scheduledTask:create`, since a read-only role could previously open the create dialog only to 403 on submit.

Error toasts in `handleApiError` are now keyed by message (sonner `id`), so any repeating identical failure — permission errors from several queries, a failing poll — refreshes a single toast instead of stacking duplicates.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>