### PR TITLE
fix(sandbox): tear down an environment's Dagger engine when it is deleted

### DIFF
--- a/platform/backend/src/k8s/dagger-environment-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/manager.test.ts
@@ -775,4 +775,62 @@ describe("reconcileOrganizationDefault", () => {
       (config.daggerRuntime as { runnerHost?: string }).runnerHost = original;
     }
   });
+
+  it("teardownEnvironmentEngine deletes the environment's engine in its namespace", async () => {
+    await daggerEnvironmentRuntimeManager.teardownEnvironmentEngine(
+      makeEnv({
+        id: "abcdef00-1111-2222-3333-444455556666",
+        namespace: "env-ns",
+      }),
+    );
+
+    expect(mockCreateK8sClients).toHaveBeenCalledWith(
+      expect.anything(),
+      "env-ns",
+    );
+    expect(clients.appsApi.deleteNamespacedStatefulSet).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: "env-ns" }),
+    );
+    const pvcCall =
+      clients.coreApi.deleteNamespacedPersistentVolumeClaim.mock.calls[0][0];
+    expect(pvcCall.namespace).toBe("env-ns");
+    expect(pvcCall.name).toMatch(/^varlib-.*-0$/);
+    expect(clients.coreApi.deleteNamespacedConfigMap).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: "env-ns" }),
+    );
+    expect(
+      clients.networkingApi.deleteNamespacedNetworkPolicy,
+    ).toHaveBeenCalledWith(expect.objectContaining({ namespace: "env-ns" }));
+  });
+
+  // Unlike the org-default engine, a per-environment engine is provisioned even
+  // behind a BYO runner host — so its teardown must run too, not short-circuit.
+  it("teardownEnvironmentEngine tears down even behind a BYO runner host", async () => {
+    const original = config.daggerRuntime.runnerHost;
+    (config.daggerRuntime as { runnerHost?: string }).runnerHost =
+      "tcp://byo:1234";
+    try {
+      await daggerEnvironmentRuntimeManager.teardownEnvironmentEngine(
+        makeEnv({ namespace: "env-ns" }),
+      );
+      expect(clients.appsApi.deleteNamespacedStatefulSet).toHaveBeenCalled();
+    } finally {
+      (config.daggerRuntime as { runnerHost?: string }).runnerHost = original;
+    }
+  });
+
+  it("teardownEnvironmentEngine no-ops when the runtime is disabled", async () => {
+    const originalEnabled = config.skillsSandbox.enabled;
+    (config.skillsSandbox as { enabled: boolean }).enabled = false;
+    try {
+      await daggerEnvironmentRuntimeManager.teardownEnvironmentEngine(
+        makeEnv({ namespace: "env-ns" }),
+      );
+      expect(
+        clients.appsApi.deleteNamespacedStatefulSet,
+      ).not.toHaveBeenCalled();
+    } finally {
+      (config.skillsSandbox as { enabled: boolean }).enabled = originalEnabled;
+    }
+  });
 });

--- a/platform/backend/src/k8s/dagger-environment-runtime/manager.test.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/manager.test.ts
@@ -833,4 +833,23 @@ describe("reconcileOrganizationDefault", () => {
       (config.skillsSandbox as { enabled: boolean }).enabled = originalEnabled;
     }
   });
+
+  // If the engine pod can't be removed, its egress policy must stay — pruning it
+  // would leave a running privileged pod egressing unrestricted.
+  it("keeps the egress policy when the StatefulSet delete fails", async () => {
+    clients.appsApi.deleteNamespacedStatefulSet.mockRejectedValueOnce(
+      new Error("apiserver unavailable"),
+    );
+
+    await daggerEnvironmentRuntimeManager.teardownEnvironmentEngine(
+      makeEnv({ namespace: "env-ns" }),
+    );
+
+    expect(
+      clients.networkingApi.deleteNamespacedNetworkPolicy,
+    ).not.toHaveBeenCalled();
+    expect(
+      clients.customObjectsApi.deleteNamespacedCustomObject,
+    ).not.toHaveBeenCalled();
+  });
 });

