### PR TITLE
feat(hackathon): one-minute final cut, cutting that shrinks the upload, and a limit that stops contradicting itself

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -111666,6 +111666,14 @@
                         "hackathonRecorderOverrideActive": {
                           "type": "boolean"
                         },
+                        "hackathonVideoDownloadEnabled": {
+                          "type": "boolean"
+                        },
+                        "hackathonMaxFinalCutMs": {
+                          "type": "integer",
+                          "exclusiveMinimum": true,
+                          "maximum": 9007199254740991
+                        },
                         "hackathonGalleryRepo": {
                           "nullable": true,
                           "type": "object",
@@ -111710,6 +111718,8 @@
                         "kbAutoSyncPermissionsEnabled",
                         "hackathonRecorderEnabled",
                         "hackathonRecorderOverrideActive",
+                        "hackathonVideoDownloadEnabled",
+                        "hackathonMaxFinalCutMs",
                         "hackathonGalleryRepo"
                       ],
                       "additionalProperties": false

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -1,4 +1,5 @@
 import {
+  APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
   isValidK8sCpuQuantity,
   isValidK8sMemoryQuantity,
 } from "@archestra/shared";
@@ -2763,10 +2764,14 @@ describe("deriveOllamaNativeBaseUrl", () => {
 });
 
 describe("parseHackathonRecorderMaxFinalCutMs", () => {
-  test("defaults to three minutes when unset", () => {
-    expect(parseHackathonRecorderMaxFinalCutMs(undefined)).toBe(180_000);
-    expect(parseHackathonRecorderMaxFinalCutMs("")).toBe(180_000);
-    expect(parseHackathonRecorderMaxFinalCutMs("   ")).toBe(180_000);
+  test("defaults to the shared limit when unset", () => {
+    expect(parseHackathonRecorderMaxFinalCutMs(undefined)).toBe(60_000);
+    expect(parseHackathonRecorderMaxFinalCutMs("")).toBe(
+      APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
+    );
+    expect(parseHackathonRecorderMaxFinalCutMs("   ")).toBe(
+      APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
+    );
   });
 
   test("takes a deployment's own limit", () => {

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -43,6 +43,7 @@ import config, {
   parseFileStorageS3Config,
   parseHackathonGalleryRepo,
   parseHackathonRecorderEnabled,
+  parseHackathonRecorderMaxFinalCutMs,
   parseK8sResourceQuantity,
   parseLogFormat,
   parseMetricsPort,
@@ -2758,5 +2759,33 @@ describe("deriveOllamaNativeBaseUrl", () => {
         ollamaBaseUrl: undefined,
       }),
     ).toBe("http://proxy.internal/v1/ollama");
+  });
+});
+
+describe("parseHackathonRecorderMaxFinalCutMs", () => {
+  test("defaults to three minutes when unset", () => {
+    expect(parseHackathonRecorderMaxFinalCutMs(undefined)).toBe(180_000);
+    expect(parseHackathonRecorderMaxFinalCutMs("")).toBe(180_000);
+    expect(parseHackathonRecorderMaxFinalCutMs("   ")).toBe(180_000);
+  });
+
+  test("takes a deployment's own limit", () => {
+    expect(parseHackathonRecorderMaxFinalCutMs("30000")).toBe(30_000);
+    expect(parseHackathonRecorderMaxFinalCutMs(" 600000 ")).toBe(600_000);
+  });
+
+  test("refuses a value it cannot honour rather than silently defaulting", () => {
+    // Falling back would read as the platform ignoring the operator's limit —
+    // the one failure mode a length cap must not have.
+    expect(() => parseHackathonRecorderMaxFinalCutMs("abc")).toThrow(
+      /whole number of milliseconds/,
+    );
+    expect(() => parseHackathonRecorderMaxFinalCutMs("60.5")).toThrow();
+    expect(() => parseHackathonRecorderMaxFinalCutMs("-1000")).toThrow();
+  });
+
+  test("refuses a limit so small nothing could ever be submitted", () => {
+    expect(() => parseHackathonRecorderMaxFinalCutMs("10")).toThrow();
+    expect(parseHackathonRecorderMaxFinalCutMs("5000")).toBe(5_000);
   });
 });

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2,6 +2,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
   DEFAULT_ADMIN_EMAIL,
   DEFAULT_ADMIN_EMAIL_ENV_VAR_NAME,
   DEFAULT_ADMIN_PASSWORD,
@@ -1452,6 +1453,44 @@ export function parseHackathonRecorderEnabled(params: {
 }
 
 /**
+ * The longest final cut a recording may be submitted or exported at, in ms.
+ *
+ * One bound behind every length surface — the submit button, the submission
+ * flow's own backstop, the video export, the editor's trim-to-limit control and
+ * the tour's "keep it under N" note — so a deployment that raises it raises all
+ * of them together and no surface can quote a number the checks disagree with.
+ *
+ * Rejects a value that is not a positive integer number of milliseconds rather
+ * than silently falling back: a typo here would otherwise read as the platform
+ * ignoring the operator's limit. A hard floor keeps a fat-fingered tiny value
+ * from making every recording unsubmittable.
+ *
+ * Undocumented on purpose, like the rest of the recorder — not in .env.example
+ * or the deployment docs.
+ *
+ * @public — exported for testability
+ */
+export function parseHackathonRecorderMaxFinalCutMs(
+  value: string | undefined,
+): number {
+  const raw = value?.trim();
+  if (!raw) return APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < MIN_HACKATHON_FINAL_CUT_MS) {
+    throw new Error(
+      `ARCHESTRA_HACKATHON_RECORDER_MAX_FINAL_CUT_MS must be a whole number of milliseconds >= ${MIN_HACKATHON_FINAL_CUT_MS}, got "${raw}"`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Floor for the configurable final-cut limit. Below a few seconds nothing is a
+ * demo and every recording would be born over the line.
+ */
+const MIN_HACKATHON_FINAL_CUT_MS = 5_000;
+
+/**
  * Defaults for the "Archestra App Gallery" sharing surface — the PUBLIC
  * device-flow OAuth client id and the public gallery repository. Baked in so
  * every non-enterprise deployment (local dev and OSS included) offers sharing
@@ -2112,6 +2151,23 @@ const config = {
      */
     overrideActive:
       process.env.ARCHESTRA_HACKATHON_RECORDER_ENTERPRISE_OVERRIDE === "true",
+    /**
+     * Offering the offline VIDEO export (the player's download button and the
+     * render endpoints behind it). Off unless a deployment opts in: a render
+     * drives a headless Chromium for as long as the cut runs, which is a cost
+     * no deployment should pay by surprise — and the gallery submission, which
+     * is what the hackathon actually needs, does not depend on it.
+     *
+     * Undocumented on purpose, like the rest of the recorder — not in
+     * .env.example or the deployment docs.
+     */
+    videoDownloadEnabled:
+      process.env.ARCHESTRA_HACKATHON_RECORDER_VIDEO_DOWNLOAD_ENABLED ===
+      "true",
+    /** The longest final cut that may be submitted or exported (see the parser). */
+    maxFinalCutMs: parseHackathonRecorderMaxFinalCutMs(
+      process.env.ARCHESTRA_HACKATHON_RECORDER_MAX_FINAL_CUT_MS,
+    ),
     /**
      * Sharing a recording to the public App Gallery (a PR filed on the
      * participant's own GitHub account). Both values default to the official

--- a/platform/backend/src/routes/app-recording/app-recording.routes.ts
+++ b/platform/backend/src/routes/app-recording/app-recording.routes.ts
@@ -13,7 +13,10 @@ import {
 } from "@/services/apps/app-recording-enhancement";
 import { renderJobClient } from "@/services/apps/app-recording-render-client";
 import { RENDER_BUNDLE_BODY_LIMIT_BYTES } from "@/services/apps/app-recording-render-protocol";
-import { assertAppsHackathonAvailable } from "@/services/apps/apps-hackathon-gate";
+import {
+  assertAppRecordingVideoDownloadAvailable,
+  assertAppsHackathonAvailable,
+} from "@/services/apps/apps-hackathon-gate";
 import { ApiError, constructResponseSchema, UuidIdSchema } from "@/types";
 
 /**
@@ -32,6 +35,14 @@ const REVIEW_FETCH_TIMEOUT_MS = 15_000;
  * not buffer an unbounded response an attacker points `src` at.
  */
 const REVIEW_BUNDLE_MAX_BYTES = 15 * 1024 * 1024;
+
+/** The four endpoints that make up one video render's lifecycle. */
+const VIDEO_ROUTE_IDS = new Set<string | undefined>([
+  RouteId.RenderAppRecordingVideo,
+  RouteId.GetAppRecordingRenderStatus,
+  RouteId.DownloadAppRecordingVideo,
+  RouteId.CancelAppRecordingRender,
+]);
 
 /**
  * App session recordings are captured, stored (IndexedDB, one per
@@ -57,6 +68,13 @@ const appRecordingRoutes: FastifyPluginAsyncZod = async (fastify) => {
     if (request.routeOptions.schema?.operationId === RouteId.ReviewAppRecording)
       return;
     await assertAppsHackathonAvailable(request.organizationId);
+    // The video export is a second, narrower opt-in on top of the recorder.
+    // Gated here rather than per handler for the same reason the hackathon gate
+    // is: four endpoints make up one render's lifecycle, and a fifth added
+    // later would otherwise have to remember.
+    if (VIDEO_ROUTE_IDS.has(request.routeOptions.schema?.operationId)) {
+      assertAppRecordingVideoDownloadAvailable();
+    }
   });
 
   fastify.post(

--- a/platform/backend/src/routes/app-recording/render.app-recording.route.test.ts
+++ b/platform/backend/src/routes/app-recording/render.app-recording.route.test.ts
@@ -11,6 +11,25 @@ describe("POST /api/app-recordings/render", () => {
     await makeMember(ctx.user.id, ctx.organizationId);
     config.hackathonRecorder.enabled = true;
     config.hackathonRecorder.overrideActive = true;
+    // The video export is its own opt-in on top of the recorder, so every
+    // render test has to turn it on the way a deployment would.
+    config.hackathonRecorder.videoDownloadEnabled = true;
+  });
+
+  test("403s when the deployment does not offer video download", async () => {
+    // Hiding the button is presentation; this is the check. An endpoint that
+    // still answered would let anyone spend a headless-browser render by
+    // calling it directly, on a deployment that never opted in.
+    config.hackathonRecorder.videoDownloadEnabled = false;
+
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: "/api/app-recordings/render",
+      body: { bundle: {}, title: "Nope" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toMatch(/not available/i);
   });
 
   test("a bundle over the size ceiling is refused from its headers, with the number and the remedy", async () => {

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -97,6 +97,18 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               /** Staging override active: recorder bypasses the hackathon date window. */
               hackathonRecorderOverrideActive: z.boolean(),
               /**
+               * The offline video export is offered. Off by default: a render
+               * drives a headless browser for as long as the cut runs, and the
+               * gallery submission does not depend on it.
+               */
+              hackathonVideoDownloadEnabled: z.boolean(),
+              /**
+               * The longest final cut this deployment accepts, in ms. Every
+               * length surface reads it from here, so the number the author is
+               * shown is always the number the checks enforce.
+               */
+              hackathonMaxFinalCutMs: z.number().int().positive(),
+              /**
                * The public App Gallery repository shared recordings are
                * submitted to, or null when this deployment does not offer
                * sharing. The frontend files the PR against this repository
@@ -159,6 +171,9 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           hackathonRecorderEnabled: config.hackathonRecorder.enabled,
           hackathonRecorderOverrideActive:
             config.hackathonRecorder.overrideActive,
+          hackathonVideoDownloadEnabled:
+            config.hackathonRecorder.videoDownloadEnabled,
+          hackathonMaxFinalCutMs: config.hackathonRecorder.maxFinalCutMs,
           hackathonGalleryRepo:
             (config.hackathonRecorder.gallery.githubClientId &&
               config.hackathonRecorder.gallery.repo) ||

--- a/platform/backend/src/services/apps/app-recording-render.ts
+++ b/platform/backend/src/services/apps/app-recording-render.ts
@@ -3,6 +3,8 @@ import {
   APP_RECORDING_RENDER_REGION_SELECTOR,
   APP_RECORDING_RENDER_ROUTE,
   type AppRecordingBundle,
+  exceedsFinalCutLimit,
+  formatDurationMs,
 } from "@archestra/shared";
 import type { CDPSession } from "playwright-core";
 import config from "@/config";
@@ -309,10 +311,15 @@ async function renderWithBrowser(params: {
     // number — refusing a session trimmed to 14s for being 35s long is what
     // measuring that one gets you.
     const maxFinalCutMs = config.hackathonRecorder.maxFinalCutMs;
-    if (durationMs > maxFinalCutMs) {
+    // Judged and phrased exactly as the player does it -- same shared check,
+    // same m:ss. Rounding to seconds HERE while the browser floored to m:ss
+    // gave the server its own version of the paradox: it refused cuts the UI
+    // had already cleared, and told the author a different number than every
+    // surface they had been reading.
+    if (exceedsFinalCutLimit(durationMs, maxFinalCutMs)) {
       throw new ApiError(
         400,
-        `This cut runs ${Math.round(durationMs / 1000)}s. Trim it to ${Math.round(maxFinalCutMs / 1000)} seconds or less to export a video.`,
+        `This cut runs ${formatDurationMs(durationMs)}. Trim it to ${formatDurationMs(maxFinalCutMs)} or less to export a video.`,
       );
     }
 

--- a/platform/backend/src/services/apps/app-recording-render.ts
+++ b/platform/backend/src/services/apps/app-recording-render.ts
@@ -1,5 +1,4 @@
 import {
-  APP_RECORDING_MAX_EXPORT_MS,
   APP_RECORDING_RENDER_FPS,
   APP_RECORDING_RENDER_REGION_SELECTOR,
   APP_RECORDING_RENDER_ROUTE,
@@ -309,10 +308,11 @@ async function renderWithBrowser(params: {
     // already applied. The raw recording is a different and always larger
     // number — refusing a session trimmed to 14s for being 35s long is what
     // measuring that one gets you.
-    if (durationMs > APP_RECORDING_MAX_EXPORT_MS) {
+    const maxFinalCutMs = config.hackathonRecorder.maxFinalCutMs;
+    if (durationMs > maxFinalCutMs) {
       throw new ApiError(
         400,
-        `This cut runs ${Math.round(durationMs / 1000)}s. Trim it to ${Math.round(APP_RECORDING_MAX_EXPORT_MS / 1000)} seconds or less to export a video.`,
+        `This cut runs ${Math.round(durationMs / 1000)}s. Trim it to ${Math.round(maxFinalCutMs / 1000)} seconds or less to export a video.`,
       );
     }
 

--- a/platform/backend/src/services/apps/apps-hackathon-gate.ts
+++ b/platform/backend/src/services/apps/apps-hackathon-gate.ts
@@ -51,3 +51,21 @@ export async function assertAppsHackathonAvailable(
     );
   }
 }
+
+/**
+ * 403 unless this deployment offers the offline VIDEO export.
+ *
+ * A separate opt-in on top of the recorder itself: a render drives a headless
+ * browser for as long as the cut runs, so it stays off unless an operator asks
+ * for it. Enforced on the render routes and not only in the UI — hiding the
+ * download button is a presentation choice, and an endpoint that still answers
+ * would let anyone spend that budget by calling it directly.
+ */
+export function assertAppRecordingVideoDownloadAvailable(): void {
+  if (!config.hackathonRecorder.videoDownloadEnabled) {
+    throw new ApiError(
+      403,
+      "Video download is not available on this deployment.",
+    );
+  }
+}

--- a/platform/backend/src/static/archestra-app-recording-sdk.js
+++ b/platform/backend/src/static/archestra-app-recording-sdk.js
@@ -276,16 +276,14 @@
    * the gallery upload can carry. Content below the ceiling never feels it —
    * a static UI encodes to skip blocks whatever the ceiling says.
    */
-  // Sized by what GitHub will accept, not by what looks best. The bundle
-  // stores video base64 in JSON and the upload base64-encodes that JSON again,
-  // so a byte of video costs ~1.78 bytes on the wire — and api.github.com
-  // refuses a request body much past 45MB (measured: a 57MB bundle was turned
-  // away by both the contents API and the blob endpoint). At 3 Mbit/s a
-  // three-minute capture reached ~86MB and could never be submitted; at
-  // 1 Mbit/s it lands near 29MB, ~38MB on the wire, inside the limit with room
-  // to spare. The cost is visible softness on full-motion apps, which is the
-  // right trade for a gallery card that can actually be uploaded.
-  const VIDEO_GOVERNOR_MAX_BPS = 1_000_000;
+  // Sized against what a submission may actually be. The bound that matters is
+  // the FINAL CUT's length, not the ceiling here: at one minute this rate puts
+  // a worst-case all-motion cut near 29MB as a bundle and ~38MB once the
+  // upload base64-encodes it, both inside GitHub's strictest 50MB endpoint
+  // limit whichever of the two it applies to. It was briefly lowered to
+  // 1 Mbit/s to survive a three-minute cut, which cost visible sharpness on
+  // full-motion apps for a length no longer offered.
+  const VIDEO_GOVERNOR_MAX_BPS = 3_000_000;
   /**
    * Wide enough for the frame shed to hold the ceiling even when single
    * frames are enormous: the shed can only space frames out, so its floor is

--- a/platform/backend/src/static/archestra-app-recording-sdk.js
+++ b/platform/backend/src/static/archestra-app-recording-sdk.js
@@ -275,7 +275,16 @@
    * a minutes-long raw take stays under the ~100MB ceilings of the render
    * and gallery-upload paths. Content below the ceiling never feels it.
    */
-  const VIDEO_GOVERNOR_MAX_BPS = 3_000_000;
+  // Sized by what GitHub will accept, not by what looks best. The bundle
+  // stores video base64 in JSON and the upload base64-encodes that JSON again,
+  // so a byte of video costs ~1.78 bytes on the wire — and api.github.com
+  // refuses a request body much past 45MB (measured: a 57MB bundle was turned
+  // away by both the contents API and the blob endpoint). At 3 Mbit/s a
+  // three-minute capture reached ~86MB and could never be submitted; at
+  // 1 Mbit/s it lands near 29MB, ~38MB on the wire, inside the limit with room
+  // to spare. The cost is visible softness on full-motion apps, which is the
+  // right trade for a gallery card that can actually be uploaded.
+  const VIDEO_GOVERNOR_MAX_BPS = 1_000_000;
   /**
    * Wide enough for the frame shed to hold the ceiling even when single
    * frames are enormous: the shed can only space frames out, so its floor is

--- a/platform/backend/src/static/archestra-app-recording-sdk.js
+++ b/platform/backend/src/static/archestra-app-recording-sdk.js
@@ -271,9 +271,10 @@
    * must not cost three times a one-canvas app. Content that outruns even the
    * maximum quantizer settles at the frame shed's line — this ceiling times
    * its headroom — so the ceiling is sized from there: a worst-case
-   * all-motion 30s cut stays ~14MB of video (~19MB as a shared bundle), and
-   * a minutes-long raw take stays under the ~100MB ceilings of the render
-   * and gallery-upload paths. Content below the ceiling never feels it.
+   * all-motion minute stays ~7.5MB of video (~10MB as a bundle, ~13MB once
+   * the upload base64s that bundle again), so what governs the number is what
+   * the gallery upload can carry. Content below the ceiling never feels it —
+   * a static UI encodes to skip blocks whatever the ceiling says.
    */
   // Sized by what GitHub will accept, not by what looks best. The bundle
   // stores video base64 in JSON and the upload base64-encodes that JSON again,

--- a/platform/frontend/src/components/app-session-recording/app-gallery-share-dialog.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-gallery-share-dialog.tsx
@@ -3,6 +3,7 @@
 import {
   APP_GALLERY_CATEGORIES,
   type AppRecordingBundle,
+  exceedsFinalCutLimit,
   pruneCutEvents,
   validateRecordingBundle,
 } from "@archestra/shared";
@@ -214,7 +215,7 @@ export function AppGalleryShareButton(props: {
         // gallery plays; the raw capture is a different and always larger
         // number.
         const finalCutMs = finalCutDurationMs(trimmed);
-        if (finalCutMs > maxFinalCutMs) {
+        if (exceedsFinalCutLimit(finalCutMs, maxFinalCutMs)) {
           failedTitle = "Recording too long";
           fail(
             `This cut runs ${formatMs(finalCutMs)}. Trim it to ${formatMs(maxFinalCutMs)} or less to submit.`,

--- a/platform/frontend/src/components/app-session-recording/app-gallery-share-dialog.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-gallery-share-dialog.tsx
@@ -63,12 +63,17 @@ import {
   submitRecordingToAppGallery,
   takeCachedGithubToken,
 } from "@/lib/app-session-recording/app-gallery-share";
+import { useMaxFinalCutMs } from "@/lib/app-session-recording/app-recording.query";
 import { reviveRecordingEvents } from "@/lib/app-session-recording/app-recording-binary";
 import { recordingStore } from "@/lib/app-session-recording/app-recording-store";
 import { copyToClipboard } from "@/lib/clipboard";
 import { useFeature } from "@/lib/config/config.query";
 import { cn } from "@/lib/utils";
-import { buildPlayback, presentedTranscript } from "./app-session-player";
+import {
+  buildPlayback,
+  formatMs,
+  presentedTranscript,
+} from "./app-session-player";
 
 /**
  * The player's "Submit to Archestra for review" action: one click runs GitHub
@@ -89,6 +94,7 @@ export function AppGalleryShareButton(props: {
   disabledReason?: React.ReactNode;
 }) {
   const galleryRepo = useFeature("hackathonGalleryRepo");
+  const maxFinalCutMs = useMaxFinalCutMs();
   const [open, setOpen] = useState(false);
   const [state, setState] = useState<ShareState>({ step: "idle" });
   // The pull request this app already has (submitted now or remembered from
@@ -197,6 +203,24 @@ export function AppGalleryShareButton(props: {
           return;
         }
 
+        // The length limit, enforced on the SUBMISSION and not only on the
+        // button that opens it. The button's disabled state is a courtesy the
+        // player computes from the recording it happens to be showing; this is
+        // the check the upload actually clears, so a cut that grew after the
+        // dialog opened (or a path that reached submit some other way) cannot
+        // ship a recording the gallery will refuse to render downstream.
+        // Measured on the final cut — cuts applied — because that is what the
+        // gallery plays; the raw capture is a different and always larger
+        // number.
+        const finalCutMs = finalCutDurationMs(trimmed);
+        if (finalCutMs > maxFinalCutMs) {
+          failedTitle = "Recording too long";
+          fail(
+            `This cut runs ${formatMs(finalCutMs)}. Trim it to ${formatMs(maxFinalCutMs)} or less to submit.`,
+          );
+          return;
+        }
+
         const token = takeCachedGithubToken();
         if (!token) {
           failedTitle = "Sign-in failed";
@@ -300,7 +324,7 @@ export function AppGalleryShareButton(props: {
         );
       }
     },
-    [galleryRepo, props.conversationId, category],
+    [galleryRepo, props.conversationId, category, maxFinalCutMs],
   );
 
   // The fallback when the automatic flow fails: hand the participant the

--- a/platform/frontend/src/components/app-session-recording/app-gallery-share-dialog.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-gallery-share-dialog.tsx
@@ -3,7 +3,7 @@
 import {
   APP_GALLERY_CATEGORIES,
   type AppRecordingBundle,
-  pruneTrailingTrimEvents,
+  pruneCutEvents,
   validateRecordingBundle,
 } from "@archestra/shared";
 import {
@@ -180,8 +180,9 @@ export function AppGalleryShareButton(props: {
           fail(`This recording can't be shared. ${validation.reason}`);
           return;
         }
-        // Same size trim the video export ships (renders identically).
-        const trimmed = pruneTrailingTrimEvents(validation.bundle);
+        // Same cut-away pruning the video export ships: what the edit hides
+        // never leaves the browser (replays identically).
+        const trimmed = pruneCutEvents(validation.bundle);
         slug = gallerySubmissionSlug(trimmed);
 
         // Never block a working recording on a missing AI draft. Guarantee a
@@ -347,7 +348,7 @@ export function AppGalleryShareButton(props: {
       });
       return;
     }
-    const trimmed = pruneTrailingTrimEvents(validation.bundle);
+    const trimmed = pruneCutEvents(validation.bundle);
     const token = takeCachedGithubToken();
     const identity = token
       ? await fetchGithubIdentity(token, cancellation.signal)

--- a/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
+++ b/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
@@ -1,4 +1,8 @@
-import { type AppRecordingBundle, pruneCutEvents } from "@archestra/shared";
+import {
+  type AppRecordingBundle,
+  exceedsFinalCutLimit,
+  pruneCutEvents,
+} from "@archestra/shared";
 import { describe, expect, it } from "vitest";
 import {
   backfilledEnhancement,
@@ -746,7 +750,9 @@ describe("trimCutsToExportLimit", () => {
     const next = trimCutsToExportLimit(rec, 30_000);
     expect(next).not.toBeNull();
     const after = durationWith(rec, next ?? []);
-    expect(after).toBeLessThanOrEqual(30_000);
+    // Judged the way the gate judges it — a fraction of a second over is not
+    // something an author can trim, and is not refused (exceedsFinalCutLimit).
+    expect(exceedsFinalCutLimit(after, 30_000)).toBe(false);
     expect(after).toBeGreaterThan(29_900);
   });
 
@@ -758,7 +764,9 @@ describe("trimCutsToExportLimit", () => {
     expect(next).toContainEqual(mid);
     expect(next).toHaveLength(2);
     const after = durationWith(rec, next ?? []);
-    expect(after).toBeLessThanOrEqual(30_000);
+    // Judged the way the gate judges it — a fraction of a second over is not
+    // something an author can trim, and is not refused (exceedsFinalCutLimit).
+    expect(exceedsFinalCutLimit(after, 30_000)).toBe(false);
     expect(after).toBeGreaterThan(29_900);
   });
 
@@ -770,14 +778,18 @@ describe("trimCutsToExportLimit", () => {
     expect(next).not.toBeNull();
     expect(next).toHaveLength(1);
     const after = durationWith(rec, next ?? []);
-    expect(after).toBeLessThanOrEqual(30_000);
+    // Judged the way the gate judges it — a fraction of a second over is not
+    // something an author can trim, and is not refused (exceedsFinalCutLimit).
+    expect(exceedsFinalCutLimit(after, 30_000)).toBe(false);
     expect(after).toBeGreaterThan(29_900);
   });
 
   it("never lands a hair over the limit when it falls inside an idle-compressed gap", () => {
     // Activity to 28s, dead air to 120s (compressed to a beat), activity
     // again: the limit instant maps deep into the raw gap, where a naive
-    // rounded boundary re-expands to MORE than the limit.
+    // rounded boundary re-expands past the limit. It may now land a fraction
+    // of a second over — deliberate, and invisible at m:ss — but never past
+    // what the gate accepts, which is what "hair over" always meant.
     const rec = withEvents(125_000, [
       ...activity(0, 28_000),
       ...activity(120_000, 125_000),
@@ -785,7 +797,9 @@ describe("trimCutsToExportLimit", () => {
     const next = trimCutsToExportLimit(rec, 30_000);
     expect(next).not.toBeNull();
     const after = durationWith(rec, next ?? []);
-    expect(after).toBeLessThanOrEqual(30_000);
+    // Judged the way the gate judges it — a fraction of a second over is not
+    // something an author can trim, and is not refused (exceedsFinalCutLimit).
+    expect(exceedsFinalCutLimit(after, 30_000)).toBe(false);
     expect(after).toBeGreaterThan(29_900);
   });
 });
@@ -1434,6 +1448,91 @@ describe("planPaintFlush", () => {
       key,
       { kind: "video-flush", sel: "#v" },
     ]);
+  });
+});
+
+describe("trimCutsToExportLimit finds a boundary instead of giving up", () => {
+  /**
+   * The dead-pill case. A closing reply's reveal is charged against however
+   * many raw milliseconds are left after it, so the final raw span can carry
+   * seconds of playback in ONE millisecond of recording. The limit instant
+   * then rounds onto the raw end, and the old guard read that as a degenerate
+   * recording and returned null — so "Trim to 1:00" did nothing while the
+   * tooltip demanded a trim, with a fitting boundary sitting right there.
+   */
+  function reveaClampedTail() {
+    const events: Recording["events"] = [{ kind: "segment", t: 0, version: 1 }];
+    for (let t = 0; t <= 40_000; t += 400) {
+      events.push({ kind: "pointer", t, type: "click", x: 1, y: 1 });
+    }
+    const long = "a fairly long assistant reply. ".repeat(60);
+    return recording({
+      durationMs: 40_001,
+      events,
+      // TWO replies on the same instant: their reveals SUM there, so the last
+      // raw millisecond carries more playback than the whole slack the limit
+      // check allows — which is what makes this reachable at all.
+      transcript: [
+        {
+          id: "r1",
+          role: "assistant",
+          atMs: 40_000,
+          parts: [{ type: "text", text: long }],
+        },
+        {
+          id: "r2",
+          role: "assistant",
+          atMs: 40_000,
+          parts: [{ type: "text", text: long }],
+        },
+      ] as Recording["transcript"],
+    });
+  }
+
+  it("trims a cut whose limit instant rounds onto the raw end", () => {
+    const rec = reveaClampedTail();
+    const playback = buildPlayback(rec);
+    const tailStart = playback.toPlaybackMs(40_000);
+    // A limit landing in the upper half of that one-millisecond span, so the
+    // mapped-and-rounded boundary lands ON the raw end.
+    const limit = Math.round(
+      tailStart + (playback.duration - tailStart) * 0.55,
+    );
+
+    // The geometry the old guard bailed on, asserted rather than assumed.
+    expect(Math.round(playback.toRawMs(limit))).toBe(40_001);
+    // …while the cut really is over the limit, by more than the second of
+    // slack the check allows — so a trim is genuinely owed.
+    expect(exceedsFinalCutLimit(playback.duration, limit)).toBe(true);
+
+    const next = trimCutsToExportLimit(rec, limit);
+    // The fix: a boundary, not null. Null here is the dead pill.
+    expect(next).not.toBeNull();
+    const after = buildPlayback({
+      ...rec,
+      edits: { ...rec.edits, cuts: next ?? [] },
+    }).duration;
+    expect(exceedsFinalCutLimit(after, limit)).toBe(false);
+  });
+
+  it("still returns null when the cut already fits", () => {
+    const rec = recording({
+      durationMs: 5_000,
+      events: [
+        { kind: "segment", t: 0, version: 1 },
+        { kind: "pointer", t: 1_000, type: "click", x: 1, y: 1 },
+      ] as Recording["events"],
+    });
+    expect(trimCutsToExportLimit(rec, 60_000)).toBeNull();
+  });
+
+  it("does not refuse a cut that is over only by a fraction of a second", () => {
+    // The paradox at the player level: a hair over the limit displays as the
+    // limit, so there is nothing an author could trim. It must simply fit.
+    expect(exceedsFinalCutLimit(60_000.75, 60_000)).toBe(false);
+    expect(
+      trimCutsToExportLimit(recording({ durationMs: 60_000 }), 60_000),
+    ).toBeNull();
   });
 });
 

--- a/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
+++ b/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
@@ -104,6 +104,128 @@ describe("buildPlayback", () => {
     expect(gap).toBeLessThanOrEqual(900);
   });
 
+  // A reply inside a cut used to buy its own reveal time, so the cut spanned
+  // real playback seconds: resuming inside one crawled through the removed
+  // stretch instead of stepping over it, and a minute of kept material
+  // reported as longer than a minute.
+  const reply = (id: string, atMs: number) => ({
+    id,
+    role: "assistant" as const,
+    atMs,
+    parts: [
+      { type: "text" as const, text: "a fairly long reply. ".repeat(40) },
+    ],
+  });
+
+  it("a cut costs zero playback time, however much was said inside it", () => {
+    const base = {
+      durationMs: 80_000,
+      events: [
+        { kind: "segment", t: 0, version: 1 },
+        { kind: "pointer", t: 10_000, type: "click", x: 1, y: 1 },
+        { kind: "pointer", t: 40_000, type: "click", x: 2, y: 2 },
+        { kind: "pointer", t: 70_000, type: "click", x: 3, y: 3 },
+      ] as Recording["events"],
+      transcript: [
+        reply("a1", 30_000),
+        reply("a2", 45_000),
+      ] as Recording["transcript"],
+      edits: { cuts: [{ fromMs: 20_000, toMs: 60_000 }] },
+    };
+    const playback = buildPlayback(recording(base));
+
+    // The whole cut is one instant — both edges land on the same moment.
+    expect(playback.toPlaybackMs(60_000)).toBe(playback.toPlaybackMs(20_000));
+    // And nothing inside it sits anywhere else.
+    expect(playback.toPlaybackMs(40_000)).toBe(playback.toPlaybackMs(20_000));
+
+    // Removing the two replies entirely cannot make the cut any cheaper —
+    // which is the point: what was said in a removed stretch costs nothing.
+    const withoutReplies = buildPlayback(
+      recording({ ...base, transcript: [] }),
+    );
+    expect(playback.duration).toBe(withoutReplies.duration);
+  });
+
+  it("resuming inside a cut steps to the next kept moment, not through the cut", () => {
+    const playback = buildPlayback(
+      recording({
+        durationMs: 80_000,
+        events: [
+          { kind: "segment", t: 0, version: 1 },
+          { kind: "pointer", t: 10_000, type: "click", x: 1, y: 1 },
+          { kind: "pointer", t: 70_000, type: "click", x: 2, y: 2 },
+        ] as Recording["events"],
+        transcript: [reply("a1", 30_000)] as Recording["transcript"],
+        edits: { cuts: [{ fromMs: 20_000, toMs: 60_000 }] },
+      }),
+    );
+
+    // The playhead sat at 40s when the cut was made. Its clock lands on the
+    // collapse instant, and the very next moment of playback is the cut's far
+    // edge — there is no span of removed material to sit through first.
+    const clock = playback.toPlaybackMs(40_000);
+    expect(playback.toRawMs(clock)).toBe(60_000);
+    expect(playback.toRawMs(clock + 1)).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it("still holds a reply that was mid-reveal when the cut began", () => {
+    // The defended case: trimming the pause AFTER a long answer cannot
+    // un-draw the answer — it is on screen, still typing, when the cut starts.
+    const withReply = buildPlayback(
+      recording({
+        durationMs: 80_000,
+        events: [
+          { kind: "segment", t: 0, version: 1 },
+          { kind: "pointer", t: 10_000, type: "click", x: 1, y: 1 },
+          { kind: "pointer", t: 70_000, type: "click", x: 2, y: 2 },
+        ] as Recording["events"],
+        transcript: [reply("a1", 19_000)] as Recording["transcript"],
+        edits: { cuts: [{ fromMs: 20_000, toMs: 60_000 }] },
+      }),
+    );
+    const withoutReply = buildPlayback(
+      recording({
+        durationMs: 80_000,
+        events: [
+          { kind: "segment", t: 0, version: 1 },
+          { kind: "pointer", t: 10_000, type: "click", x: 1, y: 1 },
+          { kind: "pointer", t: 70_000, type: "click", x: 2, y: 2 },
+        ] as Recording["events"],
+        edits: { cuts: [{ fromMs: 20_000, toMs: 60_000 }] },
+      }),
+    );
+    expect(withReply.duration).toBeGreaterThan(withoutReply.duration);
+  });
+
+  it("marks a collapsed reply as already sent so it never types over the app", () => {
+    const playback = buildPlayback(
+      recording({
+        durationMs: 80_000,
+        events: [
+          { kind: "segment", t: 0, version: 1 },
+          { kind: "pointer", t: 70_000, type: "click", x: 1, y: 1 },
+        ] as Recording["events"],
+        transcript: [
+          reply("kept", 10_000),
+          reply("cut", 30_000),
+        ] as Recording["transcript"],
+        edits: { cuts: [{ fromMs: 20_000, toMs: 60_000 }] },
+      }),
+    );
+    expect(playback.transcript.map((m) => m.settled)).toEqual([
+      undefined,
+      true,
+    ]);
+    // And the schedule gives it no typing time at all, so it renders complete
+    // the moment the playhead reaches it.
+    const { schedule } = revealSchedule(playback.transcript, playback.duration);
+    const slot = schedule.get("cut");
+    expect(slot?.end).toBe(slot?.start);
+    const keptSlot = schedule.get("kept");
+    expect(keptSlot?.end).toBeGreaterThan(keptSlot?.start ?? 0);
+  });
+
   it("collapses a cut range to zero time without dropping its events", () => {
     const base = {
       durationMs: 10_000,

--- a/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
+++ b/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
@@ -1,7 +1,4 @@
-import {
-  type AppRecordingBundle,
-  pruneTrailingTrimEvents,
-} from "@archestra/shared";
+import { type AppRecordingBundle, pruneCutEvents } from "@archestra/shared";
 import { describe, expect, it } from "vitest";
 import {
   backfilledEnhancement,
@@ -1318,7 +1315,7 @@ describe("planPaintFlush", () => {
   });
 });
 
-describe("pruneTrailingTrimEvents keeps buildPlayback identical", () => {
+describe("pruneCutEvents keeps buildPlayback identical", () => {
   // The offline renderer drives buildPlayback frame by frame, so the prune is
   // lossless iff buildPlayback's output — events, segments, transcript, duration
   // and the time mapping — is byte-for-byte the same on the pruned bundle.
@@ -1349,7 +1346,7 @@ describe("pruneTrailingTrimEvents keeps buildPlayback identical", () => {
   }
 
   function pruned(rec: Recording): Recording {
-    const out = pruneTrailingTrimEvents(recToBundle(rec));
+    const out = pruneCutEvents(recToBundle(rec));
     return {
       ...rec,
       events: out.recording.events as unknown as Recording["events"],
@@ -1422,7 +1419,7 @@ describe("pruneTrailingTrimEvents keeps buildPlayback identical", () => {
     expectSamePlayback(rec);
   });
 
-  it("leaves a mid cut alone and keeps playback identical", () => {
+  it("leaves a mid cut's non-video events alone and keeps playback identical", () => {
     const rec = recording({
       durationMs: 5_000,
       events: [
@@ -1434,6 +1431,64 @@ describe("pruneTrailingTrimEvents keeps buildPlayback identical", () => {
     });
     expect(pruned(rec).events.length).toBe(rec.events.length);
     expectSamePlayback(rec);
+  });
+
+  it("drops a mid cut's hidden video without moving playback, and leaves a decodable stream", () => {
+    const vchunk = (t: number, type: "key" | "delta") => ({
+      kind: "video-chunk" as const,
+      t,
+      sel: "#v",
+      type,
+      tsUs: t * 1_000,
+      bytes: new Uint8Array([t % 256]),
+    });
+    const rec = recording({
+      durationMs: 7_000,
+      events: [
+        { kind: "segment", t: 0, version: 1 },
+        vchunk(1_000, "key"),
+        vchunk(1_500, "delta"),
+        vchunk(2_500, "delta"), // hidden, and nothing visible decodes through it
+        vchunk(3_000, "key"), // hidden, but what the resume decodes FROM
+        vchunk(3_500, "delta"),
+        vchunk(4_500, "delta"), // in view
+        { kind: "canvas", t: 6_000, sel: "#c", blob: new Blob(["end"]) },
+      ],
+      edits: { cuts: [{ fromMs: 2_000, toMs: 4_000 }] },
+    });
+
+    const before = buildPlayback(rec);
+    const after = buildPlayback(pruned(rec));
+    // The timing contract: a hidden chunk sits where playback collapses to
+    // zero time, so removing it cannot move the clock or anything on it.
+    expect(after.duration).toBe(before.duration);
+    expect(after.segments).toEqual(before.segments);
+    expect(after.transcript).toEqual(before.transcript);
+    for (const ms of [0, before.duration / 2, before.duration]) {
+      expect(after.toPlaybackMs(ms)).toBeCloseTo(before.toPlaybackMs(ms), 6);
+      expect(after.toRawMs(ms)).toBe(before.toRawMs(ms));
+    }
+    // Exactly one chunk left, and it is the one no visible frame needed.
+    // Tagged by the ENCODER timestamp, not `t`: playback collapses the cut, so
+    // every chunk inside it comes back mapped to the same instant.
+    const tag = (event: { kind: string; t: number; tsUs?: number }) =>
+      `${event.kind}@${event.tsUs ?? event.t}`;
+    expect(after.events.map(tag)).toEqual(
+      before.events.map(tag).filter((it) => it !== "video-chunk@2500000"),
+    );
+    // And what remains still decodes: the stream re-opens on a KEYFRAME after
+    // the gap, which is the whole reason 3000 and 3500 were kept.
+    const kept = after.events.filter(
+      (event): event is Extract<typeof event, { kind: "video-chunk" }> =>
+        event.kind === "video-chunk",
+    );
+    expect(kept.map((event) => [event.tsUs / 1_000, event.type])).toEqual([
+      [1_000, "key"],
+      [1_500, "delta"],
+      [3_000, "key"],
+      [3_500, "delta"],
+      [4_500, "delta"],
+    ]);
   });
 
   it("merges overlapping cuts that together reach the end", () => {

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -122,6 +122,12 @@ type RecordingEnhancement = NonNullable<AppRecordingBundle["enhancement"]>;
 type TimelineEvent = PlaybackRecording["events"][number];
 type McpTimelineEvent = Extract<TimelineEvent, { kind: "mcp" }>;
 type TranscriptMessage = PlaybackRecording["transcript"][number];
+/**
+ * A transcript message as PLAYBACK sees it. `settled` marks one a cut
+ * collapsed: it is shown in full the instant it is reached, because the
+ * stretch it was said in was removed and there is no time left to type it in.
+ */
+type PlaybackTranscriptMessage = TranscriptMessage & { settled?: boolean };
 type PlayerAudioStatus =
   | { status: "loading" }
   | { status: "ready" }
@@ -230,7 +236,7 @@ export function backfilledEnhancement(
 }
 
 export function revealSchedule(
-  transcript: TranscriptMessage[],
+  transcript: PlaybackTranscriptMessage[],
   durationMs: number,
 ): {
   schedule: Map<string, { start: number; end: number }>;
@@ -241,9 +247,11 @@ export function revealSchedule(
     let previousEnd = Number.NEGATIVE_INFINITY;
     for (const message of transcript) {
       const start = Math.max(message.atMs, previousEnd);
+      // A settled message takes no time: a cut removed the stretch it was said
+      // in, so it is already on screen in full when the playhead arrives.
       const end =
         start +
-        (message.role === "assistant"
+        (message.role === "assistant" && !message.settled
           ? messageRevealMs(message.parts) * scale
           : 0);
       slots.set(message.id, { start, end });
@@ -4341,7 +4349,7 @@ function ReplayChatPane({
   preview,
   onEnterEdit,
 }: {
-  transcript: TranscriptMessage[];
+  transcript: PlaybackTranscriptMessage[];
   clockMs: number;
   /** The playback's end. The reveal schedule must fit inside it — see below. */
   durationMs: number;
@@ -4539,7 +4547,7 @@ export function ReplayChatEditPane({
   onRestore,
   onDone,
 }: {
-  transcript: TranscriptMessage[];
+  transcript: PlaybackTranscriptMessage[];
   enhancement: RecordingEnhancement | null;
   chat: RecordingChatEdits | undefined;
   saving: boolean;
@@ -5405,7 +5413,7 @@ function ReplayAppStage({
 export function buildPlayback(recording: PlaybackRecording): {
   events: TimelineEvent[];
   segments: PlaybackRecording["segments"];
-  transcript: TranscriptMessage[];
+  transcript: PlaybackTranscriptMessage[];
   duration: number;
   /** Map a playback-timeline time back to raw recording time — the coordinate
    * space cuts are stored in, stable across player versions. */
@@ -5415,6 +5423,14 @@ export function buildPlayback(recording: PlaybackRecording): {
 } {
   const source = finalVersionOnly(recording);
   const cuts = normalizeCuts(source.edits?.cuts ?? []);
+  /**
+   * A moment a cut removes — one that collapses onto the cut's instant rather
+   * than playing. The cut's own START still plays (it is the last kept
+   * moment); its END does not, matching how the bundle pruner and the
+   * trailing-trim filter read the same boundaries.
+   */
+  const insideCut = (t: number) =>
+    cuts.some((cut) => cut.fromMs < t && t <= cut.toMs);
   const anchors = new Set<number>([0, Math.max(0, source.durationMs)]);
   // When the author was actually USING the app, bounded by their first and last
   // input to it. Time inside that stretch is never compressed: it is the app
@@ -5508,6 +5524,16 @@ export function buildPlayback(recording: PlaybackRecording): {
   const revealAt = new Map<number, number>();
   for (const message of source.transcript) {
     if (message.role !== "assistant") continue;
+    // A reply the cut REMOVED buys no time. It still replays — collapsed onto
+    // the cut's instant, arriving already sent (see `settled` below) — but a
+    // cut that costs a second and a half per reply inside it is not a cut: the
+    // playhead crawls through a removed stretch instead of stepping over it,
+    // and a minute of kept material reports as longer than a minute.
+    //
+    // A reply said BEFORE the cut still holds (that clamp is further down),
+    // because trimming the pause after a long answer cannot un-draw the
+    // answer — it is still on screen, mid-reveal, when the cut begins.
+    if (insideCut(message.atMs)) continue;
     revealAt.set(
       message.atMs,
       (revealAt.get(message.atMs) ?? 0) + messageRevealMs(message.parts),
@@ -5632,12 +5658,17 @@ export function buildPlayback(recording: PlaybackRecording): {
     // A cut removes ONLY the app replay in its range (events, frames, segments
     // — filtered/collapsed above); the chat is never trimmed. Every captured
     // message still replays: one inside a removed stretch collapses onto the
-    // cut's instant the same way the app events there do, and the reveal
-    // cascade streams that collapsed run in quickly — so the conversation plays
-    // in full, only sped up across the cut rather than losing what was said.
+    // cut's instant the same way the app events there do, so the conversation
+    // plays in full rather than losing what was said.
+    //
+    // It arrives ALREADY SENT, though (`settled`). The stretch it was said in
+    // is gone, so there is no time left to type it in — and typing it anyway
+    // is the thing that made a cut cost real seconds and put the chat pane's
+    // animation back on top of an app replay that had already moved on.
     transcript: source.transcript.map((message) => ({
       ...message,
       atMs: map(message.atMs),
+      ...(insideCut(message.atMs) ? { settled: true as const } : {}),
     })),
     // The full compressed span — the last anchor, which may be a message that
     // lands just after the app interaction ends.

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -2,7 +2,6 @@
 
 import {
   APP_RECORDING_DESCRIPTION_MAX_CHARS,
-  APP_RECORDING_MAX_EXPORT_MS,
   APP_RECORDING_RENDER_REGION_ATTR,
   APP_RECORDING_VIEWPORT_ASPECT,
   ARCHESTRA_MCP_CATALOG_ID,
@@ -81,6 +80,7 @@ import {
   useAppRecordingEditor,
   useEnhanceAppRecording,
   useIsRenderingAppRecordingVideo,
+  useMaxFinalCutMs,
   useRenderAppRecordingVideo,
 } from "@/lib/app-session-recording/app-recording.query";
 import {
@@ -96,7 +96,7 @@ import {
 } from "@/lib/app-session-recording/app-recording-binary";
 import type { AppRecordingBundle } from "@/lib/app-session-recording/app-recording-store";
 import { getMcpSandboxBaseUrl } from "@/lib/config/config";
-import { useMcpSandboxDomain } from "@/lib/config/config.query";
+import { useFeature, useMcpSandboxDomain } from "@/lib/config/config.query";
 import { DEFAULT_APP_LOGO } from "@/lib/hooks/use-app-name";
 import { usePlatform } from "@/lib/hooks/use-platform";
 import { cn } from "@/lib/utils";
@@ -565,7 +565,12 @@ export function AppSessionPlayer({
     () => (recording ? buildPlayback(recording).duration : 0),
     [recording],
   );
-  const tooLongToExport = finalCutMs > APP_RECORDING_MAX_EXPORT_MS;
+  const videoDownloadEnabled = useFeature("hackathonVideoDownloadEnabled");
+  const maxFinalCutMs = useMaxFinalCutMs();
+  // The one label every length surface quotes, formatted like the durations
+  // beside it (m:ss) so "runs 4:12 / trim to 3:00" reads as one comparison.
+  const finalCutLimitLabel = formatMs(maxFinalCutMs);
+  const tooLongToExport = finalCutMs > maxFinalCutMs;
   const exportBlocked = descriptionEditing || surfaceEditing || tooLongToExport;
 
   // The quick action behind the tooltip pills (and the timeline's limit
@@ -574,10 +579,10 @@ export function AppSessionPlayer({
   // one undoable step.
   const trimToExportLimit = useCallback(() => {
     if (!recording) return;
-    const next = trimCutsToExportLimit(recording, APP_RECORDING_MAX_EXPORT_MS);
+    const next = trimCutsToExportLimit(recording, maxFinalCutMs);
     if (!next) return;
     editor.applyEdits({ cuts: next, chat: recording.edits?.chat });
-  }, [recording, editor]);
+  }, [recording, editor, maxFinalCutMs]);
   // The over-length tooltips end with the fix, not just the diagnosis.
   // Quietly: an invitation to trim, not an alarm — neutral until hovered.
   const trimPill = (
@@ -593,7 +598,7 @@ export function AppSessionPlayer({
       onPointerDown={trimToExportLimit}
     >
       <Scissors className="size-3" />
-      Trim to {MAX_EXPORT_SECONDS}s
+      Trim to {finalCutLimitLabel}
     </button>
   );
 
@@ -837,78 +842,85 @@ export function AppSessionPlayer({
                     aria-hidden="true"
                   />
 
-                  <Tooltip>
-                    {/* The wrapper is what makes the blocked case explain
+                  {/* The offline video export is off unless the deployment
+                      opts in (a render drives a headless browser for as long as
+                      the cut runs). Absent, not disabled: a greyed button with
+                      no way to enable it is a dead end, and the tour skips any
+                      stop whose element is missing, so its "Video download"
+                      step drops out with it. */}
+                  {videoDownloadEnabled && (
+                    <Tooltip>
+                      {/* The wrapper is what makes the blocked case explain
                         itself: a disabled button fires no pointer events, so
                         the tooltip below — the only thing that says WHY the
                         export is unavailable — never opened on the one button
                         that needed it. Same span the play and replay buttons
                         use. */}
-                    <TooltipTrigger asChild>
-                      <span className="inline-flex">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="group size-7 text-muted-foreground hover:text-foreground"
-                          aria-label={
-                            rendering
-                              ? "Cancel preparing the video"
-                              : "Download a video of this session"
-                          }
-                          data-tour="download"
-                          // Live while rendering — this is the way back out of
-                          // a render started by mistake, and the spinner is
-                          // where the author looks for it.
-                          disabled={!rendering && exportBlocked}
-                          onClick={() => {
-                            if (rendering) {
-                              cancelAppRecordingVideoRender();
-                              return;
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="group size-7 text-muted-foreground hover:text-foreground"
+                            aria-label={
+                              rendering
+                                ? "Cancel preparing the video"
+                                : "Download a video of this session"
                             }
-                            if (!recording) return;
-                            renderVideo.mutate({
-                              conversationId: authoringConversationId,
-                              title,
-                            });
-                          }}
-                        >
-                          {rendering ? (
-                            <>
-                              <Loader
-                                size={14}
-                                className="group-hover:hidden"
-                              />
-                              <X className="hidden size-4 group-hover:block" />
-                            </>
-                          ) : (
-                            <DownloadIcon className="size-4" />
-                          )}
-                        </Button>
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent className="max-w-[260px] text-xs">
-                      {rendering ? (
-                        "Preparing your video — click to cancel."
-                      ) : tooLongToExport ? (
-                        <>
-                          This cut runs {formatMs(finalCutMs)}. Trim it to{" "}
-                          {MAX_EXPORT_SECONDS} seconds or less to export a
-                          video.
-                          {trimPill}
-                        </>
-                      ) : descriptionEditing || surfaceEditing ? (
-                        "Finish editing to export a video."
-                      ) : (
-                        "Downloads a video of this session with your edits applied. Takes up to a minute."
-                      )}
-                    </TooltipContent>
-                  </Tooltip>
+                            data-tour="download"
+                            // Live while rendering — this is the way back out of
+                            // a render started by mistake, and the spinner is
+                            // where the author looks for it.
+                            disabled={!rendering && exportBlocked}
+                            onClick={() => {
+                              if (rendering) {
+                                cancelAppRecordingVideoRender();
+                                return;
+                              }
+                              if (!recording) return;
+                              renderVideo.mutate({
+                                conversationId: authoringConversationId,
+                                title,
+                              });
+                            }}
+                          >
+                            {rendering ? (
+                              <>
+                                <Loader
+                                  size={14}
+                                  className="group-hover:hidden"
+                                />
+                                <X className="hidden size-4 group-hover:block" />
+                              </>
+                            ) : (
+                              <DownloadIcon className="size-4" />
+                            )}
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-[260px] text-xs">
+                        {rendering ? (
+                          "Preparing your video — click to cancel."
+                        ) : tooLongToExport ? (
+                          <>
+                            This cut runs {formatMs(finalCutMs)}. Trim it to{" "}
+                            {finalCutLimitLabel} or less to export a video.
+                            {trimPill}
+                          </>
+                        ) : descriptionEditing || surfaceEditing ? (
+                          "Finish editing to export a video."
+                        ) : (
+                          "Downloads a video of this session with your edits applied. Takes up to a minute."
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
 
                   {/* Renders nothing unless the deployment offers the gallery.
                       Blocked exactly like the download — mid-edit AND over the
-                      export length cap: the gallery renders the submitted cut
-                      to video downstream, so the same 30-second bound applies. */}
+                      final-cut length limit: the gallery renders the submitted
+                      cut to video downstream, so the same bound applies. */}
                   <AppGalleryShareButton
                     conversationId={authoringConversationId}
                     disabled={exportBlocked}
@@ -916,7 +928,7 @@ export function AppSessionPlayer({
                       tooLongToExport ? (
                         <>
                           This cut runs {formatMs(finalCutMs)}. Trim it to{" "}
-                          {MAX_EXPORT_SECONDS} seconds or less to submit.
+                          {finalCutLimitLabel} or less to submit.
                           {trimPill}
                         </>
                       ) : (
@@ -1451,16 +1463,18 @@ function PlayerSurface({
   // The timeline's export-limit mark: where played time crosses the allowed
   // length on the FULL strip, and the one-click trim down to it. Committed
   // with the same optimistic-cuts bridge every other timeline edit uses.
+  const maxFinalCutMs = useMaxFinalCutMs();
+  const finalCutLimitLabel = formatMs(maxFinalCutMs);
   const exportLimitBaseMs =
-    duration > APP_RECORDING_MAX_EXPORT_MS
-      ? basePlayback.toPlaybackMs(playback.toRawMs(APP_RECORDING_MAX_EXPORT_MS))
+    duration > maxFinalCutMs
+      ? basePlayback.toPlaybackMs(playback.toRawMs(maxFinalCutMs))
       : null;
   const trimToExportLimit = useCallback(() => {
-    const next = trimCutsToExportLimit(recording, APP_RECORDING_MAX_EXPORT_MS);
+    const next = trimCutsToExportLimit(recording, maxFinalCutMs);
     if (!next) return;
     setPendingCuts(next);
     applyEdits({ cuts: next, chat: chatEdits });
-  }, [recording, applyEdits, chatEdits]);
+  }, [recording, applyEdits, chatEdits, maxFinalCutMs]);
 
   // ── Chat edits: presentation-only operations over the captured transcript
   // (drop a message, override a user message's text, hide the AI-enhanced
@@ -2974,6 +2988,7 @@ function PlayerSurface({
                     : null
             }
             exportLimit={review ? null : exportLimitBaseMs}
+            exportLimitLabel={finalCutLimitLabel}
             onSeek={review ? seekPlayback : seekBase}
             onScrub={review ? scrubPlayback : scrubBase}
             onCut={cutBaseRange}
@@ -3473,6 +3488,7 @@ function ReplayTimeline({
   saving,
   readOnly = false,
   exportLimit,
+  exportLimitLabel,
   onSeek,
   onScrub,
   demo,
@@ -3505,6 +3521,8 @@ function ReplayTimeline({
   /** Where played time crosses the export cap on this strip — the clickable
    * "trim to the limit" mark; null while the cut already fits. */
   exportLimit: number | null;
+  /** The configured limit, formatted — the mark and its tooltip quote it. */
+  exportLimitLabel: string;
   /** Editing anything pauses the replay and locks the play controls. */
   onEditingChange?: (editing: boolean) => void;
   onSeek: (ms: number) => void;
@@ -4060,12 +4078,12 @@ function ReplayTimeline({
               >
                 <span className="flex h-4 items-center gap-0.5 rounded-full border bg-background px-1 font-medium text-[10px] text-muted-foreground shadow-sm transition-colors group-hover:border-destructive/50 group-hover:text-destructive">
                   <Scissors className="size-2.5" />
-                  {MAX_EXPORT_SECONDS}s
+                  {exportLimitLabel}
                 </span>
               </button>
             </TooltipTrigger>
             <TooltipContent className="text-xs">
-              Trim to the max allowed length ({MAX_EXPORT_SECONDS}s)
+              Trim to the max allowed length ({exportLimitLabel})
             </TooltipContent>
           </Tooltip>
         )}
@@ -6218,15 +6236,12 @@ function stableStringify(value: unknown): string {
     .join(",")}}`;
 }
 
-function formatMs(ms: number): string {
+export function formatMs(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000);
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
-
-/** The export ceiling in whole seconds, for the copy that quotes it. */
-const MAX_EXPORT_SECONDS = Math.round(APP_RECORDING_MAX_EXPORT_MS / 1000);
 
 /**
  * Point the recorded document's platform assets at the origin that will
@@ -6428,7 +6443,7 @@ const PLAYER_TOUR_STEP_KEY = "app-recording-player-tour-step";
  * elements. Each key matches a `data-tour` attribute on the element it
  * explains; stops whose element isn't on screen are skipped.
  */
-const playerTourSteps = (modKey: "Cmd" | "Ctrl") => [
+const playerTourSteps = (modKey: "Cmd" | "Ctrl", limitLabel: string) => [
   {
     key: "description",
     title: "App description",
@@ -6485,7 +6500,7 @@ const playerTourSteps = (modKey: "Cmd" | "Ctrl") => [
     key: "download",
     title: "Video download",
     text: "Final cut with all your edits applied.",
-    note: `Keep your final cut under ${MAX_EXPORT_SECONDS} seconds.`,
+    note: `Keep your final cut under ${limitLabel}.`,
   },
   // Absent (and skipped) on deployments that don't offer the gallery — the
   // share button renders nothing there.
@@ -6493,7 +6508,7 @@ const playerTourSteps = (modKey: "Cmd" | "Ctrl") => [
     key: "share",
     title: "Submit to Archestra for review!",
     text: "Authorize Archestra to Create a Pull Request to Apps Hackathon repository on GitHub for you.\nFinal cut with all your edits applied.",
-    note: `Keep your final cut under ${MAX_EXPORT_SECONDS} seconds.`,
+    note: `Keep your final cut under ${limitLabel}.`,
   },
   {
     key: "tour",
@@ -6526,7 +6541,11 @@ function PlayerTour({
   // Shortcut copy names the platform's own modifier — Cmd exists only on Mac
   // keyboards; Windows/Linux read Ctrl.
   const { modKey } = usePlatform();
-  const steps = useMemo(() => playerTourSteps(modKey), [modKey]);
+  const limitLabel = formatMs(useMaxFinalCutMs());
+  const steps = useMemo(
+    () => playerTourSteps(modKey, limitLabel),
+    [modKey, limitLabel],
+  );
   // Resume where a mid-tour player close left off (progress persists per
   // browser until the tour finishes or is skipped).
   const [index, setIndex] = useState(() => {
@@ -6536,7 +6555,7 @@ function PlayerTour({
       10,
     );
     return Number.isFinite(stored) && stored > 0
-      ? Math.min(stored, playerTourSteps("Ctrl").length - 1)
+      ? Math.min(stored, playerTourSteps("Ctrl", "").length - 1)
       : 0;
   });
   useEffect(() => {

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -5,6 +5,8 @@ import {
   APP_RECORDING_RENDER_REGION_ATTR,
   APP_RECORDING_VIEWPORT_ASPECT,
   ARCHESTRA_MCP_CATALOG_ID,
+  exceedsFinalCutLimit,
+  formatDurationMs,
   getArchestraToolShortName,
   normalizeCuts,
   parseFullToolName,
@@ -578,7 +580,7 @@ export function AppSessionPlayer({
   // The one label every length surface quotes, formatted like the durations
   // beside it (m:ss) so "runs 4:12 / trim to 3:00" reads as one comparison.
   const finalCutLimitLabel = formatMs(maxFinalCutMs);
-  const tooLongToExport = finalCutMs > maxFinalCutMs;
+  const tooLongToExport = exceedsFinalCutLimit(finalCutMs, maxFinalCutMs);
   const exportBlocked = descriptionEditing || surfaceEditing || tooLongToExport;
 
   // The quick action behind the tooltip pills (and the timeline's limit
@@ -3415,7 +3417,7 @@ export function trimCutsToExportLimit(
   limitMs: number,
 ): { fromMs: number; toMs: number }[] | null {
   const playback = buildPlayback(recording);
-  if (playback.duration <= limitMs) return null;
+  if (!exceedsFinalCutLimit(playback.duration, limitMs)) return null;
   const base = buildPlayback(uncutRecording(recording));
   const rawStart = Math.round(base.toRawMs(0));
   const rawEnd = Math.round(base.toRawMs(Math.max(base.duration, 1)));
@@ -3433,11 +3435,19 @@ export function trimCutsToExportLimit(
       ...recording,
       edits: { ...recording.edits, cuts: next },
     }).duration;
-    return { next, fits: duration <= limitMs };
+    return { next, fits: !exceedsFinalCutLimit(duration, limitMs) };
   };
-  // The natural candidate: the raw instant currently playing at the limit.
-  let hi = Math.round(playback.toRawMs(limitMs));
-  if (hi - rawStart < 1 || rawEnd - hi < 1) return null;
+  // The natural candidate: the raw instant currently playing at the limit,
+  // CLAMPED inside the session rather than rejected when it lands on the end.
+  //
+  // A closing reply's reveal is charged against however many raw milliseconds
+  // are left after it, so the final raw span can carry a second of playback in
+  // one millisecond of recording — and the limit instant then rounds onto
+  // `rawEnd`. Reading that as "degenerate recording" and returning null is how
+  // the pill became a no-op while the tooltip demanded a trim: a fitting
+  // boundary existed, the bisection just never ran.
+  let hi = Math.min(Math.round(playback.toRawMs(limitMs)), rawEnd - 1);
+  if (hi - rawStart < 1) return null;
   const first = trial(hi);
   if (first.fits) return first.next;
   let lo = rawStart + 1; // a whole-session trim always fits
@@ -4077,7 +4087,7 @@ function ReplayTimeline({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label="Trim to the maximum allowed length"
+                aria-label={`Trim to the maximum allowed length (${exportLimitLabel})`}
                 className="group absolute top-0 z-30 flex h-2.5 -translate-x-1/2 cursor-pointer items-center"
                 style={{ left: leftPct(exportLimit) }}
                 disabled={saving}
@@ -4086,7 +4096,11 @@ function ReplayTimeline({
               >
                 <span className="flex h-4 items-center gap-0.5 rounded-full border bg-background px-1 font-medium text-[10px] text-muted-foreground shadow-sm transition-colors group-hover:border-destructive/50 group-hover:text-destructive">
                   <Scissors className="size-2.5" />
-                  {exportLimitLabel}
+                  {/* "max 1:00", never a bare "1:00": the strip under it is
+                      the UNCUT timeline, so a bare duration reads as one of
+                      its ruler ticks — and with a head trim this badge sits
+                      well to the right of the tick that shares its number. */}
+                  max {exportLimitLabel}
                 </span>
               </button>
             </TooltipTrigger>
@@ -6267,12 +6281,12 @@ function stableStringify(value: unknown): string {
     .join(",")}}`;
 }
 
-export function formatMs(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${String(seconds).padStart(2, "0")}`;
-}
+/**
+ * `m:ss`, from the shared implementation the length CHECK is defined against
+ * — a formatter that could disagree with the check is what printed "runs 1:00
+ * … trim to 1:00 or less".
+ */
+export const formatMs = formatDurationMs;
 
 /**
  * Point the recorded document's platform assets at the origin that will

--- a/platform/frontend/src/components/app-session-recording/use-app-session-recorder.test.tsx
+++ b/platform/frontend/src/components/app-session-recording/use-app-session-recorder.test.tsx
@@ -28,8 +28,8 @@ vi.mock("@/lib/organization.query", () => ({
 }));
 vi.mock("@/lib/app-session-recording/app-recording.query", () => ({
   useInvalidateAppRecording: () => vi.fn(),
-  // Capture stops at the same length the final cut may be submitted at.
-  useMaxFinalCutMs: () => 180_000,
+  // Capture runs to a multiple of this; the final cut is bounded by it.
+  useMaxFinalCutMs: () => 60_000,
 }));
 // The recorder is off on small screens; stubbed to a desktop viewport by
 // default (jsdom has no real matchMedia), flipped per test where it matters.

--- a/platform/frontend/src/components/app-session-recording/use-app-session-recorder.test.tsx
+++ b/platform/frontend/src/components/app-session-recording/use-app-session-recorder.test.tsx
@@ -28,6 +28,8 @@ vi.mock("@/lib/organization.query", () => ({
 }));
 vi.mock("@/lib/app-session-recording/app-recording.query", () => ({
   useInvalidateAppRecording: () => vi.fn(),
+  // Capture stops at the same length the final cut may be submitted at.
+  useMaxFinalCutMs: () => 180_000,
 }));
 // The recorder is off on small screens; stubbed to a desktop viewport by
 // default (jsdom has no real matchMedia), flipped per test where it matters.

--- a/platform/frontend/src/components/app-session-recording/use-app-session-recorder.tsx
+++ b/platform/frontend/src/components/app-session-recording/use-app-session-recorder.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  APP_RECORDING_CAPTURE_HEADROOM,
   APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
   APP_RECORDING_LIMITS,
   archestraApiSdk,
@@ -103,15 +104,17 @@ const MAX_SEGMENTS = APP_RECORDING_LIMITS.maxSegments - 5;
 /**
  * How long a capture may run before it stops itself.
  *
- * The SAME bound as the final cut, and deliberately so. The stored bundle
- * carries the whole CAPTURE — cuts are presentation, not deletion — so a long
- * recording trimmed to a short final cut still ships at the capture's size.
- * Letting capture run far past what may be submitted was how a participant
- * ended up with a recording they could edit but never upload. Following the
- * configured limit keeps the two from drifting: raise the deployment's limit
- * and both move together.
+ * A MULTIPLE of the final cut, so there is something to edit. A take that
+ * stopped dead at the submittable length left the author nothing to cut, and
+ * one that ran without limit produced recordings that could be edited but
+ * never uploaded — the stored bundle used to carry the whole capture however
+ * much of it was cut away. Pruning the cut-away video (`pruneCutEvents`) is
+ * what makes the headroom safe: an edit down to the limit now ships at the
+ * limit's size. Both bounds follow the deployment's configured limit, so
+ * raising it moves them together.
  */
-const DEFAULT_MAX_DURATION_MS = APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS;
+const DEFAULT_MAX_DURATION_MS =
+  APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS * APP_RECORDING_CAPTURE_HEADROOM;
 /**
  * The SDK flushes its buffer on stop; give that final batch time to arrive —
  * including the video-encoder drain, which flushes each canvas's encoder and
@@ -537,10 +540,10 @@ export function useOwnAppSessionRecorder(params: {
   const coreRef = useRef<AppRecorderCore | null>(null);
   if (enabled && !coreRef.current) coreRef.current = new AppRecorderCore();
   const core = enabled ? coreRef.current : null;
-  // Capture stops at the same length the final cut may be submitted at, so a
-  // participant can never record more than they are allowed to ship.
+  // Capture may run past the submittable length — enough to leave room to
+  // edit, not enough to run away — since what an edit cuts no longer ships.
   const maxFinalCutMs = useMaxFinalCutMs();
-  if (core) core.maxDurationMs = maxFinalCutMs;
+  if (core) core.maxDurationMs = maxFinalCutMs * APP_RECORDING_CAPTURE_HEADROOM;
 
   const { data: app } = useApp(appId, { toastOnError: false });
   const { data: session } = useSession();

--- a/platform/frontend/src/components/app-session-recording/use-app-session-recorder.tsx
+++ b/platform/frontend/src/components/app-session-recording/use-app-session-recorder.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
   APP_RECORDING_LIMITS,
   archestraApiSdk,
   connectedMcpServerNames,
@@ -23,6 +24,7 @@ import { useApp, useAppTools } from "@/lib/app.query";
 import {
   fallbackRecordingDescription,
   useInvalidateAppRecording,
+  useMaxFinalCutMs,
 } from "@/lib/app-session-recording/app-recording.query";
 import { serializeRecordingEvents } from "@/lib/app-session-recording/app-recording-binary";
 import {
@@ -98,7 +100,18 @@ export interface AppSessionRecorder {
  */
 const MAX_EVENTS = APP_RECORDING_LIMITS.maxEvents - 5_000;
 const MAX_SEGMENTS = APP_RECORDING_LIMITS.maxSegments - 5;
-const MAX_DURATION_MS = 10 * 60_000;
+/**
+ * How long a capture may run before it stops itself.
+ *
+ * The SAME bound as the final cut, and deliberately so. The stored bundle
+ * carries the whole CAPTURE — cuts are presentation, not deletion — so a long
+ * recording trimmed to a short final cut still ships at the capture's size.
+ * Letting capture run far past what may be submitted was how a participant
+ * ended up with a recording they could edit but never upload. Following the
+ * configured limit keeps the two from drifting: raise the deployment's limit
+ * and both move together.
+ */
+const DEFAULT_MAX_DURATION_MS = APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS;
 /**
  * The SDK flushes its buffer on stop; give that final batch time to arrive —
  * including the video-encoder drain, which flushes each canvas's encoder and
@@ -148,6 +161,12 @@ type RecorderStatus = AppSessionRecorder["status"];
  */
 class AppRecorderCore {
   status: RecorderStatus = "idle";
+  /**
+   * The capture ceiling this deployment configured. Settable rather than
+   * constructor-fixed: the core outlives any one render, and the value arrives
+   * with the config, which resolves after the first paint.
+   */
+  maxDurationMs = DEFAULT_MAX_DURATION_MS;
 
   private readonly listeners = new Set<() => void>();
   private startEpoch = 0;
@@ -331,7 +350,7 @@ class AppRecorderCore {
     this.rebroadcastTimer = setInterval(() => {
       this.postControl("start");
       // Hard stop at the ceiling so a forgotten recording can't grow unbounded.
-      if (Date.now() - this.startEpoch >= MAX_DURATION_MS) void this.stop();
+      if (Date.now() - this.startEpoch >= this.maxDurationMs) void this.stop();
     }, START_REBROADCAST_MS);
   }
 
@@ -518,6 +537,10 @@ export function useOwnAppSessionRecorder(params: {
   const coreRef = useRef<AppRecorderCore | null>(null);
   if (enabled && !coreRef.current) coreRef.current = new AppRecorderCore();
   const core = enabled ? coreRef.current : null;
+  // Capture stops at the same length the final cut may be submitted at, so a
+  // participant can never record more than they are allowed to ship.
+  const maxFinalCutMs = useMaxFinalCutMs();
+  if (core) core.maxDurationMs = maxFinalCutMs;
 
   const { data: app } = useApp(appId, { toastOnError: false });
   const { data: session } = useSession();

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.test.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.test.ts
@@ -122,31 +122,15 @@ describe("submitRecordingToAppGallery", () => {
         if (method === "GET" && url.includes("/git/ref/heads/main")) {
           return Response.json({ object: { sha: "base-sha" } });
         }
-        if (method === "GET" && url.includes("/git/ref/heads/")) {
-          // The submission branch's own head, read before committing onto it.
-          return Response.json({ object: { sha: "branch-sha" } });
-        }
         if (method === "POST" && url.includes("/git/refs")) {
           return Response.json({}, { status: 201 });
         }
-        if (method === "GET" && url.includes("/git/commits/")) {
-          return Response.json({ tree: { sha: "base-tree-sha" } });
-        }
-        if (method === "POST" && url.includes("/git/blobs")) {
-          return Response.json({ sha: "blob-sha" }, { status: 201 });
-        }
-        if (method === "POST" && url.includes("/git/trees")) {
-          return Response.json({ sha: "tree-sha" }, { status: 201 });
-        }
-        if (method === "POST" && url.includes("/git/commits")) {
-          return Response.json({ sha: "commit-sha" }, { status: 201 });
-        }
-        if (method === "PATCH" && url.includes("/git/refs/heads/")) {
-          return Response.json({}, { status: 200 });
-        }
         if (method === "GET" && url.includes("/contents/")) {
-          // The gallery presence probe: the app isn't published yet.
+          // Fresh branch: the file isn't there yet.
           return Response.json({ message: "Not Found" }, { status: 404 });
+        }
+        if (method === "PUT" && url.includes("/contents/")) {
+          return Response.json({}, { status: 201 });
         }
         if (method === "POST" && url.endsWith("/pulls")) {
           return Response.json({
@@ -204,16 +188,8 @@ describe("submitRecordingToAppGallery", () => {
       "POST /repos/archestra-ai/app-gallery/forks",
       "GET /repos/sam/app-gallery/git/ref/heads/main",
       "POST /repos/sam/app-gallery/git/refs",
-      // The upload is the GIT DATA API, not the contents API: the contents
-      // endpoint gives out well below its advertised ceiling on a recording-
-      // sized file. Blob, tree, commit, then move the ref — ONE commit, so a
-      // half-finished submission can't exist on the branch.
-      "GET /repos/sam/app-gallery/git/ref/heads/submission/pr_review_queue",
-      "GET /repos/sam/app-gallery/git/commits/branch-sha",
-      "POST /repos/sam/app-gallery/git/blobs",
-      "POST /repos/sam/app-gallery/git/trees",
-      "POST /repos/sam/app-gallery/git/commits",
-      "PATCH /repos/sam/app-gallery/git/refs/heads/submission/pr_review_queue",
+      "GET /repos/sam/app-gallery/contents/apps/sam_pr_review_queue/recording.json",
+      "PUT /repos/sam/app-gallery/contents/apps/sam_pr_review_queue/recording.json",
       "POST /repos/archestra-ai/app-gallery/pulls",
     ]);
 
@@ -226,18 +202,18 @@ describe("submitRecordingToAppGallery", () => {
     expect(preflight?.url).toContain("state=all");
 
     // The committed file is the bundle itself, byte for byte, with the
-    // submitter's GitHub identity stamped on (the mocked /user has no public
-    // name, so it lands as null). A blob carries content only — no path, no
-    // prior sha — which is what makes overwriting a leftover file a non-event.
-    const upload = calls.find(
-      (c) => c.method === "POST" && c.url.includes("/git/blobs"),
-    ) as { body: { content: string; encoding: string } };
+    // submitter's GitHub identity stamped on (the mocked /user has no
+    // public name, so it lands as null) — and a fresh branch uploads
+    // without an update sha.
+    const upload = calls.find((c) => c.method === "PUT") as {
+      body: { content: string; branch: string };
+    };
     const expected = makeBundle();
     expect(JSON.parse(atob(upload.body.content))).toEqual({
       ...expected,
       meta: { ...expected.meta, github: { login: "sam", name: null } },
     });
-    expect(upload.body.encoding).toBe("base64");
+    expect(upload.body).not.toHaveProperty("sha");
 
     // The PR names the participant's branch as head and carries the metadata.
     const pr = calls.at(-1)?.body as {
@@ -270,9 +246,9 @@ describe("submitRecordingToAppGallery", () => {
 
     await submit();
 
-    const upload = calls.find(
-      (c) => c.method === "POST" && c.url.includes("/git/blobs"),
-    ) as { body: { content: string } };
+    const upload = calls.find((c) => c.method === "PUT") as {
+      body: { content: string };
+    };
     const uploaded = JSON.parse(atob(upload.body.content));
     expect(uploaded.meta.github).toEqual({
       login: "sam",
@@ -302,18 +278,11 @@ describe("submitRecordingToAppGallery", () => {
 
     await submit({ bundle });
 
-    const uploads = calls.filter(
-      (c) => c.method === "POST" && c.url.includes("/git/blobs"),
-    );
+    const uploads = calls.filter((c) => c.method === "PUT");
     expect(uploads).toHaveLength(2);
-    // Blobs carry no path; the tree is where the files get their names.
-    const tree = calls.find((c) => c.url.includes("/git/trees")) as {
-      body: { tree: { path: string }[] };
-    };
-    expect(tree.body.tree.map((entry) => entry.path)).toEqual([
-      "apps/sam_pr_review_queue/recording.json",
-      "apps/sam_pr_review_queue/thumbnail.webp",
-    ]);
+    expect(uploads[1].url).toContain(
+      "/contents/apps/sam_pr_review_queue/thumbnail.webp",
+    );
     // The committed bytes are the re-encoded (4:5-framed) frame, not the raw
     // canvas capture — the framing runs before upload.
     expect(atob((uploads[1].body as { content: string }).content)).toBe(
@@ -334,9 +303,7 @@ describe("submitRecordingToAppGallery", () => {
 
     await submit({ bundle });
 
-    const uploads = calls.filter(
-      (c) => c.method === "POST" && c.url.includes("/git/blobs"),
-    );
+    const uploads = calls.filter((c) => c.method === "PUT");
     // The automatic path stamps the submitter's GitHub identity onto the
     // bundle before serializing it (the dialog does the same for the manual
     // download) — mirror that here so this compares against what the
@@ -348,13 +315,9 @@ describe("submitRecordingToAppGallery", () => {
     const files = await buildGallerySubmissionFiles(stamped);
     // Same files, same order, same bytes — the manual fallback's downloads
     // must match what the automatic path commits, byte for byte.
-    // Blobs are content-only, so the NAMES come from the tree entries.
-    const tree = calls.find((c) => c.url.includes("/git/trees")) as {
-      body: { tree: { path: string }[] };
-    };
-    expect(tree.body.tree.map((entry) => entry.path.split("/").at(-1))).toEqual(
-      files.map((f) => f.name),
-    );
+    expect(
+      uploads.map((u) => new URL(u.url).pathname.split("/").at(-1)),
+    ).toEqual(files.map((f) => f.name));
     for (const [i, upload] of uploads.entries()) {
       const uploadedBinary = atob((upload.body as { content: string }).content);
       const fileBinary = Array.from(files[i].bytes, (b) =>
@@ -528,18 +491,9 @@ describe("submitRecordingToAppGallery", () => {
     expect(
       calls.filter((c) => c.method === "GET" && c.url.includes("/pulls?")),
     ).toHaveLength(2);
-    // …and the commit replaced the stale file instead of failing on it. No
-    // prior-blob-sha dance is needed any more: the tree writes the path
-    // outright, over whatever was there.
-    const tree = calls.find((c) => c.url.includes("/git/trees")) as {
-      body: { base_tree: string; tree: { path: string }[] };
-    };
-    expect(tree.body.tree.map((entry) => entry.path)).toContain(
-      "apps/sam_pr_review_queue/recording.json",
-    );
-    // Committed onto the branch's CURRENT head, not where it started — the
-    // leftover branch has moved since it was created.
-    expect(tree.body.base_tree).toBe("base-tree-sha");
+    // …and the upload replaced the stale file instead of failing on it.
+    const upload = calls.find((c) => c.method === "PUT");
+    expect((upload?.body as { sha?: string }).sha).toBe("stale-blob-sha");
   });
 
   test("a pull request that appears mid-run stops the flow and names it", async () => {
@@ -687,6 +641,59 @@ describe("submitRecordingToAppGallery", () => {
     await expect(submit()).rejects.toThrow(
       "GitHub refused the request. Validation Failed",
     );
+  });
+
+  test("retries a ruleset-validation timeout on the upload", async () => {
+    let attempts = 0;
+    stubGithub({
+      respond: (method, url) => {
+        if (method !== "PUT" || !url.includes("/contents/")) return null;
+        attempts++;
+        // GitHub's ruleset check giving up rather than judging the request —
+        // the refusal a large submission draws, which a manual "Try again"
+        // clears. Deliberately NOT a 5xx: what marks it retriable is the
+        // message, since a 5xx is already covered by its own rule.
+        return attempts === 1
+          ? Response.json(
+              { message: "Timed out validating rule" },
+              { status: 422 },
+            )
+          : null;
+      },
+    });
+
+    vi.useFakeTimers();
+    try {
+      const submission = submit();
+      // Enough passes for the flow to reach the failed upload, schedule its
+      // wait, and burn it — without the suite paying the delay in real time.
+      for (let i = 0; i < 4; i++) await vi.advanceTimersByTimeAsync(1_500);
+      await expect(submission).resolves.toEqual({
+        prUrl: "https://github.com/archestra-ai/app-gallery/pull/7",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    // Retried once, then it went through — the participant never saw it.
+    expect(attempts).toBe(2);
+  });
+
+  test("a verdict on the upload surfaces immediately instead of retrying", async () => {
+    let attempts = 0;
+    stubGithub({
+      respond: (method, url) => {
+        if (method !== "PUT" || !url.includes("/contents/")) return null;
+        attempts++;
+        return Response.json({ message: "size is too large" }, { status: 422 });
+      },
+    });
+
+    await expect(submit()).rejects.toThrow(
+      "GitHub refused the request. size is too large",
+    );
+    // Retrying a verdict spends the participant's time and buries the one
+    // message that tells them what to fix.
+    expect(attempts).toBe(1);
   });
 });
 

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.test.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.test.ts
@@ -336,11 +336,10 @@ describe("submitRecordingToAppGallery", () => {
 
     const failure = await submit({ bundle }).catch((error) => error);
     expect(failure).toBeInstanceOf(Error);
-    // GitHub's real ceiling, phrased as GitHub's — never a product quota.
-    // The number is what api.github.com accepts as a REQUEST BODY (measured:
-    // a 57MB bundle was refused by the contents API AND the blob endpoint),
-    // less the room base64 takes on the way there.
-    expect(String(failure)).toMatch(/GitHub refuses uploads over 34MB/);
+    // GitHub's own strictest ceiling, phrased as GitHub's — never a product
+    // quota, and never tightened on our side: a submission GitHub would have
+    // taken must not be refused here.
+    expect(String(failure)).toMatch(/GitHub refuses uploads over 50MB/);
     // Not even the duplicate pre-flight ran — no request left the browser.
     expect(calls).toHaveLength(0);
   });

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.test.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.test.ts
@@ -122,15 +122,31 @@ describe("submitRecordingToAppGallery", () => {
         if (method === "GET" && url.includes("/git/ref/heads/main")) {
           return Response.json({ object: { sha: "base-sha" } });
         }
+        if (method === "GET" && url.includes("/git/ref/heads/")) {
+          // The submission branch's own head, read before committing onto it.
+          return Response.json({ object: { sha: "branch-sha" } });
+        }
         if (method === "POST" && url.includes("/git/refs")) {
           return Response.json({}, { status: 201 });
         }
-        if (method === "GET" && url.includes("/contents/")) {
-          // Fresh branch: the file isn't there yet.
-          return Response.json({ message: "Not Found" }, { status: 404 });
+        if (method === "GET" && url.includes("/git/commits/")) {
+          return Response.json({ tree: { sha: "base-tree-sha" } });
         }
-        if (method === "PUT" && url.includes("/contents/")) {
-          return Response.json({}, { status: 201 });
+        if (method === "POST" && url.includes("/git/blobs")) {
+          return Response.json({ sha: "blob-sha" }, { status: 201 });
+        }
+        if (method === "POST" && url.includes("/git/trees")) {
+          return Response.json({ sha: "tree-sha" }, { status: 201 });
+        }
+        if (method === "POST" && url.includes("/git/commits")) {
+          return Response.json({ sha: "commit-sha" }, { status: 201 });
+        }
+        if (method === "PATCH" && url.includes("/git/refs/heads/")) {
+          return Response.json({}, { status: 200 });
+        }
+        if (method === "GET" && url.includes("/contents/")) {
+          // The gallery presence probe: the app isn't published yet.
+          return Response.json({ message: "Not Found" }, { status: 404 });
         }
         if (method === "POST" && url.endsWith("/pulls")) {
           return Response.json({
@@ -188,8 +204,16 @@ describe("submitRecordingToAppGallery", () => {
       "POST /repos/archestra-ai/app-gallery/forks",
       "GET /repos/sam/app-gallery/git/ref/heads/main",
       "POST /repos/sam/app-gallery/git/refs",
-      "GET /repos/sam/app-gallery/contents/apps/sam_pr_review_queue/recording.json",
-      "PUT /repos/sam/app-gallery/contents/apps/sam_pr_review_queue/recording.json",
+      // The upload is the GIT DATA API, not the contents API: the contents
+      // endpoint gives out well below its advertised ceiling on a recording-
+      // sized file. Blob, tree, commit, then move the ref — ONE commit, so a
+      // half-finished submission can't exist on the branch.
+      "GET /repos/sam/app-gallery/git/ref/heads/submission/pr_review_queue",
+      "GET /repos/sam/app-gallery/git/commits/branch-sha",
+      "POST /repos/sam/app-gallery/git/blobs",
+      "POST /repos/sam/app-gallery/git/trees",
+      "POST /repos/sam/app-gallery/git/commits",
+      "PATCH /repos/sam/app-gallery/git/refs/heads/submission/pr_review_queue",
       "POST /repos/archestra-ai/app-gallery/pulls",
     ]);
 
@@ -202,18 +226,18 @@ describe("submitRecordingToAppGallery", () => {
     expect(preflight?.url).toContain("state=all");
 
     // The committed file is the bundle itself, byte for byte, with the
-    // submitter's GitHub identity stamped on (the mocked /user has no
-    // public name, so it lands as null) — and a fresh branch uploads
-    // without an update sha.
-    const upload = calls.find((c) => c.method === "PUT") as {
-      body: { content: string; branch: string };
-    };
+    // submitter's GitHub identity stamped on (the mocked /user has no public
+    // name, so it lands as null). A blob carries content only — no path, no
+    // prior sha — which is what makes overwriting a leftover file a non-event.
+    const upload = calls.find(
+      (c) => c.method === "POST" && c.url.includes("/git/blobs"),
+    ) as { body: { content: string; encoding: string } };
     const expected = makeBundle();
     expect(JSON.parse(atob(upload.body.content))).toEqual({
       ...expected,
       meta: { ...expected.meta, github: { login: "sam", name: null } },
     });
-    expect(upload.body).not.toHaveProperty("sha");
+    expect(upload.body.encoding).toBe("base64");
 
     // The PR names the participant's branch as head and carries the metadata.
     const pr = calls.at(-1)?.body as {
@@ -246,9 +270,9 @@ describe("submitRecordingToAppGallery", () => {
 
     await submit();
 
-    const upload = calls.find((c) => c.method === "PUT") as {
-      body: { content: string };
-    };
+    const upload = calls.find(
+      (c) => c.method === "POST" && c.url.includes("/git/blobs"),
+    ) as { body: { content: string } };
     const uploaded = JSON.parse(atob(upload.body.content));
     expect(uploaded.meta.github).toEqual({
       login: "sam",
@@ -278,11 +302,18 @@ describe("submitRecordingToAppGallery", () => {
 
     await submit({ bundle });
 
-    const uploads = calls.filter((c) => c.method === "PUT");
-    expect(uploads).toHaveLength(2);
-    expect(uploads[1].url).toContain(
-      "/contents/apps/sam_pr_review_queue/thumbnail.webp",
+    const uploads = calls.filter(
+      (c) => c.method === "POST" && c.url.includes("/git/blobs"),
     );
+    expect(uploads).toHaveLength(2);
+    // Blobs carry no path; the tree is where the files get their names.
+    const tree = calls.find((c) => c.url.includes("/git/trees")) as {
+      body: { tree: { path: string }[] };
+    };
+    expect(tree.body.tree.map((entry) => entry.path)).toEqual([
+      "apps/sam_pr_review_queue/recording.json",
+      "apps/sam_pr_review_queue/thumbnail.webp",
+    ]);
     // The committed bytes are the re-encoded (4:5-framed) frame, not the raw
     // canvas capture — the framing runs before upload.
     expect(atob((uploads[1].body as { content: string }).content)).toBe(
@@ -303,7 +334,9 @@ describe("submitRecordingToAppGallery", () => {
 
     await submit({ bundle });
 
-    const uploads = calls.filter((c) => c.method === "PUT");
+    const uploads = calls.filter(
+      (c) => c.method === "POST" && c.url.includes("/git/blobs"),
+    );
     // The automatic path stamps the submitter's GitHub identity onto the
     // bundle before serializing it (the dialog does the same for the manual
     // download) — mirror that here so this compares against what the
@@ -315,9 +348,13 @@ describe("submitRecordingToAppGallery", () => {
     const files = await buildGallerySubmissionFiles(stamped);
     // Same files, same order, same bytes — the manual fallback's downloads
     // must match what the automatic path commits, byte for byte.
-    expect(
-      uploads.map((u) => new URL(u.url).pathname.split("/").at(-1)),
-    ).toEqual(files.map((f) => f.name));
+    // Blobs are content-only, so the NAMES come from the tree entries.
+    const tree = calls.find((c) => c.url.includes("/git/trees")) as {
+      body: { tree: { path: string }[] };
+    };
+    expect(tree.body.tree.map((entry) => entry.path.split("/").at(-1))).toEqual(
+      files.map((f) => f.name),
+    );
     for (const [i, upload] of uploads.entries()) {
       const uploadedBinary = atob((upload.body as { content: string }).content);
       const fileBinary = Array.from(files[i].bytes, (b) =>
@@ -489,9 +526,18 @@ describe("submitRecordingToAppGallery", () => {
     expect(
       calls.filter((c) => c.method === "GET" && c.url.includes("/pulls?")),
     ).toHaveLength(2);
-    // …and the upload replaced the stale file instead of failing on it.
-    const upload = calls.find((c) => c.method === "PUT");
-    expect((upload?.body as { sha?: string }).sha).toBe("stale-blob-sha");
+    // …and the commit replaced the stale file instead of failing on it. No
+    // prior-blob-sha dance is needed any more: the tree writes the path
+    // outright, over whatever was there.
+    const tree = calls.find((c) => c.url.includes("/git/trees")) as {
+      body: { base_tree: string; tree: { path: string }[] };
+    };
+    expect(tree.body.tree.map((entry) => entry.path)).toContain(
+      "apps/sam_pr_review_queue/recording.json",
+    );
+    // Committed onto the branch's CURRENT head, not where it started — the
+    // leftover branch has moved since it was created.
+    expect(tree.body.base_tree).toBe("base-tree-sha");
   });
 
   test("a pull request that appears mid-run stops the flow and names it", async () => {

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.test.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.test.ts
@@ -373,9 +373,11 @@ describe("submitRecordingToAppGallery", () => {
 
     const failure = await submit({ bundle }).catch((error) => error);
     expect(failure).toBeInstanceOf(Error);
-    // GitHub's real per-file ceiling, phrased as GitHub's — never a
-    // product quota.
-    expect(String(failure)).toMatch(/GitHub refuses files over 100MB/);
+    // GitHub's real ceiling, phrased as GitHub's — never a product quota.
+    // The number is what api.github.com accepts as a REQUEST BODY (measured:
+    // a 57MB bundle was refused by the contents API AND the blob endpoint),
+    // less the room base64 takes on the way there.
+    expect(String(failure)).toMatch(/GitHub refuses uploads over 34MB/);
     // Not even the duplicate pre-flight ran — no request left the browser.
     expect(calls).toHaveLength(0);
   });

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
@@ -524,12 +524,11 @@ function thumbnailFile(thumbnail: {
 }
 
 /**
- * The one size rule a submission must meet — GitHub's own ceiling on what a
- * single API request may carry, NOT a product quota. Returns the refusal
- * message when a
- * file is over it, null when everything fits. The dialog calls this at the
- * Share click so nobody signs in to GitHub only to learn the recording
- * can't be uploaded.
+ * The one size rule a submission must meet — GitHub's own strictest ceiling,
+ * NOT a product quota, and never tighter than GitHub's. Returns the refusal
+ * message when a file is over it, null when everything fits. The dialog calls
+ * this at the Share click so nobody signs in to GitHub only to learn the
+ * recording can't be uploaded.
  */
 export function oversizedGallerySubmissionFile(
   bundle: AppRecordingBundle,
@@ -1343,31 +1342,22 @@ function base64ToBytes(base64: string): Uint8Array {
 }
 
 /**
- * What api.github.com accepts as a REQUEST BODY. This — not any file or blob
- * size — is the limit submissions actually hit.
+ * The strictest ceiling api.github.com imposes on any endpoint this upload
+ * could use. GitHub's number, not a product quota, and deliberately not a
+ * millimetre under it: a submission GitHub would have taken must never be
+ * refused here.
  *
- * Measured, not assumed. A 57MB bundle was refused by BOTH upload paths: the
- * contents API answered "the file is too large to be processed" and the Git
- * Data API's blob endpoint answered "your input was too large to process",
- * despite GitHub documenting 100MB blobs. The common factor is the request
- * itself — 57MB base64-encodes to ~76MB on the wire, and no REST endpoint
- * takes that. Changing endpoints cannot raise this ceiling; only a smaller
- * bundle can, which is why the upload stays on the plain contents API.
- */
-const GITHUB_MAX_REQUEST_BODY_BYTES = 45 * 1024 * 1024;
-
-/**
- * The largest bundle that still fits a request once base64 has had its way
- * with it: base64 costs 4 bytes per 3, so the raw ceiling is 3/4 of the body
- * limit.
+ * The one measurement we have is a 57MB bundle refused by BOTH upload paths —
+ * the contents API answered "the file is too large to be processed", the Git
+ * Data API's blob endpoint "your input was too large to process". That is
+ * consistent with this ceiling and says nothing about which endpoint to use,
+ * which is why the upload stays on the plain contents API.
  *
- * Worth carrying when reasoning about capture — the bundle's video chunks are
- * ALREADY base64 inside its JSON and the upload encodes that JSON again, so a
- * byte of recorded video costs ~1.78 bytes by the time it reaches GitHub.
+ * Capture is what keeps real bundles far below it rather than this check: a
+ * minute at the SDK's governor lands around 10MB, so the gate exists for
+ * recordings made before those bounds, not for new ones.
  */
-const GITHUB_MAX_FILE_BYTES = Math.floor(
-  (GITHUB_MAX_REQUEST_BODY_BYTES * 3) / 4,
-);
+const GITHUB_MAX_FILE_BYTES = 50 * 1024 * 1024;
 
 function mb(bytes: number): number {
   return Math.round(bytes / (1024 * 1024));

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
@@ -331,79 +331,24 @@ export async function submitRecordingToAppGallery(params: {
   // The same builder backs the manual-submission download, so what a
   // participant hand-uploads is byte-identical to what this commits.
   const dir = gallerySubmissionFolder(viewer.login, appSlug);
-  // Uploaded through the GIT DATA API (blob → tree → commit → ref), not the
-  // contents API.
-  //
-  // The contents API accepts a whole file in one PUT and gives out long before
-  // its advertised ceiling: a 45MB recording came back "Sorry, the file is too
-  // large to be processed. Consider creating/updating the file in a local
-  // clone", and one merely large enough to slow the commit came back "Timed
-  // out validating rule" instead. Neither is a limit the size gate could have
-  // predicted, and both read to a participant as the platform being broken.
-  // The blob endpoint is GitHub's documented path for large files and takes
-  // the whole recording, which is what makes a minutes-long cut submittable at
-  // all.
-  //
-  // It also lands the submission as ONE commit instead of one per file, so a
-  // half-finished submission can't exist on the branch: either the ref moves
-  // or nothing did.
-  const files = await buildGallerySubmissionFiles(bundleWithGithub);
-  onProgress({
-    stage: "upload",
-    label: `Uploading ${files.length === 1 ? files[0].name : `${files.length} files`} to ${forkName}…`,
-  });
-  // Where the branch actually is now — `baseRef` is where it STARTED, and a
-  // reused branch from a rejected submission has moved since. Committing onto
-  // a stale parent would drop whatever is already there.
-  const head = await gh<{ object: { sha: string } }>(
-    "GET",
-    // Not encodeURIComponent: the branch is a ref PATH, and escaping its
-    // slash to %2F asks GitHub for a ref that does not exist.
-    `${forkPath}/git/ref/heads/${branch}`,
-  );
-  const headCommit = await gh<{ tree: { sha: string } }>(
-    "GET",
-    `${forkPath}/git/commits/${head.object.sha}`,
-  );
-  const blobs: { path: string; sha: string }[] = [];
-  for (const file of files) {
-    const blob = await githubWithRetry(() =>
-      gh<{ sha: string }>("POST", `${forkPath}/git/blobs`, {
+  for (const file of await buildGallerySubmissionFiles(bundleWithGithub)) {
+    onProgress({
+      stage: "upload",
+      label: `Uploading ${file.name} to ${forkName}…`,
+    });
+    // Updating a file left by an earlier (rejected) submission needs its
+    // blob sha; on a fresh branch the lookup 404s and the PUT creates it.
+    const path = `${forkPath}/contents/${dir}/${file.name}`;
+    const priorSha = await fetchExistingFileSha({ gh, path, branch });
+    await githubWithRetry(() =>
+      gh("PUT", path, {
+        message: `Add ${file.name} for: ${bundle.app.name}`,
         content: toBase64(file.bytes),
-        encoding: "base64",
+        branch,
+        ...(priorSha ? { sha: priorSha } : {}),
       }),
     );
-    blobs.push({ path: `${dir}/${file.name}`, sha: blob.sha });
   }
-  // `base_tree` carries the rest of the repository forward, so the commit
-  // touches only these paths — and an existing file at one of them is
-  // overwritten without needing its prior blob sha first.
-  const tree = await githubWithRetry(() =>
-    gh<{ sha: string }>("POST", `${forkPath}/git/trees`, {
-      base_tree: headCommit.tree.sha,
-      tree: blobs.map((blob) => ({
-        path: blob.path,
-        mode: "100644",
-        type: "blob",
-        sha: blob.sha,
-      })),
-    }),
-  );
-  const commit = await githubWithRetry(() =>
-    gh<{ sha: string }>("POST", `${forkPath}/git/commits`, {
-      message: `Add submission for: ${bundle.app.name}`,
-      tree: tree.sha,
-      parents: [head.object.sha],
-    }),
-  );
-  // Not forced: the parent above is this branch's real head, so a fast-forward
-  // is the only correct outcome. A refusal means something else moved the
-  // branch mid-run, which must surface rather than be overwritten.
-  await githubWithRetry(() =>
-    gh("PATCH", `${forkPath}/git/refs/heads/${branch}`, {
-      sha: commit.sha,
-    }),
-  );
 
   onProgress({
     stage: "pr",
@@ -579,8 +524,9 @@ function thumbnailFile(thumbnail: {
 }
 
 /**
- * The one size rule a submission must meet — GitHub's own per-file limit on
- * its contents API, NOT a product quota. Returns the refusal message when a
+ * The one size rule a submission must meet — GitHub's own ceiling on what a
+ * single API request may carry, NOT a product quota. Returns the refusal
+ * message when a
  * file is over it, null when everything fits. The dialog calls this at the
  * Share click so nobody signs in to GitHub only to learn the recording
  * can't be uploaded.
@@ -1406,7 +1352,7 @@ function base64ToBytes(base64: string): Uint8Array {
  * despite GitHub documenting 100MB blobs. The common factor is the request
  * itself — 57MB base64-encodes to ~76MB on the wire, and no REST endpoint
  * takes that. Changing endpoints cannot raise this ceiling; only a smaller
- * bundle can.
+ * bundle can, which is why the upload stays on the plain contents API.
  */
 const GITHUB_MAX_REQUEST_BODY_BYTES = 45 * 1024 * 1024;
 

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
@@ -331,22 +331,79 @@ export async function submitRecordingToAppGallery(params: {
   // The same builder backs the manual-submission download, so what a
   // participant hand-uploads is byte-identical to what this commits.
   const dir = gallerySubmissionFolder(viewer.login, appSlug);
-  for (const file of await buildGallerySubmissionFiles(bundleWithGithub)) {
-    onProgress({
-      stage: "upload",
-      label: `Uploading ${file.name} to ${forkName}…`,
-    });
-    // Updating a file left by an earlier (rejected) submission needs its
-    // blob sha; on a fresh branch the lookup 404s and the PUT creates it.
-    const path = `${forkPath}/contents/${dir}/${file.name}`;
-    const priorSha = await fetchExistingFileSha({ gh, path, branch });
-    await gh("PUT", path, {
-      message: `Add ${file.name} for: ${bundle.app.name}`,
-      content: toBase64(file.bytes),
-      branch,
-      ...(priorSha ? { sha: priorSha } : {}),
-    });
+  // Uploaded through the GIT DATA API (blob → tree → commit → ref), not the
+  // contents API.
+  //
+  // The contents API accepts a whole file in one PUT and gives out long before
+  // its advertised ceiling: a 45MB recording came back "Sorry, the file is too
+  // large to be processed. Consider creating/updating the file in a local
+  // clone", and one merely large enough to slow the commit came back "Timed
+  // out validating rule" instead. Neither is a limit the size gate could have
+  // predicted, and both read to a participant as the platform being broken.
+  // The blob endpoint is GitHub's documented path for large files and takes
+  // the whole recording, which is what makes a minutes-long cut submittable at
+  // all.
+  //
+  // It also lands the submission as ONE commit instead of one per file, so a
+  // half-finished submission can't exist on the branch: either the ref moves
+  // or nothing did.
+  const files = await buildGallerySubmissionFiles(bundleWithGithub);
+  onProgress({
+    stage: "upload",
+    label: `Uploading ${files.length === 1 ? files[0].name : `${files.length} files`} to ${forkName}…`,
+  });
+  // Where the branch actually is now — `baseRef` is where it STARTED, and a
+  // reused branch from a rejected submission has moved since. Committing onto
+  // a stale parent would drop whatever is already there.
+  const head = await gh<{ object: { sha: string } }>(
+    "GET",
+    // Not encodeURIComponent: the branch is a ref PATH, and escaping its
+    // slash to %2F asks GitHub for a ref that does not exist.
+    `${forkPath}/git/ref/heads/${branch}`,
+  );
+  const headCommit = await gh<{ tree: { sha: string } }>(
+    "GET",
+    `${forkPath}/git/commits/${head.object.sha}`,
+  );
+  const blobs: { path: string; sha: string }[] = [];
+  for (const file of files) {
+    const blob = await githubWithRetry(() =>
+      gh<{ sha: string }>("POST", `${forkPath}/git/blobs`, {
+        content: toBase64(file.bytes),
+        encoding: "base64",
+      }),
+    );
+    blobs.push({ path: `${dir}/${file.name}`, sha: blob.sha });
   }
+  // `base_tree` carries the rest of the repository forward, so the commit
+  // touches only these paths — and an existing file at one of them is
+  // overwritten without needing its prior blob sha first.
+  const tree = await githubWithRetry(() =>
+    gh<{ sha: string }>("POST", `${forkPath}/git/trees`, {
+      base_tree: headCommit.tree.sha,
+      tree: blobs.map((blob) => ({
+        path: blob.path,
+        mode: "100644",
+        type: "blob",
+        sha: blob.sha,
+      })),
+    }),
+  );
+  const commit = await githubWithRetry(() =>
+    gh<{ sha: string }>("POST", `${forkPath}/git/commits`, {
+      message: `Add submission for: ${bundle.app.name}`,
+      tree: tree.sha,
+      parents: [head.object.sha],
+    }),
+  );
+  // Not forced: the parent above is this branch's real head, so a fast-forward
+  // is the only correct outcome. A refusal means something else moved the
+  // branch mid-run, which must surface rather than be overwritten.
+  await githubWithRetry(() =>
+    gh("PATCH", `${forkPath}/git/refs/heads/${branch}`, {
+      sha: commit.sha,
+    }),
+  );
 
   onProgress({
     stage: "pr",
@@ -533,7 +590,7 @@ export function oversizedGallerySubmissionFile(
 ): string | null {
   const { bytes } = recordingFile(bundle);
   if (bytes.byteLength > GITHUB_MAX_FILE_BYTES) {
-    return `This recording is ${mb(bytes.byteLength)}MB — GitHub refuses files over ${mb(GITHUB_MAX_FILE_BYTES)}MB. Re-record a shorter session.`;
+    return `This recording is ${mb(bytes.byteLength)}MB — GitHub refuses files over ${mb(GITHUB_MAX_FILE_BYTES)}MB. Trim it, or re-record a shorter session.`;
   }
   return null;
 }
@@ -729,6 +786,52 @@ async function toGithubRequestError(
     `GitHub refused the request.${detail ? ` ${detail}` : ""}`,
     status,
   );
+}
+
+/**
+ * Re-run a write that failed for a reason GitHub itself calls temporary.
+ *
+ * Large submissions draw transient refusals from the commit path — "Timed out
+ * validating rule" is the one seen in practice, a ruleset check giving up
+ * rather than a verdict on the request. Clicking the dialog's Try again does
+ * clear it, so this is not rescuing an unrecoverable state; it spends the
+ * retry on the participant's behalf instead of making them notice, read a
+ * scary error, and click through it.
+ *
+ * Only transient shapes retry. A refusal that is a VERDICT — too large, no
+ * permission, a bad token — must surface immediately: retrying it wastes the
+ * participant's time and buries the one message that tells them what to fix.
+ */
+async function githubWithRetry<T>(call: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < GITHUB_WRITE_ATTEMPTS; attempt++) {
+    try {
+      return await call();
+    } catch (error) {
+      if (!isTransientGithubRefusal(error)) throw error;
+      lastError = error;
+      // Linear, not exponential: two short waits inside one click, not a
+      // backoff schedule the participant sits through.
+      await new Promise((resolve) =>
+        setTimeout(resolve, GITHUB_RETRY_DELAY_MS * (attempt + 1)),
+      );
+    }
+  }
+  throw lastError;
+}
+
+/** Three tries total — enough for a blip, short enough to stay one click. */
+const GITHUB_WRITE_ATTEMPTS = 3;
+const GITHUB_RETRY_DELAY_MS = 1_500;
+
+/**
+ * A refusal GitHub is likely to answer differently a moment later: its own
+ * 5xx weather, and the ruleset-validation timeout that large commits provoke.
+ */
+function isTransientGithubRefusal(error: unknown): boolean {
+  if (!(error instanceof GithubRequestError)) return false;
+  if (error.status >= 500) return true;
+  return /timed out validating rule/i.test(error.message);
 }
 
 /** An api.github.com refusal, keeping the status for retry decisions. */
@@ -1293,7 +1396,12 @@ function base64ToBytes(base64: string): Uint8Array {
   return bytes;
 }
 
-/** GitHub's ceiling for a file created through its contents API. */
+/**
+ * GitHub's ceiling for a blob created through the Git Data API — the endpoint
+ * the submission uploads through. Measured on the RAW bytes, which is what the
+ * limit is about: the request carries them base64-encoded (~4/3 the size), but
+ * the blob GitHub stores and bounds is the decoded file.
+ */
 const GITHUB_MAX_FILE_BYTES = 100 * 1024 * 1024;
 
 function mb(bytes: number): number {

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
@@ -590,7 +590,7 @@ export function oversizedGallerySubmissionFile(
 ): string | null {
   const { bytes } = recordingFile(bundle);
   if (bytes.byteLength > GITHUB_MAX_FILE_BYTES) {
-    return `This recording is ${mb(bytes.byteLength)}MB — GitHub refuses files over ${mb(GITHUB_MAX_FILE_BYTES)}MB. Trim it, or re-record a shorter session.`;
+    return `This recording is ${mb(bytes.byteLength)}MB — GitHub refuses uploads over ${mb(GITHUB_MAX_FILE_BYTES)}MB. Trim it, or re-record a shorter session.`;
   }
   return null;
 }
@@ -1397,12 +1397,31 @@ function base64ToBytes(base64: string): Uint8Array {
 }
 
 /**
- * GitHub's ceiling for a blob created through the Git Data API — the endpoint
- * the submission uploads through. Measured on the RAW bytes, which is what the
- * limit is about: the request carries them base64-encoded (~4/3 the size), but
- * the blob GitHub stores and bounds is the decoded file.
+ * What api.github.com accepts as a REQUEST BODY. This — not any file or blob
+ * size — is the limit submissions actually hit.
+ *
+ * Measured, not assumed. A 57MB bundle was refused by BOTH upload paths: the
+ * contents API answered "the file is too large to be processed" and the Git
+ * Data API's blob endpoint answered "your input was too large to process",
+ * despite GitHub documenting 100MB blobs. The common factor is the request
+ * itself — 57MB base64-encodes to ~76MB on the wire, and no REST endpoint
+ * takes that. Changing endpoints cannot raise this ceiling; only a smaller
+ * bundle can.
  */
-const GITHUB_MAX_FILE_BYTES = 100 * 1024 * 1024;
+const GITHUB_MAX_REQUEST_BODY_BYTES = 45 * 1024 * 1024;
+
+/**
+ * The largest bundle that still fits a request once base64 has had its way
+ * with it: base64 costs 4 bytes per 3, so the raw ceiling is 3/4 of the body
+ * limit.
+ *
+ * Worth carrying when reasoning about capture — the bundle's video chunks are
+ * ALREADY base64 inside its JSON and the upload encodes that JSON again, so a
+ * byte of recorded video costs ~1.78 bytes by the time it reaches GitHub.
+ */
+const GITHUB_MAX_FILE_BYTES = Math.floor(
+  (GITHUB_MAX_REQUEST_BODY_BYTES * 3) / 4,
+);
 
 function mb(bytes: number): number {
   return Math.round(bytes / (1024 * 1024));

--- a/platform/frontend/src/lib/app-session-recording/app-recording.query.test.tsx
+++ b/platform/frontend/src/lib/app-session-recording/app-recording.query.test.tsx
@@ -4,8 +4,10 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useFeature } from "@/lib/config/config.query";
 import {
   cancelAppRecordingVideoRender,
+  useMaxFinalCutMs,
   useRenderAppRecordingVideo,
 } from "./app-recording.query";
 import { type AppRecordingBundle, recordingStore } from "./app-recording-store";
@@ -25,6 +27,7 @@ vi.mock("@archestra/shared", async (importOriginal) => {
   };
 });
 vi.mock("sonner");
+vi.mock("@/lib/config/config.query");
 
 const sdk = vi.mocked(archestraApiSdk);
 
@@ -234,5 +237,28 @@ describe("useRenderAppRecordingVideo", () => {
     expect(sdk.cancelAppRecordingRender).toHaveBeenCalledWith({
       path: { jobId: "job-b" },
     });
+  });
+});
+
+describe("useMaxFinalCutMs", () => {
+  // The number every length surface quotes AND enforces. A surface reading a
+  // different one is the failure this hook exists to prevent, so the fallback
+  // matters as much as the configured value.
+  it("uses the deployment's configured limit", () => {
+    vi.mocked(useFeature).mockReturnValue(
+      30_000 as ReturnType<typeof useFeature>,
+    );
+    expect(renderHook(() => useMaxFinalCutMs()).result.current).toBe(30_000);
+  });
+
+  it("falls back to three minutes before the config resolves", () => {
+    // Undefined here is the offline renderer (no session, so no authenticated
+    // config) and the first paint of any player. The render route enforces the
+    // real configured limit server-side, so this fallback cannot let an
+    // over-length cut through — it only keeps the UI from quoting NaN.
+    vi.mocked(useFeature).mockReturnValue(
+      undefined as ReturnType<typeof useFeature>,
+    );
+    expect(renderHook(() => useMaxFinalCutMs()).result.current).toBe(180_000);
   });
 });

--- a/platform/frontend/src/lib/app-session-recording/app-recording.query.test.tsx
+++ b/platform/frontend/src/lib/app-session-recording/app-recording.query.test.tsx
@@ -1,4 +1,7 @@
-import { archestraApiSdk } from "@archestra/shared";
+import {
+  APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
+  archestraApiSdk,
+} from "@archestra/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -259,6 +262,8 @@ describe("useMaxFinalCutMs", () => {
     vi.mocked(useFeature).mockReturnValue(
       undefined as ReturnType<typeof useFeature>,
     );
-    expect(renderHook(() => useMaxFinalCutMs()).result.current).toBe(180_000);
+    expect(renderHook(() => useMaxFinalCutMs()).result.current).toBe(
+      APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
+    );
   });
 });

--- a/platform/frontend/src/lib/app-session-recording/app-recording.query.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-recording.query.ts
@@ -3,7 +3,7 @@ import {
   APP_RECORDING_RENDER_FPS,
   archestraApiSdk,
   type archestraApiTypes,
-  pruneTrailingTrimEvents,
+  pruneCutEvents,
   validateRecordingBundle,
 } from "@archestra/shared";
 import {
@@ -190,11 +190,11 @@ export function useRenderAppRecordingVideo() {
 
       try {
         const started = await renderAppRecordingVideo({
-          // Ship the trimmed recording without its cut-away tail: a size
-          // optimization that renders byte-for-byte the same (see
-          // pruneTrailingTrimEvents). Nothing else about the bundle changes.
+          // Ship the recording without what its cuts put out of view: a size
+          // optimization that renders identically (see pruneCutEvents).
+          // Nothing else about the bundle changes.
           body: {
-            bundle: pruneTrailingTrimEvents(validation.bundle),
+            bundle: pruneCutEvents(validation.bundle),
             title: params.title,
           },
         });

--- a/platform/frontend/src/lib/app-session-recording/app-recording.query.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-recording.query.ts
@@ -1,4 +1,5 @@
 import {
+  APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
   APP_RECORDING_RENDER_FPS,
   archestraApiSdk,
   type archestraApiTypes,
@@ -22,6 +23,7 @@ import {
   recordingStore,
   subscribeToRecordingChanges,
 } from "@/lib/app-session-recording/app-recording-store";
+import { useFeature } from "@/lib/config/config.query";
 import { handleApiError, toApiError } from "@/lib/utils";
 
 const {
@@ -368,6 +370,28 @@ export function useIsRenderingAppRecordingVideo(): boolean {
 const RENDER_VIDEO_MUTATION_KEY = ["app-recording", "render-video"] as const;
 
 /** The description used when AI generation is unavailable or still pending. */
+/**
+ * The longest final cut this deployment accepts, in ms.
+ *
+ * ONE source for every length surface — the submit button and the submission's
+ * own backstop, the video export, the editor's trim-to-limit control, the
+ * timeline's limit mark and the tour's "keep it under" note — so raising the
+ * deployment's limit raises all of them together and no surface can quote a
+ * number the checks disagree with.
+ *
+ * Falls back to the shared default while the config is still loading, and in
+ * the offline renderer, which drives the replay page with no session and so
+ * never resolves the authenticated config. Nothing is gated there (it renders,
+ * it does not offer buttons) and the render route enforces the real configured
+ * limit server-side, so the fallback cannot let an over-length cut through.
+ */
+export function useMaxFinalCutMs(): number {
+  return (
+    useFeature("hackathonMaxFinalCutMs") ??
+    APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS
+  );
+}
+
 export function fallbackRecordingDescription(appName: string): string {
   return `${appName} — an interactive app built in chat.`;
 }

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -1,4 +1,7 @@
-import type { archestraApiTypes } from "@archestra/shared";
+import {
+  APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
+  type archestraApiTypes,
+} from "@archestra/shared";
 
 type Config = archestraApiTypes.GetConfigResponses["200"];
 
@@ -50,6 +53,9 @@ export function makeConfig(
       kbAutoSyncPermissionsEnabled: false,
       hackathonRecorderEnabled: true,
       hackathonRecorderOverrideActive: false,
+      // Off by default, exactly as a real deployment has it.
+      hackathonVideoDownloadEnabled: false,
+      hackathonMaxFinalCutMs: APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
       hackathonGalleryRepo: null,
       ...overrides.features,
       maintenanceMode: overrides.features?.maintenanceMode ?? null,

--- a/platform/shared/app-recording.test.ts
+++ b/platform/shared/app-recording.test.ts
@@ -8,7 +8,7 @@ import {
   healBundleMcpServers,
   isAppsHackathonOpen,
   normalizeCuts,
-  pruneTrailingTrimEvents,
+  pruneCutEvents,
   redactSensitiveText,
   sanitizeRecordingBundle,
   validateRecordingBundle,
@@ -336,7 +336,7 @@ describe("normalizeCuts", () => {
   });
 });
 
-describe("pruneTrailingTrimEvents", () => {
+describe("pruneCutEvents", () => {
   const seg = { kind: "segment", t: 0, version: 1 } as const;
 
   function trimBundle(
@@ -387,7 +387,7 @@ describe("pruneTrailingTrimEvents", () => {
       ],
       [{ fromMs: 2000, toMs: 5000 }],
     );
-    const out = pruneTrailingTrimEvents(b);
+    const out = pruneCutEvents(b);
     expect(out.recording.events).toEqual([seg, before, view]);
     // Everything else is untouched.
     expect(out.edits).toEqual(b.edits);
@@ -405,9 +405,9 @@ describe("pruneTrailingTrimEvents", () => {
       ],
       [{ fromMs: 2000, toMs: 4980 }],
     );
-    expect(pruneTrailingTrimEvents(b).recording.events.map((e) => e.t)).toEqual(
-      [0, 4990],
-    );
+    expect(pruneCutEvents(b).recording.events.map((e) => e.t)).toEqual([
+      0, 4990,
+    ]);
   });
 
   it("no-ops without cuts", () => {
@@ -415,10 +415,10 @@ describe("pruneTrailingTrimEvents", () => {
       seg,
       { kind: "canvas", t: 1000, sel: "#c", data: "x" },
     ]);
-    expect(pruneTrailingTrimEvents(b)).toBe(b);
+    expect(pruneCutEvents(b)).toBe(b);
   });
 
-  it("no-ops for a mid cut that does not reach the data end", () => {
+  it("leaves a mid cut's non-video events whole — later playback needs their state", () => {
     const b = trimBundle(
       [
         seg,
@@ -427,7 +427,148 @@ describe("pruneTrailingTrimEvents", () => {
       ],
       [{ fromMs: 1000, toMs: 2000 }],
     );
-    expect(pruneTrailingTrimEvents(b)).toBe(b);
+    expect(pruneCutEvents(b)).toBe(b);
+  });
+
+  // ── Mid-cut video pruning: the one payload a cut can throw away.
+  const chunk = (t: number, type: "key" | "delta", sel = "#c") =>
+    ({
+      kind: "video-chunk",
+      t,
+      sel,
+      type,
+      tsUs: t * 1000,
+      data: "bytes",
+    }) as const;
+  const chunksOf = (b: AppRecordingBundle) =>
+    b.recording.events.filter(
+      (event): event is Extract<typeof event, { kind: "video-chunk" }> =>
+        event.kind === "video-chunk",
+    );
+
+  it("a mid cut drops the video it hides, back to the keyframe the resume decodes from", () => {
+    const b = trimBundle(
+      [
+        seg,
+        chunk(1000, "key"),
+        chunk(1500, "delta"),
+        chunk(2500, "delta"), // hidden, and nothing still visible needs it
+        chunk(3000, "key"), // hidden, but what the resume decodes FROM
+        chunk(3500, "delta"), // hidden, and on the path from that keyframe
+        chunk(4500, "delta"), // in view
+        { kind: "canvas", t: 5500, sel: "#c", data: "end" },
+      ],
+      [{ fromMs: 2000, toMs: 4000 }],
+      6_000,
+    );
+
+    const kept = chunksOf(pruneCutEvents(b));
+    expect(kept.map((event) => event.t)).toEqual([
+      1000, 1500, 3000, 3500, 4500,
+    ]);
+    // The invariant a decoder needs: every RUN of kept chunks opens on a
+    // keyframe. The cut split this stream in two, so the second run opens at
+    // 3000 — a chunk the cut hides, kept precisely so 4500 decodes to the same
+    // pixels it always did.
+    expect(kept.map((event) => event.type)).toEqual([
+      "key",
+      "delta",
+      "key",
+      "delta",
+      "delta",
+    ]);
+  });
+
+  it("keeps hidden chunks when they are the chain the resume decodes through", () => {
+    const b = trimBundle(
+      [
+        seg,
+        chunk(1000, "key"),
+        chunk(2500, "delta"), // hidden, but there is no keyframe after it
+        chunk(4500, "delta"), // in view — decodes through 2500
+        { kind: "canvas", t: 5500, sel: "#c", data: "end" },
+      ],
+      [{ fromMs: 2000, toMs: 4000 }],
+      6_000,
+    );
+    // Nothing can go: the visible chunk's only path to a keyframe runs
+    // straight through the cut.
+    expect(pruneCutEvents(b)).toBe(b);
+  });
+
+  it("prunes each canvas's stream on its own keyframes", () => {
+    const b = trimBundle(
+      [
+        seg,
+        chunk(1000, "key", "#a"),
+        chunk(1000, "key", "#b"),
+        chunk(2500, "delta", "#a"), // droppable — #a re-keys inside the cut
+        chunk(2500, "delta", "#b"), // NOT droppable — #b never re-keys
+        chunk(3000, "key", "#a"),
+        chunk(4500, "delta", "#a"),
+        chunk(4500, "delta", "#b"),
+        { kind: "canvas", t: 5500, sel: "#a", data: "end" },
+      ],
+      [{ fromMs: 2000, toMs: 4000 }],
+      6_000,
+    );
+    // A keyframe in one canvas's stream says nothing about another's.
+    expect(
+      chunksOf(pruneCutEvents(b)).map((event) => `${event.sel}@${event.t}`),
+    ).toEqual([
+      "#a@1000",
+      "#b@1000",
+      "#b@2500",
+      "#a@3000",
+      "#a@4500",
+      "#b@4500",
+    ]);
+  });
+
+  it("never drops a video-config — it is what opens the stream", () => {
+    const config = {
+      kind: "video-config",
+      t: 2200,
+      sel: "#c",
+      codec: "vp09.00.10.08",
+      codedWidth: 640,
+      codedHeight: 800,
+    } as const;
+    const b = trimBundle(
+      [
+        seg,
+        chunk(1000, "key"),
+        config, // hidden by the cut, kept anyway
+        chunk(2500, "delta"),
+        chunk(3000, "key"),
+        chunk(4500, "delta"),
+        { kind: "canvas", t: 5500, sel: "#c", data: "end" },
+      ],
+      [{ fromMs: 2000, toMs: 4000 }],
+      6_000,
+    );
+    const out = pruneCutEvents(b);
+    expect(out.recording.events).toContainEqual(config);
+    // The 2500 delta still went — a config is not a decode anchor on its own.
+    expect(chunksOf(out).map((event) => event.t)).toEqual([1000, 3000, 4500]);
+  });
+
+  it("a pruned bundle is still a valid bundle", () => {
+    const b = trimBundle(
+      [
+        seg,
+        chunk(1000, "key"),
+        chunk(2500, "delta"),
+        chunk(3000, "key"),
+        chunk(4500, "delta"),
+        { kind: "canvas", t: 5500, sel: "#c", data: "end" },
+      ],
+      [{ fromMs: 2000, toMs: 4000 }],
+      6_000,
+    );
+    const out = pruneCutEvents(b);
+    expect(chunksOf(out)).toHaveLength(3);
+    expect(validateRecordingBundle(out).ok).toBe(true);
   });
 
   it("keeps an mcp that straddles the trim — its start anchor sits in the kept region", () => {
@@ -449,7 +590,7 @@ describe("pruneTrailingTrimEvents", () => {
       [{ fromMs: 4_000, toMs: 10_000 }],
       10_000,
     );
-    const out = pruneTrailingTrimEvents(b);
+    const out = pruneCutEvents(b);
     expect(out.recording.events).toContainEqual(straddle);
     expect(out.recording.events.map((e) => e.t)).toEqual([0, 5_000]);
   });
@@ -466,7 +607,7 @@ describe("pruneTrailingTrimEvents", () => {
       [{ fromMs: 500, toMs: 3000 }],
       2_000, // durationMs < 3000
     );
-    expect(pruneTrailingTrimEvents(b)).toBe(b);
+    expect(pruneCutEvents(b)).toBe(b);
   });
 });
 

--- a/platform/shared/app-recording.test.ts
+++ b/platform/shared/app-recording.test.ts
@@ -5,6 +5,8 @@ import {
   APPS_HACKATHON_OPENS_AT_MS,
   type AppRecordingBundle,
   connectedMcpServerNames,
+  exceedsFinalCutLimit,
+  formatDurationMs,
   healBundleMcpServers,
   isAppsHackathonOpen,
   normalizeCuts,
@@ -333,6 +335,49 @@ describe("normalizeCuts", () => {
         { fromMs: 2000, toMs: 3500 }, // bridges the 1000–2500 and 3000–4000 runs
       ]),
     ).toEqual([{ fromMs: 1000, toMs: 4000 }]);
+  });
+});
+
+describe("exceedsFinalCutLimit", () => {
+  // The paradox this exists to prevent: the gates compared raw float
+  // milliseconds while every message rendered m:ss, so the whole second above
+  // the limit was refused AND printed as exactly the limit — "This cut runs
+  // 1:00. Trim it to 1:00 or less to submit", a demand with nothing to do.
+  it("judges at the precision the limit is spoken at", () => {
+    expect(exceedsFinalCutLimit(59_999, 60_000)).toBe(false);
+    expect(exceedsFinalCutLimit(60_000, 60_000)).toBe(false);
+    // The band that used to be refused while displaying as the limit itself.
+    expect(exceedsFinalCutLimit(60_000.0001, 60_000)).toBe(false);
+    expect(exceedsFinalCutLimit(60_003.75, 60_000)).toBe(false);
+    expect(exceedsFinalCutLimit(60_999, 60_000)).toBe(false);
+    // A second over is a second the author can see, and can edit away.
+    expect(exceedsFinalCutLimit(61_000, 60_000)).toBe(true);
+  });
+
+  it("never refuses a duration that formats as the limit", () => {
+    const limit = 60_000;
+    const label = formatDurationMs(limit);
+    for (let ms = 59_000; ms <= 62_000; ms++) {
+      if (formatDurationMs(ms) === label) {
+        expect(exceedsFinalCutLimit(ms, limit)).toBe(false);
+      }
+    }
+  });
+
+  it("holds for a limit that is not a whole minute", () => {
+    expect(exceedsFinalCutLimit(30_400, 30_000)).toBe(false);
+    expect(exceedsFinalCutLimit(31_000, 30_000)).toBe(true);
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("floors to whole seconds as m:ss", () => {
+    expect(formatDurationMs(0)).toBe("0:00");
+    expect(formatDurationMs(59_999)).toBe("0:59");
+    expect(formatDurationMs(60_000)).toBe("1:00");
+    expect(formatDurationMs(60_999.9)).toBe("1:00");
+    expect(formatDurationMs(61_000)).toBe("1:01");
+    expect(formatDurationMs(603_000)).toBe("10:03");
   });
 });
 

--- a/platform/shared/app-recording.ts
+++ b/platform/shared/app-recording.ts
@@ -487,22 +487,44 @@ export const APP_RECORDING_RENDER_FPS = 24;
  * export's cost is its length. The editor asks for a short cut up front and the
  * submit/export buttons hold the line rather than starting work that outlives
  * anyone's patience.
+ *
+ * A minute is also the length that makes a full-motion canvas app submittable
+ * at all. The bundle stores video base64 inside its JSON and the upload
+ * base64-encodes that JSON again, so a byte of recorded video costs ~1.78
+ * bytes by the time api.github.com sees it: at the SDK's 1 Mbit/s governor
+ * ceiling a minute lands near 13MB on the wire, comfortably under the largest
+ * submission the gallery has actually accepted. Two minutes at the old
+ * 3 Mbit/s ceiling reached ~76MB and was refused outright.
  */
-export const APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS = 180_000;
+export const APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS = 60_000;
 
 /**
- * The largest recording bundle (its serialized JSON) the export surfaces
- * accept, shared by the video renderer and the gallery submission.
+ * How much longer than the final cut a capture may RUN, as a multiple of the
+ * configured limit.
  *
- * The number is GitHub's: the gallery submits the bundle as one file through
- * the contents API, which refuses files over 100MB — and refuses them as
- * opaque 5xx weather, not as a limit anyone can read. The renderer could
- * technically chew somewhat past this, but a bundle too big to share is
- * already broken for its purpose, and one ceiling with one honest message
- * beats two. Capture keeps real bundles far below it: the recording SDK's
- * byte-rate governor bounds video at ~4 Mbit/s across all streams, so even a
- * three-minute all-motion raw take stays around 90MB serialized, and a
- * typical 30s cut is ~20MB.
+ * Capture needs room the final cut does not: a participant records loosely and
+ * edits down, and a take that stops dead at the submittable length leaves them
+ * nothing to cut. It is bounded rather than open-ended because everything
+ * captured sits in the browser until it is edited.
+ *
+ * What makes the headroom safe is that cutting now shrinks the bundle:
+ * {@link pruneCutEvents} drops the video a cut removes, so a loose take edited
+ * to a minute ships like a minute — not like the take. Before that, headroom
+ * would only have produced recordings that could be edited but never uploaded.
+ */
+export const APP_RECORDING_CAPTURE_HEADROOM = 3;
+
+/**
+ * The largest recording bundle (its serialized JSON) the VIDEO RENDERER
+ * accepts — a backstop on what may be posted to our own render route, not a
+ * statement about what GitHub takes.
+ *
+ * The gallery submission is bounded separately and far more tightly, by what
+ * api.github.com accepts as a request body once base64 has had its way with
+ * the bundle. This one only has to keep a renderer from being handed
+ * something absurd: capture keeps real bundles orders of magnitude below it —
+ * the SDK's governor bounds video at 1 Mbit/s across all streams, so even a
+ * three-minute all-motion raw take stays near 30MB serialized.
  */
 export const APP_RECORDING_MAX_BUNDLE_BYTES = 100 * 1024 * 1024;
 
@@ -835,7 +857,7 @@ export function validateRecordingBundle(
 }
 
 // =============================================================================
-// Trailing-trim pruning — drop a cut-away tail from the bundle
+// Cut pruning — drop what an edit puts permanently out of view
 // =============================================================================
 
 type RecordingCut = NonNullable<AppRecordingBundle["edits"]>["cuts"][number];
@@ -872,6 +894,22 @@ export function normalizeCuts(cuts: RecordingCut[]): RecordingCut[] {
 }
 
 /**
+ * Drop what the recording's cuts put permanently out of view, so an edited
+ * recording ships — and renders — at the size of what it actually shows.
+ *
+ * A size optimization only: the result replays and renders identically to the
+ * original. Two passes, each lossless for its own reason — a trailing trim
+ * takes everything past it, and a mid cut takes the encoded video it hides
+ * (and only that). Neither touches timing, cuts, segments or transcript.
+ *
+ * Cutting really removing bytes is what lets capture run longer than the final
+ * cut may be: a loose take edited down to a minute ships like a minute.
+ */
+export function pruneCutEvents(bundle: AppRecordingBundle): AppRecordingBundle {
+  return pruneCutVideoChunks(pruneTrailingTrimEvents(bundle));
+}
+
+/**
  * Drop captured events that a trailing END trim removes, so a trimmed recording
  * ships — and renders — without its cut-away tail. A size optimization only: the
  * result replays and renders byte-for-byte the same as the original.
@@ -900,27 +938,14 @@ export function normalizeCuts(cuts: RecordingCut[]): RecordingCut[] {
  * case where data runs past the recorded duration and removal would move the
  * trim boundary itself.
  */
-export function pruneTrailingTrimEvents(
+function pruneTrailingTrimEvents(
   bundle: AppRecordingBundle,
 ): AppRecordingBundle {
   const cuts = bundle.edits?.cuts;
   if (!cuts || cuts.length === 0) return bundle;
 
-  const { events, segments, transcript, durationMs } = bundle.recording;
-
-  // The last moment of real data — mirrors buildPlayback's rawDataEnd, which
-  // starts at the recorded duration and grows to the furthest event, segment or
-  // message. A trailing trim is a cut that reaches this end.
-  const dataEndOf = (
-    keptEvents: AppRecordingBundle["recording"]["events"],
-  ): number => {
-    let end = Math.max(0, durationMs);
-    for (const event of keptEvents) end = Math.max(end, event.t);
-    for (const segment of segments) end = Math.max(end, segment.atMs);
-    for (const message of transcript) end = Math.max(end, message.atMs);
-    return end;
-  };
-  const rawDataEnd = dataEndOf(events);
+  const { events } = bundle.recording;
+  const rawDataEnd = dataEndOf(bundle.recording, events);
 
   const tail = normalizeCuts(cuts).find(
     (cut) =>
@@ -951,7 +976,105 @@ export function pruneTrailingTrimEvents(
   // Never let the pruned data end fall short of the original: that would move
   // the tail-trim boundary and change the replay. Holds whenever the recorded
   // duration already covers all the data (the normal case).
-  if (dataEndOf(kept) !== rawDataEnd) return bundle;
+  if (dataEndOf(bundle.recording, kept) !== rawDataEnd) return bundle;
 
   return { ...bundle, recording: { ...bundle.recording, events: kept } };
+}
+
+/**
+ * Drop the encoded video a MID cut hides — the one payload a cut can throw
+ * away without changing a single rendered frame.
+ *
+ * Mid cuts otherwise stay whole (see {@link pruneTrailingTrimEvents}): the
+ * player collapses a cut to one instant but still APPLIES the events inside
+ * it, because a DOM mutation or an input in there is what leaves the app in
+ * the state everything AFTER the cut plays from. Video is the exception. A
+ * stream's state lives in its decoder, and a decoder is rebuilt from a
+ * keyframe alone — so the frames a cut hides need not ship for the frames
+ * after it to decode to the same pixels.
+ *
+ * KEYFRAME-AWARE, which is the whole of the correctness argument: every kept
+ * run of chunks BEGINS with a keyframe. Per stream, the chunks in view are
+ * kept, then each run is extended backwards to the last keyframe at or before
+ * it, taking the deltas in between — usually chunks the cut hides, which is
+ * the point. Hand a decoder a keyframe and the deltas that follow and it
+ * produces exactly what the whole stream would have; hand it a delta whose
+ * predecessors were dropped and it produces nothing or garbage. Keyframes land
+ * on a fixed cadence, so that preamble costs at most one cadence per cut.
+ *
+ * Timing is untouched: only chunks strictly inside a cut are candidates, and
+ * playback collapses a cut to zero time, so nothing in there carries a
+ * timeline anchor — the same reason the trailing pass gives. `video-config`
+ * events are never candidates; they are a few hundred bytes and they are what
+ * opens the stream.
+ */
+function pruneCutVideoChunks(bundle: AppRecordingBundle): AppRecordingBundle {
+  const cuts = normalizeCuts(bundle.edits?.cuts ?? []);
+  if (cuts.length === 0) return bundle;
+
+  const { events } = bundle.recording;
+  // The trailing pass's boundary treatment exactly: a chunk sitting ON a cut's
+  // start still plays, one sitting on its end does not.
+  const hidden = (t: number) =>
+    cuts.some((cut) => cut.fromMs < t && t <= cut.toMs);
+
+  // Per stream, because chunk dependencies run within one canvas's stream and
+  // a keyframe in one says nothing about another.
+  const streams = new Map<string, { at: number; t: number; key: boolean }[]>();
+  events.forEach((event, at) => {
+    if (event.kind !== "video-chunk") return;
+    const chunk = { at, t: event.t, key: event.type === "key" };
+    const stream = streams.get(event.sel);
+    if (stream) stream.push(chunk);
+    else streams.set(event.sel, [chunk]);
+  });
+
+  const dropped = new Set<number>();
+  for (const chunks of streams.values()) {
+    const keep = new Set<number>();
+    chunks.forEach((chunk, i) => {
+      if (!hidden(chunk.t)) keep.add(i);
+    });
+    for (let i = 0; i < chunks.length; i++) {
+      // Only the FIRST chunk of each kept run needs a preamble — every later
+      // chunk in the run already has its predecessors in front of it.
+      if (!keep.has(i) || keep.has(i - 1)) continue;
+      let key = i;
+      while (key >= 0 && !chunks[key].key) key--;
+      // A run with no keyframe anywhere before it belongs to a stream that
+      // cannot be decoded from the middle at all — keep it whole rather than
+      // gamble on which of its chunks matter.
+      if (key < 0) key = 0;
+      for (let back = key; back < i; back++) keep.add(back);
+    }
+    chunks.forEach((chunk, i) => {
+      if (!keep.has(i)) dropped.add(chunk.at);
+    });
+  }
+  if (dropped.size === 0) return bundle;
+
+  const kept = events.filter((_, at) => !dropped.has(at));
+  // The same self-guard the trailing pass carries: a bundle whose data runs
+  // past its recorded duration could otherwise have its end moved by this,
+  // which would move the cut boundaries with it.
+  if (dataEndOf(bundle.recording, kept) !== dataEndOf(bundle.recording, events))
+    return bundle;
+
+  return { ...bundle, recording: { ...bundle.recording, events: kept } };
+}
+
+/**
+ * The last moment of real data — mirrors buildPlayback's rawDataEnd, which
+ * starts at the recorded duration and grows to the furthest event, segment or
+ * message. A trailing trim is a cut that reaches this end.
+ */
+function dataEndOf(
+  recording: AppRecordingBundle["recording"],
+  events: AppRecordingBundle["recording"]["events"],
+): number {
+  let end = Math.max(0, recording.durationMs);
+  for (const event of events) end = Math.max(end, event.t);
+  for (const segment of recording.segments) end = Math.max(end, segment.atMs);
+  for (const message of recording.transcript) end = Math.max(end, message.atMs);
+  return end;
 }

--- a/platform/shared/app-recording.ts
+++ b/platform/shared/app-recording.ts
@@ -499,6 +499,43 @@ export const APP_RECORDING_RENDER_FPS = 24;
 export const APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS = 60_000;
 
 /**
+ * A duration as every length surface says it out loud: `m:ss`, floored to the
+ * second. One implementation, because the limit is JUDGED at this precision
+ * too (see {@link exceedsFinalCutLimit}) and a formatter that disagreed with
+ * the check is exactly how a cut came to be refused for running "1:00" when
+ * the limit was "1:00".
+ */
+export function formatDurationMs(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  return `${Math.floor(totalSeconds / 60)}:${String(totalSeconds % 60).padStart(2, "0")}`;
+}
+
+/**
+ * Whether a final cut is over the limit — judged at the precision the limit is
+ * SPOKEN at, whole seconds, not raw float milliseconds.
+ *
+ * This is the whole of the fix for a paradox that reached participants: the
+ * gates compared floats while every message rendered `m:ss`, so the entire
+ * second above the limit was refused AND printed as exactly the limit. The
+ * tooltip read "This cut runs 1:00. Trim it to 1:00 or less to submit." — a
+ * demand with nothing to do — and the trim button beside it could be a no-op,
+ * because a fraction of a second is not something an author can edit away.
+ *
+ * Compared floored rather than rounded so the rule reads the way the number
+ * does: if it says 1:00 it is a minute, and a minute is allowed. The slack is
+ * at most one second of render, which costs ~24 frames.
+ *
+ * Every gate must use THIS — player, submission backstop, and the server's
+ * render route — or a cut passes one and is refused by the next.
+ */
+export function exceedsFinalCutLimit(
+  durationMs: number,
+  limitMs: number,
+): boolean {
+  return Math.floor(durationMs / 1000) > Math.floor(limitMs / 1000);
+}
+
+/**
  * How much longer than the final cut a capture may RUN, as a multiple of the
  * configured limit.
  *

--- a/platform/shared/app-recording.ts
+++ b/platform/shared/app-recording.ts
@@ -473,15 +473,22 @@ export const APP_RECORDING_RENDER_ROUTE = "/app-recording-render";
 export const APP_RECORDING_RENDER_FPS = 24;
 
 /**
- * The longest final cut that can be exported to video.
+ * The DEFAULT longest final cut a recording may be submitted or exported at.
  *
- * Every frame costs about the same to render, so the export's cost is its
- * length: half a minute of video is already a minute of rendering. The limit is
- * as much editorial as technical — a session demo that runs longer than this
- * stops being a demo — so the editor asks for it up front and the export button
- * holds the line rather than starting a render that outlives anyone's patience.
+ * A deployment overrides it with `ARCHESTRA_HACKATHON_RECORDER_MAX_FINAL_CUT_MS`
+ * — this constant is the fallback and the shape of the bound, never the
+ * authority. Read the resolved value from the config (`hackathonMaxFinalCutMs`
+ * on the frontend, `config.hackathonRecorder.maxFinalCutMs` on the backend), so
+ * every surface that quotes a number to the author quotes the SAME number the
+ * checks enforce.
+ *
+ * The limit is as much editorial as technical: a session demo that runs long
+ * stops being a demo, and every frame costs about the same to render, so an
+ * export's cost is its length. The editor asks for a short cut up front and the
+ * submit/export buttons hold the line rather than starting work that outlives
+ * anyone's patience.
  */
-export const APP_RECORDING_MAX_EXPORT_MS = 30_000;
+export const APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS = 180_000;
 
 /**
  * The largest recording bundle (its serialized JSON) the export surfaces

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -30981,6 +30981,8 @@ export type GetConfigResponses = {
             kbAutoSyncPermissionsEnabled: boolean;
             hackathonRecorderEnabled: boolean;
             hackathonRecorderOverrideActive: boolean;
+            hackathonVideoDownloadEnabled: boolean;
+            hackathonMaxFinalCutMs: number;
             hackathonGalleryRepo: {
                 owner: string;
                 name: string;


### PR DESCRIPTION
Started as two operator controls and grew into the submission-size and
timeline-correctness work that came out of testing them.

## Two controls

- `ARCHESTRA_HACKATHON_RECORDER_VIDEO_DOWNLOAD_ENABLED` — hides the video
  download button, **off by default**. Gated server-side too, so the render
  routes refuse when it is off rather than only hiding the button.
- `ARCHESTRA_HACKATHON_RECORDER_MAX_FINAL_CUT_MS` — the final-cut length limit,
  threaded through every surface that quotes it: the over-length checks, the
  submit gate, the "trim to length" pill and timeline mark, and the tour.

**The default final cut is now one minute** (was three). That is what makes a
full-motion canvas app submittable: video is base64 inside the bundle JSON and
the upload base64-encodes that JSON again, so a byte of recorded video costs
~1.78 bytes by the time GitHub sees it.

## Cutting now removes bytes

Trimming used to be presentation only — a cut hid frames but the bundle still
carried them, so a three-minute take edited to thirty seconds uploaded like a
three-minute take. `pruneCutEvents` drops the video a mid cut hides,
**keyframe-aware**: per stream, the chunks in view are kept and each run is
extended back to the last keyframe at or before it. Every kept run therefore
opens on a keyframe, which is the whole correctness argument — a keyframe plus
its deltas decodes to exactly what the full stream would have.

Measured on a three-minute capture edited to a minute: **31.6MB → 10.5MB**, 33%
of the bytes. Capture gets 3x headroom now that editing is worth something.

Nothing is needed on the consumer side: the gallery validator and the website
player see a bundle with fewer events, which was always legal, and old bundles
are untouched. Pruning happens on the way OUT, never to what is stored, so cuts
stay editable locally.

## Timeline fixes found while testing this

**A cut cost real playback time.** Every assistant reply inside a cut still
reserved its reveal (up to 1.2s each), so resuming inside a fresh cut crawled
through the removed stretch, and a minute of kept material reported as 1:03. A
removed reply now buys no time and arrives already sent. A reply said *before*
the cut still holds — trimming the pause after a long answer cannot un-draw the
answer. Ported to the website's vendored playback in
archestra-ai/archestra-website#605, so the gallery replay and the editor preview
agree on what a cut costs.

**"This cut runs 1:00. Trim it to 1:00 or less to submit."** Every gate compared
raw float milliseconds while every message rendered `m:ss`, so the whole second
above the limit was refused *and* printed as exactly the limit. Reproduced at
60003.75ms, byte-identical to the reported screenshot. `exceedsFinalCutLimit`
now judges at the precision the limit is spoken at, shared by all four gates —
player, submission backstop, trim bisection, and the server's render route,
which had been rounding differently and could refuse a cut the UI had cleared.

**The trim button could be a no-op.** `trimCutsToExportLimit` returned null
before its bisection ran whenever the limit instant rounded onto the raw end —
reachable because a closing reply's reveal is charged against however many raw
milliseconds remain, so the final span can carry seconds of playback in one
millisecond of recording. Both affordances swallow null silently, so the author
got a warning, a dead pill and a dead limit mark. Measured across 222 natural
in-band recordings: 3 hit it.

## Submission size

The gate is GitHub's strictest endpoint ceiling, 50MB, and deliberately not
tighter — an earlier revision derived 34MB by stacking a base64 correction on an
assumed request-body limit and refused a 41MB recording GitHub would have taken.
Capture stays at the 3 Mbit/s governor: at one minute a worst-case all-motion
cut is ~29MB as a bundle and ~38MB on the wire, inside 50MB either way.

The upload also went to the Git Data API mid-branch and came back: the endpoint
was never the problem (a 57MB bundle is refused by both paths). Its retry for
transient refusals — "Timed out validating rule" — stayed, with tests.

## Verification

type-check, lint and knip clean; shared 583, frontend recording 186, backend
529. New coverage: the pruner's keyframe invariant and playback identity, the
cut-cost and resume-position cases, the limit predicate across the contradiction
band, and the trim clamp. Four pre-existing trim assertions compared raw
milliseconds against the limit — right under the old rule, wrong under this one;
they now assert what the gate itself decides.

## Open

- The gallery and the editor disagree about chat inside a cut: the gallery drops
  a removed reply from the replay, the platform keeps it (settled). Timing now
  matches; this does not. Pre-existing, and a product call.
- Whether GitHub's 50MB applies to the decoded file or the request body. It does
  not bind anything shipping here (new recordings top out near 10MB), but it
  decides the fate of a pre-existing 37-50MB bundle.
