### PR TITLE
perf(db): kill registry-list author-privilege N+1 and cache gateway knowledge-source presence

### DIFF
--- a/platform/backend/src/models/agent-connector-assignment.ts
+++ b/platform/backend/src/models/agent-connector-assignment.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray } from "drizzle-orm";
 import db, { schema } from "@/database";
 import type { AgentConnectorAssignment } from "@/types";
+import { agentKnowledgeSourcesCache } from "./agent-knowledge-sources-cache";
 
 class AgentConnectorAssignmentModel {
   static async findByAgent(
@@ -28,6 +29,7 @@ class AgentConnectorAssignmentModel {
       .insert(schema.agentConnectorAssignmentsTable)
       .values({ agentId, connectorId })
       .onConflictDoNothing();
+    agentKnowledgeSourcesCache.invalidate(agentId);
   }
 
   static async unassign(
@@ -46,6 +48,7 @@ class AgentConnectorAssignmentModel {
         agentId: schema.agentConnectorAssignmentsTable.agentId,
       });
 
+    agentKnowledgeSourcesCache.invalidate(agentId);
     return rows.length > 0;
   }
 
@@ -57,6 +60,7 @@ class AgentConnectorAssignmentModel {
         agentId: schema.agentConnectorAssignmentsTable.agentId,
       });
 
+    agentKnowledgeSourcesCache.invalidate(agentId);
     return rows.length;
   }
 
