### PR TITLE
feat(chat): show Anthropic thinking text for models that think by default

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3892,6 +3892,14 @@
                   },
                   "budget_tokens": {
                     "type": "number"
+                  },
+                  "display": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "summarized",
+                      "omitted"
+                    ]
                   }
                 },
                 "required": [
@@ -3920,6 +3928,14 @@
                     "type": "string",
                     "enum": [
                       "adaptive"
+                    ]
+                  },
+                  "display": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "summarized",
+                      "omitted"
                     ]
                   }
                 },
@@ -22783,6 +22799,14 @@
                   },
                   "budget_tokens": {
                     "type": "number"
+                  },
+                  "display": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "summarized",
+                      "omitted"
+                    ]
                   }
                 },
                 "required": [
@@ -22813,6 +22837,14 @@
                     "type": "string",
                     "enum": [
                       "adaptive"
+                    ]
+                  },
+                  "display": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "summarized",
+                      "omitted"
                     ]
                   }
                 },
@@ -85720,6 +85752,14 @@
                           },
                           "budget_tokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -85748,6 +85788,14 @@
                             "type": "string",
                             "enum": [
                               "adaptive"
+                            ]
+                          },
+                          "display": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
                             ]
                           }
                         },
@@ -87285,6 +87333,14 @@
                           },
                           "budget_tokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -87313,6 +87369,14 @@
                             "type": "string",
                             "enum": [
                               "adaptive"
+                            ]
+                          },
+                          "display": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
                             ]
                           }
                         },
@@ -88860,6 +88924,14 @@
                           },
                           "budget_tokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -88888,6 +88960,14 @@
                             "type": "string",
                             "enum": [
                               "adaptive"
+                            ]
+                          },
+                          "display": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
                             ]
                           }
                         },
@@ -90190,6 +90270,14 @@
                           },
                           "budget_tokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -90218,6 +90306,14 @@
                             "type": "string",
                             "enum": [
                               "adaptive"
+                            ]
+                          },
+                          "display": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
                             ]
                           }
                         },
@@ -136289,6 +136385,14 @@
                                               },
                                               "budget_tokens": {
                                                 "type": "number"
+                                              },
+                                              "display": {
+                                                "nullable": true,
+                                                "type": "string",
+                                                "enum": [
+                                                  "summarized",
+                                                  "omitted"
+                                                ]
                                               }
                                             },
                                             "required": [
@@ -136319,6 +136423,14 @@
                                                 "type": "string",
                                                 "enum": [
                                                   "adaptive"
+                                                ]
+                                              },
+                                              "display": {
+                                                "nullable": true,
+                                                "type": "string",
+                                                "enum": [
+                                                  "summarized",
+                                                  "omitted"
                                                 ]
                                               }
                                             },
@@ -137632,6 +137744,14 @@
                                               },
                                               "budget_tokens": {
                                                 "type": "number"
+                                              },
+                                              "display": {
+                                                "nullable": true,
+                                                "type": "string",
+                                                "enum": [
+                                                  "summarized",
+                                                  "omitted"
+                                                ]
                                               }
                                             },
                                             "required": [
@@ -137662,6 +137782,14 @@
                                                 "type": "string",
                                                 "enum": [
                                                   "adaptive"
+                                                ]
+                                              },
+                                              "display": {
+                                                "nullable": true,
+                                                "type": "string",
+                                                "enum": [
+                                                  "summarized",
+                                                  "omitted"
                                                 ]
                                               }
                                             },
@@ -165554,6 +165682,14 @@
                                         },
                                         "budget_tokens": {
                                           "type": "number"
+                                        },
+                                        "display": {
+                                          "nullable": true,
+                                          "type": "string",
+                                          "enum": [
+                                            "summarized",
+                                            "omitted"
+                                          ]
                                         }
                                       },
                                       "required": [
@@ -165584,6 +165720,14 @@
                                           "type": "string",
                                           "enum": [
                                             "adaptive"
+                                          ]
+                                        },
+                                        "display": {
+                                          "nullable": true,
+                                          "type": "string",
+                                          "enum": [
+                                            "summarized",
+                                            "omitted"
                                           ]
                                         }
                                       },
