### PR TITLE
docs: remove references to the private archestra-ai/website repo

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -122,7 +122,8 @@ ARCHESTRA_COHERE_BASE_URL=https://api.cohere.ai
 # ARCHESTRA_MICROSOFT_365_COPILOT_AUTH_BASE_URL=http://localhost:9092/microsoft-login
 
 # Public MCP catalog URL.
-# If you are making changes to the MCP catalog, point it to the port the archestra-ai/website listens on.
+# Defaults to the production catalog API (https://www.archestra.ai/mcp-catalog/api).
+# If you are making changes to the MCP catalog API, point it to the port your locally running catalog server listens on.
 # ARCHESTRA_MCP_CATALOG_API_BASE_URL=http://localhost:3001/mcp-catalog/api
 
 # Per-request timeout (ms) for an upstream MCP tool call made through the gateway.

--- a/platform/PROVIDER_SMOKE_TEST.md
+++ b/platform/PROVIDER_SMOKE_TEST.md
@@ -87,7 +87,7 @@ Before starting, verify the development environment is running:
 1. Navigate to Chat (`http://localhost:3000/chat`)
 2. Select the profile with GitHub tools assigned
 3. Start a new conversation
-4. Send message: "Give a short overview of the open issues in https://github.com/archestra-ai/website"
+4. Send message: "Give a short overview of the open issues in https://github.com/archestra-ai/archestra"
 
 ### Expected Result
 
@@ -148,7 +148,7 @@ Create a tool invocation policy:
 2. Enable "Tool Result Compression (TOON)" at organization level
 3. Navigate to Chat and start a NEW conversation
 4. Select the profile with GitHub tools
-5. Send message: "Give a short overview of the open issues in https://github.com/archestra-ai/website"
+5. Send message: "Give a short overview of the open issues in https://github.com/archestra-ai/archestra"
 
 ### Expected Result
 
@@ -193,7 +193,7 @@ If `list_issues` is blocked in untrusted context due to Test 5:
    - Enabled: true
 3. Navigate to Chat and start a NEW conversation
 4. Send a short message that matches the rule condition:
-   "Give a short overview of the open issues in https://github.com/archestra-ai/website"
+   "Give a short overview of the open issues in https://github.com/archestra-ai/archestra"
 
 ### Expected Result
 


### PR DESCRIPTION
## What

Follow-up to the MCP catalog migration (#6718): the last two places in this public repo that still reference the now-private `archestra-ai/website` repo (404 for anyone outside the org).

- **`platform/PROVIDER_SMOKE_TEST.md`** (3 occurrences): the GitHub-tools smoke prompts asked for "open issues in archestra-ai/website" — a private repo, so the smoke test only worked for testers whose GitHub connection has org access. Now points at the public `archestra-ai/archestra` repo.
- **`platform/.env.example`**: the `ARCHESTRA_MCP_CATALOG_API_BASE_URL` comment told readers to point at "the port the archestra-ai/website listens on". Reworded to describe the production default and a local catalog server without naming the private repo.

## Verification

`git grep -iE 'archestra-ai(%2F|/)website'` on this branch returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>