### PR TITLE
fix(chat): Surface OpenAI reasoning in Chat by requesting summaries

### DIFF
--- a/platform/backend/src/agents/a2a-executor.stream.test.ts
+++ b/platform/backend/src/agents/a2a-executor.stream.test.ts
@@ -24,10 +24,14 @@ const {
   mockGetChatMcpTools,
   mockCreateLLMModelForAgent,
   mockResolveConversationLlmSelectionForAgent,
+  mockIsOpenAiReasoningSummaryMarkedUnsupported,
+  mockMarkOpenAiReasoningSummaryUnsupported,
 } = vi.hoisted(() => ({
   mockGetChatMcpTools: vi.fn(),
   mockCreateLLMModelForAgent: vi.fn(),
   mockResolveConversationLlmSelectionForAgent: vi.fn(),
+  mockIsOpenAiReasoningSummaryMarkedUnsupported: vi.fn(),
+  mockMarkOpenAiReasoningSummaryUnsupported: vi.fn(),
 }));
 
 vi.mock("@/clients/chat-mcp-client", () => ({
@@ -48,6 +52,23 @@ vi.mock("@/utils/llm-resolution", async () => {
     ...actual,
     resolveConversationLlmSelectionForAgent: (...args: unknown[]) =>
       mockResolveConversationLlmSelectionForAgent(...args),
+  };
+});
+
+// Cache verdict boundary only — the detector and the strip-retry stay real so
+// these tests exercise the actual recovery. Unset (→ awaited falsy) the check
+// means summaries are requested; the negative-cache test flips it. The mark is
+// mocked so the wiring test can observe the verdict write.
+vi.mock("@/agents/openai-reasoning-summary", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/agents/openai-reasoning-summary")
+  >("@/agents/openai-reasoning-summary");
+  return {
+    ...actual,
+    isOpenAiReasoningSummaryMarkedUnsupported: (...args: unknown[]) =>
+      mockIsOpenAiReasoningSummaryMarkedUnsupported(...args),
+    markOpenAiReasoningSummaryUnsupported: (...args: unknown[]) =>
+      mockMarkOpenAiReasoningSummaryUnsupported(...args),
   };
 });
 
@@ -156,6 +177,38 @@ function primeAgent(model: MockLanguageModelV3) {
     provider: "gemini",
     apiKeySource: "org",
   });