@@ -166897,6 +167041,14 @@
                                         },
                                         "budget_tokens": {
                                           "type": "number"
+                                        },
+                                        "display": {
+                                          "nullable": true,
+                                          "type": "string",
+                                          "enum": [
+                                            "summarized",
+                                            "omitted"
+                                          ]
                                         }
                                       },
                                       "required": [
@@ -166927,6 +167079,14 @@
                                           "type": "string",
                                           "enum": [
                                             "adaptive"
+                                          ]
+                                        },
+                                        "display": {
+                                          "nullable": true,
+                                          "type": "string",
+                                          "enum": [
+                                            "summarized",
+                                            "omitted"
                                           ]
                                         }
                                       },

--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -17,13 +17,27 @@ import { describe, expect, it, test } from "@/test";
 // Mock the gemini-client module before importing llm-client
 const mockIsVertexAiEnabled = vi.hoisted(() => vi.fn(() => false));
 const mockIsAzureOpenAiEntraIdEnabled = vi.hoisted(() => vi.fn(() => false));
+// Capture the fetch option passed to createAnthropic, so the thinking-display
+// injection can be asserted against the body that actually goes out.
+const capturedCreateAnthropicOptions = vi.hoisted(() => ({
+  fetch: undefined as typeof globalThis.fetch | undefined,
+}));
 const mockCreateAnthropic = vi.hoisted(() =>
-  vi.fn(({ headers }: { headers?: Record<string, string> }) =>
-    vi.fn((modelName: string) => ({
-      provider: "anthropic",
-      modelName,
+  vi.fn(
+    ({
       headers,
-    })),
+      fetch,
+    }: {
+      headers?: Record<string, string>;
+      fetch?: typeof globalThis.fetch;
+    }) => {
+      capturedCreateAnthropicOptions.fetch = fetch;
+      return vi.fn((modelName: string) => ({
+        provider: "anthropic",
+        modelName,
+        headers,
+      }));
+    },
   ),
 );
 vi.mock("@/clients/gemini-client", () => ({
@@ -386,6 +400,85 @@ describe("createDirectLLMModel", () => {
       });
 
       expect(mockFetch.mock.calls[0][1].body).toBe("not json");
+    });
+  });
+
+  // Sonnet 5 / Fable 5-class models think — and bill those tokens — on every
+  // request, but `display` defaults to "omitted", so without an injected
+  // `thinking` config the response carries only empty signature blocks and
+  // the chat UI has nothing to render. The installed @ai-sdk/anthropic has no
+  // `display` provider option (its closed Zod schema strips unknown thinking
+  // keys), so the injection happens in a fetch wrapper against the raw
+  // request body — these tests pin that wire-level rewrite.
+  describe("anthropic thinking display injection", () => {
+    const sendBody = async (body: string): Promise<RequestInit> => {
+      const mockFetch = vi.fn().mockResolvedValue(new Response("{}"));
+      // Must be stubbed BEFORE the model is built: the wrapper captures
+      // globalThis.fetch at construction time.
+      vi.stubGlobal("fetch", mockFetch);
+
+      createDirectLLMModel({
+        provider: "anthropic",
+        apiKey: "test-key",
+        modelName: "claude-sonnet-5",
+        baseUrl: null,
+      });
+      const wrapped = capturedCreateAnthropicOptions.fetch;
+      if (!wrapped) {
+        throw new Error("Expected anthropic fetch wrapper to be configured");
+      }
+
+      await wrapped("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        body,
+      });
+
+      return mockFetch.mock.calls[0][1];
+    };
+
+    const wireBodyFor = async (
+      requestBody: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => {
+      const init = await sendBody(JSON.stringify(requestBody));
+      return JSON.parse(init.body as string);
+    };
+
+    it("requests summarized thinking for models that think by default", async () => {
+      for (const model of [
+        "claude-sonnet-5",
+        "claude-sonnet-5-20250929",
+        "claude-fable-5",
+      ]) {
+        const body = await wireBodyFor({ model, messages: [] });
+        expect(body.thinking).toEqual({
+          type: "adaptive",
+          display: "summarized",
+        });
+      }
+    });
+
+    it("leaves models whose thinking is off by default untouched", async () => {
+      // Injecting thinking here would ENABLE it — new tokens, new cost —
+      // rather than surface what already runs.
+      const body = await wireBodyFor({
+        model: "claude-opus-4-8",
+        messages: [],
+      });
+      expect(body).not.toHaveProperty("thinking");
+    });
+
+    it("respects an explicit thinking configuration", async () => {
+      const body = await wireBodyFor({
+        model: "claude-sonnet-5",
+        messages: [],
+        thinking: { type: "disabled" },
+      });
+      expect(body.thinking).toEqual({ type: "disabled" });
+    });
+
+    it("passes a non-JSON body through untouched", async () => {
+      const init = await sendBody("not json");
+      expect(init.body).toBe("not json");
     });
   });
 

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -10,6 +10,7 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createXai } from "@ai-sdk/xai";
 import type { InteractionSource } from "@archestra/shared";
 import {
+  anthropicThinksByDefault,
   CHAT_API_KEY_ID_HEADER,
   EXTERNAL_AGENT_ID_HEADER,
   isProviderApiKeyOptional,
@@ -408,7 +409,14 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
 
   anthropic: {
     createModel: ({ apiKey, modelName, baseURL, headers, fetch }) =>
-      createAnthropic({ apiKey, baseURL, headers, fetch })(modelName),
+      createAnthropic({
+        apiKey,
+        baseURL,
+        headers,
+        // Models that think by default return their thinking text only on
+        // request — see createAnthropicThinkingDisplayFetch.
+        fetch: createAnthropicThinkingDisplayFetch(fetch),
+      })(modelName),
     defaultBaseUrl: config.llm.anthropic.baseUrl,
     apiKeyRequiredMessage:
       "Anthropic API key is required. Please configure ANTHROPIC_API_KEY.",
@@ -796,6 +804,62 @@ function createOllamaNativeFetch(
     }
 
     return baseFetch(input, { ...forwarded, body: JSON.stringify(body) });
+  };
+}
+
+/**
+ * Wraps fetch to surface thinking text on Anthropic models that think by
+ * default (see anthropicThinksByDefault).
+ *
+ * On those models thinking already runs — and is billed — on every request,
+ * but `display` defaults to `"omitted"`, so responses carry only empty
+ * thinking blocks with a signature and the UI has nothing to render.
+ * Requesting `thinking: {type: "adaptive", display: "summarized"}` returns the
+ * summary text. Per Anthropic's docs this changes neither billing nor prompt
+ * caching: `adaptive` is those models' default, and explicitly sending a
+ * default is equivalent to omitting it.
+ *
+ * The field is injected at the HTTP boundary because the installed
+ * @ai-sdk/anthropic (3.x) has no `display` provider option — its closed Zod
+ * schema strips unknown thinking keys, so no providerOptions value can carry
+ * it (same constraint as OLLAMA_THINK_EXPLICIT_HEADER above).
+ *
+ * A request that already carries a `thinking` configuration is forwarded
+ * untouched, as is any model where thinking is off by default (Opus 4.8 and
+ * earlier) — enabling thinking there would add cost.
+ */
+function createAnthropicThinkingDisplayFetch(
+  providedFetch?: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  const baseFetch = providedFetch ?? globalThis.fetch;
+
+  return (input, init) => {
+    if (typeof init?.body !== "string") {
+      return baseFetch(input, init);
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(init.body);
+      if (typeof parsed !== "object" || parsed === null) {
+        return baseFetch(input, init);
+      }
+      body = parsed as Record<string, unknown>;
+    } catch {
+      // Not JSON we understand — forward verbatim rather than guessing.
+      return baseFetch(input, init);
+    }
+
+    if (
+      typeof body.model !== "string" ||
+      !anthropicThinksByDefault(body.model) ||
+      "thinking" in body
+    ) {
+      return baseFetch(input, init);
+    }
+
+    body.thinking = { type: "adaptive", display: "summarized" };
+    return baseFetch(input, { ...init, body: JSON.stringify(body) });
   };
 }
 

