### PR TITLE
fix(deps): raise shell-quote override to >=1.9.0 to clear GHSA-395f-4hp3-45gv

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -38,7 +38,7 @@ overrides:
   protobufjs: '>=8.6.0'
   '@protobufjs/utf8': '>=1.1.1'
   vite: 7.3.5
-  shell-quote: '>=1.8.4'
+  shell-quote: '>=1.9.0'
   ws@>=8: '>=8.21.0'
   botframework-streaming>ws: '>=8.21.0'
   websocket-driver: '>=0.7.5'
@@ -1618,14 +1618,8 @@ packages:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
-  '@better-auth/utils@0.4.1':
-    resolution: {integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==}
-
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
-
-  '@better-fetch/fetch@1.1.21':
-    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
@@ -9863,8 +9857,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -12020,15 +12014,9 @@ snapshots:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
-  '@better-auth/utils@0.4.1':
-    dependencies:
-      '@noble/hashes': 2.0.1
-
   '@better-auth/utils@0.4.2':
     dependencies:
       '@noble/hashes': 2.0.1
-
-  '@better-fetch/fetch@1.1.21': {}
 
   '@better-fetch/fetch@1.3.1': {}
 
@@ -17264,8 +17252,8 @@ snapshots:
 
   better-call@1.3.7(zod@4.3.6):
     dependencies:
-      '@better-auth/utils': 0.4.1
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
       rou3: 0.7.12
       set-cookie-parser: 3.0.1
     optionalDependencies:
@@ -17635,7 +17623,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -21051,7 +21039,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -36,7 +36,11 @@ overrides:
   protobufjs: '>=8.6.0'
   '@protobufjs/utf8': '>=1.1.1'
   vite: 7.3.5
-  shell-quote: '>=1.8.4'
+  # CVE / GHSA-395f-4hp3-45gv (HIGH, CVSS 8.7): quadratic-complexity DoS in
+  # shell-quote's parse() on plain space-separated input. Vulnerable range is
+  # <= 1.8.4, fixed in 1.9.0 — the floor must be >=1.9.0, since a >=1.8.4 floor
+  # still resolves the vulnerable 1.8.4.
+  shell-quote: '>=1.9.0'
   ws@>=8: '>=8.21.0'
   # botframework-streaming pins ws 8.20.1, which the range selector above doesn't
   # catch; force that edge to the CVE-2026-48779 fix too.


### PR DESCRIPTION
## Summary

`shell-quote` at or below `1.8.4` carries **GHSA-395f-4hp3-45gv** (HIGH, CVSS 8.7): its `parse()` builds results with quadratic-complexity array concatenation, so moderately sized space-separated input — no shell metacharacters required — pins the Node.js event loop and yields a denial of service.

The workspace already had a `shell-quote` override, but its floor was `>=1.8.4` — and the advisory's vulnerable range is `<= 1.8.4`. A pnpm floor resolves to the *lowest* satisfying version, so the override kept pinning the exact vulnerable `1.8.4` it was meant to exclude. The package is transitive (pulled by `concurrently`), so a direct manifest bump isn't available; the override is the only lever. Raising the floor to `>=1.9.0` moves the resolution to `1.10.0`, outside the vulnerable range.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>