### PR TITLE
fix(mcp-server): honor target userId for personal installs

### DIFF
--- a/platform/backend/src/routes/mcp-server.install-target-user.test.ts
+++ b/platform/backend/src/routes/mcp-server.install-target-user.test.ts
@@ -196,6 +196,13 @@ describe("MCP Server Install - explicit target user", () => {
       await makeMember(admin.id, organizationId);
       await makeMember(target.id, organizationId);
       const catalog = await makeOrgCatalog(makeInternalMcpCatalog, admin.id);
+      connectAndGetToolsMock.mockResolvedValue([
+        {
+          name: "list_items",
+          description: "",
+          inputSchema: { type: "object" },
+        },
+      ]);
 
       currentUser = admin;
       const first = await install({
@@ -213,6 +220,26 @@ describe("MCP Server Install - explicit target user", () => {
       expect(second.statusCode).toBe(200);
       expect(second.json().id).toBe(first.json().id);
       expect(second.json().ownerId).toBe(target.id);
+
+      // The duplicate-return branch re-assigns catalog tools; they must land
+      // on the target's gateway (idempotently), never the caller's.
+      const targetGateway = await AgentModel.getPersonalMcpGateway(
+        target.id,
+        organizationId,
+      );
+      if (!targetGateway) throw new Error("target gateway was not created");
+      expect(
+        await AgentToolModel.findToolIdsByAgent(targetGateway.id),
+      ).toHaveLength(1);
+      const callerGateway = await AgentModel.getPersonalMcpGateway(
+        admin.id,
+        organizationId,
+      );
+      if (callerGateway) {
+        expect(
+          await AgentToolModel.findToolIdsByAgent(callerGateway.id),
+        ).toHaveLength(0);
+      }
     });
 
     test("a non-admin caller targeting another user gets 403 and no install is created", async ({

--- a/platform/backend/src/routes/mcp-server.install-target-user.test.ts
+++ b/platform/backend/src/routes/mcp-server.install-target-user.test.ts
@@ -1,0 +1,364 @@
+import { vi } from "vitest";
+import { hasPermission, userHasPermission } from "@/auth/utils";
+import { AgentModel, AgentToolModel, McpServerModel } from "@/models";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+const { connectAndGetToolsMock } = vi.hoisted(() => ({
+  connectAndGetToolsMock: vi.fn(),
+}));
+
+vi.mock("@/clients/mcp-client", () => ({
+  McpServerNotReadyError: class extends Error {},
+  McpServerConnectionTimeoutError: class extends Error {},
+  default: {
+    connectAndGetTools: connectAndGetToolsMock,
+    invalidateConnectionsForServer: vi.fn(),
+    inspectServer: vi.fn(),
+  },
+}));
+
+vi.mock("@/auth/utils");
+
+const hasPermissionMock = vi.mocked(hasPermission);
+const userHasPermissionMock = vi.mocked(userHasPermission);
+
+/**
+ * Admin pre-provisioning of a personal install for another user: a request
+ * with `scope: "personal"` and an explicit `userId` must create (or return)
+ * the install owned by that target user, not by the authenticated caller.
+ */
+describe("MCP Server Install - explicit target user", () => {
+  let app: FastifyInstanceWithZod;
+  let currentUser: User;
+  let organizationId: string;
+
+  beforeEach(async ({ makeOrganization }) => {
+    vi.clearAllMocks();
+    // Caller passes every permission gate unless a test narrows it.
+    hasPermissionMock.mockResolvedValue({ success: true, error: null });
+    userHasPermissionMock.mockResolvedValue(true);
+    connectAndGetToolsMock.mockResolvedValue([]);
+
+    organizationId = (await makeOrganization()).id;
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (request as typeof request & { user: User }).user = currentUser;
+      (request as typeof request & { organizationId: string }).organizationId =
+        organizationId;
+    });
+
+    const { default: mcpServerRoutes } = await import("./mcp-server");
+    await app.register(mcpServerRoutes);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  function install(payload: Record<string, unknown>) {
+    return app.inject({
+      method: "POST",
+      url: "/api/mcp_server",
+      // `name` is overwritten from the catalog row; the schema still requires it.
+      payload: { name: "install", serverType: "remote", ...payload },
+    });
+  }
+
+  async function makeOrgCatalog(
+    makeInternalMcpCatalog: (
+      overrides: Record<string, unknown>,
+    ) => Promise<{ id: string }>,
+    authorId: string,
+  ) {
+    return makeInternalMcpCatalog({
+      organizationId,
+      authorId,
+      scope: "org",
+      serverType: "remote",
+      serverUrl: "https://example.test/mcp",
+    });
+  }
+
+  describe("installing for another user", () => {
+    test("admin installing with userId creates the personal install for the target user", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const admin = await makeUser();
+      const target = await makeUser();
+      await makeMember(admin.id, organizationId);
+      await makeMember(target.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, admin.id);
+
+      currentUser = admin;
+      const res = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+        userId: target.id,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.scope).toBe("personal");
+      expect(body.ownerId).toBe(target.id);
+      expect(body.users).toContain(target.id);
+    });
+
+    test("discovered tools are assigned to the target user's personal gateway, not the caller's", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const admin = await makeUser();
+      const target = await makeUser();
+      await makeMember(admin.id, organizationId);
+      await makeMember(target.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, admin.id);
+      connectAndGetToolsMock.mockResolvedValue([
+        {
+          name: "list_items",
+          description: "",
+          inputSchema: { type: "object" },
+        },
+      ]);
+
+      currentUser = admin;
+      const res = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+        userId: target.id,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const targetGateway = await AgentModel.getPersonalMcpGateway(
+        target.id,
+        organizationId,
+      );
+      if (!targetGateway) throw new Error("target gateway was not created");
+      expect(
+        await AgentToolModel.findToolIdsByAgent(targetGateway.id),
+      ).toHaveLength(1);
+
+      const callerGateway = await AgentModel.getPersonalMcpGateway(
+        admin.id,
+        organizationId,
+      );
+      if (callerGateway) {
+        expect(
+          await AgentToolModel.findToolIdsByAgent(callerGateway.id),
+        ).toHaveLength(0);
+      }
+    });
+
+    test("admin's own personal install does not shadow an install requested for another user", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const admin = await makeUser();
+      const target = await makeUser();
+      await makeMember(admin.id, organizationId);
+      await makeMember(target.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, admin.id);
+
+      currentUser = admin;
+      const own = await install({ catalogId: catalog.id, scope: "personal" });
+      expect(own.statusCode).toBe(200);
+      expect(own.json().ownerId).toBe(admin.id);
+
+      // Duplicate detection must key on the effective target user, not the
+      // caller — the admin's own install is not a duplicate of the target's.
+      const forTarget = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+        userId: target.id,
+      });
+
+      expect(forTarget.statusCode).toBe(200);
+      const body = forTarget.json();
+      expect(body.id).not.toBe(own.json().id);
+      expect(body.ownerId).toBe(target.id);
+    });
+
+    test("repeat install for the same target user idempotently returns the target's existing install", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const admin = await makeUser();
+      const target = await makeUser();
+      await makeMember(admin.id, organizationId);
+      await makeMember(target.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, admin.id);
+
+      currentUser = admin;
+      const first = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+        userId: target.id,
+      });
+      expect(first.statusCode).toBe(200);
+
+      const second = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+        userId: target.id,
+      });
+      expect(second.statusCode).toBe(200);
+      expect(second.json().id).toBe(first.json().id);
+      expect(second.json().ownerId).toBe(target.id);
+    });
+
+    test("a non-admin caller targeting another user gets 403 and no install is created", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const caller = await makeUser();
+      const target = await makeUser();
+      await makeMember(caller.id, organizationId);
+      await makeMember(target.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, caller.id);
+      hasPermissionMock.mockResolvedValue({ success: false, error: null });
+      userHasPermissionMock.mockResolvedValue(false);
+
+      currentUser = caller;
+      const res = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+        userId: target.id,
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(await McpServerModel.findByCatalogId(catalog.id)).toHaveLength(0);
+    });
+
+    test("a non-admin caller may pass their own id explicitly", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const caller = await makeUser();
+      await makeMember(caller.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, caller.id);
+      hasPermissionMock.mockResolvedValue({ success: false, error: null });
+      userHasPermissionMock.mockResolvedValue(false);
+
+      currentUser = caller;
+      const res = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+        userId: caller.id,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().ownerId).toBe(caller.id);
+    });
+
+    test("a target userId with a non-personal scope is rejected", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const admin = await makeUser();
+      const target = await makeUser();
+      await makeMember(admin.id, organizationId);
+      await makeMember(target.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, admin.id);
+
+      currentUser = admin;
+      const res = await install({
+        catalogId: catalog.id,
+        scope: "org",
+        userId: target.id,
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    test("a target user outside the organization is rejected", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const admin = await makeUser();
+      const outsider = await makeUser();
+      await makeMember(admin.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, admin.id);
+
+      currentUser = admin;
+      const res = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+        userId: outsider.id,
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(await McpServerModel.findByCatalogId(catalog.id)).toHaveLength(0);
+    });
+  });
+
+  describe("installing for oneself (unchanged behavior)", () => {
+    test("a personal install without userId is owned by the caller and feeds the caller's gateway", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const caller = await makeUser();
+      await makeMember(caller.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, caller.id);
+      connectAndGetToolsMock.mockResolvedValue([
+        {
+          name: "list_items",
+          description: "",
+          inputSchema: { type: "object" },
+        },
+      ]);
+
+      currentUser = caller;
+      const res = await install({ catalogId: catalog.id, scope: "personal" });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.ownerId).toBe(caller.id);
+      expect(body.users).toContain(caller.id);
+
+      const gateway = await AgentModel.getPersonalMcpGateway(
+        caller.id,
+        organizationId,
+      );
+      if (!gateway) throw new Error("caller gateway was not created");
+      expect(await AgentToolModel.findToolIdsByAgent(gateway.id)).toHaveLength(
+        1,
+      );
+    });
+
+    test("repeating a personal install without userId returns the caller's existing install", async ({
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+    }) => {
+      const caller = await makeUser();
+      await makeMember(caller.id, organizationId);
+      const catalog = await makeOrgCatalog(makeInternalMcpCatalog, caller.id);
+
+      currentUser = caller;
+      const first = await install({ catalogId: catalog.id, scope: "personal" });
+      expect(first.statusCode).toBe(200);
+
+      const second = await install({
+        catalogId: catalog.id,
+        scope: "personal",
+      });
+      expect(second.statusCode).toBe(200);
+      expect(second.json().id).toBe(first.json().id);
+      expect(second.json().ownerId).toBe(caller.id);
+    });
+  });
+});

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -23,6 +23,7 @@ import {
   AgentToolModel,
   InternalMcpCatalogModel,
   McpServerModel,
+  MemberModel,
   TeamModel,
   ToolModel,
 } from "@/models";