--- a/platform/backend/src/types/llm-providers/anthropic/api.test.ts
+++ b/platform/backend/src/types/llm-providers/anthropic/api.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { MessagesRequestSchema } from "./api";
+
+describe("MessagesRequestSchema", () => {
+  // Fastify replaces request.body with the Zod parse result, so any thinking
+  // field this schema drops never reaches the upstream provider. `display` is
+  // what turns thinking text on in responses: the chat client injects it for
+  // models that think by default, and external proxy clients may send it
+  // themselves.
+  test("keeps thinking.display through body validation", () => {
+    const parsed = MessagesRequestSchema.parse({
+      model: "claude-sonnet-5",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 1024,
+      thinking: { type: "adaptive", display: "summarized" },
+    });
+
+    expect(parsed.thinking).toEqual({
+      type: "adaptive",
+      display: "summarized",
+    });
+  });
+
+  test("keeps display on extended thinking requests", () => {
+    const parsed = MessagesRequestSchema.parse({
+      model: "claude-sonnet-4-5",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 1024,
+      thinking: { type: "enabled", budget_tokens: 2048, display: "omitted" },
+    });
+
+    expect(parsed.thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 2048,
+      display: "omitted",
+    });
+  });
+
+  test("accepts a thinking configuration without display", () => {
+    const parsed = MessagesRequestSchema.parse({
+      model: "claude-sonnet-5",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 1024,
+      thinking: { type: "adaptive" },
+    });
+
+    expect(parsed.thinking).toEqual({ type: "adaptive" });
+  });
+});

