### PR TITLE
fix(mcp-catalog): save remote catalog edits directly instead of showing the restart confirm bar

### DIFF
--- a/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.test.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.test.ts
@@ -44,8 +44,12 @@ describe("cascade scenarios — frontend full-outcome sweep", () => {
       affectedServerCount: 1,
     });
 
+    // `frontendBar` is a permanent, by-design divergence from the
+    // backend path; `knownFrontendOverride` is a temporary bug marker.
     const frontendExpected =
-      scenario.knownFrontendOverride?.actual ?? scenario.expected;
+      scenario.frontendBar ??
+      scenario.knownFrontendOverride?.actual ??
+      scenario.expected;
     expect(outcome.mode).toBe(frontendExpected);
     // None of the matrix scenarios rename — the rename decisions have
     // their own describe below.
@@ -118,6 +122,91 @@ describe("computeCascadeOutcome — rename decisions", () => {
         affectedServerCount: 0,
       }),
     ).toEqual({ mode: "skip", renamed: true });
+  });
+});
+
+describe("computeCascadeOutcome — remote auto path saves without a bar", () => {
+  const remote = (over: Partial<CascadeSnapshot> = {}): CascadeSnapshot => ({
+    name: "linear",
+    serverType: "remote",
+    serverUrl: "https://api.example.com/mcp",
+    oauthConfig: { clientId: "abc", scopes: ["read"] },
+    userConfig: {},
+    ...over,
+  });
+
+  test("serverUrl change → 'skip' (backend re-syncs tools in the background; nothing restarts)", () => {
+    expect(
+      computeCascadeOutcome(
+        remote(),
+        remote({ serverUrl: "https://api.example.com/mcp/v2" }),
+        { affectedServerCount: 3 },
+      ),
+    ).toEqual({ mode: "skip", renamed: false });
+  });
+
+  test("oauthConfig content change (OAuth present on both sides) → 'skip'", () => {
+    expect(
+      computeCascadeOutcome(
+        remote(),
+        remote({
+          oauthConfig: {
+            clientId: "abc",
+            scopes: ["read"],
+            protectedResource: "https://api.example.com",
+          },
+        }),
+        { affectedServerCount: 1 },
+      ),
+    ).toEqual({ mode: "skip", renamed: false });
+  });
+
+  test("breaking change + rename → 'rename' (clients must still reload renamed tools)", () => {
+    expect(
+      computeCascadeOutcome(
+        remote(),
+        remote({
+          name: "linear-v2",
+          serverUrl: "https://api.example.com/mcp/v2",
+        }),
+        { affectedServerCount: 2 },
+      ),
+    ).toEqual({ mode: "rename", renamed: true });
+  });
+});
+
+describe("computeCascadeOutcome — remote manual paths survive the no-bar auto rule", () => {
+  const remote = (over: Partial<CascadeSnapshot> = {}): CascadeSnapshot => ({
+    name: "linear",
+    serverType: "remote",
+    serverUrl: "https://api.example.com/mcp",
+    oauthConfig: null,
+    userConfig: {},
+    ...over,
+  });
+
+  test("OAuth added → 'manual' (auth model flips; installs must re-authenticate)", () => {
+    expect(
+      computeCascadeOutcome(
+        remote(),
+        remote({ oauthConfig: { clientId: "abc" } }),
+        { affectedServerCount: 1 },
+      ).mode,
+    ).toBe("manual");
+  });
+
+  test("required userConfig field added → 'manual' (install must supply a value)", () => {
+    expect(
+      computeCascadeOutcome(
+        remote(),
+        remote({
+          userConfig: {
+            api_key: { type: "string", required: true },
+          },
+        }),
+        { affectedServerCount: 1 },
+      ).mode,
+    ).toBe("manual");
   });
 });
 
@@ -640,7 +729,7 @@ describe("API-shape prev vs transform-shape next — shape-mismatch regression",
     ).toBe("skip");
   });
 
