### PR TITLE
fix(frontend): never surface raw HTML error pages in error toasts

### DIFF
--- a/platform/frontend/src/components/chat/chat-error.utils.test.ts
+++ b/platform/frontend/src/components/chat/chat-error.utils.test.ts
@@ -248,6 +248,22 @@ describe("chat-error.utils", () => {
       });
     });
 
+    it("maps an HTML error page to a retryable ServerError with friendly copy", () => {
+      // The AI SDK throws the response text verbatim, so a proxy/ingress 502
+      // in front of the backend produces an Error whose message is raw HTML.
+      const result = mapClientError(
+        new Error(
+          "<html> <head><title>502 Bad Gateway</title></head> <body> <center><h1>502 Bad Gateway</h1></center> </body> </html> <!-- a padding to disable MSIE and Chrome friendly error page -->",
+        ),
+      );
+      expect(result).toEqual({
+        code: ChatErrorCode.ServerError,
+        message:
+          "The service is temporarily unavailable. Please try again shortly.",
+        isRetryable: true,
+      });
+    });
+
     it("maps api_internal_server_error to retryable ServerError", () => {
       expect(
         mapClientError(

--- a/platform/frontend/src/components/chat/chat-error.utils.ts
+++ b/platform/frontend/src/components/chat/chat-error.utils.ts
@@ -5,6 +5,10 @@ import {
   isChatErrorResponse,
   RetryableErrorCodes,
 } from "@archestra/shared";
+import {
+  getUserFacingApiErrorMessage,
+  isHtmlDocumentMessage,
+} from "@archestra/shared/api-error";
 
 /**
  * AI SDK internal error type names that aren't useful to show users
@@ -148,6 +152,16 @@ export function mapClientError(error: Error): ChatErrorResponse {
         isRetryable: RetryableErrorCodes.has(pattern.code),
       };
     }
+  }
+
+  // An HTML error page (a proxy/ingress 502 reaching the client instead of a
+  // JSON envelope) must not be rendered verbatim — surface friendly copy.
+  if (isHtmlDocumentMessage(msg)) {
+    return {
+      code: ChatErrorCode.ServerError,
+      message: getUserFacingApiErrorMessage(msg),
+      isRetryable: RetryableErrorCodes.has(ChatErrorCode.ServerError),
+    };
   }
 
   // Try to extract message + type from backend's { error: { message, type } } format

--- a/platform/shared/api-error.test.ts
+++ b/platform/shared/api-error.test.ts
@@ -68,4 +68,40 @@ describe("getUserFacingApiErrorMessage", () => {
     );
     expect(getUserFacingApiErrorMessage(new Error("boom"))).toBe("boom");
   });
+
+  test("never surfaces an HTML error page; maps its status line instead", () => {
+    // What a proxy/ingress in front of the API returns on a bad gateway —
+    // reaches the client verbatim because it isn't the JSON envelope.
+    const nginx502 =
+      "<html> <head><title>502 Bad Gateway</title></head> <body> <center><h1>502 Bad Gateway</h1></center> </body> </html> <!-- a padding to disable MSIE and Chrome friendly error page -->";
+    const unavailable =
+      "The service is temporarily unavailable. Please try again shortly.";
+
+    expect(getUserFacingApiErrorMessage(nginx502)).toBe(unavailable);
+    expect(getUserFacingApiErrorMessage(new Error(nginx502))).toBe(unavailable);
+    expect(
+      getUserFacingApiErrorMessage(
+        "<html><head><title>504 Gateway Time-out</title></head><body></body></html>",
+      ),
+    ).toBe(unavailable);
+    expect(
+      getUserFacingApiErrorMessage(
+        "<!DOCTYPE html><html><head><title>Maintenance</title></head><body>Down for maintenance</body></html>",
+        "fallback",
+      ),
+    ).toBe("fallback");
+    expect(getUserFacingApiErrorMessage("<html><body></body></html>")).toBe(
+      "Something went wrong. Please try again.",
+    );
+  });
+
+  test("humanizes plain-text gateway status lines, with or without the code", () => {
+    const unavailable =
+      "The service is temporarily unavailable. Please try again shortly.";
+    expect(getUserFacingApiErrorMessage("502 Bad Gateway")).toBe(unavailable);
+    expect(getUserFacingApiErrorMessage("Bad Gateway")).toBe(unavailable);
+    expect(getUserFacingApiErrorMessage("503 Service Unavailable")).toBe(
+      unavailable,
+    );
+  });
 });

--- a/platform/shared/api-error.ts
+++ b/platform/shared/api-error.ts
@@ -25,14 +25,21 @@ export function getUserFacingApiErrorMessage(
 ): string {
   const { message, type } = extractApiErrorParts(error);
 
-  if (message && !isRawStatusMessage(message)) {
+  if (
+    message &&
+    !isHtmlDocumentMessage(message) &&
+    !isRawStatusMessage(message)
+  ) {
     return message;
   }
 
   // A bare status token implies the error category even when `type` is absent
-  // (e.g. an Error("Forbidden") thrown far from the API layer).
-  const impliedType = message
-    ? RAW_STATUS_MESSAGE_TO_TYPE[message.trim().toLowerCase()]
+  // (e.g. an Error("Forbidden") thrown far from the API layer). An HTML error
+  // page — a proxy/ingress 502 reaching the client instead of the API's JSON
+  // envelope — implies it via the status line in its <title>/<h1>.
+  const statusToken = message ? extractStatusToken(message) : undefined;
+  const impliedType = statusToken
+    ? RAW_STATUS_MESSAGE_TO_TYPE[statusToken]
     : undefined;
 
   const friendly =
@@ -40,6 +47,16 @@ export function getUserFacingApiErrorMessage(
       (type as ApiErrorType | undefined) ?? impliedType ?? "unknown_api_error"
     ];
   return friendly ?? fallback;
+}
+
+/**
+ * Whether a message is an HTML/XML document rather than human-readable text —
+ * what the client receives when a proxy or ingress in front of the API answers
+ * with its own error page (e.g. nginx's 502) instead of the JSON envelope.
+ * Such a body must never be shown to the user verbatim.
+ */
+export function isHtmlDocumentMessage(message: string): boolean {
+  return /^\s*(<!doctype\b|<\?xml\b|<html\b|<head\b|<body\b)/i.test(message);
 }
 
 // === Internal helpers
@@ -75,12 +92,35 @@ const RAW_STATUS_MESSAGE_TO_TYPE: Record<string, ApiErrorType> = {
   conflict: "api_conflict_error",
   "payload too large": "api_payload_too_large_error",
   "service unavailable": "api_service_unavailable_error",
+  "bad gateway": "api_service_unavailable_error",
+  "gateway timeout": "api_service_unavailable_error",
+  "gateway time-out": "api_service_unavailable_error",
   "internal server error": "api_internal_server_error",
   "internal error": "api_internal_server_error",
 };
 
 function isRawStatusMessage(message: string): boolean {
-  return message.trim().toLowerCase() in RAW_STATUS_MESSAGE_TO_TYPE;
+  return normalizeStatusToken(message) in RAW_STATUS_MESSAGE_TO_TYPE;
+}
+
+/**
+ * The status token of a message, if it carries one: the status line of an HTML
+ * error page's <title>/<h1>, or the message itself for plain text. A leading
+ * HTTP status code ("502 Bad Gateway" -> "bad gateway") is dropped either way.
+ */
+function extractStatusToken(message: string): string | undefined {
+  if (!isHtmlDocumentMessage(message)) {
+    return normalizeStatusToken(message);
+  }
+  const match = /<(title|h1)[^>]*>([^<]+)<\/\1>/i.exec(message);
+  return match ? normalizeStatusToken(match[2]) : undefined;
+}
+
+function normalizeStatusToken(message: string): string {
+  return message
+    .trim()
+    .replace(/^\d{3}\s+/, "")
+    .toLowerCase();
 }
 
 /**


### PR DESCRIPTION
## Problem

When a proxy or ingress in front of the backend answers with its own error page — e.g. an nginx-style HTML `502 Bad Gateway` page — instead of the API's `{ error: { message, type } }` JSON envelope, the frontend showed the raw HTML markup verbatim to the user:

- The generated API client throws the response text when the body isn't JSON, and `getUserFacingApiErrorMessage` passed any non-empty string straight through — so error toasts rendered `<html> <head><title>502 Bad Gateway</title></head> ... <!-- a padding to disable MSIE and Chrome friendly error page --> ...`.
- The AI SDK's chat transport does the same (`throw new Error(await response.text())`), so the inline chat error card had the identical problem.

## Fix

**`shared/api-error.ts`** (the helper behind `handleApiError`/`throwOnApiError`/`callApi`, i.e. effectively every error toast):

- Detect HTML/XML document bodies (`<!doctype`, `<?xml`, `<html`, `<head`, `<body`) and never return them as the message.
- Map the status line from the page's `<title>`/`<h1>` to the existing friendly copy — gateway errors (502/503/504) become "The service is temporarily unavailable. Please try again shortly." — otherwise fall back to the generic copy.
- Plain-text status bodies with a leading code ("502 Bad Gateway") are humanized the same way.

**`chat-error.utils.ts` `mapClientError`** (AI SDK streaming path, bypasses the API client): the same guard maps an HTML body to a retryable `ServerError` with the friendly copy, so the inline chat error card offers a retry instead of dumping markup.

## Tests

- `shared/api-error.test.ts`: HTML 502/504 pages (realistic nginx body), unrecognized HTML titles falling back to generic copy, plain-text gateway status lines.
- `chat-error.utils.test.ts`: HTML body maps to retryable `ServerError` with friendly copy.

All existing tests in both files still pass; `lint` + `type-check` clean on `shared` and `frontend`.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>