--- a/platform/backend/src/types/llm-providers/anthropic/api.ts
+++ b/platform/backend/src/types/llm-providers/anthropic/api.ts
@@ -42,11 +42,23 @@ const OutputConfigSchema = z.object({
     .optional(),
 });
 
-// Mirrors @anthropic-ai/sdk BetaThinkingConfigParam.
+// Mirrors @anthropic-ai/sdk BetaThinkingConfigParam. `display` controls
+// whether thinking text appears in the response ("summarized") or only the
+// signature comes back ("omitted", the newest models' default); without it in
+// the schema, Fastify's Zod validation would silently strip the field before
+// the body is forwarded upstream.
+const ThinkingDisplaySchema = z
+  .enum(["summarized", "omitted"])
+  .nullable()
+  .optional();
 const ThinkingConfigSchema = z.union([
-  z.object({ type: z.literal("enabled"), budget_tokens: z.number() }),
+  z.object({
+    type: z.literal("enabled"),
+    budget_tokens: z.number(),
+    display: ThinkingDisplaySchema,
+  }),
   z.object({ type: z.literal("disabled") }),
-  z.object({ type: z.literal("adaptive") }),
+  z.object({ type: z.literal("adaptive"), display: ThinkingDisplaySchema }),
 ]);
 
 export const MessagesRequestSchema = z.object({

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -1425,10 +1425,12 @@ export type AnthropicMessagesRequestInput = {
     thinking?: {
         type: 'enabled';
         budget_tokens: number;
+        display?: 'summarized' | 'omitted';
     } | {
         type: 'disabled';
     } | {
         type: 'adaptive';
+        display?: 'summarized' | 'omitted';
     };
     tool_choice?: {
         type: 'auto';
@@ -7194,10 +7196,12 @@ export type AnthropicMessagesRequest = {
     thinking?: {
         type: 'enabled';
         budget_tokens: number;
+        display?: 'summarized' | 'omitted';
     } | {
         type: 'disabled';
     } | {
         type: 'adaptive';
+        display?: 'summarized' | 'omitted';
     };
     tool_choice?: {
         type: 'auto';
@@ -24431,10 +24435,12 @@ export type BedrockInvokeWithDefaultAgentAndModelData = {
         thinking?: {
             type: 'enabled';
             budget_tokens: number;
+            display?: 'summarized' | 'omitted';
         } | {
             type: 'disabled';
         } | {
             type: 'adaptive';
+            display?: 'summarized' | 'omitted';
         };
         tool_choice?: {
             type: 'auto';
@@ -24759,10 +24765,12 @@ export type BedrockInvokeWithAgentAndModelData = {
         thinking?: {
             type: 'enabled';
             budget_tokens: number;
+            display?: 'summarized' | 'omitted';
         } | {
             type: 'disabled';
         } | {
             type: 'adaptive';
+            display?: 'summarized' | 'omitted';
         };
         tool_choice?: {
             type: 'auto';
@@ -25088,10 +25096,12 @@ export type BedrockInvokeStreamWithDefaultAgentAndModelData = {
         thinking?: {
             type: 'enabled';
             budget_tokens: number;
+            display?: 'summarized' | 'omitted';
         } | {
             type: 'disabled';
         } | {
             type: 'adaptive';
+            display?: 'summarized' | 'omitted';
         };
         tool_choice?: {
             type: 'auto';
@@ -25349,10 +25359,12 @@ export type BedrockInvokeStreamWithAgentAndModelData = {
         thinking?: {
             type: 'enabled';
             budget_tokens: number;
+            display?: 'summarized' | 'omitted';
         } | {
             type: 'disabled';
         } | {
             type: 'adaptive';
+            display?: 'summarized' | 'omitted';
         };
         tool_choice?: {
             type: 'auto';
@@ -37459,10 +37471,12 @@ export type GetInteractionsResponses = {
                 thinking?: {
                     type: 'enabled';
                     budget_tokens: number;
+                    display?: 'summarized' | 'omitted';
                 } | {
                     type: 'disabled';
                 } | {
                     type: 'adaptive';
+                    display?: 'summarized' | 'omitted';
                 };
                 tool_choice?: {
                     type: 'auto';
@@ -37697,10 +37711,12 @@ export type GetInteractionsResponses = {
                 thinking?: {
                     type: 'enabled';
                     budget_tokens: number;
+                    display?: 'summarized' | 'omitted';
                 } | {
                     type: 'disabled';
                 } | {
                     type: 'adaptive';
+                    display?: 'summarized' | 'omitted';
                 };
                 tool_choice?: {
                     type: 'auto';
@@ -43409,10 +43425,12 @@ export type GetInteractionResponses = {
             thinking?: {
                 type: 'enabled';
                 budget_tokens: number;
+                display?: 'summarized' | 'omitted';
             } | {
                 type: 'disabled';
             } | {
                 type: 'adaptive';
+                display?: 'summarized' | 'omitted';
             };
             tool_choice?: {
                 type: 'auto';
@@ -43647,10 +43665,12 @@ export type GetInteractionResponses = {
             thinking?: {
                 type: 'enabled';
                 budget_tokens: number;
+                display?: 'summarized' | 'omitted';
             } | {
                 type: 'disabled';
             } | {
                 type: 'adaptive';
+                display?: 'summarized' | 'omitted';
             };
             tool_choice?: {
                 type: 'auto';

--- a/platform/shared/model-constants.test.ts
+++ b/platform/shared/model-constants.test.ts
@@ -1,10 +1,32 @@
 import { describe, expect, test } from "vitest";
 import {
+  anthropicThinksByDefault,
   getProvidersWithOptionalApiKey,
   isProviderApiKeyOptional,
   isSelfHostedProvider,
   requiresOpenAiResponsesApi,
 } from "./model-constants";
+
+describe("anthropicThinksByDefault", () => {
+  test("matches models whose thinking is always on, including dated snapshots", () => {
+    expect(anthropicThinksByDefault("claude-sonnet-5")).toBe(true);
+    expect(anthropicThinksByDefault("claude-sonnet-5-20250929")).toBe(true);
+    expect(anthropicThinksByDefault("claude-fable-5")).toBe(true);
+    expect(anthropicThinksByDefault("claude-mythos-5")).toBe(true);
+    expect(anthropicThinksByDefault("claude-mythos-preview")).toBe(true);
+  });
+
+  test("excludes models where thinking is off until requested", () => {
+    // Opus 4.8/4.7 hide thinking text too (`display` defaults to "omitted"),
+    // but thinking itself is off by default there — requesting it would add
+    // cost, so they are deliberately not matched.
+    expect(anthropicThinksByDefault("claude-opus-4-8")).toBe(false);
+    expect(anthropicThinksByDefault("claude-opus-4-7")).toBe(false);
+    expect(anthropicThinksByDefault("claude-sonnet-4-6")).toBe(false);
+    expect(anthropicThinksByDefault("claude-sonnet-4-5")).toBe(false);
+    expect(anthropicThinksByDefault("claude-3-5-haiku-20241022")).toBe(false);
+  });
+});
 
 describe("requiresOpenAiResponsesApi", () => {
   test("matches pro reasoning models, including dated snapshots", () => {

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -502,6 +502,31 @@ export function requiresOpenAiResponsesApi(modelId: string): boolean {
 }
 
 /**
+ * True for Anthropic models where thinking is on by default (Claude Sonnet 5,
+ * Fable 5, Mythos 5, Mythos Preview): the model reasons — and bills those
+ * tokens — on every request, but the API returns the thinking text only when
+ * the request opts in with `thinking: {display: "summarized"}`. Matched as
+ * substrings so dated snapshots (`claude-sonnet-5-20250929`) are covered.
+ *
+ * Models where thinking is off until requested (Opus 4.8/4.7, Sonnet 4.6 and
+ * earlier) are deliberately excluded: turning thinking on there would add
+ * cost, which is a product decision rather than a display fix.
+ */
+export function anthropicThinksByDefault(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  return ANTHROPIC_DEFAULT_THINKING_MODEL_MARKERS.some((marker) =>
+    id.includes(marker),
+  );
+}
+
+const ANTHROPIC_DEFAULT_THINKING_MODEL_MARKERS = [
+  "sonnet-5",
+  "fable-5",
+  "mythos-5",
+  "mythos-preview",
+];
+
+/**
  * Maps models.dev provider IDs to Archestra provider names.
  * This is the single source of truth for all synchronization logic.
  *


### PR DESCRIPTION
Part of T-904 (expose model thinking/reasoning output in Chat) — Anthropic provider iteration.

## Baseline behavior

On Claude Sonnet 5 / Fable 5-class models, thinking is always on and billed, but `display` defaults to `"omitted"`: the API returns thinking blocks with an empty `thinking` field and only a signature. Chat renders nothing (empty-block suppression hides them), so users pay for reasoning they never see.

## Research summary and gate decision

- Thinking is on by default only on Sonnet 5, Fable 5, Mythos 5, and Mythos Preview ([per-model table](https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting)). On Opus 4.8/4.7 and earlier it is off until requested — enabling it there adds cost, so those models are deliberately out of scope.
- Requesting `thinking: {type: "adaptive", display: "summarized"}` changes visibility only: billing is identical either way, and explicitly sending a model's default config does not invalidate prompt caches. Switching `display` mid-conversation is supported.
- The rest of the pipeline already works end-to-end: the AI SDK parses `thinking_delta` into reasoning parts, `toUIMessageStream` forwards them by default, chat renders the accordion, reasoning parts persist verbatim, and signatures replay on later turns.
- The installed `@ai-sdk/anthropic@3.x` has no `display` provider option (its closed Zod schema strips unknown thinking keys); `display` only exists in `4.x`, which requires the `ai@7` stack. A request-body fetch wrapper (existing pattern: `createOllamaNativeFetch`) avoids that migration.

**Gate decision: go.** Default on, no flag, no UI knobs — surface what is already paid for, change nothing else.

## The change

- `shared/model-constants.ts` — `anthropicThinksByDefault()`: case-insensitive substring match on `sonnet-5`, `fable-5`, `mythos-5`, `mythos-preview` (covers dated snapshots; same shape as `requiresOpenAiResponsesApi`).
- `backend/src/clients/llm-client.ts` — `createAnthropicThinkingDisplayFetch()` wired into the anthropic factory: injects `thinking: {type: "adaptive", display: "summarized"}` when the body's model thinks by default and carries no explicit `thinking`; everything else is forwarded untouched.
- `backend/src/types/llm-providers/anthropic/api.ts` — `ThinkingConfigSchema` learns `display` (mirrors `@anthropic-ai/sdk@0.114`). Fastify replaces `request.body` with the Zod parse result, so the proxy previously stripped `display` from any client that sent it — including external passthrough clients.

## Caveats

- Zero cost change: thinking tokens on these models are billed with or without the text.
- Total turn latency is roughly unchanged; the visible thinking summary streams while the model works, so time-to-first-visible-token improves.
- Models where thinking is off by default (Opus 4.8/4.7, Sonnet 4.6 and earlier) are untouched.
- New always-on models require one marker added to `ANTHROPIC_DEFAULT_THINKING_MODEL_MARKERS`.

## Verification

- New wire-level tests pin the injection (`llm-client.test.ts`): injects for `claude-sonnet-5`, dated snapshots, `claude-fable-5`; skips `claude-opus-4-8`; respects an explicit `thinking` config; passes non-JSON bodies through.
- New `types/llm-providers/anthropic/api.test.ts` pins that the proxy schema keeps `thinking.display`.
- Predicate tests in `shared/model-constants.test.ts`.
- Full suites green: llm-client (40), anthropic api (3), model-constants (11), proxy adapter + interaction schemas (36); `type-check`, `lint`, and `knip` (backend + shared) clean.

## Docs

Audited `docs/pages`; deferred by design. Reasoning display is a ~20-provider rollout — one consolidated "Model Thinking" docs pass lands at the end of the rollout instead of per-provider edits.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
