### PR TITLE
feat(chat): surface Claude Opus 5 default-on thinking

### DIFF
--- a/platform/backend/src/clients/llm-client.test.ts
+++ b/platform/backend/src/clients/llm-client.test.ts
@@ -458,6 +458,7 @@ describe("createDirectLLMModel", () => {
 
     it("requests summarized thinking for models that think by default", async () => {
       for (const model of [
+        "claude-opus-5",
         "claude-sonnet-5",
         "claude-sonnet-5-20250929",
         "claude-fable-5",

--- a/platform/shared/model-constants.test.ts
+++ b/platform/shared/model-constants.test.ts
@@ -9,6 +9,8 @@ import {
 
 describe("anthropicThinksByDefault", () => {
   test("matches models whose thinking is always on, including dated snapshots", () => {
+    expect(anthropicThinksByDefault("claude-opus-5")).toBe(true);
+    expect(anthropicThinksByDefault("claude-opus-5-20260724")).toBe(true);
     expect(anthropicThinksByDefault("claude-sonnet-5")).toBe(true);
     expect(anthropicThinksByDefault("claude-sonnet-5-20250929")).toBe(true);
     expect(anthropicThinksByDefault("claude-fable-5")).toBe(true);
@@ -22,6 +24,8 @@ describe("anthropicThinksByDefault", () => {
     // cost, so they are deliberately not matched.
     expect(anthropicThinksByDefault("claude-opus-4-8")).toBe(false);
     expect(anthropicThinksByDefault("claude-opus-4-7")).toBe(false);
+    // Nearest substring neighbor of the "opus-5" marker — must not match.
+    expect(anthropicThinksByDefault("claude-opus-4-5-20251101")).toBe(false);
     expect(anthropicThinksByDefault("claude-sonnet-4-6")).toBe(false);
     expect(anthropicThinksByDefault("claude-sonnet-4-5")).toBe(false);
     expect(anthropicThinksByDefault("claude-3-5-haiku-20241022")).toBe(false);

--- a/platform/shared/model-constants.ts
+++ b/platform/shared/model-constants.ts
@@ -502,11 +502,11 @@ export function requiresOpenAiResponsesApi(modelId: string): boolean {
 }
 
 /**
- * True for Anthropic models where thinking is on by default (Claude Sonnet 5,
- * Fable 5, Mythos 5, Mythos Preview): the model reasons — and bills those
- * tokens — on every request, but the API returns the thinking text only when
- * the request opts in with `thinking: {display: "summarized"}`. Matched as
- * substrings so dated snapshots (`claude-sonnet-5-20250929`) are covered.
+ * True for Anthropic models where thinking is on by default (Claude Opus 5,
+ * Sonnet 5, Fable 5, Mythos 5, Mythos Preview): the model reasons — and bills
+ * those tokens — on every request, but the API returns the thinking text only
+ * when the request opts in with `thinking: {display: "summarized"}`. Matched
+ * as substrings so dated snapshots (`claude-sonnet-5-20250929`) are covered.
  *
  * Models where thinking is off until requested (Opus 4.8/4.7, Sonnet 4.6 and
  * earlier) are deliberately excluded: turning thinking on there would add
@@ -520,6 +520,7 @@ export function anthropicThinksByDefault(modelId: string): boolean {
 }
 
 const ANTHROPIC_DEFAULT_THINKING_MODEL_MARKERS = [
+  "opus-5",
   "sonnet-5",
   "fable-5",
   "mythos-5",


### PR DESCRIPTION
## What

Add the `opus-5` marker to `ANTHROPIC_DEFAULT_THINKING_MODEL_MARKERS` so the Anthropic thinking-display injection from #6826 covers Claude Opus 5, plus predicate tests (including the nearest-miss `claude-opus-4-5`) and a wire-level injection test. The fetch wrapper and proxy schema are model-agnostic and unchanged; explicit `thinking` configs (Opus 5 accepts `disabled` at effort ≤ high) are still respected by the existing guard.

## Why

`claude-opus-5` (released 2026-07-24) thinks by default with `display` defaulting to `"omitted"` ([per-model table](https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting)) — the exact paid-but-invisible reasoning case #6826 fixed, which anticipated new default-thinking models needing one marker.

## Testing

- `shared/model-constants.test.ts` (11) and `backend/src/clients/llm-client.test.ts` (38) green
- `type-check` and lint clean in shared + backend (the one shared lint warning is pre-existing in `consts.ts`)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>