### PR TITLE
fix(chat): keep markdown tables readable in themed message bubbles

### DIFF
--- a/platform/frontend/src/components/ai-elements/response.test.ts
+++ b/platform/frontend/src/components/ai-elements/response.test.ts
@@ -60,6 +60,58 @@ describe("isSameOriginUrl", () => {
   });
 });
 
+const TABLE_MARKDOWN = "| a | b |\n| --- | --- |\n| 1 | 2 |";
+
+describe("Response markdown tables", () => {
+  // Streamdown paints table-wrapper with an opaque bg-sidebar mat that clashes
+  // with themed chat bubbles (bg-secondary), and ignores its className prop, so
+  // Response must flatten it via descendant overrides on the root. Guards both
+  // sides of that contract: the override classes, and the data-streamdown
+  // attribute + mat class they target (either can drift on a streamdown upgrade).
+  it("flattens streamdown's opaque table-wrapper mat", () => {
+    const { container } = renderResponse(TABLE_MARKDOWN);
+    const wrapper = container.querySelector(
+      '[data-streamdown="table-wrapper"]',
+    );
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain("bg-sidebar");
+
+    const root = container.firstElementChild;
+    expect(root?.className).toContain(
+      "[&_[data-streamdown='table-wrapper']]:bg-transparent",
+    );
+    expect(root?.className).toContain(
+      "[&_[data-streamdown='table-wrapper']]:border-0",
+    );
+    expect(root?.className).toContain(
+      "[&_[data-streamdown='table-wrapper']]:p-0",
+    );
+    // The toolbar loses its mat backdrop, so its buttons must inherit the
+    // bubble's paired text color to stay visible on bg-secondary.
+    expect(root?.className).toContain(
+      "[&_[data-streamdown='table-wrapper']_button]:text-inherit",
+    );
+    // Opaque bg-background surfaces inside the wrapper must re-pair with
+    // text-foreground, not the bubble's inherited secondary-foreground.
+    expect(root?.className).toContain(
+      "[&_[data-streamdown='table-wrapper']_.bg-background]:text-foreground",
+    );
+  });
+
+  it("keeps the table scroll cap and sticky header overrides", () => {
+    const { container } = renderResponse(TABLE_MARKDOWN);
+    expect(container.querySelector('[data-streamdown="table"]')).not.toBeNull();
+
+    const root = container.firstElementChild;
+    expect(root?.className).toContain(
+      "[&_[data-streamdown='table-wrapper']>div:last-child]:max-h-[420px]",
+    );
+    expect(root?.className).toContain(
+      "[&_[data-streamdown='table-header']]:sticky",
+    );
+  });
+});
+
 // Renders through the real Streamdown pipeline (including rehype-harden), so it
 // verifies the repair runs before harden — harden would otherwise drop a
 // slash-less relative link and it would never reach an <a href>.

--- a/platform/frontend/src/components/ai-elements/response.tsx
+++ b/platform/frontend/src/components/ai-elements/response.tsx
@@ -101,6 +101,20 @@ export const Response = memo(
           "[&_pre]:bg-muted [&_pre]:p-3 [&_pre]:rounded [&_pre]:my-2 [&_pre]:overflow-x-auto",
           // Fix streamdown code blocks - remove padding from code elements inside them
           "[&_[data-streamdown='code-block']_code]:p-0 [&_[data-streamdown='code-block']_code]:bg-transparent",
+          // Streamdown mats tables in an opaque bg-sidebar card (and ignores its
+          // className prop), which clashes with themed message bubbles
+          // (bg-secondary); flatten the mat so the bubble shows through and only
+          // the inner bg-background table card stays.
+          "[&_[data-streamdown='table-wrapper']]:bg-transparent [&_[data-streamdown='table-wrapper']]:border-0 [&_[data-streamdown='table-wrapper']]:p-0",
+          // With the mat gone the toolbar sits on the bubble itself, where
+          // text-muted-foreground can vanish (theme-twitter's secondary equals
+          // muted-foreground); inherit the bubble's paired text color instead.
+          "[&_[data-streamdown='table-wrapper']_button]:text-inherit",
+          // Text inside the wrapper otherwise inherits the bubble's
+          // secondary-foreground, which is unreadable on the opaque
+          // bg-background surfaces (table card, copy-menu panel) in themes with
+          // a dark secondary; re-pair those surfaces with text-foreground.
+          "[&_[data-streamdown='table-wrapper']_.bg-background]:text-foreground",
           // Keep large markdown tables readable without letting them dominate the chat scroll.
           "[&_[data-streamdown='table-wrapper']>div:last-child]:max-h-[420px]",
           "[&_[data-streamdown='table-header']]:sticky [&_[data-streamdown='table-header']]:top-0 [&_[data-streamdown='table-header']]:z-10",


### PR DESCRIPTION
## Summary

Markdown tables in chat replies rendered with clashing colors under non-neutral white-label themes. Streamdown wraps every table in an opaque `bg-sidebar` mat and ignores its `className` prop, so inside the themed `bg-secondary` assistant bubble the mat showed as a saturated double ring around the table (e.g. the caffeine theme's peach). Worse, everything inside the wrapper inherited the bubble's `text-secondary-foreground`, so in themes with a dark secondary (e.g. Twitter light) the table text and the copy-menu items rendered white-on-white — invisible — and the toolbar icons' `text-muted-foreground` matched the bubble color exactly.

`Response` now re-pairs each surface with its theme token via descendant overrides (the same idiom already used there for link colors): the wrapper mat is flattened to transparent so the bubble frames the table card directly, toolbar buttons inherit the bubble's paired foreground, and the wrapper's opaque `bg-background` surfaces (table card, copy-menu panel) reset to `text-foreground`. Neutral default themes look effectively unchanged; every theme keeps token-pair contrast. The sticky header and 420px scroll cap for large tables are unaffected — the inner card stays opaque.

## Screenshots

Before/After

<img width="368" height="319" alt="image" src="https://github.com/user-attachments/assets/c72cc755-9933-450a-a11a-7785521b1abb" />

<img width="350" height="311" alt="image" src="https://github.com/user-attachments/assets/bbc15536-41c2-49fc-9ce6-a179da7766ee" />


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>