### PR TITLE
fix(gemini): tolerate blocked and nonconforming generateContent responses

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2167,6 +2167,7 @@
         "type": "object",
         "properties": {
           "candidates": {
+            "description": "Candidate responses from the model",
             "type": "array",
             "items": {
               "type": "object",
@@ -2592,26 +2593,33 @@
                 },
                 "finishReason": {
                   "description": "\n  The reason why the model stopped generating tokens.\n\n  If empty, the model has not stopped generating tokens.\n\n  https://ai.google.dev/api/generate-content#FinishReason\n",
-                  "type": "string",
-                  "enum": [
-                    "FINISH_REASON_UNSPECIFIED",
-                    "STOP",
-                    "MAX_TOKENS",
-                    "SAFETY",
-                    "RECITATION",
-                    "LANGUAGE",
-                    "OTHER",
-                    "BLOCKLIST",
-                    "PROHIBITED_CONTENT",
-                    "SPII",
-                    "MALFORMED_FUNCTION_CALL",
-                    "IMAGE_SAFETY",
-                    "IMAGE_PROHIBITED_CONTENT",
-                    "IMAGE_OTHER",
-                    "NO_IMAGE",
-                    "IMAGE_RECITATION",
-                    "UNEXPECTED_TOOL_CALL",
-                    "TOO_MANY_TOOL_CALLS"
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "FINISH_REASON_UNSPECIFIED",
+                        "STOP",
+                        "MAX_TOKENS",
+                        "SAFETY",
+                        "RECITATION",
+                        "LANGUAGE",
+                        "OTHER",
+                        "BLOCKLIST",
+                        "PROHIBITED_CONTENT",
+                        "SPII",
+                        "MALFORMED_FUNCTION_CALL",
+                        "IMAGE_SAFETY",
+                        "IMAGE_PROHIBITED_CONTENT",
+                        "IMAGE_OTHER",
+                        "NO_IMAGE",
+                        "IMAGE_RECITATION",
+                        "UNEXPECTED_TOOL_CALL",
+                        "TOO_MANY_TOOL_CALLS"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
                   ]
                 },
                 "safetyRatings": {
@@ -2704,21 +2712,16 @@
                 "logprobsResult": {},
                 "urlContextMetadata": {},
                 "index": {
-                  "type": "number",
-                  "description": "Index of the candidate in the list of response candidates."
+                  "description": "Index of the candidate in the list of response candidates.",
+                  "type": "number"
                 },
                 "finishMessage": {
                   "description": "Details the reason why the model stopped generating tokens. This is populated only when finishReason is set.",
                   "type": "string"
                 }
               },
-              "required": [
-                "content",
-                "index"
-              ],
               "description": "https://ai.google.dev/api/generate-content#candidate"
-            },
-            "description": "Candidate responses from the model"
+            }
           },
           "promptFeedback": {
             "description": "Returns the prompt's feedback related to the content filters",
@@ -2726,14 +2729,21 @@
             "properties": {
               "blockReason": {
                 "description": "Specifies the reason why the prompt was blocked. https://ai.google.dev/api/generate-content#BlockReason",
-                "type": "string",
-                "enum": [
-                  "BLOCK_REASON_UNSPECIFIED",
-                  "SAFETY",
-                  "OTHER",
-                  "BLOCKLIST",
-                  "PROHIBITED_CONTENT",
-                  "IMAGE_SAFETY"
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "BLOCK_REASON_UNSPECIFIED",
+                      "SAFETY",
+                      "OTHER",
+                      "BLOCKLIST",
+                      "PROHIBITED_CONTENT",
+                      "IMAGE_SAFETY"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
                 ]
               },
               "safetyRatings": {
@@ -2782,10 +2792,7 @@
                   "description": "https://ai.google.dev/api/generate-content#v1beta.SafetyRating"
                 }
               }
-            },
-            "required": [
-              "safetyRatings"
-            ]
+            }
           },
           "usageMetadata": {
             "description": "Metadata on the generation requests' token usage",
@@ -2927,10 +2934,7 @@
             "description": "The unique response ID.",
             "type": "string"
           }
