### PR TITLE
test(models): pin Amazon `-vN` model ids as distinct

### DIFF
--- a/platform/backend/src/services/cross-provider-pricing.test.ts
+++ b/platform/backend/src/services/cross-provider-pricing.test.ts
@@ -64,6 +64,20 @@ const MODELS_DEV: ModelsDevApiResponse = {
         name: "Claude Sonnet 4.5 (Bedrock)",
         cost: { input: 3, output: 15 },
       },
+      // Two generations of one Amazon model, distinguished only by the `-vN`
+      // segment, priced five times apart. Amazon ids carry that segment as part
+      // of the model's identity rather than as a Bedrock version, so collapsing
+      // it would merge these two entries onto one key.
+      "amazon.titan-embed-text-v1": {
+        id: "amazon.titan-embed-text-v1",
+        name: "Titan Embeddings G1 Text",
+        cost: { input: 0.1, output: 0 },
+      },
+      "amazon.titan-embed-text-v2:0": {
+        id: "amazon.titan-embed-text-v2:0",
+        name: "Titan Text Embeddings V2",
+        cost: { input: 0.02, output: 0 },
+      },
     },
   },
 };
@@ -183,6 +197,26 @@ describe("resolveCrossProviderPrices — Bedrock", () => {
     // canonical anthropic entry must win so cache prices are recovered.
     expect(prices?.cacheReadPricePerToken).toBe("3e-7");
     expect(prices?.cacheWritePricePerToken).toBe("0.00000375");
+  });
+
+  // The version-stripping that canonicalises `…-v1:0` to `…` is correct for
+  // every vendor mapped to a canonical registry entry, where `-vN` is a Bedrock
+  // version. Amazon is not one of those vendors, and its `-vN` is part of the
+  // model name — so these two ids must keep resolving to their own entries.
+  test("keeps two Amazon generations that differ only by `-vN` distinct", () => {
+    const v1 = resolveCrossProviderPrices({
+      provider: "bedrock",
+      modelId: "amazon.titan-embed-text-v1",
+      modelsDevData: MODELS_DEV,
+    });
+    const v2 = resolveCrossProviderPrices({
+      provider: "bedrock",
+      modelId: "amazon.titan-embed-text-v2:0",
+      modelsDevData: MODELS_DEV,
+    });
+
+    expect(v1?.promptPricePerToken).toBe("1e-7");
+    expect(v2?.promptPricePerToken).toBe("2e-8");
   });
 
   test("returns null for an unknown vendor", () => {


### PR DESCRIPTION
Bedrock ids ending in `-vN:N` are canonicalised by stripping the whole `-vN:N` segment. That is right for every vendor mapped to a canonical registry entry — there `-v1:0` is a Bedrock version and the registry keys the model without it, so `claude-sonnet-4-5-20250929-v1:0` has to become `claude-sonnet-4-5-20250929` to match.

Amazon is not one of those vendors. In its ids the `-vN` is part of the model name: `amazon.titan-embed-text-v1` and `amazon.titan-embed-text-v2:0` are different models priced five times apart ($0.10/M against $0.02/M). Applying the same canonicalisation to them would merge two models onto one key and price one of them as the other.

Nothing goes wrong today, because Amazon ids reach only the `amazon-bedrock` lookup, which keeps the version suffix. What is missing is anything that holds that in place. Every existing case covers a vendor whose `-vN` genuinely is a version, so all of them still pass if the two Amazon generations collapse onto one entry — the assumption is load-bearing and unguarded.

This pins the pair to their own prices. It fails if the version-stripping is extended to the `amazon-bedrock` lookup, and it fails if `amazon` is added to the canonical vendor map without accounting for its naming — the likely next step for anyone reaching Amazon's own models through a vendor entry.

No production code changes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>