### PR TITLE
fix(chat): store uploads the model can't read as conversation files instead of rejecting

### DIFF
--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -3,7 +3,7 @@ title: Chat
 category: Agents
 order: 2
 description: Built-in Chat interface for working with agents and MCP tools
-lastUpdated: 2026-07-18
+lastUpdated: 2026-07-23
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -68,4 +68,4 @@ When auto-compaction frees tokens, a note appears in the panel showing how many 
 
 Chat attachments are scoped to their conversation. To reuse files across related sessions, add them to a [Project](./platform-projects) instead, where files are shared across all of the project's chats.
 
-Which files you can attach depends on the agent. Without a code sandbox, uploads are limited to types the model can read directly: images, PDFs, and common text documents (`.txt`, `.md`, `.csv`, `.tsv`, `.json`, `.xml`, `.yaml`, `.toml`); large text files are rejected rather than truncated. When the code sandbox is available for the agent, any file type can be attached and is staged into the sandbox for the agent to process.
+You can attach any file type. Images, PDFs, and common text documents (`.txt`, `.md`, `.csv`, `.tsv`, `.json`, `.xml`, `.yaml`, `.toml`) go straight to the model. Other files — a zip archive, for example — are saved to the chat's Files panel. When the agent has a code sandbox, those files are also staged there for the agent to process; without one, the agent can't read them and tells you so.

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
@@ -416,10 +416,10 @@ describe("assertInlineAttachmentsAcceptable", () => {
     ).not.toThrow();
   });
 
