### PR TITLE
fix: make replay start fast and visibly loading, top-align review layout

### DIFF
--- a/platform/backend/src/static/archestra-app-recording-sdk.js
+++ b/platform/backend/src/static/archestra-app-recording-sdk.js
@@ -2397,5 +2397,30 @@
   // SDK parsed AFTER the host had already marked it ready. Every document
   // announces for itself, so the player re-delivers to whichever document
   // ends up being the one on screen.
-  post({ type: EVENT_TYPE, replayReady: true });
+  //
+  // Announced AFTER THE DOCUMENT HAS PAINTED, not when this script runs. This
+  // script is injected first in <head> and is parser-blocking, so at execution
+  // time there is no <body>, no app stylesheet and no app markup: announcing
+  // here told the player "ready" while the frame was still empty, and the
+  // replay then played its whole head against a blank stage, with the app
+  // popping in fully formed once the document finally painted.
+  //
+  // A double animation frame after DOMContentLoaded is the signal: rAF
+  // callbacks do not run until render-blocking stylesheets have resolved, so
+  // the second one lands after the first paint. `origRaf` (not the patched
+  // window.requestAnimationFrame) is deliberate — the patched one queues
+  // callbacks while the replay is frozen, which is the state a paused player
+  // hands a fresh frame, and the announcement would never be posted.
+  const announceReplayReady = () => {
+    origRaf(() => {
+      origRaf(() => post({ type: EVENT_TYPE, replayReady: true }));
+    });
+  };
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", announceReplayReady, {
+      once: true,
+    });
+  } else {
+    announceReplayReady();
+  }
 })();

