### PR TITLE
fix: hold the replay clock until the app frame really renders

### DIFF
--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -329,6 +329,25 @@ const APP_FRAME_READY_TRIES = 200;
  * one animated timeline.
  */
 const PREROLL_MS = 1_200;
+/**
+ * Ready-fallback fuses for a frame whose SDK never posts the replay-ready
+ * announcement (a stale HTTP-cached SDK that predates it). Real readiness is
+ * always the announcement; these only stop a silent frame from freezing the
+ * replay forever.
+ *
+ * The `initialized` fuse is short: that signal comes from the app SDK RUNNING
+ * inside the inner document, so the document is on screen and only the
+ * announcement is missing. The `connect` fuse is long: connect is a
+ * proxy-level signal that resolves while the inner document may not even be
+ * written yet — on a cold sandbox subdomain the document's own chain (proxy
+ * handshake, HTML delivery, the parser-blocking SDK fetch) runs many seconds
+ * behind it. Arming the clock off connect after 1.5s is exactly what played
+ * the replay's whole head against a blank white stage: the chat animated,
+ * the app frame was still loading, and when it finally announced, the
+ * catch-up made it pop in fully formed mid-timeline.
+ */
+const INITIALIZED_READY_FALLBACK_MS = 1_500;
+const CONNECT_READY_FALLBACK_MS = 8_000;
 
 type ReplayActivity = { kind: "tool"; name: string } | null;
 
