### PR TITLE
fix(llm-providers): render native Ollama thinking above the answer

### DIFF
--- a/platform/backend/src/clients/ollama-native-reasoning-order.test.ts
+++ b/platform/backend/src/clients/ollama-native-reasoning-order.test.ts
@@ -1,0 +1,176 @@
+import { createOllama } from "ollama-ai-provider-v2";
+import { describe, expect, test } from "@/test";
+
+/**
+ * Pins the stream-part ordering of the patched ollama-ai-provider-v2
+ * (patches/ollama-ai-provider-v2@3.6.0.patch).
+ *
+ * Native Ollama `/api/chat` sends `"content": ""` on every thinking-phase
+ * chunk. Unpatched, the package opened the text part on `content != null` and
+ * processed text before thinking, so the assistant message's text part was
+ * created before its reasoning part and chat rendered the answer above the
+ * thinking block. If a package bump drops the patch, these tests fail.
+ */
+
+type StreamPart = { type: string; id?: string; delta?: string };
+
+const PROMPT = [
+  {
+    role: "user" as const,
+    content: [{ type: "text" as const, text: "How many r's in strawberry?" }],
+  },
+];
+
+describe("ollama-ai-provider-v2 reasoning ordering (patched)", () => {
+  test("opens the reasoning part before the text part when thinking streams first", async () => {
+    const model = makeModel(
+      ndjson([
+        wireChunk({ role: "assistant", content: "", thinking: "Let me " }),
+        wireChunk({ role: "assistant", content: "", thinking: "count." }),
+        wireChunk({ role: "assistant", content: "There are" }),
+        wireChunk({ role: "assistant", content: " three." }),
+        wireChunk(
+          { role: "assistant", content: "" },
+          {
+            done: true,
+            done_reason: "stop",
+            prompt_eval_count: 5,
+            eval_count: 10,
+          },
+        ),
+      ]),
+    );
+
+    const { stream } = await model.doStream({ prompt: PROMPT });
+    const parts = await collectParts(stream);
+    const types = parts.map((part) => part.type);
+
+    const reasoningStart = types.indexOf("reasoning-start");
+    const textStart = types.indexOf("text-start");
+    expect(reasoningStart).toBeGreaterThanOrEqual(0);
+    expect(textStart).toBeGreaterThanOrEqual(0);
+    expect(reasoningStart).toBeLessThan(textStart);
+
+    expect(deltasOf(parts, "reasoning-delta")).toEqual(["Let me ", "count."]);
+    // The empty `content` on thinking-phase and done chunks must not leak
+    // empty text deltas or open the text part early.
+    expect(deltasOf(parts, "text-delta")).toEqual(["There are", " three."]);
+  });
+
+  test("emits no text part when the response is thinking only", async () => {
+    const model = makeModel(
+      ndjson([
+        wireChunk({ role: "assistant", content: "", thinking: "Let me " }),
+        wireChunk({ role: "assistant", content: "", thinking: "count." }),
+        wireChunk(
+          { role: "assistant", content: "" },
+          { done: true, done_reason: "stop" },
+        ),
+      ]),
+    );
+
+    const { stream } = await model.doStream({ prompt: PROMPT });
+    const parts = await collectParts(stream);
+
+    expect(deltasOf(parts, "reasoning-delta")).toEqual(["Let me ", "count."]);
+    // Deliberate: all-empty `content` yields zero text parts, matching the
+    // OpenAI-compatible `/v1` transport.
+    expect(parts.map((part) => part.type)).not.toContain("text-start");
+  });
+
+  test("keeps plain text streaming intact for non-thinking responses", async () => {
+    const model = makeModel(
+      ndjson([
+        wireChunk({ role: "assistant", content: "Hello" }),
+        wireChunk({ role: "assistant", content: " there." }),
+        wireChunk(
+          { role: "assistant", content: "" },
+          { done: true, done_reason: "stop" },
+        ),
+      ]),
+    );
+
+    const { stream } = await model.doStream({ prompt: PROMPT });
+    const parts = await collectParts(stream);
+
+    expect(deltasOf(parts, "text-delta")).toEqual(["Hello", " there."]);
+    expect(parts.map((part) => part.type)).not.toContain("reasoning-start");
+  });
+
+  test("orders reasoning before text in non-streaming generate results", async () => {
+    const model = makeModel(
+      JSON.stringify(
+        wireChunk(
+          {
+            role: "assistant",
+            content: "There are three.",
+            thinking: "Let me count.",
+          },
+          { done: true, done_reason: "stop" },
+        ),
+      ),
+    );
+
+    const { content } = await model.doGenerate({ prompt: PROMPT });
+
+    expect(content).toEqual([
+      expect.objectContaining({ type: "reasoning", text: "Let me count." }),
+      expect.objectContaining({ type: "text", text: "There are three." }),
+    ]);
+  });
+});
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/** Builds a chat model whose fetch returns the given canned response body. */
+function makeModel(body: string) {
+  const fetchStub: typeof globalThis.fetch = async () =>
+    new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/x-ndjson" },
+    });
+  return createOllama({
+    baseURL: "http://ollama.test/api",
+    fetch: fetchStub,
+  }).chat("qwen3:0.6b");
+}
+
+/** One native `/api/chat` NDJSON object, as Ollama puts it on the wire. */
+function wireChunk(
+  message: { role: string; content: string; thinking?: string },
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    model: "qwen3:0.6b",
+    created_at: "2026-01-01T00:00:00.000Z",
+    message,
+    done: false,
+    ...overrides,
+  };
+}
+
+function ndjson(chunks: unknown[]): string {
+  return `${chunks.map((chunk) => JSON.stringify(chunk)).join("\n")}\n`;
+}
+
+async function collectParts(
+  stream: ReadableStream<unknown>,
+): Promise<StreamPart[]> {
+  const parts: StreamPart[] = [];
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parts.push(value as StreamPart);
+  }
+  return parts;
+}
+
+function deltasOf(
+  parts: StreamPart[],
+  type: string,
+): Array<string | undefined> {
+  return parts.filter((part) => part.type === type).map((part) => part.delta);
+}

