### PR TITLE
fix(skills): keep built-in skill ids out of the repository filter

### DIFF
--- a/platform/backend/src/models/skill.ts
+++ b/platform/backend/src/models/skill.ts
@@ -17,6 +17,7 @@ import {
 import db, { schema, type Transaction, withDbTransaction } from "@/database";
 import logger from "@/logging";
 import { skillInEnvironmentPredicate } from "@/services/environments/environment-isolation";
+import { isBuiltInSkillSourceRef } from "@/skills/built-in-skills";
 import type {
   InsertSkill,
   InsertSkillFile,
@@ -106,6 +107,12 @@ class SkillModel {
    * Distinct `owner/repo` strings across the org's imported skills, derived
    * from the `source_ref` provenance column (formatted as
    * `owner/repo@ref:path`).
+   *
+   * Built-in skills also carry a `source_ref`, but it is a `builtin:<id>`
+   * identity token rather than a repository — and one that embeds the
+   * unbranded product id, which would leak into the white-labeled repository
+   * filter. They are excluded, matching how the skills table suppresses the
+   * same refs in favor of the app-name badge.
    */
   static async findDistinctSourceRepos(params: {
     organizationId: string;
@@ -125,6 +132,7 @@ class SkillModel {
     const repos = new Set<string>();
     for (const { sourceRef } of rows) {
       if (!sourceRef) continue;
+      if (isBuiltInSkillSourceRef(sourceRef)) continue;
       const atIdx = sourceRef.indexOf("@");
       const repo = atIdx === -1 ? sourceRef : sourceRef.slice(0, atIdx);
       if (repo) repos.add(repo);

--- a/platform/backend/src/routes/skill/skill.test-helpers.ts
+++ b/platform/backend/src/routes/skill/skill.test-helpers.ts
@@ -1,4 +1,5 @@
 import { SkillModel, SkillTeamModel } from "@/models";
+import { builtInSkillSourceRef } from "@/skills/built-in-skills";
 import type { ResourceVisibilityScope } from "@/types/visibility";
 
 export const MANIFEST = [
@@ -27,6 +28,33 @@ export function manifestNamed(name: string, extraFrontmatter = ""): string {
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+/**
+ * A built-in skill written directly through the model layer, carrying the
+ * `builtin:<id>` identity token that startup sync stores in `source_ref`.
+ */
+export async function seedBuiltInSkill(params: {
+  organizationId: string;
+  name: string;
+  builtInSkillId: string;
+}) {
+  const skill = await SkillModel.createWithFiles({
+    skill: {
+      organizationId: params.organizationId,
+      authorId: null,
+      name: params.name,
+      description: `${params.name} description`,
+      content: `# ${params.name}`,
+      metadata: {},
+      sourceType: "built_in",
+      sourceRef: builtInSkillSourceRef(params.builtInSkillId),
+      scope: "org",
+    },
+    files: [],
+  });
+  if (!skill) throw new Error("seed failed");
+  return skill;
 }
 
 /** A github-sourced skill written directly through the model layer. */

--- a/platform/backend/src/routes/skill/source-repos.skill.route.test.ts
+++ b/platform/backend/src/routes/skill/source-repos.skill.route.test.ts
@@ -1,7 +1,7 @@
 import { ADMIN_ROLE_NAME, MEMBER_ROLE_NAME } from "@archestra/shared";
 import { describe, expect, test, useRouteTestApp } from "@/test";
 import skillRoutes from "./skill.routes";
-import { seedImportedSkill } from "./skill.test-helpers";
+import { seedBuiltInSkill, seedImportedSkill } from "./skill.test-helpers";
 
 describe("GET /api/skills/source-repos", () => {
   const ctx = useRouteTestApp(skillRoutes);
@@ -101,6 +101,42 @@ describe("GET /api/skills/source-repos", () => {
       "secret/private-repo",
       "shared/org-repo",
     ]);
+  });
+
+  test("built-in skills are not offered as repositories", async ({
+    makeMember,
+  }) => {
+    await makeMember(ctx.user.id, ctx.organizationId, {
+      role: ADMIN_ROLE_NAME,
+    });
+
+    await seedBuiltInSkill({
+      organizationId: ctx.organizationId,
+      name: "Platform Operations",
+      builtInSkillId: "archestra-platform-operations",
+    });
+    await seedBuiltInSkill({
+      organizationId: ctx.organizationId,
+      name: "Build App",
+      builtInSkillId: "build-app",
+    });
+    await seedImportedSkill({
+      organizationId: ctx.organizationId,
+      name: "org-imported",
+      sourceRef: "shared/org-repo@main:SKILL.md",
+      scope: "org",
+    });
+
+    const response = await ctx.app.inject({
+      method: "GET",
+      url: "/api/skills/source-repos",
+    });
+
+    expect(response.statusCode).toBe(200);
+    // A built-in skill's `builtin:<id>` ref is an identity token, not a
+    // repository — and it embeds the unbranded product id, so surfacing it
+    // would leak that id into a white-labeled deployment's filter.
+    expect(response.json().repos).toEqual(["shared/org-repo"]);
   });
 
   test("non-admins with no accessible imported skills see no repositories", async ({

--- a/platform/backend/src/skills/built-in-skills.ts
+++ b/platform/backend/src/skills/built-in-skills.ts
@@ -48,6 +48,15 @@ export function builtInSkillSourceRef(builtInSkillId: string): string {
   return `${BUILT_IN_SKILL_SOURCE_REF_PREFIX}${builtInSkillId}`;
 }
 
+/**
+ * Whether a `source_ref` is a built-in identity token rather than an imported
+ * GitHub source. True even for an id we no longer ship, so a stale row is still
+ * recognized as built-in.
+ */
+export function isBuiltInSkillSourceRef(sourceRef: string): boolean {
+  return sourceRef.startsWith(BUILT_IN_SKILL_SOURCE_REF_PREFIX);
+}
+
 /** Resolve the shipped definition behind a `builtin:<id>` source ref, if any. */
 export function findBuiltInSkillBySourceRef(
   sourceRef: string,

--- a/platform/frontend/src/app/skills/page.client.tsx
+++ b/platform/frontend/src/app/skills/page.client.tsx
@@ -503,29 +503,34 @@ function SkillsList() {
                   ownerLabelPlural="skills"
                   adminPermission={{ skill: ["admin"] }}
                 />
-                <Select
-                  value={sourceRepo || "all"}
-                  onValueChange={(value) =>
-                    setSourceRepoFilter(value === "all" ? "" : value)
-                  }
-                >
-                  <SelectTrigger
-                    aria-label="Filter by repository"
-                    className="w-[260px]"
+                {/* Only imported skills have a repository, so the filter would
+                    be a single inert "All repositories" entry until at least
+                    one skill is imported. */}
+                {sourceRepos.length > 0 && (
+                  <Select
+                    value={sourceRepo || "all"}
+                    onValueChange={(value) =>
+                      setSourceRepoFilter(value === "all" ? "" : value)
+                    }
                   >
-                    <SelectValue placeholder="All repositories" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All repositories</SelectItem>
-                    {sourceRepos.map((repo) => (
-                      <SelectItem key={repo} value={repo}>
-                        <span className="truncate font-mono text-xs">
-                          {repo}
-                        </span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                    <SelectTrigger
+                      aria-label="Filter by repository"
+                      className="w-[260px]"
+                    >
+                      <SelectValue placeholder="All repositories" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All repositories</SelectItem>
+                      {sourceRepos.map((repo) => (
+                        <SelectItem key={repo} value={repo}>
+                          <span className="truncate font-mono text-xs">
+                            {repo}
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
               </div>
               <ActiveFilterBadges adminPermission={{ skill: ["admin"] }} />
             </div>


### PR DESCRIPTION
## Summary

The Skills page's repository filter listed the built-in skills' `builtin:<id>` refs as if they were repositories, so a white-labeled deployment saw the unbranded product id sitting in its dropdown next to real `owner/repo` entries.

Built-in skills do carry a `source_ref`, but it is an **identity token**, not an import source. It is deliberately left unbranded — it is the stable key that keeps a renamed skill attached to its shipped definition, so it must not move when the app name changes. Everything user-facing about a built-in skill (name, description, body, bundled files) is already rebranded at write time by `applyBuiltInSkillBranding`; only this ref is not, by design.

`SkillModel.findDistinctSourceRepos` treated every `source_ref` as `owner/repo` and split on `@`. Built-in tokens have no `@`, so the entire string was added to the list verbatim.

## Changes

- **`models/skill.ts`** — skip built-in refs in `findDistinctSourceRepos`, via a new `isBuiltInSkillSourceRef` predicate that keeps the `builtin:` prefix defined in exactly one place. Fixed at the model rather than the UI because that is the source of truth, and it is where the endpoint's own contract — *"repositories that skills in this organization were imported from"* — was being violated. This also matches the guard the skills table already applies to the same refs, where they are suppressed in favor of the app-name badge.
- **`skills/page.client.tsx`** — with built-ins excluded, an organization that has not imported anything has no repositories at all, so the filter would render as a lone inert "All repositories" entry. Hide it until there is something to filter by. An active-but-unmatched filter still yields the filtered empty state with its clear-filters button, so no filter can get stuck.

## Note on the alternative

Rewriting the ref's brand on read was considered and rejected: the branding singleton is only primed per-organization during the sync flows, so a read path would be rebranding against whatever org was synced last. Suppressing a value that was never meant to be user-facing is both correct and cheaper than making it presentable — and it would only have fixed one of the two entries anyway, since the second built-in ref carries no brand at all.

## Testing

- New `source-repos` route test seeds both built-in skills alongside an imported one and asserts only the real repository comes back. Verified non-vacuous: it fails on the pre-fix model and passes after.
- The existing route tests seeded only imported skills, which is how this went unnoticed.
- `backend` + `frontend` `type-check`, `lint`, and `knip` (dev + production) all clean.
- Full `src/routes/skill` + `src/skills` suites: 443/444 pass. The one failure is `skill-sandbox-runtime-service.test.ts`, which fails identically on the unmodified base commit — a local `.env` sets a Dagger runner host the test expects to be absent. Unrelated to this change.

## Docs

No change needed. `platform-agent-skills.md` describes this control as filtering by *source repository*, and uses "repository" throughout to mean the GitHub import source — which is exactly what it filters by after this fix.

## Possible follow-up

If filtering down to built-in skills is something people actually want, the right control is a source/scope filter rather than the repository dropdown; the app-name badge already marks them in the list today.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>