### PR TITLE
fix(database): classify multi-address connection failures as transient

### DIFF
--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -195,6 +195,42 @@ describe("getTransientDbErrorCode", () => {
     expect(getTransientDbErrorCode("not an error")).toBeNull();
     expect(getTransientDbErrorCode(null)).toBeNull();
   });
+
+  // A DB host resolving to several addresses (e.g. IPv6 + IPv4) where every
+  // connect fails: net.connect throws AggregateError with an EMPTY message,
+  // the syscall code on `code`, and one error per address in `errors`.
+  test("detects a multi-address connection failure (AggregateError, empty message)", () => {
+    const aggregate = Object.assign(
+      new AggregateError(
+        [
+          new Error("connect ECONNREFUSED ::1:5432"),
+          new Error("connect ECONNREFUSED 127.0.0.1:5432"),
+        ],
+        "",
+      ),
+      { code: "ECONNREFUSED" },
+    );
+    expect(getTransientDbErrorCode(aggregate)).toBe("ECONNREFUSED");
+
+    const drizzleWrapped = new Error("Failed query: select 1", {
+      cause: aggregate,
+    });
+    expect(getTransientDbErrorCode(drizzleWrapped)).toBe("ECONNREFUSED");
+    expect(isTransientDbError(drizzleWrapped)).toBe(true);
+  });
+
+  test("traverses AggregateError sub-errors when no code is set on the aggregate", () => {
+    const aggregate = new AggregateError(
+      [new Error("connect ETIMEDOUT 10.0.0.1:5432")],
+      "",
+    );
+    expect(getTransientDbErrorCode(aggregate)).toBe("ETIMEDOUT");
+  });
+
+  test("returns null for an AggregateError of non-transient errors", () => {
+    const aggregate = new AggregateError([new Error("duplicate key")], "");
+    expect(getTransientDbErrorCode(aggregate)).toBeNull();
+  });
 });
 
 describe("withDbRetry", () => {
@@ -213,6 +249,25 @@ describe("withDbRetry", () => {
     const fn = vi
       .fn()
       .mockRejectedValueOnce(new Error("connect ECONNREFUSED 10.2.124.50:5432"))
+      .mockResolvedValue("recovered");
+
+    const result = await withDbRetry(fn, { maxRetries: 3 });
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries a multi-address connection failure (AggregateError) and succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new AggregateError(
+          [
+            new Error("connect ECONNREFUSED ::1:5432"),
+            new Error("connect ECONNREFUSED 127.0.0.1:5432"),
+          ],
+          "",
+        ),
+      )
       .mockResolvedValue("recovered");
 
     const result = await withDbRetry(fn, { maxRetries: 3 });

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -76,6 +76,19 @@ const TRANSIENT_ERROR_PATTERNS: ReadonlyArray<{
   { pattern: "timeout expired", code: "timeout_expired" },
 ];
 
+/**
+ * Transient network syscall codes, matched against `error.code` directly.
+ * Message matching alone misses Node's multi-address connection failure: when
+ * a database host resolves to several addresses (e.g. IPv6 + IPv4) and all
+ * fail, net.connect throws an AggregateError whose message is EMPTY — the
+ * syscall code lives on `error.code` and the per-address errors in `errors`.
+ */
+const TRANSIENT_NETWORK_CODES = new Set(
+  TRANSIENT_ERROR_PATTERNS.filter(({ pattern, code }) => pattern === code).map(
+    ({ code }) => code,
+  ),
+);
+
 /** Maximum depth for cause-chain traversal to guard against circular references */
 const MAX_CAUSE_DEPTH = 5;
 
@@ -106,9 +119,11 @@ export function getTransientDbErrorCode(
   if (!(error instanceof Error)) return null;
   if (depth > MAX_CAUSE_DEPTH) return null;
 
-  // Check PostgreSQL error code (set by node-postgres on query errors)
-  const pgCode = (error as Error & { code?: string }).code;
-  if (pgCode && TRANSIENT_PG_CODES.has(pgCode)) return pgCode;
+  // Check PostgreSQL error code (set by node-postgres on query errors) and
+  // Node network syscall codes (the only signal on empty-message errors)
+  const errorCode = (error as Error & { code?: string }).code;
+  if (errorCode && TRANSIENT_PG_CODES.has(errorCode)) return errorCode;
+  if (errorCode && TRANSIENT_NETWORK_CODES.has(errorCode)) return errorCode;
 
   // Check error message for known transient patterns
   const message = error.message;
@@ -116,6 +131,15 @@ export function getTransientDbErrorCode(
     message.includes(pattern),
   );
   if (matched) return matched.code;
+
+  // A multi-address connection failure is an AggregateError holding one error
+  // per attempted address in `errors` (not `cause`) — check each of them.
+  if (error instanceof AggregateError) {
+    for (const subError of error.errors) {
+      const code = getTransientDbErrorCode(subError, depth + 1);
+      if (code) return code;
+    }
+  }
 
   // DrizzleQueryError wraps the underlying pg error as `cause`
   const cause = (error as Error & { cause?: unknown }).cause;


### PR DESCRIPTION
## Problem

When the database host resolves to several addresses (e.g. IPv6 + IPv4) and every connect fails, Node's `net.connect` throws an `AggregateError` with an **empty message**, the syscall code on `error.code`, and one error per attempted address in `error.errors` — not `error.cause`:

```
AggregateError { message: '', code: 'ECONNREFUSED', errors: [connect ECONNREFUSED ::1:5432, connect ECONNREFUSED 127.0.0.1:5432] }
```

`getTransientDbErrorCode` only matched message substrings and walked the `cause` chain, so this shape was classified non-transient. Two consequences:

1. **No retry** — `withDbRetry` re-threw immediately, so brief connection blips surfaced as user-facing 500s (`Failed query: …`) instead of being retried away within the budget.
2. **No grouping** — the shared error-tracking policy never assigned its `db-transient/<code>` fingerprint, so one connectivity blip fragmented into one error-tracking issue per SQL statement that happened to be in flight.

## Fix

In `getTransientDbErrorCode`:
- match `error.code` against the transient network syscall codes (ECONNREFUSED, ECONNRESET, EPIPE, ETIMEDOUT, EAI_AGAIN, ENOTFOUND) directly — the only signal on empty-message errors;
- traverse `AggregateError.errors`, depth-bounded exactly like the existing cause-chain traversal.

This automatically fixes `withDbRetry`, `withTransactionRetry`, the pool wrapper, the process-level safety net, and the error-tracking fingerprint, which all share this classifier.

## Testing

- 4 new unit tests: AggregateError with code, code-less AggregateError traversal, Drizzle-wrapped AggregateError, non-transient AggregateError stays null, and a `withDbRetry` behavior test pinning that the shape is retried.
- Full `retry.test.ts` + observability suites (196 tests), type-check, and lint pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>