### PR TITLE
fix(observability): group DB statement timeouts under one stable error-tracking fingerprint

### DIFF
--- a/platform/backend/src/database/retry.test.ts
+++ b/platform/backend/src/database/retry.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test } from "@/test";
 import {
   getTransientDbErrorCode,
   installDbErrorSafetyNet,
+  isDbStatementTimeoutError,
   isTransientDbError,
   withDbRetry,
   withTransactionRetry,
@@ -230,6 +231,58 @@ describe("getTransientDbErrorCode", () => {
   test("returns null for an AggregateError of non-transient errors", () => {
     const aggregate = new AggregateError([new Error("duplicate key")], "");
     expect(getTransientDbErrorCode(aggregate)).toBeNull();
+  });
+});
+
+describe("isDbStatementTimeoutError", () => {
+  test("detects the pg error by SQLSTATE code 57014", () => {
+    const error = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      { code: "57014" },
+    );
+    expect(isDbStatementTimeoutError(error)).toBe(true);
+  });
+
+  test("detects the statement-timeout message without a code", () => {
+    expect(
+      isDbStatementTimeoutError(
+        new Error("canceling statement due to statement timeout"),
+      ),
+    ).toBe(true);
+  });
+
+  test("unwraps the cause chain (DrizzleQueryError pattern)", () => {
+    const pgError = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      { code: "57014" },
+    );
+    const drizzleError = new Error('Failed query: select "id" from "agents"', {
+      cause: pgError,
+    });
+    expect(isDbStatementTimeoutError(drizzleError)).toBe(true);
+  });
+
+  test("returns false for other errors and non-errors", () => {
+    expect(isDbStatementTimeoutError(new Error("duplicate key"))).toBe(false);
+    const otherPgError = Object.assign(new Error("db error"), {
+      code: "23505",
+    });
+    expect(isDbStatementTimeoutError(otherPgError)).toBe(false);
+    expect(isDbStatementTimeoutError("not an error")).toBe(false);
+    expect(isDbStatementTimeoutError(null)).toBe(false);
+  });
+
+  // Retrying a query that just burned the full statement timeout would
+  // multiply load on an already-slow database, so it must stay non-transient.
+  test("statement timeouts are not classified as transient (not retried)", () => {
+    const pgError = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      { code: "57014" },
+    );
+    const drizzleError = new Error("Failed query: select 1", {
+      cause: pgError,
+    });
+    expect(isTransientDbError(drizzleError)).toBe(false);
   });
 });
 

