### PR TITLE
fix(chat): surface Zhipu AI GLM thinking as reasoning in chat

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13580,6 +13580,10 @@
                       "nullable": true,
                       "type": "string"
                     },
+                    "reasoning_content": {
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "name": {
                       "type": "string"
                     },
@@ -33209,6 +33213,10 @@
                       ]
                     },
                     "content": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "reasoning_content": {
                       "nullable": true,
                       "type": "string"
                     },

--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -294,14 +294,17 @@ describe("createDirectLLMModel", () => {
     expect(responseFormat?.json_schema?.schema).toBeDefined();
   });
 
-  it("creates a model for zhipuai provider", () => {
+  it("creates Zhipu AI models on the openai-compatible provider", () => {
     const model = createDirectLLMModel({
       provider: "zhipuai",
       apiKey: "test-key",
-      modelName: "glm-4-flash",
+      modelName: "glm-4.7",
       baseUrl: null,
     });
-    expect(model).toBeDefined();
+    // GLM thinking mode streams the chain of thought in `reasoning_content`,
+    // which the strict openai provider ("openai.chat") drops; the
+    // openai-compatible provider parses it into native reasoning parts.
+    expect((model as { provider: string }).provider).toBe("zhipuai.chat");
   });
 
   it("throws ApiError for unsupported provider", () => {

--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -307,6 +307,70 @@ describe("createDirectLLMModel", () => {
     expect((model as { provider: string }).provider).toBe("zhipuai.chat");
   });
 
+  // generateObject callers (KB reranker, dual-LLM subagents, tool-call arg
+  // repair) hand their schema to the provider via responseFormat. Z.ai's API
+  // accepts only `text`/`json_object` response formats (mirrored by the proxy
+  // request schema in types/llm-providers/zhipuai/api.ts), so the strict
+  // openai provider's `json_schema` request would be rejected; the
+  // openai-compatible provider must fall back to bare `json_object` and leave
+  // schema enforcement to the SDK's validation of the returned text.
+  describe("zhipuai structured output fallback", () => {
+    it("sends response_format json_object for generateObject and parses the result", async () => {
+      let sent: Record<string, unknown> | undefined;
+      const mockFetch = vi.fn(
+        async (_input: unknown, init: RequestInit | undefined) => {
+          sent = JSON.parse(init?.body as string);
+          return new Response(
+            JSON.stringify({
+              id: "chatcmpl-glm",
+              object: "chat.completion",
+              created: 0,
+              model: "glm-4.7",
+              choices: [
+                {
+                  index: 0,
+                  message: {
+                    role: "assistant",
+                    content: '{"scores":[{"index":0,"score":9}]}',
+                  },
+                  finish_reason: "stop",
+                },
+              ],
+              usage: {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        },
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      const model = createDirectLLMModel({
+        provider: "zhipuai",
+        apiKey: "test-key",
+        modelName: "glm-4.7",
+        baseUrl: null,
+      });
+
+      const { object } = await generateObject({
+        model,
+        schema: z.object({
+          scores: z.array(z.object({ index: z.number(), score: z.number() })),
+        }),
+        prompt: "Score the passage.",
+        maxRetries: 0,
+      });
+
+      // Exact match: a `json_schema` response_format here would 400 against
+      // the real API and the proxy's request validation alike.
+      expect(sent?.response_format).toEqual({ type: "json_object" });
+      expect(object).toEqual({ scores: [{ index: 0, score: 9 }] });
+    });
+  });
+
   it("throws ApiError for unsupported provider", () => {
     expect(() =>
       createDirectLLMModel({

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -588,8 +588,15 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
   },
 
   zhipuai: {
-    createModel: ({ apiKey, modelName, baseURL, headers, fetch }) =>
-      createOpenAI({ apiKey, baseURL, headers, fetch }).chat(modelName),
+    // GLM thinking mode (on by default; glm-4.7 thinks unconditionally) streams
+    // its chain of thought in `reasoning_content`. Z.ai accepts only
+    // `text`/`json_object` response formats, so this deliberately stays off
+    // supportsStructuredOutputs: generateObject falls back to bare
+    // `json_object` and the SDK validates the returned JSON against the schema.
+    createModel: reasoningCompatibleCreateModel({
+      name: "zhipuai",
+      missingBaseUrlMessage: "Zhipu AI base URL is required.",
+    }),
     defaultBaseUrl: config.llm.zhipuai.baseUrl,
     apiKeyRequiredMessage:
       "Zhipu AI API key is required. Please configure ZHIPUAI_API_KEY.",

--- a/platform/backend/src/routes/proxy/routes/provider-matrix.test.ts
+++ b/platform/backend/src/routes/proxy/routes/provider-matrix.test.ts
@@ -2177,7 +2177,9 @@ describe("LLM proxy provider matrix", () => {
       // proxy must round-trip the field in both directions: request body
       // validation must not strip it before it reaches the upstream, and
       // response serialization must not strip it before it reaches the client.
-      test.skipIf(config.family !== "openai")(
+      // The zhipuai family shares the wire format: GLM thinking mode uses the
+      // same `reasoning_content` field through its bespoke adapter.
+      test.skipIf(config.family !== "openai" && config.family !== "zhipuai")(
         "round-trips reasoning_content for thinking-mode tool calls",
         async ({ makeAgent }) => {
           const agent = await makeAgent({

--- a/platform/backend/src/types/llm-providers/zhipuai/messages.ts
+++ b/platform/backend/src/types/llm-providers/zhipuai/messages.ts
@@ -60,6 +60,10 @@ const AssistantMessageParamSchema = z
   .object({
     role: z.enum(["assistant"]),
     content: z.string().nullable().optional(),
+    // GLM thinking mode returns the chain of thought in `reasoning_content`;
+    // clients (and @ai-sdk/openai-compatible) may pass it back on tool-call
+    // turns, so body validation must let it through instead of stripping it.
+    reasoning_content: z.string().nullable().optional(),
     name: z.string().optional(),
     tool_calls: z.array(ToolCallSchema).optional(),
     function_call: z

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -4206,6 +4206,7 @@ export type ZhipuaiChatCompletionRequestInput = {
     } | {
         role: 'assistant';
         content?: string | null;
+        reasoning_content?: string | null;
         name?: string;
         tool_calls?: Array<{
             id: string;
@@ -10049,6 +10050,7 @@ export type ZhipuaiChatCompletionRequest = {
     } | {
         role: 'assistant';
         content?: string | null;
+        reasoning_content?: string | null;
         name?: string;
         tool_calls?: Array<{
             id: string;


### PR DESCRIPTION
## What

- Chat now builds Zhipu AI models on `@ai-sdk/openai-compatible` instead of the strict `@ai-sdk/openai` chat provider, so GLM thinking mode's `reasoning_content` deltas become native reasoning parts the chat UI already renders (`includeUsage: true` keeps the streaming usage chunk so cost metrics are unaffected).
- The Zhipu AI proxy assistant-message schema accepts `reasoning_content`, so body validation no longer strips it when clients pass thinking back on tool-call turns. Regenerated the OpenAPI spec (additive optional field only).

## Why

GLM thinking mode (on by default; glm-4.7 thinks unconditionally) streams its chain of thought in a `reasoning_content` delta field that the strict `@ai-sdk/openai` chat parser drops, so during long reasoning turns (1 min+) chat showed no progress at all. Same fix shape as DeepSeek in #6790; minimax/kimi/vllm are handled in a separate PR.

## Testing

- Unit test pins Zhipu AI to the openai-compatible provider (`zhipuai.chat`).
- Unit test pins the structured-output fallback: `generateObject` against a Zhipu AI model sends `response_format: {"type": "json_object"}` — Z.ai accepts only `text`/`json_object`, so the strict provider's `json_schema` request would have been rejected — and the SDK validates the returned JSON against the schema.
- The provider-matrix `reasoning_content` round-trip test now runs for the zhipuai family (previously OpenAI-family only) and passes: request body validation keeps the field on the way upstream and response serialization keeps it on the way back.
- `vitest`: llm-client + chat reasoning round-trip suites (42 passed), full proxy provider matrix (141 passed); `pnpm type-check` clean across all workspaces.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