--- a/platform/backend/src/k8s/dagger-environment-runtime/manager.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/manager.ts
@@ -258,6 +258,21 @@ class DaggerEnvironmentRuntimeManager {
     await this.teardownEngine(deriveOrgEngineId(organization.id), from);
   }
 
+  /**
+   * Delete an environment's engine when the environment is removed. A deleted
+   * environment otherwise leaves its privileged StatefulSet and retained cache
+   * PVC running with nothing routing to them. Mirrors reconcileEnvironment's
+   * guard — a per-environment engine exists even behind a BYO runner host, so
+   * this does not early-return on one. Best-effort and idempotent.
+   */
+  async teardownEnvironmentEngine(environment: Environment): Promise<void> {
+    if (!this.isEnabled()) return;
+    await this.teardownEngine(
+      environment.id,
+      this.engineNamespace(environment.namespace),
+    );
+  }
+
   // Remove one engine's StatefulSet, its cache PVC (the volumeClaimTemplate is
   // Retain, so deleting the StatefulSet alone would strand it — safe to drop
   // here since the build cache is rebuildable and the engine has left this

--- a/platform/backend/src/k8s/dagger-environment-runtime/manager.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/manager.ts
@@ -286,8 +286,11 @@ class DaggerEnvironmentRuntimeManager {
     const clients = createK8sClients(kubeConfig, namespace);
     const name = daggerEngineDeploymentName(engineId);
 
-    await this.deleteIfPresent("StatefulSet", namespace, name, () =>
-      clients.appsApi.deleteNamespacedStatefulSet({ name, namespace }),
+    const workloadRemoved = await this.deleteIfPresent(
+      "StatefulSet",
+      namespace,
+      name,
+      () => clients.appsApi.deleteNamespacedStatefulSet({ name, namespace }),
     );
     await this.deleteIfPresent(
       "PersistentVolumeClaim",
@@ -309,30 +312,41 @@ class DaggerEnvironmentRuntimeManager {
           namespace,
         }),
     );
-    // Empty desired set → every managed policy kind is pruned.
-    await this.pruneStalePolicies(
-      clients,
-      namespace,
-      constructManagedNetworkPolicyName(name),
-      new Set(),
-    );
+    // Only drop the egress policies once the engine pod is gone. If the
+    // StatefulSet delete failed, the privileged pod is still running — pruning
+    // its NetworkPolicy would leave it egressing unrestricted. Leave the policy
+    // in place; the next teardown retries the workload.
+    if (workloadRemoved) {
+      // Empty desired set → every managed policy kind is pruned.
+      await this.pruneStalePolicies(
+        clients,
+        namespace,
+        constructManagedNetworkPolicyName(name),
+        new Set(),
+      );
+    }
   }
 
+  // Returns true when the object is gone (deleted now, or already absent),
+  // false when the delete failed and it may still exist.
   private async deleteIfPresent(
     kind: string,
     namespace: string,
     name: string,
     del: () => Promise<unknown>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await del();
+      return true;
     } catch (error) {
-      if (!isK8sNotFoundError(error)) {
-        logger.warn(
-          { err: error, namespace, name, kind },
-          "[DaggerEnvRuntime] failed to delete engine resource on teardown",
-        );
+      if (isK8sNotFoundError(error)) {
+        return true;
       }
+      logger.warn(
+        { err: error, namespace, name, kind },
+        "[DaggerEnvRuntime] failed to delete engine resource on teardown",
+      );
+      return false;
     }
   }
 

