### PR TITLE
fix(llm-proxy): record interactions for streams that end without usage

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -462,6 +462,76 @@ describe("LLM Proxy Handler Prometheus Metrics", () => {
       expect(rows[0].inputTokens).toBe(0);
       expect(rows[0].outputTokens).toBe(0);
     });
+
+    test("streaming failure after SSE headers and content persists an error interaction", async () => {
+      // The provider fails mid-stream: SSE headers and content chunks are already
+      // on the wire, but the usage-bearing final chunk never arrives. The
+      // finally-block persist is gated on usage, so this must be covered by the
+      // catch path or the failure leaves no trace in LLM logs / session history.
+      openAiStubOptions.throwAtChunk = 2;
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+          "user-agent": "test-client",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "Hello!" }],
+          stream: true,
+        },
+      });
+
+      // Headers were already committed, so the failure surfaces as an SSE error
+      // event on a 200 response rather than an HTTP error status.
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain("event: error");
+
+      const rows = await db
+        .select()
+        .from(schema.interactionsTable)
+        .where(eq(schema.interactionsTable.profileId, testAgent.id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].response).toMatchObject({
+        error: expect.stringContaining("Simulated OpenAI stream failure"),
+      });
+      expect(rows[0].inputTokens).toBe(0);
+      expect(rows[0].outputTokens).toBe(0);
+    });
+
+    test("stream ending early without usage persists a partial interaction", async () => {
+      // The provider closes the stream cleanly mid-way (no throw) before the
+      // usage chunk. Nothing raises, so the catch path never runs and the
+      // finally-block persist is gated on usage — the call must still be
+      // recorded rather than vanishing from interaction history.
+      openAiStubOptions.interruptAtChunk = 2;
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+          "user-agent": "test-client",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "Hello!" }],
+          stream: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const rows = await db
+        .select()
+        .from(schema.interactionsTable)
+        .where(eq(schema.interactionsTable.profileId, testAgent.id));
+      expect(rows).toHaveLength(1);
+    });
   });
 
   describe("Anthropic", () => {

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -63,6 +63,7 @@ import {
   type GatewayAgent,
   type InteractionAuthMethod,
   type InteractionRequest,
+  type InteractionResponse,
   type LLMProvider,
   type LLMStreamAdapter,
   type ToolCompressionStats,
@@ -1199,6 +1200,49 @@ async function handleStreaming<
   // to prevent streaming data for tools that appear after a blocked tool.
   let bufferAllToolCalls = false;
 
+  // The finally-block persist is gated on usage, so any stream that ends without
+  // the provider ever reporting usage — a mid-stream failure, or a stream the
+  // provider truncates cleanly — would otherwise leave no trace in LLM logs /
+  // session history. Both paths funnel through here; the flag keeps a failed
+  // stream from being recorded twice (the catch persists, then finally runs).
+  let usagelessInteractionRecorded = false;
+  const recordUsagelessInteraction = async (response: unknown) => {
+    if (usagelessInteractionRecorded) {
+      return;
+    }
+    usagelessInteractionRecorded = true;
+
+    try {
+      await InteractionModel.create({
+        profileId: agent.id,
+        externalAgentId,
+        executionId,
+        userId,
+        virtualKeyId,
+        passthroughVirtualKeyId,
+        sessionId,
+        sessionSource,
+        source,
+        authMethod,
+        authenticatedAppId: authenticatedApp?.id,
+        authenticatedAppName: authenticatedApp?.name,
+        type: provider.interactionType,
+        request: originalRequest as InteractionRequest,
+        processedRequest: request as InteractionRequest,
+        response: response as InteractionResponse,
+        model: actualModel,
+        baselineModel,
+        inputTokens: 0,
+        outputTokens: 0,
+      });
+    } catch (interactionError) {
+      logger.error(
+        { err: interactionError, profileId: agent.id },
+        "Failed to create interaction record for stream without usage",
+      );
+    }
+  };
+
   logger.debug(
     { model: actualModel },
     `[${providerName}Proxy] Starting streaming request`,
@@ -1544,44 +1588,16 @@ async function handleStreaming<
       requestDurationRecorded = true;
     }
 
-    // The finally-block persist below is gated on usage, so a stream that
-    // fails before any usage arrives (e.g. a provider 400 rejecting the
-    // request) would otherwise leave no trace in LLM logs / session history.
+    // A stream that fails before any usage arrives (e.g. a provider 400
+    // rejecting the request, or a mid-stream failure once SSE headers and
+    // content are already on the wire) still has to reach interaction history.
     if (!streamAdapter.state.usage) {
-      try {
-        const errorMessage = provider.extractErrorMessage(error);
-        logger.info(
-          { profileId: agent.id, errorMessage },
-          "Persisting error interaction record for failed stream",
-        );
-        await InteractionModel.create({
-          profileId: agent.id,
-          externalAgentId,
-          executionId,
-          userId,
-          virtualKeyId,
-          passthroughVirtualKeyId,
-          sessionId,
-          sessionSource,
-          source,
-          authMethod,
-          authenticatedAppId: authenticatedApp?.id,
-          authenticatedAppName: authenticatedApp?.name,
-          type: provider.interactionType,
-          request: originalRequest as InteractionRequest,
-          processedRequest: request as InteractionRequest,
-          response: { error: errorMessage },
-          model: actualModel,
-          baselineModel,
-          inputTokens: 0,
-          outputTokens: 0,
-        });
-      } catch (interactionError) {
-        logger.error(
-          { err: interactionError, profileId: agent.id },
-          "Failed to create error interaction record for failed stream",
-        );
-      }
+      const errorMessage = provider.extractErrorMessage(error);
+      logger.info(
+        { profileId: agent.id, errorMessage },
+        "Persisting error interaction record for failed stream",
+      );
+      await recordUsagelessInteraction({ error: errorMessage });
     }
 
     return handleError(
@@ -1692,6 +1708,12 @@ async function handleStreaming<
           "Failed to create interaction record (agent may have been deleted)",
         );
       }
+    } else {
+      // No usage ever arrived. On the error path the catch has already recorded
+      // the failure; otherwise the provider ended the stream early (a truncated
+      // response), and the partial content is all we have to log. Either way the
+      // call must not disappear from interaction history.
+      await recordUsagelessInteraction(streamAdapter.toProviderResponse());
     }
   }
 }

