### PR TITLE
fix(deps): patch brace-expansion CVE-2026-14257 in the MCP base image

### DIFF
--- a/platform/mcp_server_docker_image/Dockerfile
+++ b/platform/mcp_server_docker_image/Dockerfile
@@ -43,12 +43,25 @@ RUN uv pip sync \
 FROM ${NODE_IMAGE} AS node-builder
 
 # Upgrade npm to a version whose bundled dependencies already include the fixes for
-# tar CVE-2026-59873/CVE-2026-59874 (bundle ships tar 7.5.19), brace-expansion
-# CVE-2026-13149 (bundle ships 5.0.7 via minimatch 10.2.5), picomatch
+# tar CVE-2026-59873/CVE-2026-59874 (bundle ships tar 7.5.19), picomatch
 # CVE-2026-33671, sigstore CVE-2026-48815, and undici CVE-2026-12151 (bundle
 # ships 6.27.0, which previously required a manual bundle swap on 11.17.0).
 # npm 11.18.0 was published 2026-06-29 and has cleared the 7-day release-age practice.
-RUN npm install -g npm@11.18.0
+# Overwrite bundled brace-expansion to patch CVE-2026-14257 (uncontrolled resource
+# consumption): the bundle ships 5.0.7 via minimatch 10.2.5, and no npm release carries
+# the fixed 5.0.8 — 11.18.0 is the last 11.x, while 12.0.0/12.0.1 still bundle 5.0.7 and
+# require Node >=22 (this stage is node:20-alpine). Same-major swap, API compatible:
+# minimatch 10.2.5 asks for ^5.0.5, and 5.0.8 keeps 5.0.7's `balanced-match: ^4.0.2`,
+# already satisfied by the bundled balanced-match 4.0.4. `npm pack` must run BEFORE the
+# old copy is removed: npm reaches brace-expansion through minimatch/glob, so deleting it
+# first leaves npm unable to run the very command that fetches the replacement.
+RUN npm install -g npm@11.18.0 && \
+    cd /usr/local/lib/node_modules/npm/node_modules && \
+    npm pack brace-expansion@5.0.8 && \
+    rm -rf brace-expansion && \
+    tar -xzf brace-expansion-5.0.8.tgz && \
+    mv package brace-expansion && \
+    rm brace-expansion-5.0.8.tgz
 
 WORKDIR /opt/node-deps
 


### PR DESCRIPTION
## Summary

The merge queue has been ejecting **every** PR for ~24 hours (18 distinct PRs, 32 failed runs since 2026-07-24T07:20Z). The ejector is `Docker Image Scanning (MCP Server Base)` — a required status check — failing on a single package:

```
✗ HIGH CVE-2026-14257 [Uncontrolled Resource Consumption]  brace-expansion 5.0.7 → 5.0.8
1 vulnerability found in 1 package
##[error]Detected 1 vulnerable packages
```

**The vulnerable copy is not a declared dependency.** `brace-expansion` does not appear in `mcp_server_docker_image/package-lock.json` at all — it ships bundled inside the globally installed npm (via `minimatch` 10.2.5), and the runtime stage copies that bundle wholesale (`COPY --from=node-builder /usr/local/lib/node_modules/npm ...`). No pnpm override or lockfile change can reach it.

**No npm release carries the fix.** 11.18.0 is the last 11.x; 12.0.0 and 12.0.1 both still bundle 5.0.7 (verified by tarball inspection) and require `node ^22.22.2 || ^24.15.0 || >=26.0.0`, while this stage is `node:20-alpine`. So the bundled copy is overwritten in place — the same workaround this file already used for `undici` on npm 11.17.0, removed in #6726 when 11.18.0 made it unnecessary.

## Changes

`platform/mcp_server_docker_image/Dockerfile` only — no lockfile churn.

Note the ordering: `npm pack` runs **before** the old copy is removed. npm reaches `brace-expansion` through minimatch/glob, so deleting it first leaves npm unable to run the very command that fetches the replacement (this fails with `tar: can't open 'brace-expansion-5.0.8.tgz'`).

## Test plan

Verified in `node:20-alpine` at the pinned digest:

- [x] bundle goes `5.0.7` → `5.0.8`
- [x] npm stays functional after the swap: `npm --version`, `npm ls -g`, `npm view`, and a real `npm install minimatch@10.2.5`
- [x] swap safety: exactly one real copy in the bundle (the other two `package.json` hits are `dist/*/{"type":...}` markers); `minimatch@10.2.5` requires `^5.0.5`; 5.0.8 keeps 5.0.7's `balanced-match: ^4.0.2`, already satisfied by the bundled 4.0.4
- [ ] CI `Docker Image Scanning (MCP Server Base)` passes on this PR

## Notes for reviewers

- Like the previous `undici` swap, this bypasses the 7-day `minimumReleaseAge` practice for the swapped package (5.0.8 was published 2026-07-23). That is the deliberate tradeoff for clearing a HIGH that blocks all merges.
- **Out of scope:** `Docker Image Scanning (Platform)` is also red (`postcss` 8.5.10, `find-my-way` 9.5.0, `better-auth` 1.6.13), but it is **not** a required check and is not what ejects PRs from the queue. That leg needs `pnpm-workspace.yaml` bumps plus `minimumReleaseAgeExclude` entries for `find-my-way` — worth its own PR. Dependabot #6842 already covers `better-auth`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>