### PR TITLE
fix(llm-cost): price self-hosted providers at zero, not the $50 estimate

### DIFF
--- a/platform/backend/src/models/model.test.ts
+++ b/platform/backend/src/models/model.test.ts
@@ -1280,6 +1280,48 @@ describe("ModelModel", () => {
       expect(pricing.pricePerMillionCacheRead).toBe("5");
       expect(pricing.cacheSource).toBe("derived_multiplier");
     });
+
+    // Ollama charges no per-token rate on either transport, so the generic
+    // estimate would bill local inference at $50/M against a real rate of zero.
+    test.each([
+      "ollama",
+      "ollama-native",
+    ] as const)("prices an unpriced %s model at zero rather than the generic estimate", async (provider) => {
+      const model = await ModelModel.create({
+        externalId: `${provider}/qwen3:8b`,
+        provider,
+        modelId: "qwen3:8b",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        lastSyncedAt: new Date(),
+      });
+
+      const pricing = ModelModel.getEffectivePricing(model);
+
+      expect(pricing.pricePerMillionInput).toBe("0.00");
+      expect(pricing.pricePerMillionOutput).toBe("0.00");
+    });
+
+    test("prices an unknown Ollama model at zero from the provider hint alone", () => {
+      const pricing = ModelModel.getEffectivePricing(
+        null,
+        "some-local-model",
+        "ollama",
+      );
+
+      expect(pricing.pricePerMillionInput).toBe("0.00");
+      expect(pricing.pricePerMillionOutput).toBe("0.00");
+    });
+
+    test("leaves the generic estimate in place for other providers", () => {
+      const pricing = ModelModel.getEffectivePricing(
+        null,
+        "some-unknown-model",
+        "openai",
+      );
+
+      expect(pricing.pricePerMillionInput).toBe("50.00");
+    });
   });
 
   describe("configuredParameters (native Ollama)", () => {

--- a/platform/backend/src/models/model.test.ts
+++ b/platform/backend/src/models/model.test.ts
@@ -1286,6 +1286,7 @@ describe("ModelModel", () => {
     test.each([
       "ollama",
       "ollama-native",
+      "vllm",
     ] as const)("prices an unpriced %s model at zero rather than the generic estimate", async (provider) => {
       const model = await ModelModel.create({
         externalId: `${provider}/qwen3:8b`,

--- a/platform/backend/src/models/model.ts
+++ b/platform/backend/src/models/model.ts
@@ -666,7 +666,7 @@ class ModelModel {
     provider?: SupportedProvider,
   ): EffectivePricing {
     const { pricePerMillionInput, pricePerMillionOutput, source } =
-      ModelModel.getEffectiveBasePricing(model, modelId);
+      ModelModel.getEffectiveBasePricing(model, modelId, provider);
     const cache = ModelModel.getEffectiveCachePricing(
       model,
       pricePerMillionInput,
@@ -687,6 +687,7 @@ class ModelModel {
   private static getEffectiveBasePricing(
     model: Model | null,
     modelId?: string,
+    provider?: SupportedProvider,
   ): {
     pricePerMillionInput: string;
     pricePerMillionOutput: string;
@@ -720,7 +721,21 @@ class ModelModel {
       };
     }
 
-    // Tier 3: Default fallback
+    // Tier 3: Default fallback. Ollama bills no per-token rate on either
+    // transport — a self-hosted server charges nothing, and Ollama's cloud
+    // offering is a flat monthly subscription metered on GPU time rather than
+    // tokens. The generic estimate below would otherwise price local inference
+    // at $50/M, inflating recorded spend and burning cost limits against tokens
+    // nobody is billed for.
+    const resolvedProvider = model?.provider ?? provider;
+    if (resolvedProvider === "ollama" || resolvedProvider === "ollama-native") {
+      return {
+        pricePerMillionInput: "0.00",
+        pricePerMillionOutput: "0.00",
+        source: "default",
+      };
+    }
+
     const nameForDefault = model?.modelId ?? modelId ?? "";
     return {
       ...getDefaultModelPrice(nameForDefault),

--- a/platform/backend/src/models/model.ts
+++ b/platform/backend/src/models/model.ts
@@ -43,6 +43,17 @@ interface EffectivePricing {
 }
 
 /**
+ * Providers that charge no per-token rate, so their real price is zero rather
+ * than unknown: the operator runs the server (vLLM, self-hosted Ollama), or the
+ * vendor bills a flat subscription metered on compute time (Ollama's cloud).
+ */
+const PROVIDERS_BILLING_NO_TOKEN_RATE = new Set<SupportedProvider>([
+  "ollama",
+  "ollama-native",
+  "vllm",
+]);
+
+/**
  * Returns default token prices for a model.
  * Cheaper models (-haiku, -nano, -mini) get $30/million tokens.
  * All other models get $50/million tokens.
@@ -721,14 +732,22 @@ class ModelModel {
       };
     }
 
-    // Tier 3: Default fallback. Ollama bills no per-token rate on either
-    // transport — a self-hosted server charges nothing, and Ollama's cloud
-    // offering is a flat monthly subscription metered on GPU time rather than
-    // tokens. The generic estimate below would otherwise price local inference
-    // at $50/M, inflating recorded spend and burning cost limits against tokens
-    // nobody is billed for.
+    // Tier 3: Default fallback. The generic estimate below assumes an unknown
+    // price exists to be approximated; for these providers none does, so it
+    // fabricates one — inflating recorded spend and burning cost limits against
+    // tokens nobody is billed for. vLLM is an inference server the operator
+    // runs. Ollama bills no per-token rate on either transport: a self-hosted
+    // server charges nothing, and its cloud offering is a flat monthly
+    // subscription metered on GPU time rather than tokens.
+    //
+    // Listed explicitly rather than derived from the self-hosted-provider set
+    // it currently matches, so that adding a keyless provider that does bill
+    // per token cannot silently make its traffic free.
     const resolvedProvider = model?.provider ?? provider;
-    if (resolvedProvider === "ollama" || resolvedProvider === "ollama-native") {
+    if (
+      resolvedProvider &&
+      PROVIDERS_BILLING_NO_TOKEN_RATE.has(resolvedProvider)
+    ) {
       return {
         pricePerMillionInput: "0.00",
         pricePerMillionOutput: "0.00",

--- a/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
+++ b/platform/backend/src/routes/proxy/utils/cost-optimization.test.ts
@@ -69,6 +69,44 @@ describe("calculateCost", () => {
     expect(cost).toBeCloseTo(0.05);
   });
 
+  test("records no cost for a provider that charges no per-token rate", async () => {
+    await ModelModel.create({
+      externalId: "ollama/qwen3:8b",
+      provider: "ollama",
+      modelId: "qwen3:8b",
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      lastSyncedAt: new Date(),
+    });
+
+    // Ollama publishes no per-token price, so the generic estimate must not
+    // apply: 50k tokens would otherwise be recorded as $2.50 of spend.
+    const cost = await calculateCost("qwen3:8b", 40000, 10000, "ollama");
+    expect(cost).toBe(0);
+  });
+
+  test("an operator's custom price overrides the zero rate", async () => {
+    const model = await ModelModel.create({
+      externalId: "vllm/mixtral",
+      provider: "vllm",
+      modelId: "mixtral",
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      lastSyncedAt: new Date(),
+    });
+
+    await ModelModel.update(model.id, {
+      customPricePerMillionInput: "2.00",
+      customPricePerMillionOutput: "6.00",
+    });
+
+    // Self-hosted deployments may still charge internally; a custom price is
+    // an explicit statement and outranks the zero.
+    // 1000 * $2/M + 500 * $6/M = 0.002 + 0.003
+    const cost = await calculateCost("mixtral", 1000, 500, "vllm");
+    expect(cost).toBeCloseTo(0.005);
+  });
+
   test("falls back to default pricing when model not in database", async () => {
     // Default pricing for non-mini models: $50/M input, $50/M output
     // 1000 input tokens = 1000/1M * $50 = $0.05

--- a/platform/backend/src/services/model-capability-matrix.test.ts
+++ b/platform/backend/src/services/model-capability-matrix.test.ts
@@ -804,7 +804,8 @@ const MATRIX: MatrixRow[] = [
     },
   },
 
-  // --- Ollama: local models, absent from models.dev entirely --------------
+  // --- Ollama: local models, absent from models.dev entirely, and billed
+  // no per-token rate on either transport (zero, not the generic estimate) ---
   {
     name: "ollama/a Modelfile num_ctx caps the window below the architectural one",
     provider: "ollama",
@@ -819,8 +820,8 @@ const MATRIX: MatrixRow[] = [
       inputModalities: ["text"],
       outputModalities: ["text"],
       supportsToolCalling: null,
-      pricePerMillionInput: "50.00",
-      pricePerMillionOutput: "50.00",
+      pricePerMillionInput: "0.00",
+      pricePerMillionOutput: "0.00",
       priceSource: "default",
       pricePerMillionCacheRead: null,
       pricePerMillionCacheWrite: null,
@@ -838,8 +839,8 @@ const MATRIX: MatrixRow[] = [
       inputModalities: ["text"],
       outputModalities: ["text"],
       supportsToolCalling: null,
-      pricePerMillionInput: "50.00",
-      pricePerMillionOutput: "50.00",
+      pricePerMillionInput: "0.00",
+      pricePerMillionOutput: "0.00",
       priceSource: "default",
       pricePerMillionCacheRead: null,
       pricePerMillionCacheWrite: null,
@@ -857,8 +858,8 @@ const MATRIX: MatrixRow[] = [
       inputModalities: ["text"],
       outputModalities: [],
       supportsToolCalling: null,
-      pricePerMillionInput: "50.00",
-      pricePerMillionOutput: "50.00",
+      pricePerMillionInput: "0.00",
+      pricePerMillionOutput: "0.00",
       priceSource: "default",
       pricePerMillionCacheRead: null,
       pricePerMillionCacheWrite: null,


### PR DESCRIPTION
A model with no entry in the public model registry falls back to a flat estimate of $50 per million tokens, or $30 for ids that read as small. Ollama and vLLM have no registry entry at all, so every model on them was recorded at that rate.

Neither charges a per-token rate. vLLM is an inference server the operator runs. Ollama bills nothing per token on either transport: a self-hosted server charges nothing, and its cloud offering is a flat monthly subscription metered on GPU time rather than tokens. The estimate was therefore not an approximation of an unknown price but a fabrication of one that does not exist.

That figure was not confined to display. It flowed into recorded interaction cost, cost statistics, optimization-rule savings and token-cost limits, so self-hosted inference consumed an API budget it never spent. In one development database it accounted for roughly a third of all recorded spend, from a single model.

The consequence worth stating plainly: usage on these providers no longer counts toward token-cost limits. That follows from the spend genuinely being zero, but it does remove a de facto guardrail for anyone who was relying on the inflated figure to bound local inference. Bounding it by tokens rather than cost is the remaining lever. Nothing else changes — a model on any other provider with no registry price keeps the existing estimate.

Resolved in the default pricing tier rather than stored against the model, so it needs no migration and cannot be undone by a later sync writing a null price back over it. The providers are listed explicitly rather than derived from the self-hosted set they currently match, so that adding a keyless provider which does bill per token cannot silently make its traffic free.
