### PR TITLE
chore(mcp): stop declaring the roots capability no client implements

### DIFF
--- a/platform/backend/src/clients/chat-mcp-client.ts
+++ b/platform/backend/src/clients/chat-mcp-client.ts
@@ -638,8 +638,11 @@ export async function getChatMcpClient(
     // Create StreamableHTTP transport with profile token authentication
     const transport = createLoopbackGatewayTransport(mcpGatewayUrl, authToken);
 
+    // No `roots` here: the capability promises to answer `roots/list`, which
+    // no client in this codebase implements — a server taking the declaration
+    // at its word got method-not-found. Roots is also deprecated in the
+    // 2026-07-28 MCP revision.
     const capabilities: ClientCapabilitiesWithExtensions = {
-      roots: { listChanged: true },
       extensions: MCP_APPS_CLIENT_EXTENSION_CAPABILITIES,
     };
 

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -1204,8 +1204,10 @@ class McpClient {
     }
 
     // Create the client with UI extension capabilities
+    // No `roots`: nothing here implements `roots/list`, and declaring it
+    // invited upstream servers to call a method we always failed. Deprecated
+    // in 2026-07-28 besides.
     const baseCapabilities: ClientCapabilitiesWithExtensions = {
-      roots: { listChanged: true },
       extensions: MCP_CLIENT_EXTENSION_CAPABILITIES,
     };
     const capabilities = elicitationHandler
@@ -3246,8 +3248,8 @@ class McpClient {
           secretId,
         );
 
+        // No `roots` — see the identical omission above.
         const capabilities: ClientCapabilitiesWithExtensions = {
-          roots: { listChanged: true },
           extensions: MCP_CLIENT_EXTENSION_CAPABILITIES,
         };
 


### PR DESCRIPTION
Follow-up nit from the #6953 chat-client review. All three MCP client constructions (chat loopback client, both upstream client paths in `mcp-client.ts`) declared `roots: { listChanged: true }` — but no `roots/list` handler exists anywhere in this codebase, so a server acting on the declaration always got method-not-found. Roots is also deprecated in 2026-07-28.

Removing a client capability only reduces what servers attempt; nothing that worked can break. Verified: `tsc`, `biome ci`, `knip` clean; 157 tests across `mcp-client` and the chat-client suites pass.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>