### PR TITLE
fix(bench): restore CI with dedicated Dagger engine

### DIFF
--- a/.github/bench/README.md
+++ b/.github/bench/README.md
@@ -1,7 +1,7 @@
 # Benchmark CI
 
 `.github/workflows/benchmark.yml` runs `archestra-bench` daily against the currently-deployed
-staging platform image, an ephemeral Postgres sidecar, and the shared staging managed Dagger engine.
+staging platform image, an ephemeral Postgres sidecar, and a short-lived benchmark-owned Dagger engine.
 It never mutates the live staging Deployment, its DB, or its data. Trigger manually from the Actions
 tab (`workflow_dispatch`) or wait for the daily cron.
 
@@ -18,6 +18,7 @@ Files:
 - `runner-entrypoint.sh` (`run-benchmark`) — writes `/app/.env`, runs the bench, then exports
   TensorBoard, uploads to GCS, and posts Slack. The reporting scripts live in `ai-labs/scripts/` and
   are copied into the image as `/bench/scripts/`.
+- `dagger-job.yaml` — an isolated, tokenless Dagger engine pod and its public-only egress policy.
 - `job.yaml` — the k8s Job (bench container + `pgvector` sidecar). `${...}` filled by `envsubst` in CI.
 
 ## One-time prerequisites (not automated)

--- a/.github/bench/dagger-job.yaml
+++ b/.github/bench/dagger-job.yaml
@@ -1,0 +1,138 @@
+# Short-lived, benchmark-owned Dagger engine. It runs separately from the secret-bearing benchmark
+# pod, has no Kubernetes token, and is reachable only through kube-pod:// exec. `${RUN_NUMBER}` is
+# filled by envsubst in CI.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: archestra-bench-dagger-config
+  namespace: archestra
+data:
+  engine.json: |
+    {
+      "logLevel": "info",
+      "security": { "insecureRootCapabilities": false },
+      "gc": { "maxUsedSpace": "40GB", "reservedSpace": "5GB", "minFreeSpace": "20%" }
+    }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: archestra-bench-dagger-egress
+  namespace: archestra
+spec:
+  podSelector:
+    matchLabels:
+      app: archestra-bench-dagger
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - { protocol: UDP, port: 53 }
+        - { protocol: TCP, port: 53 }
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 100.64.0.0/10
+              - 127.0.0.0/8
+              - 169.254.0.0/16
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: archestra-bench-dagger-${RUN_NUMBER}
+  namespace: archestra
+  labels:
+    app: archestra-bench-dagger
+    run: "${RUN_NUMBER}"
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+spec:
+  activeDeadlineSeconds: 23400
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  terminationGracePeriodSeconds: 30
+  containers:
+    - name: dagger-engine
+      image: registry.dagger.io/engine:v0.21.5@sha256:3dd06d85a150defe5299bf7a4ca000c8cb2bfc8a4121b712aa146f0e7aeb3be1
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          set -eu
+          CGROUP="archestra-bench-${POD_UID}"
+          CGROUP_PATH="/sys/fs/cgroup/${CGROUP}"
+          printf '[worker.oci]\n  defaultCgroupParent = "/%s"\n' "${CGROUP}" > /etc/dagger/engine.toml
+          cap() {
+            mkdir -p "${CGROUP_PATH}" 2>/dev/null &&
+            echo 5368709120 > "${CGROUP_PATH}/memory.max" 2>/dev/null &&
+            echo '200000 100000' > "${CGROUP_PATH}/cpu.max" 2>/dev/null &&
+            { echo 0 > "${CGROUP_PATH}/memory.swap.max" 2>/dev/null || true; }
+          }
+          i=0
+          until cap; do
+            if [ "${i}" -ge 60 ]; then
+              echo 'archestra: could not cap benchmark sandboxes with cgroup v2' >&2
+              exit 1
+            fi
+            i=$((i + 1))
+            sleep 1
+          done
+          exec /usr/local/bin/dagger-entrypoint.sh
+      env:
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: "2"
+          memory: 6Gi
+        limits:
+          memory: 6Gi
+      readinessProbe:
+        exec:
+          command: ["buildctl", "debug", "workers"]
+        periodSeconds: 2
+        timeoutSeconds: 2
+        failureThreshold: 60
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - rmdir "/sys/fs/cgroup/archestra-bench-${POD_UID}" 2>/dev/null || true
+      volumeMounts:
+        - name: varlib
+          mountPath: /var/lib/dagger
+        - name: run
+          mountPath: /run/dagger
+        - name: config
+          mountPath: /etc/dagger/engine.json
+          subPath: engine.json
+  volumes:
+    - name: varlib
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes: [ReadWriteOnce]
+            resources:
+              requests:
+                storage: 50Gi
+    - name: run
+      emptyDir:
+        medium: Memory
+    - name: config
+      configMap:
+        name: archestra-bench-dagger-config

