### PR TITLE
fix(llm-proxy): harden ollama-native content and Bedrock stopReason schemas

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13413,8 +13413,7 @@
               }
             },
             "required": [
-              "role",
-              "content"
+              "role"
             ],
             "additionalProperties": {}
           },
@@ -33052,8 +33051,7 @@
               }
             },
             "required": [
-              "role",
-              "content"
+              "role"
             ],
             "additionalProperties": {}
           },
@@ -80027,15 +80025,24 @@
                       "additionalProperties": false
                     },
                     "stopReason": {
-                      "type": "string",
-                      "enum": [
-                        "end_turn",
-                        "tool_use",
-                        "max_tokens",
-                        "stop_sequence",
-                        "guardrail_intervened",
-                        "content_filtered",
-                        "model_context_window_exceeded"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "end_turn",
+                            "tool_use",
+                            "max_tokens",
+                            "stop_sequence",
+                            "guardrail_intervened",
+                            "content_filtered",
+                            "malformed_model_output",
+                            "malformed_tool_use",
+                            "model_context_window_exceeded"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
                       ]
                     },
                     "usage": {
@@ -81366,15 +81373,24 @@
                       "additionalProperties": false
                     },
                     "stopReason": {
-                      "type": "string",
-                      "enum": [
-                        "end_turn",
-                        "tool_use",
-                        "max_tokens",
-                        "stop_sequence",
-                        "guardrail_intervened",
-                        "content_filtered",
-                        "model_context_window_exceeded"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "end_turn",
+                            "tool_use",
+                            "max_tokens",
+                            "stop_sequence",
+                            "guardrail_intervened",
+                            "content_filtered",
+                            "malformed_model_output",
+                            "malformed_tool_use",
+                            "model_context_window_exceeded"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
                       ]
                     },
                     "usage": {
@@ -84458,15 +84474,24 @@
                       "additionalProperties": false
                     },
                     "stopReason": {
-                      "type": "string",
-                      "enum": [
-                        "end_turn",
-                        "tool_use",
-                        "max_tokens",
-                        "stop_sequence",
-                        "guardrail_intervened",
-                        "content_filtered",
-                        "model_context_window_exceeded"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "end_turn",
+                            "tool_use",
+                            "max_tokens",
+                            "stop_sequence",
+                            "guardrail_intervened",
+                            "content_filtered",
+                            "malformed_model_output",
+                            "malformed_tool_use",
+                            "model_context_window_exceeded"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
                       ]
                     },
                     "usage": {
@@ -135756,15 +135781,24 @@
                                         "additionalProperties": false
                                       },
                                       "stopReason": {
-                                        "type": "string",
-                                        "enum": [
-                                          "end_turn",
-                                          "tool_use",
-                                          "max_tokens",
-                                          "stop_sequence",
-                                          "guardrail_intervened",
-                                          "content_filtered",
-                                          "model_context_window_exceeded"
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "enum": [
+                                              "end_turn",
+                                              "tool_use",
+                                              "max_tokens",
+                                              "stop_sequence",
+                                              "guardrail_intervened",
+                                              "content_filtered",
+                                              "malformed_model_output",
+                                              "malformed_tool_use",
+                                              "model_context_window_exceeded"
+                                            ]
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
                                         ]
                                       },
                                       "usage": {
@@ -165409,15 +165443,24 @@
                                   "additionalProperties": false
                                 },
                                 "stopReason": {
-                                  "type": "string",
-                                  "enum": [
-                                    "end_turn",
-                                    "tool_use",
-                                    "max_tokens",
-                                    "stop_sequence",
-                                    "guardrail_intervened",
-                                    "content_filtered",
-                                    "model_context_window_exceeded"
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "end_turn",
+                                        "tool_use",
+                                        "max_tokens",
+                                        "stop_sequence",
+                                        "guardrail_intervened",
+                                        "content_filtered",
+                                        "malformed_model_output",
+                                        "malformed_tool_use",
+                                        "model_context_window_exceeded"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
                                   ]
                                 },
                                 "usage": {

--- a/platform/backend/src/types/llm-providers/bedrock/api.test.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/api.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { ConverseResponseSchema } from "./api";
+
+describe("ConverseResponseSchema", () => {
+  test("accepts an unknown stopReason string", () => {
+    const result = ConverseResponseSchema.safeParse({
+      output: {
+        message: {
+          role: "assistant",
+          content: [{ text: "hi" }],
+        },
+      },
+      stopReason: "new_bedrock_reason",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/platform/backend/src/types/llm-providers/bedrock/api.test.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/api.test.ts
@@ -2,6 +2,25 @@ import { describe, expect, test } from "vitest";
 import { ConverseResponseSchema } from "./api";
 
 describe("ConverseResponseSchema", () => {
+  test("accepts documented malformed_* stopReasons", () => {
+    for (const stopReason of [
+      "malformed_model_output",
+      "malformed_tool_use",
+    ] as const) {
+      const result = ConverseResponseSchema.safeParse({
+        output: {
+          message: {
+            role: "assistant",
+            content: [{ text: "hi" }],
+          },
+        },
+        stopReason,
+        usage: { inputTokens: 1, outputTokens: 1 },
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
   test("accepts an unknown stopReason string", () => {
     const result = ConverseResponseSchema.safeParse({
       output: {

--- a/platform/backend/src/types/llm-providers/bedrock/api.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/api.ts
@@ -140,16 +140,19 @@ const MetricsSchema = z.object({
   latencyMs: z.number().optional(),
 });
 
-// Stop reason
-const StopReasonSchema = z.enum([
-  "end_turn",
-  "tool_use",
-  "max_tokens",
-  "stop_sequence",
-  "guardrail_intervened",
-  "content_filtered",
-  "model_context_window_exceeded",
-]);
+// Stop reason — tolerate unknown values so new Bedrock reasons don't 500
+// Fastify response serialization / interaction read-back.
+const StopReasonSchema = z
+  .enum([
+    "end_turn",
+    "tool_use",
+    "max_tokens",
+    "stop_sequence",
+    "guardrail_intervened",
+    "content_filtered",
+    "model_context_window_exceeded",
+  ])
+  .or(z.string());
 
 // Output message
 const OutputMessageSchema = z.object({

--- a/platform/backend/src/types/llm-providers/bedrock/api.ts
+++ b/platform/backend/src/types/llm-providers/bedrock/api.ts
@@ -140,8 +140,8 @@ const MetricsSchema = z.object({
   latencyMs: z.number().optional(),
 });
 
-// Stop reason — tolerate unknown values so new Bedrock reasons don't 500
-// Fastify response serialization / interaction read-back.
+// Stop reason — current Converse values plus catch-all for future AWS additions:
+// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
 const StopReasonSchema = z
   .enum([
     "end_turn",
@@ -150,6 +150,8 @@ const StopReasonSchema = z
     "stop_sequence",
     "guardrail_intervened",
     "content_filtered",
+    "malformed_model_output",
+    "malformed_tool_use",
     "model_context_window_exceeded",
   ])
   .or(z.string());

--- a/platform/backend/src/types/llm-providers/ollama-native/api.test.ts
+++ b/platform/backend/src/types/llm-providers/ollama-native/api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   ChatRequestSchema,
+  ChatResponseSchema,
   MAX_KEEP_ALIVE_SECONDS,
   OptionsSchema,
 } from "./api";
@@ -196,5 +197,26 @@ describe("ChatRequestSchema", () => {
       expect(parsed.logprobs).toBe(true);
       expect(parsed._debug_render_only).toBe(true);
     });
+  });
+});
+
+describe("ChatResponseSchema", () => {
+  test("accepts a tool-call reply that omits message.content", () => {
+    const result = ChatResponseSchema.safeParse({
+      model: "llama3.2",
+      message: {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "search",
+              arguments: { q: "hi" },
+            },
+          },
+        ],
+      },
+      done: true,
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/platform/backend/src/types/llm-providers/ollama-native/api.ts
+++ b/platform/backend/src/types/llm-providers/ollama-native/api.ts
@@ -115,7 +115,9 @@ export const ChatRequestSchema = z
 
 const ResponseMessageSchema = z.looseObject({
   role: z.string(),
-  content: z.string(),
+  // Tool-call-only replies often omit `content`; the adapter already treats it
+  // as optional (`content ?? ""`). Requiring the key 500s response serialization.
+  content: z.string().optional(),
   thinking: z.string().optional(),
   tool_calls: z.array(ToolCallSchema).nullable().optional(),
 });

--- a/platform/backend/src/types/llm-providers/ollama-native/api.ts
+++ b/platform/backend/src/types/llm-providers/ollama-native/api.ts
@@ -115,8 +115,9 @@ export const ChatRequestSchema = z
 
 const ResponseMessageSchema = z.looseObject({
   role: z.string(),
-  // Tool-call-only replies often omit `content`; the adapter already treats it
-  // as optional (`content ?? ""`). Requiring the key 500s response serialization.
+  // Tool-call replies clear/omit textual content; adapter coalesces with `?? ""`.
+  // https://docs.ollama.com/api/chat
+  // https://github.com/ollama/ollama/issues/7488
   content: z.string().optional(),
   thinking: z.string().optional(),
   tool_calls: z.array(ToolCallSchema).nullable().optional(),

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -4150,7 +4150,7 @@ export type OllamaNativeChatResponseInput = {
     created_at?: string;
     message: {
         role: string;
-        content: string;
+        content?: string;
         thinking?: string;
         tool_calls?: Array<{
             id?: string;
@@ -9994,7 +9994,7 @@ export type OllamaNativeChatResponse = {
     created_at?: string;
     message: {
         role: string;
-        content: string;
+        content?: string;
         thinking?: string;
         tool_calls?: Array<{
             id?: string;
@@ -23136,7 +23136,7 @@ export type BedrockConverseWithDefaultAgentResponses = {
                 }>;
             };
         };
-        stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'model_context_window_exceeded';
+        stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'malformed_model_output' | 'malformed_tool_use' | 'model_context_window_exceeded' | string;
         usage: {
             inputTokens: number;
             outputTokens: number;
@@ -23475,7 +23475,7 @@ export type BedrockConverseWithAgentResponses = {
                 }>;
             };
         };
-        stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'model_context_window_exceeded';
+        stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'malformed_model_output' | 'malformed_tool_use' | 'model_context_window_exceeded' | string;
         usage: {
             inputTokens: number;
             outputTokens: number;
@@ -24233,7 +24233,7 @@ export type BedrockConverseWithAgentAndModelResponses = {
                 }>;
             };
         };
-        stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'model_context_window_exceeded';
+        stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'malformed_model_output' | 'malformed_tool_use' | 'model_context_window_exceeded' | string;
         usage: {
             inputTokens: number;
             outputTokens: number;
@@ -37423,7 +37423,7 @@ export type GetInteractionsResponses = {
                         }>;
                     };
                 };
-                stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'model_context_window_exceeded';
+                stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'malformed_model_output' | 'malformed_tool_use' | 'model_context_window_exceeded' | string;
                 usage: {
                     inputTokens: number;
                     outputTokens: number;
@@ -43441,7 +43441,7 @@ export type GetInteractionResponses = {
                     }>;
                 };
             };
-            stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'model_context_window_exceeded';
+            stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | 'guardrail_intervened' | 'content_filtered' | 'malformed_model_output' | 'malformed_tool_use' | 'model_context_window_exceeded' | string;
             usage: {
                 inputTokens: number;
                 outputTokens: number;


### PR DESCRIPTION
## Summary
- Ollama-native tool-call replies often omit `message.content` (the adapter already does `content ?? \"\"`), but the response Zod schema required the key → Fastify 500.
- Bedrock `stopReason` was a closed enum; unknown values fail response serialization / interaction read-back. Expanded to the current Converse allowlist (incl. `malformed_model_output` / `malformed_tool_use`) plus a catch-all.
- These providers are outside #6881 (OpenAI-compat + Anthropic/Cohere). Relax both schemas and pin with unit tests.

## References
- [Ollama `/api/chat`](https://docs.ollama.com/api/chat) — `content` + optional `tool_calls`; tool-call replies clear textual content ([ollama#7488](https://github.com/ollama/ollama/issues/7488))
- [Bedrock Converse `stopReason`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) — `end_turn | tool_use | max_tokens | stop_sequence | guardrail_intervened | content_filtered | malformed_model_output | malformed_tool_use | model_context_window_exceeded`

## Test plan
- [x] `pnpm exec vitest run src/types/llm-providers/ollama-native/api.test.ts src/types/llm-providers/bedrock/api.test.ts` (17 passed)