### PR TITLE
fix(llm-logs): show one session per Archestra Chat and badge sub-agent calls

### DIFF
--- a/platform/backend/src/models/interaction.test.ts
+++ b/platform/backend/src/models/interaction.test.ts
@@ -1,4 +1,5 @@
 import {
+  BUILT_IN_AGENT_IDS,
   ChatErrorCode,
   CLAUDE_CLIENT_FILTER,
   CLAUDE_CLIENT_ID,
@@ -1339,6 +1340,107 @@ describe("InteractionModel", () => {
       expect(Number(session?.totalCost)).toBeCloseTo(7, 5);
       expect(Number(session?.totalBilledCost)).toBeCloseTo(2, 5);
       expect(Number(session?.totalSubscriptionCost)).toBeCloseTo(5, 5);
+    });
+  });
+
+  describe("getSessions Archestra Chat session identity (T-894)", () => {
+    // A new Archestra Chat fires two LLM calls that share one session_id (the
+    // conversation id): the user's turn under their agent (source "chat") and
+    // the auto title-generation call under the built-in title subagent
+    // (source "chat:title_generation"). The sessions listing must treat this as
+    // ONE session, not two, and attribute it to the user's agent.
+    async function seedChatPlusTitleGen(sessionId: string) {
+      const chatAgent = await AgentModel.create({
+        name: "My Assistant",
+        teams: [],
+        scope: "org",
+      });
+      const titleAgent = await AgentModel.create({
+        name: "Chat Title Generation Subagent",
+        teams: [],
+        scope: "org",
+        builtInAgentConfig: { name: BUILT_IN_AGENT_IDS.CHAT_TITLE_GENERATION },
+      });
+      const base = {
+        sessionId,
+        sessionSource: "header",
+        request: {
+          model: "gpt-4",
+          messages: [{ role: "user", content: "Reply with just hello" }],
+        },
+        response: {
+          id: "r",
+          object: "chat.completion" as const,
+          created: Date.now(),
+          model: "gpt-4",
+          choices: [],
+        },
+        type: "openai:chatCompletions" as const,
+      };
+      await InteractionModel.create({
+        ...base,
+        profileId: chatAgent.id,
+        source: "chat",
+      });
+      await InteractionModel.create({
+        ...base,
+        profileId: titleAgent.id,
+        source: "chat:title_generation",
+      });
+      return { chatAgent, titleAgent };
+    }
+
+    test("collapses the chat and its title-generation subagent into a single session attributed to the primary agent", async ({
+      makeAdmin,
+    }) => {
+      const admin = await makeAdmin();
+      const sessionId = "t894-session-collapse";
+      const { chatAgent } = await seedChatPlusTitleGen(sessionId);
+
+      const sessions = await InteractionModel.getSessions(
+        { limit: 100, offset: 0 },
+        admin.id,
+        true,
+        { sessionId },
+      );
+
+      // One chat => one session (previously it split into two because the
+      // GROUP BY keyed on profile_id/agent name).
+      expect(sessions.data).toHaveLength(1);
+      expect(sessions.pagination.total).toBe(1);
+      // Both interactions are counted within that one session.
+      expect(sessions.data[0].requestCount).toBe(2);
+      // Attributed to the user's (non-built-in) agent — id AND name from the
+      // same agent, never the built-in title subagent.
+      expect(sessions.data[0].profileId).toBe(chatAgent.id);
+      expect(sessions.data[0].profileName).toBe("My Assistant");
+    });
+
+    test("badges the auxiliary chat call as a subagent and the user turn as main in the session detail list", async ({
+      makeAdmin,
+    }) => {
+      const admin = await makeAdmin();
+      const sessionId = "t894-session-badges";
+      await seedChatPlusTitleGen(sessionId);
+
+      const result = await InteractionModel.findAllPaginated(
+        { limit: 100, offset: 0 },
+        undefined,
+        admin.id,
+        true,
+        { sessionId },
+      );
+
+      const bySource = new Map(
+        result.data.map((i) => [
+          i.source,
+          i as unknown as { source: string | null; requestType: string },
+        ]),
+      );
+      expect(bySource.get("chat")?.requestType).toBe("main");
+      expect(bySource.get("chat:title_generation")?.requestType).toBe(
+        "subagent",
+      );
     });
   });
 

