### PR TITLE
fix(cost-optimization): scope rules to the agent's organization

### DIFF
--- a/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
@@ -1,4 +1,4 @@
-import { ModelModel } from "@/models";
+import { ModelModel, OptimizationRuleModel } from "@/models";
 import { describe, expect, test } from "@/test";
 import { TiktokenTokenizer } from "@/tokenizers";
 import type { CommonMcpToolDefinition } from "@/types";
@@ -434,5 +434,66 @@ describe("estimateToolTokens", () => {
 
     const tokens = estimateToolTokens(tools, tokenizer);
     expect(tokens).toBeGreaterThan(0);
+  });
+});
+
+describe("getOptimizedModel organization scoping", () => {
+  test("uses the agent's organization, not another org's rules", async ({
+    makeAgent,
+    makeOrganization,
+  }) => {
+    const orgA = await makeOrganization();
+    const orgB = await makeOrganization();
+    const agentA = await makeAgent({ organizationId: orgA.id });
+
+    // Org B gets a catch-all rewrite; org A has none. Teamless agent A must
+    // not pick up org B via getFirstOrganizationId().
+    await OptimizationRuleModel.create({
+      entityType: "organization",
+      entityId: orgB.id,
+      conditions: [{ maxLength: 1_000_000 }],
+      provider: "openai",
+      targetModel: "gpt-4o-mini",
+      enabled: true,
+    });
+
+    const { getOptimizedModel } = await import("./cost-optimization");
+    const result = await getOptimizedModel(
+      { ...agentA, labels: [] },
+      [{ role: "user", content: "hi" }],
+      "openai",
+      false,
+      [],
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("applies rules from the agent's own organization", async ({
+    makeAgent,
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+    const agent = await makeAgent({ organizationId: org.id });
+
+    await OptimizationRuleModel.create({
+      entityType: "organization",
+      entityId: org.id,
+      conditions: [{ maxLength: 1_000_000 }],
+      provider: "openai",
+      targetModel: "gpt-4o-mini",
+      enabled: true,
+    });
+
+    const { getOptimizedModel } = await import("./cost-optimization");
+    const result = await getOptimizedModel(
+      { ...agent, labels: [] },
+      [{ role: "user", content: "hi" }],
+      "openai",
+      false,
+      [],
+    );
+
+    expect(result).toBe("gpt-4o-mini");
   });
 });

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.ts
@@ -3,12 +3,7 @@ import {
   type SupportedProvider,
 } from "@archestra/shared";
 import logger from "@/logging";
-import {
-  AgentTeamModel,
-  ModelModel,
-  OptimizationRuleModel,
-  TeamModel,
-} from "@/models";
+import { ModelModel, OptimizationRuleModel } from "@/models";
 import {
   getTokenizer,
   type ProviderMessage,
@@ -95,33 +90,10 @@ export async function getOptimizedModel<
 ): Promise<string | null> {
   const agentId = agent.id;
 
-  // Get organizationId the same way limits do: from agent's teams OR fallback
-  let organizationId: string | null = null;
-  const agentTeamIds = await AgentTeamModel.getTeamsForAgent(agentId);
-
-  if (agentTeamIds.length > 0) {
-    // Get organizationId from agent's first team
-    const teams = await TeamModel.findByIds(agentTeamIds);
-    if (teams.length > 0 && teams[0].organizationId) {
-      organizationId = teams[0].organizationId;
-      logger.info(
-        { agentId, organizationId },
-        "[CostOptimization] resolved organizationId from team",
-      );
-    }
-  } else {
-    // If agent has no teams, check if there are any organization optimization rules to apply (fallback)
-    // TODO: this fallback doesn't work if there are multiple organizations.
-    organizationId = await OptimizationRuleModel.getFirstOrganizationId();
-
-    if (organizationId) {
-      logger.info(
-        { agentId, organizationId },
-        "[CostOptimization] agent has no teams - using fallback organization",
-      );
-    }
-  }
-
+  // Always scope rules to the agent's own organization. The previous
+  // team-then-getFirstOrganizationId fallback could apply another org's rules
+  // to a teamless agent in multi-tenant deployments.
+  const organizationId = agent.organizationId;
   if (!organizationId) {
     logger.warn(
       { agentId },
@@ -129,6 +101,11 @@ export async function getOptimizedModel<
     );
     return null;
   }
+
+  logger.info(
+    { agentId, organizationId },
+    "[CostOptimization] resolved organizationId from agent",
+  );
 
   // Fetch enabled optimization rules for this organization, agent, and provider
   const rules =


### PR DESCRIPTION
## Summary
- Teamless agents previously fell back to `getFirstOrganizationId()`, which could apply another organization's optimization rules in multi-tenant deployments.
- `getOptimizedModel` now uses `agent.organizationId` directly.
- Added tests that a teamless agent in org A does not pick up org B's rules, and that org A's own rules still apply.

## Test plan
- [x] `pnpm exec vitest run src/routes/proxy/utils/cost-optimization.test.ts`