### PR TITLE
fix(frontend): cover /api/organization/members in the MSW handler set

### DIFF
--- a/platform/frontend/src/mocks/handlers.ts
+++ b/platform/frontend/src/mocks/handlers.ts
@@ -101,6 +101,15 @@ export const handlers: HttpHandler[] = [
   ...getJson("/api/config/public", publicConfigSeed),
   ...getJson("/health", healthSeed),
   ...getJson("/api/organization", organizationSeed),
+  // The roster behind owner pickers and the scope filter's "member" facet —
+  // the seeded admin, mirroring the session identity.
+  ...getJson("/api/organization/members", [
+    {
+      id: sessionSeed.user.id,
+      name: sessionSeed.user.name,
+      email: sessionSeed.user.email,
+    },
+  ]),
   ...getJson("/api/organization/appearance-settings", appearanceSettingsSeed),
   // Onboarding nudges: everything already seen / nothing eligible, so neither
   // the red dots nor the survey/feedback dialogs interfere with other tests.


### PR DESCRIPTION
Every merge-queue run of the **Frontend Integration Tests (MSW)** job has been failing since #6875: the Skills page's new Org/Team/Personal scope filter fetches `GET /api/organization/members`, which had no MSW handler, so the three `skills-import` specs die with `MSW coverage gap: 2 request(s) escaped MSW` (client + SSR). The job only runs in the merge group, so PR-level checks never showed it — it isn't in the required-checks set either, which is why queue merges still went through red (observed identically on the #6942 and #6944 queue runs).

Seeds the roster with the session identity the neighboring auth handlers already use. All 6 `skills-import` specs pass locally with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>