### PR TITLE
feat(mcp): show which identity a tool call ran as

### DIFF
--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -250,6 +250,14 @@ flowchart TD
     style J fill:#f8d7da,stroke:#dc3545
 ```
 
+#### Ran As
+
+Every tool call records which connection served it. Chat shows it on the tool call card — "Ran as me", "Ran as Grace Hopper", "Ran as Platform Team", or "Ran as the organization". The same identity appears in the **Ran As** column of the MCP Gateway logs, next to the user who made the call. So a call through a shared service account reads as "ran as that account, on behalf of the caller".
+
+Calls that use a token minted for the caller — Identity Provider Token Exchange, or a forwarded JWKS token — are shown as running as the caller.
+
+MCP clients see the same identity on the tool result, under the `_meta.archestraExecutedAs` key.
+
 #### Missing Credentials
 
 When no credential can be resolved for a caller, the gateway returns an actionable error message that includes a direct link to install the MCP server with their own credentials:

--- a/docs/pages/mcp-authentication.md
+++ b/docs/pages/mcp-authentication.md
@@ -250,11 +250,11 @@ flowchart TD
     style J fill:#f8d7da,stroke:#dc3545
 ```
 
-#### Ran As
+#### Called As
 
-Every tool call records which connection served it. Chat shows it on the tool call card — "Ran as me", "Ran as Grace Hopper", "Ran as Platform Team", or "Ran as the organization". The same identity appears in the **Ran As** column of the MCP Gateway logs, next to the user who made the call. So a call through a shared service account reads as "ran as that account, on behalf of the caller".
+Every tool call records the identity whose credential served it. Chat shows it on the tool call card. The MCP Gateway logs show it in the **Called as** column, next to the user who made the call. A call through a shared service account reads as that account, on behalf of the caller.
 
-Calls that use a token minted for the caller — Identity Provider Token Exchange, or a forwarded JWKS token — are shown as running as the caller.
+The identity is a person, a team, or the organization. Calls that use a token minted for the caller — Identity Provider Token Exchange, or a forwarded JWKS token — run as that caller. A call made with a gateway token runs as the team or the organization that issued the token.
 
 MCP clients see the same identity on the tool result, under the `_meta.archestraExecutedAs` key.
 

--- a/platform/backend/src/clients/chat-mcp-client.app-readability.integration.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.app-readability.integration.test.ts
@@ -156,8 +156,9 @@ test("REAL: drops the UI resource when the upstream returns -32601 on resources/
       },
     });
 
