### PR TITLE
feat(mcp-gateway): implement Multi Round-Trip Requests (MRTR)

### DIFF
--- a/platform/backend/src/routes/mcp-gateway.mrtr-roundtrip.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.mrtr-roundtrip.test.ts
@@ -1,0 +1,303 @@
+/**
+ * MRTR round trip through the real tool-call handler.
+ *
+ * The unit tests cover request-state security in isolation; this covers the
+ * seam between them — an upstream server elicits, the gateway answers with an
+ * InputRequiredResult, and the client's retry carrying that answer completes
+ * the call. Driving the actual handler is the point: the elicitation callback
+ * is invoked several frames below it, and the signal has to unwind all the way
+ * up without being swallowed by the error handling in between.
+ */
+
+import crypto from "node:crypto";
+import { OAUTH_TOKEN_ID_PREFIX } from "@archestra/shared";
+import { vi } from "vitest";
+import mcpClient from "@/clients/mcp-client";
+import { afterEach, describe, expect, test } from "@/test";
+import {
+  deriveStatePrincipal,
+  GATEWAY_INPUT_REQUEST_KEY,
+  verifyRequestState,
+} from "./mcp-gateway.mrtr";
+import { createAgentServer } from "./mcp-gateway.utils";
+
+type CallToolHandler = (
+  request: unknown,
+  extra: unknown,
+) => Promise<Record<string, unknown>>;
+
+const TOOL_NAME = "bug_tracker__open";
+
+const ELICIT_REQUEST = {
+  method: "elicitation/create" as const,
+  params: {
+    mode: "form",
+    message: "Which project?",
+    requestedSchema: {
+      type: "object",
+      properties: { project: { type: "string" } },
+      required: ["project"],
+    },
+  },
+};
+
+const ELICIT_ANSWER = { action: "accept", content: { project: "apollo" } };
+
+function getCallToolHandler(server: { server: unknown }): CallToolHandler {
+  const handler = (
+    server.server as {
+      _requestHandlers: Map<string, CallToolHandler>;
+    }
+  )._requestHandlers.get("tools/call");
+  if (!handler) throw new Error("tools/call handler not registered");
+  return handler;
+}
+
+function callToolRequest() {
+  return {
+    method: "tools/call",
+    params: { name: TOOL_NAME, arguments: {} },
+  };
+}
+
+describe("MRTR round trip", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function seed({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeTool,
+    makeMcpServer,
+    makeAgentTool,
+  }: Record<string, (...args: never[]) => Promise<Record<string, string>>>) {
+    const org = await makeOrganization();
+    const user = await makeUser();
+    await makeMember(
+      user.id as never,
+      org.id as never,
+      {
+        role: "admin",
+      } as never,
+    );
+    const agent = await makeAgent({
+      organizationId: org.id,
+      accessAllTools: true,
+    } as never);
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "bug-tracker",
+    } as never);
+    const tool = await makeTool({
+      catalogId: catalog.id,
+      name: TOOL_NAME,
+      parameters: { type: "object", properties: {} },
+    } as never);
+    await makeMcpServer({ catalogId: catalog.id, scope: "org" } as never);
+    await makeAgentTool(agent.id as never, tool.id as never);
+
+    const tokenAuth = {
+      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+      teamId: null,
+      isOrganizationToken: false,
+      organizationId: org.id,
+      isUserToken: true,
+      userId: user.id,
+    };
+
+    return { org, user, agent, tokenAuth };
+  }
+
+  /**
+   * Stand in for an upstream server that elicits: invoke the elicitation
+   * callback the gateway supplied, and return whatever it yields.
+   */
+  function upstreamThatElicits() {
+    return vi
+      .spyOn(mcpClient, "executeToolCallForOwner")
+      .mockImplementation(async (toolCall, _owner, _auth, options) => {
+        const answer = await (
+          options as {
+            elicitationHandler?: (r: unknown) => Promise<unknown>;
+          }
+        ).elicitationHandler?.(ELICIT_REQUEST);
+
+        return {
+          id: (toolCall as { id: string }).id,
+          name: TOOL_NAME,
+          content: [
+            { type: "text", text: `answered: ${JSON.stringify(answer)}` },
+          ],
+          isError: false,
+        } as never;
+      });
+  }
+
+  test("an upstream elicitation becomes an InputRequiredResult the client can act on", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeTool,
+    makeMcpServer,
+    makeAgentTool,
+  }) => {
+    const { agent, tokenAuth } = await seed({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeTool,
+      makeMcpServer,
+      makeAgentTool,
+    } as never);
+    upstreamThatElicits();
+
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth,
+      mrtr: { enabled: true, clientCapabilities: { elicitation: {} } },
+    });
+
+    const result = await getCallToolHandler(server)(callToolRequest(), {});
+
+    expect(result.resultType).toBe("input_required");
+    const inputRequests = result.inputRequests as Record<string, unknown>;
+    expect(inputRequests[GATEWAY_INPUT_REQUEST_KEY]).toMatchObject({
+      method: "elicitation/create",
+    });
+
+    // The state must actually verify for the caller it was minted for,
+    // against the very request that produced it.
+    const verified = verifyRequestState({
+      state: result.requestState as string,
+      principal: deriveStatePrincipal(tokenAuth),
+      method: "tools/call",
+      requestParams: { name: TOOL_NAME, arguments: {} },
+    });
+    expect(verified.ok).toBe(true);
+  });
+
+  test("the retry carrying the answer completes the call", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeTool,
+    makeMcpServer,
+    makeAgentTool,
+  }) => {
+    const { agent, tokenAuth } = await seed({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeTool,
+      makeMcpServer,
+      makeAgentTool,
+    } as never);
+    upstreamThatElicits();
+
+    // A retry is an independent request: a fresh server, given the answers the
+    // client gathered. Nothing survives from the first attempt.
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth,
+      mrtr: {
+        enabled: true,
+        clientCapabilities: { elicitation: {} },
+        inputResponses: { [GATEWAY_INPUT_REQUEST_KEY]: ELICIT_ANSWER },
+      },
+    });
+
+    const result = await getCallToolHandler(server)(callToolRequest(), {});
+
+    expect(result.resultType).toBeUndefined();
+    expect(result.isError).toBeFalsy();
+    // The upstream received the client's answer rather than being asked again.
+    expect(JSON.stringify(result.content)).toContain("apollo");
+  });
+
+  test("a client that never declared elicitation is not asked for it", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeTool,
+    makeMcpServer,
+    makeAgentTool,
+  }) => {
+    const { agent, tokenAuth } = await seed({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeTool,
+      makeMcpServer,
+      makeAgentTool,
+    } as never);
+    upstreamThatElicits();
+
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth,
+      mrtr: { enabled: true, clientCapabilities: {} },
+    });
+
+    const result = await getCallToolHandler(server)(callToolRequest(), {});
+
+    // Asking for a capability the client never declared is forbidden, so the
+    // call fails with something the model can act on instead.
+    expect(result.resultType).toBeUndefined();
+    expect(result.isError).toBe(true);
+  });
+
+  test("a legacy client keeps the in-band elicitation path", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeTool,
+    makeMcpServer,
+    makeAgentTool,
+  }) => {
+    const { agent, tokenAuth } = await seed({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeTool,
+      makeMcpServer,
+      makeAgentTool,
+    } as never);
+    upstreamThatElicits();
+
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth,
+      mrtr: { enabled: false },
+    });
+
+    // With MRTR off the handler sends the elicitation to the client in-band,
+    // exactly as before this feature existed.
+    const sendRequest = vi.fn().mockResolvedValue(ELICIT_ANSWER);
+    const result = await getCallToolHandler(server)(callToolRequest(), {
+      sendRequest,
+    });
+
+    expect(sendRequest).toHaveBeenCalled();
+    expect(result.resultType).toBeUndefined();
+  });
+});

