### PR TITLE
fix(connection): show the Archestra mark for brand-name variants too

### DIFF
--- a/platform/backend/src/services/claude-code-startup-guard.test.ts
+++ b/platform/backend/src/services/claude-code-startup-guard.test.ts
@@ -406,10 +406,19 @@ describe("renderClaudeCodeStartupGuardScript", () => {
     expect(script).toContain('read -rs -n 1 -t "$TICK" key');
   });
 
-  test("renders the Archestra mark for the default brand, plain title when white-labeled", () => {
+  test("renders the Archestra mark for the default brand and its own variants, plain title when genuinely white-labeled", () => {
     const branded = renderClaudeCodeStartupGuardScript(CTX);
     expect(branded).toContain("▟██▙");
     expect(branded).toContain("Secure access to your AI tools");
+
+    // an org named "Archestra Staging" is still Archestra's own brand — the
+    // mark must not disappear just because the name isn't an exact match
+    const variant = renderClaudeCodeStartupGuardScript({
+      ...CTX,
+      appName: "Archestra Staging",
+    });
+    expect(variant).toContain("▟██▙");
+    expect(variant).toContain("'Archestra Staging'");
 
     const whiteLabel = renderClaudeCodeStartupGuardScript({
       ...CTX,

--- a/platform/backend/src/services/claude-code-startup-guard.ts
+++ b/platform/backend/src/services/claude-code-startup-guard.ts
@@ -5,8 +5,8 @@ import {
   CLAUDE_CODE_GUARD_SCRIPT_RELPATH,
   CLAUDE_CODE_GUARD_SKIP_RELPATH,
   CLAUDE_CODE_PROXY_ENV_KEYS,
-  DEFAULT_APP_NAME,
   EXTERNAL_AGENT_ID_HEADER,
+  isDefaultBrandedAppName,
   VIRTUAL_KEY_HEADER,
 } from "@archestra/shared";
 import { CONNECTION_HEALTH_PATH } from "@/routes/route-paths";
@@ -835,11 +835,12 @@ function splitResourceUrl(
 
 /**
  * The pre-loader header: the Archestra mark with the title beside it, the way
- * Claude Code draws its own logo — but only for the default brand. White-label
- * deployments get the plain title line.
+ * Claude Code draws its own logo — but only for the default brand or one of
+ * its own variants (e.g. "Archestra Staging"). White-label deployments get
+ * the plain title line.
  */
 function guardHeader(ctx: ClaudeCodeStartupGuardContext): string {
-  if (ctx.appName !== DEFAULT_APP_NAME) {
+  if (!isDefaultBrandedAppName(ctx.appName)) {
     return `printf '%s%s%s\\n\\n' "$C_TITLE" "$APP_NAME" "$C_RESET"`;
   }
   const [m0, m1, m2, m3, m4] = ARCHESTRA_GUARD_MARK_LINES;

--- a/platform/backend/src/services/claude-code-startup-guard.windows.test.ts
+++ b/platform/backend/src/services/claude-code-startup-guard.windows.test.ts
@@ -180,10 +180,19 @@ describe("renderClaudeCodeStartupGuardPowerShell", () => {
     expect(script).toContain("function Exit-ArchGuard");
   });
 
-  test("renders the Archestra mark for the default brand, plain title when white-labeled", () => {
+  test("renders the Archestra mark for the default brand and its own variants, plain title when genuinely white-labeled", () => {
     const branded = renderClaudeCodeStartupGuardPowerShell(CTX);
     expect(branded).toContain("▟██▙");
     expect(branded).toContain("Secure access to your AI tools");
+
+    // an org named "Archestra Staging" is still Archestra's own brand — the
+    // mark must not disappear just because the name isn't an exact match
+    const variant = renderClaudeCodeStartupGuardPowerShell({
+      ...CTX,
+      appName: "Archestra Staging",
+    });
+    expect(variant).toContain("▟██▙");
+    expect(variant).toContain("'Archestra Staging'");
 
     const whiteLabel = renderClaudeCodeStartupGuardPowerShell({
       ...CTX,

--- a/platform/backend/src/services/claude-code-startup-guard.windows.ts
+++ b/platform/backend/src/services/claude-code-startup-guard.windows.ts
@@ -5,8 +5,8 @@ import {
   CLAUDE_CODE_GUARD_PS_SCRIPT_RELPATH,
   CLAUDE_CODE_GUARD_SKIP_RELPATH,
   CLAUDE_CODE_PROXY_ENV_KEYS,
-  DEFAULT_APP_NAME,
   EXTERNAL_AGENT_ID_HEADER,
+  isDefaultBrandedAppName,
   VIRTUAL_KEY_HEADER,
 } from "@archestra/shared";
 import {
@@ -776,11 +776,12 @@ function psq(value: string): string {
 }
 
 /**
- * The pre-loader header: the Archestra mark with the title beside it, only
- * for the default brand (same rule as the bash guard and the setup banner).
+ * The pre-loader header: the Archestra mark with the title beside it, for the
+ * default brand or one of its own variants (same rule as the bash guard and
+ * the setup banner).
  */
 function guardHeader(ctx: ClaudeCodeStartupGuardContext): string {
-  if (ctx.appName !== DEFAULT_APP_NAME) {
+  if (!isDefaultBrandedAppName(ctx.appName)) {
     return `Write-Arch $AppName Cyan
 Write-Host ''`;
   }

--- a/platform/backend/src/services/connection-setup-script.test.ts
+++ b/platform/backend/src/services/connection-setup-script.test.ts
@@ -996,6 +996,16 @@ describe("banner", () => {
     expect(branded).toContain("Configures:");
     expect(branded).toContain("one-time setup");
 
+    // an org named "Archestra Staging" is still Archestra's own brand — the
+    // mark must not disappear just because the name isn't an exact match
+    const variant = renderSetupScript({
+      ...fullContext("claude-code"),
+      appName: "Archestra Staging",
+    });
+    await expectValidBash(variant);
+    expect(variant).toContain("▟██▙");
+    expect(variant).toContain("Archestra Staging");
+
     const whiteLabel = renderSetupScript({
       ...fullContext("claude-code"),
       appName: "Acme AI",

--- a/platform/backend/src/services/connection-setup-script.ts
+++ b/platform/backend/src/services/connection-setup-script.ts
@@ -3,8 +3,8 @@ import {
   CLAUDE_CODE_CUSTOM_HEADERS_ENV_KEY,
   CLAUDE_CODE_PROXY_ENV_KEYS,
   CODEX_CLIENT_ID,
-  DEFAULT_APP_NAME,
   EXTERNAL_AGENT_ID_HEADER,
+  isDefaultBrandedAppName,
   type SupportedProvider,
   VIRTUAL_KEY_HEADER,
 } from "@archestra/shared";
@@ -296,9 +296,8 @@ function banner(ctx: SetupScriptContext): string {
   // A monospace rendition of the Archestra mark: a white tilted rounded bar
   // and dot on the terminal's dark field, echoing the real logo-icon.svg.
   // Block/quadrant glyphs (UTF-8) render as solid shapes in any modern terminal.
-  const logo =
-    ctx.appName === DEFAULT_APP_NAME
-      ? `   ╭──────────────────╮
+  const logo = isDefaultBrandedAppName(ctx.appName)
+    ? `   ╭──────────────────╮
    │                  │
    │        ▟██▙      │
    │        ████      │     ${ctx.appName}
@@ -307,7 +306,7 @@ function banner(ctx: SetupScriptContext): string {
    │      ▜██▛  ▜▛    │
    │                  │
    ╰──────────────────╯`
-      : `   ${ctx.appName}
+    : `   ${ctx.appName}
    Secure access to your AI tools`;
 
   const details = [

--- a/platform/backend/src/services/connection-setup-script.windows.ts
+++ b/platform/backend/src/services/connection-setup-script.windows.ts
@@ -2,8 +2,8 @@ import {
   CLAUDE_CODE_CLIENT_ID,
   CLAUDE_CODE_CUSTOM_HEADERS_ENV_KEY,
   CLAUDE_CODE_PROXY_ENV_KEYS,
-  DEFAULT_APP_NAME,
   EXTERNAL_AGENT_ID_HEADER,
+  isDefaultBrandedAppName,
   VIRTUAL_KEY_HEADER,
 } from "@archestra/shared";
 import type { ConnectionSetupClientId } from "@/types";
@@ -145,9 +145,8 @@ function banner(ctx: SetupScriptContext): string {
   // echoing logo-icon.svg. The built-in Windows PowerShell 5.1 console can
   // render block/quadrant Unicode glyphs as mojibake (legacy codepage), so this
   // mirrors the macOS/Linux block-mark's composition with portable ASCII only.
-  const logo =
-    ctx.appName === DEFAULT_APP_NAME
-      ? `   .------------------.
+  const logo = isDefaultBrandedAppName(ctx.appName)
+    ? `   .------------------.
    |                  |
    |        ,##.      |
    |        ####      |     ${ctx.appName}
@@ -156,7 +155,7 @@ function banner(ctx: SetupScriptContext): string {
    |       \`##' \`'    |
    |                  |
    '------------------'`
-      : `   ${ctx.appName}
+    : `   ${ctx.appName}
    Secure access to your AI tools`;
 
   const details = [

--- a/platform/shared/consts.test.ts
+++ b/platform/shared/consts.test.ts
@@ -3,6 +3,7 @@ import {
   ARCHESTRA_TOKEN_PREFIX,
   getArchestraTokenPrefix,
   hasArchestraTokenPrefix,
+  isDefaultBrandedAppName,
   isEditableTextFile,
   LEGACY_ARCHESTRA_TOKEN_PREFIXES,
 } from "./consts";
@@ -29,6 +30,20 @@ describe("token prefix helpers", () => {
   test("returns null for non-platform prefixes", () => {
     expect(getArchestraTokenPrefix("sk-abc123")).toBeNull();
     expect(hasArchestraTokenPrefix("sk-abc123")).toBe(false);
+  });
+});
+
+describe("isDefaultBrandedAppName", () => {
+  test("matches the default brand and its own variants", () => {
+    for (const name of ["Archestra", "Archestra Staging", "Archestra Dev"]) {
+      expect(isDefaultBrandedAppName(name)).toBe(true);
+    }
+  });
+
+  test("rejects a genuinely different white-labeled name", () => {
+    for (const name of ["Acme AI", "", "archestra", "MyArchestra"]) {
+      expect(isDefaultBrandedAppName(name)).toBe(false);
+    }
   });
 });
 

--- a/platform/shared/consts.ts
+++ b/platform/shared/consts.ts
@@ -5,6 +5,17 @@ export const DEFAULT_APP_DESCRIPTION =
   "Enterprise MCP-native Secure AI Platform";
 
 /**
+ * True for the default brand or one of its own variants (e.g. "Archestra
+ * Staging", "Archestra Dev") — never true for a genuinely different
+ * white-labeled name. Used to gate Archestra-only visuals, like the mark the
+ * Claude Code startup guard draws, that must never appear under someone
+ * else's brand.
+ */
+export function isDefaultBrandedAppName(appName: string): boolean {
+  return appName.startsWith(DEFAULT_APP_NAME);
+}
+
+/**
  * Prefix used for newly generated platform-managed tokens (team tokens, user
  * tokens, virtual API keys, API keys). Keep this branding-neutral.
  */


### PR DESCRIPTION
The guard's pre-loader and the connect script's own banner both checked appName === "Archestra" exactly, so an org configured with a variant like "Archestra Staging" fell into the white-label branch and lost the mark entirely — the same brand, just a longer name. Add a shared isDefaultBrandedAppName() (prefix match) in shared/consts.ts and use it everywhere the mark's visibility is decided, so it shows for any name starting with the default brand while still hiding for a genuinely different white-labeled name.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>