--- a/platform/backend/src/models/interaction.ts
+++ b/platform/backend/src/models/interaction.ts
@@ -96,7 +96,19 @@ function getMessageText(
 function computeRequestType(
   request: unknown,
   sessionSource: string | null,
+  source: string | null,
 ): "main" | "subagent" {
+  // Archestra Chat marks its auxiliary LLM calls with a `chat:<subtype>` source
+  // (title generation, context compaction, tool-call repair); the user's own
+  // turn is plain "chat". These auxiliary calls are sub-agent work — title
+  // generation and compaction even run under dedicated built-in sub-agents — so
+  // the session detail view must badge them as "subagent". A chat session's
+  // session_source is not a Claude source, so without this the heuristics below
+  // would fall through to "main" and mislabel every auxiliary chat call.
+  if (source?.startsWith("chat:")) {
+    return "subagent";
+  }
+
   // Only apply detection heuristics for Claude sessions (claude_metadata, plus
   // the legacy claude_code / claude_desktop values on older rows).
   if (!isClaudeSessionSource(sessionSource)) {
@@ -498,6 +510,7 @@ class InteractionModel {
         requestType: computeRequestType(
           full?.request ?? interaction.request,
           interaction.sessionSource,
+          interaction.source,
         ),
         // Resolve externalAgentId to human-readable label (supports delegation chains)
         externalAgentIdLabel: resolveExternalAgentIdLabel(
@@ -1101,8 +1114,20 @@ class InteractionModel {
           firstRequestTime: min(schema.interactionsTable.createdAt),
           lastRequestTime: max(schema.interactionsTable.createdAt),
           models: sql<string>`STRING_AGG(DISTINCT ${schema.interactionsTable.model}, ',')`,
-          profileId: sql<string | null>`MAX(${schema.agentsTable.id}::text)`,
-          profileName: max(schema.agentsTable.name),
+          // Attribute the session to its primary (non-built-in) agent. A chat
+          // session mixes the user's agent with built-in utility subagents (e.g.
+          // title generation), all sharing one session_id; without the FILTER,
+          // MAX(id) and MAX(name) could resolve to different interactions and
+          // surface the utility subagent. Preferring built_in = false keeps id
+          // and name from the same agent; COALESCE falls back to any agent for
+          // sessions that only ran built-in agents. API/Claude-Code sessions have
+          // a single profile per session, so this is a no-op for them.
+          profileId: sql<
+            string | null
+          >`COALESCE(MAX(${schema.agentsTable.id}::text) FILTER (WHERE ${schema.agentsTable.builtIn} = false), MAX(${schema.agentsTable.id}::text))`,
+          profileName: sql<
+            string | null
+          >`COALESCE(MAX(${schema.agentsTable.name}) FILTER (WHERE ${schema.agentsTable.builtIn} = false), MAX(${schema.agentsTable.name}))`,
           externalAgentIds: sql<string>`STRING_AGG(DISTINCT ${schema.interactionsTable.externalAgentId}, ',')`,
           authMethods: sql<string>`STRING_AGG(DISTINCT ${schema.interactionsTable.authMethod}, ',')`,
           authenticatedAppNames: sql<
@@ -1131,11 +1156,14 @@ class InteractionModel {
         )
         .leftJoin(schema.conversationsTable, sessionIdMatchesConversation())
         .where(whereClause)
-        .groupBy(
-          sessionGroupExpr,
-          schema.interactionsTable.profileId,
-          schema.agentsTable.name,
-        )
+        // A session is identified by its session id alone (COALESCE(session_id,
+        // id) for sessionless rows). profile_id / agent name must NOT be part of
+        // the group key: an Archestra Chat writes its title-generation call under
+        // a separate built-in subagent, so grouping by agent split one chat into
+        // two "sessions". This now matches the `total` count below, which already
+        // counts distinct session ids only. Agent attribution is aggregated in
+        // the SELECT (MAX) instead of being part of the key.
+        .groupBy(sessionGroupExpr)
         .orderBy(desc(max(schema.interactionsTable.createdAt)))
         .limit(pagination.limit)
         .offset(pagination.offset),


### PR DESCRIPTION
## Problem

Creating a new Archestra Chat shows up as **two sessions** in LLM Logs (T-894).

A new chat fires two LLM calls that share one `session_id` (the conversation id) but run under different agents:

| call | source | agent (`profile_id`) |
|---|---|---|
| the user's turn | `chat` | the conversation's agent |
| auto title generation | `chat:title_generation` | the built-in **Chat Title Generation Subagent** |

`InteractionModel.getSessions` grouped by `(COALESCE(session_id, id), profile_id, agent name)`, so the two rows landed in two buckets → one chat rendered as two sessions. This was already inconsistent with the sibling `total` count, which counts `DISTINCT session_id` only (list said 2, total said 1).

## Fix

All in `backend/src/models/interaction.ts`:

1. **Group sessions by session id alone** — drop `profile_id` / agent name from the `GROUP BY`. Now consistent with the `total` count.
2. **Attribute the session to its primary (non-built-in) agent** — `profileId` / `profileName` prefer `built_in = false` (with a `COALESCE` fallback), so both resolve from the *same* real agent instead of `MAX()` occasionally surfacing the utility subagent.
3. **Fix the Main/Sub-agent badge on the session detail table** — `computeRequestType` only handled Claude sources, so chat rows all fell through to `main`. It now badges chat's auxiliary `chat:<subtype>` calls (`title_generation`, `compaction`, `tool_call_repair`) as **subagent**, and the user's `chat` turn as **main**.

No API request/response schema change (the returned fields already existed), so no codegen.

## Verification

Reproduced end-to-end on a dev stack, then confirmed the fix against the same data:

- **Session list:** one chat → **1 session** (`total 1`), attributed to the real chat agent, `requestCount 2`.
- **Detail table:** `chat` → **Main**, `chat:title_generation` → **Subagent**.

Tests: 2 new regression tests (session collapse + primary-agent attribution; detail badge attribution); full `interaction.test.ts` 72/72 pass; `type-check`, `lint`, and `knip` clean.

Closes T-894.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>