@@ -193,9 +194,34 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         serverType: "local",
       };
 
-      // Set owner_id and userId to current user
-      serverData.ownerId = user.id;
-      serverData.userId = user.id;
+      // Personal installs may be pre-provisioned for another user by an
+      // installation admin; everyone else installs for themselves.
+      const requestedUserId = serverData.userId;
+      let targetUserId = user.id;
+      if (requestedUserId && requestedUserId !== user.id) {
+        if (serverData.scope !== "personal") {
+          throw new ApiError(
+            400,
+            "userId can only be provided for personal-scoped installations",
+          );
+        }
+        const { success: canInstallForOthers } = await hasPermission(
+          { mcpServerInstallation: ["admin"] },
+          headers,
+        );
+        if (!canInstallForOthers) {
+          throw new ApiError(
+            403,
+            "You don't have permission to install MCP servers for other users",
+          );
+        }
+        if (!(await MemberModel.getByUserId(requestedUserId, organizationId))) {
+          throw new ApiError(404, "Target user not found in this organization");
+        }
+        targetUserId = requestedUserId;
+      }
+      serverData.ownerId = targetUserId;
+      serverData.userId = targetUserId;
 
       // Track if we created a new secret (for cleanup on failure)
       let createdSecretId: string | undefined;
@@ -300,7 +326,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         // Return existing server instead of erroring (idempotent behavior)
         if (serverData.scope === "personal") {
           const existingPersonal = existingServers.find(
-            (s) => s.scope === "personal" && s.ownerId === user.id,
+            (s) => s.scope === "personal" && s.ownerId === targetUserId,
           );
           if (existingPersonal) {
             const catalogTools = await ToolModel.findByCatalogId(
@@ -310,7 +336,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             if (toolIds.length > 0) {
               const personalGateway = await AgentModel.ensurePersonalMcpGateway(
                 {
-                  userId: user.id,
+                  userId: targetUserId,
                   organizationId,
                 },
               );
@@ -858,7 +884,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     if (!mcpServer.teamId) {
                       const personalGateway =
                         await AgentModel.ensurePersonalMcpGateway({
-                          userId: user.id,
+                          userId: targetUserId,
                           organizationId,
                         });
                       targetAgentIds.push(personalGateway.id);
@@ -1020,7 +1046,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
             if (!mcpServer.teamId) {
               const personalGateway = await AgentModel.ensurePersonalMcpGateway(
                 {
-                  userId: user.id,
+                  userId: targetUserId,
                   organizationId,
                 },
               );


### PR DESCRIPTION
## Summary

`POST /api/mcp_server` accepted a `userId` field in its schema but overwrote it with the authenticated caller's id, so an admin could not pre-provision a personal MCP server for another user: the install silently landed on the admin's own account, or — when the admin already had a personal install of the same catalog item — idempotently returned the admin's install while provisioning nothing for the target. This blocked the Terraform provider's admin workflow of installing servers on behalf of users.

The route now resolves an effective target user. Targeting another user requires `scope: "personal"`, the `mcpServerInstallation:admin` permission (403 otherwise), and the target being a member of the organization (404 otherwise); non-personal scopes reject a foreign `userId` with 400. Ownership (`ownerId`, `mcp_server_user`), duplicate-install detection, and personal-gateway tool assignment all key on the target user. Requests that omit `userId` (or pass the caller's own id) behave exactly as before, with no new permission requirement.

Tool discovery deliberately keeps using the installer's credentials, mirroring shared enterprise-managed installs: the target typically hasn't linked their IdP yet at pre-provisioning time, and runtime tool calls exchange each caller's own token.

Fixes #4452

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>