### PR TITLE
fix(interactions): harden tool-arg JSON parse and last tool-call id

### DIFF
--- a/platform/shared/interactions/llmProviders/anthropic.test.ts
+++ b/platform/shared/interactions/llmProviders/anthropic.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { Interaction } from "./common";
+import AnthropicMessagesInteraction from "./anthropic";
+
+describe("AnthropicMessagesInteraction.getLastToolCallId", () => {
+  it("returns the last tool_use_id when a user message has multiple tool_results", () => {
+    const interaction = new AnthropicMessagesInteraction({
+      type: "anthropic:messages",
+      model: "claude-sonnet-4-5",
+      request: {
+        model: "claude-sonnet-4-5",
+        max_tokens: 1024,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_first",
+                content: "one",
+              },
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_second",
+                content: "two",
+              },
+            ],
+          },
+        ],
+      },
+      response: {
+        id: "msg_1",
+        content: [],
+        model: "claude-sonnet-4-5",
+        role: "assistant",
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        type: "message",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    } as unknown as Interaction);
+
+    expect(interaction.getLastToolCallId()).toBe("toolu_second");
+  });
+});

--- a/platform/shared/interactions/llmProviders/anthropic.test.ts
+++ b/platform/shared/interactions/llmProviders/anthropic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { Interaction } from "./common";
 import AnthropicMessagesInteraction from "./anthropic";
