### PR TITLE
fix(llm-pricing): read Amazon's global-endpoint price marker for Nova

### DIFF
--- a/platform/backend/src/services/bedrock-aws-prices.json
+++ b/platform/backend/src/services/bedrock-aws-prices.json
@@ -331,15 +331,27 @@
   },
   "Nova 2.0 Lite": {
     "in": 0.33,
+    "out": 2.75
+  },
+  "Nova 2.0 Lite|global": {
+    "in": 0.3,
     "out": 2.5
   },
   "Nova 2.0 Omni": {
+    "in": 0.3,
+    "out": 2.8
+  },
+  "Nova 2.0 Omni|global": {
     "in": 0.3,
     "out": 2.5
   },
   "Nova 2.0 Pro": {
     "in": 1.375,
     "out": 11
+  },
+  "Nova 2.0 Pro|global": {
+    "in": 1.25,
+    "out": 10
   },
   "Nova Lite": {
     "in": 0.06,

--- a/platform/backend/src/services/bedrock-aws-pricing.test.ts
+++ b/platform/backend/src/services/bedrock-aws-pricing.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "vitest";
+import awsPricesJson from "./bedrock-aws-prices.json";
 import {
   AWS_PRICE_IDENTITY,
   resolveBedrockAwsPrices,
 } from "./bedrock-aws-pricing";
+
+const AWS_PRICES: Record<string, { in?: number; out?: number } | undefined> =
+  awsPricesJson;
 
 function resolve(modelId: string, underlyingModelName?: string) {
   return resolveBedrockAwsPrices({
@@ -23,6 +27,32 @@ describe("resolveBedrockAwsPrices", () => {
     expect(global?.completionPricePerToken).toBe("0.000015");
     expect(regional?.promptPricePerToken).toBe("0.0000033");
     expect(regional?.completionPricePerToken).toBe("0.0000165");
+  });
+
+  test("reads Amazon's global-endpoint convention, not only Anthropic's", () => {
+    // Anthropic marks the global SKU with a `_Global` usage-type suffix, but
+    // Amazon's own Nova models use `-cross-region-global`. Reading one
+    // convention alone pairs a regional input with a global output, a
+    // combination AWS never charges.
+    const regional = resolve("us.amazon.nova-2-lite-v1:0");
+    const global = resolve("global.amazon.nova-2-lite-v1:0");
+
+    expect(regional?.promptPricePerToken).toBe("3.3e-7");
+    expect(regional?.completionPricePerToken).toBe("0.00000275");
+    expect(global?.promptPricePerToken).toBe("3e-7");
+    expect(global?.completionPricePerToken).toBe("0.0000025");
+  });
+
+  test("never prices a global endpoint above its regional counterpart", () => {
+    // The global tier is the cheaper one wherever AWS publishes both. A
+    // snapshot entry that inverts this has crossed two tiers.
+    for (const [key, entry] of Object.entries(AWS_PRICES)) {
+      if (!key.endsWith("|global")) continue;
+      const regional = AWS_PRICES[key.slice(0, -"|global".length)];
+      if (!regional) continue;
+      expect(entry?.in ?? 0, key).toBeLessThanOrEqual(regional.in ?? 0);
+      expect(entry?.out ?? 0, key).toBeLessThanOrEqual(regional.out ?? 0);
+    }
   });
 
   test("prices a model the registry does not carry at all", () => {

--- a/platform/backend/src/services/bedrock-aws-pricing.ts
+++ b/platform/backend/src/services/bedrock-aws-pricing.ts
@@ -12,11 +12,17 @@ import awsPricesJson from "./bedrock-aws-prices.json";
  * `region_index.json`. Refreshing means re-reading those documents; AWS has
  * published roughly monthly.
  *
- * Three rules govern the transcription, each of which is easy to get wrong:
+ * Four rules govern the transcription, each of which is easy to get wrong:
  * a price is published per 1K *or* per 1M tokens and both appear in one
  * document; `batch`, `flex`, `priority` and latency-optimized SKUs sit beside
- * the standard on-demand price and must not be read as it; and a `_Global`
- * suffix on the usage type marks the cheaper global-endpoint price.
+ * the standard on-demand price and must not be read as it; the global-endpoint
+ * price is marked by a `_Global` suffix on the usage type for Anthropic and
+ * TwelveLabs listings but by `-cross-region-global` for Amazon's own Nova
+ * models, so reading only one convention silently mixes the two tiers into one
+ * entry; and a model serving more than text splits its dimensions by modality
+ * (`text-`, `speech-`, `input-audio-`, `input-image-`), of which only the text
+ * pair belongs here.
+ *
  * A `|global` suffix marks the global-endpoint price; `out` is absent for models
  * AWS prices on input alone.
  */


### PR DESCRIPTION
## Summary

The vendored AWS snapshot identifies a global-endpoint SKU by a `_Global` suffix on the usage type. That is Anthropic's and TwelveLabs' convention. Amazon's own Nova models mark it `-cross-region-global` instead, so no global entry was ever transcribed for them — and worse, the single entry that was transcribed crossed the two tiers: `Nova 2.0 Lite` held a regional input beside a global output, a pair AWS charges at neither endpoint. `Nova 2.0 Omni` was wrong the same way. `Nova 2.0 Pro` had a correct regional entry but no global one, so a `global.` profile silently paid the regional rate.

A `global.` inference profile is now priced at the global rate and a regional one at the regional rate, instead of both resolving to a figure assembled from each.

Re-read from the offer document, standard on-demand, text dimensions only:

| model | regional | global |
|---|---|---|
| Nova 2.0 Lite | 0.33 / 2.75 | 0.30 / 2.50 |
| Nova 2.0 Omni | 0.30 / 2.80 | 0.30 / 2.50 |
| Nova 2.0 Pro | 1.375 / 11 | 1.25 / 10 |

Omni's input is genuinely the same on both tiers; only its output carries the premium. It does not follow the uniform 1.1× uplift the Claude listings show, which is why every value is read per dimension rather than derived from one.

A sweep of both offer documents puts the split at exactly these three models: everything else publishing a global SKU uses `_Global`.

`Nova Sonic 2.0` is deliberately untouched. It splits its dimensions by modality, and the stored 0.33/2.75 is its text pair; the 3.00 sitting beside it is `speech-input-tokens` and belongs to a different meter. Both conventions are now recorded in the transcription rules, since reading either one wrongly produces a price that looks plausible.

## Scope

Only `Nova 2.0 Lite` has an `AWS_PRICE_IDENTITY` mapping, so it is the one whose price changes today. The `Omni` and `Pro` entries stay latent until a deployment serves those ids, and correcting them now keeps the snapshot from carrying a tier-crossed figure into whichever release does.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
