### PR TITLE
fix(sso): honour the org default role on first-time SSO login

### DIFF
--- a/platform/backend/src/auth/idp.ee.ts
+++ b/platform/backend/src/auth/idp.ee.ts
@@ -177,7 +177,11 @@ export async function syncSsoRole(
         providerId: idpProvider.providerId,
       },
     },
-    "member",
+    // Only consulted when no rule matched, and this function returns early in
+    // that case rather than rewriting an established member's role — so this
+    // fallback never reaches a membership. New memberships get the org default
+    // via ssoConfig.organizationProvisioning → resolveSsoRole.
+    MEMBER_ROLE_NAME,
   );
   const extractedGroups = extractGroupsFromClaims(
     tokenClaims,

--- a/platform/backend/src/models/identity-provider.ee.test.ts
+++ b/platform/backend/src/models/identity-provider.ee.test.ts
@@ -2467,6 +2467,101 @@ describe("resolveSsoRole", () => {
     });
   });
 
+  describe("organization default role fallback", () => {
+    test("uses the org default role when the provider has no role mapping", async ({
+      makeOrganization,
+      makeIdentityProvider,
+    }) => {
+      const org = await makeOrganization({ defaultMemberRole: "editor" });
+      const provider = await makeIdentityProvider(org.id);
+
+      const params = createParams({
+        user: { id: "user-1", email: "user@example.com" },
+        provider: { providerId: provider.providerId },
+        token: { email: "user@example.com" },
+      });
+
+      const result = await IdentityProviderModel.resolveSsoRole(params);
+
+      expect(result).toBe("editor");
+    });
+
+    test("uses the org default role when no rule matches and the provider has no defaultRole", async ({
+      makeOrganization,
+      makeIdentityProvider,
+    }) => {
+      const org = await makeOrganization({ defaultMemberRole: "editor" });
+      const roleMapping: IdpRoleMappingConfig = {
+        rules: [
+          {
+            expression: '{{#includes groups "admins"}}true{{/includes}}',
+            role: "admin",
+          },
+        ],
+      };
+      const provider = await makeIdentityProvider(org.id, {
+        roleMapping: roleMapping as unknown as Record<string, unknown>,
+      });
+
+      const params = createParams({
+        user: { id: "user-1", email: "user@example.com" },
+        provider: { providerId: provider.providerId },
+        token: { groups: ["users"] },
+      });
+
+      const result = await IdentityProviderModel.resolveSsoRole(params);
+
+      expect(result).toBe("editor");
+    });
+
+    test("prefers the provider's own defaultRole over the org default", async ({
+      makeOrganization,
+      makeIdentityProvider,
+    }) => {
+      const org = await makeOrganization({ defaultMemberRole: "editor" });
+      const roleMapping: IdpRoleMappingConfig = {
+        rules: [
+          {
+            expression: '{{#includes groups "admins"}}true{{/includes}}',
+            role: "admin",
+          },
+        ],
+        defaultRole: "viewer",
+      };
+      const provider = await makeIdentityProvider(org.id, {
+        roleMapping: roleMapping as unknown as Record<string, unknown>,
+      });
+
+      const params = createParams({
+        user: { id: "user-1", email: "user@example.com" },
+        provider: { providerId: provider.providerId },
+        token: { groups: ["users"] },
+      });
+
+      const result = await IdentityProviderModel.resolveSsoRole(params);
+
+      expect(result).toBe("viewer");
+    });
+
+    test("falls back to the member role when the org leaves the default unset", async ({
+      makeOrganization,
+      makeIdentityProvider,
+    }) => {
+      const org = await makeOrganization();
+      const provider = await makeIdentityProvider(org.id);
+
+      const params = createParams({
+        user: { id: "user-1", email: "user@example.com" },
+        provider: { providerId: provider.providerId },
+        token: { email: "user@example.com" },
+      });
+
+      const result = await IdentityProviderModel.resolveSsoRole(params);
+
+      expect(result).toBe(MEMBER_ROLE_NAME);
+    });
+  });
+
   describe("role mapping with rules", () => {
     test("returns matched role when rule matches", async ({
       makeOrganization,

--- a/platform/backend/src/models/identity-provider.ee.ts
+++ b/platform/backend/src/models/identity-provider.ee.ts
@@ -33,6 +33,7 @@ import { ApiError } from "@/types";
 import { isPrivateOrLoopbackHostname } from "@/utils/network";
 import AccountModel from "./account";
 import MemberModel from "./member";
+import OrganizationModel from "./organization";
 
 interface RoleMappingContext {
   token?: Record<string, unknown>;
@@ -221,6 +222,10 @@ class IdentityProviderModel {
       );
     }
 
+    // Captured outside the try so the terminal fallback below can still resolve
+    // the organization's default role after an evaluation error.
+    let idpOrganizationId: string | null = null;
+
     try {
       // Fetch the identity provider configuration to get role mapping rules
       logger.debug(
@@ -230,6 +235,7 @@ class IdentityProviderModel {
       const idpProvider = await IdentityProviderModel.findByProviderId(
         provider.providerId,
       );
+      idpOrganizationId = idpProvider?.organizationId ?? null;
 
       logger.debug(
         {
@@ -344,7 +350,9 @@ class IdentityProviderModel {
               providerId: provider.providerId,
             },
           },
-          MEMBER_ROLE_NAME,
+          await IdentityProviderModel.resolveDefaultRole(
+            idpProvider.organizationId,
+          ),
         );
 
         logger.debug(
@@ -459,14 +467,16 @@ class IdentityProviderModel {
     }
 
     // Fallback to default role when no role mapping is configured
+    const fallbackRole =
+      await IdentityProviderModel.resolveDefaultRole(idpOrganizationId);
     logger.debug(
       {
         providerId: provider?.providerId,
-        fallbackRole: MEMBER_ROLE_NAME,
+        fallbackRole,
       },
       "[resolveSsoRole] Using fallback role because no mapping was configured or evaluation failed",
     );
-    return MEMBER_ROLE_NAME;
+    return fallbackRole;
   }
 
   /**
@@ -946,6 +956,38 @@ class IdentityProviderModel {
       domainVerified: row.domainVerified ?? null,
       ssoLoginEnabled: row.ssoLoginEnabled,
     };
+  }
+
+  /**
+   * Terminal fallback role for a first-time SSO login: the organization's
+   * configured default role for new users, which itself falls back to
+   * "member". This keeps SSO in step with the other provisioning paths —
+   * invitation acceptance and ChatOps auto-provisioning both already honour
+   * the org setting.
+   *
+   * Only reached when the IdP has no role mapping at all, or its rules
+   * produced no match and it defines no `defaultRole` of its own; an explicit
+   * per-IdP default still wins over the org-wide one.
+   *
+   * Never throws: a failure to read the setting degrades to "member" rather
+   * than blocking the login.
+   */
+  private static async resolveDefaultRole(
+    organizationId: string | null,
+  ): Promise<string> {
+    if (!organizationId) {
+      return MEMBER_ROLE_NAME;
+    }
+
+    try {
+      return await OrganizationModel.getDefaultMemberRole(organizationId);
+    } catch (error) {
+      logger.error(
+        { err: error, organizationId },
+        "[resolveSsoRole] Failed to read the organization default role, falling back to the member role",
+      );
+      return MEMBER_ROLE_NAME;
+    }
   }
 }
 

--- a/platform/backend/src/models/organization.ts
+++ b/platform/backend/src/models/organization.ts
@@ -42,9 +42,10 @@ class OrganizationModel {
 
   /**
    * The role slug assigned to newly provisioned members that don't carry an
-   * explicit role (email/password self-signup, ChatOps auto-provisioning).
-   * Falls back to the built-in "member" role when unset. Org-wide mirror of the
-   * per-IdP SSO `roleMapping.defaultRole` fallback.
+   * explicit role (email/password self-signup, ChatOps auto-provisioning, and
+   * first-time SSO logins whose IdP defines no `roleMapping.defaultRole`).
+   * Falls back to the built-in "member" role when unset. A per-IdP SSO
+   * `roleMapping.defaultRole` still takes precedence over this org-wide value.
    */
   static async getDefaultMemberRole(organizationId: string): Promise<string> {
     const [organization] = await db

--- a/platform/backend/src/test/fixtures.ts
+++ b/platform/backend/src/test/fixtures.ts
@@ -192,6 +192,7 @@ async function makeOrganization(
       | "defaultDiscoveredToolInvocationPolicy"
       | "defaultDiscoveredToolResultPolicy"
       | "defaultEnvironmentNamespace"
+      | "defaultMemberRole"
       | "defaultNetworkPolicy"
     >
   > = {},


### PR DESCRIPTION
First-time SSO provisioning hardcoded the built-in `member` role as its terminal fallback, so the org-level "Default Role for New Users" setting was ignored for SSO users — even though invitation acceptance and ChatOps auto-provisioning both already honoured it. That left the setting silently inconsistent depending on how a user arrived.

`resolveSsoRole` — the path better-auth invokes **only when creating a new membership** — now falls back to `OrganizationModel.getDefaultMemberRole()` for the organization owning the identity provider.

### Changes

- **`models/identity-provider.ee.ts`** — both terminal fallbacks (no role mapping configured, and rules-with-no-match where the IdP defines no `defaultRole`) resolve through a new private `resolveDefaultRole()`. It degrades to `member` when the provider has no organization or the lookup throws, so a settings read can never block a login. The organization id is captured outside the `try` so the post-error fallback can still reach it.
- **`models/organization.ts`** — doc comment on `getDefaultMemberRole` corrected; it described SSO as a peer of this setting when SSO did not actually consume it.
- **`auth/idp.ee.ts`** — bare `"member"` literal replaced with `MEMBER_ROLE_NAME`, plus a comment recording why that particular fallback is inert.

### Precedence is unchanged

A per-IdP `roleMapping.defaultRole` still takes precedence over the org-wide value. The org default only applies where the code previously used the hardcoded literal.

### The re-sync path is deliberately untouched

`syncSsoRole` runs on *every* SSO login, but it returns early when `!result.matched` and leaves an established member's role alone. Routing the org default through it would make changing the setting retroactively re-role existing users — wrong for a setting scoped to *new* users.

### Tests

Four tests in `identity-provider.ee.test.ts` pin the behaviour: no mapping → org default; no match and no IdP default → org default; IdP `defaultRole` wins; org default unset → `member`. `makeOrganization` gained a `defaultMemberRole` override.

### Verification

Verified end-to-end on a dev stack against a mock OIDC provider, with the org default set to `editor`:

```
you+t942a@company.com     | member  | org_default=editor   <- before fix
you+t942b@company.com     | member  | org_default=editor   <- before fix
you+t942fix@company.com   | editor  | org_default=editor   <- after fix
```

Also manually verified through the UI.

`type-check` and `lint` clean; 218 tests pass across the affected suites (identity-provider model + routes, organization, chatops auto-provision, invitation).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>