@@ -79,43 +83,56 @@ class AgentConnectorAssignmentModel {
       .delete(schema.agentConnectorAssignmentsTable)
       .where(eq(schema.agentConnectorAssignmentsTable.agentId, agentId));
 
-    if (connectorIds.length === 0) return;
-
-    await db
-      .insert(schema.agentConnectorAssignmentsTable)
-      .values(
-        connectorIds.map((connectorId) => ({
-          agentId,
-          connectorId,
-        })),
-      )
-      .onConflictDoNothing();
+    if (connectorIds.length > 0) {
+      await db
+        .insert(schema.agentConnectorAssignmentsTable)
+        .values(
+          connectorIds.map((connectorId) => ({
+            agentId,
+            connectorId,
+          })),
+        )
+        .onConflictDoNothing();
+    }
+    agentKnowledgeSourcesCache.invalidate(agentId);
   }
 
   static async syncForAgentAssignments(params: {
     connectorId: string;
     agentIds: string[];
   }): Promise<void> {
-    await db
+    // Returning the previously-assigned agents so their cached
+    // knowledge-source presence is invalidated along with the new set's.
+    const removed = await db
       .delete(schema.agentConnectorAssignmentsTable)
       .where(
         eq(
           schema.agentConnectorAssignmentsTable.connectorId,
           params.connectorId,
         ),
-      );
-
-    if (params.agentIds.length === 0) return;
-
-    await db
-      .insert(schema.agentConnectorAssignmentsTable)
-      .values(
-        params.agentIds.map((agentId) => ({
-          agentId,
-          connectorId: params.connectorId,
-        })),
       )
-      .onConflictDoNothing();
+      .returning({
+        agentId: schema.agentConnectorAssignmentsTable.agentId,
+      });
+
+    if (params.agentIds.length > 0) {
+      await db
+        .insert(schema.agentConnectorAssignmentsTable)
+        .values(
+          params.agentIds.map((agentId) => ({
+            agentId,
+            connectorId: params.connectorId,
+          })),
+        )
+        .onConflictDoNothing();
+    }
+
+    for (const agentId of new Set([
+      ...removed.map((r) => r.agentId),
+      ...params.agentIds,
+    ])) {
+      agentKnowledgeSourcesCache.invalidate(agentId);
+    }
   }
 
   /**

--- a/platform/backend/src/models/agent-knowledge-base.ts
+++ b/platform/backend/src/models/agent-knowledge-base.ts
@@ -2,6 +2,7 @@ import { and, eq, getTableColumns, inArray } from "drizzle-orm";
 import db, { schema } from "@/database";
 import { notDeleted } from "@/database/schemas/soft-deletable-table";
 import type { AgentKnowledgeBase } from "@/types";
+import { agentKnowledgeSourcesCache } from "./agent-knowledge-sources-cache";
 
 class AgentKnowledgeBaseModel {
   static async findByAgent(agentId: string): Promise<AgentKnowledgeBase[]> {
@@ -34,6 +35,7 @@ class AgentKnowledgeBaseModel {
       .insert(schema.agentKnowledgeBasesTable)
       .values({ agentId, knowledgeBaseId })
       .onConflictDoNothing();
+    agentKnowledgeSourcesCache.invalidate(agentId);
   }
 
   static async unassign(
@@ -50,6 +52,7 @@ class AgentKnowledgeBaseModel {
       )
       .returning({ agentId: schema.agentKnowledgeBasesTable.agentId });
 
+    agentKnowledgeSourcesCache.invalidate(agentId);
     return deleted.length > 0;
   }
 
@@ -61,17 +64,18 @@ class AgentKnowledgeBaseModel {
       .delete(schema.agentKnowledgeBasesTable)
       .where(eq(schema.agentKnowledgeBasesTable.agentId, agentId));
 
-    if (knowledgeBaseIds.length === 0) return;
-
-    await db
-      .insert(schema.agentKnowledgeBasesTable)
-      .values(
-        knowledgeBaseIds.map((knowledgeBaseId) => ({
-          agentId,
-          knowledgeBaseId,
-        })),
-      )
-      .onConflictDoNothing();
+    if (knowledgeBaseIds.length > 0) {
+      await db
+        .insert(schema.agentKnowledgeBasesTable)
+        .values(
+          knowledgeBaseIds.map((knowledgeBaseId) => ({
+            agentId,
+            knowledgeBaseId,
+          })),
+        )
+        .onConflictDoNothing();
+    }
+    agentKnowledgeSourcesCache.invalidate(agentId);
   }
 
   static async getKnowledgeBaseIds(agentId: string): Promise<string[]> {

--- a/platform/backend/src/models/agent-knowledge-sources-cache.ts
+++ b/platform/backend/src/models/agent-knowledge-sources-cache.ts
@@ -1,0 +1,38 @@
+import { TimeInMs } from "@archestra/shared";
+import { LRUCacheManager } from "@/cache-manager";
+import { registerProcessLocalCache } from "@/process-local-cache-registry";
+
+/**
+ * Process-local cache for "does this agent have any knowledge sources?" —
+ * read on every MCP gateway tools listing, which otherwise pays two
+ * junction-table lookups per request on the gateway hot path. Assignment
+ * writes in this process invalidate immediately; other pods converge within
+ * the TTL. Staleness only affects whether the query_knowledge_sources tool is
+ * surfaced (a UX affordance) — the knowledge query path itself re-checks
+ * access and environment isolation.
+ *
+ * Lives in its own module (not on ToolModel) so the junction-table models can
+ * invalidate on write without importing the tool model, which imports them.
+ */
+class AgentKnowledgeSourcesCache {
+  private readonly cache = registerProcessLocalCache(
+    new LRUCacheManager<boolean>({
+      maxSize: 5000,
+      defaultTtl: 30 * TimeInMs.Second,
+    }),
+  );
+
+  get(agentId: string): boolean | undefined {
+    return this.cache.get(agentId);
+  }
+
+  set(agentId: string, hasKnowledgeSources: boolean): void {
+    this.cache.set(agentId, hasKnowledgeSources);
+  }
+
+  invalidate(agentId: string): void {
+    this.cache.delete(agentId);
+  }
+}
+
+export const agentKnowledgeSourcesCache = new AgentKnowledgeSourcesCache();

--- a/platform/backend/src/models/tool.test.ts
+++ b/platform/backend/src/models/tool.test.ts
@@ -18,6 +18,8 @@ import { getArchestraMcpCatalogMetadata } from "@/archestra-mcp-server/metadata"
 import config from "@/config";
 import db, { schema } from "@/database";
 import { describe, expect, test } from "@/test";
+import AgentConnectorAssignmentModel from "./agent-connector-assignment";
+import AgentKnowledgeBaseModel from "./agent-knowledge-base";
 import AgentToolModel from "./agent-tool";
 import OrganizationModel from "./organization";
 import TeamModel from "./team";
@@ -2005,6 +2007,45 @@ describe("ToolModel", () => {
       expect(toolNames).toContain(TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME);
     });
 