@@ -1226,18 +1245,6 @@ function PlayerSurface({
   mutedRef.current = muted;
   const playStateRef = useRef(playState);
   playStateRef.current = playState;
-
-  // A remount (version switch, restart, or seek) makes the frame not-ready
-  // until its SDK reconnects. The deps ARE the remount triggers even though the
-  // body only resets the flag.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: segmentIndex/runNonce are the intended re-run triggers
-  useEffect(() => {
-    setFrameReady(false);
-    if (legacyReadyTimerRef.current) {
-      clearTimeout(legacyReadyTimerRef.current);
-      legacyReadyTimerRef.current = null;
-    }
-  }, [segmentIndex, runNonce]);
 
   // Which recorded version segment is visible at a given clock time, by the
   // segment's own `atMs` — independent of the `segment` marker events (which a
@@ -2435,6 +2442,23 @@ function PlayerSurface({
     return replayBridge;
   }, [conversationId, segmentIndex, runNonce, sandboxUrl.href]);
 
+  // A remount makes the frame not-ready until its SDK announces again. Keyed
+  // on the bridge, which is rebuilt exactly once per app-frame instance
+  // (segment switch, restart, seek — and the sandboxUrl swap when the
+  // sandbox-domain config lands after mount): every way the frame element is
+  // replaced resets readiness, so the clock can never keep running against a
+  // frame that is still loading. Keying on segmentIndex/runNonce alone left
+  // the sandboxUrl remount armed — the clock free-ran over the new frame's
+  // cold handshake and the replay's head played against a blank stage.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the bridge IS the frame-instance identity; the body only resets state
+  useEffect(() => {
+    setFrameReady(false);
+    if (legacyReadyTimerRef.current) {
+      clearTimeout(legacyReadyTimerRef.current);
+      legacyReadyTimerRef.current = null;
+    }
+  }, [bridge]);
+
   // A tool call's `t` is its completion time, so its in-flight window is
   // [t - durationMs, t] — the app top bar shows a "running" chip during it.
   const mcpWindows = useMemo(
@@ -2649,7 +2673,14 @@ function PlayerSurface({
             </span>
           </button>
           <ReplayAppStage viewport={viewport}>
-            {segment ? (
+            {/* Held until the sandbox origin is KNOWN (undefined = the config
+                queries are still resolving; they always settle to a domain or
+                null). Mounting before that points the frame at the same-origin
+                proxy URL, which a sandbox-domain deployment refuses with a 403
+                — a doomed first mount that is then torn down and repeated on
+                the real origin when the config lands. Every cold tab (each
+                Slack Replay link opens one) paid that double handshake. */}
+            {segment && mcpSandboxDomain !== undefined ? (
               <SandboxIframe
                 key={`${conversationId}:${segmentIndex}:${runNonce}`}
                 html={replayHtml}
@@ -2677,13 +2708,32 @@ function PlayerSurface({
                     armReplayFrame();
                   }
                 }}
-                // Fallback for a stale cached SDK that predates the
-                // announcement: after a beat, treat connect as ready.
+                // Stale-SDK fallback, tier 1: the app SDK inside the inner
+                // document finished its handshake, so the document is really
+                // on screen — only the announcement is missing. Re-armed per
+                // announcing document (a settling sandbox can navigate more
+                // than once); the announcement itself clears it.
+                onInitialized={() => {
+                  if (legacyReadyTimerRef.current) {
+                    clearTimeout(legacyReadyTimerRef.current);
+                  }
+                  legacyReadyTimerRef.current = setTimeout(() => {
+                    if (!frameReadyRef.current) armReplayFrame();
+                  }, INITIALIZED_READY_FALLBACK_MS);
+                }}
+                // Stale-SDK fallback, tier 2 (last resort): connect is a
+                // proxy-level signal that resolves while the inner document
+                // may not even be written yet, so its fuse is LONG — arming
+                // the clock 1.5s after connect is what used to play the
+                // replay's head against a blank white stage on every cold
+                // sandbox origin (see the fallback constants). This tier only
+                // exists so a frame whose SDK never runs at all cannot freeze
+                // the replay forever.
                 onConnected={() => {
                   if (legacyReadyTimerRef.current) return;
                   legacyReadyTimerRef.current = setTimeout(() => {
                     if (!frameReadyRef.current) armReplayFrame();
-                  }, 1500);
+                  }, CONNECT_READY_FALLBACK_MS);
                 }}
               />
             ) : null}

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -933,6 +933,7 @@ export function SandboxIframe({
   onIframeElement,
   onRecordingEvents,
   onConnected,
+  onInitialized,
   ownedApp,
 }: {
   html: string;
@@ -965,10 +966,14 @@ export function SandboxIframe({
   onIframeElement?: (el: HTMLIFrameElement | null) => void;
   /** Raw recorder batch (`mcp-apps:recording-event`) forwarded by the proxy. */
   onRecordingEvents?: (data: unknown, frame?: HTMLIFrameElement) => void;
-  /** Fired when the guest bridge connects — the injected app SDK (and its
-   * replay listener) is live. The session player gates replay on this so early
-   * events aren't posted to a frame whose SDK hasn't attached yet. */
+  /** Fired when the guest bridge connects. A PROXY-level signal: it can
+   * resolve while the inner app document is still being written, so it says
+   * nothing about the app being on screen — gate on `onInitialized` (or the
+   * replay announcement) for that. */
   onConnected?: () => void;
+  /** Fired when the app inside the inner document reports `initialized` —
+   * the injected SDK has actually run in the document that is on screen. */
+  onInitialized?: () => void;
   /** Archestra-owned app: its envelope carries the platform CSP, so the proxy
    * must not inject a second one. A trusted host signal, not derived from HTML. */
   ownedApp?: boolean;
@@ -992,6 +997,7 @@ export function SandboxIframe({
   const onIframeElementRef = useRef(onIframeElement);
   const onRecordingEventsRef = useRef(onRecordingEvents);
   const onConnectedRef = useRef(onConnected);
+  const onInitializedRef = useRef(onInitialized);
   // Read at iframe-creation time only; a ref keeps it out of the effect deps so
   // the iframe never remounts when the height changes.
   const initialHeightRef = useRef(initialHeight);
@@ -1017,6 +1023,7 @@ export function SandboxIframe({
     onIframeElementRef.current = onIframeElement;
     onRecordingEventsRef.current = onRecordingEvents;
     onConnectedRef.current = onConnected;
+    onInitializedRef.current = onInitialized;
     initialHeightRef.current = initialHeight;
     maxHeightRef.current = maxHeight;
   });
@@ -1201,6 +1208,7 @@ export function SandboxIframe({
 
     appBridge.oninitialized = () => {
       setInitialized(true);
+      onInitializedRef.current?.();
     };
   }, [ready, appBridge]);
 


### PR DESCRIPTION
## Bug

Most hackathon submission replays (and any app-session replay opened in a cold tab) played their head against an **empty white app pane**: the chat side animated normally while the app stage stayed blank for most of the timeline, then the app **popped in fully formed** near the end. Reported against the submission review panel with PR #21 / #22 recordings; the recordings themselves are fine (single segment at `atMs: 0` — the full app HTML should be on screen from the first frame).

## Root cause

The player already has the right design — *"hold the clock until the current app frame's SDK has connected"* — but three defects defeated it:

1. **False ready.** The "stale cached SDK" fallback armed `frameReady` 1.5s after `AppBridge.connect`. Connect is a **proxy-level** signal: it resolves before the inner app document is even written (the live flow sends the HTML only *after* connect). On a cold sandbox subdomain, the inner chain — proxy handshake → HTML delivery → parser-blocking `archestra-app-sdk.js` fetch → replay-ready announcement — runs many seconds behind connect. The clock started against a frame that had rendered nothing; when the document finally announced, the catch-up delivery (`armReplayFrame` → `applyEventsUpTo(clock)`) made the app appear mid-timeline.
2. **Stale ready.** `setFrameReady(false)` was keyed on `[segmentIndex, runNonce]` only. The frame remount caused by the sandbox-domain config landing after mount (the documented `sandboxUrl` swap that already rebuilds the bridge) kept the torn-down frame's ready flag, letting the clock free-run over the new frame's cold handshake.
3. **Doomed first mount.** The frame mounted before the sandbox origin was known, pointing at the same-origin proxy URL — which sandbox-domain deployments refuse with a 403 — then tore down and repeated the full handshake on the real origin. Every cold tab paid this double handshake, and each Slack **Replay** link opens a cold tab, which is why reviewers hit this on "most" submissions.

## Fix

- Real readiness stays the SDK's **replay-ready announcement** (unchanged).
- The app SDK's `initialized` notification — a true *in-document* signal, now exposed as `SandboxIframe.onInitialized` — takes over the short stale-SDK fuse (1.5s): if the SDK ran but is too old to announce, the document is already on screen when the fuse fires.
- `onConnected` is demoted to an **8s last resort** so a frame whose SDK never runs at all still can't freeze the replay forever (stays under the offline renderer's 10s opening gate).
- `frameReady` resets whenever the replay **bridge** changes — the bridge is rebuilt exactly once per frame instance (segment switch, restart, seek, *and* the sandboxUrl swap), so every frame replacement now holds the clock.
- The frame mounts only once `useMcpSandboxDomain()` has settled (`undefined` = still resolving; both config schemas declare the field `.nullable()`, so it always settles to a domain or `null`).

Net effect: on a cold review tab the replay now *starts* a beat later (one clean frame mount, clock held until the app is actually on screen) and plays from 0:00 with the app visible — nothing is skipped, nothing pops in.

Also fixes the same free-run for the native player preview and the offline video renderer (which previously could film white frames when the 1.5s fuse beat the announcement).

## Verification

- `biome check` clean on both files; `tsc --noEmit` clean.
- `vitest run` on `app-session-recording`, `mcp-app`, and `right-side-panel` suites: **125 tests, 11 files, all passing**.
- Timeline math for the two reported recordings replicated against `buildPlayback` to confirm the recordings put the app at playback-start (bug had to be frame gating, not data).
- Live apps are unaffected: `onInitialized` is a new optional prop, unset outside the player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>