### PR TITLE
fix(frontend): derive AuditEventName from the strict query enum

### DIFF
--- a/platform/frontend/src/app/audit/logs/_components/audit-log-detail-dialog.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-detail-dialog.tsx
@@ -7,7 +7,7 @@ import { FormDialog } from "@/components/form-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DialogStickyFooter } from "@/components/ui/dialog";
-import type { AuditLog } from "@/lib/audit-log/audit-log.query";
+import type { AuditEventName, AuditLog } from "@/lib/audit-log/audit-log.query";
 import { formatDate, formatRelativeTimeFromNow } from "@/lib/utils";
 import {
   ACTION_BADGE_VARIANT,
@@ -82,7 +82,9 @@ function AuditLogDetailBody({ event }: { event: AuditLog }) {
 
         <DetailRow label="Action">
           <div className="flex flex-wrap items-center gap-2">
-            <Badge variant={ACTION_BADGE_VARIANT[event.action]}>
+            <Badge
+              variant={ACTION_BADGE_VARIANT[event.action as AuditEventName]}
+            >
               {formatAction(event.action)}
             </Badge>
             <Badge variant={OUTCOME_BADGE_VARIANT[event.outcome]}>

--- a/platform/frontend/src/lib/audit-log/audit-log.query.ts
+++ b/platform/frontend/src/lib/audit-log/audit-log.query.ts
@@ -11,7 +11,10 @@ type AuditLogsQuery = NonNullable<archestraApiTypes.GetAuditLogsData["query"]>;
 type AuditLogsResponse = archestraApiTypes.GetAuditLogsResponses["200"];
 
 export type AuditLog = AuditLogsResponse["data"][number];
-export type AuditEventName = AuditLog["action"];
+// Derived from the query filter enum, not the response: the response `action`
+// is deliberately open (accepts unknown legacy names), so only the query side
+// carries the strict catalog of known event names.
+export type AuditEventName = NonNullable<AuditLogsQuery["action"]>;
 export type AuditActorType = AuditLog["actorType"];
 export type AuditOutcome = AuditLog["outcome"];
 


### PR DESCRIPTION
## Summary

Fixes the frontend type-check break on `main` that is currently failing merge-queue runs (first seen on the queue run for #6872: [job](https://github.com/archestra-ai/archestra/actions/runs/30298632125/job/90085788244)).

#6874 made the audit read-back schema tolerate unknown action names, which widened the generated response `action` type to `union | string` (= `string`). `AuditEventName` was derived from the response type, so it collapsed to `string` and is no longer assignable to the still-strict query filter enum in `useAuditLogs` — `tsc` fails at `audit-log.query.ts:79`.

#6874's own runs never surfaced this because no frontend file changed, so `@frontend#check:ci` was a turbo cache hit; any PR touching frontend files gets a cache miss and trips over it in the merge queue.

## Changes

- `AuditEventName` now derives from the query filter enum (`NonNullable<AuditLogsQuery["action"]>`) — the strict catalog of known event names — instead of the deliberately-open response type. This also restores the `ACTION_LABEL` `Record` exhaustiveness check.
- The detail dialog's `ACTION_BADGE_VARIANT[event.action]` lookup gets the same `as AuditEventName` cast the table already uses (the variant map is a Proxy that handles unknown names).

## Testing

- `pnpm type-check` in `platform/frontend`: clean (fails on `main` without this change)
- `pnpm check:ci` in `platform/frontend`: type-check/knip/biome green; the only test failures are the pre-existing locale-sensitive `llm/(costs)/limits` date assertions, which pass under `en_US` (CI's locale) and are untouched by this change
- Audit page tests: 3 files / 58 tests pass

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>