### PR TITLE
fix(projects): don't list instructions.md twice in a project chat's Files panel

### DIFF
--- a/platform/backend/src/models/file.ts
+++ b/platform/backend/src/models/file.ts
@@ -13,6 +13,7 @@ type PersistedFileMeta = {
   mimeType: string;
   sizeBytes: number;
   createdAt: Date;
+  projectId: string | null;
 };
 
 const artifactColumns = {
@@ -270,6 +271,7 @@ class FileModel {
         mimeType: schema.filesTable.mimeType,
         sizeBytes: schema.filesTable.sizeBytes,
         createdAt: schema.filesTable.createdAt,
+        projectId: schema.filesTable.projectId,
       })
       .from(schema.filesTable)
       .where(

--- a/platform/backend/src/services/conversation-files.test.ts
+++ b/platform/backend/src/services/conversation-files.test.ts
@@ -302,6 +302,114 @@ test("project chat: projectFiles is every project file (any author, any chat), f
   expect(result.projectName).toBe("filespanel");
 });
 
+test("project chat: the project's instructions file never lists as an ordinary row, even with this chat's conversation id", async ({
+  makeUser,
+  makeOrganization,
+  makeAgent,
+}) => {
+  const org = await makeOrganization();
+  const owner = await makeUser({});
+  const agent = await makeAgent({ organizationId: org.id });
+
+  const project = await projectService.create({
+    organizationId: org.id,
+    userId: owner.id,
+    name: "instructionsdup",
+    description: null,
+  });
+  const conv = await ConversationModel.create({
+    userId: owner.id,
+    organizationId: org.id,
+    agentId: agent.id,
+    projectId: project.id,
+  });
+  const sandbox = await SkillSandboxModel.create({
+    organizationId: org.id,
+    userId: owner.id,
+    conversationId: conv.id,
+    defaultCwd: "/home/sandbox",
+    isDefault: true,
+  });
+  // The agent saved instructions.md in this chat (save_file / download_file
+  // stamp both project_id and conversation_id) — the same row shape a chat
+  // file gets when its chat seeds a project. The panel surfaces it only as the
+  // pinned Instructions entry, so it must not also list under `generated`.
+  await fileStore.put({
+    organizationId: org.id,
+    userId: owner.id,
+    projectId: project.id,
+    conversationId: conv.id,
+    sandboxId: sandbox.id,
+    filename: "instructions.md",
+    mimeType: "text/markdown",
+    sizeBytes: 5,
+    data: Buffer.from("rules"),
+  });
+  const ordinary = await fileStore.put({
+    organizationId: org.id,
+    userId: owner.id,
+    projectId: project.id,
+    conversationId: conv.id,
+    sandboxId: sandbox.id,
+    filename: "report.md",
+    mimeType: "text/markdown",
+    sizeBytes: 2,
+    data: Buffer.from("ok"),
+  });
+
+  const result = await conversationFilesService.list({
+    conversationId: conv.id,
+    organizationId: org.id,
+    requestingUserId: owner.id,
+  });
+  expect(result.generated.map((f) => f.name)).toEqual(["report.md"]);
+  expect(result.generated.map((f) => f.id)).toEqual([ordinary.id]);
+  // not duplicated into projectFiles either — it's this chat's own output
+  expect(result.projectFiles).toEqual([]);
+});
+
+test("personal chat: a file named instructions.md is an ordinary generated file", async ({
+  makeUser,
+  makeOrganization,
+  makeAgent,
+  makeConversation,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser({});
+  const agent = await makeAgent({ organizationId: org.id });
+  const conv = await makeConversation(agent.id, {
+    userId: user.id,
+    organizationId: org.id,
+  });
+  const sandbox = await SkillSandboxModel.create({
+    organizationId: org.id,
+    userId: user.id,
+    conversationId: conv.id,
+    defaultCwd: "/home/sandbox",
+    isDefault: true,
+  });
+  // Outside a project there is no pinned entry, so the name is not special and
+  // the file must stay visible.
+  const file = await fileStore.put({
+    organizationId: org.id,
+    userId: user.id,
+    projectId: null,
+    conversationId: conv.id,
+    sandboxId: sandbox.id,
+    filename: "instructions.md",
+    mimeType: "text/markdown",
+    sizeBytes: 5,
+    data: Buffer.from("notes"),
+  });
+
+  const result = await conversationFilesService.list({
+    conversationId: conv.id,
+    organizationId: org.id,
+    requestingUserId: user.id,
+  });
+  expect(result.generated.map((f) => f.id)).toEqual([file.id]);
+});
+
 test("project chat: a requester without project access sees no project files", async ({
   makeUser,
   makeOrganization,

--- a/platform/backend/src/services/conversation-files.ts
+++ b/platform/backend/src/services/conversation-files.ts
@@ -1,3 +1,4 @@
+import { PROJECT_INSTRUCTIONS_FILENAME } from "@archestra/shared";
 import ConversationModel from "@/models/conversation";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import FileModel from "@/models/file";
@@ -42,14 +43,27 @@ class ConversationFilesService {
           organizationId: params.organizationId,
         }),
       ]);
-    const { files: projectFiles, projectName } = projectScope;
+    const { files: projectFiles, projectId, projectName } = projectScope;
 
     // A file created in this chat is already in `generated`; keep it out of
     // `projectFiles` so a project chat doesn't list it twice.
     const generatedIds = new Set(artifacts.map((a) => a.id));
 
+    // The project's instructions file is surfaced by the Files panel as its own
+    // pinned entry, never as an ordinary row. The row can carry this chat's
+    // conversation id — the agent saved it here via the sandbox file tools, or
+    // it moved in with the chat that seeded the project — which would otherwise
+    // list it in `generated` next to the pinned entry (the panel only filters
+    // `projectFiles` by name).
+    const ordinaryArtifacts = artifacts.filter(
+      (a) =>
+        projectId === null ||
+        a.projectId !== projectId ||
+        a.filename !== PROJECT_INSTRUCTIONS_FILENAME,
+    );
+
     return {
-      generated: artifacts.map((a) => ({
+      generated: ordinaryArtifacts.map((a) => ({
         id: a.id,
         name: a.filename,
         mimeType: a.mimeType,
@@ -124,7 +138,11 @@ class ConversationFilesService {
     conversationId: string;
     organizationId: string;
     requestingUserId: string;
-  }): Promise<{ files: ProjectFile[]; projectName: string | null }> {
+  }): Promise<{
+    files: ProjectFile[];
+    projectId: string | null;
+    projectName: string | null;
+  }> {
     let scope: ProjectFileScope | null = null;
     try {
       scope = await resolveProjectFileScope({
@@ -139,14 +157,18 @@ class ConversationFilesService {
     }
 
     if (!scope) {
-      return { files: [], projectName: null };
+      return { files: [], projectId: null, projectName: null };
     }
 
     const files = await FileModel.listByProject({
       organizationId: params.organizationId,
       projectId: scope.projectId,
     });
-    return { files, projectName: scope.projectName };
+    return {
+      files,
+      projectId: scope.projectId,
+      projectName: scope.projectName,
+    };
   }
 }
 


### PR DESCRIPTION
## Problem

The chat Files panel surfaces a project's `instructions.md` as a pinned entry and filters it by name out of the **project files** section — but not out of the **generated** ("this chat's outputs") section, which is built purely by `conversation_id` with no name filtering. Whenever the project's real `instructions.md` row carries a conversation id, that chat shows the pinned Instructions entry **plus** an ordinary `instructions.md` row.

Two scenarios produce such a row:

1. **The agent saves it in a project chat.** The sandbox `save_file`/`download_file` tools may write `instructions.md` (by design — it's an ordinary writable project file; only deletion is blocked), and they stamp the row with both `project_id` and the chat's `conversation_id`. That chat then shows the file twice, permanently — the row can't even be deleted to clean it up. The owner's Instructions editor writes the row with no conversation id, which is why the normal path never reproduces the bug.
2. **Turning a chat into a project.** In a personal chat `instructions.md` is a legal generated filename. `createProjectFromConversation` re-points the chat's files to the new project while keeping their conversation id, so that file becomes the project's instructions and stays in the seeding chat's generated list — same duplicate.

## Fix

In `conversation-files.ts` (the backend service assembling the panel payload), exclude the owning project's `instructions.md` from the `generated` section, so it is surfaced solely through the pinned entry — which reads the same row, so no content is lost. The filter matches on project id + exact name:

- a personal chat's `instructions.md` (no pinned entry exists there) stays a visible ordinary file;
- a stray no-project file in a project chat is unaffected.

`FileModel.listMetadataByConversationId` now also returns `projectId` to support the precise match.

## Tests

Added two service tests in `conversation-files.test.ts`:

- project chat: an `instructions.md` row carrying this chat's conversation id is not listed in `generated` (nor duplicated into `projectFiles`), while sibling files remain;
- personal chat: a file named `instructions.md` remains an ordinary generated file.

All 7 conversation-files service tests pass; backend type-check and Biome are clean.

https://claude.ai/code/session_013JBpFXr1hG9ev7UDhz7NtV

---
_Generated by [Claude Code](https://claude.ai/code/session_013JBpFXr1hG9ev7UDhz7NtV)_

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>