### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 to clear GHSA-4w2j-m93h-cj5j

### DIFF
--- a/ai-labs/Cargo.lock
+++ b/ai-labs/Cargo.lock
@@ -2189,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

`quinn-proto` below `0.11.15` in the ai-labs Rust workspace carries **GHSA-4w2j-m93h-cj5j** (HIGH, CVSS 7.5): its stream-reassembly path lets a remote peer exhaust memory by sending out-of-order stream fragments with many gaps, inflating per-connection buffer overhead on the receiver. The advisory's fix landed in `0.11.15`; this is a patch-level bump within the `0.11.x` line, so the resolution moves with no API surface change.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>