### PR TITLE
fix(chat): store attachments the model can't take instead of rejecting them

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -111575,6 +111575,9 @@
                         "chatAttachmentStorageBytesLimit": {
                           "type": "number"
                         },
+                        "apiBodyLimitBytes": {
+                          "type": "number"
+                        },
                         "byosEnabled": {
                           "type": "boolean"
                         },
@@ -111701,6 +111704,7 @@
                         "sandbox",
                         "sandboxArtifactBytesLimit",
                         "chatAttachmentStorageBytesLimit",
+                        "apiBodyLimitBytes",
                         "byosEnabled",
                         "byosVaultKvVersion",
                         "azureOpenAiEntraIdEnabled",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -111572,6 +111572,9 @@
                         "sandboxArtifactBytesLimit": {
                           "type": "number"
                         },
+                        "chatAttachmentStorageBytesLimit": {
+                          "type": "number"
+                        },
                         "byosEnabled": {
                           "type": "boolean"
                         },
@@ -111697,6 +111700,7 @@
                         "orchestratorK8sRuntime",
                         "sandbox",
                         "sandboxArtifactBytesLimit",
+                        "chatAttachmentStorageBytesLimit",
                         "byosEnabled",
                         "byosVaultKvVersion",
                         "azureOpenAiEntraIdEnabled",

--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -72,4 +72,4 @@ Chat attachments are scoped to their conversation. To reuse files across related
 
 You can attach any file type. Images, PDFs, and common text documents (`.txt`, `.md`, `.csv`, `.tsv`, `.json`, `.xml`, `.yaml`, `.toml`) go straight to the model. Other files — a zip archive, for example — are saved to the chat's Files panel. When the agent has a code sandbox, those files are also staged there for the agent to process; without one, the agent can't read them and tells you so.
 
-Large files are kept too. A file too big for the code sandbox skips it and still lands in the Files panel, ready to download. Admins set the maximum upload size; see [Deployment](./platform-deployment).
+Large files are kept too. Anything the model can't take — the wrong file type, too big for the code sandbox, or simply too big to send — lands in the Files panel instead, ready to download, and the agent is told it is there. Admins set the maximum upload size; see [Deployment](./platform-deployment).

--- a/docs/pages/platform-chat.md
+++ b/docs/pages/platform-chat.md
@@ -3,7 +3,7 @@ title: Chat
 category: Agents
 order: 2
 description: Built-in Chat interface for working with agents and MCP tools
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-28
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -71,3 +71,5 @@ Ollama models often run with a smaller context window than the model architectur
 Chat attachments are scoped to their conversation. To reuse files across related sessions, add them to a [Project](./platform-projects) instead, where files are shared across all of the project's chats.
 
 You can attach any file type. Images, PDFs, and common text documents (`.txt`, `.md`, `.csv`, `.tsv`, `.json`, `.xml`, `.yaml`, `.toml`) go straight to the model. Other files — a zip archive, for example — are saved to the chat's Files panel. When the agent has a code sandbox, those files are also staged there for the agent to process; without one, the agent can't read them and tells you so.
+
+Large files are kept too. A file too big for the code sandbox skips it and still lands in the Files panel, ready to download. Admins set the maximum upload size; see [Deployment](./platform-deployment).

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -723,9 +723,9 @@ The following environment variables can be used to configure Archestra Platform.
   - Example: `ARCHESTRA_TRUST_PROXY=true`
 
 - **`ARCHESTRA_API_BODY_LIMIT`** - Maximum request body size for LLM proxy and chat routes.
-  - Default: `50MB` (52428800 bytes)
-  - Format: Numeric bytes (e.g., `52428800`) or human-readable (e.g., `50MB`, `100KB`, `1GB`)
-  - Note: Increase this if you have conversations with very large context windows (100k+ tokens) or large file attachments in chat
+  - Default: `70MB` (73400320 bytes)
+  - Format: Numeric bytes (e.g., `73400320`) or human-readable (e.g., `70MB`, `100KB`, `1GB`)
+  - Note: Increase this if you have conversations with very large context windows (100k+ tokens) or large file attachments in chat. The default carries a max-size chat attachment as base64 plus room for history; raising `ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT` requires raising this too.
 
 - **`ARCHESTRA_FRONTEND_URL`** - Setting this variable enables origin validation for CORS and authentication. When set, only requests from this origin (and any in `ARCHESTRA_AUTH_ADDITIONAL_TRUSTED_ORIGINS`) are allowed. When not set, all origins are accepted.
   - Example: `https://frontend.example.com`
@@ -788,8 +788,9 @@ Upgrading from a chart that ran the bundled engine leaves its cache volume behin
   - Default: `120`
 - **`ARCHESTRA_SKILLS_SANDBOX_OUTPUT_BYTES_LIMIT`** - Maximum captured stdout/stderr per command; output beyond this is truncated.
   - Default: `262144` (256 KiB)
-- **`ARCHESTRA_SKILLS_SANDBOX_ARTIFACT_BYTES_LIMIT`** - Maximum size of a file the sandbox can export to the conversation's Files panel.
+- **`ARCHESTRA_SKILLS_SANDBOX_ARTIFACT_BYTES_LIMIT`** - Maximum size of a file the sandbox can export to the conversation's Files panel, and of a chat attachment it can stage for the agent to read.
   - Default: `16777216` (16 MiB)
+  - This does not cap what chat can upload. A larger attachment skips sandbox staging and is still stored — see `ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT`.
 - **`ARCHESTRA_DAGGER_RUNTIME_MAX_CONCURRENT`** - Sandbox commands the shared Dagger session runs at once, deployment-wide. Raise it with the engine's CPU and memory.
   - Default: `10`
 - **`ARCHESTRA_DAGGER_RUNTIME_MAX_QUEUE_LENGTH`** - Sandbox commands allowed to wait for a free slot. Past this, a command fails with a runtime-at-capacity error instead of queueing.
@@ -1209,6 +1210,11 @@ Enable polling compatibility only when your database endpoint cannot keep sessio
   - This is a client-side convenience nudge, not a data-loss-prevention control: it runs in the browser and can be bypassed with "Send anyway".
   - Detection runs entirely in the browser — no message content is sent to the backend for scanning. The flag is read from the backend at runtime via `/api/config`, so toggling it does not require a frontend rebuild.
   - Values: `true`, `false`
+
+- **`ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT`** - Largest single file a chat upload may store as a conversation attachment.
+  - Default: `52428800` (50 MiB)
+  - This is the only size gate on a chat upload. A file above `ARCHESTRA_SKILLS_SANDBOX_ARTIFACT_BYTES_LIMIT` is not rejected: it skips sandbox staging and is still stored in the conversation's Files panel, where the user can download it. The agent is told it cannot read the contents.
+  - Raise `ARCHESTRA_API_BODY_LIMIT` alongside this. Uploads arrive base64-encoded (about 4/3 the byte size) in the same request as the conversation history, so the body limit must exceed this value by a comfortable margin.
 
 - **`ARCHESTRA_CHAT_MAX_OUTPUT_TOKENS`** - Upper bound on the output tokens an agent turn (interactive chat and A2A/headless) may generate.
   - Default: `32768`

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -726,6 +726,7 @@ The following environment variables can be used to configure Archestra Platform.
   - Default: `70MB` (73400320 bytes)
   - Format: Numeric bytes (e.g., `73400320`) or human-readable (e.g., `70MB`, `100KB`, `1GB`)
   - Note: Increase this if you have conversations with very large context windows (100k+ tokens) or large file attachments in chat. The default carries a max-size chat attachment as base64 plus room for history; raising `ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT` requires raising this too.
+  - All attachments of one chat message travel in a single request, so this also bounds their combined size. The chat composer blocks a message whose attachments exceed it and asks the user to send them separately.
 
 - **`ARCHESTRA_FRONTEND_URL`** - Setting this variable enables origin validation for CORS and authentication. When set, only requests from this origin (and any in `ARCHESTRA_AUTH_ADDITIONAL_TRUSTED_ORIGINS`) are allowed. When not set, all origins are accepted.
   - Example: `https://frontend.example.com`

--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1214,8 +1214,13 @@ Enable polling compatibility only when your database endpoint cannot keep sessio
 
 - **`ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT`** - Largest single file a chat upload may store as a conversation attachment.
   - Default: `52428800` (50 MiB)
-  - This is the only size gate on a chat upload. A file above `ARCHESTRA_SKILLS_SANDBOX_ARTIFACT_BYTES_LIMIT` is not rejected: it skips sandbox staging and is still stored in the conversation's Files panel, where the user can download it. The agent is told it cannot read the contents.
+  - This is the only size gate on a chat upload. A file the model cannot read, one too big for the sandbox, or one over `ARCHESTRA_CHAT_ATTACHMENT_INLINE_BYTES_LIMIT` is not rejected: it is stored in the conversation's Files panel, where the user can download it, and the agent is told it is there.
   - Raise `ARCHESTRA_API_BODY_LIMIT` alongside this. Uploads arrive base64-encoded (about 4/3 the byte size) in the same request as the conversation history, so the body limit must exceed this value by a comfortable margin.
+
+- **`ARCHESTRA_CHAT_ATTACHMENT_INLINE_BYTES_LIMIT`** - Largest single attachment that may be embedded in a request to the LLM provider.
+  - Default: `16777216` (16 MiB)
+  - Storing a file and sending it to a model are separate decisions. A file above this is still stored and downloadable; it just never reaches the model, so a large upload cannot inflate a request past what the provider accepts.
+  - The effective ceiling is the lower of this value and the provider's own documented request limit (Anthropic 32 MiB, Bedrock 20 MiB).
 
 - **`ARCHESTRA_CHAT_MAX_OUTPUT_TOKENS`** - Upper bound on the output tokens an agent turn (interactive chat and A2A/headless) may generate.
   - Default: `32768`

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -613,6 +613,12 @@ ARCHESTRA_CHAT_SECRET_SCAN_ENABLED=true
 # with the conversation JSON.
 # ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT=52428800
 
+# Largest single attachment that may be embedded in a request to the LLM
+# provider. Default 16777216 (16 MiB). Separate from the storage cap above: a
+# bigger file is still stored and downloadable, it just never reaches the model,
+# which is told it is in the Files panel.
+# ARCHESTRA_CHAT_ATTACHMENT_INLINE_BYTES_LIMIT=16777216
+
 # Maximum request body size for LLM proxy and chat routes. Default 73400320
 # (70 MiB) — sized to carry a max-size chat attachment as base64 plus history.
 # Accepts plain bytes or a suffixed size (e.g. "70MB").

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -605,3 +605,15 @@ ARCHESTRA_CHAT_SECRET_SCAN_ENABLED=true
 # even a one-word message is rejected with a 413 before generating a token.
 # Default 4096. Raise it on higher provider tiers to allow longer generations.
 # ARCHESTRA_CHAT_RATE_METERED_MAX_OUTPUT_TOKENS=4096
