### PR TITLE
fix(llm-proxy): classify client aborts as 499 and string-payload stream errors as upstream

### DIFF
--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -678,6 +678,33 @@ describe("handleError", () => {
     );
   });
 
+  test("classifies a downstream client abort as a 499", () => {
+    // The fetch AbortError raised when the client-disconnect signal fires.
+    expect(
+      throwStatusFor(
+        new DOMException("This operation was aborted", "AbortError"),
+      ),
+    ).toBe(499);
+    // The provider SDKs' wrapper for a caller-supplied signal firing mid-call.
+    expect(
+      throwStatusFor(
+        Object.assign(new Error("Request was aborted."), {
+          name: "APIUserAbortError",
+        }),
+      ),
+    ).toBe(499);
+  });
+
+  test("keeps classifying an abort-due-to-timeout as a 504, not a client abort", () => {
+    expect(
+      throwStatusFor(
+        Object.assign(new Error("The operation was aborted due to timeout"), {
+          name: "TimeoutError",
+        }),
+      ),
+    ).toBe(504);
+  });
+
   function makeStreamedOverloadError(headers?: Headers) {
     const body = {
       type: "error",

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -807,6 +807,21 @@ describe("handleError", () => {
     expect(thrown.upstream).toBe(true);
   });
 
+  test("marks a status-less in-stream provider error with a bare-string payload as upstream", () => {
+    // OpenAI-compatible upstreams may put a plain string under the stream's
+    // `error` member; the SDK relays it verbatim with no HTTP status.
+    const thrown = throwErrorFor(
+      Object.assign(new Error("tool call refused by upstream"), {
+        error: "tool call refused by upstream",
+        headers: new Headers(),
+      }),
+      makeReply(false).reply,
+    );
+
+    expect(thrown.statusCode).toBe(500);
+    expect(thrown.upstream).toBe(true);
+  });
+
   test("does not mark an internal 500 as an upstream failure", () => {
     const thrown = throwErrorFor(
       new TypeError("cannot read x of undefined"),

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -382,9 +382,19 @@ export function handleError(
 
   // Some SDK transport and streaming failures do not carry an HTTP status.
   if (!hasExplicitStatus) {
-    const upstreamStatus = classifyTransientUpstreamError(error);
-    if (upstreamStatus !== undefined) {
-      statusCode = upstreamStatus;
+    if (isClientAbortError(error)) {
+      // The proxy client disconnected and the disconnect was propagated to
+      // the in-flight provider call as an AbortSignal (see
+      // createDownstreamAbortSignal). Nobody is waiting for this response —
+      // report 499 (client closed request) so the interaction record names
+      // the cause and error tracking's 4xx rule treats it as expected
+      // instead of a crash of ours.
+      statusCode = 499;
+    } else {
+      const upstreamStatus = classifyTransientUpstreamError(error);
+      if (upstreamStatus !== undefined) {
+        statusCode = upstreamStatus;
+      }
     }
   }
 
@@ -505,6 +515,23 @@ export function handleError(
 function hasProviderHttpErrorShape(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return "error" in error || "headers" in error || "$metadata" in error;
+}
+
+/**
+ * Whether the error is an abort of a request we initiated — the fetch/SDK
+ * AbortError raised when the signal wired to the proxy client's disconnect
+ * fires, or the SDK's own user-abort wrapper around it. Deliberately does NOT
+ * match AbortSignal.timeout's TimeoutError ("… aborted due to timeout", a 504
+ * classified below): the message fallback is anchored so only a bare abort
+ * matches.
+ */
+function isClientAbortError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "AbortError" ||
+    error.name === "APIUserAbortError" ||
+    /\boperation was aborted\.?$/i.test(error.message)
+  );
 }
 
 /**

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -407,7 +407,7 @@ export function handleError(
     statusCode >= 500 &&
     !(error instanceof ApiError) &&
     hasProviderHttpErrorShape(error) &&
-    (hasExplicitStatus || extractUpstreamErrorBody(error) !== undefined);
+    (hasExplicitStatus || hasUpstreamErrorPayload(error));
 
   const errorMessage = extractErrorMessage(error);
   const adapterInternalCode = extractInternalCode(error);
@@ -581,6 +581,19 @@ function nestedProviderErrorType(error: Error): string | undefined {
     }
   }
   return undefined;
+}
+
+/**
+ * Whether the SDK error carries an upstream error payload. OpenAI-compatible
+ * upstreams are free-form in what they put under the stream's `error` member —
+ * usually an object, but some send a bare string — and the SDK relays either
+ * verbatim, so both shapes identify an in-stream provider failure.
+ */
+function hasUpstreamErrorPayload(error: unknown): boolean {
+  if (extractUpstreamErrorBody(error) !== undefined) return true;
+  if (!(error instanceof Error)) return false;
+  const body = (error as Error & { error?: unknown }).error;
+  return typeof body === "string" && body.length > 0;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #6968 (now merged) — rebased onto main, only this PR's two commits remain.

## Problem

Two more classes of expected failures were reported as crashes of ours by the LLM proxy's error boundary:

1. **Downstream client aborts.** When the proxy client disconnects mid-request, the disconnect propagates to the in-flight provider call as an AbortSignal (`createDownstreamAbortSignal`), and the aborted call surfaces as a status-less `AbortError` ("This operation was aborted") or the SDKs' `APIUserAbortError` wrapper. `handleError` defaulted these to a generic 500 — a routine disconnect recorded as a server crash and reported to error tracking.
2. **Bare-string in-stream error payloads.** #6968 marks status-less in-stream provider failures as upstream relays when the SDK error carries a parsed provider error *object*. OpenAI-compatible upstreams are free-form here — some put a plain string under the stream's `error` member (e.g. self-hosted model servers relaying tool-call rejections or engine errors), which the SDK relays verbatim. Those still fell through as unmarked 500s.

## Fix

- `isClientAbortError` in `handleError`: status-less aborts classify as **499** (client closed request). The interaction record names the real cause, and error tracking's existing 4xx rule treats it as expected — no policy change needed. `AbortSignal.timeout`'s `TimeoutError` ("… aborted due to timeout") deliberately does not match and keeps classifying as a 504.
- `hasUpstreamErrorPayload`: the status-less upstream-relay check now accepts a non-empty string `error` payload in addition to an object body.
