### PR TITLE
fix(llm-cost): exclude subscription usage from default user limits

### DIFF
--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -35,7 +35,7 @@ Each interaction records a billing mode. Metered traffic is billed per token, so
 
 The "Actual Cost" line and the per-team, per-agent, and per-model cost figures show billed spend. Subscription usage appears as a separate "Subscription (Not Billed)" line on the Costs chart and as a badge on the affected sessions.
 
-Archestra detects the billing mode from the credential itself. Anthropic subscription logins (Claude Code on a Max or Pro plan, for example) use OAuth tokens with a distinct format, so no configuration is needed. Turn detection off with `ARCHESTRA_LLM_COST_SUBSCRIPTION_AUTODETECT=false` to treat all traffic as metered.
+Archestra detects the billing mode from the credential itself. Anthropic subscription logins (Claude Code on a Max or Pro plan, for example) use OAuth tokens with a distinct format, and ChatGPT subscription (Codex) credentials are similarly recognized, so no configuration is needed. Turn detection off with `ARCHESTRA_LLM_COST_SUBSCRIPTION_AUTODETECT=false` to treat all traffic as metered.
 
 Detection applies to new interactions. Traffic recorded before detection existed stays metered.
 

--- a/platform/backend/src/models/limit.test.ts
+++ b/platform/backend/src/models/limit.test.ts
@@ -2422,6 +2422,68 @@ describe("cleanupLimitsIfNeeded", () => {
     expect(result?.[1]).toContain("user-level cost limit");
   });
 
