### PR TITLE
fix(mcp-catalog): roll the shared deployment on a multitenant execution edit

### DIFF
--- a/platform/backend/src/routes/internal-mcp-catalog.multitenant-rollout.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.multitenant-rollout.test.ts
@@ -1,0 +1,284 @@
+import { eq } from "drizzle-orm";
+import { type Mock, vi } from "vitest";
+import db, { schema } from "@/database";
+import { InternalMcpCatalogModel } from "@/models";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+vi.mock("@/auth");
+
+// Force the K8s runtime ON so the shared-deployment recreate is reachable, and
+// stub the cluster calls — we assert which primitive the route picks, not what
+// it does to a pod.
+vi.mock("@/k8s/mcp-server-runtime/manager", () => ({
+  default: {
+    isEnabled: true,
+    getOrLoadDeployment: vi.fn().mockResolvedValue(undefined),
+    tearDownOldNamespaceDeployments: vi.fn().mockResolvedValue(undefined),
+    reinstallSharedDeployment: vi.fn().mockResolvedValue(undefined),
+    restartServer: vi.fn().mockResolvedValue(undefined),
+    validateNamespace: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { hasPermission } from "@/auth";
+import mcpServerRuntimeManager from "@/k8s/mcp-server-runtime/manager";
+
+const mockHasPermission = hasPermission as Mock;
+const reinstallSharedSpy =
+  mcpServerRuntimeManager.reinstallSharedDeployment as Mock;
+
+async function drainCascade(): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+/**
+ * A multi-tenant local catalog has one shared K8s Deployment. Execution-config
+ * drift on it is a catalog-scope event owned by the admin doing the edit, so
+ * the recreate runs on save rather than waiting behind the card's Reinstall
+ * button — and no tenant is marked reinstall-required, because stored
+ * credentials stay valid. The exception is an edit that also changes the
+ * prompted schema: the pod can't come back on a spec nobody has supplied
+ * values for, so that defers to `catalogReinstallRequired`.
+ */
+describe("PUT /api/internal_mcp_catalog/:id — multi-tenant shared-pod rollout", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+
+  beforeEach(async ({ makeOrganization, makeUser, makeMember }) => {
+    vi.clearAllMocks();
+    mockHasPermission.mockResolvedValue({ success: true, error: null });
+
+    user = await makeUser();
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    await makeMember(user.id, organization.id, { role: "admin" });
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (request as typeof request & { user: unknown }).user = user;
+      (request as typeof request & { organizationId: string }).organizationId =
+        organizationId;
+    });
+
+    const { default: routes } = await import("./internal-mcp-catalog");
+    await app.register(routes);
+  });
+
+  afterEach(async () => {
+    await drainCascade();
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  const localConfig = {
+    command: "node",
+    arguments: ["server.js"],
+    dockerImage: "example/image:1.0",
+    environment: [],
+  };
+
+  async function makeCatalogWithInstalls(
+    makeMcpServer: (overrides: {
+      catalogId: string;
+    }) => Promise<{ id: string }>,
+    options: { multitenant: boolean; installCount?: number },
+  ) {
+    const name = `mt-rollout-${crypto.randomUUID().slice(0, 8)}`;
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name,
+        serverType: "local",
+        multitenant: options.multitenant,
+        localConfig,
+        scope: "org",
+      },
+      { organizationId },
+    );
+    const servers = [];
+    for (let i = 0; i < (options.installCount ?? 1); i++) {
+      servers.push(await makeMcpServer({ catalogId: catalog.id }));
+    }
+    return { catalog, name, serverIds: servers.map((s) => s.id) };
+  }
+
+  async function getCatalogRow(catalogId: string) {
+    const [row] = await db
+      .select()
+      .from(schema.internalMcpCatalogTable)
+      .where(eq(schema.internalMcpCatalogTable.id, catalogId));
+    return row;
+  }
+
+  async function getServerRow(serverId: string) {
+    const [row] = await db
+      .select()
+      .from(schema.mcpServersTable)
+      .where(eq(schema.mcpServersTable.id, serverId));
+    return row;
+  }
+
+  test("image bump recreates the shared deployment once and leaves every tenant unflagged", async ({
+    makeMcpServer,
+  }) => {
+    const { catalog, name, serverIds } = await makeCatalogWithInstalls(
+      makeMcpServer,
+      { multitenant: true, installCount: 2 },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local",
+        localConfig: { ...localConfig, dockerImage: "example/image:2.0" },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    await drainCascade();
+
+    // One recreate for the one shared pod — not one per install.
+    expect(reinstallSharedSpy).toHaveBeenCalledTimes(1);
+    expect(reinstallSharedSpy).toHaveBeenCalledWith(catalog.id);
+
+    // Nothing is left pending: no card banner, no per-tenant Reinstall button.
+    expect((await getCatalogRow(catalog.id)).catalogReinstallRequired).toBe(
+      false,
+    );
+    for (const serverId of serverIds) {
+      const row = await getServerRow(serverId);
+      expect(row.reinstallRequired).toBe(false);
+      expect(row.reinstallReason).toBeNull();
+    }
+  });
+
+  test("command change takes the same rollout path as an image bump", async ({
+    makeMcpServer,
+  }) => {
+    const { catalog, name, serverIds } = await makeCatalogWithInstalls(
+      makeMcpServer,
+      { multitenant: true },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local",
+        localConfig: { ...localConfig, command: "bash" },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    await drainCascade();
+
+    expect(reinstallSharedSpy).toHaveBeenCalledWith(catalog.id);
+    expect((await getCatalogRow(catalog.id)).catalogReinstallRequired).toBe(
+      false,
+    );
+    expect((await getServerRow(serverIds[0])).reinstallRequired).toBe(false);
+  });
+
+  test("an image bump carrying a new required prompted env var defers the recreate instead", async ({
+    makeMcpServer,
+  }) => {
+    const { catalog, name, serverIds } = await makeCatalogWithInstalls(
+      makeMcpServer,
+      { multitenant: true },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local",
+        localConfig: {
+          ...localConfig,
+          dockerImage: "example/image:2.0",
+          environment: [
+            {
+              key: "API_TOKEN",
+              type: "secret",
+              sensitive: true,
+              required: true,
+              promptOnInstallation: true,
+            },
+          ],
+        },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    await drainCascade();
+
+    // The pod would come back missing a value no tenant has supplied.
+    expect(reinstallSharedSpy).not.toHaveBeenCalled();
+    expect((await getCatalogRow(catalog.id)).catalogReinstallRequired).toBe(
+      true,
+    );
+    const row = await getServerRow(serverIds[0]);
+    expect(row.reinstallRequired).toBe(true);
+    expect(row.reinstallReason).toBe("new-input");
+  });
+
+  test("a failed recreate falls back to the catalog Reinstall button", async ({
+    makeMcpServer,
+  }) => {
+    const { catalog, name } = await makeCatalogWithInstalls(makeMcpServer, {
+      multitenant: true,
+    });
+    reinstallSharedSpy.mockRejectedValueOnce(new Error("cluster unreachable"));
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local",
+        localConfig: { ...localConfig, dockerImage: "example/image:2.0" },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    await drainCascade();
+
+    // Attempted-then-failed, not skipped — the flag has to come from the
+    // catch, otherwise this passes for a deferral that never tried.
+    expect(reinstallSharedSpy).toHaveBeenCalledWith(catalog.id);
+    // Pod is still on the old spec — the admin needs a retry affordance.
+    expect((await getCatalogRow(catalog.id)).catalogReinstallRequired).toBe(
+      true,
+    );
+  });
+
+  test("single-tenant image bump still marks installs and never touches the shared primitive", async ({
+    makeMcpServer,
+  }) => {
+    const { catalog, name, serverIds } = await makeCatalogWithInstalls(
+      makeMcpServer,
+      { multitenant: false },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local",
+        localConfig: { ...localConfig, dockerImage: "example/image:2.0" },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    await drainCascade();
+
+    expect(reinstallSharedSpy).not.toHaveBeenCalled();
+    const row = await getServerRow(serverIds[0]);
+    expect(row.reinstallRequired).toBe(true);
+    expect(row.reinstallReason).toBe("restart");
+  });
+});

--- a/platform/backend/src/routes/internal-mcp-catalog.multitenant-rollout.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.multitenant-rollout.test.ts
@@ -194,6 +194,88 @@ describe("PUT /api/internal_mcp_catalog/:id — multi-tenant shared-pod rollout"
     expect((await getServerRow(serverIds[0])).reinstallRequired).toBe(false);
   });
 
+  test("a non-prompted env var change recreates the shared pod without touching execution config", async ({
+    makeMcpServer,
+  }) => {
+    const { catalog, name, serverIds } = await makeCatalogWithInstalls(
+      makeMcpServer,
+      { multitenant: true },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local",
+        // Image, command and args all identical — only the shared env moves.
+        localConfig: {
+          ...localConfig,
+          environment: [
+            {
+              key: "LOG_LEVEL",
+              type: "plain_text",
+              value: "debug",
+              promptOnInstallation: false,
+            },
+          ],
+        },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    await drainCascade();
+
+    // Non-prompted entries are baked into the shared pod's spec, so this takes
+    // the one-shot recreate rather than the per-install auto path.
+    expect(reinstallSharedSpy).toHaveBeenCalledWith(catalog.id);
+    expect((await getCatalogRow(catalog.id)).catalogReinstallRequired).toBe(
+      false,
+    );
+    expect((await getServerRow(serverIds[0])).reinstallRequired).toBe(false);
+  });
+
+  test("a prompted-only change leaves the shared pod alone and defers to per-install input", async ({
+    makeMcpServer,
+  }) => {
+    const { catalog, name, serverIds } = await makeCatalogWithInstalls(
+      makeMcpServer,
+      { multitenant: true },
+    );
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local",
+        localConfig: {
+          ...localConfig,
+          environment: [
+            {
+              key: "API_TOKEN",
+              type: "secret",
+              sensitive: true,
+              required: true,
+              promptOnInstallation: true,
+            },
+          ],
+        },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    await drainCascade();
+
+    // Prompted entries are per-install secrets resolved at request time; they
+    // never reach the shared pod, so nothing about it changed.
+    expect(reinstallSharedSpy).not.toHaveBeenCalled();
+    expect((await getCatalogRow(catalog.id)).catalogReinstallRequired).toBe(
+      false,
+    );
+    const row = await getServerRow(serverIds[0]);
+    expect(row.reinstallRequired).toBe(true);
+    expect(row.reinstallReason).toBe("new-input");
+  });
+
   test("an image bump carrying a new required prompted env var defers the recreate instead", async ({
     makeMcpServer,
   }) => {

--- a/platform/backend/src/routes/internal-mcp-catalog.multitenant-rollout.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.multitenant-rollout.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { type Mock, vi } from "vitest";
 import db, { schema } from "@/database";
-import { InternalMcpCatalogModel } from "@/models";
+import { InternalMcpCatalogModel, McpServerModel } from "@/models";
 import type { FastifyInstanceWithZod } from "@/server";
 import { createFastifyInstance } from "@/server";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
@@ -53,6 +53,15 @@ describe("PUT /api/internal_mcp_catalog/:id — multi-tenant shared-pod rollout"
   beforeEach(async ({ makeOrganization, makeUser, makeMember }) => {
     vi.clearAllMocks();
     mockHasPermission.mockResolvedValue({ success: true, error: null });
+    // The recreate's second phase syncs tools per install, which otherwise
+    // reaches the real MCP client. Its failure path writes exactly the
+    // `reinstallRequired` / `reinstallReason` fields these tests assert on, so
+    // leaving it live would decide those assertions by whether a doomed
+    // connection attempt happens to settle inside `drainCascade` — and the
+    // pending promise would outlive this file's database (see test/setup.ts).
+    vi.spyOn(McpServerModel, "getToolsFromServer").mockResolvedValue([
+      { name: "test-tool", description: "A test tool", inputSchema: {} },
+    ]);
 
     user = await makeUser();
     const organization = await makeOrganization();
@@ -251,6 +260,37 @@ describe("PUT /api/internal_mcp_catalog/:id — multi-tenant shared-pod rollout"
     // catch, otherwise this passes for a deferral that never tried.
     expect(reinstallSharedSpy).toHaveBeenCalledWith(catalog.id);
     // Pod is still on the old spec — the admin needs a retry affordance.
+    expect((await getCatalogRow(catalog.id)).catalogReinstallRequired).toBe(
+      true,
+    );
+  });
+
+  test("a queued recreate stands down when the catalog already owes a manual reinstall", async ({
+    makeMcpServer,
+  }) => {
+    const { catalog, name } = await makeCatalogWithInstalls(makeMcpServer, {
+      multitenant: true,
+    });
+    // An earlier edit needed input no tenant has supplied yet.
+    await InternalMcpCatalogModel.update(catalog.id, {
+      catalogReinstallRequired: true,
+    });
+
+    const response = await app.inject({
+      method: "PUT",
+      url: `/api/internal_mcp_catalog/${catalog.id}`,
+      payload: {
+        name,
+        serverType: "local",
+        localConfig: { ...localConfig, dockerImage: "example/image:2.0" },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    await drainCascade();
+
+    // Rolling now would bring the pod back on a spec nobody can satisfy, and
+    // clear the flag that asks for the values.
+    expect(reinstallSharedSpy).not.toHaveBeenCalled();
     expect((await getCatalogRow(catalog.id)).catalogReinstallRequired).toBe(
       true,
     );

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -2148,7 +2148,25 @@ function reinstallMultitenantCatalogInBackground(
 ): void {
   setImmediate(async () => {
     try {
-      await reinstallMultitenantCatalog(catalogItem);
+      // Re-read rather than closing over the caller's row: another edit can
+      // land while this sits queued, and the recreate both syncs tools against
+      // whichever row it's handed and clears `catalogReinstallRequired`
+      // unconditionally when it succeeds.
+      const current = await InternalMcpCatalogModel.findById(catalogItem.id, {
+        expandSecrets: false,
+      });
+      if (!current) return;
+      // That later edit deferred its own rollout because it needs values no
+      // tenant has supplied. Recreating now would roll a spec nobody can
+      // satisfy and clear the very flag asking for those values.
+      if (current.catalogReinstallRequired) {
+        logger.info(
+          { catalogId: catalogItem.id },
+          "Newer catalog edit is awaiting manual reinstall - skipping background recreate",
+        );
+        return;
+      }
+      await reinstallMultitenantCatalog(current);
     } catch (error) {
       logger.error(
         { err: error, catalogId: catalogItem.id },

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -49,8 +49,8 @@ import {
 } from "@/services/mcp-install-policy";
 import {
   autoReinstallServer,
-  localExecutionConfigChanged,
   manualReinstallReason,
+  multitenantSharedPodChanged,
   onlyForwardCompatibleEnvDiff,
   reinstallMultitenantCatalog,
   requiresNewUserInputForReinstall,
@@ -1966,30 +1966,14 @@ async function cascadeReinstallForCatalog(
 
   // Multi-tenant local catalogs have one shared K8s Deployment across all
   // installs. Execution-config drift (image, command, args, transport) on
-  // this kind of catalog is a catalog-level event — one rollout serves
-  // every tenant — so we flag it on the catalog row instead of marking
-  // each install reinstall-required. An admin/owner clears the flag via
-  // POST /api/internal-mcp-catalog/:id/reinstall, which does the actual
-  // pod recreate + tool cascade. Single-tenant catalogs continue to use
-  // the per-install flag (see `requiresNewUserInputForReinstall`).
-  const catalogScopeChangeOnMultitenant =
-    catalogItem.multitenant === true &&
-    catalogItem.serverType === "local" &&
-    (localExecutionConfigChanged(originalCatalogItem, catalogItem) ||
-      multitenantSharedEnvChanged(originalCatalogItem, catalogItem));
-
-  if (catalogScopeChangeOnMultitenant) {
-    logger.info(
-      { catalogId: catalogItem.id, serverCount: installedServers.length },
-      "Catalog execution config changed on multi-tenant local catalog - setting catalogReinstallRequired",
-    );
-    await InternalMcpCatalogModel.update(catalogItem.id, {
-      catalogReinstallRequired: true,
-    });
-    // Fall through to also evaluate per-install marking: a prompt-input
-    // change could have landed in the same edit and still needs per-tenant
-    // input on top of the catalog-level rollout.
-  }
+  // this kind of catalog is a catalog-level event — one rollout serves every
+  // tenant — so it's handled as a single shared-pod recreate rather than by
+  // marking each install reinstall-required. Single-tenant catalogs continue
+  // to use the per-install flag (see `requiresNewUserInputForReinstall`).
+  const catalogScopeChangeOnMultitenant = multitenantSharedPodChanged(
+    originalCatalogItem,
+    catalogItem,
+  );
 
   // Manual path is authoritative: a re-prompt edit blocks both the
   // gate-decided auto path AND the forced auto path. Run it before any
@@ -1999,6 +1983,14 @@ async function cascadeReinstallForCatalog(
   // an install still owing input from an earlier edit.
   const manualReason = manualReinstallReason(originalCatalogItem, catalogItem);
   if (manualReason !== null) {
+    // A shared pod can't roll onto a spec whose new prompted fields no
+    // tenant has filled in yet, so the recreate waits for the catalog
+    // Reinstall button rather than firing now.
+    if (catalogScopeChangeOnMultitenant) {
+      await InternalMcpCatalogModel.update(catalogItem.id, {
+        catalogReinstallRequired: true,
+      });
+    }
     logger.info(
       {
         catalogId: catalogItem.id,
@@ -2019,18 +2011,17 @@ async function cascadeReinstallForCatalog(
     return;
   }
 
-  // If we set the catalog-level flag and nothing else needs handling per
-  // install, skip the auto-cascade. The pod is still running the old
-  // spec; the catalog-reinstall endpoint will recreate it and cascade
-  // tool sync to every install in one shot. Without this short-circuit,
-  // every install would auto-cascade against the unchanged pod, flipping
-  // statuses to "success" while the catalog flag still says "reinstall
-  // required" — a confusing mixed signal.
+  // Execution-only drift on a shared deployment. The admin who saved the
+  // edit is the sole owner of that pod and no tenant owes new input, so the
+  // recreate runs now instead of parking behind a second click. Not routed
+  // through `autoReinstallInstallsInBackground`: that reinstalls per install,
+  // which against one shared pod would recreate it N times.
   if (catalogScopeChangeOnMultitenant) {
     logger.info(
-      { catalogId: catalogItem.id },
-      "Catalog reinstall pending - skipping auto-cascade; admin clicks 'Reinstall catalog' to apply",
+      { catalogId: catalogItem.id, serverCount: installedServers.length },
+      "Catalog execution config changed on multi-tenant local catalog - recreating shared deployment",
     );
+    reinstallMultitenantCatalogInBackground(catalogItem);
     return;
   }
 
@@ -2144,6 +2135,40 @@ function autoReinstallInstallsInBackground(
 }
 
 /**
+ * Recreate a multi-tenant catalog's shared deployment and cascade tool sync to
+ * every install, off the request path.
+ *
+ * A failed recreate leaves the pod on the old spec, so the catalog falls back
+ * to `catalogReinstallRequired` — that surfaces the card's Reinstall button for
+ * a retry. `reinstallMultitenantCatalog` has already marked the installs
+ * themselves `error` by then.
+ */
+function reinstallMultitenantCatalogInBackground(
+  catalogItem: InternalMcpCatalog,
+): void {
+  setImmediate(async () => {
+    try {
+      await reinstallMultitenantCatalog(catalogItem);
+    } catch (error) {
+      logger.error(
+        { err: error, catalogId: catalogItem.id },
+        "Shared deployment recreate failed - flagging catalog for manual reinstall",
+      );
+      try {
+        await InternalMcpCatalogModel.update(catalogItem.id, {
+          catalogReinstallRequired: true,
+        });
+      } catch (flagError) {
+        logger.error(
+          { err: flagError, catalogId: catalogItem.id },
+          "Failed to flag catalog for manual reinstall after a failed recreate",
+        );
+      }
+    }
+  });
+}
+
+/**
  * Release the auto-reinstall that a gated catalog edit deferred: once an admin
  * approves the image, roll every install onto it. Single-tenant catalogs
  * auto-reinstall each pod; multi-tenant catalogs flag `catalogReinstallRequired`
@@ -2214,28 +2239,6 @@ function getSettledErrorMessage(result: PromiseRejectedResult): string {
   return result.reason instanceof Error
     ? result.reason.message
     : "Unknown error";
-}
-
-/**
- * Non-prompted env entries land directly in the shared K8s pod's env on a
- * multi-tenant local catalog, so any change to one of them requires a pod
- * recreate. Prompted entries are per-install secrets surfaced at request
- * time — they don't live on the shared pod and are tracked separately by
- * `promptedEnvVarsChanged`, so we exclude them here. Compared fields are
- * `key + type + value` only;
- * `description`, `required`, and other metadata don't reach the pod env.
- */
-function multitenantSharedEnvChanged(
-  oldCatalog: InternalMcpCatalog,
-  newCatalog: InternalMcpCatalog,
-): boolean {
-  const project = (cat: InternalMcpCatalog) =>
-    (cat.localConfig?.environment ?? [])
-      .filter((e) => !e.promptOnInstallation)
-      .map((e) => ({ key: e.key, type: e.type, value: e.value }));
-  return (
-    JSON.stringify(project(oldCatalog)) !== JSON.stringify(project(newCatalog))
-  );
 }
 
 /**

--- a/platform/backend/src/services/mcp-reinstall.test.ts
+++ b/platform/backend/src/services/mcp-reinstall.test.ts
@@ -44,6 +44,7 @@ async function getCatalogTools(catalogId: string) {
 
 import {
   autoReinstallServer,
+  multitenantSharedPodChanged,
   onlyForwardCompatibleEnvDiff,
   reinstallMultitenantCatalog,
   reloadToolsForServer,
@@ -1678,6 +1679,17 @@ function simulateCascadeOutcome(
   prev: InternalMcpCatalog,
   next: InternalMcpCatalog,
 ): "skip" | "auto" | "manual" {
+  // Gate order matches the route: the manual check and the multitenant
+  // shared-pod recreate both run ahead of the metadata / forward-compat
+  // gates and return early. Ordering is load-bearing for the multitenant
+  // branch — `dockerImage` isn't part of the forward-compat projection, so
+  // an image bump reaching that gate would be misread as "skip".
+  if (requiresNewUserInputForReinstall(prev, next)) {
+    return "manual";
+  }
+  if (multitenantSharedPodChanged(prev, next)) {
+    return "auto";
+  }
   if (
     isMetadataOnlyEdit(
       prev as unknown as Record<string, unknown>,
@@ -1688,9 +1700,6 @@ function simulateCascadeOutcome(
   }
   if (onlyForwardCompatibleEnvDiff(prev, next)) {
     return "skip";
-  }
-  if (requiresNewUserInputForReinstall(prev, next)) {
-    return "manual";
   }
   return "auto";
 }

--- a/platform/backend/src/services/mcp-reinstall.ts
+++ b/platform/backend/src/services/mcp-reinstall.ts
@@ -14,7 +14,8 @@ import { broadcastMcpInstallationStatus } from "@/websocket";
  * Checks if a catalog edit requires a manual reinstall.
  *
  * Returns true (manual reinstall required) when:
- * - Local execution config changed (command/args/docker/transport) - restart should be explicit
+ * - Local execution config changed (command/args/docker/transport) on a
+ *   single-tenant catalog - restart should be explicit
  * - Prompted env vars changed: added, removed, or key/required/type changed (local servers)
  * - OAuth config changed: added or removed (remote servers)
  * - Required userConfig fields changed: added, removed, or type changed (local + remote servers)
@@ -76,13 +77,12 @@ export function manualReinstallReason(
       return "new-input";
     }
 
-    // Multi-tenant catalogs handle execution-config drift via the
-    // catalog-level `catalogReinstallRequired` flag (one shared pod across
-    // all installs; the catalog-reinstall endpoint applies the change for
-    // everyone in one shot). Single-tenant: each install owns its own pod,
-    // so a silent auto-restart of others' pods would surprise them; mark
-    // every install reinstall-required and let owners reinstall explicitly.
-    // Stored credentials stay valid — no re-prompt, just a restart.
+    // Single-tenant only: each install owns its own pod, so auto-restarting
+    // everyone's on one admin's save would surprise them; mark every install
+    // reinstall-required and let owners restart explicitly. Stored
+    // credentials stay valid — no re-prompt, just a restart. A multi-tenant
+    // catalog's one shared pod belongs to the admin doing the edit and rolls
+    // immediately instead — see `multitenantSharedPodChanged`.
     if (
       !newCatalogItem.multitenant &&
       localExecutionConfigChanged(oldCatalogItem, newCatalogItem)
@@ -129,6 +129,43 @@ export function manualReinstallReason(
 
   // Builtin servers don't need reinstall
   return null;
+}
+
+/**
+ * True when an edit changes what a multi-tenant local catalog's single shared
+ * pod runs — execution config, or the non-prompted env vars baked into its
+ * spec. Prompted entries are per-install secrets resolved at request time and
+ * never reach the shared pod, so they're excluded (they're tracked separately
+ * by `promptedEnvVarsChanged`). Shared env is compared on `key + type + value`
+ * only; `description`, `required`, and other metadata don't reach the pod env.
+ *
+ * The catalog edit route recreates the shared deployment when this is true and
+ * no manual reason applies. Mirrored on the frontend by the identically-named
+ * predicate in `frontend/.../cascade-decision.ts`.
+ */
+export function multitenantSharedPodChanged(
+  oldCatalogItem: InternalMcpCatalog,
+  newCatalogItem: InternalMcpCatalog,
+): boolean {
+  if (
+    newCatalogItem.multitenant !== true ||
+    newCatalogItem.serverType !== "local"
+  ) {
+    return false;
+  }
+  if (localExecutionConfigChanged(oldCatalogItem, newCatalogItem)) return true;
+
+  const sharedEnv = (catalog: InternalMcpCatalog) =>
+    JSON.stringify(
+      (catalog.localConfig?.environment ?? [])
+        .filter((entry) => !entry.promptOnInstallation)
+        .map((entry) => ({
+          key: entry.key,
+          type: entry.type,
+          value: entry.value,
+        })),
+    );
+  return sharedEnv(oldCatalogItem) !== sharedEnv(newCatalogItem);
 }
 
 /**
@@ -698,7 +735,7 @@ function promptedEnvVarsRuntimeChanged(
   return false;
 }
 
-export function localExecutionConfigChanged(
+function localExecutionConfigChanged(
   oldCatalog: InternalMcpCatalog,
   newCatalog: InternalMcpCatalog,
 ): boolean {

--- a/platform/backend/src/services/mcp-reinstall.ts
+++ b/platform/backend/src/services/mcp-reinstall.ts
@@ -133,15 +133,20 @@ export function manualReinstallReason(
 
 /**
  * True when an edit changes what a multi-tenant local catalog's single shared
- * pod runs — execution config, or the non-prompted env vars baked into its
- * spec. Prompted entries are per-install secrets resolved at request time and
- * never reach the shared pod, so they're excluded (they're tracked separately
- * by `promptedEnvVarsChanged`). Shared env is compared on `key + type + value`
- * only; `description`, `required`, and other metadata don't reach the pod env.
+ * pod runs. The catalog edit route recreates the shared deployment when this is
+ * true and no manual reason applies. Mirrored on the frontend by the
+ * identically-named predicate in `frontend/.../cascade-decision.ts`.
  *
- * The catalog edit route recreates the shared deployment when this is true and
- * no manual reason applies. Mirrored on the frontend by the identically-named
- * predicate in `frontend/.../cascade-decision.ts`.
+ * Covers exactly two dimensions: execution config, and the non-prompted entries
+ * of `localConfig.environment` compared on `key + type + value` (`description`,
+ * `required`, and friends don't reach the pod env). Prompted entries are
+ * per-install secrets resolved at request time, never on the shared pod —
+ * `promptedEnvVarsChanged` tracks those.
+ *
+ * Deliberately NOT covered, despite also reaching the pod: `envFrom` and
+ * `imagePullSecrets`. Those fall through to the per-install auto path, which
+ * predates this predicate. Widening the projection changes which edits trigger
+ * a shared recreate, so it needs its own change with its own scenarios.
  */
 export function multitenantSharedPodChanged(
   oldCatalogItem: InternalMcpCatalog,

--- a/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.ts
@@ -7,16 +7,20 @@
  * Decision tree (must match backend exactly):
  *   1. No installs to affect → "skip"
  *   2. Any field requires user re-prompt → "manual"
- *      (covers: runtime config, prompted env schema breaks,
- *       required userConfig changes, OAuth added/removed —
+ *      (covers: single-tenant runtime config, prompted env schema
+ *       breaks, required userConfig changes, OAuth added/removed —
  *       NOT the name: a rename is a pure DB cascade)
- *   3. Only forward-compatible env/userConfig changes (or pure
+ *   3. Execution-config or shared-env drift on a multitenant local
+ *      catalog → "auto". One shared pod serves every tenant, so the
+ *      backend recreates it once on save rather than marking each
+ *      install; no tenant owes input, so there's nothing to re-prompt.
+ *   4. Only forward-compatible env/userConfig changes (or pure
  *      metadata) → "skip" — unless the name changed: a rename alone →
  *      "rename" (tools re-slug in place, no pod restarts), upgraded to
  *      "manual" when the catalog's deploymentSpecYaml references the
  *      serverName placeholder (the one way the display name reaches a
  *      pod spec, so those installs genuinely need a reinstall).
- *   4. Otherwise → "auto" (breaking change with no re-prompt needed).
+ *   5. Otherwise → "auto" (breaking change with no re-prompt needed).
  *      Remote catalogs don't pause here: the backend cascade restarts
  *      nothing for them (no pod — it only re-syncs tools), so the form
  *      saves directly ("skip"), or shows "rename" when a rename rides
@@ -127,6 +131,16 @@ export function computeCascadeOutcome(
   // re-issue secrets, etc.).
   if (requiresUserReprompt(prev, next)) return { mode: "manual", renamed };
 
+  // ── Multitenant shared-pod rollout ───────────────────────────────
+  // Mirror of the backend's `catalogScopeChangeOnMultitenant` branch,
+  // which returns before the forward-compat gate below ever runs. It
+  // has to sit here for that reason: `dockerImage` and friends aren't
+  // in `anyNonForwardCompatChange`'s projection, so an image bump would
+  // otherwise fall through as "skip" and the bar would never appear.
+  if (multitenantSharedPodChanged(prev, next)) {
+    return { mode: "auto", renamed };
+  }
+
   // ── Skip / rename via forward-compat ─────────────────────────────
   // Mirror of backend `onlyForwardCompatibleEnvDiff`. After the manual
   // checks pass, the remaining diffs may be entirely forward-
@@ -176,8 +190,17 @@ function requiresUserReprompt(
     // Name changes are handled by the rename mode, not here — deployment
     // identity is frozen and secret names are id-keyed, so a rename needs
     // no re-prompt.
-    // 1. localExecutionConfigChanged
-    if (localExecutionConfigChanged(prev, next)) return true;
+    // 1. localExecutionConfigChanged. Single-tenant only: each install owns
+    //    its own pod, so restarting everyone's on one admin's save would
+    //    surprise them. A multitenant catalog's single shared pod is the
+    //    saving admin's own, and rolls immediately — see
+    //    `multitenantSharedPodChanged`.
+    if (
+      !(next.multitenant ?? prev.multitenant) &&
+      localExecutionConfigChanged(prev, next)
+    ) {
+      return true;
+    }
     // 2. promptedEnvVarsChanged (schema evolution on prompted env vars)
     if (promptedEnvVarsChanged(prev, next)) return true;
     // 3. requiredUserConfigChanged (required field added/removed/type)
@@ -211,6 +234,33 @@ function localExecutionConfigChanged(
     serviceAccount: s.localConfig?.serviceAccount ?? "",
   });
   return JSON.stringify(shape(prev)) !== JSON.stringify(shape(next));
+}
+
+/**
+ * Mirror of the backend route's `catalogScopeChangeOnMultitenant`. True when
+ * an edit changes what the one shared pod runs — execution config, or the
+ * non-prompted env vars baked into its spec. Prompted entries are per-install
+ * secrets resolved at request time, so they never reach the shared pod.
+ */
+function multitenantSharedPodChanged(
+  prev: CascadeSnapshot,
+  next: CascadeSnapshot,
+): boolean {
+  const serverType = next.serverType ?? prev.serverType;
+  if (serverType !== "local") return false;
+  if (!(next.multitenant ?? prev.multitenant)) return false;
+
+  if (localExecutionConfigChanged(prev, next)) return true;
+
+  // `key + type + value` only — the backend ignores description/required
+  // and other metadata that doesn't reach the pod env.
+  const sharedEnv = (s: CascadeSnapshot) =>
+    JSON.stringify(
+      (s.localConfig?.environment ?? [])
+        .filter((e) => !e?.promptOnInstallation)
+        .map((e) => ({ key: e.key, type: e.type, value: e.value })),
+    );
+  return sharedEnv(prev) !== sharedEnv(next);
 }
 
 // Schema-evolution predicates. Mirror of backend/src/services/mcp-reinstall.ts.

--- a/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.ts
+++ b/platform/frontend/src/app/mcp/registry/_parts/cascade-decision.ts
@@ -237,10 +237,14 @@ function localExecutionConfigChanged(
 }
 
 /**
- * Mirror of the backend route's `catalogScopeChangeOnMultitenant`. True when
- * an edit changes what the one shared pod runs — execution config, or the
- * non-prompted env vars baked into its spec. Prompted entries are per-install
- * secrets resolved at request time, so they never reach the shared pod.
+ * Mirror of `multitenantSharedPodChanged` in
+ * `backend/src/services/mcp-reinstall.ts`. True when an edit changes what the
+ * one shared pod runs: execution config, or the non-prompted entries of
+ * `localConfig.environment`. Prompted entries are per-install secrets resolved
+ * at request time, so they never reach the shared pod.
+ *
+ * `envFrom` and `imagePullSecrets` reach the pod too but are deliberately out
+ * of scope on both sides — see the backend docstring.
  */
 function multitenantSharedPodChanged(
   prev: CascadeSnapshot,

--- a/platform/shared/cascade-scenarios.ts
+++ b/platform/shared/cascade-scenarios.ts
@@ -398,8 +398,8 @@ export const CASCADE_SCENARIOS: CascadeScenario[] = [
     expected: "auto",
     sharedPredicate: "non-metadata-diff",
     rationale:
-      "Diverges from `docker-image-change` on multitenancy alone. One shared pod serves every tenant and it belongs to the admin doing the edit — nobody else's workload is disturbed and no tenant owes a value — so the recreate runs on save instead of parking behind a second click. The single-tenant case stays manual because each install owns its own pod.",
-    ref: "staging report: image bump showed 'Save change — shared deployment will need a Reinstall'",
+      "Diverges from `docker-image-change` on multitenancy alone. One shared pod serves every tenant and it belongs to the admin doing the edit — nobody else's workload is disturbed and no tenant owes a value — so the recreate runs on save instead of parking behind a second click. The single-tenant case stays manual because each install owns its own pod. Regression: an image bump used to show the manual bar claiming the change 'needs a new value', which no dialog ever collected.",
+    ref: "#6870",
   },
   {
     id: "command-change-multitenant",

--- a/platform/shared/cascade-scenarios.ts
+++ b/platform/shared/cascade-scenarios.ts
@@ -390,6 +390,45 @@ export const CASCADE_SCENARIOS: CascadeScenario[] = [
     rationale:
       "dockerImage is a runtime field. Pods on the old tag must reinstall to pick up the new image.",
   },
+  {
+    id: "docker-image-change-multitenant",
+    shape: "multitenantLocalShared",
+    userAction: "Admin bumps dockerImage tag on a multitenant local catalog",
+    edit: replaceDockerImage("mendhak/http-https-echo:31"),
+    expected: "auto",
+    sharedPredicate: "non-metadata-diff",
+    rationale:
+      "Diverges from `docker-image-change` on multitenancy alone. One shared pod serves every tenant and it belongs to the admin doing the edit — nobody else's workload is disturbed and no tenant owes a value — so the recreate runs on save instead of parking behind a second click. The single-tenant case stays manual because each install owns its own pod.",
+    ref: "staging report: image bump showed 'Save change — shared deployment will need a Reinstall'",
+  },
+  {
+    id: "command-change-multitenant",
+    shape: "multitenantLocalShared",
+    userAction:
+      "Admin changes localConfig.command on a multitenant local catalog",
+    edit: replaceCommand("bash"),
+    expected: "auto",
+    sharedPredicate: "non-metadata-diff",
+    rationale:
+      "The multitenant rollout is keyed on execution config as a whole, not on dockerImage specifically — pins that `command` takes the same shared-pod recreate path as an image bump.",
+  },
+  {
+    id: "docker-image-change-multitenant-plus-required-prompt",
+    shape: "multitenantLocalShared",
+    userAction:
+      "Admin bumps dockerImage AND adds a required prompted env var on a multitenant local catalog",
+    edit: (base) =>
+      addEnvVar({
+        key: "NEW_REQUIRED_PROMPT",
+        type: "plain_text",
+        promptOnInstallation: true,
+        required: true,
+      })(replaceDockerImage("mendhak/http-https-echo:31")(base)),
+    expected: "manual",
+    sharedPredicate: "non-metadata-diff",
+    rationale:
+      "Re-prompt beats the shared-pod rollout: the pod can't come back on a spec whose new required field no tenant has supplied yet. The recreate is deferred to the catalog Reinstall button and every install is marked new-input.",
+  },
 
   // ── env var schema evolution (the optional-vs-required distinction) ─
   {

--- a/platform/shared/catalog-shape-fixtures.ts
+++ b/platform/shared/catalog-shape-fixtures.ts
@@ -303,6 +303,7 @@ export const CATALOG_SHAPES = {
       command: "node",
       arguments: ["server.js"],
       environment: [],
+      dockerImage: "mendhak/http-https-echo:30",
       transportType: "stdio",
     },
     userConfig: {},


### PR DESCRIPTION
Bumping the docker image on a multi-tenant local MCP catalog showed the manual confirm bar — "Save change — shared deployment will need a Reinstall" — whose body tells the admin the change "needs a new value" and that the deployment keeps running on the old config "until someone clicks Reinstall and provides the value". No value is owed for an execution-config edit, and no dialog anywhere collects one; the admin's only remaining action was a second click that recreated the pod.

The frontend's `computeCascadeOutcome` mirrored the backend gate as it stood before the multi-tenant carve-out in #6776, so `requiresUserReprompt` classified any local execution change as needing new input regardless of tenancy. The scenario matrix that exists to catch exactly this drift crossed multitenancy only with a description-only edit, and `simulateCascadeOutcome` never modelled the edit route's multi-tenant branch — so neither layer's sweep could observe the disagreement.

An execution-only edit on a multi-tenant local catalog now recreates the shared deployment on save and shows "Restart the shared deployment now? / Save and restart", the same bar single-tenant auto edits already use. One shared pod serves every tenant and it belongs to the admin performing the edit, so nobody else's workload is disturbed and there is no input to collect. Single-tenant catalogs are unchanged: each install owns its own pod, so those still mark every install and let owners restart explicitly.

`catalogReinstallRequired` keeps two narrower roles. An edit that also changes the prompted schema still defers, because the pod cannot come back on a spec whose newly required fields no tenant has supplied yet. And a failed recreate sets it, so the catalog card offers a retry while the pod stays on the old spec.

`multitenantSharedPodChanged` replaces the route-private predicate as the single backend definition, consumed by both the edit route and the gate simulator and mirrored by name on the frontend. Three hand-maintained copies of one rule are what allowed the drift in the first place.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>