--- a/.github/bench/dagger-job.yaml
+++ b/.github/bench/dagger-job.yaml
@@ -35,13 +35,18 @@ spec:
       ports:
         - { protocol: UDP, port: 53 }
         - { protocol: TCP, port: 53 }
+    # Public IPv4 only, mirroring the platform's FLOOR_DENIED_IPV4_CIDRS
+    # (backend/src/k8s/mcp-server-runtime/network-policy.ts). No `::/0` rule, so IPv6 egress is denied
+    # outright — deliberate on an IPv4-only cluster; add one here if staging ever goes dual-stack.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
             except:
+              - 0.0.0.0/8
               - 10.0.0.0/8
               - 100.64.0.0/10
               - 127.0.0.0/8
+              - 168.63.129.16/32
               - 169.254.0.0/16
               - 172.16.0.0/12
               - 192.168.0.0/16
@@ -122,6 +127,8 @@ spec:
           mountPath: /etc/dagger/engine.json
           subPath: engine.json
   volumes:
+    # Sized for one run, not for a warm cache: this engine is created per run and the claim dies with
+    # it, so it never carries layers forward the way the platform's retained 50Gi engine PVC does.
     - name: varlib
       ephemeral:
         volumeClaimTemplate:
@@ -129,7 +136,7 @@ spec:
             accessModes: [ReadWriteOnce]
             resources:
               requests:
-                storage: 50Gi
+                storage: 20Gi
     - name: run
       emptyDir:
         medium: Memory

--- a/.github/bench/job.yaml
+++ b/.github/bench/job.yaml
@@ -1,6 +1,7 @@
 # Short-lived benchmark Job. Runs the bench container against an ephemeral Postgres sidecar (zero blast
-# radius on staging's DB) and the shared staging Dagger engine (reached via kube-pod:// with the
-# platform service account's RBAC). The pod owns reporting: it uploads results to GCS and posts Slack,
+# radius on staging's DB) and a short-lived benchmark-owned Dagger engine (reached via kube-pod://
+# with the platform service account's RBAC). The pod owns reporting: it uploads results to GCS and
+# posts Slack,
 # so CI applies the Job and leaves. activeDeadlineSeconds / ttlSecondsAfterFinished handle teardown.
 # `${...}` are filled by envsubst.
 #
@@ -64,10 +65,11 @@ spec:
               value: "basic"
             - name: BENCH_LANES
               value: "glm,deepseek-flash,qwen37-plus,gemma-4-31b,gpt-56-luna,mimo-25,qwen36-35b-a3b,qwen36-27b"
-            # Dagger runner host is resolved from the live staging Deployment by CI.
-            # Setting it also turns on the code sandbox (gated on the host's presence).
+            # Setting the benchmark-owned engine host also turns on the code sandbox.
             - name: ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST
               value: "${DAGGER_RUNNER_HOST}"
+            - name: DAGGER_ENGINE_POD
+              value: "${DAGGER_ENGINE_POD}"
             - name: ZAI_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/.github/bench/runner-entrypoint.sh
+++ b/.github/bench/runner-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Drives one benchmark run inside the prod platform image and owns reporting end to end: provisions the
-# bench env file, runs the benchmark against the Postgres sidecar + staging Dagger engine, then exports
+# bench env file, runs the benchmark against its Postgres sidecar + dedicated Dagger engine, then exports
 # TensorBoard scalars, uploads artifacts to GCS, and posts the Slack summary. The final publish step's
 # exit code encodes harness health (zero passes ⇒ broken), so the pod's terminal phase is the signal CI
 # reads — CI applies the Job and leaves, it does not wait or copy anything out.
@@ -10,6 +10,25 @@ umask 077
 : "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (shared with the postgres sidecar)}"
 BENCH_ENVS="${BENCH_ENVS:-basic}"
 BENCH_LANES="${BENCH_LANES:-glm}"