--- a/platform/backend/src/static/mcp-sandbox-proxy.html
+++ b/platform/backend/src/static/mcp-sandbox-proxy.html
@@ -153,9 +153,19 @@ function buildCSP(csp) {
 }
 
 /**
- * Build CSP violation listener script (Inspector pattern).
- * Forwards securitypolicyviolation events to the host via postMessage
- * so violations can be surfaced for debugging.
+ * Build the guest's inline bootstrap: a CSP-violation listener plus a
+ * document-ready announcement.
+ *
+ * Forwards securitypolicyviolation events to the host via postMessage so
+ * violations can be surfaced for debugging, and posts
+ * `mcp-apps:sandbox-content-loaded` at DOMContentLoaded — the one signal a
+ * host can trust to mean the GUEST document is really on screen. Everything
+ * else the host observes (proxy-ready, bridge connect, resource-ready)
+ * happens while the inner frame is still empty, and the inner frame's own
+ * load event cannot be told apart from the about:blank it starts on. It
+ * comes from the guest document itself, so there is no such ambiguity, and
+ * it fires even when the app's SDK script fails to load — the recorded
+ * markup is still on screen, which is what the app-session player waits for.
  *
  * Violations originating from a platform-served guest SDK file are not
  * forwarded: the SDK probes code-generation support at load with a try/catch
@@ -183,6 +193,9 @@ document.addEventListener("securitypolicyviolation", function(e) {\
     timestamp: Date.now()\
   };\
   window.parent.postMessage(violation, "*");\
+});\
+document.addEventListener("DOMContentLoaded", function() {\
+  window.parent.postMessage({ type: "mcp-apps:sandbox-content-loaded" }, "*");\
 });\
 <\/script>';
 }
@@ -304,21 +317,6 @@ const RESOURCE_READY_NOTIFICATION =
 const PROXY_READY_NOTIFICATION =
   "ui/notifications/sandbox-proxy-ready";
 
-// The one signal that says the guest document is REALLY on screen: the inner
-// frame's own load event, after its content was written. Everything else the
-// host can observe (proxy-ready, bridge connect, resource-ready) happens while
-// the inner document is still empty — a host that treats those as "the app is
-// showing" paints nothing and looks broken. Guarded by `contentWritten`
-// because appending an iframe fires a load for its initial about:blank, which
-// would announce an empty frame as ready.
-let contentWritten = false;
-inner.addEventListener("load", function () {
-  if (!contentWritten) return;
-  window.parent.postMessage(
-    { type: "mcp-apps:sandbox-content-loaded" },
-    EXPECTED_HOST_ORIGIN || "*",
-  );
-});
 
 // Message relay: This Sandbox (outer iframe) acts as a bidirectional bridge,
 // forwarding messages between:
@@ -369,11 +367,6 @@ window.addEventListener("message", async (event) => {
         // One code path for all modes — CSP is always in the HTML, not HTTP headers.
         const processedHtml = injectCSP(html, buildCSP(csp), ownedApp === true);
 
-        // From here on, an inner load event means the GUEST document finished
-        // loading (document.close() and srcdoc both fire one), which is what
-        // the host waits for before it may treat the app as on screen.
-        contentWritten = true;
-
         if (IS_OPAQUE_ORIGIN) {
           // Opaque origin (production fallback): use srcdoc
           inner.srcdoc = processedHtml;
@@ -412,7 +405,8 @@ window.addEventListener("message", async (event) => {
         data.type === "mcp-apps:csp-violation" ||
         data.type === "mcp-apps:runtime-error" ||
         data.type === "mcp-apps:screenshot" ||
-        data.type === "mcp-apps:recording-event"
+        data.type === "mcp-apps:recording-event" ||
+        data.type === "mcp-apps:sandbox-content-loaded"
       ) {
         window.parent.postMessage(data, EXPECTED_HOST_ORIGIN || "*");
       }

--- a/platform/backend/src/static/mcp-sandbox-proxy.html
+++ b/platform/backend/src/static/mcp-sandbox-proxy.html
@@ -304,6 +304,22 @@ const RESOURCE_READY_NOTIFICATION =
 const PROXY_READY_NOTIFICATION =
   "ui/notifications/sandbox-proxy-ready";
 
+// The one signal that says the guest document is REALLY on screen: the inner
+// frame's own load event, after its content was written. Everything else the
+// host can observe (proxy-ready, bridge connect, resource-ready) happens while
+// the inner document is still empty — a host that treats those as "the app is
+// showing" paints nothing and looks broken. Guarded by `contentWritten`
+// because appending an iframe fires a load for its initial about:blank, which
+// would announce an empty frame as ready.
+let contentWritten = false;
+inner.addEventListener("load", function () {
+  if (!contentWritten) return;
+  window.parent.postMessage(
+    { type: "mcp-apps:sandbox-content-loaded" },
+    EXPECTED_HOST_ORIGIN || "*",
+  );
+});
+
 // Message relay: This Sandbox (outer iframe) acts as a bidirectional bridge,
 // forwarding messages between:
 //
@@ -352,6 +368,11 @@ window.addEventListener("message", async (event) => {
         // Inject CSP as meta tag + violation listener into the HTML (Inspector pattern).
         // One code path for all modes — CSP is always in the HTML, not HTTP headers.
         const processedHtml = injectCSP(html, buildCSP(csp), ownedApp === true);
+
+        // From here on, an inner load event means the GUEST document finished
+        // loading (document.close() and srcdoc both fire one), which is what
+        // the host waits for before it may treat the app as on screen.
+        contentWritten = true;
 
         if (IS_OPAQUE_ORIGIN) {
           // Opaque origin (production fallback): use srcdoc

--- a/platform/backend/src/static/mcp-sandbox-proxy.html
+++ b/platform/backend/src/static/mcp-sandbox-proxy.html
@@ -55,6 +55,33 @@ const ARCHESTRA_APP_SDK_URL = location.origin + "/_sandbox/archestra-app-sdk.js"
 // resolves against this proxy origin, so style-src must allowlist this URL.
 const ARCHESTRA_APP_BASE_CSS_URL = location.origin + "/_sandbox/archestra-app-base.css";
 
+// Warm the guest-SDK assets NOW, while the host handshake (proxy-ready →
+// bridge connect → resource-ready) is still in flight: the inner document is
+// about to load these same-origin files, its parser blocks on the SDK script,
+// and on a cold sandbox origin those fetches are exactly what a viewer waits
+// on before an app (or a replay) can appear. All three are served cacheable,
+// so the preloads land in the HTTP cache the inner document reads from. The
+// ext-apps preload carries `crossorigin` to match the SDK's module import
+// (cors request mode); the classic script and stylesheet must not, or the
+// preload wouldn't match their no-cors fetches. Best-effort — a failed
+// preload costs nothing, the inner document just fetches as before.
+try {
+  [
+    [ARCHESTRA_APP_SDK_URL, "script", false],
+    [APP_SDK_URL, "script", true],
+    [ARCHESTRA_APP_BASE_CSS_URL, "style", false],
+  ].forEach(function (spec) {
+    var warm = document.createElement("link");
+    warm.rel = "preload";
+    warm.href = spec[0];
+    warm.as = spec[1];
+    if (spec[2]) warm.crossOrigin = "anonymous";
+    document.head.appendChild(warm);
+  });
+} catch (e) {
+  // never let warming break the proxy
+}
+
 function buildAllowAttribute(permissions) {
   if (!permissions) return "";
 

--- a/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
+++ b/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
@@ -9,6 +9,7 @@ import {
   classifyCut,
   classifyTimelineGesture,
   consolidatedTranscript,
+  deferThirdPartyStylesheets,
   dominantViewport,
   keptTimelineRanges,
   neutralizeAppScripts,
@@ -987,6 +988,45 @@ describe("neutralizeAppScripts", () => {
     expect(html).toContain("scrollbar-width: none");
     expect(html).toContain("::-webkit-scrollbar");
     expect(html).toContain("<body>app</body>");
+  });
+});
+
+describe("deferThirdPartyStylesheets", () => {
+  it("parks a remote stylesheet on media=print and remembers what to restore", () => {
+    // A render-blocking third-party sheet has no browser timeout: until it
+    // resolves the replayed document paints NOTHING, which is how a recording
+    // whose app links Google Fonts replayed as a white stage for many seconds.
+    const html = deferThirdPartyStylesheets(
+      `<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bungee&amp;display=swap">`,
+    );
+    expect(html).toContain(`media="print"`);
+    expect(html).toContain(`data-archestra-replay-css="all"`);
+    expect(html).toContain("fonts.googleapis.com");
+  });
+
+  it("keeps the app's own media query so promotion restores it", () => {
+    const html = deferThirdPartyStylesheets(
+      `<link rel="stylesheet" media="screen and (min-width: 600px)" href="https://cdn.jsdelivr.net/x.css">`,
+    );
+    expect(html).toContain(`media="print"`);
+    expect(html).toContain(
+      `data-archestra-replay-css="screen and (min-width: 600px)"`,
+    );
+    expect(html).not.toContain(`media="screen and (min-width: 600px)"`);
+  });
+
+  it("leaves platform and relative stylesheets render-blocking", () => {
+    // The baseline theme IS the app's look and is same-origin + preloaded, so
+    // its (bounded) blocking is wanted — deferring it would flash unstyled.
+    const platform = `<link rel="stylesheet" href="https://abc.sandbox.example.com/_sandbox/archestra-app-base.css">`;
+    const relative = `<link rel="stylesheet" href="/styles/app.css">`;
+    expect(deferThirdPartyStylesheets(platform)).toBe(platform);
+    expect(deferThirdPartyStylesheets(relative)).toBe(relative);
+  });
+
+  it("ignores non-stylesheet links", () => {
+    const icon = `<link rel="icon" href="https://example.com/favicon.png">`;
+    expect(deferThirdPartyStylesheets(icon)).toBe(icon);
   });
 });
 

--- a/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
+++ b/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
@@ -1028,6 +1028,17 @@ describe("deferThirdPartyStylesheets", () => {
     const icon = `<link rel="icon" href="https://example.com/favicon.png">`;
     expect(deferThirdPartyStylesheets(icon)).toBe(icon);
   });
+
+  it("is opt-out for the offline renderer, which must film the real fonts", () => {
+    // Nobody waits on an export, and its frames are the artifact the gallery
+    // keeps — so filming keeps the sheet render-blocking rather than risking
+    // opening frames drawn in a fallback face.
+    const html = `<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bungee">`;
+    expect(
+      neutralizeAppScripts(html, { deferRemoteStylesheets: false }),
+    ).toContain(html);
+    expect(neutralizeAppScripts(html)).toContain(`media="print"`);
+  });
 });
 
 describe("relocalizeSandboxAssets", () => {

--- a/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
+++ b/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
@@ -14,6 +14,7 @@ import {
   neutralizeAppScripts,
   planPaintFlush,
   presentedTranscript,
+  relocalizeSandboxAssets,
   replayRegionLayout,
   replayStageFit,
   revealSchedule,
@@ -986,6 +987,44 @@ describe("neutralizeAppScripts", () => {
     expect(html).toContain("scrollbar-width: none");
     expect(html).toContain("::-webkit-scrollbar");
     expect(html).toContain("<body>app</body>");
+  });
+});
+
+describe("relocalizeSandboxAssets", () => {
+  const base = "https://abc123.sandbox.example.com";
+
+  it("points every recorded /_sandbox/ URL — script, CSP meta, bootstrap sdkUrl, stylesheet — at the replaying sandbox origin", () => {
+    // A segment captured on another deployment carries that deployment's
+    // absolute asset URLs in four shapes at once; all must move together or
+    // the frame mixes origins (and the CSP meta blocks the moved ones).
+    const recorded =
+      `<meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline' https://frontend.other.dev/_sandbox/ext-apps-app.js https://frontend.other.dev/_sandbox/archestra-app-sdk.js; style-src https://frontend.other.dev/_sandbox/archestra-app-base.css">` +
+      `<link rel="stylesheet" href="https://frontend.other.dev/_sandbox/archestra-app-base.css">` +
+      `<script data-archestra-app-bootstrap>window.__ARCHESTRA_APP_CONTEXT__={"sdkUrl":"https://frontend.other.dev/_sandbox/ext-apps-app.js"};</script>` +
+      `<script data-archestra-app-sdk src="https://frontend.other.dev/_sandbox/archestra-app-sdk.js"></script>`;
+    const html = relocalizeSandboxAssets(recorded, base);
+    expect(html).not.toContain("frontend.other.dev");
+    expect(html).toContain(`src="${base}/_sandbox/archestra-app-sdk.js"`);
+    expect(html).toContain(`href="${base}/_sandbox/archestra-app-base.css"`);
+    expect(html).toContain(`"sdkUrl":"${base}/_sandbox/ext-apps-app.js"`);
+    expect(html).toContain(
+      `script-src 'unsafe-inline' ${base}/_sandbox/ext-apps-app.js ${base}/_sandbox/archestra-app-sdk.js;`,
+    );
+  });
+
+  it("leaves URLs outside /_sandbox/ alone and tolerates a trailing slash on the base", () => {
+    const recorded =
+      `<img src="https://cdn.jsdelivr.net/pic.png">` +
+      `<script src="https://frontend.other.dev/_sandbox/archestra-app-sdk.js"></script>`;
+    const html = relocalizeSandboxAssets(recorded, `${base}/`);
+    expect(html).toContain(`https://cdn.jsdelivr.net/pic.png`);
+    expect(html).toContain(`src="${base}/_sandbox/archestra-app-sdk.js"`);
+    expect(html).not.toContain(`${base}//_sandbox`);
+  });
+
+  it("returns the html unchanged when there is no base to point at", () => {
+    const recorded = `<script src="https://a.dev/_sandbox/x.js"></script>`;
+    expect(relocalizeSandboxAssets(recorded, "")).toBe(recorded);
   });
 });
 

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -6252,21 +6252,70 @@ export const replaySandboxPrefix = (conversationId: string | undefined) =>
 export function neutralizeAppScripts(html: string): string {
   return (
     REPLAY_CHROME_CSS +
-    html.replace(/<script\b([^>]*)>/gi, (tag: string, attrs: string) => {
-      if (/data-archestra-app-(sdk|bootstrap)/i.test(attrs)) return tag;
-      // Any `type` the app set must be REMOVED, not merely followed by the
-      // replay type: the HTML parser drops duplicate attributes and keeps the
-      // FIRST, so `<script type="module" type="application/…">` still parses
-      // as a module — and executes. That is how a module-based app re-ran
-      // itself inside its own replay, rolling fresh Math.random state and
-      // repainting its canvas over the recorded frames.
-      const rest = attrs.replace(
-        /\stype(\s*=\s*("[^"]*"|'[^']*'|[^\s]*))?(?=\s|$)/gi,
-        "",
-      );
-      return `<script${rest} type="application/archestra-replayed-script">`;
-    })
+    deferThirdPartyStylesheets(html).replace(
+      /<script\b([^>]*)>/gi,
+      (tag: string, attrs: string) => {
+        if (/data-archestra-app-(sdk|bootstrap)/i.test(attrs)) return tag;
+        // Any `type` the app set must be REMOVED, not merely followed by the
+        // replay type: the HTML parser drops duplicate attributes and keeps the
+        // FIRST, so `<script type="module" type="application/…">` still parses
+        // as a module — and executes. That is how a module-based app re-ran
+        // itself inside its own replay, rolling fresh Math.random state and
+        // repainting its canvas over the recorded frames.
+        const rest = attrs.replace(
+          /\stype(\s*=\s*("[^"]*"|'[^']*'|[^\s]*))?(?=\s|$)/gi,
+          "",
+        );
+        return `<script${rest} type="application/archestra-replayed-script">`;
+      },
+    )
   );
+}
+
+/**
+ * Stop a remote stylesheet from holding the replay's first paint hostage.
+ *
+ * A recorded app may link a third-party stylesheet — Google Fonts is the
+ * common one, and the platform's own app CSP allowlists it. A
+ * `<link rel="stylesheet">` is RENDER-BLOCKING and, unlike a script, has no
+ * browser timeout: until it resolves, the replayed document paints nothing at
+ * all, however fast everything the platform serves is. That is a stall of
+ * unbounded length on a surface whose whole job is to play back at a fixed
+ * pace, for a resource that only changes which font the recording is drawn
+ * in.
+ *
+ * So remote sheets load NON-blocking: parked on `media="print"` (fetched,
+ * never render-blocking) and promoted to `media="all"` on load, the standard
+ * async-CSS pattern. The app paints immediately in fallback fonts and adopts
+ * the real ones a moment later, instead of showing nothing for as long as the
+ * third party takes. Platform assets are untouched — by this point
+ * {@link relocalizeSandboxAssets} has pointed them at the replaying sandbox
+ * origin, so they are same-origin, already preloaded by the proxy, and their
+ * blocking is both bounded and wanted (the app's baseline theme).
+ *
+ * @public — exported for testability
+ */
+export function deferThirdPartyStylesheets(html: string): string {
+  return html.replace(/<link\b[^>]*>/gi, (tag: string) => {
+    if (!/\brel\s*=\s*["']?stylesheet\b/i.test(tag)) return tag;
+    // Same-origin/relative hrefs are the platform's own; only a remote sheet
+    // (an origin this deployment does not serve) gets deferred.
+    const href = /\bhref\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(tag);
+    const url = href ? (href[2] ?? href[3] ?? href[4] ?? "") : "";
+    if (!/^https?:\/\//i.test(url)) return tag;
+    if (url.includes("/_sandbox/")) return tag;
+    // An app that already set `media` gets it replaced: whatever it asked for
+    // is restored by the promoter below, keyed off the saved value.
+    const media = /\bmedia\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(tag);
+    const original = media
+      ? (media[2] ?? media[3] ?? media[4] ?? "all")
+      : "all";
+    const withoutMedia = media ? tag.replace(media[0], "") : tag;
+    return withoutMedia.replace(
+      /\s*\/?>$/,
+      ` media="print" data-archestra-replay-css="${original.replace(/"/g, "&quot;")}">`,
+    );
+  });
 }
 
 /**
@@ -6287,7 +6336,41 @@ export function neutralizeAppScripts(html: string): string {
 const REPLAY_CHROME_CSS = `<style data-archestra-replay-chrome>
   ::-webkit-scrollbar { width: 0; height: 0; }
   html { scrollbar-width: none; }
-</style>`;
+</style>
+<script data-archestra-replay-chrome>
+(function () {
+  // Promote the remote stylesheets parked by deferThirdPartyStylesheets: each
+  // applies the moment IT loads, so a slow third party delays only its own
+  // fonts instead of the whole document's first paint. Prepended with the
+  // chrome, i.e. AFTER the app's own scripts were neutralized, so this one
+  // still runs. Best-effort: if it is ever blocked, the replay simply keeps
+  // the app's fallback fonts.
+  var promote = function () {
+    try {
+      var parked = document.querySelectorAll("link[data-archestra-replay-css]");
+      for (var i = 0; i < parked.length; i++) {
+        (function (link) {
+          var restore = function () {
+            link.media = link.getAttribute("data-archestra-replay-css") || "all";
+          };
+          // Already loaded (a warm cache resolves it before this runs), else
+          // when it arrives.
+          if (link.sheet) restore();
+          else link.addEventListener("load", restore, { once: true });
+        })(parked[i]);
+      }
+    } catch (e) {}
+  };
+  // This script is prepended ahead of the document, so the parked links do not
+  // exist yet — wait for the parse. They are media="print" and therefore not
+  // render-blocking, so nothing here delays first paint.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", promote, { once: true });
+  } else {
+    promote();
+  }
+})();
+</script>`;
 
 // =============================================================================
 // Guided tour

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -2604,8 +2604,14 @@ function PlayerSurface({
     () =>
       neutralizeAppScripts(
         relocalizeSandboxAssets(segment?.html ?? "", sandboxResult.baseUrl),
+        // Deferring a remote stylesheet trades font fidelity for a fast first
+        // paint — the right trade for someone watching, the wrong one for an
+        // export. Nobody is waiting on the offline renderer, and its output is
+        // the artifact the gallery keeps, so there the sheet stays
+        // render-blocking and every filmed frame carries the real fonts.
+        { deferRemoteStylesheets: !filming },
       ),
-    [segment?.html, sandboxResult.baseUrl],
+    [segment?.html, sandboxResult.baseUrl, filming],
   );
 
   return (
@@ -6249,10 +6255,13 @@ export const replaySandboxPrefix = (conversationId: string | undefined) =>
  *
  * @public — exported for testability
  */
-export function neutralizeAppScripts(html: string): string {
+export function neutralizeAppScripts(
+  html: string,
+  { deferRemoteStylesheets = true }: { deferRemoteStylesheets?: boolean } = {},
+): string {
   return (
     REPLAY_CHROME_CSS +
-    deferThirdPartyStylesheets(html).replace(
+    (deferRemoteStylesheets ? deferThirdPartyStylesheets(html) : html).replace(
       /<script\b([^>]*)>/gi,
       (tag: string, attrs: string) => {
         if (/data-archestra-app-(sdk|bootstrap)/i.test(attrs)) return tag;

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -648,7 +648,14 @@ export function AppSessionPlayer({
             </div>
           </div>
           {recording ? (
-            <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
+            // Top-aligned, not centered: the surface's height is derived from
+            // the SCREEN (replayRegionLayout), so in this docked host it is
+            // usually shorter than the panel — centering floated it into the
+            // middle and opened a dead band between the heading above and the
+            // replay's cards, which read as broken layout. Pinned to the top,
+            // the cards sit right under the heading and the slack falls below
+            // the transport where trailing space is normal.
+            <div className="flex min-h-0 flex-1 items-start justify-center overflow-auto p-4">
               <PlayerSurface
                 key={review.submission.sub}
                 conversationId={review.submission.sub}
@@ -2382,7 +2389,7 @@ function PlayerSurface({
     () =>
       getMcpSandboxBaseUrl(
         mcpSandboxDomain,
-        `archestra-app-replay-${conversationId}`,
+        replaySandboxPrefix(conversationId),
       ),
     [mcpSandboxDomain, conversationId],
   );
@@ -2532,12 +2539,18 @@ function PlayerSurface({
   }, [nextMessage, transcript, displayClock, duration]);
 
   const segment = segments[segmentIndex] ?? segments[0];
-  // Recomputed only when the shown version changes — rebuilding this string on
-  // every render would hand SandboxIframe new HTML each time and remount the
-  // app, throwing away the very run we are trying to reproduce.
+  // Recomputed only when the shown version (or the sandbox origin) changes —
+  // rebuilding this string on every render would hand SandboxIframe new HTML
+  // each time and remount the app, throwing away the very run we are trying
+  // to reproduce. Assets are pointed at the replaying sandbox origin FIRST so
+  // the frame loads them same-origin (see relocalizeSandboxAssets), then the
+  // app's own scripts are neutralized.
   const replayHtml = useMemo(
-    () => neutralizeAppScripts(segment?.html ?? ""),
-    [segment?.html],
+    () =>
+      neutralizeAppScripts(
+        relocalizeSandboxAssets(segment?.html ?? "", sandboxResult.baseUrl),
+      ),
+    [segment?.html, sandboxResult.baseUrl],
   );
 
   return (
@@ -2640,6 +2653,21 @@ function PlayerSurface({
           {activity && (
             <div className="pointer-events-none absolute right-3 top-3 z-20">
               <ReplayActivityChip activity={activity} />
+            </div>
+          )}
+          {/* The frame's loading state, made visible: while the clock is held
+              for the app frame (cold sandbox origin, remount after a seek or
+              version switch), the stage would otherwise sit silently blank and
+              read as a hung player. Never while filming — the renderer waits
+              out readiness between frames, and this pill must not be filmed
+              into an export. z-10 with the stage content: above the frame,
+              below the play/pause hover affordance. */}
+          {!frameReady && !filming && (
+            <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+              <div className="flex items-center gap-2 rounded-md bg-foreground/60 px-3 py-2 text-xs font-medium text-background shadow-sm backdrop-blur-sm">
+                <Loader size={14} />
+                <span>Loading replay…</span>
+              </div>
             </div>
           )}
           {/* The whole stage is a play/pause surface: hovering names the
@@ -6108,6 +6136,51 @@ function formatMs(ms: number): string {
 
 /** The export ceiling in whole seconds, for the copy that quotes it. */
 const MAX_EXPORT_SECONDS = Math.round(APP_RECORDING_MAX_EXPORT_MS / 1000);
+
+/**
+ * Point the recorded document's platform assets at the origin that will
+ * actually replay it.
+ *
+ * A segment's HTML is captured from the served resource, so its SDK scripts,
+ * baseline stylesheet, CSP meta sources and bootstrap `sdkUrl` all carry
+ * ABSOLUTE `/_sandbox/…` URLs of the deployment the RECORDING was made on.
+ * Replayed as-is, the sandboxed frame must open fresh cross-origin
+ * connections back to that frontend for every one of those fetches — a
+ * parser-blocking chain of cold DNS+TLS handshakes that is what a viewer on a
+ * cold tab actually waits on before the replay can start (and a recording
+ * from another deployment would phone that other deployment entirely).
+ *
+ * Rewriting every `/_sandbox/` asset URL to the replaying sandbox origin
+ * makes each of them same-origin with the proxy document: one already-warm
+ * connection, the proxy's preload links apply, and gallery bundles replay
+ * self-contained on whatever deployment shows them. The backend serves the
+ * identical files on both origins, and one regex covers attributes, the CSP
+ * meta and the bootstrap JSON alike because the segment is a single
+ * serialized string in which those URLs only ever appear verbatim.
+ *
+ * @public — exported for testability
+ */
+export function relocalizeSandboxAssets(
+  html: string,
+  sandboxBaseUrl: string,
+): string {
+  const base = sandboxBaseUrl.replace(/\/+$/, "");
+  if (!base) return html;
+  return html.replace(
+    /https?:\/\/[^"'`\s\\]*\/_sandbox\//g,
+    `${base}/_sandbox/`,
+  );
+}
+
+/**
+ * The sandbox server-prefix a conversation's replay frame runs under — the
+ * value that picks its dedicated sandbox subdomain. Shared with the review
+ * host so it can PRECONNECT to that exact origin while the recording bundle
+ * is still downloading, taking the cold DNS+TLS handshake off the critical
+ * path the frame pays on mount.
+ */
+export const replaySandboxPrefix = (conversationId: string | undefined) =>
+  `archestra-app-replay-${conversationId}`;
 
 /**
  * Stop the app's own code from running in a replay.

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -335,19 +335,25 @@ const PREROLL_MS = 1_200;
  * always the announcement; these only stop a silent frame from freezing the
  * replay forever.
  *
- * The `initialized` fuse is short: that signal comes from the app SDK RUNNING
- * inside the inner document, so the document is on screen and only the
- * announcement is missing. The `connect` fuse is long: connect is a
- * proxy-level signal that resolves while the inner document may not even be
- * written yet — on a cold sandbox subdomain the document's own chain (proxy
- * handshake, HTML delivery, the parser-blocking SDK fetch) runs many seconds
- * behind it. Arming the clock off connect after 1.5s is exactly what played
- * the replay's whole head against a blank white stage: the chat animated,
- * the app frame was still loading, and when it finally announced, the
- * catch-up made it pop in fully formed mid-timeline.
+ * BOTH fuses hang off a signal that means the guest document is actually on
+ * screen — the app SDK reporting `initialized` (it ran INSIDE that document),
+ * or the sandbox proxy reporting the guest document's load event. Nothing
+ * arms off the bridge connect any more: connect is a PROXY-level signal that
+ * resolves while the inner frame is still empty, so a fuse hung off it starts
+ * playback against a blank stage — the replay's whole head played white, and
+ * the app popped in fully formed mid-timeline when it finally loaded. A
+ * signal that can lie about pixels must never gate the clock, however long
+ * its fuse.
  */
 const INITIALIZED_READY_FALLBACK_MS = 1_500;
-const CONNECT_READY_FALLBACK_MS = 8_000;
+const CONTENT_LOADED_READY_FALLBACK_MS = 1_500;
+/**
+ * How long the frame may take before the loading state says so out loud. Under
+ * this, a fast load just flashes — worse than showing nothing.
+ */
+const LOADING_NOTICE_DELAY_MS = 250;
+/** When to admit the load is slow rather than merely in progress. */
+const LOADING_SLOW_AFTER_MS = 4_000;
 
 type ReplayActivity = { kind: "tool"; name: string } | null;
 
@@ -1211,6 +1217,33 @@ function PlayerSurface({
   // a mid-timeline version switch that remounts the frame).
   const [frameReady, setFrameReady] = useState(false);
   /**
+   * How the held clock is presented: nothing at first (a fast load must not
+   * flash a spinner), then "loading", then an explicit slow state. A silent
+   * frozen player is indistinguishable from a broken one — the whole reason
+   * the hold got reported as a hang.
+   */
+  const [loadingNotice, setLoadingNotice] = useState<
+    "none" | "loading" | "slow"
+  >("none");
+  useEffect(() => {
+    if (frameReady || filming) {
+      setLoadingNotice("none");
+      return;
+    }
+    const show = setTimeout(
+      () => setLoadingNotice("loading"),
+      LOADING_NOTICE_DELAY_MS,
+    );
+    const slow = setTimeout(
+      () => setLoadingNotice("slow"),
+      LOADING_SLOW_AFTER_MS,
+    );
+    return () => {
+      clearTimeout(show);
+      clearTimeout(slow);
+    };
+  }, [frameReady, filming]);
+  /**
    * Bumped per replay-frame announcement. The sandbox can navigate its inner
    * document more than once while settling, and each document announces for
    * itself — every announcement gets its own full catch-up delivery, so the
@@ -1696,6 +1729,28 @@ function PlayerSurface({
     setFrameReady(true);
     setFrameReadyNonce((nonce) => nonce + 1);
   }, [segments, events]);
+
+  /**
+   * Arm a stale-SDK ready fallback, replacing any pending one.
+   *
+   * Only signals that mean the guest document is really on screen may call
+   * this (see the fallback constants). Re-arming rather than first-wins keeps
+   * the fuse tied to the LATEST such signal: a settling sandbox can navigate
+   * its inner document more than once, and the fuse must measure from the
+   * document that ended up there.
+   */
+  const armReadyFallback = useCallback(
+    (delayMs: number) => {
+      if (frameReadyRef.current) return;
+      if (legacyReadyTimerRef.current) {
+        clearTimeout(legacyReadyTimerRef.current);
+      }
+      legacyReadyTimerRef.current = setTimeout(() => {
+        if (!frameReadyRef.current) armReplayFrame();
+      }, delayMs);
+    },
+    [armReplayFrame],
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: frameReadyNonce re-delivers to each announcing document
   useEffect(() => {
@@ -2658,15 +2713,20 @@ function PlayerSurface({
           {/* The frame's loading state, made visible: while the clock is held
               for the app frame (cold sandbox origin, remount after a seek or
               version switch), the stage would otherwise sit silently blank and
-              read as a hung player. Never while filming — the renderer waits
-              out readiness between frames, and this pill must not be filmed
-              into an export. z-10 with the stage content: above the frame,
-              below the play/pause hover affordance. */}
-          {!frameReady && !filming && (
+              read as a hung player — which is exactly how the hold was
+              reported. Never while filming: the renderer waits out readiness
+              between frames, and this must not be filmed into an export.
+              z-10 with the stage content: above the frame, below the
+              play/pause hover affordance. */}
+          {loadingNotice !== "none" && (
             <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
-              <div className="flex items-center gap-2 rounded-md bg-foreground/60 px-3 py-2 text-xs font-medium text-background shadow-sm backdrop-blur-sm">
+              <div className="flex max-w-[80%] items-center gap-2 rounded-md bg-foreground/60 px-3 py-2 text-center text-xs font-medium text-background shadow-sm backdrop-blur-sm">
                 <Loader size={14} />
-                <span>Loading replay…</span>
+                <span>
+                  {loadingNotice === "slow"
+                    ? "Still loading the recorded app…"
+                    : "Loading the recorded app…"}
+                </span>
               </div>
             </div>
           )}
@@ -2741,28 +2801,23 @@ function PlayerSurface({
                 // on screen — only the announcement is missing. Re-armed per
                 // announcing document (a settling sandbox can navigate more
                 // than once); the announcement itself clears it.
-                onInitialized={() => {
-                  if (legacyReadyTimerRef.current) {
-                    clearTimeout(legacyReadyTimerRef.current);
-                  }
-                  legacyReadyTimerRef.current = setTimeout(() => {
-                    if (!frameReadyRef.current) armReplayFrame();
-                  }, INITIALIZED_READY_FALLBACK_MS);
-                }}
-                // Stale-SDK fallback, tier 2 (last resort): connect is a
-                // proxy-level signal that resolves while the inner document
-                // may not even be written yet, so its fuse is LONG — arming
-                // the clock 1.5s after connect is what used to play the
-                // replay's head against a blank white stage on every cold
-                // sandbox origin (see the fallback constants). This tier only
-                // exists so a frame whose SDK never runs at all cannot freeze
-                // the replay forever.
-                onConnected={() => {
-                  if (legacyReadyTimerRef.current) return;
-                  legacyReadyTimerRef.current = setTimeout(() => {
-                    if (!frameReadyRef.current) armReplayFrame();
-                  }, CONNECT_READY_FALLBACK_MS);
-                }}
+                onInitialized={() =>
+                  armReadyFallback(INITIALIZED_READY_FALLBACK_MS)
+                }
+                // Stale-SDK fallback, tier 2: the proxy says the guest
+                // document finished loading. Also about pixels — it fires on
+                // the inner frame's own load event — so arming after it is
+                // honest even when the SDK is too old to announce or never
+                // runs at all (a document whose script 404s still renders its
+                // markup, and that markup IS the replay's first frame).
+                //
+                // There is deliberately NO fallback on the bridge connect: it
+                // resolves before the guest document exists, and gating the
+                // clock on it is what played the replay's head against a
+                // blank stage.
+                onContentLoaded={() =>
+                  armReadyFallback(CONTENT_LOADED_READY_FALLBACK_MS)
+                }
               />
             ) : null}
           </ReplayAppStage>

--- a/platform/frontend/src/components/chat/right-side-panel.tsx
+++ b/platform/frontend/src/components/chat/right-side-panel.tsx
@@ -10,6 +10,7 @@ import { AppWindow, ExternalLink, GitPullRequest, Lock } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef } from "react";
 import {
   AppSessionPlayer,
+  replaySandboxPrefix,
   useReviewPanelWidth,
 } from "@/components/app-session-recording/app-session-player";
 import { useAppSessionRecorder } from "@/components/app-session-recording/use-app-session-recorder";
@@ -21,6 +22,8 @@ import { ResizableRightPanel } from "@/components/chat/resizable-right-panel";
 import { QueryLoadError } from "@/components/query-load-error";
 import { ScheduleRunsList } from "@/components/scheduled-tasks/schedule-runs-list";
 import type { ChatReviewContext } from "@/lib/chat/chat-review-context";
+import { getMcpSandboxBaseUrl } from "@/lib/config/config";
+import { useMcpSandboxDomain } from "@/lib/config/config.query";
 import { useScheduleTrigger } from "@/lib/schedule-trigger.query";
 
 export type RightPanelTab = "runs" | "files" | "browser" | "apps" | "review";
@@ -250,6 +253,29 @@ export function ReviewPanel({
     error,
     refetch,
   } = useReviewRecordingBundle(src);
+
+  // Warm the replay frame's sandbox origin WHILE the bundle downloads: the
+  // player will mount an iframe on `replaySandboxPrefix(sub).<domain>`, and on
+  // a cold tab that origin's DNS+TLS handshake is pure serial wait before the
+  // replay can start. A preconnect here overlaps it with the bundle fetch. No
+  // `crossorigin` attribute — the frame navigation and the guest's asset
+  // fetches ride the credentialed connection pool, which is the one this
+  // warms. Same-origin sandboxes (no dedicated domain) need nothing.
+  const mcpSandboxDomain = useMcpSandboxDomain();
+  useEffect(() => {
+    const { baseUrl, hasCrossOrigin } = getMcpSandboxBaseUrl(
+      mcpSandboxDomain,
+      replaySandboxPrefix(sub || src),
+    );
+    if (!hasCrossOrigin) return;
+    const link = document.createElement("link");
+    link.rel = "preconnect";
+    link.href = baseUrl;
+    document.head.appendChild(link);
+    return () => {
+      link.remove();
+    };
+  }, [mcpSandboxDomain, sub, src]);
 
   return (
     <div className="flex h-full flex-col">

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -934,6 +934,7 @@ export function SandboxIframe({
   onRecordingEvents,
   onConnected,
   onInitialized,
+  onContentLoaded,
   ownedApp,
 }: {
   html: string;
@@ -974,6 +975,11 @@ export function SandboxIframe({
   /** Fired when the app inside the inner document reports `initialized` —
    * the injected SDK has actually run in the document that is on screen. */
   onInitialized?: () => void;
+  /** Fired when the sandbox proxy reports the GUEST document finished loading
+   * — the app's markup and its subresources are on screen. The only signal
+   * here that says anything about pixels: proxy-ready and bridge connect both
+   * resolve while the inner frame is still empty. */
+  onContentLoaded?: () => void;
   /** Archestra-owned app: its envelope carries the platform CSP, so the proxy
    * must not inject a second one. A trusted host signal, not derived from HTML. */
   ownedApp?: boolean;
@@ -998,6 +1004,7 @@ export function SandboxIframe({
   const onRecordingEventsRef = useRef(onRecordingEvents);
   const onConnectedRef = useRef(onConnected);
   const onInitializedRef = useRef(onInitialized);
+  const onContentLoadedRef = useRef(onContentLoaded);
   // Read at iframe-creation time only; a ref keeps it out of the effect deps so
   // the iframe never remounts when the height changes.
   const initialHeightRef = useRef(initialHeight);
@@ -1024,6 +1031,7 @@ export function SandboxIframe({
     onRecordingEventsRef.current = onRecordingEvents;
     onConnectedRef.current = onConnected;
     onInitializedRef.current = onInitialized;
+    onContentLoadedRef.current = onContentLoaded;
     initialHeightRef.current = initialHeight;
     maxHeightRef.current = maxHeight;
   });
@@ -1150,6 +1158,8 @@ export function SandboxIframe({
         // live frames of the same app (one per rendered app message, plus the
         // right panel), and the recorder must keep exactly one of them.
         onRecordingEventsRef.current?.(event.data, iframe);
+      } else if (type === "mcp-apps:sandbox-content-loaded") {
+        onContentLoadedRef.current?.();
       }
     };
 


### PR DESCRIPTION
Follow-up to #6850. That fix made the player hold the clock until the app frame really renders — correct, but on a cold review tab the hold ran **up to ~15s with zero indication**, reading as a hung player. This PR attacks the wait itself and makes whatever remains visible. It also fixes the review layout's dead band.

## Why the frame was slow

The recorded segment HTML carries **absolute `/_sandbox/…` URLs of the deployment it was captured on** (SDK script, ext-apps module in the bootstrap `sdkUrl`, CSP meta sources, base stylesheet). The sandboxed frame therefore paid, in series, after the proxy handshake: cold cross-origin DNS+TLS to that frontend origin + a parser-blocking 118KB `archestra-app-sdk.js` (served `max-age=60`, so cold on nearly every open) + 322KB `ext-apps-app.js` + base CSS — all while the host tab is busy hydrating the chat app. Measured cold: each leg ~0.4–0.7s from a fast link, several seconds each from a real browser under load.

## Load-time fixes (one per serial leg)

- **`relocalizeSandboxAssets()`** (player): rewrites every recorded `/_sandbox/` URL — script `src`, stylesheet `href`, CSP meta sources, bootstrap `sdkUrl` — to the **replaying sandbox origin**. All guest fetches become same-origin with the proxy document and ride its already-warm connection. Side benefit: gallery bundles replay self-contained on **any** deployment instead of phoning the deployment they were recorded on. (Backend serves identical files on both origins — verified on staging.)
- **Proxy preloads** (`mcp-sandbox-proxy.html`): the proxy `<link rel=preload>`s the SDK, ext-apps module (`crossorigin` to match its module import) and base CSS the moment it parses — overlapping those fetches with the proxy-ready → connect → resource-ready handshake. All three are cacheable, so the inner document reads them from the HTTP cache. Benefits every live MCP app render too, not just replays.
- **Review-panel preconnect**: while the recording bundle is still downloading ("Loading submission…"), the panel preconnects to the replay frame's exact sandbox origin (shared `replaySandboxPrefix()` keeps the subdomain hash in lockstep with the player), taking the cold TLS handshake off the critical path entirely.

## UX

- While the frame isn't ready, the stage shows a **"Loading replay…" pill** (spinner + label, platform `Loader`). Never while filming — the offline renderer waits out readiness between frames and must not export the pill.

## Layout

- The docked review host wrapped the surface in `items-center`, floating the screen-height-derived player into the middle of the panel and opening a dead band between the heading and the chat+app cards (reported as "strange empty margin"). Now **top-aligned**: cards sit right under the heading, slack falls below the transport where trailing space is normal.

## Verification

- `biome check` clean; `tsc --noEmit` clean.
- `vitest`: app-session-recording + mcp-app + right-side-panel suites — **128 tests passing**, including 3 new `relocalizeSandboxAssets` cases (multi-shape rewrite incl. CSP meta + bootstrap JSON, non-`/_sandbox/` URLs untouched, empty-base no-op).
- Staging asset topology verified by hand: sandbox wildcard origin serves identical `/_sandbox` files; proxy page CSP is `frame-ancestors`-only so the preloads are unrestricted; frontend-origin proxy 403s (why the pre-#6850 first mount was doomed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>