--- a/platform/backend/src/services/environments/environment.test.ts
+++ b/platform/backend/src/services/environments/environment.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect } from "vitest";
+import { describe, expect, vi } from "vitest";
+import { daggerEnvironmentRuntimeManager } from "@/k8s/dagger-environment-runtime/manager";
 import { InternalMcpCatalogModel, OrganizationModel } from "@/models";
 import {
   assertCanAssignEnvironment,
@@ -123,6 +124,35 @@ describe("EnvironmentService", () => {
     ).resolves.toBeUndefined();
     const listed = await listEnvironments(org.id);
     expect(listed.environments.some((e) => e.id === env.id)).toBe(false);
+  });
+
+  test("deleteEnvironment tears down the environment's engine on success, not on a rejected delete", async ({
+    makeOrganization,
+  }) => {
+    const teardown = vi
+      .spyOn(daggerEnvironmentRuntimeManager, "teardownEnvironmentEngine")
+      .mockResolvedValue();
+    try {
+      const org = await makeOrganization();
+      const env = await createEnvironment({
+        organizationId: org.id,
+        data: { name: "Sandbox" },
+      });
+
+      await deleteEnvironment({ id: env.id, organizationId: org.id });
+      expect(teardown).toHaveBeenCalledWith(
+        expect.objectContaining({ id: env.id }),
+      );
+
+      // A rejected delete must not tear down anything.
+      teardown.mockClear();
+      await expect(
+        deleteEnvironment({ id: MISSING_ID, organizationId: org.id }),
+      ).rejects.toThrow();
+      expect(teardown).not.toHaveBeenCalled();
+    } finally {
+      teardown.mockRestore();
+    }
   });
 
   test("createEnvironment persists restricted=true and lists it back", async ({

--- a/platform/backend/src/services/environments/environment.ts
+++ b/platform/backend/src/services/environments/environment.ts
@@ -29,6 +29,24 @@ function reconcileEnvironmentEngine(environment: Environment): void {
     );
 }
 
+/**
+ * Tear down the environment's Dagger engine after the environment is deleted,
+ * so it does not leave a privileged pod and retained cache PVC behind.
+ * Fire-and-forget for symmetry with reconcile: the row is already gone, a k8s
+ * hiccup must not fail the deletion, and the manager no-ops when
+ * code-runtime/k8s is off.
+ */
+function teardownEnvironmentEngine(environment: Environment): void {
+  void daggerEnvironmentRuntimeManager
+    .teardownEnvironmentEngine(environment)
+    .catch((err) =>
+      logger.error(
+        { err, environmentId: environment.id },
+        "[DaggerEnvRuntime] background teardown failed",
+      ),
+    );
+}
+
 // === Public API ===
 
 export async function listEnvironments(
@@ -253,6 +271,8 @@ export async function deleteEnvironment(params: {
   if (!deleted) {
     throw new ApiError(404, "Environment not found");
   }
+
+  teardownEnvironmentEngine(environment);
 }
 
 // === Internal helpers ===


### PR DESCRIPTION
## Summary

Deleting an environment removed only its database row. The environment's per-environment Dagger engine — a privileged StatefulSet plus its Retain-policy cache PVC, ConfigMap, and egress policies — kept running in the namespace with nothing routing to it, so engines and their retained volumes accumulated on every deletion.

`deleteEnvironment` now tears that engine down, keyed by the environment id in the environment's namespace, reusing the existing teardown primitive. It is fire-and-forget for symmetry with the create/update reconcile — the row is already gone, so a Kubernetes hiccup must not fail the deletion — and it runs even behind a bring-your-own runner host, because per-environment engines are provisioned in that mode too. The cache PVC is reclaimed despite its Retain policy: Retain guards against a reconcile bug destroying a warm cache, but a deliberate environment deletion is permanent and the buildkit cache is rebuildable.

Teardown also now drops the egress NetworkPolicy only once the StatefulSet is confirmed removed. Previously the policy was pruned unconditionally after the workload delete, so a StatefulSet delete that failed while policy pruning succeeded left a privileged pod running with unrestricted egress. That path now runs on every environment delete, not just the namespace-move case it was written for, so the ordering is gated: a pod still running keeps its policy, and the next teardown retries the workload.

Organization deletion has no code path, so there is no org-default engine to tear down there.

## Known limitation

Teardown is best-effort. A transient Kubernetes failure during deletion is logged, not retried, and nothing sweeps engines whose environment no longer exists — so a failed teardown orphans the engine until a manual cleanup or a future reconcile-time sweep. The ordering gate above still holds on that path: an orphaned engine keeps its egress policy rather than egressing unrestricted.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>