### PR TITLE
fix(hackathon): keep the recording replay in its recorded order

### DIFF
--- a/platform/frontend/src/components/app-session-recording/app-session-player.playback.test.ts
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.playback.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { buildPlayback, revealSchedule } from "./app-session-player";
+
+/**
+ * The replayed session has to keep the ORDER the builder actually worked in.
+ *
+ * A recorded session is sequential by nature: the builder asks, reads the
+ * reply, then touches the app, then goes back to chat. The timeline compresses
+ * the dead waiting between those beats — that part is wanted, a build that took
+ * forty minutes still has to make a short video. What is not wanted is the
+ * compression reaching into time the CHAT PANE is still using: an assistant
+ * reply reveals over real wall-clock time, and squeezing the gap after it below
+ * that reveal replays the app's half on top of a reply still typing, which
+ * invents a concurrency the session never had.
+ *
+ * These tests pin the invariant directly on the timeline arithmetic, which is
+ * what every surface shares: the recorder's player/editor, the submission
+ * review page, the review player docked in the chat panel, and the offline
+ * video renderer all drive this one function.
+ */
+
+/** Long enough to reveal for the full STREAM_MAX_MS beat. */
+const LONG_REPLY = "x".repeat(4_000);
+
+function textPart(text: string) {
+  return { type: "text" as const, text };
+}
+
+/**
+ * The canonical sequential session, with a wide real gap on either side of the
+ * app interaction so any overlap is the compression's doing and not a genuinely
+ * simultaneous capture:
+ *   t=0       the builder asks
+ *   t=1_000   the agent answers at length
+ *   t=30_000  the builder clicks in the app — long after the reply landed
+ *   t=40_000  the builder returns to chat
+ */
+function sequentialSession() {
+  const transcript = [
+    { id: "ask-1", role: "user", atMs: 0, parts: [textPart("Build a thing.")] },
+    {
+      id: "reply-1",
+      role: "assistant",
+      atMs: 1_000,
+      parts: [textPart(LONG_REPLY)],
+    },
+    {
+      id: "ask-2",
+      role: "user",
+      atMs: 40_000,
+      parts: [textPart("Now make it blue.")],
+    },
+  ];
+  return {
+    title: "sequential",
+    startedAt: new Date(0).toISOString(),
+    durationMs: 50_000,
+    events: [
+      {
+        kind: "pointer" as const,
+        t: 30_000,
+        type: "click" as const,
+        x: 5,
+        y: 5,
+      },
+    ],
+    segments: [{ version: 1, html: "<div>app</div>", atMs: 0 }],
+    transcript,
+    originalTranscript: transcript,
+    appName: "Sequential App",
+  };
+}
+
+/** Every message's reveal window on the built timeline, by message id. */
+function revealWindows(recording: ReturnType<typeof sequentialSession>) {
+  const playback = buildPlayback(recording as never);
+  const { schedule, revealScale } = revealSchedule(
+    playback.transcript,
+    playback.duration,
+  );
+  return { playback, schedule, revealScale };
+}
+
+describe("replay ordering: the app pane never plays over a revealing chat", () => {
+  it("holds the app interaction until the reply has finished revealing", () => {
+    const { playback, schedule } = revealWindows(sequentialSession());
+
+    const reply = schedule.get("reply-1");
+    const click = playback.events.find((event) => event.kind === "pointer");
+
+    expect(reply).toBeDefined();
+    expect(click).toBeDefined();
+    // The regression: the click used to land at 3000ms inside a 2100–3300ms
+    // reveal, i.e. 300ms before the reply had finished drawing — for two
+    // moments that sat 29 SECONDS apart in the real session.
+    expect(click?.t).toBeGreaterThanOrEqual(reply?.end ?? 0);
+  });
+
+  it("keeps the whole chat/app/chat sequence in its recorded order", () => {
+    const { playback, schedule } = revealWindows(sequentialSession());
+
+    const firstAsk = schedule.get("ask-1")?.start ?? 0;
+    const reply = schedule.get("reply-1");
+    const click =
+      playback.events.find((event) => event.kind === "pointer")?.t ?? 0;
+    const secondAsk = schedule.get("ask-2")?.start ?? 0;
+
+    expect(firstAsk).toBeLessThanOrEqual(reply?.start ?? 0);
+    expect(reply?.end ?? 0).toBeLessThanOrEqual(click);
+    expect(click).toBeLessThanOrEqual(secondAsk);
+  });
+
+  it("reveals at full speed rather than racing to fit the timeline", () => {
+    // A scale below 1 means the reveal was sped up to fit a timeline too short
+    // for it — the same overlap expressed as a squeezed animation instead of a
+    // late one. Reserving the time in the timeline is what keeps this at 1.
+    expect(revealWindows(sequentialSession()).revealScale).toBe(1);
+  });
+
+  it("still time-lapses dead waiting that no reveal is using", () => {
+    // Guards the other direction: the fix reserves reveal time, it does NOT
+    // abandon compression. Two user messages 30s apart carry no reveal between
+    // them, so that stretch must still collapse rather than replay in full.
+    const transcript = [
+      { id: "a", role: "user", atMs: 0, parts: [textPart("first")] },
+      { id: "b", role: "user", atMs: 30_000, parts: [textPart("second")] },
+    ];
+    const playback = buildPlayback({
+      ...sequentialSession(),
+      events: [],
+      durationMs: 30_000,
+      transcript,
+      originalTranscript: transcript,
+    } as never);
+
+    expect(playback.duration).toBeLessThan(5_000);
+  });
+});

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -5479,6 +5479,21 @@ export function buildPlayback(recording: PlaybackRecording): {
   );
   const withinEnd = (t: number) => !tailCut || t <= tailCut.fromMs;
 
