### PR TITLE
test(e2e): wait for credential options before reading them

### DIFF
--- a/platform/e2e-tests/utils/mcp-gateway.ts
+++ b/platform/e2e-tests/utils/mcp-gateway.ts
@@ -653,6 +653,16 @@ export async function getVisibleCredentials(page: Page): Promise<string[]> {
 export async function getVisibleStaticCredentials(
   page: Page,
 ): Promise<string[]> {
+  // allTextContents() does not auto-wait: read at the wrong instant it
+  // answers [] for a dialog that is still rendering its options — which is
+  // exactly how this helper hard-failed two merge-queue runs in a row. Its
+  // only caller asserts a non-empty list, so wait for the first option to
+  // exist before reading the set.
+  await page
+    .getByTestId(E2eTestId.StaticCredentialToUse)
+    .first()
+    .waitFor({ state: "visible", timeout: 15_000 });
+
   const credentialLabels = await page
     .getByTestId(E2eTestId.StaticCredentialToUse)
     .allTextContents();


### PR DESCRIPTION
**This flake is currently failing the merge queue for everyone, not just one PR.** Small fix, worth fast-tracking.

## Evidence

- #6952 was kicked from the queue twice; both runs hard-failed `static-credentials-management.spec.ts:351` ("Verify tool calling using different static credentials").
- The controlled comparison: **pr-6957's queue run — containing none of #6952's code, on the same base SHA — failed with 7 hits on the same test.** So this is main-side, independent of any PR in flight.
- Meanwhile branch runs (e.g. `feat/mcp-tasks-extension`, which contains the whole 2026-07-28 stack) pass — the queue runners just lose the race more often.

## Mechanism

`getVisibleStaticCredentials` reads `allTextContents()` **with no waiting** — Playwright does not auto-wait for that call, so a read landing before the assignment dialog has rendered its options returns `[]`. That is byte-for-byte the observed failure: `expected "admin@example.com", received []`. The companion failure in the first kicked run — the dialog's confirm button detaching mid-click — is the same dialog racing its own render, and that path already carries a `force: true` retry.

## Fix

Wait for the first credential option to be visible before reading the set. The helper's only caller asserts a non-empty list, so no semantics change — it just stops sampling a dialog mid-render.

## Note on #6952

The same commit rides #6952 (`3d77e9614`) so that PR is safe to re-queue independently; the diffs are identical, so whichever lands first merges cleanly under the other.

Not addressed here: the confirm-button detach path (`tool-assignments.ts:62`) mostly self-recovers via its existing retry and recovered in run 2; if it keeps flaking it needs its own look rather than a rider on this fix.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>