+  test("subscription-billed interactions do not count toward default user limits", async ({
+    makeAgent,
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeInteraction,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id);
+    const agent = await makeAgent({ organizationId: org.id });
+
+    await EnvironmentDefaultUserLimitModel.create({
+      organizationId: org.id,
+      environmentId: null,
+      limitValue: 1,
+      model: ["gpt-4o"],
+      cleanupInterval: "1w",
+    });
+
+    const subscriptionInteraction = await makeInteraction(agent.id, {
+      model: "gpt-4o",
+      inputTokens: 100,
+      outputTokens: 100,
+      billingMode: "subscription",
+    });
+    await db
+      .update(schema.interactionsTable)
+      .set({
+        userId: user.id,
+        cost: "5",
+      })
+      .where(eq(schema.interactionsTable.id, subscriptionInteraction.id));
+
+    const allowed = await LimitValidationService.checkLimitsBeforeRequest({
+      agentId: agent.id,
+      userId: user.id,
+    });
+    expect(allowed).toBeNull();
+
+    const meteredInteraction = await makeInteraction(agent.id, {
+      model: "gpt-4o",
+      inputTokens: 100,
+      outputTokens: 100,
+      billingMode: "metered",
+    });
+    await db
+      .update(schema.interactionsTable)
+      .set({
+        userId: user.id,
+        cost: "2",
+      })
+      .where(eq(schema.interactionsTable.id, meteredInteraction.id));
+
+    const blocked = await LimitValidationService.checkLimitsBeforeRequest({
+      agentId: agent.id,
+      userId: user.id,
+    });
+    expect(blocked).not.toBeNull();
+    expect(blocked?.[1]).toContain("user-level cost limit");
+  });
+
   test("custom user limits override the inherited default user limit", async ({
     makeAgent,
     makeOrganization,

--- a/platform/backend/src/models/limit.ts
+++ b/platform/backend/src/models/limit.ts
@@ -1475,6 +1475,9 @@ async function getDefaultUserLimitUsage(params: {
 }) {
   const conditions: SQL[] = [
     eq(schema.interactionsTable.userId, params.userId),
+    // Subscription traffic is covered by a plan ($0 billed spend) and must not
+    // burn default user limits — same rule as updateUsageAfterInteraction.
+    eq(schema.interactionsTable.billingMode, "metered"),
     buildUsagePeriodStartCondition(params.cleanupInterval),
   ];
 

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -13,7 +13,10 @@ import type {
 } from "openai/resources/responses/responses";
 import config from "@/config";
 import { metrics } from "@/observability";
-import { decodeOpenAiCodexCredential } from "@/services/openai-codex-credentials";
+import {
+  decodeOpenAiCodexCredential,
+  isOpenAiCodexCredential,
+} from "@/services/openai-codex-credentials";
 import type {
   ChunkProcessingResult,
   CommonMcpToolDefinition,
@@ -75,6 +78,13 @@ export const openAiResponsesAdapterFactory: LLMProvider<
 
   extractApiKey(headers: OpenAiResponsesHeaders): string | undefined {
     return headers.authorization;
+  },
+
+  isSubscriptionCredential(apiKey: string | undefined): boolean {
+    // ChatGPT-subscription (Codex) credentials are encoded with a marker
+    // prefix; they are covered by a flat-rate plan and must not burn metered
+    // cost limits (same as Anthropic sk-ant-oat… OAuth tokens).
+    return isOpenAiCodexCredential(apiKey);
   },
 
   getBaseUrl(): string | undefined {

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -1479,6 +1479,13 @@ export const openaiAdapterFactory: LLMProvider<
     return headers.authorization;
   },
 
+  isSubscriptionCredential(apiKey: string | undefined): boolean {
+    // ChatGPT-subscription (Codex) credentials are encoded with a marker
+    // prefix; they are covered by a flat-rate plan and must not burn metered
+    // cost limits (same as Anthropic sk-ant-oat… OAuth tokens).
+    return isOpenAiCodexCredential(apiKey);
+  },
+
   getBaseUrl(): string | undefined {
     return config.llm.openai.baseUrl;
   },

--- a/platform/backend/src/routes/proxy/utils/billing-mode.test.ts
+++ b/platform/backend/src/routes/proxy/utils/billing-mode.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { anthropicAdapterFactory } from "../adapters/anthropic";
+import { openaiAdapterFactory } from "../adapters/openai";
+import { openAiResponsesAdapterFactory } from "../adapters/openai-responses";
+import { encodeOpenAiCodexCredential } from "@/services/openai-codex-credentials";
 import { resolveInteractionBillingMode } from "./billing-mode";
 
 describe("resolveInteractionBillingMode", () => {
@@ -59,5 +62,41 @@ describe("anthropic isSubscriptionCredential (credential format)", () => {
 
   test("undefined credential stays metered", () => {
     expect(isSubscription(undefined)).toBe(false);
+  });
+});
+
+describe("openai isSubscriptionCredential (Codex credential format)", () => {
+  const codexCredential = encodeOpenAiCodexCredential({
+    refreshToken: "rt_test",
+    accountId: "acct_test",
+  });
+
+  test("chatgpt-oauth encoded credential => subscription on chat completions", () => {
+    expect(
+      openaiAdapterFactory.isSubscriptionCredential?.(codexCredential),
+    ).toBe(true);
+  });
+
+  test("chatgpt-oauth encoded credential => subscription on responses", () => {
+    expect(
+      openAiResponsesAdapterFactory.isSubscriptionCredential?.(codexCredential),
+    ).toBe(true);
+  });
+
+  test("plain sk- API key stays metered", () => {
+    expect(
+      openaiAdapterFactory.isSubscriptionCredential?.("sk-proj-abc123"),
+    ).toBe(false);
+    expect(
+      openAiResponsesAdapterFactory.isSubscriptionCredential?.(
+        "sk-proj-abc123",
+      ),
+    ).toBe(false);
+  });
+
+  test("undefined credential stays metered", () => {
+    expect(openaiAdapterFactory.isSubscriptionCredential?.(undefined)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Default user limit recomputation still summed list-price `cost` for subscription-billed interactions, so Pro/Max (and similar) traffic could trip inherited user caps.
- ChatGPT Codex credentials were never classified as subscription, so they accrued as metered usage.
- Filter default-user usage to `billingMode = metered`, add `isSubscriptionCredential` for OpenAI chat + Responses adapters, and update costs/limits docs.

## Test plan
- [x] `pnpm exec vitest run src/routes/proxy/utils/billing-mode.test.ts`
- [x] `pnpm exec vitest run src/models/limit.test.ts -t "subscription-billed"`