### PR TITLE
fix(statistics): stop casting token sums to INTEGER, which overflows for large orgs

### DIFF
--- a/platform/backend/src/models/statistics.test.ts
+++ b/platform/backend/src/models/statistics.test.ts
@@ -466,6 +466,45 @@ describe("StatisticsModel", () => {
       expect(aliceRow.lastActiveAt).not.toBeNull();
     });
 
+    test("sums token totals beyond int32 without overflowing", async ({
+      makeUser,
+      makeOrganization,
+      makeAgent,
+      makeInteraction,
+    }) => {
+      const org = await makeOrganization();
+      const agent = await makeAgent({ organizationId: org.id });
+      const user = await makeUser();
+
+      // Each row fits the int32 column, but the org-wide SUM crosses int32 —
+      // an INTEGER cast on the aggregate raised "integer out of range".
+      const perRow = 1_500_000_000;
+      await makeInteraction(agent.id, {
+        userId: user.id,
+        inputTokens: perRow,
+        outputTokens: perRow,
+        cost: "1.0000000000",
+        model: "gpt-4o",
+      });
+      await makeInteraction(agent.id, {
+        userId: user.id,
+        inputTokens: perRow,
+        outputTokens: perRow,
+        cost: "1.0000000000",
+        model: "gpt-4o",
+      });
+
+      const result = await StatisticsModel.getUserStatistics({
+        ...baseParams,
+        requestingUserId: user.id,
+      });
+
+      const row = result.data[0];
+      expect(row.inputTokens).toBe(2 * perRow);
+      expect(row.outputTokens).toBe(2 * perRow);
+      expect(row.totalTokens).toBe(4 * perRow);
+    });
+
     test("reports subscription-covered usage separately from billed spend", async ({
       makeUser,
       makeOrganization,

--- a/platform/backend/src/models/statistics.ts
+++ b/platform/backend/src/models/statistics.ts
@@ -324,8 +324,8 @@ class StatisticsModel {
         teamName: schema.teamsTable.name,
         timeBucket: sql<string>`DATE_TRUNC(${sql.raw(`'${timeBucket}'`)}, ${schema.interactionsTable.createdAt})`,
         requests: sql<number>`CAST(COUNT(*) AS INTEGER)`,
-        inputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.inputTokens}), 0) AS INTEGER)`,
-        outputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.outputTokens}), 0) AS INTEGER)`,
+        inputTokens: tokenSum(schema.interactionsTable.inputTokens),
+        outputTokens: tokenSum(schema.interactionsTable.outputTokens),
         // Billed spend: subscription-fulfilled traffic incurs no per-token
         // charge, so its list-price `cost` is excluded from the reported total.
         cost: billedSum(schema.interactionsTable.cost, "DOUBLE PRECISION"),
@@ -493,9 +493,9 @@ class StatisticsModel {
         teamName: schema.teamsTable.name,
         timeBucket: sql<string>`DATE_TRUNC(${sql.raw(`'${timeBucket}'`)}, ${schema.interactionsTable.createdAt})`,
         requests: sql<number>`CAST(COUNT(*) AS INTEGER)`,
-        inputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.inputTokens}), 0) AS INTEGER)`,
-        outputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.outputTokens}), 0) AS INTEGER)`,
-        cacheReadTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.cacheReadTokens}), 0) AS INTEGER)`,
+        inputTokens: tokenSum(schema.interactionsTable.inputTokens),
+        outputTokens: tokenSum(schema.interactionsTable.outputTokens),
+        cacheReadTokens: tokenSum(schema.interactionsTable.cacheReadTokens),
         // Billed spend: subscription-fulfilled traffic incurs no per-token
         // charge, so its list-price `cost` is excluded from the reported total.
         cost: billedSum(schema.interactionsTable.cost, "DOUBLE PRECISION"),
@@ -633,9 +633,9 @@ class StatisticsModel {
         model: schema.interactionsTable.model,
         timeBucket: sql<string>`DATE_TRUNC(${sql.raw(`'${timeBucket}'`)}, ${schema.interactionsTable.createdAt})`,
         requests: sql<number>`CAST(COUNT(*) AS INTEGER)`,
-        inputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.inputTokens}), 0) AS INTEGER)`,
-        outputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.outputTokens}), 0) AS INTEGER)`,
-        cacheReadTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.cacheReadTokens}), 0) AS INTEGER)`,
+        inputTokens: tokenSum(schema.interactionsTable.inputTokens),
+        outputTokens: tokenSum(schema.interactionsTable.outputTokens),
+        cacheReadTokens: tokenSum(schema.interactionsTable.cacheReadTokens),
         // Billed spend: subscription-fulfilled traffic incurs no per-token
         // charge, so its list-price `cost` is excluded from the reported total.
         cost: billedSum(schema.interactionsTable.cost, "DOUBLE PRECISION"),
