### PR TITLE
fix(llm-models): lock embedding config of the model backing the knowledge base

### DIFF
--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -3,7 +3,7 @@ title: Knowledge
 category: Knowledge
 order: 1
 description: Built-in RAG knowledge — Knowledge Bases, connectors, and retrieval architecture
-lastUpdated: 2026-07-21
+lastUpdated: 2026-07-23
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -27,7 +27,7 @@ Pick the API key and embedding model. The embedding model vectorizes ingested do
 - **Key** — only keys whose synced models have configured embedding dimensions appear in this list. If yours is missing, go to **LLM Providers > Models**, sync the provider, and set the dimensions for the embedding model. Supported dimensions: 384, 768, 1024, 1536, 3072.
 - **Model** — any embedding-capable model exposed by the selected key.
 
-To change the embedding model, click **Drop** to clear the existing index — every document will need to be re-embedded on the next connector sync.
+To change the embedding model, click **Drop** to clear the existing index — every document will need to be re-embedded on the next connector sync. The lock also applies in **LLM Providers > Models**: the configured model's embedding dimensions cannot be edited until the configuration is dropped.
 
 ### Reranking Configuration
 

--- a/platform/backend/src/models/organization.ts
+++ b/platform/backend/src/models/organization.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_THEME_ID,
   MEMBER_ROLE_NAME,
   type OrganizationCustomFont,
+  type SupportedProvider,
 } from "@archestra/shared";
 import { and, eq, isNull } from "drizzle-orm";
 import { CacheKey, cacheManager } from "@/cache-manager";
