### PR TITLE
fix(sidebar): gate the apps query behind app:read

### DIFF
--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -180,8 +180,7 @@ export function ChatSidebarSection({
   const pinProjectMutation = usePinProject();
   const pinnedProjects = (projectsData ?? []).filter((p) => p.pinnedAt);
   // Pinned apps join the sidebar's Pinned section exactly like pinned projects.
-  // /api/apps is access-filtered (returns the caller's accessible apps), so it
-  // needs no permission gate.
+  // useApps skips the request for roles without app:read.
   const { data: appsData } = useApps({ limit: 100, offset: 0 });
   const pinAppMutation = usePinApp();
   const openAppMutation = useOpenAppInChat();

--- a/platform/frontend/src/lib/app.query.test.ts
+++ b/platform/frontend/src/lib/app.query.test.ts
@@ -3,7 +3,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { usePinApp } from "@/lib/app.query";
+import { useApps, usePinApp } from "@/lib/app.query";
+import { useHasPermissions } from "@/lib/auth/auth.query";
+
+vi.mock("@/lib/auth/auth.query");
 
 vi.mock("@archestra/shared", () => ({
   archestraApiSdk: {
@@ -82,6 +85,77 @@ const pinnedOf = (queryClient: QueryClient, key: unknown[]) =>
       data: Array<{ pinnedAt: string | null }>;
     }
   ).data.map((app) => app.pinnedAt);
+
+describe("useApps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderApps(options?: Parameters<typeof useApps>[1]) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    return renderHook(() => useApps({ limit: 100, offset: 0 }, options), {
+      wrapper,
+    });
+  }
+
+  it("does not request apps for a role without app:read", async () => {
+    vi.mocked(useHasPermissions).mockReturnValue({ data: false } as never);
+    vi.mocked(archestraApiSdk.getApps).mockResolvedValue({
+      error: undefined,
+      data: listResponse([]),
+    } as never);
+
+    renderApps();
+
+    // Flush a macrotask so a wrongly-enabled query would have fired.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(vi.mocked(archestraApiSdk.getApps)).not.toHaveBeenCalled();
+  });
+
+  it("does not request apps while permissions are still loading", async () => {
+    vi.mocked(useHasPermissions).mockReturnValue({ data: undefined } as never);
+    vi.mocked(archestraApiSdk.getApps).mockResolvedValue({
+      error: undefined,
+      data: listResponse([]),
+    } as never);
+
+    renderApps();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(vi.mocked(archestraApiSdk.getApps)).not.toHaveBeenCalled();
+  });
+
+  it("keeps a caller's enabled:false even when the role has app:read", async () => {
+    vi.mocked(useHasPermissions).mockReturnValue({ data: true } as never);
+    vi.mocked(archestraApiSdk.getApps).mockResolvedValue({
+      error: undefined,
+      data: listResponse([]),
+    } as never);
+
+    renderApps({ enabled: false });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(vi.mocked(archestraApiSdk.getApps)).not.toHaveBeenCalled();
+  });
+
+  it("fetches apps for a role with app:read", async () => {
+    vi.mocked(useHasPermissions).mockReturnValue({ data: true } as never);
+    vi.mocked(archestraApiSdk.getApps).mockResolvedValue({
+      error: undefined,
+      data: listResponse([ownedApp(null)]),
+    } as never);
+
+    const { result } = renderApps();
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual(listResponse([ownedApp(null)])),
+    );
+  });
+});
 
 describe("usePinApp", () => {
   beforeEach(() => {

--- a/platform/frontend/src/lib/app.query.ts
+++ b/platform/frontend/src/lib/app.query.ts
@@ -1,6 +1,7 @@
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { useHasPermissions } from "@/lib/auth/auth.query";
 import { handleApiError, throwOnApiError } from "@/lib/utils";
 
 const {
@@ -38,9 +39,12 @@ export function useApps(
   options?: { enabled?: boolean; toastOnError?: boolean },
 ) {
   const toastOnError = options?.toastOnError;
+  // The endpoint requires app:read; skip the request for users whose role
+  // lacks it (e.g. the chat sidebar mounts this for everyone) instead of 403ing.
+  const { data: canReadApps } = useHasPermissions({ app: ["read"] });
   return useQuery({
     queryKey: ["apps", "paginated", params],
-    enabled: options?.enabled ?? true,
+    enabled: (options?.enabled ?? true) && !!canReadApps,
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const { data, error } = await getApps({ query: params });


### PR DESCRIPTION
## Summary

For users whose custom role lacks `app:read`, every chat page popped a red error toast — *"You don't have permission to get apps. Missing permission: app:read…"* — because the shared chat sidebar fetches `GET /api/apps` (for its pinned-apps section) unconditionally, while the endpoint requires `app:read`. The toast names a permission unrelated to anything the user did, and it recently misdirected a bug report: a user blocked from `/chat` by a role missing `chat:read` blamed the Apps permission, because the apps toast was the only permission named on screen.

`useApps` now disables its query for callers without `app:read` — the same in-hook gate `useProjects` uses (#5802 follow-up `ad3466136` fixed this identically for projects; apps was missed). Restricted roles no longer fire the doomed request or see the toast; pinned apps simply don't render, which is what their permissions mean. Permitted users are unaffected. The stale comment at the sidebar call site claiming `/api/apps` "needs no permission gate" is corrected.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>