### PR TITLE
feat(mcp-gateway): stop advertising unimplemented subscriptions, refuse removed methods

### DIFF
--- a/docs/pages/platform-mcp-gateway.md
+++ b/docs/pages/platform-mcp-gateway.md
@@ -3,7 +3,7 @@ title: MCP Gateway
 category: MCP
 order: 1
 description: Unified access point for all MCP servers
-lastUpdated: 2026-07-29
+lastUpdated: 2026-07-30
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -104,6 +104,7 @@ Older revisions still work too. Anything back to `2024-11-05` is accepted and se
 | Result caching hints | Sent, ignored by older clients | `ttlMs` and `cacheScope` on tool, prompt, and resource results |
 | Result envelope | Plain result | `resultType`, plus server identity in `_meta` |
 | Missing-resource error | `-32002` | `-32602` |
+| `ping` and `logging/setLevel` | Answered | Removed — method-not-found |
 
 Both revisions see the same tools, the same access control, and the same policies. The differences are all in how a client talks to the gateway, not in what it can reach.
 

--- a/platform/backend/src/routes/mcp-gateway/index.ts
+++ b/platform/backend/src/routes/mcp-gateway/index.ts
@@ -19,6 +19,7 @@ import {
   buildDiscoverResult,
   extractTraceContext,
   isDiscoverRequest,
+  isMethodRemovedForRevision,
   MCP_PROTOCOL_VERSION_HEADER,
   type McpProtocolRevision,
   type ProtocolResolution,
@@ -470,6 +471,28 @@ const mcpGatewayRoutes: FastifyPluginAsyncZod = async (fastify) => {
             id: (request.body as { id?: string | number })?.id ?? null,
           };
         }
+      }
+
+      // 2026-07-28 removes ping, logging/setLevel, and resources
+      // subscription methods. A client that declared that revision gets
+      // method-not-found rather than an answer from a surface it opted out
+      // of; legacy clients are untouched.
+      const bodyMethod = (request.body as { method?: string })?.method;
+      if (
+        isMethodRemovedForRevision({
+          method: bodyMethod,
+          revision: resolution.revision,
+        })
+      ) {
+        reply.header(MCP_PROTOCOL_VERSION_HEADER, resolution.revision);
+        return {
+          jsonrpc: "2.0",
+          error: {
+            code: -32601,
+            message: `Method "${bodyMethod}" was removed in protocol version ${resolution.revision}.`,
+          },
+          id: (request.body as { id?: string | number })?.id ?? null,
+        };
       }
 
       // `server/discover` replaces the `initialize` handshake under 2026-07-28.

--- a/platform/backend/src/routes/mcp-gateway/protocol-negotiation.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/protocol-negotiation.test.ts
@@ -338,6 +338,59 @@ describe("MCP Gateway - protocol revision negotiation", () => {
     expect(names).toEqual([...names].sort());
   });
 
