### PR TITLE
feat(mcp): mirror x-mcp-header tool parameters into upstream headers

### DIFF
--- a/docs/pages/platform-mcp-gateway.md
+++ b/docs/pages/platform-mcp-gateway.md
@@ -106,6 +106,7 @@ Older revisions still work too. Anything back to `2024-11-05` is accepted and se
 | Missing-resource error | `-32002` | `-32602` |
 | `ping` and `logging/setLevel` | Answered | Removed — method-not-found |
 | Change notifications | None | `subscriptions/listen` stream for tool-list changes |
+| `x-mcp-header` params | Ignored | Mirrored to `Mcp-Param-*` headers on upstream calls |
 
 Both revisions see the same tools, the same access control, and the same policies. The differences are all in how a client talks to the gateway, not in what it can reach.
 

--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -8690,3 +8690,164 @@ describe("executed-as identity", () => {
     });
   });
 });
+
+describe("x-mcp-header mirroring (SEP-2243)", () => {
+  async function seedAnnotatedTool({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }: {
+    makeOrganization: () => Promise<{ id: string }>;
+    makeUser: (a?: object) => Promise<{ id: string }>;
+    makeMember: (u: string, o: string) => Promise<unknown>;
+    makeAgent: (a?: object) => Promise<{ id: string }>;
+  }) {
+    const org = await makeOrganization();
+    const admin = await makeUser({ email: "xh-admin@example.com" });
+    const caller = await makeUser({ email: "xh-caller@example.com" });
+    await makeMember(caller.id, org.id);
+    const agent = await makeAgent({ organizationId: org.id });
+
+    const catalog = await InternalMcpCatalogModel.create({
+      name: "spanner",
+      serverType: "remote",
+      serverUrl: "https://mcp.spanner.example/mcp",
+    });
+    const secret = await secretManager().createSecret(
+      { access_token: "spanner-token" },
+      "spanner-secret",
+    );
+    const server = await McpServerModel.create({
+      name: "spanner",
+      catalogId: catalog.id,
+      secretId: secret.id,
+      serverType: "remote",
+      ownerId: admin.id,
+      scope: "org",
+    });
+    await InternalMcpCatalogModel.update(catalog.id, {
+      dynamicConnectionMcpServerId: server.id,
+    });
+
+    const tool = await ToolModel.createToolIfNotExists({
+      name: "spanner__execute_sql",
+      description: "Execute SQL",
+      parameters: {
+        type: "object",
+        properties: {
+          region: { type: "string", "x-mcp-header": "Region" },
+          query: { type: "string" },
+        },
+        required: ["region", "query"],
+      },
+      catalogId: catalog.id,
+    });
+    await AgentToolModel.createOrUpdateCredentials(
+      agent.id,
+      tool.id,
+      null,
+      "dynamic",
+    );
+
+    const tokenAuth = {
+      tokenId: "xh-token",
+      teamId: null,
+      isOrganizationToken: false,
+      isUserToken: true,
+      userId: caller.id,
+      organizationId: org.id,
+    };
+
+    return { agent, tokenAuth };
+  }
+
+  async function lastTransportHeaders(): Promise<Headers> {
+    const { StreamableHTTPClientTransport } = await import(
+      "@modelcontextprotocol/sdk/client/streamableHttp.js"
+    );
+    const calls = vi.mocked(StreamableHTTPClientTransport).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1][1]?.requestInit?.headers as Headers;
+  }
+
+  test("annotated argument values reach the upstream transport as Mcp-Param headers", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    const { agent, tokenAuth } = await seedAnnotatedTool({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeAgent,
+    });
+
+    mockCallTool.mockResolvedValueOnce({
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    });
+
+    const result = await mcpClient.executeToolCallForOwner(
+      {
+        id: "call_xh_1",
+        name: "spanner__execute_sql",
+        arguments: { region: "us-west1", query: "SELECT 1" },
+      },
+      agentOwner(agent.id),
+      tokenAuth,
+    );
+
+    expect(result).toMatchObject({ isError: false });
+    const headers = await lastTransportHeaders();
+    expect(headers.get("mcp-param-region")).toBe("us-west1");
+    // Only annotated params are mirrored — the body-only param stays put.
+    expect(headers.get("mcp-param-query")).toBeNull();
+  });
+
+  test("a second call with a different value gets its own headers, not the first call's", async ({
+    makeOrganization,
+    makeUser,
+    makeMember,
+    makeAgent,
+  }) => {
+    // The leakage this guards: connections are pooled, and a header baked at
+    // connection creation must not survive onto a call that supplied a
+    // different value. The credential-fingerprint check rebuilds the
+    // connection when the header set changes.
+    const { agent, tokenAuth } = await seedAnnotatedTool({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeAgent,
+    });
+
+    mockCallTool.mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    });
+
+    await mcpClient.executeToolCallForOwner(
+      {
+        id: "call_xh_2",
+        name: "spanner__execute_sql",
+        arguments: { region: "us-west1", query: "SELECT 1" },
+      },
+      agentOwner(agent.id),
+      tokenAuth,
+    );
+    await mcpClient.executeToolCallForOwner(
+      {
+        id: "call_xh_3",
+        name: "spanner__execute_sql",
+        arguments: { region: "eu-central1", query: "SELECT 2" },
+      },
+      agentOwner(agent.id),
+      tokenAuth,
+    );
+
+    const headers = await lastTransportHeaders();
+    expect(headers.get("mcp-param-region")).toBe("eu-central1");
+  });
+});

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -96,6 +96,7 @@ import {
   type McpElicitationHandler,
   withMcpElicitationCapability,
 } from "./mcp-elicitation";
