### PR TITLE
fix(onboarding): make first-login survey scroll so Send stays reachable

### DIFF
--- a/platform/frontend/src/components/onboarding-survey-dialog.test.tsx
+++ b/platform/frontend/src/components/onboarding-survey-dialog.test.tsx
@@ -125,6 +125,23 @@ describe("OnboardingSurveyDialog", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
+  it("puts the questions in a scroll region so the Send button never clips on short viewports", () => {
+    // The dialog is non-dismissible and capped at max-h-[90dvh]; without an
+    // internal scroll region the Send button clips off-screen on short
+    // viewports, leaving the admin stuck. jsdom can't measure layout, so we
+    // pin the structural contract: the questions scroll, Send stays pinned.
+    render(<OnboardingSurveyDialog />);
+
+    const scrollRegion = screen
+      .getByRole("button", { name: "Software engineer" })
+      .closest(".overflow-y-auto");
+    expect(scrollRegion).not.toBeNull();
+
+    // The Send button lives in a pinned footer, outside the scroll region.
+    const send = screen.getByRole("button", { name: "Send" });
+    expect(scrollRegion?.contains(send)).toBe(false);
+  });
+
   it("blocks submit on a malformed email", async () => {
     const user = userEvent.setup();
     render(<OnboardingSurveyDialog />);

--- a/platform/frontend/src/components/onboarding-survey-dialog.tsx
+++ b/platform/frontend/src/components/onboarding-survey-dialog.tsx
@@ -89,7 +89,7 @@ export function OnboardingSurveyDialog() {
         className="gap-0 overflow-hidden p-0 sm:max-w-xl"
       >
         {/* Header with a soft radial wash in the org's primary color */}
-        <DialogHeader className="relative space-y-2 px-8 pt-8 pb-6 text-left">
+        <DialogHeader className="relative shrink-0 space-y-2 px-8 pt-8 pb-6 text-left">
           <div
             aria-hidden
             className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-transparent"
@@ -116,7 +116,11 @@ export function OnboardingSurveyDialog() {
           </div>
         </DialogHeader>
 
-        <div className="divide-y divide-border/70 border-t border-border/70">
+        {/* The questions/email section is the scroll region: on short
+            viewports the dialog is capped at max-h-[90dvh] and the header and
+            footer stay pinned, so this scrolls instead of clipping the
+            (non-dismissible) Send button off-screen. */}
+        <div className="min-h-0 flex-1 divide-y divide-border/70 overflow-y-auto border-t border-border/70">
           <SurveyQuestion
             index={1}
             label="What do you do?"
@@ -168,7 +172,7 @@ export function OnboardingSurveyDialog() {
           </div>
         </div>
 
-        <div className="border-t border-border/70 bg-muted/40 px-8 py-5">
+        <div className="shrink-0 border-t border-border/70 bg-muted/40 px-8 py-5">
           <Button
             size="lg"
             className="w-full transition-all"


### PR DESCRIPTION
The first-login onboarding survey is non-dismissible and its dialog is capped at `max-h-[90dvh]` with `overflow-hidden`, but had no internal scroll region. On short viewports (small laptops, short windows, browser zoom) the questions, email field, and Send button clipped off-screen with no scrollbar, leaving the admin stuck.

Make the questions/email section the scroll region (`min-h-0 flex-1 overflow-y-auto`) and pin the header and footer (`shrink-0`) so Send stays reachable at any viewport height.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>