### PR TITLE
fix(apps): let the review player load a submission as large as the gallery accepts

### DIFF
--- a/platform/backend/src/routes/app-recording/app-recording.routes.ts
+++ b/platform/backend/src/routes/app-recording/app-recording.routes.ts
@@ -1,5 +1,6 @@
 import {
   APP_RECORDING_MAX_BUNDLE_BYTES,
+  GITHUB_MAX_FILE_BYTES,
   RouteId,
   validateRecordingBundle,
 } from "@archestra/shared";
@@ -30,11 +31,13 @@ const REVIEW_BUNDLE_HOST = "raw.githubusercontent.com";
 /** Give up on a slow GitHub fetch rather than holding the request open. */
 const REVIEW_FETCH_TIMEOUT_MS = 15_000;
 /**
- * Cap the fetched body well below the recorder's own bundle ceiling: a review
- * recording is already trimmed for submission, and a reviewer's request must
- * not buffer an unbounded response an attacker points `src` at.
+ * Cap the fetched body at GitHub's own file ceiling — the same bound the
+ * gallery submission gate enforces. The cap exists so a reviewer's request
+ * cannot buffer an unbounded response an attacker points `src` at; it must
+ * never be tighter than what the gallery accepts, or a submission the gallery
+ * took becomes one the review player refuses to even load.
  */