+import type { Interaction } from "./common";
 
 describe("AnthropicMessagesInteraction.getLastToolCallId", () => {
   it("returns the last tool_use_id when a user message has multiple tool_results", () => {

--- a/platform/shared/interactions/llmProviders/anthropic.ts
+++ b/platform/shared/interactions/llmProviders/anthropic.ts
@@ -42,7 +42,8 @@ class AnthropicMessagesInteraction implements InteractionUtils {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
       if (message.role === "user" && Array.isArray(message.content)) {
-        for (const block of message.content) {
+        for (let j = message.content.length - 1; j >= 0; j--) {
+          const block = message.content[j];
           if (isToolResultBlock(block)) {
             return block.tool_use_id;
           }

--- a/platform/shared/interactions/llmProviders/bedrock.test.ts
+++ b/platform/shared/interactions/llmProviders/bedrock.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import BedrockConverseInteraction from "./bedrock";
+import type { Interaction } from "./common";
+
+describe("BedrockConverseInteraction.getLastToolCallId", () => {
+  it("returns the last toolUseId when a user message has multiple toolResults", () => {
+    const interaction = new BedrockConverseInteraction({
+      type: "bedrock:converse",
+      model: "anthropic.claude-sonnet-4-5-v1:0",
+      request: {
+        modelId: "anthropic.claude-sonnet-4-5-v1:0",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { toolResult: { toolUseId: "tooluse_first", content: "one" } },
+              { toolResult: { toolUseId: "tooluse_second", content: "two" } },
+            ],
+          },
+        ],
+      },
+      response: { output: { message: { role: "assistant", content: [] } } },
+    } as unknown as Interaction);
+
+    expect(interaction.getLastToolCallId()).toBe("tooluse_second");
+  });
+
+  it("returns null when the last user message has no toolResult blocks", () => {
+    const interaction = new BedrockConverseInteraction({
+      type: "bedrock:converse",
+      model: "anthropic.claude-sonnet-4-5-v1:0",
+      request: {
+        modelId: "anthropic.claude-sonnet-4-5-v1:0",
+        messages: [{ role: "user", content: [{ text: "hello" }] }],
+      },
+      response: { output: { message: { role: "assistant", content: [] } } },
+    } as unknown as Interaction);
+
+    expect(interaction.getLastToolCallId()).toBeNull();
+  });
+});

--- a/platform/shared/interactions/llmProviders/bedrock.ts
+++ b/platform/shared/interactions/llmProviders/bedrock.ts
@@ -98,7 +98,8 @@ class BedrockConverseInteraction implements InteractionUtils {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
       if (message.role === "user" && Array.isArray(message.content)) {
-        for (const block of message.content) {
+        for (let j = message.content.length - 1; j >= 0; j--) {
+          const block = message.content[j];
           if (block.toolResult?.toolUseId) {
             return block.toolResult.toolUseId;
           }

--- a/platform/shared/interactions/llmProviders/gemini.test.ts
+++ b/platform/shared/interactions/llmProviders/gemini.test.ts
@@ -162,4 +162,49 @@ describe("GeminiGenerateContentInteraction", () => {
       expect(gemini.getLastUserMessage()).toBe("Second message");
     });
   });
+
+  describe("modelName", () => {
+    it("prefers the stored interaction.model over response.modelVersion", () => {
+      const gemini = new GeminiGenerateContentInteraction({
+        model: "gemini-2.5-pro",
+        request: { contents: [] },
+        response: {},
+      } as unknown as Interaction);
+
+      expect(gemini.modelName).toBe("gemini-2.5-pro");
+    });
+  });
+
+  describe("getLastToolCallId", () => {
+    it("returns the last functionResponse id in a multi-tool user turn", () => {
+      const gemini = new GeminiGenerateContentInteraction({
+        request: {
+          contents: [
+            {
+              role: "user",
+              parts: [
+                {
+                  functionResponse: {
+                    id: "fr_first",
+                    name: "a",
+                    response: {},
+                  },
+                },
+                {
+                  functionResponse: {
+                    id: "fr_second",
+                    name: "b",
+                    response: {},
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        response: { modelVersion: "gemini-2.5-pro" },
+      } as unknown as Interaction);
+
+      expect(gemini.getLastToolCallId()).toBe("fr_second");
+    });
+  });
 });

--- a/platform/shared/interactions/llmProviders/gemini.test.ts
+++ b/platform/shared/interactions/llmProviders/gemini.test.ts
@@ -164,14 +164,35 @@ describe("GeminiGenerateContentInteraction", () => {
   });
 
   describe("modelName", () => {
+    // Every other provider mapper resolves `interaction.model` first, and the
+    // logs UI builds its model badges from that same column — Gemini reading
+    // `response.modelVersion` made the detail view disagree with the list.
     it("prefers the stored interaction.model over response.modelVersion", () => {
       const gemini = new GeminiGenerateContentInteraction({
         model: "gemini-2.5-pro",
         request: { contents: [] },
-        response: {},
+        response: { modelVersion: "gemini-2.5-pro-preview-03-25" },
       } as unknown as Interaction);
 
       expect(gemini.modelName).toBe("gemini-2.5-pro");
+    });
+
+    it("falls back to response.modelVersion when no model is stored", () => {
+      const gemini = new GeminiGenerateContentInteraction({
+        request: { contents: [] },
+        response: { modelVersion: "gemini-2.5-pro-preview-03-25" },
+      } as unknown as Interaction);
+
+      expect(gemini.modelName).toBe("gemini-2.5-pro-preview-03-25");
+    });
+
+    it("is an empty string rather than undefined when neither is present", () => {
+      const gemini = new GeminiGenerateContentInteraction({
+        request: { contents: [] },
+        response: {},
+      } as unknown as Interaction);
+
+      expect(gemini.modelName).toBe("");
     });
   });
 

--- a/platform/shared/interactions/llmProviders/gemini.ts
+++ b/platform/shared/interactions/llmProviders/gemini.ts
@@ -109,7 +109,8 @@ class GeminiGenerateContentInteraction implements InteractionUtils {
       interaction.request as archestraApiTypes.GeminiGenerateContentRequest;
     this.response =
       interaction.response as archestraApiTypes.GeminiGenerateContentResponse;
-    this.modelName = this.response.modelVersion as string;
+    this.modelName =
+      interaction.model ?? (this.response.modelVersion as string) ?? "";
   }
 
   isLastMessageToolCall(): boolean {
@@ -139,7 +140,8 @@ class GeminiGenerateContentInteraction implements InteractionUtils {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
       if (message.role === "user" && Array.isArray(message.parts)) {
-        for (const part of message.parts) {
+        for (let j = message.parts.length - 1; j >= 0; j--) {
+          const part = message.parts[j];
           if (hasFunctionResponse(part) && part.functionResponse.id) {
             return part.functionResponse.id;
           }

--- a/platform/shared/interactions/llmProviders/gemini.ts
+++ b/platform/shared/interactions/llmProviders/gemini.ts
@@ -1,8 +1,8 @@
+import type * as archestraApiTypes from "../../hey-api/clients/api/types.gen";
 import {
   ARCHESTRA_TOOL_NAME_TAG,
-  type archestraApiTypes,
   parseArchestraToolRefusal,
-} from "../../index";
+} from "../../tool-refusal";
 import type { PartialUIMessage } from "../types";
 import type { DualLlmAnalysis, Interaction, InteractionUtils } from "./common";
 

--- a/platform/shared/interactions/llmProviders/json.ts
+++ b/platform/shared/interactions/llmProviders/json.ts
@@ -1,0 +1,13 @@
+/**
+ * Tool-call arguments and tool outputs arrive as provider-supplied strings that
+ * are only *expected* to be JSON. Truncated streams and models that emit invalid
+ * JSON both reach the interaction log verbatim, so parsing has to be total:
+ * returning the raw string keeps the log viewer rendering instead of throwing.
+ */
+export function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}

--- a/platform/shared/interactions/llmProviders/openai-responses.ts
+++ b/platform/shared/interactions/llmProviders/openai-responses.ts
@@ -1,6 +1,7 @@
 import { parseArchestraToolRefusal } from "../../tool-refusal";
 import type { PartialUIMessage } from "../types";
 import type { Interaction, InteractionUtils } from "./common";
+import { tryParseJson } from "./json";
 
 type OpenAiResponsesArm = Extract<
   Interaction,
@@ -264,12 +265,4 @@ function extractInputMessageText(content: unknown): string {
       return [];
     })
     .join("\n");
-}
-
-function tryParseJson(value: string): unknown {
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
 }

--- a/platform/shared/interactions/llmProviders/openai.test.ts
+++ b/platform/shared/interactions/llmProviders/openai.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { Interaction } from "./common";
+import OpenAiChatCompletionInteraction from "./openai";
+
+describe("OpenAiChatCompletionInteraction", () => {
+  it("maps tool calls with malformed JSON arguments without throwing", () => {
+    const interaction = new OpenAiChatCompletionInteraction({
+      type: "openai:chatCompletions",
+      model: "gpt-4o",
+      request: {
+        model: "gpt-4o",
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: {
+                  name: "search",
+                  arguments: "{incomplete",
+                },
+              },
+            ],
+          },
+        ],
+      },
+      response: {
+        id: "chatcmpl-1",
+        choices: [],
+        created: 0,
+        model: "gpt-4o",
+        object: "chat.completion",
+      },
+    } as unknown as Interaction);
+
+    expect(() => interaction.mapToUiMessages()).not.toThrow();
+    const messages = interaction.mapToUiMessages();
+    expect(messages[0]?.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "dynamic-tool",
+          toolName: "search",
+          toolCallId: "call_1",
+          input: "{incomplete",
+        }),
+      ]),
+    );
+  });
+});

--- a/platform/shared/interactions/llmProviders/openai.ts
+++ b/platform/shared/interactions/llmProviders/openai.ts
@@ -1,4 +1,5 @@
-import { type archestraApiTypes, parseArchestraToolRefusal } from "../../index";
+import type * as archestraApiTypes from "../../hey-api/clients/api/types.gen";
+import { parseArchestraToolRefusal } from "../../tool-refusal";
 import type { PartialUIMessage } from "../types";
 import type { DualLlmAnalysis, Interaction, InteractionUtils } from "./common";
 
@@ -171,7 +172,7 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
               toolName: toolCall.function.name,
               toolCallId: toolCall.id,
               state: "input-available",
-              input: JSON.parse(toolCall.function.arguments),
+              input: tryParseJson(toolCall.function.arguments),
             });
           } else if (toolCall.type === "custom") {
             parts.push({
@@ -179,7 +180,7 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
               toolName: toolCall.custom.name,
               toolCallId: toolCall.id,
               state: "input-available",
-              input: JSON.parse(toolCall.custom.input),
+              input: tryParseJson(toolCall.custom.input),
             });
           }
         }