-        },
-        "required": [
-          "candidates"
-        ]
+        }
       },
       "AnthropicMessagesRequestInput": {
         "type": "object",
@@ -21324,6 +21328,7 @@
         "type": "object",
         "properties": {
           "candidates": {
+            "description": "Candidate responses from the model",
             "type": "array",
             "items": {
               "type": "object",
@@ -21770,26 +21775,33 @@
                 },
                 "finishReason": {
                   "description": "\n  The reason why the model stopped generating tokens.\n\n  If empty, the model has not stopped generating tokens.\n\n  https://ai.google.dev/api/generate-content#FinishReason\n",
-                  "type": "string",
-                  "enum": [
-                    "FINISH_REASON_UNSPECIFIED",
-                    "STOP",
-                    "MAX_TOKENS",
-                    "SAFETY",
-                    "RECITATION",
-                    "LANGUAGE",
-                    "OTHER",
-                    "BLOCKLIST",
-                    "PROHIBITED_CONTENT",
-                    "SPII",
-                    "MALFORMED_FUNCTION_CALL",
-                    "IMAGE_SAFETY",
-                    "IMAGE_PROHIBITED_CONTENT",
-                    "IMAGE_OTHER",
-                    "NO_IMAGE",
-                    "IMAGE_RECITATION",
-                    "UNEXPECTED_TOOL_CALL",
-                    "TOO_MANY_TOOL_CALLS"
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "FINISH_REASON_UNSPECIFIED",
+                        "STOP",
+                        "MAX_TOKENS",
+                        "SAFETY",
+                        "RECITATION",
+                        "LANGUAGE",
+                        "OTHER",
+                        "BLOCKLIST",
+                        "PROHIBITED_CONTENT",
+                        "SPII",
+                        "MALFORMED_FUNCTION_CALL",
+                        "IMAGE_SAFETY",
+                        "IMAGE_PROHIBITED_CONTENT",
+                        "IMAGE_OTHER",
+                        "NO_IMAGE",
+                        "IMAGE_RECITATION",
+                        "UNEXPECTED_TOOL_CALL",
+                        "TOO_MANY_TOOL_CALLS"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
                   ]
                 },
                 "safetyRatings": {
@@ -21885,22 +21897,17 @@
                 "logprobsResult": {},
                 "urlContextMetadata": {},
                 "index": {
-                  "type": "number",
-                  "description": "Index of the candidate in the list of response candidates."
+                  "description": "Index of the candidate in the list of response candidates.",
+                  "type": "number"
                 },
                 "finishMessage": {
                   "description": "Details the reason why the model stopped generating tokens. This is populated only when finishReason is set.",
                   "type": "string"
                 }
               },
-              "required": [
-                "content",
-                "index"
-              ],
               "additionalProperties": false,
               "description": "https://ai.google.dev/api/generate-content#candidate"
-            },
-            "description": "Candidate responses from the model"
+            }
           },
           "promptFeedback": {
             "description": "Returns the prompt's feedback related to the content filters",
@@ -21908,14 +21915,21 @@
             "properties": {
               "blockReason": {
                 "description": "Specifies the reason why the prompt was blocked. https://ai.google.dev/api/generate-content#BlockReason",
-                "type": "string",
-                "enum": [
-                  "BLOCK_REASON_UNSPECIFIED",
-                  "SAFETY",
-                  "OTHER",
-                  "BLOCKLIST",
-                  "PROHIBITED_CONTENT",
-                  "IMAGE_SAFETY"
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "BLOCK_REASON_UNSPECIFIED",
+                      "SAFETY",
+                      "OTHER",
+                      "BLOCKLIST",
+                      "PROHIBITED_CONTENT",
+                      "IMAGE_SAFETY"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
                 ]
               },
               "safetyRatings": {
@@ -21966,9 +21980,6 @@
                 }
               }
             },
-            "required": [
-              "safetyRatings"
-            ],
             "additionalProperties": false
           },
           "usageMetadata": {
@@ -22117,9 +22128,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "candidates"
-        ],
         "additionalProperties": false
       },
       "AnthropicMessagesRequest": {

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "@/test";
-import type { OpenAi } from "@/types";
-import { openaiToGemini } from "./gemini-openai-translator";
+import type { Gemini, OpenAi } from "@/types";
+import {
+  geminiResponseToOpenai,
+  openaiToGemini,
+} from "./gemini-openai-translator";
 
 type OpenAiRequest = OpenAi.Types.ChatCompletionsRequest;
 
@@ -185,5 +188,54 @@ describe("openaiToGemini — multimodal user content", () => {
         },
       },
     ]);
