### PR TITLE
fix(apps): bound app tool calls at the LLM ceiling and cancel abandoned calls

### DIFF
--- a/platform/backend/src/archestra-mcp-server/app-llm.test.ts
+++ b/platform/backend/src/archestra-mcp-server/app-llm.test.ts
@@ -192,6 +192,32 @@ describe("app llm completion", () => {
     expect(archestraError(result).message).not.toContain("boom");
   });
 
+  test("a caller that gave up cancels the model call instead of reporting a provider failure", async () => {
+    const controller = new AbortController();
+    vi.mocked(generateText).mockImplementation(async () => {
+      // The caller disconnects while the model is thinking; the AI SDK then
+      // rejects with the abort, as the real call would.
+      controller.abort();
+      throw new DOMException("This operation was aborted", "AbortError");
+    });
+
+    const result = await executeArchestraTool(
+      llmTool,
+      { prompt: "x" },
+      { ...context, abortSignal: controller.signal },
+    );
+
+    // The signal reaches the model call, so the completion actually stops.
+    expect(vi.mocked(generateText)).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: controller.signal }),
+    );
+    expect((result as any).isError).toBe(true);
+    expect((result as any).content[0].text).toContain("cancelled");
+    // Not a provider failure: no llm_unavailable envelope for the app to
+    // branch on.
+    expect(archestraError(result)).toBeUndefined();
+  });
+
   test("reports llm_unavailable when no provider key is configured", async () => {
     vi.mocked(resolveAgentLlmOrDefault).mockResolvedValue({
       provider: "anthropic",

--- a/platform/backend/src/archestra-mcp-server/app-llm.ts
+++ b/platform/backend/src/archestra-mcp-server/app-llm.ts
@@ -130,9 +130,16 @@ async function runAppLlmCompletion(
       model,
       system: system || undefined,
       prompt: args.prompt,
+      abortSignal: context.abortSignal,
     });
     return structuredSuccessResult({ text: result.text }, result.text);
   } catch (error) {
+    // The caller gave up (its request timeout fired, or the app was torn
+    // down): nobody receives this result, so stop the completion without
+    // treating the abort as a provider failure.
+    if (context.abortSignal?.aborted) {
+      return errorResult("The LLM completion was cancelled.");
+    }
     // 429 is an upstream provider rate limit; 402 is the Archestra token-cost
     // limit block. Both surface to apps as llm_quota — the app-visible action
     // (stop and back off) is the same, so the message does not assert a

--- a/platform/backend/src/routes/mcp-app-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-app-gateway.utils.ts
@@ -136,7 +136,7 @@ export async function createAppServer(
 
   server.setRequestHandler(
     CallToolRequestSchema,
-    async ({ params: { name, arguments: args } }) => {
+    async ({ params: { name, arguments: args } }, extra) => {
       // The synthetic launch tool just points the host at the app's UI resource.
       if (name === APP_LAUNCH_TOOL_NAME) {
         return {
@@ -168,6 +168,10 @@ export async function createAppServer(
           userId: tokenAuth.userId,
           organizationId: tokenAuth.organizationId,
           tokenAuth,
+          // Aborts when the caller gives up on the request (the route closes
+          // the transport on client disconnect), so a long dispatch — the LLM
+          // completion in particular — stops instead of running unobserved.
+          abortSignal: extra.signal,
         });
         try {
           await McpToolCallModel.create({
@@ -200,6 +204,7 @@ export async function createAppServer(
         toolCall,
         appOwner(appId),
         tokenAuth,
+        { abortSignal: extra.signal },
       );
       return {
         content: Array.isArray(result.content)

--- a/platform/backend/src/routes/mcp-app-proxy.ts
+++ b/platform/backend/src/routes/mcp-app-proxy.ts
@@ -153,6 +153,7 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
       let hijacked = false;
       let server: McpServer | undefined;
       let serverHealthy = false;
+      let clientAborted = false;
       try {
         server =
           (useServerCache
@@ -172,11 +173,31 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
         hijacked = true;
 
         ensureRequestSocketDestroySoon(request.raw);
-        await transport.handleRequest(
-          request.raw as IncomingMessage,
-          reply.raw as ServerResponse,
-          body,
-        );
+        // A caller that gives up mid-call (the guest's request timeout or
+        // cancellation, a closed tab) surfaces here only as the connection
+        // closing before the response is written. Closing the transport makes
+        // the protocol abort the in-flight handler's signal, which stops the
+        // dispatched work — an LLM completion in particular. The race is
+        // required because in JSON-response mode an aborted handler never
+        // produces a response, so handleRequest would never settle.
+        const clientGaveUp = new Promise<void>((resolve) => {
+          reply.raw.on("close", () => resolve());
+        }).then(async () => {
+          if (reply.raw.writableEnded) return;
+          clientAborted = true;
+          await transport.close();
+        });
+        const handling = transport
+          .handleRequest(
+            request.raw as IncomingMessage,
+            reply.raw as ServerResponse,
+            body,
+          )
+          .catch((error) => {
+            // Write failures after the client vanished are expected noise.
+            if (!clientAborted) throw error;
+          });
+        await Promise.race([handling, clientGaveUp]);
       } catch (error) {
         fastify.log.error(
           { error, appId },
@@ -198,8 +219,15 @@ const mcpAppProxyRoutes: FastifyPluginAsyncZod = async (fastify) => {
           );
         }
       } finally {
+        // An aborted request leaves the server's transport closed mid-flight;
+        // evict it rather than reuse it.
         if (server && useServerCache)
-          appServerCache.release(appId, userId, server, serverHealthy);
+          appServerCache.release(
+            appId,
+            userId,
+            server,
+            serverHealthy && !clientAborted,
+          );
       }
     },
   );

--- a/platform/backend/src/services/apps/app-sdk-runtime.test.ts
+++ b/platform/backend/src/services/apps/app-sdk-runtime.test.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 
 /**
  * Executes the REAL static SDK file (static/archestra-app-sdk.js) in this
@@ -25,11 +25,31 @@ const GUEST_MODULE = `
 export class App {
   constructor() {}
   async connect() {}
-  async callServerTool(params) {
+  async callServerTool(params, options) {
     globalThis.__sdkTestCalls.push(params);
-    const result = globalThis.__sdkTestResults.shift();
-    if (!result) throw new Error("sdk test: no stub result queued");
-    return result;
+    const queued = globalThis.__sdkTestResults.shift();
+    if (!queued) throw new Error("sdk test: no stub result queued");
+    if (!queued.__slow) return queued;
+    // Slow-result path mirrors the request-timeout contract of
+    // @modelcontextprotocol/sdk shared/protocol.js for a host that emits no
+    // progress notifications: the per-request timer is options.timeout
+    // (60s when the caller passes none), and firing it rejects with the
+    // RequestTimeout McpError (-32001).
+    const timeout =
+      options && options.timeout != null ? options.timeout : 60000;
+    return await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          Object.assign(new Error("MCP error -32001: Request timed out"), {
+            code: -32001,
+          }),
+        );
+      }, timeout);
+      setTimeout(() => {
+        clearTimeout(timer);
+        resolve(queued.result);
+      }, queued.delayMs);
+    });
   }
 }
 export class PostMessageTransport {
@@ -434,6 +454,28 @@ describe("Apps SDK runtime", () => {
     await expect(archestra.llm.complete("x")).rejects.toMatchObject({
       code: "llm_unavailable",
     });
+  });
+
+  test("llm.complete resolves for a completion that outlasts the MCP SDK's 60s default request timeout (reasoning models think for minutes)", async () => {
+    vi.useFakeTimers();
+    try {
+      const reasoningLatencyMs = 3 * 60_000;
+      results.push({
+        __slow: true,
+        delayMs: reasoningLatencyMs,
+        result: {
+          content: [{ type: "text", text: "a slowly reasoned answer" }],
+          structuredContent: { text: "a slowly reasoned answer" },
+        },
+      });
+      const pending = archestra.llm.complete("prove it step by step");
+      const settled = expect(pending).resolves.toBe("a slowly reasoned answer");
+      await vi.advanceTimersByTimeAsync(reasoningLatencyMs);
+      await settled;
+      calls.pop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("llm.prompt builds a string with no host round-trip", () => {

--- a/platform/backend/src/services/apps/app-sdk-runtime.test.ts
+++ b/platform/backend/src/services/apps/app-sdk-runtime.test.ts
@@ -478,6 +478,28 @@ describe("Apps SDK runtime", () => {
     }
   });
 
+  test("llm.complete stays bounded: a completion beyond the 10-minute tool-call ceiling still times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const ceilingMs = 10 * 60_000;
+      results.push({
+        __slow: true,
+        delayMs: ceilingMs + 60_000,
+        result: {
+          content: [{ type: "text", text: "too late" }],
+          structuredContent: { text: "too late" },
+        },
+      });
+      const pending = archestra.llm.complete("run forever");
+      const settled = expect(pending).rejects.toThrow("MCP error -32001");
+      await vi.advanceTimersByTimeAsync(ceilingMs + 60_000);
+      await settled;
+      calls.pop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("llm.prompt builds a string with no host round-trip", () => {
     const before = calls.length;
     const built = archestra.llm.prompt`Hello ${"world"} (${42})`;

--- a/platform/backend/src/static/archestra-app-sdk.js
+++ b/platform/backend/src/static/archestra-app-sdk.js
@@ -257,6 +257,12 @@
   };
   const LLM_COMPLETE_TOOL = "archestra__llm_complete";
 
+  // Upper bound for one host tool round-trip, overriding the MCP SDK's 60s
+  // default request timeout. A reasoning model spends minutes thinking before
+  // the completion returns, so the guest must not gate tool calls stricter
+  // than the platform's own upstream LLM client ceiling (10 minutes).
+  const TOOL_CALL_TIMEOUT_MS = 10 * 60 * 1000;
+
   const textOf = (result) =>
     (result.content || [])
       .filter((c) => c && c.type === "text")
@@ -284,7 +290,10 @@
    */
   const callTool = async (name, args) => {
     const app = await connectPromise;
-    const result = await app.callServerTool({ name, arguments: args || {} });
+    const result = await app.callServerTool(
+      { name, arguments: args || {} },
+      { timeout: TOOL_CALL_TIMEOUT_MS },
+    );
     if (result.isError) {
       const platformError = archestraErrorOf(result);
       if (

--- a/platform/frontend/src/components/chat/mcp-app-container.test.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.test.tsx
@@ -1507,7 +1507,12 @@ describe("McpAppSection owned-app panel chrome", () => {
 describe("McpAppRuntime auth banner recovery", () => {
   const AUTH_URL = "http://localhost:3000/mcp/registry?install=cat_test";
   type CapturedBridge = {
-    oncalltool: ((params: { name: string }) => Promise<unknown>) | null;
+    oncalltool:
+      | ((
+          params: { name: string },
+          extra: { signal: AbortSignal },
+        ) => Promise<unknown>)
+      | null;
   };
   type PendingToolCall = {
     toolName: string;
@@ -1693,7 +1698,12 @@ describe("McpAppRuntime auth banner recovery", () => {
   function callTool(bridge: CapturedBridge, name: string): Promise<unknown> {
     if (!bridge.oncalltool)
       throw new Error("Bridge tool callback not installed");
-    return bridge.oncalltool({ name });
+    // The real AppBridge always passes the per-request handler extra; the
+    // handler threads its abort signal into the gateway fetch.
+    return bridge.oncalltool(
+      { name },
+      { signal: new AbortController().signal },
+    );
   }
 
   async function settleToolCall(

--- a/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
+++ b/platform/frontend/src/components/mcp-app/mcp-app-view.tsx
@@ -391,7 +391,11 @@ export const McpAppRuntime = function McpAppRuntime({
     // Every exchange (request, response, latency) is reported to the session
     // recorder — these captures are the "mocked MCP responses" a recorded demo
     // replays instead of a live gateway. No-op unless the user is recording.
-    const mcpProxy = async (method: string, params: unknown) => {
+    const mcpProxy = async (
+      method: string,
+      params: unknown,
+      signal?: AbortSignal,
+    ) => {
       const proxyStartedAt = Date.now();
       const recordExchange = (result: unknown, isError: boolean) => {
         recorderRef.current?.captureMcp({
@@ -418,6 +422,11 @@ export const McpAppRuntime = function McpAppRuntime({
           method,
           params,
         }),
+        // The guest's cancellation (its request timeout, or the bridge tearing
+        // down) must reach the backend as a closed connection, or the
+        // dispatched work — an LLM completion in particular — runs and bills
+        // unobserved.
+        signal,
       });
       if (!response.ok) {
         recordExchange({ message: response.statusText }, true);
@@ -446,12 +455,15 @@ export const McpAppRuntime = function McpAppRuntime({
       setToolCallAuthError(null);
     };
     setToolCallAuthError(null);
-    const proxyToolCall = async (params: {
-      name: string;
-      arguments?: unknown;
-    }) => {
+    const proxyToolCall = async (
+      params: {
+        name: string;
+        arguments?: unknown;
+      },
+      signal?: AbortSignal,
+    ) => {
       const generation = ++nextToolCallGeneration;
-      const result = await mcpProxy("tools/call", params);
+      const result = await mcpProxy("tools/call", params, signal);
       if (cancelled) return result;
 
       const authState = resolveMcpAppToolCallAuthState(result);
@@ -492,16 +504,19 @@ export const McpAppRuntime = function McpAppRuntime({
     if (endpoint.kind === "agent") {
       const serverPrefix = endpoint.serverPrefix;
 
-      appBridge.oncalltool = async (params) => {
+      appBridge.oncalltool = async (params, extra) => {
         // Always enforce the server prefix — strip any existing prefix to prevent
         // a compromised MCP App from calling tools on a different server.
         const rawName = parseFullToolName(params.name).toolName;
         const toolName = buildFullToolName(serverPrefix, rawName);
 
-        return proxyToolCall({
-          name: toolName,
-          arguments: params.arguments,
-        });
+        return proxyToolCall(
+          {
+            name: toolName,
+            arguments: params.arguments,
+          },
+          extra.signal,
+        );
       };
 
       // Scope resource/prompt handlers to the owning server to prevent a compromised
@@ -567,11 +582,14 @@ export const McpAppRuntime = function McpAppRuntime({
       // (and ignores the requested URI), and implements ONLY resources/read — so
       // list/template/prompt handlers return empty rather than hitting an
       // unimplemented method.
-      appBridge.oncalltool = async (params) =>
-        proxyToolCall({
-          name: params.name,
-          arguments: params.arguments,
-        });
+      appBridge.oncalltool = async (params, extra) =>
+        proxyToolCall(
+          {
+            name: params.name,
+            arguments: params.arguments,
+          },
+          extra.signal,
+        );
       appBridge.onreadresource = async (params) =>
         mcpProxy("resources/read", params);
       appBridge.onlistresources = async () => ({ resources: [] });


### PR DESCRIPTION
## Summary

An app's `archestra.llm.complete()` rejected with `MCP error -32001: Request timed out` whenever the attached model needed more than 60 seconds — which reasoning models routinely do, since the app path is the platform's only non-streaming LLM call and all thinking time accumulates into the single response (T-981). The timer was the MCP SDK's default request timeout in the app iframe's guest client: the SDK passed no request options to `callServerTool`, and nothing downstream was stricter, so the guest always lost the race while the backend kept generating (and the proxy kept billing) a result nobody would receive. Live measurement on a dev stack: the app showed the error at exactly 60s while the same completion returned HTTP 200 at 100s and was recorded in LLM logs ~40s after the app had already failed.

The guest now bounds host tool calls at 10 minutes, matching the platform's own upstream LLM client ceiling (`ANTHROPIC_CLIENT_TIMEOUT_MS`) rather than gating stricter than it. Cancellation travels the whole chain: the guest's timeout or teardown aborts the host bridge's fetch via the `oncalltool` handler's `extra.signal`; the app proxy route closes the per-request transport when the client disconnects, which makes the protocol abort the in-flight handler's signal; that signal reaches `executeArchestraTool` (as the existing `context.abortSignal`) and `executeToolCallForOwner` (its existing `abortSignal` option); and an aborted LLM completion stops quietly instead of logging an error and claiming `llm_unavailable`.

Two route-level details deserve reviewer attention. In JSON-response mode an aborted handler never produces a response, so `transport.handleRequest` never settles — the route races it against the client-disconnect path instead of awaiting it bare. And an aborted request leaves its transport closed mid-flight, so the per-(app,user) cached server is evicted rather than released for reuse; the cache's exclusive `acquire` guarantees the closed transport can only ever belong to the aborted request.

## Validation

- `app-sdk-runtime.test.ts`: the guest-module stub now honors the MCP SDK's request-options timeout contract; new tests pin that a 3-minute completion resolves (red before this fix, failing with the exact reported error) and that a completion beyond the 10-minute ceiling still times out.
- `app-llm.test.ts`: an aborted call cancels the model call and reports cancellation, not a provider failure.
- Live on a dev stack with a reasoning model (glm-5.1): a 188-second completion resolves in the real iframe chain where it previously died at 60s; killing the viewer 25 seconds into a call produced the cancelled tool-call record within ~1 second.

## Follow-up

The LLM proxy's non-streaming handlers do not tie their own upstream request to their client's disconnect, so a cancelled completion can still run to completion inside the proxy and record the interaction (observed landing two minutes after the abort). That gap predates this change, spans every provider adapter, and equally affects non-streamed chat cancellation — left for its own change.

No docs change: the apps page never promised a timeout, and the fix restores its documented behavior (`llm.complete` resolves to the model's text).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>