+
+# Largest single file a chat upload may store as a conversation attachment
+# (Files panel). Default 52428800 (50 MiB). Files above the sandbox artifact
+# limit skip sandbox staging but are still stored. Raise ARCHESTRA_API_BODY_LIMIT
+# alongside this: uploads arrive base64-encoded (~4/3 the byte size) together
+# with the conversation JSON.
+# ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT=52428800
+
+# Maximum request body size for LLM proxy and chat routes. Default 73400320
+# (70 MiB) — sized to carry a max-size chat attachment as base64 plus history.
+# Accepts plain bytes or a suffixed size (e.g. "70MB").
+# ARCHESTRA_API_BODY_LIMIT=73400320

--- a/platform/backend/src/agents/a2a-executor.ts
+++ b/platform/backend/src/agents/a2a-executor.ts
@@ -1062,6 +1062,10 @@ function rejectionText(reason: ChatUploadRejectionReason): string {
       return "text too large to inline";
     case "too_large_for_sandbox":
       return "exceeds the sandbox size limit";
+    // Unreachable here: A2A has no Files panel for its callers, so it never
+    // opts into the file-storage fallback that produces this reason.
+    case "too_large_to_store":
+      return "too large to store";
     case "unsupported_type":
       return "type not supported by this model";
   }

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_ADMIN_PASSWORD,
   DEFAULT_ADMIN_PASSWORD_ENV_VAR_NAME,
   DEFAULT_APP_NAME,
+  DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES,
   DEFAULT_MODELS,
   DEFAULT_VAULT_TOKEN,
   isValidK8sCpuQuantity,
