### PR TITLE
fix(frontend): guard crypto.randomUUID for insecure contexts

### DIFF
--- a/platform/frontend/src/components/a2a-connection-instructions.tsx
+++ b/platform/frontend/src/components/a2a-connection-instructions.tsx
@@ -46,6 +46,7 @@ import {
   useTokens,
 } from "@/lib/teams/team-token.query";
 import { useFetchUserTokenValue, useUserToken } from "@/lib/user-token.query";
+import { generateUuid } from "@/lib/uuid";
 import {
   AgentEmailDisabledMessage,
   EmailNotConfiguredMessage,
@@ -92,10 +93,10 @@ export function A2AConnectionInstructions({
 
   // messageId is required by the A2A protocol and must be unique per message,
   // so each example gets a real UUID (fresh per dialog open).
-  const [sendExampleMessageId] = useState(() => crypto.randomUUID());
-  const [streamExampleMessageId] = useState(() => crypto.randomUUID());
-  const [replyExampleMessageId] = useState(() => crypto.randomUUID());
-  const [approvalExampleMessageId] = useState(() => crypto.randomUUID());
+  const [sendExampleMessageId] = useState(() => generateUuid());
+  const [streamExampleMessageId] = useState(() => generateUuid());
+  const [replyExampleMessageId] = useState(() => generateUuid());
+  const [approvalExampleMessageId] = useState(() => generateUuid());
 
   // Mirror the /connection page's base-URL fallback chain so the A2A panel
   // honors the same admin curation (descriptions, default flag, hidden URLs).

--- a/platform/frontend/src/components/agent-hooks-editor.tsx
+++ b/platform/frontend/src/components/agent-hooks-editor.tsx
@@ -39,6 +39,7 @@ import {
   useDeleteHook,
   useUpdateHook,
 } from "@/lib/hook.query";
+import { generateUuid } from "@/lib/uuid";
 
 export interface AgentHooksEditorRef {
   /**
@@ -336,7 +337,7 @@ const AgentHooksEditorContent = forwardRef<
         setPendingHooks((hooks) => [
           ...hooks,
           {
-            localId: crypto.randomUUID(),
+            localId: generateUuid(),
             event: values.event,
             fileName,
             content: values.content,

--- a/platform/frontend/src/lib/chat/chat-message-queue.ts
+++ b/platform/frontend/src/lib/chat/chat-message-queue.ts
@@ -12,6 +12,7 @@
 import type { ChatSkillMetadata } from "@archestra/shared";
 import { useSyncExternalStore } from "react";
 import { conversationStorageKeys } from "@/lib/chat/chat-utils";
+import { generateUuid } from "@/lib/uuid";
 
 export interface QueuedChatMessage {
   id: string;
@@ -46,7 +47,7 @@ class ChatMessageQueueStore {
   ): QueuedChatMessage {
     const queued: QueuedChatMessage = {
       ...message,
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       queuedAt: new Date().toISOString(),
     };
     this.setQueue(conversationId, [...this.get(conversationId), queued]);

--- a/platform/frontend/src/lib/uuid.test.ts
+++ b/platform/frontend/src/lib/uuid.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateUuid } from "./uuid";
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+// `randomUUID` may live on the instance or on `Crypto.prototype` depending on
+// the environment; shadow it with an own property and restore afterwards.
+const originalDescriptor = Object.getOwnPropertyDescriptor(
+  crypto,
+  "randomUUID",
+);
+
+function setCryptoRandomUUID(value: (() => string) | undefined) {
+  Object.defineProperty(crypto, "randomUUID", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  if (originalDescriptor) {
+    Object.defineProperty(crypto, "randomUUID", originalDescriptor);
+  } else {
+    delete (crypto as { randomUUID?: unknown }).randomUUID;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("generateUuid", () => {
+  it("uses crypto.randomUUID when available", () => {
+    const randomUUID = vi
+      .fn<() => string>()
+      .mockReturnValue("11111111-2222-4333-8444-555555555555");
+    setCryptoRandomUUID(randomUUID);
+
+    expect(generateUuid()).toBe("11111111-2222-4333-8444-555555555555");
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to getRandomValues when crypto.randomUUID is unavailable (insecure context)", () => {
+    setCryptoRandomUUID(undefined);
+    const getRandomValues = vi.spyOn(crypto, "getRandomValues");
+
+    const uuid = generateUuid();
+
+    expect(getRandomValues).toHaveBeenCalledOnce();
+    expect(uuid).toMatch(UUID_V4_PATTERN);
+  });
+
+  it("fallback sets the version and variant bits regardless of the random bytes", () => {
+    setCryptoRandomUUID(undefined);
+    const fillWith = (byte: number) =>
+      vi.spyOn(crypto, "getRandomValues").mockImplementation((array) => {
+        if (array instanceof Uint8Array) {
+          array.fill(byte);
+        }
+        return array;
+      });
+
+    fillWith(0x00);
+    expect(generateUuid()).toBe("00000000-0000-4000-8000-000000000000");
+
+    fillWith(0xff);
+    expect(generateUuid()).toBe("ffffffff-ffff-4fff-bfff-ffffffffffff");
+  });
+
+  it("fallback produces distinct values", () => {
+    setCryptoRandomUUID(undefined);
+
+    expect(generateUuid()).not.toBe(generateUuid());
+  });
+});

--- a/platform/frontend/src/lib/uuid.ts
+++ b/platform/frontend/src/lib/uuid.ts
@@ -1,0 +1,38 @@
+/**
+ * Generates a random UUIDv4 string.
+ *
+ * `crypto.randomUUID` only exists in secure contexts (HTTPS or localhost), so
+ * deployments reached over plain HTTP (e.g. `http://<lan-ip>:3000`) don't get
+ * it at all and unguarded calls crash the page. In that case fall back to
+ * building a v4 UUID from `crypto.getRandomValues`, which is available in
+ * insecure contexts too.
+ *
+ * Not for security-sensitive identifiers (tokens, secrets) — use a dedicated
+ * mechanism for those.
+ */
+export function generateUuid(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return fallbackUuidV4();
+}
+
+// === Internal helpers ===
+
+function fallbackUuidV4(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  // RFC 4122 §4.4: set the version (4) and variant (10xx) bits
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10).join(""),
+  ].join("-");
+}


### PR DESCRIPTION
## What

- Add `frontend/src/lib/uuid.ts` with `generateUuid()`: `crypto.randomUUID()` when available, otherwise a `crypto.getRandomValues`-based UUIDv4 fallback (works in insecure contexts), plus unit tests for both paths.
- Migrate all production `crypto.randomUUID` call sites: `a2a-connection-instructions.tsx` (4), `agent-hooks-editor.tsx`, `chat-message-queue.ts`. Test-file call sites are untouched — vitest runs under Node where `randomUUID` always exists.

## Why

`crypto.randomUUID` only exists in secure contexts (HTTPS or localhost), so self-hosted deployments served over plain HTTP (e.g. a LAN IP) crash with a client-side `TypeError: crypto.randomUUID is not a function` — notably on the Messaging Channels → A2A page. Same bug class and same fix shape as the `navigator.clipboard` helper in #6689.

## Testing

- New `uuid.test.ts`: both paths, version/variant bit pinning (all-`00`/all-`ff` bytes), distinctness.
- `pnpm lint`, `pnpm knip`, and the frontend unit suite pass (the only failures are pre-existing `app-session-recording` ones from missing local optional deps, identical on a clean tree).
- Audited the frontend for other secure-context-only APIs (`crypto.subtle`, `navigator.share`, service workers, `mediaDevices`, `Notification`, `navigator.credentials`): none in production code — only the dev-only, tree-shaken MSW service worker.


## Archestra banner

> [ ![Archestra Contributor](https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp) ](https://archestra.ai/contributor-onboard)

