### PR TITLE
fix(oauth): forward the RFC 9207 iss parameter from the callback

### DIFF
--- a/platform/backend/src/routes/oauth-issuer-validation.test.ts
+++ b/platform/backend/src/routes/oauth-issuer-validation.test.ts
@@ -82,12 +82,26 @@ describe("validateAuthorizationResponseIssuer", () => {
     ).toEqual({ ok: true });
   });
 
-  test("a present iss with nothing recorded cannot be verified, so is rejected", () => {
+  test("a present iss with nothing recorded proceeds unverified", () => {
+    // Proxy flows skip authorization-server discovery by design and so never
+    // record an issuer. Rejecting them would prove nothing and break every
+    // such install; this leaves them exactly where they were before the check.
     expect(
       validateAuthorizationResponseIssuer({
         responseIssuer: ISSUER,
         recordedIssuer: null,
         issParameterSupported: true,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  test("a mismatch is still caught whenever an issuer was recorded", () => {
+    // The relaxation above must not weaken the case the check exists for.
+    expect(
+      validateAuthorizationResponseIssuer({
+        responseIssuer: "https://evil.example.com",
+        recordedIssuer: ISSUER,
+        issParameterSupported: false,
       }),
     ).toEqual({ ok: false, reason: "issuer_mismatch" });
   });

--- a/platform/backend/src/routes/oauth-issuer-validation.ts
+++ b/platform/backend/src/routes/oauth-issuer-validation.ts
@@ -52,10 +52,13 @@ export function validateAuthorizationResponseIssuer(params: {
       : { ok: true };
   }
 
-  // A present `iss` with nothing recorded to compare against cannot be
-  // verified, so it cannot be trusted.
+  // Nothing recorded to compare against. This is not evidence of a mix-up:
+  // proxy flows skip authorization-server discovery by design, so they never
+  // record an issuer. Treating that as a mismatch would reject those flows
+  // outright while proving nothing, so the request proceeds unverified —
+  // exactly where it stood before this check existed.
   if (!recordedIssuer) {
-    return { ok: false, reason: "issuer_mismatch" };
+    return { ok: true };
   }
 
   return issuersMatch(responseIssuer, recordedIssuer)

--- a/platform/backend/src/routes/oauth.test.ts
+++ b/platform/backend/src/routes/oauth.test.ts
@@ -847,6 +847,242 @@ describe("OAuth routes", () => {
     expect(requestBody.get("code")).toBe("authorization-code");
     expect(requestBody.has("resource")).toBe(false);
   });
+  test("forwards a matching iss through the callback (RFC 9207)", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Direct OAuth MCP",
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com/v1/mcp",
+      oauthConfig: {
+        name: "Direct OAuth MCP",
+        server_url: "https://mcp.example.com/v1/mcp",
+        grant_type: "authorization_code",
+        auth_server_url: "https://login.example.com/oauth",
+        authorization_endpoint: "https://login.example.com/oauth/authorize",
+        token_endpoint: "https://login.example.com/oauth/token",
+        client_id: "public-client-id",
+        client_secret: "public-client-secret",
+        redirect_uris: ["http://localhost:3000/oauth-callback"],
+        scopes: ["read", "write"],
+        default_scopes: ["read", "write"],
+        supports_resource_metadata: false,
+      },
+    });
+
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+
+      if (url === "https://login.example.com/oauth/token") {
+        const body = init?.body as URLSearchParams;
+        if (body.has("resource")) {
+          return {
+            ok: false,
+            status: 400,
+            text: async () =>
+              JSON.stringify({
+                error: "invalid_target",
+                error_description: "Incorrect resource parameters",
+              }),
+          };
+        }
+
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: "new-access-token",
+            refresh_token: "new-refresh-token",
+            expires_in: 3600,
+          }),
+          text: async () =>
+            JSON.stringify({
+              access_token: "new-access-token",
+              refresh_token: "new-refresh-token",
+              expires_in: 3600,
+            }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          authorization_endpoint: "https://login.example.com/oauth/authorize",
+          token_endpoint: "https://login.example.com/oauth/token",
+        }),
+      };
+    }) as Mock;
+    globalThis.fetch = fetchMock;
+
+    const initiateResponse = await app.inject({
+      method: "POST",
+      url: "/api/oauth/initiate",
+      payload: {
+        catalogId: catalog.id,
+      },
+    });
+    expect(initiateResponse.statusCode, initiateResponse.body).toBe(200);
+    const authorizationUrl = new URL(initiateResponse.json().authorizationUrl);
+    expect(authorizationUrl.searchParams.has("resource")).toBe(false);
+    const state = initiateResponse.json().state;
+
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS keyv_cache (
+        key text PRIMARY KEY,
+        value text NOT NULL
+      )
+    `);
+    await db.execute(sql`
+      INSERT INTO keyv_cache (key, value)
+      VALUES (
+        ${`keyv:${CacheKey.OAuthState}-${state}`},
+        ${JSON.stringify({
+          value: {
+            catalogId: catalog.id,
+            codeVerifier: "test-code-verifier",
+            clientId: "public-client-id",
+            clientSecret: "public-client-secret",
+            issuer: "https://login.example.com",
+            issParameterSupported: true,
+          },
+          expires: Date.now() + 60_000,
+        })}
+      )
+      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+    `);
+
+    const callbackResponse = await app.inject({
+      method: "POST",
+      url: "/api/oauth/callback",
+      payload: {
+        code: "authorization-code",
+        state,
+        iss: "https://login.example.com",
+      },
+    });
+
+    // Regression: the browser must forward `iss`. When it did not, a server
+    // advertising RFC 9207 support had every flow rejected for its absence.
+    expect(callbackResponse.statusCode, callbackResponse.body).toBe(200);
+  });
+
+  test("rejects a callback whose iss is not the server the flow started with", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      name: "Direct OAuth MCP",
+      serverType: "remote",
+      serverUrl: "https://mcp.example.com/v1/mcp",
+      oauthConfig: {
+        name: "Direct OAuth MCP",
+        server_url: "https://mcp.example.com/v1/mcp",
+        grant_type: "authorization_code",
+        auth_server_url: "https://login.example.com/oauth",
+        authorization_endpoint: "https://login.example.com/oauth/authorize",
+        token_endpoint: "https://login.example.com/oauth/token",
+        client_id: "public-client-id",
+        client_secret: "public-client-secret",
+        redirect_uris: ["http://localhost:3000/oauth-callback"],
+        scopes: ["read", "write"],
+        default_scopes: ["read", "write"],
+        supports_resource_metadata: false,
+      },
+    });
+
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+
+      if (url === "https://login.example.com/oauth/token") {
+        const body = init?.body as URLSearchParams;
+        if (body.has("resource")) {
+          return {
+            ok: false,
+            status: 400,
+            text: async () =>
+              JSON.stringify({
+                error: "invalid_target",
+                error_description: "Incorrect resource parameters",
+              }),
+          };
+        }
+
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: "new-access-token",
+            refresh_token: "new-refresh-token",
+            expires_in: 3600,
+          }),
+          text: async () =>
+            JSON.stringify({
+              access_token: "new-access-token",
+              refresh_token: "new-refresh-token",
+              expires_in: 3600,
+            }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          authorization_endpoint: "https://login.example.com/oauth/authorize",
+          token_endpoint: "https://login.example.com/oauth/token",
+        }),
+      };
+    }) as Mock;
+    globalThis.fetch = fetchMock;
+
+    const initiateResponse = await app.inject({
+      method: "POST",
+      url: "/api/oauth/initiate",
+      payload: {
+        catalogId: catalog.id,
+      },
+    });
+    expect(initiateResponse.statusCode, initiateResponse.body).toBe(200);
+    const authorizationUrl = new URL(initiateResponse.json().authorizationUrl);
+    expect(authorizationUrl.searchParams.has("resource")).toBe(false);
+    const state = initiateResponse.json().state;
+
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS keyv_cache (
+        key text PRIMARY KEY,
+        value text NOT NULL
+      )
+    `);
+    await db.execute(sql`
+      INSERT INTO keyv_cache (key, value)
+      VALUES (
+        ${`keyv:${CacheKey.OAuthState}-${state}`},
+        ${JSON.stringify({
+          value: {
+            catalogId: catalog.id,
+            codeVerifier: "test-code-verifier",
+            clientId: "public-client-id",
+            clientSecret: "public-client-secret",
+            issuer: "https://login.example.com",
+            issParameterSupported: true,
+          },
+          expires: Date.now() + 60_000,
+        })}
+      )
+      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+    `);
+
+    const callbackResponse = await app.inject({
+      method: "POST",
+      url: "/api/oauth/callback",
+      payload: {
+        code: "authorization-code",
+        state,
+        iss: "https://evil.example.com",
+      },
+    });
+
+    expect(callbackResponse.statusCode).toBe(400);
+    expect(callbackResponse.body).toContain("issuer");
+  });
 
   test("includes configured OAuth resource when refreshing access tokens", async ({
     makeInternalMcpCatalog,

--- a/platform/frontend/src/app/oauth-callback/oauth-callback.utils.test.ts
+++ b/platform/frontend/src/app/oauth-callback/oauth-callback.utils.test.ts
@@ -1,4 +1,6 @@
 import {
+  buildOAuthCallbackPayload,
+  extractOAuthCallbackParams,
   getOAuthCallbackErrorState,
   toInternalReturnPath,
 } from "./oauth-callback.utils";
@@ -92,5 +94,62 @@ describe("getOAuthCallbackErrorState", () => {
       description:
         "The OAuth provider redirected back without a state value. Start the installation again and retry the sign-in flow.",
     });
+  });
+});
+
+describe("extractOAuthCallbackParams", () => {
+  it("reads every parameter the callback consumes, including iss", () => {
+    // Regression: iss was sent by RFC 9207 servers, accepted by the backend,
+    // and dropped here. Before the fix this extraction did not read it, so
+    // this assertion is the one that would have failed.
+    const params = new URLSearchParams({
+      code: "auth-code",
+      state: "state-1",
+      iss: "https://login.example.com",
+    });
+
+    expect(extractOAuthCallbackParams(params)).toEqual({
+      code: "auth-code",
+      error: null,
+      errorDescription: null,
+      state: "state-1",
+      iss: "https://login.example.com",
+    });
+  });
+
+  it("reports absent parameters as null rather than omitting them", () => {
+    const params = extractOAuthCallbackParams(new URLSearchParams());
+
+    expect(params.iss).toBeNull();
+    expect(params.code).toBeNull();
+  });
+});
+
+describe("buildOAuthCallbackPayload", () => {
+  it("carries iss to the token exchange when the server sent one", () => {
+    expect(
+      buildOAuthCallbackPayload({
+        code: "auth-code",
+        state: "state-1",
+        iss: "https://login.example.com",
+      }),
+    ).toEqual({
+      code: "auth-code",
+      state: "state-1",
+      iss: "https://login.example.com",
+    });
+  });
+
+  it("omits iss entirely when the server sent none", () => {
+    // Absent, not null: the backend schema takes an optional string, and the
+    // RFC 9207 decision table distinguishes absent from present.
+    const payload = buildOAuthCallbackPayload({
+      code: "auth-code",
+      state: "state-1",
+      iss: null,
+    });
+
+    expect(payload).toEqual({ code: "auth-code", state: "state-1" });
+    expect("iss" in payload).toBe(false);
   });
 });