@@ -2124,6 +2125,17 @@ const config = {
     ),
     rateMeteredMaxOutputTokensCeiling: parseChatRateMeteredMaxOutputTokens(
       process.env.ARCHESTRA_CHAT_RATE_METERED_MAX_OUTPUT_TOKENS,
+    ),
+    /**
+     * Largest single upload a chat turn may store as a conversation
+     * attachment. Independent of the sandbox artifact limit: bigger files skip
+     * sandbox staging but still land in the Files panel. Raising this needs
+     * `ARCHESTRA_API_BODY_LIMIT` raised too — uploads arrive base64-encoded
+     * (~4/3 of the byte size) alongside the conversation JSON.
+     */
+    attachmentStorageBytesLimit: parsePositiveInt(
+      process.env.ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT,
+      DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES,
     ),
   },
   enterpriseFeatures: {

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_ADMIN_PASSWORD,
   DEFAULT_ADMIN_PASSWORD_ENV_VAR_NAME,
   DEFAULT_APP_NAME,
+  DEFAULT_CHAT_ATTACHMENT_INLINE_BYTES,
   DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES,
   DEFAULT_MODELS,
   DEFAULT_VAULT_TOKEN,
@@ -2136,6 +2137,16 @@ const config = {
     attachmentStorageBytesLimit: parsePositiveInt(
       process.env.ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT,
       DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES,
+    ),
+    /**
+     * Largest attachment that may be embedded in a provider request. Separate
+     * from the storage cap on purpose: a file over this is still stored and
+     * downloadable, it just never reaches the model. Keeps a big upload from
+     * inflating a request past what the provider accepts.
+     */
+    attachmentInlineBytesLimit: parsePositiveInt(
+      process.env.ARCHESTRA_CHAT_ATTACHMENT_INLINE_BYTES_LIMIT,
+      DEFAULT_CHAT_ATTACHMENT_INLINE_BYTES,
     ),
   },
   enterpriseFeatures: {

--- a/platform/backend/src/models/conversation-attachment.ts
+++ b/platform/backend/src/models/conversation-attachment.ts
@@ -67,6 +67,26 @@ class ConversationAttachmentModel {
     return result ? normalizeByteaField(result, "fileData") : null;
   }
 
+  /**
+   * Batch metadata lookup that leaves the bytea column alone. Lets a caller
+   * decide which attachments it actually needs bytes for before paying to read
+   * them — an over-the-sandbox-limit file can be described from metadata alone.
+   */
+  static async findByIdsWithoutData(
+    ids: string[],
+  ): Promise<Omit<ConversationAttachment, "fileData">[]> {
+    if (ids.length === 0) return [];
+    return db
+      .select(metadataColumns)
+      .from(schema.conversationAttachmentsTable)
+      .where(
+        and(
+          inArray(schema.conversationAttachmentsTable.id, ids),
+          isNull(schema.conversationAttachmentsTable.deletedAt),
+        ),
+      );
+  }
+
   static async findByIdsWithData(
     ids: string[],
   ): Promise<ConversationAttachment[]> {

--- a/platform/backend/src/routes/chat/normalization/enforce-request-size-limit.ts
+++ b/platform/backend/src/routes/chat/normalization/enforce-request-size-limit.ts
@@ -20,6 +20,18 @@ const PROVIDER_ATTACHMENT_LIMIT_BYTES: Partial<
   anthropic: 32 * 1024 * 1024,
 };
 
+/**
+ * The provider's documented per-request attachment ceiling, or `undefined` when
+ * it publishes none. Materialization bounds its own inline budget by this so a
+ * single attachment can never be the reason a request is refused — it is left
+ * in the Files panel instead.
+ */
+export function providerAttachmentLimitBytes(
+  provider: SupportedProvider,
+): number | undefined {
+  return PROVIDER_ATTACHMENT_LIMIT_BYTES[provider];
+}
+
 const BASE64_MARKER = ";base64,";
 
 const MiB = 1024 * 1024;

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.test.ts
@@ -370,7 +370,11 @@ test("parseAttachmentIdFromUrl validates the URL shape", () => {
 });
 
 describe("assertInlineAttachmentsAcceptable", () => {
-  const SANDBOX_LIMIT = 16 * 1024 * 1024;
+  // Scaled down from the real defaults (16 MiB / 50 MiB) so the cases below can
+  // allocate real buffers cheaply. Both must stay above INLINE_TEXT_MAX_BYTES
+  // for the oversized-text cases, and the storage cap above the sandbox limit.
+  const SANDBOX_LIMIT = 512 * 1024;
+  const STORAGE_LIMIT = 1024 * 1024;
 
   function policy(
     overrides: Partial<InlineAttachmentPolicy> = {},
@@ -379,6 +383,7 @@ describe("assertInlineAttachmentsAcceptable", () => {
       ingestibleMimeTypes: new Set(["image/png", "application/pdf"]),
       sandboxAvailable: false,
       sandboxByteLimit: SANDBOX_LIMIT,
+      fileStorageByteLimit: STORAGE_LIMIT,
       ...overrides,
     };
   }
@@ -407,7 +412,7 @@ describe("assertInlineAttachmentsAcceptable", () => {
   }
 
   test("accepts a model-ingestible type regardless of sandbox", () => {
-    expect(() => assert("image/png", 5_000_000, policy())).not.toThrow();
+    expect(() => assert("image/png", STORAGE_LIMIT, policy())).not.toThrow();
   });
 
   test("accepts a small inlineable text file without a sandbox", () => {
@@ -442,17 +447,39 @@ describe("assertInlineAttachmentsAcceptable", () => {
     ).not.toThrow();
   });
 
-  test("rejects a file over the storage limit regardless of sandbox availability", () => {
+  test("accepts a file over the sandbox limit but under the storage cap", () => {
+    // The sandbox is bypassed, not the gatekeeper: the file is still stored as
+    // a conversation attachment and reachable from the chat Files panel.
     expect(() =>
       assert(
         "application/zip",
         SANDBOX_LIMIT + 1,
         policy({ sandboxAvailable: true }),
       ),
-    ).toThrow();
+    ).not.toThrow();
     expect(() =>
       assert("application/zip", SANDBOX_LIMIT + 1, policy()),
-    ).toThrow();
+    ).not.toThrow();
+  });
+
+  test("rejects a file over the storage cap regardless of sandbox availability", () => {
+    for (const sandboxAvailable of [true, false]) {
+      expect(() =>
+        assert(
+          "application/zip",
+          STORAGE_LIMIT + 1,
+          policy({ sandboxAvailable }),
+        ),
+      ).toThrow('"file.zip" is too large to attach (max 1 MB).');
+    }
+  });
+
+  test("rejects a model-ingestible type over the storage cap", () => {
+    // Every accepted upload persists its bytes, so the cap binds readable types
+    // too — otherwise a huge PNG would slip past the only remaining gate.
+    expect(() => assert("image/png", STORAGE_LIMIT + 1, policy())).toThrow(
+      '"file.png" is too large to attach (max 1 MB).',
+    );
   });
 
   test("does not throw on a malformed (un-decodable) data: URL", () => {

--- a/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/extract-inline-attachments.ts
@@ -101,16 +101,17 @@ export async function extractInlineAttachments(args: {
 
 /**
  * Policy describing which uploaded attachments this turn may accept, evaluated
- * before any bytes are persisted. A file is acceptable when the model can ingest
- * its type, OR it is an inlineable text document within the inline budget, OR it
- * fits the sandbox artifact size limit — files the model can't read still land
- * as conversation attachments the user reaches from the chat Files panel (and,
- * when a sandbox is available, are additionally staged there for the model).
+ * before any bytes are persisted. Every accepted file lands as a conversation
+ * attachment the user reaches from the chat Files panel, so the only rejection
+ * is exceeding `fileStorageByteLimit`. `sandboxByteLimit` decides nothing about
+ * acceptance — it only bounds what is additionally staged into the sandbox for
+ * the model; a bigger file skips staging and is still stored.
  */
 export type InlineAttachmentPolicy = {
   ingestibleMimeTypes: Set<string>;
   sandboxAvailable: boolean;
   sandboxByteLimit: number;
+  fileStorageByteLimit: number;
 };
 
 /**
@@ -141,7 +142,7 @@ export function assertInlineAttachmentsAcceptable(args: {
         sandboxByteLimit: policy.sandboxByteLimit,
         // Chat uploads always have a landing surface: the attachment row shows
         // in the conversation's Files panel even when the model can't read it.
-        fileStorageFallback: true,
+        fileStorageByteLimit: policy.fileStorageByteLimit,
       });
       if (reason) {
         throw new ApiError(400, rejectionMessage(reason, inspected, policy));
@@ -383,6 +384,11 @@ function rejectionMessage(
 ): string {
   const { mimeType, filename } = file;
   switch (reason) {
+    // Chat always passes a storage cap, so "too_large_to_store" is the only
+    // reachable reason here; the rest stay for the shared union (A2A uses it
+    // without the Files-panel fallback).
+    case "too_large_to_store":
+      return `"${filename}" is too large to attach (max ${formatBytes(policy.fileStorageByteLimit)}).`;
     case "text_too_large":
       return `"${filename}" is too large to include (max ${formatBytes(INLINE_TEXT_MAX_BYTES)} of text without a sandbox).`;
     case "too_large_for_sandbox":

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
@@ -1060,6 +1060,109 @@ test("an inline data: binary document is dropped with a notice on a non-native e
   expect(part.url).toBeUndefined();
 });
 
+test("keeps an attachment over the inline budget out of the request", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  // A file the model reads perfectly well, just too big to send. Storing it and
+  // sending it are separate decisions — it stays in the Files panel instead of
+  // being inlined and refused by the provider.
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.from("%PDF-1.4 pretend this is large", "utf8");
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "manual.pdf",
+    mimeType: "application/pdf",
+    // Declared size drives the decision; the row's bytes stay small so the
+    // test doesn't allocate tens of megabytes.
+    fileSize: 45 * 1024 * 1024,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const input: ChatMessage[] = [
+    {
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: `/api/chat/attachments/${row.id}/content`,
+          mediaType: "application/pdf",
+          filename: "manual.pdf",
+        },
+      ],
+    },
+  ];
+
+  const output = await materializeAttachments({
+    messages: input,
+    conversationId: conversation.id,
+    // The model reads PDFs — size is the only reason to divert this one.
+    ingestibleMimeTypes: INGESTIBLE,
+    sandboxAvailable: false,
+    inlineByteLimit: 16 * 1024 * 1024,
+  });
+
+  const part = expectPresent(output[0].parts?.[0]);
+  expect(part.type).toBe("text");
+  expect(part.text).toContain("too large to send to this model");
+  expect(part.text).toContain("Files panel");
+  expect(part.text).toContain(JSON.stringify("manual.pdf"));
+  // Never embedded, so it can't inflate the request past the provider's cap.
+  expect(part.text).not.toContain("data:");
+  expect(part.url).toBeUndefined();
+});
+
+test("inlines a readable attachment that fits the inline budget", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+  const bytes = Buffer.from("%PDF-1.4 small", "utf8");
+  const row = await ConversationAttachmentModel.create({
+    organizationId: conversation.organizationId,
+    conversationId: conversation.id,
+    uploadedByUserId: conversation.userId,
+    originalName: "small.pdf",
+    mimeType: "application/pdf",
+    fileSize: bytes.byteLength,
+    contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+    fileData: bytes,
+  });
+
+  const output = await materializeAttachments({
+    messages: [
+      {
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            url: `/api/chat/attachments/${row.id}/content`,
+            mediaType: "application/pdf",
+            filename: "small.pdf",
+          },
+        ],
+      },
+    ],
+    conversationId: conversation.id,
+    ingestibleMimeTypes: INGESTIBLE,
+    sandboxAvailable: false,
+    inlineByteLimit: 16 * 1024 * 1024,
+  });
+
+  expect(expectPresent(output[0].parts?.[0]).url).toBe(
+    `data:application/pdf;base64,${bytes.toString("base64")}`,
+  );
+});
+
 test("reads bytes only for attachments that are actually inlined", async ({
   makeAgent,
   makeConversation,

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.test.ts
@@ -2,6 +2,7 @@ import {
   getModelReadableMimeTypes,
   INLINE_TEXT_MAX_BYTES,
 } from "@archestra/shared";
+import { vi } from "vitest";
 import config from "@/config";
 import ConversationAttachmentModel from "@/models/conversation-attachment";
 import { expect, test } from "@/test";
@@ -1057,6 +1058,93 @@ test("an inline data: binary document is dropped with a notice on a non-native e
   // The data: bytes are NOT emitted as a document block the endpoint rejects.
   expect(part.text).not.toContain("data:");
   expect(part.url).toBeUndefined();
+});
+
+test("reads bytes only for attachments that are actually inlined", async ({
+  makeAgent,
+  makeConversation,
+}) => {
+  // A conversation can carry a large file the model will never read (it only
+  // ever gets a one-line notice). Loading its bytes on every subsequent turn
+  // would re-stream it out of Postgres for the life of the conversation.
+  const agent = await makeAgent();
+  const conversation = await makeConversation(agent.id, {
+    organizationId: agent.organizationId,
+  });
+
+  const makeRow = async (mimeType: string, name: string) => {
+    const bytes = Buffer.from(`bytes for ${name}`, "utf8");
+    return ConversationAttachmentModel.create({
+      organizationId: conversation.organizationId,
+      conversationId: conversation.id,
+      uploadedByUserId: conversation.userId,
+      originalName: name,
+      mimeType,
+      fileSize: bytes.byteLength,
+      contentHash: ConversationAttachmentModel.computeContentHash(bytes),
+      fileData: bytes,
+    });
+  };
+  const readable = await makeRow("image/png", "chart.png");
+  const unreadable = await makeRow("application/octet-stream", "archive.zip");
+
+  const refPart = (id: string, mediaType: string, filename: string) => ({
+    type: "file" as const,
+    url: `/api/chat/attachments/${id}/content`,
+    mediaType,
+    filename,
+  });
+
+  const withDataSpy = vi.spyOn(
+    ConversationAttachmentModel,
+    "findByIdsWithData",
+  );
+  try {
+    const output = await materializeAttachments({
+      messages: [
+        {
+          role: "user",
+          parts: [
+            refPart(readable.id, "image/png", "chart.png"),
+            refPart(unreadable.id, "application/octet-stream", "archive.zip"),
+          ],
+        },
+      ],
+      conversationId: conversation.id,
+      ingestibleMimeTypes: INGESTIBLE,
+      sandboxAvailable: true,
+    });
+
+    expect(withDataSpy).toHaveBeenCalledTimes(1);
+    expect(withDataSpy).toHaveBeenCalledWith([readable.id]);
+
+    // Output is unchanged by the optimization: the PNG still inlines, the
+    // opaque binary still becomes a sandbox notice.
+    const inlined = expectPresent(output[0].parts?.[0]);
+    expect(inlined.url).toContain("data:image/png;base64,");
+    const notice = expectPresent(output[0].parts?.[1]);
+    expect(notice.type).toBe("text");
+    expect(notice.text).toContain("/home/sandbox/attachments");
+
+    // A turn referencing only the unreadable file touches no bytes at all.
+    withDataSpy.mockClear();
+    await materializeAttachments({
+      messages: [
+        {
+          role: "user",
+          parts: [
+            refPart(unreadable.id, "application/octet-stream", "archive.zip"),
+          ],
+        },
+      ],
+      conversationId: conversation.id,
+      ingestibleMimeTypes: INGESTIBLE,
+      sandboxAvailable: true,
+    });
+    expect(withDataSpy).toHaveBeenCalledWith([]);
+  } finally {
+    withDataSpy.mockRestore();
+  }
 });
 
 test("no refs in messages returns a clone without DB hits", async () => {

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -13,7 +13,7 @@ import {
 } from "./extract-inline-attachments";
 
 type Attachment = Awaited<
-  ReturnType<typeof ConversationAttachmentModel.findByIdsWithData>
+  ReturnType<typeof ConversationAttachmentModel.findByIdsWithoutData>
 >[number];
 
 /**
@@ -63,10 +63,13 @@ export async function materializeAttachments({
   // data: URL file parts (legacy messages or same-tab follow-ups whose FE
   // state lags the backend rewrite) need cache_control applied here, since
   // the alternative is Anthropic re-billing the full file on every turn.
+  //
+  // Metadata first: an attachment the model can't read is described from its
+  // mime type and size alone. Reading its bytes on every turn would mean
+  // re-streaming a large file out of Postgres for the whole life of the
+  // conversation just to render a one-line notice.
   const attachments =
-    refIds.length === 0
-      ? []
-      : await ConversationAttachmentModel.findByIdsWithData(refIds);
+    await ConversationAttachmentModel.findByIdsWithoutData(refIds);
   // Filter to attachments owned by the current conversation. Anything
   // referencing an id outside this conversation is silently dropped from
   // the rehydration map — those parts stay with their ref URL, which
@@ -76,6 +79,15 @@ export async function materializeAttachments({
       .filter((a) => a.conversationId === conversationId)
       .map((a) => [a.id, a]),
   );
+
+  const inlinedIds = Array.from(byId.values())
+    .filter((attachment) =>
+      willInline(attachment, ingestibleMimeTypes, rerouteBinaryDocsToSandbox),
+    )
+    .map((attachment) => attachment.id);
+  const withData =
+    await ConversationAttachmentModel.findByIdsWithData(inlinedIds);
+  const bytesById = new Map(withData.map((a) => [a.id, a.fileData]));
 
   return messages.map((message) => {
     if (!message.parts || message.parts.length === 0) {
@@ -87,6 +99,7 @@ export async function materializeAttachments({
         materializePart(
           part,
           byId,
+          bytesById,
           ingestibleMimeTypes,
           applyAnthropicCacheControl,
           rerouteBinaryDocsToSandbox,
@@ -95,6 +108,28 @@ export async function materializeAttachments({
       ),
     };
   });
+}
+
+/**
+ * Whether this attachment's bytes end up embedded in the prompt as a `data:`
+ * URL. When false it becomes a text notice built from metadata alone, so its
+ * bytes are never read. Mirrors the branch in {@link materializePart}.
+ */
+function willInline(
+  attachment: Attachment,
+  ingestibleMimeTypes: Set<string> | undefined,
+  rerouteBinaryDocsToSandbox: boolean,
+): boolean {
+  const modelCannotRead =
+    ingestibleMimeTypes !== undefined &&
+    !ingestibleMimeTypes.has(attachment.mimeType);
+  const endpointRejectsBinaryDoc =
+    rerouteBinaryDocsToSandbox &&
+    isNonInlineableBinaryDocMimeType(attachment.mimeType);
+  const textTooLargeToInline =
+    isInlineableTextMimeType(attachment.mimeType) &&
+    attachment.fileSize > INLINE_TEXT_MAX_BYTES;
+  return !(modelCannotRead || endpointRejectsBinaryDoc || textTooLargeToInline);
 }
 
 function collectRefIds(messages: ChatMessage[]): string[] {
@@ -114,6 +149,7 @@ function collectRefIds(messages: ChatMessage[]): string[] {
 function materializePart(
   part: ChatMessagePart,
   byId: Map<string, Attachment>,
+  bytesById: Map<string, Buffer>,
   ingestibleMimeTypes: Set<string> | undefined,
   applyAnthropicCacheControl: boolean,
   rerouteBinaryDocsToSandbox: boolean,
@@ -167,30 +203,30 @@ function materializePart(
   }
 
   // A file the selected model can't read must not be inlined as a document the
-  // provider would reject (which hard-errors the whole turn). Two cases:
-  //   - the model's modalities don't cover this mime; or
-  //   - an Anthropic-compatible third-party endpoint can't accept the binary
-  //     `document` block this mime would become (PDF and other non-image,
-  //     non-text-inlineable types), regardless of the model's nominal modality.
-  // Either way the file has auto-staged into the sandbox, so reference it there.
-  const modelCannotRead =
-    ingestibleMimeTypes !== undefined &&
-    !ingestibleMimeTypes.has(attachment.mimeType);
-  const endpointRejectsBinaryDoc =
-    rerouteBinaryDocsToSandbox &&
-    isNonInlineableBinaryDocMimeType(attachment.mimeType);
-  // A text document over the inline budget is routed to the sandbox instead of
-  // being embedded in the prompt. The ingest gate only admits an over-budget
-  // text file when the sandbox is available, so it has been auto-staged there.
-  const textTooLargeToInline =
-    isInlineableTextMimeType(attachment.mimeType) &&
-    attachment.fileData.byteLength > INLINE_TEXT_MAX_BYTES;
-  if (modelCannotRead || endpointRejectsBinaryDoc || textTooLargeToInline) {
+  // provider would reject (which hard-errors the whole turn). Three cases,
+  // spelled out in `willInline`: the model's modalities don't cover this mime;
+  // an Anthropic-compatible third-party endpoint can't accept the binary
+  // `document` block it would become; or it is a text document over the inline
+  // budget. In each the file lives in the Files panel — and in the sandbox when
+  // it fits — so reference it there rather than embedding it.
+  if (
+    !willInline(attachment, ingestibleMimeTypes, rerouteBinaryDocsToSandbox)
+  ) {
     return referenceSandboxFilePart(attachment, sandboxAvailable);
   }
 
   // findByIdsWithData normalizes bytea to Buffer at the model boundary
-  const dataUrl = `data:${attachment.mimeType};base64,${attachment.fileData.toString("base64")}`;
+  const fileData = bytesById.get(id);
+  if (!fileData) {
+    // Soft-deleted between the metadata and byte reads. Same outcome as a
+    // missing row: leave the ref unresolved rather than fail the turn.
+    logger.warn(
+      { attachmentId: id },
+      "[materializeAttachments] Attachment bytes not found; skipping materialization",
+    );
+    return { ...part };
+  }
+  const dataUrl = `data:${attachment.mimeType};base64,${fileData.toString("base64")}`;
   // Mark the part for Anthropic ephemeral prompt caching when the endpoint
   // accepts it. The AI SDK reads this via the file UI part's provider metadata
   // (`providerMetadata`); convertToModelMessages translates it into the
@@ -249,9 +285,7 @@ function dualAvailabilityPointer(
   if (!sandboxAvailable || !isInlineableTextMimeType(attachment.mimeType)) {
     return null;
   }
-  if (
-    attachment.fileData.byteLength > config.skillsSandbox.artifactBytesLimit
-  ) {
+  if (attachment.fileSize > config.skillsSandbox.artifactBytesLimit) {
     return null;
   }
 
@@ -322,7 +356,7 @@ function referenceSandboxFilePart(
   attachment: Attachment,
   sandboxAvailable: boolean,
 ): ChatMessagePart {
-  const sizeBytes = attachment.fileData.byteLength;
+  const sizeBytes = attachment.fileSize;
   const name = JSON.stringify(attachment.originalName ?? "attachment");
   const label = `${name} (${attachment.mimeType}, ${sizeBytes} bytes)`;
   const limit = config.skillsSandbox.artifactBytesLimit;

--- a/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
+++ b/platform/backend/src/routes/chat/normalization/materialize-attachments.ts
@@ -50,6 +50,11 @@ export async function materializeAttachments({
   // the sandbox or `run_command`: a file it can't read inline gets a neutral
   // "not processed this turn" notice instead. Fail-closed (defaults off).
   sandboxAvailable = false,
+  // Ceiling on what one attachment may contribute to the provider request.
+  // Storing a file and sending it are separate decisions: a heavier file stays
+  // in the Files panel (and the sandbox, when it fits) instead of inflating the
+  // request past what the provider accepts. Unbounded when omitted.
+  inlineByteLimit = Number.POSITIVE_INFINITY,
 }: {
   messages: ChatMessage[];
   conversationId: string;
@@ -57,6 +62,7 @@ export async function materializeAttachments({
   applyAnthropicCacheControl?: boolean;
   rerouteBinaryDocsToSandbox?: boolean;
   sandboxAvailable?: boolean;
+  inlineByteLimit?: number;
 }): Promise<ChatMessage[]> {
   const refIds = collectRefIds(messages);
   // Even when there are no refs to rehydrate, we still walk every part —
@@ -80,10 +86,16 @@ export async function materializeAttachments({
       .map((a) => [a.id, a]),
   );
 
+  const policy: MaterializePolicy = {
+    ingestibleMimeTypes,
+    applyAnthropicCacheControl,
+    rerouteBinaryDocsToSandbox,
+    sandboxAvailable,
+    inlineByteLimit,
+  };
+
   const inlinedIds = Array.from(byId.values())
-    .filter((attachment) =>
-      willInline(attachment, ingestibleMimeTypes, rerouteBinaryDocsToSandbox),
-    )
+    .filter((attachment) => bypassReason(attachment, policy) === null)
     .map((attachment) => attachment.id);
   const withData =
     await ConversationAttachmentModel.findByIdsWithData(inlinedIds);
@@ -96,40 +108,50 @@ export async function materializeAttachments({
     return {
       ...message,
       parts: message.parts.flatMap((part) =>
-        materializePart(
-          part,
-          byId,
-          bytesById,
-          ingestibleMimeTypes,
-          applyAnthropicCacheControl,
-          rerouteBinaryDocsToSandbox,
-          sandboxAvailable,
-        ),
+        materializePart({ part, byId, bytesById, policy }),
       ),
     };
   });
 }
 
+type MaterializePolicy = {
+  ingestibleMimeTypes: Set<string> | undefined;
+  applyAnthropicCacheControl: boolean;
+  rerouteBinaryDocsToSandbox: boolean;
+  sandboxAvailable: boolean;
+  inlineByteLimit: number;
+};
+
 /**
- * Whether this attachment's bytes end up embedded in the prompt as a `data:`
- * URL. When false it becomes a text notice built from metadata alone, so its
- * bytes are never read. Mirrors the branch in {@link materializePart}.
+ * Why this attachment is kept out of the provider request, or `null` when its
+ * bytes are embedded as a `data:` URL. A bypassed attachment becomes a text
+ * notice built from metadata alone, so its bytes are never read.
+ *
+ * Every reason is a form of "the model can't take this": the wrong type for
+ * its modalities, a content block the endpoint rejects, or simply too many
+ * bytes. None of them is a failure — the file is stored either way, and the
+ * notice points the model and user at it.
  */
-function willInline(
+function bypassReason(
   attachment: Attachment,
-  ingestibleMimeTypes: Set<string> | undefined,
-  rerouteBinaryDocsToSandbox: boolean,
-): boolean {
+  policy: MaterializePolicy,
+): "unreadable" | "too_large_to_send" | null {
+  const { ingestibleMimeTypes, rerouteBinaryDocsToSandbox, inlineByteLimit } =
+    policy;
   const modelCannotRead =
     ingestibleMimeTypes !== undefined &&
     !ingestibleMimeTypes.has(attachment.mimeType);
   const endpointRejectsBinaryDoc =
     rerouteBinaryDocsToSandbox &&
     isNonInlineableBinaryDocMimeType(attachment.mimeType);
-  const textTooLargeToInline =
-    isInlineableTextMimeType(attachment.mimeType) &&
-    attachment.fileSize > INLINE_TEXT_MAX_BYTES;
-  return !(modelCannotRead || endpointRejectsBinaryDoc || textTooLargeToInline);
+  if (modelCannotRead || endpointRejectsBinaryDoc) return "unreadable";
+
+  // Text has a tighter budget than binary: an over-budget text document would
+  // blow the context window even though the provider would accept the bytes.
+  const textBudget = isInlineableTextMimeType(attachment.mimeType)
+    ? Math.min(INLINE_TEXT_MAX_BYTES, inlineByteLimit)
+    : inlineByteLimit;
+  return attachment.fileSize > textBudget ? "too_large_to_send" : null;
 }
 
 function collectRefIds(messages: ChatMessage[]): string[] {
@@ -146,15 +168,22 @@ function collectRefIds(messages: ChatMessage[]): string[] {
   return Array.from(ids);
 }
 
-function materializePart(
-  part: ChatMessagePart,
-  byId: Map<string, Attachment>,
-  bytesById: Map<string, Buffer>,
-  ingestibleMimeTypes: Set<string> | undefined,
-  applyAnthropicCacheControl: boolean,
-  rerouteBinaryDocsToSandbox: boolean,
-  sandboxAvailable: boolean,
-): ChatMessagePart | ChatMessagePart[] {
+function materializePart({
+  part,
+  byId,
+  bytesById,
+  policy,
+}: {
+  part: ChatMessagePart;
+  byId: Map<string, Attachment>;
+  bytesById: Map<string, Buffer>;
+  policy: MaterializePolicy;
+}): ChatMessagePart | ChatMessagePart[] {
+  const {
+    applyAnthropicCacheControl,
+    rerouteBinaryDocsToSandbox,
+    sandboxAvailable,
+  } = policy;
   if (part.type !== "file" || typeof part.url !== "string") {
     return { ...part };
   }
@@ -202,17 +231,13 @@ function materializePart(
     return { ...part };
   }
 
-  // A file the selected model can't read must not be inlined as a document the
-  // provider would reject (which hard-errors the whole turn). Three cases,
-  // spelled out in `willInline`: the model's modalities don't cover this mime;
-  // an Anthropic-compatible third-party endpoint can't accept the binary
-  // `document` block it would become; or it is a text document over the inline
-  // budget. In each the file lives in the Files panel — and in the sandbox when
-  // it fits — so reference it there rather than embedding it.
-  if (
-    !willInline(attachment, ingestibleMimeTypes, rerouteBinaryDocsToSandbox)
-  ) {
-    return referenceSandboxFilePart(attachment, sandboxAvailable);
+  // Anything the model can't take — wrong type, a block the endpoint rejects,
+  // or too many bytes — is kept out of the request rather than sent and
+  // refused, which would hard-error the whole turn. The file is stored either
+  // way, so reference it in the Files panel (and the sandbox when it fits).
+  const bypass = bypassReason(attachment, policy);
+  if (bypass) {
+    return referenceSandboxFilePart(attachment, bypass, sandboxAvailable);
   }
 
   // findByIdsWithData normalizes bytea to Buffer at the model boundary
@@ -354,30 +379,37 @@ function unavailableBinaryDocPart(
  */
 function referenceSandboxFilePart(
   attachment: Attachment,
+  reason: "unreadable" | "too_large_to_send",
   sandboxAvailable: boolean,
 ): ChatMessagePart {
   const sizeBytes = attachment.fileSize;
   const name = JSON.stringify(attachment.originalName ?? "attachment");
   const label = `${name} (${attachment.mimeType}, ${sizeBytes} bytes)`;
   const limit = config.skillsSandbox.artifactBytesLimit;
+  // Say which it is: "can't read this type" and "too big to send" call for
+  // different follow-ups from the model.
+  const why =
+    reason === "too_large_to_send"
+      ? "is too large to send to this model"
+      : "can't be read by this model";
 
   if (!sandboxAvailable) {
     return {
       type: "text",
-      text: `[Attachment ${label} can't be read by this model and no code sandbox is available to process it this turn. It is saved in this conversation's Files panel, where the user can view and download it. Let the user know you can't read its contents.]`,
+      text: `[Attachment ${label} ${why} and no code sandbox is available to process it this turn. It is saved in this conversation's Files panel, where the user can view and download it. Let the user know you can't read its contents.]`,
     };
   }
 
   if (sizeBytes > limit) {
     return {
       type: "text",
-      text: `[Attachment ${label} can't be shown to this model and is too large (limit ${limit} bytes) to use in your sandbox this turn. The user can still download it from this conversation's Files panel.]`,
+      text: `[Attachment ${label} ${why} and is too large (limit ${limit} bytes) to use in your sandbox this turn. The user can still download it from this conversation's Files panel.]`,
     };
   }
 
   return {
     type: "text",
-    text: `[Attachment ${label} can't be shown to this model inline. It has been placed in your sandbox under ${SKILL_SANDBOX_ATTACHMENTS_DIR} — run \`ls ${SKILL_SANDBOX_ATTACHMENTS_DIR}\` to find it (the filename may be sanitized), then read it with run_command.]`,
+    text: `[Attachment ${label} ${why}, so it is not shown inline. It has been placed in your sandbox under ${SKILL_SANDBOX_ATTACHMENTS_DIR} — run \`ls ${SKILL_SANDBOX_ATTACHMENTS_DIR}\` to find it (the filename may be sanitized), then read it with run_command.]`,
   };
 }
 

--- a/platform/backend/src/routes/chat/prepare-model-messages.ts
+++ b/platform/backend/src/routes/chat/prepare-model-messages.ts
@@ -11,6 +11,7 @@ import {
   type ToolResultPart,
   type UIMessage,
 } from "ai";
+import config from "@/config";
 import logger from "@/logging";
 import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
 import type { ChatMessage } from "@/types";
@@ -20,9 +21,28 @@ import {
   compactMessagesForChat,
 } from "./context-compaction";
 import { applyPromptCacheBreakpoints } from "./normalization/apply-prompt-cache";
-import { assertRequestWithinProviderPayloadLimit } from "./normalization/enforce-request-size-limit";
+import {
+  assertRequestWithinProviderPayloadLimit,
+  providerAttachmentLimitBytes,
+} from "./normalization/enforce-request-size-limit";
 import { materializeAttachments } from "./normalization/materialize-attachments";
 import { prepareMessagesForProvider } from "./normalization/prepare-for-provider";
+
+/**
+ * Providers whose chat-completion request schema has no content part able to
+ * carry a binary document — text and images only. Sending a PDF to one is a
+ * guaranteed 400, and a model row with no recorded input modalities defaults to
+ * "reads PDFs", so the file has to be diverted here rather than trusted to the
+ * modality set.
+ *
+ * Membership is asserted from a provider's own request schema, never inferred:
+ * `zhipuai`'s content part is a union of text and `image_url`
+ * (`types/llm-providers/zhipuai/messages.ts`). Add a provider only after
+ * reading its schema — a wrong entry silently stops sending documents that
+ * would have worked.
+ */
+const PROVIDERS_WITHOUT_DOCUMENT_CONTENT_PARTS: ReadonlySet<SupportedProvider> =
+  new Set<SupportedProvider>(["zhipuai"]);
 
 type CompactionStreamEvent =
   | { type: "data-context-compaction-start"; data: { trigger: "auto" } }
@@ -172,14 +192,25 @@ async function buildModelMessagesForProvider(params: {
   // attachment id. Legacy inline data URLs pass through unchanged. Returns a
   // deep copy — the original messages keep their refs for any subsequent
   // persistence step.
+  // What we may send is bounded by our own inline budget and, where the
+  // provider publishes one, its documented request ceiling — whichever is
+  // smaller. Anything above stays in the Files panel rather than being sent
+  // and refused.
+  const providerLimit = providerAttachmentLimitBytes(params.provider);
+  const inlineByteLimit = Math.min(
+    config.chat.attachmentInlineBytesLimit,
+    providerLimit ?? Number.POSITIVE_INFINITY,
+  );
   const materialized = await materializeAttachments({
     messages: params.messages,
     conversationId: params.conversationId,
     ingestibleMimeTypes: params.ingestibleMimeTypes,
     applyAnthropicCacheControl,
     rerouteBinaryDocsToSandbox:
-      params.provider === "anthropic" && !anthropicNativeEndpoint,
+      (params.provider === "anthropic" && !anthropicNativeEndpoint) ||
+      PROVIDERS_WITHOUT_DOCUMENT_CONTENT_PARTS.has(params.provider),
     sandboxAvailable: params.sandboxAvailable,
+    inlineByteLimit,
   });
   // Reject oversized inline attachments here, before the provider call, so the
   // user gets an actionable size error instead of a generic provider rejection.

--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -358,13 +358,14 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
       }
 
       // Gate uploaded attachments before any bytes are persisted: anything
-      // within the storage byte limit is accepted — a file the model can't
-      // ingest still lands in the conversation's Files panel (and is staged
-      // into the sandbox when one is available). The frontend mirrors this for
-      // UX, but a custom client bypasses it, so this is the authoritative
-      // check. Runs before extractInlineAttachments and before the active run
-      // is acquired, so a rejected request stores nothing. Skipped (with its
-      // model/sandbox lookups) on the common turn that uploads nothing.
+      // within the attachment storage cap is accepted — a file the model can't
+      // ingest, or one too big for the sandbox, still lands in the
+      // conversation's Files panel (and is staged into the sandbox when one is
+      // available and the file fits it). The frontend mirrors this for UX, but
+      // a custom client bypasses it, so this is the authoritative check. Runs
+      // before extractInlineAttachments and before the active run is acquired,
+      // so a rejected request stores nothing. Skipped (with its model/sandbox
+      // lookups) on the common turn that uploads nothing.
       if (messagesHaveNewInlineAttachments(messages as ChatMessage[])) {
         const attachmentModelRow = conversation.modelId
           ? await ModelModel.findById(conversation.modelId)
@@ -381,6 +382,7 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
               agentId: conversation.agentId,
             }),
             sandboxByteLimit: config.skillsSandbox.artifactBytesLimit,
+            fileStorageByteLimit: config.chat.attachmentStorageBytesLimit,
           },
         });
       }

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -2823,11 +2823,45 @@ describe("POST /api/chat handler composition", () => {
     expect(attachments[0].mimeType).toBe("application/zip");
   });
 
-  test("rejects an attachment over the storage byte limit and persists nothing", async () => {
-    // Just over the artifact/storage limit — too big for the sandbox AND for
-    // Files-panel storage, so the gate still rejects before any bytes persist.
-    const oversized = Buffer.alloc(
+  test("accepts an attachment over the sandbox limit and stores it", async () => {
+    // Too big to stage into the sandbox, but well under the storage cap: the
+    // sandbox is bypassed and the file still lands in the Files panel.
+    const overSandbox = Buffer.alloc(
       config.skillsSandbox.artifactBytesLimit + 1,
+      0x61,
+    );
+    const dataUrl = `data:application/zip;base64,${overSandbox.toString("base64")}`;
+    const response = await postMessage([
+      {
+        id: "msg-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "process this" },
+          {
+            type: "file",
+            url: dataUrl,
+            mediaType: "application/zip",
+            filename: "big.zip",
+          },
+        ],
+      },
+    ]);
+
+    expect(response.statusCode).toBe(200);
+    const attachments =
+      await ConversationAttachmentModel.findByConversationIdWithoutData(
+        conversationId,
+      );
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].originalName).toBe("big.zip");
+    expect(attachments[0].fileSize).toBe(overSandbox.byteLength);
+  });
+
+  test("rejects an attachment over the attachment storage cap and persists nothing", async () => {
+    // Past the one remaining gate — no surface can hold it, so the request is
+    // refused before any bytes persist.
+    const oversized = Buffer.alloc(
+      config.chat.attachmentStorageBytesLimit + 1,
       0x61,
     );
     const dataUrl = `data:application/zip;base64,${oversized.toString("base64")}`;
@@ -2848,6 +2882,7 @@ describe("POST /api/chat handler composition", () => {
     ]);
 
     expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toContain("is too large to attach");
     const attachments =
       await ConversationAttachmentModel.findByConversationIdWithoutData(
         conversationId,

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -71,6 +71,10 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               // panel). Bounds the composer's file picker and its per-file
               // policy; independent of what the sandbox can stage.
               chatAttachmentStorageBytesLimit: z.number(),
+              // Request body ceiling. A turn's attachments travel base64-encoded
+              // in one request, so the composer needs this to stop a send that
+              // the body parser would reject with an opaque 413.
+              apiBodyLimitBytes: z.number(),
               byosEnabled: z.boolean(),
               byosVaultKvVersion: z.enum(["1", "2"]).nullable(),
               azureOpenAiEntraIdEnabled: z.boolean(),
@@ -153,6 +157,7 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           sandboxArtifactBytesLimit: config.skillsSandbox.artifactBytesLimit,
           chatAttachmentStorageBytesLimit:
             config.chat.attachmentStorageBytesLimit,
+          apiBodyLimitBytes: config.api.bodyLimit,
           byosEnabled: isByosEnabled(),
           byosVaultKvVersion: getByosVaultKvVersion(),
           azureOpenAiEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -67,6 +67,10 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               // Max size of a file the sandbox can stage. The chat composer caps
               // sandbox-routed uploads at this instead of guessing.
               sandboxArtifactBytesLimit: z.number(),
+              // Max size of a chat upload the conversation can store (Files
+              // panel). Bounds the composer's file picker and its per-file
+              // policy; independent of what the sandbox can stage.
+              chatAttachmentStorageBytesLimit: z.number(),
               byosEnabled: z.boolean(),
               byosVaultKvVersion: z.enum(["1", "2"]).nullable(),
               azureOpenAiEntraIdEnabled: z.boolean(),
@@ -147,6 +151,8 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           orchestratorK8sRuntime: McpServerRuntimeManager.isEnabled,
           sandbox: skillSandboxRuntimeService.isEnabled,
           sandboxArtifactBytesLimit: config.skillsSandbox.artifactBytesLimit,
+          chatAttachmentStorageBytesLimit:
+            config.chat.attachmentStorageBytesLimit,
           byosEnabled: isByosEnabled(),
           byosVaultKvVersion: getByosVaultKvVersion(),
           azureOpenAiEntraIdEnabled: isAzureOpenAiEntraIdEnabled(),

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -1,5 +1,6 @@
 import { type ChatSkillMetadata, E2eTestId } from "@archestra/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { chatMessageQueue } from "@/lib/chat/chat-message-queue";
 import { NEW_CHAT_DRAFT_STORAGE_KEY } from "@/lib/chat/chat-utils";
@@ -22,6 +23,7 @@ const {
   mockFeatureState: {
     chatSecretScanEnabled: false,
     chatAttachmentStorageBytesLimit: undefined as number | undefined,
+    apiBodyLimitBytes: undefined as number | undefined,
   },
   mockProfileState: {
     agent: null as { sandboxAvailable: boolean } | null,
@@ -58,6 +60,11 @@ Object.defineProperty(window, "matchMedia", {
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
   })),
+});
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() });
+  return { toast, Toaster: () => null };
 });
 
 // Mock all the complex dependencies
@@ -330,9 +337,13 @@ describe("ArchestraPromptInput", () => {
       if (flag === "chatAttachmentStorageBytesLimit") {
         return mockFeatureState.chatAttachmentStorageBytesLimit;
       }
+      if (flag === "apiBodyLimitBytes") {
+        return mockFeatureState.apiBodyLimitBytes;
+      }
       return undefined;
     });
     mockFeatureState.chatAttachmentStorageBytesLimit = undefined;
+    mockFeatureState.apiBodyLimitBytes = undefined;
     mockUploadPolicy.maxFileSize = undefined;
     mockUploadPolicy.validateFile = undefined;
     mockUseChatPlaceholder.mockReturnValue({
@@ -717,6 +728,45 @@ describe("ArchestraPromptInput", () => {
 
       expect(onCompactConversation).toHaveBeenCalledTimes(1);
       expect(mockTextInputClear).toHaveBeenCalled();
+    });
+  });
+
+  describe("turn attachment budget", () => {
+    // Each file passes the per-file cap on its own, but they all ride in one
+    // request body. Without this guard the send reaches the body parser and
+    // dies with an opaque 413.
+    const dataUrlOfBytes = (bytes: number) => ({
+      url: `data:application/pdf;base64,${"A".repeat(bytes)}`,
+    });
+
+    it("blocks a send whose attachments exceed the body limit", () => {
+      const onSubmit = vi.fn();
+      mockFeatureState.apiBodyLimitBytes = 10 * 1024 * 1024;
+      mockControllerState.value = "here are two files";
+      mockControllerState.files = [
+        dataUrlOfBytes(6 * 1024 * 1024),
+        dataUrlOfBytes(6 * 1024 * 1024),
+      ];
+
+      render(<ArchestraPromptInput {...defaultProps} onSubmit={onSubmit} />);
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining("Send them in separate messages."),
+      );
+    });
+
+    it("allows a single attachment that fits on its own", () => {
+      const onSubmit = vi.fn();
+      mockFeatureState.apiBodyLimitBytes = 10 * 1024 * 1024;
+      mockControllerState.value = "here is one file";
+      mockControllerState.files = [dataUrlOfBytes(6 * 1024 * 1024)];
+
+      render(<ArchestraPromptInput {...defaultProps} onSubmit={onSubmit} />);
+      fireEvent.submit(screen.getByTestId("prompt-input"));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/platform/frontend/src/app/chat/prompt-input.test.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.test.tsx
@@ -12,15 +12,26 @@ const {
   mockControllerState,
   mockFeatureState,
   mockProfileState,
+  mockUploadPolicy,
 } = vi.hoisted(() => ({
   mockUseChatPlaceholder: vi.fn(),
   mockUseSkillsPaginated: vi.fn(),
   mockTextInputSetInput: vi.fn(),
   mockTextInputClear: vi.fn(),
   mockControllerState: { value: "", files: [] as { url: string }[] },
-  mockFeatureState: { chatSecretScanEnabled: false },
+  mockFeatureState: {
+    chatSecretScanEnabled: false,
+    chatAttachmentStorageBytesLimit: undefined as number | undefined,
+  },
   mockProfileState: {
     agent: null as { sandboxAvailable: boolean } | null,
+  },
+  // The upload policy the composer hands to the file picker: the byte cap it
+  // enforces and the per-file check it runs. Captured so tests can exercise
+  // the real policy the way the picker does.
+  mockUploadPolicy: {
+    maxFileSize: undefined as number | undefined,
+    validateFile: undefined as ((file: File) => string | null) | undefined,
   },
 }));
 
@@ -149,9 +160,19 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
   PromptInputHeader: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  PromptInputProvider: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  PromptInputProvider: ({
+    children,
+    maxFileSize,
+    validateFile,
+  }: {
+    children: React.ReactNode;
+    maxFileSize?: number;
+    validateFile?: (file: File) => string | null;
+  }) => {
+    mockUploadPolicy.maxFileSize = maxFileSize;
+    mockUploadPolicy.validateFile = validateFile;
+    return <div>{children}</div>;
+  },
   PromptInputSpeechButton: () => <button type="button">Speech</button>,
   PromptInputSubmit: ({
     status,
@@ -306,8 +327,14 @@ describe("ArchestraPromptInput", () => {
       if (flag === "chatSecretScanEnabled") {
         return mockFeatureState.chatSecretScanEnabled;
       }
+      if (flag === "chatAttachmentStorageBytesLimit") {
+        return mockFeatureState.chatAttachmentStorageBytesLimit;
+      }
       return undefined;
     });
+    mockFeatureState.chatAttachmentStorageBytesLimit = undefined;
+    mockUploadPolicy.maxFileSize = undefined;
+    mockUploadPolicy.validateFile = undefined;
     mockUseChatPlaceholder.mockReturnValue({
       placeholder: "Animated placeholder",
       isAnimating: true,
@@ -420,6 +447,64 @@ describe("ArchestraPromptInput", () => {
       expect(
         screen.queryByTestId(E2eTestId.ChatDisabledFileUploadButton),
       ).not.toBeInTheDocument();
+    });
+
+    describe("attachment size policy", () => {
+      // The policy reads `file.size`, never the bytes, so declare the size
+      // rather than allocating tens of megabytes per case.
+      const sized = (bytes: number, name = "archive.zip"): File => {
+        const file = new File([], name, { type: "application/zip" });
+        Object.defineProperty(file, "size", { value: bytes });
+        return file;
+      };
+
+      const renderComposer = () =>
+        render(
+          <ArchestraPromptInput
+            {...defaultProps}
+            allowFileUploads={true}
+            inputModalities={["text", "image"]}
+          />,
+        );
+
+      it("caps the picker at the server's storage limit", () => {
+        mockFeatureState.chatAttachmentStorageBytesLimit = 8 * 1024 * 1024;
+        renderComposer();
+
+        expect(mockUploadPolicy.maxFileSize).toBe(8 * 1024 * 1024);
+      });
+
+      it("rejects a file over the storage limit, naming that limit", () => {
+        mockFeatureState.chatAttachmentStorageBytesLimit = 8 * 1024 * 1024;
+        renderComposer();
+
+        expect(
+          mockUploadPolicy.validateFile?.(sized(8 * 1024 * 1024 + 1)),
+        ).toBe('"archive.zip" exceeds the maximum attachment size of 8 MB.');
+      });
+
+      it("accepts a file the model can't read and the sandbox can't take", () => {
+        // Over the 16 MiB sandbox artifact limit but under the storage cap: it
+        // skips the sandbox and still lands in the conversation's Files panel.
+        mockFeatureState.chatAttachmentStorageBytesLimit = 50 * 1024 * 1024;
+        renderComposer();
+
+        expect(
+          mockUploadPolicy.validateFile?.(sized(20 * 1024 * 1024)),
+        ).toBeNull();
+      });
+
+      it("falls back to the 50 MB default before /api/config resolves", () => {
+        renderComposer();
+
+        expect(mockUploadPolicy.maxFileSize).toBe(50 * 1024 * 1024);
+        expect(
+          mockUploadPolicy.validateFile?.(sized(50 * 1024 * 1024)),
+        ).toBeNull();
+        expect(
+          mockUploadPolicy.validateFile?.(sized(50 * 1024 * 1024 + 1)),
+        ).toBe('"archive.zip" exceeds the maximum attachment size of 50 MB.');
+      });
     });
 
     it("should render enabled file upload button for text-only models", () => {

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -4,6 +4,7 @@ import {
   type ChatSkillMetadata,
   type ContextWindowBreakdown,
   chatUploadRejectionReason,
+  DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES,
   E2eTestId,
   getMediaType,
   getModelReadableMimeTypes,
@@ -73,8 +74,6 @@ import {
   type SkillCommand,
 } from "./skill-commands";
 
-const CHAT_ATTACHMENT_MAX_BYTES = 50 * 1024 * 1024;
-const CHAT_ATTACHMENT_MAX_MB = CHAT_ATTACHMENT_MAX_BYTES / (1024 * 1024);
 // Fallback sandbox artifact limit when /api/config has not loaded yet (mirrors
 // the backend default). Only consulted when a sandbox is available.
 const DEFAULT_SANDBOX_ARTIFACT_BYTES = 16 * 1024 * 1024;
@@ -83,6 +82,18 @@ function formatBytes(bytes: number): string {
   return bytes >= 1024 * 1024
     ? `${Math.round(bytes / (1024 * 1024))} MB`
     : `${Math.round(bytes / 1024)} KB`;
+}
+
+/**
+ * The largest file the conversation can store, as configured by the server.
+ * Both the file picker's hard cap and the per-file policy read this one value,
+ * so the composer can never advertise a size it then refuses.
+ */
+function useChatAttachmentStorageByteLimit(): number {
+  return (
+    useFeature("chatAttachmentStorageBytesLimit") ??
+    DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES
+  );
 }
 
 /**
@@ -213,6 +224,7 @@ const PromptInputContent = ({
   const internalTextareaRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = externalTextareaRef ?? internalTextareaRef;
   const controller = usePromptInputController();
+  const storageByteLimit = useChatAttachmentStorageByteLimit();
   const [subscriptionConnectRequest, setSubscriptionConnectRequest] =
     useState(0);
   const requestSubscriptionConnect = useCallback(() => {
@@ -616,13 +628,13 @@ const PromptInputContent = ({
         toast.error("File uploads are disabled");
       } else if (err.code === "max_file_size") {
         toast.error(
-          `File is too large. Maximum size is ${CHAT_ATTACHMENT_MAX_MB} MB.`,
+          `File is too large. Maximum size is ${formatBytes(storageByteLimit)}.`,
         );
       } else if (err.code === "max_files") {
         toast.error("Too many files attached.");
       }
     },
-    [],
+    [storageByteLimit],
   );
 
   const submitStatus = status === "error" ? "ready" : status;
@@ -829,7 +841,7 @@ const PromptInputContent = ({
         multiple
         onSubmit={handleWrappedSubmit}
         accept={showFileUploadButton ? undefined : "application/x-empty"}
-        maxFileSize={CHAT_ATTACHMENT_MAX_BYTES}
+        maxFileSize={storageByteLimit}
         onError={handleFileError}
       >
         {/* File attachments display - shown inline above textarea */}
@@ -992,6 +1004,7 @@ const ArchestraPromptInput = ({
   const sandboxAvailable = activeAgent?.sandboxAvailable ?? false;
   const sandboxByteLimit =
     useFeature("sandboxArtifactBytesLimit") ?? DEFAULT_SANDBOX_ARTIFACT_BYTES;
+  const storageByteLimit = useChatAttachmentStorageByteLimit();
 
   // Per-file policy mirroring the backend ingest gate (which is authoritative).
   // Returns a friendly reason to drop the file, or null to accept it.
@@ -1003,16 +1016,19 @@ const ArchestraPromptInput = ({
         ingestibleMimeTypes: getModelReadableMimeTypes(inputModalities),
         sandboxAvailable,
         sandboxByteLimit,
-        // Mirrors the backend gate: a file the model can't read is still
-        // accepted and lands in the conversation's Files panel.
-        fileStorageFallback: true,
+        // Mirrors the backend gate: a file the model can't read — or one too
+        // big for the sandbox — is still accepted and lands in the
+        // conversation's Files panel, so only the storage cap can reject.
+        fileStorageByteLimit: storageByteLimit,
       });
       switch (reason) {
         case null:
           return null;
         // With the Files-panel fallback the only reachable reason is
-        // "too_large_for_sandbox" (generic over-the-limit); the other cases
-        // stay for exhaustiveness over the shared union.
+        // "too_large_to_store"; the other cases stay for exhaustiveness over
+        // the shared union.
+        case "too_large_to_store":
+          return `"${file.name}" exceeds the maximum attachment size of ${formatBytes(storageByteLimit)}.`;
         case "text_too_large":
           return `"${file.name}" is too large to include as text (max ${formatBytes(INLINE_TEXT_MAX_BYTES)}).`;
         case "too_large_for_sandbox":
@@ -1021,7 +1037,7 @@ const ArchestraPromptInput = ({
           return `This model can't read "${file.name}".`;
       }
     },
-    [inputModalities, sandboxAvailable, sandboxByteLimit],
+    [inputModalities, sandboxAvailable, sandboxByteLimit, storageByteLimit],
   );
 
   const handleProviderFileError = useCallback(
@@ -1031,23 +1047,23 @@ const ArchestraPromptInput = ({
     }) => {
       if (err.code === "max_file_size") {
         toast.error(
-          `File is too large. Maximum size is ${CHAT_ATTACHMENT_MAX_MB} MB.`,
+          `File is too large. Maximum size is ${formatBytes(storageByteLimit)}.`,
         );
       } else if (err.code === "max_files") {
         toast.error("Too many files attached.");
       } else if (err.code === "rejected") {
-        // Policy rejection (unsupported type / too large to inline). Gentle,
-        // not an error toast — the message already explains the next step.
+        // Policy rejection (over the storage cap). Gentle, not an error toast —
+        // the message already explains the next step.
         toast(err.message);
       }
     },
-    [],
+    [storageByteLimit],
   );
 
   return (
     <div className="flex size-full flex-col justify-end">
       <PromptInputProvider
-        maxFileSize={CHAT_ATTACHMENT_MAX_BYTES}
+        maxFileSize={storageByteLimit}
         validateFile={validateFile}
         onError={handleProviderFileError}
       >

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -96,6 +96,35 @@ function useChatAttachmentStorageByteLimit(): number {
   );
 }
 
+// Fallback request body ceiling before /api/config resolves (mirrors the
+// backend default). Leaves room for the message text, history refs, and the
+// JSON envelope that ride alongside the attachments in the same request.
+const DEFAULT_API_BODY_LIMIT_BYTES = 70 * 1024 * 1024;
+const TURN_BODY_RESERVE_BYTES = 2 * 1024 * 1024;
+
+/**
+ * How many base64 attachment characters one turn may carry. A single file is
+ * bounded by the storage cap, but nothing bounds their sum — and every
+ * attachment of a turn travels base64-encoded in one request, so two
+ * within-cap files can still overrun the body parser. It rejects the request
+ * before any handler runs, so the composer has to catch this itself or the
+ * user gets an opaque 413.
+ */
+function useTurnAttachmentBudget(): number {
+  const bodyLimit =
+    useFeature("apiBodyLimitBytes") ?? DEFAULT_API_BODY_LIMIT_BYTES;
+  return Math.max(0, bodyLimit - TURN_BODY_RESERVE_BYTES);
+}
+
+/**
+ * Serialized size of a turn's attachments. By submit time each file's `url` is
+ * already the base64 `data:` URL that goes on the wire, so its length is the
+ * exact cost — no encoding estimate needed.
+ */
+function attachmentPayloadBytes(files: readonly { url?: string }[]): number {
+  return files.reduce((total, file) => total + (file.url?.length ?? 0), 0);
+}
+
 /**
  * Options riding alongside a submitted message. At most one is set: a `/`
  * slash command activates a skill, a `!` prefix marks the message for direct
@@ -225,6 +254,7 @@ const PromptInputContent = ({
   const textareaRef = externalTextareaRef ?? internalTextareaRef;
   const controller = usePromptInputController();
   const storageByteLimit = useChatAttachmentStorageByteLimit();
+  const turnAttachmentBudget = useTurnAttachmentBudget();
   const [subscriptionConnectRequest, setSubscriptionConnectRequest] =
     useState(0);
   const requestSubscriptionConnect = useCallback(() => {
@@ -519,6 +549,17 @@ const PromptInputContent = ({
         return;
       }
 
+      // Each file passed the per-file cap on its own, but they all ride in one
+      // request. Stop here rather than letting the body parser 413 the send.
+      const payloadBytes = attachmentPayloadBytes(message.files);
+      if (payloadBytes > turnAttachmentBudget) {
+        e.preventDefault();
+        toast.error(
+          `These attachments total ${formatBytes(payloadBytes)}, over the ${formatBytes(turnAttachmentBudget)} limit for one message. Send them in separate messages.`,
+        );
+        return;
+      }
+
       const trimmed = message.text.trim();
 
       if (trimmed === "/compact" && onCompactConversation) {
@@ -586,6 +627,7 @@ const PromptInputContent = ({
       sensitiveDataDetectionEnabled,
       skillCommands,
       subscriptionConnectRequired,
+      turnAttachmentBudget,
     ],
   );
 

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -1,6 +1,7 @@
 import {
   APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,
   type archestraApiTypes,
+  DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES,
 } from "@archestra/shared";
 
 type Config = archestraApiTypes.GetConfigResponses["200"];
@@ -33,6 +34,7 @@ export function makeConfig(
       orchestratorK8sRuntime: false,
       sandbox: false,
       sandboxArtifactBytesLimit: 16 * 1024 * 1024,
+      chatAttachmentStorageBytesLimit: DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES,
       byosEnabled: false,
       byosVaultKvVersion: "1",
       azureOpenAiEntraIdEnabled: false,

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -35,6 +35,7 @@ export function makeConfig(
       sandbox: false,
       sandboxArtifactBytesLimit: 16 * 1024 * 1024,
       chatAttachmentStorageBytesLimit: DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES,
+      apiBodyLimitBytes: 70 * 1024 * 1024,
       byosEnabled: false,
       byosVaultKvVersion: "1",
       azureOpenAiEntraIdEnabled: false,

--- a/platform/shared/chat.test.ts
+++ b/platform/shared/chat.test.ts
@@ -255,6 +255,8 @@ describe("chatUploadRejectionReason", () => {
     sandboxAvailable: false,
     sandboxByteLimit: 16 * 1024 * 1024,
   };
+  // Deliberately above the sandbox limit — the two caps are independent.
+  const STORAGE_LIMIT = 50 * 1024 * 1024;
 
   test("accepts a model-ingestible type at any size", () => {
     expect(
@@ -327,7 +329,7 @@ describe("chatUploadRejectionReason", () => {
     expect(
       chatUploadRejectionReason({
         ...base,
-        fileStorageFallback: true,
+        fileStorageByteLimit: STORAGE_LIMIT,
         mimeType: "application/zip",
         byteLength: 1_000,
       }),
@@ -338,22 +340,58 @@ describe("chatUploadRejectionReason", () => {
     expect(
       chatUploadRejectionReason({
         ...base,
-        fileStorageFallback: true,
+        fileStorageByteLimit: STORAGE_LIMIT,
         mimeType: "text/csv",
         byteLength: INLINE_TEXT_MAX_BYTES + 1,
       }),
     ).toBeNull();
   });
 
-  test("file-storage fallback still rejects a file over the storage limit", () => {
+  test("file-storage fallback accepts a file over the sandbox limit", () => {
+    // The sandbox is bypassed rather than made the gatekeeper: the file still
+    // lands in the Files panel, so acceptance answers only to the storage cap.
+    for (const sandboxAvailable of [true, false]) {
+      expect(
+        chatUploadRejectionReason({
+          ...base,
+          sandboxAvailable,
+          fileStorageByteLimit: STORAGE_LIMIT,
+          mimeType: "application/zip",
+          byteLength: base.sandboxByteLimit + 1,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  test("file-storage fallback rejects a file over the storage cap", () => {
     expect(
       chatUploadRejectionReason({
         ...base,
-        fileStorageFallback: true,
+        fileStorageByteLimit: STORAGE_LIMIT,
         mimeType: "application/zip",
-        byteLength: base.sandboxByteLimit + 1,
+        byteLength: STORAGE_LIMIT + 1,
       }),
-    ).toBe("too_large_for_sandbox");
+    ).toBe("too_large_to_store");
+  });
+
+  test("the storage cap bounds even a model-ingestible type", () => {
+    // Bytes are persisted for every accepted upload, so the cap applies to
+    // types the model reads natively too — but only when the fallback is on.
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        fileStorageByteLimit: STORAGE_LIMIT,
+        mimeType: "image/png",
+        byteLength: STORAGE_LIMIT + 1,
+      }),
+    ).toBe("too_large_to_store");
+    expect(
+      chatUploadRejectionReason({
+        ...base,
+        mimeType: "image/png",
+        byteLength: STORAGE_LIMIT + 1,
+      }),
+    ).toBeNull();
   });
 
   test("size-gates inlineable text even when the model lists it as ingestible", () => {

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -582,17 +582,27 @@ export function isInlineableTextMimeType(mimeType: string): boolean {
 export const INLINE_TEXT_MAX_BYTES = 256 * 1024;
 
 /**
+ * Default cap on what a single chat upload may store as a conversation
+ * attachment. Deliberately independent of the sandbox artifact limit: a file
+ * too big for the sandbox still has the Files panel to land in, so the sandbox
+ * is bypassed rather than made the gatekeeper. Shared so the backend default
+ * and the frontend's pre-`/api/config` fallback can never drift.
+ */
+export const DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES = 50 * 1024 * 1024;
+
+/**
  * Why an upload is not acceptable, or `null` when it is. Single source of truth
  * for the attachment policy shared by the backend ingest gate (authoritative)
  * and the frontend composer (mirrors it for UX). A file is acceptable when the
  * model can ingest its type, OR it is a small inlineable text document, OR a
  * sandbox is available to stage it within the sandbox artifact size limit, OR
- * (with `fileStorageFallback`) it fits the same byte limit and is stored as a
- * conversation file the user can reach from the chat Files panel.
+ * (with `fileStorageByteLimit`) it is stored as a conversation file the user can
+ * reach from the chat Files panel.
  */
 export type ChatUploadRejectionReason =
   | "text_too_large"
   | "too_large_for_sandbox"
+  | "too_large_to_store"
   | "unsupported_type";
 
 export function chatUploadRejectionReason(params: {
@@ -602,12 +612,13 @@ export function chatUploadRejectionReason(params: {
   sandboxAvailable: boolean;
   sandboxByteLimit: number;
   /**
-   * Whether a file the model can't read (and the sandbox can't take) is still
-   * accepted and kept as a conversation attachment surfaced in the chat Files
-   * panel. The chat upload path has that surface, so it passes true; A2A has no
-   * per-conversation Files panel for its callers and keeps rejecting.
+   * Cap on what may be stored as a conversation attachment surfaced in the chat
+   * Files panel, enabling that fallback for files the model can't read and the
+   * sandbox can't take. The chat upload path has that surface, so it passes its
+   * configured cap; A2A has no per-conversation Files panel for its callers, so
+   * it omits this and keeps rejecting.
    */
-  fileStorageFallback?: boolean;
+  fileStorageByteLimit?: number;
 }): ChatUploadRejectionReason | null {
   const {
     mimeType,
@@ -615,36 +626,41 @@ export function chatUploadRejectionReason(params: {
     ingestibleMimeTypes,
     sandboxAvailable,
     sandboxByteLimit,
-    fileStorageFallback = false,
+    fileStorageByteLimit,
   } = params;
 
-  // The sandbox artifact limit doubles as the storage cap for Files-panel-only
-  // attachments: both paths persist the same conversation_attachments row, so
-  // one knob bounds what a chat turn may store.
-  const fitsStorage = byteLength <= sandboxByteLimit;
-  const fitsSandbox = sandboxAvailable && fitsStorage;
-  const fitsFileStorage = fileStorageFallback && fitsStorage;
+  // Every accepted upload is persisted as a conversation attachment — the Files
+  // panel and sandbox staging both read that one row — so when the fallback is
+  // active its cap bounds the turn, including types the model reads natively.
+  const fileStorageFallback = fileStorageByteLimit != null;
+  if (fileStorageFallback && byteLength > fileStorageByteLimit) {
+    return "too_large_to_store";
+  }
+
+  // Under the storage cap, the sandbox limit only decides whether the file can
+  // additionally be staged for the model — never whether it is accepted.
+  const fitsSandbox = sandboxAvailable && byteLength <= sandboxByteLimit;
 
   // Inlineable text is size-gated even though a text-capable model lists these
   // MIMEs as readable: a large text file would otherwise blow the context
   // window. Checked before the generic ingestible short-circuit for that reason.
   if (isInlineableTextMimeType(mimeType)) {
-    if (byteLength <= INLINE_TEXT_MAX_BYTES || fitsSandbox || fitsFileStorage) {
+    if (
+      byteLength <= INLINE_TEXT_MAX_BYTES ||
+      fitsSandbox ||
+      fileStorageFallback
+    ) {
       return null;
     }
-    return sandboxAvailable || fileStorageFallback
-      ? "too_large_for_sandbox"
-      : "text_too_large";
+    return sandboxAvailable ? "too_large_for_sandbox" : "text_too_large";
   }
 
   // Non-text types the model can ingest natively (images, PDFs, …) carry no
-  // inline-text budget; the request body limit is the only size bound.
+  // inline-text budget; only the storage cap above bounds them.
   if (ingestibleMimeTypes.has(mimeType)) return null;
 
-  if (fitsSandbox || fitsFileStorage) return null;
-  return sandboxAvailable || fileStorageFallback
-    ? "too_large_for_sandbox"
-    : "unsupported_type";
+  if (fitsSandbox || fileStorageFallback) return null;
+  return sandboxAvailable ? "too_large_for_sandbox" : "unsupported_type";
 }
 
 /**

--- a/platform/shared/chat.ts
+++ b/platform/shared/chat.ts
@@ -591,6 +591,15 @@ export const INLINE_TEXT_MAX_BYTES = 256 * 1024;
 export const DEFAULT_CHAT_ATTACHMENT_STORAGE_BYTES = 50 * 1024 * 1024;
 
 /**
+ * Default ceiling on what a single attachment may contribute to a provider
+ * request. Storing a file and sending it to a model are separate questions:
+ * anything heavier than this stays in the Files panel (and the sandbox, when it
+ * fits) rather than being embedded in the prompt, so a large upload can never
+ * inflate a request past what the provider accepts.
+ */
+export const DEFAULT_CHAT_ATTACHMENT_INLINE_BYTES = 16 * 1024 * 1024;
+
+/**
  * Why an upload is not acceptable, or `null` when it is. Single source of truth
  * for the attachment policy shared by the backend ingest gate (authoritative)
  * and the frontend composer (mirrors it for UX). A file is acceptable when the

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -30955,6 +30955,7 @@ export type GetConfigResponses = {
             orchestratorK8sRuntime: boolean;
             sandbox: boolean;
             sandboxArtifactBytesLimit: number;
+            chatAttachmentStorageBytesLimit: number;
             byosEnabled: boolean;
             byosVaultKvVersion: '1' | '2';
             azureOpenAiEntraIdEnabled: boolean;

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -30956,6 +30956,7 @@ export type GetConfigResponses = {
             sandbox: boolean;
             sandboxArtifactBytesLimit: number;
             chatAttachmentStorageBytesLimit: number;
+            apiBodyLimitBytes: number;
             byosEnabled: boolean;
             byosVaultKvVersion: '1' | '2';
             azureOpenAiEntraIdEnabled: boolean;


### PR DESCRIPTION
## Problem

Chat uploads were gated by a single number: `ARCHESTRA_SKILLS_SANDBOX_ARTIFACT_BYTES_LIMIT` (16 MiB). A file over it was refused at ingest with a 400 — even though a file the sandbox can't take still has somewhere to go, the conversation's Files panel. The shared policy said so outright: "the sandbox artifact limit doubles as the storage cap". So the sandbox acted as gatekeeper for a path that doesn't need it, and the composer meanwhile offered a 50 MB file picker, letting users attach a file the backend then rejected.

Storing a file, staging it into the sandbox, and sending it to a model are three different questions. This splits them.

| | Cap | Over it |
|---|---|---|
| **Store** (Files panel) | `ARCHESTRA_CHAT_ATTACHMENT_STORAGE_BYTES_LIMIT`, 50 MiB | Rejected — the only remaining rejection |
| **Send to the model** | `ARCHESTRA_CHAT_ATTACHMENT_INLINE_BYTES_LIMIT`, 16 MiB | Stored, not sent; model told where it is |
| **Stage into the sandbox** | `ARCHESTRA_SKILLS_SANDBOX_ARTIFACT_BYTES_LIMIT`, 16 MiB | Stored, not staged; model told where it is |

What reaches a provider is unchanged at 16 MiB. Only what may be *stored* went up.

## Changes

**shared** (`chat.ts`)
- `chatUploadRejectionReason`'s `fileStorageFallback` boolean becomes `fileStorageByteLimit?: number` — the cap that actually bounds storage, independent of `sandboxByteLimit`. Under it a file is accepted whether or not the sandbox can stage it; over it, the new `too_large_to_store`.
- A2A omits the param, so its behavior is unchanged — its callers have no Files panel.
- One deliberate semantic change: with the fallback active the cap also bounds model-ingestible types (PNG, PDF), which were previously unbounded at the gate. Correct, since every accepted upload persists its bytes.

**backend**
- `materializeAttachments` folds every "the model can't take this" check into one `bypassReason`: wrong type for the model's modalities, a content block the endpoint rejects, or over the inline budget. Each yields the existing Files-panel/sandbox notice, now worded to say which it was — "can't be read by this model" and "is too large to send" call for different follow-ups.
- The inline ceiling is the lower of our knob and the provider's own documented limit (Anthropic 32 MiB, Bedrock 20 MiB), so one attachment can never be the reason a request is refused.
- Providers whose request schema has no content part able to carry a binary document bypass PDFs outright. `zhipuai` is the first entry — its content part is a union of text and `image_url` — asserted from the schema, not inferred. This fixes a **pre-existing** bug: a model row with no recorded input modalities defaults to "reads PDFs", so *any* PDF on zhipuai died with `body/messages/N Invalid input`, at any size.
- `materializeAttachments` now reads attachment metadata first and loads bytes only for parts it will actually inline. A large unreadable attachment was previously re-streamed out of Postgres on every turn just to render a one-line notice.

**frontend**
- The picker's `maxFileSize` and `validateFile` both read the served storage cap, so the composer can't advertise a size it then refuses.
- All of a turn's attachments travel in one request, so the composer sums them at submit and blocks a send the body parser would reject. The backend can't produce a good error there — the body is refused before any handler runs — so the user previously got a raw 413 naming `ARCHESTRA_API_BODY_LIMIT`.

**docs**
- `platform-chat.md` attachment section; `platform-deployment.md` gains both new variables, and its `ARCHESTRA_API_BODY_LIMIT` entry is corrected (it claimed 50 MB; the code default is 70 MiB).

## Testing

- Unit: new/updated cases in `shared/chat.test.ts`, `extract-inline-attachments.test.ts` (over-sandbox accepted, over-storage rejected), `stream-route.test.ts` (route-level: over the sandbox limit → 200 + persisted row; over the storage cap → 400 + nothing persisted), `materialize-attachments.test.ts` (over-budget diverted with a "too large to send" notice; bytes fetched only for inlined parts), `prompt-input.test.tsx` (served cap drives the picker; over-budget multi-file send blocked).
- Manual, on a live stack (zhipuai/glm-5.1, no sandbox):
  - 17 MiB zip → 200, listed under Attachments, downloads back at exactly 17,825,792 bytes.
  - 51 MiB zip → 400, `"huge.zip" is too large to attach (max 50 MB).`
  - 45 MB PDF (previously a hard turn failure) → 200, stored and downloadable, model replies that it is too large to read.
  - 193-byte PDF (previously `body/messages/1 Invalid input`) → replies pointing at the Files panel.

## Known gap

`assertRequestWithinProviderPayloadLimit` still errors when several within-budget attachments together exceed a provider's cumulative cap. Which of them to drop isn't obvious, so that case keeps its explicit error rather than guessing.