-    // Dropped -> plain text, no MCP App registered.
-    expect(result).toBe("ran");
+    // Dropped -> no MCP App registered; the result still names who it ran for.
+    expect(result).toMatchObject({ content: "ran" });
+    expect((result as { _meta?: { ui?: unknown } })._meta?.ui).toBeUndefined();
   } finally {
     await server.close();
   }

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -1,4 +1,5 @@
 import {
+  extractMcpExecutedAs,
   getArchestraToolFullName,
   MCP_EXECUTED_AS_META_KEY,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
@@ -907,7 +908,7 @@ describe("chat-mcp-client tool caching", () => {
       { messages: [] } as any,
     );
 
-    expect(result).toBe("Workspace projects");
+    expect(result).toMatchObject({ content: "Workspace projects" });
     expect(mcpClient.executeToolCallForOwner).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "workspace__find_projects",
@@ -1048,7 +1049,7 @@ describe("chat-mcp-client tool caching", () => {
       { messages: [] } as any,
     );
 
-    expect(result).toBe("Export queued");
+    expect(result).toMatchObject({ content: "Export queued" });
     expect(mcpClient.executeToolCallForOwner).toHaveBeenCalledWith(
       expect.objectContaining({
         name: targetTool.name,
@@ -2007,7 +2008,11 @@ describe("buildArchestraToolOutput", () => {
       agentId: agent.id,
     });
 
-    expect(result).toBe("Diagram displayed!");
+    expect(result).toMatchObject({ content: "Diagram displayed!" });
+    expect(extractMcpExecutedAs(result)).toEqual({
+      kind: "platform",
+      callerUserId: null,
+    });
   });
 
   test("carries an image block as one media part without base64 in the text (end to end)", async ({
@@ -2110,7 +2115,7 @@ describe("buildArchestraToolOutput", () => {
       agentId: agent.id,
     });
 
-    expect(result).toBe(`Created app "Todo" (app-1).`);
+    expect(result).toMatchObject({ content: `Created app "Todo" (app-1).` });
   });
 
   test("returns the rich shape for a run_tool dispatch with a bare edit_app target", async ({
@@ -2152,7 +2157,9 @@ describe("buildArchestraToolOutput", () => {
       agentId: agent.id,
     });
 
-    expect(result).toBe("Error: Authentication required.");
+    expect(result).toMatchObject({
+      content: "Error: Authentication required.",
+    });
   });
 
   test("returns plain text for list_apps despite structuredContent", async ({
@@ -2170,7 +2177,7 @@ describe("buildArchestraToolOutput", () => {
       agentId: agent.id,
     });
 
-    expect(result).toBe("2 apps");
+    expect(result).toMatchObject({ content: "2 apps" });
   });
 
   test("attaches the target tool's UI resource when dispatched via run_tool", async ({
@@ -2254,7 +2261,7 @@ describe("buildArchestraToolOutput", () => {
     });
   });
 
-  test("stays plain text for a dispatched tool that carries no platform metadata", async ({
+  test("attributes a dispatched tool that reached no server to the caller", async ({
     makeAgent,
     makeAgentTool,
     makeInternalMcpCatalog,
@@ -2276,9 +2283,16 @@ describe("buildArchestraToolOutput", () => {
       toolName: "archestra__run_tool",
       toolArguments: { tool_name: "grain__list_meetings", tool_args: {} },
       agentId: agent.id,
+      userId: "user-9",
     });
 
-    expect(result).toBe("2 meetings");
+    // No upstream identity came back (the dispatch never reached a server), so
+    // the card still says who Archestra ran it for rather than nothing.
+    expect(result).toMatchObject({ content: "2 meetings" });
+    expect(extractMcpExecutedAs(result)).toEqual({
+      kind: "platform",
+      callerUserId: "user-9",
+    });
   });
 
   test("does not attach the UI resource when its upstream resource can't be read", async ({
@@ -2313,7 +2327,8 @@ describe("buildArchestraToolOutput", () => {
       agentId: agent.id,
     });
 
-    expect(result).toBe("Diagram displayed!");
+    expect(result).toMatchObject({ content: "Diagram displayed!" });
+    expect((result as { _meta?: { ui?: unknown } })._meta?.ui).toBeUndefined();
   });
 
   test("does not attach the UI resource when the target tool is not assigned to the agent", async ({
@@ -2346,7 +2361,8 @@ describe("buildArchestraToolOutput", () => {
       agentId: otherAgent.id,
     });
 
-    expect(result).toBe("Diagram displayed!");
+    expect(result).toMatchObject({ content: "Diagram displayed!" });
+    expect((result as { _meta?: { ui?: unknown } })._meta?.ui).toBeUndefined();
   });
 
   test("attaches the target tool's UI resource for an unassigned tool reached via dynamic access", async ({
@@ -2516,7 +2532,8 @@ describe("buildArchestraToolOutput", () => {
       organizationId: org.id,
     });
 
-    expect(result).toBe("Diagram displayed!");
+    expect(result).toMatchObject({ content: "Diagram displayed!" });
+    expect((result as { _meta?: { ui?: unknown } })._meta?.ui).toBeUndefined();
   });
 
   test("returns plain text when the dispatched target has no UI resource", async ({
@@ -2541,7 +2558,8 @@ describe("buildArchestraToolOutput", () => {
       agentId: agent.id,
     });
 
-    expect(result).toBe("Diagram displayed!");
+    expect(result).toMatchObject({ content: "Diagram displayed!" });
+    expect((result as { _meta?: { ui?: unknown } })._meta?.ui).toBeUndefined();
   });
 
   test("preserves a structured auth error (with credential scope) for a run_tool dispatch so chat renders the rich card", async ({
@@ -2600,7 +2618,7 @@ describe("buildArchestraToolOutput", () => {
       agentId: agent.id,
     });
 
-    expect(result).toBe("Error: rate limited.");
+    expect(result).toMatchObject({ content: "Error: rate limited." });
   });
 });
 

--- a/platform/backend/src/clients/chat-mcp-client.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.test.ts
@@ -1,5 +1,6 @@
 import {
   getArchestraToolFullName,
+  MCP_EXECUTED_AS_META_KEY,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
   TOOL_QUERY_KNOWLEDGE_SOURCES_FULL_NAME,
   TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
@@ -2206,6 +2207,78 @@ describe("buildArchestraToolOutput", () => {
       },
       structuredContent: { checkpoint: "abc" },
     });
+  });
+
+  test("keeps the identity a dispatched tool ran as, which chat shows on the card", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    const agent = await makeAgent();
+    const catalog = await makeInternalMcpCatalog();
+    // A plain dispatched tool with no MCP App UI — the case the bare-text
+    // fallback used to flatten, dropping the identity from the card.
+    const targetTool = await makeTool({
+      name: "grain__list_meetings",
+      catalogId: catalog.id,
+    });
+    await makeAgentTool(agent.id, targetTool.id);
+
+    const result = await buildArchestraToolOutput({
+      response: {
+        content: [{ type: "text" as const, text: "2 meetings" }],
+        isError: false,
+        _meta: {
+          [MCP_EXECUTED_AS_META_KEY]: {
+            kind: "personal",
+            ownerUserId: "user-1",
+            ownerName: "Ada Lovelace",
+          },
+        },
+      },
+      toolName: "archestra__run_tool",
+      toolArguments: { tool_name: "grain__list_meetings", tool_args: {} },
+      agentId: agent.id,
+    });
+
+    expect(result).toMatchObject({
+      content: "2 meetings",
+      _meta: {
+        [MCP_EXECUTED_AS_META_KEY]: {
+          kind: "personal",
+          ownerUserId: "user-1",
+          ownerName: "Ada Lovelace",
+        },
+      },
+    });
+  });
+
+  test("stays plain text for a dispatched tool that carries no platform metadata", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeTool,
+  }) => {
+    const agent = await makeAgent();
+    const catalog = await makeInternalMcpCatalog();
+    const targetTool = await makeTool({
+      name: "grain__list_meetings",
+      catalogId: catalog.id,
+    });
+    await makeAgentTool(agent.id, targetTool.id);
+
+    const result = await buildArchestraToolOutput({
+      response: {
+        content: [{ type: "text" as const, text: "2 meetings" }],
+        isError: false,
+      },
+      toolName: "archestra__run_tool",
+      toolArguments: { tool_name: "grain__list_meetings", tool_args: {} },
+      agentId: agent.id,
+    });
+
+    expect(result).toBe("2 meetings");
   });
 
   test("does not attach the UI resource when its upstream resource can't be read", async ({

--- a/platform/backend/src/clients/chat-mcp-client.tools.test.ts
+++ b/platform/backend/src/clients/chat-mcp-client.tools.test.ts
@@ -8,6 +8,7 @@
 // the external-IdP session token resolver (IdP network call).
 import {
   getArchestraToolFullName,
+  MCP_EXECUTED_AS_META_KEY,
   TOOL_GET_AGENT_SHORT_NAME,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
 } from "@archestra/shared";
@@ -357,6 +358,60 @@ describe("getChatMcpTools MCP tool execute pipeline", () => {
         toolName: "extsrv__fetch_data",
         isError: false,
       }),
+    );
+  });
+
+  test("shows the identity the gateway resolved, not one the server's tool definition claims", async () => {
+    const { org, agent, baseParams } = await setupChatToolEnv({
+      gatewayTools: [externalTool("extsrv__fetch_data")],
+    });
+    const catalog = await f.makeInternalMcpCatalog({ organizationId: org.id });
+    // Tool definitions are authored upstream and synced by tools/list, and they
+    // are merged over the result's metadata — so a server could otherwise
+    // declare an identity here and have every card show it.
+    const tool = await f.makeTool({
+      catalogId: catalog.id,
+      name: "extsrv__fetch_data",
+      meta: {
+        _meta: {
+          [MCP_EXECUTED_AS_META_KEY]: { kind: "org" },
+          vendorHint: "from the tool definition",
+        },
+      },
+    });
+    await f.makeAgentTool(agent.id, tool.id);
+    vi.spyOn(hookDispatcherService, "fire").mockResolvedValue({
+      decision: "proceed",
+      runs: [],
+    });
+    vi.mocked(mcpClient.executeToolCallForOwner).mockResolvedValue({
+      content: [{ type: "text", text: "external result" }],
+      isError: false,
+      _meta: {
+        [MCP_EXECUTED_AS_META_KEY]: {
+          kind: "personal",
+          ownerUserId: "user-1",
+          ownerName: "Ada Lovelace",
+        },
+      },
+    } as never);
+
+    const tools = await chatClient.getChatMcpTools(baseParams);
+    const result = await tools.extsrv__fetch_data.execute?.(
+      { query: "q" },
+      execOptions("call-forged-identity"),
+    );
+
+    expect((result as { _meta?: Record<string, unknown> })._meta).toMatchObject(
+      {
+        [MCP_EXECUTED_AS_META_KEY]: {
+          kind: "personal",
+          ownerUserId: "user-1",
+          ownerName: "Ada Lovelace",
+        },
+        // the definition's non-reserved metadata still applies
+        vendorHint: "from the tool definition",
+      },
     );
   });
 

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -8,7 +8,9 @@ import {
   extractMcpToolError,
   isAppRenderingArchestraToolShortName,
   isBrowserMcpTool,
+  MCP_EXECUTED_AS_META_KEY,
   parseFullToolName,
+  platformExecutedAs,
   stripReservedPlatformMeta,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
   TOOL_RUN_TOOL_SHORT_NAME,
@@ -547,6 +549,13 @@ export async function buildArchestraToolOutput(params: {
     organizationId,
     tokenAuth,
   } = params;
+  // A dispatched third-party tool already carries the identity whose
+  // credential served it. Everything else here Archestra ran itself, with the
+  // caller's own permissions — say so rather than leaving the card unable to
+  // answer "as who did this run?".
+  const executedAs =
+    extractMcpExecutedAs(response) ?? platformExecutedAs(userId);
+  const executedAsMeta = { [MCP_EXECUTED_AS_META_KEY]: executedAs };
   // Never stringify an image block into the text summary — its base64 would
   // bloat context and evade the history image-stripper. Images ride rawContent
   // and reach the model as bounded media parts via toModelOutput instead.
@@ -566,7 +575,10 @@ export async function buildArchestraToolOutput(params: {
   if (!response.isError && response.content.some((c) => c.type === "image")) {
     return {
       content: text,
-      _meta: response._meta as Record<string, unknown> | undefined,
+      _meta: {
+        ...(response._meta as Record<string, unknown>),
+        ...executedAsMeta,
+      },
       rawContent: response.content as ContentBlock[],
     };
   }
@@ -592,14 +604,16 @@ export async function buildArchestraToolOutput(params: {
   ) {
     return {
       content: text,
+      _meta: executedAsMeta,
       structuredContent: response.structuredContent,
       rawContent: response.content as ContentBlock[],
     };
   }
 
   if (targetToolName === toolName) {
-    // Not a run_tool dispatch — no UI resource to attach.
-    return text;
+    // Not a run_tool dispatch — no UI resource to attach, but the card still
+    // names who the platform ran this for.
+    return { content: text, _meta: executedAsMeta };
   }
 
   let resourceUri: string | undefined;
@@ -647,20 +661,17 @@ export async function buildArchestraToolOutput(params: {
     // badge). Mirrors the direct path (executeMcpTool), which keeps these
     // fields. In-process Archestra tools carry neither and stay plain text, so
     // plain-output parsing (e.g. knowledge-source citations) is unaffected.
-    if (
-      (response.isError && extractMcpToolError(response)) ||
-      extractMcpExecutedAs(response)
-    ) {
-      return {
-        content: text,
-        _meta: response._meta as Record<string, unknown> | undefined,
-        structuredContent: response.structuredContent as
-          | Record<string, unknown>
-          | undefined,
-        rawContent: response.content as ContentBlock[],
-      };
-    }
-    return text;
+    return {
+      content: text,
+      _meta: {
+        ...(response._meta as Record<string, unknown>),
+        ...executedAsMeta,
+      },
+      structuredContent: response.structuredContent as
+        | Record<string, unknown>
+        | undefined,
+      rawContent: response.content as ContentBlock[],
+    };
   }
 
   // Bind the app's callbacks to the concrete install so its SDK `callServerTool`
@@ -677,6 +688,7 @@ export async function buildArchestraToolOutput(params: {
     content: text,
     _meta: {
       ...response._meta,
+      ...executedAsMeta,
       ui: { resourceUri, ...(mcpServerId ? { mcpServerId } : {}) },
     },
     structuredContent: response.structuredContent as

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -4,10 +4,12 @@
 // execution). Must not import chat-mcp-client.ts (cycle).
 import { randomUUID } from "node:crypto";
 import {
+  extractMcpExecutedAs,
   extractMcpToolError,
   isAppRenderingArchestraToolShortName,
   isBrowserMcpTool,
   parseFullToolName,
+  stripReservedPlatformMeta,
   TOOL_INVOCATION_APPROVAL_REQUIRED_AUTONOMOUS_REASON,
   TOOL_RUN_TOOL_SHORT_NAME,
 } from "@archestra/shared";
@@ -562,7 +564,11 @@ export async function buildArchestraToolOutput(params: {
   // through so the model can see them — toModelOutput turns them into media
   // parts, bounded by size/count there. Image-free results are unaffected.
   if (!response.isError && response.content.some((c) => c.type === "image")) {
-    return { content: text, rawContent: response.content as ContentBlock[] };
+    return {
+      content: text,
+      _meta: response._meta as Record<string, unknown> | undefined,
+      rawContent: response.content as ContentBlock[],
+    };
   }
 
   const targetToolName = resolveRunToolTargetName(toolName, toolArguments);
@@ -632,14 +638,19 @@ export async function buildArchestraToolOutput(params: {
     resourceUri = undefined;
   }
   if (!resourceUri) {
-    // A dispatched third-party tool with no MCP-App UI. If it returned a
-    // structured Archestra error (e.g. the expired-auth re-auth payload),
-    // preserve `_meta`/`structuredContent` so chat renders the same rich card
-    // as a direct call. The bare-text fallback below strips
-    // `_meta.archestraError`/`structuredContent.archestraError`, degrading the
-    // card to a text-parsed one (which loses e.g. the credential scope). Mirrors
-    // the direct path (executeMcpTool), which keeps these fields on error.
-    if (response.isError && extractMcpToolError(response)) {
+    // A dispatched third-party tool with no MCP-App UI. If it carries platform
+    // metadata — a structured Archestra error (e.g. the expired-auth re-auth
+    // payload) or the identity the upstream call ran as — preserve
+    // `_meta`/`structuredContent` so chat renders the same rich card as a
+    // direct call. The bare-text fallback below drops them, degrading the card
+    // to a text-parsed one (losing e.g. the credential scope or the "ran as"
+    // badge). Mirrors the direct path (executeMcpTool), which keeps these
+    // fields. In-process Archestra tools carry neither and stay plain text, so
+    // plain-output parsing (e.g. knowledge-source citations) is unaffected.
+    if (
+      (response.isError && extractMcpToolError(response)) ||
+      extractMcpExecutedAs(response)
+    ) {
       return {
         content: text,
         _meta: response._meta as Record<string, unknown> | undefined,
@@ -1242,8 +1253,14 @@ async function executeMcpTool(ctx: ToolExecutionContext): Promise<{
     const toolDef = await ToolModel.findByNameForAgent(toolName, agentId);
     if (toolDef?.meta) {
       // Extract _meta from the stored structure: { _meta: {...}, annotations: {...} }
-      toolDefinitionMeta = (toolDef.meta as { _meta?: ToolDefinitionMeta })
-        ?._meta;
+      // A tool definition is authored upstream and synced by tools/list, and it
+      // is merged over the result's own metadata below — so strip the
+      // platform-reserved keys here too, or a hostile server could declare a
+      // forged error, seeded-render marker or executed-as identity in its tool
+      // definition and override the platform's value on every card.
+      toolDefinitionMeta = stripReservedPlatformMeta(
+        (toolDef.meta as { _meta?: ToolDefinitionMeta })?._meta,
+      ) as ToolDefinitionMeta | undefined;
     }
   } catch (error) {
     logger.debug(

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -8657,7 +8657,7 @@ describe("executed-as identity", () => {
     expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({ kind: "org" });
   });
 
-  test("omits the identity when the call never resolved a credential", async ({
+  test("attributes a call the platform refused to the caller", async ({
     makeOrganization,
     makeUser,
     makeMember,
@@ -8668,8 +8668,8 @@ describe("executed-as identity", () => {
     await makeMember(caller.id, org.id, { role: "member" });
     const agent = await makeAgent({ organizationId: org.id });
     const { tool } = await makeRemoteCatalogTool(agent.id);
-    // No connection exists for the catalog, so resolution fails before any
-    // upstream credential is chosen.
+    // No connection exists, so the call is refused before any credential is
+    // chosen — but the platform still ran it on the caller's behalf.
 
     const result = await callTool({
       agentId: agent.id,
@@ -8678,6 +8678,9 @@ describe("executed-as identity", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toBeUndefined();
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+      kind: "platform",
+      callerUserId: caller.id,
+    });
   });
 });

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -3440,6 +3440,7 @@ describe("McpClient", () => {
         // not as the owner of the installation it was routed through.
         expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
           kind: "idp_exchange",
+          callerUserId: user.id,
         });
 
         const { StreamableHTTPClientTransport } = await import(
@@ -8485,6 +8486,7 @@ describe("executed-as identity", () => {
 
     expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
       kind: "idp_passthrough",
+      callerUserId: caller.id,
     });
   });
 
@@ -8540,6 +8542,7 @@ describe("executed-as identity", () => {
 
     expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
       kind: "caller_headers",
+      callerUserId: caller.id,
     });
   });
 

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -6,6 +6,7 @@ import {
   MCP_CATALOG_REAUTH_QUERY_PARAM,
   MCP_CATALOG_SERVER_QUERY_PARAM,
   MCP_ENTERPRISE_AUTH_EXTENSION_ID,
+  MCP_EXECUTED_AS_META_KEY,
   OAUTH_TOKEN_TYPE,
   SEEDED_APP_RENDER_META_KEY,
 } from "@archestra/shared";
@@ -90,6 +91,15 @@ vi.mock("@/k8s/mcp-server-runtime", () => ({
     getOrLoadDeployment: mockGetOrLoadDeployment,
   },
 }));
+
+// The shared fixture connection below is personal-scope with no owner (as a
+// connection looks once its owning user is deleted), so calls through it run
+// as an unattributed personal connection.
+const OWNERLESS_PERSONAL_CONNECTION = {
+  kind: "personal",
+  ownerUserId: null,
+  ownerName: null,
+};
 
 describe("McpClient", () => {
   let agentId: string;
@@ -1829,6 +1839,10 @@ describe("McpClient", () => {
             content: [{ type: "text", text: "Limiter http" }],
             isError: false,
             name: "github-mcp-server__limiter_http",
+            structuredContent: undefined,
+            _meta: {
+              [MCP_EXECUTED_AS_META_KEY]: OWNERLESS_PERSONAL_CONNECTION,
+            },
           });
         } finally {
           runWithLimitSpy.mockRestore();
@@ -1936,6 +1950,10 @@ describe("McpClient", () => {
           content: [{ type: "text", text: "Success from HTTP transport" }],
           isError: false,
           name: "local-streamable-http-server__test_tool",
+          structuredContent: undefined,
+          _meta: {
+            [MCP_EXECUTED_AS_META_KEY]: OWNERLESS_PERSONAL_CONNECTION,
+          },
         });
       });
 
@@ -1985,6 +2003,7 @@ describe("McpClient", () => {
               type: "generic",
               message: expect.stringContaining("No HTTP endpoint URL found"),
             },
+            [MCP_EXECUTED_AS_META_KEY]: OWNERLESS_PERSONAL_CONNECTION,
           },
           structuredContent: {
             archestraError: {
@@ -3417,6 +3436,11 @@ describe("McpClient", () => {
         );
 
         expect(result.isError).toBe(false);
+        // The credential was minted for this caller, so the call ran as them —
+        // not as the owner of the installation it was routed through.
+        expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+          kind: "idp_exchange",
+        });
 
         const { StreamableHTTPClientTransport } = await import(
           "@modelcontextprotocol/sdk/client/streamableHttp.js"
@@ -7665,7 +7689,12 @@ describe("McpClient", () => {
         );
 
         expect(result.isError).toBe(false);
-        expect(result._meta).toEqual(toolMeta);
+        // The upstream tool's own metadata passes through, alongside the
+        // identity the platform resolved for the call.
+        expect(result._meta).toEqual({
+          ...toolMeta,
+          [MCP_EXECUTED_AS_META_KEY]: OWNERLESS_PERSONAL_CONNECTION,
+        });
       });
 
       test("passes structuredContent from callTool result into CommonToolResult", async () => {
@@ -8197,5 +8226,458 @@ describe("readResource (assignment + all-tools dynamic access, end to end)", () 
       ),
     ).rejects.toThrow(/Resource not found/);
     expect(mockReadResource).not.toHaveBeenCalled();
+  });
+});
+
+// Every upstream call runs under some credential the gateway resolves — the
+// caller's own connection, a team or organization connection, a connection an
+// admin pinned as a service account, or a token minted for the caller. The
+// result and its log row name that identity so a tool call can answer "on
+// whose behalf did this run?".
+describe("executed-as identity", () => {
+  beforeEach(() => {
+    // This block sits outside the main describe, so it owns its mock state:
+    // a queued result left over from an earlier test would otherwise be handed
+    // to the next call instead of the one that test set up.
+    mockCallTool.mockReset();
+    mockConnect.mockReset();
+    mockListTools.mockReset();
+  });
+
+  const userToken = (
+    userId: string,
+    organizationId: string,
+    overrides: Partial<TokenAuthContext> = {},
+  ): TokenAuthContext => ({
+    tokenId: randomUUID(),
+    teamId: null,
+    isOrganizationToken: false,
+    isUserToken: true,
+    userId,
+    organizationId,
+    ...overrides,
+  });
+
+  async function makeRemoteCatalogTool(agentId: string) {
+    const catalogItem = await InternalMcpCatalogModel.create({
+      name: `executed-as-${randomUUID().slice(0, 8)}`,
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+    });
+    const tool = await ToolModel.createToolIfNotExists({
+      name: `${catalogItem.name}__do_thing`,
+      description: "Executed-as tool",
+      parameters: {},
+      catalogId: catalogItem.id,
+    });
+    await AgentToolModel.create(agentId, tool.id, {
+      credentialResolutionMode: "dynamic",
+    });
+    return { catalogItem, tool };
+  }
+
+  async function makeConnection(params: {
+    catalogId: string;
+    ownerId?: string;
+    teamId?: string;
+    scope?: "personal" | "team" | "org";
+    withStoredCredential?: boolean;
+  }) {
+    const secret = params.withStoredCredential
+      ? await secretManager().createSecret(
+          { access_token: "stored-upstream-token" },
+          `executed-as-${randomUUID().slice(0, 8)}`,
+        )
+      : null;
+    return await McpServerModel.create({
+      name: `connection-${randomUUID().slice(0, 8)}`,
+      catalogId: params.catalogId,
+      serverType: "remote",
+      secretId: secret?.id,
+      ownerId: params.ownerId,
+      teamId: params.teamId,
+      scope: params.scope,
+    });
+  }
+
+  async function callTool(params: {
+    agentId: string;
+    toolName: string;
+    tokenAuth: TokenAuthContext;
+    upstreamResult?: Record<string, unknown>;
+  }) {
+    mockConnect.mockResolvedValue(undefined);
+    mockListTools.mockResolvedValue({ tools: [] });
+    mockCallTool.mockResolvedValueOnce(
+      params.upstreamResult ?? {
+        content: [{ type: "text", text: "upstream ok" }],
+        isError: false,
+      },
+    );
+    return await mcpClient.executeToolCallForOwner(
+      {
+        id: `call_${randomUUID().slice(0, 8)}`,
+        name: params.toolName,
+        arguments: {},
+      },
+      agentOwner(params.agentId),
+      params.tokenAuth,
+    );
+  }
+
+  test("names the caller's own connection", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser({ name: "Ada Lovelace" });
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    await makeConnection({
+      catalogId: catalogItem.id,
+      ownerId: caller.id,
+      withStoredCredential: true,
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id),
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+      kind: "personal",
+      ownerUserId: caller.id,
+      ownerName: "Ada Lovelace",
+    });
+  });
+
+  test("names the owner of a connection pinned as the catalog's service account", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const owner = await makeUser({ name: "Grace Hopper" });
+    const caller = await makeUser({ name: "Ada Lovelace" });
+    await makeMember(owner.id, org.id, { role: "admin" });
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    // The caller has their own connection, but the catalog pins everyone to the
+    // owner's — so the call runs as the owner, not as the caller.
+    await makeConnection({
+      catalogId: catalogItem.id,
+      ownerId: caller.id,
+      withStoredCredential: true,
+    });
+    const serviceAccount = await makeConnection({
+      catalogId: catalogItem.id,
+      ownerId: owner.id,
+      withStoredCredential: true,
+    });
+    await InternalMcpCatalogModel.update(catalogItem.id, {
+      dynamicConnectionMcpServerId: serviceAccount.id,
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id),
+    });
+
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+      kind: "personal",
+      ownerUserId: owner.id,
+      ownerName: "Grace Hopper",
+    });
+  });
+
+  test("names the owning team for a team connection", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeTeam,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    await makeMember(caller.id, org.id, { role: "member" });
+    const team = await makeTeam(org.id, caller.id, { name: "Platform Team" });
+    const { TeamModel } = await import("@/models");
+    await TeamModel.addMember(team.id, caller.id, "member");
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    await makeConnection({
+      catalogId: catalogItem.id,
+      teamId: team.id,
+      scope: "team",
+      withStoredCredential: true,
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id),
+    });
+
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+      kind: "team",
+      teamId: team.id,
+      teamName: "Platform Team",
+    });
+  });
+
+  test("reports an organization connection", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    await makeConnection({
+      catalogId: catalogItem.id,
+      scope: "org",
+      withStoredCredential: true,
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id),
+    });
+
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({ kind: "org" });
+  });
+
+  test("reports the caller's own token when the connection stores no credential of its own", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    // No stored credential, so the transport forwards the caller's own JWT and
+    // the upstream server sees the caller, not the connection's owner.
+    await makeConnection({ catalogId: catalogItem.id, scope: "org" });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id, {
+        isExternalIdp: true,
+        rawToken: "caller-jwt",
+      }),
+    });
+
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+      kind: "idp_passthrough",
+    });
+  });
+
+  test("reports the connection's identity when it has a stored credential the caller's token cannot displace", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    await makeConnection({
+      catalogId: catalogItem.id,
+      scope: "org",
+      withStoredCredential: true,
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id, {
+        isExternalIdp: true,
+        rawToken: "caller-jwt",
+      }),
+    });
+
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({ kind: "org" });
+  });
+
+  test("reports an authorization header the caller supplied", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    await makeConnection({ catalogId: catalogItem.id, scope: "org" });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id, {
+        passthroughHeaders: { Authorization: "Bearer caller-supplied" },
+      }),
+    });
+
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({
+      kind: "caller_headers",
+    });
+  });
+
+  test("replaces an identity the upstream server tried to forge", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser({ name: "Ada Lovelace" });
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    await makeConnection({
+      catalogId: catalogItem.id,
+      ownerId: caller.id,
+      withStoredCredential: true,
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id),
+      upstreamResult: {
+        content: [{ type: "text", text: "upstream ok" }],
+        isError: false,
+        _meta: {
+          [MCP_EXECUTED_AS_META_KEY]: { kind: "org" },
+          upstreamOwn: "kept",
+        },
+      },
+    });
+
+    expect(result._meta).toMatchObject({
+      upstreamOwn: "kept",
+      [MCP_EXECUTED_AS_META_KEY]: {
+        kind: "personal",
+        ownerUserId: caller.id,
+        ownerName: "Ada Lovelace",
+      },
+    });
+  });
+
+  test("records the identity on the tool call log row", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser({ name: "Ada Lovelace" });
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    await makeConnection({
+      catalogId: catalogItem.id,
+      ownerId: caller.id,
+      withStoredCredential: true,
+    });
+
+    await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id),
+    });
+
+    const [logRow] = await db
+      .select()
+      .from(schema.mcpToolCallsTable)
+      .where(eq(schema.mcpToolCallsTable.agentId, agent.id));
+
+    // The caller is recorded alongside the identity the call ran as, so the log
+    // reads "ran as X on behalf of Y".
+    expect(logRow?.userId).toBe(caller.id);
+    expect(
+      (logRow?.toolResult as { _meta?: Record<string, unknown> })?._meta?.[
+        MCP_EXECUTED_AS_META_KEY
+      ],
+    ).toEqual({
+      kind: "personal",
+      ownerUserId: caller.id,
+      ownerName: "Ada Lovelace",
+    });
+  });
+
+  test("keeps the identity on a result the upstream server flagged as an error", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { catalogItem, tool } = await makeRemoteCatalogTool(agent.id);
+    await makeConnection({
+      catalogId: catalogItem.id,
+      scope: "org",
+      withStoredCredential: true,
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id),
+      upstreamResult: {
+        content: [{ type: "text", text: "rate limited" }],
+        isError: true,
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toEqual({ kind: "org" });
+  });
+
+  test("omits the identity when the call never resolved a credential", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    const caller = await makeUser();
+    await makeMember(caller.id, org.id, { role: "member" });
+    const agent = await makeAgent({ organizationId: org.id });
+    const { tool } = await makeRemoteCatalogTool(agent.id);
+    // No connection exists for the catalog, so resolution fails before any
+    // upstream credential is chosen.
+
+    const result = await callTool({
+      agentId: agent.id,
+      toolName: tool.name,
+      tokenAuth: userToken(caller.id, org.id),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result._meta?.[MCP_EXECUTED_AS_META_KEY]).toBeUndefined();
   });
 });

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -2985,16 +2985,20 @@ class McpClient {
       secrets,
     } = params;
 
+    // These three all mean "the calling user's own identity reached the
+    // server", so they name that user rather than an installed connection.
+    const callerUserId = tokenAuth?.userId ?? null;
+
     if (enterpriseTransportCredential) {
-      return { kind: "idp_exchange" };
+      return { kind: "idp_exchange", callerUserId };
     }
 
     if (!hasStaticAuthorizationCredential(secrets)) {
       if (tokenAuth?.isExternalIdp && tokenAuth.rawToken) {
-        return { kind: "idp_passthrough" };
+        return { kind: "idp_passthrough", callerUserId };
       }
       if (hasPassthroughAuthorizationHeader(tokenAuth?.passthroughHeaders)) {
-        return { kind: "caller_headers" };
+        return { kind: "caller_headers", callerUserId };
       }
     }
 

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -16,6 +16,7 @@ import {
   type McpExecutedAs,
   type McpToolError,
   parseFullToolName,
+  platformExecutedAs,
   stripReservedPlatformMeta,
   TimeInMs,
 } from "@archestra/shared";
