### PR TITLE
fix(llm-cost): price a model the proxy discovers under a mismatched provider

### DIFF
--- a/platform/backend/src/models/model.test.ts
+++ b/platform/backend/src/models/model.test.ts
@@ -787,6 +787,28 @@ describe("ModelModel", () => {
       );
       expect(after?.discoveredViaLlmProxy).toBe(false);
     });
+
+    test("a repeat call neither duplicates the row nor resets its fields", async () => {
+      await ModelModel.ensureModelExists("repeat-model", "openai");
+      const first = await ModelModel.findByProviderAndModelId(
+        "openai",
+        "repeat-model",
+      );
+      await ModelModel.update(first?.id ?? "", {
+        customPricePerMillionInput: "4.00",
+      });
+
+      await ModelModel.ensureModelExists("repeat-model", "openai");
+
+      const all = await ModelModel.findAll({ provider: "openai" });
+      expect(all.filter((m) => m.modelId === "repeat-model")).toHaveLength(1);
+      const after = await ModelModel.findByProviderAndModelId(
+        "openai",
+        "repeat-model",
+      );
+      expect(after?.id).toBe(first?.id);
+      expect(after?.customPricePerMillionInput).toBe("4.00");
+    });
   });
 
   describe("findLlmProxyModels", () => {

--- a/platform/backend/src/models/model.ts
+++ b/platform/backend/src/models/model.ts
@@ -642,8 +642,12 @@ class ModelModel {
   static async ensureModelExists(
     modelId: string,
     provider: SupportedProvider,
-  ): Promise<void> {
-    await db
+  ): Promise<Model | null> {
+    // RETURNING yields a row only when this call did the insert, which is what
+    // tells the caller a model was seen for the first time and still needs its
+    // registry data. On conflict it yields nothing, so a repeat sighting costs
+    // one statement and leaves the existing row untouched.
+    const [inserted] = await db
       .insert(schema.modelsTable)
       .values({
         externalId: `${provider}/${modelId}`,
@@ -652,7 +656,32 @@ class ModelModel {
         discoveredViaLlmProxy: true,
         lastSyncedAt: new Date(),
       })
-      .onConflictDoNothing();
+      .onConflictDoNothing()
+      .returning();
+
+    return inserted ?? null;
+  }
+
+  /**
+   * Write registry-sourced price and limits onto a model, leaving every other
+   * column (custom prices, team links, provenance) as it is.
+   */
+  static async applyRegistryCapabilities(
+    id: string,
+    capabilities: {
+      promptPricePerToken: string | null;
+      completionPricePerToken: string | null;
+      cacheReadPricePerToken: string | null;
+      cacheWritePricePerToken: string | null;
+      contextLength: number | null;
+      outputLength: number | null;
+      supportsToolCalling: boolean | null;
+    },
+  ): Promise<void> {
+    await db
+      .update(schema.modelsTable)
+      .set({ ...capabilities, lastSyncedAt: new Date() })
+      .where(eq(schema.modelsTable.id, id));
   }
 
   /**

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -29,6 +29,7 @@ import { LRUCacheManager } from "@/cache-manager";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
+import { modelsDevClient } from "@/clients/models-dev-client";
 import config from "@/config";
 import logger from "@/logging";
 import {
@@ -59,6 +60,7 @@ import {
   EVENT_GENAI_CONTENT_COMPLETION,
   type SpanTeamInfo,
 } from "@/observability/tracing";
+import { enrichDiscoveredModel } from "@/services/discovered-model-enrichment";
 import {
   ApiError,
   type DualLlmAnalysis,
@@ -766,10 +768,31 @@ export async function handleLLMProxy<
     );
 
     // Ensure model entries exist for cost tracking
-    await ModelModel.ensureModelExists(baselineModel, providerName);
+    const discovered = [
+      await ModelModel.ensureModelExists(baselineModel, providerName),
+      actualModel !== baselineModel
+        ? await ModelModel.ensureModelExists(actualModel, providerName)
+        : null,
+    ].filter((model) => model !== null);
 
-    if (actualModel !== baselineModel) {
-      await ModelModel.ensureModelExists(actualModel, providerName);
+    // Only a first sighting reaches here, so the registry fetch (cached) and the
+    // update stay off the per-request path. Enrichment is best-effort: a model
+    // that cannot be priced must not fail the request it arrived on.
+    if (discovered.length > 0) {
+      try {
+        const modelsDevData = await modelsDevClient.fetchModelsFromApi();
+        for (const model of discovered) {
+          await enrichDiscoveredModel({ model, modelsDevData });
+        }
+      } catch (error) {
+        logger.warn(
+          {
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
+          },
+          "Failed to enrich proxy-discovered models",
+        );
+      }
     }
 
     // Prepare SSE headers for lazy commitment if streaming.

--- a/platform/backend/src/services/cross-provider-pricing.test.ts
+++ b/platform/backend/src/services/cross-provider-pricing.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 import type { ModelsDevApiResponse } from "@/clients/models-dev-client";
-import { resolveCrossProviderPrices } from "./cross-provider-pricing";
+import {
+  resolveCrossProviderPrices,
+  resolveDiscoveredModelRegistryEntry,
+} from "./cross-provider-pricing";
 
 // Minimal models.dev fixture mirroring real shapes: the canonical `anthropic`
 // entry carries cache prices; the `amazon-bedrock` entry is keyed by the Bedrock
@@ -297,4 +300,60 @@ test("returns null for providers that match models.dev keys directly", () => {
   });
 
   expect(prices).toBeNull();
+});
+
+describe("resolveDiscoveredModelRegistryEntry", () => {
+  // A client can send any model name to any gateway endpoint, and the row is
+  // recorded under the endpoint's provider. Provider-scoped resolution then
+  // matches nothing, even when the registry lists the model under its own
+  // vendor, so the model lands on the fabricated default estimate.
+  test("prices a vendor model that arrived at a mismatched provider endpoint", () => {
+    const resolved = resolveDiscoveredModelRegistryEntry({
+      provider: "bedrock",
+      modelId: "gpt-4o",
+      modelsDevData: MODELS_DEV,
+    });
+
+    expect(resolved?.prices).toEqual({
+      promptPricePerToken: "0.0000025",
+      completionPricePerToken: "0.00001",
+      cacheReadPricePerToken: "0.00000125",
+      cacheWritePricePerToken: null,
+    });
+  });
+
+  test("still prefers the provider-scoped match when one exists", () => {
+    const resolved = resolveDiscoveredModelRegistryEntry({
+      provider: "bedrock",
+      modelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      modelsDevData: MODELS_DEV,
+    });
+
+    // The bedrock entry, not a registry-wide guess.
+    expect(resolved?.prices?.promptPricePerToken).toBe("0.000003");
+    expect(resolved?.metadata?.contextLength).toBeNull();
+  });
+
+  test("abstains when no first-party vendor lists the model", () => {
+    expect(
+      resolveDiscoveredModelRegistryEntry({
+        provider: "bedrock",
+        modelId: "somevendor.private-model-v3",
+        modelsDevData: MODELS_DEV,
+      }),
+    ).toBeNull();
+  });
+
+  test("does not resolve a model listed only by a reseller", () => {
+    // `us.meta.llama3-3-70b-instruct-v1:0` exists in the fixture under
+    // amazon-bedrock only. Reached as a bare id under another provider it must
+    // not be priced from that reseller row.
+    expect(
+      resolveDiscoveredModelRegistryEntry({
+        provider: "openai",
+        modelId: "us.meta.llama3-3-70b-instruct-v1:0",
+        modelsDevData: MODELS_DEV,
+      }),
+    ).toBeNull();
+  });
 });

--- a/platform/backend/src/services/cross-provider-pricing.ts
+++ b/platform/backend/src/services/cross-provider-pricing.ts
@@ -42,8 +42,7 @@ export function resolveCrossProviderPrices(params: {
 }): CrossProviderPrices | null {
   // Entries are ordered by preference (a vendor's canonical entry, which has
   // cache prices, before the region-keyed amazon-bedrock fallback).
-  const entry = resolveCrossProviderEntries(params).find((e) => e.cost);
-  return entry?.cost ? modelsDevCostToPerToken(entry.cost) : null;
+  return pricesFromEntries(resolveCrossProviderEntries(params));
 }
 
 /**
@@ -79,30 +78,47 @@ export function resolveCrossProviderMetadata(params: {
   underlyingModelName?: string | null;
   modelsDevData: ModelsDevApiResponse;
 }): CrossProviderMetadata | null {
-  const entries = resolveCrossProviderEntries(params).reverse();
-  const [preferred] = entries;
-  if (!preferred) {
+  return metadataFromEntries(resolveCrossProviderEntries(params));
+}
+
+/**
+ * Registry match for a model recorded by the LLM proxy, which names the
+ * endpoint's provider rather than the model's own.
+ *
+ * A client may send any model name to any gateway endpoint, so the stored
+ * provider is the endpoint's. Provider-scoped resolution then matches nothing
+ * and the model falls to the fabricated default estimate even when the registry
+ * lists it plainly -- an OpenAI model reaching a Bedrock endpoint is priced at
+ * $50/M against a published $2.50.
+ *
+ * The provider-scoped match is still preferred, because a reseller's own entry
+ * carries the price and limits that actually apply. Only when nothing matches
+ * does this fall back to looking the bare id up among the vendors that make
+ * models, deliberately skipping resellers and aggregators: they republish each
+ * other's models at their own margins, so matching one would trade a wrong
+ * price for a differently wrong price.
+ */
+export function resolveDiscoveredModelRegistryEntry(params: {
+  provider: SupportedProvider;
+  modelId: string;
+  underlyingModelName?: string | null;
+  modelsDevData: ModelsDevApiResponse;
+}): {
+  prices: CrossProviderPrices | null;
+  metadata: CrossProviderMetadata | null;
+} | null {
+  const scoped = resolveCrossProviderEntries(params);
+  const entries = scoped.length
+    ? scoped
+    : toArray(
+        findFirstPartyRegistryEntry(params.modelId, params.modelsDevData),
+      );
+  if (!entries.length) {
     return null;
   }
-
   return {
-    // Limits come from the preferred entry alone. Falling back to the next entry
-    // for a missing limit would reintroduce the overstatement this ordering
-    // exists to prevent: a reseller row that omits `limit.context` would publish
-    // the vendor's larger window — Anthropic's 1M for a model Bedrock serves at
-    // 200K — and an inflated window over-allocates the output budget and admits
-    // requests the reseller rejects. Unknown is reported as null instead.
-    contextLength: preferred.limit?.context ?? null,
-    outputLength: sanitizeOutputLimit(preferred.limit?.output),
-    // Modalities and tool support carry no such risk, so a reseller row that
-    // omits them still benefits from the vendor's values.
-    inputModalities: firstPresent(entries, (entry) =>
-      entry.modalities?.input?.length ? entry.modalities.input : null,
-    ),
-    outputModalities: firstPresent(entries, (entry) =>
-      entry.modalities?.output?.length ? entry.modalities.output : null,
-    ),
-    supportsToolCalling: firstPresent(entries, (entry) => entry.tool_call),
+    prices: pricesFromEntries(entries),
+    metadata: metadataFromEntries(entries),
   };
 }
 
@@ -284,6 +300,82 @@ function findModelsDevModel(params: {
     }
   }
 
+  return null;
+}
+
+function pricesFromEntries(
+  entries: ModelsDevModel[],
+): CrossProviderPrices | null {
+  const entry = entries.find((e) => e.cost);
+  return entry?.cost ? modelsDevCostToPerToken(entry.cost) : null;
+}
+
+function metadataFromEntries(
+  entries: ModelsDevModel[],
+): CrossProviderMetadata | null {
+  const ordered = [...entries].reverse();
+  const [preferred] = ordered;
+  if (!preferred) {
+    return null;
+  }
+
+  return {
+    // Limits come from the preferred entry alone. Falling back to the next entry
+    // for a missing limit would reintroduce the overstatement this ordering
+    // exists to prevent: a reseller row that omits `limit.context` would publish
+    // the vendor's larger window -- Anthropic's 1M for a model Bedrock serves at
+    // 200K -- and an inflated window over-allocates the output budget and admits
+    // requests the reseller rejects. Unknown is reported as null instead.
+    contextLength: preferred.limit?.context ?? null,
+    outputLength: sanitizeOutputLimit(preferred.limit?.output),
+    // Modalities and tool support carry no such risk, so a reseller row that
+    // omits them still benefits from the vendor's values.
+    inputModalities: firstPresent(ordered, (entry) =>
+      entry.modalities?.input?.length ? entry.modalities.input : null,
+    ),
+    outputModalities: firstPresent(ordered, (entry) =>
+      entry.modalities?.output?.length ? entry.modalities.output : null,
+    ),
+    supportsToolCalling: firstPresent(ordered, (entry) => entry.tool_call),
+  };
+}
+
+/**
+ * models.dev providers that publish their own models, in preference order.
+ * Resellers and aggregators are excluded on purpose: they list other vendors'
+ * models at their own rates, so a match there asserts a price the caller is not
+ * being charged.
+ */
+const FIRST_PARTY_REGISTRY_PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "meta",
+  "mistral",
+  "deepseek",
+  "xai",
+  "cohere",
+  "moonshotai",
+  "minimax",
+  "alibaba",
+  "nvidia",
+];
+
+function findFirstPartyRegistryEntry(
+  modelId: string,
+  modelsDevData: ModelsDevApiResponse,
+): ModelsDevModel | null {
+  const candidates = dedupe([modelId, stripModelDateSuffix(modelId)]);
+  for (const modelsDevProviderId of FIRST_PARTY_REGISTRY_PROVIDERS) {
+    const entry = findModelsDevModel({
+      modelsDevData,
+      modelsDevProviderId,
+      candidates,
+    });
+    if (entry) {
+      return entry;
+    }
+  }
   return null;
 }
 

--- a/platform/backend/src/services/discovered-model-enrichment.test.ts
+++ b/platform/backend/src/services/discovered-model-enrichment.test.ts
@@ -1,0 +1,111 @@
+import type { SupportedProvider } from "@archestra/shared";
+import type { ModelsDevApiResponse } from "@/clients/models-dev-client";
+import { ModelModel } from "@/models";
+import { expect, test } from "@/test";
+import { enrichDiscoveredModel } from "./discovered-model-enrichment";
+
+/** `ensureModelExists` reports null for a model already present; these tests
+ * always create a fresh one, so a null here is a broken fixture. */
+async function discover(modelId: string, provider: SupportedProvider) {
+  const model = await ModelModel.ensureModelExists(modelId, provider);
+  if (!model) {
+    throw new Error(`expected ${provider}/${modelId} to be newly created`);
+  }
+  return model;
+}
+
+const MODELS_DEV: ModelsDevApiResponse = {
+  openai: {
+    id: "openai",
+    name: "OpenAI",
+    models: {
+      "gpt-4o": {
+        id: "gpt-4o",
+        name: "GPT-4o",
+        cost: { input: 2.5, output: 10, cache_read: 1.25 },
+        limit: { context: 128000, output: 16384 },
+        tool_call: true,
+      },
+    },
+  },
+  "amazon-bedrock": {
+    id: "amazon-bedrock",
+    name: "Amazon Bedrock",
+    models: {
+      "amazon.nova-pro-v1:0": {
+        id: "amazon.nova-pro-v1:0",
+        name: "Nova Pro",
+        cost: { input: 0.8, output: 3.2 },
+        limit: { context: 300000, output: 8192 },
+      },
+    },
+  },
+};
+
+test("prices a model recorded under the endpoint's provider, not its own", async () => {
+  // A client sent an OpenAI model name to a Bedrock endpoint, so the row was
+  // written with provider "bedrock".
+  const created = await discover("gpt-4o", "bedrock");
+
+  const enriched = await enrichDiscoveredModel({
+    model: created,
+    modelsDevData: MODELS_DEV,
+  });
+
+  expect(enriched).toBe(true);
+  const model = await ModelModel.findByProviderAndModelId("bedrock", "gpt-4o");
+  expect(Number(model?.promptPricePerToken)).toBe(0.0000025);
+  expect(Number(model?.completionPricePerToken)).toBe(0.00001);
+  expect(model?.contextLength).toBe(128000);
+  expect(model?.supportsToolCalling).toBe(true);
+  // The row is still what it is: discovered through the proxy.
+  expect(model?.discoveredViaLlmProxy).toBe(true);
+});
+
+test("the enriched model no longer reports the fabricated default price", async () => {
+  const created = await discover("gpt-4o", "bedrock");
+  await enrichDiscoveredModel({ model: created, modelsDevData: MODELS_DEV });
+
+  const model = await ModelModel.findByProviderAndModelId("bedrock", "gpt-4o");
+  const pricing = ModelModel.getEffectivePricing(model ?? null, "gpt-4o");
+
+  expect(pricing.pricePerMillionInput).toBe("2.50");
+  expect(pricing.pricePerMillionOutput).toBe("10.00");
+  expect(pricing.source).not.toBe("default");
+});
+
+test("still resolves through the provider-scoped path when it matches", async () => {
+  const created = await discover("us.amazon.nova-pro-v1:0", "bedrock");
+
+  expect(
+    await enrichDiscoveredModel({ model: created, modelsDevData: MODELS_DEV }),
+  ).toBe(true);
+  const model = await ModelModel.findByProviderAndModelId(
+    "bedrock",
+    "us.amazon.nova-pro-v1:0",
+  );
+  expect(Number(model?.promptPricePerToken)).toBe(0.0000008);
+  expect(model?.contextLength).toBe(300000);
+});
+
+test("leaves a model the registry cannot place untouched", async () => {
+  const created = await discover(
+    "us.anthropic.claude-notarealmodel-v1:0",
+    "bedrock",
+  );
+
+  expect(
+    await enrichDiscoveredModel({ model: created, modelsDevData: MODELS_DEV }),
+  ).toBe(false);
+  const model = await ModelModel.findByProviderAndModelId(
+    "bedrock",
+    "us.anthropic.claude-notarealmodel-v1:0",
+  );
+  expect(model?.promptPricePerToken).toBeNull();
+});
+
+test("a second sighting reports no insert, so enrichment does not re-run", async () => {
+  await discover("gpt-4o", "bedrock");
+
+  expect(await ModelModel.ensureModelExists("gpt-4o", "bedrock")).toBeNull();
+});

--- a/platform/backend/src/services/discovered-model-enrichment.ts
+++ b/platform/backend/src/services/discovered-model-enrichment.ts
@@ -1,0 +1,52 @@
+import type { ModelsDevApiResponse } from "@/clients/models-dev-client";
+import logger from "@/logging";
+import { ModelModel } from "@/models";
+import { resolveDiscoveredModelRegistryEntry } from "@/services/cross-provider-pricing";
+import type { Model } from "@/types";
+
+/**
+ * Fill in a model the LLM proxy has just recorded for the first time.
+ *
+ * Sync only ever writes models a provider's own API returned, so a model that
+ * only ever arrives through the proxy is never reached by it, and
+ * `deleteOrphanedModels` spares proxy-discovered rows by design. Without this
+ * the row keeps a null price for its whole life and every request against it is
+ * costed at the fabricated default estimate, which is what
+ * `interactions.cost`, the cost statistics and the token-cost limits are all
+ * computed from.
+ *
+ * Returns whether anything was written; a model the registry cannot place is
+ * left alone rather than guessed at.
+ */
+export async function enrichDiscoveredModel(params: {
+  model: Model;
+  modelsDevData: ModelsDevApiResponse;
+}): Promise<boolean> {
+  const { model, modelsDevData } = params;
+
+  const resolved = resolveDiscoveredModelRegistryEntry({
+    provider: model.provider,
+    modelId: model.modelId,
+    modelsDevData,
+  });
+  if (!resolved) {
+    return false;
+  }
+
+  const { prices, metadata } = resolved;
+  await ModelModel.applyRegistryCapabilities(model.id, {
+    promptPricePerToken: prices?.promptPricePerToken ?? null,
+    completionPricePerToken: prices?.completionPricePerToken ?? null,
+    cacheReadPricePerToken: prices?.cacheReadPricePerToken ?? null,
+    cacheWritePricePerToken: prices?.cacheWritePricePerToken ?? null,
+    contextLength: metadata?.contextLength ?? null,
+    outputLength: metadata?.outputLength ?? null,
+    supportsToolCalling: metadata?.supportsToolCalling ?? null,
+  });
+
+  logger.info(
+    { provider: model.provider, modelId: model.modelId },
+    "Enriched proxy-discovered model from the registry",
+  );
+  return true;
+}

--- a/platform/backend/src/services/model-capability-matrix.test.ts
+++ b/platform/backend/src/services/model-capability-matrix.test.ts
@@ -8,6 +8,8 @@ import type {
   ModelOutputModality,
   PriceSource,
 } from "@/types";
+import { resolveDiscoveredModelRegistryEntry } from "./cross-provider-pricing";
+import { enrichDiscoveredModel } from "./discovered-model-enrichment";
 import { buildModelsToUpsert } from "./model-sync";
 
 /**
@@ -270,6 +272,13 @@ interface MatrixRow {
   modelId: string;
   underlyingModelName?: string;
   fetched?: FetchedModelCapabilities;
+  /**
+   * Route the row through the LLM proxy's discovery path instead of a sync.
+   * A model the proxy names is written bare under the *endpoint's* provider and
+   * is never revisited by a sync, so it resolves through a different path and
+   * belongs in the same table rather than a private one.
+   */
+  discovered?: true;
   expected: ExpectedCapabilities;
 }
 
@@ -474,6 +483,71 @@ const MATRIX: MatrixRow[] = [
       pricePerMillionCacheRead: "0.3",
       pricePerMillionCacheWrite: "3.75",
       cachePriceSource: "models_dev",
+    },
+  },
+
+  // --- Proxy discovery: model recorded under the endpoint's provider -------
+  {
+    name: "discovered/bedrock:gpt-4o — a vendor model that reached a mismatched endpoint",
+    provider: "bedrock",
+    modelId: "gpt-4o",
+    discovered: true,
+    expected: {
+      contextLength: 128000,
+      outputLength: 16384,
+      // Enrichment deliberately writes no modalities: validating them against
+      // the column schema lives in the sync path.
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: true,
+      pricePerMillionInput: "2.50",
+      pricePerMillionOutput: "10.00",
+      priceSource: "models_dev",
+      pricePerMillionCacheRead: "1.25",
+      // The registry entry carries no cache-write price, so it derives from the
+      // input price rather than being synced.
+      pricePerMillionCacheWrite: "3.125",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "discovered/bedrock:us.amazon.nova-lite — still resolves through the provider-scoped path",
+    provider: "bedrock",
+    modelId: "us.amazon.nova-lite-v1:0",
+    discovered: true,
+    expected: {
+      contextLength: 300000,
+      outputLength: 8192,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: true,
+      pricePerMillionInput: "0.06",
+      pricePerMillionOutput: "0.24",
+      // The AWS snapshot lists this model at the same rate, so the stored price
+      // matches it and the provenance reads as AWS.
+      priceSource: "aws",
+      pricePerMillionCacheRead: "0.015",
+      pricePerMillionCacheWrite: "0.075",
+      cachePriceSource: "models_dev",
+    },
+  },
+  {
+    name: "discovered/bedrock:unlisted — no first-party vendor lists it, so no price is asserted",
+    provider: "bedrock",
+    modelId: "us.anthropic.claude-notarealmodel-v1:0",
+    discovered: true,
+    expected: {
+      contextLength: null,
+      outputLength: null,
+      inputModalities: null,
+      outputModalities: null,
+      supportsToolCalling: null,
+      pricePerMillionInput: "50.00",
+      pricePerMillionOutput: "50.00",
+      priceSource: "default",
+      pricePerMillionCacheRead: "5",
+      pricePerMillionCacheWrite: "62.5",
+      cachePriceSource: "derived_multiplier",
     },
   },
 
@@ -1008,24 +1082,48 @@ const MATRIX: MatrixRow[] = [
  * the guard below fails until someone updates this number, which is the moment
  * to ask whether that model should really be unpriced.
  */
-const EXPECTED_DEFAULT_PRICED_ROWS = 7;
+const EXPECTED_DEFAULT_PRICED_ROWS = 8;
+
+/**
+ * Reproduce what the LLM proxy does the first time it sees a model: write the
+ * bare row under the endpoint's provider, then enrich it from the registry.
+ */
+async function discoverAndEnrich(row: MatrixRow) {
+  const created = await ModelModel.ensureModelExists(row.modelId, row.provider);
+  if (!created) {
+    throw new Error(`expected ${row.provider}/${row.modelId} to be created`);
+  }
+  await enrichDiscoveredModel({ model: created, modelsDevData: MODELS_DEV });
+  const model = await ModelModel.findByProviderAndModelId(
+    row.provider,
+    row.modelId,
+  );
+  if (!model) {
+    throw new Error(`expected ${row.provider}/${row.modelId} to be readable`);
+  }
+  return model;
+}
 
 describe("model capability matrix", () => {
   for (const row of MATRIX) {
     test(row.name, async () => {
-      const [model] = await ModelModel.bulkUpsert(
-        buildModelsToUpsert({
-          provider: row.provider,
-          models: [
-            {
-              id: row.modelId,
-              capabilities: row.fetched,
-              underlyingModelName: row.underlyingModelName ?? null,
-            },
-          ],
-          modelsDevData: MODELS_DEV,
-        }),
-      );
+      const model = row.discovered
+        ? await discoverAndEnrich(row)
+        : (
+            await ModelModel.bulkUpsert(
+              buildModelsToUpsert({
+                provider: row.provider,
+                models: [
+                  {
+                    id: row.modelId,
+                    capabilities: row.fetched,
+                    underlyingModelName: row.underlyingModelName ?? null,
+                  },
+                ],
+                modelsDevData: MODELS_DEV,
+              }),
+            )
+          )[0];
 
       const capabilities = ModelModel.toCapabilities(model);
 
@@ -1050,6 +1148,18 @@ describe("model capability matrix", () => {
 
   test("only the known-unpriced models fall through to the estimate", () => {
     const unpriced = MATRIX.filter((row) => {
+      // Each row is judged by the path it actually takes. Running a discovered
+      // row through the sync builder would report it unpriced for a resolution
+      // it never performs, hiding the estimate this guard exists to surface.
+      if (row.discovered) {
+        return (
+          resolveDiscoveredModelRegistryEntry({
+            provider: row.provider,
+            modelId: row.modelId,
+            modelsDevData: MODELS_DEV,
+          })?.prices?.promptPricePerToken == null
+        );
+      }
       const [built] = buildModelsToUpsert({
         provider: row.provider,
         models: [


### PR DESCRIPTION
## Summary

A client can name any model on any gateway endpoint. The row the LLM proxy writes carries the **endpoint's** provider, not the model's — so sending `gpt-5.4` to a Bedrock endpoint records `bedrock/gpt-5.4`. Registry resolution is scoped to that provider, so it matches nothing, and the model is recorded at the fabricated $50/M default estimate against a published $2.50 — a 20× overstatement flowing into `interactions.cost`, cost statistics, optimization-rule savings and token-cost limits.

It stays wrong for the row's entire life. Sync only revisits models a provider's own API returned, and it never returns that id; `deleteOrphanedModels` spares proxy-discovered rows by design so an admin can price them by hand. Nothing else ever looks at the row.

Resolution now falls back to looking the bare model id up across the vendors that make models — but only after the provider-scoped match fails, because a reseller's own entry carries the price and limits that actually apply. The fallback skips resellers and aggregators deliberately: eighteen registry providers list `gpt-5.4`, and two of them (`cortecs` at $3/$16.13, `unorouter` at $1.80/$10.80) disagree with OpenAI's own rate, so matching one would trade a wrong price for a differently wrong price. When no first-party vendor lists a model, no price is asserted and today's behaviour stands.

`ensureModelExists` now reports whether it actually inserted. Enrichment runs on a model's first sighting rather than on every request, and it is best-effort: a registry failure cannot fail the request that discovered the model.

The row keeps `discoveredViaLlmProxy = true` and its "Observed in requests" badge, which is accurate provenance — it just no longer misreports the price and context window.

Modalities are deliberately left out of the enrichment: validating them against the column schema lives in the sync path, and duplicating it would widen this beyond the pricing bug.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>