### PR TITLE
fix(apps): stop reporting unshared apps as deleted, and warn before sharing a chat that renders them

### DIFF
--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -3,7 +3,7 @@ title: MCP Apps
 category: Apps
 order: 1
 description: User-authored MCP Apps — sandboxed HTML interfaces with their own data store and tools
-lastUpdated: 2026-07-14
+lastUpdated: 2026-07-28
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -25,6 +25,8 @@ Authoring is a staged flow — each tool's result points at the next step:
 Editing the HTML forks a new immutable version, and the head version is served when the app runs. The procedure and the SDK conventions live in the built-in **build-app** skill, not in the tool descriptions, so the model loads them on demand.
 
 Run or author an app at `/a/:id` (no chat chrome, no sidebar), or run it from chat: a successful `scaffold_app`, `edit_app`, or `render_app` call renders the app inline in the conversation. All surfaces drive the same app-bound runtime, so behavior is identical. Because every owned app is backed by its own MCP server, its server settings — visibility (sharing), environment, assigned tools, and deletion — are managed from its card in the [MCP registry](./platform-mcp), not the authoring page.
+
+Sharing a chat does not share the apps it renders. Each viewer resolves an app against that app's own visibility. An app you have not shared with someone shows an access message in their view — a personal app in a chat you shared, for example. Change who can use the app from its settings.
 
 The `/apps` gallery lists everything the viewer can reach in two sections: apps you own, and the interactive apps exposed by your installed external [MCP servers](./platform-mcp). Each `ui://` resource is its own card, titled by the server's display name (*Task Tracker*); when one server exposes several UIs, the title carries the tool — *Task Tracker / show_board*. A card opens the app in a new chat. That chat stays out of your conversation list until you write into it. An owned card carries **Open in new tab** and **Delete** in its overflow menu; an external card carries **Open in new tab** (the standalone runtime) and a link to the backing **MCP server** page (where the server — and its uninstall — lives).
 