@@ -366,3 +367,11 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
 }
 
 export default OpenAiChatCompletionInteraction;
+
+function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}

--- a/platform/shared/interactions/llmProviders/openai.ts
+++ b/platform/shared/interactions/llmProviders/openai.ts
@@ -2,6 +2,7 @@ import type * as archestraApiTypes from "../../hey-api/clients/api/types.gen";
 import { parseArchestraToolRefusal } from "../../tool-refusal";
 import type { PartialUIMessage } from "../types";
 import type { DualLlmAnalysis, Interaction, InteractionUtils } from "./common";
+import { tryParseJson } from "./json";
 
 class OpenAiChatCompletionInteraction implements InteractionUtils {
   private request: archestraApiTypes.OpenAiChatCompletionRequest;
@@ -367,11 +368,3 @@ class OpenAiChatCompletionInteraction implements InteractionUtils {
 }
 
 export default OpenAiChatCompletionInteraction;
-
-function tryParseJson(value: string): unknown {
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-}


### PR DESCRIPTION
## Summary
- Malformed/truncated tool-call arguments crashed OpenAI chat `mapToUiMessages` (LLM logs UI) via bare `JSON.parse`.
- `getLastToolCallId` returned the first tool result in a parallel multi-tool turn for Anthropic/Bedrock/Gemini.
- Gemini ignored stored `interaction.model` when `modelVersion` was missing.
- Also stop importing OpenAI mapper helpers through the shared barrel to avoid a fragile circular import.

## Test plan
- [x] `pnpm exec vitest run interactions/llmProviders/openai.test.ts interactions/llmProviders/anthropic.test.ts interactions/llmProviders/gemini.test.ts interactions/llmProviders/openai-responses.test.ts`