### PR TITLE
test(projects): pin permission gate for deep-linked ?schedule= dialog fetch

### DIFF
--- a/platform/frontend/src/app/projects/[id]/project-schedules-section.test.tsx
+++ b/platform/frontend/src/app/projects/[id]/project-schedules-section.test.tsx
@@ -131,6 +131,18 @@ describe("ProjectSchedulesSection without scheduledTask:read", () => {
 
     expect(useScheduleTriggers).not.toHaveBeenCalled();
   });
+
+  it("never fetches a deep-linked ?schedule= trigger", () => {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams("schedule=trigger-1") as unknown as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+
+    render(<ProjectSchedulesSection projectId="project-1" />);
+
+    expect(useScheduleTrigger).not.toHaveBeenCalled();
+  });
 });
 
 describe("ProjectSchedulesSection with scheduledTask:read only", () => {


### PR DESCRIPTION
## Summary

The schedules permission-gate tests assert that the list query never mounts for a role without `scheduledTask:read`, but not the URL-dialog fetch: a refactor hoisting `useScheduleTrigger(scheduleId)` above the gate would silently re-introduce a 403 (and its permission toast) for users deep-linked to `/projects/<id>?schedule=<id>`. This pins that the deep-link fetch stays behind the gate.

Stacked on #6762; retargets to `main` when that merges.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>