### PR TITLE
fix(a2a): reject contentless message turns instead of sending them to the provider

### DIFF
--- a/platform/backend/src/agents/a2a/a2a-manager.test.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.test.ts
@@ -313,6 +313,32 @@ describe("A2AManager.sendMessage", () => {
     expect(executeA2AMessage.mock.calls[0][0].message).toBe("first\nsecond");
   });
 
+  test("a blank text part does not pad the joined turn", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "agent1", teams: [] });
+    const manager = new A2AManager();
+    executeA2AMessage.mockClear();
+    executeA2AMessage.mockReturnValue({
+      responseUiMessage: {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        parts: [{ type: "text", text: "response" }],
+      },
+      text: "response(text)",
+    });
+
+    await sendMessageWithParts(manager, agent.id, [
+      { text: "" },
+      { text: "hi" },
+    ]);
+
+    expect(executeA2AMessage).toHaveBeenCalledTimes(1);
+    // Not "\nhi" — the blank part is gone before the join, so it contributes no
+    // separator to the text the model receives.
+    expect(executeA2AMessage.mock.calls[0][0].message).toBe("hi");
+  });
+
   test("a message carrying only a file part executes", async ({
     makeAgent,
   }) => {

--- a/platform/backend/src/agents/a2a/a2a-manager.test.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.test.ts
@@ -168,6 +168,186 @@ describe("A2AManager.sendMessage", () => {
     expect(await A2AMessageModel.getTotalCount()).toBe(prevMessageCount);
   });
 
+  test.for([
+    ["an empty", ""],
+    ["a whitespace-only", "   \n  "],
+  ])("%s text part is nothing to execute", async ([, text], { makeAgent }) => {
+    const agent = await makeAgent({ name: "agent1", teams: [] });
+    const manager = new A2AManager();
+    executeA2AMessage.mockClear();
+    const prevContextCount = await A2AContextModel.getTotalCount();
+    const prevTaskCount = await A2ATaskModel.getTotalCount();
+    const prevMessageCount = await A2AMessageModel.getTotalCount();
+
+    const err = await getThrown(async () =>
+      sendMessageWithParts(manager, agent.id, [{ text }]),
+    );
+
+    expect(err).toBeInstanceOf(A2AError);
+    expect((err as A2AError).kind).toBe(A2AErrorKind.NothingToExecute);
+    // The defect this pins was a *provider* call, not the error code: a blank
+    // turn reached the model as prior context alone, ending on an assistant
+    // message, which providers without prefill support reject.
+    expect(executeA2AMessage).not.toHaveBeenCalled();
+    expect(await A2AContextModel.getTotalCount()).toBe(prevContextCount);
+    expect(await A2ATaskModel.getTotalCount()).toBe(prevTaskCount);
+    expect(await A2AMessageModel.getTotalCount()).toBe(prevMessageCount);
+  });
+
+  test("a blank text part alongside a file still executes", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "agent1", teams: [] });
+    const manager = new A2AManager();
+    executeA2AMessage.mockClear();
+    executeA2AMessage.mockReturnValue({
+      responseUiMessage: {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        parts: [{ type: "text", text: "response" }],
+      },
+      text: "response(text)",
+    });
+
+    await sendMessageWithParts(manager, agent.id, [
+      { text: "" },
+      {
+        raw: new Uint8Array([1, 2, 3]),
+        mediaType: "image/png",
+        filename: "pixel.png",
+      },
+    ]);
+
+    expect(executeA2AMessage).toHaveBeenCalledTimes(1);
+    expect(executeA2AMessage.mock.calls[0][0].attachments).toHaveLength(1);
+  });
+
+  test("a single part carrying blank text and a file keeps the file", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "agent1", teams: [] });
+    const manager = new A2AManager();
+    executeA2AMessage.mockClear();
+    executeA2AMessage.mockReturnValue({
+      responseUiMessage: {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        parts: [{ type: "text", text: "response" }],
+      },
+      text: "response(text)",
+    });
+
+    await sendMessageWithParts(manager, agent.id, [
+      {
+        text: "",
+        raw: new Uint8Array([1, 2, 3]),
+        mediaType: "image/png",
+        filename: "pixel.png",
+      },
+    ]);
+
+    expect(executeA2AMessage).toHaveBeenCalledTimes(1);
+    expect(executeA2AMessage.mock.calls[0][0].attachments).toHaveLength(1);
+  });
+
+  test("a single part carrying text and a file sends both", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "agent1", teams: [] });
+    const manager = new A2AManager();
+    executeA2AMessage.mockClear();
+    executeA2AMessage.mockReturnValue({
+      responseUiMessage: {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        parts: [{ type: "text", text: "response" }],
+      },
+      text: "response(text)",
+    });
+
+    await sendMessageWithParts(manager, agent.id, [
+      {
+        text: "look at this",
+        raw: new Uint8Array([1, 2, 3]),
+        mediaType: "image/png",
+        filename: "pixel.png",
+      },
+    ]);
+
+    // The text branch returns before the file branch, so the file never becomes
+    // a message part — it still reaches the executor because attachments are
+    // collected from the request parts independently.
+    expect(executeA2AMessage).toHaveBeenCalledTimes(1);
+    const call = executeA2AMessage.mock.calls[0][0];
+    expect(call.message).toBe("look at this");
+    expect(call.attachments).toEqual([
+      {
+        contentType: "image/png",
+        contentBase64: Buffer.from([1, 2, 3]).toString("base64"),
+        name: "pixel.png",
+      },
+    ]);
+  });
+
+  test("multiple text parts are joined into the executed turn", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "agent1", teams: [] });
+    const manager = new A2AManager();
+    executeA2AMessage.mockClear();
+    executeA2AMessage.mockReturnValue({
+      responseUiMessage: {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        parts: [{ type: "text", text: "response" }],
+      },
+      text: "response(text)",
+    });
+
+    await sendMessageWithParts(manager, agent.id, [
+      { text: "first" },
+      { text: "second" },
+    ]);
+
+    expect(executeA2AMessage).toHaveBeenCalledTimes(1);
+    expect(executeA2AMessage.mock.calls[0][0].message).toBe("first\nsecond");
+  });
+
+  test("a message carrying only a file part executes", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent({ name: "agent1", teams: [] });
+    const manager = new A2AManager();
+    executeA2AMessage.mockClear();
+    executeA2AMessage.mockReturnValue({
+      responseUiMessage: {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        parts: [{ type: "text", text: "response" }],
+      },
+      text: "response(text)",
+    });
+
+    await sendMessageWithParts(manager, agent.id, [
+      {
+        raw: new Uint8Array([1, 2, 3]),
+        mediaType: "image/png",
+        filename: "pixel.png",
+      },
+    ]);
+
+    expect(executeA2AMessage).toHaveBeenCalledTimes(1);
+    const call = executeA2AMessage.mock.calls[0][0];
+    expect(call.message).toBe("");
+    expect(call.attachments).toEqual([
+      {
+        contentType: "image/png",
+        contentBase64: Buffer.from([1, 2, 3]).toString("base64"),
+        name: "pixel.png",
+      },
+    ]);
+  });
+
   test("Text message", async ({ makeAgent }) => {
     const agent = await makeAgent({ name: "agent1", teams: [] });
     const manager = new A2AManager();

--- a/platform/backend/src/agents/a2a/a2a-manager.ts
+++ b/platform/backend/src/agents/a2a/a2a-manager.ts
@@ -207,7 +207,13 @@ export class A2AManager {
 
       const messageParts: (TextPart | FilePart)[] = [];
       (request.message.parts || []).forEach((p) => {
-        if (p.text !== undefined) {
+        // Blank text carries no turn: the executor only builds a current user
+        // turn from text that survives `trim()`, so keeping it would let
+        // `needToExecute` pass and send the prior context — which ends with an
+        // assistant turn — as the whole request. Blank text falls through to
+        // the file branch rather than returning, so a part carrying both keeps
+        // its payload.
+        if (p.text !== undefined && p.text.trim() !== "") {
           messageParts.push({ type: "text" as const, text: p.text });
           return;
         }

--- a/platform/backend/src/routes/a2a-v2.stream.test.ts
+++ b/platform/backend/src/routes/a2a-v2.stream.test.ts
@@ -209,6 +209,45 @@ describe("a2a v2 streaming route", () => {
     expect(new Set(taskIds).size).toBe(1);
   });
 
+  test("SendMessage with a blank text part on an existing context never starts the agent run", async () => {
+    const sendMessage = (id: number, parts: unknown[], contextId?: string) =>
+      app.inject({
+        method: "POST",
+        url: `/v2/a2a/${agentId}`,
+        headers: { authorization: "Bearer test-token" },
+        payload: {
+          jsonrpc: "2.0",
+          id,
+          method: "SendMessage",
+          params: {
+            message: {
+              messageId: crypto.randomUUID(),
+              role: "ROLE_USER",
+              ...(contextId ? { contextId } : {}),
+              parts,
+            },
+          },
+        },
+      });
+
+    // Seed the context so its history ends with an agent turn — the state that
+    // made a contentless follow-up send prior context alone, terminating on an
+    // assistant message that providers without prefill support reject.
+    const seeded = await sendMessage(10, [{ text: "Hello there" }]);
+    const contextId = seeded.json().result.message.contextId;
+    expect(contextId).toBeDefined();
+    expect(mockExecuteA2AMessage).toHaveBeenCalledTimes(1);
+
+    const response = await sendMessage(11, [{ text: "   " }], contextId);
+
+    expect(response.headers["content-type"]).not.toContain("text/event-stream");
+    const body = response.json();
+    expect(body.result).toBeUndefined();
+    expect(body.error).toEqual({ code: -32602, message: "Nothing to execute" });
+    // Still 1: the blank follow-up added no run of its own.
+    expect(mockExecuteA2AMessage).toHaveBeenCalledTimes(1);
+  });
+
   test("returns a buffered JSON-RPC error (not an SSE stream) when the token is unauthorized", async () => {
     mockValidateMCPGatewayToken.mockResolvedValue(null);
 


### PR DESCRIPTION
## Summary

An A2A `SendMessage` whose only text part is empty or whitespace passed the execute gate but produced no current user turn, so the agent re-sent the conversation's prior context verbatim. Prior context always ends with the agent's last reply, so the request reached the provider terminating on an assistant message. Recent Claude models no longer support assistant prefill and reject such a request with a 400, which surfaced to users as the generic "There was an issue with your request. Please try again."

The gate and the executor disagreed on what counts as content: `needToExecute` asks whether any part exists, while the executor builds a current user turn only from text that survives `trim()`. A blank text part satisfies the first and not the second.

Blank text parts are now dropped when assembling `messageParts`, so both conditions read the same input. A contentless turn returns the existing `Nothing to execute` error (`-32602`), never reaches the provider, and no longer persists an empty user message into context history. A blank part mixed with real text also stops contributing a stray separator to the joined turn the model receives.

Blank text falls through to the file branch rather than returning early, so a part carrying both blank text and a file keeps its payload — otherwise an attachment-only turn would be rejected, since `needToExecute` is evaluated before attachments are collected. Task resumption via `taskOps` is unaffected: it executes through `taskWasSwitchedToWorkingState`, independent of message parts.

Known behavior change worth a reviewer's attention: a blank-text turn carrying an ephemeral execution prefix — chatops server-side sessions, where a 1:1 message has no text, no delivered attachment, and no skipped-attachment note — previously executed on the framing alone and now returns `Nothing to execute`. Whether a prefix-only turn should execute at all is unresolved.