### PR TITLE
fix(llm-pricing): drop Bedrock AWS price entries matched to a model family

### DIFF
--- a/platform/backend/src/services/bedrock-aws-pricing.test.ts
+++ b/platform/backend/src/services/bedrock-aws-pricing.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { resolveBedrockAwsPrices } from "./bedrock-aws-pricing";
+import {
+  AWS_PRICE_IDENTITY,
+  resolveBedrockAwsPrices,
+} from "./bedrock-aws-pricing";
 
 function resolve(modelId: string, underlyingModelName?: string) {
   return resolveBedrockAwsPrices({
@@ -85,5 +88,31 @@ describe("resolveBedrockAwsPrices", () => {
         modelId: "claude-sonnet-4-5",
       }),
     ).toBeNull();
+  });
+
+  test("does not price a model AWS omits by falling back to a generic entry", () => {
+    // AWS lists no Opus 4.7/4.8/5, Sonnet 5 or Fable 5. Their names share a
+    // prefix with the legacy "Claude" and "Claude Opus 4" listings, whose prices
+    // are three to four times wrong for them, so each must resolve to nothing
+    // and let the registry price it.
+    for (const modelId of [
+      "us.anthropic.claude-opus-4-8",
+      "us.anthropic.claude-opus-4-7",
+      "us.anthropic.claude-opus-5",
+      "us.anthropic.claude-sonnet-5",
+      "us.anthropic.claude-fable-5",
+    ]) {
+      expect(resolve(modelId)).toBeNull();
+    }
+  });
+
+  test("every mapped identity is priced, and none is a bare family name", () => {
+    // A generic listing such as "Claude" or "Claude Opus 4" prices a whole
+    // family at one legacy rate; mapping a specific model onto one is the
+    // failure this guards.
+    const GENERIC = new Set(["Claude", "Claude Opus 4", "Amazon Bedrock"]);
+    for (const identity of Object.values(AWS_PRICE_IDENTITY)) {
+      expect(GENERIC.has(identity)).toBe(false);
+    }
   });
 });

--- a/platform/backend/src/services/bedrock-aws-pricing.test.ts
+++ b/platform/backend/src/services/bedrock-aws-pricing.test.ts
@@ -111,8 +111,12 @@ describe("resolveBedrockAwsPrices", () => {
     // family at one legacy rate; mapping a specific model onto one is the
     // failure this guards.
     const GENERIC = new Set(["Claude", "Claude Opus 4", "Amazon Bedrock"]);
-    for (const identity of Object.values(AWS_PRICE_IDENTITY)) {
+    for (const [modelId, identity] of Object.entries(AWS_PRICE_IDENTITY)) {
       expect(GENERIC.has(identity)).toBe(false);
+      // The identity is transcribed from AWS by hand, so a typo — or a listing
+      // AWS renames on a later refresh — resolves to nothing and drops the
+      // model onto the fabricated estimate without failing anything else.
+      expect(resolve(modelId)).not.toBeNull();
     }
   });
 });

--- a/platform/backend/src/services/bedrock-aws-pricing.ts
+++ b/platform/backend/src/services/bedrock-aws-pricing.ts
@@ -46,7 +46,8 @@ export interface BedrockAwsPrices {
  * revision, and `titan-embed-text-v1` and `-v2` are different models priced five
  * times apart.
  */
-const AWS_PRICE_IDENTITY: Record<string, string> = {
+/** @public — asserted by bedrock-aws-pricing.test.ts to stay free of generic identities. */
+export const AWS_PRICE_IDENTITY: Record<string, string> = {
   "amazon.nova-2-lite-v1": "Nova 2.0 Lite",
   "amazon.nova-2-sonic-v1": "Nova Sonic 2.0",
   "amazon.nova-lite-v1": "Nova Lite",
@@ -57,18 +58,13 @@ const AWS_PRICE_IDENTITY: Record<string, string> = {
   "amazon.titan-embed-text-v2": "TitanEmbeddingsV2-Text-input",
   "anthropic.claude-3-haiku-20240307-v1": "Claude 3 Haiku",
   "anthropic.claude-3-sonnet-20240229-v1": "Claude 3 Sonnet",
-  "anthropic.claude-fable-5": "Claude",
   "anthropic.claude-haiku-4-5-20251001-v1": "Claude Haiku 4.5",
   "anthropic.claude-opus-4-1-20250805-v1": "Claude Opus 4.1",
   "anthropic.claude-opus-4-5-20251101-v1": "Claude Opus 4.5",
   "anthropic.claude-opus-4-6-v1": "Claude Opus 4.6",
-  "anthropic.claude-opus-4-7": "Claude Opus 4",
-  "anthropic.claude-opus-4-8": "Claude Opus 4",
-  "anthropic.claude-opus-5": "Claude",
   "anthropic.claude-sonnet-4-20250514-v1": "Claude Sonnet 4",
   "anthropic.claude-sonnet-4-5-20250929-v1": "Claude Sonnet 4.5",
   "anthropic.claude-sonnet-4-6": "Claude Sonnet 4.6",
-  "anthropic.claude-sonnet-5": "Claude",
   "deepseek.r1-v1": "R1",
   "deepseek.v3.2": "DeepSeek v3.2",
   "google.gemma-3-12b-it": "Gemma 3 12B",

--- a/platform/backend/src/services/bedrock-aws-pricing.ts
+++ b/platform/backend/src/services/bedrock-aws-pricing.ts
@@ -45,8 +45,12 @@ export interface BedrockAwsPrices {
  * Keys keep the `-vN` segment: for Amazon it is part of the model name, not a
  * revision, and `titan-embed-text-v1` and `-v2` are different models priced five
  * times apart.
+ *
+ * Every value names one model. A family name like `Claude Opus 4` matches a
+ * listing whose price belongs to a sibling, so it is rejected by test.
+ *
+ * @public — exported for that test; knip --production sees no other consumer.
  */
-/** @public — asserted by bedrock-aws-pricing.test.ts to stay free of generic identities. */
 export const AWS_PRICE_IDENTITY: Record<string, string> = {
   "amazon.nova-2-lite-v1": "Nova 2.0 Lite",
   "amazon.nova-2-sonic-v1": "Nova Sonic 2.0",


### PR DESCRIPTION
## Summary

The AWS Price List names a model by human-readable display name, not by model id, so the Bedrock id→identity map was built by matching those names as substrings. Five ids have no listing of their own and matched a whole family instead:

| Bedrock id | matched | AWS rate | real rate |
|---|---|---|---|
| `anthropic.claude-opus-4-8` | `Claude Opus 4` | $15 / $75 | $5 / $25 |
| `anthropic.claude-opus-4-7` | `Claude Opus 4` | $15 / $75 | $5 / $25 |
| `anthropic.claude-opus-5` | `Claude` | $8 / $24 | $5 / $25 |
| `anthropic.claude-sonnet-5` | `Claude` | $8 / $24 | $2 / $10 |
| `anthropic.claude-fable-5` | `Claude` | $8 / $24 | $10 / $30 |

Every request against those models recorded up to 4× its real cost in `interactions.cost`, and that number is what cost statistics, optimization-rule savings and token-cost limits are computed from — so the flagship Claude models were burning down usage limits several times faster than the spend they represent.

Removing the five entries lets each id resolve through models.dev, which lists all of them at the published rate. Prices correct themselves on the next successful sync; the price columns are overwritten unconditionally on upsert, so no backfill is needed.

A guard pins the five ids to no AWS price, and a second rejects any mapped identity that is a bare family name, so regenerating the map cannot quietly reintroduce the class.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>