### PR TITLE
fix(frontend): stop the limits page crashing when a limit is created or deleted

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -215906,6 +215906,33 @@
                     "updatedAt": {
                       "type": "string",
                       "format": "date-time"
+                    },
+                    "modelUsage": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "tokensIn": {
+                            "type": "number"
+                          },
+                          "tokensOut": {
+                            "type": "number"
+                          },
+                          "cost": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "model",
+                          "tokensIn",
+                          "tokensOut",
+                          "cost"
+                        ],
+                        "additionalProperties": false
+                      }
                     }
                   },
                   "required": [

--- a/platform/backend/src/routes/limits.test.ts
+++ b/platform/backend/src/routes/limits.test.ts
@@ -384,6 +384,106 @@ describe("limits routes", () => {
     });
   });
 
+  describe("GET /api/limits/:id", () => {
+    test("returns the limit for the caller's organization", async () => {
+      const created = await LimitModel.create({
+        entityType: "organization",
+        entityId: organizationId,
+        limitType: "token_cost",
+        limitValue: 1000,
+        model: ["gpt-4o"],
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/limits/${created.id}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        id: created.id,
+        entityType: "organization",
+        entityId: organizationId,
+        limitType: "token_cost",
+        limitValue: 1000,
+        model: ["gpt-4o"],
+      });
+    });
+
+    test("includes the per-model usage breakdown for token_cost limits", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({ organizationId });
+      const created = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "token_cost",
+        limitValue: 500,
+        model: ["gpt-4o"],
+      });
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/limits/${created.id}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().modelUsage).toMatchObject([
+        { model: "gpt-4o", tokensIn: 0, tokensOut: 0, cost: 0 },
+      ]);
+    });
+
+    test("resets usage before reporting the breakdown", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({ organizationId });
+      const created = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "token_cost",
+        limitValue: 1000000,
+        model: ["gpt-4o"],
+      });
+      await LimitModel.updateTokenLimitUsage(
+        "agent",
+        agent.id,
+        "gpt-4o",
+        500,
+        500,
+      );
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/limits/${created.id}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().modelUsage).toMatchObject([
+        { model: "gpt-4o", tokensIn: 0, tokensOut: 0 },
+      ]);
+    });
+
+    test("omits the usage breakdown for non-token_cost limits", async ({
+      makeAgent,
+    }) => {
+      const agent = await makeAgent({ organizationId });
+      const created = await LimitModel.create({
+        entityType: "agent",
+        entityId: agent.id,
+        limitType: "tool_calls",
+        limitValue: 25,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/limits/${created.id}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ limitType: "tool_calls" });
+      expect(response.json().modelUsage).toBeUndefined();
+    });
+  });
+
   describe("PATCH /api/limits/:id", () => {
     test("resets usage when cleanup interval changes", async ({
       makeAgent,

--- a/platform/backend/src/routes/limits.ts
+++ b/platform/backend/src/routes/limits.ts
@@ -113,17 +113,28 @@ const limitsRoutes: FastifyPluginAsyncZod = async (fastify) => {
         params: z.object({
           id: UuidIdSchema,
         }),
-        response: constructResponseSchema(SelectLimitSchema),
+        response: constructResponseSchema(LimitWithUsageSchema),
       },
     },
     async ({ params: { id }, organizationId }, reply) => {
+      // Same cleanup the list read performs, so an elapsed reset window is
+      // applied before the usage counters are reported either way.
+      await LimitModel.cleanupLimitsIfNeeded({
+        allForOrganizationId: organizationId,
+      });
+
       const limit = await LimitModel.findByIdInOrganization(id, organizationId);
 
       if (!limit) {
         throw new ApiError(404, "Limit not found");
       }
 
-      return reply.send(limit);
+      if (limit.limitType !== "token_cost") {
+        return reply.send(limit);
+      }
+
+      const modelUsage = await LimitModel.getModelUsageBreakdown(limit.id);
+      return reply.send({ ...limit, modelUsage });
     },
   );
 

--- a/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.test.tsx
@@ -4,8 +4,8 @@ import LimitsPage, { getLimitModels } from "./page";
 
 const mockSetCostsAction = vi.fn();
 const mockUseLimits = vi.fn();
-const mockUseLimit = vi.fn();
 const mockUseAllVirtualApiKeys = vi.fn();
+const mockDataTableSearchParams = vi.fn(() => new URLSearchParams());
 
 // The ?edit= dialog deep-link syncs open state to the URL through
 // useDialogUrlParam, which reads next/navigation hooks. Bare vi.mock resolves
@@ -35,7 +35,6 @@ vi.mock("@/app/llm/(costs)/layout", () => ({
 
 vi.mock("@/lib/limits.query", () => ({
   useLimits: (...args: unknown[]) => mockUseLimits(...args),
-  useLimit: (...args: unknown[]) => mockUseLimit(...args),
   useCreateLimit: () => ({ mutateAsync: vi.fn() }),
   useUpdateLimit: () => ({ mutateAsync: vi.fn() }),
   useDeleteLimit: () => ({ mutateAsync: vi.fn() }),
@@ -94,7 +93,7 @@ vi.mock("@/lib/agent.query", () => ({
 
 vi.mock("@/lib/hooks/use-data-table-query-params", () => ({
   useDataTableQueryParams: () => ({
-    searchParams: new URLSearchParams(),
+    searchParams: mockDataTableSearchParams(),
     updateQueryParams: vi.fn(),
   }),
 }));
@@ -249,7 +248,7 @@ vi.mock("@/components/ui/progress", () => ({
 }));
 
 vi.mock("@/components/ui/input", () => ({
-  Input: () => <input />,
+  Input: (props: React.ComponentProps<"input">) => <input {...props} />,
 }));
 
 vi.mock("@/components/ui/label", () => ({
@@ -335,7 +334,7 @@ describe("LimitsPage", () => {
     vi.mocked(useSearchParams).mockReturnValue(
       new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>,
     );
-    mockUseLimit.mockReturnValue({ data: undefined });
+    mockDataTableSearchParams.mockReturnValue(new URLSearchParams());
     vi.mocked(useHasPermissions).mockReturnValue({
       data: true,
       isPending: false,
@@ -643,5 +642,33 @@ describe("LimitsPage", () => {
     render(<LimitsPage />);
     const row = screen.getByTestId("data-table-row-limit-proxy");
     expect(row).toHaveTextContent("Unknown LLM proxy");
+  });
+
+  it("opens the edit dialog seeded from an ?edit= deep link", async () => {
+    const limit = {
+      id: "limit-proxy",
+      entityType: "agent",
+      entityId: "proxy-1",
+      limitType: "token_cost",
+      limitValue: 1000,
+      model: null,
+      mcpServerName: null,
+      toolName: null,
+      lastCleanup: null,
+      createdAt: "2026-01-01",
+      updatedAt: "2026-01-01",
+      modelUsage: [],
+    };
+    mockUseLimits.mockReturnValue({ data: [limit], isPending: false });
+    const params = new URLSearchParams({ edit: limit.id });
+    mockDataTableSearchParams.mockReturnValue(params);
+    vi.mocked(useSearchParams).mockReturnValue(
+      params as unknown as ReturnType<typeof useSearchParams>,
+    );
+
+    render(<LimitsPage />);
+
+    expect(await screen.findByText("Save changes")).toBeInTheDocument();
+    expect(screen.getByLabelText("Limit value")).toHaveValue("1,000");
   });
 });

--- a/platform/frontend/src/app/llm/(costs)/limits/page.tsx
+++ b/platform/frontend/src/app/llm/(costs)/limits/page.tsx
@@ -71,7 +71,6 @@ import { useDialogUrlParam } from "@/lib/hooks/use-dialog-url-param";
 import {
   useCreateLimit,
   useDeleteLimit,
-  useLimit,
   useLimits,
   useUpdateLimit,
 } from "@/lib/limits.query";
@@ -223,14 +222,16 @@ export default function LimitsPage() {
     useState<LimitFormState>(DEFAULT_FORM_STATE);
 
   const editId = searchParams.get("edit");
-  const { data: limitFromUrl } = useLimit(editId ?? undefined);
+  // The list is unfiltered and unpaginated, so every limit the `edit` param can
+  // name is already in it.
+  const limitFromUrl = limits.find((limit) => limit.id === editId) ?? null;
   const {
     entity: editingLimit,
     open: openEditDialog,
     close: closeEditDialog,
   } = useDialogUrlParam<LimitData>({
     paramName: "edit",
-    entityFromUrl: limitFromUrl ?? null,
+    entityFromUrl: limitFromUrl,
   });
 
   const llmLimits = useMemo(

--- a/platform/frontend/src/lib/limits.query.test.ts
+++ b/platform/frontend/src/lib/limits.query.test.ts
@@ -1,0 +1,153 @@
+import { archestraApiSdk } from "@archestra/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useCreateLimit,
+  useDeleteLimit,
+  useLimit,
+  useLimits,
+  useUpdateLimit,
+} from "@/lib/limits.query";
+
+vi.mock("sonner");
+
+vi.mock("@archestra/shared", () => ({
+  archestraApiSdk: {
+    getLimits: vi.fn(),
+    getLimit: vi.fn(),
+    createLimit: vi.fn(),
+    updateLimit: vi.fn(),
+    deleteLimit: vi.fn(),
+  },
+}));
+
+const limitRow = {
+  id: "limit-1",
+  entityType: "agent",
+  entityId: "proxy-1",
+  limitType: "token_cost",
+  limitValue: 100,
+  modelUsage: [],
+};
+
+/**
+ * Mirrors the limits page: the list mounts first, then the by-id query for the
+ * `edit` search param — which is absent on a plain page load, so it gets no id.
+ * The mount order decides which queryFn a shared cache entry ends up holding.
+ *
+ * Tests rerender around the mutation because an observer re-applies its options
+ * to its query on every render, and the page renders again once the mutation
+ * settles — which is when a poisoned cache entry reaches the table.
+ */
+function renderLimitsPage(editId?: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  const { result, rerender } = renderHook(
+    () => ({
+      list: useLimits(),
+      detail: useLimit(editId),
+      create: useCreateLimit(),
+      update: useUpdateLimit(),
+      remove: useDeleteLimit(),
+    }),
+    { wrapper },
+  );
+  return { queryClient, result, rerender };
+}
+
+describe("limits query cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(archestraApiSdk.getLimits).mockResolvedValue({
+      error: undefined,
+      data: [limitRow],
+    } as never);
+  });
+
+  it("gives the list and an id-less detail query separate cache entries", async () => {
+    const { queryClient, result } = renderLimitsPage();
+    await waitFor(() => expect(result.current.list.data).toEqual([limitRow]));
+
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(2);
+  });
+
+  it("keeps the list populated after creating a limit", async () => {
+    vi.mocked(archestraApiSdk.createLimit).mockResolvedValue({
+      error: undefined,
+      data: limitRow,
+    } as never);
+
+    const { result, rerender } = renderLimitsPage();
+    await waitFor(() => expect(result.current.list.data).toEqual([limitRow]));
+    rerender();
+
+    await act(async () => {
+      await result.current.create.mutateAsync({} as never);
+    });
+    rerender();
+
+    expect(result.current.list.data).toEqual([limitRow]);
+  });
+
+  it("keeps the list populated after deleting a limit", async () => {
+    vi.mocked(archestraApiSdk.deleteLimit).mockResolvedValue({
+      error: undefined,
+      data: { success: true },
+    } as never);
+
+    const { result, rerender } = renderLimitsPage();
+    await waitFor(() => expect(result.current.list.data).toEqual([limitRow]));
+    rerender();
+
+    await act(async () => {
+      await result.current.remove.mutateAsync({ id: limitRow.id });
+    });
+    rerender();
+
+    expect(result.current.list.data).toEqual([limitRow]);
+  });
+
+  it("fetches a limit by id for the edit dialog", async () => {
+    vi.mocked(archestraApiSdk.getLimit).mockResolvedValue({
+      error: undefined,
+      data: limitRow,
+    } as never);
+
+    const { result } = renderLimitsPage(limitRow.id);
+
+    await waitFor(() => expect(result.current.detail.data).toEqual(limitRow));
+    expect(vi.mocked(archestraApiSdk.getLimit)).toHaveBeenCalledWith({
+      path: { id: limitRow.id },
+    });
+  });
+
+  it("keeps the list populated after updating a limit being edited", async () => {
+    vi.mocked(archestraApiSdk.getLimit).mockResolvedValue({
+      error: undefined,
+      data: limitRow,
+    } as never);
+    vi.mocked(archestraApiSdk.updateLimit).mockResolvedValue({
+      error: undefined,
+      data: { ...limitRow, limitValue: 250 },
+    } as never);
+
+    const { result, rerender } = renderLimitsPage(limitRow.id);
+    await waitFor(() => expect(result.current.list.data).toEqual([limitRow]));
+    rerender();
+
+    await act(async () => {
+      await result.current.update.mutateAsync({
+        id: limitRow.id,
+        limitValue: 250,
+      });
+    });
+    rerender();
+
+    expect(result.current.list.data).toEqual([limitRow]);
+  });
+});

--- a/platform/frontend/src/lib/limits.query.ts
+++ b/platform/frontend/src/lib/limits.query.ts
@@ -6,25 +6,26 @@ import { handleApiError, throwOnApiError } from "@/lib/utils";
 const { getLimits, createLimit, getLimit, updateLimit, deleteLimit } =
   archestraApiSdk;
 
-type LimitsQuery = NonNullable<archestraApiTypes.GetLimitsData["query"]>;
-type LimitsParams = Partial<LimitsQuery>;
 type UpdateLimitParams = archestraApiTypes.UpdateLimitData["path"] &
   Partial<archestraApiTypes.UpdateLimitData["body"]>;
 type DeleteLimitParams = archestraApiTypes.DeleteLimitData["path"];
 
-export function useLimits(params?: LimitsParams) {
+// The "list"/"detail" segments keep the two queries in separate cache entries.
+// Without them an id-less detail query and the unfiltered list hash alike, and
+// a mutation's refetch resolves the shared entry with whichever queryFn was
+// applied last — overwriting the list array with the detail query's null.
+export const limitKeys = {
+  all: ["limits"] as const,
+  lists: () => [...limitKeys.all, "list"] as const,
+  details: () => [...limitKeys.all, "detail"] as const,
+  detail: (id: string | undefined) => [...limitKeys.details(), id] as const,
+};
+
+export function useLimits() {
   return useQuery({
-    queryKey: ["limits", params],
+    queryKey: limitKeys.lists(),
     queryFn: async () => {
-      const { data, error } = await getLimits({
-        query: params
-          ? {
-              ...(params.entityType && { entityType: params.entityType }),
-              ...(params.entityId && { entityId: params.entityId }),
-              ...(params.limitType && { limitType: params.limitType }),
-            }
-          : undefined,
-      });
+      const { data, error } = await getLimits();
       throwOnApiError(error, { toastOnError: false });
       return data ?? [];
     },
@@ -37,7 +38,7 @@ export function useLimits(params?: LimitsParams) {
 
 export function useLimit(id: string | undefined) {
   return useQuery({
-    queryKey: ["limits", id],
+    queryKey: limitKeys.detail(id),
     queryFn: async () => {
       if (!id) return null;
       const { data, error } = await getLimit({ path: { id } });
@@ -61,7 +62,7 @@ export function useCreateLimit() {
     },
     onSuccess: async (result) => {
       if (!result) return;
-      await queryClient.invalidateQueries({ queryKey: ["limits"] });
+      await queryClient.invalidateQueries({ queryKey: limitKeys.all });
       toast.success("Limit created successfully");
     },
   });
@@ -80,9 +81,9 @@ export function useUpdateLimit() {
     },
     onSuccess: async (result, variables) => {
       if (!result) return;
-      await queryClient.invalidateQueries({ queryKey: ["limits"] });
+      await queryClient.invalidateQueries({ queryKey: limitKeys.all });
       await queryClient.invalidateQueries({
-        queryKey: ["limits", variables.id],
+        queryKey: limitKeys.detail(variables.id),
       });
       toast.success("Limit updated successfully");
     },
@@ -102,8 +103,8 @@ export function useDeleteLimit() {
     },
     onSuccess: async (result, variables) => {
       if (!result) return;
-      await queryClient.invalidateQueries({ queryKey: ["limits"] });
-      queryClient.removeQueries({ queryKey: ["limits", variables.id] });
+      await queryClient.invalidateQueries({ queryKey: limitKeys.all });
+      queryClient.removeQueries({ queryKey: limitKeys.detail(variables.id) });
       toast.success("Limit deleted successfully");
     },
   });

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -55281,6 +55281,12 @@ export type GetLimitResponses = {
         lastCleanup: string | null;
         createdAt: string;
         updatedAt: string;
+        modelUsage?: Array<{
+            model: string;
+            tokensIn: number;
+            tokensOut: number;
+            cost: number;
+        }>;
     };
 };
 


### PR DESCRIPTION
## Summary

Creating or deleting a cost limit on `/llm/limits` took the whole page down with `TypeError: Cannot read properties of null (reading 'filter')`. The limit was saved, but the table was replaced by an error boundary until a manual reload. Any scope hit it — LLM proxy, organization, anything.

`useLimits()` and `useLimit(undefined)` both hashed to the query key `["limits",null]`, so one TanStack cache entry served both an array-returning and a null-returning `queryFn`. Each `QueryObserver.setOptions()` writes its options onto the shared `Query`, and `invalidateQueries` refetches through `query.fetch()` without passing options — so a mutation's refetch ran whichever `queryFn` was applied last. That is the detail hook's, since it mounts second, and it wrote `null` over the list array. Editing an existing limit never crashed because `?edit=<id>` gave the two hooks distinct keys.

A `limitKeys` factory now puts the list and detail queries in separate namespaces, following the `roleKeys` shape the other query modules already use, so the two can no longer land on one cache entry. `useLimits`' `params` argument was unreachable — its only call site passes nothing — so it is gone rather than being given a namespace of its own.

The edit dialog resolves its entity from the already-loaded list instead of issuing a second by-id fetch. The list is unfiltered and unpaginated, so every id the `edit` param can name is already in it. This also fixes a quieter bug: the by-id response was assigned where the richer list type was expected and type-checked only because `modelUsage` is optional, so a deep-linked `?edit=<id>` dialog rendered an empty usage breakdown while the same dialog opened by row click showed real numbers.

`GET /api/limits/:id` now returns that usage breakdown as well, behind the same cleanup sweep the list read performs, so an elapsed reset window is applied before the counters are reported through either endpoint.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>