### PR TITLE
fix(chat): only auto-collapse thinking blocks that streamed live

### DIFF
--- a/platform/frontend/src/components/ai-elements/reasoning.test.tsx
+++ b/platform/frontend/src/components/ai-elements/reasoning.test.tsx
@@ -1,6 +1,6 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { Reasoning, ReasoningTrigger } from "./reasoning";
+import { Reasoning, ReasoningContent, ReasoningTrigger } from "./reasoning";
 
 describe("Reasoning trigger label", () => {
   it("does not stay pinned on 'Thinking…' for a non-streaming block with no duration", () => {
@@ -44,6 +44,83 @@ describe("Reasoning trigger label", () => {
       );
 
       expect(screen.getByText(/Thought for 3 seconds/)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("Reasoning auto-collapse", () => {
+  it("mounts a persisted block collapsed and never auto-collapses it", () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <Reasoning>
+          <ReasoningTrigger />
+          <ReasoningContent>persisted thinking</ReasoningContent>
+        </Reasoning>,
+      );
+
+      const trigger = screen.getByRole("button");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a manually expanded persisted block open", () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <Reasoning>
+          <ReasoningTrigger />
+          <ReasoningContent>persisted thinking</ReasoningContent>
+        </Reasoning>,
+      );
+
+      const trigger = screen.getByRole("button");
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("mounts a live block open and collapses it shortly after streaming ends", () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(
+        <Reasoning isStreaming>
+          <ReasoningTrigger />
+          <ReasoningContent>live thinking</ReasoningContent>
+        </Reasoning>,
+      );
+
+      const trigger = screen.getByRole("button");
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+      rerender(
+        <Reasoning isStreaming={false}>
+          <ReasoningTrigger />
+          <ReasoningContent>live thinking</ReasoningContent>
+        </Reasoning>,
+      );
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
     } finally {
       vi.useRealTimers();
     }

--- a/platform/frontend/src/components/ai-elements/reasoning.tsx
+++ b/platform/frontend/src/components/ai-elements/reasoning.tsx
@@ -48,7 +48,10 @@ export const Reasoning = memo(
     className,
     isStreaming = false,
     open,
-    defaultOpen = true,
+    // A block that mounts mid-stream starts open; a persisted block (a
+    // reopened conversation) mounts collapsed, so loading a chat doesn't flash
+    // every thinking accordion open and then auto-close it one second later.
+    defaultOpen = isStreaming,
     onOpenChange,
     duration: durationProp,
     children,
@@ -70,11 +73,13 @@ export const Reasoning = memo(
     });
 
     const [hasAutoClosed, setHasAutoClosed] = useState(false);
+    const [hasStreamed, setHasStreamed] = useState(isStreaming);
     const [startTime, setStartTime] = useState<number | null>(null);
 
     // Track duration when streaming starts and ends
     useEffect(() => {
       if (isStreaming) {
+        setHasStreamed(true);
         if (startTime === null) {
           setStartTime(Date.now());
         }
@@ -84,9 +89,13 @@ export const Reasoning = memo(
       }
     }, [isStreaming, startTime, setDuration]);
 
-    // Auto-open when streaming starts, auto-close when streaming ends (once only)
+    // Auto-close once, shortly after a live block finishes streaming. Gated on
+    // hasStreamed rather than defaultOpen — defaultOpen tracks isStreaming and
+    // is already false again on the render where streaming ends — and so that
+    // persisted blocks, which never streamed in this mount, stay put instead of
+    // flicker-closing on conversation load.
     useEffect(() => {
-      if (defaultOpen && !isStreaming && isOpen && !hasAutoClosed) {
+      if (hasStreamed && !isStreaming && isOpen && !hasAutoClosed) {
         // Add a small delay before closing to allow user to see the content
         const timer = setTimeout(() => {
           setIsOpen(false);
@@ -95,7 +104,7 @@ export const Reasoning = memo(
 
         return () => clearTimeout(timer);
       }
-    }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosed]);
+    }, [isStreaming, isOpen, hasStreamed, setIsOpen, hasAutoClosed]);
 
     const handleOpenChange = (newOpen: boolean) => {
       setIsOpen(newOpen);


### PR DESCRIPTION
## What

The thinking accordion (`ai-elements/reasoning.tsx`) now mounts open only while its block is actively streaming (`defaultOpen = isStreaming` instead of `true`), and the 1s auto-close effect is gated on a new `hasStreamed` flag, so it only fires for blocks that finished streaming live in this mount. Persisted blocks mount collapsed and stay put. Three regression tests added.

## Why

Loading a conversation with thinking blocks flashed every accordion open and auto-collapsed it a second later, jumping the layout. Raised in review on #6826: https://github.com/archestra-ai/archestra/pull/6826#issuecomment-5068977717 — this implements the suggested "auto-collapse only in live chat" behavior. The gate must be `hasStreamed` rather than `defaultOpen` because `defaultOpen` tracks `isStreaming` and is already false again on the render where streaming ends.

## Testing

- `pnpm --filter @frontend test reasoning` — 6/6 (3 new: persisted block mounts collapsed and never auto-collapses, manually expanded persisted block stays open, live block collapses ~1s after streaming ends)
- Consumer suites `chat-messages` + `message-thread` — 133/133
- `pnpm type-check` and `pnpm lint` clean

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>