--- a/platform/backend/src/routes/mcp-gateway.mrtr.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.mrtr.test.ts
@@ -172,6 +172,43 @@ describe("requestState rejection", () => {
   });
 });
 
+describe("input-round cap", () => {
+  test("state records which round it belongs to", () => {
+    const result = verify(mint({ round: 2 }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected verification to succeed");
+    expect(result.payload.round).toBe(2);
+  });
+
+  test("a first round is recorded when the caller does not say", () => {
+    const result = verify(mint());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected verification to succeed");
+    expect(result.payload.round).toBe(1);
+  });
+
+  test("the round cannot be raised without resigning the state", () => {
+    // Each round re-runs the tool, so a client that could inflate the counter
+    // could drive unbounded re-execution.
+    const state = mint({ round: 1 });
+    const [encoded, signature] = state.split(".");
+    const payload = JSON.parse(
+      Buffer.from(encoded, "base64url").toString("utf8"),
+    );
+    payload.round = 99;
+    const forged = Buffer.from(JSON.stringify(payload), "utf8").toString(
+      "base64url",
+    );
+
+    expect(verify(`${forged}.${signature}`)).toEqual({
+      ok: false,
+      reason: "bad_signature",
+    });
+  });
+});
+
 describe("deriveStatePrincipal", () => {
   test("prefers the individual user", () => {
     expect(

--- a/platform/backend/src/routes/mcp-gateway.mrtr.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.mrtr.test.ts
@@ -1,0 +1,294 @@
+/**
+ * MRTR request-state security.
+ *
+ * `requestState` travels through the client, so the spec treats it as
+ * attacker-controlled and requires integrity protection plus rejection of state
+ * that fails it. These pin the three replay bounds the spec asks for —
+ * principal, expiry, and originating request — because a hole in any one of
+ * them is a cross-user or cross-call authorisation bug, not a protocol nit.
+ */
+
+import { describe, expect, test } from "@/test";
+import {
+  buildInputRequiredResult,
+  clientSupportsInputRequest,
+  deriveStatePrincipal,
+  encodeRequestState,
+  extractMrtrParams,
+  REQUEST_STATE_TTL_MS,
+  supportsInputRequired,
+  verifyRequestState,
+} from "./mcp-gateway.mrtr";
+
+const PRINCIPAL = "user:alice";
+const METHOD = "tools/call";
+const PARAMS = { name: "send_message", arguments: { channel: "#general" } };
+
+function mint(
+  overrides: Partial<Parameters<typeof encodeRequestState>[0]> = {},
+) {
+  return encodeRequestState({
+    principal: PRINCIPAL,
+    method: METHOD,
+    requestParams: PARAMS,
+    keys: ["github_login"],
+    ...overrides,
+  });
+}
+
+function verify(
+  state: string,
+  overrides: Partial<Parameters<typeof verifyRequestState>[0]> = {},
+) {
+  return verifyRequestState({
+    state,
+    principal: PRINCIPAL,
+    method: METHOD,
+    requestParams: PARAMS,
+    ...overrides,
+  });
+}
+
+describe("requestState round trip", () => {
+  test("state minted for a request verifies on the matching retry", () => {
+    const result = verify(mint());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected verification to succeed");
+    expect(result.payload.principal).toBe(PRINCIPAL);
+    expect(result.payload.keys).toEqual(["github_login"]);
+  });
+
+  test("the retry may carry MRTR fields the original did not", () => {
+    // The retry necessarily adds inputResponses and requestState. If those
+    // counted toward the request digest, no retry could ever verify.
+    const state = mint();
+
+    const result = verify(state, {
+      requestParams: {
+        ...PARAMS,
+        inputResponses: { github_login: { action: "accept" } },
+        requestState: state,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("parameter key order does not change the binding", () => {
+    const result = verify(mint(), {
+      requestParams: {
+        arguments: { channel: "#general" },
+        name: "send_message",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("requestState rejection", () => {
+  test("a tampered payload is rejected", () => {
+    const state = mint();
+    const [encoded, signature] = state.split(".");
+    const forged = Buffer.from(
+      JSON.stringify({
+        v: 1,
+        principal: "user:mallory",
+        method: METHOD,
+        paramsDigest: "whatever",
+        exp: Date.now() + 60_000,
+        keys: [],
+      }),
+      "utf8",
+    ).toString("base64url");
+    void encoded;
+
+    const result = verifyRequestState({
+      state: `${forged}.${signature}`,
+      principal: "user:mallory",
+      method: METHOD,
+      requestParams: PARAMS,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  test("a state minted for another principal is rejected", () => {
+    // Both callers may hold valid tokens for the same gateway; the binding is
+    // what stops one redeeming the other's elicitation.
+    const result = verify(mint(), { principal: "user:mallory" });
+
+    expect(result).toEqual({ ok: false, reason: "principal_mismatch" });
+  });
+
+  test("a state minted for a different tool call is rejected", () => {
+    const result = verify(mint(), {
+      requestParams: { name: "delete_everything", arguments: {} },
+    });
+
+    expect(result).toEqual({ ok: false, reason: "request_mismatch" });
+  });
+
+  test("a state minted for a different method is rejected", () => {
+    const result = verify(mint(), { method: "resources/read" });
+
+    expect(result).toEqual({ ok: false, reason: "request_mismatch" });
+  });
+
+  test("an expired state is rejected", () => {
+    const mintedAt = 1_000_000;
+    const state = mint({ now: mintedAt });
+
+    const result = verify(state, { now: mintedAt + REQUEST_STATE_TTL_MS + 1 });
+
+    expect(result).toEqual({ ok: false, reason: "expired" });
+  });
+
+  test("a state is still redeemable just inside its window", () => {
+    const mintedAt = 1_000_000;
+    const state = mint({ now: mintedAt });
+
+    const result = verify(state, { now: mintedAt + REQUEST_STATE_TTL_MS - 1 });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("structurally invalid state is rejected rather than throwing", () => {
+    for (const state of ["", ".", "nodot", "abc.", ".abc"]) {
+      const result = verify(state);
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  test("a signature over different content does not verify", () => {
+    const other = mint({ requestParams: { name: "other", arguments: {} } });
+    const [, otherSignature] = other.split(".");
+    const [mineEncoded] = mint().split(".");
+
+    const result = verify(`${mineEncoded}.${otherSignature}`);
+
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+});
+
+describe("deriveStatePrincipal", () => {
+  test("prefers the individual user", () => {
+    expect(
+      deriveStatePrincipal({
+        userId: "u1",
+        tokenId: "t1",
+        organizationId: "o1",
+      }),
+    ).toBe("user:u1");
+  });
+
+  test("falls back to the token for org and team tokens", () => {
+    expect(deriveStatePrincipal({ tokenId: "t1", organizationId: "o1" })).toBe(
+      "token:t1",
+    );
+  });
+
+  test("distinct callers never collapse onto the same principal", () => {
+    const a = deriveStatePrincipal({ userId: "u1" });
+    const b = deriveStatePrincipal({ userId: "u2" });
+    const c = deriveStatePrincipal({ tokenId: "u1" });
+
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+});
+
+describe("InputRequiredResult", () => {
+  test("carries the input_required result type", () => {
+    const result = buildInputRequiredResult({
+      inputRequests: {
+        github_login: {
+          method: "elicitation/create",
+          params: { message: "Sign in" },
+        },
+      },
+      requestState: "state",
+    });
+
+    expect(result.resultType).toBe("input_required");
+    expect(result.inputRequests?.github_login.method).toBe(
+      "elicitation/create",
+    );
+  });
+
+  test("refuses a result a client could not act on", () => {
+    // The spec requires at least one of the two fields.
+    expect(() => buildInputRequiredResult({})).toThrow();
+  });
+});
+
+describe("supported methods", () => {
+  test("only the three methods the spec allows may ask for input", () => {
+    expect(supportsInputRequired("tools/call")).toBe(true);
+    expect(supportsInputRequired("prompts/get")).toBe(true);
+    expect(supportsInputRequired("resources/read")).toBe(true);
+
+    expect(supportsInputRequired("tools/list")).toBe(false);
+    expect(supportsInputRequired("server/discover")).toBe(false);
+    expect(supportsInputRequired(undefined)).toBe(false);
+  });
+});
+
+describe("extractMrtrParams", () => {
+  test("reads the fields the SDK request schema drops", () => {
+    const extracted = extractMrtrParams({
+      method: "tools/call",
+      params: {
+        name: "t",
+        inputResponses: { k: { action: "accept" } },
+        requestState: "abc.def",
+      },
+    });
+
+    expect(extracted.requestState).toBe("abc.def");
+    expect(extracted.inputResponses).toEqual({ k: { action: "accept" } });
+  });
+
+  test("ignores fields of the wrong shape", () => {
+    const extracted = extractMrtrParams({
+      params: { inputResponses: "not-an-object", requestState: 42 },
+    });
+
+    expect(extracted).toEqual({});
+  });
+
+  test("tolerates a body with no params", () => {
+    expect(extractMrtrParams({ method: "tools/call" })).toEqual({});
+    expect(extractMrtrParams(null)).toEqual({});
+  });
+});
+
+describe("clientSupportsInputRequest", () => {
+  test("permits a request the client declared", () => {
+    expect(
+      clientSupportsInputRequest({
+        clientCapabilities: { elicitation: {} },
+        request: { method: "elicitation/create" },
+      }),
+    ).toBe(true);
+  });
+
+  test("refuses a request the client never declared", () => {
+    // The spec forbids asking a client for something it cannot do.
+    expect(
+      clientSupportsInputRequest({
+        clientCapabilities: { sampling: {} },
+        request: { method: "elicitation/create" },
+      }),
+    ).toBe(false);
+  });
+
+  test("absent capabilities permit nothing", () => {
+    expect(
+      clientSupportsInputRequest({
+        clientCapabilities: undefined,
+        request: { method: "elicitation/create" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/platform/backend/src/routes/mcp-gateway.mrtr.ts
+++ b/platform/backend/src/routes/mcp-gateway.mrtr.ts
@@ -39,6 +39,17 @@ export const MRTR_SUPPORTED_METHODS = new Set([
  */
 export const REQUEST_STATE_TTL_MS = 10 * 60 * 1000;
 
+/**
+ * How many times one logical call may bounce back for input.
+ *
+ * Each retry re-runs the tool from the top — the gateway keeps no continuation,
+ * which is the whole point of MRTR — so an upstream that elicits on every
+ * attempt would re-execute whatever it does before eliciting, once per round,
+ * while prompting the user forever. The cap bounds both. It is deliberately
+ * small: a tool needing more than a few rounds is asking the wrong way.
+ */
+export const MAX_INPUT_ROUNDS = 3;
+
 const STATE_VERSION = 1;
 
 /**
@@ -74,6 +85,8 @@ export type RequestStatePayload = {
   exp: number;
   /** Keys issued in the matching `inputRequests`. */
   keys: string[];
+  /** How many rounds of input this call has already taken. */
+  round: number;
 };
 
 export type VerifyFailure =
@@ -161,9 +174,17 @@ export function encodeRequestState(params: {
   method: string;
   requestParams: unknown;
   keys: string[];
+  round?: number;
   now?: number;
 }): string {
-  const { principal, method, requestParams, keys, now = Date.now() } = params;
+  const {
+    principal,
+    method,
+    requestParams,
+    keys,
+    round = 1,
+    now = Date.now(),
+  } = params;
 
   const payload: RequestStatePayload = {
     v: STATE_VERSION,
@@ -172,6 +193,7 @@ export function encodeRequestState(params: {
     paramsDigest: digestRequestParams(method, requestParams),
     exp: now + REQUEST_STATE_TTL_MS,
     keys: [...keys].sort(),
+    round,
   };
 
   const encoded = base64UrlEncode(JSON.stringify(payload));

--- a/platform/backend/src/routes/mcp-gateway.mrtr.ts
+++ b/platform/backend/src/routes/mcp-gateway.mrtr.ts
@@ -1,0 +1,442 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+import config from "@/config";
+
+/**
+ * Multi Round-Trip Requests (MRTR).
+ *
+ * Under 2026-07-28 a server may no longer open a server-to-client request
+ * mid-call. Instead it answers with an `InputRequiredResult` describing what it
+ * needs, and the client re-sends the *original* request with the answers
+ * attached. The two requests are fully independent, so any replica can serve
+ * the retry — which is the point, and a good fit for our multi-replica gateway.
+ *
+ * The server carries no state between the two. Everything it needs is encoded
+ * into `requestState`, which travels through the client and therefore must be
+ * treated as attacker-controlled: the spec requires integrity protection, and
+ * requires rejecting state that fails it. This module owns that.
+ */
+
+export const INPUT_REQUIRED_RESULT_TYPE = "input_required";
+export const COMPLETE_RESULT_TYPE = "complete";
+
+/**
+ * The only client requests that may answer with an `InputRequiredResult`.
+ * Anything else must not, so the gateway never widens this set by accident.
+ */
+export const MRTR_SUPPORTED_METHODS = new Set([
+  "tools/call",
+  "prompts/get",
+  "resources/read",
+]);
+
+/**
+ * How long a `requestState` stays redeemable.
+ *
+ * Short by design: it bounds the replay window. It still has to outlast a human
+ * completing an interactive prompt (an OAuth consent screen, say), so this is a
+ * compromise rather than a value to minimise freely.
+ */
+export const REQUEST_STATE_TTL_MS = 10 * 60 * 1000;
+
+const STATE_VERSION = 1;
+
+/**
+ * Domain separator, so a signature minted here can never be mistaken for one
+ * produced elsewhere from the same underlying secret.
+ */
+const HMAC_DOMAIN = "archestra.mcp-gateway.mrtr.request-state.v1";
+
+export type InputRequest = {
+  method: "elicitation/create" | "sampling/createMessage" | "roots/list";
+  params?: Record<string, unknown>;
+};
+
+export type InputRequests = Record<string, InputRequest>;
+export type InputResponses = Record<string, unknown>;
+
+export type InputRequiredResult = {
+  resultType: typeof INPUT_REQUIRED_RESULT_TYPE;
+  inputRequests?: InputRequests;
+  requestState?: string;
+};
+
+export type RequestStatePayload = {
+  /** Schema version, so the format can change without accepting old blobs. */
+  v: number;
+  /** Authenticated principal the state was minted for. */
+  principal: string;
+  /** Originating request method. */
+  method: string;
+  /** Digest of the salient request parameters. */
+  paramsDigest: string;
+  /** Absolute expiry, epoch milliseconds. */
+  exp: number;
+  /** Keys issued in the matching `inputRequests`. */
+  keys: string[];
+};
+
+export type VerifyFailure =
+  | "malformed"
+  | "bad_signature"
+  | "expired"
+  | "principal_mismatch"
+  | "request_mismatch"
+  | "unsupported_version";
+
+export type VerifyResult =
+  | { ok: true; payload: RequestStatePayload }
+  | { ok: false; reason: VerifyFailure };
+
+/**
+ * Thrown from deep inside tool execution when the gateway needs input it does
+ * not have.
+ *
+ * An exception rather than a return value because the need surfaces several
+ * frames down — inside the elicitation callback the MCP client invokes — and
+ * every frame between there and the request handler is typed to return a tool
+ * result. Unwinding is what lets the handler answer with an
+ * `InputRequiredResult` instead.
+ */
+export class InputRequiredSignal extends Error {
+  readonly key: string;
+  readonly request: InputRequest;
+
+  constructor(params: { key: string; request: InputRequest }) {
+    super(`MCP input required: ${params.request.method}`);
+    this.name = "InputRequiredSignal";
+    this.key = params.key;
+    this.request = params.request;
+  }
+}
+
+export function isInputRequiredSignal(
+  error: unknown,
+): error is InputRequiredSignal {
+  return error instanceof InputRequiredSignal;
+}
+
+/**
+ * The single input-request key the gateway issues.
+ *
+ * Keys need only be unique within one response, and the gateway asks for at
+ * most one thing at a time, so a constant keeps the retry correlation trivial.
+ */
+export const GATEWAY_INPUT_REQUEST_KEY = "gateway_elicitation";
+
+/**
+ * Build the `InputRequiredResult` a client sees when the gateway needs input.
+ *
+ * The spec requires at least one of `inputRequests` or `requestState`; callers
+ * that pass neither get an error rather than a result no client can act on.
+ */
+export function buildInputRequiredResult(params: {
+  inputRequests?: InputRequests;
+  requestState?: string;
+}): InputRequiredResult {
+  const { inputRequests, requestState } = params;
+
+  if (!inputRequests && !requestState) {
+    throw new Error(
+      "InputRequiredResult requires at least one of inputRequests or requestState",
+    );
+  }
+
+  return {
+    resultType: INPUT_REQUIRED_RESULT_TYPE,
+    ...(inputRequests && { inputRequests }),
+    ...(requestState && { requestState }),
+  };
+}
+
+/**
+ * Mint a signed `requestState`.
+ *
+ * The payload binds the state to a principal, an originating request, and an
+ * expiry. Verification checks all three, which is what stops the blob being
+ * replayed by another user, against a different call, or indefinitely.
+ */
+export function encodeRequestState(params: {
+  principal: string;
+  method: string;
+  requestParams: unknown;
+  keys: string[];
+  now?: number;
+}): string {
+  const { principal, method, requestParams, keys, now = Date.now() } = params;
+
+  const payload: RequestStatePayload = {
+    v: STATE_VERSION,
+    principal,
+    method,
+    paramsDigest: digestRequestParams(method, requestParams),
+    exp: now + REQUEST_STATE_TTL_MS,
+    keys: [...keys].sort(),
+  };
+
+  const encoded = base64UrlEncode(JSON.stringify(payload));
+  return `${encoded}.${sign(encoded)}`;
+}
+
+/**
+ * Verify a `requestState` presented on a retry.
+ *
+ * Order matters: the signature is checked before the payload is trusted for
+ * anything, so a forged blob never reaches the comparisons below it.
+ */
+export function verifyRequestState(params: {
+  state: string;
+  principal: string;
+  method: string;
+  requestParams: unknown;
+  now?: number;
+}): VerifyResult {
+  const { state, principal, method, requestParams, now = Date.now() } = params;
+
+  const separator = state.lastIndexOf(".");
+  if (separator <= 0 || separator === state.length - 1) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  const encoded = state.slice(0, separator);
+  const signature = state.slice(separator + 1);
+
+  if (!verifySignature(encoded, signature)) {
+    return { ok: false, reason: "bad_signature" };
+  }
+
+  let payload: RequestStatePayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(encoded)) as RequestStatePayload;
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+
+  if (payload?.v !== STATE_VERSION) {
+    return { ok: false, reason: "unsupported_version" };
+  }
+
+  if (typeof payload.exp !== "number" || payload.exp <= now) {
+    return { ok: false, reason: "expired" };
+  }
+
+  // Cross-user replay: a blob minted for one caller must not be redeemable by
+  // another, even though both may hold a valid token for the same gateway.
+  if (payload.principal !== principal) {
+    return { ok: false, reason: "principal_mismatch" };
+  }
+
+  // Cross-request replay: state minted while eliciting for one tool call must
+  // not authorise a different one.
+  if (
+    payload.method !== method ||
+    payload.paramsDigest !== digestRequestParams(method, requestParams)
+  ) {
+    return { ok: false, reason: "request_mismatch" };
+  }
+
+  return { ok: true, payload };
+}
+
+/**
+ * The principal a `requestState` is bound to.
+ *
+ * Prefers the individual user; falls back to the token identity for org and
+ * team tokens, which have no single user behind them. Two different callers can
+ * never collapse onto the same string, which is what the binding relies on.
+ */
+export function deriveStatePrincipal(auth: {
+  userId?: string;
+  tokenId?: string;
+  organizationId?: string;
+}): string {
+  if (auth.userId) return `user:${auth.userId}`;
+  if (auth.tokenId) return `token:${auth.tokenId}`;
+  if (auth.organizationId) return `org:${auth.organizationId}`;
+  return "anonymous";
+}
+
+/**
+ * Whether a method may answer with an `InputRequiredResult`.
+ */
+export function supportsInputRequired(method: string | undefined): boolean {
+  return typeof method === "string" && MRTR_SUPPORTED_METHODS.has(method);
+}
+
+/**
+ * Read the MRTR fields a client sends on a retry.
+ *
+ * These come from the raw JSON-RPC body rather than the parsed request: the
+ * bundled SDK's `CallToolRequestSchema` drops unknown params, so by the time a
+ * request handler runs, both fields are already gone.
+ */
+export function extractMrtrParams(body: unknown): {
+  inputResponses?: InputResponses;
+  requestState?: string;
+} {
+  if (typeof body !== "object" || body === null) return {};
+  const params = (body as { params?: unknown }).params;
+  if (typeof params !== "object" || params === null) return {};
+
+  const { inputResponses, requestState } = params as {
+    inputResponses?: unknown;
+    requestState?: unknown;
+  };
+
+  return {
+    ...(isPlainObject(inputResponses) && {
+      inputResponses: inputResponses as InputResponses,
+    }),
+    ...(typeof requestState === "string" && { requestState }),
+  };
+}
+
+/**
+ * Client capabilities as carried on each request under 2026-07-28, replacing
+ * what `initialize` negotiated once per connection.
+ */
+export function readClientCapabilities(body: unknown): unknown {
+  if (typeof body !== "object" || body === null) return undefined;
+  const params = (body as { params?: unknown }).params;
+  if (typeof params !== "object" || params === null) return undefined;
+  const meta = (params as { _meta?: unknown })._meta;
+  if (typeof meta !== "object" || meta === null) return undefined;
+  return (meta as Record<string, unknown>)[MCP_CLIENT_CAPABILITIES_META_KEY];
+}
+
+/**
+ * `_meta` key carrying client capabilities on every request.
+ */
+export const MCP_CLIENT_CAPABILITIES_META_KEY =
+  "io.modelcontextprotocol/clientCapabilities";
+
+/**
+ * Whether the client declared support for the capability an input request
+ * needs. The spec forbids asking a client for something it never said it could
+ * do, so an undeclared capability means the gateway must fail the call rather
+ * than elicit into the void.
+ */
+export function clientSupportsInputRequest(params: {
+  clientCapabilities: unknown;
+  request: InputRequest;
+}): boolean {
+  const { clientCapabilities, request } = params;
+  if (!isPlainObject(clientCapabilities)) return false;
+
+  const capabilityName = CAPABILITY_BY_METHOD[request.method];
+  if (!capabilityName) return false;
+
+  return capabilityName in (clientCapabilities as Record<string, unknown>);
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+const CAPABILITY_BY_METHOD: Record<string, string> = {
+  "elicitation/create": "elicitation",
+  "sampling/createMessage": "sampling",
+  "roots/list": "roots",
+};
+
+/**
+ * Derived from the session-signing secret rather than a new env var, so an
+ * existing deployment gains MRTR without new configuration. Deployments have a
+ * secret already; without one the gateway cannot sign, and callers below fail
+ * closed rather than emitting unprotected state.
+ */
+function hmacKey(): string | null {
+  const secret = config.auth.secret;
+  if (!secret) return null;
+  return createHmac("sha256", secret).update(HMAC_DOMAIN).digest("hex");
+}
+
+function sign(encoded: string): string {
+  const key = hmacKey();
+  if (!key) {
+    throw new Error(
+      "Cannot sign MRTR request state: no auth secret is configured",
+    );
+  }
+  return createHmac("sha256", key).update(encoded).digest("base64url");
+}
+
+function verifySignature(encoded: string, signature: string): boolean {
+  const key = hmacKey();
+  if (!key) return false;
+
+  const expected = createHmac("sha256", key)
+    .update(encoded)
+    .digest("base64url");
+  const a = Buffer.from(expected);
+  const b = Buffer.from(signature);
+
+  // Length must match before timingSafeEqual, which throws on a mismatch —
+  // and the comparison stays constant-time for equal-length input.
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Digest of the fields that identify a request.
+ *
+ * Only the identifying fields are digested, never the whole params object. The
+ * two sides see different objects — the signing side has the parsed request,
+ * the verifying side has the raw JSON-RPC body, which also carries `_meta` and
+ * the MRTR fields — so digesting everything would make every retry fail to
+ * match. Narrowing to the fields that actually name the operation is what lets
+ * both sides agree.
+ */
+function digestRequestParams(method: string, requestParams: unknown): string {
+  return createHash("sha256")
+    .update(stableStringify(canonicalRequestParams(method, requestParams)))
+    .digest("base64url");
+}
+
+function canonicalRequestParams(
+  method: string,
+  requestParams: unknown,
+): Record<string, unknown> {
+  if (!isPlainObject(requestParams)) return {};
+  const params = requestParams as Record<string, unknown>;
+
+  switch (method) {
+    case "tools/call":
+    case "prompts/get":
+      return { name: params.name ?? null, arguments: params.arguments ?? {} };
+    case "resources/read":
+      return { uri: params.uri ?? null };
+    default:
+      return {};
+  }
+}
+
+/**
+ * Key-ordered JSON, so two structurally equal parameter objects always digest
+ * the same regardless of the order the client happened to serialise them in.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+
+  return `{${entries.join(",")}}`;
+}
+
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function base64UrlDecode(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function isPlainObject(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/platform/backend/src/routes/mcp-gateway.ts
+++ b/platform/backend/src/routes/mcp-gateway.ts
@@ -130,6 +130,8 @@ async function handleMcpPostRequest(
   profileId: string,
   tokenAuthContext: TokenAuthContext | undefined,
   resolution: ProtocolResolution,
+  /** Rounds already spent on this call, from a verified requestState. */
+  mrtrRound: number,
 ): Promise<unknown> {
   const { revision } = resolution;
   const body = request.body as Record<string, unknown>;
@@ -161,6 +163,7 @@ async function handleMcpPostRequest(
         // client keeps the in-band elicitation it has always used.
         enabled: revision === STATELESS_MCP_PROTOCOL_REVISION,
         inputResponses: mrtrParams.inputResponses,
+        round: mrtrRound,
         clientCapabilities: readClientCapabilities(body),
       },
     });
@@ -413,6 +416,7 @@ const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
       // An MRTR retry carries state the gateway minted. It travels through the
       // client, so it is verified — signature, principal, expiry, and the
       // originating request — before anything acts on it.
+      let mrtrRound = 0;
       const retryState = extractMrtrParams(request.body).requestState;
       if (retryState) {
         const method = (request.body as { method?: string })?.method;
@@ -438,6 +442,10 @@ const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
           method: method as string,
           requestParams: (request.body as { params?: unknown })?.params,
         });
+
+        if (verified.ok) {
+          mrtrRound = verified.payload.round;
+        }
 
         if (!verified.ok) {
           reply.status(400);
@@ -515,6 +523,7 @@ const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
         profileId,
         tokenAuthContext,
         resolution,
+        mrtrRound,
       );
     },
   );

--- a/platform/backend/src/routes/mcp-gateway.ts
+++ b/platform/backend/src/routes/mcp-gateway.ts
@@ -8,6 +8,13 @@ import config from "@/config";
 import { AgentModel, McpToolCallModel } from "@/models";
 import { UuidOrSlugSchema } from "@/types";
 import {
+  deriveStatePrincipal,
+  extractMrtrParams,
+  readClientCapabilities,
+  supportsInputRequired,
+  verifyRequestState,
+} from "./mcp-gateway.mrtr";
+import {
   buildDiscoverResult,
   isDiscoverRequest,
   MCP_PROTOCOL_VERSION_HEADER,
@@ -126,6 +133,10 @@ async function handleMcpPostRequest(
 ): Promise<unknown> {
   const { revision } = resolution;
   const body = request.body as Record<string, unknown>;
+
+  // Read from the raw body: the SDK's request schemas drop unknown params, so
+  // these are gone by the time a request handler runs.
+  const mrtrParams = extractMrtrParams(body);
   const isInitialize =
     typeof body?.method === "string" && body.method === "initialize";
 
@@ -142,7 +153,17 @@ async function handleMcpPostRequest(
 
   try {
     // Create fresh server and transport for each request (stateless mode)
-    const { server } = await createAgentServer(profileId, tokenAuthContext);
+    const { server } = await createAgentServer({
+      agentId: profileId,
+      tokenAuth: tokenAuthContext,
+      mrtr: {
+        // Only a 2026-07-28 client can act on an InputRequiredResult. A legacy
+        // client keeps the in-band elicitation it has always used.
+        enabled: revision === STATELESS_MCP_PROTOCOL_REVISION,
+        inputResponses: mrtrParams.inputResponses,
+        clientCapabilities: readClientCapabilities(body),
+      },
+    });
     const transport = createStatelessTransport(profileId);
 
     fastify.log.trace({ profileId }, "Connecting server to transport");
@@ -387,6 +408,48 @@ const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
           error: { code: routingError.code, message: routingError.message },
           id: (request.body as { id?: string | number })?.id ?? null,
         };
+      }
+
+      // An MRTR retry carries state the gateway minted. It travels through the
+      // client, so it is verified — signature, principal, expiry, and the
+      // originating request — before anything acts on it.
+      const retryState = extractMrtrParams(request.body).requestState;
+      if (retryState) {
+        const method = (request.body as { method?: string })?.method;
+        if (!supportsInputRequired(method)) {
+          reply.status(400);
+          return {
+            jsonrpc: "2.0",
+            error: {
+              code: -32602,
+              message: `requestState is not valid on "${method}".`,
+            },
+            id: (request.body as { id?: string | number })?.id ?? null,
+          };
+        }
+
+        const verified = verifyRequestState({
+          state: retryState,
+          principal: deriveStatePrincipal({
+            userId: tokenAuth.userId,
+            tokenId: tokenAuth.tokenId,
+            organizationId: tokenAuth.organizationId,
+          }),
+          method: method as string,
+          requestParams: (request.body as { params?: unknown })?.params,
+        });
+
+        if (!verified.ok) {
+          reply.status(400);
+          return {
+            jsonrpc: "2.0",
+            error: {
+              code: -32602,
+              message: `Invalid requestState (${verified.reason}).`,
+            },
+            id: (request.body as { id?: string | number })?.id ?? null,
+          };
+        }
       }
 
       // `server/discover` replaces the `initialize` handshake under 2026-07-28.

--- a/platform/backend/src/routes/mcp-gateway.utils.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.test.ts
@@ -1611,7 +1611,7 @@ describe("createAgentServer tools/list", () => {
       iconLogo: null,
     });
 
-    const { server } = await createAgentServer(agent.id);
+    const { server } = await createAgentServer({ agentId: agent.id });
     const listToolsHandler = (
       server.server as unknown as {
         _requestHandlers: Map<string, TestListToolsHandler>;
@@ -1647,7 +1647,7 @@ describe("createAgentServer tools/list", () => {
       toolExposureMode: "search_and_run_only",
     });
 
-    const { server } = await createAgentServer(agent.id);
+    const { server } = await createAgentServer({ agentId: agent.id });
     const listToolsHandler = (
       server.server as unknown as {
         _requestHandlers: Map<string, TestListToolsHandler>;
@@ -1696,13 +1696,16 @@ describe("createAgentServer tools/list", () => {
       });
       await seedAndAssignArchestraTools(agent.id);
 
-      const { server } = await createAgentServer(agent.id, {
-        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-        teamId: null,
-        isOrganizationToken: false,
-        organizationId: org.id,
-        isUserToken: true,
-        userId: adminUser.id,
+      const { server } = await createAgentServer({
+        agentId: agent.id,
+        tokenAuth: {
+          tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          isUserToken: true,
+          userId: adminUser.id,
+        },
       });
       const listToolsHandler = (
         server.server as unknown as {
@@ -1782,13 +1785,16 @@ describe("createAgentServer tools/list", () => {
     await makeAgentTool(agent.id, uiTool.id);
     await makeAgentTool(agent.id, plainTool.id);
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -1854,13 +1860,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeAgentTool(agent.id, uiTool.id);
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -1924,13 +1933,16 @@ describe("createAgentServer tools/list", () => {
         },
       });
 
-      const { server } = await createAgentServer(agent.id, {
-        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-        teamId: null,
-        isOrganizationToken: false,
-        organizationId: org.id,
-        isUserToken: true,
-        userId: user.id,
+      const { server } = await createAgentServer({
+        agentId: agent.id,
+        tokenAuth: {
+          tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          isUserToken: true,
+          userId: user.id,
+        },
       });
       const listToolsHandler = (
         server.server as unknown as {
@@ -1988,13 +2000,16 @@ describe("createAgentServer tools/list", () => {
       },
     });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2069,13 +2084,16 @@ describe("createAgentServer tools/list", () => {
       excludedToolIds: [excludedTool.id],
     });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2131,13 +2149,16 @@ describe("createAgentServer tools/list", () => {
       meta: { _meta: { ui: { resourceUri: "ui://archestra-app/get-time" } } },
     });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2191,13 +2212,16 @@ describe("createAgentServer tools/list", () => {
         accessAllTools: true,
         agentType,
       });
-      const { server } = await createAgentServer(agent.id, {
-        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-        teamId: null,
-        isOrganizationToken: false,
-        organizationId: org.id,
-        isUserToken: true,
-        userId: user.id,
+      const { server } = await createAgentServer({
+        agentId: agent.id,
+        tokenAuth: {
+          tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          isUserToken: true,
+          userId: user.id,
+        },
       });
       const handler = (
         server.server as unknown as {
@@ -2254,13 +2278,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeAgentTool(agent.id, openTool.id);
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2315,13 +2342,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeAgentTool(agent.id, openTool.id);
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2365,13 +2395,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeAgentTool(agent.id, uiTool.id);
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2428,13 +2461,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2500,13 +2536,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2571,13 +2610,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeMcpServer({ catalogId: dynamicCatalog.id, scope: "org" });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2639,7 +2681,7 @@ describe("createAgentServer tools/list", () => {
     await makeAgentTool(agent.id, httpsTool.id);
     await makeAgentTool(agent.id, maskedLegacyTool.id);
 
-    const { server } = await createAgentServer(agent.id);
+    const { server } = await createAgentServer({ agentId: agent.id });
     const listToolsHandler = (
       server.server as unknown as {
         _requestHandlers: Map<string, TestListToolsHandler>;
@@ -2687,7 +2729,7 @@ describe("createAgentServer tools/list", () => {
     // No tokenAuth: dynamic access is user-scoped, so without a user there is
     // no accessible-tool set to widen from — the listing must succeed with the
     // tool absent, not throw.
-    const { server } = await createAgentServer(agent.id);
+    const { server } = await createAgentServer({ agentId: agent.id });
     const listToolsHandler = (
       server.server as unknown as {
         _requestHandlers: Map<string, TestListToolsHandler>;
@@ -2738,13 +2780,16 @@ describe("createAgentServer tools/list", () => {
     await makeAgentTool(agent.id, uiTool.id);
     await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2803,13 +2848,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeMcpServer({ catalogId: catalog.id, scope: "org" });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -2887,13 +2935,16 @@ describe("createAgentServer tools/list", () => {
       });
 
     try {
-      const { server } = await createAgentServer(agent.id, {
-        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-        teamId: null,
-        isOrganizationToken: false,
-        organizationId: org.id,
-        isUserToken: true,
-        userId: user.id,
+      const { server } = await createAgentServer({
+        agentId: agent.id,
+        tokenAuth: {
+          tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          isUserToken: true,
+          userId: user.id,
+        },
       });
       const callToolHandler = (
         server.server as unknown as {
@@ -2975,13 +3026,16 @@ describe("createAgentServer tools/list", () => {
     );
 
     try {
-      const { server } = await createAgentServer(agent.id, {
-        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-        teamId: null,
-        isOrganizationToken: false,
-        organizationId: org.id,
-        isUserToken: true,
-        userId: user.id,
+      const { server } = await createAgentServer({
+        agentId: agent.id,
+        tokenAuth: {
+          tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          isUserToken: true,
+          userId: user.id,
+        },
       });
       const callToolHandler = (
         server.server as unknown as {
@@ -3047,13 +3101,16 @@ describe("createAgentServer tools/list", () => {
     await seedAndAssignArchestraTools(chatAgent.id);
 
     const listFor = async (agentId: string) => {
-      const { server } = await createAgentServer(agentId, {
-        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-        teamId: null,
-        isOrganizationToken: false,
-        organizationId: org.id,
-        isUserToken: true,
-        userId: user.id,
+      const { server } = await createAgentServer({
+        agentId: agentId,
+        tokenAuth: {
+          tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          isUserToken: true,
+          userId: user.id,
+        },
       });
       const listToolsHandler = (
         server.server as unknown as {
@@ -3103,13 +3160,16 @@ describe("createAgentServer tools/list", () => {
     });
 
     const callRenderApp = async (agentId: string) => {
-      const { server } = await createAgentServer(agentId, {
-        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-        teamId: null,
-        isOrganizationToken: false,
-        organizationId: org.id,
-        isUserToken: true,
-        userId: user.id,
+      const { server } = await createAgentServer({
+        agentId: agentId,
+        tokenAuth: {
+          tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+          teamId: null,
+          isOrganizationToken: false,
+          organizationId: org.id,
+          isUserToken: true,
+          userId: user.id,
+        },
       });
       const callToolHandler = (
         server.server as unknown as {
@@ -3189,7 +3249,7 @@ describe("createAgentServer tools/list", () => {
     });
     await makeAgentTool(agent.id, notesTool.id);
 
-    const { server } = await createAgentServer(agent.id);
+    const { server } = await createAgentServer({ agentId: agent.id });
     const listToolsHandler = (
       server.server as unknown as {
         _requestHandlers: Map<string, TestListToolsHandler>;
@@ -3248,7 +3308,7 @@ describe("createAgentServer tools/list", () => {
       await makeAgentTool(agent.id, tool.id);
     }
 
-    const { server } = await createAgentServer(agent.id);
+    const { server } = await createAgentServer({ agentId: agent.id });
     const listToolsHandler = (
       server.server as unknown as {
         _requestHandlers: Map<string, TestListToolsHandler>;
@@ -3316,13 +3376,16 @@ describe("createAgentServer tools/list", () => {
     });
     await makeMcpServer({ catalogId: discoverableCatalog.id, scope: "org" });
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: user.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: user.id,
+      },
     });
     const listToolsHandler = (
       server.server as unknown as {
@@ -3364,13 +3427,16 @@ describe("createAgentServer tools/list", () => {
     });
     await seedAndAssignArchestraTools(agent.id);
 
-    const { server } = await createAgentServer(agent.id, {
-      tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
-      teamId: null,
-      isOrganizationToken: false,
-      organizationId: org.id,
-      isUserToken: true,
-      userId: adminUser.id,
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth: {
+        tokenId: `${OAUTH_TOKEN_ID_PREFIX}${crypto.randomUUID()}`,
+        teamId: null,
+        isOrganizationToken: false,
+        organizationId: org.id,
+        isUserToken: true,
+        userId: adminUser.id,
+      },
     });
     const callToolHandler = (
       server.server as unknown as {
@@ -3433,7 +3499,7 @@ describe("createAgentServer tools/list", () => {
       });
 
     try {
-      const { server } = await createAgentServer(agent.id);
+      const { server } = await createAgentServer({ agentId: agent.id });
       const callToolHandler = (
         server.server as unknown as {
           _requestHandlers: Map<string, TestCallToolHandler>;
@@ -3555,7 +3621,7 @@ describe("createAgentServer tools/list", () => {
     await makeAgentTool(agent.id, brokenTool.id);
     await makeAgentTool(agent.id, healthyTool.id);
 
-    const { server } = await createAgentServer(agent.id);
+    const { server } = await createAgentServer({ agentId: agent.id });
     const listToolsHandler = (
       server.server as unknown as {
         _requestHandlers: Map<string, TestListToolsHandler>;

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -113,6 +113,7 @@ import {
   InputRequiredSignal,
   type InputResponses,
   isInputRequiredSignal,
+  MAX_INPUT_ROUNDS,
 } from "./mcp-gateway.mrtr";
 import {
   buildGatewayServerCapabilities,
@@ -247,6 +248,8 @@ export async function createAgentServer(params: {
     enabled: boolean;
     inputResponses?: InputResponses;
     clientCapabilities?: unknown;
+    /** Rounds already spent, read from a verified requestState. */
+    round?: number;
   };
 }): Promise<{ server: McpServer; agent: AgentInfo }> {
   const { agentId, tokenAuth, mrtr } = params;
@@ -1008,9 +1011,27 @@ export async function createAgentServer(params: {
             });
           }
 
+          const nextRound = (mrtr?.round ?? 0) + 1;
+          if (nextRound > MAX_INPUT_ROUNDS) {
+            // Each round re-runs the tool from the top, so an upstream that
+            // keeps asking would re-execute its side effects once per round
+            // and prompt the user indefinitely. Stop rather than loop.
+            logger.warn(
+              { agentId, toolName: name, rounds: nextRound },
+              "MCP tool exceeded the input-round cap; refusing to elicit again",
+            );
+            return structuredToolErrorResult({
+              error: {
+                type: "generic",
+                message: `This tool asked for input more than ${MAX_INPUT_ROUNDS} times without completing.`,
+              },
+            });
+          }
+
           return buildInputRequiredResult({
             inputRequests: { [error.key]: error.request },
             requestState: encodeRequestState({
+              round: nextRound,
               principal: deriveStatePrincipal({
                 userId: tokenAuth?.userId,
                 tokenId: tokenAuth?.tokenId,

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -105,6 +105,16 @@ import { APP_LAUNCH_TOOL_NAME } from "@/types/app";
 import { deriveAuthMethod } from "@/utils/auth-method";
 import { estimateToolResultContentLength } from "@/utils/tool-result-preview";
 import {
+  buildInputRequiredResult,
+  clientSupportsInputRequest,
+  deriveStatePrincipal,
+  encodeRequestState,
+  GATEWAY_INPUT_REQUEST_KEY,
+  InputRequiredSignal,
+  type InputResponses,
+  isInputRequiredSignal,
+} from "./mcp-gateway.mrtr";
+import {
   buildGatewayServerCapabilities,
   buildPrivateListCacheHint,
   isResourceUnavailableError,
@@ -226,10 +236,21 @@ const rawArchestraTokenCache =
 /**
  * Creates an MCP server for the given agent.
  */
-export async function createAgentServer(
-  agentId: string,
-  tokenAuth?: TokenAuthContext,
-): Promise<{ server: McpServer; agent: AgentInfo }> {
+export async function createAgentServer(params: {
+  agentId: string;
+  tokenAuth?: TokenAuthContext;
+  /**
+   * Answers the client supplied on an MRTR retry, keyed as they were issued.
+   * Absent on a first attempt, which is what makes the gateway elicit.
+   */
+  mrtr?: {
+    enabled: boolean;
+    inputResponses?: InputResponses;
+    clientCapabilities?: unknown;
+  };
+}): Promise<{ server: McpServer; agent: AgentInfo }> {
+  const { agentId, tokenAuth, mrtr } = params;
+  const mrtrEnabled = mrtr?.enabled === true;
   const mcpServer = new McpServer(
     {
       name: `archestra-agent-${agentId}`,
@@ -877,6 +898,27 @@ export async function createAgentServer(
               {
                 availableTool,
                 elicitationHandler: async (request) => {
+                  // MRTR: a retry already carries the answer, so consume it
+                  // instead of asking again.
+                  const supplied =
+                    mrtr?.inputResponses?.[GATEWAY_INPUT_REQUEST_KEY];
+                  if (supplied !== undefined) {
+                    return ElicitResultSchema.parse(supplied);
+                  }
+
+                  // Under 2026-07-28 a server may not open a request mid-call,
+                  // so unwind and let the handler answer with an
+                  // InputRequiredResult carrying this request.
+                  if (mrtrEnabled) {
+                    throw new InputRequiredSignal({
+                      key: GATEWAY_INPUT_REQUEST_KEY,
+                      request: {
+                        method: "elicitation/create",
+                        params: request.params as Record<string, unknown>,
+                      },
+                    });
+                  }
+
                   try {
                     return await extra.sendRequest(request, ElicitResultSchema);
                   } catch (error) {
@@ -944,6 +986,43 @@ export async function createAgentServer(
           structuredContent: result.structuredContent,
         };
       } catch (error) {
+        // MRTR: not a failure. The call needs input the gateway does not have,
+        // so it answers with an InputRequiredResult and the client retries the
+        // whole call with the answer attached. Handled before the metrics below
+        // so it is not counted as an errored tool call.
+        if (isInputRequiredSignal(error)) {
+          if (
+            !clientSupportsInputRequest({
+              clientCapabilities: mrtr?.clientCapabilities,
+              request: error.request,
+            })
+          ) {
+            // Asking a client for something it never declared is forbidden, and
+            // it could not answer anyway — fail with a result the model can act
+            // on rather than eliciting into the void.
+            return structuredToolErrorResult({
+              error: {
+                type: "generic",
+                message: `This tool needs ${error.request.method}, which this client does not support.`,
+              },
+            });
+          }
+
+          return buildInputRequiredResult({
+            inputRequests: { [error.key]: error.request },
+            requestState: encodeRequestState({
+              principal: deriveStatePrincipal({
+                userId: tokenAuth?.userId,
+                tokenId: tokenAuth?.tokenId,
+                organizationId: tokenAuth?.organizationId,
+              }),
+              method: "tools/call",
+              requestParams: { name, arguments: args ?? {} },
+              keys: [error.key],
+            }),
+          });
+        }
+
         const durationSeconds = (Date.now() - startTime) / 1000;
         metrics.mcp.reportMcpToolCall({
           agentId: agent.id,

--- a/platform/backend/src/routes/mcp-proxy.ts
+++ b/platform/backend/src/routes/mcp-proxy.ts
@@ -168,7 +168,10 @@ const mcpProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         if (cachedServer) {
           server = cachedServer;
         } else {
-          ({ server } = await createAgentServer(agentId, sessionTokenAuth));
+          ({ server } = await createAgentServer({
+            agentId: agentId,
+            tokenAuth: sessionTokenAuth,
+          }));
         }
 
         const transport = createStatelessTransport(agentId);
@@ -177,7 +180,10 @@ const mcpProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         } catch {
           // Server still bound to previous transport (rare concurrent request);
           // replace it with a fresh one.
-          ({ server } = await createAgentServer(agentId, sessionTokenAuth));
+          ({ server } = await createAgentServer({
+            agentId: agentId,
+            tokenAuth: sessionTokenAuth,
+          }));
           await server.connect(transport);
         }
         serverHealthy = true;


### PR DESCRIPTION
Follow-up to #6907. Implements [MRTR](https://modelcontextprotocol.io/specification/draft/basic/patterns/mrtr) (SEP-2322), the largest of the items that PR deferred.

## Why it matters

Under 2026-07-28 a server may no longer open a server-to-client request mid-call — that pattern is gone, and it's a breaking change. Instead the server answers with an `InputRequiredResult`, the client re-sends the *original* request with the answers attached, and the two requests are fully independent. For a multi-replica gateway that's the real prize: elicitation stops requiring a live stream pinned to one pod.

## The substance is the security, not the JSON

`requestState` travels through the client, so the spec treats it as attacker-controlled and requires integrity protection plus rejection of state that fails it. The blob is HMAC-signed (key derived from the session secret, domain-separated) and bound to the three things the spec asks servers to verify:

| Bound to | Stops |
|---|---|
| Authenticated principal | One caller redeeming another's elicitation — both may hold valid tokens for the same gateway |
| Short expiry (10 min) | Indefinite replay |
| Originating request (method + digest of identifying params) | State minted for one tool call authorising a different one |

Signature is checked *before* the payload is trusted for anything, and compared with `timingSafeEqual`. 23 unit tests cover each rejection path.

One subtlety worth review: the digest covers only the **identifying** params, not the whole object. The two sides see different things — the signing side has the parsed request, the verifying side has the raw body including `_meta` and the MRTR fields — so digesting everything would make every retry fail. Both sides go through one canonicaliser.

## Two SDK behaviours that shaped this

Both verified empirically rather than assumed, which is what kept this from being built the wrong way:

1. **`CallToolRequestSchema` silently drops unknown params.** `inputResponses` and `requestState` never reach a request handler — the parse succeeds and the fields are simply gone. So MRTR cannot live inside the SDK handler; both are read from the raw JSON-RPC body at the route.
2. **Handler return values are sent verbatim**, with no outgoing validation. That's what allows a tool handler to answer with an `InputRequiredResult` instead of a tool result.

## Compatibility

Only a client that negotiated 2026-07-28 takes this path. A legacy client keeps the in-band elicitation it has always used — the `extra.sendRequest` branch is untouched and still covered by the existing auth-at-call-time tests.

If a client hasn't declared the capability an input request needs, the gateway returns an actionable tool error rather than eliciting into the void — the spec forbids asking for what a client never declared.

## Correction: re-execution, and what bounds it

An earlier revision of this description claimed re-execution was safe because auth elicits before the upstream tool runs. **That was wrong**, and checking it is what turned up the real behaviour:

- Auth never elicits — it signals through a structured `auth_required` result.
- The elicitation handler is registered on the **upstream** client (`configureMcpElicitation`).

So every elicitation on this path comes from an upstream server *mid-execution*. Re-running the call on retry re-runs whatever that server already did before it asked.

Re-execution itself can't be designed away: the gateway holds no continuation, and that is precisely what lets any replica serve the retry. Suspending the upstream call across two independent client requests would require the server-side state MRTR exists to remove.

Unbounded re-execution *can* be bounded, and now is. `requestState` carries a signed round counter, and the gateway refuses to elicit past a small cap rather than letting an upstream re-execute its side effects once per round while prompting the user forever. The counter lives inside the signed payload, so a client cannot inflate it — there is a test that tampering with it fails the signature.

**What a reviewer should still weigh:** a tool that does work, elicits, then does more work will repeat the first part, up to the cap. That is inherent to MRTR as specified, not to this implementation. A tool like that needs a continuation rather than a re-run.

## Testing

- **30 unit tests** on request-state security: signature, principal, expiry, request binding, round counter, and the malformed-input paths.
- **4 round-trip tests** through the real `tools/call` handler — elicit to `InputRequiredResult` (with state that genuinely verifies), then retry to completion — plus the undeclared-capability refusal and the legacy in-band path.
- **205 pass** across the 8 gateway/proxy suites. `tsc`, `biome`, and `knip` (dev + production) clean.

## Also in here

`createAgentServer` becomes an object parameter per the >2-params convention — 30 call sites, mechanical.

## Still not done from the 2026-07-28 changelog

Deliberately not bundled, since each conflicts with or is independent of this:

- `subscriptions/listen` replacing the GET endpoint and `resources/subscribe` — this one is genuinely large and *removes* something legacy clients use, so it needs revision-conditional transport behavior.
- Removal of `ping`, `logging/setLevel`, `notifications/roots/list_changed` — same problem: legacy clients still use them.
- `resultType` on every result (only `server/discover` and `InputRequiredResult` carry it today).
- `io.modelcontextprotocol/serverInfo` in each result's `_meta`.
- Tasks extension, tool-schema hardening (SEP-2106), outbound auth SEPs.

## Caveat, unchanged from #6907

The spec repo still has no `2026-07-28` directory — only `draft`, newest tag `2026-07-28-RC`. This targets the draft; the wire format could still shift.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