+
+cleanup_dagger() {
+  status=$?
+  trap - EXIT
+  if [ -n "${DAGGER_ENGINE_POD:-}" ]; then
+    service_account_dir=/var/run/secrets/kubernetes.io/serviceaccount
+    namespace=$(cat "${service_account_dir}/namespace")
+    if ! curl -fsS --max-time 10 --request DELETE \
+      --cacert "${service_account_dir}/ca.crt" \
+      --header "Authorization: Bearer $(cat "${service_account_dir}/token")" \
+      "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS:-443}/api/v1/namespaces/${namespace}/pods/${DAGGER_ENGINE_POD}" \
+      >/dev/null; then
+      printf 'warning: could not delete Dagger pod %s\n' "${DAGGER_ENGINE_POD}" >&2
+    fi
+  fi
+  exit "${status}"
+}
+trap cleanup_dagger EXIT
+trap 'exit 143' HUP INT TERM
 
 # The bench resolves its Postgres from ARCHESTRA_BENCH_DATABASE_URL and creates a fresh per-run
 # database on it; the backend's own ARCHESTRA_DATABASE_URL is then derived from that. `Instance::start`
@@ -55,5 +74,5 @@ else
 fi
 
 # Final step: uploads to GCS, posts Slack, and exits non-zero on a broken harness so the pod's terminal
-# phase reflects run health.
-exec python3 /bench/scripts/publish_run.py --tb /work/tb --run-dir /work/run --tarball /work/run.tgz
+# phase reflects run health. The EXIT trap removes the separate Dagger pod after publishing.
+python3 /bench/scripts/publish_run.py --tb /work/tb --run-dir /work/run --tarball /work/run.tgz

