### PR TITLE
feat(knowledge): scope GitHub repository file sync to folders

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -202979,6 +202979,12 @@
                                       "type": "string"
                                     }
                                   },
+                                  "includePaths": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
                                   "labelsToSkip": {
                                     "type": "array",
                                     "items": {
@@ -204263,6 +204269,12 @@
                               "type": "string"
                             }
                           },
+                          "includePaths": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
                           "labelsToSkip": {
                             "type": "array",
                             "items": {
@@ -205160,6 +205172,12 @@
                               "type": "boolean"
                             },
                             "fileTypes": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "includePaths": {
                               "type": "array",
                               "items": {
                                 "type": "string"
@@ -206395,6 +206413,12 @@
                                 "type": "string"
                               }
                             },
+                            "includePaths": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
                             "labelsToSkip": {
                               "type": "array",
                               "items": {
@@ -207511,6 +207535,12 @@
                               "type": "string"
                             }
                           },
+                          "includePaths": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
                           "labelsToSkip": {
                             "type": "array",
                             "items": {
@@ -208406,6 +208436,12 @@
                               "type": "boolean"
                             },
                             "fileTypes": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "includePaths": {
                               "type": "array",
                               "items": {
                                 "type": "string"

--- a/docs/pages/platform-knowledge.md
+++ b/docs/pages/platform-knowledge.md
@@ -3,7 +3,7 @@ title: Knowledge
 category: Knowledge
 order: 1
 description: Built-in RAG knowledge — Knowledge Bases, connectors, and retrieval architecture
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-28
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -179,6 +179,7 @@ Sync issues, pull request discussions, and repository files from GitHub.
 | Include Pull Requests | Toggle to sync pull requests and their comments (default: on)                                   |
 | Include Repository Files | Toggle to sync repository files (default: off)                                               |
 | File Types            | Comma-separated file extensions to index when repository files are enabled (defaults to `.md`, `.mdx`, `.yaml`, `.yml`) |
+| Folders               | Comma-separated folders to index, relative to the repository root (optional -- leave blank to index the whole repository) |
 | Labels to Skip        | Comma-separated labels to exclude (optional)                                                    |
 
 ### GitLab

--- a/platform/backend/src/knowledge-base/connectors/github/github-connector.test.ts
+++ b/platform/backend/src/knowledge-base/connectors/github/github-connector.test.ts
@@ -1048,6 +1048,113 @@ describe("GithubConnector", () => {
       expect(mdDocs[2].content).toBe("apiVersion: v1");
     });
 
+    test("indexes only files under the configured folders", async () => {
+      mockListForRepo.mockResolvedValueOnce({ data: [] });
+      mockListForRepo.mockResolvedValueOnce({ data: [] });
+
+      mockGetRef.mockResolvedValueOnce({
+        data: { object: { sha: "abc123" } },
+      });
+
+      mockGetTree.mockResolvedValueOnce({
+        data: {
+          tree: [
+            { type: "blob", path: "README.md", sha: "sha1" },
+            { type: "blob", path: "docs/guide.md", sha: "sha2" },
+            { type: "blob", path: "docs/nested/deep.md", sha: "sha3" },
+            // Shares the "docs" prefix but is a sibling folder, so the
+            // separator boundary has to keep it out.
+            { type: "blob", path: "docs-internal/secret.md", sha: "sha4" },
+            { type: "blob", path: "handbook/policy.md", sha: "sha5" },
+            { type: "blob", path: "src/index.md", sha: "sha6" },
+          ],
+        },
+      });
+
+      mockGetContent
+        .mockResolvedValueOnce({
+          data: { content: Buffer.from("guide").toString("base64") },
+        })
+        .mockResolvedValueOnce({
+          data: { content: Buffer.from("deep").toString("base64") },
+        })
+        .mockResolvedValueOnce({
+          data: { content: Buffer.from("policy").toString("base64") },
+        });
+
+      const batches: ConnectorSyncBatch[] = [];
+      for await (const batch of connector.sync({
+        config: {
+          ...validConfig,
+          includeRepositoryFiles: true,
+          // Deliberately messy: surrounding slashes are user habit, not intent.
+          includePaths: ["docs", "/handbook/"],
+        },
+        credentials,
+        checkpoint: null,
+      })) {
+        batches.push(batch);
+      }
+
+      const fileDocs = batches
+        .flatMap((b) => b.documents)
+        .filter((d) => d.metadata.kind === "repository_file");
+
+      expect(fileDocs.map((d) => d.metadata.filePath)).toEqual([
+        "docs/guide.md",
+        "docs/nested/deep.md",
+        "handbook/policy.md",
+      ]);
+    });
+
+    test("treats a root-only folder list as the whole repository", async () => {
+      mockListForRepo.mockResolvedValueOnce({ data: [] });
+      mockListForRepo.mockResolvedValueOnce({ data: [] });
+
+      mockGetRef.mockResolvedValueOnce({
+        data: { object: { sha: "abc123" } },
+      });
+
+      mockGetTree.mockResolvedValueOnce({
+        data: {
+          tree: [
+            { type: "blob", path: "README.md", sha: "sha1" },
+            { type: "blob", path: "docs/guide.md", sha: "sha2" },
+          ],
+        },
+      });
+
+      mockGetContent
+        .mockResolvedValueOnce({
+          data: { content: Buffer.from("readme").toString("base64") },
+        })
+        .mockResolvedValueOnce({
+          data: { content: Buffer.from("guide").toString("base64") },
+        });
+
+      const batches: ConnectorSyncBatch[] = [];
+      for await (const batch of connector.sync({
+        config: {
+          ...validConfig,
+          includeRepositoryFiles: true,
+          includePaths: ["/", "", " ", ".", "./"],
+        },
+        credentials,
+        checkpoint: null,
+      })) {
+        batches.push(batch);
+      }
+
+      const fileDocs = batches
+        .flatMap((b) => b.documents)
+        .filter((d) => d.metadata.kind === "repository_file");
+
+      expect(fileDocs.map((d) => d.metadata.filePath)).toEqual([
+        "README.md",
+        "docs/guide.md",
+      ]);
+    });
+
     test("uses configured file types for repository file indexing", async () => {
       mockListForRepo.mockResolvedValueOnce({ data: [] });
       mockListForRepo.mockResolvedValueOnce({ data: [] });

--- a/platform/backend/src/knowledge-base/connectors/github/github-connector.ts
+++ b/platform/backend/src/knowledge-base/connectors/github/github-connector.ts
@@ -376,9 +376,10 @@ export class GithubConnector extends BaseConnector {
     const { octokit, config, repo, checkpoint, isLastGroup } = params;
     const repoFullName = `${repo.owner}/${repo.name}`;
     const indexedExtensions = getIndexedFileExtensions(config);
+    const indexedPathPrefixes = getIndexedPathPrefixes(config);
 
     this.log.info(
-      { repo: repoFullName, indexedExtensions },
+      { repo: repoFullName, indexedExtensions, indexedPathPrefixes },
       "Starting repository file sync",
     );
 
@@ -436,6 +437,7 @@ export class GithubConnector extends BaseConnector {
           (item) =>
             item.type === "blob" &&
             item.path &&
+            isWithinIndexedPaths(item.path, indexedPathPrefixes) &&
             isIndexedRepositoryFile(item.path, indexedExtensions) &&
             item.sha,
         )
@@ -443,6 +445,16 @@ export class GithubConnector extends BaseConnector {
           path: item.path as string,
           sha: item.sha as string,
         }));
+
+      // GitHub caps a recursive tree listing; past the cap it returns a partial
+      // tree with `truncated: true`. Silently indexing a subset looks identical
+      // to "that folder has no matching files", so say it out loud.
+      if (treeResponse.data.truncated) {
+        this.log.warn(
+          { repo: repoFullName, branch, treeSha },
+          "Repository tree was truncated by GitHub, some files will not be indexed",
+        );
+      }
 
       this.log.info(
         {
@@ -1233,6 +1245,36 @@ function getIndexedFileExtensions(config: GithubConfig): string[] {
 function isIndexedRepositoryFile(path: string, extensions: string[]): boolean {
   const lower = path.toLowerCase();
   return extensions.some((extension) => lower.endsWith(extension));
+}
+
+/**
+ * Normalize the configured folders into repo-root-relative prefixes: users
+ * paste `/docs`, `docs/`, or `./docs` interchangeably, and a tree path never
+ * carries a leading slash. Entries that just name the repository root (`/`,
+ * `./`, `.`, blank) normalize away, leaving no filter at all rather than a
+ * prefix that matches nothing.
+ */
+function getIndexedPathPrefixes(config: GithubConfig): string[] {
+  return (config.includePaths ?? [])
+    .map((entry) =>
+      entry
+        .trim()
+        .replace(/^\.?\/+/, "")
+        .replace(/\/+$/, ""),
+    )
+    .filter((entry) => entry !== "" && entry !== ".");
+}
+
+/**
+ * A file is in scope when it sits at or under one of the prefixes. The `/`
+ * boundary matters: `docs` must not swallow `docs-internal/guide.md`.
+ * Comparison is case-sensitive because git paths are.
+ */
+function isWithinIndexedPaths(path: string, prefixes: string[]): boolean {
+  if (prefixes.length === 0) return true;
+  return prefixes.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
 }
 
 async function getFileContent(

--- a/platform/backend/src/types/knowledge-connector.ts
+++ b/platform/backend/src/types/knowledge-connector.ts
@@ -163,6 +163,13 @@ export const GithubConfigSchema = z.object({
   includePullRequests: z.boolean().optional(),
   includeRepositoryFiles: z.boolean().optional(),
   fileTypes: z.array(z.string()).optional(),
+  /**
+   * Repository folders to index when `includeRepositoryFiles` is on. Each entry
+   * is a path relative to the repository root (`docs`, `packages/api/src`); a
+   * file matches when it sits at or under one of them. Empty/absent means the
+   * whole repository, which is the pre-existing behaviour.
+   */
+  includePaths: z.array(z.string()).optional(),
   labelsToSkip: z.array(z.string()).optional(),
 });
 export type GithubConfig = z.infer<typeof GithubConfigSchema>;

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/github-config-fields.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/github-config-fields.tsx
@@ -236,23 +236,44 @@ export function GithubConfigFields({
       )}
 
       {!hideRepositoryOptions && includeRepositoryFiles === true && (
-        <FormField
-          control={form.control}
-          name={`${prefix}.fileTypes`}
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>File Types (optional)</FormLabel>
-              <FormControl>
-                <Input placeholder=".md, .mdx, .yaml, .yml" {...field} />
-              </FormControl>
-              <FormDescription>
-                Comma-separated extensions to index when repository files are
-                enabled. Defaults to Markdown and YAML.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <>
+          <FormField
+            control={form.control}
+            name={`${prefix}.fileTypes`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>File Types (optional)</FormLabel>
+                <FormControl>
+                  <Input placeholder=".md, .mdx, .yaml, .yml" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Comma-separated extensions to index when repository files are
+                  enabled. Defaults to Markdown and YAML.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name={`${prefix}.includePaths`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Folders (optional)</FormLabel>
+                <FormControl>
+                  <Input placeholder="docs, packages/api/src" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Comma-separated folders to index, relative to the repository
+                  root. Applies to every selected repository. Leave blank to
+                  index the whole repository.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </>
       )}
     </div>
   );

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/transform-config-array-fields.test.ts
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/transform-config-array-fields.test.ts
@@ -28,11 +28,13 @@ describe("transformConfigArrayFields", () => {
       projectGids: "111, 222",
       tagsToSkip: "wip, archived",
       objects: "Account, Contact",
+      includePaths: "docs, packages/api/src",
     };
 
     const result = transformConfigArrayFields(config);
 
     expect(result.repos).toEqual(["a", "b"]);
+    expect(result.includePaths).toEqual(["docs", "packages/api/src"]);
     expect(result.teamIds).toEqual(["team-1", "team-2"]);
     expect(result.spaceKeys).toEqual(["TEAM", "DEV"]);
     expect(result.pageIds).toEqual(["page-1", "page-2"]);

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/transform-config-array-fields.ts
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/transform-config-array-fields.ts
@@ -24,6 +24,7 @@ export function transformConfigArrayFields(
     "assignmentGroups",
     "driveIds",
     "fileTypes",
+    "includePaths",
     "depotPaths",
     "excludePaths",
     "userIds",

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -52114,6 +52114,7 @@ export type GetConnectorsResponses = {
                 includePullRequests?: boolean;
                 includeRepositoryFiles?: boolean;
                 fileTypes?: Array<string>;
+                includePaths?: Array<string>;
                 labelsToSkip?: Array<string>;
             } | {
                 type: 'gitlab';
@@ -52291,6 +52292,7 @@ export type CreateConnectorData = {
             includePullRequests?: boolean;
             includeRepositoryFiles?: boolean;
             fileTypes?: Array<string>;
+            includePaths?: Array<string>;
             labelsToSkip?: Array<string>;
         } | {
             type: 'gitlab';
@@ -52524,6 +52526,7 @@ export type CreateConnectorResponses = {
             includePullRequests?: boolean;
             includeRepositoryFiles?: boolean;
             fileTypes?: Array<string>;
+            includePaths?: Array<string>;
             labelsToSkip?: Array<string>;
         } | {
             type: 'gitlab';
@@ -52851,6 +52854,7 @@ export type GetConnectorResponses = {
             includePullRequests?: boolean;
             includeRepositoryFiles?: boolean;
             fileTypes?: Array<string>;
+            includePaths?: Array<string>;
             labelsToSkip?: Array<string>;
         } | {
             type: 'gitlab';
@@ -53014,6 +53018,7 @@ export type UpdateConnectorData = {
             includePullRequests?: boolean;
             includeRepositoryFiles?: boolean;
             fileTypes?: Array<string>;
+            includePaths?: Array<string>;
             labelsToSkip?: Array<string>;
         } | {
             type: 'gitlab';
@@ -53248,6 +53253,7 @@ export type UpdateConnectorResponses = {
             includePullRequests?: boolean;
             includeRepositoryFiles?: boolean;
             fileTypes?: Array<string>;
+            includePaths?: Array<string>;
             labelsToSkip?: Array<string>;
         } | {
             type: 'gitlab';


### PR DESCRIPTION
## Problem

The GitHub knowledge connector can sync repository files, but the only filter is file extension. `syncRepoFiles` walks the entire repo tree and keeps every blob whose suffix matches `fileTypes`. Pointing a Knowledge Base at a repo's `docs/` folder was not possible — you got every Markdown file in the repository, wherever it lived.

Every other file-oriented connector already has some form of path scoping (Perforce `depotPaths`, Web Crawler `includePathPrefixes`, Dropbox `rootPath`, SharePoint/GDrive `folderPath`). GitHub had none.

## Change

Adds an optional `includePaths` to `GithubConfigSchema` — folders relative to the repository root, applied to every selected repository. A file is indexed when it sits at or under one of them. Absent, blank, or root-only entries keep the existing whole-repository behaviour, so this is backwards compatible and needs no data migration (the config is a JSONB column).

Two details worth calling out:

- **Separator boundary.** `docs` matches `docs/guide.md` and `docs/nested/deep.md`, but not `docs-internal/secret.md`. A naive `startsWith` would silently pull in the sibling folder.
- **Input normalization.** `/docs`, `docs/`, and `./docs` all mean the same thing, because that is what people paste. Entries that just name the root (`/`, `.`, blank) normalize away to "no filter" rather than to a prefix that matches nothing.

Matching is case-sensitive, because git paths are.

### Drive-by

`git.getTree` caps a recursive listing and returns a partial tree with `truncated: true`, which the connector ignored. On a repo past the cap, a folder's files could go unindexed and look identical to "that folder has no matching files". Now it logs a warning. Relevant here because folder scoping is most useful on exactly the large repos that hit the cap.

## UI

New **Folders** input in the GitHub connector form, rendered alongside **File Types** under the existing `includeRepositoryFiles` toggle — it only appears when repository file sync is on.

## Tests

- `indexes only files under the configured folders` — nested paths, multiple folders, the `docs` / `docs-internal` boundary, and messy slash input in one case.
- `treats a root-only folder list as the whole repository` — `/`, blank, whitespace, `.`, `./` all normalize away.
- Frontend: `includePaths` added to the `transformConfigArrayFields` coverage so the comma-separated input is submitted as an array.

Both new backend tests fail without the filter (they would index 6 files instead of 3).

## Verification

- `pnpm type-check` — 8/8
- `pnpm lint` — clean for touched files (three unrelated pre-existing failures on `main` in `mcp-backing.app.route.test.ts`, `mcp-gateway.test.ts`, `startup-guard.test.ts`)
- `backend`: `github-connector.test.ts` + `knowledge-connector.test.ts` — 94 passed
- `frontend`: `transform-config-array-fields.test.ts` + `edit-connector-dialog.test.tsx` — 15 passed
- `pnpm knip` (dev + production) — clean
- `pnpm codegen` — regenerated `openapi.json` and the API client

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>