### PR TITLE
fix(deps): bump dompurify override to 3.4.12 to clear GHSA-cmwh-pvxp-8882 & GHSA-c2j3-45gr-mqc4

### DIFF
--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -47,7 +47,7 @@ overrides:
   form-data@<4: 3.0.5
   '@hono/node-server': 1.19.14
   body-parser: 2.2.1
-  dompurify: 3.4.10
+  dompurify: 3.4.12
   glob: 11.1.0
   esbuild: '>=0.28.1'
   adm-zip: 0.6.0
@@ -398,8 +398,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
       dompurify:
-        specifier: 3.4.10
-        version: 3.4.10
+        specifier: 3.4.12
+        version: 3.4.12
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -741,8 +741,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       dompurify:
-        specifier: 3.4.10
-        version: 3.4.10
+        specifier: 3.4.12
+        version: 3.4.12
       elkjs:
         specifier: ^0.11.1
         version: 0.11.1
@@ -7340,8 +7340,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -18000,7 +18000,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.10:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -19602,7 +19602,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.19
-      dompurify: 3.4.10
+      dompurify: 3.4.12
       es-toolkit: 1.45.1
       katex: 0.16.28
       khroma: 2.1.0
@@ -19849,7 +19849,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.10
+      dompurify: 3.4.12
       marked: 14.0.0
 
   ms@2.1.3: {}
@@ -20337,7 +20337,7 @@ snapshots:
       '@posthog/core': 1.40.2
       '@posthog/types': 1.393.0
       core-js: 3.49.0
-      dompurify: 3.4.10
+      dompurify: 3.4.12
       fflate: 0.4.8
       preact: 10.29.7
       query-selector-shadow-dom: 1.0.1

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -62,7 +62,9 @@ overrides:
   form-data@<4: 3.0.5
   '@hono/node-server': 1.19.14
   body-parser: 2.2.1
-  dompurify: 3.4.10
+  # GHSA-cmwh-pvxp-8882 (fixed 3.4.11) and GHSA-c2j3-45gr-mqc4 (fixed 3.4.12).
+  # Kept an exact pin (was 3.4.10) so dompurify stays deduped to one version.
+  dompurify: 3.4.12
   glob: 11.1.0
   # GHSA-gv7w-rqvm-qjhr (esbuild "Untrusted Search Path", HIGH) fixed in 0.28.1.
   esbuild: '>=0.28.1'

--- a/platform/pnpm-workspace.yaml
+++ b/platform/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
   '@hono/node-server': 1.19.14
   body-parser: 2.2.1
   # GHSA-cmwh-pvxp-8882 (fixed 3.4.11) and GHSA-c2j3-45gr-mqc4 (fixed 3.4.12).
-  # Kept an exact pin (was 3.4.10) so dompurify stays deduped to one version.
+  # Pinned exact so dompurify stays deduped to one version.
   dompurify: 3.4.12
   glob: 11.1.0
   # GHSA-gv7w-rqvm-qjhr (esbuild "Untrusted Search Path", HIGH) fixed in 0.28.1.


### PR DESCRIPTION
## Summary

`dompurify` is pinned by a pnpm `override` to the exact `3.4.10`, which is vulnerable to two open advisories — **GHSA-cmwh-pvxp-8882** (fixed 3.4.11) and **GHSA-c2j3-45gr-mqc4** (fixed 3.4.12). Because the override forces the resolution, bumping only the `package.json` specifier (as Dependabot #6758 does) leaves dompurify at 3.4.10 — the lockfile there still resolves the vulnerable version. Raising the override to `3.4.12` moves every resolution to the patched release and clears both advisories, while keeping dompurify deduped to a single version.

Supersedes #6758, whose lockfile also fails the repo's `minimumReleaseAge` supply-chain policy (33 too-new entries from Dependabot's regeneration). This PR regenerates the lockfile fresh, so it passes that policy.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>