@@ -424,14 +425,16 @@ class McpClient {
       availableTool?: CatalogTool;
     },
   ): Promise<CommonToolResult> {
-    // Derive auth info for logging. Reassigned once the outbound credential is
-    // resolved below, so every result built from that point on also names the
-    // identity the upstream call ran as.
+    // Derive auth info for logging. Until a credential resolves, the call is
+    // one the platform is serving itself (it may never reach a server — an app
+    // launch, or a refusal), so it starts attributed to the caller and is
+    // reassigned below once an upstream credential is settled.
     let authInfo: ToolCallAuthInfo | undefined =
       tokenAuth && Object.keys(tokenAuth).length
         ? {
             userId: tokenAuth.userId,
             authMethod: deriveAuthMethod(tokenAuth),
+            executedAs: platformExecutedAs(tokenAuth.userId),
           }
         : undefined;
 
@@ -484,6 +487,7 @@ class McpClient {
         owner,
         tokenAuth,
         catalogItem,
+        authInfo,
       });
     if ("error" in targetMcpServerIdResult) {
       return targetMcpServerIdResult.error;
@@ -1623,12 +1627,16 @@ class McpClient {
     toolCall,
     owner,
     catalogItem,
+    authInfo,
   }: {
     tool: McpToolAssignment;
     toolCall: CommonToolCall;
     owner: ToolOwner;
     tokenAuth?: TokenAuthContext;
     catalogItem: InternalMcpCatalog;
+    // Identity of the caller, so a refusal here is recorded and rendered like
+    // any other result rather than as an anonymous error.
+    authInfo?: ToolCallAuthInfo;
   }): Promise<
     | {
         targetMcpServerId: string;
@@ -1689,7 +1697,7 @@ class McpClient {
             owner,
             reconnectError.message,
             fallbackName,
-            undefined,
+            authInfo,
             reconnectError,
           ),
         };
@@ -1740,6 +1748,7 @@ class McpClient {
             owner,
             "Enterprise-managed credentials are configured, but no MCP server installation is available for this catalog.",
             fallbackName,
+            authInfo,
           ),
         };
       }
@@ -1760,6 +1769,7 @@ class McpClient {
           owner,
           "Dynamic team credential is enabled but no token authentication provided. Use a profile token to authenticate.",
           fallbackName,
+          authInfo,
         ),
       };
     }
@@ -1770,6 +1780,7 @@ class McpClient {
           owner,
           "Dynamic team credential is enabled but tool has no catalogId.",
           fallbackName,
+          authInfo,
         ),
       };
     }
@@ -1845,6 +1856,7 @@ class McpClient {
           owner,
           "Organization-wide tokens are not supported for tools with dynamic credential resolution. Use a personal or team token instead.",
           fallbackName,
+          authInfo,
         ),
       };
     }
@@ -1904,7 +1916,7 @@ class McpClient {
         owner,
         authError.message,
         fallbackName,
-        undefined,
+        authInfo,
         authError,
       ),
     };

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -11,10 +11,12 @@ import {
   MCP_CATALOG_REAUTH_QUERY_PARAM,
   MCP_CATALOG_SERVER_QUERY_PARAM,
   MCP_ENTERPRISE_AUTH_EXTENSION_CAPABILITIES,
+  MCP_EXECUTED_AS_META_KEY,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
+  type McpExecutedAs,
   type McpToolError,
   parseFullToolName,
-  SEEDED_APP_RENDER_META_KEY,
+  stripReservedPlatformMeta,
   TimeInMs,
 } from "@archestra/shared";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -45,6 +47,7 @@ import {
   McpToolCallModel,
   TeamModel,
   ToolModel,
+  UserModel,
 } from "@/models";
 import McpCatalogTeamModel from "@/models/mcp-catalog-team";
 import { discoverOAuthEndpoints, refreshOAuthToken } from "@/routes/oauth";
@@ -159,6 +162,26 @@ export type TokenAuthContext = {
   isSessionAuth?: boolean;
   /** Headers to forward to downstream MCP servers (extracted from incoming request per gateway allowlist) */
   passthroughHeaders?: Record<string, string>;
+};
+
+/**
+ * The ownership fields of the install a tool call resolved to — everything
+ * needed to say whose credential served the call.
+ */
+type ResolvedInstallIdentity = Pick<
+  McpServer,
+  "id" | "ownerId" | "teamId" | "scope"
+>;
+
+/**
+ * Identity fields attached to every persisted tool call and returned result:
+ * who called (inbound), how they authenticated, and — once a credential has
+ * been resolved — whose credential the upstream call ran under.
+ */
+type ToolCallAuthInfo = {
+  userId?: string;
+  authMethod?: MCPGatewayAuthMethod;
+  executedAs?: McpExecutedAs;
 };
 
 /**
@@ -401,8 +424,10 @@ class McpClient {
       availableTool?: CatalogTool;
     },
   ): Promise<CommonToolResult> {
-    // Derive auth info for logging
-    const authInfo =
+    // Derive auth info for logging. Reassigned once the outbound credential is
+    // resolved below, so every result built from that point on also names the
+    // identity the upstream call ran as.
+    let authInfo: ToolCallAuthInfo | undefined =
       tokenAuth && Object.keys(tokenAuth).length
         ? {
             userId: tokenAuth.userId,
@@ -463,7 +488,8 @@ class McpClient {
     if ("error" in targetMcpServerIdResult) {
       return targetMcpServerIdResult.error;
     }
-    const { targetMcpServerId, mcpServerName } = targetMcpServerIdResult;
+    const { targetMcpServerId, mcpServerName, resolvedServer } =
+      targetMcpServerIdResult;
     const effectiveEnterpriseManagedConfig =
       catalogItem.enterpriseManagedConfig ?? null;
     if (
@@ -522,6 +548,19 @@ class McpClient {
       return secretsResult.error;
     }
     const { secrets, secretId, serverState } = secretsResult;
+
+    // The outbound credential is fully settled here (install secrets loaded,
+    // enterprise exchange done), so every result below can name the identity
+    // it ran as — including the ones the token-refresh retry produces.
+    const executedAs = await this.describeExecutedAs({
+      resolvedServer,
+      tokenAuth,
+      enterpriseTransportCredential,
+      secrets,
+    });
+    if (executedAs) {
+      authInfo = { ...authInfo, executedAs };
+    }
 
     // Build connection cache key using the resolved target server ID.
     // Agents: when conversationId is provided, each (agent, conversation) gets
@@ -1591,7 +1630,15 @@ class McpClient {
     tokenAuth?: TokenAuthContext;
     catalogItem: InternalMcpCatalog;
   }): Promise<
-    | { targetMcpServerId: string; mcpServerName: string }
+    | {
+        targetMcpServerId: string;
+        mcpServerName: string;
+        // The install whose stored credential serves the call, so the caller
+        // can report which identity the upstream call ran as. Null only when
+        // the install row could not be loaded (a pin whose row vanished
+        // between resolution and lookup).
+        resolvedServer: ResolvedInstallIdentity | null;
+      }
     | { error: CommonToolResult }
   > {
     const fallbackName = tool.catalogName || "unknown";
@@ -1629,6 +1676,7 @@ class McpClient {
           return {
             targetMcpServerId: resolved.id,
             mcpServerName: resolved.name,
+            resolvedServer: resolved,
           };
         }
         const reconnectError = this.buildReconnectRequiredMessage(
@@ -1662,6 +1710,7 @@ class McpClient {
       return {
         targetMcpServerId: tool.mcpServerId,
         mcpServerName: mcpServer?.name || fallbackName,
+        resolvedServer: mcpServer ?? null,
       };
     }
 
@@ -1676,6 +1725,7 @@ class McpClient {
         return {
           targetMcpServerId: explicitTargetMcpServerId,
           mcpServerName: mcpServer?.name || fallbackName,
+          resolvedServer: mcpServer ?? null,
         };
       }
 
@@ -1697,6 +1747,7 @@ class McpClient {
       return {
         targetMcpServerId: resolvedServer.id,
         mcpServerName: resolvedServer.name,
+        resolvedServer,
       };
     }
 
@@ -1747,6 +1798,7 @@ class McpClient {
         return {
           targetMcpServerId: pinnedServer.id,
           mcpServerName: pinnedServer.name,
+          resolvedServer: pinnedServer,
         };
       }
       logger.warn(
@@ -1781,6 +1833,7 @@ class McpClient {
       return {
         targetMcpServerId: resolvedServer.id,
         mcpServerName: resolvedServer.name,
+        resolvedServer,
       };
     }
 
@@ -1823,6 +1876,7 @@ class McpClient {
         return {
           targetMcpServerId: idpFallbackServer.id,
           mcpServerName: idpFallbackServer.name,
+          resolvedServer: idpFallbackServer,
         };
       }
     }
@@ -2335,6 +2389,17 @@ class McpClient {
     return nameMap.get(strippedToolName.toLowerCase()) ?? strippedToolName;
   }
 
+  // The reserved `_meta` entry naming the identity a call ran as, or nothing
+  // when no upstream credential was resolved (a platform built-in, an app
+  // launch, or a failure before resolution).
+  private executedAsMeta(
+    authInfo: ToolCallAuthInfo | undefined,
+  ): Record<string, McpExecutedAs> {
+    return authInfo?.executedAs
+      ? { [MCP_EXECUTED_AS_META_KEY]: authInfo.executedAs }
+      : {};
+  }
+
   /**
    * Create and persist an error result
    */
