### PR TITLE
fix(hackathon): extend the Apps Hackathon close to 30 July 00:00 UTC

### DIFF
--- a/platform/shared/app-recording.test.ts
+++ b/platform/shared/app-recording.test.ts
@@ -31,12 +31,12 @@ describe("isAppsHackathonOpen", () => {
     expect(isAppsHackathonOpen(APPS_HACKATHON_CLOSES_AT_MS)).toBe(false);
   });
 
-  it("spells the window as 22–29 July 2026, 00:00 UK (BST = UTC+1)", () => {
+  it("opens 22 July 2026 00:00 UK (BST = UTC+1) and closes 30 July 2026 00:00 UTC", () => {
     expect(new Date(APPS_HACKATHON_OPENS_AT_MS).toISOString()).toBe(
       "2026-07-21T23:00:00.000Z",
     );
     expect(new Date(APPS_HACKATHON_CLOSES_AT_MS).toISOString()).toBe(
-      "2026-07-28T23:00:00.000Z",
+      "2026-07-30T00:00:00.000Z",
     );
   });
 });

--- a/platform/shared/app-recording.ts
+++ b/platform/shared/app-recording.ts
@@ -20,10 +20,11 @@ import { parseFullToolName } from "./utils";
 // =============================================================================
 
 /**
- * The Apps Hackathon window: 00:00 on 22 July 2026 until 00:00 on 29 July
- * 2026, UK time. July is BST (UTC+1), so those instants are 23:00 UTC on the
- * 21st and the 28th — spelled in UTC rather than local time so every
- * deployment agrees on them regardless of server zone.
+ * The Apps Hackathon window: 00:00 on 22 July 2026, UK time (July is BST,
+ * UTC+1, so that instant is 23:00 UTC on the 21st), until 00:00 UTC on
+ * 30 July 2026 — the end of 29 July everywhere up to UTC. Spelled in UTC
+ * rather than local time so every deployment agrees on the bounds regardless
+ * of server zone.
  *
  * Outside this window the recorder hard-disables everywhere, whatever a
  * deployment or an organization still has switched on. The bounds are read at
@@ -33,16 +34,17 @@ import { parseFullToolName } from "./utils";
  * the recorder route and useAppsHackathonOffered).
  */
 export const APPS_HACKATHON_OPENS_AT_MS = Date.UTC(2026, 6, 21, 23, 0, 0);
-export const APPS_HACKATHON_CLOSES_AT_MS = Date.UTC(2026, 6, 28, 23, 0, 0);
+export const APPS_HACKATHON_CLOSES_AT_MS = Date.UTC(2026, 6, 30, 0, 0, 0);
 
 /**
  * The window above rendered as human copy for the UI. Kept here, next to the
  * epochs it describes, so the composer tooltip and the settings block share one
  * string that cannot drift from each other or lag the gate: whoever moves the
- * dates edits this in the same place. The label reads a day later than the UTC
- * epochs because the hackathon's dates are stated in its own timezone (UTC+1:
- * the 21st 23:00 UTC is already the 22nd there), so it is written out rather
- * than formatted from the epochs, which would shift per viewer.
+ * dates edits this in the same place. The range is inclusive — the hackathon
+ * runs through the whole of 29 July, closing at 00:00 UTC on the 30th — and
+ * its dates are stated in the hackathon's own timezone (UTC+1: the 21st
+ * 23:00 UTC is already the 22nd there), so it is written out rather than
+ * formatted from the epochs, which would shift per viewer.
  */
 export const APPS_HACKATHON_DATE_RANGE_LABEL = "July 22–29";
 


### PR DESCRIPTION
## Why

The Apps Hackathon recorder hard-disables outside its date window. The window closed at `Date.UTC(2026, 6, 28, 23:00)` — 00:00 UK on 29 July — which cut the recorder off before the end of 29 July. Users updating to 1.3.19 around the close reported the recorder cluster (and its settings toggle) vanishing from the chat composer with no way to re-enable it, which is the window gate working as designed, but on the wrong date.

## What

- Move `APPS_HACKATHON_CLOSES_AT_MS` to `Date.UTC(2026, 6, 30, 0, 0, 0)` — 00:00 UTC on 30 July, so the whole of 29 July is inside the window everywhere up to UTC.
- Update the window/label doc comments to describe the new close.
- Pin the new close instant in the shared test's ISO assertions.

The user-facing "July 22–29" date-range label is unchanged: the 29th is now fully included in the window.

## Testing

- `platform/shared` vitest: 42 passed (includes the window-boundary and ISO-instant tests)
- `platform/backend` `enhance.app-recording.route.test.ts`: 9 passed (gate tests are relative to the constants)
- `platform/frontend` `apps-hackathon.test.tsx`: 8 passed
- Biome + `tsc --noEmit` clean on shared (one pre-existing warning, untouched)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>