--- a/platform/backend/src/test/llm-provider-stubs.ts
+++ b/platform/backend/src/test/llm-provider-stubs.ts
@@ -6,6 +6,12 @@ export interface OpenAiStubOptions {
   interruptAtChunk?: number;
   /** Reject streaming requests with this error message before any chunk arrives (e.g. a provider 400). */
   failStreamWithError?: string;
+  /**
+   * Throw from the stream iterator at this chunk index, after earlier chunks have
+   * already been yielded — a mid-stream failure once SSE headers and content are
+   * on the wire, but before the usage-bearing final chunk arrives.
+   */
+  throwAtChunk?: number;
 }
 
 export interface AnthropicStubOptions {
@@ -247,6 +253,13 @@ function createOpenAiStream(options: OpenAiStubOptions) {
 
       return {
         async next() {
+          if (
+            options.throwAtChunk !== undefined &&
+            index === options.throwAtChunk
+          ) {
+            throw new Error("Simulated OpenAI stream failure before usage");
+          }
+
           if (
             options.interruptAtChunk !== undefined &&
             index === options.interruptAtChunk


### PR DESCRIPTION
## Context

`handleStreaming`'s `finally`-block persist is gated on the provider reporting usage. Any stream that ends before usage arrives therefore writes no row to `interactions` at all — the call disappears from LLM logs and session history entirely.

Two distinct paths reach that state, and only one of them was covered:

1. **The stream fails.** The catch persists an error interaction when no usage is present. This already worked — #6223 added it — but the only regression test exercised a failure *before any chunk*. The case originally reported in #5948 (a failure once SSE headers and content chunks are already on the wire) was never pinned by a test, which is why the issue stayed open even though the behavior was fixed.

2. **The stream ends cleanly before the usage chunk** (a truncated response). Nothing raises, so the catch never runs and `streamCompleted` is set to `true` — this path recorded nothing whatsoever. That directly contradicts the block's own comment, *"Always record interaction (whether stream completed or was aborted)"*, and its `!streamCompleted` branch logging *"recording partial interaction"* never even fires here. Existing coverage in `openai.test.ts` drives this exact input but only asserts it "handles gracefully" (200 + partial SSE), never checking for a row.

## Changes

- **`llm-proxy-handler.ts`** — both no-usage paths now funnel through a single `recordUsagelessInteraction` helper, guarded by a flag so a failed stream is not recorded twice (the catch persists, then `finally` runs). The catch passes `{ error }` as before; the new `finally` else-branch passes `streamAdapter.toProviderResponse()`, so a truncated stream logs the partial content it did receive rather than vanishing. This collapses the ~20-field `InteractionModel.create` call from two copies to one.
- **`llm-provider-stubs.ts`** — adds a `throwAtChunk` option to the OpenAI stub, which throws from the stream iterator *after* earlier chunks have been yielded. The existing `interruptAtChunk` ends the stream cleanly instead, so it could not express a mid-stream failure.
- **`llm-proxy-handler.test.ts`** — regression tests for both paths: a mid-stream failure after SSE headers and content are committed (asserts 200 + `event: error` + one zero-token row carrying the error), and a stream that ends early without usage.

## Behavior change

Truncated streams now produce zero-token interaction rows in LLM logs and session history where previously there were none. That is the point of the fix, but it is user-visible. Cost is unaffected — the rows carry `inputTokens: 0` / `outputTokens: 0`.

## Testing

- `vitest run src/routes/proxy` — 1125 passed across 61 files, no regressions in any provider
- `tsc --noEmit`, `biome check`, and `knip` (dev + production) all clean
- Verified the streaming `try` block has exactly one `return` and no other `InteractionModel.create`, so the new branch cannot fire on a policy-blocked or early-return path

Closes #5948

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>