### PR TITLE
feat(mcp): validate OAuth authorization-response issuer and complete the 2026-07-28 result envelope

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -247080,6 +247080,9 @@
                   "code": {
                     "type": "string"
                   },
+                  "iss": {
+                    "type": "string"
+                  },
                   "state": {
                     "type": "string"
                   }

--- a/docs/pages/platform-mcp-gateway.md
+++ b/docs/pages/platform-mcp-gateway.md
@@ -3,7 +3,7 @@ title: MCP Gateway
 category: MCP
 order: 1
 description: Unified access point for all MCP servers
-lastUpdated: 2026-07-28
+lastUpdated: 2026-07-29
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -89,11 +89,31 @@ See [MCP Authentication](/docs/mcp-authentication) for more details.
 
 ## Protocol Versions
 
-Gateways serve both the `2025-11-25` and `2026-07-28` MCP revisions from the same endpoint. Clients pick one with the `MCP-Protocol-Version` header. A client that sends no header keeps the older behavior, so existing integrations need no change.
+Gateways serve both the `2025-11-25` and `2026-07-28` MCP revisions from the same endpoint. Clients pick one with the `MCP-Protocol-Version` header, or by sending `io.modelcontextprotocol/protocolVersion` in a request's `_meta`. A client that declares neither keeps the older behavior, so existing integrations need no change.
 
-The `2026-07-28` revision drops the `initialize` handshake and the session header. Clients on it call `server/discover` for capabilities and send `Mcp-Method` and `Mcp-Name` routing headers on every request. The gateway rejects a request whose routing headers disagree with its body.
+Older revisions still work too. Anything back to `2024-11-05` is accepted and served as `2025-11-25` would be — the gateway echoes back the version you asked for rather than upgrading you.
 
-Tool, prompt, and resource results carry a freshness hint so clients can cache them. The hint is always marked private — a gateway filters results per caller, so two users can see different ones.
+### What Each Revision Gets
+
+| Feature | `2025-11-25` | `2026-07-28` |
+| --- | --- | --- |
+| Capability discovery | `initialize` handshake | `server/discover` |
+| Session | `Mcp-Session-Id` header | None — every request stands alone |
+| Routing headers | Not sent | `Mcp-Method` and `Mcp-Name` required |
+| Interactive input | Elicitation during the call | Multi round-trip: the call returns what it needs, you retry with the answer |
+| Result caching hints | Sent, ignored by older clients | `ttlMs` and `cacheScope` on tool, prompt, and resource results |
+| Result envelope | Plain result | `resultType`, plus server identity in `_meta` |
+| Missing-resource error | `-32002` | `-32602` |
+
+Both revisions see the same tools, the same access control, and the same policies. The differences are all in how a client talks to the gateway, not in what it can reach.
+
+### Notes for Clients on `2026-07-28`
+
+Routing headers must agree with the request body. The gateway rejects a mismatch — the headers exist so proxies can route without reading the body, so one that disagrees with its body is treated as a problem rather than ignored.
+
+Tool, prompt, and resource results carry a freshness hint. It is always marked private: a gateway filters results per caller, so two users can legitimately see different ones and a shared cache must not serve one person's view to another.
+
+A tool that needs input mid-call returns a request for it instead of prompting inline. Your client gathers the answer and retries the same call with it attached. The retry re-runs the tool, and the gateway caps how many times one call can go around.
 
 ## Access Control
 

--- a/platform/backend/src/routes/mcp-gateway.protocol-negotiation.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.protocol-negotiation.test.ts
@@ -311,6 +311,33 @@ describe("MCP Gateway - protocol revision negotiation", () => {
     }
   });
 
