### PR TITLE
feat(mcp): bind credentials to their issuer, complete the result envelope, and finish the error-code migration

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -1032,7 +1032,10 @@ describe("McpClient", () => {
         url: {},
       });
       expect(mockSetRequestHandler).toHaveBeenCalledOnce();
-      expect(mockSetNotificationHandler).toHaveBeenCalledOnce();
+      // No notification handler: 2026-07-28 removes
+      // `notifications/elicitation/complete`, since under MRTR the client
+      // learns the outcome by retrying the original request.
+      expect(mockSetNotificationHandler).not.toHaveBeenCalled();
     });
 
     describe("Secrets caching (N+1 prevention)", () => {

--- a/platform/backend/src/clients/mcp-elicitation.ts
+++ b/platform/backend/src/clients/mcp-elicitation.ts
@@ -39,16 +39,10 @@ export function configureMcpElicitation(
   client: Client,
   handler: McpElicitationHandler,
 ): void {
+  // `notifications/elicitation/complete` is removed in 2026-07-28: under MRTR a
+  // client learns an out-of-band interaction's outcome by retrying the original
+  // request, so a server-initiated completion signal no longer fits. The
+  // handler only logged, so nothing is lost by not registering it — and a
+  // 2025-11-25 server that still sends one is simply ignored.
   client.setRequestHandler(ElicitRequestSchema, handler);
-  client.setNotificationHandler(
-    ElicitationCompleteNotificationSchema,
-    async ({ params }) => {
-      // The URL flow is completed out-of-band by the server/client pair. The
-      // chat bridge has no local resource to release here, so we only log it.
-      logger.info(
-        { elicitationId: params.elicitationId },
-        "MCP URL elicitation completed",
-      );
-    },
-  );
 }

--- a/platform/backend/src/routes/mcp-app-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-app-gateway.utils.ts
@@ -51,6 +51,7 @@ import type { CommonToolCall } from "@/types";
 import { appOwner } from "@/types";
 import { APP_LAUNCH_TOOL_NAME, type App } from "@/types/app";
 import type { McpServerCapabilitiesWithExtensions } from "@/types/mcp-capabilities";
+import { RESOURCE_NOT_FOUND_ERROR_CODE } from "./mcp-gateway.protocol";
 import {
   deriveAuthMethod,
   normalizeToolInputSchema,
@@ -125,7 +126,7 @@ export async function createAppServer(
       // a foreign URI (keeps listed == served and avoids mislabeled caching).
       if (uri !== getArchestraAppResourceUri(appId)) {
         throw {
-          code: -32002,
+          code: RESOURCE_NOT_FOUND_ERROR_CODE,
           message: `Resource not found: ${uri}`,
         };
       }
@@ -232,7 +233,10 @@ export async function buildAppUiResource(
     ? await AppVersionModel.findByAppAndVersion(appId, current.latestVersion)
     : null;
   if (!head) {
-    throw { code: -32002, message: `App resource not found for ${appId}` };
+    throw {
+      code: RESOURCE_NOT_FOUND_ERROR_CODE,
+      message: `App resource not found for ${appId}`,
+    };
   }
   const viewer = tokenAuth.userId
     ? await UserModel.getById(tokenAuth.userId)

--- a/platform/backend/src/routes/mcp-app-proxy.test.ts
+++ b/platform/backend/src/routes/mcp-app-proxy.test.ts
@@ -539,7 +539,8 @@ describe("mcpAppProxyRoutes POST /api/mcp/app/:appId", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json().error?.code).toBe(-32002);
+    // SEP-2164 moved missing-resource errors onto JSON-RPC Invalid Params.
+    expect(response.json().error?.code).toBe(-32602);
   });
 
   // ---- External MCP clients (Bearer token) ----

--- a/platform/backend/src/routes/mcp-gateway.mrtr-roundtrip.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.mrtr-roundtrip.test.ts
@@ -220,7 +220,9 @@ describe("MRTR round trip", () => {
 
     const result = await getCallToolHandler(server)(callToolRequest(), {});
 
-    expect(result.resultType).toBeUndefined();
+    // Completed calls are stamped "complete"; only MRTR interim results carry
+    // "input_required".
+    expect(result.resultType).toBe("complete");
     expect(result.isError).toBeFalsy();
     // The upstream received the client's answer rather than being asked again.
     expect(JSON.stringify(result.content)).toContain("apollo");
@@ -262,6 +264,52 @@ describe("MRTR round trip", () => {
     expect(result.isError).toBe(true);
   });
 
+  test("an ordinary tool result carries the complete envelope", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+    makeInternalMcpCatalog,
+    makeTool,
+    makeMcpServer,
+    makeAgentTool,
+  }) => {
+    // tools/call results were the gap: list and read results already carried
+    // the envelope, so a client could not rely on it being present everywhere.
+    const { agent, tokenAuth } = await seed({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeAgent,
+      makeInternalMcpCatalog,
+      makeTool,
+      makeMcpServer,
+      makeAgentTool,
+    } as never);
+
+    vi.spyOn(mcpClient, "executeToolCallForOwner").mockResolvedValue({
+      id: "call_1",
+      name: TOOL_NAME,
+      content: [{ type: "text", text: "done" }],
+      isError: false,
+    } as never);
+
+    const { server } = await createAgentServer({
+      agentId: agent.id,
+      tokenAuth,
+      mrtr: { enabled: true, clientCapabilities: { elicitation: {} } },
+    });
+
+    const result = await getCallToolHandler(server)(callToolRequest(), {});
+
+    expect(result.resultType).toBe("complete");
+    expect(
+      (result._meta as Record<string, unknown>)[
+        "io.modelcontextprotocol/serverInfo"
+      ],
+    ).toMatchObject({ name: `archestra-agent-${agent.id}` });
+  });
+
   test("a legacy client keeps the in-band elicitation path", async ({
     makeOrganization,
     makeUser,
@@ -298,6 +346,6 @@ describe("MRTR round trip", () => {
     });
 
     expect(sendRequest).toHaveBeenCalled();
-    expect(result.resultType).toBeUndefined();
+    expect(result.resultType).toBe("complete");
   });
 });

--- a/platform/backend/src/routes/mcp-gateway.protocol.test.ts
+++ b/platform/backend/src/routes/mcp-gateway.protocol.test.ts
@@ -15,6 +15,7 @@ import {
   buildGatewayServerCapabilities,
   buildPrivateListCacheHint,
   deriveRequestTargetName,
+  extractTraceContext,
   isDiscoverRequest,
   isResourceUnavailableError,
   LEGACY_MCP_PROTOCOL_REVISION,
@@ -363,6 +364,48 @@ describe("server/discover", () => {
     expect(capabilities.extensions).toHaveProperty(
       "io.modelcontextprotocol/ui",
     );
+  });
+});
+
+describe("extractTraceContext", () => {
+  const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+  test("reads W3C trace context a client attached", () => {
+    expect(
+      extractTraceContext({
+        params: {
+          _meta: { traceparent, tracestate: "vendor=x", baggage: "k=v" },
+        },
+      }),
+    ).toEqual({ traceparent, tracestate: "vendor=x", baggage: "k=v" });
+  });
+
+  test("traceparent alone is enough to join a trace", () => {
+    expect(extractTraceContext({ params: { _meta: { traceparent } } })).toEqual(
+      {
+        traceparent,
+      },
+    );
+  });
+
+  test("context without traceparent cannot join a trace", () => {
+    // tracestate and baggage only decorate traceparent; without it there is
+    // nothing to link spans to.
+    expect(
+      extractTraceContext({ params: { _meta: { tracestate: "vendor=x" } } }),
+    ).toBeUndefined();
+  });
+
+  test("a request carrying no context reports none", () => {
+    expect(extractTraceContext({ params: {} })).toBeUndefined();
+    expect(extractTraceContext({})).toBeUndefined();
+    expect(extractTraceContext(null)).toBeUndefined();
+  });
+
+  test("non-string values are ignored rather than propagated", () => {
+    expect(
+      extractTraceContext({ params: { _meta: { traceparent: 42 } } }),
+    ).toBeUndefined();
   });
 });
 

--- a/platform/backend/src/routes/mcp-gateway.protocol.ts
+++ b/platform/backend/src/routes/mcp-gateway.protocol.ts
@@ -69,11 +69,63 @@ export const MCP_CLIENT_CAPABILITIES_META_KEY =
 export const SERVER_DISCOVER_METHOD = "server/discover";
 
 /**
+ * W3C Trace Context keys the revision fixes for `_meta` (SEP-414).
+ *
+ * Naming them in the spec is the whole value: a host, its client SDK, this
+ * gateway, and the upstream server can join one span tree in an OpenTelemetry
+ * backend instead of each inventing a key.
+ */
+export const TRACE_CONTEXT_META_KEYS = [
+  "traceparent",
+  "tracestate",
+  "baggage",
+] as const;
+
+export type TraceContext = Partial<
+  Record<(typeof TRACE_CONTEXT_META_KEYS)[number], string>
+>;
+
+/**
+ * Read W3C trace context a client attached to a request.
+ *
+ * Returns undefined when nothing usable is present, so callers can tell "no
+ * context" apart from "empty context" without inspecting the object.
+ */
+export function extractTraceContext(body: unknown): TraceContext | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const params = (body as { params?: unknown }).params;
+  if (typeof params !== "object" || params === null) return undefined;
+  const meta = (params as { _meta?: unknown })._meta;
+  if (typeof meta !== "object" || meta === null) return undefined;
+
+  const source = meta as Record<string, unknown>;
+  const context: TraceContext = {};
+  for (const key of TRACE_CONTEXT_META_KEYS) {
+    const value = source[key];
+    if (typeof value === "string" && value !== "") {
+      context[key] = value;
+    }
+  }
+
+  // `traceparent` is what actually links spans; tracestate and baggage only
+  // decorate it, so context without it cannot join a trace.
+  return context.traceparent ? context : undefined;
+}
+
+/**
  * Error codes from the revision's allocation policy, which reserves
  * -32020..-32099 for the specification. These replace the generic JSON-RPC
  * codes an earlier draft used, so they are not interchangeable with -32600.
  */
 export const HEADER_MISMATCH_ERROR_CODE = -32020;
