### PR TITLE
fix(models): price dated snapshot ids and carry reseller capabilities

### DIFF
--- a/docs/pages/platform-costs-and-limits.md
+++ b/docs/pages/platform-costs-and-limits.md
@@ -2,7 +2,7 @@
 title: Costs & Limits
 category: LLM Proxy
 order: 4
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-28
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -81,7 +81,7 @@ Model pricing is configured on the provider model settings pages. Pricing is the
 - optimization reports use it to calculate savings
 - TOON compression savings are reported in dollars using the configured model price
 
-When you add a provider, Archestra syncs known input, output, and cache prices from a public model registry. You can override any of these per model, including cache read and write prices. A model the registry does not recognize falls back to an estimated flat price, shown as "estimated" in the model editor — set a custom price so cost reporting stays accurate. Amazon Bedrock and Azure model ids do not match the registry directly, so Archestra maps them back to the underlying vendor model to recover real prices (including cache prices) where possible.
+When you add a provider, Archestra syncs known input, output, and cache prices from a public model registry. You can override any of these per model, including cache read and write prices. A model the registry does not recognize falls back to an estimated flat price, shown as "estimated" in the model editor — set a custom price so cost reporting stays accurate. Amazon Bedrock and Azure model ids do not match the registry directly. Archestra maps them back to the underlying vendor model to recover real prices — cache prices included — and the context window.
 
 If you use custom or self-hosted models, add pricing explicitly so cost reporting stays meaningful.
 