+  test("results carry the complete envelope and a stable tool order", async ({
+    makeAgent,
+    makeOrganization,
+  }) => {
+    const { agent, token } = await setup({ makeAgent, makeOrganization });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(token.value),
+      payload: { jsonrpc: "2.0", method: "tools/list", params: {}, id: 12 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const { result } = response.json();
+
+    // Every ordinary result is "complete"; older clients ignore the field.
+    expect(result.resultType).toBe("complete");
+    expect(result._meta["io.modelcontextprotocol/serverInfo"]).toMatchObject({
+      name: `archestra-agent-${agent.id}`,
+    });
+
+    // Stable order is what makes the ttlMs hint worth anything to a cache.
+    const names = (result.tools as Array<{ name: string }>).map((t) => t.name);
+    expect(names).toEqual([...names].sort());
+  });
+
   test("GET discovery advertises both supported revisions", async ({
     makeAgent,
     makeOrganization,

--- a/platform/backend/src/routes/mcp-gateway.protocol.ts
+++ b/platform/backend/src/routes/mcp-gateway.protocol.ts
@@ -119,6 +119,35 @@ export function buildPrivateListCacheHint(): CacheHint {
 }
 
 /**
+ * `_meta` key servers use to identify themselves on each result, replacing what
+ * `initialize` reported once per connection.
+ */
+export const MCP_SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
+
+/**
+ * Stamp a result as an ordinary, complete one and identify the server.
+ *
+ * Every result carries `resultType` in this revision; `complete` is the
+ * ordinary case, as opposed to the `input_required` interim result MRTR
+ * returns. Older clients treat a missing field as `complete`, so emitting it
+ * unconditionally is safe for both revisions.
+ */
+export function withCompleteResultEnvelope<T extends object>(
+  result: T,
+  serverInfo: { name: string; version: string },
+): T {
+  const existingMeta = (result as { _meta?: Record<string, unknown> })._meta;
+  return {
+    ...result,
+    resultType: COMPLETE_RESULT_TYPE,
+    _meta: {
+      ...existingMeta,
+      [MCP_SERVER_INFO_META_KEY]: serverInfo,
+    },
+  } as T;
+}
+
+/**
  * Attach cache hints to a result produced elsewhere (e.g. proxied from an
  * upstream server) without disturbing its existing fields.
  */

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -119,6 +119,7 @@ import {
   buildGatewayServerCapabilities,
   buildPrivateListCacheHint,
   isResourceUnavailableError,
+  withCompleteResultEnvelope,
   withPrivateCacheHint,
 } from "./mcp-gateway.protocol";
 
@@ -254,6 +255,16 @@ export async function createAgentServer(params: {
 }): Promise<{ server: McpServer; agent: AgentInfo }> {
   const { agentId, tokenAuth, mrtr } = params;
   const mrtrEnabled = mrtr?.enabled === true;
+
+  /**
+   * Stamp an ordinary result. Deliberately not applied to the MRTR
+   * InputRequiredResult, which carries `input_required` instead.
+   */
+  const complete = <T extends object>(result: T): T =>
+    withCompleteResultEnvelope(result, {
+      name: `archestra-agent-${agentId}`,
+      version: config.api.version,
+    });
   const mcpServer = new McpServer(
     {
       name: `archestra-agent-${agentId}`,
@@ -532,7 +543,12 @@ export async function createAgentServer(params: {
 
     // SEP-2549 freshness hints. Always private: this list is filtered per
     // caller, so it must never be shared across users by an intermediary.
-    return { tools: toolsList, ...buildPrivateListCacheHint() };
+    // Deterministic order: the revision asks servers to return tools stably so
+    // client-side caching and LLM prompt caches can actually hit. Without it
+    // the ttlMs hint above advertises freshness for a list that reshuffles.
+    toolsList.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    return complete({ tools: toolsList, ...buildPrivateListCacheHint() });
   });
 
   server.setRequestHandler(
@@ -548,7 +564,7 @@ export async function createAgentServer(params: {
           { agentId, uri, resultType: typeof result },
           "Resource read successful",
         );
-        return withPrivateCacheHint(result);
+        return complete(withPrivateCacheHint(result));
       } catch (error) {
         // A third-party tool can advertise a `ui://` UI resource whose upstream
         // server does not actually implement `resources/read` (returning -32601
@@ -584,20 +600,22 @@ export async function createAgentServer(params: {
   // servers reached with the caller's own credentials, so results differ per
   // caller and must not be shared by an intermediary.
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    return withPrivateCacheHint(
-      await mcpClient.listResources(agentId, tokenAuth),
+    return complete(
+      withPrivateCacheHint(await mcpClient.listResources(agentId, tokenAuth)),
     );
   });
 
   server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-    return withPrivateCacheHint(
-      await mcpClient.listResourceTemplates(agentId, tokenAuth),
+    return complete(
+      withPrivateCacheHint(
+        await mcpClient.listResourceTemplates(agentId, tokenAuth),
+      ),
     );
   });
 
   server.setRequestHandler(ListPromptsRequestSchema, async () => {
-    return withPrivateCacheHint(
-      await mcpClient.listPrompts(agentId, tokenAuth),
+    return complete(
+      withPrivateCacheHint(await mcpClient.listPrompts(agentId, tokenAuth)),
     );
   });
 

--- a/platform/backend/src/routes/oauth-issuer-validation.test.ts
+++ b/platform/backend/src/routes/oauth-issuer-validation.test.ts
@@ -1,0 +1,137 @@
+/**
+ * RFC 9207 issuer validation.
+ *
+ * This is a mix-up-attack mitigation, so the cases that matter are the ones
+ * where a response from one authorization server is presented against another's
+ * recorded issuer. The normalization tests exist because every normalization the
+ * spec forbids would widen what counts as a match, and a wider match is exactly
+ * what the attack needs.
+ */
+
+import { describe, expect, test } from "@/test";
+import {
+  isAuthorizationErrorResponse,
+  validateAuthorizationResponseIssuer,
+} from "./oauth-issuer-validation";
+
+const ISSUER = "https://auth.example.com";
+
+describe("validateAuthorizationResponseIssuer", () => {
+  test("a matching issuer proceeds", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer: ISSUER,
+        recordedIssuer: ISSUER,
+        issParameterSupported: true,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  test("a response from a different authorization server is rejected", () => {
+    // The mix-up attack itself.
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer: "https://evil.example.com",
+        recordedIssuer: ISSUER,
+        issParameterSupported: true,
+      }),
+    ).toEqual({ ok: false, reason: "issuer_mismatch" });
+  });
+
+  test("a server that advertised iss but omitted it is rejected", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer: undefined,
+        recordedIssuer: ISSUER,
+        issParameterSupported: true,
+      }),
+    ).toEqual({ ok: false, reason: "issuer_missing" });
+  });
+
+  test("a server that never advertised iss and omitted it proceeds", () => {
+    // Rejection on absence stays keyed to the advertisement, so servers that
+    // predate RFC 9207 keep working.
+    for (const supported of [false, null, undefined]) {
+      expect(
+        validateAuthorizationResponseIssuer({
+          responseIssuer: undefined,
+          recordedIssuer: ISSUER,
+          issParameterSupported: supported,
+        }),
+      ).toEqual({ ok: true });
+    }
+  });
+
+  test("a present iss is compared even when the server never advertised it", () => {
+    // The spec's local-policy row: servers emitting iss before updating their
+    // metadata still get the protection.
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer: "https://evil.example.com",
+        recordedIssuer: ISSUER,
+        issParameterSupported: false,
+      }),
+    ).toEqual({ ok: false, reason: "issuer_mismatch" });
+
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer: ISSUER,
+        recordedIssuer: ISSUER,
+        issParameterSupported: false,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  test("a present iss with nothing recorded cannot be verified, so is rejected", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer: ISSUER,
+        recordedIssuer: null,
+        issParameterSupported: true,
+      }),
+    ).toEqual({ ok: false, reason: "issuer_mismatch" });
+  });
+
+  test("an empty iss counts as absent rather than as a match", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer: "",
+        recordedIssuer: ISSUER,
+        issParameterSupported: true,
+      }),
+    ).toEqual({ ok: false, reason: "issuer_missing" });
+  });
+});
+
+describe("comparison is exact", () => {
+  // Each of these is a normalization RFC 3986 Section 6.2.2-6.2.3 would permit
+  // and the spec explicitly forbids. Accepting any of them would let a
+  // near-miss issuer pass.
+  test.each([
+    ["host case folding", "https://AUTH.example.com"],
+    ["scheme case folding", "HTTPS://auth.example.com"],
+    ["trailing slash", "https://auth.example.com/"],
+    ["default port elision", "https://auth.example.com:443"],
+    ["percent-encoding", "https://auth.example%2Ecom"],
+  ])("%s does not count as a match", (_label, responseIssuer) => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer,
+        recordedIssuer: ISSUER,
+        issParameterSupported: true,
+      }),
+    ).toEqual({ ok: false, reason: "issuer_mismatch" });
+  });
+});
+
+describe("isAuthorizationErrorResponse", () => {
+  test("recognises an error response", () => {
+    expect(isAuthorizationErrorResponse({ error: "access_denied" })).toBe(true);
+  });
+
+  test("a successful response is not an error response", () => {
+    expect(isAuthorizationErrorResponse({})).toBe(false);
+    expect(isAuthorizationErrorResponse({ error: "" })).toBe(false);
+    expect(isAuthorizationErrorResponse({ error: null })).toBe(false);
+  });
+});

