### PR TITLE
feat(sandbox): raise run_command input limit to 256 KB

### DIFF
--- a/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
+++ b/platform/backend/src/archestra-mcp-server/__snapshots__/skill-tool-text.test.ts.snap
@@ -323,7 +323,7 @@ exports[`skill and sandbox tool text > archestra__run_command 1`] = `
     "properties": {
       "command": {
         "description": "Shell command to execute (bash). Runs in the sandbox's working directory (or \`cwd\` when provided). Returns text output only — use download_file for generated files.",
-        "maxLength": 16384,
+        "maxLength": 262144,
         "minLength": 1,
         "type": "string",
       },

--- a/platform/backend/src/skills-sandbox/types.ts
+++ b/platform/backend/src/skills-sandbox/types.ts
@@ -7,7 +7,7 @@ import type { SandboxFileOrigin, SandboxId } from "@/types";
  */
 export const SKILL_SANDBOX_LIMITS = {
   maxSandboxQueueLength: 10,
-  maxCommandBytes: 16 * 1024,
+  maxCommandBytes: 256 * 1024,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary
- Bump `SKILL_SANDBOX_LIMITS.maxCommandBytes` from 16 KB to 256 KB.
- Models writing HTML/asset files via `run_command` heredocs routinely exceed 16 KB and fall back to unreliable workarounds (chunked rewrites, zipping content). Command text is stored per replay-log row and re-executed on materialization, so larger commands are operationally cheap — the replay-length ceiling is about step count (overlay layers), not bytes.
- Regenerates the `skill-tool-text` schema snapshot that pins the tool schema's `maxLength`.

## Tests
- `vitest run src/archestra-mcp-server/skill-tool-text.test.ts src/archestra-mcp-server/sandbox.test.ts src/skills-sandbox/skill-sandbox-runtime-service.test.ts` — 135 passed, 1 snapshot updated

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>