--- a/platform/backend/src/services/cross-provider-pricing.ts
+++ b/platform/backend/src/services/cross-provider-pricing.ts
@@ -3,6 +3,7 @@ import {
   type ModelsDevApiResponse,
   type ModelsDevModel,
   modelsDevCostToPerToken,
+  sanitizeOutputLimit,
 } from "@/clients/models-dev-client";
 
 /**
@@ -25,8 +26,8 @@ export interface CrossProviderPrices {
  * (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`) and Azure stores arbitrary
  * deployment names — neither matches the canonical `anthropic`/`openai` keys in
  * models.dev, so without this both always fall back to the flat default price.
- * Crucially, the underlying vendor entry (e.g. `anthropic`) also carries cache
- * prices that the region-keyed `amazon-bedrock` entry omits.
+ * Crucially, the underlying vendor entry (e.g. `anthropic`) reliably carries
+ * cache prices, which the region-keyed `amazon-bedrock` entry may omit.
  *
  * Returns null when no confident match is found (caller keeps its existing
  * behaviour, i.e. the default price) — never guesses across unrelated models.
@@ -39,6 +40,98 @@ export function resolveCrossProviderPrices(params: {
   underlyingModelName?: string | null;
   modelsDevData: ModelsDevApiResponse;
 }): CrossProviderPrices | null {
+  // Entries are ordered by preference (a vendor's canonical entry, which has
+  // cache prices, before the region-keyed amazon-bedrock fallback).
+  const entry = resolveCrossProviderEntries(params).find((e) => e.cost);
+  return entry?.cost ? modelsDevCostToPerToken(entry.cost) : null;
+}
+
+/**
+ * Non-price capabilities carried by a reseller's matched registry entry.
+ * Modalities stay as raw registry strings: they are unvalidated third-party
+ * input, so the caller validates them against the same schema the column uses.
+ */
+export interface CrossProviderMetadata {
+  contextLength: number | null;
+  outputLength: number | null;
+  inputModalities: string[] | null;
+  outputModalities: string[] | null;
+  supportsToolCalling: boolean | null;
+}
+
+/**
+ * Resolve non-price capabilities for Bedrock/Azure, whose model ids never match
+ * models.dev keys directly.
+ *
+ * Preference deliberately inverts {@link resolveCrossProviderPrices}: cost reads
+ * the vendor's canonical entry first because only that reliably carries cache
+ * prices, while limits and modalities read the reseller's entry first because
+ * the reseller's numbers are the ones that apply. Claude Sonnet 4.5 forces the
+ * split — Anthropic publishes a 1M window, Bedrock serves 200K, and both
+ * entries carry identical prices.
+ *
+ * Resolved per field, so a reseller entry that omits one value still falls back
+ * to the vendor's for that value alone.
+ */
+export function resolveCrossProviderMetadata(params: {
+  provider: SupportedProvider;
+  modelId: string;
+  underlyingModelName?: string | null;
+  modelsDevData: ModelsDevApiResponse;
+}): CrossProviderMetadata | null {
+  const entries = resolveCrossProviderEntries(params).reverse();
+  const [preferred] = entries;
+  if (!preferred) {
+    return null;
+  }
+
+  return {
+    // Limits come from the preferred entry alone. Falling back to the next entry
+    // for a missing limit would reintroduce the overstatement this ordering
+    // exists to prevent: a reseller row that omits `limit.context` would publish
+    // the vendor's larger window — Anthropic's 1M for a model Bedrock serves at
+    // 200K — and an inflated window over-allocates the output budget and admits
+    // requests the reseller rejects. Unknown is reported as null instead.
+    contextLength: preferred.limit?.context ?? null,
+    outputLength: sanitizeOutputLimit(preferred.limit?.output),
+    // Modalities and tool support carry no such risk, so a reseller row that
+    // omits them still benefits from the vendor's values.
+    inputModalities: firstPresent(entries, (entry) =>
+      entry.modalities?.input?.length ? entry.modalities.input : null,
+    ),
+    outputModalities: firstPresent(entries, (entry) =>
+      entry.modalities?.output?.length ? entry.modalities.output : null,
+    ),
+    supportsToolCalling: firstPresent(entries, (entry) => entry.tool_call),
+  };
+}
+
+/**
+ * Strip a trailing date stamp from a model id, in either the contiguous Bedrock
+ * form (`-20250929`) or the hyphenated OpenAI/Azure form (`-2024-08-06`).
+ *
+ * A bare four-digit suffix is deliberately left alone: Mistral versions models
+ * as `-2407`/`-2411`, so stripping it would collapse two differently-priced
+ * models onto one registry key.
+ */
+export function stripModelDateSuffix(modelId: string): string {
+  return modelId.replace(DATE_SUFFIX, "");
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+/**
+ * Registry entries matching a reseller model, in cost preference order (the
+ * vendor's canonical entry first, the reseller's own entry second).
+ */
+function resolveCrossProviderEntries(params: {
+  provider: SupportedProvider;
+  modelId: string;
+  underlyingModelName?: string | null;
+  modelsDevData: ModelsDevApiResponse;
+}): ModelsDevModel[] {
   const { provider, modelId, underlyingModelName, modelsDevData } = params;
 
   // Prefer the foundation-model id resolved from the profile's model ARN; fall
@@ -51,25 +144,32 @@ export function resolveCrossProviderPrices(params: {
         ? toArray(resolveAzureTarget(underlyingModelName ?? modelId))
         : [];
 
-  // Targets are ordered by preference (e.g. a vendor's canonical entry, which
-  // has cache prices, before the region-keyed amazon-bedrock fallback).
+  const entries: ModelsDevModel[] = [];
   for (const target of targets) {
     const entry = findModelsDevModel({
       modelsDevData,
       modelsDevProviderId: target.modelsDevProviderId,
       candidates: target.candidates,
     });
-    if (entry?.cost) {
-      return modelsDevCostToPerToken(entry.cost);
+    if (entry) {
+      entries.push(entry);
     }
   }
-
-  return null;
+  return entries;
 }
 
-// ============================================================================
-// Internal
-// ============================================================================
+function firstPresent<T>(
+  entries: ModelsDevModel[],
+  pick: (entry: ModelsDevModel) => T | null | undefined,
+): T | null {
+  for (const entry of entries) {
+    const value = pick(entry);
+    if (value != null) {
+      return value;
+    }
+  }
+  return null;
+}
 
 interface CrossProviderTarget {
   /** The models.dev provider id whose entry hosts the canonical model. */
@@ -119,7 +219,7 @@ function resolveBedrockTargets(modelId: string): CrossProviderTarget[] {
     const canonical = rawModel.replace(BEDROCK_VERSION_SUFFIX, "");
     targets.push({
       modelsDevProviderId: canonicalProvider,
-      candidates: dedupe([canonical, canonical.replace(DATE_SUFFIX, "")]),
+      candidates: dedupe([canonical, stripModelDateSuffix(canonical)]),
     });
   }
 
@@ -130,7 +230,7 @@ function resolveBedrockTargets(modelId: string): CrossProviderTarget[] {
   // version suffix is kept (amazon-bedrock keys retain it).
   targets.push({
     modelsDevProviderId: "amazon-bedrock",
-    candidates: dedupe([withoutRegion, withoutRegion.replace(DATE_SUFFIX, "")]),
+    candidates: dedupe([withoutRegion, stripModelDateSuffix(withoutRegion)]),
   });
 
   return targets;
@@ -144,7 +244,7 @@ function resolveAzureTarget(modelName: string): CrossProviderTarget | null {
   // Azure hosts OpenAI models; their canonical pricing lives under `openai`.
   return {
     modelsDevProviderId: "openai",
-    candidates: dedupe([canonical, canonical.replace(DATE_SUFFIX, "")]),
+    candidates: dedupe([canonical, stripModelDateSuffix(canonical)]),
   };
 }
 
@@ -178,7 +278,7 @@ function findModelsDevModel(params: {
     const normalized = key.replace(BEDROCK_REGION_PREFIX, "");
     if (
       candidateSet.has(normalized) ||
-      candidateSet.has(normalized.replace(DATE_SUFFIX, ""))
+      candidateSet.has(stripModelDateSuffix(normalized))
     ) {
       return model;
     }

--- a/platform/backend/src/services/model-capability-matrix.test.ts
+++ b/platform/backend/src/services/model-capability-matrix.test.ts
@@ -1,0 +1,1068 @@
+import type { SupportedProvider } from "@archestra/shared";
+import type { ModelsDevApiResponse } from "@/clients/models-dev-client";
+import { ModelModel } from "@/models";
+import type { FetchedModelCapabilities } from "@/routes/chat/model-fetchers/types";
+import { describe, expect, test } from "@/test";
+import type {
+  ModelInputModality,
+  ModelOutputModality,
+  PriceSource,
+} from "@/types";
+import { buildModelsToUpsert } from "./model-sync";
+
+/**
+ * Black-box matrix over model metadata resolution: given a provider, a model id
+ * as the provider's own endpoint reports it, and a models.dev snapshot, what
+ * price and capabilities does the API end up serving?
+ *
+ * Each row exercises a resolution path no other row does — id shape, source
+ * tier, or fallback — so adding a model that resolves like an existing one adds
+ * maintenance without signal. Add a row when it covers a new path, or to pin a
+ * model that caused a production incident.
+ *
+ * Expected values are hand-written from each vendor's published pricing, never
+ * read back out of MODELS_DEV: expectations derived from the fixture would pass
+ * even if resolution were completely broken.
+ */
+
+/**
+ * Hand-built models.dev snapshot mirroring the real registry's shapes. Entries
+ * are transcribed from live models.dev data; models the real registry has
+ * retired (Claude 3 Sonnet, Llama 3.2, Titan embeddings) are omitted here too,
+ * which is what drives the `default`-priced rows below.
+ *
+ * `ollama` is absent on purpose — models.dev has no ollama provider entry, so
+ * local models can only ever resolve from the fetcher plus hardcoded inference.
+ */
+const MODELS_DEV: ModelsDevApiResponse = {
+  openai: {
+    id: "openai",
+    name: "OpenAI",
+    models: {
+      "gpt-4o": {
+        id: "gpt-4o",
+        name: "GPT-4o",
+        cost: { input: 2.5, output: 10, cache_read: 1.25 },
+        limit: { context: 128000, output: 16384 },
+        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+        tool_call: true,
+      },
+      "gpt-4o-mini": {
+        id: "gpt-4o-mini",
+        name: "GPT-4o mini",
+        cost: { input: 0.15, output: 0.6, cache_read: 0.075 },
+        limit: { context: 128000, output: 16384 },
+        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+        tool_call: true,
+      },
+      "gpt-4.1-nano": {
+        id: "gpt-4.1-nano",
+        name: "GPT-4.1 nano",
+        cost: { input: 0.1, output: 0.4, cache_read: 0.025 },
+        limit: { context: 1047576, output: 32768 },
+        modalities: { input: ["text", "image"], output: ["text"] },
+        tool_call: true,
+      },
+      "gpt-5.4": {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        cost: { input: 2.5, output: 15, cache_read: 0.25 },
+        limit: { context: 1050000, output: 128000 },
+        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+        tool_call: true,
+      },
+      // Present so the `gpt-3.5-turbo-0125` row proves the 4-digit suffix is
+      // deliberately NOT stripped, rather than passing because nothing matches.
+      "gpt-3.5-turbo": {
+        id: "gpt-3.5-turbo",
+        name: "GPT-3.5 Turbo",
+        cost: { input: 0.5, output: 1.5, cache_read: 0 },
+        limit: { context: 16385, output: 4096 },
+        modalities: { input: ["text"], output: ["text"] },
+        tool_call: false,
+      },
+      "text-embedding-3-small": {
+        id: "text-embedding-3-small",
+        name: "text-embedding-3-small",
+        cost: { input: 0.02, output: 0 },
+        limit: { context: 8191, output: 1536 },
+        modalities: { input: ["text"], output: ["text"] },
+        tool_call: false,
+      },
+    },
+  },
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-opus-4-8": {
+        id: "claude-opus-4-8",
+        name: "Claude Opus 4.8",
+        cost: { input: 5, output: 25, cache_read: 0.5, cache_write: 6.25 },
+        limit: { context: 1000000, output: 128000 },
+        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+        tool_call: true,
+      },
+      // The vendor entry claims a 1M window; the amazon-bedrock entry below
+      // says 200K for the same model. Bedrock's is the truthful one there.
+      "claude-sonnet-4-5": {
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
+        limit: { context: 1000000, output: 64000 },
+        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+        tool_call: true,
+      },
+      "claude-haiku-4-5": {
+        id: "claude-haiku-4-5",
+        name: "Claude Haiku 4.5",
+        cost: { input: 1, output: 5, cache_read: 0.1, cache_write: 1.25 },
+        limit: { context: 200000, output: 64000 },
+        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+        tool_call: true,
+      },
+    },
+  },
+  "amazon-bedrock": {
+    id: "amazon-bedrock",
+    name: "Amazon Bedrock",
+    models: {
+      // Same prices as the vendor entry, but a smaller (correct) window.
+      "anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        id: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        name: "Claude Sonnet 4.5",
+        cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
+        limit: { context: 200000, output: 64000 },
+        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+        tool_call: true,
+      },
+      // No canonical vendor entry exists for Amazon's own models.
+      "amazon.nova-lite-v1:0": {
+        id: "amazon.nova-lite-v1:0",
+        name: "Nova Lite",
+        cost: { input: 0.06, output: 0.24, cache_read: 0.015 },
+        limit: { context: 300000, output: 8192 },
+        modalities: { input: ["text", "image", "video"], output: ["text"] },
+        tool_call: true,
+      },
+      // No cache prices, so both directions fall to the bedrock multiplier.
+      "deepseek.r1-v1:0": {
+        id: "deepseek.r1-v1:0",
+        name: "DeepSeek R1",
+        cost: { input: 1.35, output: 5.4 },
+        limit: { context: 128000, output: 32768 },
+        modalities: { input: ["text"], output: ["text"] },
+        tool_call: true,
+      },
+      // Deliberately absent: anthropic.claude-haiku-4-5 (so that row must fall
+      // back to the vendor entry), plus the retired models the real registry
+      // no longer carries at all.
+    },
+  },
+  google: {
+    id: "google",
+    name: "Google",
+    models: {
+      "gemini-2.5-flash": {
+        id: "gemini-2.5-flash",
+        name: "Gemini 2.5 Flash",
+        cost: { input: 0.3, output: 2.5, cache_read: 0.03 },
+        limit: { context: 1048576, output: 65536 },
+        modalities: {
+          input: ["text", "image", "audio", "video", "pdf"],
+          output: ["text"],
+        },
+        tool_call: true,
+      },
+    },
+  },
+  openrouter: {
+    id: "openrouter",
+    name: "OpenRouter",
+    models: {
+      "deepseek/deepseek-chat-v3.1": {
+        id: "deepseek/deepseek-chat-v3.1",
+        name: "DeepSeek V3.1",
+        cost: { input: 0.25, output: 0.95, cache_read: 0.13 },
+        limit: { context: 163840, output: 32768 },
+        modalities: { input: ["text"], output: ["text"] },
+        tool_call: true,
+      },
+    },
+  },
+  mistral: {
+    id: "mistral",
+    name: "Mistral",
+    models: {
+      "mistral-large-latest": {
+        id: "mistral-large-latest",
+        name: "Mistral Large",
+        cost: { input: 0.5, output: 1.5 },
+        limit: { context: 262144, output: 262144 },
+        modalities: { input: ["text", "image"], output: ["text"] },
+        tool_call: true,
+      },
+    },
+  },
+  groq: {
+    id: "groq",
+    name: "Groq",
+    models: {
+      "llama-3.3-70b-versatile": {
+        id: "llama-3.3-70b-versatile",
+        name: "Llama 3.3 70B Versatile",
+        cost: { input: 0.59, output: 0.79 },
+        limit: { context: 131072, output: 32768 },
+        modalities: { input: ["text"], output: ["text"] },
+        tool_call: true,
+      },
+    },
+  },
+  deepseek: {
+    id: "deepseek",
+    name: "DeepSeek",
+    models: {
+      "deepseek-chat": {
+        id: "deepseek-chat",
+        name: "DeepSeek Chat",
+        cost: { input: 0.14, output: 0.28, cache_read: 0.0028 },
+        limit: { context: 1000000, output: 384000 },
+        modalities: { input: ["text"], output: ["text"] },
+        tool_call: true,
+      },
+    },
+  },
+  cerebras: {
+    id: "cerebras",
+    name: "Cerebras",
+    models: {
+      "gemma-4-31b": {
+        id: "gemma-4-31b",
+        name: "Gemma 4 31B",
+        cost: { input: 0.99, output: 1.49 },
+        limit: { context: 131072, output: 40960 },
+        modalities: { input: ["text", "image"], output: ["text"] },
+        tool_call: true,
+      },
+    },
+  },
+};
+
+interface ExpectedCapabilities {
+  contextLength: number | null;
+  outputLength: number | null;
+  inputModalities: ModelInputModality[] | null;
+  outputModalities: ModelOutputModality[] | null;
+  supportsToolCalling: boolean | null;
+  pricePerMillionInput: string;
+  pricePerMillionOutput: string;
+  priceSource: PriceSource;
+  pricePerMillionCacheRead: string | null;
+  pricePerMillionCacheWrite: string | null;
+  cachePriceSource: PriceSource | null;
+  embeddingDimensions?: number | null;
+}
+
+interface MatrixRow {
+  /** Reads as the test name, so it should say which path the row covers. */
+  name: string;
+  provider: SupportedProvider;
+  modelId: string;
+  underlyingModelName?: string;
+  fetched?: FetchedModelCapabilities;
+  expected: ExpectedCapabilities;
+}
+
+const MATRIX: MatrixRow[] = [
+  // --- OpenAI: same-provider registry lookup ------------------------------
+  {
+    name: "openai/gpt-4o — exact key; synced cache-read, derived cache-write",
+    provider: "openai",
+    modelId: "gpt-4o",
+    expected: {
+      contextLength: 128000,
+      outputLength: 16384,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "2.50",
+      pricePerMillionOutput: "10.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "1.25",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "openai/gpt-4o-mini-2024-07-18 — dated id resolves to the dateless key",
+    provider: "openai",
+    modelId: "gpt-4o-mini-2024-07-18",
+    expected: {
+      contextLength: 128000,
+      outputLength: 16384,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.15",
+      pricePerMillionOutput: "0.60",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.075",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "openai/gpt-4.1-nano-2025-04-14 — dated id; '-nano' must not win the $30 tier",
+    provider: "openai",
+    modelId: "gpt-4.1-nano-2025-04-14",
+    expected: {
+      contextLength: 1047576,
+      outputLength: 32768,
+      inputModalities: ["text", "image"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.10",
+      pricePerMillionOutput: "0.40",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.025",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "openai/gpt-5.4-2026-03-05 — dated id resolves to the dateless key",
+    provider: "openai",
+    modelId: "gpt-5.4-2026-03-05",
+    expected: {
+      contextLength: 1050000,
+      outputLength: 128000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "2.50",
+      pricePerMillionOutput: "15.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.25",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "openai/gpt-5.4 — undated control for the row above",
+    provider: "openai",
+    modelId: "gpt-5.4",
+    expected: {
+      contextLength: 1050000,
+      outputLength: 128000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "2.50",
+      pricePerMillionOutput: "15.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.25",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "openai/gpt-3.5-turbo — a synced cache_read of 0 stays 0, not a derived price",
+    provider: "openai",
+    modelId: "gpt-3.5-turbo",
+    expected: {
+      contextLength: 16385,
+      outputLength: 4096,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: false,
+      pricePerMillionInput: "0.50",
+      pricePerMillionOutput: "1.50",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "openai/gpt-3.5-turbo-0125 — a bare 4-digit suffix is deliberately not stripped",
+    provider: "openai",
+    modelId: "gpt-3.5-turbo-0125",
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: "12.5",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "derived_multiplier",
+    },
+  },
+  {
+    name: "openai/text-embedding-3-small — embedding model, no cache_read in the registry",
+    provider: "openai",
+    modelId: "text-embedding-3-small",
+    expected: {
+      contextLength: 8191,
+      outputLength: 1536,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: false,
+      pricePerMillionInput: "0.02",
+      pricePerMillionOutput: "0.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.005",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "derived_multiplier",
+      embeddingDimensions: 1536,
+    },
+  },
+
+  // --- Anthropic ----------------------------------------------------------
+  {
+    name: "anthropic/claude-opus-4-8 — both cache directions synced",
+    provider: "anthropic",
+    modelId: "claude-opus-4-8",
+    expected: {
+      contextLength: 1000000,
+      outputLength: 128000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "5.00",
+      pricePerMillionOutput: "25.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.5",
+      pricePerMillionCacheWrite: "6.25",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "anthropic/claude-haiku-4-5 — a registry price beats the '-haiku' $30 tier",
+    provider: "anthropic",
+    modelId: "claude-haiku-4-5",
+    expected: {
+      contextLength: 200000,
+      outputLength: 64000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "1.00",
+      pricePerMillionOutput: "5.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.1",
+      pricePerMillionCacheWrite: "1.25",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "anthropic/claude-sonnet-4-5 — 1M window direct from the vendor",
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-5",
+    expected: {
+      contextLength: 1000000,
+      outputLength: 64000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "3.00",
+      pricePerMillionOutput: "15.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.3",
+      pricePerMillionCacheWrite: "3.75",
+      cachePriceSource: "models_dev",
+    },
+  },
+
+  // --- Bedrock: cross-provider resolution ---------------------------------
+  {
+    name: "bedrock/us.anthropic.claude-sonnet-4-5 — 200K from the bedrock entry, not the vendor's 1M",
+    provider: "bedrock",
+    modelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    expected: {
+      contextLength: 200000,
+      outputLength: 64000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "3.00",
+      pricePerMillionOutput: "15.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.3",
+      pricePerMillionCacheWrite: "3.75",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "bedrock/global.anthropic.claude-sonnet-4-5 — a different region prefix resolves identically",
+    provider: "bedrock",
+    modelId: "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    expected: {
+      contextLength: 200000,
+      outputLength: 64000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "3.00",
+      pricePerMillionOutput: "15.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.3",
+      pricePerMillionCacheWrite: "3.75",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "bedrock/us.amazon.nova-lite — resolves via the amazon-bedrock entry (no vendor entry exists)",
+    provider: "bedrock",
+    modelId: "us.amazon.nova-lite-v1:0",
+    expected: {
+      contextLength: 300000,
+      outputLength: 8192,
+      inputModalities: ["text", "image", "video"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.06",
+      pricePerMillionOutput: "0.24",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.015",
+      pricePerMillionCacheWrite: "0.075",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "bedrock/us.deepseek.r1 — no synced cache, so both directions use the bedrock multiplier",
+    provider: "bedrock",
+    modelId: "us.deepseek.r1-v1:0",
+    expected: {
+      contextLength: 128000,
+      outputLength: 32768,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "1.35",
+      pricePerMillionOutput: "5.40",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.135",
+      pricePerMillionCacheWrite: "1.6875",
+      cachePriceSource: "derived_multiplier",
+    },
+  },
+  {
+    name: "bedrock/application-inference-profile — opaque id resolved via the ARN's foundation model",
+    provider: "bedrock",
+    modelId: "hq8s2mfl9k1r",
+    underlyingModelName: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    expected: {
+      contextLength: 200000,
+      outputLength: 64000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "3.00",
+      pricePerMillionOutput: "15.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.3",
+      pricePerMillionCacheWrite: "3.75",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "bedrock/us.anthropic.claude-haiku-4-5 — falls back to the vendor entry when amazon-bedrock has none",
+    provider: "bedrock",
+    modelId: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    expected: {
+      contextLength: 200000,
+      outputLength: 64000,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "1.00",
+      pricePerMillionOutput: "5.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.1",
+      pricePerMillionCacheWrite: "1.25",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "bedrock/us.anthropic.claude-3-sonnet — retired from the registry, so nothing can price it",
+    provider: "bedrock",
+    modelId: "us.anthropic.claude-3-sonnet-20240229-v1:0",
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: "5",
+      pricePerMillionCacheWrite: "62.5",
+      cachePriceSource: "derived_multiplier",
+    },
+  },
+  {
+    name: "bedrock/amazon.titan-embed-text-v1 — retired from the registry",
+    provider: "bedrock",
+    modelId: "amazon.titan-embed-text-v1",
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: "5",
+      pricePerMillionCacheWrite: "62.5",
+      cachePriceSource: "derived_multiplier",
+    },
+  },
+  {
+    name: "bedrock/us.meta.llama3-2-90b — retired from the registry",
+    provider: "bedrock",
+    modelId: "us.meta.llama3-2-90b-instruct-v1:0",
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: "5",
+      pricePerMillionCacheWrite: "62.5",
+      cachePriceSource: "derived_multiplier",
+    },
+  },
+  {
+    name: "bedrock/us.anthropic.claude-3-haiku — unpriced '-haiku' id falls to the $30 tier",
+    provider: "bedrock",
+    modelId: "us.anthropic.claude-3-haiku-20240307-v1:0",
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: null,
+      pricePerMillionInput: "30.00",
+      pricePerMillionOutput: "30.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: "3",
+      pricePerMillionCacheWrite: "37.5",
+      cachePriceSource: "derived_multiplier",
+    },
+  },
+
+  // --- Azure: deployment names carry no vendor identity -------------------
+  {
+    name: "azure/deployment with a known underlying model name",
+    provider: "azure",
+    modelId: "my-gpt4o-deploy",
+    underlyingModelName: "gpt-4o",
+    expected: {
+      contextLength: 128000,
+      outputLength: 16384,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "2.50",
+      pricePerMillionOutput: "10.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "1.25",
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "azure/deployment named after its model, with no underlying name reported",
+    provider: "azure",
+    modelId: "gpt-4o",
+    expected: {
+      contextLength: 128000,
+      outputLength: 16384,
+      inputModalities: ["text", "image", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "2.50",
+      pricePerMillionOutput: "10.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "1.25",
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "azure/opaquely-named embedding deployment — emits no output modality, despite the vendor entry claiming text",
+    provider: "azure",
+    modelId: "prod-deploy-7f3a",
+    underlyingModelName: "text-embedding-3-small",
+    expected: {
+      contextLength: 8191,
+      outputLength: 1536,
+      inputModalities: ["text"],
+      outputModalities: [],
+      supportsToolCalling: false,
+      pricePerMillionInput: "0.02",
+      pricePerMillionOutput: "0.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+    },
+  },
+  {
+    name: "azure/deployment that matches no known model",
+    provider: "azure",
+    modelId: "totally-custom-deployment",
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+    },
+  },
+
+  // --- OpenRouter: the fetcher reports its own prices ---------------------
+  {
+    name: "openrouter/:free — a fetched price of zero must survive, not fall to the default tier",
+    provider: "openrouter",
+    modelId: "deepseek/deepseek-chat-v3.1:free",
+    fetched: {
+      contextLength: 163840,
+      supportsToolCalling: true,
+      promptPricePerToken: "0",
+      completionPricePerToken: "0",
+    },
+    expected: {
+      contextLength: 163840,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.00",
+      pricePerMillionOutput: "0.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+    },
+  },
+  {
+    name: "openrouter/fetched values outrank the registry field by field",
+    provider: "openrouter",
+    modelId: "deepseek/deepseek-chat-v3.1",
+    fetched: {
+      contextLength: 99000,
+      supportsToolCalling: false,
+      promptPricePerToken: "0.000001",
+      completionPricePerToken: "0.000002",
+    },
+    expected: {
+      contextLength: 99000,
+      outputLength: 32768,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: false,
+      pricePerMillionInput: "1.00",
+      pricePerMillionOutput: "2.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.13",
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "openrouter/no fetched capabilities — everything comes from the registry",
+    provider: "openrouter",
+    modelId: "deepseek/deepseek-chat-v3.1",
+    expected: {
+      contextLength: 163840,
+      outputLength: 32768,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.25",
+      pricePerMillionOutput: "0.95",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.13",
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: "models_dev",
+    },
+  },
+
+  // --- Ollama: local models, absent from models.dev entirely --------------
+  {
+    name: "ollama/a Modelfile num_ctx caps the window below the architectural one",
+    provider: "ollama",
+    modelId: "llama3.2",
+    fetched: {
+      contextLength: 262144,
+      defaultParameters: { num_ctx: 8192 },
+    },
+    expected: {
+      contextLength: 8192,
+      outputLength: null,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+    },
+  },
+  {
+    name: "ollama/without a num_ctx the architectural window stands",
+    provider: "ollama",
+    modelId: "llama3.2",
+    fetched: { contextLength: 262144 },
+    expected: {
+      contextLength: 262144,
+      outputLength: null,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+    },
+  },
+  {
+    name: "ollama/an embedding model reports its dimension and no output modality",
+    provider: "ollama",
+    modelId: "nomic-embed-text",
+    fetched: { embeddingDimensions: 768 },
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: ["text"],
+      outputModalities: [],
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+      embeddingDimensions: 768,
+    },
+  },
+
+  // --- Gemini -------------------------------------------------------------
+  {
+    name: "gemini/gemini-2.5-flash — multimodal input from the registry",
+    provider: "gemini",
+    modelId: "gemini-2.5-flash",
+    expected: {
+      contextLength: 1048576,
+      outputLength: 65536,
+      inputModalities: ["text", "image", "audio", "video", "pdf"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.30",
+      pricePerMillionOutput: "2.50",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.03",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "gemini/gemini-embedding-2-preview — normalized to multimodal input with no output",
+    provider: "gemini",
+    modelId: "gemini-embedding-2-preview",
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: ["text", "image"],
+      outputModalities: [],
+      supportsToolCalling: false,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: "12.5",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "derived_multiplier",
+      embeddingDimensions: 3072,
+    },
+  },
+
+  // --- Provider breadth ---------------------------------------------------
+  {
+    name: "mistral/mistral-large-latest — provider has no cache pricing model",
+    provider: "mistral",
+    modelId: "mistral-large-latest",
+    expected: {
+      contextLength: 262144,
+      outputLength: 262144,
+      inputModalities: ["text", "image"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.50",
+      pricePerMillionOutput: "1.50",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+    },
+  },
+  {
+    name: "groq/llama-3.3-70b-versatile",
+    provider: "groq",
+    modelId: "llama-3.3-70b-versatile",
+    expected: {
+      contextLength: 131072,
+      outputLength: 32768,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.59",
+      pricePerMillionOutput: "0.79",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+    },
+  },
+  {
+    name: "deepseek/deepseek-chat — sub-cent cache price keeps its precision",
+    provider: "deepseek",
+    modelId: "deepseek-chat",
+    expected: {
+      contextLength: 1000000,
+      outputLength: 384000,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.14",
+      pricePerMillionOutput: "0.28",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "0.0028",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "cerebras/gemma-4-31b",
+    provider: "cerebras",
+    modelId: "gemma-4-31b",
+    expected: {
+      contextLength: 131072,
+      outputLength: 40960,
+      inputModalities: ["text", "image"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.99",
+      pricePerMillionOutput: "1.49",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: null,
+      pricePerMillionCacheWrite: null,
+      cachePriceSource: null,
+    },
+  },
+
+  // --- Negative control ---------------------------------------------------
+  {
+    name: "openai/gpt-4o-search-preview-2025-03-11 — stripping the date must not match a different model",
+    provider: "openai",
+    modelId: "gpt-4o-search-preview-2025-03-11",
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: "12.5",
+      pricePerMillionCacheWrite: "0",
+      cachePriceSource: "derived_multiplier",
+    },
+  },
+];
+
+/**
+ * How many rows above resolve to no registry price and land on the $50/$30
+ * estimate. Pinning the count makes adding another one a deliberate act:
+ * the guard below fails until someone updates this number, which is the moment
+ * to ask whether that model should really be unpriced.
+ */
+const EXPECTED_DEFAULT_PRICED_ROWS = 11;
+
+describe("model capability matrix", () => {
+  for (const row of MATRIX) {
+    test(row.name, async () => {
+      const [model] = await ModelModel.bulkUpsert(
+        buildModelsToUpsert({
+          provider: row.provider,
+          models: [
+            {
+              id: row.modelId,
+              capabilities: row.fetched,
+              underlyingModelName: row.underlyingModelName ?? null,
+            },
+          ],
+          modelsDevData: MODELS_DEV,
+        }),
+      );
+
+      const capabilities = ModelModel.toCapabilities(model);
+
+      expect({
+        contextLength: capabilities.contextLength,
+        outputLength: model.outputLength,
+        inputModalities: capabilities.inputModalities,
+        outputModalities: capabilities.outputModalities,
+        supportsToolCalling: capabilities.supportsToolCalling,
+        pricePerMillionInput: capabilities.pricePerMillionInput,
+        pricePerMillionOutput: capabilities.pricePerMillionOutput,
+        priceSource: capabilities.priceSource,
+        pricePerMillionCacheRead: capabilities.pricePerMillionCacheRead,
+        pricePerMillionCacheWrite: capabilities.pricePerMillionCacheWrite,
+        cachePriceSource: capabilities.cachePriceSource,
+        ...(row.expected.embeddingDimensions !== undefined
+          ? { embeddingDimensions: model.embeddingDimensions }
+          : {}),
+      }).toEqual(row.expected);
+    });
+  }
+
+  test("only the known-unpriced models fall through to the estimate", () => {
+    const unpriced = MATRIX.filter((row) => {
+      const [built] = buildModelsToUpsert({
+        provider: row.provider,
+        models: [
+          {
+            id: row.modelId,
+            capabilities: row.fetched,
+            underlyingModelName: row.underlyingModelName ?? null,
+          },
+        ],
+        modelsDevData: MODELS_DEV,
+      });
+      return built.promptPricePerToken === null;
+    }).map((row) => row.name);
+
+    expect(unpriced).toHaveLength(EXPECTED_DEFAULT_PRICED_ROWS);
+  });
+});

--- a/platform/backend/src/services/model-sync.ts
+++ b/platform/backend/src/services/model-sync.ts
@@ -20,8 +20,11 @@ import {
 import { modelFetchers } from "@/routes/chat/model-fetchers";
 import type { FetchedModelCapabilities } from "@/routes/chat/model-fetchers/types";
 import {
+  type CrossProviderMetadata,
   type CrossProviderPrices,
+  resolveCrossProviderMetadata,
   resolveCrossProviderPrices,
+  stripModelDateSuffix,
 } from "@/services/cross-provider-pricing";
 import type {
   CreateModel,
@@ -276,24 +279,30 @@ export function buildModelsToUpsert(params: {
   }
 
   return [...uniqueModels.values()].map((model) => {
-    // Bedrock/Azure model ids don't match models.dev keys, so derive pricing
-    // from the underlying vendor entry (which also carries cache prices).
-    const crossProviderPrices =
-      provider === "bedrock" || provider === "azure"
-        ? resolveCrossProviderPrices({
-            provider,
-            modelId: model.id,
-            underlyingModelName: model.underlyingModelName,
-            modelsDevData,
-          })
-        : null;
+    // Bedrock/Azure model ids don't match models.dev keys, so derive pricing and
+    // capabilities from the underlying vendor entry.
+    const isReseller = provider === "bedrock" || provider === "azure";
+    const crossProviderArgs = {
+      provider,
+      modelId: model.id,
+      underlyingModelName: model.underlyingModelName,
+      modelsDevData,
+    };
+    const crossProviderPrices = isReseller
+      ? resolveCrossProviderPrices(crossProviderArgs)
+      : null;
+    const crossProviderMetadata = isReseller
+      ? resolveCrossProviderMetadata(crossProviderArgs)
+      : null;
 
     const capabilities = resolveModelCapabilities({
       provider,
       modelId: model.id,
-      capabilities: capabilitiesMap.get(model.id),
+      capabilities: lookupModelsDevCapabilities(capabilitiesMap, model.id),
       fetched: model.capabilities,
       crossProviderPrices,
+      crossProviderMetadata,
+      underlyingModelName: model.underlyingModelName,
     });
 
     return {
@@ -415,18 +424,35 @@ export function resolveModelCapabilities(params: {
   fetched?: FetchedModelCapabilities;
   /** Prices derived from the underlying vendor entry for Bedrock/Azure. */
   crossProviderPrices?: CrossProviderPrices | null;
+  /** Capabilities derived from the underlying vendor entry for Bedrock/Azure. */
+  crossProviderMetadata?: CrossProviderMetadata | null;
+  /** Underlying vendor model name, when the fetcher can determine it (Azure). */
+  underlyingModelName?: string | null;
 }): ProviderModelCapabilities {
-  const { provider, modelId, capabilities, fetched, crossProviderPrices } =
-    params;
+  const {
+    provider,
+    modelId,
+    capabilities,
+    fetched,
+    crossProviderPrices,
+    crossProviderMetadata,
+    underlyingModelName,
+  } = params;
   const inferredCapabilities = inferModelCapabilities({
     provider,
     modelId,
     fetched,
+    underlyingModelName,
   });
 
-  // Priority per field: fetcher -> models.dev -> hardcoded inference.
+  // Priority per field: fetcher -> models.dev -> hardcoded inference ->
+  // cross-provider (Bedrock/Azure underlying vendor). Inference outranks the
+  // cross-provider tier because it describes the model's shape on *this*
+  // provider, which the resold vendor entry cannot: an Azure embedding
+  // deployment emits no output modality even though the OpenAI entry it
+  // resolves to lists "text".
   // Price priority: fetcher -> models.dev (same provider) -> cross-provider
-  // (Bedrock/Azure underlying vendor) -> null.
+  // -> null.
   return normalizeKnownModelCapabilities({
     provider,
     modelId,
@@ -435,17 +461,34 @@ export function resolveModelCapabilities(params: {
       contextLength:
         fetched?.contextLength ??
         capabilities?.contextLength ??
-        inferredCapabilities.contextLength,
+        inferredCapabilities.contextLength ??
+        crossProviderMetadata?.contextLength ??
+        null,
       outputLength:
-        capabilities?.outputLength ?? inferredCapabilities.outputLength,
+        capabilities?.outputLength ??
+        inferredCapabilities.outputLength ??
+        crossProviderMetadata?.outputLength ??
+        null,
       inputModalities:
-        capabilities?.inputModalities ?? inferredCapabilities.inputModalities,
+        capabilities?.inputModalities ??
+        inferredCapabilities.inputModalities ??
+        parseModalities(
+          crossProviderMetadata?.inputModalities,
+          ModelInputModalitySchema,
+        ),
       outputModalities:
-        capabilities?.outputModalities ?? inferredCapabilities.outputModalities,
+        capabilities?.outputModalities ??
+        inferredCapabilities.outputModalities ??
+        parseModalities(
+          crossProviderMetadata?.outputModalities,
+          ModelOutputModalitySchema,
+        ),
       supportsToolCalling:
         fetched?.supportsToolCalling ??
         capabilities?.supportsToolCalling ??
-        inferredCapabilities.supportsToolCalling,
+        inferredCapabilities.supportsToolCalling ??
+        crossProviderMetadata?.supportsToolCalling ??
+        null,
       promptPricePerToken:
         fetched?.promptPricePerToken ??
         capabilities?.promptPricePerToken ??
@@ -468,6 +511,27 @@ export function resolveModelCapabilities(params: {
         null,
     },
   });
+}
+
+/**
+ * Look a model up in the models.dev map, falling back to its date-stripped id.
+ *
+ * Providers hand out date-pinned snapshot ids (`gpt-4o-mini-2024-07-18`) that
+ * the registry keys without the date, so an exact-only lookup misses them and
+ * the model falls all the way through to the flat default price. The exact key
+ * still wins, making the fallback purely additive, and the fallback is itself an
+ * exact lookup, so it can only match a key the registry really has.
+ */
+function lookupModelsDevCapabilities(
+  capabilitiesMap: Map<string, ProviderModelCapabilities>,
+  modelId: string,
+): ProviderModelCapabilities | undefined {
+  const exact = capabilitiesMap.get(modelId);
+  if (exact) {
+    return exact;
+  }
+  const dateless = stripModelDateSuffix(modelId);
+  return dateless === modelId ? undefined : capabilitiesMap.get(dateless);
 }
 
 /**
@@ -523,7 +587,7 @@ function buildCapabilitiesMap(
  * Returns null if input is undefined/empty, otherwise returns validated modalities.
  */
 function parseModalities<T>(
-  modalities: string[] | undefined,
+  modalities: string[] | null | undefined,
   schema: { safeParse: (value: unknown) => { success: boolean; data?: T } },
 ): T[] | null {
   if (!modalities || modalities.length === 0) {
@@ -545,11 +609,12 @@ function inferModelCapabilities(params: {
   provider: SupportedProvider;
   modelId: string;
   fetched?: FetchedModelCapabilities;
+  underlyingModelName?: string | null;
 }): ProviderModelCapabilities {
-  const { provider, modelId, fetched } = params;
+  const { provider, modelId, fetched, underlyingModelName } = params;
 
   if (provider === "azure") {
-    return inferAzureCapabilities(modelId);
+    return inferAzureCapabilities(modelId, underlyingModelName);
   }
 
   if (provider === "gemini") {
@@ -585,8 +650,21 @@ function inferOllamaCapabilities(
   };
 }
 
-function inferAzureCapabilities(modelId: string): ProviderModelCapabilities {
-  if (!modelId.toLowerCase().includes("embedding")) {
+/**
+ * Azure deployment names are chosen by the customer, so the id alone often says
+ * nothing about the model behind it. The underlying model name settles it: an
+ * opaquely-named embedding deployment must still be classified as one, or the
+ * vendor entry it resolves to — which lists a "text" output — would make it look
+ * generative.
+ */
+function inferAzureCapabilities(
+  modelId: string,
+  underlyingModelName?: string | null,
+): ProviderModelCapabilities {
+  const isEmbedding = [modelId, underlyingModelName].some((name) =>
+    name?.toLowerCase().includes("embedding"),
+  );
+  if (!isEmbedding) {
     return emptyCapabilities();
   }
 


### PR DESCRIPTION
Model metadata resolution matched models.dev on the exact model id. Providers pin date-stamped snapshot ids (`gpt-4o-mini-2024-07-18`) that the registry keys without the date, so those models matched nothing and fell through to the flat $50/M estimate — $30/M for `-mini`/`-nano`/`-haiku` ids, which inverts the error and charges the most for models that actually cost $0.10–$0.15/M.

That estimate is not cosmetic. `calculateCost` writes it into `interactions.cost`, and it feeds cost statistics, optimization-rule savings and cost-limit enforcement, so a tenant on affected models burns their budget cap far earlier than real spend warrants. Roughly 60 of ~160 OpenAI models in a dev catalog were priced this way; the recoverable ones now carry real prices and context windows, and dated snapshots resolve to the same values as the alias they pin.

Lookups now fall back to the date-stripped id. The exact key still wins, so the change is additive, and the fallback is itself an exact lookup — it cannot match a model the registry does not have. A bare four-digit suffix is deliberately left alone: Mistral versions models as `-2407`/`-2411`, and stripping it would collapse two differently-priced models onto one key. The tradeoff accepted here is that a date-pinned snapshot inherits its alias's current price; that is bounded, and far closer than the flat estimate it replaces.

Separately, the Bedrock/Azure cross-provider tier located a vendor's registry entry and then read only its `cost`, discarding the context window, modalities and tool-calling support sitting in the same entry. Every Bedrock model therefore stored a null context window, so the models list showed no limit, the chat context ring had no denominator, and the agent output budget had no ceiling to halve.

Capabilities now come from that entry too, with preference inverted against pricing: cost reads the vendor's canonical entry first because only it reliably carries cache prices, while limits read the reseller's entry first because the reseller's numbers are the ones that apply. Anthropic publishes a 1M window for Claude Sonnet 4.5 where Bedrock serves 200K, so reusing the entry that won on price would overstate the window fivefold and mis-size generation budgets. Limits come from the preferred entry alone rather than falling back field by field, since a reseller row that omits a limit must report unknown rather than inherit the vendor's larger number.

Azure deployment names are customer-chosen, so embedding classification also consults the underlying model name — an opaquely-named embedding deployment would otherwise inherit the vendor entry's `text` output modality and look generative.

Models the registry does not carry at all still fall back to the estimate. These are retired Bedrock models — Claude 3 Sonnet, Llama 3.2, the Titan embeddings, Nova Premier — and no automated source exists for them: models.dev has dropped the entries, and neither `ListFoundationModels` nor `GetFoundationModel` returns a token limit. Pricing them needs an admin override, which is not part of this change.

`model-capability-matrix.test.ts` pins resolution for 38 real provider/model pairs — one per distinct resolution path rather than one per model — asserting the effective price, its source, context window, modalities and tool support. Rows that legitimately resolve to no registry price are pinned by count, so a model that starts falling back cannot land without that becoming a deliberate decision.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>