### PR TITLE
fix(hackathon): the staging override no longer bypasses the date window

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -111768,9 +111768,6 @@
                         "hackathonRecorderEnabled": {
                           "type": "boolean"
                         },
-                        "hackathonRecorderOverrideActive": {
-                          "type": "boolean"
-                        },
                         "hackathonVideoDownloadEnabled": {
                           "type": "boolean"
                         },
@@ -111824,7 +111821,6 @@
                         "chatopsTelegramEnabled",
                         "kbAutoSyncPermissionsEnabled",
                         "hackathonRecorderEnabled",
-                        "hackathonRecorderOverrideActive",
                         "hackathonVideoDownloadEnabled",
                         "hackathonMaxFinalCutMs",
                         "hackathonGalleryRepo"

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1474,9 +1474,10 @@ export function betaFeatureEnabled(envValue: string | undefined): boolean {
  * deployment needs no third switch of its own.
  *
  * `enterpriseOverride` is the single escape hatch: it turns the recorder on for
- * Archestra's own licensed staging AND bypasses the date window. It is
- * documented nowhere and named as an enterprise override on purpose, so no
- * customer stumbles onto the enterprise path.
+ * Archestra's own licensed staging. It affects this deployment gate only — the
+ * date window and the organization toggle still apply. It is documented
+ * nowhere and named as an enterprise override on purpose, so no customer
+ * stumbles onto the enterprise path.
  *
  * This is the DEPLOYMENT gate only. Two more gates sit above it at request
  * time — the organization's own toggle, and the hackathon date window —
@@ -2206,14 +2207,6 @@ const config = {
       enterpriseOverride:
         process.env.ARCHESTRA_HACKATHON_RECORDER_ENTERPRISE_OVERRIDE,
     }),
