### PR TITLE
fix: validate team assignments on agent and project write paths

### DIFF
--- a/docs/pages/platform-projects.md
+++ b/docs/pages/platform-projects.md
@@ -3,7 +3,7 @@ title: Projects
 category: Projects
 order: 1
 description: A shared workspace to organize your work
-lastUpdated: 2026-07-22
+lastUpdated: 2026-07-28
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -46,4 +46,4 @@ A finance person approves incoming invoices against the company's vendor list. A
 
 ![Sharing the project with the Finance team](/docs/automated_screenshots/platform-projects_sharing-dialog.webp)
 
-Everyone with access to a shared project can start their own chats and work with its files. Reading other members' chats takes a separate permission that admins have by default. Sharing with the whole organization — and deleting or unsharing an org-wide project — takes its own permission, which custom roles can withhold. Deleting a project keeps the chats but removes the files and schedules. See [Access Control](./platform-access-control) for permissions.
+Everyone with access to a shared project can start their own chats and work with its files. You can share with any team you belong to — admins can share with any team in the organization. Reading other members' chats takes a separate permission that admins have by default. Sharing with the whole organization — and deleting or unsharing an org-wide project — takes its own permission, which custom roles can withhold. Deleting a project keeps the chats but removes the files and schedules. See [Access Control](./platform-access-control) for permissions.

--- a/platform/backend/src/archestra-mcp-server/agent-resources.ts
+++ b/platform/backend/src/archestra-mcp-server/agent-resources.ts
@@ -1,6 +1,8 @@
 import { TOOL_LIST_AGENTS_SHORT_NAME } from "@archestra/shared";
 import { z } from "zod";
 import {
+  assertAgentTeams,
+  assertAssignableAgentTeams,
   getAgentTypePermissionChecker,
   isAgentTypeAdmin,
   requireAgentModifyPermission,
@@ -18,6 +20,7 @@ import {
   AgentLabelWithDetailsSchema,
   AgentScopeSchema,
   AgentToolAssignmentInputSchema,
+  ApiError,
   InsertAgentSchemaBase,
   SuggestedPromptInputSchema,
   ToolExposureModeSchema,
@@ -509,15 +512,44 @@ export async function handleEditResource<
     checker.require(existingAgent.agentType, "update");
 
     const userTeamIds = await TeamModel.getUserTeamIds(context.userId);
+    const existingTeamIds = existingAgent.teams.map((team) => team.id);
     requireAgentModifyPermission({
       checker,
       agentType: existingAgent.agentType,
       agentScope: existingAgent.scope,
       agentAuthorId: existingAgent.authorId,
-      agentTeamIds: existingAgent.teams.map((team) => team.id),
+      agentTeamIds: existingTeamIds,
       userTeamIds,
       userId: context.userId,
     });
+
+    // The check above authorizes the edit against the agent's *current* scope
+    // and teams. The incoming ones need authorizing too: otherwise a team-admin
+    // permitted to edit an agent in a team they belong to could reassign it to
+    // a team they don't, or clear its teams and leave it reachable by nobody.
+    // Mirrors the REST update path.
+    if (args.scope !== undefined || args.teams !== undefined) {
+      const scope = args.scope ?? existingAgent.scope;
+      const teamIds = args.teams ?? existingTeamIds;
+
+      try {
+        assertAssignableAgentTeams({
+          checker,
+          agentType: existingAgent.agentType,
+          requestedTeamIds: teamIds,
+          existingTeamIds,
+          userTeamIds,
+        });
+        await assertAgentTeams({
+          scope,
+          teamIds,
+          organizationId: context.organizationId,
+        });
+      } catch (error) {
+        if (error instanceof ApiError) return errorResult(error.message);
+        throw error;
+      }
+    }
 
     const updateData: Record<string, unknown> = {};
     if (args.name !== undefined) updateData.name = args.name;

--- a/platform/backend/src/archestra-mcp-server/agents.test.ts
+++ b/platform/backend/src/archestra-mcp-server/agents.test.ts
@@ -574,6 +574,177 @@ describe("agent RBAC visibility", () => {
   });
 });
 
