### PR TITLE
fix(apps): bind scaffolded apps to the agent's environment, accept Default tools as the app baseline

### DIFF
--- a/docs/pages/platform-apps.md
+++ b/docs/pages/platform-apps.md
@@ -3,7 +3,7 @@ title: MCP Apps
 category: Apps
 order: 1
 description: User-authored MCP Apps — sandboxed HTML interfaces with their own data store and tools
-lastUpdated: 2026-07-28
+lastUpdated: 2026-07-30
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -85,7 +85,7 @@ Each app has its own key-to-document store, exposed to the app's HTML as `arches
 
 ## Tools and auto-auth
 
-Beyond the data store, an app can be assigned upstream MCP-server tools — from the Tools tab of its settings in the MCP registry, or directly from chat via the `tools` parameter of `scaffold_app` (declarative: the list replaces the current assignments). Assignment mirrors the agent model (scope-aligned, dynamic credentials by default). A running app can call only its assigned tools plus its own data-store tools; everything else is refused at the route.
+Beyond the data store, an app can be assigned upstream MCP-server tools — from the Tools tab of its settings in the MCP registry, or directly from chat via the `tools` parameter of `scaffold_app` (declarative: the list replaces the current assignments). Assignment mirrors the agent model (scope-aligned, dynamic credentials by default). A running app can call only its assigned tools plus its own data-store tools; everything else is refused at the route. `scaffold_app` binds the app to the authoring agent's [environment](./platform-environments); assignable tools are that environment's plus the Default environment's.
 
 Tool calls run **as the viewing user**: the platform resolves the MCP server and credentials per viewer at call time (personal install first, then team, then org), so an app reuses whatever MCP servers the viewer has already connected — no tokens in app code, no per-app auth setup. If the viewer hasn't connected the required server yet, `archestra.tools.call` rejects with `{ code: "auth_required", url }`; the user completes authentication in the MCP registry (apps cannot run OAuth flows themselves) and the next call succeeds.
 

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -3,7 +3,7 @@ title: "Environments"
 category: Administration
 description: "Isolate tools, knowledge, skills, subagents, runtimes, and cost limits across deployment environments"
 order: 3
-lastUpdated: 2026-07-22
+lastUpdated: 2026-07-30
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -16,8 +16,9 @@ This document is the canonical reference for deployment Environments. Include:
 - Environment isolation: how an environment scopes which tools, knowledge,
   skills, and delegation targets an agent / MCP gateway / LLM proxy can use
   (strict matching; Default is a peer, not a wildcard; skills can be
-  restricted to several environments or none = everywhere; built-in servers
-  and built-in skills are exempt)
+  restricted to several environments or none = everywhere; MCP Apps accept
+  Default tools as a shared baseline; built-in servers and built-in skills
+  are exempt)
 - Network egress policies (namespace + egress policy applied to MCP server pods AND
   agent code sandboxes), provider support matrix, and domain presets
 - How environments scope per-environment cost limits
@@ -30,7 +31,7 @@ Viewing environments requires the `environment:read` permission — every predef
 
 ## The Default environment
 
-Every organization has an implicit **Default** environment. Any resource whose environment is unset belongs to Default. Default is a real peer environment, not a wildcard: a resource in Default is not visible to a resource assigned to a named environment, and vice versa. Because everything starts in Default, isolation only changes behavior once you explicitly assign a non-default environment. Default can define a Kubernetes namespace and network egress policy like any other environment.
+Every organization has an implicit **Default** environment. Any resource whose environment is unset belongs to Default. Default is a real peer environment, not a wildcard: a resource in Default is not visible to a resource assigned to a named environment, and vice versa. [MCP Apps](/docs/platform-apps) are the one exception — an app accepts Default-environment tools as a shared baseline. Because everything starts in Default, isolation only changes behavior once you explicitly assign a non-default environment. Default can define a Kubernetes namespace and network egress policy like any other environment.
 
 ## Restricted environments
 