@@ -840,10 +840,10 @@ class StatisticsModel {
           userName: schema.usersTable.name,
           userEmail: schema.usersTable.email,
           requests: sql<number>`CAST(COUNT(*) AS INTEGER)`,
-          inputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.inputTokens}), 0) AS INTEGER)`,
-          outputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.outputTokens}), 0) AS INTEGER)`,
-          cacheReadTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.cacheReadTokens}), 0) AS INTEGER)`,
-          totalTokens: sql<number>`CAST(${totalTokensExpr} AS INTEGER)`,
+          inputTokens: tokenSum(schema.interactionsTable.inputTokens),
+          outputTokens: tokenSum(schema.interactionsTable.outputTokens),
+          cacheReadTokens: tokenSum(schema.interactionsTable.cacheReadTokens),
+          totalTokens: sql<number>`CAST(${totalTokensExpr} AS DOUBLE PRECISION)`,
           billedCost: billedCostExpr,
           subscriptionCost: subscriptionCostSum("DOUBLE PRECISION"),
           activeDays: sql<number>`CAST(COUNT(DISTINCT DATE(${schema.interactionsTable.createdAt})) AS INTEGER)`,
@@ -1236,8 +1236,8 @@ class StatisticsModel {
         userId: schema.interactionsTable.userId,
         timeBucket: sql<string>`DATE_TRUNC(${sql.raw(`'${timeBucket}'`)}, ${schema.interactionsTable.createdAt})`,
         requests: sql<number>`CAST(COUNT(*) AS INTEGER)`,
-        inputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.inputTokens}), 0) AS INTEGER)`,
-        outputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.outputTokens}), 0) AS INTEGER)`,
+        inputTokens: tokenSum(schema.interactionsTable.inputTokens),
+        outputTokens: tokenSum(schema.interactionsTable.outputTokens),
         cost: billedSum(schema.interactionsTable.cost, "DOUBLE PRECISION"),
       })
       .from(schema.interactionsTable)
@@ -1285,9 +1285,9 @@ class StatisticsModel {
         userId: schema.interactionsTable.userId,
         model: schema.interactionsTable.model,
         requests: sql<number>`CAST(COUNT(*) AS INTEGER)`,
-        inputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.inputTokens}), 0) AS INTEGER)`,
-        outputTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.outputTokens}), 0) AS INTEGER)`,
-        cacheReadTokens: sql<number>`CAST(COALESCE(SUM(${schema.interactionsTable.cacheReadTokens}), 0) AS INTEGER)`,
+        inputTokens: tokenSum(schema.interactionsTable.inputTokens),
+        outputTokens: tokenSum(schema.interactionsTable.outputTokens),
+        cacheReadTokens: tokenSum(schema.interactionsTable.cacheReadTokens),
         billedCost: billedSum(
           schema.interactionsTable.cost,
           "DOUBLE PRECISION",
@@ -1335,6 +1335,16 @@ class StatisticsModel {
 // billing_mode. billing_mode is intentionally not in the statistics covering
 // index (adding it would require a write-blocking rebuild on a huge table — see
 // the interactions schema), so the FILTER reads it from the heap.
+
+/**
+ * SUM of an interaction token-count column, returned as a JS number.
+ * Cast to DOUBLE PRECISION rather than INTEGER or BIGINT: org-wide token
+ * sums exceed int32 ("integer out of range"), and node-postgres returns
+ * BIGINT as a string. float8 keeps integer sums exact up to 2^53 tokens.
+ */
+function tokenSum(column: AnyColumn): SQL<number> {
+  return sql<number>`CAST(COALESCE(SUM(${column}), 0) AS DOUBLE PRECISION)`;
+}
 
 /** SUM of an interaction cost column restricted to metered rows (billed spend). */
 function billedSum(


### PR DESCRIPTION
## Problem

The statistics aggregations cast token sums to `INTEGER`, e.g. `CAST(COALESCE(SUM(input_tokens), 0) AS INTEGER)`. Each interaction row fits int32, but org-wide sums cross 2^31 for heavy deployments, and PostgreSQL raises **`integer out of range`** — `GET /api/statistics/users` 500ed for the whole People page on a production org whose 30-day token sum crossed 2.1B.

## Fix

New `tokenSum()` helper in `models/statistics.ts` casting token-count sums to `DOUBLE PRECISION`:

- `BIGINT` would arrive as a **string** from node-postgres (no `setTypeParser` configured), breaking the `sql<number>` contract and Zod `z.number()` response validation
- float8 parses to a JS number and stays exact for integer sums up to 2^53 tokens — the same convention `billedSum`/`subscriptionCostSum` already use for costs

Applied to **every** token-sum site (user, team, agent, model, and per-user time-series/breakdown aggregations) since they all share the overflow, not just the endpoint that failed. `COUNT(*)` casts stay `INTEGER` — row counts are nowhere near int32.

## Testing

- Regression test: two interactions of 1.5B tokens each (each row fits the int32 column, the sum doesn't) now aggregate correctly instead of erroring — fails on `main` with `integer out of range`, passes here
- `models/statistics.test.ts` 39/39, `routes/statistics.test.ts` 4/4, `tsc --noEmit` and biome clean

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>