### PR TITLE
fix(chat): hide voice input mic button in insecure contexts

### DIFF
--- a/platform/frontend/src/components/ai-elements/prompt-input.test.tsx
+++ b/platform/frontend/src/components/ai-elements/prompt-input.test.tsx
@@ -5,6 +5,7 @@ import {
   PromptInput,
   PromptInputBody,
   type PromptInputProps,
+  PromptInputSpeechButton,
   PromptInputTextarea,
 } from "./prompt-input";
 
@@ -74,5 +75,27 @@ describe("PromptInputTextarea Enter handling", () => {
     await user.keyboard("{Enter}");
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PromptInputSpeechButton", () => {
+  it("renders the mic button in a secure context", () => {
+    vi.stubGlobal("isSecureContext", true);
+
+    render(<PromptInputSpeechButton />);
+
+    expect(
+      screen.getByRole("button", { name: "Start voice input" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the mic button in an insecure context where the mic cannot work", () => {
+    vi.stubGlobal("isSecureContext", false);
+
+    render(<PromptInputSpeechButton />);
+
+    expect(
+      screen.queryByRole("button", { name: "Start voice input" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/platform/frontend/src/components/ai-elements/prompt-input.tsx
@@ -1356,13 +1356,19 @@ export const PromptInputSpeechButton = ({
   const [recognition, setRecognition] = useState<SpeechRecognition | null>(
     null,
   );
+  const [isInsecureContext, setIsInsecureContext] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
 
   useEffect(() => {
-    if (
-      typeof window !== "undefined" &&
-      ("SpeechRecognition" in window || "webkitSpeechRecognition" in window)
-    ) {
+    // Chrome exposes the SpeechRecognition constructor on insecure origins,
+    // but microphone access still requires a secure context, so the button
+    // would render and then silently fail on click.
+    if (!window.isSecureContext) {
+      setIsInsecureContext(true);
+      return;
+    }
+
+    if ("SpeechRecognition" in window || "webkitSpeechRecognition" in window) {
       const SpeechRecognition =
         window.SpeechRecognition || window.webkitSpeechRecognition;
       const speechRecognition = new SpeechRecognition();
@@ -1428,6 +1434,10 @@ export const PromptInputSpeechButton = ({
       recognition.start();
     }
   }, [recognition, isListening]);
+
+  if (isInsecureContext) {
+    return null;
+  }
 
   return (
     <PromptInputButton


### PR DESCRIPTION
## What

Hide the voice-dictation mic button in the prompt input when `window.isSecureContext` is false.

## Why

Chrome exposes the `SpeechRecognition` constructor even on insecure origins (e.g. opening the app via a LAN IP over http), but microphone access still requires a secure context. The mic button rendered normally and then silently failed on click (`onerror` → state reset, no feedback). Better to not show a button that can never work.

## Testing

- Added unit tests: button renders in a secure context, hidden in an insecure one
- `pnpm test`, `pnpm lint`, `pnpm type-check` pass

## Archestra banner

> [ ![Archestra Contributor](https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp) ](https://archestra.ai/contributor-onboard)

