### PR TITLE
fix: classify recurring external-failure errors across MCP runtime, chat, and model listing

### DIFF
--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -115,6 +115,19 @@ export class McpServerConnectionTimeoutError extends Error {
 }
 
 /**
+ * Thrown when connecting to (or discovering tools from) a user's MCP server
+ * fails — the server is unreachable, rejects the connection, or errors during
+ * the handshake. An operational/config condition on the caller's side, not a
+ * bug of ours: error tracking drops it by name, and routes map it to a 502.
+ */
+class McpServerUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpServerUnreachableError";
+  }
+}
+
+/**
  * Thrown when a stored HTTP session ID is no longer valid (e.g. pod restarted).
  * Caught by executeToolCallForOwner to trigger a transparent retry with a fresh session.
  */
@@ -3126,14 +3139,14 @@ class McpClient {
         }
 
         // Last attempt failed, throw error
-        throw new Error(
+        throw new McpServerUnreachableError(
           `Failed to connect to MCP server ${catalogItem.name}: ${lastError.message}`,
         );
       }
     }
 
     // Should never reach here, but TypeScript needs it
-    throw new Error(
+    throw new McpServerUnreachableError(
       `Failed to connect to MCP server ${catalogItem.name}: ${
         lastError?.message || "Unknown error"
       }`,

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.ts
@@ -90,6 +90,19 @@ const AWS_APPLICATION_NETWORK_POLICY_RESOURCE = {
 // Ready before giving up. 5 minutes covers a slow image pull on first install.
 const POD_READY_WAIT_MS = 5 * TimeInMs.Minute;
 
+/**
+ * Thrown when a user's MCP server deployment fails to come up (crashing
+ * container, unschedulable pod, bad image/config). A condition of the user's
+ * server or environment, not a bug of ours: error tracking drops it by name,
+ * and routes surface it as an upstream failure.
+ */
+class McpServerDeploymentFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpServerDeploymentFailedError";
+  }
+}
+
 // Container waiting reasons that won't resolve without user action (bad
 // config, invalid image name, crashing server) — treat as terminal failures.
 const TERMINAL_CONTAINER_WAITING_REASONS = [
@@ -3210,7 +3223,7 @@ export default class K8sDeployment {
           if (eventCheck.hasFailure) {
             this.state = "failed";
             this.errorMessage = eventCheck.message || "Deployment failed";
-            throw new Error(
+            throw new McpServerDeploymentFailedError(
               `Deployment ${this.deploymentName} failed: ${eventCheck.message}`,
             );
           }
@@ -3236,7 +3249,7 @@ export default class K8sDeployment {
                 this.state = "failed";
                 this.errorMessage =
                   conditionCheck.message || "Pod scheduling failed";
-                throw new Error(
+                throw new McpServerDeploymentFailedError(
                   `Deployment ${this.deploymentName} failed: ${conditionCheck.message}`,
                 );
               }
@@ -3257,7 +3270,7 @@ export default class K8sDeployment {
                 ) {
                   this.state = "failed";
                   this.errorMessage = message;
-                  throw new Error(
+                  throw new McpServerDeploymentFailedError(
                     `Deployment ${this.deploymentName} failed: ${waitingReason} - ${message}`,
                   );
                 }

--- a/platform/backend/src/observability/error-tracking-policy.test.ts
+++ b/platform/backend/src/observability/error-tracking-policy.test.ts
@@ -98,6 +98,8 @@ describe("classifyErrorForTracking", () => {
     for (const name of [
       "McpServerNotReadyError",
       "McpServerConnectionTimeoutError",
+      "McpServerUnreachableError",
+      "McpServerDeploymentFailedError",
     ]) {
       expect(classifyErrorForTracking(namedError(name)).report).toBe(false);
     }

--- a/platform/backend/src/observability/error-tracking-policy.ts
+++ b/platform/backend/src/observability/error-tracking-policy.ts
@@ -96,6 +96,8 @@ export function classifyErrorForTracking(
 const MCP_UNREACHABLE_ERROR_NAMES = new Set([
   "McpServerNotReadyError",
   "McpServerConnectionTimeoutError",
+  "McpServerUnreachableError",
+  "McpServerDeploymentFailedError",
 ]);
 
 function isNonActionableError(error: unknown): boolean {

--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -1698,6 +1698,29 @@ describe("mapProviderError - Fallback behavior", () => {
     expect(result.isRetryable).toBe(false);
   });
 
+  it("should map a relayed secrets-backend outage to a retryable server error without capturing", () => {
+    // The proxy relays the secrets-manager-unavailable message; the incident
+    // is already captured and grouped at its source.
+    const error = new Error(
+      "An error occurred while accessing secrets. Please try again later or contact your administrator.",
+    );
+    const result = mapProviderError(error, "anthropic");
+
+    expect(result.code).toBe(ChatErrorCode.ServerError);
+    expect(result.isRetryable).toBe(true);
+    expect(mockSentryCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("should map Bedrock's bare internal failure message to a retryable server error without capturing", () => {
+    // Mid-stream delivery: no status code and no typed body — just the message.
+    const error = new Error("Bedrock is unable to process your request.");
+    const result = mapProviderError(error, "bedrock");
+
+    expect(result.code).toBe(ChatErrorCode.ServerError);
+    expect(result.isRetryable).toBe(true);
+    expect(mockSentryCaptureException).not.toHaveBeenCalled();
+  });
+
   it("should handle string errors", () => {
     const result = mapProviderError("Simple string error", "openai");
 

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -35,6 +35,7 @@ import logger from "@/logging";
 import { getActiveSessionId } from "@/observability/request-context";
 import { captureRawProviderErrorInSentry } from "@/observability/sentry";
 import { MICROSOFT_365_COPILOT_TOOLS_UNSUPPORTED_MESSAGE } from "@/routes/proxy/adapters/microsoft-365-copilot-graph-translator";
+import { SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
 import { LlmProviderAuthRequiredError } from "@/utils/llm-provider-auth-error";
 import { ContextWindowExceededError } from "./normalization/enforce-context-window-limit";
 import { RequestTooLargeError } from "./normalization/enforce-request-size-limit";
@@ -1891,6 +1892,29 @@ export function mapProviderError(
     errorCode = ChatErrorCode.ServerError;
   }
 
+  // A secrets-backend outage surfaces through the provider call as our own
+  // secrets-unavailable message (relayed by the proxy), often with no status
+  // code, landing on the dead-end Unknown card. The underlying incident is
+  // already captured and grouped at its source — classify it as a retryable
+  // ServerError here so the user gets a retry and the relay isn't re-captured.
+  if (
+    errorCode === ChatErrorCode.Unknown &&
+    isSecretsUnavailableMessage(errorMessage)
+  ) {
+    errorCode = ChatErrorCode.ServerError;
+  }
+
+  // Bedrock's InternalServerException arrives mid-stream as the bare message
+  // "Bedrock is unable to process your request." with no status code or typed
+  // body, so the per-provider mapper can't classify it. It's a transient
+  // provider-side failure — retryable ServerError, like any provider 5xx.
+  if (
+    errorCode === ChatErrorCode.Unknown &&
+    isProviderInternalFailureMessage(errorMessage)
+  ) {
+    errorCode = ChatErrorCode.ServerError;
+  }
+
   // Determine error type from parsed error
   const errorType =
     (parsedError as ParsedOpenAIError)?.type ||
@@ -1987,6 +2011,20 @@ function isToolApprovalPolicyBlockError(message: string): boolean {
 
 function isUpstreamProviderError(message: string): boolean {
   return /^upstream error from /i.test(message);
+}
+
+// `includes` rather than equality: the message may pick up envelope prefixes
+// on its way through the proxy, but the secrets-manager text and internal code
+// slug are stable constants.
+function isSecretsUnavailableMessage(message: string): boolean {
+  return (
+    message.includes("An error occurred while accessing secrets") ||
+    message.includes(SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE)
+  );
+}
+
+function isProviderInternalFailureMessage(message: string): boolean {
+  return message.includes("unable to process your request");
 }
 
 /**

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import config, { type AnthropicWifConfig } from "@/config";
+import { ApiError } from "@/types";
 import { fetchAnthropicModels } from "./anthropic";
 
 // No module mocks: drive the real WIF client + fetcher through the fetch
@@ -123,5 +124,37 @@ describe("fetchAnthropicModels", () => {
       "x-api-key": "",
       "anthropic-version": "2023-06-01",
     });
+  });
+
+  test("relays an upstream client error with its real status", async () => {
+    // An invalid provider key is the caller's 401, not a crash of ours.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("unauthorized", { status: 401 })),
+    );
+
+    const error = await fetchAnthropicModels(
+      "sk-ant-bad",
+      "https://api.anthropic.com",
+    ).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.statusCode).toBe(401);
+    expect(error.message).toBe("Failed to fetch Anthropic models: 401");
+  });
+
+  test("maps an upstream 5xx to a 502 upstream failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("provider down", { status: 500 })),
+    );
+
+    const error = await fetchAnthropicModels(
+      "sk-ant-key",
+      "https://api.anthropic.com",
+    ).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.statusCode).toBe(502);
   });
 });

--- a/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/anthropic.ts
@@ -7,7 +7,7 @@ import config from "@/config";
 import logger from "@/logging";
 import type { Anthropic } from "@/types";
 import { joinBaseUrl } from "@/utils/base-url";
-import type { ModelInfo } from "./types";
+import { type ModelInfo, modelFetchError } from "./types";
 
 export async function fetchAnthropicModels(
   apiKey: string,
@@ -31,7 +31,7 @@ export async function fetchAnthropicModels(
       { status: response.status, error: errorText },
       "Failed to fetch Anthropic models",
     );
-    throw new Error(`Failed to fetch Anthropic models: ${response.status}`);
+    throw modelFetchError("Anthropic models", response.status);
   }
 
   const data = (await response.json()) as {

--- a/platform/backend/src/routes/chat/model-fetchers/bedrock.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/bedrock.ts
@@ -11,7 +11,7 @@ import {
 } from "@/knowledge-base/embedding-clients/bedrock-models";
 import logger from "@/logging";
 import { joinBaseUrl } from "@/utils/base-url";
-import type { ModelInfo } from "./types";
+import { type ModelInfo, modelFetchError } from "./types";
 
 export async function fetchBedrockModels(
   apiKey: string,
@@ -440,7 +440,7 @@ async function bedrockControlPlaneGet(params: {
       { status: response.status, error: errorText },
       `Failed to fetch Bedrock ${resource} via ${authType}`,
     );
-    throw new Error(`Failed to fetch Bedrock ${resource}: ${response.status}`);
+    throw modelFetchError(`Bedrock ${resource}`, response.status);
   }
 
   return response.json();

--- a/platform/backend/src/routes/chat/model-fetchers/gemini.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/gemini.ts
@@ -4,7 +4,7 @@ import config from "@/config";
 import logger from "@/logging";
 import type { Gemini } from "@/types";
 import { joinBaseUrl } from "@/utils/base-url";
-import type { ModelInfo } from "./types";
+import { type ModelInfo, modelFetchError } from "./types";
 
 export async function fetchGeminiModels(
   apiKey: string,
@@ -27,7 +27,7 @@ export async function fetchGeminiModels(
       { status: response.status, error: errorText },
       "Failed to fetch Gemini models",
     );
-    throw new Error(`Failed to fetch Gemini models: ${response.status}`);
+    throw modelFetchError("Gemini models", response.status);
   }
 
   const data = (await response.json()) as {

--- a/platform/backend/src/routes/chat/model-fetchers/github-copilot.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/github-copilot.ts
@@ -3,7 +3,7 @@ import logger from "@/logging";
 import { createGithubCopilotFetch } from "@/services/github-copilot-token";
 import { ApiError } from "@/types";
 import { joinBaseUrl } from "@/utils/base-url";
-import type { ModelInfo } from "./types";
+import { type ModelInfo, modelFetchError } from "./types";
 
 /**
  * Fetches the models available to the Copilot subscription behind the given
@@ -43,9 +43,7 @@ export async function fetchGithubCopilotModels(
     if (response.status === 401) {
       throw new ApiError(401, extractErrorMessage(errorText));
     }
-    throw new Error(
-      `Failed to fetch GitHub Copilot models: ${response.status}`,
-    );
+    throw modelFetchError("GitHub Copilot models", response.status);
   }
 
   const payload = (await response.json()) as {

--- a/platform/backend/src/routes/chat/model-fetchers/openai-compatible.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/openai-compatible.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import logger from "@/logging";
+import { modelFetchError } from "./types";
 
 interface FetchModelsWithBearerAuthParams {
   url: string;
@@ -31,7 +32,7 @@ export async function fetchModelsWithBearerAuth<TSchema extends z.ZodType>(
       { status: response.status, error: errorText },
       `Failed to fetch ${errorLabel}`,
     );
-    throw new Error(`Failed to fetch ${errorLabel}: ${response.status}`);
+    throw modelFetchError(errorLabel, response.status);
   }
 
   const json = await response.json();

--- a/platform/backend/src/routes/chat/model-fetchers/types.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/types.ts
@@ -1,8 +1,25 @@
 import type { SupportedProvider } from "@archestra/shared";
+import { ApiError } from "@/types";
 import type { ModelDefaultParameters } from "@/types/model";
 
 export const PLACEHOLDER_API_KEY = "EMPTY";
 export const PLACEHOLDER_BEARER_TOKEN = `Bearer ${PLACEHOLDER_API_KEY}`;
+
+/**
+ * Map a provider's model-listing failure to the error surfaced to the caller.
+ * The upstream status is relayed for client errors (an invalid provider key is
+ * a 401, not a crash of ours) and mapped to 502 for provider 5xx — either way
+ * the failure carries its real classification instead of a generic 500.
+ */
+export function modelFetchError(
+  label: string,
+  upstreamStatus: number,
+): ApiError {
+  return new ApiError(
+    upstreamStatus >= 500 ? 502 : upstreamStatus,
+    `Failed to fetch ${label}: ${upstreamStatus}`,
+  );
+}
 
 /**
  * Capabilities a fetcher can read straight from a provider's models endpoint.

--- a/platform/backend/src/routes/internal-mcp-catalog.refresh-image.test.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.refresh-image.test.ts
@@ -245,4 +245,76 @@ describe("POST /api/internal_mcp_catalog/:id/refresh-image", () => {
     expect(response.json()).toEqual({ success: true });
     expect(mockAutoReinstallServer).toHaveBeenCalledTimes(2);
   });
+
+  test("surfaces an MCP runtime failure as a 502 upstream error", async () => {
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name: "single-tenant-crashing-server",
+        serverType: "local",
+        scope: "org",
+        multitenant: false,
+        localConfig: {
+          dockerImage: "registry.example.com/mcp:latest",
+        },
+      },
+      { organizationId, authorId: user.id },
+    );
+    await McpServerModel.create({
+      name: "single-tenant-crashing-server-a",
+      catalogId: catalog.id,
+      serverType: "local",
+      scope: "org",
+    });
+    // The user's container crashing on start is their server's fault, not a
+    // crash of ours — surfaced as an upstream failure.
+    const deploymentFailure = new Error(
+      "Deployment mcp-crashing failed: CrashLoopBackOff - back-off restarting failed container",
+    );
+    deploymentFailure.name = "McpServerDeploymentFailedError";
+    mockAutoReinstallServer.mockRejectedValueOnce(deploymentFailure);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/internal_mcp_catalog/${catalog.id}/refresh-image`,
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(response.json().error.message).toContain("CrashLoopBackOff");
+  });
+
+  test("maps Kubernetes API throttling to a retryable 503 with a readable message", async () => {
+    const catalog = await InternalMcpCatalogModel.create(
+      {
+        name: "single-tenant-throttled-server",
+        serverType: "local",
+        scope: "org",
+        multitenant: false,
+        localConfig: {
+          dockerImage: "registry.example.com/mcp:latest",
+        },
+      },
+      { organizationId, authorId: user.id },
+    );
+    await McpServerModel.create({
+      name: "single-tenant-throttled-server-a",
+      catalogId: catalog.id,
+      serverType: "local",
+      scope: "org",
+    });
+    // Shape of the Kubernetes client's ApiException during control-plane
+    // throttling: code 429 and an "HTTP-Code: 429" message.
+    const throttled = Object.assign(
+      new Error("HTTP-Code: 429\nMessage: Unknown API Status Code!\nBody: ..."),
+      { code: 429 },
+    );
+    mockAutoReinstallServer.mockRejectedValueOnce(throttled);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/internal_mcp_catalog/${catalog.id}/refresh-image`,
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.json().error.message).toContain("throttling");
+  });
 });

--- a/platform/backend/src/routes/internal-mcp-catalog.ts
+++ b/platform/backend/src/routes/internal-mcp-catalog.ts
@@ -1298,9 +1298,7 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
       try {
         await reinstallMultitenantCatalog(catalogItem);
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
-        throw new ApiError(500, errorMessage);
+        throw toMcpOperationApiError(error);
       }
 
       return reply.send({ success: true });
@@ -1369,7 +1367,7 @@ const internalMcpCatalogRoutes: FastifyPluginAsyncZod = async (fastify) => {
           result.status === "rejected",
       );
       if (failures.length === restartResults.length) {
-        throw new ApiError(500, getSettledErrorMessage(failures[0]));
+        throw toMcpOperationApiError(failures[0].reason);
       }
 
       return reply.send({ success: true });
@@ -2249,14 +2247,57 @@ async function refreshCatalogImage(catalogItem: InternalMcpCatalog) {
     (result): result is PromiseRejectedResult => result.status === "rejected",
   );
   if (failures.length > 0 && failures.length === restartResults.length) {
-    throw new Error(getSettledErrorMessage(failures[0]));
+    // Rethrow the original reason (not a rewrapped Error) so the route can
+    // classify it by error name in toMcpOperationApiError.
+    throw failures[0].reason;
   }
 }
 
-function getSettledErrorMessage(result: PromiseRejectedResult): string {
-  return result.reason instanceof Error
-    ? result.reason.message
-    : "Unknown error";
+/**
+ * Error names thrown by the MCP client/runtime for a user's server being
+ * unreachable, not ready, or failing to deploy. Matched by name so this route
+ * module doesn't import the runtime's error classes.
+ */
+const MCP_RUNTIME_FAILURE_ERROR_NAMES = new Set([
+  "McpServerNotReadyError",
+  "McpServerConnectionTimeoutError",
+  "McpServerUnreachableError",
+  "McpServerDeploymentFailedError",
+]);
+
+/**
+ * Map a failed install/restart operation to the ApiError surfaced to the
+ * caller. MCP-runtime failures (the user's server unreachable, its container
+ * crashing) are upstream faults → 502; Kubernetes control-plane throttling is
+ * transient → retryable 503 with a readable message (instead of the raw
+ * "HTTP-Code: 429" client error); anything else stays a 500.
+ */
+function toMcpOperationApiError(reason: unknown): ApiError {
+  const message = reason instanceof Error ? reason.message : "Unknown error";
+  if (
+    reason instanceof Error &&
+    MCP_RUNTIME_FAILURE_ERROR_NAMES.has(reason.name)
+  ) {
+    return new ApiError(502, message);
+  }
+  if (isK8sApiThrottlingError(reason)) {
+    return new ApiError(
+      503,
+      "The Kubernetes API is temporarily throttling requests. Please retry in a moment.",
+    );
+  }
+  return new ApiError(500, message);
+}
+
+/**
+ * The Kubernetes client reports API-server throttling as an ApiException with
+ * `code: 429` and an "HTTP-Code: 429" message (e.g. while etcd/storage is
+ * re-initializing during control-plane churn).
+ */
+function isK8sApiThrottlingError(reason: unknown): boolean {
+  if (!(reason instanceof Error)) return false;
+  const code = (reason as { code?: unknown }).code;
+  return code === 429 || /^HTTP-Code: 429\b/.test(reason.message);
 }
 
 /**


### PR DESCRIPTION
## Summary

Second round of fixes for the most frequent recurring production failures. All five share a root pattern: failures of **external systems** — a user's MCP server, an LLM provider, the Kubernetes control plane — surfacing as our own generic 500s.

### 1. Remote MCP server connect failures get a named error class
`connectAndGetTools` threw a plain `Error("Failed to connect to MCP server X: …")` for connection timeouts, `fetch failed`, and handshake rejections — the single most frequent remaining recurring error, hit by users across many installs daily. It now throws a named `McpServerUnreachableError`, which the error-tracking policy classifies as a caller-side operational condition (joining the existing not-ready/timeout classes) and routes surface as 502.

### 2. MCP deployment failures (CrashLoopBackOff etc.) likewise
A user's server container crashing on start (`CrashLoopBackOff`, unschedulable pods, invalid images) threw plain `Error("Deployment X failed: …")`. Now a named `McpServerDeploymentFailedError` with the same treatment — it's the user's image/config, not a platform crash.

### 3. Catalog reinstall/refresh-image routes classify failures instead of blanket-500ing
The reinstall and refresh-image endpoints wrapped any failure as `ApiError(500, message)`. They now map MCP runtime failures to 502, and Kubernetes API throttling (the K8s client's raw `"HTTP-Code: 429"` ApiException during control-plane churn) to a retryable **503 with a readable message** instead of leaking the client library's error dump. The all-failed aggregate path rethrows the original rejection reason so classification survives the Promise.allSettled fan-out.

### 4. Chat error mapper: two dead-end "Unknown" cards become retryable
Two failure shapes arrive mid-stream with no status code and fell through to the non-retryable Unknown card (and got captured as unrecognized provider errors):
- a relayed **secrets-backend outage** message — the underlying incident is already captured and grouped at its source; the chat relay now maps to a retryable ServerError
- Bedrock's bare **"unable to process your request"** internal failure — a transient provider-side 5xx in all but envelope

### 5. Model-listing fetchers relay the upstream status
`Failed to fetch <provider> models: 401` threw a plain Error that became a 500 — users with an invalid/expired provider key saw a server crash instead of their auth problem. All five fetchers (Anthropic, Gemini, Bedrock, GitHub Copilot, OpenAI-compatible) now throw an `ApiError` relaying the real classification: 4xx pass through (401 stays 401), provider 5xx maps to 502. Error message text is unchanged, so key-validation flows that parse it are unaffected.

## Tests
- Policy: the two new error names are classified non-actionable (`error-tracking-policy.test.ts`)
- Refresh-image route: MCP runtime failure → 502; K8s throttling → 503 with readable message (`internal-mcp-catalog.refresh-image.test.ts`)
- Chat mapper: secrets-outage relay and Bedrock bare failure → retryable ServerError, not captured (`errors.test.ts`)
- Anthropic fetcher: upstream 401 relayed as 401; upstream 500 → 502 (`model-fetchers/anthropic.test.ts`)

Type-check, lint, knip pass; 1150+ tests across the touched areas (mcp-server, catalog, k8s runtime, chat, model fetchers, clients) pass locally.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>