+
+/**
+ * Missing-resource errors. SEP-2164 moved these off the MCP-specific -32002
+ * onto JSON-RPC's generic Invalid Params. `isResourceUnavailableError` still
+ * accepts the old code, so an upstream that has not migrated keeps working —
+ * this is only what the gateway itself emits.
+ */
+export const RESOURCE_NOT_FOUND_ERROR_CODE = -32602;
 export const UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE = -32022;
 
 /**

--- a/platform/backend/src/routes/mcp-gateway.ts
+++ b/platform/backend/src/routes/mcp-gateway.ts
@@ -16,6 +16,7 @@ import {
 } from "./mcp-gateway.mrtr";
 import {
   buildDiscoverResult,
+  extractTraceContext,
   isDiscoverRequest,
   MCP_PROTOCOL_VERSION_HEADER,
   type McpProtocolRevision,
@@ -139,6 +140,17 @@ async function handleMcpPostRequest(
   // Read from the raw body: the SDK's request schemas drop unknown params, so
   // these are gone by the time a request handler runs.
   const mrtrParams = extractMrtrParams(body);
+
+  // SEP-414: a client may attach W3C trace context, which lets its spans, the
+  // gateway's, and the upstream server's join one trace. Logged on the request
+  // so a trace id present in the client is findable here.
+  const traceContext = extractTraceContext(body);
+  if (traceContext) {
+    fastify.log.debug(
+      { profileId, traceparent: traceContext.traceparent },
+      "MCP request carries W3C trace context",
+    );
+  }
   const isInitialize =
     typeof body?.method === "string" && body.method === "initialize";
 

--- a/platform/backend/src/routes/mcp-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-gateway.utils.ts
@@ -998,14 +998,14 @@ export async function createAgentServer(params: {
         // Transform CommonToolResult to MCP response format
         // When isError is true, we still return the content so the LLM can see
         // the error message and potentially try a different approach
-        return {
+        return complete({
           content: Array.isArray(result.content)
             ? result.content
             : [{ type: "text", text: JSON.stringify(result.content) }],
           isError: result.isError,
           _meta: result._meta,
           structuredContent: result.structuredContent,
-        };
+        });
       } catch (error) {
         // MRTR: not a failure. The call needs input the gateway does not have,
         // so it answers with an InputRequiredResult and the client retries the

--- a/platform/backend/src/routes/mcp-server-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-server-gateway.utils.ts
@@ -12,6 +12,7 @@ import mcpClient from "@/clients/mcp-client";
 import config from "@/config";
 import { ToolModel } from "@/models";
 import type { McpServerCapabilitiesWithExtensions } from "@/types/mcp-capabilities";
+import { RESOURCE_NOT_FOUND_ERROR_CODE } from "./mcp-gateway.protocol";
 import { normalizeToolInputSchema } from "./mcp-gateway.utils";
 
 type McpListTool = ListToolsResult["tools"][number];
@@ -77,7 +78,10 @@ export function createServerScopedServer(params: {
       // credentials. Refuse rather than forward (mirrors the owned-app gateway,
       // which serves only its own `ui://` resource).
       if (!uri.startsWith("ui://")) {
-        throw { code: -32002, message: `Resource not found: ${uri}` };
+        throw {
+          code: RESOURCE_NOT_FOUND_ERROR_CODE,
+          message: `Resource not found: ${uri}`,
+        };
       }
       return (await mcpClient.readResourceForServer({
         mcpServerId,

--- a/platform/backend/src/routes/mcp-server-proxy.ui-resource.test.ts
+++ b/platform/backend/src/routes/mcp-server-proxy.ui-resource.test.ts
@@ -239,7 +239,8 @@ describe("external UI server served as an MCP App (POST /api/mcp/server/:id)", (
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().error?.code).toBe(-32002);
+    // SEP-2164 moved missing-resource errors onto JSON-RPC Invalid Params.
+    expect(res.json().error?.code).toBe(-32602);
     // The refused read must never reach the upstream (no exfiltration through
     // the app runtime's install credentials).
     expect(readSpy).not.toHaveBeenCalled();

--- a/platform/backend/src/routes/oauth-issuer-binding.test.ts
+++ b/platform/backend/src/routes/oauth-issuer-binding.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Authorization-server binding for operator-configured credentials (SEP-2352).
+ *
+ * Only configured credentials can go stale here: dynamically registered ones
+ * are never persisted, so a fresh registration happens every flow. These pin
+ * the case that can actually go wrong — a resource moving to a different
+ * authorization server while a configured client id stays behind.
+ */
+
+import { describe, expect, test } from "@/test";
+import {
+  checkPreregisteredCredentialBinding,
+  isClientIdMetadataDocument,
+  sameAuthorizationServer,
+} from "./oauth-issuer-binding";
+
+const A = "https://auth-a.example.com";
+const B = "https://auth-b.example.com";
+
+describe("checkPreregisteredCredentialBinding", () => {
+  test("credentials are used against the server they were configured for", () => {
+    expect(
+      checkPreregisteredCredentialBinding({
+        configuredAuthServer: A,
+        discoveredIssuer: A,
+        clientId: "abc123",
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  test("a resource that moved to another server is refused", () => {
+    expect(
+      checkPreregisteredCredentialBinding({
+        configuredAuthServer: A,
+        discoveredIssuer: B,
+        clientId: "abc123",
+      }),
+    ).toEqual({ ok: false, reason: "preregistered_issuer_mismatch" });
+  });
+
+  test("a CIMD client id stays portable across servers", () => {
+    expect(
+      checkPreregisteredCredentialBinding({
+        configuredAuthServer: A,
+        discoveredIssuer: B,
+        clientId: "https://client.example.com/metadata.json",
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  test("missing configuration proceeds rather than failing closed", () => {
+    // Nothing to compare against is not evidence of a mismatch, and failing
+    // here would break every deployment that never set an auth server.
+    expect(
+      checkPreregisteredCredentialBinding({
+        configuredAuthServer: undefined,
+        discoveredIssuer: B,
+        clientId: "abc123",
+      }),
+    ).toEqual({ ok: true });
+
+    expect(
+      checkPreregisteredCredentialBinding({
+        configuredAuthServer: A,
+        discoveredIssuer: undefined,
+        clientId: "abc123",
+      }),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("sameAuthorizationServer", () => {
+  test("a trailing slash is tolerated", () => {
+    // Unlike the RFC 9207 response check, this side is typed by an operator
+    // into configuration, so a trailing slash is a typo rather than an attack.
+    expect(sameAuthorizationServer(A, `${A}/`)).toBe(true);
+  });
+
+  test("a different host is not the same server", () => {
+    expect(sameAuthorizationServer(A, B)).toBe(false);
+  });
+});
+
+describe("isClientIdMetadataDocument", () => {
+  test("https identifiers are portable, opaque ids and http are not", () => {
+    expect(isClientIdMetadataDocument("https://c.example.com/x.json")).toBe(
+      true,
+    );
+    expect(isClientIdMetadataDocument("abc123")).toBe(false);
+    expect(isClientIdMetadataDocument("http://c.example.com/x.json")).toBe(
+      false,
+    );
+  });
+});

--- a/platform/backend/src/routes/oauth-issuer-binding.ts
+++ b/platform/backend/src/routes/oauth-issuer-binding.ts
@@ -1,0 +1,75 @@
+/**
+ * Authorization-server binding for client credentials (SEP-2352).
+ *
+ * Client credentials belong to the authorization server that issued them. When
+ * a protected resource moves to a different one, presenting the old client
+ * identity to the new server is wrong, so the revision requires refusing reuse
+ * across a change.
+ *
+ * The requirement lands on only half of our flows. Dynamically registered
+ * credentials are never persisted here — they live in the flow's state cache
+ * and a fresh registration happens on every authorization — so they cannot go
+ * stale across a server change, and that half is satisfied by construction.
+ * Operator-configured credentials do persist, and those are what this guards:
+ * for them the spec asks for a surfaced error rather than a silent mismatch,
+ * since we cannot mint a replacement for a client someone else registered.
+ */
+
+export type CredentialBindingDecision =
+  | { ok: true }
+  | { ok: false; reason: "preregistered_issuer_mismatch" };
+
+/**
+ * Decide whether operator-configured credentials may be used against the
+ * authorization server discovery just reported.
+ *
+ * The comparison is against the authorization server the operator declared,
+ * which is the only record we have of what the credentials were registered
+ * with. Absent either side there is nothing to compare, and the call proceeds
+ * rather than failing closed on missing configuration.
+ */
+export function checkPreregisteredCredentialBinding(params: {
+  /** Authorization server the operator configured these credentials against. */
+  configuredAuthServer?: string | null;
+  /** Issuer discovered for the resource now. */
+  discoveredIssuer?: string | null;
+  /** The client id in use, to spot a portable CIMD identifier. */
+  clientId?: string | null;
+}): CredentialBindingDecision {
+  const { configuredAuthServer, discoveredIssuer, clientId } = params;
+
+  // A CIMD client id is a self-hosted HTTPS URL and means the same thing to
+  // every authorization server, so a change of server does not invalidate it.
+  if (isClientIdMetadataDocument(clientId)) {
+    return { ok: true };
+  }
+
+  if (!configuredAuthServer || !discoveredIssuer) {
+    return { ok: true };
+  }
+
+  return sameAuthorizationServer(configuredAuthServer, discoveredIssuer)
+    ? { ok: true }
+    : { ok: false, reason: "preregistered_issuer_mismatch" };
+}
+
+/**
+ * Compare a configured authorization server URL against a discovered issuer.
+ *
+ * A trailing slash is tolerated here, unlike the RFC 9207 authorization-response
+ * check, which must be byte-exact. This value is typed by an operator into
+ * configuration rather than supplied by a party in the flow, so a trailing
+ * slash is a typo rather than an attack, and rejecting it would break working
+ * setups for no security gain.
+ */
+export function sameAuthorizationServer(a: string, b: string): boolean {
+  return stripTrailingSlash(a) === stripTrailingSlash(b);
+}
+
+export function isClientIdMetadataDocument(clientId?: string | null): boolean {
+  return typeof clientId === "string" && clientId.startsWith("https://");
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}

--- a/platform/backend/src/routes/oauth.ts
+++ b/platform/backend/src/routes/oauth.ts
@@ -18,6 +18,7 @@ import {
   type OAuthRefreshOutcome,
 } from "@/services/oauth-refresh-classification";
 import { ApiError, constructResponseSchema, UuidIdSchema } from "@/types";
+import { checkPreregisteredCredentialBinding } from "./oauth-issuer-binding";
 import { validateAuthorizationResponseIssuer } from "./oauth-issuer-validation";
 
 /**
@@ -907,6 +908,26 @@ const oauthRoutes: FastifyPluginAsyncZod = async (fastify) => {
             throw new ApiError(
               502,
               `Failed to discover OAuth endpoints: ${error instanceof Error ? error.message : String(error)}. Verify the server's OAuth metadata (.well-known) endpoints are reachable.`,
+            );
+          }
+        }
+
+        // SEP-2352: operator-configured credentials belong to the authorization
+        // server they were registered with. Dynamically registered ones are not
+        // persisted — a fresh registration happens every flow — so only the
+        // configured case can go stale, and we cannot mint a replacement for
+        // it. Surface the mismatch rather than presenting one server's client
+        // identity to another.
+        if (clientId) {
+          const binding = checkPreregisteredCredentialBinding({
+            configuredAuthServer: oauthConfig.auth_server_url,
+            discoveredIssuer,
+            clientId,
+          });
+          if (!binding.ok) {
+            throw new ApiError(
+              400,
+              "The configured OAuth client belongs to a different authorization server than this resource now uses. Update the configured credentials or clear them to register with the new server.",
             );
           }
         }


### PR DESCRIPTION
Third pass on 2026-07-28, after #6907, #6930, and #6939.

## What's in

**SEP-2352 — credentials bound to their authorization server.** Client credentials belong to the server that issued them; presenting one server's client identity to another after a resource moves is what the revision forbids.

The requirement lands on only half of our flows, which is *why* my first attempt at this looked inert. Dynamically registered credentials are never persisted — `registrationResult` has no consumer outside the OAuth route, so a fresh registration happens on every authorization — and therefore cannot go stale across a server change. That half is satisfied by construction. Operator-configured credentials *do* persist, and those are what this guards: the spec asks for a surfaced error rather than a silent mismatch, since we cannot mint a replacement for a client someone else registered.

One deliberate asymmetry: a trailing slash is tolerated here, unlike the byte-exact RFC 9207 response check in #6939. That value is typed into configuration by an operator, so a trailing slash is a typo, not an attack — rejecting it would break working setups for no security gain. CIMD client ids stay portable, since a self-hosted HTTPS identifier means the same thing to every server.

**SEP-2164 — emit `-32602`.** We already *accepted* both codes but still sent `-32002` from three sites. The classifier still accepts the old code, so an unmigrated upstream is still read correctly; this changes only what we send.

**`resultType` on `tools/call`.** List, read, and discover results already carried the envelope, so a client couldn't rely on it being present everywhere — which is the only thing that makes the field useful.

**`notifications/elicitation/complete` removed.** Dropped in this revision: under MRTR a client learns an out-of-band outcome by retrying. Our handler only logged. A `2025-11-25` server that still sends one is ignored rather than erroring.

**SEP-414 — W3C trace context.** `traceparent` / `tracestate` / `baggage` read from request `_meta` under the fixed key names, so host → SDK → gateway → upstream can join one span tree. Context without `traceparent` is treated as absent, since the other two only decorate it.

## Testing

369 pass across the gateway, proxy, OAuth, and MCP-client suites. `tsc`, `biome`, `knip` clean.

New: 7 unit tests on credential binding, 5 on trace-context extraction, and a route-level test driving the real `tools/call` handler to assert the envelope reaches an ordinary tool result.

Four existing tests were updated, each pinning behavior this revision deliberately changes — two `-32002` assertions, one asserting the removed notification handler registers, and two MRTR tests asserting a finished call carried *no* `resultType`.

## Not in this PR: `x-mcp-header`

I read the spec for it and stopped short of implementing it, because it doesn't fit our transport as it stands.

`x-mcp-header` requires mirroring designated tool-parameter values into `Mcp-Param-{name}` headers **per call**. Our upstream headers are assembled once per *connection* (`requestInit.headers` at client construction), and connections are pooled and reused across calls. Making this correct means either a per-call transport or an SDK affordance I'd need to verify exists — and getting it wrong risks leaking one call's parameter values onto another call over the same pooled connection, which is worse than not having the feature.

It also carries a real validation burden the spec spells out: token syntax, no CR/LF, case-insensitive uniqueness, primitive types only (explicitly excluding `number`), integers in JS safe range, and static reachability through `properties` chains only — not through `items`, composition, conditionals, or `$ref`.

That's a PR on its own, and it should start from the connection-pooling question rather than from the schema parsing.

## Still open on 2026-07-28

- **`x-mcp-header`**, as above.
- **`resultType` on `prompts/get`** — that result is proxied straight from upstream and isn't rebuilt in our handler, so stamping it needs a different insertion point than the others.
- **Revision-conditional transport** — `subscriptions/listen`, `ping`/`logging/setLevel` removal, per-request `logLevel`, SSE resumability. Parked deliberately; each removes behavior `2025-11-25` clients still use.
- **Tasks extension** — still speculative without a long-running tool story.