+  });
+});
+
+describe("geminiResponseToOpenai — blocked replies", () => {
+  const ctx = {
+    chatcmplId: "chatcmpl-test",
+    createdUnix: 1_700_000_000,
+    requestedModel: "gemini-2.5-flash",
+  };
+
+  test("maps a candidate blocked without content to an empty content_filter choice", () => {
+    const result = geminiResponseToOpenai(
+      {
+        candidates: [{ finishReason: "SAFETY" }],
+      } as Gemini.Types.GenerateContentResponse,
+      ctx,
+    );
+
+    expect(result.choices[0].finish_reason).toBe("content_filter");
+    expect(result.choices[0].message.content).toBeNull();
+  });
+
+  test("maps a prompt-blocked reply with no candidates to content_filter", () => {
+    const result = geminiResponseToOpenai(
+      {
+        promptFeedback: { blockReason: "SAFETY" },
+      } as Gemini.Types.GenerateContentResponse,
+      ctx,
+    );
+
+    expect(result.choices[0].finish_reason).toBe("content_filter");
+    expect(result.choices[0].message.content).toBeNull();
+  });
+
+  test("still reports stop for an ordinary completion", () => {
+    const result = geminiResponseToOpenai(
+      {
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: { role: "model", parts: [{ text: "hi" }] },
+          },
+        ],
+      } as Gemini.Types.GenerateContentResponse,
+      ctx,
+    );
+
+    expect(result.choices[0].finish_reason).toBe("stop");
+    expect(result.choices[0].message.content).toBe("hi");
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini-openai-translator.ts
@@ -190,7 +190,8 @@ export function geminiResponseToOpenai(
   }> = [];
   let text = "";
 
-  for (const part of candidate?.content.parts ?? []) {
+  // Blocked candidates carry a `finishReason` but no `content`.
+  for (const part of candidate?.content?.parts ?? []) {
     if ("text" in part && part.text) {
       text += part.text;
       continue;
@@ -212,6 +213,22 @@ export function geminiResponseToOpenai(
   const promptTokens = response.usageMetadata?.promptTokenCount ?? 0;
   const completionTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
 
+  // A prompt-blocked reply carries only `promptFeedback` — no candidates, so no
+  // `finishReason` to map. Without this branch it would report a plain "stop"
+  // and the client would see an empty completion with no sign it was filtered.
+  const promptBlockReason = response.promptFeedback?.blockReason;
+  const promptBlocked =
+    candidate === undefined &&
+    promptBlockReason !== undefined &&
+    promptBlockReason !== "BLOCK_REASON_UNSPECIFIED";
+
+  let finishReason = mapGeminiFinishReason(candidate?.finishReason);
+  if (toolCalls.length > 0) {
+    finishReason = "tool_calls";
+  } else if (promptBlocked) {
+    finishReason = "content_filter";
+  }
+
   return {
     id: ctx.chatcmplId,
     object: "chat.completion",
@@ -221,10 +238,7 @@ export function geminiResponseToOpenai(
       {
         index: 0,
         logprobs: null,
-        finish_reason:
-          toolCalls.length > 0
-            ? "tool_calls"
-            : mapGeminiFinishReason(candidate?.finishReason),
+        finish_reason: finishReason,
         message: {
           role: "assistant",
           content: text || null,

--- a/platform/backend/src/types/llm-providers/gemini/api.test.ts
+++ b/platform/backend/src/types/llm-providers/gemini/api.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { GenerateContentResponseSchema } from "./api";
+
+describe("GenerateContentResponseSchema", () => {
+  test("accepts a SAFETY candidate that omits content and index", () => {
+    const result = GenerateContentResponseSchema.safeParse({
+      candidates: [{ finishReason: "SAFETY" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a promptFeedback-only blocked response with no candidates", () => {
+    const result = GenerateContentResponseSchema.safeParse({
+      promptFeedback: { blockReason: "SAFETY" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts an unknown finishReason string", () => {
+    const result = GenerateContentResponseSchema.safeParse({
+      candidates: [
+        {
+          index: 0,
+          finishReason: "BRAND_NEW_REASON",
+          content: { role: "model", parts: [{ text: "hi" }] },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/platform/backend/src/types/llm-providers/gemini/api.ts
+++ b/platform/backend/src/types/llm-providers/gemini/api.ts
@@ -160,7 +160,9 @@ export const FinishReasonSchema = z
 
 export const CandidateSchema = z
   .object({
-    // SAFETY / blocked replies often omit `content` entirely.
+    // Blocked responses leave content unset:
+    // https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/process-blocked-responses
+    // https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/configure-safety-filters
     content: ContentSchema.optional(),
     finishReason: FinishReasonSchema,
     safetyRatings: z.array(SafetyRatingSchema).optional(),
@@ -171,7 +173,8 @@ export const CandidateSchema = z
     avgLogprobs: z.number().optional(),
     logprobsResult: z.any().optional(),
     urlContextMetadata: z.any().optional(),
-    // Some upstreams omit `index`; requiring it fails response serialization.
+    // Proto marks index as optional int32 (OUTPUT_ONLY); JSON often omits it.
+    // https://github.com/googleapis/googleapis/blob/master/google/ai/generativelanguage/v1beta/generative_service.proto
     index: z
       .number()
       .optional()
@@ -201,7 +204,7 @@ const PromptFeedbackSchema = z
       .describe(
         `Specifies the reason why the prompt was blocked. https://ai.google.dev/api/generate-content#BlockReason`,
       ),
-    // Blocked prompts may omit safetyRatings entirely.
+    // Prompt-blocked replies always set blockReason; safetyRatings may be absent.
     safetyRatings: z.array(SafetyRatingSchema).optional(),
   })
   .describe(`
@@ -278,8 +281,8 @@ export const GenerateContentRequestSchema = z
 
 export const GenerateContentResponseSchema = z
   .object({
-    // Prompt-blocked responses may return only `promptFeedback` with no
-    // candidates array; requiring it fails Fastify response serialization.
+    // Prompt blocked → candidates unset (promptFeedback only):
+    // https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/process-blocked-responses
     candidates: z
       .array(CandidateSchema)
       .optional()

--- a/platform/backend/src/types/llm-providers/gemini/api.ts
+++ b/platform/backend/src/types/llm-providers/gemini/api.ts
@@ -146,6 +146,9 @@ export const FinishReasonSchema = z
     "UNEXPECTED_TOOL_CALL",
     "TOO_MANY_TOOL_CALLS",
   ])
+  // Google may introduce new finish reasons; a closed enum fails Fastify
+  // response serialization (500) for otherwise successful proxy responses.
+  .or(z.string())
   .optional()
   .describe(`
   The reason why the model stopped generating tokens.
@@ -157,7 +160,8 @@ export const FinishReasonSchema = z
 
 export const CandidateSchema = z
   .object({
-    content: ContentSchema,
+    // SAFETY / blocked replies often omit `content` entirely.
+    content: ContentSchema.optional(),
     finishReason: FinishReasonSchema,
     safetyRatings: z.array(SafetyRatingSchema).optional(),
     citationMetadata: CitationMetadataSchema.optional(),
@@ -167,8 +171,10 @@ export const CandidateSchema = z
     avgLogprobs: z.number().optional(),
     logprobsResult: z.any().optional(),
     urlContextMetadata: z.any().optional(),
+    // Some upstreams omit `index`; requiring it fails response serialization.
     index: z
       .number()
+      .optional()
       .describe("Index of the candidate in the list of response candidates."),
     finishMessage: z
       .string()
@@ -190,11 +196,13 @@ const PromptFeedbackSchema = z
         "PROHIBITED_CONTENT",
         "IMAGE_SAFETY",
       ])
+      .or(z.string())
       .optional()
       .describe(
         `Specifies the reason why the prompt was blocked. https://ai.google.dev/api/generate-content#BlockReason`,
       ),
-    safetyRatings: z.array(SafetyRatingSchema),
+    // Blocked prompts may omit safetyRatings entirely.
+    safetyRatings: z.array(SafetyRatingSchema).optional(),
   })
   .describe(`
   Returns the prompt's feedback related to the content filters.
@@ -270,8 +278,11 @@ export const GenerateContentRequestSchema = z
 
 export const GenerateContentResponseSchema = z
   .object({
+    // Prompt-blocked responses may return only `promptFeedback` with no
+    // candidates array; requiring it fails Fastify response serialization.
     candidates: z
       .array(CandidateSchema)
+      .optional()
       .describe("Candidate responses from the model"),
     promptFeedback: PromptFeedbackSchema.optional().describe(
       "Returns the prompt's feedback related to the content filters",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -872,7 +872,7 @@ export type GeminiGenerateContentResponseInput = {
     /**
      * Candidate responses from the model
      */
-    candidates: Array<{
+    candidates?: Array<{
         /**
          *
          * The base structured datatype containing multi-part content of a message.
@@ -882,7 +882,7 @@ export type GeminiGenerateContentResponseInput = {
          * https://ai.google.dev/api/caching#Content
          *
          */
-        content: {
+        content?: {
             /**
              * The role of the author of this content.
              */
@@ -1116,7 +1116,7 @@ export type GeminiGenerateContentResponseInput = {
          * https://ai.google.dev/api/generate-content#FinishReason
          *
          */
-        finishReason?: 'FINISH_REASON_UNSPECIFIED' | 'STOP' | 'MAX_TOKENS' | 'SAFETY' | 'RECITATION' | 'LANGUAGE' | 'OTHER' | 'BLOCKLIST' | 'PROHIBITED_CONTENT' | 'SPII' | 'MALFORMED_FUNCTION_CALL' | 'IMAGE_SAFETY' | 'IMAGE_PROHIBITED_CONTENT' | 'IMAGE_OTHER' | 'NO_IMAGE' | 'IMAGE_RECITATION' | 'UNEXPECTED_TOOL_CALL' | 'TOO_MANY_TOOL_CALLS';
+        finishReason?: 'FINISH_REASON_UNSPECIFIED' | 'STOP' | 'MAX_TOKENS' | 'SAFETY' | 'RECITATION' | 'LANGUAGE' | 'OTHER' | 'BLOCKLIST' | 'PROHIBITED_CONTENT' | 'SPII' | 'MALFORMED_FUNCTION_CALL' | 'IMAGE_SAFETY' | 'IMAGE_PROHIBITED_CONTENT' | 'IMAGE_OTHER' | 'NO_IMAGE' | 'IMAGE_RECITATION' | 'UNEXPECTED_TOOL_CALL' | 'TOO_MANY_TOOL_CALLS' | string;
         safetyRatings?: Array<{
             /**
              *
@@ -1155,7 +1155,7 @@ export type GeminiGenerateContentResponseInput = {
         /**
          * Index of the candidate in the list of response candidates.
          */
-        index: number;
+        index?: number;
         /**
          * Details the reason why the model stopped generating tokens. This is populated only when finishReason is set.
          */
@@ -1168,8 +1168,8 @@ export type GeminiGenerateContentResponseInput = {
         /**
          * Specifies the reason why the prompt was blocked. https://ai.google.dev/api/generate-content#BlockReason
          */
-        blockReason?: 'BLOCK_REASON_UNSPECIFIED' | 'SAFETY' | 'OTHER' | 'BLOCKLIST' | 'PROHIBITED_CONTENT' | 'IMAGE_SAFETY';
-        safetyRatings: Array<{
+        blockReason?: 'BLOCK_REASON_UNSPECIFIED' | 'SAFETY' | 'OTHER' | 'BLOCKLIST' | 'PROHIBITED_CONTENT' | 'IMAGE_SAFETY' | string;
+        safetyRatings?: Array<{
             /**
              *
              * The category for this setting
@@ -6716,7 +6716,7 @@ export type GeminiGenerateContentResponse = {
     /**
      * Candidate responses from the model
      */
-    candidates: Array<{
+    candidates?: Array<{
         /**
          *
          * The base structured datatype containing multi-part content of a message.
@@ -6726,7 +6726,7 @@ export type GeminiGenerateContentResponse = {
          * https://ai.google.dev/api/caching#Content
          *
          */
-        content: {
+        content?: {
             /**
              * The role of the author of this content.
              */
@@ -6960,7 +6960,7 @@ export type GeminiGenerateContentResponse = {
          * https://ai.google.dev/api/generate-content#FinishReason
          *
          */
-        finishReason?: 'FINISH_REASON_UNSPECIFIED' | 'STOP' | 'MAX_TOKENS' | 'SAFETY' | 'RECITATION' | 'LANGUAGE' | 'OTHER' | 'BLOCKLIST' | 'PROHIBITED_CONTENT' | 'SPII' | 'MALFORMED_FUNCTION_CALL' | 'IMAGE_SAFETY' | 'IMAGE_PROHIBITED_CONTENT' | 'IMAGE_OTHER' | 'NO_IMAGE' | 'IMAGE_RECITATION' | 'UNEXPECTED_TOOL_CALL' | 'TOO_MANY_TOOL_CALLS';
+        finishReason?: 'FINISH_REASON_UNSPECIFIED' | 'STOP' | 'MAX_TOKENS' | 'SAFETY' | 'RECITATION' | 'LANGUAGE' | 'OTHER' | 'BLOCKLIST' | 'PROHIBITED_CONTENT' | 'SPII' | 'MALFORMED_FUNCTION_CALL' | 'IMAGE_SAFETY' | 'IMAGE_PROHIBITED_CONTENT' | 'IMAGE_OTHER' | 'NO_IMAGE' | 'IMAGE_RECITATION' | 'UNEXPECTED_TOOL_CALL' | 'TOO_MANY_TOOL_CALLS' | string;
         safetyRatings?: Array<{
             /**
              *
@@ -6999,7 +6999,7 @@ export type GeminiGenerateContentResponse = {
         /**
          * Index of the candidate in the list of response candidates.
          */
-        index: number;
+        index?: number;
         /**
          * Details the reason why the model stopped generating tokens. This is populated only when finishReason is set.
          */
@@ -7012,8 +7012,8 @@ export type GeminiGenerateContentResponse = {
         /**
          * Specifies the reason why the prompt was blocked. https://ai.google.dev/api/generate-content#BlockReason
          */
-        blockReason?: 'BLOCK_REASON_UNSPECIFIED' | 'SAFETY' | 'OTHER' | 'BLOCKLIST' | 'PROHIBITED_CONTENT' | 'IMAGE_SAFETY';
-        safetyRatings: Array<{
+        blockReason?: 'BLOCK_REASON_UNSPECIFIED' | 'SAFETY' | 'OTHER' | 'BLOCKLIST' | 'PROHIBITED_CONTENT' | 'IMAGE_SAFETY' | string;
+        safetyRatings?: Array<{
             /**
              *
              * The category for this setting

--- a/platform/shared/interactions/llmProviders/gemini.ts
+++ b/platform/shared/interactions/llmProviders/gemini.ts
@@ -321,7 +321,11 @@ class GeminiGenerateContentInteraction implements InteractionUtils {
       | archestraApiTypes.GeminiGenerateContentRequest["contents"][number]
       | {
           role: "model";
-          content: archestraApiTypes.GeminiGenerateContentResponse["candidates"][number]["content"];
+          // `candidates` is optional — prompt-blocked replies carry only
+          // `promptFeedback` — so unwrap before indexing.
+          content: NonNullable<
+            archestraApiTypes.GeminiGenerateContentResponse["candidates"]
+          >[number]["content"];
         },
     _dualLlmAnalyses?: DualLlmAnalysis[],
   ): PartialUIMessage {


### PR DESCRIPTION
## Summary
- Google SAFETY / prompt-blocked `generateContent` replies often omit `candidates`, candidate `content`, `index`, or `promptFeedback.safetyRatings`, and may emit new finish/block reasons.
- Closed Zod response schemas were failing Fastify serialization (500) on otherwise valid upstream blocks — same failure class as #6874 / #6881, but Gemini was not covered.
- Harden the full Gemini response surface in one PR: optional candidates/content/index/safetyRatings, finishReason/blockReason catch-alls, plus schema tests.

## References
- [Process blocked responses](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/process-blocked-responses) — prompt blocked → `candidates` unset; response blocked → `content` unset + `finishReason` set
- [Safety and content filters](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/configure-safety-filters) — clears `Candidate.content` on block
- [FinishReason](https://ai.google.dev/api/generate-content#FinishReason) / [GenerateContentResponse](https://ai.google.dev/api/generate-content#v1beta.GenerateContentResponse)
- [Proto `Candidate.index` optional](https://github.com/googleapis/googleapis/blob/master/google/ai/generativelanguage/v1beta/generative_service.proto)

## Test plan
- [x] `pnpm exec vitest run src/types/llm-providers/gemini/api.test.ts` (3 passed)