@@ -2343,10 +2408,7 @@ class McpClient {
     owner: ToolOwner,
     error: string,
     mcpServerName: string = "unknown",
-    authInfo?: {
-      userId?: string;
-      authMethod?: MCPGatewayAuthMethod;
-    },
+    authInfo?: ToolCallAuthInfo,
     structuredError?: McpToolError,
   ): Promise<CommonToolResult> {
     const normalizedError: McpToolError = structuredError ?? {
@@ -2362,6 +2424,7 @@ class McpClient {
       error,
       _meta: {
         archestraError: normalizedError,
+        ...this.executedAsMeta(authInfo),
       },
       structuredContent: {
         archestraError: normalizedError,
@@ -2388,7 +2451,7 @@ class McpClient {
     content: ContentBlock[];
     isError: boolean;
     _meta?: Record<string, unknown>;
-    authInfo?: { userId?: string; authMethod?: MCPGatewayAuthMethod };
+    authInfo?: ToolCallAuthInfo;
     structuredContent?: Record<string, unknown>;
   }): Promise<CommonToolResult> {
     const {
@@ -2402,18 +2465,25 @@ class McpClient {
       structuredContent,
     } = opts;
 
-    // `archestraError` and the seeded-app-render marker are platform-reserved
-    // envelopes: error renderers and the trusted-data guardrail key off them to
-    // identify platform-authored results. Only the platform sets them, so strip
-    // any copy an upstream tool put in its result metadata — otherwise a
-    // hostile server could forge a dispatch error or a seeded-render marker and
-    // slip untrusted output past the injection scan.
+    // `archestraError`, the seeded-app-render marker and the executed-as
+    // identity are platform-reserved envelopes: error renderers, the
+    // trusted-data guardrail and the tool card key off them to identify
+    // platform-authored results. Only the platform sets them, so strip any copy
+    // an upstream tool put in its result metadata — otherwise a hostile server
+    // could forge a dispatch error, a seeded-render marker or an identity, and
+    // slip untrusted output past the injection scan. The platform's own
+    // executed-as value goes on after the strip.
+    const executedAsMeta = this.executedAsMeta(authInfo);
+    const strippedMeta = stripReservedPlatformMeta(_meta);
     const toolResult: CommonToolResult = {
       id: toolCall.id,
       name: toolCall.name,
       content,
       isError,
-      _meta: stripReservedPlatformMeta(_meta),
+      _meta:
+        strippedMeta || Object.keys(executedAsMeta).length
+          ? { ...strippedMeta, ...executedAsMeta }
+          : undefined,
       structuredContent: stripReservedPlatformMeta(structuredContent),
     };
 
@@ -2853,14 +2923,14 @@ class McpClient {
       return null;
     }
 
-    if (server.scope === "org") {
+    const executedAs = await this.describeInstallCredential(server);
+    if (executedAs.kind === "org") {
       return { credentialScope: "org", credentialTeamName: null };
     }
-    if (server.teamId) {
-      const [team] = await TeamModel.findByIds([server.teamId]);
+    if (executedAs.kind === "team") {
       return {
         credentialScope: "team",
-        credentialTeamName: team?.name ?? null,
+        credentialTeamName: executedAs.teamName,
       };
     }
     // Personal install. Only present it as the caller's own credential when the
@@ -2871,12 +2941,81 @@ class McpClient {
     // credentials …" and point the caller at the wrong owner.
     if (
       tokenAuth?.userId &&
-      server.ownerId &&
-      tokenAuth.userId === server.ownerId
+      executedAs.ownerUserId &&
+      tokenAuth.userId === executedAs.ownerUserId
     ) {
       return { credentialScope: "personal", credentialTeamName: null };
     }
     return null;
+  }
+
+  /**
+   * Describe which identity the upstream call ran as, so the chat card and the
+   * tool-call log record can answer "on whose behalf did this run?".
+   *
+   * The order mirrors how {@link getTransport} actually builds the outbound
+   * credential header, not how the install was picked: an enterprise-managed
+   * credential overrides the install's own secrets, and an external IdP token
+   * is forwarded only when the install carries no stored authorization of its
+   * own. Getting the order wrong would name the install's owner for a call
+   * that really ran as the caller.
+   */
+  private async describeExecutedAs(params: {
+    resolvedServer: ResolvedInstallIdentity | null;
+    tokenAuth: TokenAuthContext | undefined;
+    enterpriseTransportCredential: ResolvedEnterpriseTransportCredential | null;
+    secrets: Record<string, unknown>;
+  }): Promise<McpExecutedAs | null> {
+    const {
+      resolvedServer,
+      tokenAuth,
+      enterpriseTransportCredential,
+      secrets,
+    } = params;
+
+    if (enterpriseTransportCredential) {
+      return { kind: "idp_exchange" };
+    }
+
+    if (!hasStaticAuthorizationCredential(secrets)) {
+      if (tokenAuth?.isExternalIdp && tokenAuth.rawToken) {
+        return { kind: "idp_passthrough" };
+      }
+      if (hasPassthroughAuthorizationHeader(tokenAuth?.passthroughHeaders)) {
+        return { kind: "caller_headers" };
+      }
+    }
+
+    return resolvedServer
+      ? await this.describeInstallCredential(resolvedServer)
+      : null;
+  }
+
+  /**
+   * Map an install to the identity its stored credential belongs to. Shared by
+   * the executed-as descriptor and the expired-credential card so both read
+   * the install's scope the same way.
+   */
+  private async describeInstallCredential(
+    server: Pick<McpServer, "scope" | "teamId" | "ownerId">,
+  ): Promise<Extract<McpExecutedAs, { kind: "personal" | "team" | "org" }>> {
+    if (server.scope === "org") {
+      return { kind: "org" };
+    }
+    if (server.teamId) {
+      const [team] = await TeamModel.findByIds([server.teamId]);
+      return {
+        kind: "team",
+        teamId: server.teamId,
+        teamName: team?.name ?? null,
+      };
+    }
+    const ownerName = server.ownerId
+      ? ((await UserModel.getNamesByIds([server.ownerId])).get(
+          server.ownerId,
+        ) ?? null)
+      : null;
+    return { kind: "personal", ownerUserId: server.ownerId, ownerName };
   }
 
   private buildAssignedCredentialUnavailableMessage(
@@ -2987,10 +3126,7 @@ class McpClient {
     mcpServerName: string,
     toolCall: CommonToolCall,
     toolResult: CommonToolResult,
-    authInfo?: {
-      userId?: string;
-      authMethod?: MCPGatewayAuthMethod;
-    },
+    authInfo?: ToolCallAuthInfo,
   ): Promise<void> {
     // Skip high-frequency browser tool logging to prevent DB bloat
     // (screenshots every ~2s, tab list checks, viewport resizes)
@@ -4175,33 +4311,6 @@ function isAuthRelatedError(errorMessage: string): boolean {
   );
 }
 
-// Platform-reserved metadata keys: `archestraError` (set only by
-// createErrorResult) and the seeded-app-render marker (set only by the
-// open-in-chat conversation seeding). Renderers and the trusted-data guardrail
-// key off them to identify platform-authored results.
-const RESERVED_PLATFORM_META_KEYS = [
-  "archestraError",
-  SEEDED_APP_RENDER_META_KEY,
-] as const;
-
-// Remove platform-reserved keys from tool-supplied metadata so they can only
-// ever be present when the platform itself authored them — otherwise a hostile
-// server could forge a dispatch error or a seeded-render marker and slip
-// untrusted output past the injection scan. Returns the same reference when
-// nothing was stripped.
-function stripReservedPlatformMeta(
-  meta: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
-  if (!meta || !RESERVED_PLATFORM_META_KEYS.some((key) => key in meta)) {
-    return meta;
-  }
-  const rest = { ...meta };
-  for (const key of RESERVED_PLATFORM_META_KEYS) {
-    delete rest[key];
-  }
-  return rest;
-}
-
 function isAuthRelatedToolResult(result: {
   isError?: boolean;
   content?: Array<{ type?: string; text?: string }>;
@@ -4497,6 +4606,20 @@ function getJwtExpirationMs(token: string): number | undefined {
   }
 
   return undefined;
+}
+
+// Whether the caller's own request supplied the upstream authorization header,
+// which the transport forwards verbatim (mergePassthroughHeaders only fills
+// headers the install itself did not set) — so the call runs as the caller.
+function hasPassthroughAuthorizationHeader(
+  passthroughHeaders: Record<string, string> | undefined,
+): boolean {
+  if (!passthroughHeaders) {
+    return false;
+  }
+  return Object.keys(passthroughHeaders).some(
+    (name) => name.toLowerCase() === "authorization",
+  );
 }
 
 function hasStaticAuthorizationCredential(

--- a/platform/backend/src/routes/chat/sandbox-command-turn.test.ts
+++ b/platform/backend/src/routes/chat/sandbox-command-turn.test.ts
@@ -202,7 +202,11 @@ describe("POST /api/chat sandbox command turn", () => {
     expect(toolParts).toHaveLength(1);
     expect(toolParts[0].state).toBe("output-available");
     expect(toolParts[0].input).toEqual({ command: "echo hi" });
-    expect(typeof toolParts[0].output).toBe("string");
+    // Tool output carries the identity the call ran as alongside its text, so
+    // it is the same { content, _meta } shape every MCP tool result has.
+    expect(toolParts[0].output).toMatchObject({
+      content: expect.stringContaining("hi"),
+    });
     expect(mockRunSandboxCommand).toHaveBeenCalledTimes(1);
     expect(mockRunSandboxCommand.mock.calls[0][0].command).toBe("echo hi");
   });
@@ -280,7 +284,9 @@ describe("POST /api/chat sandbox command turn", () => {
     const toolParts = toolPartsOf(assistant as ChatMessage);
     expect(toolParts).toHaveLength(1);
     expect(toolParts[0].state).toBe("output-available");
-    expect(typeof toolParts[0].output).toBe("string");
+    expect(toolParts[0].output).toMatchObject({
+      content: expect.stringContaining("engine unreachable"),
+    });
   });
 
   test("a marked message with multiple text parts is not executed", async () => {

--- a/platform/backend/src/routes/mcp-gateway.executed-as.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.executed-as.test.ts
@@ -1,0 +1,154 @@
+import {
+  extractMcpExecutedAs,
+  TOOL_RUN_TOOL_FULL_NAME,
+  TOOL_SEARCH_TOOLS_FULL_NAME,
+} from "@archestra/shared";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { vi } from "vitest";
+import { TeamTokenModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import mcpGatewayRoutes from "./mcp-gateway";
+
+const executeToolCallForOwnerMock = vi.hoisted(() => vi.fn());
+
+// The upstream call is the process boundary here: the point of these tests is
+// what the gateway reports about the identity that served a call, not whether
+// a real server answers.
+vi.mock("@/clients/mcp-client", () => ({
+  McpServerNotReadyError: class extends Error {},
+  McpServerConnectionTimeoutError: class extends Error {},
+  default: {
+    executeToolCallForOwner: executeToolCallForOwnerMock,
+    resolveUiAppInstallIdForCaller: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+function makeMcpHeaders(token: string): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    authorization: `Bearer ${token}`,
+  };
+}
+
+describe("MCP gateway executed-as identity", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    executeToolCallForOwnerMock.mockReset();
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    await app.register(mcpGatewayRoutes);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function callTool(params: {
+    agentId: string;
+    token: string;
+    name: string;
+    arguments: Record<string, unknown>;
+  }) {
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${params.agentId}`,
+      headers: makeMcpHeaders(params.token),
+      payload: {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: params.name, arguments: params.arguments },
+        id: 2,
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    return response.json().result;
+  }
+
+  test("keeps the connection that served a dispatched tool", async ({
+    makeAgent,
+    makeAgentTool,
+    makeInternalMcpCatalog,
+    makeOrganization,
+    makeTool,
+  }) => {
+    const org = await makeOrganization();
+    const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
+    const tool = await makeTool({
+      catalogId: catalog.id,
+      name: `dispatch_target_${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      toolExposureMode: "search_and_run_only",
+    });
+    await makeAgentTool(agent.id, tool.id);
+    const { value: token } = await TeamTokenModel.create({
+      organizationId: org.id,
+      name: "Org Token",
+      teamId: null,
+      isOrganizationToken: true,
+    });
+    // The dispatched call reached a real server through an org connection.
+    executeToolCallForOwnerMock.mockResolvedValue({
+      id: "call-1",
+      name: tool.name,
+      content: [{ type: "text", text: "upstream ok" }],
+      isError: false,
+      _meta: { archestraExecutedAs: { kind: "org" } },
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      token,
+      name: TOOL_RUN_TOOL_FULL_NAME,
+      arguments: { tool_name: tool.name, tool_args: {} },
+    });
+
+    // run_tool is a platform tool, but the call it dispatched ran under the
+    // organization's connection — that is the identity clients must see.
+    expect(extractMcpExecutedAs(result)).toEqual({ kind: "org" });
+  });
+
+  test("attributes a tool the platform ran itself to the caller", async ({
+    makeAgent,
+    makeOrganization,
+    makeUser,
+    makeMember,
+  }) => {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+    const agent = await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      toolExposureMode: "search_and_run_only",
+    });
+    const { value: token } = await TeamTokenModel.create({
+      organizationId: org.id,
+      name: "Org Token",
+      teamId: null,
+      isOrganizationToken: true,
+    });
+
+    const result = await callTool({
+      agentId: agent.id,
+      token,
+      name: TOOL_SEARCH_TOOLS_FULL_NAME,
+      arguments: { query: "anything" },
+    });
+
+    // No server was contacted, so there is no connection to name — but the
+    // call still ran on someone's behalf, and the card must say so.
+    expect(extractMcpExecutedAs(result)).toMatchObject({ kind: "platform" });
+    expect(executeToolCallForOwnerMock).not.toHaveBeenCalled();
+  });
+});

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import {
   ARCHESTRA_MCP_CATALOG_ID,
+  extractMcpExecutedAs,
   hasArchestraTokenPrefix,
   isAgentTool,
   isAlwaysExposedArchestraToolShortName,
@@ -12,7 +13,6 @@ import {
   OAUTH_TOKEN_ID_PREFIX,
   parseFullToolName,
   platformExecutedAs,
-  stripReservedPlatformMeta,
   TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
   TOOL_RENDER_APP_SHORT_NAME,
   TOOL_RUN_TOOL_SHORT_NAME,
@@ -799,16 +799,17 @@ export async function createAgentServer(
               : "Archestra MCP tool call completed",
           );
 
-          // Archestra ran this tool itself, with the caller's permissions —
-          // record that as the identity so the log answers "as who" for
-          // in-process tools too, not only for calls that reached a server.
+          // `run_tool` dispatches reach a real server, and that call already
+          // named the connection that served it — keep it. Anything else here
+          // Archestra ran itself, with the caller's permissions, so the log and
+          // the client still learn who it ran for.
           const archestraResult = {
             ...response,
             _meta: {
-              ...stripReservedPlatformMeta(
-                response._meta as Record<string, unknown> | undefined,
-              ),
-              [MCP_EXECUTED_AS_META_KEY]: platformExecutedAs(tokenAuth?.userId),
+              ...(response._meta as Record<string, unknown> | undefined),
+              [MCP_EXECUTED_AS_META_KEY]:
+                extractMcpExecutedAs(response) ??
+                platformExecutedAs(tokenAuth?.userId),
             },
           };
 

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -6,10 +6,13 @@ import {
   isAgentTool,
   isAlwaysExposedArchestraToolShortName,
   isSkillTool,
+  MCP_EXECUTED_AS_META_KEY,
   MCP_GATEWAY_OAUTH_SCOPE,
   MCP_OAUTH_CLIENT_REFERENCE_PREFIX,
   OAUTH_TOKEN_ID_PREFIX,
   parseFullToolName,
+  platformExecutedAs,
+  stripReservedPlatformMeta,
   TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
   TOOL_RENDER_APP_SHORT_NAME,
   TOOL_RUN_TOOL_SHORT_NAME,
@@ -796,6 +799,19 @@ export async function createAgentServer(
               : "Archestra MCP tool call completed",
           );
 
+          // Archestra ran this tool itself, with the caller's permissions —
+          // record that as the identity so the log answers "as who" for
+          // in-process tools too, not only for calls that reached a server.
+          const archestraResult = {
+            ...response,
+            _meta: {
+              ...stripReservedPlatformMeta(
+                response._meta as Record<string, unknown> | undefined,
+              ),
+              [MCP_EXECUTED_AS_META_KEY]: platformExecutedAs(tokenAuth?.userId),
+            },
+          };
+
           // Persist archestra/agent delegation tool call to database
           try {
             await McpToolCallModel.create({
@@ -807,7 +823,7 @@ export async function createAgentServer(
                 name,
                 arguments: args || {},
               },
-              toolResult: response,
+              toolResult: archestraResult,
               userId: tokenAuth?.userId ?? null,
               authMethod: deriveAuthMethod(tokenAuth) ?? null,
             });
@@ -818,7 +834,7 @@ export async function createAgentServer(
             );
           }
 
-          return response;
+          return archestraResult;
         }
 
         logger.info(

--- a/platform/e2e-tests/tests/dynamic-credentials.spec.ts
+++ b/platform/e2e-tests/tests/dynamic-credentials.spec.ts
@@ -1,4 +1,5 @@
-import { archestraApiSdk } from "@archestra/shared";
+import { archestraApiSdk, MCP_EXECUTED_AS_META_KEY } from "@archestra/shared";
+import { expect } from "@playwright/test";
 import {
   DEFAULT_TEAM_NAME,
   ENGINEERING_TEAM_NAME,
@@ -7,7 +8,9 @@ import {
 import { test } from "../fixtures";
 import {
   addCustomSelfHostedCatalogItem,
+  callMcpTool,
   createSharedTestGatewayViaApi,
+  getTeamTokenForProfile,
   goToMcpRegistry,
   installLocalCatalogItem,
   settleRegistryAfterInstall,
@@ -188,6 +191,21 @@ test("Verify tool calling using dynamic credentials", async ({
       profileId: sharedGateway.id,
     });
   }
+
+  // The gateway reports which connection served the call, so a client (and the
+  // MCP logs behind it) can tell whose credential ran the tool.
+  const engineeringToolResult = await callMcpTool(request, {
+    profileId: sharedGateway.id,
+    token: await getTeamTokenForProfile(request, ENGINEERING_TEAM_NAME),
+    toolName: `${CATALOG_ITEM_NAME}__print_archestra_test`,
+    timeoutMs: 60_000,
+  });
+  expect(engineeringToolResult._meta?.[MCP_EXECUTED_AS_META_KEY]).toMatchObject(
+    {
+      kind: "team",
+      teamName: ENGINEERING_TEAM_NAME,
+    },
+  );
 
   // CLEANUP: Delete existing created MCP servers / installations
   await archestraApiSdk.deleteInternalMcpCatalogItem({

--- a/platform/e2e-tests/utils/mcp-gateway.ts
+++ b/platform/e2e-tests/utils/mcp-gateway.ts
@@ -274,7 +274,10 @@ export async function callMcpTool(
     arguments?: Record<string, unknown>;
     timeoutMs?: number;
   },
-): Promise<{ content: Array<{ type: string; text?: string }> }> {
+): Promise<{
+  content: Array<{ type: string; text?: string }>;
+  _meta?: Record<string, unknown>;
+}> {
   const callToolResponse = await makeApiRequest({
     request,
     method: "post",
@@ -302,7 +305,7 @@ export async function callMcpTool(
   return callResult.result;
 }
 
-async function getTeamTokenForProfile(
+export async function getTeamTokenForProfile(
   request: APIRequestContext,
   teamName: string,
 ): Promise<string> {

--- a/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { useProfiles } from "@/lib/agent.query";
 import {
   formatAuthMethod,
+  formatCallerIdentity,
   useMcpToolCall,
 } from "@/lib/mcp/mcp-tool-call.query";
 import { formatDate } from "@/lib/utils";
@@ -197,8 +198,7 @@ function McpToolCallDetail({
             <MetadataItem label="Called as">
               <ExecutedAsBadge
                 executedAs={executedAs}
-                meUserId={mcpToolCall.userId}
-                callerName={mcpToolCall.userName}
+                callerName={formatCallerIdentity(mcpToolCall)}
               />
             </MetadataItem>
           )}

--- a/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
@@ -198,6 +198,7 @@ function McpToolCallDetail({
               <ExecutedAsBadge
                 executedAs={executedAs}
                 meUserId={mcpToolCall.userId}
+                callerName={mcpToolCall.userName}
               />
             </MetadataItem>
           )}

--- a/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { type archestraApiTypes, parseFullToolName } from "@archestra/shared";
+import {
+  type archestraApiTypes,
+  extractMcpExecutedAs,
+  parseFullToolName,
+} from "@archestra/shared";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { ErrorBoundary } from "@/app/_parts/error-boundary";
+import { ExecutedAsBadge } from "@/components/executed-as-badge";
 import { JsonCodeBlock } from "@/components/json-code-block";
 import { LoadingSpinner, LoadingWrapper } from "@/components/loading";
 import { MetadataCard, MetadataItem } from "@/components/metadata-card";
@@ -97,6 +102,9 @@ function McpToolCallDetail({
     content?: unknown;
   } | null;
 
+  // Whose credential served the call upstream, recorded with the result.
+  const executedAs = extractMcpExecutedAs(mcpToolCall.toolResult);
+
   const isError =
     method === "tools/call" &&
     toolResult &&
@@ -183,6 +191,14 @@ function McpToolCallDetail({
               <Badge variant="secondary" className="text-xs">
                 {formatAuthMethod(mcpToolCall.authMethod)}
               </Badge>
+            </MetadataItem>
+          )}
+          {executedAs && (
+            <MetadataItem label="Ran As">
+              <ExecutedAsBadge
+                executedAs={executedAs}
+                meUserId={mcpToolCall.userId}
+              />
             </MetadataItem>
           )}
         </MetadataCard>

--- a/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
@@ -198,7 +198,7 @@ function McpToolCallDetail({
             <MetadataItem label="Called as">
               <ExecutedAsBadge
                 executedAs={executedAs}
-                callerName={formatCallerIdentity(mcpToolCall)}
+                caller={formatCallerIdentity(mcpToolCall)}
               />
             </MetadataItem>
           )}

--- a/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/[id]/page.client.tsx
@@ -194,7 +194,7 @@ function McpToolCallDetail({
             </MetadataItem>
           )}
           {executedAs && (
-            <MetadataItem label="Ran As">
+            <MetadataItem label="Called as">
               <ExecutedAsBadge
                 executedAs={executedAs}
                 meUserId={mcpToolCall.userId}

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { type archestraApiTypes, parseFullToolName } from "@archestra/shared";
+import {
+  type archestraApiTypes,
+  extractMcpExecutedAs,
+  parseFullToolName,
+} from "@archestra/shared";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { ChevronDown, ChevronUp, User } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { ExecutedAsBadge } from "@/components/executed-as-badge";
 import { ProfileFilterOption } from "@/components/log-filter-option";
 import { QueryLoadError } from "@/components/query-load-error";
 import { SearchInput } from "@/components/search-input";
@@ -287,6 +292,28 @@ function McpToolCallsTable({
               </Badge>
             )}
           </div>
+        );
+      },
+    },
+    {
+      id: "executedAs",
+      header: "Ran As",
+      cell: ({ row }) => {
+        // Whose credential served the call upstream. The User column above is
+        // who asked for it, so the two together read "ran as X on behalf of Y".
+        // Blank for calls the platform served in process and for rows recorded
+        // before the identity was captured.
+        const executedAs = extractMcpExecutedAs(row.original.toolResult);
+        if (!executedAs) {
+          return <div className="text-xs text-muted-foreground">—</div>;
+        }
+        // Named from the caller's perspective, not the reader's: "me" here
+        // means the call ran on the caller's own connection.
+        return (
+          <ExecutedAsBadge
+            executedAs={executedAs}
+            meUserId={row.original.userId}
+          />
         );
       },
     },

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -297,7 +297,7 @@ function McpToolCallsTable({
     },
     {
       id: "executedAs",
-      header: "Ran As",
+      header: "Called as",
       cell: ({ row }) => {
         // Whose credential served the call upstream. The User column above is
         // who asked for it, so the two together read "ran as X on behalf of Y".

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -313,7 +313,7 @@ function McpToolCallsTable({
         return (
           <ExecutedAsBadge
             executedAs={executedAs}
-            callerName={formatCallerIdentity(row.original)}
+            caller={formatCallerIdentity(row.original)}
           />
         );
       },

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -31,6 +31,7 @@ import { useDateTimeRangePicker } from "@/lib/hooks/use-date-time-range-picker";
 import { useMcpServers } from "@/lib/mcp/mcp-server.query";
 import {
   formatAuthMethod,
+  formatCallerIdentity,
   useMcpToolCalls,
 } from "@/lib/mcp/mcp-tool-call.query";
 import { formatDate } from "@/lib/utils";
@@ -307,13 +308,12 @@ function McpToolCallsTable({
         if (!executedAs) {
           return <div className="text-xs text-muted-foreground">—</div>;
         }
-        // Named from the caller's perspective, not the reader's: "me" here
-        // means the call ran on the caller's own connection.
+        // An auditor needs the person, never "Me" — the reader is rarely the
+        // caller here, so no identity is ever written from their perspective.
         return (
           <ExecutedAsBadge
             executedAs={executedAs}
-            meUserId={row.original.userId}
-            callerName={row.original.userName}
+            callerName={formatCallerIdentity(row.original)}
           />
         );
       },

--- a/platform/frontend/src/app/mcp/logs/page.client.tsx
+++ b/platform/frontend/src/app/mcp/logs/page.client.tsx
@@ -313,6 +313,7 @@ function McpToolCallsTable({
           <ExecutedAsBadge
             executedAs={executedAs}
             meUserId={row.original.userId}
+            callerName={row.original.userName}
           />
         );
       },

--- a/platform/frontend/src/components/ai-elements/tool.tsx
+++ b/platform/frontend/src/components/ai-elements/tool.tsx
@@ -61,6 +61,8 @@ export type ToolHeaderProps = {
   isCollapsible?: boolean;
   /** Optional action button to display in the header (e.g., View Logs) */
   actionButton?: React.ReactNode;
+  /** Names the identity the call ran as upstream (e.g. whose connection served it) */
+  identityBadge?: React.ReactNode;
 };
 
 const getStatusBadge = (
@@ -104,6 +106,7 @@ export const ToolHeader = ({
   icon,
   isCollapsible = true,
   actionButton,
+  identityBadge,
   ...props
 }: ToolHeaderProps) => (
   <CollapsibleTrigger
@@ -121,6 +124,7 @@ export const ToolHeader = ({
       </span>
     </div>
     <div className="flex items-center gap-3">
+      {identityBadge}
       {getStatusBadge(state)}
       {actionButton && (
         // biome-ignore lint/a11y/noStaticElementInteractions: Wrapper needs to stop event propagation

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -5,6 +5,7 @@ import {
   type archestraApiTypes,
   type ChatMessageFeedback,
   ChatMessageMetadataSchema,
+  extractMcpExecutedAs,
   getArchestraToolFullName,
   HOOK_RUN_PART_TYPE,
   parseArchestraAppResourceUri,
@@ -54,6 +55,7 @@ import {
   HookRunChip,
   type HookRunChipData,
 } from "@/components/chat/hook-run-chip";
+import { ExecutedAsBadge } from "@/components/executed-as-badge";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import {
   Tooltip,
@@ -61,7 +63,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useHasPermissions } from "@/lib/auth/auth.query";
+import { useHasPermissions, useSession } from "@/lib/auth/auth.query";
 import { useProfileToolsWithIds } from "@/lib/chat/chat.query";
 import { useUpdateChatMessage } from "@/lib/chat/chat-message.query";
 import {
@@ -1631,6 +1633,9 @@ const MessageTool = memo(
       | { resourceUri?: string; mcpServerId?: string }
       | undefined;
     const uiResourceUri = uiMeta?.resourceUri ?? earlyToolUiData?.uiResourceUri;
+    // Whose credential the gateway used against the upstream server. Present
+    // only once the call has run, so the badge appears with the result.
+    const executedAs = extractMcpExecutedAs(mcpOutput);
     // A server-scoped deep link (apps-page open-in-chat) stamps the concrete
     // install so the chat mounts against it instead of the agent gateway.
     const uiMcpServerId = uiMeta?.mcpServerId;
@@ -1685,6 +1690,8 @@ const MessageTool = memo(
     const shouldDefaultOpen = isApprovalRequested;
 
     // Hooks must be called before any early returns
+    const { data: session } = useSession();
+    const viewerUserId = session?.user?.id;
     const [isOpen, setIsOpen] = useState(shouldDefaultOpen);
     const [userDenied, setUserDenied] = useState(false);
     const [userHasInteracted, setUserHasInteracted] = useState(false);
@@ -1807,6 +1814,9 @@ const MessageTool = memo(
           })}
           isCollapsible={isExpandable}
           actionButton={logsButton}
+          identityBadge={
+            <ExecutedAsBadge executedAs={executedAs} meUserId={viewerUserId} />
+          }
         />
         <ToolContent forceMount={uiResourceUri ? true : undefined}>
           {hasInput ? <ToolInput input={displayInput} /> : null}

--- a/platform/frontend/src/components/chat/chat-messages.tsx
+++ b/platform/frontend/src/components/chat/chat-messages.tsx
@@ -1815,7 +1815,13 @@ const MessageTool = memo(
           isCollapsible={isExpandable}
           actionButton={logsButton}
           identityBadge={
-            <ExecutedAsBadge executedAs={executedAs} meUserId={viewerUserId} />
+            <span className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+              Called as
+              <ExecutedAsBadge
+                executedAs={executedAs}
+                meUserId={viewerUserId}
+              />
+            </span>
           }
         />
         <ToolContent forceMount={uiResourceUri ? true : undefined}>

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -581,10 +581,13 @@ function ExpandedToolCard({
         isCollapsible={false}
         actionButton={logsButton}
         identityBadge={
-          <ExecutedAsBadge
-            executedAs={executedAs}
-            meUserId={session?.user?.id}
-          />
+          <span className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            Called as
+            <ExecutedAsBadge
+              executedAs={executedAs}
+              meUserId={session?.user?.id}
+            />
+          </span>
         }
       />
       <ToolContent>

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -2,6 +2,7 @@
 
 import {
   ARCHESTRA_MCP_CATALOG_ID,
+  extractMcpExecutedAs,
   parseFullToolName,
   TOOL_LOAD_SKILL_SHORT_NAME,
 } from "@archestra/shared";
@@ -16,6 +17,7 @@ import {
   ToolInput,
   ToolOutput,
 } from "@/components/ai-elements/tool";
+import { ExecutedAsBadge } from "@/components/executed-as-badge";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
 import {
   Tooltip,
@@ -23,6 +25,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useSession } from "@/lib/auth/auth.query";
 import {
   getCompactToolState,
   getToolHeaderState,
@@ -553,8 +556,13 @@ function ExpandedToolCard({
   }) => void;
 }) {
   const { part, toolResultPart, toolName, errorText, nestedToolCalls } = tool;
+  const { data: session } = useSession();
   const hasInput = part.input && Object.keys(part.input).length > 0;
   const isApprovalRequested = part.state === "approval-requested";
+  // Whose credential the gateway used against the upstream server.
+  const executedAs = extractMcpExecutedAs(
+    toolResultPart ? toolResultPart.output : part.output,
+  );
 
   const logsButton = errorText ? (
     <ToolErrorLogsButton toolName={toolName} />
@@ -572,6 +580,12 @@ function ExpandedToolCard({
         state={headerState}
         isCollapsible={false}
         actionButton={logsButton}
+        identityBadge={
+          <ExecutedAsBadge
+            executedAs={executedAs}
+            meUserId={session?.user?.id}
+          />
+        }
       />
       <ToolContent>
         {hasInput ? <ToolInput input={part.input} defaultOpen /> : null}

--- a/platform/frontend/src/components/chat/knowledge-graph-citations.tsx
+++ b/platform/frontend/src/components/chat/knowledge-graph-citations.tsx
@@ -55,8 +55,7 @@ export function extractCitations(
     }> = [];
 
     try {
-      const parsed =
-        typeof part.output === "string" ? JSON.parse(part.output) : part.output;
+      const parsed = parseToolOutput(part.output);
       if (Array.isArray(parsed?.results)) {
         results = parsed.results;
       } else if (typeof parsed?.tool_result === "string") {
@@ -189,4 +188,23 @@ export function KnowledgeGraphCitations({
       </div>
     </div>
   );
+}
+
+// A tool result reaches the UI either as the raw JSON string a platform tool
+// returned, or wrapped in the MCP output object (which carries that same JSON
+// as `content`, alongside metadata such as the identity the call ran as).
+function parseToolOutput(
+  output: unknown,
+): { results?: unknown; tool_result?: unknown } | null {
+  if (typeof output === "string") {
+    return JSON.parse(output);
+  }
+  if (output && typeof output === "object") {
+    const content = (output as { content?: unknown }).content;
+    if (typeof content === "string") {
+      return JSON.parse(content);
+    }
+    return output as { results?: unknown; tool_result?: unknown };
+  }
+  return null;
 }

--- a/platform/frontend/src/components/executed-as-badge.test.tsx
+++ b/platform/frontend/src/components/executed-as-badge.test.tsx
@@ -62,12 +62,27 @@ describe("ExecutedAsBadge", () => {
     [{ kind: "idp_exchange" }, "Ran as the caller"],
     [{ kind: "idp_passthrough" }, "Ran as the caller"],
     [{ kind: "caller_headers" }, "Ran as the caller"],
+    [{ kind: "platform", callerUserId: "user-1" }, "Ran as me"],
+    [{ kind: "platform", callerUserId: "user-2" }, "Ran as the caller"],
+    [{ kind: "platform", callerUserId: null }, "Ran as the caller"],
   ] as Array<
     [McpExecutedAs, string]
   >)("labels a %o identity", (executedAs, label) => {
     render(<ExecutedAsBadge executedAs={executedAs} meUserId="user-1" />);
 
     expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("names the caller on a call Archestra ran itself", () => {
+    render(
+      <ExecutedAsBadge
+        executedAs={{ kind: "platform", callerUserId: "user-2" }}
+        meUserId="user-1"
+        callerName="Grace Hopper"
+      />,
+    );
+
+    expect(screen.getByText("Ran as Grace Hopper")).toBeInTheDocument();
   });
 
   it("renders nothing for a call that resolved no upstream credential", () => {

--- a/platform/frontend/src/components/executed-as-badge.test.tsx
+++ b/platform/frontend/src/components/executed-as-badge.test.tsx
@@ -87,32 +87,32 @@ describe("ExecutedAsBadge", () => {
       <ExecutedAsBadge
         executedAs={{ kind: "platform", callerUserId: "user-2" }}
         meUserId="user-1"
-        caller={{ label: "Grace Hopper", scope: "personal" }}
+        caller={{ name: "Grace Hopper", scope: "personal" }}
       />,
     );
 
     expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
   });
 
-  it("draws a gateway token as its own scope, not as a person", async () => {
+  it("credits a call made with a gateway token to the scope it acts for", async () => {
     const user = userEvent.setup();
     render(
       <ExecutedAsBadge
         executedAs={{ kind: "platform", callerUserId: null }}
-        caller={{ label: "Org Token", scope: "org" }}
+        caller={{ name: null, scope: "org" }}
       />,
     );
 
-    // A token belongs to the organization, so it must not wear the personal
-    // peel that names somebody's own connection.
-    const label = screen.getByText("Org Token");
+    // The organization is the identity here, so the peel is the same one an
+    // organization-wide connection wears — never a person's.
+    const label = screen.getByText("Organization");
     expect(label.closest("span")?.parentElement).toHaveClass(
       ...scopeStyles.org.split(" "),
     );
     await user.hover(label);
     expect(
       await screen.findAllByText(
-        "This call used the Org Token to reach the Acme AI",
+        "This call used the organization's own connection to the Acme AI",
       ),
     ).not.toHaveLength(0);
   });
@@ -141,7 +141,7 @@ describe("ExecutedAsBadge", () => {
     render(
       <ExecutedAsBadge
         executedAs={{ kind: "platform", callerUserId: "user-2" }}
-        caller={{ label: "Grace Hopper", scope: "personal" }}
+        caller={{ name: "Grace Hopper", scope: "personal" }}
       />,
     );
 

--- a/platform/frontend/src/components/executed-as-badge.test.tsx
+++ b/platform/frontend/src/components/executed-as-badge.test.tsx
@@ -113,6 +113,19 @@ describe("ExecutedAsBadge", () => {
     ).not.toHaveLength(0);
   });
 
+  it("names the caller for an auditor, who is not the caller", () => {
+    render(
+      <ExecutedAsBadge
+        executedAs={{ kind: "platform", callerUserId: "user-2" }}
+        callerName="Grace Hopper"
+      />,
+    );
+
+    // The tool-call log passes no viewer, so nothing ever reads as "Me" there.
+    expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
+    expect(screen.queryByText("Me")).not.toBeInTheDocument();
+  });
+
   it("renders nothing for a call that resolved no upstream credential", () => {
     const { container } = render(<ExecutedAsBadge executedAs={null} />);
 

--- a/platform/frontend/src/components/executed-as-badge.test.tsx
+++ b/platform/frontend/src/components/executed-as-badge.test.tsx
@@ -1,0 +1,78 @@
+import type { McpExecutedAs } from "@archestra/shared";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ExecutedAsBadge } from "./executed-as-badge";
+
+describe("ExecutedAsBadge", () => {
+  it("names the owner of the connection the call ran through", () => {
+    render(
+      <ExecutedAsBadge
+        executedAs={{
+          kind: "personal",
+          ownerUserId: "user-2",
+          ownerName: "Grace Hopper",
+        }}
+        meUserId="user-1"
+      />,
+    );
+
+    expect(screen.getByText("Ran as Grace Hopper")).toBeInTheDocument();
+  });
+
+  it("says the call ran as me when I own the connection", () => {
+    render(
+      <ExecutedAsBadge
+        executedAs={{
+          kind: "personal",
+          ownerUserId: "user-1",
+          ownerName: "Ada Lovelace",
+        }}
+        meUserId="user-1"
+      />,
+    );
+
+    expect(screen.getByText("Ran as me")).toBeInTheDocument();
+  });
+
+  it("names the owner rather than me when no viewer is given", () => {
+    render(
+      <ExecutedAsBadge
+        executedAs={{
+          kind: "personal",
+          ownerUserId: "user-1",
+          ownerName: "Ada Lovelace",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Ran as Ada Lovelace")).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      { kind: "personal", ownerUserId: null, ownerName: null },
+      "Ran as a personal connection",
+    ],
+    [
+      { kind: "team", teamId: "team-1", teamName: "Platform Team" },
+      "Ran as Platform Team",
+    ],
+    [{ kind: "team", teamId: "team-1", teamName: null }, "Ran as a team"],
+    [{ kind: "org" }, "Ran as the organization"],
+    [{ kind: "idp_exchange" }, "Ran as the caller"],
+    [{ kind: "idp_passthrough" }, "Ran as the caller"],
+    [{ kind: "caller_headers" }, "Ran as the caller"],
+  ] as Array<
+    [McpExecutedAs, string]
+  >)("labels a %o identity", (executedAs, label) => {
+    render(<ExecutedAsBadge executedAs={executedAs} meUserId="user-1" />);
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("renders nothing for a call that resolved no upstream credential", () => {
+    const { container } = render(<ExecutedAsBadge executedAs={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/platform/frontend/src/components/executed-as-badge.test.tsx
+++ b/platform/frontend/src/components/executed-as-badge.test.tsx
@@ -2,6 +2,7 @@ import type { McpExecutedAs } from "@archestra/shared";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { scopeStyles } from "@/components/resource-visibility-badge";
 import { useAppName } from "@/lib/hooks/use-app-name";
 import { ExecutedAsBadge } from "./executed-as-badge";
 
@@ -86,11 +87,34 @@ describe("ExecutedAsBadge", () => {
       <ExecutedAsBadge
         executedAs={{ kind: "platform", callerUserId: "user-2" }}
         meUserId="user-1"
-        callerName="Grace Hopper"
+        caller={{ label: "Grace Hopper", scope: "personal" }}
       />,
     );
 
     expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
+  });
+
+  it("draws a gateway token as its own scope, not as a person", async () => {
+    const user = userEvent.setup();
+    render(
+      <ExecutedAsBadge
+        executedAs={{ kind: "platform", callerUserId: null }}
+        caller={{ label: "Org Token", scope: "org" }}
+      />,
+    );
+
+    // A token belongs to the organization, so it must not wear the personal
+    // peel that names somebody's own connection.
+    const label = screen.getByText("Org Token");
+    expect(label.closest("span")?.parentElement).toHaveClass(
+      ...scopeStyles.org.split(" "),
+    );
+    await user.hover(label);
+    expect(
+      await screen.findAllByText(
+        "This call used the Org Token to reach the Acme AI",
+      ),
+    ).not.toHaveLength(0);
   });
 
   it("describes a platform-served call with the deployment's own name", async () => {
@@ -117,7 +141,7 @@ describe("ExecutedAsBadge", () => {
     render(
       <ExecutedAsBadge
         executedAs={{ kind: "platform", callerUserId: "user-2" }}
-        callerName="Grace Hopper"
+        caller={{ label: "Grace Hopper", scope: "personal" }}
       />,
     );
 

--- a/platform/frontend/src/components/executed-as-badge.test.tsx
+++ b/platform/frontend/src/components/executed-as-badge.test.tsx
@@ -24,7 +24,7 @@ describe("ExecutedAsBadge", () => {
       />,
     );
 
-    expect(screen.getByText("Ran as Grace Hopper")).toBeInTheDocument();
+    expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
   });
 
   it("says the call ran as me when I own the connection", () => {
@@ -39,7 +39,7 @@ describe("ExecutedAsBadge", () => {
       />,
     );
 
-    expect(screen.getByText("Ran as me")).toBeInTheDocument();
+    expect(screen.getByText("Me")).toBeInTheDocument();
   });
 
   it("names the owner rather than me when no viewer is given", () => {
@@ -53,26 +53,26 @@ describe("ExecutedAsBadge", () => {
       />,
     );
 
-    expect(screen.getByText("Ran as Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
   });
 
   it.each([
     [
       { kind: "personal", ownerUserId: null, ownerName: null },
-      "Ran as a personal connection",
+      "Personal connection",
     ],
     [
       { kind: "team", teamId: "team-1", teamName: "Platform Team" },
-      "Ran as Platform Team",
+      "Platform Team",
     ],
-    [{ kind: "team", teamId: "team-1", teamName: null }, "Ran as a team"],
-    [{ kind: "org" }, "Ran as the organization"],
-    [{ kind: "idp_exchange" }, "Ran as the caller"],
-    [{ kind: "idp_passthrough" }, "Ran as the caller"],
-    [{ kind: "caller_headers" }, "Ran as the caller"],
-    [{ kind: "platform", callerUserId: "user-1" }, "Ran as me"],
-    [{ kind: "platform", callerUserId: "user-2" }, "Ran as the caller"],
-    [{ kind: "platform", callerUserId: null }, "Ran as the caller"],
+    [{ kind: "team", teamId: "team-1", teamName: null }, "Team"],
+    [{ kind: "org" }, "Organization"],
+    [{ kind: "idp_exchange", callerUserId: "user-1" }, "Me"],
+    [{ kind: "idp_passthrough", callerUserId: "user-2" }, "The caller"],
+    [{ kind: "caller_headers", callerUserId: "user-1" }, "Me"],
+    [{ kind: "platform", callerUserId: "user-1" }, "Me"],
+    [{ kind: "platform", callerUserId: "user-2" }, "The caller"],
+    [{ kind: "platform", callerUserId: null }, "The caller"],
   ] as Array<
     [McpExecutedAs, string]
   >)("labels a %o identity", (executedAs, label) => {
@@ -90,7 +90,7 @@ describe("ExecutedAsBadge", () => {
       />,
     );
 
-    expect(screen.getByText("Ran as Grace Hopper")).toBeInTheDocument();
+    expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
   });
 
   it("describes a platform-served call with the deployment's own name", async () => {
@@ -102,7 +102,7 @@ describe("ExecutedAsBadge", () => {
       />,
     );
 
-    await user.hover(screen.getByText("Ran as me"));
+    await user.hover(screen.getByText("Me"));
 
     // White-labeled deployments must not read "Archestra" here. Radix renders
     // the copy twice (visible plus a screen-reader node).

--- a/platform/frontend/src/components/executed-as-badge.test.tsx
+++ b/platform/frontend/src/components/executed-as-badge.test.tsx
@@ -1,9 +1,17 @@
 import type { McpExecutedAs } from "@archestra/shared";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { ExecutedAsBadge } from "./executed-as-badge";
 
+vi.mock("@/lib/hooks/use-app-name");
+
 describe("ExecutedAsBadge", () => {
+  beforeEach(() => {
+    vi.mocked(useAppName).mockReturnValue("Acme AI");
+  });
+
   it("names the owner of the connection the call ran through", () => {
     render(
       <ExecutedAsBadge
@@ -83,6 +91,26 @@ describe("ExecutedAsBadge", () => {
     );
 
     expect(screen.getByText("Ran as Grace Hopper")).toBeInTheDocument();
+  });
+
+  it("describes a platform-served call with the deployment's own name", async () => {
+    const user = userEvent.setup();
+    render(
+      <ExecutedAsBadge
+        executedAs={{ kind: "platform", callerUserId: "user-1" }}
+        meUserId="user-1"
+      />,
+    );
+
+    await user.hover(screen.getByText("Ran as me"));
+
+    // White-labeled deployments must not read "Archestra" here. Radix renders
+    // the copy twice (visible plus a screen-reader node).
+    expect(
+      await screen.findAllByText(
+        "This call used your own connection to the Acme AI",
+      ),
+    ).not.toHaveLength(0);
   });
 
   it("renders nothing for a call that resolved no upstream credential", () => {

--- a/platform/frontend/src/components/executed-as-badge.tsx
+++ b/platform/frontend/src/components/executed-as-badge.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import type { McpExecutedAs, McpExecutedAsKind } from "@archestra/shared";
+import type { LucideIcon } from "lucide-react";
+import { Globe, KeyRound, User, Users } from "lucide-react";
+import { scopeStyles } from "@/components/resource-visibility-badge";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+/**
+ * Names the identity whose credential served a tool call upstream, so a tool
+ * call answers "on whose behalf did this run?" — the caller's own connection, a
+ * team or organization connection, a connection an admin pinned as a service
+ * account, or a token minted for the caller.
+ *
+ * Renders nothing when the call resolved no upstream credential (a platform
+ * built-in, a blocked call) or predates the descriptor.
+ */
+export function ExecutedAsBadge({
+  executedAs,
+  meUserId,
+}: {
+  executedAs: McpExecutedAs | null | undefined;
+  /**
+   * Whose perspective "Me" is written from: the viewer in chat, the recorded
+   * caller in the tool-call log. Omit to always name the owner.
+   */
+  meUserId?: string | null;
+}) {
+  if (!executedAs) {
+    return null;
+  }
+
+  const {
+    icon: Icon,
+    style,
+    label,
+    tooltip,
+  } = describeExecutedAs(executedAs, meUserId);
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge
+            variant="outline"
+            className={cn(
+              style,
+              "inline-flex max-w-[180px] items-center gap-1 overflow-hidden text-xs font-normal",
+            )}
+          >
+            <Icon className="h-3 w-3 shrink-0" />
+            <span className="min-w-0 flex-1 truncate">{label}</span>
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+type ExecutedAsDisplay = {
+  icon: LucideIcon;
+  style: string;
+  label: string;
+  tooltip: string;
+};
+
+const RAN_AS_PREFIX = "Ran as";
+
+// One entry per identity kind. `meUserId` decides only whether a personal
+// connection reads as the viewer's own.
+const executedAsDescriptors: {
+  [K in McpExecutedAsKind]: (
+    executedAs: Extract<McpExecutedAs, { kind: K }>,
+    meUserId: string | null | undefined,
+  ) => ExecutedAsDisplay;
+} = {
+  personal: (executedAs, meUserId) => {
+    const isMe = !!meUserId && executedAs.ownerUserId === meUserId;
+    if (isMe) {
+      return {
+        icon: User,
+        style: scopeStyles.personal,
+        label: `${RAN_AS_PREFIX} me`,
+        tooltip: "This call used your own connection to the MCP server.",
+      };
+    }
+    const ownerName = executedAs.ownerName;
+    return {
+      icon: User,
+      style: scopeStyles.personal,
+      label: ownerName
+        ? `${RAN_AS_PREFIX} ${ownerName}`
+        : `${RAN_AS_PREFIX} a personal connection`,
+      tooltip: ownerName
+        ? `This call used ${ownerName}'s connection to the MCP server.`
+        : "This call used a personal connection whose owner no longer exists.",
+    };
+  },
+  team: (executedAs) => ({
+    icon: Users,
+    style: scopeStyles.team,
+    label: `${RAN_AS_PREFIX} ${executedAs.teamName ?? "a team"}`,
+    tooltip: executedAs.teamName
+      ? `This call used the ${executedAs.teamName} team's connection to the MCP server.`
+      : "This call used a team connection to the MCP server.",
+  }),
+  org: () => ({
+    icon: Globe,
+    style: scopeStyles.org,
+    label: `${RAN_AS_PREFIX} the organization`,
+    tooltip:
+      "This call used the organization-wide connection to the MCP server.",
+  }),
+  idp_exchange: () => ({
+    icon: KeyRound,
+    style: scopeStyles.personal,
+    label: `${RAN_AS_PREFIX} the caller`,
+    tooltip:
+      "The identity provider issued a credential for the calling user, so the MCP server saw them.",
+  }),
+  idp_passthrough: () => ({
+    icon: KeyRound,
+    style: scopeStyles.personal,
+    label: `${RAN_AS_PREFIX} the caller`,
+    tooltip:
+      "The calling user's own sign-in token was forwarded to the MCP server.",
+  }),
+  caller_headers: () => ({
+    icon: KeyRound,
+    style: scopeStyles.personal,
+    label: `${RAN_AS_PREFIX} the caller`,
+    tooltip:
+      "The calling client supplied the credential the MCP server was called with.",
+  }),
+};
+
+function describeExecutedAs(
+  executedAs: McpExecutedAs,
+  meUserId: string | null | undefined,
+): ExecutedAsDisplay {
+  // Narrowed per kind by the descriptor table's mapped type; the lookup itself
+  // needs the cast because TypeScript cannot correlate key and value here.
+  const describe = executedAsDescriptors[executedAs.kind] as (
+    executedAs: McpExecutedAs,
+    meUserId: string | null | undefined,
+  ) => ExecutedAsDisplay;
+  return describe(executedAs, meUserId);
+}

--- a/platform/frontend/src/components/executed-as-badge.tsx
+++ b/platform/frontend/src/components/executed-as-badge.tsx
@@ -2,7 +2,7 @@
 
 import type { McpExecutedAs, McpExecutedAsKind } from "@archestra/shared";
 import type { LucideIcon } from "lucide-react";
-import { Globe, KeyRound, User, Users } from "lucide-react";
+import { Globe, User, Users } from "lucide-react";
 import { scopeStyles } from "@/components/resource-visibility-badge";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -24,11 +24,11 @@ import { cn } from "@/lib/utils";
  * built-in, a blocked call) or predates the descriptor.
  */
 /**
- * An identity that makes calls: a person, or a gateway token, which acts for a
- * team or for the whole organization rather than for anybody in particular.
+ * An identity that makes calls. A person has a name; a gateway token has none,
+ * because it acts for the team or the organization it belongs to.
  */
 export type CallerIdentity = {
-  label: string;
+  name: string | null;
   scope: keyof typeof scopeStyles;
 };
 
@@ -101,6 +101,34 @@ type ExecutedAsContext = {
 // How the reader's own identity reads, matching the resource peels elsewhere.
 const SELF_LABEL = "Me";
 
+// An identity the platform served a call for, but could not name.
+const UNKNOWN_CALLER = { label: "The caller", possessive: "the caller's" };
+
+// One peel per scope, shared by every identity a call can run as. A gateway
+// token is not a fourth kind of thing: it carries the authority of the team or
+// the organization it belongs to, so it wears that scope's peel and "called as
+// the organization" looks the same in chat and in the tool-call log.
+const scopePeels = {
+  personal: {
+    icon: User,
+    style: scopeStyles.personal,
+    label: "Personal connection",
+    possessive: "their",
+  },
+  team: {
+    icon: Users,
+    style: scopeStyles.team,
+    label: "Team",
+    possessive: "the team's",
+  },
+  org: {
+    icon: Globe,
+    style: scopeStyles.org,
+    label: "Organization",
+    possessive: "the organization's",
+  },
+} as const;
+
 // One entry per identity kind. The peel names the identity itself — the
 // surrounding column header or label says what the name means — so it reads
 // like the scope peels on the apps, projects and skills lists.
@@ -114,34 +142,29 @@ const executedAsDescriptors: {
     const isMe = !!meUserId && executedAs.ownerUserId === meUserId;
     if (isMe) {
       return {
-        icon: User,
-        style: scopeStyles.personal,
+        ...scopePeels.personal,
         label: SELF_LABEL,
         tooltip: "This call used your own connection to the MCP server.",
       };
     }
     const ownerName = executedAs.ownerName;
     return {
-      icon: User,
-      style: scopeStyles.personal,
-      label: ownerName ?? "Personal connection",
+      ...scopePeels.personal,
+      label: ownerName ?? scopePeels.personal.label,
       tooltip: ownerName
         ? `This call used ${ownerName}'s connection to the MCP server.`
         : "This call used a personal connection whose owner no longer exists.",
     };
   },
   team: (executedAs) => ({
-    icon: Users,
-    style: scopeStyles.team,
-    label: executedAs.teamName ?? "Team",
+    ...scopePeels.team,
+    label: executedAs.teamName ?? scopePeels.team.label,
     tooltip: executedAs.teamName
       ? `This call used the ${executedAs.teamName} team's connection to the MCP server.`
       : "This call used a team connection to the MCP server.",
   }),
   org: () => ({
-    icon: Globe,
-    style: scopeStyles.org,
-    label: "Organization",
+    ...scopePeels.org,
     tooltip:
       "This call used the organization-wide connection to the MCP server.",
   }),
@@ -167,28 +190,25 @@ const executedAsDescriptors: {
 };
 
 // The kinds that ran as the calling identity share one peel: that identity's
-// own name, or "Me" when the reader is it.
+// own name, or "Me" when the reader is it. A token has no name of its own, so
+// it reads as the scope it acts for.
 function describeCaller(
   callerUserId: string | null,
   { meUserId, caller }: ExecutedAsContext,
 ): Omit<ExecutedAsDisplay, "tooltip"> {
   if (!!meUserId && callerUserId === meUserId) {
-    return { icon: User, style: scopeStyles.personal, label: SELF_LABEL };
+    return { ...scopePeels.personal, label: SELF_LABEL };
   }
   if (!caller) {
-    return { icon: User, style: scopeStyles.personal, label: "The caller" };
+    return { ...scopePeels.personal, label: UNKNOWN_CALLER.label };
   }
-  return {
-    // A gateway token is not a person, so it carries the key icon and its own
-    // scope's color instead of reading as somebody's personal identity.
-    icon: caller.scope === "personal" ? User : KeyRound,
-    style: scopeStyles[caller.scope],
-    label: caller.label,
-  };
+  const peel = scopePeels[caller.scope];
+  return { ...peel, label: caller.name ?? peel.label };
 }
 
 // A platform call reached no MCP server, so the identity is whoever asked for
-// it — and for a token, that is the team or organization it belongs to.
+// it — and their gateway token is how they reach the platform in the first
+// place, which is the connection this names.
 function describePlatformCall(
   display: Omit<ExecutedAsDisplay, "tooltip">,
   { caller, appName }: ExecutedAsContext,
@@ -196,10 +216,14 @@ function describePlatformCall(
   if (display.label === SELF_LABEL) {
     return `This call used your own connection to the ${appName}`;
   }
-  if (caller && caller.scope !== "personal") {
-    return `This call used the ${caller.label} to reach the ${appName}`;
+  return `This call used ${callerPossessive(caller)} own connection to the ${appName}`;
+}
+
+function callerPossessive(caller: CallerIdentity | null | undefined): string {
+  if (!caller) {
+    return UNKNOWN_CALLER.possessive;
   }
-  return `This call used ${display.label}'s own connection to the ${appName}`;
+  return caller.name ? `${caller.name}'s` : scopePeels[caller.scope].possessive;
 }
 
 function describeExecutedAs(

--- a/platform/frontend/src/components/executed-as-badge.tsx
+++ b/platform/frontend/src/components/executed-as-badge.tsx
@@ -2,7 +2,7 @@
 
 import type { McpExecutedAs, McpExecutedAsKind } from "@archestra/shared";
 import type { LucideIcon } from "lucide-react";
-import { Cpu, Globe, KeyRound, User, Users } from "lucide-react";
+import { Globe, KeyRound, User, Users } from "lucide-react";
 import { scopeStyles } from "@/components/resource-visibility-badge";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -11,6 +11,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useAppName } from "@/lib/hooks/use-app-name";
 import { cn } from "@/lib/utils";
 
 /**
@@ -34,12 +35,14 @@ export function ExecutedAsBadge({
    */
   meUserId?: string | null;
   /**
-   * Display name of the user who made the call, for the calls Archestra ran
+   * Display name of the user who made the call, for the calls the platform ran
    * itself (they carry only the caller's id). Omit where it is unknown; the
    * badge then says "the caller".
    */
   callerName?: string | null;
 }) {
+  const appName = useAppName();
+
   if (!executedAs) {
     return null;
   }
@@ -49,7 +52,7 @@ export function ExecutedAsBadge({
     style,
     label,
     tooltip,
-  } = describeExecutedAs(executedAs, meUserId, callerName);
+  } = describeExecutedAs(executedAs, { meUserId, callerName, appName });
 
   return (
     <TooltipProvider>
@@ -83,14 +86,19 @@ const RAN_AS_PREFIX = "Ran as";
 
 // One entry per identity kind. `meUserId` decides only whether a personal
 // connection reads as the viewer's own.
+type ExecutedAsContext = {
+  meUserId: string | null | undefined;
+  callerName: string | null | undefined;
+  appName: string;
+};
+
 const executedAsDescriptors: {
   [K in McpExecutedAsKind]: (
     executedAs: Extract<McpExecutedAs, { kind: K }>,
-    meUserId: string | null | undefined,
-    callerName: string | null | undefined,
+    context: ExecutedAsContext,
   ) => ExecutedAsDisplay;
 } = {
-  personal: (executedAs, meUserId) => {
+  personal: (executedAs, { meUserId }) => {
     const isMe = !!meUserId && executedAs.ownerUserId === meUserId;
     if (isMe) {
       return {
@@ -148,29 +156,29 @@ const executedAsDescriptors: {
     tooltip:
       "The calling client supplied the credential the MCP server was called with.",
   }),
-  platform: (executedAs, meUserId, callerName) => {
+  platform: (executedAs, { meUserId, callerName, appName }) => {
     const isMe = !!meUserId && executedAs.callerUserId === meUserId;
     const who = isMe ? "me" : (callerName ?? "the caller");
     return {
-      icon: Cpu,
+      icon: User,
       style: scopeStyles.personal,
       label: `${RAN_AS_PREFIX} ${who}`,
-      tooltip: `Archestra ran this tool itself, with ${isMe ? "your" : "the caller's"} permissions. No MCP server connection was used.`,
+      tooltip: isMe
+        ? `This call used your own connection to the ${appName}`
+        : `This call used ${who}'s own connection to the ${appName}`,
     };
   },
 };
 
 function describeExecutedAs(
   executedAs: McpExecutedAs,
-  meUserId: string | null | undefined,
-  callerName: string | null | undefined,
+  context: ExecutedAsContext,
 ): ExecutedAsDisplay {
   // Narrowed per kind by the descriptor table's mapped type; the lookup itself
   // needs the cast because TypeScript cannot correlate key and value here.
   const describe = executedAsDescriptors[executedAs.kind] as (
     executedAs: McpExecutedAs,
-    meUserId: string | null | undefined,
-    callerName: string | null | undefined,
+    context: ExecutedAsContext,
   ) => ExecutedAsDisplay;
-  return describe(executedAs, meUserId, callerName);
+  return describe(executedAs, context);
 }

--- a/platform/frontend/src/components/executed-as-badge.tsx
+++ b/platform/frontend/src/components/executed-as-badge.tsx
@@ -23,10 +23,19 @@ import { cn } from "@/lib/utils";
  * Renders nothing when the call resolved no upstream credential (a platform
  * built-in, a blocked call) or predates the descriptor.
  */
+/**
+ * An identity that makes calls: a person, or a gateway token, which acts for a
+ * team or for the whole organization rather than for anybody in particular.
+ */
+export type CallerIdentity = {
+  label: string;
+  scope: keyof typeof scopeStyles;
+};
+
 export function ExecutedAsBadge({
   executedAs,
   meUserId,
-  callerName,
+  caller,
 }: {
   executedAs: McpExecutedAs | null | undefined;
   /**
@@ -36,11 +45,11 @@ export function ExecutedAsBadge({
    */
   meUserId?: string | null;
   /**
-   * Display name of the user who made the call, for the calls the platform ran
-   * itself (they carry only the caller's id). Omit where it is unknown; the
-   * badge then says "the caller".
+   * Who made the call, for the calls the platform ran itself (they carry only
+   * the caller's id). Omit where it is unknown; the badge then says "the
+   * caller".
    */
-  callerName?: string | null;
+  caller?: CallerIdentity | null;
 }) {
   const appName = useAppName();
 
@@ -53,7 +62,7 @@ export function ExecutedAsBadge({
     style,
     label,
     tooltip,
-  } = describeExecutedAs(executedAs, { meUserId, callerName, appName });
+  } = describeExecutedAs(executedAs, { meUserId, caller, appName });
 
   return (
     <TooltipProvider>
@@ -85,7 +94,7 @@ type ExecutedAsDisplay = {
 
 type ExecutedAsContext = {
   meUserId: string | null | undefined;
-  callerName: string | null | undefined;
+  caller: CallerIdentity | null | undefined;
   appName: string;
 };
 
@@ -152,29 +161,45 @@ const executedAsDescriptors: {
       "The calling client supplied the credential the MCP server was called with.",
   }),
   platform: (executedAs, context) => {
-    const caller = describeCaller(executedAs.callerUserId, context);
-    return {
-      ...caller,
-      tooltip:
-        caller.label === SELF_LABEL
-          ? `This call used your own connection to the ${context.appName}`
-          : `This call used ${caller.label}'s own connection to the ${context.appName}`,
-    };
+    const display = describeCaller(executedAs.callerUserId, context);
+    return { ...display, tooltip: describePlatformCall(display, context) };
   },
 };
 
-// The kinds that ran as the calling user share one peel: their own name, or
-// "Me" when the reader is that user.
+// The kinds that ran as the calling identity share one peel: that identity's
+// own name, or "Me" when the reader is it.
 function describeCaller(
   callerUserId: string | null,
-  { meUserId, callerName }: ExecutedAsContext,
+  { meUserId, caller }: ExecutedAsContext,
 ): Omit<ExecutedAsDisplay, "tooltip"> {
-  const isMe = !!meUserId && callerUserId === meUserId;
+  if (!!meUserId && callerUserId === meUserId) {
+    return { icon: User, style: scopeStyles.personal, label: SELF_LABEL };
+  }
+  if (!caller) {
+    return { icon: User, style: scopeStyles.personal, label: "The caller" };
+  }
   return {
-    icon: User,
-    style: scopeStyles.personal,
-    label: isMe ? SELF_LABEL : (callerName ?? "The caller"),
+    // A gateway token is not a person, so it carries the key icon and its own
+    // scope's color instead of reading as somebody's personal identity.
+    icon: caller.scope === "personal" ? User : KeyRound,
+    style: scopeStyles[caller.scope],
+    label: caller.label,
   };
+}
+
+// A platform call reached no MCP server, so the identity is whoever asked for
+// it — and for a token, that is the team or organization it belongs to.
+function describePlatformCall(
+  display: Omit<ExecutedAsDisplay, "tooltip">,
+  { caller, appName }: ExecutedAsContext,
+): string {
+  if (display.label === SELF_LABEL) {
+    return `This call used your own connection to the ${appName}`;
+  }
+  if (caller && caller.scope !== "personal") {
+    return `This call used the ${caller.label} to reach the ${appName}`;
+  }
+  return `This call used ${display.label}'s own connection to the ${appName}`;
 }
 
 function describeExecutedAs(

--- a/platform/frontend/src/components/executed-as-badge.tsx
+++ b/platform/frontend/src/components/executed-as-badge.tsx
@@ -82,16 +82,18 @@ type ExecutedAsDisplay = {
   tooltip: string;
 };
 
-const RAN_AS_PREFIX = "Ran as";
-
-// One entry per identity kind. `meUserId` decides only whether a personal
-// connection reads as the viewer's own.
 type ExecutedAsContext = {
   meUserId: string | null | undefined;
   callerName: string | null | undefined;
   appName: string;
 };
 
+// How the reader's own identity reads, matching the resource peels elsewhere.
+const SELF_LABEL = "Me";
+
+// One entry per identity kind. The peel names the identity itself — the
+// surrounding column header or label says what the name means — so it reads
+// like the scope peels on the apps, projects and skills lists.
 const executedAsDescriptors: {
   [K in McpExecutedAsKind]: (
     executedAs: Extract<McpExecutedAs, { kind: K }>,
@@ -104,7 +106,7 @@ const executedAsDescriptors: {
       return {
         icon: User,
         style: scopeStyles.personal,
-        label: `${RAN_AS_PREFIX} me`,
+        label: SELF_LABEL,
         tooltip: "This call used your own connection to the MCP server.",
       };
     }
@@ -112,9 +114,7 @@ const executedAsDescriptors: {
     return {
       icon: User,
       style: scopeStyles.personal,
-      label: ownerName
-        ? `${RAN_AS_PREFIX} ${ownerName}`
-        : `${RAN_AS_PREFIX} a personal connection`,
+      label: ownerName ?? "Personal connection",
       tooltip: ownerName
         ? `This call used ${ownerName}'s connection to the MCP server.`
         : "This call used a personal connection whose owner no longer exists.",
@@ -123,7 +123,7 @@ const executedAsDescriptors: {
   team: (executedAs) => ({
     icon: Users,
     style: scopeStyles.team,
-    label: `${RAN_AS_PREFIX} ${executedAs.teamName ?? "a team"}`,
+    label: executedAs.teamName ?? "Team",
     tooltip: executedAs.teamName
       ? `This call used the ${executedAs.teamName} team's connection to the MCP server.`
       : "This call used a team connection to the MCP server.",
@@ -131,44 +131,50 @@ const executedAsDescriptors: {
   org: () => ({
     icon: Globe,
     style: scopeStyles.org,
-    label: `${RAN_AS_PREFIX} the organization`,
+    label: "Organization",
     tooltip:
       "This call used the organization-wide connection to the MCP server.",
   }),
-  idp_exchange: () => ({
-    icon: KeyRound,
-    style: scopeStyles.personal,
-    label: `${RAN_AS_PREFIX} the caller`,
+  idp_exchange: (executedAs, context) => ({
+    ...describeCaller(executedAs.callerUserId, context),
     tooltip:
       "The identity provider issued a credential for the calling user, so the MCP server saw them.",
   }),
-  idp_passthrough: () => ({
-    icon: KeyRound,
-    style: scopeStyles.personal,
-    label: `${RAN_AS_PREFIX} the caller`,
+  idp_passthrough: (executedAs, context) => ({
+    ...describeCaller(executedAs.callerUserId, context),
     tooltip:
       "The calling user's own sign-in token was forwarded to the MCP server.",
   }),
-  caller_headers: () => ({
-    icon: KeyRound,
-    style: scopeStyles.personal,
-    label: `${RAN_AS_PREFIX} the caller`,
+  caller_headers: (executedAs, context) => ({
+    ...describeCaller(executedAs.callerUserId, context),
     tooltip:
       "The calling client supplied the credential the MCP server was called with.",
   }),
-  platform: (executedAs, { meUserId, callerName, appName }) => {
-    const isMe = !!meUserId && executedAs.callerUserId === meUserId;
-    const who = isMe ? "me" : (callerName ?? "the caller");
+  platform: (executedAs, context) => {
+    const caller = describeCaller(executedAs.callerUserId, context);
     return {
-      icon: User,
-      style: scopeStyles.personal,
-      label: `${RAN_AS_PREFIX} ${who}`,
-      tooltip: isMe
-        ? `This call used your own connection to the ${appName}`
-        : `This call used ${who}'s own connection to the ${appName}`,
+      ...caller,
+      tooltip:
+        caller.label === SELF_LABEL
+          ? `This call used your own connection to the ${context.appName}`
+          : `This call used ${caller.label}'s own connection to the ${context.appName}`,
     };
   },
 };
+
+// The kinds that ran as the calling user share one peel: their own name, or
+// "Me" when the reader is that user.
+function describeCaller(
+  callerUserId: string | null,
+  { meUserId, callerName }: ExecutedAsContext,
+): Omit<ExecutedAsDisplay, "tooltip"> {
+  const isMe = !!meUserId && callerUserId === meUserId;
+  return {
+    icon: User,
+    style: scopeStyles.personal,
+    label: isMe ? SELF_LABEL : (callerName ?? "The caller"),
+  };
+}
 
 function describeExecutedAs(
   executedAs: McpExecutedAs,

--- a/platform/frontend/src/components/executed-as-badge.tsx
+++ b/platform/frontend/src/components/executed-as-badge.tsx
@@ -2,7 +2,7 @@
 
 import type { McpExecutedAs, McpExecutedAsKind } from "@archestra/shared";
 import type { LucideIcon } from "lucide-react";
-import { Globe, KeyRound, User, Users } from "lucide-react";
+import { Cpu, Globe, KeyRound, User, Users } from "lucide-react";
 import { scopeStyles } from "@/components/resource-visibility-badge";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -25,6 +25,7 @@ import { cn } from "@/lib/utils";
 export function ExecutedAsBadge({
   executedAs,
   meUserId,
+  callerName,
 }: {
   executedAs: McpExecutedAs | null | undefined;
   /**
@@ -32,6 +33,12 @@ export function ExecutedAsBadge({
    * caller in the tool-call log. Omit to always name the owner.
    */
   meUserId?: string | null;
+  /**
+   * Display name of the user who made the call, for the calls Archestra ran
+   * itself (they carry only the caller's id). Omit where it is unknown; the
+   * badge then says "the caller".
+   */
+  callerName?: string | null;
 }) {
   if (!executedAs) {
     return null;
@@ -42,7 +49,7 @@ export function ExecutedAsBadge({
     style,
     label,
     tooltip,
-  } = describeExecutedAs(executedAs, meUserId);
+  } = describeExecutedAs(executedAs, meUserId, callerName);
 
   return (
     <TooltipProvider>
@@ -80,6 +87,7 @@ const executedAsDescriptors: {
   [K in McpExecutedAsKind]: (
     executedAs: Extract<McpExecutedAs, { kind: K }>,
     meUserId: string | null | undefined,
+    callerName: string | null | undefined,
   ) => ExecutedAsDisplay;
 } = {
   personal: (executedAs, meUserId) => {
@@ -140,17 +148,29 @@ const executedAsDescriptors: {
     tooltip:
       "The calling client supplied the credential the MCP server was called with.",
   }),
+  platform: (executedAs, meUserId, callerName) => {
+    const isMe = !!meUserId && executedAs.callerUserId === meUserId;
+    const who = isMe ? "me" : (callerName ?? "the caller");
+    return {
+      icon: Cpu,
+      style: scopeStyles.personal,
+      label: `${RAN_AS_PREFIX} ${who}`,
+      tooltip: `Archestra ran this tool itself, with ${isMe ? "your" : "the caller's"} permissions. No MCP server connection was used.`,
+    };
+  },
 };
 
 function describeExecutedAs(
   executedAs: McpExecutedAs,
   meUserId: string | null | undefined,
+  callerName: string | null | undefined,
 ): ExecutedAsDisplay {
   // Narrowed per kind by the descriptor table's mapped type; the lookup itself
   // needs the cast because TypeScript cannot correlate key and value here.
   const describe = executedAsDescriptors[executedAs.kind] as (
     executedAs: McpExecutedAs,
     meUserId: string | null | undefined,
+    callerName: string | null | undefined,
   ) => ExecutedAsDisplay;
-  return describe(executedAs, meUserId);
+  return describe(executedAs, meUserId, callerName);
 }

--- a/platform/frontend/src/components/executed-as-badge.tsx
+++ b/platform/frontend/src/components/executed-as-badge.tsx
@@ -30,8 +30,9 @@ export function ExecutedAsBadge({
 }: {
   executedAs: McpExecutedAs | null | undefined;
   /**
-   * Whose perspective "Me" is written from: the viewer in chat, the recorded
-   * caller in the tool-call log. Omit to always name the owner.
+   * The reader, so their own identity reads as "Me". Chat passes the viewer;
+   * the tool-call log passes nobody, because an auditor reading someone else's
+   * call needs the person's name, never "Me".
    */
   meUserId?: string | null;
   /**

--- a/platform/frontend/src/lib/mcp/caller-identity.test.ts
+++ b/platform/frontend/src/lib/mcp/caller-identity.test.ts
@@ -5,19 +5,18 @@ describe("formatCallerIdentity", () => {
   it("names the user who made the call", () => {
     expect(
       formatCallerIdentity({ userName: "Grace Hopper", authMethod: "oauth" }),
-    ).toEqual({ label: "Grace Hopper", scope: "personal" });
+    ).toEqual({ name: "Grace Hopper", scope: "personal" });
   });
 
-  it("names the token when a call carries no user", () => {
-    // Gateway tokens act for an organization or a team rather than a person,
-    // and an auditor still needs a name for whoever made the call. The scope
-    // keeps them from being drawn as somebody's personal identity.
+  it("credits a call made with a gateway token to the scope it acts for", () => {
+    // A token carries no user and is nobody's identity of its own — it holds
+    // the authority of the organization or team that issued it.
     expect(
       formatCallerIdentity({ userName: null, authMethod: "org_token" }),
-    ).toEqual({ label: "Org Token", scope: "org" });
+    ).toEqual({ name: null, scope: "org" });
     expect(
       formatCallerIdentity({ userName: null, authMethod: "team_token" }),
-    ).toEqual({ label: "Team Token", scope: "team" });
+    ).toEqual({ name: null, scope: "team" });
   });
 
   it("has nothing to name when a personal method lost its user", () => {

--- a/platform/frontend/src/lib/mcp/caller-identity.test.ts
+++ b/platform/frontend/src/lib/mcp/caller-identity.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatCallerIdentity } from "./mcp-tool-call.query";
+
+describe("formatCallerIdentity", () => {
+  it("names the user who made the call", () => {
+    expect(
+      formatCallerIdentity({ userName: "Grace Hopper", authMethod: "oauth" }),
+    ).toBe("Grace Hopper");
+  });
+
+  it("names the token when a call carries no user", () => {
+    // Gateway tokens act for an organization or a team rather than a person,
+    // and an auditor still needs a name for whoever made the call.
+    expect(
+      formatCallerIdentity({ userName: null, authMethod: "org_token" }),
+    ).toBe("Org Token");
+    expect(
+      formatCallerIdentity({ userName: null, authMethod: "team_token" }),
+    ).toBe("Team Token");
+  });
+
+  it("has nothing to name when neither is recorded", () => {
+    expect(
+      formatCallerIdentity({ userName: null, authMethod: null }),
+    ).toBeNull();
+  });
+});

--- a/platform/frontend/src/lib/mcp/caller-identity.test.ts
+++ b/platform/frontend/src/lib/mcp/caller-identity.test.ts
@@ -5,21 +5,25 @@ describe("formatCallerIdentity", () => {
   it("names the user who made the call", () => {
     expect(
       formatCallerIdentity({ userName: "Grace Hopper", authMethod: "oauth" }),
-    ).toBe("Grace Hopper");
+    ).toEqual({ label: "Grace Hopper", scope: "personal" });
   });
 
   it("names the token when a call carries no user", () => {
     // Gateway tokens act for an organization or a team rather than a person,
-    // and an auditor still needs a name for whoever made the call.
+    // and an auditor still needs a name for whoever made the call. The scope
+    // keeps them from being drawn as somebody's personal identity.
     expect(
       formatCallerIdentity({ userName: null, authMethod: "org_token" }),
-    ).toBe("Org Token");
+    ).toEqual({ label: "Org Token", scope: "org" });
     expect(
       formatCallerIdentity({ userName: null, authMethod: "team_token" }),
-    ).toBe("Team Token");
+    ).toEqual({ label: "Team Token", scope: "team" });
   });
 
-  it("has nothing to name when neither is recorded", () => {
+  it("has nothing to name when a personal method lost its user", () => {
+    expect(
+      formatCallerIdentity({ userName: null, authMethod: "oauth" }),
+    ).toBeNull();
     expect(
       formatCallerIdentity({ userName: null, authMethod: null }),
     ).toBeNull();

--- a/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
@@ -25,6 +25,20 @@ export function formatAuthMethod(authMethod: MCPGatewayAuthMethod): string {
   }
 }
 
+/**
+ * Who a tool call ran on behalf of, for the calls the platform served itself.
+ * A call made with a gateway token carries no user, and an auditor still needs
+ * a name for it — that identity is the token itself.
+ */
+export function formatCallerIdentity(row: {
+  userName: string | null;
+  authMethod: MCPGatewayAuthMethod | null;
+}): string | null {
+  return (
+    row.userName ?? (row.authMethod ? formatAuthMethod(row.authMethod) : null)
+  );
+}
+
 const { getMcpToolCall, getMcpToolCalls } = archestraApiSdk;
 
 export function useMcpToolCalls({

--- a/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
@@ -29,21 +29,21 @@ export function formatAuthMethod(authMethod: MCPGatewayAuthMethod): string {
 /**
  * Who a tool call ran on behalf of, for the calls the platform served itself.
  * A call made with a gateway token carries no user, and an auditor still needs
- * a name for it — that identity is the token, which acts for its team or for
- * the organization rather than for a person.
+ * an identity for it: the token acts for its team or for the organization, so
+ * that is who made the call. The auth method stays visible in its own column.
  */
 export function formatCallerIdentity(row: {
   userName: string | null;
   authMethod: MCPGatewayAuthMethod | null;
 }): CallerIdentity | null {
   if (row.userName) {
-    return { label: row.userName, scope: "personal" };
+    return { name: row.userName, scope: "personal" };
   }
   switch (row.authMethod) {
     case "org_token":
-      return { label: formatAuthMethod(row.authMethod), scope: "org" };
+      return { name: null, scope: "org" };
     case "team_token":
-      return { label: formatAuthMethod(row.authMethod), scope: "team" };
+      return { name: null, scope: "team" };
     default:
       // Every other method authenticates a person, so a missing name means the
       // user is gone — there is nothing to name them by.

--- a/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
+++ b/platform/frontend/src/lib/mcp/mcp-tool-call.query.ts
@@ -2,6 +2,7 @@
 
 import { archestraApiSdk, type archestraApiTypes } from "@archestra/shared";
 import { useQuery } from "@tanstack/react-query";
+import type { CallerIdentity } from "@/components/executed-as-badge";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { throwOnApiError } from "@/lib/utils";
 
@@ -28,15 +29,26 @@ export function formatAuthMethod(authMethod: MCPGatewayAuthMethod): string {
 /**
  * Who a tool call ran on behalf of, for the calls the platform served itself.
  * A call made with a gateway token carries no user, and an auditor still needs
- * a name for it — that identity is the token itself.
+ * a name for it — that identity is the token, which acts for its team or for
+ * the organization rather than for a person.
  */
 export function formatCallerIdentity(row: {
   userName: string | null;
   authMethod: MCPGatewayAuthMethod | null;
-}): string | null {
-  return (
-    row.userName ?? (row.authMethod ? formatAuthMethod(row.authMethod) : null)
-  );
+}): CallerIdentity | null {
+  if (row.userName) {
+    return { label: row.userName, scope: "personal" };
+  }
+  switch (row.authMethod) {
+    case "org_token":
+      return { label: formatAuthMethod(row.authMethod), scope: "org" };
+    case "team_token":
+      return { label: formatAuthMethod(row.authMethod), scope: "team" };
+    default:
+      // Every other method authenticates a person, so a missing name means the
+      // user is gone — there is nothing to name them by.
+      return null;
+  }
 }
 
 const { getMcpToolCall, getMcpToolCalls } = archestraApiSdk;

--- a/platform/shared/index.ts
+++ b/platform/shared/index.ts
@@ -23,6 +23,7 @@ export * from "./interactions";
 export * from "./knowledge-base";
 export * from "./labels";
 export * from "./linked-idp-auth";
+export * from "./mcp-executed-as";
 export * from "./mcp-extensions";
 export * from "./mcp-orchestrator";
 export * from "./mcp-server-config";

--- a/platform/shared/mcp-executed-as.test.ts
+++ b/platform/shared/mcp-executed-as.test.ts
@@ -36,9 +36,9 @@ describe("extractMcpExecutedAs", () => {
       { kind: "team", teamId: "team-1", teamName: "Payments" },
       { kind: "team", teamId: "team-1", teamName: null },
       { kind: "org" },
-      { kind: "idp_exchange" },
-      { kind: "idp_passthrough" },
-      { kind: "caller_headers" },
+      { kind: "idp_exchange", callerUserId: "user-1" },
+      { kind: "idp_passthrough", callerUserId: null },
+      { kind: "caller_headers", callerUserId: "user-1" },
     ];
 
     for (const executedAs of kinds) {

--- a/platform/shared/mcp-executed-as.test.ts
+++ b/platform/shared/mcp-executed-as.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "vitest";
+import {
+  extractMcpExecutedAs,
+  MCP_EXECUTED_AS_META_KEY,
+  type McpExecutedAs,
+  stripReservedPlatformMeta,
+} from "./mcp-executed-as";
+import { SEEDED_APP_RENDER_META_KEY } from "./seeded-app-render";
+
+const personal: McpExecutedAs = {
+  kind: "personal",
+  ownerUserId: "user-1",
+  ownerName: "Ada Lovelace",
+};
+
+describe("extractMcpExecutedAs", () => {
+  test("reads the descriptor from a tool result's _meta", () => {
+    expect(
+      extractMcpExecutedAs({
+        content: "ok",
+        _meta: { [MCP_EXECUTED_AS_META_KEY]: personal },
+      }),
+    ).toEqual(personal);
+  });
+
+  test("reads the descriptor from a bare _meta record", () => {
+    expect(
+      extractMcpExecutedAs({ [MCP_EXECUTED_AS_META_KEY]: personal }),
+    ).toEqual(personal);
+  });
+
+  test("reads every identity kind", () => {
+    const kinds: McpExecutedAs[] = [
+      personal,
+      { kind: "personal", ownerUserId: null, ownerName: null },
+      { kind: "team", teamId: "team-1", teamName: "Payments" },
+      { kind: "team", teamId: "team-1", teamName: null },
+      { kind: "org" },
+      { kind: "idp_exchange" },
+      { kind: "idp_passthrough" },
+      { kind: "caller_headers" },
+    ];
+
+    for (const executedAs of kinds) {
+      expect(
+        extractMcpExecutedAs({
+          _meta: { [MCP_EXECUTED_AS_META_KEY]: executedAs },
+        }),
+      ).toEqual(executedAs);
+    }
+  });
+
+  test("returns null for results that carry no descriptor", () => {
+    expect(
+      extractMcpExecutedAs({ content: "ok", _meta: { ui: {} } }),
+    ).toBeNull();
+    expect(extractMcpExecutedAs({})).toBeNull();
+    expect(extractMcpExecutedAs(null)).toBeNull();
+    expect(extractMcpExecutedAs("ok")).toBeNull();
+  });
+
+  test("returns null for a malformed descriptor rather than a partial one", () => {
+    expect(
+      extractMcpExecutedAs({
+        _meta: { [MCP_EXECUTED_AS_META_KEY]: { kind: "sudo" } },
+      }),
+    ).toBeNull();
+    expect(
+      extractMcpExecutedAs({
+        _meta: { [MCP_EXECUTED_AS_META_KEY]: { kind: "team" } },
+      }),
+    ).toBeNull();
+    expect(
+      extractMcpExecutedAs({
+        _meta: {
+          [MCP_EXECUTED_AS_META_KEY]: { ...personal, ownerEmail: "a@b.c" },
+        },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("stripReservedPlatformMeta", () => {
+  test("removes every platform-reserved key an upstream server supplied", () => {
+    expect(
+      stripReservedPlatformMeta({
+        ui: { resourceUri: "ui://app" },
+        archestraError: { type: "generic", message: "forged" },
+        [SEEDED_APP_RENDER_META_KEY]: true,
+        [MCP_EXECUTED_AS_META_KEY]: { kind: "org" },
+      }),
+    ).toEqual({ ui: { resourceUri: "ui://app" } });
+  });
+
+  test("returns the same reference when there is nothing to strip", () => {
+    const meta = { ui: { resourceUri: "ui://app" } };
+    expect(stripReservedPlatformMeta(meta)).toBe(meta);
+    expect(stripReservedPlatformMeta(undefined)).toBeUndefined();
+  });
+});

--- a/platform/shared/mcp-executed-as.ts
+++ b/platform/shared/mcp-executed-as.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+import { SEEDED_APP_RENDER_META_KEY } from "./seeded-app-render";
+
+/**
+ * Platform-reserved `_meta` key naming the identity whose credential served a
+ * tool call upstream. The gateway resolves that credential per call (the
+ * caller's own connection, a team or organization connection, a pinned
+ * service-account connection, or a per-caller identity-provider token), and
+ * without this the chat card and the MCP log record only say *what* ran, never
+ * *as whom*. Like `archestraError`, it is stripped from every upstream tool
+ * result before the platform stamps its own value, so a hostile server cannot
+ * forge an identity.
+ */
+export const MCP_EXECUTED_AS_META_KEY = "archestraExecutedAs";
+
+/**
+ * Platform-reserved metadata keys: `archestraError` (set only by the MCP
+ * client's error results), the seeded-app-render marker (set only by
+ * open-in-chat conversation seeding), and the executed-as identity. Renderers
+ * and the trusted-data guardrail key off them to identify platform-authored
+ * results, so upstream copies must never survive.
+ */
+export const RESERVED_PLATFORM_META_KEYS = [
+  "archestraError",
+  SEEDED_APP_RENDER_META_KEY,
+  MCP_EXECUTED_AS_META_KEY,
+] as const;
+
+/**
+ * Remove platform-reserved keys from metadata the platform did not author —
+ * an upstream tool result, or a tool definition synced from an upstream
+ * server's `tools/list`. Returns the same reference when nothing was stripped.
+ */
+export function stripReservedPlatformMeta(
+  meta: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!meta || !RESERVED_PLATFORM_META_KEYS.some((key) => key in meta)) {
+    return meta;
+  }
+  const rest = { ...meta };
+  for (const key of RESERVED_PLATFORM_META_KEYS) {
+    delete rest[key];
+  }
+  return rest;
+}
+
+/**
+ * Which identity the upstream call ran as. One member per way the gateway can
+ * resolve a credential; a call that never reached an upstream server (a
+ * platform built-in, a blocked call, an app launch) carries no descriptor at
+ * all rather than a catch-all member.
+ */
+export const McpExecutedAsSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("personal"),
+      /**
+       * Owner of the personal connection the call ran through — the caller
+       * themselves, or another user whose connection an admin pinned as a
+       * service account. Null once the owning user is deleted (the connection
+       * row's owner is cleared).
+       */
+      ownerUserId: z.string().nullable(),
+      ownerName: z.string().nullable(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("team"),
+      teamId: z.string(),
+      teamName: z.string().nullable(),
+    })
+    .strict(),
+  z.object({ kind: z.literal("org") }).strict(),
+  /** Enterprise-managed: a credential minted for this caller by an identity provider. */
+  z.object({ kind: z.literal("idp_exchange") }).strict(),
+  /** External IdP: the caller's own token forwarded verbatim upstream. */
+  z.object({ kind: z.literal("idp_passthrough") }).strict(),
+  /** The caller's request carried the upstream authorization header itself. */
+  z.object({ kind: z.literal("caller_headers") }).strict(),
+]);
+
+export type McpExecutedAs = z.infer<typeof McpExecutedAsSchema>;
+export type McpExecutedAsKind = McpExecutedAs["kind"];
+
+/**
+ * Read the executed-as descriptor off a tool result, a persisted tool-call log
+ * row's result, or a bare `_meta` record. Returns null for calls that never
+ * resolved a credential and for results persisted before the descriptor
+ * existed, so every surface hides rather than guesses.
+ */
+export function extractMcpExecutedAs(input: unknown): McpExecutedAs | null {
+  if (input == null || typeof input !== "object") {
+    return null;
+  }
+
+  const record = input as {
+    _meta?: { [MCP_EXECUTED_AS_META_KEY]?: unknown };
+    [MCP_EXECUTED_AS_META_KEY]?: unknown;
+  };
+  const candidate =
+    record._meta?.[MCP_EXECUTED_AS_META_KEY] ??
+    record[MCP_EXECUTED_AS_META_KEY];
+
+  const parsed = McpExecutedAsSchema.safeParse(candidate);
+  return parsed.success ? parsed.data : null;
+}

--- a/platform/shared/mcp-executed-as.ts
+++ b/platform/shared/mcp-executed-as.ts
@@ -45,10 +45,10 @@ export function stripReservedPlatformMeta(
 }
 
 /**
- * Which identity the upstream call ran as. One member per way the gateway can
- * resolve a credential; a call that never reached an upstream server (a
- * platform built-in, a blocked call, an app launch) carries no descriptor at
- * all rather than a catch-all member.
+ * Which identity a tool call ran as. One member per way the gateway can
+ * resolve a credential, plus `platform` for the calls Archestra serves itself
+ * — every tool call answers "on whose behalf did this run?", so a card is
+ * never blank where the question still has an answer.
  */
 export const McpExecutedAsSchema = z.discriminatedUnion("kind", [
   z
@@ -78,10 +78,34 @@ export const McpExecutedAsSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("idp_passthrough") }).strict(),
   /** The caller's request carried the upstream authorization header itself. */
   z.object({ kind: z.literal("caller_headers") }).strict(),
+  /**
+   * Archestra served the call itself — a built-in tool, an app launch, or a
+   * call it refused before reaching a server. No MCP server credential was
+   * involved; the call ran with the caller's own permissions. Carries only the
+   * caller's id: every surface that shows this already knows the caller's name
+   * (the log row, the chat viewer), so resolving it here would cost a query
+   * per call for nothing.
+   */
+  z
+    .object({
+      kind: z.literal("platform"),
+      callerUserId: z.string().nullable(),
+    })
+    .strict(),
 ]);
 
 export type McpExecutedAs = z.infer<typeof McpExecutedAsSchema>;
 export type McpExecutedAsKind = McpExecutedAs["kind"];
+
+/**
+ * The identity for a call Archestra serves itself: no MCP server credential is
+ * involved, so it runs with the caller's own permissions.
+ */
+export function platformExecutedAs(
+  callerUserId: string | null | undefined,
+): McpExecutedAs {
+  return { kind: "platform", callerUserId: callerUserId ?? null };
+}
 
 /**
  * Read the executed-as descriptor off a tool result, a persisted tool-call log

--- a/platform/shared/mcp-executed-as.ts
+++ b/platform/shared/mcp-executed-as.ts
@@ -73,11 +73,26 @@ export const McpExecutedAsSchema = z.discriminatedUnion("kind", [
     .strict(),
   z.object({ kind: z.literal("org") }).strict(),
   /** Enterprise-managed: a credential minted for this caller by an identity provider. */
-  z.object({ kind: z.literal("idp_exchange") }).strict(),
+  z
+    .object({
+      kind: z.literal("idp_exchange"),
+      callerUserId: z.string().nullable(),
+    })
+    .strict(),
   /** External IdP: the caller's own token forwarded verbatim upstream. */
-  z.object({ kind: z.literal("idp_passthrough") }).strict(),
+  z
+    .object({
+      kind: z.literal("idp_passthrough"),
+      callerUserId: z.string().nullable(),
+    })
+    .strict(),
   /** The caller's request carried the upstream authorization header itself. */
-  z.object({ kind: z.literal("caller_headers") }).strict(),
+  z
+    .object({
+      kind: z.literal("caller_headers"),
+      callerUserId: z.string().nullable(),
+    })
+    .strict(),
   /**
    * Archestra served the call itself — a built-in tool, an app launch, or a
    * call it refused before reaching a server. No MCP server credential was


### PR DESCRIPTION
Closes T-948.

## Why

A tool call through the MCP gateway runs under a credential the gateway resolves per call — the caller's own connection, a team or organization connection, a connection pinned as a service account (possibly another user's), or a token minted for the caller. Neither the chat tool-call card nor the MCP Gateway log said which one, so "did this read my Grain, or someone else's?" was unanswerable.

## What

The MCP client now describes the identity it resolved and stamps it on the result under a platform-reserved `_meta.archestraExecutedAs` key. From that one place it reaches every surface:

- **Chat tool-call card** — a "Ran as" badge in the header (full card and expanded compact card).
- **MCP Gateway logs** — a "Ran As" column next to the existing User column, and a detail-page row. The result is already persisted whole, so this needed **no migration, no API/schema change, and no codegen**.
- **MCP clients on the wire** — the gateway already returns result `_meta`.

The model never sees it: chat strips tool-output metadata before the result reaches the LLM (pinned by a test).

One variant per way a credential can resolve: the caller's own personal connection ("Ran as me"), another user's connection pinned as a service account (named), a team connection, the organization connection, or a token minted for the caller (enterprise IdP exchange, forwarded SSO token, caller-supplied header).

The branch order mirrors how the transport actually builds the outbound header, not how the install was picked — an enterprise-managed credential overrides the install's own secrets, and a forwarded SSO token applies only when the install stores no authorization of its own. Reversing that would name the install's owner for a call that really ran as the caller; there are tests on both sides of it.

## Two bugs found and fixed en route

- **Tool-definition metadata could forge a reserved key.** Tool definitions are authored upstream and synced by `tools/list`, and chat merged them *over* the result's own metadata. A hostile server could declare a forged identity — or a forged `archestraError`, already exploitable before this PR — and override the platform's value on every card. The reserved-key strip moved to `shared/` and now runs on that path too.
- **`run_tool` dispatch dropped result metadata on success**, flattening to bare text. That is exactly the card in the originating report, so the identity would never have appeared there. It now keeps the metadata when there is any; in-process Archestra tools carry none and stay plain text, so plain-output parsing (knowledge-source citations) is unchanged.

## Decisions

- **Owner is named everywhere** (chat, logs, wire) rather than shown as a generic "service connection". Confirmed with @piercypixel: naming is the point of the ask, and the connection display name already often reveals the owner.
- **Zero new columns.** The identity snapshots into the existing `tool_result` jsonb, which is stored untruncated, already returned by both list and detail endpoints, and free-text searchable via the existing trgm index. A snapshot also beats an FK for audit: it survives uninstall, user deletion, and re-scoping. A queryable `executed_as` column can be added later and backfilled from the jsonb if a filter is ever wanted.

## Testing

- `mcp-client.test.ts`: 11 new cases — one per resolution branch, forged-identity replacement, the persisted log row, an upstream error result, and the no-credential case. Whole file green (137).
- `chat-tool-builder`: cases for the tool-definition sanitization and `run_tool` metadata preservation.
- `shared/mcp-executed-as.test.ts` and `executed-as-badge.test.tsx` for the schema/extractor and the badge labels.
- Frontend suites for the touched components: 698 pass.
- E2E: `dynamic-credentials.spec.ts` asserts the gateway reports the team connection on the wire.
- Three pre-existing exact-equality assertions updated, since success results now carry `_meta`.

Docs: a "Ran As" section under Credential Resolution in `mcp-authentication.md`.

Not yet exercised against a running stack — the chat badge and logs column have not been seen rendering on live data.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>