--- a/platform/frontend/src/app/a/[appId]/page.client.tsx
+++ b/platform/frontend/src/app/a/[appId]/page.client.tsx
@@ -34,7 +34,8 @@ export default function AppRunPage({ appId }: { appId: string }) {
   if (!app) {
     return isPending ? null : (
       <output className="flex h-app-viewport items-center justify-center p-8 text-center text-sm text-muted-foreground">
-        This app does not exist or you do not have access to it.
+        This app does not exist, or it is not shared with you. If you expected
+        to see it, ask its owner to share it with your team or organization.
       </output>
     );
   }

--- a/platform/frontend/src/app/chat/page.tsx
+++ b/platform/frontend/src/app/chat/page.tsx
@@ -1287,6 +1287,15 @@ export function ChatPageContent({
     earlyToolUiStarts: chatSession?.earlyToolUiStarts ?? {},
     filterDeleted: true,
   });
+  // The owned apps this conversation renders. Sharing a chat does not share
+  // them, so the share dialog uses this to warn when recipients won't be able
+  // to open one.
+  const conversationOwnedAppIds = useMemo(
+    () => [
+      ...new Set(mcpApps.flatMap((app) => (app.appId ? [app.appId] : []))),
+    ],
+    [mcpApps],
+  );
   // The app currently open in the chat, reported to the backend on each user
   // message so it can restate that app's context in the turn's system prompt.
   // The backend re-resolves the id under the caller's own access, so this is a
@@ -3427,6 +3436,7 @@ export function ChatPageContent({
         {canManageShare && conversationId && (
           <ShareConversationDialog
             conversationId={conversationId}
+            appIds={conversationOwnedAppIds}
             open={isShareDialogOpen}
             onOpenChange={setIsShareDialogOpen}
           />

--- a/platform/frontend/src/components/chat/conversation-app-access-notice.test.tsx
+++ b/platform/frontend/src/components/chat/conversation-app-access-notice.test.tsx
@@ -1,0 +1,192 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConversationAppAccessNotice } from "./conversation-app-access-notice";
+
+type StubApp = {
+  id: string;
+  name: string;
+  scope: "personal" | "team" | "org";
+  enabled: boolean;
+  teams: Array<{ id: string; name: string }>;
+};
+
+let appsById: Record<string, StubApp> = {};
+
+// Hoisted so the `vi.mock` factory below (which is lifted above these
+// declarations) can close over it; the implementation is attached in beforeEach,
+// by which point `appsById` exists.
+const mockGetApp = vi.hoisted(() => vi.fn());
+
+vi.mock("@archestra/shared", async () => {
+  const actual =
+    await vi.importActual<typeof import("@archestra/shared")>(
+      "@archestra/shared",
+    );
+  return {
+    ...actual,
+    archestraApiSdk: { ...actual.archestraApiSdk, getApp: mockGetApp },
+  };
+});
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+function makeApp(overrides: Partial<StubApp> & { id: string }): StubApp {
+  return {
+    name: `App ${overrides.id}`,
+    scope: "personal",
+    enabled: true,
+    teams: [],
+    ...overrides,
+  };
+}
+
+function renderNotice(props: {
+  appIds: string[];
+  visibility: "private" | "organization" | "team" | "user";
+  teamIds?: string[];
+}) {
+  return render(
+    <ConversationAppAccessNotice
+      appIds={props.appIds}
+      visibility={props.visibility}
+      teamIds={props.teamIds ?? []}
+    />,
+    { wrapper: createWrapper() },
+  );
+}
+
+/** The warning headline, whichever singular/plural form it took. */
+const warning = () => screen.queryByText(/won't open for everyone/i);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appsById = {};
+  mockGetApp.mockImplementation(
+    async ({ path }: { path: { appId: string } }) => {
+      const app = appsById[path.appId];
+      return app
+        ? { data: app, error: undefined }
+        : { data: undefined, error: { type: "api_not_found_error" } };
+    },
+  );
+});
+
+describe("ConversationAppAccessNotice", () => {
+  it("warns that a personal app in the chat won't open for recipients", async () => {
+    appsById.a = makeApp({ id: "a", name: "Ad Spend", scope: "personal" });
+
+    renderNotice({ appIds: ["a"], visibility: "user" });
+
+    await waitFor(() => expect(warning()).toBeInTheDocument());
+    expect(screen.getByText("Ad Spend")).toBeInTheDocument();
+    // The point of the warning: these are two separate grants.
+    expect(
+      screen.getByText(/sharing a chat doesn't share the apps inside it/i),
+    ).toBeInTheDocument();
+  });
+
+  it("stays silent for an org-scoped app, which every recipient can already open", async () => {
+    appsById.a = makeApp({ id: "a", scope: "org" });
+
+    renderNotice({ appIds: ["a"], visibility: "organization" });
+
+    await waitFor(() => expect(mockGetApp).toHaveBeenCalled());
+    expect(warning()).not.toBeInTheDocument();
+  });
+
+  it("stays silent while the chat is still private", async () => {
+    appsById.a = makeApp({ id: "a", scope: "personal" });
+
+    renderNotice({ appIds: ["a"], visibility: "private" });
+
+    expect(warning()).not.toBeInTheDocument();
+  });
+
+  it("stays silent for a team app shared with exactly the teams that hold it", async () => {
+    appsById.a = makeApp({
+      id: "a",
+      scope: "team",
+      teams: [{ id: "team-1", name: "Design" }],
+    });
+
+    renderNotice({
+      appIds: ["a"],
+      visibility: "team",
+      teamIds: ["team-1"],
+    });
+
+    await waitFor(() => expect(mockGetApp).toHaveBeenCalled());
+    expect(warning()).not.toBeInTheDocument();
+  });
+
+  it("warns when a team share reaches past the teams holding the app", async () => {
+    appsById.a = makeApp({
+      id: "a",
+      name: "Design Tool",
+      scope: "team",
+      teams: [{ id: "team-1", name: "Design" }],
+    });
+
+    renderNotice({
+      appIds: ["a"],
+      visibility: "team",
+      teamIds: ["team-1", "team-2"],
+    });
+
+    await waitFor(() => expect(warning()).toBeInTheDocument());
+    expect(screen.getByText("Design Tool")).toBeInTheDocument();
+  });
+
+  it("warns for a team app shared with individual users, who need not be on that team", async () => {
+    appsById.a = makeApp({
+      id: "a",
+      scope: "team",
+      teams: [{ id: "team-1", name: "Design" }],
+    });
+
+    renderNotice({ appIds: ["a"], visibility: "user" });
+
+    await waitFor(() => expect(warning()).toBeInTheDocument());
+  });
+
+  it("warns about a disabled app, which is author-only whatever its scope", async () => {
+    appsById.a = makeApp({
+      id: "a",
+      name: "Paused",
+      scope: "org",
+      enabled: false,
+    });
+
+    renderNotice({ appIds: ["a"], visibility: "organization" });
+
+    await waitFor(() => expect(warning()).toBeInTheDocument());
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+  });
+
+  it("names only the apps recipients cannot open", async () => {
+    appsById.a = makeApp({ id: "a", name: "Private One", scope: "personal" });
+    appsById.b = makeApp({ id: "b", name: "Shared One", scope: "org" });
+
+    renderNotice({ appIds: ["a", "b"], visibility: "organization" });
+
+    await waitFor(() => expect(warning()).toBeInTheDocument());
+    expect(screen.getByText("Private One")).toBeInTheDocument();
+    expect(screen.queryByText("Shared One")).not.toBeInTheDocument();
+  });
+
+  it("says nothing about an app the sharer cannot read, rather than guessing", async () => {
+    renderNotice({ appIds: ["gone"], visibility: "organization" });
+
+    await waitFor(() => expect(mockGetApp).toHaveBeenCalled());
+    expect(warning()).not.toBeInTheDocument();
+  });
+});

--- a/platform/frontend/src/components/chat/conversation-app-access-notice.tsx
+++ b/platform/frontend/src/components/chat/conversation-app-access-notice.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { archestraApiSdk } from "@archestra/shared";
+import { useQueries } from "@tanstack/react-query";
+import { TriangleAlert } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { throwOnApiError } from "@/lib/utils";
+
+const { getApp } = archestraApiSdk;
+
+/**
+ * Warns that the conversation being shared renders apps its recipients will not
+ * be able to open.
+ *
+ * Chat sharing and app access are separate grants: a shared conversation carries
+ * only the app's id, and every viewer re-resolves it against the app's own
+ * visibility. Sharing a chat therefore never shares the apps inside it — and
+ * apps created from chat are personal by default, so the most natural flow
+ * (build an app in a chat, then share that chat) is exactly the one that breaks.
+ * Without this the sharer finds out only when the recipient reports a dead tile.
+ *
+ * Deliberately a warning rather than a "share these too" button: apps have no
+ * per-user grant, so the only one-click fix available would widen the app to a
+ * whole team or organization — much further than the chat share the user is
+ * making. Naming the apps and pointing at their settings keeps that decision
+ * explicit.
+ */
+export function ConversationAppAccessNotice({
+  appIds,
+  visibility,
+  teamIds,
+}: {
+  /** Owned apps rendered in this conversation. */
+  appIds: string[];
+  /** Visibility about to be saved. */
+  visibility: "private" | "organization" | "team" | "user";
+  /** Teams selected for a team share; ignored for other visibilities. */
+  teamIds: string[];
+}) {
+  // Same `["apps", id]` key the chat already populates, so this reads the cache
+  // rather than issuing fresh requests. An app the sharer cannot read resolves
+  // to null and is skipped — better silent than a warning we cannot substantiate.
+  const queries = useQueries({
+    queries: appIds.map((appId) => ({
+      queryKey: ["apps", appId],
+      queryFn: async () => {
+        const { data, error } = await getApp({ path: { appId } });
+        throwOnApiError(error, { allowNotFound: true, toastOnError: false });
+        return data ?? null;
+      },
+    })),
+  });
+
+  // Small lists (a conversation holds a handful of apps at most), so this runs
+  // inline rather than behind a memo whose deps would be a fresh array anyway.
+  const blockedNames: string[] = [];
+  for (const query of queries) {
+    const app = query.data;
+    if (!app) continue;
+    if (isReachableByRecipients({ app, visibility, teamIds })) continue;
+    if (!blockedNames.includes(app.name)) blockedNames.push(app.name);
+  }
+
+  if (visibility === "private" || blockedNames.length === 0) {
+    return null;
+  }
+
+  const plural = blockedNames.length > 1;
+  return (
+    <Alert variant="warning">
+      <TriangleAlert />
+      <AlertTitle>
+        {plural ? "Some apps in this chat" : "An app in this chat"} won&apos;t
+        open for everyone
+      </AlertTitle>
+      <AlertDescription>
+        <p>
+          Sharing a chat doesn&apos;t share the apps inside it.{" "}
+          <span className="font-medium">{blockedNames.join(", ")}</span>{" "}
+          {plural ? "are" : "is"} not available to everyone you&apos;re sharing
+          with, so they&apos;ll see an access message where the{" "}
+          {plural ? "apps" : "app"} should be.
+        </p>
+        <p>
+          To change that, open the {plural ? "apps" : "app"} and adjust who can
+          use {plural ? "them" : "it"} in App settings.
+        </p>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+/** Whether every recipient of this share can already open the app. */
+function isReachableByRecipients({
+  app,
+  visibility,
+  teamIds,
+}: {
+  app: { scope: string; enabled: boolean; teams: Array<{ id: string }> };
+  visibility: "private" | "organization" | "team" | "user";
+  teamIds: string[];
+}): boolean {
+  // A disabled app is author-only whatever its scope, so no recipient can open it.
+  if (!app.enabled) return false;
+  if (app.scope === "org") return true;
+  // Personal apps are reachable by their author alone — never by a recipient.
+  if (app.scope !== "team") return false;
+  // A team app is safe only when the share cannot reach past the teams that
+  // hold it, which is true only for a team share into those same teams.
+  if (visibility !== "team" || teamIds.length === 0) return false;
+  const appTeamIds = new Set(app.teams.map((team) => team.id));
+  return teamIds.every((teamId) => appTeamIds.has(teamId));
+}

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mock heavy dependencies before module import ─────────────────────────────
@@ -1329,6 +1329,39 @@ describe("McpAppSection unavailable owned app", () => {
     expect(
       screen.queryByText(/isn't available to you/i),
     ).not.toBeInTheDocument();
+    expect(document.querySelector("iframe")).not.toBeInTheDocument();
+  });
+
+  it("still shows the message while the right panel is hosting apps", async () => {
+    // A live render defers to the panel whenever there is a portal target. An
+    // unavailable app must not: it is filtered out of the panel's list, so
+    // deferring renders it nowhere and the pill is left explaining nothing.
+    function OpenPanel() {
+      const { setPortalTarget } = useApps();
+      useEffect(() => {
+        setPortalTarget(document.createElement("div"));
+      }, [setPortalTarget]);
+      return null;
+    }
+
+    await act(async () => {
+      render(
+        <AppsProvider apps={[]}>
+          <OpenPanel />
+          <McpAppSection
+            {...defaultProps}
+            appId={APP_ID}
+            appName="Dashboard"
+            toolCallId="tc1"
+            preloadedResource={preloadedResource}
+          />
+        </AppsProvider>,
+      );
+    });
+
+    expect(
+      screen.getByText(/Dashboard isn't available to you/i),
+    ).toBeInTheDocument();
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -1277,13 +1277,15 @@ describe("McpAppSection unavailable owned app", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // A settled 404: the app was deleted or access was lost.
+    // A settled 404 — the single answer the API gives both for a deleted app
+    // and for a healthy one the viewer holds no grant for. It does not tell the
+    // two apart, so neither may the message.
     mockUseApp.mockReturnValue({ data: null, isSuccess: true } as ReturnType<
       typeof useApp
     >);
   });
 
-  it("shows the error message while expanded and never mounts the runtime", async () => {
+  it("says the app is unavailable without claiming it was deleted, and never mounts the runtime", async () => {
     const user = userEvent.setup();
 
     await act(async () => {
@@ -1303,14 +1305,30 @@ describe("McpAppSection unavailable owned app", () => {
     // Apps default open, so the unavailable message shows immediately — but
     // the runtime never mounts (it would 404).
     const pill = screen.getByRole("button", { name: "Dashboard" });
-    expect(screen.getByText(/no longer available/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Dashboard isn't available to you/i),
+    ).toBeInTheDocument();
+    // The regression this guards: a healthy app that is merely not shared with
+    // the viewer — the ordinary case, since apps built in chat are personal and
+    // sharing a chat never shares them — was reported as gone, sending people
+    // after a fault that does not exist.
+    expect(screen.queryByText(/no longer available/i)).not.toBeInTheDocument();
+    // Instead it names the likely cause and the one action that resolves it.
+    expect(
+      screen.getByText(/sharing a chat doesn't share the apps inside it/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/ask its owner to share it with your team/i),
+    ).toBeInTheDocument();
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
 
     // Collapsing via the pill hides the message like any other app content.
     await act(async () => {
       await user.click(pill);
     });
-    expect(screen.queryByText(/no longer available/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/isn't available to you/i),
+    ).not.toBeInTheDocument();
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
   });
 });

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -343,6 +343,12 @@ export function McpAppEntryContent({
     !isPanelSurface &&
     !portalTarget &&
     (standalone || (!!toolCallId && isAppOpen(toolCallId)));
+  // The unavailable placeholder does not defer to the panel the way a live
+  // render does. An app that won't mount is dropped from the panel's list, so
+  // deferring would render it nowhere at all — leaving a pill that explains
+  // nothing, which is worse than the wrong message this replaced.
+  const showUnavailableInline =
+    !isPanelSurface && (standalone || (!!toolCallId && isAppOpen(toolCallId)));
 
   // Reconstruct McpCallToolResult for AppFrame. Owned apps get none — the
   // management tool's result is not app data.
@@ -406,7 +412,7 @@ export function McpAppEntryContent({
   // give the one action that resolves the likely one. Styled neutrally for the
   // same reason: not knowing which case this is, it should not look like a fault.
   if (ownedAppUnavailable) {
-    if (!expandedInline) return null;
+    if (!showUnavailableInline) return null;
     return (
       <div className="mt-2 flex w-full flex-col items-start gap-2">
         <div className="rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -217,8 +217,7 @@ export function McpAppEntryPill({
   } = useApps();
   // Owned apps can be renamed from settings; read the live app so the label
   // stays in sync after an edit (the appName prop is captured at render time).
-  const { data: ownedApp, isSuccess: ownedAppResolved } = useApp(appId ?? null);
-  const ownedAppUnavailable = !!appId && ownedAppResolved && ownedApp === null;
+  const { data: ownedApp } = useApp(appId ?? null);
   const headerName = ownedApp?.name || appName || mcpToolLabel(toolName);
 
   const standalone = !toolCallId;
@@ -238,13 +237,16 @@ export function McpAppEntryPill({
     ? (diagnosticCounts.get(appId)?.errors ?? 0) > 0
     : false;
 
+  // Note the dot tracks runtime errors only. An app that won't mount is most
+  // often one the viewer simply holds no grant for — a permission state, not a
+  // fault — and the expanded render says so, so it earns no red dot here.
   return (
     <McpAppPill
       label={headerName}
       icon={icon}
       state={state}
       pressed={pressed}
-      hasError={hasRuntimeError || ownedAppUnavailable}
+      hasError={hasRuntimeError}
       onClick={() => {
         onClick?.();
         if (!toolCallId) return;
@@ -324,9 +326,12 @@ export function McpAppEntryContent({
   // render time) and to seed the settings dialog.
   const inlineHeightCap = useInlineHeightCap();
   const { data: ownedApp, isSuccess: ownedAppResolved } = useApp(appId ?? null);
-  // A deleted (or no-longer-accessible) owned app: the fetch settled but
-  // `allowNotFound` turned the 404 into a successful `null`. Render a graceful
-  // placeholder instead of mounting the runtime, which would 404 again.
+  // An owned app this viewer cannot mount, which happens for two very different
+  // reasons the API deliberately does not tell apart: the app was deleted, or it
+  // is perfectly healthy and simply not theirs to open (the ordinary case for a
+  // personal app inside a conversation someone shared with them). Both arrive as
+  // a 404 that `allowNotFound` turns into a successful `null`. Render the
+  // placeholder rather than mounting the runtime, which would only fail alike.
   const ownedAppUnavailable = !!appId && ownedAppResolved && ownedApp === null;
 
   const headerName = ownedApp?.name || appName || mcpToolLabel(toolName);
@@ -392,16 +397,28 @@ export function McpAppEntryContent({
     ) : null;
   }
 
-  // A deleted (or no-longer-accessible) owned app: it's already dropped from the
-  // panel, so this only shows in the chat stream. Its pill carries a red error
-  // dot; while expanded, show the unavailable message styled as an error instead
-  // of mounting the runtime (which would 404).
+  // An owned app that cannot be mounted: it's already dropped from the panel, so
+  // this only shows in the chat stream. The message must not claim the app was
+  // deleted — the far more common cause is a viewer with no grant for it, since
+  // apps built in chat are personal by default and sharing a chat never shares
+  // the apps inside it. Saying "no longer available" about a healthy app sent
+  // people hunting for a fault that isn't there, so name both possibilities and
+  // give the one action that resolves the likely one. Styled neutrally for the
+  // same reason: not knowing which case this is, it should not look like a fault.
   if (ownedAppUnavailable) {
     if (!expandedInline) return null;
     return (
       <div className="mt-2 flex w-full flex-col items-start gap-2">
-        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
-          {headerName} app is no longer available
+        <div className="rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">
+            {headerName} isn&apos;t available to you
+          </p>
+          <p className="mt-1">
+            It may have been deleted, or it may not be shared with you. Sharing
+            a chat doesn&apos;t share the apps inside it — if you expected to
+            see this one, ask its owner to share it with your team or
+            organization.
+          </p>
         </div>
       </div>
     );

--- a/platform/frontend/src/components/chat/share-conversation-dialog.test.tsx
+++ b/platform/frontend/src/components/chat/share-conversation-dialog.test.tsx
@@ -1,6 +1,7 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSession } from "@/lib/auth/auth.query";
@@ -104,6 +105,19 @@ vi.mock("@/components/visibility-selector", () => ({
   ),
 }));
 
+/**
+ * The dialog embeds the app-access notice, which reads the apps cache, so every
+ * render needs a query client even when the test is only about visibility.
+ */
+function renderDialog(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
 describe("ShareConversationDialog", () => {
   beforeEach(() => {
     vi.mocked(useSession).mockReturnValue({
@@ -145,7 +159,7 @@ describe("ShareConversationDialog", () => {
   it("shares a conversation with selected teams", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderDialog(
       <ShareConversationDialog
         conversationId="conv-1"
         open
@@ -176,7 +190,7 @@ describe("ShareConversationDialog", () => {
       configurable: true,
     });
 
-    render(
+    renderDialog(
       <ShareConversationDialog
         conversationId="conv-1"
         open
@@ -216,7 +230,7 @@ describe("ShareConversationDialog", () => {
       isLoading: false,
     });
 
-    render(
+    renderDialog(
       <ShareConversationDialog
         conversationId="conv-1"
         open

--- a/platform/frontend/src/components/chat/share-conversation-dialog.tsx
+++ b/platform/frontend/src/components/chat/share-conversation-dialog.tsx
@@ -4,6 +4,7 @@ import type { archestraApiTypes } from "@archestra/shared";
 import { Globe, Lock, UserRound, Users } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ConversationAppAccessNotice } from "@/components/chat/conversation-app-access-notice";
 import { CopyableCode } from "@/components/copyable-code";
 import { FormDialog } from "@/components/form-dialog";
 import { AssignmentCombobox } from "@/components/ui/assignment-combobox";
@@ -32,10 +33,16 @@ type ShareVisibility =
 
 export function ShareConversationDialog({
   conversationId,
+  appIds = [],
   open,
   onOpenChange,
 }: {
   conversationId: string;
+  /**
+   * Owned apps rendered in this conversation. Sharing the chat does not share
+   * them, so the dialog warns when recipients won't be able to open one.
+   */
+  appIds?: string[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -260,6 +267,12 @@ export function ShareConversationDialog({
             </div>
           )}
         </VisibilitySelector>
+
+        <ConversationAppAccessNotice
+          appIds={appIds}
+          visibility={visibility}
+          teamIds={teamIds}
+        />
 
         {hasVisibleShareLink && shareLink && (
           <CopyableCode


### PR DESCRIPTION
Follow-up: **#6918** adds per-user app sharing, which turns this PR's warning from a dead end into something actionable.

## Problem

An app rendered in a chat is persisted as an **id only** — the message carries no HTML and no grant. Every viewer re-resolves it against that app's own visibility, which means **chat sharing and app access are separate grants: sharing a chat never shares the apps inside it.**

That is defensible, but two things made it land badly:

1. **The chat placeholder claimed deletion.** A recipient with no grant got `<name> app is no longer available`, in destructive-red, with a red error dot on the pill. The app is usually alive and simply unshared — and since apps built in chat are **personal by default**, "build an app in a chat, then share the chat" is precisely the case that broke. The message sent people hunting a fault that did not exist.
2. **Nothing warned the person sharing.** The sharer got no signal that recipients would hit a dead tile.

## What changed

**Honest placeholder.** `GET /api/apps/:appId` answers 404 both for a deleted app and for one the caller cannot reach, and deliberately does not distinguish them (the app runtime blends the same two cases behind a single 403). So the placeholder no longer asserts either — it names both possibilities and gives the action that resolves the likely one:

> **Ad Spend Dashboard isn't available to you**
> It may have been deleted, or it may not be shared with you. Sharing a chat doesn't share the apps inside it — if you expected to see this one, ask its owner to share it with your team or organization.

Styled neutrally, and no longer driving the pill's red error dot: a missing grant is a permission state, not a fault. The standalone `/a/:id` page gets the same treatment.

It also renders **while the right panel is open** — found by walking the flow manually. A live render defers to the panel whenever a portal target exists, but an unavailable app is filtered out of the panel's list, so it deferred into a void and left a bare pill explaining nothing. That is the panel's default state after opening an app from the apps page, so it was the common case, and "nothing at all" is worse than the wrong message this replaces.

**Warning at share time.** `ShareConversationDialog` now flags apps in the conversation that the chosen recipients will not be able to open, naming them. It reads each app's **live** scope (not the snapshot in the message), and is precise rather than noisy — silent for org-scoped apps, silent while the chat is private, and silent when a team share reaches only the teams that already hold the app.

## Notes on scope and approach

- **No new existence disclosure.** An earlier draft differentiated 403-vs-404 on the app read so the copy could be exact. That was dropped: the 404-for-both is a deliberate non-disclosure (`loadViewableApp` — *"no existence leak"*, with a test pinning it), and the runtime endpoint blends the two cases too. Honest ambiguity was the better trade than punching a hole in that for nicer copy. **Frontend-only as a result** — no backend, schema, or migration changes.
- **A warning, not a "share these too" button.** Sharing is a deliberate act; silently widening an app as a side effect of sharing a chat is the confusion this surface exists to remove. That holds even now that per-user grants exist (#6918).

## Testing

- New `conversation-app-access-notice.test.tsx` — covers the reachability rules (personal / team-in-scope / team-out-of-scope / org / disabled / unreadable / private / mixed).
- Updated `mcp-app-container.test.tsx` — asserts the placeholder does **not** claim deletion, does explain the grant plus the action, and renders with the right panel open.
- `share-conversation-dialog.test.tsx` — harness now provides a `QueryClient`, since the dialog embeds a query-backed child.
- Full frontend suite green; lint and type-check clean across all workspaces.

Verified against a local Tilt environment: a personal app in an org-shared chat warns and names the app; switching that app to Organization clears the warning (confirming it reads live scope, not the message snapshot); a private chat stays silent; `/a/:unknown-id` renders the new copy; and the placeholder shows with the panel both open and closed.