-const REVIEW_BUNDLE_MAX_BYTES = 15 * 1024 * 1024;
+const REVIEW_BUNDLE_MAX_BYTES = GITHUB_MAX_FILE_BYTES;
 
 /** The four endpoints that make up one video render's lifecycle. */
 const VIDEO_ROUTE_IDS = new Set<string | undefined>([

--- a/platform/backend/src/routes/app-recording/review.app-recording.route.test.ts
+++ b/platform/backend/src/routes/app-recording/review.app-recording.route.test.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from "node:crypto";
+import { GITHUB_MAX_FILE_BYTES } from "@archestra/shared";
+import { HttpResponse, http } from "msw";
+import { describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
+import { useRouteTestApp } from "@/test/route-test-app";
+import appRecordingRoutes from "./app-recording.routes";
+
+const RAW_URL =
+  "https://raw.githubusercontent.com/archestra-ai/apps-gallery/main/apps/example_app/recording.json";
+const RAW_ROUTE =
+  "https://raw.githubusercontent.com/:owner/:repo/:ref/apps/:slug/recording.json";
+
+/** The smallest bundle the recording contract accepts. */
+function minimalBundle() {
+  return {
+    formatVersion: 1,
+    app: { id: randomUUID(), name: "Example" },
+    recording: {
+      title: "Example demo",
+      startedAt: new Date(0).toISOString(),
+      durationMs: 1_000,
+      events: [] as unknown[],
+      segments: [{ version: 1, html: "<main>app</main>", atMs: 0 }],
+      transcript: [
+        {
+          id: "msg-1",
+          role: "user",
+          atMs: 0,
+          parts: [{ type: "text", text: "Build me an app." }],
+        },
+      ],
+    },
+    meta: {
+      authorName: "Author",
+      createdAt: new Date(0).toISOString(),
+      platform: "archestra",
+    },
+  };
+}
+
+/**
+ * A bundle the size a real full-motion submission reaches: padded with
+ * schema-valid encoded-video chunks until its JSON crosses `bytes`.
+ */
+function bundleOfAtLeast(bytes: number) {
+  const bundle = minimalBundle();
+  const data = "A".repeat(1_900_000);
+  while (JSON.stringify(bundle).length < bytes) {
+    bundle.recording.events.push({
+      kind: "video-chunk",
+      t: 0,
+      sel: "#game",
+      type: "delta",
+      tsUs: 0,
+      data,
+    });
+  }
+  return bundle;
+}
+
+describe("GET /api/app-recording/review", () => {
+  const ctx = useRouteTestApp(appRecordingRoutes);
+  // biome-ignore lint/correctness/useHookAtTopLevel: vitest lifecycle helper (per-test MSW server), not a React hook
+  const server = useMswServer();
+
+  test("admits a bundle as large as the gallery itself accepts", async () => {
+    // The gallery's only size rule is GitHub's 50MB file ceiling, so a
+    // full-motion submission legitimately reaches tens of megabytes — the
+    // recorder's governor allows ~29MB for a one-minute cut. A review cap
+    // tighter than the gallery's own (it was 15MB once) turns an accepted
+    // submission into one the review player never even receives.
+    const bundle = bundleOfAtLeast(20 * 1024 * 1024);
+    server.use(http.get(RAW_ROUTE, () => HttpResponse.json(bundle)));
+
+    const response = await ctx.app.inject({
+      method: "GET",
+      url: `/api/app-recording/review?src=${encodeURIComponent(RAW_URL)}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const returned = response.json();
+    expect(returned.formatVersion).toBe(1);
+    expect(returned.recording.events).toHaveLength(
+      bundle.recording.events.length,
+    );
+  });
+
+  test("refuses a body that runs past GitHub's own file ceiling", async () => {
+    // No gallery file can legitimately be this large — GitHub refuses the
+    // upload — so past this line the response is not a submission, and the
+    // stream is abandoned instead of buffered.
+    const chunk = new Uint8Array(1024 * 1024).fill(120);
+    const chunks = Math.floor(GITHUB_MAX_FILE_BYTES / chunk.length) + 1;
+    server.use(
+      http.get(
+        RAW_ROUTE,
+        () =>
+          new HttpResponse(
+            new ReadableStream({
+              start(controller) {
+                for (let i = 0; i < chunks; i++) controller.enqueue(chunk);
+                controller.close();
+              },
+            }),
+          ),
+      ),
+    );
+
+    const response = await ctx.app.inject({
+      method: "GET",
+      url: `/api/app-recording/review?src=${encodeURIComponent(RAW_URL)}`,
+    });
+
+    expect(response.statusCode).toBe(413);
+    expect(response.json().error.message).toMatch(/50MB review limit/);
+  });
+
+  test("refuses a source anywhere but raw.githubusercontent.com", async () => {
+    const response = await ctx.app.inject({
+      method: "GET",
+      url: `/api/app-recording/review?src=${encodeURIComponent(
+        "https://example.com/recording.json",
+      )}`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error.message).toMatch(
+      /raw\.githubusercontent\.com/,
+    );
+  });
+});

--- a/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
+++ b/platform/frontend/src/lib/app-session-recording/app-gallery-share.ts
@@ -1,6 +1,7 @@
 import {
   APP_RECORDING_VIEWPORT_ASPECT,
   archestraApiSdk,
+  GITHUB_MAX_FILE_BYTES,
   healBundleMcpServers,
   slugify,
 } from "@archestra/shared";
@@ -1340,24 +1341,6 @@ function base64ToBytes(base64: string): Uint8Array {
   }
   return bytes;
 }
-
-/**
- * The strictest ceiling api.github.com imposes on any endpoint this upload
- * could use. GitHub's number, not a product quota, and deliberately not a
- * millimetre under it: a submission GitHub would have taken must never be
- * refused here.
- *
- * The one measurement we have is a 57MB bundle refused by BOTH upload paths —
- * the contents API answered "the file is too large to be processed", the Git
- * Data API's blob endpoint "your input was too large to process". That is
- * consistent with this ceiling and says nothing about which endpoint to use,
- * which is why the upload stays on the plain contents API.
- *
- * Capture is what keeps real bundles far below it rather than this check: a
- * minute at the SDK's governor lands around 10MB, so the gate exists for
- * recordings made before those bounds, not for new ones.
- */
-const GITHUB_MAX_FILE_BYTES = 50 * 1024 * 1024;
 
 function mb(bytes: number): number {
   return Math.round(bytes / (1024 * 1024));

--- a/platform/shared/app-recording.ts
+++ b/platform/shared/app-recording.ts
@@ -493,10 +493,10 @@ export const APP_RECORDING_RENDER_FPS = 24;
  * A minute is also the length that makes a full-motion canvas app submittable
  * at all. The bundle stores video base64 inside its JSON and the upload
  * base64-encodes that JSON again, so a byte of recorded video costs ~1.78
- * bytes by the time api.github.com sees it: at the SDK's 1 Mbit/s governor
- * ceiling a minute lands near 13MB on the wire, comfortably under the largest
- * submission the gallery has actually accepted. Two minutes at the old
- * 3 Mbit/s ceiling reached ~76MB and was refused outright.
+ * bytes by the time api.github.com sees it: at the SDK's 3 Mbit/s governor
+ * ceiling a worst-case all-motion minute lands near 38MB on the wire, inside
+ * GitHub's file ceiling ({@link GITHUB_MAX_FILE_BYTES}); two minutes runs to
+ * ~76MB and is refused outright.
  */
 export const APP_RECORDING_DEFAULT_MAX_FINAL_CUT_MS = 60_000;
 
@@ -560,12 +560,33 @@ export const APP_RECORDING_CAPTURE_HEADROOM = 3;
  *
  * The gallery submission is bounded separately and far more tightly, by what
  * api.github.com accepts as a request body once base64 has had its way with
- * the bundle. This one only has to keep a renderer from being handed
- * something absurd: capture keeps real bundles orders of magnitude below it —
- * the SDK's governor bounds video at 1 Mbit/s across all streams, so even a
- * three-minute all-motion raw take stays near 30MB serialized.
+ * the bundle ({@link GITHUB_MAX_FILE_BYTES}). This one only has to keep a
+ * renderer from being handed something absurd: capture keeps real bundles
+ * below it — the SDK's byte-rate governor bounds video at 3 Mbit/s across all
+ * streams, so even the longest raw take the recorder allows (the capture
+ * headroom over a one-minute final cut) serializes under ~90MB.
  */
 export const APP_RECORDING_MAX_BUNDLE_BYTES = 100 * 1024 * 1024;
+
+/**
+ * The strictest ceiling api.github.com imposes on any endpoint a gallery
+ * submission's upload could use. GitHub's number, not a product quota, and
+ * deliberately not a millimetre under it: a submission GitHub would have
+ * taken must never be refused by a check of ours.
+ *
+ * The one measurement we have is a 57MB bundle refused by BOTH upload paths —
+ * the contents API answered "the file is too large to be processed", the Git
+ * Data API's blob endpoint "your input was too large to process". That is
+ * consistent with this ceiling and says nothing about which endpoint to use,
+ * which is why the upload stays on the plain contents API.
+ *
+ * Both ends of the gallery pipeline hold to this ONE bound: the submission
+ * gate refuses only what GitHub itself would refuse, and the review fetch
+ * admits everything the gate lets through. A cap tighter on either side
+ * turns a submission the gallery accepted into one the platform cannot
+ * review.
+ */
+export const GITHUB_MAX_FILE_BYTES = 50 * 1024 * 1024;
 
 export const APP_RECORDING_RENDER_REGION_ATTR =
   "data-app-recording-render-region";


### PR DESCRIPTION
## Problem

The replay for apps-gallery submission [PR #49 (flapster)](https://github.com/archestra-ai/apps-gallery/pull/49) never starts in the on-platform review player, while every other submission replays fine.

## Root cause

`GET /api/app-recording/review` (the server-side proxy both review surfaces — the full-page `/review` host and the chat-docked review panel — fetch the bundle through) capped the fetched `recording.json` at **15MB** and answered **413** past it. The flapster recording is **23.3MB**; every other submission so far is ≤12.1MB, which is exactly "all the others render fine".

The 23MB bundle is legitimate: the recorder SDK's byte-rate governor allows 3 Mbit/s across all streams (a worst-case all-motion minute ≈ 29MB bundle), and the gallery submission gate deliberately bounds uploads only at **GitHub's own 50MB file ceiling** — "GitHub's number, not a product quota, and deliberately not a millimetre under it". The review path contradicted that rule, so a submission the gallery accepted became one the platform could not review. (The 15MB figure traced back to stale comments in `shared/app-recording.ts` still describing a brief 1 Mbit/s governor era — "a minute lands near 13MB on the wire" — which made 15MB look generous.)

Everything else about the bundle was verified innocent end to end: it passes the strict shared contract, `buildPlayback` produces a sane 60.4s timeline (negative-time head trim, tail trim, all-negative transcript history — all handled by design and all present in already-merged submissions), and the real player seeded with the exact 23MB bundle reaches frame-ready in <1s and paints decoded VP9 frames across the whole timeline.

## Fix

- The GitHub ceiling the share path kept as a local constant is promoted to the shared `GITHUB_MAX_FILE_BYTES`, with its doc spelling out the invariant: the submission gate refuses only what GitHub itself would refuse, and the review fetch admits everything the gate lets through.
- `REVIEW_BUNDLE_MAX_BYTES` now equals that shared bound (both the content-length pre-check and the streamed-body cap), keeping its anti-abuse purpose — an attacker-pointed `src` still can't stream unbounded bytes.
- The stale 1 Mbit/s governor arithmetic in the shared size comments is corrected to the SDK's actual 3 Mbit/s ceiling.

## Tests

New `review.app-recording.route.test.ts` (the endpoint had none): a >15MB schema-valid bundle is admitted (fails against the old cap — verified), a body running past GitHub's 50MB ceiling is refused mid-stream with 413, and the raw.githubusercontent.com host allowlist still 400s elsewhere.

## Verification

On a dev stack: the flapster raw URL flipped from `413 \"larger than the 15MB review limit\"` to `200` (23.3MB bundle returned in ~2.3s, well inside the 15s fetch timeout), and the `/review` page for PR #49 now auto-plays the full replay — chat history animating, then the game with decoded video and replayed pointer input.

The public gallery website player is unaffected: it fetches the raw URL directly with no size cap and its vendored playback code processes this exact bundle correctly.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>