--- a/.github/bench/runner-entrypoint.sh
+++ b/.github/bench/runner-entrypoint.sh
@@ -16,7 +16,9 @@ cleanup_dagger() {
   trap - EXIT
   if [ -n "${DAGGER_ENGINE_POD:-}" ]; then
     service_account_dir=/var/run/secrets/kubernetes.io/serviceaccount
-    namespace=$(cat "${service_account_dir}/namespace")
+    # Never let cleanup decide the exit code: under `set -e` a failed read here would replace the
+    # publish status, and that status is the run-health signal CI reads off the pod's terminal phase.
+    namespace=$(cat "${service_account_dir}/namespace" 2>/dev/null) || namespace=archestra
     if ! curl -fsS --max-time 10 --request DELETE \
       --cacert "${service_account_dir}/ca.crt" \
       --header "Authorization: Bearer $(cat "${service_account_dir}/token")" \
@@ -74,5 +76,9 @@ else
 fi
 
 # Final step: uploads to GCS, posts Slack, and exits non-zero on a broken harness so the pod's terminal
-# phase reflects run health. The EXIT trap removes the separate Dagger pod after publishing.
+# phase reflects run health. Not `exec`ed, so the EXIT trap runs after publishing and removes the
+# separate Dagger pod. That covers a normal exit only: a SIGTERM (pod deleted, activeDeadlineSeconds)
+# reaches this shell, but sh defers the handler until the foreground command returns, so the bench
+# outlives the grace period and is SIGKILLed with the trap still pending. CI's label sweep on the next
+# run is what actually reaps an engine orphaned that way.
 python3 /bench/scripts/publish_run.py --tb /work/tb --run-dir /work/run --tarball /work/run.tgz

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,7 @@
 name: Benchmark
 
 # Runs archestra-bench once per day against staging-grade infrastructure: the currently-deployed
-# platform image, an ephemeral Postgres sidecar, and the shared staging managed Dagger engine. Never
+# platform image, an ephemeral Postgres sidecar, and a short-lived benchmark-owned Dagger engine. Never
 # mutates the live staging Deployment, its DB, or its data. See .github/bench/README.md for the
 # one-time prerequisites (GCS bucket + IAM, ZAI_API_KEY / Slack secrets).
 
@@ -58,9 +58,8 @@ jobs:
           gcloud container clusters get-credentials "${GKE_CLUSTER}" \
             --zone "${GKE_ZONE}" --project "${GKE_PROJECT}"
 
-      # Since CI releases at the fail-fast window, a prior run's pod outlives its GitHub job — the
-      # Actions-level concurrency group no longer prevents two pods sharing the Dagger engine. Refuse to
-      # start if a benchmark Job is still active, before spending a build on it.
+      # Since CI releases at the fail-fast window, a prior run's pod outlives its GitHub job. Refuse to
+      # start if a benchmark Job is still active, before spending a build on another run.
       - name: Guard against an overlapping run
         run: |
           set -euo pipefail
@@ -72,6 +71,9 @@ jobs:
             echo "::error::a benchmark Job is still active in archestra; refusing to start an overlapping run"
             exit 1
           fi
+          # No benchmark is active, so any prior engine pod is stale (node loss or interrupted cleanup).
+          kubectl delete pods -n archestra -l app=archestra-bench-dagger \
+            --ignore-not-found --wait=false
 
       - name: Resolve staging deployment facts
         id: resolve
@@ -81,22 +83,15 @@ jobs:
           PLATFORM_IMAGE=$(get '{.spec.template.spec.containers[0].image}')
           PLATFORM_SA=$(get '{.spec.template.spec.serviceAccountName}')
           [ -n "${PLATFORM_SA}" ] || PLATFORM_SA=default
-          DAGGER_RUNNER_HOST=$(get '{range .spec.template.spec.containers[0].env[?(@.name=="ARCHESTRA_CODE_RUNTIME_DAGGER_RUNNER_HOST")]}{.value}{end}')
-          if [ -z "${PLATFORM_IMAGE}" ] || [ -z "${DAGGER_RUNNER_HOST}" ]; then
-            echo "::error::could not resolve platform image / dagger host from the live Deployment (is the dagger host a literal env .value on containers[0], not a valueFrom/envFrom ref?)"
+          if [ -z "${PLATFORM_IMAGE}" ]; then
+            echo "::error::could not resolve the platform image from the live Deployment"
             exit 1
           fi
-          # Dagger namespace for the RBAC preflight: the namespace= query param of the kube-pod:// host,
-          # defaulting to archestra when absent.
-          DAGGER_NS=$(printf '%s' "${DAGGER_RUNNER_HOST}" | sed -n 's/.*[?&]namespace=\([^&]*\).*/\1/p')
-          [ -n "${DAGGER_NS}" ] || DAGGER_NS=archestra
           {
             echo "platform_image=${PLATFORM_IMAGE}"
             echo "platform_sa=${PLATFORM_SA}"
-            echo "dagger_runner_host=${DAGGER_RUNNER_HOST}"
-            echo "dagger_ns=${DAGGER_NS}"
           } >> "${GITHUB_OUTPUT}"
-          echo "Resolved image=${PLATFORM_IMAGE} sa=${PLATFORM_SA} dagger_ns=${DAGGER_NS}"
+          echo "Resolved image=${PLATFORM_IMAGE} sa=${PLATFORM_SA}"
 
       - name: Assert native sidecar support (control plane >= 1.29)
         run: |
@@ -111,17 +106,21 @@ jobs:
       - name: RBAC preflight (platform SA can exec into the Dagger pod)
         env:
           PLATFORM_SA: ${{ steps.resolve.outputs.platform_sa }}
-          DAGGER_NS: ${{ steps.resolve.outputs.dagger_ns }}
         run: |
           set -euo pipefail
           RC=0
           VERDICT=$(kubectl auth can-i create pods/exec \
-            --as="system:serviceaccount:archestra:${PLATFORM_SA}" -n "${DAGGER_NS}" 2>&1) || RC=$?
-          echo "can-i create pods/exec in ${DAGGER_NS}: ${VERDICT} (rc=${RC})"
+            --as="system:serviceaccount:archestra:${PLATFORM_SA}" -n archestra 2>&1) || RC=$?
+          echo "can-i create pods/exec in archestra: ${VERDICT} (rc=${RC})"
+          DELETE_RC=0
+          DELETE_VERDICT=$(kubectl auth can-i delete pods \
+            --as="system:serviceaccount:archestra:${PLATFORM_SA}" -n archestra 2>&1) || DELETE_RC=$?
+          echo "can-i delete pods in archestra: ${DELETE_VERDICT} (rc=${DELETE_RC})"
           # Fail closed: only an explicit allow proceeds. An API/impersonation error or a "no - <reason>"
           # response must not slip through as if permitted.
-          if [ "${RC}" -ne 0 ] || [ "${VERDICT}" != "yes" ]; then
-            echo "::error::platform SA ${PLATFORM_SA} cannot create pods/exec in ${DAGGER_NS} (verdict: ${VERDICT}); Dagger calls will fail"
+          if [ "${RC}" -ne 0 ] || [ "${VERDICT}" != "yes" ] || \
+             [ "${DELETE_RC}" -ne 0 ] || [ "${DELETE_VERDICT}" != "yes" ]; then
+            echo "::error::platform SA ${PLATFORM_SA} needs create pods/exec and delete pods in archestra"
             exit 1
           fi
 
