### PR TITLE
fix(observability): classify outbound connectivity failures and group chat MCP-gateway outages

### DIFF
--- a/platform/backend/src/observability/error-tracking-policy.test.ts
+++ b/platform/backend/src/observability/error-tracking-policy.test.ts
@@ -94,6 +94,55 @@ describe("classifyErrorForTracking", () => {
     }
   });
 
+  test("drops unmapped outbound connectivity failures", () => {
+    // undici's connect timeout, as surfaced by fetch and the proxy paths.
+    const connectTimeout = Object.assign(new Error("Connect Timeout Error"), {
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    });
+    expect(classifyErrorForTracking(connectTimeout).report).toBe(false);
+
+    // A bare libuv errno (ECONNREFUSED in the cause chain) is claimed first
+    // by the transient-DB classification, which matches network codes without
+    // DB context — kept and grouped rather than dropped. Pinned so the
+    // precedence between the two rules stays explicit.
+    const refused = Object.assign(new Error("fetch failed"), {
+      cause: Object.assign(new Error("connect ECONNREFUSED"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+    const refusedDecision = classifyErrorForTracking(refused);
+    expect(refusedDecision.report).toBe(true);
+    expect(refusedDecision.fingerprint?.[0]).toBe("db-transient");
+  });
+
+  test("drops reply-from upstream failures from the passthrough routes", () => {
+    // @fastify/reply-from's ServiceUnavailableError shape (code + 503),
+    // raised when a provider passthrough cannot reach its upstream.
+    const serviceUnavailable = Object.assign(new Error("Service Unavailable"), {
+      code: "FST_REPLY_FROM_SERVICE_UNAVAILABLE",
+      statusCode: 503,
+    });
+    expect(classifyErrorForTracking(serviceUnavailable).report).toBe(false);
+
+    // A reply-from 500 (arbitrary wrapped error) stays reported.
+    const internal = Object.assign(new Error("boom"), {
+      code: "FST_REPLY_FROM_INTERNAL_SERVER_ERROR",
+      statusCode: 500,
+    });
+    expect(classifyErrorForTracking(internal).report).toBe(true);
+  });
+
+  test("keeps and groups the chat MCP-gateway-unavailable condition", () => {
+    const error = new ApiError(
+      503,
+      "MCP tools unavailable: could not connect to MCP Gateway",
+      "mcp_tools_unavailable",
+    );
+    const decision = classifyErrorForTracking(error);
+    expect(decision.report).toBe(true);
+    expect(decision.fingerprint).toEqual(["mcp_tools_unavailable"]);
+  });
+
   test("drops MCP-server-unreachable errors by name", () => {
     for (const name of [
       "McpServerNotReadyError",

--- a/platform/backend/src/observability/error-tracking-policy.ts
+++ b/platform/backend/src/observability/error-tracking-policy.ts
@@ -4,6 +4,11 @@ import {
   isDbStatementTimeoutError,
 } from "@/database/retry";
 import { ApiError, SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
+import {
+  collectErrorCodes,
+  isConnectionErrno,
+  isTimeoutErrno,
+} from "@/utils/network-errors";
 
 /**
  * Sink-agnostic policy for what backend errors reach our exception trackers,
@@ -78,6 +83,22 @@ export function classifyErrorForTracking(
     };
   }
 
+  // Chat's own MCP gateway being unreachable (pod churn, a missing gateway
+  // token) fails every conversation the same way — an availability incident
+  // of our deployment, kept but grouped into a single issue. The internal
+  // code is set by McpToolsUnavailableError (clients/chat-mcp-client.ts);
+  // matched by string so this layer doesn't import the client module.
+  if (
+    error instanceof ApiError &&
+    error.internalCode === "mcp_tools_unavailable"
+  ) {
+    return {
+      report: true,
+      fingerprint: ["mcp_tools_unavailable"],
+      tags: { error_type: "mcp_tools_unavailable" },
+    };
+  }
+
   if (isNonActionableError(error)) {
     return { report: false };
   }
@@ -100,6 +121,17 @@ const MCP_UNREACHABLE_ERROR_NAMES = new Set([
 
 function isNonActionableError(error: unknown): boolean {
   if (error instanceof Error && MCP_UNREACHABLE_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+
+  // Low-level connectivity failures that reach the handler unmapped: an
+  // undici connect/headers/body timeout or a dropped connection from an
+  // outbound fetch, or @fastify/reply-from's upstream-failure errors
+  // (502/503/504) from the provider passthrough routes. The other end — an
+  // LLM provider, a user-configured server — was unreachable; a network
+  // condition, not a bug of ours. Database connectivity never lands here:
+  // classifyErrorForTracking classifies it first (kept and grouped).
+  if (isUpstreamConnectivityError(error)) {
     return true;
   }
 
@@ -143,4 +175,28 @@ function isNonActionableError(error: unknown): boolean {
   }
 
   return false;
+}
+
+/**
+ * Whether the error (or its cause chain) is a low-level connectivity failure
+ * to an outbound dependency: a libuv/undici network errno, or one of
+ * @fastify/reply-from's upstream-failure errors (`FST_REPLY_FROM_*` with a
+ * 502/503/504 status) raised when a passthrough proxy cannot reach its
+ * upstream.
+ */
+function isUpstreamConnectivityError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const codes = collectErrorCodes(error);
+  if (codes.some((code) => isConnectionErrno(code) || isTimeoutErrno(code))) {
+    return true;
+  }
+
+  const statusCode = (error as { statusCode?: unknown }).statusCode;
+  return (
+    codes.some((code) => code.startsWith("FST_REPLY_FROM_")) &&
+    typeof statusCode === "number" &&
+    statusCode >= 502 &&
+    statusCode <= 504
+  );
 }


### PR DESCRIPTION
## Summary

Third round of recurring-error cleanup, targeting the last two unclassified failure classes in the error-tracking policy:

### 1. Outbound connectivity failures reported as our crashes
Two recurring source-less error groups — a burst of `Service Unavailable` (503) and steady `Connect Timeout Error` events — turned out to be the **provider passthrough routes** (`/v1/<provider>/*` catch-all http-proxy) failing to reach their upstream:
- `Connect Timeout Error` is undici's connect timeout (`UND_ERR_CONNECT_TIMEOUT`)
- `Service Unavailable` is `@fastify/reply-from`'s `FST_REPLY_FROM_SERVICE_UNAVAILABLE`, raised on upstream socket failure

Both mean the other end (an LLM provider or user-configured server) was unreachable — a network condition, not a bug. The shared policy now classifies them as non-actionable: undici/network timeout codes anywhere in the cause chain, and `FST_REPLY_FROM_*` errors carrying a 502/503/504 status. A reply-from 500 (arbitrary wrapped error) deliberately stays reported.

Bare libuv errnos (e.g. `ECONNREFUSED`) are claimed first by the transient-DB classification and stay **kept and grouped** — that precedence is now pinned by a test so the two rules can't silently fight.

### 2. Chat MCP-gateway outages grouped as one availability incident
When chat's own MCP gateway is unreachable (pod churn, missing gateway token), every conversation fails with the same `MCP tools unavailable` 503. It was reported ungrouped; it's now kept as an availability incident with a stable fingerprint — same treatment as the existing secrets-backend-outage rule, because it's our deployment's availability, not noise to hide.

## Tests
- undici connect timeout → dropped; reply-from 503 → dropped; reply-from 500 → still reported
- `ECONNREFUSED` in a fetch cause chain → kept and grouped under the transient-DB rule (precedence pinned)
- `mcp_tools_unavailable` ApiError → kept with stable fingerprint

Type-check, lint, knip pass; full observability suite (14 files, 150 tests) green.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>