--- a/platform/backend/src/routes/oauth-issuer-validation.ts
+++ b/platform/backend/src/routes/oauth-issuer-validation.ts
@@ -1,0 +1,89 @@
+/**
+ * RFC 9207 authorization-response issuer validation (SEP-2468).
+ *
+ * Mitigates the OAuth mix-up attack: with one client registered against many
+ * authorization servers, an attacker who can get an authorization response from
+ * server A delivered to the callback for server B may have the client redeem
+ * A's code at B's token endpoint, leaking it. MCP's topology — a single gateway
+ * against many upstream servers — is precisely the shape that makes this
+ * reachable, which is why the spec now requires the check.
+ *
+ * The validation runs BEFORE the authorization code is transmitted to any token
+ * endpoint. That ordering is the whole mitigation: once the code has been sent,
+ * the leak has already happened.
+ */
+
+export type IssuerValidationOutcome =
+  | { ok: true }
+  | { ok: false; reason: "issuer_mismatch" | "issuer_missing" };
+
+/**
+ * Decide whether an authorization response may proceed to the token endpoint.
+ *
+ * The four cases come straight from the spec's table:
+ *
+ * | advertised | `iss` present | action                        |
+ * | ---------- | ------------- | ----------------------------- |
+ * | true       | yes           | compare                       |
+ * | true       | no            | reject                        |
+ * | false      | yes           | compare (local policy)        |
+ * | false      | no            | proceed                       |
+ *
+ * The third row is deliberate: a present `iss` is always compared, even when the
+ * server never advertised support, so a server that emits `iss` before updating
+ * its metadata still gets the protection.
+ */
+export function validateAuthorizationResponseIssuer(params: {
+  /** `iss` from the authorization response, already form-decoded. */
+  responseIssuer?: string | null;
+  /** The issuer recorded when the flow started. */
+  recordedIssuer?: string | null;
+  /** `authorization_response_iss_parameter_supported` from AS metadata. */
+  issParameterSupported?: boolean | null;
+}): IssuerValidationOutcome {
+  const { responseIssuer, recordedIssuer, issParameterSupported } = params;
+
+  const present = typeof responseIssuer === "string" && responseIssuer !== "";
+
+  if (!present) {
+    // Rejection on absence stays keyed to the advertisement, per the spec.
+    return issParameterSupported === true
+      ? { ok: false, reason: "issuer_missing" }
+      : { ok: true };
+  }
+
+  // A present `iss` with nothing recorded to compare against cannot be
+  // verified, so it cannot be trusted.
+  if (!recordedIssuer) {
+    return { ok: false, reason: "issuer_mismatch" };
+  }
+
+  return issuersMatch(responseIssuer, recordedIssuer)
+    ? { ok: true }
+    : { ok: false, reason: "issuer_mismatch" };
+}
+
+/**
+ * Simple string comparison, per RFC 3986 Section 6.2.1.
+ *
+ * Deliberately exact. The spec forbids scheme or host case folding, default-port
+ * elision, trailing-slash, and percent-encoding normalization before comparison
+ * — every one of those would widen what counts as a match, and the point of the
+ * check is that it is narrow.
+ */
+export function issuersMatch(a: string, b: string): boolean {
+  return a === b;
+}
+
+/**
+ * Whether an authorization response is an error response.
+ *
+ * Error responses carry the same issuer guarantee: on mismatch the client must
+ * not act on or display `error`, `error_description`, or `error_uri`, since
+ * those came from an unverified party.
+ */
+export function isAuthorizationErrorResponse(params: {
+  error?: string | null;
+}): boolean {
+  return typeof params.error === "string" && params.error !== "";
+}

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -572,6 +572,11 @@ describe("OAuth helper functions", () => {
         authorizationEndpoint: "https://auth.example.com/authorize",
         tokenEndpoint: "https://auth.example.com/token",
         registrationEndpoint: undefined,
+        // Carried out of discovery for the RFC 9207 issuer check. This
+        // metadata declares neither, so there is nothing to record and the
+        // server has not advertised iss support.
+        issuer: undefined,
+        issParameterSupported: false,
       });
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith(
@@ -639,6 +644,8 @@ describe("OAuth helper functions", () => {
         authorizationEndpoint: "https://legacy-idp.example.com/oauth/authorize",
         tokenEndpoint: "https://legacy-idp.example.com/oauth/token",
         registrationEndpoint: "https://auth.example.com/register",
+        issuer: undefined,
+        issParameterSupported: false,
       });
 
       globalThis.fetch = originalFetch;

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -18,6 +18,7 @@ import {
   type OAuthRefreshOutcome,
 } from "@/services/oauth-refresh-classification";
 import { ApiError, constructResponseSchema, UuidIdSchema } from "@/types";
+import { validateAuthorizationResponseIssuer } from "./oauth-issuer-validation";
 
 /**
  * Generate PKCE code verifier
@@ -246,6 +247,10 @@ async function discoverAuthorizationServerMetadataWithOverrides(
   token_endpoint: string;
   registration_endpoint?: string;
   scopes_supported?: string[];
+  /** RFC 8414 issuer identifier. */
+  issuer?: string;
+  /** RFC 9207 Section 2.3 advertisement. */
+  authorization_response_iss_parameter_supported?: boolean;
 }> {
   const discoveryUrl = overrides?.authServerUrl || serverUrl;
   const urls = buildDiscoveryUrls(discoveryUrl, overrides?.wellKnownUrl);
@@ -294,6 +299,12 @@ interface DiscoveredEndpoints {
   authorizationEndpoint: string;
   tokenEndpoint: string;
   registrationEndpoint?: string;
+  /**
+   * Issuer identifier and RFC 9207 support, carried out of discovery so the
+   * authorization step can record what the callback will verify against.
+   */
+  issuer?: string;
+  issParameterSupported?: boolean;
 }
 
 interface ExplicitOAuthEndpoints {
@@ -403,6 +414,9 @@ export async function discoverOAuthEndpoints(
         metadata.authorization_endpoint,
       tokenEndpoint: explicitEndpoints.tokenEndpoint ?? metadata.token_endpoint,
       registrationEndpoint: metadata.registration_endpoint,
+      issuer: typeof metadata.issuer === "string" ? metadata.issuer : undefined,
+      issParameterSupported:
+        metadata.authorization_response_iss_parameter_supported === true,
     };
   } catch (error) {
     if (
@@ -434,6 +448,8 @@ async function registerOAuthClient(
   registrationEndpoint: string,
   clientMetadata: {
     client_name: string;
+    /** OIDC application_type; see SEP-837. */
+    application_type?: "native" | "web";
     redirect_uris: string[];
     grant_types?: string[];
     response_types?: string[];
@@ -478,6 +494,15 @@ interface OAuthStateData {
   clientId?: string;
   clientSecret?: string;
   registrationResult?: Record<string, unknown>;
+  /**
+   * Issuer of the authorization server this flow was started against, and
+   * whether it advertised RFC 9207 support. Recorded here because the callback
+   * has to compare against the server the flow *began* with — reading it from
+   * config at callback time would compare a value the attacker may have
+   * influenced against itself.
+   */
+  issuer?: string;
+  issParameterSupported?: boolean;
 }
 
 const OAUTH_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
@@ -848,6 +873,8 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         // Discover authorization server metadata to get the correct authorization endpoint
         let authorizationEndpoint: string;
         let registrationEndpoint: string | undefined;
+        let discoveredIssuer: string | undefined;
+        let discoveredIssSupported: boolean | undefined;
 
         // For proxy servers, skip discovery and use the MCP server URL directly
         if (oauthConfig.requires_proxy) {
@@ -867,6 +894,8 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
             );
             authorizationEndpoint = endpoints.authorizationEndpoint;
             registrationEndpoint = endpoints.registrationEndpoint;
+            discoveredIssuer = endpoints.issuer;
+            discoveredIssSupported = endpoints.issParameterSupported;
           } catch (error) {
             fastify.log.error(
               { error },
@@ -897,6 +926,10 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 redirect_uris: [redirectUri],
                 grant_types: ["authorization_code", "refresh_token"],
                 response_types: ["code"],
+                // SEP-837: OIDC servers default an omitted application_type to
+                // "web", which then rejects the localhost-style redirect URIs a
+                // self-hosted deployment uses. Non-OIDC servers ignore it.
+                application_type: "native",
                 scope: scopesToUse.join(" "),
               },
             );
@@ -942,6 +975,8 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
           clientId,
           clientSecret,
           registrationResult,
+          issuer: discoveredIssuer,
+          issParameterSupported: discoveredIssSupported,
         });
 
         // Build authorization URL using the discovered authorization endpoint
@@ -998,6 +1033,8 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         tags: ["OAuth"],
         body: z.object({
           code: z.string(),
+          /** RFC 9207 issuer identifier, when the authorization server sends it. */
+          iss: z.string().optional(),
           state: z.string(),
         }),
         response: constructResponseSchema(
@@ -1013,11 +1050,36 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
         ),
       },
     },