-  test("rejects an oversized text file when no sandbox is available", () => {
+  test("accepts an oversized text file without a sandbox (stored as a conversation file)", () => {
     expect(() =>
       assert("text/csv", INLINE_TEXT_MAX_BYTES + 1, policy()),
-    ).toThrow();
+    ).not.toThrow();
   });
 
   test("routes an oversized text file to the sandbox when available", () => {
@@ -432,8 +432,8 @@ describe("assertInlineAttachmentsAcceptable", () => {
     ).not.toThrow();
   });
 
-  test("rejects an unsupported binary type without a sandbox", () => {
-    expect(() => assert("application/zip", 1_000, policy())).toThrow();
+  test("accepts an unsupported binary type without a sandbox (stored as a conversation file)", () => {
+    expect(() => assert("application/zip", 1_000, policy())).not.toThrow();
   });
 
   test("accepts an arbitrary type within the limit when the sandbox is available", () => {
@@ -442,13 +442,16 @@ describe("assertInlineAttachmentsAcceptable", () => {
     ).not.toThrow();
   });
 
-  test("rejects a file over the sandbox artifact limit even when available", () => {
+  test("rejects a file over the storage limit regardless of sandbox availability", () => {
     expect(() =>
       assert(
         "application/zip",
         SANDBOX_LIMIT + 1,
         policy({ sandboxAvailable: true }),
       ),
+    ).toThrow();
+    expect(() =>
+      assert("application/zip", SANDBOX_LIMIT + 1, policy()),
     ).toThrow();
   });
 

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
@@ -102,8 +102,10 @@ export async function extractInlineAttachments(args: {
 /**
  * Policy describing which uploaded attachments this turn may accept, evaluated
  * before any bytes are persisted. A file is acceptable when the model can ingest
- * its type, OR it is an inlineable text document within the inline budget, OR a
- * sandbox is available to stage it (within the sandbox artifact size limit).
+ * its type, OR it is an inlineable text document within the inline budget, OR it
+ * fits the sandbox artifact size limit — files the model can't read still land
+ * as conversation attachments the user reaches from the chat Files panel (and,
+ * when a sandbox is available, are additionally staged there for the model).
  */
 export type InlineAttachmentPolicy = {
   ingestibleMimeTypes: Set<string>;
@@ -137,6 +139,9 @@ export function assertInlineAttachmentsAcceptable(args: {
         ingestibleMimeTypes: policy.ingestibleMimeTypes,
         sandboxAvailable: policy.sandboxAvailable,
         sandboxByteLimit: policy.sandboxByteLimit,
+        // Chat uploads always have a landing surface: the attachment row shows
+        // in the conversation's Files panel even when the model can't read it.
+        fileStorageFallback: true,
       });
       if (reason) {
         throw new ApiError(400, rejectionMessage(reason, inspected, policy));

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
@@ -577,6 +577,60 @@ test("an over-limit non-ingestible attachment is reported as unavailable, not st
   expect(part.text).not.toContain("data:");
 });
 
+test("a non-ingestible attachment without a sandbox points at the Files panel, never the sandbox", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  // A zip: accepted at ingest (Files-panel fallback), unreadable by the model.
+  const bytes = Buffer.from("PKzip-ish", "utf8");
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "bundle.zip",
+    mimeType: "application/zip",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "application/zip",
+          filename: "bundle.zip",
+        },
+      ],
+    },
+  ];
+
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    sandboxAvailable: false,
+  });
+
+  const part = expectPresent(output[0].parts?.[0]);
+  expect(part.type).toBe("text");
+  // The file landed in the conversation's Files panel; the model is told so
+  // (and that it can't read the contents) rather than "the file was rejected".
+  expect(part.text).toContain("Files panel");
+  expect(part.text).toContain(JSON.stringify("bundle.zip"));
+  // Never point a sandbox-less agent at the sandbox or run_command.
+  expect(part.text).not.toContain("/home/sandbox/attachments");
+  expect(part.text).not.toContain("run_command");
+  expect(part.text).not.toContain("data:");
+});
+
 test("inlined text-document also gets a sandbox pointer when the sandbox is available for the agent", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -310,9 +310,10 @@ function unavailableBinaryDocPart(
  * deduplicated by the runtime) and tell the model to list it. Over the limit the
  * file is not staged, so the model is told it is unavailable this turn rather
  * than pointed at a session-authed URL it cannot fetch from the sandbox. When
- * the sandbox is not usable at all, there is no fallback surface, so the model is
- * told the file could not be processed (so it can relay that to the user) — never
- * pointed at a sandbox or `run_command` it cannot reach.
+ * the sandbox is not usable, the attachment still lives in the conversation's
+ * Files panel, so the model is told the file is saved there for the user even
+ * though it can't read the contents — never pointed at a sandbox or
+ * `run_command` it cannot reach.
  *
  * `originalName` is client-controlled, so it is JSON-encoded to keep a crafted
  * filename from breaking out of this platform-generated notice.
@@ -329,14 +330,14 @@ function referenceSandboxFilePart(
   if (!sandboxAvailable) {
     return {
       type: "text",
-      text: `[Attachment ${label} can't be read by this model and no code sandbox is available to process it this turn. Let the user know the file could not be used.]`,
+      text: `[Attachment ${label} can't be read by this model and no code sandbox is available to process it this turn. It is saved in this conversation's Files panel, where the user can view and download it. Let the user know you can't read its contents.]`,
     };
   }
 
   if (sizeBytes > limit) {
     return {
       type: "text",
-      text: `[Attachment ${label} can't be shown to this model and is too large (limit ${limit} bytes) to use in your sandbox this turn.]`,
+      text: `[Attachment ${label} can't be shown to this model and is too large (limit ${limit} bytes) to use in your sandbox this turn. The user can still download it from this conversation's Files panel.]`,
     };
   }
 

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -350,14 +350,14 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
         );
       }
 
-      // Gate uploaded attachments before any bytes are persisted: the model must
-      // be able to ingest the type, or it must be a small inlineable text
-      // document, or a sandbox must be available to stage arbitrary files. The
-      // frontend mirrors this for UX, but a custom client bypasses it, so this
-      // is the authoritative check. Runs before extractInlineAttachments and
-      // before the active run is acquired, so a rejected request stores nothing.
-      // Skipped (with its model/sandbox lookups) on the common turn that uploads
-      // nothing.
+      // Gate uploaded attachments before any bytes are persisted: anything
+      // within the storage byte limit is accepted — a file the model can't
+      // ingest still lands in the conversation's Files panel (and is staged
+      // into the sandbox when one is available). The frontend mirrors this for
+      // UX, but a custom client bypasses it, so this is the authoritative
+      // check. Runs before extractInlineAttachments and before the active run
+      // is acquired, so a rejected request stores nothing. Skipped (with its
+      // model/sandbox lookups) on the common turn that uploads nothing.
       if (messagesHaveNewInlineAttachments(messages as ChatMessage[])) {
         const attachmentModelRow = conversation.modelId
           ? await ModelModel.findById(conversation.modelId)

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@/agents/agent-system-prompt";
 import { archestraMcpBranding } from "@/archestra-mcp-server";
 import { REPEAT_CALL_TERMINATION_CEILING } from "@/clients/tool-call-repeat-tracker";
+import config from "@/config";
 import {
   FileModel,
   MessageModel,
@@ -2472,7 +2473,7 @@ describe("POST /api/chat handler composition", () => {
     expect(attachments).toHaveLength(0);
   });
 
-  test("rejects an unsupported attachment with no sandbox and persists nothing", async () => {
+  test("accepts an unsupported attachment with no sandbox and stores it as a conversation attachment", async () => {
     const dataUrl = `data:application/zip;base64,${Buffer.from("PK zip bytes").toString("base64")}`;
     const response = await postMessage([
       {
@@ -2490,8 +2491,43 @@ describe("POST /api/chat handler composition", () => {
       },
     ]);
 
-    // The gate runs before extraction and before the active run is acquired,
-    // so the request is rejected and no attachment row is written.
+    // A file the model can't read is no longer rejected: it lands as a
+    // conversation attachment surfaced in the chat Files panel, and the model
+    // is told about it via a notice at materialize time.
+    expect(response.statusCode).toBe(200);
+    const attachments =
+      await ConversationAttachmentModel.findByConversationIdWithoutData(
+        conversationId,
+      );
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].originalName).toBe("archive.zip");
+    expect(attachments[0].mimeType).toBe("application/zip");
+  });
+
+  test("rejects an attachment over the storage byte limit and persists nothing", async () => {
+    // Just over the artifact/storage limit — too big for the sandbox AND for
+    // Files-panel storage, so the gate still rejects before any bytes persist.
+    const oversized = Buffer.alloc(
+      config.skillsSandbox.artifactBytesLimit + 1,
+      0x61,
+    );
+    const dataUrl = `data:application/zip;base64,${oversized.toString("base64")}`;
+    const response = await postMessage([
+      {
+        id: "msg-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "process this" },
+          {
+            type: "file",
+            url: dataUrl,
+            mediaType: "application/zip",
+            filename: "huge.zip",
+          },
+        ],
+      },
+    ]);
+
     expect(response.statusCode).toBe(400);
     const attachments =
       await ConversationAttachmentModel.findByConversationIdWithoutData(

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -3,10 +3,7 @@
 import {
   type ContextWindowBreakdown,
   E2eTestId,
-  getSupportedFileTypesDescription,
-  type ModelInputModality,
   type SupportedProvider,
-  supportsFileUploads,
 } from "@archestra/shared";
 import { MoreVerticalIcon, PaperclipIcon, XIcon } from "lucide-react";
 import { memo, useCallback } from "react";
@@ -75,8 +72,6 @@ export interface ChatPromptInputToolsProps {
     compactedTokenEstimate?: number;
     trigger?: "auto" | "manual";
   } | null;
-  /** Input modalities supported by the selected model (for file type filtering) */
-  inputModalities?: ModelInputModality[] | null;
   /** Agent's configured LLM API key ID - passed to LlmProviderApiKeySelector */
   agentLlmApiKeyId?: string | null;
   /** Current agent ID for agent selector */
@@ -135,7 +130,6 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
   maxContextLength,
   contextWindow,
   lastCompaction,
-  inputModalities,
   agentLlmApiKeyId,
   selectorAgentId,
   onAgentChange,
@@ -170,17 +164,13 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
           ? "chat override"
           : "user override";
 
-  // Determine if file uploads should be shown
-  // 1. Organization must allow file uploads (allowFileUploads)
-  // 2. Model must support at least one file type (modelSupportsFiles)
-  // A sandbox-equipped agent can process any file (staged for run_command), so
-  // uploads are offered even when the model itself has no file modalities.
-  const showFileUploadButton =
-    allowFileUploads &&
-    (supportsFileUploads(inputModalities) || sandboxAvailable);
+  // Any file type can be attached: a file the model can't read is still stored
+  // and surfaced in the conversation's Files panel (and staged into the
+  // sandbox when one is available), so the only gate is the org-level toggle.
+  const showFileUploadButton = allowFileUploads;
   const supportedTypesDescription = sandboxAvailable
     ? "any file type"
-    : getSupportedFileTypesDescription(inputModalities);
+    : "any file type (files this model can't read are saved to the chat's Files panel)";
 
   // Check if user can update agent settings (to show settings link in tooltip)
   const { data: canUpdateAgentSettings } = useHasPermissions({
@@ -380,23 +370,19 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
             </span>
           </TooltipTrigger>
           <TooltipContent side="top" sideOffset={4}>
-            {!allowFileUploads ? (
-              canUpdateAgentSettings ? (
-                <span>
-                  File uploads are disabled.{" "}
-                  <a
-                    href="/settings/agents"
-                    className="underline hover:no-underline"
-                    aria-label="Enable file uploads in Chat settings"
-                  >
-                    Enable in settings
-                  </a>
-                </span>
-              ) : (
-                "File uploads are disabled by your administrator"
-              )
+            {canUpdateAgentSettings ? (
+              <span>
+                File uploads are disabled.{" "}
+                <a
+                  href="/settings/agents"
+                  className="underline hover:no-underline"
+                  aria-label="Enable file uploads in Chat settings"
+                >
+                  Enable in settings
+                </a>
+              </span>
             ) : (
-              "This model does not support file uploads"
+              "File uploads are disabled by your administrator"
             )}
           </TooltipContent>
         </Tooltip>

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -377,7 +377,9 @@ describe("ArchestraPromptInput", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("should render disabled file upload button when model does not support files", () => {
+    it("should render enabled file upload button even when the model has no file modalities", () => {
+      // A file the model can't read still lands in the conversation's Files
+      // panel, so uploads stay offered regardless of modalities or sandbox.
       render(
         <ArchestraPromptInput
           {...defaultProps}
@@ -386,17 +388,12 @@ describe("ArchestraPromptInput", () => {
         />,
       );
 
-      // Should find the disabled file upload button wrapper
-      const disabledButton = screen.getByTestId(
-        E2eTestId.ChatDisabledFileUploadButton,
-      );
-      expect(disabledButton).toBeInTheDocument();
-
-      // Tooltip should show message about model not supporting files
-      const tooltip = getFileUploadTooltip("does not support file uploads");
-      expect(tooltip).toHaveTextContent(
-        "This model does not support file uploads",
-      );
+      expect(
+        screen.getByTestId(E2eTestId.ChatFileUploadButton),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(E2eTestId.ChatDisabledFileUploadButton),
+      ).not.toBeInTheDocument();
     });
 
     it("should render enabled file upload button for text-only models", () => {

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -5,12 +5,11 @@ import {
   type ContextWindowBreakdown,
   chatUploadRejectionReason,
   E2eTestId,
-  getAcceptedFileTypes,
   getMediaType,
   getModelReadableMimeTypes,
   INLINE_TEXT_MAX_BYTES,
+  type ModelInputModality,
   parseSandboxCommand,
-  supportsFileUploads,
 } from "@archestra/shared";
 import type { ChatStatus } from "ai";
 import { XIcon } from "lucide-react";
@@ -121,6 +120,12 @@ export interface ArchestraPromptInputProps
   status: ChatStatus;
   // Tools integration props
   agentId: string;
+  /**
+   * Input modalities supported by the selected model. Only used to mirror the
+   * backend ingest policy in validateFile — the composer accepts any file type
+   * (a file the model can't read lands in the conversation's Files panel).
+   */
+  inputModalities?: ModelInputModality[] | null;
   // Ref for autofocus
   textareaRef?: React.RefObject<HTMLTextAreaElement | null>;
   /** Per-category breakdown of the assembled request (for context usage panel) */
@@ -184,7 +189,6 @@ const PromptInputContent = ({
   maxContextLength,
   contextWindow,
   lastCompaction,
-  inputModalities,
   agentLlmApiKeyId,
   submitDisabled = false,
   isContextCompacting = false,
@@ -227,16 +231,12 @@ const PromptInputContent = ({
     string | null
   >(null);
 
-  // Derive file upload capabilities from model input modalities. When the agent
-  // has a sandbox available, any file type is allowed (it is staged for
-  // run_command), so uploads are offered even for a non-multimodal model and the
-  // OS picker is unrestricted.
-  const showFileUploadButton =
-    allowFileUploads &&
-    (supportsFileUploads(inputModalities) || sandboxAvailable);
-  const acceptedFileTypes = sandboxAvailable
-    ? undefined
-    : getAcceptedFileTypes(inputModalities);
+  // Any file type can be attached regardless of model modalities or sandbox:
+  // a file the model can't read is still stored and surfaced in the
+  // conversation's Files panel (and staged into the sandbox when one is
+  // available), so uploads are gated only by the org-level toggle and the OS
+  // picker is unrestricted.
+  const showFileUploadButton = allowFileUploads;
 
   // Chat placeholders from organization settings
   const { data: orgData } = useOrganization();
@@ -598,11 +598,9 @@ const PromptInputContent = ({
       message: string;
     }) => {
       if (err.code === "accept") {
-        toast.error(
-          !showFileUploadButton
-            ? "This model does not support file uploads"
-            : "File format is not supported by this model",
-        );
+        // Only reachable when uploads are disabled entirely (the composer sets
+        // no accept filter otherwise — any file type is attachable).
+        toast.error("File uploads are disabled");
       } else if (err.code === "max_file_size") {
         toast.error(
           `File is too large. Maximum size is ${CHAT_ATTACHMENT_MAX_MB} MB.`,
@@ -611,7 +609,7 @@ const PromptInputContent = ({
         toast.error("Too many files attached.");
       }
     },
-    [showFileUploadButton],
+    [],
   );
 
   const submitStatus = status === "error" ? "ready" : status;
@@ -817,9 +815,7 @@ const PromptInputContent = ({
         globalDrop
         multiple
         onSubmit={handleWrappedSubmit}
-        accept={
-          showFileUploadButton ? acceptedFileTypes : "application/x-empty"
-        }
+        accept={showFileUploadButton ? undefined : "application/x-empty"}
         maxFileSize={CHAT_ATTACHMENT_MAX_BYTES}
         onError={handleFileError}
       >
@@ -872,7 +868,6 @@ const PromptInputContent = ({
             tokensUsed={tokensUsed}
             cachedTokens={cachedTokens}
             maxContextLength={maxContextLength}
-            inputModalities={inputModalities}
             agentLlmApiKeyId={agentLlmApiKeyId}
             selectorAgentId={selectorAgentId}
             onAgentChange={onAgentChange}
@@ -987,16 +982,22 @@ const ArchestraPromptInput = ({
         ingestibleMimeTypes: getModelReadableMimeTypes(inputModalities),
         sandboxAvailable,
         sandboxByteLimit,
+        // Mirrors the backend gate: a file the model can't read is still
+        // accepted and lands in the conversation's Files panel.
+        fileStorageFallback: true,
       });
       switch (reason) {
         case null:
           return null;
+        // With the Files-panel fallback the only reachable reason is
+        // "too_large_for_sandbox" (generic over-the-limit); the other cases
+        // stay for exhaustiveness over the shared union.
         case "text_too_large":
-          return `"${file.name}" is too large to include as text (max ${formatBytes(INLINE_TEXT_MAX_BYTES)}). Enable the sandbox to work with larger files.`;
+          return `"${file.name}" is too large to include as text (max ${formatBytes(INLINE_TEXT_MAX_BYTES)}).`;
         case "too_large_for_sandbox":
           return `"${file.name}" exceeds the maximum size of ${formatBytes(sandboxByteLimit)}.`;
         case "unsupported_type":
-          return `This model can't read "${file.name}". Enable the sandbox to use any file type.`;
+          return `This model can't read "${file.name}".`;
       }
     },
     [inputModalities, sandboxAvailable, sandboxByteLimit],
@@ -1050,7 +1051,6 @@ const ArchestraPromptInput = ({
           maxContextLength={maxContextLength}
           contextWindow={contextWindow}
           lastCompaction={lastCompaction}
-          inputModalities={inputModalities}
           agentLlmApiKeyId={agentLlmApiKeyId}
           submitDisabled={submitDisabled}
           isContextCompacting={isContextCompacting}

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -4,10 +4,8 @@ import {
   CONTEXT_WINDOW_CATEGORIES,
   ContextWindowBreakdownSchema,
   chatUploadRejectionReason,
-  getAcceptedFileTypes,
   getMediaType,
   getModelReadableMimeTypes,
-  getSupportedFileTypesDescription,
   hasPersistableAssistantContent,
   hasRenderableAssistantContent,
   INLINE_TEXT_MAX_BYTES,
@@ -15,7 +13,6 @@ import {
   isInlineableTextMimeType,
   OUTPUT_MODALITY_OPTIONS,
   parseSandboxCommand,
-  supportsFileUploads,
 } from "./chat";
 
 const VALID_BREAKDOWN = {
@@ -171,31 +168,10 @@ describe("chat file upload helpers", () => {
   ];
 
   test("treats text modality as supporting the inlineable text document types", () => {
-    expect(getAcceptedFileTypes(["text"])).toBe(
-      TEXT_MODALITY_MIME_TYPES.join(","),
-    );
-    expect(supportsFileUploads(["text"])).toBe(true);
-    expect(getSupportedFileTypesDescription(["text"])).not.toBeNull();
-  });
-
-  test("deduplicates mime types across modalities", () => {
-    expect(getAcceptedFileTypes(["text", "text", "pdf"])).toBe(
-      [...TEXT_MODALITY_MIME_TYPES, "application/pdf"].join(","),
-    );
-  });
-
-  test("returns no file types when modalities are missing", () => {
-    expect(getAcceptedFileTypes(null)).toBeUndefined();
-    expect(getAcceptedFileTypes(undefined)).toBeUndefined();
-    expect(getAcceptedFileTypes([])).toBeUndefined();
-    expect(supportsFileUploads(null)).toBe(false);
-    expect(getSupportedFileTypesDescription(undefined)).toBeNull();
-  });
-
-  test("joins per-modality descriptions for multiple upload modalities", () => {
-    expect(getSupportedFileTypesDescription(["image", "pdf", "audio"])).toBe(
-      "images, PDFs, audio",
-    );
+    const readable = getModelReadableMimeTypes(["text"]);
+    for (const mimeType of TEXT_MODALITY_MIME_TYPES) {
+      expect(readable.has(mimeType)).toBe(true);
+    }
   });
 
   test("uses explicit file media types when present", () => {
@@ -341,6 +317,39 @@ describe("chatUploadRejectionReason", () => {
       chatUploadRejectionReason({
         ...base,
         sandboxAvailable: true,
+        mimeType: "application/zip",
+        byteLength: base.sandboxByteLimit + 1,
+      }),
+    ).toBe("too_large_for_sandbox");
+  });
+
+  test("file-storage fallback accepts an unsupported type without a sandbox", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        fileStorageFallback: true,
+        mimeType: "application/zip",
+        byteLength: 1_000,
+      }),
+    ).toBeNull();
+  });
+
+  test("file-storage fallback accepts oversized text without a sandbox", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        fileStorageFallback: true,
+        mimeType: "text/csv",
+        byteLength: INLINE_TEXT_MAX_BYTES + 1,
+      }),
+    ).toBeNull();
+  });
+
+  test("file-storage fallback still rejects a file over the storage limit", () => {
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        fileStorageFallback: true,
         mimeType: "application/zip",
         byteLength: base.sandboxByteLimit + 1,
       }),

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -586,7 +586,9 @@ export const INLINE_TEXT_MAX_BYTES = 256 * 1024;
  * for the attachment policy shared by the backend ingest gate (authoritative)
  * and the frontend composer (mirrors it for UX). A file is acceptable when the
  * model can ingest its type, OR it is a small inlineable text document, OR a
- * sandbox is available to stage it within the sandbox artifact size limit.
+ * sandbox is available to stage it within the sandbox artifact size limit, OR
+ * (with `fileStorageFallback`) it fits the same byte limit and is stored as a
+ * conversation file the user can reach from the chat Files panel.
  */
 export type ChatUploadRejectionReason =
   | "text_too_large"
@@ -599,6 +601,13 @@ export function chatUploadRejectionReason(params: {
   ingestibleMimeTypes: Set<string>;
   sandboxAvailable: boolean;
   sandboxByteLimit: number;
+  /**
+   * Whether a file the model can't read (and the sandbox can't take) is still
+   * accepted and kept as a conversation attachment surfaced in the chat Files
+   * panel. The chat upload path has that surface, so it passes true; A2A has no
+   * per-conversation Files panel for its callers and keeps rejecting.
+   */
+  fileStorageFallback?: boolean;
 }): ChatUploadRejectionReason | null {
   const {
     mimeType,
@@ -606,24 +615,36 @@ export function chatUploadRejectionReason(params: {
     ingestibleMimeTypes,
     sandboxAvailable,
     sandboxByteLimit,
+    fileStorageFallback = false,
   } = params;
 
-  const fitsSandbox = sandboxAvailable && byteLength <= sandboxByteLimit;
+  // The sandbox artifact limit doubles as the storage cap for Files-panel-only
+  // attachments: both paths persist the same conversation_attachments row, so
+  // one knob bounds what a chat turn may store.
+  const fitsStorage = byteLength <= sandboxByteLimit;
+  const fitsSandbox = sandboxAvailable && fitsStorage;
+  const fitsFileStorage = fileStorageFallback && fitsStorage;
 
   // Inlineable text is size-gated even though a text-capable model lists these
   // MIMEs as readable: a large text file would otherwise blow the context
   // window. Checked before the generic ingestible short-circuit for that reason.
   if (isInlineableTextMimeType(mimeType)) {
-    if (byteLength <= INLINE_TEXT_MAX_BYTES || fitsSandbox) return null;
-    return sandboxAvailable ? "too_large_for_sandbox" : "text_too_large";
+    if (byteLength <= INLINE_TEXT_MAX_BYTES || fitsSandbox || fitsFileStorage) {
+      return null;
+    }
+    return sandboxAvailable || fileStorageFallback
+      ? "too_large_for_sandbox"
+      : "text_too_large";
   }
 
   // Non-text types the model can ingest natively (images, PDFs, …) carry no
   // inline-text budget; the request body limit is the only size bound.
   if (ingestibleMimeTypes.has(mimeType)) return null;
 
-  if (fitsSandbox) return null;
-  return sandboxAvailable ? "too_large_for_sandbox" : "unsupported_type";
+  if (fitsSandbox || fitsFileStorage) return null;
+  return sandboxAvailable || fileStorageFallback
+    ? "too_large_for_sandbox"
+    : "unsupported_type";
 }
 
 /**
@@ -659,14 +680,6 @@ const MODALITY_TO_MIME_TYPES: Record<
   video: ["video/mp4", "video/webm", "video/quicktime", "video/avi"],
   // PDF documents for document understanding models
   pdf: ["application/pdf"],
-};
-
-const MODALITY_TO_FILE_TYPE_DESCRIPTION: Record<ModelInputModality, string> = {
-  text: "chat prompts and text files (.txt, .md, .csv, .tsv, .json, .xml, .yaml, .toml)",
-  image: "images",
-  audio: "audio",
-  video: "video",
-  pdf: "PDFs",
 };
 
 type FileLikeWithMediaType = {
@@ -778,67 +791,18 @@ export function getMediaType(file: FileLikeWithMediaType): string {
 }
 
 /**
- * Converts an array of input modalities to a comma-separated string of MIME types
- * suitable for use with the HTML input accept attribute.
- *
- * @param modalities - Array of input modalities from model capabilities
- * @returns Comma-separated MIME types string, or undefined if no file uploads are supported
- *
- * @example
- * // Model that supports images and PDFs
- * getAcceptedFileTypes(["text", "image", "pdf"])
- * // Returns: "image/jpeg,image/png,image/gif,image/webp,image/svg+xml,application/pdf"
- *
- * @example
- * // Model that only supports text
- * getAcceptedFileTypes(["text"])
- * // Returns: "text/plain,text/csv"
- *
- * @example
- * // Model with full multimodal support
- * getAcceptedFileTypes(["text", "image", "audio", "video", "pdf"])
- * // Returns all supported MIME types
- */
-export function getAcceptedFileTypes(
-  modalities: ModelInputModality[] | null | undefined,
-): string | undefined {
-  if (!modalities || modalities.length === 0) {
-    return undefined;
-  }
-
-  const mimeTypes = new Set<SupportedChatUploadMimeType>();
-
-  for (const modality of modalities) {
-    const types = MODALITY_TO_MIME_TYPES[modality];
-    if (types) {
-      for (const type of types) {
-        mimeTypes.add(type);
-      }
-    }
-  }
-
-  // If no MIME types were collected, return undefined.
-  if (mimeTypes.size === 0) {
-    return undefined;
-  }
-
-  return [...mimeTypes].join(",");
-}
-
-/**
  * The MIME types a model can ingest directly, derived from its input
- * modalities. Unlike {@link getAcceptedFileTypes} (a comma-joined string for the
- * HTML `accept` attribute), this returns a Set for membership checks on the
- * provider-prep path: a file part whose mediaType is absent is not sent as a
- * document the provider would reject — it is referenced as a sandbox file
- * instead. Pass `undefined`/`null` modalities to fall back to a safe readable
- * default (text + images + PDF).
+ * modalities. Returns a Set for membership checks on the provider-prep path: a
+ * file part whose mediaType is absent is not sent as a document the provider
+ * would reject — it is referenced as a sandbox file instead. Pass
+ * `undefined`/`null` modalities to fall back to a safe readable default
+ * (text + images + PDF).
  */
 export function getModelReadableMimeTypes(
   modalities: ModelInputModality[] | null | undefined,
 ): Set<string> {
-  // Treat an empty array the same as null — "capabilities unknown" — matching
-  // getAcceptedFileTypes / supportsFileUploads rather than "reads nothing".
+  // Treat an empty array the same as null — "capabilities unknown" — rather
+  // than "reads nothing".
   const source =
     modalities && modalities.length > 0
       ? modalities
@@ -860,50 +824,3 @@ const DEFAULT_READABLE_MODALITIES: ModelInputModality[] = [
   "image",
   "pdf",
 ];
-
-/**
- * Checks if a model supports any file uploads based on its input modalities.
- *
- * @param modalities - Array of input modalities from model capabilities
- * @returns true if the model supports at least one file type, false otherwise
- */
-export function supportsFileUploads(
-  modalities: ModelInputModality[] | null | undefined,
-): boolean {
-  if (!modalities || modalities.length === 0) {
-    return false;
-  }
-
-  // Check if any modality enables file uploads
-  return modalities.some((modality) => {
-    const types = MODALITY_TO_MIME_TYPES[modality];
-    return types !== null && types.length > 0;
-  });
-}
-
-/**
- * Gets a human-readable description of supported file types for display.
- *
- * @param modalities - Array of input modalities from model capabilities
- * @returns Description string or null if no file types are supported
- */
-export function getSupportedFileTypesDescription(
-  modalities: ModelInputModality[] | null | undefined,
-): string | null {
-  if (!modalities || modalities.length === 0) {
-    return null;
-  }
-
-  const supportedTypes = modalities
-    .filter((modality) => {
-      const types = MODALITY_TO_MIME_TYPES[modality];
-      return types !== null && types.length > 0;
-    })
-    .map((modality) => MODALITY_TO_FILE_TYPE_DESCRIPTION[modality]);
-
-  if (supportedTypes.length === 0) {
-    return null;
-  }
-
-  return supportedTypes.join(", ");
-}


### PR DESCRIPTION
## Problem

Uploading a file type the selected model can't ingest (e.g. a `.zip`) in chat failed with **"…isn't supported by this model"** whenever no code sandbox was available for the agent — the composer blocked the file and the backend ingest gate 400'd. Meanwhile the exact same file uploaded through a project's Files panel was accepted without any type check.

Chat attachments already surface in the conversation's Files panel, so rejecting these uploads only blocked a path that works everywhere else. Files the model can't read should land in the filesystem (Files panel) right away instead of being refused.

## Changes

**shared** (`chat.ts`)
- `chatUploadRejectionReason` gains an opt-in `fileStorageFallback`: a file the model can't read — or an inlineable text document over the inline budget — is accepted up to the storage byte limit, because it always has a landing surface (the Files panel, plus the sandbox when available). A2A does not opt in (its callers have no Files panel), so its behavior is unchanged.
- Removed now-dead helpers (`getAcceptedFileTypes`, `supportsFileUploads`, `getSupportedFileTypesDescription`).

**backend**
- The chat ingest gate (`assertInlineAttachmentsAcceptable`) opts into the fallback; only over-the-limit files are rejected now.
- `materializeAttachments`: when the sandbox is unavailable, the model notice now says the file is saved in the conversation's Files panel (and that the model can't read its contents) instead of "the file could not be used". The over-sandbox-limit notice also points at the Files panel.

**frontend**
- The composer offers uploads whenever the org allows them — no longer hidden for models without file modalities, no MIME `accept` filter, and `validateFile` mirrors the new policy (only size can reject).
- Attach-button tooltip explains that files the model can't read are saved to the chat's Files panel.

**docs**
- `platform-chat.md` attachment section updated.

## Testing

- Unit: new/updated cases in `shared/chat.test.ts`, `extract-inline-attachments.test.ts`, `materialize-attachments.test.ts`, `stream-route.test.ts` (route-level: zip accepted + attachment row persisted; over-limit file still 400s and persists nothing), `prompt-input.test.tsx`.
- Manual: on a fresh instance with the code sandbox disabled, attached a `.zip` in chat → accepted with no error toast, message sent, assistant replied that it can't read the archive and pointed at the Files panel, and the Files panel lists the zip under Attachments (downloadable).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>