### PR TITLE
fix(llm-providers): surface OpenRouter reasoning deltas in chat

### DIFF
--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -191,6 +191,19 @@ describe("createDirectLLMModel", () => {
     expect((model as { provider: string }).provider).toBe("deepseek.chat");
   });
 
+  it("creates OpenRouter models on the openai-compatible provider", () => {
+    const model = createDirectLLMModel({
+      provider: "openrouter",
+      apiKey: "test-key",
+      modelName: "deepseek/deepseek-r1",
+      baseUrl: null,
+    });
+    // OpenRouter streams thinking as a `reasoning` delta field; the strict
+    // openai provider ("openai.chat") drops it, while the openai-compatible
+    // provider surfaces it as reasoning parts.
+    expect((model as { provider: string }).provider).toBe("openrouter.chat");
+  });
+
   it("creates a model for zhipuai provider", () => {
     const model = createDirectLLMModel({
       provider: "zhipuai",

--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -8,8 +8,9 @@ import {
   UNTRUSTED_CONTEXT_HEADER,
   USER_ID_HEADER,
 } from "@archestra/shared";
-import { generateText, streamText } from "ai";
+import { generateObject, generateText, streamText } from "ai";
 import { vi } from "vitest";
+import { z } from "zod";
 import { ConversationModel, LlmProviderApiKeyModel } from "@/models";
 import { encodeOpenAiCodexCredential } from "@/services/openai-codex-credentials";
 import { describe, expect, it, test } from "@/test";
@@ -202,6 +203,50 @@ describe("createDirectLLMModel", () => {
     // openai provider ("openai.chat") drops it, while the openai-compatible
     // provider surfaces it as reasoning parts.
     expect((model as { provider: string }).provider).toBe("openrouter.chat");
+  });
+
+  it("sends the json_schema response_format for OpenRouter structured outputs", async () => {
+    let sent: Record<string, unknown> | undefined;
+    const mockFetch = vi.fn(
+      async (_input: unknown, init: RequestInit | undefined) => {
+        sent = JSON.parse(init?.body as string);
+        return new Response("upstream stub", { status: 500 });
+      },
+    );
+    // Must be stubbed BEFORE the model is built: createResponseHealingFetch
+    // captures `globalThis.fetch` at construction time.
+    vi.stubGlobal("fetch", mockFetch);
+
+    const model = createDirectLLMModel({
+      provider: "openrouter",
+      apiKey: "test-key",
+      modelName: "deepseek/deepseek-r1",
+      baseUrl: null,
+    });
+
+    // The stubbed upstream fails the call; the request body is captured
+    // before that, which is all this assertion needs.
+    await generateObject({
+      model,
+      schema: z.object({ answer: z.number() }),
+      prompt: "2 + 2?",
+      maxRetries: 0,
+    }).catch(() => {});
+
+    if (!sent) {
+      throw new Error("Expected a request to reach the fetch stub");
+    }
+    // generateObject flows (KB reranker, dual-LLM subagents) rely on the
+    // provider enforcing the schema: without supportsStructuredOutputs the
+    // compatible client downgrades to a schema-less `json_object` response
+    // format, and nothing else carries the schema to the model.
+    const responseFormat = (
+      sent as {
+        response_format?: { type?: string; json_schema?: { schema?: unknown } };
+      }
+    ).response_format;
+    expect(responseFormat?.type).toBe("json_schema");
+    expect(responseFormat?.json_schema?.schema).toBeDefined();
   });
 
   it("creates a model for zhipuai provider", () => {

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -480,8 +480,26 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
   },
 
   openrouter: {
-    createModel: ({ apiKey, modelName, baseURL, headers, fetch }) =>
-      createOpenAI({ apiKey, baseURL, headers, fetch }).chat(modelName),
+    createModel: ({ apiKey, modelName, baseURL, headers, fetch }) => {
+      if (!baseURL) {
+        throw new ApiError(400, "OpenRouter base URL is required.");
+      }
+      // OpenRouter streams thinking as a `reasoning` delta field that the
+      // strict @ai-sdk/openai chat parser drops — so reasoning models' thinking
+      // never reaches the UI. @ai-sdk/openai-compatible parses
+      // `reasoning_content` / `reasoning` into native reasoning parts.
+      return createOpenAICompatible({
+        name: "openrouter",
+        apiKey,
+        baseURL,
+        headers,
+        fetch,
+        // @ai-sdk/openai always sends stream_options.include_usage; the compatible
+        // provider only sends it when asked. Keep it on so the final usage chunk
+        // still arrives and cost/usage metrics are unaffected.
+        includeUsage: true,
+      }).chatModel(modelName);
+    },
     defaultBaseUrl: config.llm.openrouter.baseUrl,
     apiKeyRequiredMessage:
       "OpenRouter API key is required. Please configure ARCHESTRA_CHAT_OPENROUTER_API_KEY.",

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -498,6 +498,13 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
         // provider only sends it when asked. Keep it on so the final usage chunk
         // still arrives and cost/usage metrics are unaffected.
         includeUsage: true,
+        // @ai-sdk/openai always sends `response_format: json_schema` for
+        // structured outputs; the compatible provider defaults to a schema-less
+        // `json_object` (and nothing else carries the schema to the model), which
+        // breaks generateObject flows (KB reranker, dual-LLM subagents) pointed
+        // at OpenRouter. OpenRouter supports json_schema; providers that can't
+        // honor it ignore it, exactly as with the strict client.
+        supportsStructuredOutputs: true,
       }).chatModel(modelName);
     },
     defaultBaseUrl: config.llm.openrouter.baseUrl,

--- a/platform/backend/src/routes/chat/openrouter-reasoning.test.ts
+++ b/platform/backend/src/routes/chat/openrouter-reasoning.test.ts
@@ -1,0 +1,233 @@
+/**
+ * OpenRouter reasoning models stream thinking as a `reasoning` delta field —
+ * the alias, NOT the `reasoning_content` field DeepSeek uses (that spelling is
+ * covered by reasoning-roundtrip.test.ts). The strict @ai-sdk/openai chat
+ * parser drops the field entirely, so with the old client the thinking never
+ * reached the UI. This file pins the CHAT-PIPELINE half of the fix: a
+ * `reasoning` delta from the upstream must surface as reasoning parts in the
+ * UI stream, and the request must still carry `stream_options.include_usage`
+ * (the compatible client only sends it when asked; without it the final usage
+ * chunk — and with it cost/usage metrics — is lost).
+ *
+ * Like reasoning-roundtrip.test.ts, this runs the real chat route and real
+ * agentic loop but MOCKS `createLLMModelForAgent`, injecting the exact
+ * openai-compatible client the fix wires up, pointed at an MSW upstream. The
+ * provider-choice half — that OpenRouter actually gets that client — is
+ * guarded by llm-client.test.ts (`provider === "openrouter.chat"`).
+ */
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { HttpResponse, http } from "msw";
+import { vi } from "vitest";
+import { ModelModel } from "@/models";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
+import type { User } from "@/types";
+
+const UPSTREAM_BASE_URL = "https://openrouter.test/api/v1";
+const UPSTREAM_URL = `${UPSTREAM_BASE_URL}/chat/completions`;
+
+const RESPONSE_REASONING = "Let me count the legs before answering.";
+const FINAL_TEXT = "23 chickens and 12 rabbits.";
+
+const mockCreateLLMModelForAgent = vi.hoisted(() =>
+  vi.fn<typeof import("@/clients/llm-client").createLLMModelForAgent>(),
+);
+const mockGetChatMcpTools = vi.hoisted(() => vi.fn());
+const mockGetChatMcpToolUiResourceUris = vi.hoisted(() => vi.fn());
+const mockExtractAndIngestDocuments = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients/llm-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/clients/llm-client")>();
+  return { ...actual, createLLMModelForAgent: mockCreateLLMModelForAgent };
+});
+
+vi.mock("@/clients/chat-mcp-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/clients/chat-mcp-client")>();
+  return {
+    ...actual,
+    getChatMcpTools: mockGetChatMcpTools,
+    getChatMcpToolUiResourceUris: mockGetChatMcpToolUiResourceUris,
+  };
+});
+
+vi.mock("@/knowledge-base", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/knowledge-base")>();
+  return {
+    ...actual,
+    extractAndIngestDocuments: mockExtractAndIngestDocuments,
+  };
+});
+
+// ===== SSE helpers (OpenAI chat.completion.chunk shape) =====
+
+interface Delta {
+  role?: "assistant";
+  content?: string | null;
+  /** OpenRouter's field name for streamed thinking (no `reasoning_content`). */
+  reasoning?: string;
+}
+
+function chunk(delta: Delta, finishReason: string | null = null) {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    created: 0,
+    model: "deepseek/deepseek-r1",
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+const USAGE_CHUNK = {
+  id: "chatcmpl-test",
+  object: "chat.completion.chunk",
+  created: 0,
+  model: "deepseek/deepseek-r1",
+  choices: [],
+  usage: { prompt_tokens: 10, completion_tokens: 10, total_tokens: 20 },
+};
+
+function sse(chunks: unknown[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const c of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(c)}\n\n`));
+      }
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+  return new HttpResponse(body, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+const RESPONSE_CHUNKS = [
+  chunk({ role: "assistant", reasoning: RESPONSE_REASONING }),
+  chunk({ content: FINAL_TEXT }),
+  chunk({}, "stop"),
+  USAGE_CHUNK,
+];
+
+describe("POST /api/chat OpenRouter `reasoning` delta", () => {
+  const server = useMswServer();
+
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+  let conversationId: string;
+  let upstreamRequests: Array<{
+    stream_options?: { include_usage?: boolean };
+  }>;
+
+  beforeEach(
+    async ({ makeAgent, makeConversation, makeOrganization, makeUser }) => {
+      upstreamRequests = [];
+
+      user = await makeUser();
+      const organization = await makeOrganization({ name: "Test Org" });
+      organizationId = organization.id;
+
+      const agent = await makeAgent({
+        organizationId,
+        name: "OpenRouter Agent",
+        systemPrompt: "You are a helpful assistant.",
+      });
+
+      const model = await ModelModel.create({
+        externalId: "openrouter/deepseek/deepseek-r1",
+        provider: "openrouter",
+        modelId: "deepseek/deepseek-r1",
+        supportsToolCalling: true,
+        contextLength: 128000,
+        outputLength: 8192,
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+      });
+
+      const conversation = await makeConversation(agent.id, {
+        userId: user.id,
+        organizationId,
+        modelId: model.id,
+      });
+      conversationId = conversation.id;
+
+      // Real openai-compatible model — the exact client the fix wires up —
+      // pointed straight at the mock upstream (the in-process proxy hop is
+      // covered by the provider matrix).
+      const llmModel = createOpenAICompatible({
+        name: "openrouter",
+        apiKey: "test-key",
+        baseURL: UPSTREAM_BASE_URL,
+        includeUsage: true,
+      }).chatModel("deepseek/deepseek-r1");
+
+      mockCreateLLMModelForAgent.mockResolvedValue({
+        model: llmModel,
+        provider: "openrouter",
+        apiKeySource: "org",
+        anthropicNativeEndpoint: false,
+      });
+
+      mockGetChatMcpTools.mockResolvedValue({});
+      mockGetChatMcpToolUiResourceUris.mockResolvedValue({});
+      mockExtractAndIngestDocuments.mockResolvedValue(undefined);
+
+      server.use(
+        http.post(UPSTREAM_URL, async ({ request }) => {
+          upstreamRequests.push(
+            (await request.json()) as (typeof upstreamRequests)[number],
+          );
+          return sse(RESPONSE_CHUNKS);
+        }),
+      );
+
+      app = createFastifyInstance();
+      app.addHook("onRequest", async (request) => {
+        (request as typeof request & { user: User }).user = user;
+        (
+          request as typeof request & { organizationId: string }
+        ).organizationId = organizationId;
+      });
+
+      const { default: chatRoutes } = await import("./routes");
+      await app.register(chatRoutes);
+    },
+  );
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test("streams the reasoning to the client as reasoning parts", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: conversationId,
+        trigger: "submit-message",
+        messages: [
+          {
+            id: crypto.randomUUID(),
+            role: "user",
+            parts: [{ type: "text", text: "35 heads, 94 legs — how many?" }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // The `reasoning` delta (OpenRouter's alias, no reasoning_content) reaches
+    // the UI stream as reasoning parts — the strict openai client dropped it.
+    expect(response.body).toContain('"type":"reasoning-delta"');
+    expect(response.body).toContain(RESPONSE_REASONING);
+    expect(response.body).toContain(FINAL_TEXT);
+
+    // The compatible client only sends stream_options.include_usage when
+    // asked; the openrouter config must keep it on or usage/cost is lost.
+    expect(upstreamRequests[0]?.stream_options?.include_usage).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

With reasoning models a single chat turn can run for a minute or more with no visible progress. OpenRouter streams thinking as a `reasoning` delta field, but the chat feature built OpenRouter models with `createOpenAI().chat()` — and the strict `@ai-sdk/openai` chat-completions parser drops that field entirely, so the thinking never reached the UI. The LLM proxy was already forwarding the deltas unchanged; the client was the layer losing them.

- The `openrouter` entry in `backend/src/clients/llm-client.ts` now uses `createOpenAICompatible(...).chatModel()`, which parses `reasoning_content` / `reasoning` deltas into native reasoning parts — the same swap DeepSeek (#6790) and Ollama (#6827) already made.
- `includeUsage: true` keeps `stream_options.include_usage` on (the compatible client only sends it when asked), so the final usage chunk — and cost/usage metrics — are unaffected.
- `supportsStructuredOutputs: true` keeps `generateObject` flows (knowledge-base reranker, reranker validation, dual-LLM subagents) on `response_format: json_schema` — exactly what the strict client sent. The compatible client otherwise downgrades to a schema-less `json_object`, and nothing else carries the schema to the model, so those flows would start failing schema validation when configured with an OpenRouter model.
- Attribution headers and the base-URL/key resolution flow through unchanged; a `baseURL` guard mirrors the DeepSeek/Ollama entries.

Known limitations (out of scope): models that emit only structured `reasoning_details` with no plain `reasoning` string (some `anthropic/*` routed via OpenRouter) still won't display thinking, and requesting reasoning via OpenRouter's `reasoning` request parameter (required for `anthropic/*` and `openai/o*`) is a separate feature.

## Testing

- New `backend/src/routes/chat/openrouter-reasoning.test.ts`: runs the real chat route and agentic loop against an MSW upstream streaming OpenRouter's `reasoning` alias (deliberately not the `reasoning_content` spelling covered by `reasoning-roundtrip.test.ts`), asserting the thinking surfaces as `"type":"reasoning-delta"` chunks in the UI stream and that `stream_options.include_usage` is still sent.
- Provider-choice guard in `llm-client.test.ts`: OpenRouter models must report provider `openrouter.chat`, so a revert to the strict client fails a test.
- Wire-body guard in `llm-client.test.ts`: `generateObject` against the OpenRouter model must send `response_format: json_schema` with the schema attached — fails without `supportsStructuredOutputs` (verified red/green).
- Locally green: the two touched test files (41 tests), provider matrix + DeepSeek round-trip suites (143 passed / 14 pre-existing skips), `pnpm type-check`, backend `pnpm knip` (dev + production), biome.
- Manual repro: add an OpenRouter key and ask a puzzle ("35 heads, 94 legs — how many chickens and rabbits?") — the Reasoning accordion now streams above the answer. Model choice: `deepseek/deepseek-r1:free` no longer has active endpoints on OpenRouter (as of July 2026 no free DeepSeek variant does); use `openai/gpt-oss-20b:free` (reasoning always on) or the paid `deepseek/deepseek-r1-0528`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