--- a/platform/patches/ollama-ai-provider-v2@3.6.0.patch
+++ b/platform/patches/ollama-ai-provider-v2@3.6.0.patch
@@ -1,0 +1,94 @@
+diff --git a/dist/index.js b/dist/index.js
+index ad6323f848138a41552515f843659fc605371e74..65206239cf6b1d858ca1b3148e10128dfe1d3466 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -629,13 +629,6 @@ var OllamaResponseProcessor = class {
+   extractContent(response) {
+     var _a, _b, _c, _d, _e;
+     const content = [];
+-    const text = response.message.content;
+-    if (text != null && text.length > 0) {
+-      content.push({
+-        type: "text",
+-        text
+-      });
+-    }
+     const thinking = response.message.thinking;
+     if (thinking != null && thinking.length > 0) {
+       content.push({
+@@ -643,6 +636,13 @@ var OllamaResponseProcessor = class {
+         text: thinking
+       });
+     }
++    const text = response.message.content;
++    if (text != null && text.length > 0) {
++      content.push({
++        type: "text",
++        text
++      });
++    }
+     for (const toolCall of (_a = response.message.tool_calls) != null ? _a : []) {
+       content.push({
+         type: "tool-call",
+@@ -1283,12 +1283,12 @@ var OllamaStreamProcessor = class {
+     }
+   }
+   processDelta(delta, controller) {
+-    this.processTextContent(delta, controller);
+     this.processThinking(delta, controller);
++    this.processTextContent(delta, controller);
+     this.processToolCalls(delta, controller);
+   }
+   processTextContent(delta, controller) {
+-    if ((delta == null ? void 0 : delta.content) != null) {
++    if (delta == null ? void 0 : delta.content) {
+       if (!this.state.hasTextStarted) {
+         controller.enqueue({ type: "text-start", id: this.state.textId });
+         this.state.hasTextStarted = true;
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 7d175b9498f2ba24853c1aa7ce92f1046e69133e..a93eba390d5df2c0f229272a2a3b1188f00866a1 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -627,13 +627,6 @@ var OllamaResponseProcessor = class {
+   extractContent(response) {
+     var _a, _b, _c, _d, _e;
+     const content = [];
+-    const text = response.message.content;
+-    if (text != null && text.length > 0) {
+-      content.push({
+-        type: "text",
+-        text
+-      });
+-    }
+     const thinking = response.message.thinking;
+     if (thinking != null && thinking.length > 0) {
+       content.push({
+@@ -641,6 +634,13 @@ var OllamaResponseProcessor = class {
+         text: thinking
+       });
+     }
++    const text = response.message.content;
++    if (text != null && text.length > 0) {
++      content.push({
++        type: "text",
++        text
++      });
++    }
+     for (const toolCall of (_a = response.message.tool_calls) != null ? _a : []) {
+       content.push({
+         type: "tool-call",
+@@ -1287,12 +1287,12 @@ var OllamaStreamProcessor = class {
+     }
+   }
+   processDelta(delta, controller) {
+-    this.processTextContent(delta, controller);
+     this.processThinking(delta, controller);
++    this.processTextContent(delta, controller);
+     this.processToolCalls(delta, controller);
+   }
+   processTextContent(delta, controller) {
+-    if ((delta == null ? void 0 : delta.content) != null) {
++    if (delta == null ? void 0 : delta.content) {
+       if (!this.state.hasTextStarted) {
+         controller.enqueue({ type: "text-start", id: this.state.textId });
+         this.state.hasTextStarted = true;

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -92,6 +92,7 @@ overrides:
 packageExtensionsChecksum: sha256-OtX37i1Ryo9P6g4B33ec8l4gf38qd6EPAZjHSLupRlQ=
 
 patchedDependencies:
+  ollama-ai-provider-v2@3.6.0: 98b56e2b73bf66546c2a30b64828a038f17206a826311e6249b506fe4488a5ca
   opus-decoder@0.7.11: 56051d0697914c234dba3419dbbdf41d5f0c8461c8ed89501a06a8c83af4e59d
 
 importers:
@@ -469,7 +470,7 @@ importers:
         version: 0.11.0
       ollama-ai-provider-v2:
         specifier: 3.6.0
-        version: 3.6.0(ai@6.0.193(zod@4.3.6))(zod@4.3.6)
+        version: 3.6.0(patch_hash=98b56e2b73bf66546c2a30b64828a038f17206a826311e6249b506fe4488a5ca)(ai@6.0.193(zod@4.3.6))(zod@4.3.6)
       openai:
         specifier: ^6.26.0
         version: 6.29.0(ws@8.21.0)(zod@4.3.6)
@@ -19996,7 +19997,7 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  ollama-ai-provider-v2@3.6.0(ai@6.0.193(zod@4.3.6))(zod@4.3.6):
+  ollama-ai-provider-v2@3.6.0(patch_hash=98b56e2b73bf66546c2a30b64828a038f17206a826311e6249b506fe4488a5ca)(ai@6.0.193(zod@4.3.6))(zod@4.3.6):
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -121,11 +121,19 @@ packageExtensions:
     dependencies:
       zod: ^4.3.4
 
-# The package root eagerly re-exports its optional worker implementation. That
-# pulls @eshaz/web-worker's Node shim into Next's Client Component SSR graph and
-# Turbopack cannot resolve the shim's intentionally dynamic import. We use only
-# the main-thread decoder, so keep that worker branch out of the package entry.
 patchedDependencies:
+  # Native Ollama /api/chat sends `"content": ""` on every thinking-phase chunk,
+  # and the package opened the text part on `content != null` and processed text
+  # before thinking — so the UI text part was created before the reasoning part
+  # and chat rendered the answer above the thinking block. The patch processes
+  # thinking first, opens text only on non-empty content, and orders reasoning
+  # before text in non-streaming results too. Upstream master (v4, needs ai@^7)
+  # has the same bug; drop the patch when moving to ai v7 after verifying a fix.
+  ollama-ai-provider-v2@3.6.0: patches/ollama-ai-provider-v2@3.6.0.patch
+  # The package root eagerly re-exports its optional worker implementation. That
+  # pulls @eshaz/web-worker's Node shim into Next's Client Component SSR graph and
+  # Turbopack cannot resolve the shim's intentionally dynamic import. We use only
+  # the main-thread decoder, so keep that worker branch out of the package entry.
   opus-decoder@0.7.11: patches/opus-decoder@0.7.11.patch
 
 # Enforce Node.js version requirements from package.json engines field.


### PR DESCRIPTION
## What

- pnpm patch for `ollama-ai-provider-v2@3.6.0` (native Ollama transport): process thinking before text in streaming deltas, open the text part only on non-empty `content`, and order reasoning before text in non-streaming results.
- Tripwire unit test (`backend/src/clients/ollama-native-reasoning-order.test.ts`, 4 tests) that fails if a future package bump drops the patch.

## Why

Native Ollama `/api/chat` sends `"content": ""` on every thinking-phase chunk. The package opened the text part on `content != null` and processed text before thinking, so the assistant message's text part was created before its reasoning part and Chat rendered the answer above the thinking block. The OpenAI-compatible `/v1` transport already renders correctly; this brings `ollama-native` in line. Upstream master (v4) has the same bug and needs `ai@^7`, so a version bump is not available on the AI SDK v6 line — the patch carries a drop condition in `pnpm-workspace.yaml`.

## Testing

- New unit tests pass patched and were verified to fail (3/3) against the unpatched package.
- Regression: `provider-matrix.test.ts` + `adapters/ollama-native.test.ts` (179 passed), `routes/ollama.test.ts` (13 passed), `pnpm type-check`, Biome — all green.
- Manual wire check against local Ollama v0.32.0 with `qwen3:0.6b` (think on): stream now emits `reasoning-start → reasoning-delta → text-start → text-delta`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>