@@ -57,7 +58,7 @@ An agent, MCP gateway, or LLM proxy assigned to **Production** can only see and 
 - [Agent Skills](/docs/platform-agent-skills#environments) restricted to Production, or restricted to no environment at all
 - [subagent delegation targets](/docs/platform-agents#delegation) in Production
 
-Matching is strict for tools, knowledge, and subagents: a Production resource matches only other Production resources, a Dev resource matches only Dev, and Default matches only Default. Skills differ — a skill can be restricted to any number of environments, and a skill with none is available everywhere. Built-in servers (the Archestra control-plane server and Playwright) and built-in skills are exempt and always available.
+Matching is strict for tools, knowledge, and subagents: a Production resource matches only other Production resources, a Dev resource matches only Dev, and Default matches only Default. Skills differ — a skill can be restricted to any number of environments, and a skill with none is available everywhere. [MCP Apps](/docs/platform-apps) differ too: an app accepts Default-environment tools alongside its own environment's, so Default acts as a shared baseline for apps. Built-in servers (the Archestra control-plane server and Playwright) and built-in skills are exempt and always available.
 
 This applies to both explicitly assigned resources and the implicit **Auto** access modes — in both cases cross-environment resources are filtered out before they are listed or executed. In the agent dialog's explicit assignment pickers, resources from another environment are shown disabled. Skill filtering covers `list_skills`, `load_skill`, chat slash commands, and the skills offered on the [connect page](/docs/platform-llm-proxy#environment); a [skill that runs in a subagent](/docs/platform-agent-skills#running-a-skill-in-a-subagent) additionally requires its designated agent in the same environment.
 

--- a/platform/backend/src/archestra-mcp-server/apps.progressive-tool-loading.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.progressive-tool-loading.test.ts
@@ -14,7 +14,7 @@ import {
   TOOL_SEARCH_TOOLS_FULL_NAME,
   TOOL_SET_APP_TOOLS_SHORT_NAME,
 } from "@archestra/shared";
-import { AppToolModel, EnvironmentModel } from "@/models";
+import { AppModel, AppToolModel, EnvironmentModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { type ArchestraContext, executeArchestraTool } from ".";
@@ -245,6 +245,7 @@ describe("app tool assignment under Load-tools-when-needed", () => {
   // Use search_tools" (T-977: "I can't assign live MCP tools to the app").
   describe("environment-bound Access-all-tools agent", () => {
     let context: ArchestraContext;
+    let envId: string;
     let envToolName: string;
 
     beforeEach(
@@ -259,6 +260,7 @@ describe("app tool assignment under Load-tools-when-needed", () => {
           organizationId,
           name: `Env ${crypto.randomUUID().slice(0, 8)}`,
         });
+        envId = env.id;
         const envCatalog = await makeInternalMcpCatalog({
           organizationId,
           environmentId: env.id,
@@ -288,6 +290,16 @@ describe("app tool assignment under Load-tools-when-needed", () => {
       await expectAssignsThroughFullDispatch(context, envToolName);
     });
 
+    test("scaffold_app binds the app to the authoring agent's environment", async () => {
+      const created = await runTool(context, SCAFFOLD_APP_FULL_NAME, {
+        name: "Env Bound App",
+        tools: [envToolName],
+      });
+      expect(created.isError, resultText(created)).toBe(false);
+      const app = await AppModel.findById(structured(created).id as string);
+      expect(app?.environmentId).toBe(envId);
+    });
+
     test("set_app_tools accepts the environment's live tool on a scaffolded app", async () => {
       // The repair path scaffold_app's partial result points to must work too:
       // scaffold bare, then assign the discovered tool after the fact.
@@ -303,6 +315,23 @@ describe("app tool assignment under Load-tools-when-needed", () => {
       });
       expect(res.isError, resultText(res)).toBe(false);
       expect(structured(res).tools).toEqual([envToolName]);
+    });
+
+    test("Default-environment tools stay assignable as the org baseline", async () => {
+      // liveToolName (outer beforeEach) lives in the Default environment; the
+      // catch-all lets any app draw from that baseline, so scaffolding from an
+      // env-bound agent may combine its environment's tools with Default's.
+      const created = await runTool(context, SCAFFOLD_APP_FULL_NAME, {
+        name: "Mixed Sources Board",
+        tools: [envToolName, liveToolName],
+      });
+      expect(created.isError, resultText(created)).toBe(false);
+      const appId = structured(created).id as string;
+      expect(
+        (await AppToolModel.getToolsForApp(appId))
+          .map((tool) => tool.name)
+          .sort(),
+      ).toEqual([envToolName, liveToolName].sort());
     });
   });
 });

--- a/platform/backend/src/archestra-mcp-server/apps.progressive-tool-loading.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.progressive-tool-loading.test.ts
@@ -1,0 +1,308 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: tests inspect MCP tool payloads dynamically
+
+// T-977 regression: under "Load tools when needed" (toolExposureMode
+// search_and_run_only — forced for Access-all-tools agents, optional for
+// custom agents), a live MCP tool the model discovers through search_tools
+// must be assignable to an app it is building: via scaffold_app's tools param
+// and via set_app_tools, dispatched exactly the way the model dispatches them
+// (run_tool with full agent context, so the assignment gate runs).
+
+import {
+  getArchestraToolFullName,
+  TOOL_RUN_TOOL_FULL_NAME,
+  TOOL_SCAFFOLD_APP_SHORT_NAME,
+  TOOL_SEARCH_TOOLS_FULL_NAME,
+  TOOL_SET_APP_TOOLS_SHORT_NAME,
+} from "@archestra/shared";
+import { AppToolModel, EnvironmentModel } from "@/models";
+import { beforeEach, describe, expect, test } from "@/test";
+import type { Agent } from "@/types";
+import { type ArchestraContext, executeArchestraTool } from ".";
+
+const SCAFFOLD_APP_FULL_NAME = getArchestraToolFullName(
+  TOOL_SCAFFOLD_APP_SHORT_NAME,
+);
+const SET_APP_TOOLS_FULL_NAME = getArchestraToolFullName(
+  TOOL_SET_APP_TOOLS_SHORT_NAME,
+);
+
+function structured(result: { structuredContent?: unknown }): any {
+  return result.structuredContent;
+}
+
+function resultText(result: { content: unknown }): string {
+  return (result.content as Array<{ text?: string }>)
+    .map((item) => item.text ?? "")
+    .join("\n");
+}
+
+/** Dispatch a built-in the way a search_and_run_only model does: through run_tool. */
+function runTool(
+  context: ArchestraContext,
+  toolName: string,
+  toolArgs: Record<string, unknown>,
+) {
+  return executeArchestraTool(
+    TOOL_RUN_TOOL_FULL_NAME,
+    { tool_name: toolName, tool_args: toolArgs },
+    context,
+  );
+}
+
+function searchTools(context: ArchestraContext, query: string) {
+  return executeArchestraTool(TOOL_SEARCH_TOOLS_FULL_NAME, { query }, context);
+}
+
+/** The searched live (source "mcp") tool names, in ranking order. */
+function mcpToolNames(searchResult: { structuredContent?: unknown }): string[] {
+  return (structured(searchResult).tools as Array<any>)
+    .filter((tool) => tool.source === "mcp")
+    .map((tool) => tool.toolName);
+}
+
+async function expectAssignsThroughFullDispatch(
+  context: ArchestraContext,
+  liveToolName: string,
+) {
+  // scaffold_app's tools param assigns the live tool at creation.
+  const created = await runTool(context, SCAFFOLD_APP_FULL_NAME, {
+    name: "Issue Board",
+    tools: [liveToolName],
+  });
+  expect(created.isError, resultText(created)).toBe(false);
+  expect(structured(created).status ?? "ok").toBe("ok");
+  const appId = structured(created).id as string;
+  expect(
+    (await AppToolModel.getToolsForApp(appId)).map((tool) => tool.name),
+  ).toEqual([liveToolName]);
+
+  // set_app_tools replaces the set after the fact (clear, then re-assign).
+  const cleared = await runTool(context, SET_APP_TOOLS_FULL_NAME, {
+    appId,
+    tools: [],
+  });
+  expect(cleared.isError, resultText(cleared)).toBe(false);
+  const reassigned = await runTool(context, SET_APP_TOOLS_FULL_NAME, {
+    appId,
+    tools: [liveToolName],
+  });
+  expect(reassigned.isError, resultText(reassigned)).toBe(false);
+  expect(structured(reassigned).tools).toEqual([liveToolName]);
+}
+
+describe("app tool assignment under Load-tools-when-needed", () => {
+  let organizationId: string;
+  let userId: string;
+  let liveToolName: string;
+  let liveToolId: string;
+
+  beforeEach(
+    async ({
+      makeOrganization,
+      makeUser,
+      makeMember,
+      makeInternalMcpCatalog,
+      makeMcpServer,
+      makeTool,
+    }) => {
+      const org = await makeOrganization();
+      organizationId = org.id;
+      const user = await makeUser();
+      userId = user.id;
+      await makeMember(user.id, organizationId, { role: "member" });
+
+      const catalog = await makeInternalMcpCatalog({ organizationId });
+      await makeMcpServer({ catalogId: catalog.id, scope: "org" });
+      liveToolName = `github__list_issues_${crypto.randomUUID().slice(0, 8)}`;
+      const liveTool = await makeTool({
+        name: liveToolName,
+        catalogId: catalog.id,
+      });
+      liveToolId = liveTool.id;
+    },
+  );
+
+  function contextFor(agent: Agent): ArchestraContext {
+    return {
+      agent: { id: agent.id, name: agent.name },
+      agentId: agent.id,
+      organizationId,
+      userId,
+    };
+  }
+
+  describe("Access-all-tools agent (progressive loading forced)", () => {
+    let context: ArchestraContext;
+
+    beforeEach(async ({ makeAgent, seedAndAssignArchestraTools }) => {
+      const agent = await makeAgent({
+        name: "All Tools Agent",
+        organizationId,
+        accessAllTools: true,
+      });
+      // Production agents get the app-authoring built-ins assigned at creation
+      // (AgentModel.create auto-assigns them); the test DB seeds the Archestra
+      // catalog on demand, so mirror that end state explicitly.
+      await seedAndAssignArchestraTools(agent.id);
+      context = contextFor(agent);
+    });
+
+    test("search_tools surfaces the live tool and the app-authoring tools", async () => {
+      const liveSearch = await searchTools(context, "github list issues");
+      expect(liveSearch.isError, resultText(liveSearch)).toBe(false);
+      expect(mcpToolNames(liveSearch)).toContain(liveToolName);
+
+      const authoringSearch = await searchTools(context, "set app tools");
+      expect(
+        (structured(authoringSearch).tools as Array<any>).map(
+          (tool) => tool.toolName,
+        ),
+      ).toContain(SET_APP_TOOLS_FULL_NAME);
+    });
+
+    test("a searched live tool is assignable via scaffold_app and set_app_tools", async () => {
+      await expectAssignsThroughFullDispatch(context, liveToolName);
+    });
+
+    test("every live tool search_tools returns is accepted by set_app_tools", async () => {
+      const search = await searchTools(context, "github list issues");
+      const names = mcpToolNames(search);
+      expect(names.length).toBeGreaterThan(0);
+
+      const created = await runTool(context, SCAFFOLD_APP_FULL_NAME, {
+        name: "Parity Probe",
+      });
+      expect(created.isError, resultText(created)).toBe(false);
+      const appId = structured(created).id as string;
+
+      for (const name of names) {
+        const res = await runTool(context, SET_APP_TOOLS_FULL_NAME, {
+          appId,
+          tools: [name],
+        });
+        expect(res.isError, `assigning ${name}: ${resultText(res)}`).toBe(
+          false,
+        );
+      }
+    });
+  });
+
+  describe("custom agent with progressive loading (assigned tools only)", () => {
+    let context: ArchestraContext;
+
+    beforeEach(
+      async ({ makeAgent, makeAgentTool, seedAndAssignArchestraTools }) => {
+        const agent = await makeAgent({
+          name: "Custom Progressive Agent",
+          organizationId,
+          accessAllTools: false,
+          toolExposureMode: "search_and_run_only",
+        });
+        await seedAndAssignArchestraTools(agent.id);
+        await makeAgentTool(agent.id, liveToolId);
+        context = contextFor(agent);
+      },
+    );
+
+    test("search_tools surfaces the assigned live tool", async () => {
+      const liveSearch = await searchTools(context, "github list issues");
+      expect(liveSearch.isError, resultText(liveSearch)).toBe(false);
+      expect(mcpToolNames(liveSearch)).toContain(liveToolName);
+    });
+
+    test("an assigned live tool is assignable via scaffold_app and set_app_tools", async () => {
+      await expectAssignsThroughFullDispatch(context, liveToolName);
+    });
+
+    test("every live tool search_tools returns is accepted by set_app_tools", async () => {
+      const search = await searchTools(context, "github list issues");
+      const names = mcpToolNames(search);
+      expect(names.length).toBeGreaterThan(0);
+
+      const created = await runTool(context, SCAFFOLD_APP_FULL_NAME, {
+        name: "Parity Probe",
+      });
+      expect(created.isError, resultText(created)).toBe(false);
+      const appId = structured(created).id as string;
+
+      for (const name of names) {
+        const res = await runTool(context, SET_APP_TOOLS_FULL_NAME, {
+          appId,
+          tools: [name],
+        });
+        expect(res.isError, `assigning ${name}: ${resultText(res)}`).toBe(
+          false,
+        );
+      }
+    });
+  });
+
+  // An agent bound to a non-default environment only ever sees (and runs) that
+  // environment's tools — search_tools fences discovery to the agent's env. The
+  // tools the model discovers there must be assignable to the app it scaffolds
+  // from that same agent, or the model is stuck in a loop: search_tools shows
+  // the tool, scaffold_app/set_app_tools reject it with "Unknown tool name(s)…
+  // Use search_tools" (T-977: "I can't assign live MCP tools to the app").
+  describe("environment-bound Access-all-tools agent", () => {
+    let context: ArchestraContext;
+    let envToolName: string;
+
+    beforeEach(
+      async ({
+        makeAgent,
+        makeInternalMcpCatalog,
+        makeMcpServer,
+        makeTool,
+        seedAndAssignArchestraTools,
+      }) => {
+        const env = await EnvironmentModel.create({
+          organizationId,
+          name: `Env ${crypto.randomUUID().slice(0, 8)}`,
+        });
+        const envCatalog = await makeInternalMcpCatalog({
+          organizationId,
+          environmentId: env.id,
+        });
+        await makeMcpServer({ catalogId: envCatalog.id, scope: "org" });
+        envToolName = `envhub__list_records_${crypto.randomUUID().slice(0, 8)}`;
+        await makeTool({ name: envToolName, catalogId: envCatalog.id });
+
+        const agent = await makeAgent({
+          name: "Env Agent",
+          organizationId,
+          accessAllTools: true,
+          environmentId: env.id,
+        });
+        await seedAndAssignArchestraTools(agent.id);
+        context = contextFor(agent);
+      },
+    );
+
+    test("search_tools surfaces the environment's live tool", async () => {
+      const search = await searchTools(context, "envhub list records");
+      expect(search.isError, resultText(search)).toBe(false);
+      expect(mcpToolNames(search)).toContain(envToolName);
+    });
+
+    test("a searched live tool is assignable via scaffold_app and set_app_tools", async () => {
+      await expectAssignsThroughFullDispatch(context, envToolName);
+    });
+
+    test("set_app_tools accepts the environment's live tool on a scaffolded app", async () => {
+      // The repair path scaffold_app's partial result points to must work too:
+      // scaffold bare, then assign the discovered tool after the fact.
+      const created = await runTool(context, SCAFFOLD_APP_FULL_NAME, {
+        name: "Env Records Board",
+      });
+      expect(created.isError, resultText(created)).toBe(false);
+      const appId = structured(created).id as string;
+
+      const res = await runTool(context, SET_APP_TOOLS_FULL_NAME, {
+        appId,
+        tools: [envToolName],
+      });
+      expect(res.isError, resultText(res)).toBe(false);
+      expect(structured(res).tools).toEqual([envToolName]);
+    });
+  });
+});

--- a/platform/backend/src/archestra-mcp-server/apps.test.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.test.ts
@@ -2217,19 +2217,19 @@ describe("set_app_tools", () => {
       environmentId: env.id,
     });
 
-    // Succeeds only because resolution fences on app.environmentId (env), not the
-    // org default (null) scaffold_app uses — a default-env resolve would reject it.
+    // Succeeds only because resolution fences on app.environmentId (env): a
+    // resolve against a different non-default environment would reject it.
     const res = await setTools({ appId: app.id, tools: [envToolName] });
     expect(res.isError).toBe(false);
     expect(structured(res).tools).toEqual([envToolName]);
   });
 
-  test("rejects a default-env tool for an env-bound app, leaving it unchanged", async ({
+  test("accepts a default-env tool for an env-bound app (the Default baseline)", async ({
     makeApp,
   }) => {
     // toolName (beforeEach) lives in the org-default environment (null); the app
-    // is bound to a non-default environment — the counterfactual of the test
-    // above. A resolve against the org default would wrongly accept it.
+    // is bound to a non-default environment. Default-environment tools are the
+    // org baseline every app may draw from, so the resolve accepts it.
     const env = await EnvironmentModel.create({
       organizationId,
       name: `Env ${crypto.randomUUID().slice(0, 8)}`,
@@ -2242,6 +2242,44 @@ describe("set_app_tools", () => {
     });
 
     const res = await setTools({ appId: app.id, tools: [toolName] });
+    expect(res.isError).toBe(false);
+    expect(structured(res).tools).toEqual([toolName]);
+    expect(
+      (await AppToolModel.getToolsForApp(app.id)).map((tool) => tool.name),
+    ).toEqual([toolName]);
+  });
+
+  test("rejects a tool from a different non-default environment, leaving the app unchanged", async ({
+    makeApp,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+    makeTool,
+  }) => {
+    // Two sibling non-default environments stay isolated: only the Default
+    // baseline crosses environment lines.
+    const appEnv = await EnvironmentModel.create({
+      organizationId,
+      name: `Env ${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const otherEnv = await EnvironmentModel.create({
+      organizationId,
+      name: `Env ${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const otherCatalog = await makeInternalMcpCatalog({
+      organizationId,
+      environmentId: otherEnv.id,
+    });
+    await makeMcpServer({ catalogId: otherCatalog.id, scope: "org" });
+    const otherToolName = `other__tool_${crypto.randomUUID().slice(0, 8)}`;
+    await makeTool({ name: otherToolName, catalogId: otherCatalog.id });
+    const app = await makeApp({
+      organizationId,
+      scope: "personal",
+      authorId: userId,
+      environmentId: appEnv.id,
+    });
+
+    const res = await setTools({ appId: app.id, tools: [otherToolName] });
     expect(res.isError).toBe(true);
     expect((res.content[0] as any).text).toContain("Unknown tool name");
     expect(await AppToolModel.getToolsForApp(app.id)).toEqual([]);

--- a/platform/backend/src/archestra-mcp-server/apps.ts
+++ b/platform/backend/src/archestra-mcp-server/apps.ts
@@ -439,23 +439,29 @@ const registry = defineArchestraTools([
       }
 
       // Resolve the tools list BEFORE creating the app, so a bad list never
-      // leaves a half-built app behind. scaffold_app creates the app at the org
-      // default environment (environment selection is deferred to the REST/UI
-      // path), so tools resolve within the default environment — not the
-      // authoring agent's — keeping assignments consistent with the app's env.
+      // leaves a half-built app behind. scaffold_app binds the app to the
+      // authoring agent's environment — the same environment search_tools
+      // discovers in — so a tool the model just found is assignable and the
+      // runtime gate agrees; an agent without one (or whose row is gone)
+      // falls back to the org Default environment. Resolution additionally
+      // accepts the Default baseline (toolInEnvironmentOrDefaultPredicate).
+      const environmentId = await AgentModel.findEnvironmentId(
+        context.agent.id,
+      );
       const toolsResolution = await resolveToolsParam({
         agentId: context.agent.id,
         userId,
         organizationId,
         tools: args.tools,
-        environmentId: null,
+        environmentId,
       });
       if (!toolsResolution.ok) return errorResult(toolsResolution.error);
       const resolvedTools = toolsResolution.tools;
 
       // Like the REST path: create the app, then its backing; on backing failure
-      // delete the app so it is never left unbacked. scaffold_app defers team +
-      // environment selection to the REST/UI path, so no teams here.
+      // delete the app so it is never left unbacked. scaffold_app defers team
+      // selection to the REST/UI path, so no teams here; the environment is the
+      // authoring agent's (resolved above).
       const appName = args.name;
       let app: App | null;
       // App names are unique per author (apps_org_author_name_uidx); a duplicate
@@ -497,7 +503,7 @@ const registry = defineArchestraTools([
         await createAppBacking({
           app: created,
           scope,
-          environmentId: null,
+          environmentId,
           userId,
           organizationId,
           teamIds: [],
@@ -1037,8 +1043,8 @@ const registry = defineArchestraTools([
       if ("error" in gate) return gate.error;
       const { app } = gate;
 
-      // Fence resolution against the app's bound environment (not the org
-      // default scaffold_app uses), so a tool only valid elsewhere is rejected.
+      // Fence resolution against the app's bound environment (plus the Default
+      // baseline), so a tool only valid in another environment is rejected.
       const resolution = await resolveToolsParam({
         agentId: context.agent.id,
         userId: auth.userId,

--- a/platform/backend/src/models/tool.ts
+++ b/platform/backend/src/models/tool.ts
@@ -51,7 +51,10 @@ import {
   type PaginatedResult,
 } from "@/database/utils/pagination";
 import logger from "@/logging";
-import { toolInEnvironmentPredicate } from "@/services/environments/environment-isolation";
+import {
+  toolInEnvironmentOrDefaultPredicate,
+  toolInEnvironmentPredicate,
+} from "@/services/environments/environment-isolation";
 import type {
   AssignedTool,
   ExtendedTool,
@@ -903,6 +906,13 @@ class ToolModel {
      * run_tool cannot reach cross-environment tools.
      */
     environmentId: string | null;
+    /**
+     * Also match Default-environment tools when `environmentId` is non-default
+     * ({@link toolInEnvironmentOrDefaultPredicate}). App tool assignment only —
+     * apps may always draw from the Default baseline; agent/gateway discovery
+     * must stay strictly fenced and never sets this.
+     */
+    includeDefaultEnvironment?: boolean;
     /** Exact-name filter for single-tool resolution (avoids loading the whole corpus). */
     name?: string;
     /**
@@ -949,7 +959,9 @@ class ToolModel {
         and(
           inArray(schema.toolsTable.catalogId, catalogIds),
           eq(schema.toolsTable.clonedPendingDiscovery, false),
-          toolInEnvironmentPredicate(params.environmentId),
+          params.includeDefaultEnvironment
+            ? toolInEnvironmentOrDefaultPredicate(params.environmentId)
+            : toolInEnvironmentPredicate(params.environmentId),
           params.name !== undefined
             ? eq(schema.toolsTable.name, params.name)
             : undefined,
@@ -2203,11 +2215,12 @@ class ToolModel {
    * Of `toolIds`, the subset assignable to an MCP App in `environmentId`:
    * catalog-backed (non-null catalogId, which app dispatch requires), org-visible
    * (the catalog belongs to the org or is a global org-less entry), not an
-   * Archestra built-in, not a clone pending discovery, and in the environment.
+   * Archestra built-in, not a clone pending discovery, and in the environment or
+   * the Default baseline ({@link toolInEnvironmentOrDefaultPredicate}).
    * This is the by-id, install-agnostic gate {@link resolveAppAssignableToolRows}
    * applies to the agent's *assigned* tools — an assigned tool is reachable
    * through its assignment without a separate discoverable install, but must
-   * still be org-visible and in-environment.
+   * still be org-visible and environment-matched.
    */
   static async filterAppAssignableToolIds(
     organizationId: string,
@@ -2227,7 +2240,7 @@ class ToolModel {
           inArray(schema.toolsTable.id, toolIds),
           ne(schema.toolsTable.catalogId, ARCHESTRA_MCP_CATALOG_ID),
           eq(schema.toolsTable.clonedPendingDiscovery, false),
-          toolInEnvironmentPredicate(environmentId),
+          toolInEnvironmentOrDefaultPredicate(environmentId),
           or(
             eq(schema.internalMcpCatalogTable.organizationId, organizationId),
             isNull(schema.internalMcpCatalogTable.organizationId),
@@ -2273,13 +2286,14 @@ class ToolModel {
   }
 
   /**
-   * Whether a tool belongs to (is assignable/callable within) `environmentId`,
-   * reusing the canonical {@link toolInEnvironmentPredicate} so the app
-   * assignment fence and call-time fence never drift from the agent isolation
-   * rules: null = org default, and the built-in Archestra/Playwright catalogs
-   * plus delegation tools are exempt.
+   * Whether a tool is assignable/callable within an *app* bound to
+   * `environmentId`: the app fences share
+   * {@link toolInEnvironmentOrDefaultPredicate} — the environment's own tools
+   * plus the Default baseline — so the assignment fence and call-time fence
+   * never drift apart. The built-in Archestra/Playwright catalogs and
+   * delegation tools are exempt as everywhere.
    */
-  static async isToolInEnvironment(
+  static async isToolInEnvironmentOrDefault(
     toolId: string,
     environmentId: string | null,
   ): Promise<boolean> {
@@ -2289,7 +2303,7 @@ class ToolModel {
       .where(
         and(
           eq(schema.toolsTable.id, toolId),
-          toolInEnvironmentPredicate(environmentId),
+          toolInEnvironmentOrDefaultPredicate(environmentId),
         ),
       )
       .limit(1);
@@ -2297,11 +2311,12 @@ class ToolModel {
   }
 
   /**
-   * Of `toolIds`, the subset that belongs to `environmentId` — the batch form of
-   * {@link isToolInEnvironment}, used to trim an app's runtime tool list to its
-   * bound environment (UX hygiene; the call-time gate is the hard fence).
+   * Of `toolIds`, the subset callable within an app bound to `environmentId` —
+   * the batch form of {@link isToolInEnvironmentOrDefault}, used to trim an
+   * app's runtime tool list to what the call-time gate would allow (UX hygiene;
+   * the call-time gate is the hard fence).
    */
-  static async filterToolIdsInEnvironment(
+  static async filterToolIdsInEnvironmentOrDefault(
     toolIds: string[],
     environmentId: string | null,
   ): Promise<Set<string>> {
@@ -2312,7 +2327,7 @@ class ToolModel {
       .where(
         and(
           inArray(schema.toolsTable.id, toolIds),
-          toolInEnvironmentPredicate(environmentId),
+          toolInEnvironmentOrDefaultPredicate(environmentId),
         ),
       );
     return new Set(rows.map((r) => r.id));
@@ -2321,7 +2336,7 @@ class ToolModel {
   /**
    * App-owner counterpart of {@link getMcpToolsAssignedToAgent}. Includes the
    * tool `id` so the runtime gate can apply the environment fence
-   * ({@link isToolInEnvironment}) against the resolved tool.
+   * ({@link isToolInEnvironmentOrDefault}) against the resolved tool.
    */
   static async getMcpToolsAssignedToApp(
     toolNames: string[],

--- a/platform/backend/src/routes/app/tools.app.route.test.ts
+++ b/platform/backend/src/routes/app/tools.app.route.test.ts
@@ -192,6 +192,41 @@ describe("/api/apps/:appId/tools", () => {
     expect(response.statusCode).toBe(400);
   });
 
+  test("assigning a Default-environment tool to an env-bound app succeeds", async ({
+    makeApp,
+    makeTool,
+    makeInternalMcpCatalog,
+  }) => {
+    // Default-environment tools are the org baseline every app may draw from,
+    // so an app bound to a non-default environment still accepts them.
+    const prod = await EnvironmentModel.create({
+      organizationId,
+      name: "production",
+    });
+    const created = await makeApp({
+      organizationId,
+      scope: "org",
+      environmentId: prod.id,
+    });
+    const defaultCatalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "base-srv",
+      serverUrl: "https://example.com/mcp/",
+    });
+    const baseTool = await makeTool({
+      name: "base__do_thing",
+      parameters: {},
+      catalogId: defaultCatalog.id,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/apps/${created.id}/tools/${baseTool.id}`,
+      payload: { credentialResolutionMode: "dynamic" },
+    });
+    expect(response.statusCode).toBe(200);
+  });
+
   test("assigning a tool in the app's environment succeeds", async ({
     makeApp,
     makeTool,

--- a/platform/backend/src/routes/mcp-app-gateway.utils.ts
+++ b/platform/backend/src/routes/mcp-app-gateway.utils.ts
@@ -429,11 +429,11 @@ function buildAppLaunchTool(appId: string, app: App): McpListTool {
 
 async function buildAppToolList(appId: string): Promise<McpListTool[]> {
   const upstream = await AppToolModel.getToolsForApp(appId);
-  // Trim the runtime list to the app's bound environment so it never offers a
-  // tool the call-time gate would refuse. UX hygiene only — the hard fence is
-  // gateAppToolCall.
+  // Trim the runtime list to the app's bound environment (plus the Default
+  // baseline) so it never offers a tool the call-time gate would refuse. UX
+  // hygiene only — the hard fence is gateAppToolCall.
   const app = await AppModel.findById(appId);
-  const inEnvIds = await ToolModel.filterToolIdsInEnvironment(
+  const inEnvIds = await ToolModel.filterToolIdsInEnvironmentOrDefault(
     upstream.map((tool) => tool.id),
     app?.environmentId ?? null,
   );

--- a/platform/backend/src/services/agent-tool-assignment.ts
+++ b/platform/backend/src/services/agent-tool-assignment.ts
@@ -184,8 +184,9 @@ export async function resolveAppToolsByName(params: {
   userId: string;
   organizationId: string;
   toolNames: readonly string[];
-  /** Environment to resolve tools within (the app's bound environment; the org
-   * default for scaffold_app, where env selection is deferred). */
+  /** Environment to resolve tools within (the app's bound environment; for
+   * scaffold_app the authoring agent's, which is where the app gets bound).
+   * The Default baseline always matches on top. */
   environmentId: string | null;
 }): Promise<
   { tools: Array<{ id: string; name: string }> } | ToolAssignmentError
@@ -293,9 +294,10 @@ export async function assignToolToApp(params: {
   }
 
   // Environment fence: a tool whose catalog is outside the app's bound
-  // environment is not assignable. This is a same-org, wrong-environment tool —
+  // environment (and outside the Default baseline, which every app may draw
+  // from) is not assignable. This is a same-org, wrong-environment tool —
   // distinct from the foreign-org not_found above — so it gets a clear 400.
-  const inEnvironment = await ToolModel.isToolInEnvironment(
+  const inEnvironment = await ToolModel.isToolInEnvironmentOrDefault(
     params.toolId,
     app.environmentId,
   );

--- a/platform/backend/src/services/apps/app-assignable-tools.ts
+++ b/platform/backend/src/services/apps/app-assignable-tools.ts
@@ -23,11 +23,14 @@ import type { Tool } from "@/types";
  * over discoverable ones, and among discoverable rows the newest wins
  * (`getMcpToolsAccessibleToUser` returns them newest-first).
  *
- * Discoverable candidates are install-scoped to what the user can actually reach
- * and run; assigned tools are reachable through their assignment without a
- * separate install. Both are fenced to `environmentId` (the assignment target:
- * the org default for scaffold_app, the app's bound env for set_app_tools),
- * exclude Archestra built-ins (apps reach the data store through
+ * Discoverable candidates follow catalog visibility, not installs — a visible
+ * catalog whose server the user has not connected yet stays assignable, and the
+ * runtime surfaces the auth-required connect link per viewer; assigned tools
+ * are reachable through their assignment without a separate install. Both are
+ * fenced to `environmentId` (the assignment target: the authoring agent's env
+ * for scaffold_app — which is where the app gets bound — and the app's bound
+ * env for set_app_tools) plus the Default-environment baseline every app may
+ * draw from, exclude Archestra built-ins (apps reach the data store through
  * archestra.storage), and are RBAC-filtered the same way search/grounding are.
  */
 export async function resolveAppAssignableToolRows(params: {
@@ -60,6 +63,7 @@ export async function resolveAppAssignableToolRows(params: {
         userId,
         organizationId,
         environmentId,
+        includeDefaultEnvironment: true,
         isAdmin: await userIsCatalogAdmin(userId, organizationId),
       })
     : [];

--- a/platform/backend/src/services/apps/app-capability-context.test.ts
+++ b/platform/backend/src/services/apps/app-capability-context.test.ts
@@ -111,7 +111,7 @@ describe("buildAppCapabilityContext", () => {
     ]);
   });
 
-  test("grounds in the app's environment, not the authoring agent's", async ({
+  test("grounds in the app's environment plus the Default baseline", async ({
     makeOrganization,
     makeUser,
     makeMember,
@@ -156,9 +156,10 @@ describe("buildAppCapabilityContext", () => {
     });
 
     const names = context.tools.map((tool) => tool.name);
-    // Grounds the app-env tool, not the agent-env one.
+    // Grounds the app-env tool AND the Default-environment baseline every app
+    // may draw from.
     expect(names).toContain("prod__deploy");
-    expect(names).not.toContain("default__thing");
+    expect(names).toContain("default__thing");
   });
 
   test("describes the window.archestra SDK surface", async ({

--- a/platform/backend/src/services/apps/app-capability-context.ts
+++ b/platform/backend/src/services/apps/app-capability-context.ts
@@ -23,13 +23,14 @@ interface AppCapabilityContext {
  * assigned MCP tools plus, when the agent has dynamic access, the tools the
  * user can otherwise reach — resolved through {@link resolveAppAssignableToolRows},
  * the exact surface `resolveAppToolsByName` assigns from. Each name maps to its
- * canonical row (RBAC-filtered, install-scoped, Archestra built-ins excluded
- * because apps reach the data store through archestra.storage), so the grounding
- * lists exactly the names that can really be attached and each description comes
- * from the row that would actually be assigned and run.
+ * canonical row (RBAC-filtered, catalog-visibility-scoped, Archestra built-ins
+ * excluded because apps reach the data store through archestra.storage), so the
+ * grounding lists exactly the names that can really be attached and each
+ * description comes from the row that would actually be assigned and run.
  *
- * Grounding resolves in the *app's* `environmentId`, not the authoring agent's:
- * an app is bound to a deliberate environment (e.g. staging/prod) and its tools
+ * Grounding resolves in the *app's* `environmentId` (plus the Default-
+ * environment baseline every app may draw from), not the authoring agent's: an
+ * app is bound to a deliberate environment (e.g. staging/prod) and its tools
  * are assigned (set_app_tools) and executed (runtime gate) there, so the
  * capability list must reflect that environment even when the agent editing the
  * app runs in a different one.

--- a/platform/backend/src/services/apps/app-tool-runtime-gate.test.ts
+++ b/platform/backend/src/services/apps/app-tool-runtime-gate.test.ts
@@ -116,44 +116,9 @@ test("refuses a tool not assigned to the app", async ({
   if (!decision.allowed) expect(decision.reason).toContain("not assigned");
 });
 
-test("refuses an assigned tool whose catalog is outside the app's bound environment", async ({
-  makeOrganization,
-  makeUser,
-  makeApp,
-  makeInternalMcpCatalog,
-  makeTool,
-  makeAppTool,
-}) => {
-  // The tool has no policy, so the env fence (which runs before policy) is the
-  // only thing that can refuse here.
-  const org = await makeOrganization();
-  const user = await makeUser();
-  const prod = await EnvironmentModel.create({
-    organizationId: org.id,
-    name: "production",
-  });
-  // The app's environment is derived from its backing catalog (FR-30); the
-  // fixture routes environmentId there.
-  const app = await makeApp({ organizationId: org.id, environmentId: prod.id });
-  // The tool's catalog is in the default (null) environment — not prod.
-  const catalog = await makeInternalMcpCatalog({ organizationId: org.id });
-  const tool = await makeTool({
-    name: `hf__search_${crypto.randomUUID().slice(0, 8)}`,
-    catalogId: catalog.id,
-  });
-  await makeAppTool(app.id, tool.id);
-
-  const decision = await gateAppToolCall({
-    appId: app.id,
-    organizationId: org.id,
-    userId: user.id,
-    toolName: tool.name,
-    toolInput: {},
-    ...BASE,
-  });
-  expect(decision.allowed).toBe(false);
-  if (!decision.allowed) expect(decision.reason).toContain("environment");
-});
+// A Default-environment tool on an env-bound app is ALLOWED (the org baseline)
+// — see "allows an assigned Default-environment tool on an env-bound app"
+// below; only tools from a different non-default environment are refused.
 
 test("refuses a management Archestra tool, allows the reserved app built-ins", async ({
   makeOrganization,
@@ -470,6 +435,44 @@ test("refuses an assigned tool whose catalog left the app's environment", async 
   expect(decision.allowed === false && decision.reason).toContain(
     "environment",
   );
+});
+
+test("allows an assigned Default-environment tool on an env-bound app", async ({
+  makeOrganization,
+  makeUser,
+  makeApp,
+  makeInternalMcpCatalog,
+  makeTool,
+  makeAppTool,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  const prod = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: "production",
+  });
+  // App bound to prod; the assigned tool's catalog is in the Default
+  // environment (null) — the org baseline every app may draw from, so the
+  // call-time gate allows it (mirroring the assignment fence).
+  const app = await makeApp({ organizationId: org.id, environmentId: prod.id });
+  const defaultCatalog = await makeInternalMcpCatalog({
+    organizationId: org.id,
+  });
+  const tool = await makeTool({
+    name: `base__y_${crypto.randomUUID().slice(0, 8)}`,
+    catalogId: defaultCatalog.id,
+  });
+  await makeAppTool(app.id, tool.id);
+
+  const decision = await gateAppToolCall({
+    appId: app.id,
+    organizationId: org.id,
+    userId: user.id,
+    toolName: tool.name,
+    toolInput: {},
+    ...BASE,
+  });
+  expect(decision.allowed).toBe(true);
 });
 
 test("allows an assigned tool in the app's bound environment", async ({

--- a/platform/backend/src/services/apps/app-tool-runtime-gate.ts
+++ b/platform/backend/src/services/apps/app-tool-runtime-gate.ts
@@ -100,8 +100,9 @@ export async function gateAppToolCall(params: {
   // Environment fence: a tool whose catalog left the app's bound environment is
   // refused at call time even though its assignment row remains
   // (re-binding an app does not strip assignments). Reuses the same predicate as
-  // the assignment fence so the two never diverge. Only upstream tools reach
-  // here — app-runtime built-ins returned above are environment-less.
+  // the assignment fence so the two never diverge; Default-environment tools
+  // are the org baseline and pass for any app environment. Only upstream tools
+  // reach here — app-runtime built-ins returned above are environment-less.
   const app = await AppModel.findById(appId);
   if (!app) {
     return {
@@ -110,7 +111,9 @@ export async function gateAppToolCall(params: {
       reason: `App "${appId}" not found.`,
     };
   }
-  if (!(await ToolModel.isToolInEnvironment(tool.id, app.environmentId))) {
+  if (
+    !(await ToolModel.isToolInEnvironmentOrDefault(tool.id, app.environmentId))
+  ) {
     return {
       allowed: false,
       code: -32601,

--- a/platform/backend/src/services/environments/environment-isolation.ts
+++ b/platform/backend/src/services/environments/environment-isolation.ts
@@ -50,6 +50,29 @@ export function toolInEnvironmentPredicate(
 }
 
 /**
+ * App-surface variant of {@link toolInEnvironmentPredicate}: a tool matches when
+ * it belongs to `environmentId` OR to the Default environment (catalog
+ * `environment_id` null) — Default is the org-wide baseline every app may draw
+ * from, so an app bound to a non-default environment accepts that environment's
+ * tools plus Default's. Non-default environments stay isolated from each other.
+ * Agent/gateway discovery keeps the strict predicate; only the app fences
+ * (assignment resolution, the REST assign validation, and the app runtime gate)
+ * use this one, together, so they cannot drift apart.
+ */
+export function toolInEnvironmentOrDefaultPredicate(
+  environmentId: string | null,
+  tools = schema.toolsTable,
+): SQL {
+  if (environmentId === null) {
+    return toolInEnvironmentPredicate(null, tools);
+  }
+  return or(
+    toolInEnvironmentPredicate(null, tools),
+    toolInEnvironmentPredicate(environmentId, tools),
+  ) as SQL;
+}
+
+/**
  * SQL predicate selecting `knowledge_base_connectors` rows that belong to
  * `agentEnvironmentId`'s environment (strict equality, null = Default). There are
  * no built-in connectors, so there are no exemptions.

--- a/platform/frontend/src/app/apps/_parts/app-tools-editor.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-tools-editor.tsx
@@ -10,7 +10,7 @@ import { Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { ToolChecklist } from "@/components/agent-tools-editor";
 import {
-  isCatalogInEnvironment,
+  isCatalogInAppEnvironment,
   sortCatalogItems,
 } from "@/components/agent-tools-editor.utils";
 import { LoadingWrapper } from "@/components/loading";
@@ -150,17 +150,18 @@ export function AppToolsEditor({
     return map;
   }, [assigned]);
 
-  // Candidate servers: every one in the app's environment (Playwright is
-  // environment-agnostic like a builtin), plus any server a current assignment
-  // already references so it can be cleaned up. The Archestra builtin catalog is
-  // never assignable.
+  // Candidate servers: every one in the app's environment or the Default
+  // baseline apps may always draw from (Playwright is environment-agnostic
+  // like a builtin), plus any server a current assignment already references
+  // so it can be cleaned up. The Archestra builtin catalog is never
+  // assignable.
   const candidates = useMemo(
     () =>
       catalogs.filter((c) => {
         if (c.id === ARCHESTRA_MCP_CATALOG_ID) return false;
         const inEnv =
           isPlaywrightCatalogItem(c.id) ||
-          isCatalogInEnvironment(c, appEnvironmentId);
+          isCatalogInAppEnvironment(c, appEnvironmentId);
         return inEnv || assignedIdsByCatalog.has(c.id);
       }),
     [catalogs, appEnvironmentId, assignedIdsByCatalog],
@@ -355,7 +356,7 @@ export function AppToolsEditor({
                   assignedIdsByCatalog.get(catalog.id) ?? new Set<string>();
                 const outOfEnv =
                   !isPlaywrightCatalogItem(catalog.id) &&
-                  !isCatalogInEnvironment(catalog, appEnvironmentId);
+                  !isCatalogInAppEnvironment(catalog, appEnvironmentId);
                 return (
                   <AppMcpServerPill
                     key={catalog.id}

--- a/platform/frontend/src/components/agent-tools-editor.utils.test.ts
+++ b/platform/frontend/src/components/agent-tools-editor.utils.test.ts
@@ -14,6 +14,7 @@ import {
   computeSharedPersonalPins,
   getCatalogAssignmentGate,
   getDefaultArchestraToolIds,
+  isCatalogInAppEnvironment,
   isCatalogInEnvironment,
   shouldResetCredentialPin,
   sortAndFilterTools,
@@ -532,6 +533,26 @@ describe("isCatalogInEnvironment", () => {
   it("exempts builtin catalogs from every environment", () => {
     expect(isCatalogInEnvironment(env("env-a", "builtin"), "env-b")).toBe(true);
     expect(isCatalogInEnvironment(env(null, "builtin"), "env-a")).toBe(true);
+  });
+});
+
+describe("isCatalogInAppEnvironment", () => {
+  const env = (environmentId: string | null, serverType = "local") => ({
+    id: "c1",
+    name: "Cat",
+    serverType,
+    environmentId,
+  });
+
+  it("accepts the app's own environment and the Default baseline", () => {
+    expect(isCatalogInAppEnvironment(env("env-a"), "env-a")).toBe(true);
+    expect(isCatalogInAppEnvironment(env(null), "env-a")).toBe(true);
+    expect(isCatalogInAppEnvironment(env(null), null)).toBe(true);
+  });
+
+  it("still rejects a different non-default environment", () => {
+    expect(isCatalogInAppEnvironment(env("env-a"), "env-b")).toBe(false);
+    expect(isCatalogInAppEnvironment(env("env-a"), null)).toBe(false);
   });
 });
 

--- a/platform/frontend/src/components/agent-tools-editor.utils.ts
+++ b/platform/frontend/src/components/agent-tools-editor.utils.ts
@@ -77,6 +77,22 @@ export function isCatalogInEnvironment(
 }
 
 /**
+ * App variant of {@link isCatalogInEnvironment}: apps additionally accept the
+ * Default environment (null) as a shared baseline, so a Default catalog is
+ * assignable to an app in any environment. Mirrors the backend's
+ * toolInEnvironmentOrDefaultPredicate; agents keep the strict helper.
+ */
+export function isCatalogInAppEnvironment(
+  catalog: EnvScopedCatalog,
+  appEnvironmentId: string | null,
+): boolean {
+  return (
+    isCatalogInEnvironment(catalog, appEnvironmentId) ||
+    (catalog.environmentId ?? null) === null
+  );
+}
+
+/**
  * Whether a catalog item may be assigned to an agent in the tools picker, and
  * how it should read when it is.
  *

--- a/platform/frontend/src/components/app-session-recording/use-app-session-recorder.test.tsx
+++ b/platform/frontend/src/components/app-session-recording/use-app-session-recorder.test.tsx
@@ -15,6 +15,13 @@ import {
   useOwnAppSessionRecorder,
 } from "./use-app-session-recorder";
 
+// The recorder hard-disables outside the Apps Hackathon date window, so this
+// suite would start failing wholesale the moment the real window closes. Pin
+// the gate open — the suite tests the recorder's behavior, not the calendar.
+vi.mock("@archestra/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@archestra/shared")>()),
+  isAppsHackathonOpen: () => true,
+}));
 // The recorder assembles a bundle and writes it to the client-side store (an
 // in-memory store here, since jsdom has no IndexedDB). Mock the surrounding
 // query/app/session hooks so the surface renders without a QueryClient.

--- a/platform/frontend/src/components/mcp-app/app-settings-form.tsx
+++ b/platform/frontend/src/components/mcp-app/app-settings-form.tsx
@@ -506,7 +506,7 @@ export function AppSettingsForm({
               value={environmentId}
               onChange={setEnvironmentId}
               resource="app"
-              helpText="The app can only be assigned and call MCP tools in this environment."
+              helpText="The app can be assigned and call MCP tools from this environment plus the Default environment."
             />
 
             <div className="space-y-2">


### PR DESCRIPTION
## Problem

An agent (or MCP gateway profile) bound to a non-default environment discovers that environment's tools through `search_tools`, but `scaffold_app` resolved its `tools` param against the org default environment and created the app there, and `set_app_tools` fences to the app's bound environment. Environment matching is strict, so every tool the model had just discovered was rejected with *"Unknown tool name(s) for this organization… Use search_tools to discover available tools"* — a loop that ends with the model telling the user it cannot assign live MCP tools to the app it is building (T-977).

## Fix

- **`scaffold_app` binds the app to the authoring agent's environment** and resolves the `tools` param there — the same environment discovery runs in, so a searched tool is assignable and the runtime gate agrees. An agent without an environment (or whose row is gone) falls back to the org Default.
- **Default-environment tools become the org baseline for apps**: a tool with no environment match is still accepted when it belongs to the Default environment. One shared predicate (`toolInEnvironmentOrDefaultPredicate`) is applied across every app fence — name resolution for `scaffold_app`/`set_app_tools`, `refine_app` grounding, the REST assign validation, the app runtime call-time gate, and the runtime `tools/list` trim — so the surfaces cannot drift. Non-default environments stay isolated from each other, and agent/gateway discovery keeps the strict predicate (no visibility widening).
- The registry app Tools picker and the environment help text mirror the new matching; the environments and MCP Apps docs record the app exception.

## Tests

- New `apps.progressive-tool-loading.test.ts` pins the full model-visible pipeline (`run_tool` dispatch with the assignment gate active, member user) across Access-all-tools, custom+progressive, and environment-bound configurations — including the two scenarios that reproduced T-977 before the fix.
- Existing suites updated where the old strict-for-apps behavior was pinned (set_app_tools, capability grounding, runtime gate, assign route), with cross-environment rejection kept pinned in each.
- Verified end-to-end on a dev stack: a scaffolded app lands in the authoring agent's environment, a Default tool assigns to and runs on an environment-bound app, and sibling-environment tools stay rejected.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>