### PR TITLE
fix(frontend): expand advanced settings before asserting the primary-key switch

### DIFF
--- a/platform/frontend/tests-integration/llm-provider-api-keys.spec.ts
+++ b/platform/frontend/tests-integration/llm-provider-api-keys.spec.ts
@@ -188,6 +188,9 @@ test.describe("LLM Provider API Keys", () => {
       .getByRole("textbox", { name: /API Key/i })
       .fill(API_KEY_PLACEHOLDER);
 
+    // The primary-key control sits behind this dialog's progressive disclosure.
+    await page.getByRole("button", { name: "Advanced settings" }).click();
+
     const primarySwitch = page.getByRole("switch", { name: /Primary key/i });
     await expect(primarySwitch).toBeChecked();
 
@@ -215,6 +218,9 @@ test.describe("LLM Provider API Keys", () => {
     await page
       .getByRole("textbox", { name: /API Key/i })
       .fill(API_KEY_PLACEHOLDER);
+
+    // Reopening the dialog mounts a fresh form, collapsed again.
+    await page.getByRole("button", { name: "Advanced settings" }).click();
 
     const secondarySwitch = page.getByRole("switch", { name: /Primary key/i });
     await expect(secondarySwitch).not.toBeChecked();


### PR DESCRIPTION
## Summary

`Frontend Integration Tests (MSW)` fails on every merge-queue run, so nothing can land. `llm-provider-api-keys.spec.ts` waits 30s for `getByRole('switch', { name: /Primary key/i })` and never finds it.

The create-key dialog passes `progressive` to `LlmProviderApiKeyForm` (`create-llm-provider-api-key-dialog.tsx:167`), and the form gates the primary-key switch on `showAdvancedSettings = !progressive || advancedSettingsOpen`. The switch and its "already the primary key" hint therefore sit behind the Advanced settings toggle, while the spec still expected them on the bare form. The hiding is deliberate; the spec is what needs to catch up.

The test now opens the disclosure in both dialogs it drives — reopening for the second key mounts a fresh form that starts collapsed again.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>