-    /**
-     * The staging override is active. It forces the recorder on for Archestra's
-     * own licensed staging (see parseHackathonRecorderEnabled) AND bypasses the
-     * hackathon date window, so staging can exercise the feature before it
-     * opens and after it closes. Undocumented, same as the override itself.
-     */
-    overrideActive:
-      process.env.ARCHESTRA_HACKATHON_RECORDER_ENTERPRISE_OVERRIDE === "true",
     /**
      * Offering the offline VIDEO export (the player's download button and the
      * render endpoints behind it). Off unless a deployment opts in: a render

--- a/platform/backend/src/routes/app-gallery/device-poll.app-gallery.route.test.ts
+++ b/platform/backend/src/routes/app-gallery/device-poll.app-gallery.route.test.ts
@@ -1,6 +1,7 @@
+import { APPS_HACKATHON_OPENS_AT_MS } from "@archestra/shared";
 import { vi } from "vitest";
 import config from "@/config";
-import { beforeEach, describe, expect, test } from "@/test";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { useRouteTestApp } from "@/test/route-test-app";
 import appGalleryRoutes from "./app-gallery.routes";
 
@@ -14,15 +15,20 @@ describe("POST /api/app-gallery/device/poll", () => {
 
   beforeEach(() => {
     // Isolated project (vi.mock in this file): config is not auto-restored,
-    // so every flag the routes read is set here. The override bypasses the
-    // hackathon date window so these cases don't depend on the wall clock.
+    // so every flag the routes read is set here. The date gate reads the wall
+    // clock and has no bypass, so pin the clock inside the hackathon window.
     config.hackathonRecorder.enabled = true;
-    config.hackathonRecorder.overrideActive = true;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS);
     config.hackathonRecorder.gallery.githubClientId = "Iv1.test-gallery";
     config.hackathonRecorder.gallery.repo = {
       owner: "archestra-ai",
       name: "app-gallery",
     };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   function poll() {

--- a/platform/backend/src/routes/app-gallery/device-start.app-gallery.route.test.ts
+++ b/platform/backend/src/routes/app-gallery/device-start.app-gallery.route.test.ts
@@ -1,6 +1,7 @@
+import { APPS_HACKATHON_OPENS_AT_MS } from "@archestra/shared";
 import { vi } from "vitest";
 import config from "@/config";
-import { beforeEach, describe, expect, test } from "@/test";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { useRouteTestApp } from "@/test/route-test-app";
 import appGalleryRoutes from "./app-gallery.routes";
 
@@ -15,15 +16,20 @@ describe("POST /api/app-gallery/device/start", () => {
   beforeEach(() => {
     // This file uses vi.mock, so it runs in the isolated project where config
     // is NOT auto-restored between tests; every case must set the baseline it
-    // needs. The override bypasses the hackathon date window so these cases
-    // don't depend on the wall clock.
+    // needs. The date gate reads the wall clock and has no bypass, so pin the
+    // clock inside the hackathon window.
     config.hackathonRecorder.enabled = true;
-    config.hackathonRecorder.overrideActive = true;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS);
     config.hackathonRecorder.gallery.githubClientId = "Iv1.test-gallery";
     config.hackathonRecorder.gallery.repo = {
       owner: "archestra-ai",
       name: "app-gallery",
     };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   test("requests a device code from GitHub with the gallery client id and public_repo scope", async () => {

--- a/platform/backend/src/routes/app-recording/enhance.app-recording.route.test.ts
+++ b/platform/backend/src/routes/app-recording/enhance.app-recording.route.test.ts
@@ -7,7 +7,7 @@ import { HttpResponse, http } from "msw";
 import { vi } from "vitest";
 import config from "@/config";
 import { ConversationModel, MessageModel, OrganizationModel } from "@/models";
-import { beforeEach, describe, expect, test } from "@/test";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import { useMswServer } from "@/test/msw";
 import { useRouteTestApp } from "@/test/route-test-app";
 import appRecordingRoutes from "./app-recording.routes";
@@ -93,12 +93,17 @@ describe("POST /api/app-recordings/enhance", () => {
   beforeEach(async ({ makeMember }) => {
     await makeMember(ctx.user.id, ctx.organizationId);
     config.hackathonRecorder.enabled = true;
-    // Bypass the date window by default so these cases don't depend on the
-    // wall clock sitting inside the hackathon — the date gate has its own
-    // tests below, which turn this back off. This file uses vi.mock, so it
-    // runs in the isolated project where config is NOT auto-restored between
-    // tests; every case must set the baseline it needs, hence both flags here.
-    config.hackathonRecorder.overrideActive = true;
+    // Pin the clock inside the hackathon window by default so these cases
+    // don't depend on the wall clock — the date gate has no bypass and has
+    // its own tests below, which move the clock outside the window. This file
+    // uses vi.mock, so it runs in the isolated project where config is NOT
+    // auto-restored between tests; every case must set the baseline it needs.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   /** A chat that built something, as the enhancement reads it. */
@@ -251,7 +256,6 @@ describe("POST /api/app-recordings/enhance", () => {
   });
 
   test("403s before the hackathon has started", async () => {
-    config.hackathonRecorder.overrideActive = false;
     vi.useFakeTimers({ shouldAdvanceTime: true });
     // Comfortably before the window: shouldAdvanceTime lets the clock tick
     // through the request, so a boundary-hugging value would slip into the
@@ -277,7 +281,6 @@ describe("POST /api/app-recordings/enhance", () => {
     // since before the closing date stops serving the feature the moment it
     // passes — with the deployment flag and the organization toggle both still
     // on, as they are here.
-    config.hackathonRecorder.overrideActive = false;
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(APPS_HACKATHON_CLOSES_AT_MS);
     try {
@@ -290,27 +293,6 @@ describe("POST /api/app-recordings/enhance", () => {
       expect(response.json().error.message).toContain(
         "The Apps Hackathon has ended",
       );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  test("the staging override bypasses the date window entirely", async () => {
-    // Staging runs the override to exercise the recorder outside the hackathon
-    // window. Outside it here (before it opens), the date gate must NOT fire —
-    // the request falls through to the ordinary ownership check instead, which
-    // is a 404 for this random conversation, not a 403 about the dates.
-    config.hackathonRecorder.overrideActive = true;
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS - 60 * 60 * 1000);
-    try {
-      const response = await ctx.app.inject({
-        method: "POST",
-        url: "/api/app-recordings/enhance",
-        payload: { conversationId: randomUUID(), appName: "Demo App" },
-      });
-      expect(response.statusCode).toBe(404);
-      expect(response.json().error.message).toContain("Conversation not found");
     } finally {
       vi.useRealTimers();
     }

--- a/platform/backend/src/routes/app-recording/render.app-recording.route.test.ts
+++ b/platform/backend/src/routes/app-recording/render.app-recording.route.test.ts
@@ -1,6 +1,9 @@
-import { APP_RECORDING_MAX_BUNDLE_BYTES } from "@archestra/shared";
+import {
+  APP_RECORDING_MAX_BUNDLE_BYTES,
+  APPS_HACKATHON_OPENS_AT_MS,
+} from "@archestra/shared";
 import config from "@/config";
-import { beforeEach, describe, expect, test } from "@/test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
 import { useRouteTestApp } from "@/test/route-test-app";
 import appRecordingRoutes from "./app-recording.routes";
 
@@ -10,10 +13,17 @@ describe("POST /api/app-recordings/render", () => {
   beforeEach(async ({ makeMember }) => {
     await makeMember(ctx.user.id, ctx.organizationId);
     config.hackathonRecorder.enabled = true;
-    config.hackathonRecorder.overrideActive = true;
+    // The date gate reads the wall clock and has no bypass, so pin the clock
+    // inside the hackathon window.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS);
     // The video export is its own opt-in on top of the recorder, so every
     // render test has to turn it on the way a deployment would.
     config.hackathonRecorder.videoDownloadEnabled = true;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   test("403s when the deployment does not offer video download", async () => {

--- a/platform/backend/src/routes/config.ts
+++ b/platform/backend/src/routes/config.ts
@@ -102,8 +102,6 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
               kbAutoSyncPermissionsEnabled: z.boolean(),
               /** App session recording (record/replay/download app demos). */
               hackathonRecorderEnabled: z.boolean(),
-              /** Staging override active: recorder bypasses the hackathon date window. */
-              hackathonRecorderOverrideActive: z.boolean(),
               /**
                * The offline video export is offered. Off by default: a render
                * drives a headless browser for as long as the cut runs, and the
@@ -180,8 +178,6 @@ const configRoutes: FastifyPluginAsyncZod = async (fastify) => {
           chatopsTelegramEnabled: config.chatops.telegramEnabled,
           kbAutoSyncPermissionsEnabled: config.kb.autoSyncPermissionsEnabled,
           hackathonRecorderEnabled: config.hackathonRecorder.enabled,
-          hackathonRecorderOverrideActive:
-            config.hackathonRecorder.overrideActive,
           hackathonVideoDownloadEnabled:
             config.hackathonRecorder.videoDownloadEnabled,
           hackathonMaxFinalCutMs: config.hackathonRecorder.maxFinalCutMs,

--- a/platform/backend/src/services/apps/apps-hackathon-gate.ts
+++ b/platform/backend/src/services/apps/apps-hackathon-gate.ts
@@ -15,9 +15,10 @@ import { ApiError } from "@/types";
  * organization must not have switched it off. Not 400 for any of them — the
  * request is well formed and there is nothing the caller can change about it.
  *
- * The staging override is the one thing that skips the date window (it forces
- * the feature on there in the first place), so Archestra's own staging can
- * exercise the recorder before the hackathon opens and after it closes.
+ * The date window has no bypass. The staging override forces the deployment
+ * flag on for Archestra's own licensed staging (see
+ * parseHackathonRecorderEnabled), but the window binds every deployment
+ * equally — the hackathon being over means over, staging included.
  *
  * Shared by every hackathon-recorder surface: the app-recording routes and the
  * gallery-share device-auth relay.
@@ -35,7 +36,7 @@ export async function assertAppsHackathonAvailable(
   }
   // Read per request rather than captured at boot: a pod that started before
   // an edge of the window would otherwise keep answering as it did then.
-  if (!config.hackathonRecorder.overrideActive && !isAppsHackathonOpen()) {
+  if (!isAppsHackathonOpen()) {
     throw new ApiError(
       403,
       Date.now() < APPS_HACKATHON_OPENS_AT_MS

--- a/platform/frontend/src/lib/app-session-recording/apps-hackathon.test.tsx
+++ b/platform/frontend/src/lib/app-session-recording/apps-hackathon.test.tsx
@@ -13,11 +13,10 @@ vi.mock("@/lib/config/config.query");
 vi.mock("@/lib/organization.query");
 vi.mock("@/lib/hooks/use-mobile");
 
-/** Drive the two public flags the hook reads, one value each. */
-function mockFeatures(flags: { enabled: boolean; override: boolean }) {
+/** Drive the public flag the hook reads. */
+function mockFeatures(flags: { enabled: boolean }) {
   vi.mocked(useFeature).mockImplementation(((flag: string) => {
     if (flag === "hackathonRecorderEnabled") return flags.enabled;
-    if (flag === "hackathonRecorderOverrideActive") return flags.override;
     return undefined;
   }) as typeof useFeature);
 }
@@ -33,31 +32,31 @@ function mockOrgToggle(enabled: boolean | undefined) {
 }
 
 describe("useAppsHackathonOffered", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    // Before the window opens, so the date gate is the thing under test.
-    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS - 60 * 60 * 1000);
-  });
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("is not offered before the window when only the deployment flag is on", () => {
-    mockFeatures({ enabled: true, override: false });
+  it("is not offered outside the window, whatever the deployment flag says", () => {
+    // The date window has no bypass — before the opening, nothing is offered.
+    vi.useFakeTimers();
+    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS - 60 * 60 * 1000);
+    mockFeatures({ enabled: true });
     const { result } = renderHook(() => useAppsHackathonOffered());
     expect(result.current).toBe(false);
   });
 
-  it("is offered before the window when the staging override is active", () => {
-    // The override that forces the feature on for staging also bypasses the
-    // date window, so staging can exercise the recorder ahead of the opening.
-    mockFeatures({ enabled: true, override: true });
+  it("is offered inside the window when the deployment flag is on", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS);
+    mockFeatures({ enabled: true });
     const { result } = renderHook(() => useAppsHackathonOffered());
     expect(result.current).toBe(true);
   });
 
-  it("is never offered when the deployment flag is off, override or not", () => {
-    mockFeatures({ enabled: false, override: true });
+  it("is never offered when the deployment flag is off, even inside the window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS);
+    mockFeatures({ enabled: false });
     const { result } = renderHook(() => useAppsHackathonOffered());
     expect(result.current).toBe(false);
   });
@@ -65,13 +64,18 @@ describe("useAppsHackathonOffered", () => {
 
 describe("useAppsHackathonAvailable", () => {
   // "Offered" is the composition of the deployment/date gates, tested above.
-  // Here we hold it true (deployment on + override, so no clock dependency) and
-  // pin how the device gate and the org toggle combine on top of it — each is
-  // an independent AND, so any one being wrong hides the recorder.
+  // Here we hold it true (deployment on, clock inside the window) and pin how
+  // the device gate and the org toggle combine on top of it — each is an
+  // independent AND, so any one being wrong hides the recorder.
   beforeEach(() => {
-    mockFeatures({ enabled: true, override: true });
+    vi.useFakeTimers();
+    vi.setSystemTime(APPS_HACKATHON_OPENS_AT_MS);
+    mockFeatures({ enabled: true });
     mockOrgToggle(true);
     vi.mocked(useIsMobile).mockReturnValue(false);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("is available when offered, on a desktop, and the org has it on", () => {
@@ -92,7 +96,7 @@ describe("useAppsHackathonAvailable", () => {
   });
 
   it("is not available when the deployment does not offer it", () => {
-    mockFeatures({ enabled: false, override: true });
+    mockFeatures({ enabled: false });
     const { result } = renderHook(() => useAppsHackathonAvailable());
     expect(result.current).toBe(false);
   });

--- a/platform/frontend/src/lib/app-session-recording/apps-hackathon.ts
+++ b/platform/frontend/src/lib/app-session-recording/apps-hackathon.ts
@@ -49,14 +49,12 @@ export const APPS_HACKATHON_SETTINGS_HREF = `/settings/agents#${APPS_HACKATHON_S
  * outside the hackathon window the whole thing goes away rather than lingering
  * as a switch that no longer does anything.
  *
- * The staging override bypasses the date window — the same bypass the backend
- * applies — so Archestra's own staging shows the recorder before the hackathon
- * opens and after it closes.
+ * The date window has no bypass — the same rule the backend enforces on every
+ * hackathon-recorder request.
  */
 export function useAppsHackathonOffered(): boolean {
   const deploymentEnabled = useFeature("hackathonRecorderEnabled") ?? false;
-  const overrideActive = useFeature("hackathonRecorderOverrideActive") ?? false;
-  return deploymentEnabled && (overrideActive || isAppsHackathonOpen());
+  return deploymentEnabled && isAppsHackathonOpen();
 }
 
 /**

--- a/platform/frontend/src/mocks/data/config.ts
+++ b/platform/frontend/src/mocks/data/config.ts
@@ -55,7 +55,6 @@ export function makeConfig(
       chatopsTelegramEnabled: false,
       kbAutoSyncPermissionsEnabled: false,
       hackathonRecorderEnabled: true,
-      hackathonRecorderOverrideActive: false,
       // Off by default, exactly as a real deployment has it.
       hackathonVideoDownloadEnabled: false,
       hackathonMaxFinalCutMs: APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS,

--- a/platform/shared/app-recording.ts
+++ b/platform/shared/app-recording.ts
@@ -28,9 +28,9 @@ import { parseFullToolName } from "./utils";
  * Outside this window the recorder hard-disables everywhere, whatever a
  * deployment or an organization still has switched on. The bounds are read at
  * REQUEST time, never captured at boot: a pod started before the window would
- * otherwise keep its answer frozen as the clock crosses either edge. The one
- * exception is the staging override, which bypasses the window entirely (see
- * the recorder route and useAppsHackathonOffered).
+ * otherwise keep its answer frozen as the clock crosses either edge. There is
+ * no bypass: the staging override forces the deployment flag on, but the
+ * window applies to every deployment equally.
  */
 export const APPS_HACKATHON_OPENS_AT_MS = Date.UTC(2026, 6, 21, 23, 0, 0);
 export const APPS_HACKATHON_CLOSES_AT_MS = Date.UTC(2026, 6, 28, 23, 0, 0);

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -31002,7 +31002,6 @@ export type GetConfigResponses = {
             chatopsTelegramEnabled: boolean;
             kbAutoSyncPermissionsEnabled: boolean;
             hackathonRecorderEnabled: boolean;
-            hackathonRecorderOverrideActive: boolean;
             hackathonVideoDownloadEnabled: boolean;
             hackathonMaxFinalCutMs: number;
             hackathonGalleryRepo: {


### PR DESCRIPTION
## Why

`ARCHESTRA_HACKATHON_RECORDER_ENTERPRISE_OVERRIDE` did two things: it forced the recorder on for Archestra's own licensed staging, and it bypassed the hackathon date window entirely. The second half meant staging kept serving the recorder after the hackathon closed for every real deployment. The window must bind every deployment equally.

## What

- `assertAppsHackathonAvailable` enforces the date window unconditionally; the override no longer skips it.
- `useAppsHackathonOffered` mirrors the same rule client-side.
- The override still forces the deployment flag on for licensed staging (`parseHackathonRecorderEnabled` is unchanged) — that is now its only effect.
- With the bypass gone, `config.hackathonRecorder.overrideActive` and the `hackathonRecorderOverrideActive` public-config flag had no consumers left, so both are removed end to end: backend config, `/api/config` response schema, generated client types, `docs/openapi.json` (surgical edits, matching what codegen emits), frontend hook, and the frontend config mock.
- Tests that used the override to dodge the window (enhance/render app-recording routes, app-gallery device-start/device-poll, frontend hook tests) now pin the clock inside the window with fake timers instead. The "override bypasses the window" test case is deleted — the behavior it pinned no longer exists.

## Testing

- `platform/backend` vitest over `routes/app-recording/` + `routes/app-gallery/`: 22 passed
- `platform/frontend` vitest over `apps-hackathon.test.tsx`, `prompt-input-tools.test.tsx`, `prompt-input.test.tsx`: 61 passed
- `pnpm type-check` and `pnpm lint` clean across workspaces
- `docs/openapi.json` re-validated as JSON after the surgical edit

Note for staging: once this deploys, staging's recorder obeys the real hackathon window like everyone else.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>