@@ -248,6 +249,35 @@ class OrganizationModel {
       .select({ id: schema.organizationsTable.id })
       .from(schema.organizationsTable);
     return rows.map((row) => row.id);
+  }
+
+  /**
+   * Whether any organization's locked knowledge embedding config points at this
+   * provider + model pair. The provider comes from the org's embedding API key,
+   * which is how the knowledge base resolves the model row at embed time.
+   */
+  static async isKnowledgeEmbeddingModel(params: {
+    provider: SupportedProvider;
+    modelId: string;
+  }): Promise<boolean> {
+    const [row] = await db
+      .select({ id: schema.organizationsTable.id })
+      .from(schema.organizationsTable)
+      .innerJoin(
+        schema.llmProviderApiKeysTable,
+        eq(
+          schema.organizationsTable.embeddingChatApiKeyId,
+          schema.llmProviderApiKeysTable.id,
+        ),
+      )
+      .where(
+        and(
+          eq(schema.organizationsTable.embeddingModel, params.modelId),
+          eq(schema.llmProviderApiKeysTable.provider, params.provider),
+        ),
+      )
+      .limit(1);
+    return !!row;
   }
 
   /**

--- a/platform/backend/src/routes/llm-provider-models.test.ts
+++ b/platform/backend/src/routes/llm-provider-models.test.ts
@@ -4,6 +4,7 @@ import { isVertexAiEnabled } from "@/clients/gemini-client";
 import LlmProviderApiKeyModel from "@/models/llm-provider-api-key";
 import LlmProviderApiKeyModelLinkModel from "@/models/llm-provider-api-key-model";
 import ModelModel from "@/models/model";
+import OrganizationModel from "@/models/organization";
 import { getSecretValueForLlmProviderApiKey } from "@/secrets-manager";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
@@ -357,6 +358,142 @@ describe("chat model routes", () => {
     expect(copilotModel.apiKeys.map((k: { id: string }) => k.id)).toEqual([
       ownKey.id,
     ]);
+  });
+
+  test("PATCH /api/llm-models/:id rejects embedding changes for the model backing the knowledge base", async ({
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const secret = await makeSecret({ secret: { apiKey: "test-key" } });
+    const apiKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: "gemini",
+      scope: "org",
+    });
+    const embeddingModel = await ModelModel.create({
+      externalId: "gemini/gemini-embedding-001",
+      provider: "gemini",
+      modelId: "gemini-embedding-001",
+      description: "Gemini Embedding 001",
+      contextLength: null,
+      inputModalities: ["text"],
+      outputModalities: [],
+      supportsToolCalling: false,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      embeddingDimensions: 3072,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+    await OrganizationModel.patch(organizationId, {
+      embeddingChatApiKeyId: apiKey.id,
+      embeddingModel: embeddingModel.modelId,
+    });
+
+    // Changing dimensions would silently corrupt the existing index.
+    const changeDimensionsResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/llm-models/${embeddingModel.id}`,
+      payload: { embeddingDimensions: 768 },
+    });
+    expect(changeDimensionsResponse.statusCode).toBe(400);
+    expect(changeDimensionsResponse.json().error.message).toContain(
+      "knowledge base embedding model",
+    );
+    expect(changeDimensionsResponse.json().error.internal_code).toBe(
+      "embedding_validation_failed",
+    );
+
+    // Clearing dimensions (turning it back into a chat model) is just as bad.
+    const clearDimensionsResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/llm-models/${embeddingModel.id}`,
+      payload: { embeddingDimensions: null },
+    });
+    expect(clearDimensionsResponse.statusCode).toBe(400);
+    expect(clearDimensionsResponse.json().error.internal_code).toBe(
+      "embedding_validation_failed",
+    );
+
+    const unchanged = await ModelModel.findById(embeddingModel.id);
+    expect(unchanged?.embeddingDimensions).toBe(3072);
+
+    // Non-embedding updates (and resending the unchanged dimensions, which is
+    // what the edit dialog does) stay allowed while the model is locked.
+    const benignResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/llm-models/${embeddingModel.id}`,
+      payload: { ignored: true, embeddingDimensions: 3072 },
+    });
+    expect(benignResponse.statusCode).toBe(200);
+    expect(benignResponse.json().ignored).toBe(true);
+  });
+
+  test("PATCH /api/llm-models/:id embedding lock is scoped to the embedding key's provider and lifts after drop", async ({
+    makeSecret,
+    makeLlmProviderApiKey,
+  }) => {
+    const secret = await makeSecret({ secret: { apiKey: "test-key" } });
+    const apiKey = await makeLlmProviderApiKey(organizationId, secret.id, {
+      provider: "gemini",
+      scope: "org",
+    });
+    const geminiModel = await ModelModel.create({
+      externalId: "gemini/gemini-embedding-001",
+      provider: "gemini",
+      modelId: "gemini-embedding-001",
+      description: "Gemini Embedding 001",
+      contextLength: null,
+      inputModalities: ["text"],
+      outputModalities: [],
+      supportsToolCalling: false,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      embeddingDimensions: 3072,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+    // Same model ID under a different provider — a different model row that the
+    // knowledge base never resolves, so it must remain editable.
+    const openrouterModel = await ModelModel.create({
+      externalId: "openrouter/gemini-embedding-001",
+      provider: "openrouter",
+      modelId: "gemini-embedding-001",
+      description: "Gemini Embedding 001 via OpenRouter",
+      contextLength: null,
+      inputModalities: ["text"],
+      outputModalities: [],
+      supportsToolCalling: false,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      embeddingDimensions: 3072,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+    await OrganizationModel.patch(organizationId, {
+      embeddingChatApiKeyId: apiKey.id,
+      embeddingModel: geminiModel.modelId,
+    });
+
+    const otherProviderResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/llm-models/${openrouterModel.id}`,
+      payload: { embeddingDimensions: 768 },
+    });
+    expect(otherProviderResponse.statusCode).toBe(200);
+    expect(otherProviderResponse.json().embeddingDimensions).toBe(768);
+
+    // Dropping the embedding config unlocks the previously locked model.
+    await OrganizationModel.patch(organizationId, {
+      embeddingChatApiKeyId: null,
+      embeddingModel: null,
+    });
+    const afterDropResponse = await app.inject({
+      method: "PATCH",
+      url: `/api/llm-models/${geminiModel.id}`,
+      payload: { embeddingDimensions: null },
+    });
+    expect(afterDropResponse.statusCode).toBe(200);
+    expect(afterDropResponse.json().embeddingDimensions).toBe(null);
   });
 
   test("syncModelsForVisibleApiKeys syncs visible keys and preserves baseUrl", async ({

--- a/platform/backend/src/routes/llm-provider-models.ts
+++ b/platform/backend/src/routes/llm-provider-models.ts
@@ -26,6 +26,7 @@ import {
   LlmProviderApiKeyModelLinkModel,
   ModelModel,
   type ModelSyncState,
+  OrganizationModel,
   TeamModel,
 } from "@/models";
 import { getSecretValueForLlmProviderApiKey } from "@/secrets-manager";
@@ -359,6 +360,26 @@ const llmModelsRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const existing = await ModelModel.findById(id);
       if (!existing) {
         throw new ApiError(404, "Model not found");
+      }
+
+      // The knowledge base reads embedding dimensions from this row at embed
+      // time, so changing them — or clearing them, which turns the model back
+      // into a chat model — while an organization's embedding config points
+      // here would silently corrupt the existing index. Mirror the
+      // knowledge-settings lock: force changes through the drop-embedding flow.
+      if (
+        body.embeddingDimensions !== undefined &&
+        body.embeddingDimensions !== existing.embeddingDimensions &&
+        (await OrganizationModel.isKnowledgeEmbeddingModel({
+          provider: existing.provider,
+          modelId: existing.modelId,
+        }))
+      ) {
+        throw new ApiError(
+          400,
+          "This model is used as the knowledge base embedding model, so its embedding configuration cannot be changed. Drop the embedding configuration in Knowledge settings first — all documents will need to be re-embedded.",
+          "embedding_validation_failed",
+        );
       }
 
       const updated = await ModelModel.update(id, body);

--- a/platform/frontend/src/app/llm/models/models-page-utils.test.ts
+++ b/platform/frontend/src/app/llm/models/models-page-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   canFilterFreeModelsForApiKey,
   filterModelsForPage,
+  isKnowledgeBaseEmbeddingModel,
   type ModelsPageAvailableApiKey,
   type ModelsPageFilterableModel,
 } from "./models-page-utils";
@@ -99,5 +100,45 @@ describe("filterModelsForPage", () => {
     });
 
     expect(result.map((model) => model.modelId)).toEqual(["openrouter/free"]);
+  });
+});
+
+describe("isKnowledgeBaseEmbeddingModel", () => {
+  const embeddingApiKeys = [
+    { id: "gemini-key", provider: "gemini" },
+    { id: "openrouter-key", provider: "openrouter" },
+  ] as const satisfies readonly ModelsPageAvailableApiKey[];
+
+  it("locks the model the org's embedding config resolves to", () => {
+    expect(
+      isKnowledgeBaseEmbeddingModel({
+        model: { modelId: "gemini-embedding-001", provider: "gemini" },
+        embeddingModel: "gemini-embedding-001",
+        embeddingChatApiKeyId: "gemini-key",
+        availableApiKeys: embeddingApiKeys,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not lock a same-ID model under a different provider", () => {
+    expect(
+      isKnowledgeBaseEmbeddingModel({
+        model: { modelId: "gemini-embedding-001", provider: "openrouter" },
+        embeddingModel: "gemini-embedding-001",
+        embeddingChatApiKeyId: "gemini-key",
+        availableApiKeys: embeddingApiKeys,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not lock anything when no embedding config is set", () => {
+    expect(
+      isKnowledgeBaseEmbeddingModel({
+        model: { modelId: "gemini-embedding-001", provider: "gemini" },
+        embeddingModel: null,
+        embeddingChatApiKeyId: null,
+        availableApiKeys: embeddingApiKeys,
+      }),
+    ).toBe(false);
   });
 });

--- a/platform/frontend/src/app/llm/models/models-page-utils.ts
+++ b/platform/frontend/src/app/llm/models/models-page-utils.ts
@@ -20,6 +20,32 @@ export type ModelsPageFilterableModel = {
   isBest?: boolean | null;
 };
 
+/**
+ * Whether this model row is the one the knowledge base resolves for embeddings:
+ * the org's configured embedding model ID under the embedding API key's
+ * provider. While that holds, its embedding configuration is locked (changes
+ * must go through the drop-embedding flow in Knowledge settings); the backend
+ * enforces the same lock.
+ */
+export function isKnowledgeBaseEmbeddingModel(params: {
+  model: { modelId: string; provider: string };
+  embeddingModel: string | null | undefined;
+  embeddingChatApiKeyId: string | null | undefined;
+  availableApiKeys: readonly ModelsPageAvailableApiKey[];
+}): boolean {
+  const { model, embeddingModel, embeddingChatApiKeyId, availableApiKeys } =
+    params;
+  if (!embeddingModel || !embeddingChatApiKeyId) {
+    return false;
+  }
+  const embeddingKeyProvider = availableApiKeys.find(
+    (key) => key.id === embeddingChatApiKeyId,
+  )?.provider;
+  return (
+    embeddingModel === model.modelId && embeddingKeyProvider === model.provider
+  );
+}
+
 export function canFilterFreeModelsForApiKey(params: {
   availableApiKeys: readonly ModelsPageAvailableApiKey[];
   apiKeyFilter: string;

--- a/platform/frontend/src/app/llm/models/page.tsx
+++ b/platform/frontend/src/app/llm/models/page.tsx
@@ -26,6 +26,7 @@ import {
   X,
 } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -83,11 +84,13 @@ import {
   useUpdateModel,
 } from "@/lib/llm-models.query";
 import { useLlmProviderApiKeys } from "@/lib/llm-provider-api-keys.query";
+import { useOrganization } from "@/lib/organization.query";
 import { formatContextLength } from "@/lib/utils";
 import { MODEL_NAV_TABS } from "../model-nav-tabs";
 import {
   canFilterFreeModelsForApiKey,
   filterModelsForPage,
+  isKnowledgeBaseEmbeddingModel,
   type ModelsPageModelTypeFilter,
   OBSERVED_MODEL_SOURCE_DESCRIPTION,
   OBSERVED_MODEL_SOURCE_LABEL,
@@ -577,7 +580,15 @@ function EditModelDialog({
   const [inputModalityToAdd, setInputModalityToAdd] = useState("");
   const [outputModalityToAdd, setOutputModalityToAdd] = useState("");
   const updateModel = useUpdateModel();
+  const { data: organization } = useOrganization();
+  const { data: apiKeys = [] } = useLlmProviderApiKeys();
   const providerConfig = PROVIDER_CONFIG[model.provider];
+  const embeddingConfigLocked = isKnowledgeBaseEmbeddingModel({
+    model,
+    embeddingModel: organization?.embeddingModel,
+    embeddingChatApiKeyId: organization?.embeddingChatApiKeyId,
+    availableApiKeys: apiKeys,
+  });
   const fallbackPricing = getFallbackPricing(model);
   // The model's provider supports prompt caching when the backend resolved a
   // cache price for it (synced, custom, or multiplier-derived).
@@ -929,6 +940,7 @@ function EditModelDialog({
                 <FormItem>
                   <Select
                     value={field.value || NOT_EMBEDDING_MODEL_VALUE}
+                    disabled={embeddingConfigLocked}
                     onValueChange={(value) =>
                       field.onChange(
                         value === NOT_EMBEDDING_MODEL_VALUE ? "" : value,
@@ -954,6 +966,20 @@ function EditModelDialog({
                       ))}
                     </SelectContent>
                   </Select>
+                  {embeddingConfigLocked && (
+                    <p className="text-sm text-muted-foreground">
+                      This model is used for knowledge base embeddings, so its
+                      embedding configuration is locked. To change it, drop the
+                      embedding configuration in{" "}
+                      <Link
+                        href="/settings/knowledge"
+                        className="underline underline-offset-2"
+                      >
+                        Knowledge settings
+                      </Link>{" "}
+                      first — all documents will need to be re-embedded.
+                    </p>
+                  )}
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
Fixes #5036
Supersedes #5319 — thanks @BeInLife for the initial frontend patch; this lands the same UX plus server-side enforcement.

## Problem

The knowledge base resolves its embedding model at embed time from the org's embedding API key provider + configured model ID, and reads `embedding_dimensions` from the `models` row. `PATCH /api/llm-models/:id` had no knowledge-base awareness, so you could change a locked embedding model's dimensions — or clear them, turning it back into a chat model — without dropping the index, silently corrupting retrieval. The knowledge-settings route already locks the org-side config; the model-side config was the open back door.

## Changes

**Backend (enforcement)**
- `OrganizationModel.isKnowledgeEmbeddingModel({ provider, modelId })` — detects whether any org's locked embedding config resolves to this model row (joined through the embedding API key so the match is provider-scoped, not just model-ID string equality).
- `PATCH /api/llm-models/:id` rejects `embeddingDimensions` changes (including clearing to `null`) for such a model with a 400 `embedding_validation_failed`, mirroring the knowledge-settings lock and pointing at the drop-embedding flow. Unchanged dimensions and non-embedding field updates stay allowed.

**Frontend (UX)**
- The edit-model dialog disables the embedding dimensions select for the locked model and explains why, linking to Knowledge settings where the Drop flow lives (per the discussion in #5036, no in-dialog drop button).
- Lock predicate extracted to `models-page-utils.ts` (provider-scoped via the embedding key).

**Tests**
- Route tests: dimension change and clear are rejected 400 with the model row untouched; benign updates and unchanged dimensions pass; a same-model-ID row under a different provider stays editable; the lock lifts after the embedding config is dropped.
- Unit tests for the frontend lock predicate.

**Docs**
- One sentence in the Knowledge page noting the lock also applies in LLM Providers > Models.

## How to test

1. Settings > Knowledge: configure an embedding key + model, save.
2. LLM Providers > Models: edit that model — the dimensions select is disabled with a pointer to Knowledge settings; `PATCH /api/llm-models/:id` with new dimensions returns 400.
3. Drop the embedding configuration; the model becomes editable again.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>