+  test("ping answers for legacy clients and is refused for 2026-07-28", async ({
+    makeAgent,
+    makeOrganization,
+  }) => {
+    const { agent, token } = await setup({ makeAgent, makeOrganization });
+
+    // A legacy client keeps the SDK's automatic pong.
+    const legacy = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(token.value),
+      payload: { jsonrpc: "2.0", method: "ping", id: 20 },
+    });
+    expect(legacy.statusCode).toBe(200);
+    expect(legacy.json()).toMatchObject({ id: 20, result: {} });
+
+    // A client that declared 2026-07-28 opted out of the surface ping
+    // belongs to, so answering would be serving the wrong revision.
+    const stateless = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(token.value, {
+        "mcp-protocol-version": STATELESS_MCP_PROTOCOL_REVISION,
+        "mcp-method": "ping",
+      }),
+      payload: { jsonrpc: "2.0", method: "ping", id: 21 },
+    });
+    expect(stateless.statusCode).toBe(200);
+    expect(stateless.json().error).toMatchObject({ code: -32601 });
+    expect(stateless.json().error.message).toContain("removed");
+  });
+
+  test("capabilities no longer advertise unimplemented subscriptions", async ({
+    makeAgent,
+    makeOrganization,
+  }) => {
+    const { agent, token } = await setup({ makeAgent, makeOrganization });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(token.value, {
+        "mcp-protocol-version": STATELESS_MCP_PROTOCOL_REVISION,
+        "mcp-method": "server/discover",
+      }),
+      payload: { jsonrpc: "2.0", method: "server/discover", id: 22 },
+    });
+
+    const { capabilities } = response.json().result;
+    expect(capabilities.resources).not.toHaveProperty("subscribe");
+    expect(capabilities.resources.listChanged).toBe(false);
+  });
+
   test("GET discovery advertises both supported revisions", async ({
     makeAgent,
     makeOrganization,

--- a/platform/backend/src/routes/mcp-gateway/protocol.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/protocol.test.ts
@@ -17,6 +17,7 @@ import {
   deriveRequestTargetName,
   extractTraceContext,
   isDiscoverRequest,
+  isMethodRemovedForRevision,
   isResourceUnavailableError,
   LEGACY_MCP_PROTOCOL_REVISION,
   resolveProtocolRevision,
@@ -359,11 +360,58 @@ describe("server/discover", () => {
     expect(result.resultType).toBe("complete");
   });
 
+  test("unimplemented subscription features are not advertised", () => {
+    // No resources/subscribe handler exists and no list_changed notification
+    // has ever been sent — advertising either made clients wait on signals
+    // that never come. Freshness is carried by the SEP-2549 cache hints.
+    const capabilities = buildGatewayServerCapabilities();
+
+    expect(capabilities.resources).not.toHaveProperty("subscribe");
+    expect(capabilities.resources).toMatchObject({ listChanged: false });
+    expect(capabilities.tools).toMatchObject({ listChanged: false });
+  });
+
   test("capabilities carry the MCP Apps extension", () => {
     const capabilities = buildGatewayServerCapabilities();
     expect(capabilities.extensions).toHaveProperty(
       "io.modelcontextprotocol/ui",
     );
+  });
+});
+
+describe("isMethodRemovedForRevision", () => {
+  test("removed methods are refused only for the revision that removed them", () => {
+    for (const method of [
+      "ping",
+      "logging/setLevel",
+      "resources/subscribe",
+      "resources/unsubscribe",
+    ]) {
+      expect(
+        isMethodRemovedForRevision({
+          method,
+          revision: STATELESS_MCP_PROTOCOL_REVISION,
+        }),
+      ).toBe(true);
+      // A legacy client keeps whatever it had — notably the SDK's ping.
+      expect(
+        isMethodRemovedForRevision({
+          method,
+          revision: LEGACY_MCP_PROTOCOL_REVISION,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("surviving methods pass through untouched", () => {
+    for (const method of ["tools/call", "tools/list", "server/discover"]) {
+      expect(
+        isMethodRemovedForRevision({
+          method,
+          revision: STATELESS_MCP_PROTOCOL_REVISION,
+        }),
+      ).toBe(false);
+    }
   });
 });
 

--- a/platform/backend/src/routes/mcp-gateway/protocol.ts
+++ b/platform/backend/src/routes/mcp-gateway/protocol.ts
@@ -69,6 +69,32 @@ export const MCP_CLIENT_CAPABILITIES_META_KEY =
 export const SERVER_DISCOVER_METHOD = "server/discover";
 
 /**
+ * Methods 2026-07-28 removes from the protocol (SEP-2575). A client that
+ * declared that revision and calls one gets method-not-found — answering would
+ * mean serving a revision surface the client explicitly opted out of. Clients
+ * on earlier revisions are unaffected; the SDK keeps answering `ping` for
+ * them, and the rest never had handlers here.
+ */
+export const METHODS_REMOVED_IN_STATELESS_REVISION = new Set([
+  "ping",
+  "logging/setLevel",
+  "resources/subscribe",
+  "resources/unsubscribe",
+]);
+
+export function isMethodRemovedForRevision(params: {
+  method: string | undefined;
+  revision: McpProtocolRevision;
+}): boolean {
+  const { method, revision } = params;
+  return (
+    revision === STATELESS_MCP_PROTOCOL_REVISION &&
+    typeof method === "string" &&
+    METHODS_REMOVED_IN_STATELESS_REVISION.has(method)
+  );
+}
+
+/**
  * W3C Trace Context keys the revision fixes for `_meta` (SEP-414).
  *
  * Naming them in the spec is the whole value: a host, its client SDK, this
@@ -216,9 +242,19 @@ export function withPrivateCacheHint<T extends object>(
  */
 export function buildGatewayServerCapabilities(): McpServerCapabilitiesWithExtensions {
   return {
+    // Neither subscription flag is advertised, in any revision, because
+    // neither was ever implemented: no `resources/subscribe` handler exists —
+    // callers always got method-not-found — and no `list_changed`
+    // notification has ever been sent (the stateless transport has no channel
+    // to carry one). Advertising them cost real behavior: a client seeing
+    // `listChanged: true` may cache its lists indefinitely waiting for a
+    // notification that never comes. Freshness is signalled by the SEP-2549
+    // `ttlMs`/`cacheScope` hints on every cacheable result instead. In
+    // 2026-07-28 `resources/subscribe` is removed outright in favour of
+    // `subscriptions/listen`, which the gateway can advertise if it ever
+    // grows an event source to back it.
     resources: {
-      subscribe: true,
-      listChanged: true,
+      listChanged: false,
     },
     extensions: {
       ...MCP_APPS_SERVER_EXTENSION_CAPABILITIES,

--- a/platform/backend/src/routes/mcp-gateway/utils.ts
+++ b/platform/backend/src/routes/mcp-gateway/utils.ts
@@ -119,6 +119,7 @@ import {
   buildGatewayServerCapabilities,
   buildPrivateListCacheHint,
   isResourceUnavailableError,
+  type McpProtocolRevision,
   withCompleteResultEnvelope,
   withPrivateCacheHint,
 } from "./protocol";

--- a/platform/e2e-tests/utils/mcp-gateway.ts
+++ b/platform/e2e-tests/utils/mcp-gateway.ts
@@ -653,6 +653,16 @@ export async function getVisibleCredentials(page: Page): Promise<string[]> {
 export async function getVisibleStaticCredentials(
   page: Page,
 ): Promise<string[]> {
+  // allTextContents() does not auto-wait: read at the wrong instant it
+  // answers [] for a dialog that is still rendering its options — which is
+  // exactly how this helper hard-failed two merge-queue runs in a row. Its
+  // only caller asserts a non-empty list, so wait for the first option to
+  // exist before reading the set.
+  await page
+    .getByTestId(E2eTestId.StaticCredentialToUse)
+    .first()
+    .waitFor({ state: "visible", timeout: 15_000 });
+
   const credentialLabels = await page
     .getByTestId(E2eTestId.StaticCredentialToUse)
     .allTextContents();


### PR DESCRIPTION
Fifth pass on 2026-07-28, and the one that closes out SEP-2575's transport items. Builds on the directory from #6947.

## The finding that reshaped this PR

I set out to make `resources.subscribe` revision-conditional — advertise it to `2025-11-25` clients, withhold it from `2026-07-28` ones. Checking the premise first: **no subscribe handler exists anywhere in the codebase, and no `list_changed` notification has ever been sent.** A client that called `resources/subscribe` always got method-not-found from the SDK, in every revision. The stateless transport has no channel to carry an unsolicited notification even if we wanted to send one.

So this was never a revision question. It was false advertising with a real cost: a client seeing `listChanged: true` may cache its lists indefinitely, waiting for an invalidation that never comes — while we've been emitting `ttlMs: 30000` cache hints saying the opposite. The fix is unconditional:

- `resources.subscribe` — no longer advertised, any revision.
- `resources.listChanged` — now `false`, matching `tools.listChanged`.

Freshness is signalled by the SEP-2549 `ttlMs`/`cacheScope` hints on every cacheable result, which is exactly the role the revision assigns them. If the gateway ever grows an event source, `subscriptions/listen` is the thing to build and advertise then.

## Removed-method enforcement

`ping`, `logging/setLevel`, `resources/subscribe`, and `resources/unsubscribe` are removed in 2026-07-28 (SEP-2575). A client that **declared** that revision now gets `-32601` with a message saying the method was removed — answering would mean serving a surface the client explicitly opted out of.

Legacy clients are untouched, verified route-level: the same `ping` that gets `-32601` under a declared `2026-07-28` header still gets the SDK's automatic pong without one.

## SEP-2575 items closed by analysis, not code

- **Per-request `logLevel` in `_meta`** gates `notifications/message` — which the gateway never emits (single JSON response per request, no notification channel). Nothing to gate.
- **SSE resumability removal** (`Last-Event-ID`) — moot: the stateless transport answers with JSON (`enableJsonResponse: true`), not SSE streams.
- **`notifications/roots/list_changed`** — client→server, and Roots is deprecated anyway; we never consumed it.

## Testing

39 unit tests in the protocol suite (+3: removed-method matrix across both revisions, honest-capability assertions). 13 route-level negotiation tests (+2: the ping split, and `server/discover` no longer advertising subscriptions). 261 pass across the 14 gateway/proxy/a2a suites. `tsc`, `biome`, `knip` clean. Docs table gets a removed-methods row.

## What remains on 2026-07-28 after this

- **`subscriptions/listen`** — now cleanly scoped: it's not "transport plumbing" anymore, it's "build an event source for tool/resource changes, then expose it." A product decision as much as a protocol one.
- **`x-mcp-header`** — still blocked on per-call headers vs pooled upstream connections (analysis on #6944).
- **Tasks extension** — deferred per instruction.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>