### PR TITLE
fix(chat): surface Perplexity reasoning by extracting <think> blocks

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8122,6 +8122,13 @@
           "stream": {
             "nullable": true,
             "type": "boolean"
+          },
+          "stream_mode": {
+            "type": "string",
+            "enum": [
+              "full",
+              "concise"
+            ]
           }
         },
         "required": [
@@ -27316,6 +27323,13 @@
           "stream": {
             "nullable": true,
             "type": "boolean"
+          },
+          "stream_mode": {
+            "type": "string",
+            "enum": [
+              "full",
+              "concise"
+            ]
           }
         },
         "required": [
@@ -139972,7 +139986,7 @@
                               "request": {
                                 "anyOf": [
                                   {
-                                    "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                                    "$ref": "#/components/schemas/PerplexityChatCompletionRequest"
                                   },
                                   {
                                     "type": "object",
@@ -139984,7 +139998,7 @@
                                 "nullable": true,
                                 "anyOf": [
                                   {
-                                    "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                                    "$ref": "#/components/schemas/PerplexityChatCompletionRequest"
                                   },
                                   {
                                     "type": "object",
@@ -169309,7 +169323,7 @@
                         "request": {
                           "anyOf": [
                             {
-                              "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                              "$ref": "#/components/schemas/PerplexityChatCompletionRequest"
                             },
                             {
                               "type": "object",
@@ -169321,7 +169335,7 @@
                           "nullable": true,
                           "anyOf": [
                             {
-                              "$ref": "#/components/schemas/XaiChatCompletionRequest"
+                              "$ref": "#/components/schemas/PerplexityChatCompletionRequest"
                             },
                             {
                               "type": "object",
@@ -270575,7 +270589,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/XaiChatCompletionRequestInput"
+                "$ref": "#/components/schemas/PerplexityChatCompletionRequestInput"
               }
             }
           }
@@ -270854,7 +270868,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/XaiChatCompletionRequestInput"
+                "$ref": "#/components/schemas/PerplexityChatCompletionRequestInput"
               }
             }
           }

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -24,7 +24,11 @@ import {
   USER_ID_HEADER,
 } from "@archestra/shared";
 import { context, propagation } from "@opentelemetry/api";
-import type { streamText } from "ai";
+import {
+  extractReasoningMiddleware,
+  type streamText,
+  wrapLanguageModel,
+} from "ai";
 import { createOllama } from "ollama-ai-provider-v2";
 import { isAnthropicNativeEndpoint } from "@/clients/anthropic-endpoint";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
@@ -490,7 +494,19 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
 
   perplexity: {
     createModel: ({ apiKey, modelName, baseURL, headers, fetch }) =>
-      createOpenAI({ apiKey, baseURL, headers, fetch }).chat(modelName),
+      // Perplexity reasoning models (sonar-reasoning-pro) stream their chain
+      // of thought as inline <think>…</think> text in `content` — there is no
+      // reasoning_content field — so no provider parser can surface it. The
+      // middleware extracts the tags into native reasoning parts; tagless
+      // responses (sonar, sonar-pro) pass through unchanged. Reasoning parts
+      // are dropped from outgoing messages by the strict openai converter,
+      // which is correct here: Perplexity does not accept reasoning back.
+      wrapLanguageModel({
+        model: createOpenAI({ apiKey, baseURL, headers, fetch }).chat(
+          modelName,
+        ),
+        middleware: extractReasoningMiddleware({ tagName: "think" }),
+      }),
     defaultBaseUrl: config.llm.perplexity.baseUrl,
     apiKeyRequiredMessage:
       "Perplexity API key is required. Please configure PERPLEXITY_API_KEY.",

--- a/platform/backend/src/clients/llm-client.ts
+++ b/platform/backend/src/clients/llm-client.ts
@@ -494,13 +494,15 @@ const providerModelConfigs: Record<SupportedProvider, ProviderModelConfig> = {
 
   perplexity: {
     createModel: ({ apiKey, modelName, baseURL, headers, fetch }) =>
-      // Perplexity reasoning models (sonar-reasoning-pro) stream their chain
-      // of thought as inline <think>…</think> text in `content` — there is no
-      // reasoning_content field — so no provider parser can surface it. The
-      // middleware extracts the tags into native reasoning parts; tagless
-      // responses (sonar, sonar-pro) pass through unchanged. Reasoning parts
-      // are dropped from outgoing messages by the strict openai converter,
-      // which is correct here: Perplexity does not accept reasoning back.
+      // Perplexity reasoning models (sonar-reasoning-pro, sonar-deep-research)
+      // stream their chain of thought as inline <think>…</think> text in
+      // `content` — there is no reasoning_content field — so no provider
+      // parser can surface it. The middleware extracts the tags into native
+      // reasoning parts; tagless responses (sonar, sonar-pro) pass through
+      // unchanged, at the accepted cost that literal <think> text in a real
+      // answer is also treated as reasoning. Reasoning parts are dropped from
+      // outgoing messages by the strict openai converter, which is correct
+      // here: Perplexity does not accept reasoning back.
       wrapLanguageModel({
         model: createOpenAI({ apiKey, baseURL, headers, fetch }).chat(
           modelName,

--- a/platform/backend/src/clients/perplexity-reasoning-extraction.test.ts
+++ b/platform/backend/src/clients/perplexity-reasoning-extraction.test.ts
@@ -1,0 +1,155 @@
+import { HttpResponse, http } from "msw";
+import { createDirectLLMModel, type LLMModel } from "@/clients/llm-client";
+import { describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
+
+/**
+ * Pins the Perplexity reasoning extraction in the model factory.
+ *
+ * Perplexity reasoning models (sonar-reasoning-pro) stream their chain of
+ * thought as inline <think>…</think> text in `content` — there is no
+ * reasoning_content field — so the factory wraps the model with
+ * extractReasoningMiddleware. These tests drive the real factory against a
+ * mocked wire and fail if the wrap is dropped or the middleware stops
+ * extracting: raw <think> text would then leak into chat answers again.
+ */
+
+type StreamPart = {
+  type: string;
+  delta?: string;
+  finishReason?: { unified?: string };
+  usage?: {
+    inputTokens?: { total?: number };
+    outputTokens?: { total?: number };
+  };
+};
+
+const PROMPT = [
+  {
+    role: "user" as const,
+    content: [{ type: "text" as const, text: "How many r's in strawberry?" }],
+  },
+];
+
+// biome-ignore lint/correctness/useHookAtTopLevel: vitest lifecycle helper (per-test MSW server), not a React hook
+const server = useMswServer();
+
+describe("perplexity reasoning extraction", () => {
+  test("streams <think> content as reasoning parts before the text part", async () => {
+    serveSse(["<think>Let me ", "count.</think>", "There are three."]);
+
+    const parts = await streamParts();
+    const types = parts.map((part) => part.type);
+
+    const reasoningStart = types.indexOf("reasoning-start");
+    const textStart = types.indexOf("text-start");
+    expect(reasoningStart).toBeGreaterThanOrEqual(0);
+    expect(textStart).toBeGreaterThanOrEqual(0);
+    expect(reasoningStart).toBeLessThan(textStart);
+
+    expect(joinedDeltas(parts, "reasoning-delta")).toBe("Let me count.");
+    expect(joinedDeltas(parts, "text-delta")).toBe("There are three.");
+    // The tags themselves must not leak into either channel.
+    expect(joinedDeltas(parts, "text-delta")).not.toContain("think");
+
+    // Usage still arrives on the finish part — cost accounting is unaffected.
+    const finish = parts.find((part) => part.type === "finish");
+    expect(finish?.finishReason?.unified).toBe("stop");
+    expect(finish?.usage?.inputTokens?.total).toBe(5);
+    expect(finish?.usage?.outputTokens?.total).toBe(10);
+  });
+
+  test("extracts reasoning when tags are split across stream chunks", async () => {
+    serveSse(["<thi", "nk>pondering</th", "ink>Done."]);
+
+    const parts = await streamParts();
+
+    expect(joinedDeltas(parts, "reasoning-delta")).toBe("pondering");
+    expect(joinedDeltas(parts, "text-delta")).toBe("Done.");
+  });
+
+  test("passes tagless responses through unchanged", async () => {
+    serveSse(["Hello", " there."]);
+
+    const parts = await streamParts();
+
+    expect(joinedDeltas(parts, "text-delta")).toBe("Hello there.");
+    expect(parts.map((part) => part.type)).not.toContain("reasoning-start");
+  });
+});
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/** Serves one streamed chat completion whose content deltas are `deltas`. */
+function serveSse(deltas: string[]) {
+  const events = [
+    ...deltas.map((delta) =>
+      chunk({ delta: { role: "assistant", content: delta } }),
+    ),
+    chunk({
+      delta: {},
+      finish_reason: "stop",
+      usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 },
+    }),
+  ];
+  const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\ndata: [DONE]\n\n`;
+  server.use(
+    http.post(
+      "https://api.perplexity.ai/chat/completions",
+      () =>
+        new HttpResponse(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+    ),
+  );
+}
+
+/** One OpenAI-style chat completion SSE chunk, as Perplexity puts it on the wire. */
+function chunk({
+  delta,
+  finish_reason = null,
+  usage,
+}: {
+  delta: Record<string, unknown>;
+  finish_reason?: string | null;
+  usage?: Record<string, number>;
+}) {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    created: 1720000000,
+    model: "sonar-reasoning-pro",
+    choices: [{ index: 0, delta, finish_reason }],
+    ...(usage ? { usage } : {}),
+  };
+}
+
+/** Streams one completion through the real factory-built model. */
+async function streamParts(): Promise<StreamPart[]> {
+  // Exclude the plain-string model ids from the union so doStream is typed.
+  const model = createDirectLLMModel({
+    provider: "perplexity",
+    apiKey: "test-key",
+    modelName: "sonar-reasoning-pro",
+    baseUrl: null,
+  }) as Exclude<LLMModel, string>;
+  const { stream } = await model.doStream({ prompt: PROMPT });
+  const parts: StreamPart[] = [];
+  const reader = (stream as unknown as ReadableStream<StreamPart>).getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parts.push(value);
+  }
+  return parts;
+}
+
+function joinedDeltas(parts: StreamPart[], type: string): string {
+  return parts
+    .filter((part) => part.type === type)
+    .map((part) => part.delta ?? "")
+    .join("");
+}

--- a/platform/backend/src/clients/perplexity-reasoning-extraction.test.ts
+++ b/platform/backend/src/clients/perplexity-reasoning-extraction.test.ts
@@ -6,9 +6,9 @@ import { useMswServer } from "@/test/msw";
 /**
  * Pins the Perplexity reasoning extraction in the model factory.
  *
- * Perplexity reasoning models (sonar-reasoning-pro) stream their chain of
- * thought as inline <think>…</think> text in `content` — there is no
- * reasoning_content field — so the factory wraps the model with
+ * Perplexity reasoning models (sonar-reasoning-pro, sonar-deep-research)
+ * stream their chain of thought as inline <think>…</think> text in `content`
+ * — there is no reasoning_content field — so the factory wraps the model with
  * extractReasoningMiddleware. These tests drive the real factory against a
  * mocked wire and fail if the wrap is dropped or the middleware stops
  * extracting: raw <think> text would then leak into chat answers again.
@@ -49,8 +49,6 @@ describe("perplexity reasoning extraction", () => {
 
     expect(joinedDeltas(parts, "reasoning-delta")).toBe("Let me count.");
     expect(joinedDeltas(parts, "text-delta")).toBe("There are three.");
-    // The tags themselves must not leak into either channel.
-    expect(joinedDeltas(parts, "text-delta")).not.toContain("think");
 
     // Usage still arrives on the finish part — cost accounting is unaffected.
     const finish = parts.find((part) => part.type === "finish");
@@ -75,6 +73,17 @@ describe("perplexity reasoning extraction", () => {
 
     expect(joinedDeltas(parts, "text-delta")).toBe("Hello there.");
     expect(parts.map((part) => part.type)).not.toContain("reasoning-start");
+  });
+
+  test("orders reasoning before text in non-streaming generate results", async () => {
+    serveJson("<think>Let me count.</think>There are three.");
+
+    const { content } = await makeModel().doGenerate({ prompt: PROMPT });
+
+    expect(content).toEqual([
+      expect.objectContaining({ type: "reasoning", text: "Let me count." }),
+      expect.objectContaining({ type: "text", text: "There are three." }),
+    ]);
   });
 });
 
@@ -127,16 +136,42 @@ function chunk({
   };
 }
 
-/** Streams one completion through the real factory-built model. */
-async function streamParts(): Promise<StreamPart[]> {
-  // Exclude the plain-string model ids from the union so doStream is typed.
-  const model = createDirectLLMModel({
+/** Serves one non-streaming chat completion whose content is `content`. */
+function serveJson(content: string) {
+  server.use(
+    http.post("https://api.perplexity.ai/chat/completions", () =>
+      HttpResponse.json({
+        id: "chatcmpl-test",
+        object: "chat.completion",
+        created: 1720000000,
+        model: "sonar-reasoning-pro",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 },
+      }),
+    ),
+  );
+}
+
+/** Builds the factory-produced model, typed so doStream/doGenerate resolve. */
+function makeModel() {
+  // Exclude the plain-string model ids from the union.
+  return createDirectLLMModel({
     provider: "perplexity",
     apiKey: "test-key",
     modelName: "sonar-reasoning-pro",
     baseUrl: null,
   }) as Exclude<LLMModel, string>;
-  const { stream } = await model.doStream({ prompt: PROMPT });
+}
+
+/** Streams one completion through the real factory-built model. */
+async function streamParts(): Promise<StreamPart[]> {
+  const { stream } = await makeModel().doStream({ prompt: PROMPT });
   const parts: StreamPart[] = [];
   const reader = (stream as unknown as ReadableStream<StreamPart>).getReader();
   for (;;) {

--- a/platform/backend/src/routes/proxy/adapters/perplexity.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity.test.ts
@@ -1,0 +1,224 @@
+import { perplexityAdapterFactory } from "@/routes/proxy/adapters/perplexity";
+import { describe, expect, test } from "@/test";
+import type { Perplexity } from "@/types";
+
+/**
+ * Pins Perplexity reasoning surfacing.
+ *
+ * Perplexity emits no chain of thought under its default `full` stream mode —
+ * the inline <think> text it used to put in `content` is gone. Reasoning is
+ * only available via `stream_mode: "concise"`, which carries it in dedicated
+ * `chat.reasoning` chunks that no OpenAI-compatible client understands. The
+ * adapter opts reasoning models into that mode and re-emits the steps as
+ * <think> content so downstream reasoning parsers can surface them.
+ */
+
+type StreamChunk = Perplexity.Types.ChatCompletionChunk;
+
+describe("perplexity request adapter: stream mode", () => {
+  test("opts reasoning models into concise streaming", () => {
+    const request = makeRequest({
+      model: "sonar-reasoning-pro",
+      stream: true,
+    });
+
+    const result = perplexityAdapterFactory
+      .createRequestAdapter(request)
+      .toProviderRequest();
+
+    expect(result.stream_mode).toBe("concise");
+  });
+
+  test("leaves tagless models on the default wire format", () => {
+    const request = makeRequest({ model: "sonar-pro", stream: true });
+
+    const result = perplexityAdapterFactory
+      .createRequestAdapter(request)
+      .toProviderRequest();
+
+    expect(result.stream_mode).toBeUndefined();
+  });
+
+  test("does not request concise mode for non-streaming calls", () => {
+    const request = makeRequest({
+      model: "sonar-reasoning-pro",
+      stream: false,
+    });
+
+    const result = perplexityAdapterFactory
+      .createRequestAdapter(request)
+      .toProviderRequest();
+
+    expect(result.stream_mode).toBeUndefined();
+  });
+
+  test("honours a stream mode the caller chose explicitly", () => {
+    const request = makeRequest({
+      model: "sonar-reasoning-pro",
+      stream: true,
+      stream_mode: "full",
+    });
+
+    const result = perplexityAdapterFactory
+      .createRequestAdapter(request)
+      .toProviderRequest();
+
+    expect(result.stream_mode).toBe("full");
+  });
+});
+
+describe("perplexity stream adapter: concise reasoning", () => {
+  test("re-emits reasoning steps as a <think> block before the answer", () => {
+    const adapter = perplexityAdapterFactory.createStreamAdapter();
+
+    const streamed = [
+      adapter.processChunk(reasoningChunk(["Searching the web..."])),
+      adapter.processChunk(reasoningChunk(["Found 15 results"])),
+      adapter.processChunk(reasoningDoneChunk()),
+      adapter.processChunk(contentChunk("There are 3 r's.")),
+    ];
+
+    expect(contentOf(streamed)).toBe(
+      "<think>Searching the web...\nFound 15 results</think>\n\nThere are 3 r's.",
+    );
+  });
+
+  test("does not repeat steps the reasoning-done chunk replays", () => {
+    const adapter = perplexityAdapterFactory.createStreamAdapter();
+
+    const streamed = [
+      adapter.processChunk(reasoningChunk(["Searching the web..."])),
+      // The done chunk carries every accumulated step, not just new ones.
+      adapter.processChunk(
+        reasoningDoneChunk(["Searching the web...", "Found 15 results"]),
+      ),
+    ];
+
+    expect(contentOf(streamed)).toBe(
+      "<think>Searching the web...\nFound 15 results</think>\n\n",
+    );
+  });
+
+  test("closes an unterminated reasoning block when the answer starts", () => {
+    const adapter = perplexityAdapterFactory.createStreamAdapter();
+
+    const streamed = [
+      adapter.processChunk(reasoningChunk(["Thinking..."])),
+      // No reasoning-done chunk: without the guard the answer would be
+      // swallowed into the reasoning block.
+      adapter.processChunk(contentChunk("Answer.")),
+    ];
+
+    expect(contentOf(streamed)).toBe("<think>Thinking...</think>\n\nAnswer.");
+  });
+
+  test("ends the stream on the concise terminal chunk", () => {
+    const adapter = perplexityAdapterFactory.createStreamAdapter();
+
+    adapter.processChunk(reasoningChunk(["Thinking..."]));
+    const midStream = adapter.processChunk(contentChunk("Answer."));
+    const terminal = adapter.processChunk(completionDoneChunk());
+
+    expect(midStream.isFinal).toBe(false);
+    expect(terminal.isFinal).toBe(true);
+    expect(adapter.toProviderResponse().usage?.completion_tokens).toBe(10);
+  });
+
+  test("keeps reasoning text out of the recorded answer", () => {
+    const adapter = perplexityAdapterFactory.createStreamAdapter();
+
+    adapter.processChunk(reasoningChunk(["Thinking..."]));
+    adapter.processChunk(reasoningDoneChunk());
+    adapter.processChunk(contentChunk("There are 3 r's."));
+    adapter.processChunk(completionDoneChunk());
+
+    // The interaction log and cost accounting record the answer, not the
+    // progress narration the reasoning stage streamed.
+    expect(adapter.toProviderResponse().choices[0].message.content).toBe(
+      "There are 3 r's.",
+    );
+  });
+
+  test("passes a full-mode stream through unchanged", () => {
+    const adapter = perplexityAdapterFactory.createStreamAdapter();
+
+    const streamed = [
+      adapter.processChunk(contentChunk("Hello")),
+      adapter.processChunk(contentChunk(" there.")),
+    ];
+
+    expect(contentOf(streamed)).toBe("Hello there.");
+    expect(streamed.every((result) => result.isFinal)).toBe(false);
+  });
+});
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+function makeRequest(overrides: {
+  model: string;
+  stream: boolean;
+  stream_mode?: "full" | "concise";
+}): Perplexity.Types.ChatCompletionsRequest {
+  return {
+    messages: [{ role: "user", content: "How many r's in strawberry?" }],
+    ...overrides,
+  } as Perplexity.Types.ChatCompletionsRequest;
+}
+
+/** A concise-mode chunk streamed during the reasoning stage. */
+function reasoningChunk(thoughts: string[]): StreamChunk {
+  return conciseChunk("chat.reasoning", {
+    reasoning_steps: thoughts.map((thought) => ({
+      thought,
+      type: "web_search",
+    })),
+  });
+}
+
+/** The chunk closing the reasoning stage; it replays accumulated steps. */
+function reasoningDoneChunk(thoughts: string[] = []): StreamChunk {
+  return conciseChunk("chat.reasoning.done", {
+    reasoning_steps: thoughts.map((thought) => ({
+      thought,
+      type: "web_search",
+    })),
+  });
+}
+
+function contentChunk(content: string): StreamChunk {
+  return conciseChunk("chat.completion.chunk", { content });
+}
+
+/** The concise-mode terminal chunk carrying final usage. */
+function completionDoneChunk(): StreamChunk {
+  return {
+    ...conciseChunk("chat.completion.done", { content: "", role: "assistant" }),
+    usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 },
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+  } as StreamChunk;
+}
+
+function conciseChunk(
+  object: string,
+  delta: Record<string, unknown>,
+): StreamChunk {
+  return {
+    id: "chatcmpl-test",
+    object,
+    created: 1720000000,
+    model: "sonar-reasoning-pro",
+    choices: [{ index: 0, delta, finish_reason: null }],
+  } as unknown as StreamChunk;
+}
+
+/** Concatenates the content deltas of every SSE payload the adapter emitted. */
+function contentOf(results: { sseData: string | Uint8Array | null }[]): string {
+  return results
+    .flatMap((result) => (result.sseData?.toString() ?? "").split("\n\n"))
+    .filter((event) => event.startsWith("data: "))
+    .map((event) => JSON.parse(event.slice(6)))
+    .map((chunk) => chunk.choices?.[0]?.delta?.content ?? "")
+    .join("");
+}

--- a/platform/backend/src/routes/proxy/adapters/perplexity.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity.test.ts
@@ -39,6 +39,19 @@ describe("perplexity request adapter: stream mode", () => {
     expect(result.stream_mode).toBeUndefined();
   });
 
+  test("leaves sonar-deep-research on the default wire format", () => {
+    // Deep research exposes no reasoning on this API in any mode; under
+    // concise it streams an empty reasoning stage, so the opt-in would change
+    // its wire format for nothing.
+    const request = makeRequest({ model: "sonar-deep-research", stream: true });
+
+    const result = perplexityAdapterFactory
+      .createRequestAdapter(request)
+      .toProviderRequest();
+
+    expect(result.stream_mode).toBeUndefined();
+  });
+
   test("does not request concise mode for non-streaming calls", () => {
     const request = makeRequest({
       model: "sonar-reasoning-pro",

--- a/platform/backend/src/routes/proxy/adapters/perplexity.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity.ts
@@ -13,7 +13,10 @@
  *
  * @see https://docs.perplexity.ai/api-reference/chat-completions-post
  */
-import { ArchestraInternalErrorCode } from "@archestra/shared";
+import {
+  ArchestraInternalErrorCode,
+  isPerplexityReasoningModel,
+} from "@archestra/shared";
 import { get } from "lodash-es";
 import OpenAIProvider from "openai";
 import type {
@@ -144,10 +147,23 @@ class PerplexityRequestAdapter
   // ---------------------------------------------------------------------------
 
   toProviderRequest(): PerplexityRequest {
-    return {
-      ...this.request,
-      model: this.getModel(),
-    };
+    const model = this.getModel();
+    const request: PerplexityRequest = { ...this.request, model };
+
+    // Perplexity emits no reasoning under the default `full` stream mode: the
+    // chain of thought used to arrive inline as <think> text in `content`, but
+    // that stopped in early 2026 and `concise` is now the only way to get it.
+    // Opt in for reasoning models only, and never override an explicit choice
+    // by the caller, so plain Sonar models keep the default wire format.
+    if (
+      request.stream === true &&
+      request.stream_mode === undefined &&
+      isPerplexityReasoningModel(model)
+    ) {
+      request.stream_mode = "concise";
+    }
+
+    return request;
   }
 
   // ---------------------------------------------------------------------------
@@ -261,6 +277,12 @@ class PerplexityStreamAdapter
 {
   readonly provider = "perplexity" as const;
   readonly state: StreamAccumulatorState;
+  /** Whether a <think> block has been opened downstream but not yet closed. */
+  private reasoningOpen = false;
+  /** Set once a concise-mode chunk is seen; it changes how the stream ends. */
+  private conciseStream = false;
+  /** Thought texts already emitted — the done chunk repeats accumulated steps. */
+  private readonly seenThoughts = new Set<string>();
 
   constructor() {
     this.state = {
@@ -298,13 +320,38 @@ class PerplexityStreamAdapter
       };
     }
 
+    // Concise stream mode carries the chain of thought in its own chunk types,
+    // which no OpenAI-compatible client understands. Re-emit their text as
+    // <think> content on ordinary completion chunks so downstream parsers
+    // (chat's reasoning middleware, the frontend fallback) surface it as
+    // reasoning instead of dropping it.
+    const chunkObject = (chunk as { object?: string }).object;
+    if (
+      chunkObject === REASONING_CHUNK ||
+      chunkObject === REASONING_DONE_CHUNK
+    ) {
+      // Concise mode ends on its own terminal chunk, never on the
+      // usage-without-choices heuristic below: the reasoning stage can report
+      // partial usage long before the answer has been streamed.
+      this.conciseStream = true;
+      const thoughts = this.takeNewThoughts(chunk);
+      const closing =
+        chunkObject === REASONING_DONE_CHUNK ? this.closeReasoning() : "";
+      const text = `${thoughts}${closing}`;
+      return {
+        sseData: text ? this.formatTextDeltaSSE(text) : null,
+        isToolCallChunk,
+        isFinal: false,
+      };
+    }
+
     const choice = chunk.choices[0];
     if (!choice) {
       // Empty choices with usage means this is the final chunk
       return {
         sseData: null,
         isToolCallChunk: false,
-        isFinal: this.state.usage !== null,
+        isFinal: !this.conciseStream && this.state.usage !== null,
       };
     }
 
@@ -313,12 +360,22 @@ class PerplexityStreamAdapter
     // Handle text content
     if (delta.content) {
       this.state.text += delta.content;
-      sseData = `data: ${JSON.stringify(chunk)}\n\n`;
+      // Answer text after an unterminated reasoning block: close it first, or
+      // the whole answer would be swallowed into the reasoning part.
+      const closing = this.closeReasoning();
+      sseData = `${closing ? this.formatTextDeltaSSE(closing) : ""}data: ${JSON.stringify(chunk)}\n\n`;
     }
 
     // Handle finish reason
     if (choice.finish_reason) {
       this.state.stopReason = choice.finish_reason;
+    }
+
+    // Concise mode ends with its own terminal chunk rather than a
+    // finish_reason on a content chunk.
+    if (chunkObject === COMPLETION_DONE_CHUNK) {
+      this.state.stopReason ??= "stop";
+      isFinal = true;
     }
 
     // Only mark as final when we have BOTH finish_reason AND usage data
@@ -427,6 +484,51 @@ class PerplexityStreamAdapter
           (this.state.usage?.outputTokens ?? 0),
       },
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the thoughts in `chunk` that have not been emitted yet, wrapped so
+   * they continue an open <think> block or start a new one. The reasoning-done
+   * chunk repeats every accumulated step, so thoughts are deduped by text.
+   */
+  private takeNewThoughts(chunk: PerplexityStreamChunk): string {
+    const steps =
+      (
+        chunk.choices?.[0]?.delta as
+          | { reasoning_steps?: { thought?: unknown }[] }
+          | undefined
+      )?.reasoning_steps ?? [];
+
+    const fresh: string[] = [];
+    for (const step of steps) {
+      const thought =
+        typeof step?.thought === "string" ? step.thought.trim() : "";
+      if (!thought || this.seenThoughts.has(thought)) {
+        continue;
+      }
+      this.seenThoughts.add(thought);
+      fresh.push(thought);
+    }
+    if (fresh.length === 0) {
+      return "";
+    }
+
+    const opening = this.reasoningOpen ? "\n" : "<think>";
+    this.reasoningOpen = true;
+    return `${opening}${fresh.join("\n")}`;
+  }
+
+  /** Closing tag for an open <think> block, or "" when none is open. */
+  private closeReasoning(): string {
+    if (!this.reasoningOpen) {
+      return "";
+    }
+    this.reasoningOpen = false;
+    return "</think>\n\n";
   }
 }
 
@@ -552,3 +654,14 @@ export const perplexityAdapterFactory: LLMProvider<
     return "Internal server error";
   },
 };
+
+// =============================================================================
+// INTERNAL CONSTANTS
+// =============================================================================
+
+/** Concise-mode chunk carrying incremental reasoning steps. */
+const REASONING_CHUNK = "chat.reasoning";
+/** Concise-mode chunk closing the reasoning stage (repeats accumulated steps). */
+const REASONING_DONE_CHUNK = "chat.reasoning.done";
+/** Concise-mode terminal chunk carrying final usage and the aggregated message. */
+const COMPLETION_DONE_CHUNK = "chat.completion.done";

--- a/platform/backend/src/types/llm-providers/perplexity/api.ts
+++ b/platform/backend/src/types/llm-providers/perplexity/api.ts
@@ -9,21 +9,41 @@
  * @see https://docs.perplexity.ai/api-reference/chat-completions-post
  */
 
+import { z } from "zod";
 import {
-  ChatCompletionRequestSchema,
   ChatCompletionsHeadersSchema,
   ChatCompletionUsageSchema,
   FinishReasonSchema,
+  ChatCompletionRequestSchema as OpenAIChatCompletionRequestSchema,
   ChatCompletionResponseSchema as OpenAIChatCompletionResponseSchema,
 } from "../openai/api";
 
-// Re-export request and other schemas from OpenAI since Perplexity is compatible
+// Re-export the schemas Perplexity shares verbatim with OpenAI
 export {
-  ChatCompletionRequestSchema,
   ChatCompletionsHeadersSchema,
   ChatCompletionUsageSchema,
   FinishReasonSchema,
 };
+
+/**
+ * Perplexity's streaming format selector.
+ *
+ * `full` (the API default) streams complete message objects and emits no
+ * reasoning. `concise` streams deltas only and adds the `chat.reasoning` /
+ * `chat.reasoning.done` chunks that carry the model's chain of thought — the
+ * only way to obtain reasoning from the chat-completions endpoint.
+ *
+ * @see https://docs.perplexity.ai/docs/sonar/pro-search/stream-mode
+ */
+export const StreamModeSchema = z.enum(["full", "concise"]);
+
+/**
+ * Perplexity request schema: OpenAI-compatible plus `stream_mode`.
+ */
+export const ChatCompletionRequestSchema =
+  OpenAIChatCompletionRequestSchema.extend({
+    stream_mode: StreamModeSchema.optional(),
+  });
 
 /**
  * Perplexity response schema with passthrough for extra fields.

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -2627,6 +2627,7 @@ export type PerplexityChatCompletionRequestInput = {
     temperature?: number | null;
     max_tokens?: number | null;
     stream?: boolean | null;
+    stream_mode?: 'full' | 'concise';
 };
 
 export type PerplexityChatCompletionResponseInput = {
@@ -8421,6 +8422,7 @@ export type PerplexityChatCompletionRequest = {
     temperature?: number | null;
     max_tokens?: number | null;
     stream?: boolean | null;
+    stream_mode?: 'full' | 'concise';
 };
 
 export type PerplexityChatCompletionResponse = {
@@ -38083,10 +38085,10 @@ export type GetInteractionsResponses = {
             billingMode: 'metered' | 'subscription';
             authenticatedAppId: string | null;
             authenticatedAppName: string | null;
-            request: XaiChatCompletionRequest | {
+            request: PerplexityChatCompletionRequest | {
                 [key: string]: unknown;
             };
-            processedRequest?: XaiChatCompletionRequest | {
+            processedRequest?: PerplexityChatCompletionRequest | {
                 [key: string]: unknown;
             } | null;
             response: PerplexityChatCompletionResponse | {
@@ -44047,10 +44049,10 @@ export type GetInteractionResponses = {
         billingMode: 'metered' | 'subscription';
         authenticatedAppId: string | null;
         authenticatedAppName: string | null;
-        request: XaiChatCompletionRequest | {
+        request: PerplexityChatCompletionRequest | {
             [key: string]: unknown;
         };
-        processedRequest?: XaiChatCompletionRequest | {
+        processedRequest?: PerplexityChatCompletionRequest | {
             [key: string]: unknown;
         } | null;
         response: PerplexityChatCompletionResponse | {
@@ -69625,7 +69627,7 @@ export type GetOrganizationMemberResponses = {
 export type GetOrganizationMemberResponse = GetOrganizationMemberResponses[keyof GetOrganizationMemberResponses];
 
 export type PerplexityChatCompletionsWithDefaultAgentData = {
-    body: XaiChatCompletionRequestInput;
+    body: PerplexityChatCompletionRequestInput;
     headers: {
         /**
          * The user agent of the client
@@ -69716,7 +69718,7 @@ export type PerplexityChatCompletionsWithDefaultAgentResponses = {
 export type PerplexityChatCompletionsWithDefaultAgentResponse = PerplexityChatCompletionsWithDefaultAgentResponses[keyof PerplexityChatCompletionsWithDefaultAgentResponses];
 
 export type PerplexityChatCompletionsWithAgentData = {
-    body: XaiChatCompletionRequestInput;
+    body: PerplexityChatCompletionRequestInput;
     headers: {
         /**
          * The user agent of the client

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -250,17 +250,20 @@ export const PERPLEXITY_MODELS = [
 ] as const;
 
 /**
- * Perplexity models that produce a chain of thought.
+ * Perplexity models whose chain of thought is retrievable over the
+ * chat-completions API.
  *
  * Perplexity only emits reasoning when the request opts into the `concise`
  * stream mode; the default `full` mode suppresses it entirely. The proxy sends
  * that opt-in for these models only, so the plain Sonar models keep the
  * default wire format.
+ *
+ * sonar-deep-research is deliberately absent: under `concise` it streams an
+ * empty reasoning stage (a bare `chat.reasoning.done`, no steps) — its
+ * research trace is not exposed on this API in any mode — so opting it in
+ * yields no reasoning while changing its wire format for nothing.
  */
-export const PERPLEXITY_REASONING_MODELS = [
-  "sonar-reasoning-pro",
-  "sonar-deep-research",
-] as const;
+export const PERPLEXITY_REASONING_MODELS = ["sonar-reasoning-pro"] as const;
 
 export function isPerplexityReasoningModel(model: string): boolean {
   return (PERPLEXITY_REASONING_MODELS as readonly string[]).includes(model);

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -246,7 +246,6 @@ export const PERPLEXITY_MODELS = [
   { id: "sonar-pro", displayName: "Sonar Pro" },
   { id: "sonar", displayName: "Sonar" },
   { id: "sonar-reasoning-pro", displayName: "Sonar Reasoning Pro" },
-  { id: "sonar-reasoning", displayName: "Sonar Reasoning" },
   { id: "sonar-deep-research", displayName: "Sonar Deep Research" },
 ] as const;
 

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -250,6 +250,23 @@ export const PERPLEXITY_MODELS = [
 ] as const;
 
 /**
+ * Perplexity models that produce a chain of thought.
+ *
+ * Perplexity only emits reasoning when the request opts into the `concise`
+ * stream mode; the default `full` mode suppresses it entirely. The proxy sends
+ * that opt-in for these models only, so the plain Sonar models keep the
+ * default wire format.
+ */
+export const PERPLEXITY_REASONING_MODELS = [
+  "sonar-reasoning-pro",
+  "sonar-deep-research",
+] as const;
+
+export function isPerplexityReasoningModel(model: string): boolean {
+  return (PERPLEXITY_REASONING_MODELS as readonly string[]).includes(model);
+}
+
+/**
  * MiniMax model definitions — single source of truth.
  * MiniMax does not provide a /v1/models endpoint, so models are maintained here.
  * @see https://platform.minimax.io/docs/guides/models-intro


### PR DESCRIPTION
## What

- Wraps the Perplexity model in the shared model factory (`backend/src/clients/llm-client.ts`) with `wrapLanguageModel` + `extractReasoningMiddleware({ tagName: "think" })`, so `<think>…</think>` blocks become native reasoning parts and render in the chat thinking accordion instead of leaking raw into the answer. Tagless models (`sonar`, `sonar-pro`) pass through unchanged; raw proxy passthrough and `/llm/logs` are unaffected. Reasoning parts are dropped from outgoing messages by the strict openai converter, which is correct — Perplexity does not accept reasoning back.
- Removes `sonar-reasoning` from `PERPLEXITY_MODELS` — retired by Perplexity on 2025-12-15.
- New regression suite `perplexity-reasoning-extraction.test.ts` driving the real factory against an MSW-mocked wire.

## Why

With reasoning models a single chat turn can run a minute or more with no visible progress. Perplexity reasoning models (`sonar-reasoning-pro`, `sonar-deep-research`) stream their chain of thought as inline `<think>` text in `content` — there is no `reasoning_content` field — so chat showed raw tags in the answer and no thinking block. Same series as the DeepSeek, Ollama, Gemini, and Zhipu AI reasoning fixes.

## Testing

- New unit tests (4/4 green): streaming reasoning-before-text ordering plus usage/finish accounting, tags split across stream chunks, tagless passthrough, and generate-path content ordering.
- `pnpm type-check` and biome clean.
- Manual smoke with a real Perplexity key (Sonar Reasoning Pro in chat) still pending — hence draft.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>