+describe("edit_agent team assignment", () => {
+  const editAgent = (
+    args: Record<string, unknown>,
+    context: ArchestraContext,
+  ) =>
+    executeArchestraTool(
+      `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}edit_agent`,
+      args,
+      context,
+    );
+
+  test("team-admin cannot move an agent to a team they do not belong to", async ({
+    makeAgent,
+    makeCustomRole,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeTeamMember,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const teamAdmin = await makeUser();
+    await makeCustomRole(org.id, {
+      role: "team_admin_role",
+      permission: { agent: ["read", "create", "update", "team-admin"] },
+    });
+    await makeMember(teamAdmin.id, org.id, { role: "team_admin_role" });
+
+    const ownTeam = await makeTeam(org.id, teamAdmin.id);
+    await makeTeamMember(ownTeam.id, teamAdmin.id);
+    const otherTeam = await makeTeam(org.id, teamAdmin.id);
+
+    const agent = await makeAgent({
+      name: "Team Scoped Agent",
+      agentType: "agent",
+      organizationId: org.id,
+      scope: "team",
+      teams: [ownTeam.id],
+    });
+
+    const result = await editAgent(
+      { id: agent.id, teams: [otherTeam.id] },
+      {
+        agent: { id: agent.id, name: agent.name },
+        userId: teamAdmin.id,
+        organizationId: org.id,
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain(
+      "teams you are a member of",
+    );
+
+    // The assignment must be untouched, not partially applied.
+    const unchanged = await AgentModel.findById(agent.id, teamAdmin.id, true);
+    expect(unchanged?.teams.map((team) => team.id)).toEqual([ownTeam.id]);
+  });
+
+  test("clearing the teams of a team-scoped agent is rejected, admin included", async ({
+    makeAgent,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const admin = await makeUser();
+    await makeMember(admin.id, org.id, { role: "admin" });
+    const team = await makeTeam(org.id, admin.id);
+
+    const agent = await makeAgent({
+      name: "Team Scoped Agent",
+      agentType: "agent",
+      organizationId: org.id,
+      scope: "team",
+      teams: [team.id],
+    });
+
+    const result = await editAgent(
+      { id: agent.id, teams: [] },
+      {
+        agent: { id: agent.id, name: agent.name },
+        userId: admin.id,
+        organizationId: org.id,
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain("at least one team");
+
+    const unchanged = await AgentModel.findById(agent.id, admin.id, true);
+    expect(unchanged?.teams.map((team) => team.id)).toEqual([team.id]);
+  });
+
+  test("a team from another organization is rejected", async ({
+    makeAgent,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const admin = await makeUser();
+    await makeMember(admin.id, org.id, { role: "admin" });
+    const team = await makeTeam(org.id, admin.id);
+
+    const otherOrg = await makeOrganization();
+    const outsider = await makeUser();
+    const foreignTeam = await makeTeam(otherOrg.id, outsider.id);
+
+    const agent = await makeAgent({
+      name: "Team Scoped Agent",
+      agentType: "agent",
+      organizationId: org.id,
+      scope: "team",
+      teams: [team.id],
+    });
+
+    const result = await editAgent(
+      { id: agent.id, teams: [foreignTeam.id] },
+      {
+        agent: { id: agent.id, name: agent.name },
+        userId: admin.id,
+        organizationId: org.id,
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain("Unknown team id");
+
+    const unchanged = await AgentModel.findById(agent.id, admin.id, true);
+    expect(unchanged?.teams.map((team) => team.id)).toEqual([team.id]);
+  });
+
+  test("an edit that leaves scope and teams alone still succeeds", async ({
+    makeAgent,
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    const org = await makeOrganization();
+    const admin = await makeUser();
+    await makeMember(admin.id, org.id, { role: "admin" });
+    const team = await makeTeam(org.id, admin.id);
+
+    const agent = await makeAgent({
+      name: "Team Scoped Agent",
+      agentType: "agent",
+      organizationId: org.id,
+      scope: "team",
+      teams: [team.id],
+    });
+
+    const result = await editAgent(
+      { id: agent.id, description: "Updated description" },
+      {
+        agent: { id: agent.id, name: agent.name },
+        userId: admin.id,
+        organizationId: org.id,
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    const updated = await AgentModel.findById(agent.id, admin.id, true);
+    expect(updated?.description).toBe("Updated description");
+    expect(updated?.teams.map((t) => t.id)).toEqual([team.id]);
+  });
+});
+
 function extractCreatedId(
   result: Awaited<ReturnType<typeof executeArchestraTool>>,
 ) {

--- a/platform/backend/src/archestra-mcp-server/projects.test.ts
+++ b/platform/backend/src/archestra-mcp-server/projects.test.ts
@@ -151,8 +151,10 @@ describe("set_project_share tool", () => {
 
   test("shares an explicit project with teams and unshares it", async ({
     makeTeam,
+    makeTeamMember,
   }) => {
     const team = await makeTeam(organizationId, userId);
+    await makeTeamMember(team.id, userId);
     const project = await projectService.create({
       organizationId,
       userId,
@@ -206,6 +208,31 @@ describe("set_project_share tool", () => {
     );
     expect(unknownTeam.isError).toBe(true);
     expect((unknownTeam.content[0] as any).text).toContain("Unknown team id");
+  });
+
+  test("rejects sharing with a team the caller does not belong to", async ({
+    makeTeam,
+  }) => {
+    // Created by the caller, but they never joined it.
+    const team = await makeTeam(organizationId, userId);
+    const project = await projectService.create({
+      organizationId,
+      userId,
+      name: "not-my-team",
+      description: null,
+    });
+
+    const result = await executeArchestraTool(
+      SHARE_TOOL_NAME,
+      { visibility: "team", team_ids: [team.id], project_id: project.id },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain(
+      "teams you are a member of",
+    );
+    expect(await ProjectShareModel.findByProjectId(project.id)).toBeNull();
   });
 
   test("errors when the chat has no project and no project_id is given", async ({

--- a/platform/backend/src/auth/agent-type-permissions.ts
+++ b/platform/backend/src/auth/agent-type-permissions.ts
@@ -4,6 +4,7 @@ import {
   type Resource,
 } from "@archestra/shared";
 import { buildForbiddenErrorMessage } from "@archestra/shared/access-control";
+import { TeamModel } from "@/models";
 import {
   type AgentScope,
   type AgentType,
@@ -231,6 +232,73 @@ export function requireScopedModifyPermission(params: {
     // fall through and implicitly grant.
     default:
       throw new ApiError(403, `Unknown ${resourceLabel} scope`);
+  }
+}
+
+/**
+ * Validate an agent's team assignments before persisting. A `team`-scoped agent
+ * must have at least one team (otherwise it matches no team membership and is
+ * invisible to everyone, including its author), and every assigned team must
+ * exist within the caller's organization — a stale, bogus, or foreign-org id
+ * fails with a clean 400 instead of an FK violation mid-write.
+ *
+ * Existence is checked for any non-empty assignment rather than only at `team`
+ * scope: `agent_team` rows are written whenever teams are supplied, and the
+ * foreign key points at the global `team` table, so an id belonging to another
+ * organization would otherwise persist unnoticed. Mirrors
+ * {@link assertMcpCatalogTeams} and its skill equivalent.
+ */
+export async function assertAgentTeams(params: {
+  scope: AgentScope;
+  teamIds: string[];
+  organizationId: string;
+}): Promise<void> {
+  if (params.scope === "team" && params.teamIds.length === 0) {
+    throw new ApiError(
+      400,
+      "A team-scoped agent must be assigned at least one team",
+    );
+  }
+  if (params.teamIds.length === 0) return;
+
+  const teams = await TeamModel.findByIds(params.teamIds);
+  const validIds = new Set(
+    teams
+      .filter((team) => team.organizationId === params.organizationId)
+      .map((team) => team.id),
+  );
+  const missing = params.teamIds.filter((id) => !validIds.has(id));
+  if (missing.length > 0) {
+    throw new ApiError(400, `Unknown team id(s): ${missing.join(", ")}`);
+  }
+}
+
+/**
+ * Enforce that a non-admin only assigns teams they belong to. Admins may assign
+ * any team in the organization, which is how an agent is set up on a team's
+ * behalf.
+ *
+ * Teams already on the agent are exempt: a team-admin editing an agent that is
+ * also shared with teams they don't belong to can still save unrelated changes,
+ * and echoing the current assignment back is never rejected. Only newly added
+ * teams are checked.
+ */
+export function assertAssignableAgentTeams(params: {
+  checker: AgentTypePermissionChecker;
+  agentType: AgentType;
+  requestedTeamIds: string[];
+  existingTeamIds: string[];
+  userTeamIds: string[];
+}): void {
+  if (params.checker.isAdmin(params.agentType)) return;
+
+  const existingTeamIdSet = new Set(params.existingTeamIds);
+  const userTeamIdSet = new Set(params.userTeamIds);
+  const invalidAdds = params.requestedTeamIds.filter(
+    (id) => !existingTeamIdSet.has(id) && !userTeamIdSet.has(id),
+  );
+  if (invalidAdds.length > 0) {
+    throw new ApiError(403, "You can only assign teams you are a member of");
   }
 }
 

--- a/platform/backend/src/routes/agent.ts
+++ b/platform/backend/src/routes/agent.ts
@@ -15,7 +15,14 @@ import {
   requireAgentModifyPermission,
   userHasPermission,
 } from "@/auth";
-import type { AgentTypePermissionChecker } from "@/auth/agent-type-permissions";
+// Imported from the module rather than the `@/auth` barrel on purpose: route
+// tests mock `@/auth` wholesale to open up permissions, and these are
+// validation rules (team existence, org ownership, the ≥1-team invariant) that
+// must keep running in those tests rather than silently becoming no-ops.
+import {
+  type AgentTypePermissionChecker,
+  assertAgentTeams,
+} from "@/auth/agent-type-permissions";
 import { knowledgeSourceAccessControlService } from "@/knowledge-base";
 import {
   AgentLabelModel,
@@ -525,11 +532,13 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
       });
 
       // A team-scoped agent with no teams is accessible to nobody (not even its
-      // author), so reject it. Applies to admins too — they can otherwise reach
-      // this via the API/UI (issue #6624).
-      assertTeamScopeHasTeams({
+      // author), so reject it, and reject teams outside this organization.
+      // Applies to admins too — they can otherwise reach this via the API/UI
+      // (issue #6624).
+      await assertAgentTeams({
         scope: body.scope ?? "personal",
-        teamCount: body.teams.length,
+        teamIds: body.teams,
+        organizationId,
       });
 
       // Omit teams if scope is not 'team' — scope takes precedence
@@ -669,12 +678,14 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
       const targetScope = body?.scope ?? sourceAgent.scope;
       const requestedTeams = body?.teams ?? [];
 
-      // A team-scoped clone must land on ≥1 team (issue #6624). Effective teams
-      // default to the source's when the caller omits them, matching
-      // AgentModel.cloneAgent. Applies to admins too.
-      assertTeamScopeHasTeams({
+      // A team-scoped clone must land on ≥1 team (issue #6624) and may only
+      // target teams in this organization. Effective teams default to the
+      // source's when the caller omits them, matching AgentModel.cloneAgent.
+      // Applies to admins too.
+      await assertAgentTeams({
         scope: targetScope,
-        teamCount: (body?.teams ?? sourceAgent.teams).length,
+        teamIds: body?.teams ?? sourceAgent.teams.map((t) => t.id),
+        organizationId,
       });
 
       if (!checker.isAdmin(sourceAgent.agentType)) {
@@ -1158,13 +1169,15 @@ const agentRoutes: FastifyPluginAsyncZod = async (fastify) => {
         throw new ApiError(400, "Shared agents cannot be made personal");
       }
 
-      // A team-scoped agent must keep ≥1 team (issue #6624). Evaluate the merged
-      // result — the team-admin path above may have rewritten body.teams — so
-      // this catches switching to team scope with none, or clearing the teams of
-      // an already team-scoped agent. Applies to admins too.
-      assertTeamScopeHasTeams({
+      // A team-scoped agent must keep ≥1 team (issue #6624) and may only be
+      // assigned teams in this organization. Evaluate the merged result — the
+      // team-admin path above may have rewritten body.teams — so this catches
+      // switching to team scope with none, or clearing the teams of an already
+      // team-scoped agent. Applies to admins too.
+      await assertAgentTeams({
         scope: body.scope ?? existingAgent.scope,
-        teamCount: (body.teams ?? existingAgent.teams).length,
+        teamIds: body.teams ?? existingAgent.teams.map((t) => t.id),
+        organizationId,
       });
 
       // Validate knowledgeBaseIds if provided
@@ -1683,23 +1696,6 @@ async function assertEnvironmentAssignable(params: {
     organizationId,
     canDeployToRestricted: hasResourceDeploy,
   });
-}
-
-/**
- * A team-scoped agent with zero teams matches no team membership, so it is
- * inaccessible to everyone including its author (issue #6624). Reject it at the
- * write paths. Callers pass the resolved effective scope and team count.
- */
-function assertTeamScopeHasTeams(params: {
-  scope: string;
-  teamCount: number;
-}): void {
-  if (params.scope === "team" && params.teamCount === 0) {
-    throw new ApiError(
-      400,
-      "A team-scoped agent must be assigned at least one team",
-    );
-  }
 }
 
 /**

--- a/platform/backend/src/routes/project/list.project.route.test.ts
+++ b/platform/backend/src/routes/project/list.project.route.test.ts
@@ -70,8 +70,10 @@ describe("GET /api/projects (scope + search)", () => {
 
   test("scope filters by share visibility (personal / team / org)", async ({
     makeTeam,
+    makeTeamMember,
   }) => {
     const team = await makeTeam(organizationId, viewer.id, { name: "T" });
+    await makeTeamMember(team.id, viewer.id);
     await create(viewer, "private-one");
     const orgP = await create(viewer, "org-one");
     await share(viewer, orgP.id, "organization");
@@ -99,9 +101,12 @@ describe("GET /api/projects (scope + search)", () => {
 
   test("scope=team + teamIds narrows to the chosen team", async ({
     makeTeam,
+    makeTeamMember,
   }) => {
     const teamA = await makeTeam(organizationId, viewer.id, { name: "A" });
+    await makeTeamMember(teamA.id, viewer.id);
     const teamB = await makeTeam(organizationId, viewer.id, { name: "B" });
+    await makeTeamMember(teamB.id, viewer.id);
     const a = await create(viewer, "shared-A");
     await share(viewer, a.id, "team", [teamA.id]);
     const b = await create(viewer, "shared-B");
@@ -166,12 +171,15 @@ describe("GET /api/projects (scope + search)", () => {
     const other = await makeUser({ email: "list-other-all@test.com" });
     await makeMember(other.id, organizationId, {});
 
-    // A team the admin belongs to, and one they don't.
+    // A team the admin belongs to, and one they don't. `other` does the
+    // sharing, so they belong to both.
     const myTeam = await makeTeam(organizationId, admin.id, { name: "Mine" });
     await makeTeamMember(myTeam.id, admin.id);
+    await makeTeamMember(myTeam.id, other.id);
     const foreignTeam = await makeTeam(organizationId, other.id, {
       name: "Foreign",
     });
+    await makeTeamMember(foreignTeam.id, other.id);
 
     await create(admin, "admin-private");
     await create(other, "other-private");
@@ -204,12 +212,14 @@ describe("GET /api/projects (scope + search)", () => {
     makeUser,
     makeMember,
     makeTeam,
+    makeTeamMember,
   }) => {
     const admin = await makeUser({ email: "list-admin-teamnames@test.com" });
     await makeMember(admin.id, organizationId, { role: ADMIN_ROLE_NAME });
     const other = await makeUser({ email: "list-other-teamnames@test.com" });
     await makeMember(other.id, organizationId, {});
     const team = await makeTeam(organizationId, other.id, { name: "Finance" });
+    await makeTeamMember(team.id, other.id);
     const p = await create(other, "team-proj");
     await share(other, p.id, "team", [team.id]);
     actingUser = admin;

--- a/platform/backend/src/routes/project/share.project.route.test.ts
+++ b/platform/backend/src/routes/project/share.project.route.test.ts
@@ -90,12 +90,14 @@ describe("PUT /api/projects/:id/share", () => {
     makeCustomRole,
     makeMember,
     makeTeam,
+    makeTeamMember,
   }) => {
     const role = await makeCustomRole(organizationId, {
       permission: PROJECT_PERMISSIONS_WITHOUT_SHARE_ORG,
     });
     await makeMember(user.id, organizationId, { role: role.role });
     const team = await makeTeam(organizationId, user.id);
+    await makeTeamMember(team.id, user.id);
     const project = await makeOwnProject();
 
     const response = await setShare(project.id, {
@@ -140,6 +142,78 @@ describe("PUT /api/projects/:id/share", () => {
     expect(
       (await ProjectShareModel.findByProjectId(project.id))?.visibility,
     ).toBe("organization");
+  });
+
+  test("an owner cannot share with a team they are not a member of", async ({
+    makeMember,
+    makeTeam,
+  }) => {
+    await makeMember(user.id, organizationId);
+    // Created by the owner, but they never joined it.
+    const team = await makeTeam(organizationId, user.id);
+    const project = await makeOwnProject();
+
+    const response = await setShare(project.id, {
+      visibility: "team",
+      teamIds: [team.id],
+    });
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error.message).toMatch(/teams you are a member of/i);
+    expect(await ProjectShareModel.findByProjectId(project.id)).toBeNull();
+  });
+
+  test("a project admin can share with any team in the organization", async ({
+    makeMember,
+    makeTeam,
+    makeUser,
+  }) => {
+    await makeMember(user.id, organizationId, { role: "admin" });
+    const other = await makeUser();
+    const team = await makeTeam(organizationId, other.id);
+    const project = await makeOwnProject();
+
+    const response = await setShare(project.id, {
+      visibility: "team",
+      teamIds: [team.id],
+    });
+    expect(response.statusCode).toBe(200);
+    expect(
+      (await ProjectShareModel.findByProjectId(project.id))?.teamIds,
+    ).toEqual([team.id]);
+  });
+
+  test("a team from another organization is rejected", async ({
+    makeMember,
+    makeOrganization,
+    makeTeam,
+    makeUser,
+  }) => {
+    await makeMember(user.id, organizationId, { role: "admin" });
+    const otherOrg = await makeOrganization();
+    const outsider = await makeUser();
+    const foreignTeam = await makeTeam(otherOrg.id, outsider.id);
+    const project = await makeOwnProject();
+
+    const response = await setShare(project.id, {
+      visibility: "team",
+      teamIds: [foreignTeam.id],
+    });
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toMatch(/unknown team id/i);
+    expect(await ProjectShareModel.findByProjectId(project.id)).toBeNull();
+  });
+
+  test("a team share with no teams is rejected", async ({ makeMember }) => {
+    await makeMember(user.id, organizationId);
+    const project = await makeOwnProject();
+
+    const response = await setShare(project.id, {
+      visibility: "team",
+      teamIds: [],
+    });
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toMatch(/at least one team/i);
+    expect(await ProjectShareModel.findByProjectId(project.id)).toBeNull();
   });
 
   test("an admin can org-share another member's project", async ({

--- a/platform/backend/src/routes/project/update.project.route.test.ts
+++ b/platform/backend/src/routes/project/update.project.route.test.ts
@@ -45,9 +45,11 @@ describe("PATCH/PUT share/DELETE /api/projects/:id", () => {
 
   test("owner can update description, share, unshare, and delete", async ({
     makeTeam,
+    makeTeamMember,
   }) => {
     const project = await seedProject();
     const team = await makeTeam(organizationId, owner.id, { name: "T" });
+    await makeTeamMember(team.id, owner.id);
 
     const patch = await app.inject({
       method: "PATCH",

--- a/platform/backend/src/services/project.ts
+++ b/platform/backend/src/services/project.ts
@@ -13,6 +13,7 @@ import {
   ProjectNameExistsError,
   ProjectPinModel,
   ProjectShareModel,
+  TeamModel,
   UserModel,
 } from "@/models";
 import { fileStore } from "@/skills-sandbox/file-store";
@@ -435,6 +436,9 @@ class ProjectService {
       await ProjectShareModel.remove(params.id);
       return;
     }
+    if (params.visibility === "team") {
+      await this.assertShareTeams(params);
+    }
     await ProjectShareModel.upsert({
       projectId: params.id,
       organizationId: params.organizationId,
@@ -704,6 +708,50 @@ class ProjectService {
       return project;
     }
     throw new ApiError(404, "Project not found");
+  }
+
+  /**
+   * Validate the teams a project is being shared with. A team share needs at
+   * least one team (otherwise it reaches nobody), every team must exist within
+   * the caller's organization — a stale, bogus, or foreign-org id fails with a
+   * clean 400 instead of an FK violation mid-write — and a caller without
+   * `project:admin` may only share with teams they belong to. A `project:admin`
+   * may share with any team in the organization, which is how a project is set
+   * up on a team's behalf. Mirrors the agent, skill, and catalog write paths.
+   */
+  private async assertShareTeams(params: {
+    teamIds: string[];
+    organizationId: string;
+    userId: string;
+  }): Promise<void> {
+    if (params.teamIds.length === 0) {
+      throw new ApiError(
+        400,
+        "A team-shared project must be shared with at least one team",
+      );
+    }
+
+    const teams = await TeamModel.findByIds(params.teamIds);
+    const validIds = new Set(
+      teams
+        .filter((team) => team.organizationId === params.organizationId)
+        .map((team) => team.id),
+    );
+    const missing = params.teamIds.filter((id) => !validIds.has(id));
+    if (missing.length > 0) {
+      throw new ApiError(400, `Unknown team id(s): ${missing.join(", ")}`);
+    }
+
+    if (await this.callerIsProjectAdmin(params)) return;
+
+    const userTeamIds = new Set(await TeamModel.getUserTeamIds(params.userId));
+    const invalid = params.teamIds.filter((id) => !userTeamIds.has(id));
+    if (invalid.length > 0) {
+      throw new ApiError(
+        403,
+        "You can only share projects with teams you are a member of",
+      );
+    }
   }
 
   private async callerIsProjectAdmin(params: {


### PR DESCRIPTION
## Why

Team assignment is validated inconsistently across resources. Skills and catalog items check that the caller belongs to the teams they assign, that the teams exist, and that they belong to the caller's organization. Agents check only the first, and only on the REST routes. Projects check none of the three.

Two concrete gaps:

**`edit_agent` accepted any team.** The handler behind `edit_agent`, `edit_mcp_gateway`, and `edit_llm_proxy` authorized the caller against the agent's *existing* scope and teams, then wrote the incoming `teams` and `scope` verbatim. A team-admin permitted to edit an agent in a team they belong to could reassign it to a team they do not, or clear its teams entirely and leave the agent reachable by nobody. The REST update path guards both; the tool guarded neither, while `create_agent` beside it already validated membership.

**`setShare` accepted any team.** Projects had no membership, existence, or organization check on the ids passed to a team share, for any caller. A bogus id surfaced as a raw foreign-key error mid-write rather than a 400.

## What changed

Agents — two rules extracted from the routes so the tool and the routes share them:

- `assertAssignableAgentTeams` — non-admins may only add teams they belong to. Teams already on the agent stay exempt, so an edit that touches something else never drops a team the caller doesn't control.
- `assertAgentTeams` — a team-scoped agent keeps at least one team, and every assigned team must exist in the caller's organization.

The organization check is new for agents. They never called `TeamModel` on write at all, and `agent_team.team_id` references the global team table, so an id from another organization inserted cleanly. Existence is checked for any non-empty assignment rather than only at team scope, since the junction rows are written whenever teams are supplied.

Projects — the same three rules on `setShare`: at least one team, every team resolves within the organization, and callers without `project:admin` may only share with teams they belong to.

Admins keep the bypass on both. Assigning a resource to a team you aren't in is the intended way to set one up on a team's behalf; the rules apply to everyone else.

## Not a cross-organization leak

Worth stating explicitly since the organization check is new: nothing was exposed across organizations before this. Both project read paths already filter by `organizationId`, so a project shared to a foreign team was invisible to that organization's members. The same holds for agents. This is data integrity and error quality, not exposure.

## Behavior changes

- Sharing a project with a team you don't belong to now returns 403 instead of succeeding (unless you hold `project:admin`).
- A team share with no teams, or with an unknown or foreign-organization team, now returns 400.
- `edit_agent` and siblings now reject a reassignment to a team the caller doesn't belong to, and reject clearing the teams of a team-scoped agent.

## Tests

- `edit_agent`: reassignment to a non-member team, clearing teams on a team-scoped agent, a foreign-organization team, and a control asserting a content-only edit still succeeds and leaves the assignment untouched. Verified the first three fail without the fix.
- Project share route: non-member team, project admin sharing with any team, foreign-organization team, empty team list.
- `set_project_share` tool: non-member team.
- Several existing tests shared with a team the sharer had only created — `makeTeam` records `createdBy` without adding membership, so they were exercising the unvalidated path rather than asserting anything about it. They now join the team first.

Full `src/routes`, `src/services`, and `src/archestra-mcp-server` sweep compared against a clean `main` baseline: same 6 pre-existing failures, no new ones. `type-check`, `lint`, and `knip` (dev + production) pass.

## Follow-ups, deliberately not in this PR

- **Author retention.** Agents, skills, and catalog items all bind the `author_id` clause of their visibility predicate to `scope = 'personal'`, so moving a resource to team scope drops its author unless they belong to the team. Projects differ — ownership is a column and sharing is additive, so the owner never loses access. Making the four consistent is a product decision, not a bug fix: the current behavior is deliberate (`routes/agent.ts` notes a team-scoped agent with no teams is reachable by nobody, its author included), and blanket retention would also let someone who leaves a team keep access to a resource they authored for it.
- **Per-team access levels for agents and skills.** `mcp_catalog_team` has a `level` of `use` or `write`; `agent_team` and `skill_team` are bare. Adding the column would let a team be given a resource to use without permission to edit it.
- **Agent access is not re-checked per turn.** Skills re-validate mounted access mid-conversation; an agent conversation only checks at bind time, so revoked team membership doesn't stop an in-flight chat.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>