### PR TITLE
fix(deps): patch find-my-way and postcss CVEs failing image scans

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -45,6 +45,7 @@ overrides:
   next@<16.3.0: '>=16.2.11 <16.3.0'
   form-data@>=4: 4.0.6
   form-data@<4: 3.0.5
+  find-my-way: 9.7.0
   '@hono/node-server': 1.19.14
   body-parser: 2.2.1
   dompurify: 3.4.10
@@ -77,7 +78,7 @@ overrides:
   picomatch@>=4: '>=4.0.4'
   picomatch@<4: '>=2.3.2'
   fastify: '>=5.8.5'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.12'
   uuid@^11: '>=11.1.1'
   ip-address: '>=10.1.1'
   brace-expansion: '>=5.0.7'
@@ -7812,8 +7813,8 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  find-my-way@9.5.0:
-    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@5.0.0:
@@ -8922,8 +8923,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9312,8 +9313,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -16321,7 +16322,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
-      postcss: 8.5.10
+      postcss: 8.5.19
       tailwindcss: 4.2.1
 
   '@tanstack/query-core@5.90.20': {}
@@ -18371,7 +18372,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.2.0
       fast-json-stringify: 6.3.0
-      find-my-way: 9.5.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -18452,7 +18453,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way@9.5.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
@@ -19888,7 +19889,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   nanoid@5.1.6: {}
 
@@ -19914,7 +19915,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.19
       caniuse-lite: 1.0.30001788
-      postcss: 8.5.10
+      postcss: 8.5.19
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
@@ -20314,9 +20315,9 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.10:
+  postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -21691,7 +21692,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.19
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -54,6 +54,11 @@ overrides:
   # exact so a `>=` floor can't pull an unvetted release.
   form-data@>=4: 4.0.6
   form-data@<4: 3.0.5
+  # CVE-2026-47219 (HIGH, prototype pollution via route params) fixed in 9.7.0,
+  # published 2026-07-21 — inside the 7-day window, so excluded from
+  # minimumReleaseAge below and pinned exact so a `>=` floor can't pull an
+  # unvetted release. Transitive via fastify (^9.0.0 range).
+  find-my-way: 9.7.0
   '@hono/node-server': 1.19.14
   body-parser: 2.2.1
   dompurify: 3.4.10
@@ -98,7 +103,8 @@ overrides:
   picomatch@>=4: '>=4.0.4'
   picomatch@<4: '>=2.3.2'
   fastify: '>=5.8.5'
-  postcss: '>=8.5.10'
+  # CVE-2026-45623 (HIGH, exposure of sensitive information) fixed in 8.5.12.
+  postcss: '>=8.5.12'
   uuid@^11: '>=11.1.1'
   ip-address: '>=10.1.1'
   # CVE-2026-13149 (HIGH, uncontrolled resource consumption) fixed in 5.0.7.
@@ -163,6 +169,10 @@ minimumReleaseAgeExclude:
   # published 2026-07-19 and clears the 7-day window on 2026-07-26. Remove
   # on/after that date — the lockfile stays pinned at 3.1.4 regardless.
   - fast-uri
+  # TEMPORARY: find-my-way 9.7.0 (fix CVE-2026-47219, HIGH) was published
+  # 2026-07-21 and clears the 7-day window on 2026-07-28. Remove on/after that
+  # date — the lockfile stays pinned at 9.7.0 regardless.
+  - find-my-way
 
 # OpenTelemetry instrumentation requires these packages hoisted to root.
 # @hookform/resolvers/zod statically imports `zod/v4/core` but does not declare


### PR DESCRIPTION
<div align="center">
<img src="https://raw.githubusercontent.com/archestra-ai/archestra/main/logo.svg" alt="Archestra" width="520" />
</div>

## What

Docker Scout flags two HIGH CVEs in the platform image, failing the Docker Image Scanning check on every PR:

- `find-my-way` 9.5.0 (transitive via fastify): CVE-2026-47219, prototype pollution, fixed in 9.7.0. The fix was published 2026-07-21 and is still inside the 7-day quarantine, so it is pinned exact and temporarily excluded from `minimumReleaseAge` (remove the exclusion on/after 2026-07-28).
- `postcss` 8.5.10: CVE-2026-45623, sensitive information exposure, fixed in 8.5.12. Raised the existing override floor from `>=8.5.10` to `>=8.5.12` (resolves to 8.5.19).

## Why

The Docker Image Scanning (Platform) job gates on critical/high CVEs and currently blocks all open PRs (e.g. #6790).

## Testing

`pnpm install` passes supply-chain policies; verified `pnpm-lock.yaml` resolves find-my-way 9.7.0 and postcss 8.5.19 with no remaining vulnerable versions. The image scan itself runs in CI on this PR.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>