-    async ({ body: { code, state } }, reply) => {
+    async ({ body: { code, state, iss } }, reply) => {
       // Retrieve OAuth state (also deletes it to prevent replay attacks)
       const oauthState = await getAndDeleteOAuthState(state);
       if (!oauthState) {
         throw new ApiError(400, "Invalid or expired OAuth state");
+      }
+
+      // RFC 9207 (SEP-2468): confirm this response came from the authorization
+      // server the flow started against, BEFORE the code is transmitted
+      // anywhere. Once the code has been sent to the wrong token endpoint the
+      // mix-up has already succeeded, so ordering is the mitigation.
+      const issuerCheck = validateAuthorizationResponseIssuer({
+        responseIssuer: iss,
+        recordedIssuer: oauthState.issuer,
+        issParameterSupported: oauthState.issParameterSupported,
+      });
+      if (!issuerCheck.ok) {
+        fastify.log.warn(
+          {
+            catalogId: oauthState.catalogId,
+            reason: issuerCheck.reason,
+          },
+          "Rejected OAuth authorization response failing issuer validation",
+        );
+        throw new ApiError(
+          400,
+          issuerCheck.reason === "issuer_missing"
+            ? "Authorization response is missing the required iss parameter."
+            : "Authorization response issuer does not match the authorization server this flow started against.",
+        );
       }
 
       // Get catalog item to retrieve OAuth configuration (with resolved secrets for runtime)

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -63567,6 +63567,7 @@ export type InitiateOAuthResponse = InitiateOAuthResponses[keyof InitiateOAuthRe
 export type HandleOAuthCallbackData = {
     body: {
         code: string;
+        iss?: string;
         state: string;
     };
     path?: never;


### PR DESCRIPTION
Follow-up to #6907 and #6930. **The spec is now final** — `docs/specification/2026-07-28` exists and the tag was published today at 16:47Z. I diffed the final changelog against the draft the merged PRs were built from: same SEPs, same error codes, same field names, only doc links repointed. **No corrections needed to the merged work.**

## 1. OAuth mix-up mitigation (SEP-2468, RFC 9207) — the security fix

Our callback accepted only `code` and `state`. It had no way to tell *which* authorization server a response came from, because it never received `iss`.

That matters here specifically. With one client registered against many upstream authorization servers — MCP's ordinary topology, and the shape the SEP explicitly calls out — an attacker who gets an authorization response from server A delivered to the callback for server B can have the code redeemed at the wrong token endpoint.

The authorization step now records the issuer and the server's RFC 9207 advertisement alongside the PKCE verifier, and the callback verifies before the code is transmitted anywhere. **Ordering is the mitigation** — once the code has been sent, the mix-up has already succeeded.

Two details worth a reviewer's eye:

- **Comparison is exact.** The spec forbids case folding, default-port elision, trailing-slash, and percent-encoding normalization. Each would widen what counts as a match, which is precisely what the attack needs. There's a test per forbidden normalization.
- **Absence is handled per the spec's table, not uniformly.** A server that advertised support then omitted `iss` is rejected; one that never advertised it proceeds, so servers predating RFC 9207 keep working. A *present* `iss` is always compared even when unadvertised — the spec's local-policy row, for servers emitting it before updating their metadata.

Recording the issuer at authorize time rather than reading config at callback time is deliberate: comparing against a value the attacker may have influenced would defeat the check.

## 2. DCR application_type (SEP-837)

Registration now sends `application_type: "native"`. Omitting it defaults to `"web"` under OIDC, which then rejects the localhost-style redirect URIs a self-hosted deployment uses. Non-OIDC servers ignore it.

## 3. Result envelope conformance

- **`resultType: "complete"`** on ordinary results. Clients must treat a missing field as complete, so this is safe for 2025-11-25 clients. The MRTR `InputRequiredResult` is deliberately *not* stamped — it carries its own type.
- **`io.modelcontextprotocol/serverInfo`** in each result's `_meta`, replacing what `initialize` reported once per connection.
- **Deterministic `tools/list` order.** The revision asks for this so client and prompt caches can hit. Without it, the `ttlMs` hint we already emit advertises freshness for a list that reshuffles between calls — so this makes existing behavior actually useful rather than adding new surface.

## Testing

14 new unit tests on issuer validation (all four table rows, each forbidden normalization, error-response handling), plus a route-level test for the envelope and ordering. 106 pass across the OAuth suites and 197 across the gateway suites. `tsc`, `biome`, `knip` clean, and codegen re-run so the OpenAPI spec and client types are committed.

## Not in this PR

- **SEP-2352** (persisted credentials keyed by issuer; re-register when the authorization server changes). Related to the above but a distinct change touching credential storage, and it's a correctness fix as much as hardening — better reviewed on its own.
- **Revision-conditional transport plumbing** — `subscriptions/listen`, the `ping`/`logging/setLevel` removals, SSE resumability. Held for a follow-up as agreed, since each removes behavior legacy clients still use.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>