--- a/platform/backend/src/database/retry.ts
+++ b/platform/backend/src/database/retry.ts
@@ -93,6 +93,16 @@ const TRANSIENT_NETWORK_CODES = new Set(
 const MAX_CAUSE_DEPTH = 5;
 
 /**
+ * SQLSTATE 57014 (query_canceled): raised when the pool's `statement_timeout`
+ * kills a query that ran too long (see createPool in database/index.ts).
+ */
+const QUERY_CANCELED_PG_CODE = "57014";
+
+/** Message emitted by PostgreSQL when statement_timeout cancels a query. */
+const STATEMENT_TIMEOUT_MESSAGE =
+  "canceling statement due to statement timeout";
+
+/**
  * Determine whether a database error is transient (i.e. retrying may succeed).
  *
  * Checks the error itself and, for DrizzleQueryError wrappers, recursively
@@ -101,6 +111,37 @@ const MAX_CAUSE_DEPTH = 5;
  */
 export function isTransientDbError(error: unknown): boolean {
   return getTransientDbErrorCode(error) !== null;
+}
+
+/**
+ * Determine whether a database error is a statement timeout — PostgreSQL
+ * canceling a query that exceeded `statement_timeout`.
+ *
+ * Deliberately NOT part of {@link isTransientDbError}: a query that just
+ * burned the full statement timeout is slow because of query shape or
+ * database load, and retrying it immediately multiplies that load. It is
+ * surfaced here only so error tracking can group all statement timeouts
+ * under one stable fingerprint instead of one issue per SQL statement
+ * (the ORM wraps the cancellation per-query as "Failed query: <sql>").
+ */
+export function isDbStatementTimeoutError(error: unknown, depth = 0): boolean {
+  if (!(error instanceof Error)) return false;
+  if (depth > MAX_CAUSE_DEPTH) return false;
+
+  const errorCode = (error as Error & { code?: string }).code;
+  if (errorCode === QUERY_CANCELED_PG_CODE) return true;
+  if (error.message.includes(STATEMENT_TIMEOUT_MESSAGE)) return true;
+
+  if (error instanceof AggregateError) {
+    for (const subError of error.errors) {
+      if (isDbStatementTimeoutError(subError, depth + 1)) return true;
+    }
+  }
+
+  const cause = (error as Error & { cause?: unknown }).cause;
+  if (cause) return isDbStatementTimeoutError(cause, depth + 1);
+
+  return false;
 }
 
 /**

--- a/platform/backend/src/observability/error-tracking-policy.test.ts
+++ b/platform/backend/src/observability/error-tracking-policy.test.ts
@@ -109,6 +109,26 @@ describe("classifyErrorForTracking", () => {
     });
   });
 
+  test("groups statement timeouts under one stable fingerprint", () => {
+    // The ORM wraps the cancellation per-query, so without a stable
+    // fingerprint every distinct SQL statement becomes its own issue.
+    const pgError = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      { code: "57014" },
+    );
+    const dbError = new Error(
+      'Failed query: select "id" from "agents" where "slug" = $1',
+      { cause: pgError },
+    );
+    const decision = classifyErrorForTracking(dbError);
+    expect(decision.report).toBe(true);
+    expect(decision.fingerprint).toEqual(["db-statement-timeout"]);
+    expect(decision.tags).toMatchObject({
+      error_type: "db_statement_timeout",
+      db_error_code: "57014",
+    });
+  });
+
   test("groups secrets-backend outages by the root condition", () => {
     const error = new ApiError(
       503,

--- a/platform/backend/src/observability/error-tracking-policy.ts
+++ b/platform/backend/src/observability/error-tracking-policy.ts
@@ -1,5 +1,8 @@
 import { ArchestraInternalErrorCode } from "@archestra/shared";
-import { getTransientDbErrorCode } from "@/database/retry";
+import {
+  getTransientDbErrorCode,
+  isDbStatementTimeoutError,
+} from "@/database/retry";
 import { ApiError, SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
 
 /**
@@ -45,6 +48,20 @@ export function classifyErrorForTracking(
       report: true,
       fingerprint: ["db-transient", transientDbErrorCode],
       tags: { error_type: "db_transient", db_error_code: transientDbErrorCode },
+    };
+  }
+
+  // Statement timeouts (PostgreSQL canceling a query that exceeded
+  // statement_timeout) happen under database load or against a slow query
+  // plan, and the ORM wraps each one per-query as "Failed query: <sql>" —
+  // fragmenting one load incident into an issue per SQL statement. They are
+  // deliberately not retried (see isDbStatementTimeoutError), but they should
+  // group into a single issue the same way transient connectivity does.
+  if (isDbStatementTimeoutError(error)) {
+    return {
+      report: true,
+      fingerprint: ["db-statement-timeout"],
+      tags: { error_type: "db_statement_timeout", db_error_code: "57014" },
     };
   }
 


### PR DESCRIPTION
## Why

A big share of the open "Failed query" issues in our exception sinks trace back to PostgreSQL statement timeouts (`canceling statement due to statement timeout`, SQLSTATE 57014). The ORM wraps each cancellation per-query as `Failed query: <sql>`, and the shared error-tracking policy has no classification for it — so every occurrence gets a raw content-hash fingerprint, and one database-load incident fragments into a separate issue per SQL statement (and again per release, since stack frames shift). Over the last 90 days this pattern alone minted 5 distinct issues (one with 92 events), and it is still creating new ones — unlike transient connectivity errors, which already group cleanly under `db-transient/<code>` (#6563), and the empty-message `AggregateError` gap, which #6786 closed.

## What

- `database/retry.ts`: new `isDbStatementTimeoutError()` — detects SQLSTATE 57014 / the statement-timeout message across the same cause-chain and `AggregateError` traversal the transient classifier uses.
- `observability/error-tracking-policy.ts`: statement timeouts now report with the stable fingerprint `db-statement-timeout` and `error_type` / `db_error_code` tags, mirroring the `db-transient` pattern, in both sinks (the policy is shared).
- Statement timeouts stay **deliberately non-transient**: a query that just burned the full `statement_timeout` is slow because of query shape or database load — retrying it immediately would multiply that load. A test pins this.

## Tests

- `retry.test.ts`: detection by code, by message, through the Drizzle cause chain; negatives; pins that 57014 is *not* classified transient/retryable.
- `error-tracking-policy.test.ts`: a wrapped statement timeout groups under `["db-statement-timeout"]` with the expected tags.

`vitest` (both files, 68 passed), `tsc --noEmit`, `biome check`, and `pnpm knip` (dev + production) all pass.

## Out of scope / follow-ups

- Why the statement timeouts fire at all (slow queries under load) — tracked by the ongoing staging performance remediation.
- One genuine bug spotted while triaging: setting a member's default chat API key can hit the `member_default_chat_api_key_id` FK when the key was deleted concurrently — worth a separate small fix.
- Bulk-resolving the historical fragmented issues in the trackers once this deploys.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>