### PR TITLE
fix(llm-proxy): mark status-less in-stream provider errors as upstream failures

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -785,6 +785,28 @@ describe("handleError", () => {
     expect(providerFault.upstream).toBe(true);
   });
 
+  test("marks a status-less in-stream provider error as an upstream failure", () => {
+    // Once the provider's stream commits 200, a failure arrives as an SSE
+    // `error` event that the SDK relays with a parsed provider body but no
+    // HTTP status — e.g. Anthropic's mid-stream `api_error` ("Internal
+    // server error"). Without the upstream marker it was captured as a
+    // crash of ours.
+    const body = {
+      type: "error",
+      error: { type: "api_error", message: "Internal server error" },
+    };
+    const thrown = throwErrorFor(
+      Object.assign(new Error(JSON.stringify(body)), {
+        error: body,
+        headers: new Headers(),
+      }),
+      makeReply(false).reply,
+    );
+
+    expect(thrown.statusCode).toBe(500);
+    expect(thrown.upstream).toBe(true);
+  });
+
   test("does not mark an internal 500 as an upstream failure", () => {
     const thrown = throwErrorFor(
       new TypeError("cannot read x of undefined"),

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -399,11 +399,15 @@ export function handleError(
   // Provider-returned 5xx relays (an SDK error carrying the provider's own
   // HTTP failure) are upstream faults, not crashes of ours — marked so error
   // tracking drops the relay as noise while clients still get the status.
+  // The status-less variant is an in-stream failure: once the provider's
+  // stream commits 200, a failure arrives as an SSE `error` event that the
+  // SDK relays with a parsed provider body but no HTTP status (e.g.
+  // Anthropic's mid-stream `api_error` "Internal server error").
   const isUpstreamProviderFailure =
-    hasExplicitStatus &&
     statusCode >= 500 &&
     !(error instanceof ApiError) &&
-    hasProviderHttpErrorShape(error);
+    hasProviderHttpErrorShape(error) &&
+    (hasExplicitStatus || extractUpstreamErrorBody(error) !== undefined);
 
   const errorMessage = extractErrorMessage(error);
   const adapterInternalCode = extractInternalCode(error);


### PR DESCRIPTION
## Problem

The LLM proxy's error boundary marks relayed provider 5xx failures as upstream faults (`ApiError.upstream`) so error tracking drops them as noise while clients still get the status. That marker required the error to carry an **explicit HTTP status**.

But once a provider's stream commits HTTP 200, a subsequent failure arrives as an SSE `error` event, which the provider SDK rethrows with the parsed provider body and response headers but **no HTTP status** (the Anthropic SDK does `new APIError(undefined, body, undefined, headers)`). Example: Anthropic's mid-stream `api_error` with message "Internal server error".

These relays fell through as unmarked generic 500s and were reported to error tracking as crashes of ours, even though the provider itself failed. #6874 fixed the status-less *overload* variant of this; the status-less *api_error* variant still slipped through.

## Fix

Extend `isUpstreamProviderFailure` in `handleError` to cover the status-less variant: a non-`ApiError` with provider HTTP error shape **and** a parsed provider error body (`extractUpstreamErrorBody`) is an upstream fault even without an explicit status.

- Error tracking now drops these via the existing `error.upstream` policy
- No client-facing change: clients still receive the 500 with the provider's message
- Genuine internal 500s (no provider body/shape) still report — pinned by the existing "does not mark an internal 500 as an upstream failure" test