### PR TITLE
fix(rbac): gate sandbox artifact mutate routes on file:manage

### DIFF
--- a/docs/pages/platform-access-control.md
+++ b/docs/pages/platform-access-control.md
@@ -165,7 +165,7 @@ The following table lists all available permissions that can be assigned to cust
 | `environment:create` | Create deployment environments |
 | `environment:update` | Modify deployment environments, including the org default environment |
 | `environment:delete` | Delete deployment environments |
-| `file:manage` | List, read, write, and delete files in chats and projects |
+| `file:manage` | List, read, write, and delete files in chats and projects (including Files-panel artifact edit/delete REST routes; matches the MCP `save_file` / `edit_file` / `delete_file` tools) |
 | `githubAppConfig:read` | View GitHub App configurations |
 | `githubAppConfig:create` | Create GitHub App configurations |
 | `githubAppConfig:update` | Modify GitHub App configurations |

--- a/platform/shared/access-control.test.ts
+++ b/platform/shared/access-control.test.ts
@@ -119,6 +119,25 @@ describe("access-control", () => {
         requiredEndpointPermissionsMap[RouteId.GetSkillSandboxArtifact];
       expect(required?.sandbox).toContain("execute");
     });
+
+    // Mutate routes operate on skill_sandbox_files like MCP save/edit/delete_file
+    // (file:manage). Requiring sandbox:execute here 403s roles that can already
+    // mutate files through the chat tools.
+    test("DeleteSkillSandboxArtifact requires file:manage, not sandbox:execute", () => {
+      const required =
+        requiredEndpointPermissionsMap[RouteId.DeleteSkillSandboxArtifact];
+      expect(required?.file).toContain("manage");
+      expect(required?.sandbox).toBeUndefined();
+    });
+
+    test("UpdateSkillSandboxArtifactContent requires file:manage, not sandbox:execute", () => {
+      const required =
+        requiredEndpointPermissionsMap[
+          RouteId.UpdateSkillSandboxArtifactContent
+        ];
+      expect(required?.file).toContain("manage");
+      expect(required?.sandbox).toBeUndefined();
+    });
   });
 
   describe("project file routes", () => {

--- a/platform/shared/access-control.ts
+++ b/platform/shared/access-control.ts
@@ -1644,10 +1644,14 @@ export const requiredEndpointPermissionsMap: Partial<
   [RouteId.SetProjectInstructions]: { project: ["update"] },
   [RouteId.PinProject]: { project: ["read"] },
   [RouteId.UnpinProject]: { project: ["read"] },
-  [RouteId.DeleteSkillSandboxArtifact]: { sandbox: ["execute"] },
+  // Artifact mutate routes operate on `skill_sandbox_files` (same store as the
+  // MCP save_file / edit_file / delete_file tools), so they gate on
+  // `file:manage`. Per-file authorization stays in the handlers. Byte GET
+  // (GetSkillSandboxArtifact) remains sandbox:execute — it serves download_file.
+  [RouteId.DeleteSkillSandboxArtifact]: { file: ["manage"] },
   // Editing a file's text content shares the delete path's authorization
   // (author / project access), enforced per-file in the store handler.
-  [RouteId.UpdateSkillSandboxArtifactContent]: { sandbox: ["execute"] },
+  [RouteId.UpdateSkillSandboxArtifactContent]: { file: ["manage"] },
 
   // Audit Log Routes
   [RouteId.GetAuditLogs]: {


### PR DESCRIPTION
## Summary
- `DELETE` / `PUT` skill-sandbox artifact REST routes required `sandbox:execute`, while the matching MCP tools (`save_file` / `edit_file` / `delete_file`) gate on `file:manage`.
- Roles with `file:manage` (and without `sandbox:execute`) could mutate files in chat but got 403 from the Files panel REST routes.
- Align mutate routes to `file:manage` (byte GET stays on `sandbox:execute` for `download_file`), update access-control docs, and pin with map tests.

## Test plan
- [x] `pnpm exec vitest run access-control.test.ts` (23 passed)