### PR TITLE
feat(chat): surface Gemini reasoning by requesting thought summaries

### DIFF
--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -13,6 +13,7 @@ import {
   RouteId,
   requiresOpenAiResponsesApi,
   type SupportedProvider,
+  supportsGeminiThoughtSummaries,
   TimeInMs,
   type TokenUsage,
 } from "@archestra/shared";
@@ -1278,6 +1279,22 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     google: {
                       responseModalities: ["TEXT", "IMAGE"],
                     },
+                  };
+                }
+
+                // Gemini thinking models bill thought tokens either way, but
+                // the API only streams thought summaries (surfaced in the UI
+                // as reasoning parts) when explicitly asked. Only for models
+                // with thinking on by default: includeThoughts on an inactive-
+                // thinking model is a 400.
+                if (
+                  provider === "gemini" &&
+                  !isGeminiImageModel &&
+                  supportsGeminiThoughtSummaries(selectedModel)
+                ) {
+                  streamTextConfig.providerOptions = {
+                    ...streamTextConfig.providerOptions,
+                    google: { thinkingConfig: { includeThoughts: true } },
                   };
                 }
 

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1109,6 +1109,119 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(mockStreamText.mock.calls[0]?.[0].tools).toBeUndefined();
   });
 
+  // Seeds a synced Gemini model row so resolveConversationModel dereferences
+  // the conversation to that model id + the gemini provider.
+  const makeGeminiModelRow = (geminiModelId: string) =>
+    ModelModel.create({
+      externalId: `gemini/${geminiModelId}`,
+      provider: "gemini",
+      modelId: geminiModelId,
+      description: geminiModelId,
+      contextLength: null,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+
+  test("requests Gemini thought summaries for a default-thinking model", async ({
+    makeConversation,
+  }) => {
+    const model = await makeGeminiModelRow("gemini-2.5-pro");
+    const geminiConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: model.id,
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: geminiConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+    expect(mockStreamText.mock.calls[0]?.[0].providerOptions?.google).toEqual({
+      thinkingConfig: { includeThoughts: true },
+    });
+  });
+
+  test("omits thinkingConfig for a Gemini model with thinking off by default", async ({
+    makeConversation,
+  }) => {
+    // flash-lite does not think unless asked; a bare includeThoughts on it is
+    // rejected by the API with a 400, so the turn must not carry it.
+    const model = await makeGeminiModelRow("gemini-2.5-flash-lite");
+    const geminiConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: model.id,
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: geminiConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+    expect(
+      mockStreamText.mock.calls[0]?.[0].providerOptions?.google,
+    ).toBeUndefined();
+  });
+
+  test("keeps Gemini image-model providerOptions free of thinkingConfig", async ({
+    makeConversation,
+  }) => {
+    const model = await makeGeminiModelRow("gemini-2.5-flash-image");
+    const geminiConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: model.id,
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: geminiConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+    expect(mockStreamText.mock.calls[0]?.[0].providerOptions?.google).toEqual({
+      responseModalities: ["TEXT", "IMAGE"],
+    });
+  });
+
   test("adds load-tools guidance when the agent has no authored prompt", async () => {
     const { AgentModel } = await import("@/models");
     await AgentModel.update(agentId, {

--- a/platform/shared/gemini-models.test.ts
+++ b/platform/shared/gemini-models.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   isLegacyGeminiModel,
   isUsableGeminiCatalogModel,
+  supportsGeminiThoughtSummaries,
 } from "./gemini-models";
 
 describe("isUsableGeminiCatalogModel", () => {
@@ -46,6 +47,38 @@ describe("isUsableGeminiCatalogModel", () => {
   test("is case-insensitive", () => {
     expect(isUsableGeminiCatalogModel("Gemini-2.5-Pro")).toBe(true);
     expect(isUsableGeminiCatalogModel("GEMINI-1.5-PRO")).toBe(false);
+  });
+});
+
+describe("supportsGeminiThoughtSummaries", () => {
+  test.each([
+    // Gemini chat models >= 2.5 think by default.
+    ["gemini-2.5-pro", true],
+    ["gemini-2.5-flash", true],
+    ["gemini-2.5-pro-preview-06-05", true],
+    ["gemini-3-pro-preview", true],
+    ["gemini-3-flash-preview", true],
+    ["gemini-3.5-flash", true],
+    // flash-lite has thinking off by default; bare includeThoughts is a 400.
+    ["gemini-2.5-flash-lite", false],
+    ["gemini-3.5-flash-lite", false],
+    // gemma has no thinking support.
+    ["gemma-3-27b-it", false],
+    // Pre-thinking generations.
+    ["gemini-2.0-flash", false],
+    ["gemini-1.5-pro", false],
+    // Non-text output and embedding variants.
+    ["gemini-2.5-flash-image", false],
+    ["gemini-2.5-flash-preview-tts", false],
+    ["gemini-embedding-001", false],
+    // Unversioned ids.
+    ["gemini-pro", false],
+  ])("%s -> thoughts=%s", (modelId, expected) => {
+    expect(supportsGeminiThoughtSummaries(modelId)).toBe(expected);
+  });
+
+  test("is case-insensitive", () => {
+    expect(supportsGeminiThoughtSummaries("Gemini-2.5-Pro")).toBe(true);
   });
 });
 

--- a/platform/shared/gemini-models.ts
+++ b/platform/shared/gemini-models.ts
@@ -26,6 +26,13 @@ const GEMINI_FAMILY_LEGACY_MAX_VERSION: GeminiVersion = [3, 0];
 const GEMINI_EMBEDDING_PREFIX = "gemini-embedding-";
 
 /**
+ * Lowest generation whose chat models think by default. Deliberately its own
+ * constant: catalog policy ({@link GEMINI_FAMILY_MIN_VERSION}) can move
+ * independently of the thinking capability boundary.
+ */
+const GEMINI_THINKING_MIN_VERSION: GeminiVersion = [2, 5];
+
+/**
  * True when the model should appear in the selectable catalog: first-class
  * Gemini embeddings, or a text-output `gemini-`/`gemma-` chat model at or above
  * {@link GEMINI_FAMILY_MIN_VERSION}. Drops TTS/image/audio/live variants and
@@ -63,6 +70,31 @@ export function isLegacyGeminiModel(modelId: string): boolean {
   return (
     version !== null &&
     compareVersion(version, GEMINI_FAMILY_LEGACY_MAX_VERSION) <= 0
+  );
+}
+
+/**
+ * True when it is safe to request thought summaries
+ * (`thinkingConfig.includeThoughts`) from the model: Gemini chat models at or
+ * above {@link GEMINI_THINKING_MIN_VERSION}, where thinking is on by default.
+ * Excluded because the API rejects `includeThoughts` with a 400 when thinking
+ * is inactive: `flash-lite` variants (thinking off by default), `gemma-*`
+ * (no thinking support), and non-text-output variants.
+ */
+export function supportsGeminiThoughtSummaries(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+
+  if (!id.startsWith("gemini-") || id.includes("flash-lite")) {
+    return false;
+  }
+  if (NON_TEXT_GEMINI_PATTERNS.some((pattern) => id.includes(pattern))) {
+    return false;
+  }
+
+  const version = parseGeminiFamilyVersion(id);
+  return (
+    version !== null &&
+    compareVersion(version, GEMINI_THINKING_MIN_VERSION) >= 0
   );
 }
 


### PR DESCRIPTION
## What

With reasoning models a single chat turn can run for a minute or more with no visible progress. The chat frontend already renders reasoning parts as an accordion and the AI SDK stream already forwards them (`sendReasoning` defaults to true) — but the Gemini API only streams thought summaries when explicitly asked. This wires the missing request-side flag.

- New shared helper `supportsGeminiThoughtSummaries(modelId)` (`platform/shared/gemini-models.ts`): true for Gemini chat models at or above 2.5, where thinking is on by default. Excluded: `flash-lite` variants (thinking off by default), `gemma-*` (no thinking support), pre-2.5 generations, and non-text variants (image/tts/audio/live) — the cases where the API rejects `includeThoughts` with a 400 ("Thinking_config.include_thoughts is only enabled when thinking is enabled"). Future generations (3.5, 4, ...) pass automatically.
- The chat route (`backend/src/routes/chat/routes.ts`) merges `google: { thinkingConfig: { includeThoughts: true } }` into `streamTextConfig.providerOptions` for those models, mutually exclusive with the Gemini image-model branch.

No cost or latency regression: Gemini bills thought tokens whether or not summaries are returned, so requesting them only surfaces reasoning that is already being paid for — and improves perceived latency. The Vertex AI path is covered too: `@ai-sdk/google-vertex` falls back to reading the `google` providerOptions namespace.

## Testing

- New unit table for the helper (`shared/gemini-models.test.ts`): 16 model-id cases plus case-insensitivity, including forward-looking pins (`gemini-3.5-flash` stays on, `gemini-3.5-flash-lite` stays off).
- Three new route tests in `stream-route.test.ts` asserting the actual `streamText` call: a default-thinking model gets `thinkingConfig`, `flash-lite` carries no `google` namespace, and an image model keeps only `responseModalities`.
- `stream-route` suite 52/52, shared suite 56/56, `pnpm type-check`, lint, and shared `knip` (dev + production) all green locally.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