@@ -142,6 +141,26 @@ jobs:
             --cache-to "type=registry,ref=${CACHE_REF},mode=max" \
             -t "${BENCH_IMAGE}" .
           echo "bench_image=${BENCH_IMAGE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Start benchmark Dagger engine
+        id: dagger
+        run: |
+          set -euo pipefail
+          RUN_NUMBER="${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
+          POD="archestra-bench-dagger-${RUN_NUMBER}"
+          export RUN_NUMBER
+          envsubst '${RUN_NUMBER}' < .github/bench/dagger-job.yaml | kubectl apply -f -
+          echo "pod_name=${POD}" >> "${GITHUB_OUTPUT}"
+
+          if ! kubectl wait --for=condition=Ready "pod/${POD}" -n archestra --timeout=5m; then
+            kubectl describe "pod/${POD}" -n archestra || true
+            kubectl logs "${POD}" -n archestra -c dagger-engine --tail=80 || true
+            exit 1
+          fi
+          {
+            echo "run_number=${RUN_NUMBER}"
+            echo "runner_host=kube-pod://${POD}?namespace=archestra&container=dagger-engine"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Create bench secret
         env:
@@ -164,20 +183,21 @@ jobs:
         env:
           BENCH_IMAGE: ${{ steps.image.outputs.bench_image }}
           PLATFORM_SA: ${{ steps.resolve.outputs.platform_sa }}
-          DAGGER_RUNNER_HOST: ${{ steps.resolve.outputs.dagger_runner_host }}
+          DAGGER_RUNNER_HOST: ${{ steps.dagger.outputs.runner_host }}
+          DAGGER_ENGINE_POD: ${{ steps.dagger.outputs.pod_name }}
+          RUN_NUMBER: ${{ steps.dagger.outputs.run_number }}
         run: |
           set -euo pipefail
-          RUN_NUMBER="${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           # An ephemeral, localhost-only sidecar password (the DB dies with the pod); alphanumeric so it
           # is safe in the bench .env URL.
           POSTGRES_PASSWORD=$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')
-          export BENCH_IMAGE PLATFORM_SA DAGGER_RUNNER_HOST RUN_NUMBER POSTGRES_PASSWORD
+          export BENCH_IMAGE PLATFORM_SA DAGGER_RUNNER_HOST DAGGER_ENGINE_POD RUN_NUMBER POSTGRES_PASSWORD
           export GCS_BUCKET RUN_URL GITHUB_RUN_NUMBER GITHUB_RUN_ATTEMPT
           echo "run_number=${RUN_NUMBER}" >> "${GITHUB_OUTPUT}"
           # The single-quoted list is envsubst's allowlist of vars to expand (not shell expansion).
           # shellcheck disable=SC2016
-          envsubst '${BENCH_IMAGE} ${PLATFORM_SA} ${DAGGER_RUNNER_HOST} ${RUN_NUMBER} ${POSTGRES_PASSWORD} ${GCS_BUCKET} ${RUN_URL} ${GITHUB_RUN_NUMBER} ${GITHUB_RUN_ATTEMPT}' \
+          envsubst '${BENCH_IMAGE} ${PLATFORM_SA} ${DAGGER_RUNNER_HOST} ${DAGGER_ENGINE_POD} ${RUN_NUMBER} ${POSTGRES_PASSWORD} ${GCS_BUCKET} ${RUN_URL} ${GITHUB_RUN_NUMBER} ${GITHUB_RUN_ATTEMPT}' \
             < .github/bench/job.yaml | kubectl apply -f -
 
       # The pod runs the full benchmark and reports its own results (GCS + Slack), so CI does not wait
@@ -228,3 +248,12 @@ jobs:
           done
           echo "::error::pod ${POD} never cleared the fast-fail window (stuck Pending / slow pull?)"
           exit 1
+
+      - name: Clean up Dagger after CI failure
+        if: ${{ always() && steps.dagger.outputs.pod_name != '' && job.status != 'success' }}
+        env:
+          DAGGER_ENGINE_POD: ${{ steps.dagger.outputs.pod_name }}
+        run: |
+          RUN_NUMBER="${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
+          kubectl delete "job/archestra-bench-${RUN_NUMBER}" "pod/${DAGGER_ENGINE_POD}" \
+            -n archestra --ignore-not-found --wait=false

--- a/platform/scripts/check-dagger-version-sync.sh
+++ b/platform/scripts/check-dagger-version-sync.sh
@@ -11,13 +11,18 @@ manager_ts="$root_dir/backend/src/k8s/dagger-environment-runtime/manager.ts"
 # its image tag has to be checked here or it silently drifts.
 quickstart_manifest="$root_dir/docker/dagger-engine.quickstart.yaml"
 bench_dagger_compose="$root_dir/../ai-labs/dev/docker-compose.bench-dagger.yml"
+bench_dagger_job="$root_dir/../.github/bench/dagger-job.yaml"
 
 # Image refs must carry the `v` prefix: registry.dagger.io publishes `v0.21.5`,
 # not `0.21.5`. Accepting a bare tag here would let a ref that pulls nothing pass
 # this check. The Dockerfile's DAGGER_VERSION is a version string rather than a
 # tag, so it stays tolerant of the prefix.
 engine_image_tag() {
-  sed -n 's#^[[:space:]]*image:[[:space:]]*registry.dagger.io/engine:v\([0-9][^"[:space:]]*\)[[:space:]]*$#\1#p' "$1"
+  sed -n 's#^[[:space:]]*image:[[:space:]]*registry.dagger.io/engine:v\([0-9][^"@[:space:]]*\)\(@sha256:[0-9a-f]\{64\}\)\{0,1\}[[:space:]]*$#\1#p' "$1"
+}
+
+engine_image_digest() {
+  sed -n 's#^[[:space:]]*image:[^@]*@\(sha256:[0-9a-f]\{64\}\)[[:space:]]*$#\1#p' "$1"
 }
 
 docker_version="$(sed -n 's/^ARG DAGGER_VERSION=v\{0,1\}\([0-9][^[:space:]]*\)$/\1/p' "$dockerfile")"
@@ -27,17 +32,24 @@ cargo_version="$(sed -n 's/^dagger-sdk = "=\([0-9][^"]*\)"$/\1/p' "$cargo_toml")
 engine_image_version="$(sed -n 's#^[[:space:]]*const[[:space:]][[:space:]]*ENGINE_IMAGE[[:space:]]*=[[:space:]]*"registry.dagger.io/engine:v\([0-9][^"]*\)".*#\1#p' "$manager_ts")"
 quickstart_version="$(engine_image_tag "$quickstart_manifest")"
 bench_dagger_version="$(engine_image_tag "$bench_dagger_compose")"
+bench_dagger_job_version="$(engine_image_tag "$bench_dagger_job")"
+bench_dagger_job_digest="$(engine_image_digest "$bench_dagger_job")"
 
-case "$docker_version:$cargo_version:$engine_image_version:$quickstart_version:$bench_dagger_version" in
+if [ -z "$bench_dagger_job_digest" ]; then
+  echo "the privileged benchmark Dagger image must be pinned by sha256 digest" >&2
+  exit 1
+fi
+
+case "$docker_version:$cargo_version:$engine_image_version:$quickstart_version:$bench_dagger_version:$bench_dagger_job_version" in
   *::* | :* | *:)
-    echo "failed to read Dagger versions from Dockerfile, archestra-rs/sandbox-core/Cargo.toml, backend/src/k8s/dagger-environment-runtime/manager.ts, docker/dagger-engine.quickstart.yaml, and ai-labs/dev/docker-compose.bench-dagger.yml" >&2
+    echo "failed to read one or more pinned Dagger versions" >&2
     exit 1
     ;;
-  "$cargo_version:$cargo_version:$cargo_version:$cargo_version:$cargo_version")
+  "$cargo_version:$cargo_version:$cargo_version:$cargo_version:$cargo_version:$cargo_version")
     exit 0
     ;;
   *)
-    echo "Dagger version mismatch: Dockerfile has $docker_version, dagger-sdk has $cargo_version, manager.ts ENGINE_IMAGE has $engine_image_version, quickstart manifest has $quickstart_version, bench-dagger compose has $bench_dagger_version" >&2
+    echo "Dagger version mismatch: Dockerfile has $docker_version, dagger-sdk has $cargo_version, manager.ts ENGINE_IMAGE has $engine_image_version, quickstart manifest has $quickstart_version, bench-dagger compose has $bench_dagger_version, benchmark Job has $bench_dagger_job_version" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- run a short-lived benchmark-owned Dagger pod instead of reading the removed staging runner host
- isolate the privileged engine from benchmark credentials and clean it up on completion or CI failure
- pin and version-check the benchmark engine image

## Testing

- `platform/scripts/check-dagger-version-sync.sh`
- shell syntax checks for benchmark scripts
- YAML parse and envsubst rendering checks
- Kubernetes server-side dry-run against staging for both rendered manifests

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>