+}
+
+// OpenAI variant of primeAgent: a Responses-routed model (gpt-5.6) resolved to
+// a stored credential, so the reasoning-summary gate is in play.
+function primeOpenAiAgent(model: MockLanguageModelV3) {
+  mockResolveConversationLlmSelectionForAgent.mockResolvedValue({
+    chatApiKeyId: "org-key",
+    selectedModel: "gpt-5.6",
+    selectedProvider: "openai",
+  });
+  mockGetChatMcpTools.mockResolvedValue({});
+  mockCreateLLMModelForAgent.mockResolvedValue({
+    model,
+    provider: "openai",
+    apiKeySource: "org",
+    chatApiKeyId: "credential-1",
+  });
+}
+
+// The unverified-org rejection surfaced as a stream error part, the shape the
+// probe sees when OpenAI 400s the whole request over `reasoning.summary`.
+function reasoningSummaryVerificationErrorChunks(): ModelStreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    {
+      type: "error",
+      error: new Error(
+        "Your organization must be verified to generate reasoning summaries.",
+      ),
+    },
+    { type: "finish", finishReason: { unified: "error", raw: "error" }, usage },
+  ];
 }
 
 describe("executeA2AMessage real stream boundary", () => {
@@ -422,6 +475,96 @@ describe("executeA2AMessage real stream boundary", () => {
       model.doStreamCalls[0].prompt.length,
     );
     expect(result.text).toBe("Recovered after trim");
+  });
+
+  test("requests OpenAI reasoning summaries on a Responses-routed a2a turn", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const model = modelEmitting(textChunks("Summarized answer"));
+    primeOpenAiAgent(model);
+
+    const result = await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: "conv-1",
+    });
+
+    expect(result.text).toBe("Summarized answer");
+    expect(model.doStreamCalls).toHaveLength(1);
+    expect(model.doStreamCalls[0]?.providerOptions?.openai).toEqual({
+      store: false,
+      reasoningSummary: "auto",
+    });
+  });
+
+  test("omits reasoningSummary on an a2a turn while the credential is negative-cached", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const model = modelEmitting(textChunks("Plain answer"));
+    primeOpenAiAgent(model);
+    mockIsOpenAiReasoningSummaryMarkedUnsupported.mockResolvedValueOnce(true);
+
+    const result = await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: "conv-1",
+    });
+
+    expect(result.text).toBe("Plain answer");
+    expect(model.doStreamCalls).toHaveLength(1);
+    expect(model.doStreamCalls[0]?.providerOptions?.openai).toEqual({
+      store: false,
+    });
+  });
+
+  test("negative-caches the resolved credential and retries without summaries on the verification 400", async ({
+    makeOrganization,
+    makeUser,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    const agent = await makeInternalAgent({ organizationId: org.id });
+    const model = modelEmitting(
+      reasoningSummaryVerificationErrorChunks(),
+      textChunks("Recovered without summaries"),
+    );
+    primeOpenAiAgent(model);
+
+    const result = await executeA2AMessage({
+      agentId: agent.id,
+      message: "Handle this",
+      organizationId: org.id,
+      userId: user.id,
+      conversationId: "conv-1",
+    });
+
+    expect(result.text).toBe("Recovered without summaries");
+    expect(model.doStreamCalls).toHaveLength(2);
+    // the retry dropped only the summary option; store:false must survive
+    expect(model.doStreamCalls[1]?.providerOptions?.openai).toEqual({
+      store: false,
+    });
+    // the verdict is keyed by the credential the turn ran on, not the
+    // agent's configured key
+    expect(mockMarkOpenAiReasoningSummaryUnsupported).toHaveBeenCalledTimes(1);
+    expect(mockMarkOpenAiReasoningSummaryUnsupported).toHaveBeenCalledWith(
+      `openai-reasoning-summary-unsupported-${org.id}:credential-1`,
+    );
   });
 
   test("stops via the repeat-call ceiling and surfaces a termination notice as text", async ({

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -343,18 +343,19 @@ export async function executeA2AMessage(
     // Pass sessionId to group A2A requests with the calling session
     // Pass delegationChain as externalAgentId so agent names appear in logs
     // Pass agent's llmApiKeyId so it can be used without user access check
-    const { model, anthropicNativeEndpoint } = await createLLMModelForAgent({
-      organizationId,
-      userId,
-      agentId: agent.id,
-      model: selectedModel,
-      provider,
-      sessionId,
-      source,
-      externalAgentId: delegationChain,
-      agentLlmApiKeyId: agent.llmApiKeyId,
-      contextIsTrusted: parentContextIsTrusted,
-    });
+    const { model, anthropicNativeEndpoint, chatApiKeyId } =
+      await createLLMModelForAgent({
+        organizationId,
+        userId,
+        agentId: agent.id,
+        model: selectedModel,
+        provider,
+        sessionId,
+        source,
+        externalAgentId: delegationChain,
+        agentLlmApiKeyId: agent.llmApiKeyId,
+        contextIsTrusted: parentContextIsTrusted,
+      });
 
     // Which attachment mime types this model can read. A missing model row
     // (lookup failure or unknown model) falls back to the safe default set
@@ -460,7 +461,7 @@ export async function executeA2AMessage(
       provider === "openai" && requiresOpenAiResponsesApi(selectedModel)
         ? openAiReasoningSummaryCacheKey({
             organizationId,
-            llmApiKeyId: agent.llmApiKeyId,
+            llmApiKeyId: chatApiKeyId ?? null,
           })
         : null;
     const requestOpenAiReasoningSummary =

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -25,6 +25,11 @@ import { MAX_AGENT_STEPS, runAgentStream } from "@/agents/agent-run-stream";
 import { buildAgentSystemPrompt } from "@/agents/agent-system-prompt";
 import { DelegationLoopError } from "@/agents/errors";
 import { MIN_IMAGE_ATTACHMENT_SIZE } from "@/agents/incoming-email/constants";
+import {
+  isOpenAiReasoningSummaryMarkedUnsupported,
+  markOpenAiReasoningSummaryUnsupported,
+  openAiReasoningSummaryCacheKey,
+} from "@/agents/openai-reasoning-summary";
 import { createStepContextGuard } from "@/agents/step-context-guard";
 import { subagentExecutionTracker } from "@/agents/subagent-execution-tracker";
 import { closeChatMcpClient, getChatMcpTools } from "@/clients/chat-mcp-client";
@@ -445,6 +450,25 @@ export async function executeA2AMessage(
           })
         : undefined;
 
+    // Responses-routed OpenAI turns request reasoning summaries, mirroring the
+    // interactive chat route: reasoning is billed either way, the summary is
+    // the only visible signal, and scheduled-run views render it through the
+    // same chat reasoning UI. Skipped while the credential is negative-cached
+    // as unable to generate summaries (unverified OpenAI org) — the
+    // runAgentStream recovery marks it and retries without.
+    const openAiReasoningSummaryKey =
+      provider === "openai" && requiresOpenAiResponsesApi(selectedModel)
+        ? openAiReasoningSummaryCacheKey({
+            organizationId,
+            llmApiKeyId: agent.llmApiKeyId,
+          })
+        : null;
+    const requestOpenAiReasoningSummary =
+      openAiReasoningSummaryKey !== null &&
+      !(await isOpenAiReasoningSummaryMarkedUnsupported(
+        openAiReasoningSummaryKey,
+      ));
+
     const baseConfig = {
       model,
       system: systemPrompt,
@@ -489,7 +513,16 @@ export async function executeA2AMessage(
           : {
               maxOutputTokens,
               ...(provider === "openai"
-                ? { providerOptions: { openai: { store: false } } }
+                ? {
+                    providerOptions: {
+                      openai: {
+                        store: false,
+                        ...(requestOpenAiReasoningSummary
+                          ? { reasoningSummary: "auto" }
+                          : {}),
+                      },
+                    },
+                  }
                 : {}),
             }),
       // Per-step context guard: cap oversized tool results and keep the
@@ -535,7 +568,17 @@ export async function executeA2AMessage(
     try {
       const runStream = await runAgentStream({
         config: streamConfig,
-        recovery: { logContext: { agentId: agent.id, sessionId } },
+        recovery: {
+          logContext: { agentId: agent.id, sessionId },
+          ...(openAiReasoningSummaryKey !== null
+            ? {
+                onReasoningSummaryUnsupported: () =>
+                  markOpenAiReasoningSummaryUnsupported(
+                    openAiReasoningSummaryKey,
+                  ),
+              }
+            : {}),
+        },
       });
       const stream = runStream.result;
       getCapturedStreamError = runStream.getCapturedStreamError;

--- a/platform/backend/src/agents/agent-run-stream.test.ts
+++ b/platform/backend/src/agents/agent-run-stream.test.ts
@@ -315,6 +315,14 @@ function errorChunks(error: Error): ModelStreamPart[] {
   ];
 }
 
+// The rejection OpenAI returns for `reasoning.summary` from an unverified
+// organization; the strip-retry detection matches the message fragment.
+function reasoningSummaryVerificationError(): Error {
+  return new Error(
+    "Your organization must be verified to generate reasoning summaries. Please go to: https://platform.openai.com/settings/organization/general and click on Verify Organization.",
+  );
+}
+
 // drains the returned stream's fullStream so simulated streams don't leak.
 async function drain(result: { fullStream: AsyncIterable<unknown> }) {
   for await (const _ of result.fullStream) {
@@ -437,6 +445,74 @@ describe("runAgentStream", () => {
       model.doStreamCalls[0].prompt.length,
     );
     expect(await result.text).toBe("hi");
+  });
+
+  test("strips reasoningSummary and retries when the OpenAI org is not verified for summaries", async () => {
+    const model = modelFor(
+      errorChunks(reasoningSummaryVerificationError()),
+      renderableChunks(),
+    );
+    const onReasoningSummaryUnsupported = vi.fn(async () => {});
+
+    const { result } = await runAgentStream({
+      config: {
+        model,
+        prompt: "hello",
+        providerOptions: { openai: { store: false, reasoningSummary: "auto" } },
+      },
+      recovery: { onReasoningSummaryUnsupported },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(2);
+    // the retry drops only the summary option; store:false must survive
+    expect(model.doStreamCalls[1]?.providerOptions?.openai).toEqual({
+      store: false,
+    });
+    expect(onReasoningSummaryUnsupported).toHaveBeenCalledTimes(1);
+    expect(await result.text).toBe("hi");
+  });
+
+  test("does not strip-retry a verification error when no reasoningSummary was requested", async () => {
+    // Nothing to strip means retrying reproduces the same rejection — the
+    // error must surface through the merge instead of a futile silent retry.
+    const model = modelFor(
+      errorChunks(reasoningSummaryVerificationError()),
+      renderableChunks(),
+    );
+    const onReasoningSummaryUnsupported = vi.fn(async () => {});
+
+    const { result } = await runAgentStream({
+      config: {
+        model,
+        prompt: "hello",
+        providerOptions: { openai: { store: false } },
+      },
+      recovery: { onReasoningSummaryUnsupported },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(1);
+    expect(onReasoningSummaryUnsupported).not.toHaveBeenCalled();
+  });
+
+  test("does not strip-retry an unrelated provider error even with reasoningSummary set", async () => {
+    const unrelatedError = new Error(
+      "You exceeded your current quota, please check your plan and billing details.",
+    );
+    const model = modelFor(errorChunks(unrelatedError), renderableChunks());
+
+    const { result, getCapturedStreamError } = await runAgentStream({
+      config: {
+        model,
+        prompt: "hello",
+        providerOptions: { openai: { store: false, reasoningSummary: "auto" } },
+      },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(1);
+    expect(getCapturedStreamError()).toBe(unrelatedError);
   });
 
   test("does not trim a prompt-only run; returns the errored result for the merge", async () => {

--- a/platform/backend/src/agents/agent-run-stream.test.ts
+++ b/platform/backend/src/agents/agent-run-stream.test.ts
@@ -473,6 +473,30 @@ describe("runAgentStream", () => {
     expect(await result.text).toBe("hi");
   });
 
+  test("continues the strip-retry when the unsupported callback itself fails", async () => {
+    const model = modelFor(
+      errorChunks(reasoningSummaryVerificationError()),
+      renderableChunks(),
+    );
+    const onReasoningSummaryUnsupported = vi.fn(async () => {
+      throw new Error("cache unavailable");
+    });
+
+    const { result } = await runAgentStream({
+      config: {
+        model,
+        prompt: "hello",
+        providerOptions: { openai: { store: false, reasoningSummary: "auto" } },
+      },
+      recovery: { onReasoningSummaryUnsupported },
+    });
+    await drain(result);
+
+    // the callback is bookkeeping; its failure must not cost the recovery
+    expect(model.doStreamCalls).toHaveLength(2);
+    expect(await result.text).toBe("hi");
+  });
+
   test("does not strip-retry a verification error when no reasoningSummary was requested", async () => {
     // Nothing to strip means retrying reproduces the same rejection — the
     // error must surface through the merge instead of a futile silent retry.

--- a/platform/backend/src/agents/agent-run-stream.ts
+++ b/platform/backend/src/agents/agent-run-stream.ts
@@ -205,7 +205,16 @@ export async function runAgentStream(params: {
           logContext,
           "[ReasoningSummary] OpenAI org not verified for reasoning summaries, retrying without",
         );
-        await recovery?.onReasoningSummaryUnsupported?.();
+        try {
+          await recovery?.onReasoningSummaryUnsupported?.();
+        } catch (callbackError) {
+          // The callback is bookkeeping (negative-caching the verdict); its
+          // failure must not abort a recovery that can still save the turn.
+          logger.warn(
+            { ...logContext, error: callbackError },
+            "[ReasoningSummary] onReasoningSummaryUnsupported callback failed, continuing retry",
+          );
+        }
         currentConfig = withoutOpenAiReasoningSummary(currentConfig);
         result = runAttempt();
         continue;

--- a/platform/backend/src/agents/agent-run-stream.ts
+++ b/platform/backend/src/agents/agent-run-stream.ts
@@ -14,6 +14,7 @@
 // the underlying generation and break the subsequent `toUIMessageStream` merge.
 
 import { streamText } from "ai";
+import { isReasoningSummaryVerificationError } from "@/agents/openai-reasoning-summary";
 import logger from "@/logging";
 import {
   parseContextLengthError,
@@ -69,6 +70,13 @@ export async function runAgentStream(params: {
      * consumer yet, so the caller can persist state it would otherwise lose.
      */
     onEmptyResponseExhausted?: () => Promise<void>;
+    /**
+     * Fires when a probed error shows the OpenAI credential cannot generate
+     * reasoning summaries (unverified organization) and the attempt is being
+     * retried without them — so the caller can negative-cache the verdict and
+     * skip the doomed request on later turns.
+     */
+    onReasoningSummaryUnsupported?: () => Promise<void> | void;
   };
 }): Promise<{
   result: ReturnType<typeof streamText>;
@@ -102,9 +110,14 @@ export async function runAgentStream(params: {
   // recovers most. On the cap we return the abortive result so the abortive-turn
   // tracker surfaces IncompleteToolCall, the same outcome as before this retry.
   const MAX_ABORTIVE_TOOL_CALL_ATTEMPTS = 2;
+  // requesting `reasoning.summary` from an unverified OpenAI org rejects the
+  // whole request; retrying once without the option recovers the turn (minus
+  // the thinking block). The strip is deterministic, so a second cannot help.
+  const MAX_REASONING_SUMMARY_STRIP_ATTEMPTS = 1;
   let emptyResponseAttempts = 0;
   let contextTrimAttempts = 0;
   let abortiveToolCallAttempts = 0;
+  let reasoningSummaryStripAttempts = 0;
 
   // Capture only the committed attempt's stream error. Reset before each
   // streamText call so a discarded retry's error never leaks into the mapping.
@@ -179,6 +192,21 @@ export async function runAgentStream(params: {
           prompt: undefined,
           messages: trimmed,
         };
+        result = runAttempt();
+        continue;
+      }
+      if (
+        reasoningSummaryStripAttempts < MAX_REASONING_SUMMARY_STRIP_ATTEMPTS &&
+        configRequestsOpenAiReasoningSummary(currentConfig) &&
+        isReasoningSummaryVerificationError(probe.error)
+      ) {
+        reasoningSummaryStripAttempts++;
+        logger.warn(
+          logContext,
+          "[ReasoningSummary] OpenAI org not verified for reasoning summaries, retrying without",
+        );
+        await recovery?.onReasoningSummaryUnsupported?.();
+        currentConfig = withoutOpenAiReasoningSummary(currentConfig);
         result = runAttempt();
         continue;
       }
@@ -387,4 +415,24 @@ export async function probeFirstRenderableEvent(
         break;
     }
   }
+}
+
+function configRequestsOpenAiReasoningSummary(
+  config: StreamTextConfig,
+): boolean {
+  return config.providerOptions?.openai?.reasoningSummary != null;
+}
+
+function withoutOpenAiReasoningSummary(
+  config: StreamTextConfig,
+): StreamTextConfig {
+  const { reasoningSummary: _stripped, ...openaiOptions } =
+    config.providerOptions?.openai ?? {};
+  return {
+    ...config,
+    providerOptions: {
+      ...config.providerOptions,
+      openai: openaiOptions,
+    },
+  };
 }

--- a/platform/backend/src/agents/openai-reasoning-summary.test.ts
+++ b/platform/backend/src/agents/openai-reasoning-summary.test.ts
@@ -1,0 +1,137 @@
+// Unit tests for the OpenAI reasoning-summary capability gate: the
+// verification-rejection detector that drives the strip-retry recovery, the
+// per-credential cache key, and the cache helpers' degrade-don't-fail
+// contract.
+
+import { describe, expect, test } from "@/test";
+import {
+  isOpenAiReasoningSummaryMarkedUnsupported,
+  isReasoningSummaryVerificationError,
+  markOpenAiReasoningSummaryUnsupported,
+  openAiReasoningSummaryCacheKey,
+} from "./openai-reasoning-summary";
+
+const VERIFICATION_MESSAGE =
+  "Your organization must be verified to generate reasoning summaries. Please go to: https://platform.openai.com/settings/organization/general and click on Verify Organization.";
+
+describe("isReasoningSummaryVerificationError", () => {
+  test("matches the rejection in the error message", () => {
+    expect(
+      isReasoningSummaryVerificationError(new Error(VERIFICATION_MESSAGE)),
+    ).toBe(true);
+  });
+
+  test("matches the rejection carried only in an APICallError-style responseBody", () => {
+    const error = Object.assign(new Error("Bad Request"), {
+      responseBody: JSON.stringify({
+        error: {
+          message: VERIFICATION_MESSAGE,
+          type: "invalid_request_error",
+          param: null,
+          code: null,
+        },
+      }),
+    });
+    expect(isReasoningSummaryVerificationError(error)).toBe(true);
+  });
+
+  test("matches a reworded 400 that still blames the reasoning.summary param in the responseBody", () => {
+    const error = Object.assign(new Error("Bad Request"), {
+      responseBody:
+        '{"error":{"message":"Unsupported parameter for this model.","type":"invalid_request_error","param":"reasoning.summary","code":null}}',
+    });
+    expect(isReasoningSummaryVerificationError(error)).toBe(true);
+  });
+
+  test("matches a reworded 400 that blames the reasoning.summary param in the parsed error data", () => {
+    const error = Object.assign(new Error("Bad Request"), {
+      data: {
+        error: {
+          message: "Unsupported parameter for this model.",
+          param: "reasoning.summary",
+        },
+      },
+    });
+    expect(isReasoningSummaryVerificationError(error)).toBe(true);
+  });
+
+  test("matches a rejection nested under an SDK wrapper's cause chain", () => {
+    const wrapped = new Error("Stream processing failed", {
+      cause: new Error("Failed after 1 attempt", {
+        cause: new Error(VERIFICATION_MESSAGE),
+      }),
+    });
+    expect(isReasoningSummaryVerificationError(wrapped)).toBe(true);
+  });
+
+  test("terminates on a self-referential cause chain without matching", () => {
+    const cyclic = new Error("Bad Request");
+    (cyclic as Error & { cause: unknown }).cause = cyclic;
+    expect(isReasoningSummaryVerificationError(cyclic)).toBe(false);
+  });
+
+  test("rejects unrelated errors, other offending params, and non-object errors", () => {
+    expect(
+      isReasoningSummaryVerificationError(
+        new Error(
+          "You exceeded your current quota, please check your plan and billing details.",
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      isReasoningSummaryVerificationError(
+        Object.assign(new Error("Bad Request"), {
+          data: { error: { param: "temperature" } },
+        }),
+      ),
+    ).toBe(false);
+    expect(isReasoningSummaryVerificationError(VERIFICATION_MESSAGE)).toBe(
+      false,
+    );
+    expect(isReasoningSummaryVerificationError(null)).toBe(false);
+    expect(isReasoningSummaryVerificationError(undefined)).toBe(false);
+  });
+});
+
+describe("openAiReasoningSummaryCacheKey", () => {
+  test("keys the verdict by organization and resolved credential", () => {
+    expect(
+      openAiReasoningSummaryCacheKey({
+        organizationId: "org-1",
+        llmApiKeyId: "key-1",
+      }),
+    ).toBe("openai-reasoning-summary-unsupported-org-1:key-1");
+    // environment-variable keys have no credential row; they share one slot
+    expect(
+      openAiReasoningSummaryCacheKey({
+        organizationId: "org-1",
+        llmApiKeyId: null,
+      }),
+    ).toBe("openai-reasoning-summary-unsupported-org-1:env");
+  });
+});
+
+describe("cache verdict helpers", () => {
+  // Both helpers must degrade rather than fail the turn: an unavailable or
+  // unmarked cache reads as "summaries supported", and a failed verdict write
+  // resolves anyway (it only costs one wasted round-trip on a later turn).
+  test("an unmarked credential reads as not-unsupported", async () => {
+    const key = openAiReasoningSummaryCacheKey({
+      organizationId: "org-never-marked",
+      llmApiKeyId: null,
+    });
+    await expect(isOpenAiReasoningSummaryMarkedUnsupported(key)).resolves.toBe(
+      false,
+    );
+  });
+
+  test("marking a credential never rejects", async () => {
+    const key = openAiReasoningSummaryCacheKey({
+      organizationId: "org-never-marked",
+      llmApiKeyId: null,
+    });
+    await expect(
+      markOpenAiReasoningSummaryUnsupported(key),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/platform/backend/src/agents/openai-reasoning-summary.ts
+++ b/platform/backend/src/agents/openai-reasoning-summary.ts
@@ -1,0 +1,70 @@
+// OpenAI reasoning-summary capability gate.
+//
+// Responses-routed OpenAI reasoning models bill reasoning tokens whether or
+// not summaries are requested, so agent turns ask for them ("auto") to surface
+// the thinking that is already paid for. But `reasoning.summary` rejects the
+// whole request for unverified OpenAI organizations ("Your organization must
+// be verified to generate reasoning summaries"), so turn builders consult a
+// per-credential negative cache before requesting, and the agent-run-stream
+// recovery loop detects the rejection mid-turn, retries without summaries, and
+// records the verdict here through its caller.
+
+import { TimeInMs } from "@archestra/shared";
+import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
+import logger from "@/logging";
+
+export function openAiReasoningSummaryCacheKey(params: {
+  organizationId: string;
+  llmApiKeyId: string | null;
+}): AllowedCacheKey {
+  const { organizationId, llmApiKeyId } = params;
+  return `${CacheKey.OpenaiReasoningSummaryUnsupported}-${organizationId}:${llmApiKeyId ?? "env"}`;
+}
+
+export async function isOpenAiReasoningSummaryMarkedUnsupported(
+  key: AllowedCacheKey,
+): Promise<boolean> {
+  return (await cacheManager.get<boolean>(key)) === true;
+}
+
+export async function markOpenAiReasoningSummaryUnsupported(
+  key: AllowedCacheKey,
+): Promise<void> {
+  try {
+    await cacheManager.set(key, true, UNSUPPORTED_VERDICT_TTL);
+  } catch (error) {
+    // Best-effort: a lost negative-cache write only costs another wasted
+    // round-trip on a later turn; never fail the in-flight recovery over it.
+    logger.warn(
+      { error, key },
+      "Failed to cache the reasoning-summary unsupported verdict",
+    );
+  }
+}
+
+export function isReasoningSummaryVerificationError(error: unknown): boolean {
+  if (error === null || typeof error !== "object") {
+    return false;
+  }
+  const { message, responseBody } = error as {
+    message?: unknown;
+    responseBody?: unknown;
+  };
+  return (
+    (typeof message === "string" && VERIFICATION_ERROR_PATTERN.test(message)) ||
+    (typeof responseBody === "string" &&
+      VERIFICATION_ERROR_PATTERN.test(responseBody))
+  );
+}
+
+// The unverified-org rejection: "Your organization must be verified to
+// generate reasoning summaries. Please go to: .../organization/general and
+// click on Verify Organization." Matched on the stable middle fragment so
+// wording drift around it stays harmless.
+const VERIFICATION_ERROR_PATTERN =
+  /must be verified to generate reasoning summaries/i;
+
+// Verification can complete at any time and propagates within ~15-30 minutes,
+// so the verdict must expire: the retry cost is one wasted round-trip per
+// credential per TTL window.
+const UNSUPPORTED_VERDICT_TTL = TimeInMs.Hour;

--- a/platform/backend/src/agents/openai-reasoning-summary.ts
+++ b/platform/backend/src/agents/openai-reasoning-summary.ts
@@ -13,6 +13,14 @@ import { TimeInMs } from "@archestra/shared";
 import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
 import logger from "@/logging";
 
+/**
+ * Cache key for one credential's verdict. `llmApiKeyId` must be the resolved
+ * credential id (`chatApiKeyId` from `createLLMModelForAgent`), not the
+ * agent's configured key: resolution can land on a personal/team/org key or
+ * substitute a per-user ChatGPT-subscription credential, and the verified-org
+ * verdict belongs to the credential the turn actually ran on. Null means an
+ * environment-variable key.
+ */
 export function openAiReasoningSummaryCacheKey(params: {
   organizationId: string;
   llmApiKeyId: string | null;
@@ -43,18 +51,56 @@ export async function markOpenAiReasoningSummaryUnsupported(
 }
 
 export function isReasoningSummaryVerificationError(error: unknown): boolean {
-  if (error === null || typeof error !== "object") {
-    return false;
+  // SDK wrappers can nest the provider rejection under `cause` (a RetryError,
+  // a stream-error wrapper), so walk a bounded chain instead of trusting the
+  // top-level shape.
+  let current: unknown = error;
+  for (
+    let depth = 0;
+    depth < MAX_ERROR_CAUSE_DEPTH &&
+    current !== null &&
+    typeof current === "object";
+    depth++
+  ) {
+    if (isVerificationRejection(current)) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
   }
-  const { message, responseBody } = error as {
+  return false;
+}
+
+function isVerificationRejection(error: object): boolean {
+  const { message, responseBody, data } = error as {
     message?: unknown;
     responseBody?: unknown;
+    data?: unknown;
   };
-  return (
-    (typeof message === "string" && VERIFICATION_ERROR_PATTERN.test(message)) ||
-    (typeof responseBody === "string" &&
-      VERIFICATION_ERROR_PATTERN.test(responseBody))
-  );
+  if (typeof message === "string" && VERIFICATION_ERROR_PATTERN.test(message)) {
+    return true;
+  }
+  if (
+    typeof responseBody === "string" &&
+    (VERIFICATION_ERROR_PATTERN.test(responseBody) ||
+      REJECTED_SUMMARY_PARAM_PATTERN.test(responseBody))
+  ) {
+    return true;
+  }
+  return rejectedOpenAiParam(data) === "reasoning.summary";
+}
+
+// APICallError.data carries the parsed OpenAI error body ({ error: { message,
+// type, param, code } }) when the SDK could parse the response.
+function rejectedOpenAiParam(data: unknown): string | null {
+  if (data === null || typeof data !== "object") {
+    return null;
+  }
+  const inner = (data as { error?: unknown }).error;
+  if (inner === null || typeof inner !== "object") {
+    return null;
+  }
+  const param = (inner as { param?: unknown }).param;
+  return typeof param === "string" ? param : null;
 }
 
 // The unverified-org rejection: "Your organization must be verified to
@@ -63,6 +109,16 @@ export function isReasoningSummaryVerificationError(error: unknown): boolean {
 // wording drift around it stays harmless.
 const VERIFICATION_ERROR_PATTERN =
   /must be verified to generate reasoning summaries/i;
+
+// Wording-drift fallback: `reasoning.summary` only appears in our requests
+// because this module's callers added it, so any 400 that names it as the
+// offending param is recoverable by stripping the option, whatever the
+// message says.
+const REJECTED_SUMMARY_PARAM_PATTERN = /"param"\s*:\s*"reasoning\.summary"/;
+
+// Wrapper errors nest the provider rejection under `cause`; five levels covers
+// SDK wrapping depth while keeping self-referential chains terminating.
+const MAX_ERROR_CAUSE_DEPTH = 5;
 
 // Verification can complete at any time and propagates within ~15-30 minutes,
 // so the verdict must expire: the retry cost is one wasted round-trip per

--- a/platform/backend/src/cache-manager.ts
+++ b/platform/backend/src/cache-manager.ts
@@ -34,6 +34,8 @@ export const CacheKey = {
   ChatActiveStream: "chat-active-stream",
   /** Pending MCP elicitation responses from the chat UI */
   ChatMcpElicitation: "chat-mcp-elicitation",
+  /** OpenAI credentials that cannot generate reasoning summaries (unverified org) */
+  OpenaiReasoningSummaryUnsupported: "openai-reasoning-summary-unsupported",
   /** Channel discovery TTL per workspace */
   ChannelDiscovery: "channel-discovery",
   /** Slack user ID → email mapping */

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -258,6 +258,14 @@ export async function createLLMModelForAgent(params: {
    * proxy's `anthropic-beta` header gating so the two can't drift.
    */
   anthropicNativeEndpoint: boolean;
+  /**
+   * The resolved credential row id, when a stored key was used (undefined for
+   * environment-variable keys and keyless auth). This is the credential the
+   * turn actually runs on — resolution can land on a personal/team/org key or
+   * substitute a per-user ChatGPT-subscription credential, not just the
+   * agent's own configured key.
+   */
+  chatApiKeyId?: string;
 }> {
   const {
     organizationId,
@@ -361,7 +369,13 @@ export async function createLLMModelForAgent(params: {
     baseUrl,
   });
 
-  return { model, provider, apiKeySource, anthropicNativeEndpoint };
+  return {
+    model,
+    provider,
+    apiKeySource,
+    anthropicNativeEndpoint,
+    chatApiKeyId,
+  };
 }
 
 // =============================================================================

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -36,6 +36,11 @@ import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { resolveAgentMaxOutputTokens } from "@/agents/agent-output-budget";
 import { MAX_AGENT_STEPS, runAgentStream } from "@/agents/agent-run-stream";
+import {
+  isOpenAiReasoningSummaryMarkedUnsupported,
+  markOpenAiReasoningSummaryUnsupported,
+  openAiReasoningSummaryCacheKey,
+} from "@/agents/openai-reasoning-summary";
 import { hasAnyAgentTypeAdminPermission, userHasPermission } from "@/auth";
 import { CacheKey, cacheManager } from "@/cache-manager";
 import {
@@ -1305,13 +1310,35 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 // (Codex) backend, which forces store:false and therefore never
                 // has the referenced items ("Items are not persisted when
                 // `store` is set to false").
-                if (
+                //
+                // They also reason by default and bill reasoning tokens either
+                // way, but only stream human-readable summaries when asked —
+                // request them so chat surfaces thinking it already pays for.
+                // Unverified OpenAI orgs reject the whole request over the
+                // summary option, so it is skipped while the credential is
+                // negative-cached as unsupported (the runAgentStream recovery
+                // marks it and retries the rejected turn without summaries).
+                const openAiReasoningSummaryKey =
                   provider === "openai" &&
                   requiresOpenAiResponsesApi(selectedModel)
-                ) {
+                    ? openAiReasoningSummaryCacheKey({
+                        organizationId,
+                        llmApiKeyId: agent.llmApiKeyId,
+                      })
+                    : null;
+                if (openAiReasoningSummaryKey !== null) {
+                  const summariesUnsupported =
+                    await isOpenAiReasoningSummaryMarkedUnsupported(
+                      openAiReasoningSummaryKey,
+                    );
                   streamTextConfig.providerOptions = {
                     ...streamTextConfig.providerOptions,
-                    openai: { store: false },
+                    openai: {
+                      store: false,
+                      ...(summariesUnsupported
+                        ? {}
+                        : { reasoningSummary: "auto" }),
+                    },
                   };
                 }
 
@@ -1389,6 +1416,14 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                     config: streamTextConfig,
                     recovery: {
                       logContext: { conversationId },
+                      ...(openAiReasoningSummaryKey !== null
+                        ? {
+                            onReasoningSummaryUnsupported: () =>
+                              markOpenAiReasoningSummaryUnsupported(
+                                openAiReasoningSummaryKey,
+                              ),
+                          }
+                        : {}),
                       onEmptyResponseExhausted: async () => {
                         // Persist before the throw — nothing has merged yet, so the
                         // stream onError/onFinish won't fire to do it.

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -897,7 +897,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 // (the inline connect card) rather than a generic server error.
                 // Pass agent's llmApiKeyId so it's used without a user access
                 // check; pass conversationId as sessionId to group the session.
-                const { model, anthropicNativeEndpoint } =
+                const { model, anthropicNativeEndpoint, chatApiKeyId } =
                   await createLLMModelForAgent({
                     organizationId,
                     userId: user.id,
@@ -1323,7 +1323,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                   requiresOpenAiResponsesApi(selectedModel)
                     ? openAiReasoningSummaryCacheKey({
                         organizationId,
-                        llmApiKeyId: agent.llmApiKeyId,
+                        llmApiKeyId: chatApiKeyId ?? null,
                       })
                     : null;
                 if (openAiReasoningSummaryKey !== null) {

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -50,6 +50,8 @@ const mockCompactMessagesForChat = vi.hoisted(() => vi.fn());
 // the negative-cache test flips it. Mocked because the real check reads the
 // distributed cacheManager, which is not started in unit tests.
 const mockIsOpenAiReasoningSummaryMarkedUnsupported = vi.hoisted(() => vi.fn());
+// Observed by the verification-400 wiring test; mocked for the same reason.
+const mockMarkOpenAiReasoningSummaryUnsupported = vi.hoisted(() => vi.fn());
 
 vi.mock("ai", async (importOriginal) => {
   const actual = await importOriginal<typeof import("ai")>();
@@ -77,6 +79,8 @@ vi.mock("@/agents/openai-reasoning-summary", async (importOriginal) => {
     ...actual,
     isOpenAiReasoningSummaryMarkedUnsupported:
       mockIsOpenAiReasoningSummaryMarkedUnsupported,
+    markOpenAiReasoningSummaryUnsupported:
+      mockMarkOpenAiReasoningSummaryUnsupported,
   };
 });
 
@@ -1350,6 +1354,76 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(mockStreamText.mock.calls[0]?.[0].providerOptions?.openai).toEqual({
       store: false,
     });
+  });
+
+  test("retries without summaries and negative-caches the resolved credential on the verification 400", async ({
+    makeConversation,
+  }) => {
+    const model = await makeOpenAiModelRow("gpt-5.6");
+    const openAiConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: model.id,
+    });
+    // the turn runs on a resolved stored credential, not the agent's own key
+    mockCreateLLMModelForAgent.mockResolvedValueOnce({
+      model: "mock-model",
+      chatApiKeyId: "credential-1",
+    });
+    mockStreamText.mockClear();
+    mockMarkOpenAiReasoningSummaryUnsupported.mockClear();
+    // First attempt: the stream carries only the unverified-org rejection.
+    // The beforeEach default implementation then serves the retry.
+    mockStreamText.mockImplementationOnce(() => ({
+      fullStream: {
+        [Symbol.asyncIterator]: () => {
+          const events = [
+            {
+              type: "error",
+              error: new Error(
+                "Your organization must be verified to generate reasoning summaries.",
+              ),
+            },
+          ];
+          let index = 0;
+          return {
+            next: async () =>
+              index < events.length
+                ? { done: false, value: events[index++] }
+                : { done: true, value: undefined },
+          };
+        },
+      },
+    }));
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: openAiConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(mockStreamText.mock.calls[0]?.[0].providerOptions?.openai).toEqual({
+      store: false,
+      reasoningSummary: "auto",
+    });
+    // the retry dropped only the summary option; store:false must survive
+    expect(mockStreamText.mock.calls[1]?.[0].providerOptions?.openai).toEqual({
+      store: false,
+    });
+    // the verdict is keyed by the credential the turn ran on
+    expect(mockMarkOpenAiReasoningSummaryUnsupported).toHaveBeenCalledTimes(1);
+    expect(mockMarkOpenAiReasoningSummaryUnsupported).toHaveBeenCalledWith(
+      `openai-reasoning-summary-unsupported-${organizationId}:credential-1`,
+    );
   });
 
   test("adds load-tools guidance when the agent has no authored prompt", async () => {

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -46,6 +46,10 @@ const mockFetchToolUiResource = vi.hoisted(() => vi.fn());
 const mockExtractAndIngestDocuments = vi.hoisted(() => vi.fn());
 const mockStartActiveChatSpan = vi.hoisted(() => vi.fn());
 const mockCompactMessagesForChat = vi.hoisted(() => vi.fn());
+// Unset (→ awaited falsy) by default so turns request reasoning summaries;
+// the negative-cache test flips it. Mocked because the real check reads the
+// distributed cacheManager, which is not started in unit tests.
+const mockIsOpenAiReasoningSummaryMarkedUnsupported = vi.hoisted(() => vi.fn());
 
 vi.mock("ai", async (importOriginal) => {
   const actual = await importOriginal<typeof import("ai")>();
@@ -63,6 +67,16 @@ vi.mock("@/clients/llm-client", async (importOriginal) => {
   return {
     ...actual,
     createLLMModelForAgent: mockCreateLLMModelForAgent,
+  };
+});
+
+vi.mock("@/agents/openai-reasoning-summary", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/agents/openai-reasoning-summary")>();
+  return {
+    ...actual,
+    isOpenAiReasoningSummaryMarkedUnsupported:
+      mockIsOpenAiReasoningSummaryMarkedUnsupported,
   };
 });
 
@@ -1219,6 +1233,122 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     expect(mockStreamText).toHaveBeenCalledTimes(1);
     expect(mockStreamText.mock.calls[0]?.[0].providerOptions?.google).toEqual({
       responseModalities: ["TEXT", "IMAGE"],
+    });
+  });
+
+  // Seeds a synced OpenAI model row so resolveConversationModel dereferences
+  // the conversation to that model id + the openai provider.
+  const makeOpenAiModelRow = (openAiModelId: string) =>
+    ModelModel.create({
+      externalId: `openai/${openAiModelId}`,
+      provider: "openai",
+      modelId: openAiModelId,
+      description: openAiModelId,
+      contextLength: null,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+
+  test("requests OpenAI reasoning summaries for a Responses-routed model", async ({
+    makeConversation,
+  }) => {
+    const model = await makeOpenAiModelRow("gpt-5.6");
+    const openAiConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: model.id,
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: openAiConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+    expect(mockStreamText.mock.calls[0]?.[0].providerOptions?.openai).toEqual({
+      store: false,
+      reasoningSummary: "auto",
+    });
+  });
+
+  test("omits reasoningSummary for a chat-completions-routed OpenAI model", async ({
+    makeConversation,
+  }) => {
+    // Chat completions never returns reasoning content, and the summary
+    // option only exists on the Responses transport — the turn must carry
+    // neither it nor store:false, only the max_completion_tokens budget.
+    const model = await makeOpenAiModelRow("gpt-5-mini");
+    const openAiConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: model.id,
+    });
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: openAiConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+    expect(mockStreamText.mock.calls[0]?.[0].providerOptions?.openai).toEqual({
+      maxCompletionTokens: expect.any(Number),
+    });
+  });
+
+  test("omits reasoningSummary while the credential is negative-cached as unsupported", async ({
+    makeConversation,
+  }) => {
+    const model = await makeOpenAiModelRow("gpt-5.6");
+    const openAiConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: model.id,
+    });
+    mockIsOpenAiReasoningSummaryMarkedUnsupported.mockResolvedValueOnce(true);
+    mockStreamText.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: openAiConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+    expect(mockStreamText.mock.calls[0]?.[0].providerOptions?.openai).toEqual({
+      store: false,
     });
   });
 

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.test.ts
@@ -40,3 +40,92 @@ describe("OpenAiResponsesRequestAdapter.getMessages", () => {
     expect(messages).toEqual([{ role: "user", content: "typed" }]);
   });
 });
+
+describe("OpenAiResponsesStreamAdapter.toProviderResponse", () => {
+  // Reasoning turns (`store: false`) finish with `response.completed` carrying
+  // an empty `output`, even though the text arrived in delta chunks. Persisting
+  // that envelope verbatim dropped the assistant side of the interaction, so
+  // LLM Logs had nothing to render for the turn.
+  test("restores accumulated output when the completed envelope is empty", () => {
+    const adapter = openAiResponsesAdapterFactory.createStreamAdapter();
+
+    adapter.processChunk({
+      type: "response.output_text.delta",
+      item_id: "msg_1",
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 1,
+      delta: "Three r's.",
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    adapter.processChunk({
+      type: "response.completed",
+      sequence_number: 2,
+      response: {
+        id: "resp_1",
+        object: "response",
+        status: "completed",
+        model: "gpt-5.6",
+        store: false,
+        output: [],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 4,
+          total_tokens: 14,
+        },
+      },
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    const persisted = adapter.toProviderResponse();
+
+    // The upstream envelope is kept (ids, echoed request config)...
+    expect(persisted).toMatchObject({ id: "resp_1", store: false });
+    // ...but the assistant turn is no longer lost.
+    expect(persisted.output).toContainEqual(
+      expect.objectContaining({
+        type: "message",
+        role: "assistant",
+        content: [
+          expect.objectContaining({ type: "output_text", text: "Three r's." }),
+        ],
+      }),
+    );
+  });
+
+  test("keeps the upstream output when the completed envelope carries it", () => {
+    const adapter = openAiResponsesAdapterFactory.createStreamAdapter();
+
+    adapter.processChunk({
+      type: "response.output_text.delta",
+      item_id: "msg_1",
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 1,
+      delta: "streamed",
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    const upstreamOutput = [
+      {
+        id: "msg_1",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "upstream", annotations: [] }],
+      },
+    ];
+
+    adapter.processChunk({
+      type: "response.completed",
+      sequence_number: 2,
+      response: {
+        id: "resp_2",
+        object: "response",
+        status: "completed",
+        model: "gpt-5.6",
+        output: upstreamOutput,
+      },
+    } as unknown as Parameters<typeof adapter.processChunk>[0]);
+
+    expect(adapter.toProviderResponse().output).toEqual(upstreamOutput);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -641,10 +641,6 @@ class OpenAiResponsesStreamAdapter
   }
 
   toProviderResponse(): OpenAiResponsesResponse {
-    if (this.replacedText === null && this.completedResponse) {
-      return this.completedResponse;
-    }
-
     const outputItems: OpenAiResponsesResponse["output"] = [];
 
     const messageText = this.replacedText ?? this.state.text;
@@ -675,6 +671,24 @@ class OpenAiResponsesStreamAdapter
           status: "completed" as const,
         })),
       );
+    }
+
+    // The upstream `response.completed` envelope is the richest record (it
+    // echoes tools, reasoning config and the real ids), so it wins — but only
+    // when it actually carries the turn. Reasoning turns finish with an empty
+    // `output` even though the text arrived in `response.output_text.delta`
+    // chunks; persisting that verbatim lost the whole assistant side of the
+    // interaction, leaving LLM Logs with nothing to render. Keep the envelope
+    // and restore the items we accumulated.
+    if (this.replacedText === null && this.completedResponse) {
+      const upstreamOutput = this.completedResponse.output;
+      if (
+        (Array.isArray(upstreamOutput) && upstreamOutput.length > 0) ||
+        outputItems.length === 0
+      ) {
+        return this.completedResponse;
+      }
+      return { ...this.completedResponse, output: outputItems };
     }
 
     return {

--- a/platform/shared/interactions/llmProviders/openai-responses.test.ts
+++ b/platform/shared/interactions/llmProviders/openai-responses.test.ts
@@ -33,4 +33,70 @@ describe("OpenAiResponsesInteraction", () => {
 
     expect(interaction.getToolNamesUsed()).toEqual(["read_file"]);
   });
+
+  // The AI SDK serializes Responses turns as "easy input" messages — bare
+  // `{role, content}` with no `type` — which the proxy's request adapter
+  // already understands. Requiring the tag here dropped every SDK-sent message,
+  // so LLM Logs rendered "No message" with an empty conversation preview.
+  it("reads easy-input messages that omit a top-level type", () => {
+    const interaction = new OpenAiResponsesInteraction({
+      type: "openai:responses",
+      model: "gpt-5.6",
+      request: {
+        model: "gpt-5.6",
+        input: [
+          { role: "developer", content: "You are helpful." },
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "count the r's" }],
+          },
+        ],
+      },
+      response: { output: [] },
+    } as unknown as Interaction);
+
+    expect(interaction.getLastUserMessage()).toBe("count the r's");
+    expect(interaction.mapToUiMessages()).toEqual([
+      { role: "system", parts: [{ type: "text", text: "You are helpful." }] },
+      { role: "user", parts: [{ type: "text", text: "count the r's" }] },
+    ]);
+  });
+
+  it("still reads explicitly typed message items", () => {
+    const interaction = new OpenAiResponsesInteraction({
+      type: "openai:responses",
+      model: "gpt-5.6",
+      request: {
+        model: "gpt-5.6",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "typed" }],
+          },
+        ],
+      },
+      response: { output: [] },
+    } as unknown as Interaction);
+
+    expect(interaction.getLastUserMessage()).toBe("typed");
+  });
+
+  it("does not treat non-message input items as messages", () => {
+    const interaction = new OpenAiResponsesInteraction({
+      type: "openai:responses",
+      model: "gpt-5.6",
+      request: {
+        model: "gpt-5.6",
+        input: [
+          { type: "function_call_output", call_id: "call_1", output: "{}" },
+          { type: "reasoning", id: "rs_1", summary: [] },
+        ],
+      },
+      response: { output: [] },
+    } as unknown as Interaction);
+
+    expect(interaction.getLastUserMessage()).toBe("");
+    expect(interaction.mapToUiMessages()).toEqual([]);
+  });
 });

--- a/platform/shared/interactions/llmProviders/openai-responses.ts
+++ b/platform/shared/interactions/llmProviders/openai-responses.ts
@@ -132,7 +132,7 @@ class OpenAiResponsesInteraction implements InteractionUtils {
       }
 
       messages.push({
-        role: item.role === "assistant" ? "assistant" : "user",
+        role: responsesRoleToUiMessageRole(item.role),
         parts: [{ type: "text", text: extractInputMessageText(item.content) }],
       });
     }
@@ -187,15 +187,32 @@ class OpenAiResponsesInteraction implements InteractionUtils {
 
 export default OpenAiResponsesInteraction;
 
+// `type` is optional on Responses input messages — it defaults to "message" —
+// and the AI SDK omits it, serializing plain turns as bare `{role, content}`.
+// Requiring the tag dropped every SDK-sent message on the floor, so the logs
+// rendered "No message" with an empty conversation. Key off `role` instead and
+// only reject items that tag themselves as something else (function_call,
+// function_call_output, reasoning).
 function isRequestMessage(
   item: unknown,
-): item is { type: "message"; role: "user" | "assistant"; content: unknown } {
-  return (
-    !!item &&
-    typeof item === "object" &&
-    "type" in item &&
-    item.type === "message"
-  );
+): item is { type?: "message"; role: string; content: unknown } {
+  if (!item || typeof item !== "object" || !("role" in item)) {
+    return false;
+  }
+  const type = (item as { type?: unknown }).type;
+  return type === undefined || type === "message";
+}
+
+// Mirrors the chat-completions mapper: instruction turns render as the "System
+// Prompt" block rather than as a user message.
+function responsesRoleToUiMessageRole(role: string): PartialUIMessage["role"] {
+  if (role === "assistant") {
+    return "assistant";
+  }
+  if (role === "system" || role === "developer") {
+    return "system";
+  }
+  return "user";
 }
 
 function isFunctionCallOutputItem(


### PR DESCRIPTION
## Summary

With reasoning models a chat turn can run for a minute with no visible progress. Responses-routed OpenAI models (gpt-5.6 family, `-pro`) reason by default and bill reasoning tokens either way, but only stream human-readable summaries when `reasoning.summary` is requested — so users paid for thinking they never saw. Part of T-904 (expose model thinking/reasoning output in Chat), OpenAI provider iteration.

- The chat and A2A turn builders now send `reasoningSummary: "auto"` alongside `store: false` for Responses-routed OpenAI models, so the existing reasoning UI surfaces the thinking. Chat-completions-routed models are untouched — that transport never returns reasoning content.
- Unverified OpenAI organizations reject the whole request over the summary option, so the `runAgentStream` recovery loop gains a strip-retry branch: on the verification 400 it retries once without the option and the caller negative-caches the verdict per credential (1h TTL — verification propagates in ~15–30 minutes), so later turns skip the doomed request.
- Hardening pass: verification-400 detection walks the error cause chain and also matches a 400 naming `reasoning.summary` as the offending param, the strip-retry survives a throwing `onReasoningSummaryUnsupported` callback, and the negative cache is keyed by the credential the turn actually ran on (`chatApiKeyId`, now returned by `createLLMModelForAgent`) instead of the agent's configured key.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests

Ran the four touched suites (`openai-reasoning-summary`, `agent-run-stream`, `a2a-executor.stream`, `stream-route`): 109/109 passing.

## Changes

| File | Change |
|------|--------|
| `agents/openai-reasoning-summary.ts` (+test) | New helper: builds the reasoning providerOptions, detects the verification 400, cache-key derivation |
| `agents/agent-run-stream.ts` (+test) | Strip-retry recovery branch with guarded callback |
| `agents/a2a-executor.ts` (+stream test) | A2A turns request summaries, wire the negative cache |
| `routes/chat/routes.ts` (+`stream-route.test.ts`) | Chat turns request summaries, verification-400 → negative-cache wiring |
| `clients/llm-client.ts` | `createLLMModelForAgent` returns the resolved `chatApiKeyId` |
| `cache-manager.ts` | New namespace for the per-credential verdict cache |

## Does this introduce a user-facing change?

Yes — OpenAI reasoning models now show their thinking in the chat reasoning accordion, instead of a silent wait until the answer starts.

## Special notes for reviewers

- No cost regression: OpenAI bills reasoning tokens whether or not summaries are requested; this only surfaces what is already paid for.
- The 1h negative-cache TTL is deliberate: org verification propagates on OpenAI's side in ~15–30 minutes, so a shorter TTL would re-probe too eagerly and a longer one would hide freshly verified orgs.

Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>