### PR TITLE
fix(connection): clarify provider-key gating across the setup wizard

### DIFF
--- a/platform/frontend/src/app/connection/connect-command-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useHasPermissions } from "@/lib/auth/auth.query";
@@ -61,6 +61,14 @@ vi.mock("@/components/github-copilot-sign-in", () => ({
 vi.mock("@/components/create-llm-provider-api-key-dialog", () => ({
   CreateLlmProviderApiKeyDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="add-provider-key-dialog" /> : null,
+}));
+
+// Stubbed so the gate's provider logo doesn't pull next/image into jsdom; the
+// branded-CTA test asserts on the provider it's told to render.
+vi.mock("@/components/provider-icon", () => ({
+  ProviderIcon: ({ provider }: { provider: string }) => (
+    <span data-testid="provider-icon" data-provider={provider} />
+  ),
 }));
 
 function findClient(id: string) {
@@ -318,7 +326,7 @@ describe("ConnectCommandPanel", () => {
     expect(onProviderSelect).toHaveBeenCalledWith("bedrock");
   });
 
-  it("opens an inline add-provider-key dialog when no provider can mint a virtual key", async () => {
+  it("opens an inline add-provider-key dialog from the auth editor when no provider can mint a virtual key", async () => {
     // No configured provider key, but the user may create one
     // (hasPermissionsMock defaults to true for llmProviderApiKey:create).
     availableKeysMock.mockReturnValue({ data: [] });
@@ -327,11 +335,72 @@ describe("ConnectCommandPanel", () => {
 
     await user.click(screen.getByTestId("connect-change-proxy"));
     await user.click(screen.getByRole("tab", { name: "Virtual key" }));
+    await user.click(screen.getByTestId("connect-auth-add-provider-key"));
+
+    expect(screen.getByTestId("add-provider-key-dialog")).toBeInTheDocument();
+  });
+
+  it("gates step 3 and hides the OAuth step when virtual-key auth has no backing key", async () => {
+    availableKeysMock.mockReturnValue({ data: [] });
+    const user = userEvent.setup();
+    renderPanel();
+
+    // Passthrough by default → a runnable command, plus the OAuth step.
+    await screen.findByText(COMMAND);
+    expect(
+      screen.getByRole("heading", { name: "Finish the OAuth flow" }),
+    ).toBeInTheDocument();
+
+    // Switch the proxy auth to a virtual key that nothing can back.
+    await user.click(screen.getByTestId("connect-change-proxy"));
+    await user.click(screen.getByRole("tab", { name: "Virtual key" }));
+
+    // Step 3 gates on adding a key instead of shipping a command...
+    const gateButton = await screen.findByTestId(
+      "connect-gate-add-provider-key",
+    );
+    // Two supported providers (Anthropic, Bedrock) → the CTA stays generic.
+    expect(gateButton).toHaveTextContent("Add a provider key");
+    expect(screen.queryByText(COMMAND)).not.toBeInTheDocument();
+    // ...and the setup, now unproducible as configured, drops the OAuth step.
+    expect(
+      screen.queryByRole("heading", { name: "Finish the OAuth flow" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the add-provider-key dialog from the step-3 gate", async () => {
+    availableKeysMock.mockReturnValue({ data: [] });
+    const user = userEvent.setup();
+    renderPanel();
+    await screen.findByText(COMMAND);
+
+    await user.click(screen.getByTestId("connect-change-proxy"));
+    await user.click(screen.getByRole("tab", { name: "Virtual key" }));
     await user.click(
-      screen.getByRole("button", { name: /add a provider key/i }),
+      await screen.findByTestId("connect-gate-add-provider-key"),
     );
 
     expect(screen.getByTestId("add-provider-key-dialog")).toBeInTheDocument();
+  });
+
+  it("brands the step-3 gate CTA to the sole provider (Codex → OpenAI)", async () => {
+    availableKeysMock.mockReturnValue({ data: [] });
+    const user = userEvent.setup();
+    renderPanel({ client: findClient("codex") });
+
+    await screen.findByText(COMMAND);
+    await user.click(screen.getByTestId("connect-change-proxy"));
+    await user.click(screen.getByRole("tab", { name: "Virtual key" }));
+
+    const gateButton = await screen.findByTestId(
+      "connect-gate-add-provider-key",
+    );
+    // OpenAI-branded, not a generic "provider key".
+    expect(gateButton).toHaveTextContent("Add an OpenAI key");
+    expect(within(gateButton).getByTestId("provider-icon")).toHaveAttribute(
+      "data-provider",
+      "openai",
+    );
   });
 
   it("skips skills entirely for non-admin users", async () => {
@@ -455,6 +524,48 @@ describe("ConnectCommandPanel", () => {
       expect(
         screen.queryByRole("button", { name: /Sign in with GitHub/i }),
       ).not.toBeInTheDocument();
+    });
+
+    it("keeps the auth toggle reachable after Virtual key falls back to GitHub Copilot", async () => {
+      // With no configured keys, switching Copilot CLI to a virtual key collapses
+      // the provider list to GitHub Copilot (the only per-user one). The toggle
+      // must stay so the user isn't stranded in virtual-key mode.
+      availableKeysMock.mockReturnValue({ data: [] });
+      const user = userEvent.setup();
+      renderPanel({ client: findClient("copilot-cli") });
+
+      await screen.findByText(COMMAND);
+      await user.click(screen.getByTestId("connect-change-proxy"));
+      await user.click(screen.getByRole("tab", { name: "Virtual key" }));
+
+      // We fell back to the GitHub Copilot connect gate...
+      expect(
+        await screen.findByRole("button", { name: /Sign in with GitHub/i }),
+      ).toBeInTheDocument();
+      // ...but both auth tabs are still there to switch back.
+      expect(
+        screen.getByRole("tab", { name: "Your provider key" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: "Virtual key" }),
+      ).toBeInTheDocument();
+    });
+
+    it("switches back to passthrough off the per-user provider so the choice sticks", async () => {
+      availableKeysMock.mockReturnValue({ data: [] });
+      const onProviderSelect = vi.fn();
+      const user = userEvent.setup();
+      renderPanel({ client: findClient("copilot-cli"), onProviderSelect });
+
+      await screen.findByText(COMMAND);
+      await user.click(screen.getByTestId("connect-change-proxy"));
+      await user.click(screen.getByRole("tab", { name: "Virtual key" }));
+      await screen.findByRole("button", { name: /Sign in with GitHub/i });
+
+      // Clicking back to passthrough moves off GitHub Copilot (which forces
+      // virtual-key) to the first passthrough-capable provider.
+      await user.click(screen.getByRole("tab", { name: "Your provider key" }));
+      expect(onProviderSelect).toHaveBeenCalledWith("openai");
     });
   });
 });

--- a/platform/frontend/src/app/connection/connect-command-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.tsx
@@ -5,7 +5,14 @@ import {
   providerRequiresPerUserCredential,
   type SupportedProvider,
 } from "@archestra/shared";
-import { Check, CircleDashed, Copy, Loader2, RotateCcw } from "lucide-react";
+import {
+  Check,
+  CircleDashed,
+  Copy,
+  KeyRound,
+  Loader2,
+  RotateCcw,
+} from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -16,6 +23,7 @@ import {
 import { CreditWarningNotice } from "@/components/connection/credit-warning-notice";
 import { CreateLlmProviderApiKeyDialog } from "@/components/create-llm-provider-api-key-dialog";
 import { GithubCopilotSignIn } from "@/components/github-copilot-sign-in";
+import { ProviderIcon } from "@/components/provider-icon";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -246,6 +254,13 @@ export function ConnectCommandPanel({
   // only joins the command when a provider is also resolved.
   const proxy = (llmProxies ?? []).find((p) => p.id === llmProxyId) ?? null;
   const proxyActive = !!(proxy && provider);
+  // Virtual-key auth was chosen, but nothing can back it: the client routes only
+  // providers with no configured key (and none are per-user), so no virtual key
+  // can be minted. Emitting the script anyway would silently drop the inference
+  // proxy, so — like the per-user connect gate — step 3 gates on adding a key
+  // instead of shipping a half-configured command.
+  const virtualKeyUnbacked =
+    !!proxy && !provider && proxyAuth === "virtual-key";
   const hasAnything = Boolean(gateway || proxyActive || includeSkills);
 
   // The setup command only registers the MCP gateway (`claude mcp add`); the
@@ -253,7 +268,8 @@ export function ConnectCommandPanel({
   // in their client. Surface that as an explicit final step — mirrors the
   // Claude Desktop panel's "Finish the OAuth flow" step. The gateway is the
   // thing being authorized, so the step is gateway-gated.
-  const showOAuthStep = client.id === "claude-code" && !!gateway;
+  const showOAuthStep =
+    client.id === "claude-code" && !!gateway && !virtualKeyUnbacked;
   const appName = useAppName();
   // The exact name the script registers the gateway under — referenced in the
   // OAuth step so the user can find it in the `claude /mcp` list.
@@ -353,14 +369,22 @@ export function ConnectCommandPanel({
   useEffect(() => {
     setResult(null);
     setFailed(false);
-    // Don't try to generate a command until the user has connected their
-    // per-user account — the backend would reject it (no key to mint from).
-    if (!hasAnything || needsPerUserConnect) return;
+    // Don't try to generate a command until the setup can actually be produced:
+    // not before a per-user account is connected, and not for a virtual key that
+    // has no provider key to mint from — either way the backend would reject it
+    // (or the script would silently drop the proxy).
+    if (!hasAnything || needsPerUserConnect || virtualKeyUnbacked) return;
     const timer = setTimeout(() => {
       void runGeneration(inputsKey);
     }, 350);
     return () => clearTimeout(timer);
-  }, [inputsKey, hasAnything, needsPerUserConnect, runGeneration]);
+  }, [
+    inputsKey,
+    hasAnything,
+    needsPerUserConnect,
+    virtualKeyUnbacked,
+    runGeneration,
+  ]);
 
   // Each summary line owns its inline editor. A line is editable only when it
   // has a real choice (e.g. more than one gateway); otherwise no "Change".
@@ -437,10 +461,34 @@ export function ConnectCommandPanel({
       : supportedNames.length === 1
         ? `${client.label} routes ${supportedNames[0]}, which has no key to mint a virtual key from.`
         : `${client.label} routes ${formatList(supportedNames)}, none of which has a key to mint a virtual key from.`;
+  // Brand the "add a key" CTA to the one provider a single-provider client
+  // routes (e.g. Codex → OpenAI), matching how the per-user gate is branded to
+  // its client. With several providers there's nothing single to name, so the
+  // wording stays generic.
+  const soleProvider =
+    supportedProviders.length === 1 ? supportedProviders[0] : null;
+  const addKeyPhrase = soleProvider
+    ? `${indefiniteArticle(providerDisplayNames[soleProvider])} ${providerDisplayNames[soleProvider]} key`
+    : "a provider key";
   const providerKeyDialogDescription =
     supportedNames.length === 0
       ? "Add a provider API key so a virtual key can be minted from it."
       : `Add a provider API key so a virtual key can be minted from it. ${client.label} routes ${formatList(supportedNames)}, so a key for one of those unlocks the virtual-key option for this client.`;
+
+  // A per-user provider (GitHub Copilot) forces virtual-key auth, so switching
+  // the toggle back to passthrough while it's selected would re-force virtual
+  // key and appear to do nothing. Move to the first passthrough-capable provider
+  // as well, so the toggle can never strand the user in the per-user state.
+  const handleProxyAuthChange = (value: string) => {
+    const next = value as ConnectProxyAuth;
+    setProxyAuth(next);
+    if (next === "provider-key" && providerIsPerUser) {
+      const firstPassthrough = supportedProviders.find(
+        (p) => !providerRequiresPerUserCredential(p),
+      );
+      if (firstPassthrough) onProviderSelect(firstPassthrough);
+    }
+  };
 
   const proxyEditor = proxy ? (
     <div className="grid gap-3">
@@ -460,56 +508,50 @@ export function ConnectCommandPanel({
       )}
       <EditorField label="Auth">
         <div className="grid gap-1.5">
-          {/* Per-user providers (GitHub Copilot) can't use passthrough — their
-              raw token must never be embedded in a shared command — so only the
-              virtual-key path is offered. */}
-          {providerIsPerUser ? (
-            <p className="text-xs text-muted-foreground">
-              {providerDisplayNames[provider]} runs through a personal virtual
-              key — connect your own account below.
-            </p>
-          ) : (
-            <>
-              <Tabs
-                value={proxyAuth}
-                onValueChange={(v) => setProxyAuth(v as ConnectProxyAuth)}
-              >
-                <TabsList>
-                  <TabsTrigger value="provider-key">
-                    Your provider key
-                  </TabsTrigger>
-                  <TabsTrigger value="virtual-key">Virtual key</TabsTrigger>
-                </TabsList>
-              </Tabs>
-              <p className="text-xs text-muted-foreground">
-                {proxyAuth === "provider-key" ? (
-                  passthroughAttributes ? (
-                    "Passthrough — the command only rewires the base URL, so you reuse your own API key or existing subscription (e.g. Claude or ChatGPT plan). Your personal auth key is created for you and wired into the command via ANTHROPIC_CUSTOM_HEADERS."
-                  ) : (
-                    "Passthrough — the command only rewires the base URL, so you reuse your own API key or existing subscription (e.g. Claude or ChatGPT plan)."
-                  )
-                ) : providers.length === 0 ? (
-                  canCreateProviderKey ? (
-                    <>
-                      {noVirtualKeyReason}{" "}
-                      <button
-                        type="button"
-                        className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
-                        onClick={() => setShowAddProviderKey(true)}
-                      >
-                        Add a provider key
-                      </button>{" "}
-                      or switch to your provider key.
-                    </>
-                  ) : (
-                    `${noVirtualKeyReason} Switch to your provider key, or ask an admin to add a provider key.`
-                  )
-                ) : (
-                  "A virtual key is created for you and wired into the command."
-                )}
-              </p>
-            </>
-          )}
+          {/* The toggle stays visible even for a per-user provider (GitHub
+              Copilot), which forces virtual-key auth. Hiding it there stranded
+              the user in virtual-key mode with no way back;
+              handleProxyAuthChange moves off the per-user provider when
+              switching to passthrough, so the choice sticks. */}
+          <Tabs
+            value={effectiveProxyAuth}
+            onValueChange={handleProxyAuthChange}
+          >
+            <TabsList>
+              <TabsTrigger value="provider-key">Your provider key</TabsTrigger>
+              <TabsTrigger value="virtual-key">Virtual key</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <p className="text-xs text-muted-foreground">
+            {effectiveProxyAuth === "provider-key" ? (
+              passthroughAttributes ? (
+                "Passthrough — the command only rewires the base URL, so you reuse your own API key or existing subscription (e.g. Claude or ChatGPT plan). Your personal auth key is created for you and wired into the command via ANTHROPIC_CUSTOM_HEADERS."
+              ) : (
+                "Passthrough — the command only rewires the base URL, so you reuse your own API key or existing subscription (e.g. Claude or ChatGPT plan)."
+              )
+            ) : providerIsPerUser && provider ? (
+              `${providerDisplayNames[provider]} runs through a personal virtual key — connect your own account below.`
+            ) : providers.length === 0 ? (
+              canCreateProviderKey ? (
+                <>
+                  {noVirtualKeyReason}{" "}
+                  <button
+                    type="button"
+                    className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+                    onClick={() => setShowAddProviderKey(true)}
+                    data-testid="connect-auth-add-provider-key"
+                  >
+                    Add {addKeyPhrase}
+                  </button>{" "}
+                  or switch to your provider key.
+                </>
+              ) : (
+                `${noVirtualKeyReason} Switch to your provider key, or ask an admin to add ${addKeyPhrase}.`
+              )
+            ) : (
+              "A virtual key is created for you and wired into the command."
+            )}
+          </p>
         </div>
       </EditorField>
     </div>
@@ -740,6 +782,14 @@ export function ConnectCommandPanel({
                   }
                 }}
               />
+            ) : virtualKeyUnbacked ? (
+              <ProviderKeyGate
+                reason={noVirtualKeyReason}
+                provider={soleProvider}
+                addKeyPhrase={addKeyPhrase}
+                canAddKey={canCreateProviderKey === true}
+                onAddKey={() => setShowAddProviderKey(true)}
+              />
             ) : (
               <CommandLine
                 command={result?.command ?? null}
@@ -802,7 +852,7 @@ export function ConnectCommandPanel({
       <CreateLlmProviderApiKeyDialog
         open={showAddProviderKey}
         onOpenChange={setShowAddProviderKey}
-        title="Add a provider key"
+        title={`Add ${addKeyPhrase}`}
         description={providerKeyDialogDescription}
         defaultValues={
           supportedProviders[0]
@@ -916,6 +966,57 @@ function PerUserConnectGate({
 }
 
 /**
+ * Step-3 gate for the virtual-key path when no provider key can back it. Mirrors
+ * the per-user connect gate: instead of emitting a script that silently drops
+ * the inference proxy, it names the blocker and offers the fix inline — add a
+ * provider key, or switch the proxy to your provider key up in the review step.
+ */
+function ProviderKeyGate({
+  reason,
+  provider,
+  addKeyPhrase,
+  canAddKey,
+  onAddKey,
+}: {
+  reason: string;
+  /** The lone provider to brand the CTA with, or null when several are routed. */
+  provider: SupportedProvider | null;
+  /** e.g. "an OpenAI key" / "a provider key" — used in both the copy and button. */
+  addKeyPhrase: string;
+  canAddKey: boolean;
+  onAddKey: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3 px-5 py-4">
+      <p className="text-[13px] text-[#e5e7eb]">
+        {reason}{" "}
+        {canAddKey
+          ? `Add ${addKeyPhrase} to mint one from, or switch to your provider key in the review above.`
+          : `Ask an admin to add ${addKeyPhrase}, or switch to your provider key in the review above.`}
+      </p>
+      {canAddKey && (
+        <div>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onAddKey}
+            data-testid="connect-gate-add-provider-key"
+          >
+            {provider ? (
+              <ProviderIcon provider={provider} size={16} />
+            ) : (
+              <KeyRound className="size-4" />
+            )}
+            Add {addKeyPhrase}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
  * One review line: a status icon, the summary text, and (when there's a real
  * choice) an inline "Change" that expands the row's own editor right below it.
  */
@@ -1021,6 +1122,11 @@ function formatList(items: string[]): string {
   if (items.length <= 1) return items[0] ?? "";
   if (items.length === 2) return `${items[0]} and ${items[1]}`;
   return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+/** "a" or "an" for `word`, by its leading letter (good enough for brand names). */
+function indefiniteArticle(word: string): string {
+  return /^[aeiou]/i.test(word) ? "an" : "a";
 }
 
 /** label + control row inside an inline editor. */

--- a/platform/frontend/src/app/connection/connect-config-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-config-panel.test.tsx
@@ -53,19 +53,34 @@ vi.mock("@/components/create-llm-provider-api-key-dialog", () => ({
   CreateLlmProviderApiKeyDialog: () => null,
 }));
 
+// The gateway summary pulls its own unmocked queries; the visibility tests only
+// care that the gateway review row (and thus step 5) is present, not its body.
+vi.mock("./gateway-servers-summary", () => ({
+  GatewayServersSummary: () => null,
+}));
+
 const proxy = {
   id: "proxy-1",
   name: "Prod Proxy",
   agentType: "llm_proxy" as const,
 };
 
-function renderPanel() {
+const gateway = {
+  id: "gateway-1",
+  name: "Prod Gateway",
+  agentType: "mcp_gateway" as const,
+};
+
+const IMPORT_STEP_TITLE = "Import the profile into Claude Desktop";
+const OAUTH_STEP_TITLE = "Finish the OAuth flow";
+
+function renderPanel({ withGateway = false }: { withGateway?: boolean } = {}) {
   return render(
     <ConnectConfigPanel
-      mcpGateways={null}
-      mcpGatewayId={null}
+      mcpGateways={withGateway ? [gateway] : null}
+      mcpGatewayId={withGateway ? gateway.id : null}
       onMcpGatewaySelect={() => {}}
-      gatewaySlug={null}
+      gatewaySlug={withGateway ? gateway.id : null}
       llmProxies={[proxy]}
       llmProxyId={proxy.id}
       onLlmProxySelect={() => {}}
@@ -198,5 +213,63 @@ describe("ConnectConfigPanel — shared skills marketplace", () => {
         expectedName: "archestra-acme-skills",
       },
     ]);
+  });
+});
+
+describe("ConnectConfigPanel — import & OAuth step visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubKeyProvisioning();
+  });
+
+  it("shows the import and OAuth steps once a profile can be downloaded", async () => {
+    grantAllPermissions();
+    vi.mocked(useAvailableLlmProviderApiKeys).mockReturnValue({
+      data: [{ provider: "anthropic" }],
+    } as ReturnType<typeof useAvailableLlmProviderApiKeys>);
+
+    renderPanel({ withGateway: true });
+
+    // The download button only renders once key provisioning resolves; both
+    // follow-up steps are present alongside it.
+    await screen.findByTestId("connect-download-config");
+    expect(screen.getByText(IMPORT_STEP_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(OAUTH_STEP_TITLE)).toBeInTheDocument();
+  });
+
+  it("hides the import and OAuth steps when no Anthropic key is configured", () => {
+    grantAllPermissions();
+    // A key exists, but not for Anthropic — the profile still can't be minted.
+    vi.mocked(useAvailableLlmProviderApiKeys).mockReturnValue({
+      data: [{ provider: "openai" }],
+    } as ReturnType<typeof useAvailableLlmProviderApiKeys>);
+
+    renderPanel({ withGateway: true });
+
+    // Step 3 still renders and explains the blocker...
+    expect(screen.getByText(/authorize inference/)).toBeInTheDocument();
+    // ...but the steps that depend on a downloaded profile are gone.
+    expect(screen.queryByText(IMPORT_STEP_TITLE)).toBeNull();
+    expect(screen.queryByText(OAUTH_STEP_TITLE)).toBeNull();
+  });
+
+  it("hides the import and OAuth steps when the user can't create virtual keys", () => {
+    // Everything permitted except minting virtual keys — the profile can never
+    // be produced, so the follow-up steps are noise.
+    vi.mocked(useHasPermissions).mockImplementation((perms) => {
+      const isVirtualKeyCreate =
+        JSON.stringify(perms) === JSON.stringify({ llmVirtualKey: ["create"] });
+      return { data: !isVirtualKeyCreate } as ReturnType<
+        typeof useHasPermissions
+      >;
+    });
+    vi.mocked(useAvailableLlmProviderApiKeys).mockReturnValue({
+      data: [{ provider: "anthropic" }],
+    } as ReturnType<typeof useAvailableLlmProviderApiKeys>);
+
+    renderPanel({ withGateway: true });
+
+    expect(screen.queryByText(IMPORT_STEP_TITLE)).toBeNull();
+    expect(screen.queryByText(OAUTH_STEP_TITLE)).toBeNull();
   });
 });

--- a/platform/frontend/src/app/connection/connect-config-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-config-panel.tsx
@@ -123,6 +123,13 @@ export function ConnectConfigPanel({
   const skillIds = useMemo(() => skills.map((s) => s.id), [skills]);
   const [includeSkills, setIncludeSkills] = useState(true);
 
+  // The steps after the download — importing the profile and finishing the
+  // OAuth flow — only make sense once a profile can actually be produced. When
+  // the download is blocked for good (no virtual-key permission, or no Anthropic
+  // key to back the embedded key), they're just noise, so we hide them and let
+  // step 3 carry the explanation.
+  const { unavailable: downloadBlocked } = useConfigProfileAvailability();
+
   const gateway = mcpGateways?.find((g) => g.id === mcpGatewayId) ?? null;
   const proxy = (llmProxies ?? []).find((p) => p.id === llmProxyId) ?? null;
 
@@ -295,7 +302,11 @@ export function ConnectConfigPanel({
         </ul>
       </WizardStep>
 
-      <WizardStep n={3} title="Download your configuration profile">
+      <WizardStep
+        n={3}
+        title="Download your configuration profile"
+        last={downloadBlocked}
+      >
         <div className="flex flex-col gap-3">
           <Alert variant="info">
             <Info />
@@ -319,49 +330,51 @@ export function ConnectConfigPanel({
         </div>
       </WizardStep>
 
-      <WizardStep
-        n={4}
-        title="Import the profile into Claude Desktop"
-        last={!gateway}
-      >
-        <div className="space-y-4 text-sm text-muted-foreground">
-          <ol className="list-decimal space-y-2 pl-5">
-            <li>
-              From the Claude menu choose{" "}
-              <strong className="font-medium text-foreground">
-                Help → Troubleshooting → Enable Developer Mode
-              </strong>
-              .
-            </li>
-            <li>
-              From the Claude menu choose{" "}
-              <strong className="font-medium text-foreground">
-                Developer → Configure Third-Party Inference…
-              </strong>
-              .
-            </li>
-            <li>
-              Click the{" "}
-              <strong className="font-medium text-foreground">Default</strong>{" "}
-              dropdown in the top-right corner and choose{" "}
-              <strong className="font-medium text-foreground">
-                Import configuration…
-              </strong>
-              .
-            </li>
-            <li>Select the configuration file you downloaded above.</li>
-            <li>
-              Click{" "}
-              <strong className="font-medium text-foreground">
-                Apply Changes
-              </strong>{" "}
-              and restart Claude Desktop.
-            </li>
-          </ol>
-        </div>
-      </WizardStep>
+      {!downloadBlocked && (
+        <WizardStep
+          n={4}
+          title="Import the profile into Claude Desktop"
+          last={!gateway}
+        >
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                From the Claude menu choose{" "}
+                <strong className="font-medium text-foreground">
+                  Help → Troubleshooting → Enable Developer Mode
+                </strong>
+                .
+              </li>
+              <li>
+                From the Claude menu choose{" "}
+                <strong className="font-medium text-foreground">
+                  Developer → Configure Third-Party Inference…
+                </strong>
+                .
+              </li>
+              <li>
+                Click the{" "}
+                <strong className="font-medium text-foreground">Default</strong>{" "}
+                dropdown in the top-right corner and choose{" "}
+                <strong className="font-medium text-foreground">
+                  Import configuration…
+                </strong>
+                .
+              </li>
+              <li>Select the configuration file you downloaded above.</li>
+              <li>
+                Click{" "}
+                <strong className="font-medium text-foreground">
+                  Apply Changes
+                </strong>{" "}
+                and restart Claude Desktop.
+              </li>
+            </ol>
+          </div>
+        </WizardStep>
+      )}
 
-      {gateway && (
+      {!downloadBlocked && gateway && (
         <WizardStep n={5} title={FINISH_OAUTH_FLOW_TITLE} last>
           <p className="mb-3 text-sm text-muted-foreground">
             The profile only registers the connector — the gateway grants tool
@@ -422,6 +435,47 @@ type ProvisionState =
   | { status: "error" };
 
 /**
+ * The two prerequisites for producing a configuration profile: permission to
+ * mint virtual keys, and an {Anthropic} provider key for the embedded key to be
+ * minted from. Read both by the download step (which explains a missing one)
+ * and by the panel (which hides the import/OAuth steps once the download is
+ * known impossible).
+ *
+ * `unavailable` flips true only once a prerequisite is *known* missing — never
+ * while the checks are still loading — so the happy path never flashes the
+ * later steps out and back in. A transient provisioning error is deliberately
+ * not "unavailable": it's retryable, so the follow-up steps stay put.
+ */
+function useConfigProfileAvailability(): {
+  canCreateVirtualKey: boolean | undefined;
+  canCreateProviderKey: boolean | undefined;
+  anthropicHasKey: boolean;
+  unavailable: boolean;
+} {
+  const { data: canCreateVirtualKey } = useHasPermissions({
+    llmVirtualKey: ["create"],
+  });
+  const { data: canCreateProviderKey } = useHasPermissions({
+    llmProviderApiKey: ["create"],
+  });
+  const { data: availableKeys } = useAvailableLlmProviderApiKeys();
+  const anthropicHasKey = (availableKeys ?? []).some(
+    (k) => k.provider === "anthropic",
+  );
+  const unavailable =
+    canCreateVirtualKey === false ||
+    (canCreateVirtualKey === true &&
+      availableKeys !== undefined &&
+      !anthropicHasKey);
+  return {
+    canCreateVirtualKey,
+    canCreateProviderKey,
+    anthropicHasKey,
+    unavailable,
+  };
+}
+
+/**
  * The artifact step. Provisions the caller's passthrough + standard virtual
  * keys (the standard key needs a configured Anthropic provider key — mirrors
  * the command panel's handling), builds the profile, and offers the download.
@@ -445,17 +499,8 @@ function ConfigDownloadStep({
   includeSkills: boolean;
   skillIds: string[];
 }) {
-  const { data: canCreateVirtualKey } = useHasPermissions({
-    llmVirtualKey: ["create"],
-  });
-  const { data: canCreateProviderKey } = useHasPermissions({
-    llmProviderApiKey: ["create"],
-  });
-  const { data: availableKeys } = useAvailableLlmProviderApiKeys();
-  const anthropicHasKey = useMemo(
-    () => (availableKeys ?? []).some((k) => k.provider === "anthropic"),
-    [availableKeys],
-  );
+  const { canCreateVirtualKey, canCreateProviderKey, anthropicHasKey } =
+    useConfigProfileAvailability();
 
   const { mutateAsync: provisionPassthrough } =
     useCreateConnectionPassthroughKey();
@@ -567,9 +612,9 @@ function ConfigDownloadStep({
     return (
       <>
         <p className="text-sm text-muted-foreground">
-          A configuration profile embeds a virtual key minted from your{" "}
-          {providerDisplayNames.anthropic} provider key, but none is configured
-          yet.{" "}
+          You need an {providerDisplayNames.anthropic} provider key before you
+          can download a profile — the profile uses it to authorize inference,
+          and none is configured yet.{" "}
           {canCreateProviderKey ? (
             <button
               type="button"


### PR DESCRIPTION
## What & why

The connection wizard ("Give your AI secure access to tools") showed several confusing states around the LLM-proxy auth choice. Original report (T‑943) was the Claude Desktop page; three closely-related bugs on the command-panel clients surfaced while fixing it. All four are on the connection page's provider-key / virtual-key gating.

### 1. Claude Desktop — hide dead steps, clarify the blocker
When a configuration profile can't be produced (no virtual-key permission, or no Anthropic provider key), the wizard still showed **Step 4 "Import the profile"** and **Step 5 "Finish the OAuth flow"** — steps for a profile that can't exist. They're now hidden until the download is actually possible, and Step 3's message leads with the action:

> ~~A configuration profile embeds a virtual key minted from your Anthropic provider key, but none is configured yet.~~
> **You need an Anthropic provider key before you can download a profile — the profile uses it to authorize inference, and none is configured yet.**

### 2. Claude Code — gate the script instead of silently dropping inference
Selecting **Virtual key** with no backing Anthropic/Bedrock key made `provider` resolve to `null`, so the proxy was silently dropped from the generated script — yet Step 3 still emitted a runnable (inference-less) script and the OAuth step stayed visible. Step 3 now shows a gated CTA (mirroring the Copilot per-user gate) and the OAuth step is hidden until the setup can be produced.

### 3. Brand the "add a key" CTA to a single-provider client
For a client that routes exactly one provider (e.g. **Codex → OpenAI**), the CTA is now provider-named and badged — **"Add an OpenAI key"** with the OpenAI logo — instead of a generic "Add a provider key", matching how the GitHub Copilot gate is branded. Multi-provider clients (Claude Code → Anthropic/Bedrock) keep the generic wording.

### 4. Copilot CLI — the auth toggle no longer traps you
Switching Copilot CLI to **Virtual key** with no configured keys collapsed the provider list to just GitHub Copilot (the sole per-user provider), which hid the entire auth toggle — leaving no way back to passthrough except a page reload. The toggle now stays visible, and switching back to "Your provider key" moves off the per-user provider so the choice sticks.

## Testing

- `connect-config-panel.test.tsx` / `connect-command-panel.test.tsx`: added coverage for each behavior above; full `src/app/connection` suite green (118 tests).
- `pnpm type-check` and Biome clean.
- Manually verified each state in a running stack (Claude Desktop / Claude Code / Codex / Copilot CLI).

Task: T‑943

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>