### PR TITLE
fix(llm-proxy): relay provider rate-limit errors uncorrupted

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -527,10 +527,19 @@ describe("handleError", () => {
   function makeReply(headersSent: boolean) {
     const writes: string[] = [];
     const headers: Record<string, string> = {};
-    const reply = {
+    const sent: { statusCode?: number; body?: unknown } = {};
+    const replyShape = {
       header: (name: string, value: string) => {
         headers[name] = value;
-        return reply;
+        return replyShape;
+      },
+      status: (statusCode: number) => {
+        sent.statusCode = statusCode;
+        return replyShape;
+      },
+      send: (body: unknown) => {
+        sent.body = body;
+        return replyShape;
       },
       raw: {
         headersSent,
@@ -540,8 +549,9 @@ describe("handleError", () => {
         },
         end: () => {},
       },
-    } as unknown as FastifyReply;
-    return { reply, writes, headers };
+    };
+    const reply = replyShape as unknown as FastifyReply;
+    return { reply, writes, headers, sent };
   }
 
   const extractMessage = (error: unknown) =>
@@ -688,14 +698,17 @@ describe("handleError", () => {
     throw new Error("handleError did not throw");
   }
 
-  test("classifies a streamed Anthropic overload as 529 with the normalized code", () => {
-    const { reply } = makeReply(false);
-    const thrown = throwErrorFor(makeStreamedOverloadError(), reply);
+  test("relays a streamed Anthropic overload as 529 with the provider body verbatim", () => {
+    const { reply, sent } = makeReply(false);
+    const error = makeStreamedOverloadError();
 
-    expect(thrown.statusCode).toBe(529);
-    expect(thrown.internalCode).toBe(
-      ArchestraInternalErrorCode.ProviderOverloaded,
-    );
+    handleError(error, reply, extractMessage, true, () => undefined);
+
+    expect(sent.statusCode).toBe(529);
+    expect(sent.body).toEqual({
+      type: "error",
+      error: { type: "overloaded_error", message: "Overloaded" },
+    });
   });
 
   test("classifies generic overload wording without a status as 503", () => {
@@ -746,12 +759,14 @@ describe("handleError", () => {
   });
 
   test("forwards the upstream Retry-After header before headers commit", () => {
-    const { reply, headers } = makeReply(false);
+    const { reply, headers, sent } = makeReply(false);
     const error = makeStreamedOverloadError(
       new Headers({ "retry-after": "30" }),
     );
 
-    expect(throwErrorFor(error, reply).statusCode).toBe(529);
+    handleError(error, reply, extractMessage, true, () => undefined);
+
+    expect(sent.statusCode).toBe(529);
     expect(headers["retry-after"]).toBe("30");
   });
 
@@ -781,6 +796,161 @@ describe("handleError", () => {
     const payload = JSON.parse(writes[0].replace(/^event: error\ndata: /, ""));
     expect(payload.error.internal_code).toBe(
       ArchestraInternalErrorCode.ProviderOverloaded,
+    );
+  });
+
+  // A provider rate limit must reach native clients uncorrupted: the provider
+  // error body is relayed verbatim (not rewrapped into the Archestra envelope,
+  // which rewrote `rate_limit_error` to `unknown_api_error`) and the
+  // provider's ratelimit headers are forwarded so clients can tell an
+  // account/usage limit apart from server-side throttling.
+  function makeAnthropicRateLimitError(headers?: unknown) {
+    const body = {
+      type: "error",
+      error: {
+        type: "rate_limit_error",
+        message: "This request would exceed your account's rate limit.",
+      },
+    };
+    return Object.assign(new Error(JSON.stringify(body)), {
+      status: 429,
+      error: body,
+      headers,
+    });
+  }
+
+  test("relays an Anthropic 429 body verbatim with its original error type", () => {
+    const { reply, sent } = makeReply(false);
+
+    handleError(
+      makeAnthropicRateLimitError(),
+      reply,
+      extractMessage,
+      false,
+      () => undefined,
+    );
+
+    expect(sent.statusCode).toBe(429);
+    expect(sent.body).toEqual({
+      type: "error",
+      error: {
+        type: "rate_limit_error",
+        message: "This request would exceed your account's rate limit.",
+      },
+    });
+  });
+
+  test("rewraps an OpenAI-style 429 error member into the provider's original body shape", () => {
+    const { reply, sent } = makeReply(false);
+    const error = Object.assign(new Error("Rate limit reached"), {
+      status: 429,
+      // OpenAI-compatible SDKs store the body's `error` member directly.
+      error: {
+        message: "Rate limit reached for requests",
+        type: "requests",
+        code: "rate_limit_exceeded",
+      },
+    });
+
+    handleError(error, reply, extractMessage, false, () => undefined);
+
+    expect(sent.statusCode).toBe(429);
+    expect(sent.body).toEqual({
+      error: {
+        message: "Rate limit reached for requests",
+        type: "requests",
+        code: "rate_limit_exceeded",
+      },
+    });
+  });
+
+  test("forwards the provider's ratelimit headers on a rate-limited response", () => {
+    const { reply, headers } = makeReply(false);
+    const error = makeAnthropicRateLimitError(
+      new Headers({
+        "anthropic-ratelimit-unified-status": "rejected",
+        "anthropic-ratelimit-unified-reset": "1753257600",
+        "x-ratelimit-remaining-tokens": "0",
+        "retry-after": "60",
+        // Unrelated headers must not leak through.
+        "x-request-id": "req_123",
+      }),
+    );
+
+    handleError(error, reply, extractMessage, false, () => undefined);
+
+    expect(headers["anthropic-ratelimit-unified-status"]).toBe("rejected");
+    expect(headers["anthropic-ratelimit-unified-reset"]).toBe("1753257600");
+    expect(headers["x-ratelimit-remaining-tokens"]).toBe("0");
+    expect(headers["retry-after"]).toBe("60");
+    expect(headers["x-request-id"]).toBeUndefined();
+  });
+
+  test("drops a ratelimit header value with non-printable characters", () => {
+    const { reply, headers } = makeReply(false);
+    const error = makeAnthropicRateLimitError({
+      "anthropic-ratelimit-unified-status": "reject\u0000ed",
+    });
+
+    handleError(error, reply, extractMessage, false, () => undefined);
+
+    expect(headers["anthropic-ratelimit-unified-status"]).toBeUndefined();
+  });
+
+  test("keeps the provider's error type in the mid-stream SSE event for a rate limit", () => {
+    const { reply, writes } = makeReply(true);
+
+    handleError(
+      makeAnthropicRateLimitError(),
+      reply,
+      extractMessage,
+      true,
+      () => undefined,
+    );
+
+    expect(writes).toHaveLength(1);
+    const payload = JSON.parse(writes[0].replace(/^event: error\ndata: /, ""));
+    expect(payload.error.type).toBe("rate_limit_error");
+  });
+
+  test("falls back to the Archestra envelope for a 429 without a provider body", () => {
+    const { reply } = makeReply(false);
+    const error = Object.assign(new Error("rate limited"), { status: 429 });
+
+    const thrown = throwErrorFor(error, reply);
+    expect(thrown.statusCode).toBe(429);
+  });
+
+  test("keeps the Archestra envelope for an internal ApiError 429 (usage-limit block)", () => {
+    const { reply } = makeReply(false);
+    const error = new ApiError(429, "Usage limit exceeded");
+
+    const thrown = throwErrorFor(error, reply);
+    expect(thrown.statusCode).toBe(429);
+    expect(thrown.message).toBe("Usage limit exceeded");
+  });
+
+  test("lets an adapter's intentional reclassification win over body passthrough", () => {
+    const { reply } = makeReply(false);
+    const error = makeAnthropicRateLimitError();
+
+    const thrown = (() => {
+      try {
+        handleError(
+          error,
+          reply,
+          extractMessage,
+          false,
+          () => ArchestraInternalErrorCode.ProviderInsufficientBalance,
+        );
+      } catch (caught) {
+        return caught as ApiError;
+      }
+      throw new Error("handleError did not throw");
+    })();
+
+    expect(thrown.internalCode).toBe(
+      ArchestraInternalErrorCode.ProviderInsufficientBalance,
     );
   });
 });

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -388,12 +388,27 @@ export function handleError(
       classifyUpstreamOverload(error) !== undefined);
 
   const errorMessage = extractErrorMessage(error);
+  const adapterInternalCode = extractInternalCode(error);
   const internalCode =
-    extractInternalCode(error) ??
+    adapterInternalCode ??
     (error instanceof ApiError ? error.internalCode : undefined) ??
     (isUpstreamOverload
       ? ArchestraInternalErrorCode.ProviderOverloaded
       : undefined);
+
+  // Provider rate limits and overloads are relayed uncorrupted. Rewrapping
+  // them in the Archestra error envelope rewrites the provider's error type
+  // (e.g. Anthropic's `rate_limit_error` became `unknown_api_error`), which
+  // makes native clients misclassify the failure — a subscription usage-limit
+  // 429 gets reported to the user as server-side throttling. Internal
+  // ApiErrors (Archestra's own limit blocks) and errors the adapter
+  // intentionally reclassifies (adapterInternalCode) keep the envelope.
+  const upstreamPassthroughBody =
+    !(error instanceof ApiError) &&
+    adapterInternalCode === undefined &&
+    (statusCode === 429 || statusCode === 529)
+      ? extractUpstreamErrorBody(error)
+      : undefined;
 
   // Headers cannot be changed after streaming starts.
   if (!reply.raw.headersSent) {
@@ -401,6 +416,7 @@ export function handleError(
     if (retryAfter !== undefined) {
       reply.header("retry-after", retryAfter);
     }
+    forwardUpstreamRateLimitHeaders(error, reply);
   }
 
   // If headers already sent (mid-stream error), write error to stream.
@@ -412,7 +428,12 @@ export function handleError(
     const errorEvent = {
       type: "error",
       error: {
-        type: "api_error",
+        // Keep the provider's own error type for rate limits/overloads so
+        // native streaming clients classify the failure correctly.
+        type:
+          (upstreamPassthroughBody !== undefined && error instanceof Error
+            ? nestedProviderErrorType(error)
+            : undefined) ?? "api_error",
         message: errorMessage,
         // Surface the normalized code (e.g. provider_insufficient_balance)
         // mid-stream too, so a failure after headers commit stays classifiable.
@@ -430,6 +451,15 @@ export function handleError(
       );
     }
     return reply;
+  }
+
+  // Provider rate-limit/overload body is relayed verbatim (bypassing the
+  // Archestra envelope the central handler would build): the proxy's provider
+  // routes speak each provider's wire format, and native clients parse this
+  // body for the error type. Statuses 429/529 have no response schema entry,
+  // so the payload is serialized as-is.
+  if (upstreamPassthroughBody !== undefined) {
+    return reply.status(statusCode).send(upstreamPassthroughBody);
   }
 
   // Headers not sent yet - throw ApiError to let central handler return proper status code
@@ -512,6 +542,68 @@ function nestedProviderErrorType(error: Error): string | undefined {
   }
   return undefined;
 }
+
+/**
+ * The parsed upstream error body carried by a provider SDK error. The
+ * Anthropic SDK stores the full response envelope
+ * (`{ type: "error", error: { type, message } }`) on `.error`, while
+ * OpenAI-compatible SDKs store only the body's `error` member — the latter is
+ * re-wrapped so the relayed body matches what the provider originally sent.
+ */
+function extractUpstreamErrorBody(error: unknown): object | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const body = (error as Error & { error?: unknown }).error;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return undefined;
+  }
+  if ("error" in body) return body;
+  return { error: body };
+}
+
+/**
+ * Forward the provider's rate-limit state headers so native clients can tell
+ * an account/usage limit apart from server-side throttling and show reset
+ * times (e.g. Anthropic's `anthropic-ratelimit-unified-status` drives the
+ * "usage limit" vs "server is limiting requests" distinction in clients).
+ * Values are validated to printable ASCII so junk is not relayed.
+ */
+function forwardUpstreamRateLimitHeaders(
+  error: unknown,
+  reply: FastifyReply,
+): void {
+  if (!(error instanceof Error)) return;
+  const headers = (error as Error & { headers?: unknown }).headers;
+
+  let entries: [string, unknown][];
+  if (headers instanceof Headers) {
+    entries = [...headers.entries()];
+  } else if (headers && typeof headers === "object") {
+    entries = Object.entries(headers);
+  } else {
+    return;
+  }
+
+  for (const [name, value] of entries) {
+    const lowerName = name.toLowerCase();
+    if (
+      !RATE_LIMIT_HEADER_PREFIXES.some((prefix) => lowerName.startsWith(prefix))
+    ) {
+      continue;
+    }
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (
+      trimmed.length === 0 ||
+      trimmed.length > 256 ||
+      /[^\t\x20-\x7e]/.test(trimmed)
+    ) {
+      continue;
+    }
+    reply.header(lowerName, trimmed);
+  }
+}
+
+const RATE_LIMIT_HEADER_PREFIXES = ["anthropic-ratelimit-", "x-ratelimit-"];
 
 /**
  * Read a valid Retry-After value from current or legacy SDK error headers.


### PR DESCRIPTION
## Problem

When an upstream LLM provider returns a rate-limit (429) or overload (529) error, the LLM proxy rewraps it into the internal Archestra error envelope (`{ error: { message, type } }`). This corrupts the error in two ways:

1. **The provider's error type is rewritten** — e.g. Anthropic's `rate_limit_error` becomes `unknown_api_error` (429 has no mapping in `ApiError`), and the body loses the provider's native envelope shape.
2. **The provider's ratelimit response headers are dropped** — only `retry-after` was forwarded. Anthropic's `anthropic-ratelimit-*` headers (notably `anthropic-ratelimit-unified-status` / `-unified-reset`) are what native clients use to distinguish *the account's own usage limit* from *server-side throttling* and to show reset times.

The visible symptom: a client whose subscription usage limit is exhausted gets told by its tooling that the server is temporarily limiting requests and it is "not your usage limit" — the opposite of what actually happened — because the signal that would have said otherwise never made it through the proxy.

## Fix

In `handleError` (`llm-proxy-helpers.ts`), for provider-origin 429/529 errors:

- **Relay the provider's original error body verbatim** with the upstream status instead of throwing the envelope-building `ApiError`. The Anthropic SDK carries the full response envelope on `.error`; OpenAI-compatible SDKs carry the body's `error` member, which is re-wrapped to match the original wire shape. Statuses 429/529 have no response-schema entry, so the payload serializes as-is.
- **Forward `anthropic-ratelimit-*` / `x-ratelimit-*` headers** (values validated to printable ASCII, capped length) alongside the existing `retry-after` forwarding.
- **Keep the provider's error type in mid-stream SSE error events** (previously hardcoded `api_error`), so streaming clients classify the failure correctly after headers commit.

Deliberately unchanged:
- Archestra's own limit blocks (internal `ApiError`s) keep the envelope — including the usage-limit 429 the chat UI special-cases.
- Errors an adapter intentionally reclassifies (e.g. Anthropic balance-too-low → `provider_insufficient_balance`) keep the envelope and internal code.
- Other error statuses (400/401/…) keep the envelope; this PR is scoped to the rate-limit/overload class.
- Chat is unaffected: its per-provider mappers already understand native `rate_limit_error` / `overloaded_error` bodies and map them to the same `ChatErrorCode`s as before.

## Tests

Extended `llm-proxy-helpers.test.ts` (`handleError` suite, 52 passing): verbatim Anthropic 429 body relay, OpenAI-style error-member rewrap, ratelimit-header forwarding (with junk-value and unrelated-header rejection), provider type in mid-stream SSE, and the envelope fallbacks (429 without a body, internal `ApiError` 429, adapter reclassification wins). Also ran the provider matrix, proxy handler, Anthropic adapter, virtual-key, and chat-error suites (314 passing), plus backend type-check and lint.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>