### PR TITLE
fix(hackathon): settle only a MID cut's chat, never a head trim's

### DIFF
--- a/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
+++ b/platform/frontend/src/components/app-session-recording/app-session-playback.test.ts
@@ -202,6 +202,64 @@ describe("buildPlayback", () => {
     expect(withReply.duration).toBeGreaterThan(withoutReply.duration);
   });
 
+  it("leaves a head trim's chat animating — it starts the demo later, it does not delete conversation", () => {
+    // The regression this guards. A head trim is stored as ONE cut reaching the
+    // axis floor, and pre-recording chat carries large negative times: a real
+    // submission trims its first 25s and stores {fromMs: -58041135, toMs:
+    // 25073}. Treating everything in there as removed settled 73 of 73 messages
+    // on one live gallery card and 20 of 20 on another — both replayed a
+    // fully-formed chat that never typed a character.
+    const playback = buildPlayback(
+      recording({
+        durationMs: 40_000,
+        events: [
+          { kind: "segment", t: 0, version: 1 },
+          { kind: "pointer", t: 30_000, type: "click", x: 1, y: 1 },
+        ] as Recording["events"],
+        transcript: [
+          reply("history-1", -8_047_639),
+          reply("history-2", -357_100),
+          reply("recorded", 5_000),
+        ] as Recording["transcript"],
+        edits: { cuts: [{ fromMs: -8_048_839, toMs: 10_000 }] },
+      }),
+    );
+
+    // Nothing is settled: the trim removed app replay, not the conversation.
+    expect(playback.transcript.map((m) => m.settled)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    // And every reply still draws itself.
+    const { schedule } = revealSchedule(playback.transcript, playback.duration);
+    for (const message of playback.transcript) {
+      const slot = schedule.get(message.id);
+      expect(slot?.end).toBeGreaterThan(slot?.start ?? 0);
+    }
+  });
+
+  it("leaves an end trim's chat animating too", () => {
+    const playback = buildPlayback(
+      recording({
+        durationMs: 40_000,
+        events: [
+          { kind: "segment", t: 0, version: 1 },
+          { kind: "pointer", t: 5_000, type: "click", x: 1, y: 1 },
+        ] as Recording["events"],
+        transcript: [
+          reply("kept", 1_000),
+          reply("in-tail", 30_000),
+        ] as Recording["transcript"],
+        edits: { cuts: [{ fromMs: 20_000, toMs: 40_000 }] },
+      }),
+    );
+    expect(playback.transcript.map((m) => m.settled)).toEqual([
+      undefined,
+      undefined,
+    ]);
+  });
+
   it("marks a collapsed reply as already sent so it never types over the app", () => {
     const playback = buildPlayback(
       recording({

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -5437,14 +5437,6 @@ export function buildPlayback(recording: PlaybackRecording): {
 } {
   const source = finalVersionOnly(recording);
   const cuts = normalizeCuts(source.edits?.cuts ?? []);
-  /**
-   * A moment a cut removes — one that collapses onto the cut's instant rather
-   * than playing. The cut's own START still plays (it is the last kept
-   * moment); its END does not, matching how the bundle pruner and the
-   * trailing-trim filter read the same boundaries.
-   */
-  const insideCut = (t: number) =>
-    cuts.some((cut) => cut.fromMs < t && t <= cut.toMs);
   const anchors = new Set<number>([0, Math.max(0, source.durationMs)]);
   // When the author was actually USING the app, bounded by their first and last
   // input to it. Time inside that stretch is never compressed: it is the app
@@ -5528,6 +5520,34 @@ export function buildPlayback(recording: PlaybackRecording): {
       cut.toMs >= rawDataEnd - TRIM_EDGE_EPS_MS && cut.fromMs < rawDataEnd,
   );
   const withinEnd = (t: number) => !tailCut || t <= tailCut.fromMs;
+
+  /**
+   * A moment a MID cut removes — one that collapses onto the cut's instant
+   * rather than playing. The cut's own START still plays (it is the last kept
+   * moment); its END does not, matching how the bundle pruner and the
+   * trailing-trim filter read the same boundaries.
+   *
+   * ONLY mid cuts, and that restriction is the whole point. A head trim is
+   * stored as one cut reaching the axis floor, and pre-recording chat carries
+   * large NEGATIVE times — a real submission trims its first 25 seconds and
+   * stores {fromMs: -58041135, toMs: 25073}. Reading that as "everything in
+   * here was removed" swallows the entire conversation: measured across the
+   * live gallery it settled 73 of 73 and 20 of 20 messages, and those players
+   * replayed a fully-formed chat that never typed a character.
+   *
+   * A head trim does not delete conversation — it starts the demo later, and
+   * the history before it is exactly what this player exists to animate. A MID
+   * cut is the one that genuinely removes a stretch, so it is the one whose
+   * chat collapses. An end trim leaves its messages alone too: they still
+   * play, and charging them nothing would only shorten the tail nobody sees.
+   */
+  const midCuts = cuts.filter(
+    (cut) =>
+      cut.fromMs > leadStart + TRIM_EDGE_EPS_MS &&
+      cut.toMs < rawDataEnd - TRIM_EDGE_EPS_MS,
+  );
+  const insideCut = (t: number) =>
+    midCuts.some((cut) => cut.fromMs < t && t <= cut.toMs);
 
   // How long the chat pane will still be animating from each raw instant. An
   // assistant turn reveals over real wall-clock time (see messageRevealMs),


### PR DESCRIPTION
Follow-up to #6902, which shipped a predicate that silences the chat on real
recordings.

## The bug

`insideCut` read "inside a cut" too broadly. A head trim is stored as **one cut
reaching the axis floor**, and pre-recording chat carries large **negative**
times — a live gallery submission trims its first 25 seconds and stores
`{fromMs: -58041135, toMs: 25073}`. That single cut spans the entire
conversation, so every message was marked `settled` and none animated.

Measured across all 16 live gallery submissions:

| | before this PR | after |
|---|---|---|
| `secureops_dashboard` | **0 of 35** replies animate | 35 of 35 |
| `release_war_room` | **0 of 10** | 10 of 10 |
| gallery-wide | 59 of 157 | 156 of 157 |

Two cards replayed a fully-formed chat that never typed a character.

## The rule

A head trim does not delete conversation — it starts the demo later, and the
history before it is exactly what this player exists to animate. A **mid** cut
genuinely removes a stretch, so it is the only one whose chat collapses to an
instant and arrives already sent. An end trim leaves its messages alone too.

## The trade, stated

A head trim now charges its own chat's reveal. That time is honest — the viewer
really does spend it reading — but it means a head-trimmed recording measures
longer than the sum of its kept ranges. Mid and end cuts still cost exactly
zero, so the playhead still steps over the stretches a builder actually removed.

Four candidate rules were measured against all 16 live bundles before choosing,
each measurement independently re-derived by a second agent:

- **Keep head trims free** (what #6902 did) — kills the chat, as above.
- **Free every cut, no settling** — reintroduces the #6900 overlap: **1,145 app
  events** replay on top of a still-typing reply, across 5 submissions.
- **This PR** — chat animates, zero overlap (0 of 43,747 app events), head trims
  charged.

## Tests

A head trim keeps every reply animating and marks nothing settled; an end trim
likewise. Both were run against the unfixed code first to prove they fail there.
Platform recording suites 188/188.

The website's vendored copy of this timing logic carries the identical change in
archestra-ai/website#608 — the two drift silently otherwise.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>