### PR TITLE
fix(auth): reject expired invitations on sign-in auto-accept

### DIFF
--- a/platform/backend/src/models/invitation.test.ts
+++ b/platform/backend/src/models/invitation.test.ts
@@ -506,5 +506,102 @@ describe("InvitationModel", () => {
 
       expect(found).toBeUndefined();
     });
+
+    test("should ignore expired pending invitations", async ({
+      makeOrganization,
+      makeUser,
+      makeInvitation,
+    }) => {
+      const org = await makeOrganization();
+      const inviter = await makeUser();
+
+      await makeInvitation(org.id, inviter.id, {
+        email: "expired@example.com",
+        expiresAt: new Date(Date.now() - 60_000),
+      });
+
+      const found = await InvitationModel.findPendingByEmail(
+        "expired@example.com",
+      );
+
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe("accept guards", () => {
+    test("does not accept an expired invitation", async ({
+      makeOrganization,
+      makeUser,
+      makeInvitation,
+    }) => {
+      const org = await makeOrganization();
+      const inviter = await makeUser();
+      const invitee = await makeUser({ email: "invitee-expired@example.com" });
+      const invitation = await makeInvitation(org.id, inviter.id, {
+        email: invitee.email,
+        expiresAt: new Date(Date.now() - 60_000),
+      });
+
+      const session = {
+        id: crypto.randomUUID(),
+        userId: invitee.id,
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        token: "test",
+        ipAddress: null,
+        userAgent: null,
+        activeOrganizationId: null,
+        impersonatedBy: null,
+      } as BetterAuthSession;
+
+      await InvitationModel.accept(
+        session,
+        invitee as BetterAuthSessionUser,
+        invitation.id,
+      );
+
+      const member = await MemberModel.getByUserId(invitee.id, org.id);
+      expect(member).toBeUndefined();
+      const stillPending = await InvitationModel.getById(invitation.id);
+      expect(stillPending?.status).toBe("pending");
+    });
+
+    test("does not accept an invitation for a different email", async ({
+      makeOrganization,
+      makeUser,
+      makeInvitation,
+    }) => {
+      const org = await makeOrganization();
+      const inviter = await makeUser();
+      const invitee = await makeUser({ email: "actual@example.com" });
+      const invitation = await makeInvitation(org.id, inviter.id, {
+        email: "someone-else@example.com",
+      });
+
+      const session = {
+        id: crypto.randomUUID(),
+        userId: invitee.id,
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        token: "test",
+        ipAddress: null,
+        userAgent: null,
+        activeOrganizationId: null,
+        impersonatedBy: null,
+      } as BetterAuthSession;
+
+      await InvitationModel.accept(
+        session,
+        invitee as BetterAuthSessionUser,
+        invitation.id,
+      );
+
+      const member = await MemberModel.getByUserId(invitee.id, org.id);
+      expect(member).toBeUndefined();
+      const stillPending = await InvitationModel.getById(invitation.id);
+      expect(stillPending?.status).toBe("pending");
+    });
   });
 });

--- a/platform/backend/src/models/invitation.ts
+++ b/platform/backend/src/models/invitation.ts
@@ -54,7 +54,8 @@ class InvitationModel {
   }
 
   /**
-   * Find the first pending invitation for an email address
+   * Find the first still-valid pending invitation for an email address.
+   * Expired and non-pending rows must not be auto-accepted on sign-in.
    */
   static async findPendingByEmail(email: string) {
     logger.debug(
@@ -62,7 +63,12 @@ class InvitationModel {
       "InvitationModel.findPendingByEmail: fetching pending invitation",
     );
     const invitations = await InvitationModel.findByEmail(email);
-    const pending = invitations.find((inv) => inv.status === "pending");
+    const now = new Date();
+    const pending = invitations.find(
+      (inv) =>
+        inv.status === "pending" &&
+        (!inv.expiresAt || new Date(inv.expiresAt) >= now),
+    );
     logger.debug(
       { email, found: !!pending },
       "InvitationModel.findPendingByEmail: completed",
@@ -93,6 +99,32 @@ class InvitationModel {
 
       if (!invitation) {
         logger.error(`❌ Invitation ${invitationId} not found`);
+        return;
+      }
+
+      // Mirror the sign-up beforeHook guards: only a still-pending, unexpired
+      // invitation for this user's email may grant membership. Sign-in
+      // auto-accept previously skipped these checks and could revive expired
+      // pending rows into org membership.
+      if (invitation.status !== "pending") {
+        logger.error(
+          `❌ Invitation ${invitationId} is not pending (status=${invitation.status})`,
+        );
+        return;
+      }
+
+      if (invitation.expiresAt && new Date(invitation.expiresAt) < new Date()) {
+        logger.error(`❌ Invitation ${invitationId} has expired`);
+        return;
+      }
+
+      if (
+        invitation.email &&
+        invitation.email.toLowerCase() !== user.email.toLowerCase()
+      ) {
+        logger.error(
+          `❌ Invitation ${invitationId} email does not match user ${user.email}`,
+        );
         return;
       }
 


### PR DESCRIPTION
## Summary
- Sign-up already rejects expired / non-pending invitations, but sign-in auto-accept did not: `findPendingByEmail` only checked `status === "pending"`, and `InvitationModel.accept` had no expiry/status/email guards.
- An expired pending row could still grant org membership on the next sign-in.
- Filter expired invites in `findPendingByEmail`, and gate `accept` on pending status, expiry, and email match (same invariants as the sign-up beforeHook).

## Test plan
- [x] `pnpm exec vitest run src/models/invitation.test.ts` (22 passed)