--- a/platform/frontend/src/app/oauth-callback/oauth-callback.utils.ts
+++ b/platform/frontend/src/app/oauth-callback/oauth-callback.utils.ts
@@ -1,3 +1,46 @@
+/**
+ * Every query parameter the OAuth callback consumes, read in one place.
+ *
+ * Extracted from the page component so the set is pinned by tests: the RFC
+ * 9207 regression was exactly a parameter (`iss`) that the server sent, the
+ * backend accepted, and this layer silently dropped — invisible to both the
+ * component's rendering and the backend's route tests.
+ */
+export interface OAuthCallbackParams {
+  code: string | null;
+  error: string | null;
+  errorDescription: string | null;
+  state: string | null;
+  /** RFC 9207 authorization-server identifier, when the server sends one. */
+  iss: string | null;
+}
+
+export function extractOAuthCallbackParams(searchParams: {
+  get(name: string): string | null;
+}): OAuthCallbackParams {
+  return {
+    code: searchParams.get("code"),
+    error: searchParams.get("error"),
+    errorDescription: searchParams.get("error_description"),
+    state: searchParams.get("state"),
+    iss: searchParams.get("iss"),
+  };
+}
+
+/**
+ * The exact body for the token-exchange call. `iss` rides along whenever the
+ * server sent it — the backend compares it against the server the flow
+ * started with, so it has to reach the wire.
+ */
+export function buildOAuthCallbackPayload(params: {
+  code: string;
+  state: string;
+  iss: string | null;
+}): { code: string; state: string; iss?: string } {
+  const { code, state, iss } = params;
+  return { code, state, ...(iss ? { iss } : {}) };
+}
+
 export interface OAuthCallbackErrorState {
   title: string;
   description: string;

--- a/platform/frontend/src/app/oauth-callback/page.tsx
+++ b/platform/frontend/src/app/oauth-callback/page.tsx
@@ -61,6 +61,11 @@ function OAuthCallbackContent() {
       const error = searchParams.get("error");
       const errorDescription = searchParams.get("error_description");
       const state = searchParams.get("state");
+      // RFC 9207: the authorization server may identify itself on the
+      // response. The backend compares it against the server the flow started
+      // with, so it has to reach it — dropping it here makes that check fail
+      // closed against exactly the servers that implement the RFC.
+      const iss = searchParams.get("iss");
 
       const initialError = getOAuthCallbackErrorState({
         code,
@@ -97,7 +102,11 @@ function OAuthCallbackContent() {
       try {
         // Exchange authorization code for access token
         const { catalogId, name, secretId } =
-          await callbackMutation.mutateAsync({ code, state });
+          await callbackMutation.mutateAsync({
+            code,
+            state,
+            ...(iss ? { iss } : {}),
+          });
 
         // Check if this is a re-authentication flow
         const mcpServerId = getOAuthMcpServerId();

--- a/platform/frontend/src/app/oauth-callback/page.tsx
+++ b/platform/frontend/src/app/oauth-callback/page.tsx
@@ -40,6 +40,8 @@ import {
 } from "@/lib/mcp/mcp-server.query";
 import { replaceBrowserUrl } from "@/lib/utils/browser-redirect";
 import {
+  buildOAuthCallbackPayload,
+  extractOAuthCallbackParams,
   getOAuthCallbackErrorState,
   type OAuthCallbackErrorState,
   toInternalReturnPath,
@@ -57,15 +59,8 @@ function OAuthCallbackContent() {
 
   useEffect(() => {
     const handleOAuthCallback = async () => {
-      const code = searchParams.get("code");
-      const error = searchParams.get("error");
-      const errorDescription = searchParams.get("error_description");
-      const state = searchParams.get("state");
-      // RFC 9207: the authorization server may identify itself on the
-      // response. The backend compares it against the server the flow started
-      // with, so it has to reach it — dropping it here makes that check fail
-      // closed against exactly the servers that implement the RFC.
-      const iss = searchParams.get("iss");
+      const { code, error, errorDescription, state, iss } =
+        extractOAuthCallbackParams(searchParams);
 
       const initialError = getOAuthCallbackErrorState({
         code,
@@ -102,11 +97,9 @@ function OAuthCallbackContent() {
       try {
         // Exchange authorization code for access token
         const { catalogId, name, secretId } =
-          await callbackMutation.mutateAsync({
-            code,
-            state,
-            ...(iss ? { iss } : {}),
-          });
+          await callbackMutation.mutateAsync(
+            buildOAuthCallbackPayload({ code, state, iss }),
+          );
 
         // Check if this is a re-authentication flow
         const mcpServerId = getOAuthMcpServerId();


### PR DESCRIPTION
Fixes a regression I introduced in #6939

## The bug

#6939 added authorization-response issuer validation and wired the backend to accept `iss`. Nothing ever put it there.

- `oauth-callback/page.tsx` reads `code`, `error`, `error_description`, `state` and calls `mutateAsync({ code, state })`.
- `iss` appears **nowhere** in `platform/frontend/src` — verified by grep across the whole tree.

So `responseIssuer` was permanently `undefined`. In `validateAuthorizationResponseIssuer`, an absent `iss` returns `issuer_missing` whenever `issParameterSupported === true`, which the route turns into a 400.

`issParameterSupported` comes from the authorization server's own discovery metadata. **The servers that broke are precisely the ones implementing RFC 9207 correctly** — they advertise the parameter, return it in the redirect, and we discarded it and then failed the flow for its absence.

Not universal: servers that don't advertise the flag, and flows where discovery failed, were unaffected.

## The fix, both halves

**Frontend forwards `iss`.** Only the token-exchange mutation needs it; reauth and install run *after* the exchange.

**An absent recorded issuer is no longer a mismatch.** The second-order issue the reviewer raised is real: `requires_proxy` (oauth.ts:880) skips discovery by design, so `issuer` stays undefined on that path. Once `iss` started arriving, my `!recordedIssuer` branch would have 400'd those flows instead.

I had chosen to reject there, reasoning that an unverifiable `iss` shouldn't be trusted. That was the wrong trade: rejecting proves nothing and breaks every proxy install. Those now proceed unverified — exactly where they stood before the check existed. A mismatch is still rejected whenever an issuer *was* recorded, which is the case the check exists for, and there's a test pinning that the relaxation didn't weaken it.

## Testing

15 unit tests on the validator, 50 in the OAuth route suite. Two route-level tests drive the real callback with `issParameterSupported: true` — a matching `iss` reaches 200, a mismatched one is rejected.

Those pin the backend contract; the regression itself lived a layer above, where the browser dropped the parameter before it reached the route. That layer is now guarded too: param extraction and the token-exchange payload are lifted out of `page.tsx` into `oauth-callback.utils.ts` as pure functions, and the utils suite pins the full parameter set the callback reads — so silently dropping one is a failing assertion, not an invisible omission. It also pins that `iss` is *omitted* (not `null`) when absent, which the RFC 9207 decision table distinguishes.

I verified the guard has teeth by mutation: reverting the extraction to drop `iss` fails the suite; restoring it goes green.

## Worth confirming before merge

The reviewer suggested one real install against a server that advertises the flag. I'd second that — the chain is unambiguous in code, but neither of us has reproduced it live.