+import { mcpParamHeadersForCall } from "./mcp-param-headers";
 
 const MCP_CLIENT_EXTENSION_CAPABILITIES = {
   ...MCP_APPS_CLIENT_EXTENSION_CAPABILITIES,
@@ -450,6 +451,26 @@ class McpClient {
     const { tool, catalogItem, resolvedToolCall } = validationResult;
     // Use the resolved name (may have been prefixed by suffix fallback lookup)
     toolCall = resolvedToolCall;
+
+    // SEP-2243 x-mcp-header: mirror annotated argument values into
+    // Mcp-Param-* headers on the upstream call. Widening the passthrough set
+    // deliberately reuses its whole pipeline — the headers are merged into the
+    // transport exactly where passthrough headers are, and the credential
+    // fingerprint check discards a cached connection whose baked headers no
+    // longer match, so per-call values cannot leak across pooled calls.
+    const mcpParamHeaders = mcpParamHeadersForCall({
+      inputSchema: tool.parameters,
+      args: toolCall.arguments,
+    });
+    if (mcpParamHeaders && tokenAuth) {
+      tokenAuth = {
+        ...tokenAuth,
+        passthroughHeaders: {
+          ...tokenAuth.passthroughHeaders,
+          ...mcpParamHeaders,
+        },
+      };
+    }
 
     // App backing servers have no upstream to connect to: the `open` launch tool is
     // served in-process. Hand the host the app's UI resource pointer (the
@@ -1424,6 +1445,8 @@ class McpClient {
     if (!tool && availableTool && availableTool.name === toolCall.name) {
       tool = {
         toolName: availableTool.name,
+        parameters:
+          (availableTool.parameters as Record<string, unknown> | null) ?? null,
         rawName: availableTool.rawName,
         mcpServerId: null,
         credentialResolutionMode: "dynamic",

--- a/platform/backend/src/clients/mcp-param-headers.test.ts
+++ b/platform/backend/src/clients/mcp-param-headers.test.ts
@@ -1,0 +1,238 @@
+/**
+ * x-mcp-header validation, extraction, and encoding (SEP-2243).
+ *
+ * Validation is most of the surface because the spec makes every violation
+ * invalidate the whole tool definition — each constraint here is one row of
+ * that contract. Encoding matters because a header is an injection vector:
+ * the base64 wrapper is what keeps CR/LF and non-ASCII out of the wire.
+ */
+
+import { describe, expect, test } from "@/test";
+import {
+  buildMcpParamHeaders,
+  collectMcpHeaderAnnotations,
+  mcpParamHeadersForCall,
+} from "./mcp-param-headers";
+
+const VALID_SCHEMA = {
+  type: "object",
+  properties: {
+    region: { type: "string", "x-mcp-header": "Region" },
+    depth: {
+      type: "object",
+      properties: {
+        tenant: { type: "string", "x-mcp-header": "Tenant" },
+      },
+    },
+    count: { type: "integer", "x-mcp-header": "Count" },
+    dryRun: { type: "boolean", "x-mcp-header": "Dry-Run" },
+    query: { type: "string" },
+  },
+};
+
+describe("collectMcpHeaderAnnotations", () => {
+  test("collects annotations along properties chains, including nested ones", () => {
+    const scan = collectMcpHeaderAnnotations(VALID_SCHEMA);
+    if (!scan.ok) throw new Error(scan.reason);
+
+    expect(scan.annotations).toEqual(
+      expect.arrayContaining([
+        { path: ["region"], name: "Region", type: "string" },
+        { path: ["depth", "tenant"], name: "Tenant", type: "string" },
+        { path: ["count"], name: "Count", type: "integer" },
+        { path: ["dryRun"], name: "Dry-Run", type: "boolean" },
+      ]),
+    );
+  });
+
+  test("a schema with no annotations is valid and empty", () => {
+    expect(
+      collectMcpHeaderAnnotations({
+        type: "object",
+        properties: { q: { type: "string" } },
+      }),
+    ).toEqual({ ok: true, annotations: [] });
+  });
+
+  test.each([
+    ["empty value", { type: "string", "x-mcp-header": "" }],
+    ["non-string value", { type: "string", "x-mcp-header": 7 }],
+    ["whitespace in name", { type: "string", "x-mcp-header": "Bad Name" }],
+    ["CR/LF smuggling", { type: "string", "x-mcp-header": "X\r\nEvil" }],
+    ["type number", { type: "number", "x-mcp-header": "N" }],
+    ["no type", { "x-mcp-header": "N" }],
+    ["type object", { type: "object", "x-mcp-header": "N", properties: {} }],
+  ])("rejects the whole definition for %s", (_label, property) => {
+    const scan = collectMcpHeaderAnnotations({
+      type: "object",
+      properties: { p: property },
+    });
+    expect(scan.ok).toBe(false);
+  });
+
+  test.each([
+    [
+      "items",
+      { type: "array", items: { type: "string", "x-mcp-header": "A" } },
+    ],
+    ["oneOf", { oneOf: [{ type: "string", "x-mcp-header": "A" }] }],
+    ["allOf", { allOf: [{ type: "string", "x-mcp-header": "A" }] }],
+    ["not", { not: { type: "string", "x-mcp-header": "A" } }],
+    ["if", { if: { type: "string", "x-mcp-header": "A" } }],
+  ])("an annotation reached through %s is not statically reachable, so invalid", (_label, property) => {
+    const scan = collectMcpHeaderAnnotations({
+      type: "object",
+      properties: { p: property },
+    });
+    expect(scan.ok).toBe(false);
+    if (scan.ok) return;
+    expect(scan.reason).toContain("statically reachable");
+  });
+
+  test("properties nested under a composition branch are also unreachable", () => {
+    // The chain must consist solely of `properties` keys from the root; one
+    // composition step anywhere poisons everything below it.
+    const scan = collectMcpHeaderAnnotations({
+      type: "object",
+      properties: {
+        p: {
+          anyOf: [
+            {
+              type: "object",
+              properties: { q: { type: "string", "x-mcp-header": "Q" } },
+            },
+          ],
+        },
+      },
+    });
+    expect(scan.ok).toBe(false);
+  });
+
+  test("case-insensitively colliding names invalidate the definition", () => {
+    const scan = collectMcpHeaderAnnotations({
+      type: "object",
+      properties: {
+        a: { type: "string", "x-mcp-header": "Region" },
+        b: { type: "string", "x-mcp-header": "region" },
+      },
+    });
+    expect(scan.ok).toBe(false);
+    if (scan.ok) return;
+    expect(scan.reason).toContain("collide");
+  });
+
+  test("a property literally named x-mcp-header is not an annotation", () => {
+    // `properties` keys are parameter names; only the extension keyword on a
+    // schema object is an annotation.
+    const scan = collectMcpHeaderAnnotations({
+      type: "object",
+      properties: { "x-mcp-header": { type: "string" } },
+    });
+    expect(scan).toEqual({ ok: true, annotations: [] });
+  });
+});
+
+describe("buildMcpParamHeaders", () => {
+  const annotations = (() => {
+    const scan = collectMcpHeaderAnnotations(VALID_SCHEMA);
+    if (!scan.ok) throw new Error(scan.reason);
+    return scan.annotations;
+  })();
+
+  test("mirrors values at the exact property paths", () => {
+    expect(
+      buildMcpParamHeaders({
+        annotations,
+        args: {
+          region: "us-west1",
+          depth: { tenant: "acme" },
+          count: -7,
+          dryRun: false,
+          query: "SELECT 1",
+        },
+      }),
+    ).toEqual({
+      "Mcp-Param-Region": "us-west1",
+      "Mcp-Param-Tenant": "acme",
+      "Mcp-Param-Count": "-7",
+      "Mcp-Param-Dry-Run": "false",
+    });
+  });
+
+  test("an absent value omits the header", () => {
+    expect(
+      buildMcpParamHeaders({ annotations, args: { query: "SELECT 1" } }),
+    ).toEqual({});
+  });
+
+  test("a value of the wrong type is omitted, not coerced", () => {
+    // A coerced header could disagree with the body it summarizes — the exact
+    // mismatch routing headers exist to prevent.
+    expect(
+      buildMcpParamHeaders({
+        annotations,
+        args: { region: 42, count: "many", dryRun: "yes" },
+      }),
+    ).toEqual({});
+  });
+
+  test("unsafe integers are omitted", () => {
+    expect(
+      buildMcpParamHeaders({
+        annotations,
+        args: { count: Number.MAX_SAFE_INTEGER + 2 },
+      }),
+    ).toEqual({});
+    expect(buildMcpParamHeaders({ annotations, args: { count: 3.5 } })).toEqual(
+      {},
+    );
+  });
+
+  test.each([
+    ["non-ASCII", "münchen"],
+    ["newline", "a\nb"],
+    ["carriage return", "a\rb"],
+    ["leading whitespace", " padded"],
+    ["trailing whitespace", "padded "],
+  ])("%s values ride in the base64 wrapper", (_label, value) => {
+    const headers = buildMcpParamHeaders({
+      annotations,
+      args: { region: value },
+    });
+    const encoded = headers["Mcp-Param-Region"];
+    expect(encoded).toMatch(/^=\?base64\?[A-Za-z0-9+/=]+\?=$/);
+    const inner = encoded.slice("=?base64?".length, -"?=".length);
+    expect(Buffer.from(inner, "base64").toString("utf8")).toBe(value);
+  });
+
+  test("interior spaces are plain-ASCII safe and stay unencoded", () => {
+    expect(
+      buildMcpParamHeaders({ annotations, args: { region: "us west 1" } }),
+    ).toEqual({ "Mcp-Param-Region": "us west 1" });
+  });
+});
+
+describe("mcpParamHeadersForCall", () => {
+  test("an invalid schema mirrors nothing", () => {
+    // Acting on annotations from a definition the spec says to reject would
+    // be worse than losing the optimization.
+    expect(
+      mcpParamHeadersForCall({
+        inputSchema: {
+          type: "object",
+          properties: { p: { type: "number", "x-mcp-header": "N" } },
+        },
+        args: { p: 1 },
+      }),
+    ).toBeUndefined();
+  });
+
+  test("a schema without annotations mirrors nothing", () => {
+    expect(
+      mcpParamHeadersForCall({
+        inputSchema: { type: "object", properties: { q: { type: "string" } } },
+        args: { q: "x" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/platform/backend/src/clients/mcp-param-headers.ts
+++ b/platform/backend/src/clients/mcp-param-headers.ts
@@ -1,0 +1,253 @@
+import logger from "@/logging";
+
+/**
+ * `x-mcp-header` (2026-07-28, SEP-2243): a server may annotate tool parameters
+ * whose values a Streamable HTTP client mirrors into `Mcp-Param-{name}`
+ * headers, so intermediaries can route on them without parsing bodies.
+ *
+ * The gateway is that client for every upstream call, and the spec puts two
+ * obligations on it. A tool definition with an invalid annotation must be
+ * rejected — excluded from `tools/list` with a warning, so one malformed tool
+ * cannot poison the rest. And a valid annotation's value must be mirrored with
+ * the exact encoding rules, because a sloppily-encoded header is an injection
+ * vector, which is why most of this module is validation.
+ */
+
+/** @public — granular surface exercised directly by the unit suite */
+export interface McpHeaderAnnotation {
+  /** Chain of `properties` keys from the schema root to the annotated param. */
+  path: string[];
+  /** The name portion of the resulting `Mcp-Param-{name}` header. */
+  name: string;
+  type: "string" | "integer" | "boolean";
+}
+
+type AnnotationScan =
+  | { ok: true; annotations: McpHeaderAnnotation[] }
+  | { ok: false; reason: string };
+
+/**
+ * Collect and validate every `x-mcp-header` annotation in a tool input schema.
+ *
+ * Any violation invalidates the whole definition, per spec — including an
+ * annotation in a position that is not statically reachable (through `items`,
+ * composition keywords, conditionals, or `$ref`), which cannot be extracted
+ * deterministically and therefore must not exist at all.
+ */
+/** @public — granular surface exercised directly by the unit suite */
+export function collectMcpHeaderAnnotations(
+  inputSchema: unknown,
+): AnnotationScan {
+  if (!isRecord(inputSchema)) return { ok: true, annotations: [] };
+
+  const annotations: McpHeaderAnnotation[] = [];
+  let failure: string | null = null;
+
+  const fail = (reason: string): void => {
+    if (!failure) failure = reason;
+  };
+
+  const visitSchema = (
+    schema: unknown,
+    path: string[],
+    reachable: boolean,
+  ): void => {
+    if (failure || !isRecord(schema)) return;
+
+    if ("x-mcp-header" in schema) {
+      const name = schema["x-mcp-header"];
+      if (!reachable) {
+        fail(
+          `x-mcp-header at ${path.join(".") || "<root>"} is not statically reachable`,
+        );
+        return;
+      }
+      if (typeof name !== "string" || name.length === 0) {
+        fail(`x-mcp-header at ${path.join(".")} must be a non-empty string`);
+        return;
+      }
+      // RFC 9110 field-name token syntax; excludes CR/LF and all controls.
+      if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(name)) {
+        fail(`x-mcp-header "${name}" is not a valid HTTP field-name token`);
+        return;
+      }
+      const type = schema.type;
+      if (type !== "string" && type !== "integer" && type !== "boolean") {
+        // `number` is explicitly forbidden: its string form is not canonical.
+        fail(
+          `x-mcp-header "${name}" is on a parameter of type ${JSON.stringify(type)}; only string, integer, and boolean are permitted`,
+        );
+        return;
+      }
+      annotations.push({ path, name, type });
+    }
+
+    // `properties` keys are the only reachability-preserving step. Everything
+    // else that nests schemas is walked so a stray annotation is FOUND, but
+    // what it contains is not reachable.
+    const { properties } = schema;
+    if (isRecord(properties)) {
+      for (const [key, child] of Object.entries(properties)) {
+        visitSchema(child, [...path, key], reachable);
+      }
+    }
+
+    for (const keyword of [
+      "items",
+      "additionalProperties",
+      "not",
+      "if",
+      "then",
+      "else",
+    ]) {
+      if (keyword in schema) visitSchema(schema[keyword], path, false);
+    }
+    for (const keyword of ["oneOf", "anyOf", "allOf", "prefixItems"]) {
+      const branches = schema[keyword];
+      if (Array.isArray(branches)) {
+        for (const branch of branches) visitSchema(branch, path, false);
+      }
+    }
+    for (const keyword of ["$defs", "definitions", "patternProperties"]) {
+      const map = schema[keyword];
+      if (isRecord(map)) {
+        for (const child of Object.values(map)) visitSchema(child, path, false);
+      }
+    }
+  };
+
+  visitSchema(inputSchema, [], true);
+  if (failure) return { ok: false, reason: failure };
+
+  // Case-insensitive uniqueness across every annotation in the schema: two
+  // params mapping onto the same header would silently overwrite each other.
+  const seen = new Map<string, string>();
+  for (const { name } of annotations) {
+    const key = name.toLowerCase();
+    const existing = seen.get(key);
+    if (existing !== undefined) {
+      return {
+        ok: false,
+        reason: `x-mcp-header values "${existing}" and "${name}" collide case-insensitively`,
+      };
+    }
+    seen.set(key, name);
+  }
+
+  return { ok: true, annotations };
+}
+
+/**
+ * Whether a tool definition must be excluded from `tools/list`.
+ *
+ * Logs the warning the spec asks for, naming the tool and the reason, so a
+ * vanished tool is diagnosable rather than silently missing.
+ */
+export function isToolRejectedForMcpHeaders(params: {
+  toolName: string;
+  inputSchema: unknown;
+}): boolean {
+  const scan = collectMcpHeaderAnnotations(params.inputSchema);
+  if (scan.ok) return false;
+  logger.warn(
+    { toolName: params.toolName, reason: scan.reason },
+    "Excluding tool from tools/list: invalid x-mcp-header annotation",
+  );
+  return true;
+}
+
+/**
+ * Build the `Mcp-Param-{name}` headers for one call.
+ *
+ * Extraction reads the instance value at the annotation's exact property path;
+ * an absent value omits the header. A value that does not match the annotated
+ * type is also omitted rather than coerced — the upstream will reject the
+ * argument itself, and a coerced header could disagree with the body it
+ * summarizes, which is the mismatch the routing headers exist to prevent.
+ */
+/** @public — granular surface exercised directly by the unit suite */
+export function buildMcpParamHeaders(params: {
+  annotations: McpHeaderAnnotation[];
+  args: unknown;
+}): Record<string, string> {
+  const { annotations, args } = params;
+  const headers: Record<string, string> = {};
+
+  for (const annotation of annotations) {
+    const value = readPath(args, annotation.path);
+    if (value === undefined || value === null) continue;
+
+    let text: string;
+    if (annotation.type === "string" && typeof value === "string") {
+      text = value;
+    } else if (
+      annotation.type === "integer" &&
+      typeof value === "number" &&
+      Number.isInteger(value) &&
+      Math.abs(value) <= Number.MAX_SAFE_INTEGER
+    ) {
+      text = String(value);
+    } else if (annotation.type === "boolean" && typeof value === "boolean") {
+      text = value ? "true" : "false";
+    } else {
+      logger.debug(
+        { header: annotation.name, expected: annotation.type },
+        "Skipping Mcp-Param header: argument value does not match annotated type",
+      );
+      continue;
+    }
+
+    headers[`Mcp-Param-${annotation.name}`] = encodeHeaderValue(text);
+  }
+
+  return headers;
+}
+
+/**
+ * Compute the mirrored headers for a call in one step, or nothing when the
+ * schema has no valid annotations. An invalid schema mirrors nothing: acting
+ * on annotations from a definition the spec says to reject would be worse
+ * than omitting the optimization.
+ */
+export function mcpParamHeadersForCall(params: {
+  inputSchema: unknown;
+  args: unknown;
+}): Record<string, string> | undefined {
+  const scan = collectMcpHeaderAnnotations(params.inputSchema);
+  if (!scan.ok || scan.annotations.length === 0) return undefined;
+  const headers = buildMcpParamHeaders({
+    annotations: scan.annotations,
+    args: params.args,
+  });
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/**
+ * RFC 9110 header values are visible ASCII plus interior space and tab. A
+ * value outside that — or with leading/trailing whitespace, which header
+ * parsing strips — is carried Base64-encoded in the spec's wrapper so it
+ * round-trips exactly and can never smuggle CR/LF.
+ */
+function encodeHeaderValue(value: string): string {
+  const asciiSafe = /^[\x20\x09\x21-\x7E]*$/.test(value);
+  const noEdgeWhitespace = value === value.trim();
+  if (asciiSafe && noEdgeWhitespace) return value;
+  return `=?base64?${Buffer.from(value, "utf8").toString("base64")}?=`;
+}
+
+function readPath(value: unknown, path: string[]): unknown {
+  let current: unknown = value;
+  for (const key of path) {
+    if (!isRecord(current)) return undefined;
+    current = current[key];
+  }
+  return current;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -2052,6 +2052,7 @@ class ToolModel {
         catalogId: schema.toolsTable.catalogId,
         catalogName: schema.internalMcpCatalogTable.name,
         meta: schema.toolsTable.meta,
+        parameters: schema.toolsTable.parameters,
       })
       .from(schema.toolsTable)
       .innerJoin(
@@ -2165,6 +2166,7 @@ class ToolModel {
         catalogId: schema.toolsTable.catalogId,
         catalogName: schema.internalMcpCatalogTable.name,
         meta: schema.toolsTable.meta,
+        parameters: schema.toolsTable.parameters,
       })
       .from(schema.toolsTable)
       .innerJoin(
@@ -2339,6 +2341,7 @@ class ToolModel {
         catalogId: schema.toolsTable.catalogId,
         catalogName: schema.internalMcpCatalogTable.name,
         meta: schema.toolsTable.meta,
+        parameters: schema.toolsTable.parameters,
       })
       .from(schema.toolsTable)
       .innerJoin(
@@ -2384,6 +2387,7 @@ class ToolModel {
         catalogId: schema.toolsTable.catalogId,
         catalogName: schema.internalMcpCatalogTable.name,
         meta: schema.toolsTable.meta,
+        parameters: schema.toolsTable.parameters,
       })
       .from(schema.toolsTable)
       .innerJoin(

--- a/platform/backend/src/routes/mcp-gateway/protocol-negotiation.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/protocol-negotiation.test.ts
@@ -392,6 +392,61 @@ describe("MCP Gateway - protocol revision negotiation", () => {
     expect(capabilities.resources.listChanged).toBe(false);
   });
 
+  test("a tool with an invalid x-mcp-header annotation is excluded from tools/list", async ({
+    makeAgent,
+    makeOrganization,
+    makeInternalMcpCatalog,
+    makeTool,
+    makeAgentTool,
+  }) => {
+    const agent = await makeAgent();
+    const org = await makeOrganization();
+    const token = await TeamTokenModel.create({
+      organizationId: org.id,
+      name: "Org Token",
+      teamId: null,
+      isOrganizationToken: true,
+    });
+    const catalog = await makeInternalMcpCatalog({
+      organizationId: org.id,
+      name: "xh-catalog",
+    });
+
+    // Invalid: number is explicitly forbidden as an annotated type.
+    const invalid = await makeTool({
+      catalogId: catalog.id,
+      name: "xh-catalog__bad",
+      parameters: {
+        type: "object",
+        properties: { n: { type: "number", "x-mcp-header": "N" } },
+      },
+    });
+    const valid = await makeTool({
+      catalogId: catalog.id,
+      name: "xh-catalog__good",
+      parameters: {
+        type: "object",
+        properties: { region: { type: "string", "x-mcp-header": "Region" } },
+      },
+    });
+    await makeAgentTool(agent.id, invalid.id);
+    await makeAgentTool(agent.id, valid.id);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/mcp/${agent.id}`,
+      headers: makeMcpHeaders(token.value),
+      payload: { jsonrpc: "2.0", method: "tools/list", params: {}, id: 30 },
+    });
+
+    const names = (response.json().result.tools as Array<{ name: string }>).map(
+      (t) => t.name,
+    );
+    // One malformed definition must not poison the rest of the list.
+    expect(names).toContain("xh-catalog__good");
+    expect(names).not.toContain("xh-catalog__bad");
+  });
+
   test("GET discovery advertises both supported revisions", async ({
     makeAgent,
     makeOrganization,

--- a/platform/backend/src/routes/mcp-gateway/utils.ts
+++ b/platform/backend/src/routes/mcp-gateway/utils.ts
@@ -48,6 +48,7 @@ import { structuredToolErrorResult } from "@/archestra-mcp-server/helpers";
 import { userHasPermission } from "@/auth/utils";
 import { LRUCacheManager } from "@/cache-manager";
 import mcpClient, { type TokenAuthContext } from "@/clients/mcp-client";
+import { isToolRejectedForMcpHeaders } from "@/clients/mcp-param-headers";
 import config from "@/config";
 import { evaluateSingleMcpToolInvocationPolicy } from "@/guardrails/tool-invocation";
 import { buildPolicyBlockedToolResult } from "@/guardrails/tool-policy-link";
@@ -315,8 +316,19 @@ export async function createAgentServer(params: {
     // filter runs BEFORE filterExposedTools, so an excluded always-exposed
     // built-in is dropped here and never re-admitted below. Empty (no-op)
     // unless the agent's accessAllTools setting is on.
-    const { tools: mcpTools, exclusionSets } =
+    const { tools: fetchedMcpTools, exclusionSets } =
       await agentToolExclusionsService.getFilteredMcpToolsByAgent(agentId);
+
+    // SEP-2243: a tool definition with an invalid x-mcp-header annotation must
+    // be excluded from tools/list (with a warning), so one malformed upstream
+    // definition cannot poison the rest of the list.
+    const mcpTools = fetchedMcpTools.filter(
+      (tool) =>
+        !isToolRejectedForMcpHeaders({
+          toolName: tool.name,
+          inputSchema: tool.parameters,
+        }),
+    );
 
     // A tools/list is served to one of two surfaces, and the whole gateway/chat
     // difference lives in this policy. An internal chat (agentType "agent") is

--- a/platform/backend/src/types/agent-tool.ts
+++ b/platform/backend/src/types/agent-tool.ts
@@ -106,4 +106,6 @@ export type McpToolAssignment = {
   catalogId: string | null;
   catalogName: string | null;
   meta: Record<string, unknown> | null;
+  /** Tool input schema, for x-mcp-header extraction on the call path. */
+  parameters?: Record<string, unknown> | null;
 };


### PR DESCRIPTION
Seventh pass on 2026-07-28: [`x-mcp-header`](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#x-mcp-header), the other half of SEP-2243. **Stacked on #6953.**

## What unblocked this

This was deferred twice over one question: the spec requires **per-call** headers (`Mcp-Param-{name}` derived from that call's arguments), but our upstream connections are pooled and their headers are baked at transport creation. A naive merge would leak call A's `region` onto call B over the same connection.

The answer was already in the codebase: passthrough headers have the same per-call-into-pooled-connection shape, and the **credential-fingerprint check** (`getOrCreateClient`) discards a cached connection whose baked headers no longer match the ones this attempt computed. So mirrored headers ride the passthrough pipeline — merged where passthrough headers merge, zero new threading — and the existing invalidation guarantees isolation. An integration test alternates values across two calls and asserts the transport got each call's own value.

Cost worth naming: alternating values on consecutive calls causes reconnect churn (fingerprint mismatch → rebuild). Correctness first; a value-keyed pool is the optimization if it ever matters.

## Both client obligations, per spec

**1. Reject invalid definitions.** A tool whose schema carries a bad annotation is excluded from `tools/list` with a warning naming the tool and reason — one malformed upstream definition must not poison the rest. Validation covers the full constraint table: RFC 9110 token syntax, non-empty, case-insensitive uniqueness, primitive types only (`number` explicitly forbidden), and static reachability — an annotation reached through `items`, composition keywords, conditionals, or `$defs` invalidates the whole definition, including `properties` nested *under* a composition branch. The walk distinguishes a parameter literally *named* `x-mcp-header` from the annotation keyword.

**2. Mirror with exact encoding.** Strings as-is; integers decimal (outside ±2⁵³−1 omitted); booleans lowercased; anything non-ASCII, control-bearing, or whitespace-edged carried in the `=?base64?...?=` wrapper — round-trips exactly, can never smuggle CR/LF. A value not matching the annotated type is **omitted, not coerced**: a coerced header could disagree with the body it summarizes, which is the exact mismatch routing headers exist to prevent. An invalid schema mirrors nothing — acting on annotations from a definition the spec says to reject would be worse than losing the optimization.

## Plumbing

Assignment queries now project the tool's input schema (`parameters`) so the call path reads annotations without a per-call lookup. One dedicated `tools/list` route test pins the exclusion behavior end-to-end.

## Testing

29 unit tests (full validation matrix as `test.each` rows, extraction paths, every encoding case with base64 round-trip assertions), 2 integration tests through `executeToolCallForOwner` asserting the actual transport headers (including the cross-call isolation case), 1 route-level `tools/list` exclusion test. **402 pass** across the 14 client/gateway suites. `tsc`, `biome`, `knip` clean (test-only granular exports carry the repo's `@public` tag). Docs table row added.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>