+  // How long the chat pane will still be animating from each raw instant. An
+  // assistant turn reveals over real wall-clock time (see messageRevealMs),
+  // and that reveal is the ONLY thing on the timeline whose length is not a
+  // recorded duration — so the compression has to be told about it. Summed per
+  // instant because a burst stamped at one timestamp cascades in
+  // revealSchedule rather than landing at once.
+  const revealAt = new Map<number, number>();
+  for (const message of source.transcript) {
+    if (message.role !== "assistant") continue;
+    revealAt.set(
+      message.atMs,
+      (revealAt.get(message.atMs) ?? 0) + messageRevealMs(message.parts),
+    );
+  }
+
   const sorted = [...anchors].sort((a, b) => a - b);
   const compressedAt = new Map<number, number>();
   // The timeline opens at the lead's start, so the very first message
@@ -5486,6 +5501,11 @@ export function buildPlayback(recording: PlaybackRecording): {
   // opening already sent.
   let compressed = 0;
   compressedAt.set(sorted[0] ?? 0, compressed);
+  // The compressed instant the chat pane is busy revealing until. Nothing may
+  // be scheduled before it: the recorded session was SEQUENTIAL — the builder
+  // read the reply, then touched the app — and replaying the app's half over a
+  // reply that is still typing invents a concurrency that never happened.
+  let revealBusyUntil = revealAt.get(sorted[0] ?? 0) ?? 0;
   for (let i = 1; i < sorted.length; i++) {
     const gapInCut = cuts.some(
       (cut) => cut.fromMs <= sorted[i - 1] && sorted[i] <= cut.toMs,
@@ -5502,7 +5522,15 @@ export function buildPlayback(recording: PlaybackRecording): {
           : MAX_IDLE_MS;
       compressed += Math.min(sorted[i] - sorted[i - 1], cap);
     }
+    // Hold every later anchor behind the pending reveal — including one whose
+    // own gap was cut away. A cut removes RECORDED time; it cannot remove the
+    // time the chat pane needs to finish drawing a reply that is still on
+    // screen, and letting it would put the bug back exactly where a builder
+    // trimmed the pause after a long answer.
+    compressed = Math.max(compressed, revealBusyUntil);
     compressedAt.set(sorted[i], compressed);
+    const reveal = revealAt.get(sorted[i]);
+    if (reveal) revealBusyUntil = compressed + reveal;
   }
   const map = (t: number) => compressedAt.get(t) ?? t;
 


### PR DESCRIPTION
The replay let the **app pane act while the chat pane was still typing**, so a session the builder worked through strictly in sequence — ask, read the reply, then touch the app, then back to chat — played back as though both halves happened at once.

## The measurement

A session with a wide real gap either side of the app interaction (ask at t=0, agent replies at t=1s, builder clicks the app at t=30s, back to chat at t=40s):

```
playback duration       = 4800 ms   (from 50 s of session)
reply reveal window     = 2100 → 3300 ms
app click playback time = 3000 ms   ← INSIDE the reveal
```

The click replayed **300 ms before the reply had finished drawing**, for two moments that sat **29 seconds apart** in the real session.

## Why

`buildPlayback` compresses every idle gap to `MAX_IDLE_MS = 900`, but an assistant reply reveals over real wall-clock time (`messageRevealMs`, capped at `STREAM_MAX_MS = 1200`). The compression budget knew nothing about that reveal, so the gap after a long answer could be squeezed below the time the chat still needed, and the app's next event landed on top. `revealSchedule` already pushes messages behind *each other* (`start = max(atMs, previousEnd)`) — nothing kept app events behind the chat.

## The change

The timeline tracks how long the chat pane is still animating (`revealBusyUntil`) and holds every later anchor behind it.

Two deliberate calls worth review:

- **Cut gaps are held too.** A cut removes *recorded* time; it cannot remove the time the pane needs to finish drawing a reply still on screen. Exempting them would put the bug back exactly where a builder trimmed the pause after a long answer.
- **Dead waiting is still time-lapsed.** That is the point of the compression — a forty-minute build still has to make a short video. The reservation only adds time where a reveal was actually pending, at most the difference between one reveal and `MAX_IDLE_MS` (~300 ms per assistant turn), so exports stay well clear of the 30 s cap.

## Reach

One component serves the recorder's player/editor, the submission review page, the review player docked in the chat panel, and the **offline video renderer** — so this lands on all four at once, including the MP4 reviewers actually watch.

## Backward compatibility

Player-side arithmetic only: no bundle field, no schema change, no migration. Stored cuts live in raw coordinates (documented in-code as *"stable across player versions"*), so **every recording already submitted replays under the new ordering with nothing to re-record**.

## Testing

`buildPlayback` had **no test coverage at all**. The new tests pin the invariant in both directions:

- no app event falls inside a reveal window
- the full chat → app → chat sequence keeps its recorded order
- `revealScale === 1` — an overlap can also express itself as a *sped-up* reveal rather than a late event
- dead air with no reveal pending still collapses, so nobody later "fixes" this into replaying sessions at full wall-clock length

**Both ordering tests fail without the change** (verified by reverting it). Suite: 108/108 for app-session-recording, type-check 8/8, lint clean.

## Companion PR

The website gallery player carries its own copy of this logic. Same fix + the same tests mirrored: archestra-ai/website#605

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>