+    test("reflects knowledge-source assignment changes immediately despite the presence cache", async ({
+      makeAgent,
+      makeOrganization,
+      makeKnowledgeBase,
+      seedAndAssignArchestraTools,
+    }) => {
+      const tempAgent = await makeAgent({ name: "Temp Agent for Seeding" });
+      await seedAndAssignArchestraTools(tempAgent.id);
+
+      const org = await makeOrganization();
+      const kg = await makeKnowledgeBase(org.id);
+      const agent = await makeAgent({
+        name: "Cache Invalidation Agent",
+        organizationId: org.id,
+      });
+      await ToolModel.assignDefaultArchestraToolsToAgent(agent.id);
+
+      // The first listing caches "no knowledge sources" for the agent.
+      let toolNames = (await ToolModel.getMcpToolsByAgent(agent.id)).map(
+        (t) => t.name,
+      );
+      expect(toolNames).not.toContain(TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME);
+
+      // Assigning through the model invalidates the cached presence, so the
+      // next listing surfaces the knowledge tool without waiting out a TTL.
+      await AgentKnowledgeBaseModel.assign(agent.id, kg.id);
+      toolNames = (await ToolModel.getMcpToolsByAgent(agent.id)).map(
+        (t) => t.name,
+      );
+      expect(toolNames).toContain(TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME);
+
+      // Unassigning invalidates again.
+      await AgentKnowledgeBaseModel.unassign(agent.id, kg.id);
+      toolNames = (await ToolModel.getMcpToolsByAgent(agent.id)).map(
+        (t) => t.name,
+      );
+      expect(toolNames).not.toContain(TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME);
+    });
+
     test("is idempotent - does not create duplicates", async ({
       makeAgent,
       seedAndAssignArchestraTools,
@@ -2267,9 +2308,10 @@ describe("ToolModel", () => {
       const connector = await makeKnowledgeBaseConnector(kb.id, org.id);
 
       const agent = await makeAgent({ organizationId: org.id });
-      await db
-        .insert(schema.agentConnectorAssignmentsTable)
-        .values({ agentId: agent.id, connectorId: connector.id });
+      // Through the model (not a raw insert/delete): production only writes
+      // assignments via the model, whose writes invalidate the cached
+      // knowledge-source presence read by getMcpToolsByAgent.
+      await AgentConnectorAssignmentModel.assign(agent.id, connector.id);
       await seedAndAssignArchestraTools(agent.id);
 
       // Verify tool is present
@@ -2279,14 +2321,7 @@ describe("ToolModel", () => {
       );
 
       // Unassign the connector
-      await db
-        .delete(schema.agentConnectorAssignmentsTable)
-        .where(
-          and(
-            eq(schema.agentConnectorAssignmentsTable.agentId, agent.id),
-            eq(schema.agentConnectorAssignmentsTable.connectorId, connector.id),
-          ),
-        );
+      await AgentConnectorAssignmentModel.unassign(agent.id, connector.id);
 
       // Tool should no longer appear
       tools = await ToolModel.getMcpToolsByAgent(agent.id);

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -70,6 +70,7 @@ import type {
 import { isUniqueConstraintError } from "@/utils/db";
 import AgentModel from "./agent";
 import AgentConnectorAssignmentModel from "./agent-connector-assignment";
+import { agentKnowledgeSourcesCache } from "./agent-knowledge-sources-cache";
 import AgentTeamModel from "./agent-team";
 import AgentToolModel from "./agent-tool";
 import McpCatalogTeamModel from "./mcp-catalog-team";
@@ -3709,6 +3710,13 @@ class ToolModel {
   private static async getAgentHasKnowledgeSources(
     agentId: string,
   ): Promise<boolean> {
+    // Cached: this runs on every gateway tools listing, and the two
+    // junction-table lookups below were a measurable share of gateway DB
+    // traffic. Assignment writes invalidate (see agentKnowledgeSourcesCache).
+    const cached = agentKnowledgeSourcesCache.get(agentId);
+    if (cached !== undefined) {
+      return cached;
+    }
     const [kbRows, connectorIds] = await Promise.all([
       db
         .select({
@@ -3719,7 +3727,9 @@ class ToolModel {
         .limit(1),
       AgentConnectorAssignmentModel.getConnectorIds(agentId),
     ]);
-    return kbRows.length > 0 || connectorIds.length > 0;
+    const hasKnowledgeSources = kbRows.length > 0 || connectorIds.length > 0;
+    agentKnowledgeSourcesCache.set(agentId, hasKnowledgeSources);
+    return hasKnowledgeSources;
   }
 
   /**

--- a/platform/backend/src/services/mcp-install-policy.ts
+++ b/platform/backend/src/services/mcp-install-policy.ts
@@ -88,34 +88,16 @@ export async function flagImageApprovalRequired(
   );
   if (gateable.length === 0) return required;
 
-  // Privileged authors (admin / team-admin) are exempt — only a plain member's
-  // untrusted image needs approval. Resolve privilege once per distinct author.
-  const privilegedByAuthor = new Map<string, boolean>();
-  await Promise.all(
-    [
-      ...new Set(
-        gateable
-          .map((c) => c.authorId)
-          .filter((id): id is string => id !== null),
-      ),
-    ].map(async (authorId) => {
-      privilegedByAuthor.set(
-        authorId,
-        await isAuthorPrivileged({ authorId, organizationId }),
-      );
-    }),
-  );
-  const candidates = gateable.filter(
-    (c) => !(c.authorId && privilegedByAuthor.get(c.authorId)),
-  );
-  if (candidates.length === 0) return required;
-
+  // Resolve trusted registries first: when no environment restricts images
+  // (the common case), nothing can be gated, and no author-privilege lookups
+  // are needed. Resolving privilege first cost a member+role lookup per
+  // distinct author on every registry listing — an N+1 on the list route.
   const registriesByEnv = new Map<
     string | null,
     TrustedImageRegistries | null
   >();
   await Promise.all(
-    [...new Set(candidates.map((c) => c.environmentId ?? null))].map(
+    [...new Set(gateable.map((c) => c.environmentId ?? null))].map(
       async (environmentId) => {
         const { registries } = await resolveTrustedImageRegistries({
           environmentId,
@@ -125,10 +107,34 @@ export async function flagImageApprovalRequired(
       },
     ),
   );
+  const gated = gateable.filter(
+    (item) =>
+      gatedImagesForRegistries(
+        item,
+        registriesByEnv.get(item.environmentId ?? null) ?? null,
+      ).length > 0,
+  );
+  if (gated.length === 0) return required;
 
-  for (const item of candidates) {
-    const registries = registriesByEnv.get(item.environmentId ?? null) ?? null;
-    if (gatedImagesForRegistries(item, registries).length > 0) {
+  // Privileged authors (admin / team-admin) are exempt — only a plain member's
+  // untrusted image needs approval. Resolve privilege once per distinct author,
+  // and only for authors of actually-gated items.
+  const privilegedByAuthor = new Map<string, boolean>();
+  await Promise.all(
+    [
+      ...new Set(
+        gated.map((c) => c.authorId).filter((id): id is string => id !== null),
+      ),
+    ].map(async (authorId) => {
+      privilegedByAuthor.set(
+        authorId,
+        await isAuthorPrivileged({ authorId, organizationId }),
+      );
+    }),
+  );
+
+  for (const item of gated) {
+    if (!(item.authorId && privilegedByAuthor.get(item.authorId))) {
       required.add(item.id);
     }
   }


### PR DESCRIPTION
## Summary

Fourth round of production-health work, this time on the recurring **N+1 / slow-query** hotspots. Two code changes, plus verification that the other flagged patterns are already handled.

### 1. Registry listing N+1: author privilege resolved before it's needed
`GET /api/internal_mcp_catalog` ran a member + role lookup **per distinct author** of every unapproved local-image catalog item — before checking whether any trusted-image registries are even configured. In the common case (no registries configured → nothing can be gated), that's pure wasted N+1 on every registry page load. `flagImageApprovalRequired` now resolves trusted registries first, filters to actually-gated items, and only then resolves privilege for those items' authors. Existing behavior tests pin the outcomes.

### 2. Gateway hot path: cache knowledge-source presence per agent
Every MCP gateway tools listing paid two junction-table lookups (`agent_knowledge_bases`, `agent_connector_assignment`) just to decide whether to surface the `query_knowledge_sources` tool. That presence bit now lives in a process-local LRU (30s TTL, registered with the test-clearing cache registry) and every assignment write path through the models invalidates it. Cross-pod staleness is bounded by the TTL and only affects tool *surfacing* — the knowledge query path re-checks access and environment isolation itself.

New behavior test: listing → assign (via model) → listing reflects the change immediately; same for unassign. The existing connector-unassignment test now writes through the model instead of raw junction SQL — matching production, where the models are the only writers.

### Verified already-handled (no code needed)
- The per-request SSO trusted-provider-list query is already behind a process-local cache on main.
- The active-run replay poll already uses the combined single-statement status+events read on main.
- `agent_connector_assignment`, `member (user_id, organization_id)`, and the other flagged lookups are all index-backed — the remaining slow-query flags trace to connection-pool pressure on a deployment running an older release, not to query plans.

## Tests
- `tool.test.ts`: cache invalidation behavior (assign/unassign through models reflects immediately) — 149 tests green
- `mcp-install-policy.test.ts`: existing gating/exemption behavior pins the reorder
- Full model suite + gateway + install policy: 96 files, 2,254 tests green locally; type-check, lint, knip clean

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>