### PR TITLE
feat(guardrails): default a coding CLI's native tools to Allow always at discovery

### DIFF
--- a/docs/pages/platform-ai-tool-guardrails.md
+++ b/docs/pages/platform-ai-tool-guardrails.md
@@ -102,6 +102,8 @@ Available actions:
 
 Use tool call policies to separate safe internal read paths from tools that could exfiltrate data or cause side effects.
 
+A coding CLI's own tools (Claude Code's `Bash`, for example) are discovered with **Allow always** so the client keeps working when the session turns sensitive. The client's MCP tools — names starting with `mcp__` — get the configured default instead. Each stamp is a per-tool policy you can tighten.
+
 For example, a `send_email` tool may only be acceptable for internal recipients:
 
 ```json

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -436,6 +436,8 @@ class ToolModel {
     toolId: string,
     options?: {
       invocationAction?: ToolInvocation.ToolInvocationPolicyAction;
+      /** Shown in the policy editor to explain a non-org-default stamp. */
+      invocationReason?: string | null;
       resultAction?: TrustedData.TrustedDataPolicyAction;
     },
   ): Promise<void> {
@@ -444,7 +446,7 @@ class ToolModel {
       toolId,
       conditions: [],
       action: options?.invocationAction ?? "block_when_context_is_untrusted",
-      reason: null,
+      reason: options?.invocationReason ?? null,
     });
 
     // Create default result policy
@@ -3024,6 +3026,17 @@ class ToolModel {
       name: string;
       description?: string | null;
       parameters?: Record<string, unknown>;
+      /**
+       * Per-tool override of the default invocation policy stamped at
+       * discovery, taking precedence over `defaults.invocationAction` (e.g.
+       * native coding-CLI tools default to allow so the client stays usable).
+       * The reason is recorded on the policy row so the override is
+       * self-explaining in the policy editor.
+       */
+      invocationDefaultOverride?: {
+        action: ToolInvocation.ToolInvocationPolicyAction;
+        reason: string;
+      };
     }>,
     /** @deprecated No longer used. Proxy tools are shared (agentId=NULL). Kept for call-site compatibility. */
     _agentId: string,
@@ -3078,8 +3091,23 @@ class ToolModel {
         .returning();
 
       // Create default policies for newly inserted tools
+      const overridesByName = new Map(
+        tools
+          .filter((t) => t.invocationDefaultOverride)
+          .map((t) => [t.name, t.invocationDefaultOverride]),
+      );
       for (const tool of insertedTools) {
-        await ToolModel.createDefaultPolicies(tool.id, defaults);
+        const override = overridesByName.get(tool.name);
+        await ToolModel.createDefaultPolicies(
+          tool.id,
+          override
+            ? {
+                ...defaults,
+                invocationAction: override.action,
+                invocationReason: override.reason,
+              }
+            : defaults,
+        );
       }
 
       // If some tools weren't inserted due to conflict, fetch them

--- a/platform/backend/src/routes/proxy/utils/tools.test.ts
+++ b/platform/backend/src/routes/proxy/utils/tools.test.ts
@@ -92,6 +92,88 @@ describe("persistTools", () => {
     expect(trusted[0].action).toBe("mark_as_trusted");
   });
 
+  test("defaults a coding CLI's native tools to Allow always, keeping the org default for its MCP tools", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "CLI Agent" });
+
+    await persistTools(
+      [
+        {
+          toolName: "Bash",
+          toolParameters: { type: "object", properties: {} },
+          toolDescription: "Run a shell command",
+        },
+        {
+          toolName: "mcp__github__create_issue",
+          toolParameters: { type: "object", properties: {} },
+          toolDescription: "Create a GitHub issue",
+        },
+      ],
+      agent.id,
+      // A strict org default: exactly the configuration that bricks a CLI.
+      {
+        invocationAction: "block_when_context_is_untrusted",
+        resultAction: "mark_as_untrusted",
+      },
+      { userId: undefined, externalAgentId: "anthropic_claude_code" },
+    );
+
+    const nativeTool = await ToolModel.findByName("Bash");
+    if (!nativeTool) throw new Error("expected native tool to be persisted");
+    const [nativePolicy] = await db
+      .select()
+      .from(schema.toolInvocationPoliciesTable)
+      .where(eq(schema.toolInvocationPoliciesTable.toolId, nativeTool.id));
+    expect(nativePolicy.action).toBe("allow_when_context_is_untrusted");
+    expect(nativePolicy.reason).toContain("Native Claude client tool");
+
+    // The result policy is NOT overridden: native results still flip the
+    // session sensitive so downstream guardrails keep working.
+    const [nativeResultPolicy] = await db
+      .select()
+      .from(schema.trustedDataPoliciesTable)
+      .where(eq(schema.trustedDataPoliciesTable.toolId, nativeTool.id));
+    expect(nativeResultPolicy.action).toBe("mark_as_untrusted");
+
+    const mcpTool = await ToolModel.findByName("mcp__github__create_issue");
+    if (!mcpTool) throw new Error("expected MCP tool to be persisted");
+    const [mcpPolicy] = await db
+      .select()
+      .from(schema.toolInvocationPoliciesTable)
+      .where(eq(schema.toolInvocationPoliciesTable.toolId, mcpTool.id));
+    expect(mcpPolicy.action).toBe("block_when_context_is_untrusted");
+    expect(mcpPolicy.reason).toBeNull();
+  });
+
+  test("keeps the org default for unattributed requests, even for unprefixed names", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "Unattributed Agent" });
+
+    await persistTools(
+      [
+        {
+          toolName: "some_custom_tool",
+          toolParameters: { type: "object", properties: {} },
+          toolDescription: "A tool from an unknown client",
+        },
+      ],
+      agent.id,
+      { invocationAction: "block_when_context_is_untrusted" },
+      // No client attribution: the request did not come from a known CLI.
+      { userId: undefined, externalAgentId: undefined },
+    );
+
+    const tool = await ToolModel.findByName("some_custom_tool");
+    if (!tool) throw new Error("expected tool to be persisted");
+    const [policy] = await db
+      .select()
+      .from(schema.toolInvocationPoliciesTable)
+      .where(eq(schema.toolInvocationPoliciesTable.toolId, tool.id));
+    expect(policy.action).toBe("block_when_context_is_untrusted");
+  });
+
   test("handles empty tools array without errors", async ({ makeAgent }) => {
     const agent = await makeAgent({ name: "Test Agent" });
 

--- a/platform/backend/src/routes/proxy/utils/tools.ts
+++ b/platform/backend/src/routes/proxy/utils/tools.ts
@@ -1,4 +1,8 @@
-import { isAgentTool } from "@archestra/shared";
+import {
+  CLIENT_MCP_TOOL_NAME_PREFIX,
+  clientForExternalAgentIds,
+  isAgentTool,
+} from "@archestra/shared";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import logger from "@/logging";
 import { ToolModel, ToolObservationModel } from "@/models";
@@ -102,6 +106,24 @@ export const persistTools = async (
       "[tools] persistTools: no new tools to auto-discover",
     );
   } else {
+    // A coding CLI's native tools (Bash, shell, apply_patch, …) default to
+    // "Allow always" regardless of the org's discovered-tool call policy: a
+    // strict default would block them on the first sensitive tool result and
+    // make the CLI unusable — which drives users to disconnect the proxy and
+    // lose every guardrail. The client namespaces its MCP-server tools with
+    // the mcp__ prefix, so those (and everything else) keep the org default,
+    // and the override is a visible per-tool policy an admin can tighten.
+    const observerClientFamily = clientForExternalAgentIds([
+      observer?.externalAgentId,
+    ]);
+    const nativeClientToolOverride = (toolName: string) =>
+      observerClientFamily && !toolName.startsWith(CLIENT_MCP_TOOL_NAME_PREFIX)
+        ? {
+            action: "allow_when_context_is_untrusted" as const,
+            reason: `Native ${observerClientFamily.label} client tool, allowed by default so the client keeps working in sensitive context`,
+          }
+        : undefined;
+
     // Bulk create tools (single query to check existing + single insert for new)
     logger.debug(
       { agentId, toolCount: toolsToAutoDiscover.length },
@@ -113,6 +135,7 @@ export const persistTools = async (
           name: toolName,
           parameters: toolParameters,
           description: toolDescription,
+          invocationDefaultOverride: nativeClientToolOverride(toolName),
         }),
       ),
       agentId,

--- a/platform/frontend/src/app/settings/security/page.tsx
+++ b/platform/frontend/src/app/settings/security/page.tsx
@@ -81,7 +81,10 @@ export default function SecuritySettingsPage() {
         description={
           <>
             Every new tool your agents use — whether discovered through the LLM
-            Proxy or added from an MCP server — starts with these guardrails.{" "}
+            Proxy or added from an MCP server — starts with these guardrails.
+            One exception: a coding CLI&apos;s own tools (Claude Code&apos;s
+            Bash, for example) start with an &quot;Allow always&quot; call
+            policy so the client keeps working in sensitive context.{" "}
             <ExternalDocsLink
               href={getDocsUrl(DocsPage.PlatformAiToolGuardrails)}
               className="text-primary hover:underline"

--- a/platform/shared/interactions/client.ts
+++ b/platform/shared/interactions/client.ts
@@ -11,6 +11,16 @@ import type { SupportedProvider } from "../model-constants";
  * {@link CLAUDE_CLIENT_LABEL} in the UI.
  */
 
+/**
+ * The prefix coding-CLI clients put on MCP-server tool names in their LLM
+ * requests (`mcp__<server>__<tool>`). Claude Code always applies it; Codex
+ * uses the same prefix by default (codex-rs `LEGACY_MCP_TOOL_NAME_PREFIX`),
+ * though it ships an opt-in mode that omits it per server. A tool name in an
+ * attributed coding-CLI request WITHOUT this prefix is one of the client's own
+ * native tools (Bash, shell, apply_patch, …).
+ */
+export const CLIENT_MCP_TOOL_NAME_PREFIX = "mcp__";
+
 /** Human-readable label for every Claude client id in the UI. */
 export const CLAUDE_CLIENT_LABEL = "Claude";
 


### PR DESCRIPTION
## Problem

With a strict org default for discovered tools ("Block in sensitive context"), connecting a coding CLI through the LLM proxy bricks it: the CLI's own tools (`Bash`, `Read`, `shell`, `apply_patch`, …) are auto-discovered with that default, the first tool result flips the session sensitive, and every subsequent native call is refused. The observed response is users disconnecting the proxy entirely — losing all guardrails, including the MCP-tool enforcement where the platform's control actually bites. Follow-up to #6869, which made these blocks debuggable (naming the origin) and findable (user/client filters); this prevents the next deployment from hitting the failure at all.

## Change

Tools discovered from a request attributed to a known coding-CLI client family (Claude, Codex — via the interaction client-attribution id) whose name lacks the client's `mcp__` MCP-server prefix are stamped with a call policy of **Allow always** at discovery, instead of the org's discovered-tool default. The stamp records a reason on the policy row ("Native Claude client tool, allowed by default so the client keeps working in sensitive context") so it is self-explaining in the policy editor and remains an ordinary per-tool policy an admin can tighten.

Everything else keeps the org default: the client's `mcp__`-prefixed MCP tools, unattributed requests, and all result policies — native tool results still mark the session sensitive, so sensitive-context detection and MCP-tool gating keep working exactly as before.

**Why a prefix heuristic rather than a per-client native-tool allowlist:** Codex's native tool set churns across versions and feature flags (namespaced `web.run`, unified exec, `imagegen`, …), so an allowlist rots — and it fails closed into re-bricking whenever the client ships a new native tool. The prefix heuristic fails open into a visible, adjustable policy. Codex names MCP tools `mcp__<server>__<tool>` by default (codex-rs `LEGACY_MCP_TOOL_NAME_PREFIX`); its opt-in non-prefixed mode is the one known gap and is documented on the shared constant.

Implementation: a per-tool `invocationDefaultOverride` on `ToolModel.bulkCreateProxyToolsIfNotExists`, an `invocationReason` passthrough in `createDefaultPolicies`, and detection in `persistTools` (which already receives the request's client attribution). New shared constant `CLIENT_MCP_TOOL_NAME_PREFIX`.

Docs: a note in the tool-guardrails page; the Settings → Security "Default Guardrails for MCP Tools" description now states the exception.

## Tests

Two new `persistTools` cases pin the behavior: a native Claude tool gets Allow-always-with-reason while a sibling `mcp__` tool keeps the strict org default and both result policies stay Sensitive; unattributed requests get no carve-out even for unprefixed names. Full persistTools (16) and tool-model (148) suites pass; repo-wide type-check/lint/knip green.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>