-  test("serverUrl edit still triggers auto (sanity check the projection isn't too loose)", () => {
+  test("serverUrl edit on this remote catalog → 'skip' (breaking diff detected, but remote saves without a bar)", () => {
     const transformedNext: CascadeSnapshot = {
       name: "Test1",
       description: "old description",
@@ -657,6 +746,44 @@ describe("API-shape prev vs transform-shape next — shape-mismatch regression",
     };
     expect(
       computeCascadeOutcome(apiPrev, transformedNext, {
+        affectedServerCount: 3,
+      }).mode,
+    ).toBe("skip");
+  });
+
+  test("envFrom edit on a local catalog still triggers auto (sanity check the projection isn't too loose)", () => {
+    const localPrev = {
+      ...apiPrev,
+      serverType: "local",
+      serverUrl: null,
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [],
+        envFrom: [],
+      },
+    } as unknown as CascadeSnapshot;
+    const transformedNext: CascadeSnapshot = {
+      name: "Test1",
+      description: "old description",
+      serverType: "local",
+      multitenant: false,
+      serverUrl: null,
+      authMethod: "none",
+      authHeaderName: "",
+      includeBearerPrefix: false,
+      oauthConfig: null,
+      enterpriseManagedConfig: null,
+      localConfig: {
+        command: "node",
+        arguments: ["server.js"],
+        environment: [],
+        envFrom: [{ type: "secret", name: "shared-creds" }],
+      },
+      userConfig: {},
+    };
+    expect(
+      computeCascadeOutcome(localPrev, transformedNext, {
         affectedServerCount: 3,
       }).mode,
     ).toBe("auto");

--- a/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.ts
@@ -16,7 +16,11 @@
  *      "manual" when the catalog's deploymentSpecYaml references the
  *      serverName placeholder (the one way the display name reaches a
  *      pod spec, so those installs genuinely need a reinstall).
- *   4. Otherwise → "auto" (breaking change with no re-prompt needed)
+ *   4. Otherwise → "auto" (breaking change with no re-prompt needed).
+ *      Remote catalogs don't pause here: the backend cascade restarts
+ *      nothing for them (no pod — it only re-syncs tools), so the form
+ *      saves directly ("skip"), or shows "rename" when a rename rides
+ *      along.
  *
  * `renamed` rides along with the mode so the confirm bar can append the
  * MCP-client tool-list reload warning even when a rename composes with
@@ -24,7 +28,10 @@
  *
  * If this diverges from the backend gate, the scenario matrix's
  * frontend + backend sweeps will disagree. That's the contract — fix
- * either the code or the scenario, not the test.
+ * either the code or the scenario, not the test. The one by-design
+ * divergence is the remote auto path above: the backend still runs its
+ * background cascade, but the form shows no bar. Scenarios encode it
+ * via `frontendBar`.
  */
 
 import { SERVER_NAME_PLACEHOLDER } from "@archestra/shared";
@@ -143,9 +150,17 @@ export function computeCascadeOutcome(
 
   // ── Auto ─────────────────────────────────────────────────────────
   // A breaking diff exists but doesn't need a user re-prompt. The
-  // backend will fire its setImmediate background restart (which also
+  // backend will fire its setImmediate background cascade (which also
   // regenerates a placeholder-bearing YAML with the new name, so a
-  // combined rename needs no extra flag here).
+  // combined rename needs no extra flag here). For local servers that
+  // cascade restarts pods — a disruption worth a confirm bar. A remote
+  // server has no pod: the backend only re-syncs tools and nothing
+  // goes offline, so there is nothing to confirm — save directly,
+  // unless a rename rides along (connected clients must still reload
+  // the renamed tools).
+  if ((next.serverType ?? prev.serverType) === "remote") {
+    return { mode: renamed ? "rename" : "skip", renamed };
+  }
   return { mode: "auto", renamed };
 }
 

--- a/platform/shared/cascade-scenarios.ts
+++ b/platform/shared/cascade-scenarios.ts
@@ -59,8 +59,11 @@ export type CascadeOutcome =
    *  old config. Bar shows "Reinstall required" / "Save and mark for
    *  reinstall". */
   | "manual"
-  /** Backend immediately restarts pods. Bar shows "Servers will
-   *  reinstall" / "Save and reinstall". */
+  /** Backend cascades immediately in the background: local servers get
+   *  a pod restart; remote servers just get a tool re-sync (no pod, so
+   *  nothing goes offline). Bar shows "Restart N installs now?" /
+   *  "Save and restart" for local; remote saves without a bar — the
+   *  scenario carries that via `frontendBar`. */
   | "auto";
 
 /** What the shared `isMetadataOnlyEdit` predicate should return for
@@ -104,6 +107,12 @@ export interface CascadeScenario {
     actual: CascadeOutcome;
     issue: string;
   };
+  /** Intentional, permanent frontend divergence — NOT a bug marker.
+   *  The backend still enacts `expected`; the confirm bar behaves as
+   *  this value instead. Sole current use: remote catalogs on the auto
+   *  path save without a bar ("skip") because the background cascade
+   *  restarts nothing for them. */
+  frontendBar?: CascadeOutcome;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -560,6 +569,18 @@ export const CASCADE_SCENARIOS: CascadeScenario[] = [
     sharedPredicate: "non-metadata-diff",
     rationale:
       "For a static header-mapped userConfig entry (no install prompt), the form writes the admin's value into `userConfig[field].default` — that IS the runtime header sent on the wire. Changing it means installs would keep sending the old value until pods restart. The auto path is correct (no re-prompt needed; admin already provided the value). Caught by `userConfigChangedBreakingly` on both sides. Distinct from prompted headers where `default` is just a placeholder.",
+  },
+
+  {
+    id: "server-url-change-remote",
+    shape: "test1RemoteOAuthBag",
+    userAction: "Admin changes the server URL on a remote OAuth catalog",
+    edit: (base) => ({ ...base, serverUrl: "https://example.test/mcp/v2" }),
+    expected: "auto",
+    frontendBar: "skip",
+    sharedPredicate: "non-metadata-diff",
+    rationale:
+      "Auth is untouched, so existing installs stay valid — the backend applies the change and re-syncs tools in the background (auto). But a remote server has no pod: nothing restarts or goes offline, so the form saves without a confirm bar. A restart warning here would describe an event that never happens.",
   },
 
   // ── identity / nothing-changed sanity ─────────────────────────────


### PR DESCRIPTION
## Summary

Editing a remote MCP catalog's non-auth config (server URL, OAuth endpoint overrides, header values) showed the confirm bar "Restart N installs now? Each will briefly go offline… / Save and restart". That copy is false for remote servers: the backend's auto cascade (`autoReinstallServer`) only restarts pods for `serverType === "local"` — for remote it just re-syncs tools, and nothing goes offline. The bar made admins pause to approve a restart that never happens.

Since the auto path has no disruptive consequence for remote servers, there is nothing to confirm: `computeCascadeOutcome` now routes remote auto-path edits to a direct save (same as metadata-only edits), or to the existing rename bar when a rename rides along — that warning stays real because connected MCP clients must reload renamed tools. Local catalogs, the manual-reinstall path (OAuth added/removed, required userConfig changes), and the backend gate are unchanged: the background cascade still fires; only the UI pause is gone.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>