### PR TITLE
fix(github-copilot): verify model invocability at sync, surface an actionable model-not-supported error

### DIFF
--- a/platform/backend/src/routes/chat/errors.test.ts
+++ b/platform/backend/src/routes/chat/errors.test.ts
@@ -22,6 +22,7 @@ vi.mock("@sentry/node", () => ({
 
 import { NoSuchToolError, UnsupportedFunctionalityError } from "ai";
 import { MICROSOFT_365_COPILOT_TOOLS_UNSUPPORTED_MESSAGE } from "@/routes/proxy/adapters/microsoft-365-copilot-graph-translator";
+import { GithubCopilot } from "@/types";
 import { LlmProviderAuthRequiredError } from "@/utils/llm-provider-auth-error";
 import {
   buildAbortiveTurnError,
@@ -2371,6 +2372,49 @@ describe("mapProviderError - Microsoft 365 Copilot tools rejection", () => {
       isRetryable: false,
     };
     const result = mapProviderError(error, "microsoft-365-copilot");
+
+    expect(result.code).toBe(ChatErrorCode.InvalidRequest);
+  });
+});
+
+describe("mapProviderError - GitHub Copilot model rejection", () => {
+  it("maps Copilot's model-not-supported 400 to the actionable NotFound copy (T-959)", () => {
+    // The proxy's error wrapping keeps message/type but drops the upstream
+    // `model_not_supported` code — this is the exact shape the chat receives.
+    const error = {
+      name: "AI_APICallError",
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        error: {
+          message: GithubCopilot.API.MODEL_NOT_SUPPORTED_MESSAGE,
+          type: "api_validation_error",
+        },
+      }),
+      isRetryable: false,
+    };
+    const result = mapProviderError(error, "github-copilot");
+
+    expect(result.code).toBe(ChatErrorCode.NotFound);
+    expect(result.isRetryable).toBe(false);
+    // "The selected model is not available. Please choose a different model."
+    // — not the retry-suggesting invalid-request copy: retrying a
+    // deterministic rejection fails identically every time.
+    expect(result.message).toBe(ChatErrorMessages[ChatErrorCode.NotFound]);
+  });
+
+  it("keeps other github-copilot 400s on the generic invalid-request code", () => {
+    const error = {
+      name: "AI_APICallError",
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        error: {
+          message: "messages must be non-empty",
+          type: "invalid_request_error",
+        },
+      }),
+      isRetryable: false,
+    };
+    const result = mapProviderError(error, "github-copilot");
 
     expect(result.code).toBe(ChatErrorCode.InvalidRequest);
   });

--- a/platform/backend/src/routes/chat/errors.ts
+++ b/platform/backend/src/routes/chat/errors.ts
@@ -35,7 +35,10 @@ import logger from "@/logging";
 import { getActiveSessionId } from "@/observability/request-context";
 import { captureRawProviderErrorInSentry } from "@/observability/sentry";
 import { MICROSOFT_365_COPILOT_TOOLS_UNSUPPORTED_MESSAGE } from "@/routes/proxy/adapters/microsoft-365-copilot-graph-translator";
-import { SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE } from "@/types";
+import {
+  GithubCopilot,
+  SECRETS_MANAGER_UNAVAILABLE_INTERNAL_CODE,
+} from "@/types";
 import { LlmProviderAuthRequiredError } from "@/utils/llm-provider-auth-error";
 import { ContextWindowExceededError } from "./normalization/enforce-context-window-limit";
 import { RequestTooLargeError } from "./normalization/enforce-request-size-limit";
@@ -1381,6 +1384,32 @@ function mapMicrosoft365CopilotErrorToCode(
 }
 
 /**
+ * GitHub Copilot shares the OpenAI-compatible error body, but the LLM proxy's
+ * error wrapping keeps only `message`/`type` — the upstream
+ * `model_not_supported` code is gone by the time the chat maps the error, so
+ * the one Copilot-specific case is keyed on the message. Copilot catalogues
+ * models its chat/completions endpoint rejects (the model fetcher verifies
+ * invocability, but a conversation can stay pinned to a model that has since
+ * been dropped), and that deterministic rejection must surface the actionable
+ * "choose a different model" copy, not the retry-suggesting invalid-request
+ * one.
+ */
+function mapGithubCopilotErrorToCode(
+  statusCode: number | undefined,
+  parsedError: ParsedOpenAIError | null,
+): ChatErrorCode {
+  if (
+    statusCode === 400 &&
+    parsedError?.message?.includes(
+      GithubCopilot.API.MODEL_NOT_SUPPORTED_MESSAGE,
+    )
+  ) {
+    return ChatErrorCode.NotFound;
+  }
+  return mapOpenAIErrorToCode(statusCode, parsedError);
+}
+
+/**
  * Registry of provider-specific error parse/map pairs.
  * Using Record<SupportedProvider, ...> ensures TypeScript will error
  * if a new provider is added to SupportedProvider without updating this map.
@@ -1404,7 +1433,10 @@ const providerErrorHandlers: Record<SupportedProvider, ProviderErrorHandler> = {
   zhipuai: providerErrorHandler(parseZhipuaiError, mapZhipuaiErrorToCode),
   deepseek: openAiCompatibleErrorHandler,
   kimi: openAiCompatibleErrorHandler,
-  "github-copilot": openAiCompatibleErrorHandler,
+  "github-copilot": providerErrorHandler(
+    parseOpenAIError,
+    mapGithubCopilotErrorToCode,
+  ),
   "microsoft-365-copilot": providerErrorHandler(
     parseOpenAIError,
     mapMicrosoft365CopilotErrorToCode,

--- a/platform/backend/src/routes/chat/model-fetchers/github-copilot.test.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/github-copilot.test.ts
@@ -1,11 +1,42 @@
 import { vi } from "vitest";
 import { fetchGithubCopilotModels } from "@/routes/chat/model-fetchers/github-copilot";
 import { afterEach, describe, expect, test } from "@/test";
+import { GithubCopilot } from "@/types";
 
 let tokenCounter = 0;
 function uniqueGithubToken(): string {
   tokenCounter += 1;
   return `gho_fetcher_test_${Date.now()}_${tokenCounter}`;
+}
+
+/** What a live model answers the zero-inference invocability probe. */
+function aliveProbeResponse() {
+  return Response.json(
+    { error: { message: "messages must be non-empty", code: "" } },
+    { status: 400 },
+  );
+}
+
+/** What a dead-but-catalogued model answers any chat/completions request. */
+function modelNotSupportedResponse() {
+  return Response.json(
+    {
+      error: {
+        message: GithubCopilot.API.MODEL_NOT_SUPPORTED_MESSAGE,
+        code: GithubCopilot.API.MODEL_NOT_SUPPORTED_CODE,
+        param: "model",
+        type: "invalid_request_error",
+      },
+    },
+    { status: 400 },
+  );
+}
+
+function tokenExchangeResponse() {
+  return Response.json({
+    token: "copilot-bearer",
+    expires_at: Math.floor(Date.now() / 1000) + 1800,
+  });
 }
 
 afterEach(() => {
@@ -21,12 +52,10 @@ describe("fetchGithubCopilotModels", () => {
     const fetchMock = vi.fn().mockImplementation((input: string | URL) => {
       const url = String(input);
       if (url.includes("copilot_internal")) {
-        return Promise.resolve(
-          Response.json({
-            token: "copilot-bearer",
-            expires_at: Math.floor(Date.now() / 1000) + 1800,
-          }),
-        );
+        return Promise.resolve(tokenExchangeResponse());
+      }
+      if (url.endsWith("/chat/completions")) {
+        return Promise.resolve(aliveProbeResponse());
       }
       return Promise.resolve(
         Response.json({
@@ -98,12 +127,107 @@ describe("fetchGithubCopilotModels", () => {
     ]);
 
     const modelsCall = fetchMock.mock.calls.find(
-      ([input]) => !String(input).includes("copilot_internal"),
+      ([input]) =>
+        !String(input).includes("copilot_internal") &&
+        !String(input).endsWith("/chat/completions"),
     );
     expect(modelsCall).toBeDefined();
     const headers = modelsCall?.[1]?.headers as Headers;
     expect(headers.get("authorization")).toBe("Bearer copilot-bearer");
     expect(headers.get("copilot-integration-id")).toBe("vscode-chat");
+
+    // Only the statically-kept candidates are probed for invocability — the
+    // Responses-only/disabled/embedding entries are already out.
+    const probedModels = fetchMock.mock.calls
+      .filter(([input]) => String(input).endsWith("/chat/completions"))
+      .map(([, init]) => JSON.parse(String(init?.body)).model)
+      .sort();
+    expect(probedModels).toEqual(["claude-sonnet-4", "gpt-4o"]);
+  });
+
+  test("drops a catalogued model that chat/completions rejects as not supported (T-959)", async () => {
+    // Mirrors the live catalog: `gpt-4` is listed by /models with the same
+    // field shape as working models (chat type, no supported_endpoints, no
+    // policy), but chat/completions rejects it with `model_not_supported`.
+    let probeBody: unknown;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation((input: string | URL, init) => {
+        const url = String(input);
+        if (url.includes("copilot_internal")) {
+          return Promise.resolve(tokenExchangeResponse());
+        }
+        if (url.endsWith("/chat/completions")) {
+          const body = JSON.parse(String(init?.body)) as { model?: string };
+          if (body.model === "gpt-4") {
+            probeBody = body;
+            return Promise.resolve(modelNotSupportedResponse());
+          }
+          return Promise.resolve(aliveProbeResponse());
+        }
+        return Promise.resolve(
+          Response.json({
+            data: [
+              { id: "gpt-4o", name: "GPT-4o", capabilities: { type: "chat" } },
+              { id: "gpt-4", name: "GPT 4", capabilities: { type: "chat" } },
+            ],
+          }),
+        );
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const models = await fetchGithubCopilotModels(uniqueGithubToken());
+
+    expect(models.map((model) => model.id)).toEqual(["gpt-4o"]);
+    // The probe is deliberately invalid (empty messages) so nothing is ever
+    // generated: the model is validated before the payload.
+    expect(probeBody).toEqual({ model: "gpt-4", messages: [] });
+  });
+
+  test("keeps a model when the invocability probe is inconclusive", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementation((input: string | URL, init) => {
+        const url = String(input);
+        if (url.includes("copilot_internal")) {
+          return Promise.resolve(tokenExchangeResponse());
+        }
+        if (url.endsWith("/chat/completions")) {
+          const body = JSON.parse(String(init?.body)) as { model?: string };
+          if (body.model === "rate-limited-model") {
+            return Promise.resolve(
+              Response.json(
+                { error: { message: "rate limited", code: "rate_limit" } },
+                { status: 429 },
+              ),
+            );
+          }
+          if (body.model === "unreachable-model") {
+            return Promise.reject(new Error("socket hang up"));
+          }
+          return Promise.resolve(aliveProbeResponse());
+        }
+        return Promise.resolve(
+          Response.json({
+            data: [
+              { id: "gpt-4o", capabilities: { type: "chat" } },
+              { id: "rate-limited-model", capabilities: { type: "chat" } },
+              { id: "unreachable-model", capabilities: { type: "chat" } },
+            ],
+          }),
+        );
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const models = await fetchGithubCopilotModels(uniqueGithubToken());
+
+    // Only a definite model_not_supported drops a model — an outage must not
+    // empty the catalog.
+    expect(models.map((model) => model.id).sort()).toEqual([
+      "gpt-4o",
+      "rate-limited-model",
+      "unreachable-model",
+    ]);
   });
 
   test("surfaces the curated 401 when the token exchange rejects the GitHub token", async () => {

--- a/platform/backend/src/routes/chat/model-fetchers/github-copilot.ts
+++ b/platform/backend/src/routes/chat/model-fetchers/github-copilot.ts
@@ -1,7 +1,7 @@
 import config from "@/config";
 import logger from "@/logging";
 import { createGithubCopilotFetch } from "@/services/github-copilot-token";
-import { ApiError } from "@/types";
+import { ApiError, GithubCopilot } from "@/types";
 import { joinBaseUrl } from "@/utils/base-url";
 import { type ModelInfo, modelFetchError } from "./types";
 
@@ -19,6 +19,16 @@ import { type ModelInfo, modelFetchError } from "./types";
  * model is a Responses-only one, while every usable chat model is
  * picker=false, so that flag would surface an unusable model and hide the
  * working ones (verified against a live subscription).
+ *
+ * The catalog fields alone are not enough: `/models` also lists entries that
+ * `/chat/completions` rejects outright with `model_not_supported` — retired
+ * aliases next to their still-working snapshots (`gpt-4` vs `gpt-4o`,
+ * `gpt-3.5-turbo` vs `gpt-3.5-turbo-0613`), client-internal agent models
+ * (`copilot-search-*`, `exec-agent-*`), and per-plan-unavailable models that
+ * still declare `"/chat/completions"` in `supported_endpoints`. No field
+ * discriminates them (verified live: a dead alias can be field-identical to a
+ * working model, down to `version`), so every candidate is verified with a
+ * zero-inference probe before it is catalogued.
  */
 export async function fetchGithubCopilotModels(
   apiKey: string,
@@ -50,21 +60,123 @@ export async function fetchGithubCopilotModels(
     data?: GithubCopilotModel[];
   };
 
-  return (Array.isArray(payload.data) ? payload.data : [])
-    .filter(isChatCompletionsModel)
-    .map((model) => ({
-      id: model.id,
-      displayName: model.name || model.id,
-      provider: "github-copilot" as const,
-      capabilities: {
-        contextLength:
-          model.capabilities?.limits?.max_context_window_tokens ?? null,
-        supportsToolCalling: model.capabilities?.supports?.tool_calls ?? null,
-      },
-    }));
+  const candidates = (Array.isArray(payload.data) ? payload.data : []).filter(
+    isChatCompletionsModel,
+  );
+  const invocable = await dropModelsRejectedUpstream({
+    candidates,
+    copilotFetch,
+    baseUrl,
+    extraHeaders,
+  });
+
+  return invocable.map((model) => ({
+    id: model.id,
+    displayName: model.name || model.id,
+    provider: "github-copilot" as const,
+    capabilities: {
+      contextLength:
+        model.capabilities?.limits?.max_context_window_tokens ?? null,
+      supportsToolCalling: model.capabilities?.supports?.tool_calls ?? null,
+    },
+  }));
 }
 
 // ===== Internal helpers =====
+
+/** Concurrent invocability probes per sync (a catalog is a few dozen entries). */
+const VERIFY_CONCURRENCY = 8;
+
+/**
+ * Drops candidates Copilot's `/chat/completions` would reject with
+ * `model_not_supported`, using a deliberately invalid, zero-inference request:
+ * CAPI validates the model before the payload, so a dead model answers
+ * `model_not_supported` while a live one answers "messages must be non-empty"
+ * (verified live). No tokens are generated and no model is ever invoked, so
+ * the probe cannot consume a premium request.
+ *
+ * Only a definite `model_not_supported` drops a model. Anything inconclusive
+ * (429, 5xx, network failure — or a validation-order change upstream) keeps
+ * it, so an outage degrades to today's unverified catalog instead of an empty
+ * one.
+ */
+async function dropModelsRejectedUpstream(params: {
+  candidates: GithubCopilotModel[];
+  copilotFetch: ReturnType<typeof createGithubCopilotFetch>;
+  baseUrl: string;
+  extraHeaders?: Record<string, string> | null;
+}): Promise<GithubCopilotModel[]> {
+  const { candidates, copilotFetch, baseUrl, extraHeaders } = params;
+  if (candidates.length === 0) {
+    return candidates;
+  }
+
+  const invocable: boolean[] = new Array(candidates.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(VERIFY_CONCURRENCY, candidates.length) },
+    async () => {
+      while (nextIndex < candidates.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        invocable[index] = await isModelInvocable({
+          modelId: candidates[index].id,
+          copilotFetch,
+          baseUrl,
+          extraHeaders,
+        });
+      }
+    },
+  );
+  await Promise.all(workers);
+
+  const dropped = candidates.filter((_, index) => !invocable[index]);
+  if (dropped.length > 0) {
+    logger.info(
+      { droppedModelIds: dropped.map((model) => model.id) },
+      "Dropped GitHub Copilot models the chat/completions endpoint rejects",
+    );
+  }
+  return candidates.filter((_, index) => invocable[index]);
+}
+
+async function isModelInvocable(params: {
+  modelId: string;
+  copilotFetch: ReturnType<typeof createGithubCopilotFetch>;
+  baseUrl: string;
+  extraHeaders?: Record<string, string> | null;
+}): Promise<boolean> {
+  const { modelId, copilotFetch, baseUrl, extraHeaders } = params;
+  try {
+    const response = await copilotFetch(
+      joinBaseUrl(baseUrl, "/chat/completions"),
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(extraHeaders ?? {}),
+        },
+        // Invalid on purpose: the model is validated before the payload, so
+        // this never generates output — see dropModelsRejectedUpstream.
+        body: JSON.stringify({ model: modelId, messages: [] }),
+      },
+    );
+    if (response.ok) {
+      await response.body?.cancel();
+      return true;
+    }
+    const errorText = await response.text();
+    try {
+      const parsed = JSON.parse(errorText) as { error?: { code?: string } };
+      return parsed.error?.code !== GithubCopilot.API.MODEL_NOT_SUPPORTED_CODE;
+    } catch {
+      return true;
+    }
+  } catch {
+    // Network failure is inconclusive — keep the model.
+    return true;
+  }
+}
 
 /** True if the model is usable through Copilot's `/chat/completions` endpoint. */
 function isChatCompletionsModel(model: GithubCopilotModel): boolean {

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -1326,6 +1326,55 @@ describe("POST /api/chat toUIMessageStream onError deduplication", () => {
     });
   });
 
+  // T-959: a GitHub Copilot conversation pins a models.id UUID; the turn must
+  // dereference it to the catalogued provider model name before dispatch —
+  // Copilot 400s ("The requested model is not supported") on anything else.
+  test("dereferences a GitHub Copilot conversation's model FK to the provider model name", async ({
+    makeConversation,
+  }) => {
+    const model = await ModelModel.create({
+      externalId: "github-copilot/gpt-4o",
+      provider: "github-copilot",
+      modelId: "gpt-4o",
+      description: "gpt-4o",
+      contextLength: null,
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsToolCalling: true,
+      promptPricePerToken: null,
+      completionPricePerToken: null,
+      ignored: false,
+      lastSyncedAt: new Date(),
+    });
+    const copilotConversation = await makeConversation(agentId, {
+      userId: user.id,
+      organizationId,
+      modelId: model.id,
+    });
+    mockCreateLLMModelForAgent.mockClear();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/chat",
+      payload: {
+        id: copilotConversation.id,
+        messages: [
+          { id: "msg-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    expect(mockCreateLLMModelForAgent).toHaveBeenCalledTimes(1);
+    const dispatch = mockCreateLLMModelForAgent.mock.calls[0]?.[0];
+    expect(dispatch.provider).toBe("github-copilot");
+    // The provider model name — never the models.id UUID the conversation stores.
+    expect(dispatch.model).toBe("gpt-4o");
+    expect(dispatch.model).not.toBe(model.id);
+  });
+
   test("omits reasoningSummary while the credential is negative-cached as unsupported", async ({
     makeConversation,
   }) => {

--- a/platform/backend/src/routes/proxy/routes/github-copilot.test.ts
+++ b/platform/backend/src/routes/proxy/routes/github-copilot.test.ts
@@ -1,0 +1,160 @@
+/**
+ * GitHub Copilot proxy route tests.
+ *
+ * Regression coverage for T-959: Copilot's /chat/completions can reject a
+ * model that its own /models catalog advertises (and that we therefore
+ * synced and offered in the picker) with a 400
+ * `{"error":{"message":"The requested model is not supported.","type":"api_validation_error"}}`.
+ *
+ * These tests drive the real route, adapter, and Copilot fetch wrapper
+ * (token exchange + editor-identity headers) with the network faked at the
+ * wire, pinning:
+ *   - the exact request Copilot receives (catalogued model name — never a
+ *     models.id UUID — plus the exchanged bearer and integration headers)
+ *   - how the upstream rejection surfaces to the proxy caller
+ */
+import Fastify from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { http, HttpResponse } from "msw";
+import { describe, expect, test } from "@/test";
+import { useMswServer } from "@/test/msw";
+import { ApiError } from "@/types";
+import githubCopilotProxyRoutes from "./github-copilot";
+
+const COPILOT_TOKEN_EXCHANGE_URL =
+  "https://api.github.com/copilot_internal/v2/token";
+const COPILOT_CHAT_COMPLETIONS_URL =
+  "https://api.githubcopilot.com/chat/completions";
+
+/** The exact upstream rejection observed in T-959. */
+const MODEL_NOT_SUPPORTED_BODY = {
+  error: {
+    message: "The requested model is not supported.",
+    type: "api_validation_error",
+  },
+};
+
+// The Copilot bearer cache is keyed by the GitHub token, so each test uses a
+// fresh token to stay independent of the singleton token manager's state.
+let tokenCounter = 0;
+function uniqueGithubToken(): string {
+  tokenCounter += 1;
+  return `gho_proxy_test_${Date.now()}_${tokenCounter}`;
+}
+
+function createTestApp() {
+  const app = Fastify().withTypeProvider<ZodTypeProvider>();
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof ApiError) {
+      return reply.status(error.statusCode).send({
+        error: { message: error.message, type: error.type },
+      });
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return reply.status(500).send({
+      error: { message, type: "api_internal_server_error" },
+    });
+  });
+  return app;
+}
+
+const server = useMswServer();
+
+function stubTokenExchange() {
+  server.use(
+    http.get(COPILOT_TOKEN_EXCHANGE_URL, () =>
+      HttpResponse.json({
+        token: "copilot-bearer-test",
+        expires_at: Math.floor(Date.now() / 1000) + 1800,
+      }),
+    ),
+  );
+}
+
+describe("GitHub Copilot proxy — upstream model rejection (T-959)", () => {
+  test("non-streaming: sends the catalogued model name with the exchanged bearer, surfaces Copilot's 400", async ({
+    makeAgent,
+  }) => {
+    const app = createTestApp();
+    await app.register(githubCopilotProxyRoutes);
+    const agent = await makeAgent({ name: "Copilot Proxy Agent" });
+
+    stubTokenExchange();
+    let upstreamModel: unknown;
+    let upstreamAuthorization: string | null = null;
+    let upstreamIntegrationId: string | null = null;
+    server.use(
+      http.post(COPILOT_CHAT_COMPLETIONS_URL, async ({ request }) => {
+        const body = (await request.json()) as { model?: unknown };
+        upstreamModel = body.model;
+        upstreamAuthorization = request.headers.get("authorization");
+        upstreamIntegrationId = request.headers.get("copilot-integration-id");
+        return HttpResponse.json(MODEL_NOT_SUPPORTED_BODY, { status: 400 });
+      }),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/github-copilot/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${uniqueGithubToken()}`,
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      },
+    });
+
+    // What Copilot received: the catalogued model name (never a models.id
+    // UUID), the exchanged short-lived bearer, and the editor identity.
+    expect(upstreamModel).toBe("gpt-4");
+    expect(upstreamAuthorization).toBe("Bearer copilot-bearer-test");
+    expect(upstreamIntegrationId).toBe("vscode-chat");
+
+    // The deterministic upstream rejection reaches the caller as a 400 with
+    // the provider's message intact (not a masked 500).
+    expect(response.statusCode, response.body).toBe(400);
+    expect(response.body).toContain("The requested model is not supported.");
+  });
+
+  test("streaming: the same 400 surfaces instead of a stream", async ({
+    makeAgent,
+  }) => {
+    const app = createTestApp();
+    await app.register(githubCopilotProxyRoutes);
+    const agent = await makeAgent({ name: "Copilot Proxy Streaming Agent" });
+
+    stubTokenExchange();
+    server.use(
+      http.post(COPILOT_CHAT_COMPLETIONS_URL, () =>
+        HttpResponse.json(MODEL_NOT_SUPPORTED_BODY, { status: 400 }),
+      ),
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/github-copilot/${agent.id}/chat/completions`,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${uniqueGithubToken()}`,
+        "user-agent": "test-client",
+      },
+      payload: {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(400);
+    expect(response.body).toContain("The requested model is not supported.");
+  });
+});

--- a/platform/backend/src/routes/proxy/routes/github-copilot.test.ts
+++ b/platform/backend/src/routes/proxy/routes/github-copilot.test.ts
@@ -19,10 +19,10 @@ import {
   validatorCompiler,
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
-import { http, HttpResponse } from "msw";
+import { HttpResponse, http } from "msw";
 import { describe, expect, test } from "@/test";
 import { useMswServer } from "@/test/msw";
-import { ApiError } from "@/types";
+import { ApiError, GithubCopilot } from "@/types";
 import githubCopilotProxyRoutes from "./github-copilot";
 
 const COPILOT_TOKEN_EXCHANGE_URL =
@@ -33,7 +33,7 @@ const COPILOT_CHAT_COMPLETIONS_URL =
 /** The exact upstream rejection observed in T-959. */
 const MODEL_NOT_SUPPORTED_BODY = {
   error: {
-    message: "The requested model is not supported.",
+    message: GithubCopilot.API.MODEL_NOT_SUPPORTED_MESSAGE,
     type: "api_validation_error",
   },
 };
@@ -64,6 +64,7 @@ function createTestApp() {
   return app;
 }
 
+// biome-ignore lint/correctness/useHookAtTopLevel: vitest lifecycle helper (per-test MSW server), not a React hook
 const server = useMswServer();
 
 function stubTokenExchange() {

--- a/platform/backend/src/types/llm-providers/github-copilot/api.ts
+++ b/platform/backend/src/types/llm-providers/github-copilot/api.ts
@@ -24,6 +24,16 @@ export {
   FinishReasonSchema,
 };
 
+/**
+ * Copilot's rejection of a model its `/chat/completions` endpoint does not
+ * serve — returned even for models `/models` catalogues. The code appears on
+ * direct upstream responses; the message is what survives the LLM proxy's
+ * error wrapping (the proxy keeps `message`/`type` but drops `code`).
+ */
+export const MODEL_NOT_SUPPORTED_CODE = "model_not_supported";
+export const MODEL_NOT_SUPPORTED_MESSAGE =
+  "The requested model is not supported.";
+
 /** Request schema with passthrough for Copilot-specific params. */
 export const ChatCompletionRequestSchema =
   OpenAIChatCompletionRequestSchema.passthrough();


### PR DESCRIPTION
Fixes T-959: chat on the GitHub Copilot provider could fail with `400 {"message": "The requested model is not supported.", "type": "api_validation_error"}` for models Archestra itself offered in the model picker.

## Root cause

Copilot's `/models` is not an invocability catalog. Verified against a live subscription: 13 of the 24 entries our static filter kept were rejected outright by `/chat/completions` with `model_not_supported` — retired aliases listed next to their still-working snapshots (`gpt-4` vs `gpt-4o`, `gpt-3.5-turbo` vs `gpt-3.5-turbo-0613`), client-internal agent models (`copilot-search-*`, `exec-agent-*`), and per-plan-unavailable models that still declare `"/chat/completions"` in `supported_endpoints`. No catalog field discriminates dead from alive entries (a dead alias can be field-identical to a working model, down to `version`), and on the verified plan every entry is `model_picker_enabled: false`, so no static filter can compute the usable set. GitHub's own clients avoid the problem only because their picker never exposes these entries.

## Fix

**Verify invocability during model sync.** CAPI validates the model before the payload, so a deliberately invalid `{"model": …, "messages": []}` request is a zero-inference oracle: a dead model answers `model_not_supported`, a live one answers "messages must be non-empty". Nothing is generated and no model is ever invoked, so the probe cannot consume premium requests. The fetcher now probes every statically-kept candidate (8 concurrent) and drops only definite `model_not_supported` answers — 429/5xx/network failures keep the model, so an upstream outage degrades to the previous unverified catalog rather than an empty one. Runs everywhere the fetcher is used: connect-time key validation, lazy re-sync, explicit sync, and the proxy `/models` listing.

**Actionable error for the residual window.** A conversation can stay pinned to a model that has since died (the proxy's error wrapping keeps `message`/`type` but drops the upstream `code`). The chat error mapper now classifies Copilot's model-not-supported 400 as `NotFound` — "The selected model is not available. Please choose a different model." — instead of the retry-suggesting invalid-request copy, which misleads on a deterministic rejection.

## Testing

- New proxy route tests drive the real adapter and Copilot fetch wrapper (token exchange + editor-identity headers) against a faked wire, pinning that the catalogued model name goes upstream and the upstream 400 surfaces for both streaming and non-streaming.
- New chat stream test pins that a github-copilot conversation's model FK is dereferenced to the provider model name before dispatch.
- Fetcher tests cover the verification: a listed-but-rejected model is dropped, probes only target statically-kept candidates, inconclusive probes (429/network) keep the model.
- Error-mapper tests cover the NotFound classification and that other Copilot 400s keep the generic invalid-request code.
- Live validation on a dev stack with a real subscription: synced catalog went from 24 models (13 dead) to the invocable set; picking any listed model chats successfully; a conversation pinned to a dead model shows the actionable copy.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>