### PR TITLE
test(proxy): pin current tool-availability and refusal-shape behaviour

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -121,6 +121,29 @@ describe("AnthropicResponseAdapter", () => {
     });
   });
 
+  describe("toRefusalResponse", () => {
+    // A refusal replaces the whole message: the model's own text and any tool
+    // call that was allowed are dropped along with the blocked one, and the
+    // turn is reported as finished.
+    test("replaces all content and reports end_turn", () => {
+      const adapter = anthropicAdapterFactory.createResponseAdapter({
+        ...createMockResponse([
+          { type: "text", text: "Checking the cluster." },
+          { type: "tool_use", id: "toolu_ok", name: "allowed_tool", input: {} },
+          { type: "tool_use", id: "toolu_no", name: "blocked_tool", input: {} },
+        ]),
+        stop_reason: "tool_use",
+      });
+
+      const refusal = adapter.toRefusalResponse("refusal", "blocked message");
+
+      expect(refusal.content).toEqual([
+        { type: "text", text: "blocked message", citations: null },
+      ]);
+      expect(refusal.stop_reason).toBe("end_turn");
+    });
+  });
+
   describe("getUsage", () => {
     test("captures the 1h portion of the cache-creation split", () => {
       const response = {
@@ -147,6 +170,58 @@ describe("AnthropicResponseAdapter", () => {
         cacheWrite1hTokens: 400,
       });
     });
+  });
+});
+
+// Availability checks compare the names a caller declared against the names the
+// model called. These two adapters disagree about provider built-ins, and that
+// disagreement decides whether a call is treated as available — pinned here so
+// any change to either side is visible.
+describe("declared tools vs called tools", () => {
+  const messages = [
+    { role: "user", content: "Hello" },
+  ] as Anthropic.Types.MessagesRequest["messages"];
+
+  test("getTools omits provider built-ins, which carry a type and no input schema", () => {
+    const tools = [
+      {
+        name: "github__list_issues",
+        description: "list issues",
+        input_schema: { type: "object", properties: {} },
+      },
+      { type: "bash_20250124", name: "bash" },
+      { type: "text_editor_20250124", name: "str_replace_editor" },
+    ] as unknown as Anthropic.Types.MessagesRequest["tools"];
+
+    const adapter = anthropicAdapterFactory.createRequestAdapter(
+      createMockRequest(messages, { tools }),
+    );
+
+    expect(adapter.getTools().map((t) => t.name)).toEqual([
+      "github__list_issues",
+    ]);
+  });
+
+  test("a tool declared without a type counts as custom", () => {
+    const tools = [
+      { name: "bash", input_schema: { type: "object", properties: {} } },
+    ] as unknown as Anthropic.Types.MessagesRequest["tools"];
+
+    const adapter = anthropicAdapterFactory.createRequestAdapter(
+      createMockRequest(messages, { tools }),
+    );
+
+    expect(adapter.getTools().map((t) => t.name)).toEqual(["bash"]);
+  });
+
+  test("getToolCalls returns built-in tool calls, which getTools never lists", () => {
+    const adapter = anthropicAdapterFactory.createResponseAdapter(
+      createMockResponse([
+        { type: "tool_use", id: "toolu_bash", name: "bash", input: {} },
+      ]),
+    );
+
+    expect(adapter.getToolCalls().map((c) => c.name)).toEqual(["bash"]);
   });
 });
 
@@ -774,6 +849,36 @@ describe("AnthropicStreamAdapter policy refusal terminal", () => {
 
     expect(endEvents).toContain('"stop_reason":"end_turn"');
     expect(endEvents).not.toContain('"stop_reason":"tool_use"');
+  });
+
+  // The refusal block index is derived only from non-tool blocks, so it can
+  // land on an index a tool_use block already occupies. Harmless while those
+  // blocks stay buffered; a collision on the wire once they are forwarded.
+  test("formatCompleteTextSSE ignores tool_use indices when choosing its own", () => {
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+    adapter.processChunk({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    } as Chunk);
+    adapter.processChunk({ type: "content_block_stop", index: 0 } as Chunk);
+    adapter.processChunk({
+      type: "content_block_start",
+      index: 1,
+      content_block: {
+        type: "tool_use",
+        id: "toolu_1",
+        name: "list",
+        input: {},
+      },
+    } as Chunk);
+    adapter.processChunk({ type: "content_block_stop", index: 1 } as Chunk);
+
+    const refusal = adapter.formatCompleteTextSSE("blocked").join("");
+
+    // 2 would clear the tool_use block; 1 reuses its index.
+    expect(refusal).toContain('"index":1');
+    expect(refusal).not.toContain('"index":2');
   });
 
   test("refusal text block is placed after already-streamed blocks (no index reuse)", () => {

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -21,6 +21,7 @@ import { vi } from "vitest";
 import db, { schema } from "@/database";
 import type { PolicyBlockResult } from "@/guardrails/tool-invocation";
 import {
+  InteractionModel,
   LlmProviderApiKeyModel,
   ModelModel,
   ModelTeamModel,
@@ -1009,6 +1010,77 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       });
     });
 
+    // Same refusal condition as the Anthropic streaming case, on the other axis
+    // of the matrix: OpenAI forces `stop` through the same replaced-response
+    // path, so the turn reads as finished while a tool_call is on the wire.
+    test("a refusal after streamed tool calls closes the turn as stop", async () => {
+      openAiStubOptions.includeToolCalls = true;
+
+      mockEvaluatePolicies.mockResolvedValue({
+        refusalMessage: "Tool get_weather is not enabled here",
+        contentMessage: "Tool get_weather is not enabled here",
+        reason: "Tool invocation blocked: disabled for conversation",
+        blockedToolName: "get_weather",
+        toolInput: {},
+        allToolCallNames: ["get_weather"],
+      } satisfies PolicyBlockResult);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain("call_test_weather");
+      expect(response.body).toContain("Tool get_weather is not enabled here");
+      // Upstream closed as tool_calls; the refusal overrides it.
+      expect(response.body).toContain('"finish_reason":"stop"');
+      expect(response.body).not.toContain('"finish_reason":"tool_calls"');
+    });
+
+    // Buffered turns can still be edited when the refusal lands, and the whole
+    // message is replaced: the model's text and every tool call go with it.
+    test("a refusal replaces the entire buffered message", async () => {
+      mockEvaluatePolicies.mockResolvedValue({
+        refusalMessage: "Tool list_files is not enabled here",
+        contentMessage: "Tool list_files is not enabled here",
+        reason: "Tool invocation blocked: disabled for conversation",
+        blockedToolName: "list_files",
+        toolInput: {},
+        allToolCallNames: ["list_files"],
+      } satisfies PolicyBlockResult);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "List the files" }],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const choice = response.json().choices[0];
+      expect(choice.message.content).toBe(
+        "Tool list_files is not enabled here",
+      );
+      expect(choice.message.tool_calls).toBeUndefined();
+      expect(choice.finish_reason).toBe("stop");
+    });
+
     test("calls recordBlockedToolSpans when policy blocks tool calls", async () => {
       const blockResult: PolicyBlockResult = {
         refusalMessage: "Tool blocked by policy",
@@ -1122,6 +1194,79 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
         customPricePerMillionOutput: "15.00",
         lastSyncedAt: new Date(),
       });
+    });
+
+    // Billed spend is derived by filtering on billing_mode, so the value the
+    // handler stamps on the interaction decides whether a call is charged.
+    // It is classified from the credential format alone.
+    test.for([
+      ["sk-ant-oat-token", "subscription"],
+      ["sk-ant-api-token", "metered"],
+    ])("a %s credential persists billing_mode %s", async ([key, expected]) => {
+      mockEvaluatePolicies.mockResolvedValue(null);
+
+      await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": key,
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+
+      const interactions = await InteractionModel.getAllInteractionsForProfile(
+        testAgent.id,
+      );
+      expect(interactions).toHaveLength(1);
+      expect(interactions[0].billingMode).toBe(expected);
+    });
+
+    // The buffered counterpart on the incident's own provider: the assistant
+    // message is discarded down to the refusal text, taking the model's prose
+    // and the tool call with it.
+    test("a refusal replaces the entire buffered message", async () => {
+      anthropicStubOptions.includeToolUseNonStreaming = true;
+
+      mockEvaluatePolicies.mockResolvedValue({
+        refusalMessage: "Tool get_weather is not enabled here",
+        contentMessage: "Tool get_weather is not enabled here",
+        reason: "Tool invocation blocked: disabled for conversation",
+        blockedToolName: "get_weather",
+        toolInput: {},
+        allToolCallNames: ["get_weather"],
+      } satisfies PolicyBlockResult);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "What's the weather?" }],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.content).toEqual([
+        {
+          type: "text",
+          text: "Tool get_weather is not enabled here",
+          citations: null,
+        },
+      ]);
+      expect(body.stop_reason).toBe("end_turn");
     });
 
     // The set the handler hands to evaluatePolicies decides which model tool

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -28,6 +28,7 @@ import {
 } from "@/models";
 import { afterEach, beforeEach, describe, expect, test } from "@/test";
 import {
+  type AnthropicStubOptions,
   createAnthropicTestClient,
   createGeminiTestClient,
   createOpenAiTestClient,
@@ -61,14 +62,17 @@ vi.mock("prom-client", () => ({
 // Mock tool-invocation to control policy evaluation results.
 // Default: evaluatePolicies → null (allow), matching the real behavior when no
 // policies exist in the DB.
-const mockEvaluatePolicies = vi.fn<() => Promise<PolicyBlockResult | null>>();
+// Args are forwarded so tests can assert what the handler computed and passed
+// in (notably the availability set), not just that evaluation happened.
+const mockEvaluatePolicies =
+  vi.fn<(...args: unknown[]) => Promise<PolicyBlockResult | null>>();
 
 vi.mock("@/guardrails/tool-invocation", async (importOriginal) => {
   const original =
     await importOriginal<typeof import("@/guardrails/tool-invocation")>();
   return {
     ...original,
-    evaluatePolicies: (..._args: unknown[]) => mockEvaluatePolicies(),
+    evaluatePolicies: (...args: unknown[]) => mockEvaluatePolicies(...args),
   };
 });
 
@@ -956,10 +960,7 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
   let app: FastifyInstance;
   let testAgent: Agent;
   let openAiStubOptions: OpenAiStubOptions;
-  let anthropicStubOptions: {
-    includeToolUse?: boolean;
-    interruptAtChunk?: number;
-  };
+  let anthropicStubOptions: AnthropicStubOptions;
 
   beforeEach(async ({ makeAgent }) => {
     vi.clearAllMocks();
@@ -1121,6 +1122,86 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
         customPricePerMillionOutput: "15.00",
         lastSyncedAt: new Date(),
       });
+    });
+
+    // The set the handler hands to evaluatePolicies decides which model tool
+    // calls count as available. It is built from getTools(), which drops
+    // provider built-ins, so a caller that declares `bash` alongside a custom
+    // tool has `bash` judged unavailable.
+    test("the availability set passed to evaluatePolicies omits declared built-ins", async () => {
+      anthropicStubOptions.includeToolUse = true;
+      mockEvaluatePolicies.mockResolvedValue(null);
+
+      await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+          tools: [
+            {
+              name: "get_weather",
+              description: "weather",
+              input_schema: { type: "object", properties: {} },
+            },
+            { type: "bash_20250124", name: "bash" },
+          ],
+        },
+      });
+
+      expect(mockEvaluatePolicies).toHaveBeenCalled();
+      const enabledToolNames = mockEvaluatePolicies.mock
+        .calls[0][4] as Set<string>;
+      expect([...enabledToolNames]).toEqual(["get_weather"]);
+    });
+
+    // The shape the client actually receives when a refusal lands after tool
+    // calls have already been written to the wire. Every assertion here is the
+    // current behavior, including the parts that make the turn unanswerable:
+    // the tool_use survives with no way to resolve it, and the turn is closed
+    // as finished even though a tool_result is still owed.
+    test("a refusal after streamed tool calls leaves the tool_use on the wire and closes the turn", async () => {
+      anthropicStubOptions.includeToolUse = true;
+      anthropicStubOptions.streamStopReason = "tool_use";
+
+      mockEvaluatePolicies.mockResolvedValue({
+        refusalMessage: "Tool get_weather is not enabled here",
+        contentMessage: "Tool get_weather is not enabled here",
+        reason: "Tool invocation blocked: disabled for conversation",
+        blockedToolName: "get_weather",
+        toolInput: {},
+        allToolCallNames: ["get_weather"],
+      } satisfies PolicyBlockResult);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain("toolu_test_weather");
+      expect(response.body).toContain("Tool get_weather is not enabled here");
+      // Upstream said tool_use; the refusal overrides it.
+      expect(response.body).toContain('"stop_reason":"end_turn"');
+      expect(response.body).not.toContain('"stop_reason":"tool_use"');
     });
 
     test("calls recordBlockedToolSpans when streaming response contains blocked tool calls", async () => {

--- a/platform/backend/src/test/llm-provider-stubs.ts
+++ b/platform/backend/src/test/llm-provider-stubs.ts
@@ -23,6 +23,8 @@ export interface AnthropicStubOptions {
   zeroOutputTokens?: boolean;
   /** Report this many `cache_read_input_tokens` to exercise the fallback's cache guard. */
   cacheReadInputTokens?: number;
+  /** Terminal `message_delta` stop reason. A real turn carrying tool_use ends as `tool_use`. */
+  streamStopReason?: "end_turn" | "tool_use" | "max_tokens" | "stop_sequence";
 }
 
 export interface GeminiStubOptions {
@@ -379,7 +381,7 @@ function createAnthropicStream(options: AnthropicStubOptions) {
       type: "message_delta",
       delta: {
         container: null,
-        stop_reason: "end_turn",
+        stop_reason: options.streamStopReason ?? "end_turn",
         stop_sequence: null,
       },
       usage: {

--- a/platform/backend/src/test/llm-provider-stubs.ts
+++ b/platform/backend/src/test/llm-provider-stubs.ts
@@ -12,6 +12,8 @@ export interface OpenAiStubOptions {
    * on the wire, but before the usage-bearing final chunk arrives.
    */
   throwAtChunk?: number;
+  /** Stream a `get_weather` tool call, closing the turn as `tool_calls`. */
+  includeToolCalls?: boolean;
 }
 
 export interface AnthropicStubOptions {
@@ -25,6 +27,12 @@ export interface AnthropicStubOptions {
   cacheReadInputTokens?: number;
   /** Terminal `message_delta` stop reason. A real turn carrying tool_use ends as `tool_use`. */
   streamStopReason?: "end_turn" | "tool_use" | "max_tokens" | "stop_sequence";
+  /**
+   * Return a tool_use block from the buffered (non-streaming) response. Separate
+   * from `includeToolUse`, which existing tests set while making buffered calls
+   * that expect text.
+   */
+  includeToolUseNonStreaming?: boolean;
 }
 
 export interface GeminiStubOptions {
@@ -118,15 +126,27 @@ export function createAnthropicTestClient(options: AnthropicStubOptions = {}) {
           type: "message",
           container: null,
           role: "assistant",
-          content: [
-            {
-              type: "text",
-              text: "Hello! How can I help you today?",
-              citations: [],
-            },
-          ],
+          content: options.includeToolUseNonStreaming
+            ? [
+                { type: "text", text: "Checking the weather.", citations: [] },
+                {
+                  type: "tool_use",
+                  id: "toolu_test_weather",
+                  name: "get_weather",
+                  input: { location: "SF" },
+                },
+              ]
+            : [
+                {
+                  type: "text",
+                  text: "Hello! How can I help you today?",
+                  citations: [],
+                },
+              ],
           model: "claude-3-5-sonnet-20241022",
-          stop_reason: "end_turn",
+          stop_reason: options.includeToolUseNonStreaming
+            ? "tool_use"
+            : "end_turn",
           stop_sequence: null,
           usage: {
             input_tokens: options.zeroInputTokens ? 0 : 12,
@@ -184,7 +204,100 @@ export function createGeminiTestClient(options: GeminiStubOptions = {}) {
   };
 }
 
+/** Same iteration semantics (throwAtChunk / interruptAtChunk) over any chunk list. */
+function openAiStreamOver(
+  chunks: OpenAI.Chat.Completions.ChatCompletionChunk[],
+  options: OpenAiStubOptions,
+) {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0;
+      return {
+        async next() {
+          if (
+            options.throwAtChunk !== undefined &&
+            index === options.throwAtChunk
+          ) {
+            throw new Error("Simulated OpenAI stream failure before usage");
+          }
+          if (
+            options.interruptAtChunk !== undefined &&
+            index === options.interruptAtChunk
+          ) {
+            return { done: true, value: undefined };
+          }
+          if (index < chunks.length) {
+            return { done: false, value: chunks[index++] };
+          }
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+}
+
 function createOpenAiStream(options: OpenAiStubOptions) {
+  if (options.includeToolCalls) {
+    return openAiStreamOver(
+      [
+        {
+          id: "chatcmpl-test-openai",
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: "gpt-4o",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_test_weather",
+                    type: "function",
+                    function: { name: "get_weather", arguments: "" },
+                  },
+                ],
+              },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-test-openai",
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: "gpt-4o",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: { arguments: '{"location":"SF"}' },
+                  },
+                ],
+              },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-test-openai",
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: "gpt-4o",
+          choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+          usage: { prompt_tokens: 12, completion_tokens: 10, total_tokens: 22 },
+        },
+      ] as OpenAI.Chat.Completions.ChatCompletionChunk[],
+      options,
+    );
+  }
+
   const chunks: OpenAI.Chat.Completions.ChatCompletionChunk[] = [
     {
       id: "chatcmpl-test-openai",


### PR DESCRIPTION
## Summary

The Anthropic proxy path decides whether a model's tool call is available by comparing the names a caller declared against the names the model called. Those two sets come from different adapter methods with different inclusion rules, and when they disagree the proxy rewrites the assistant message — dropping content, appending a text steer, and overriding the turn's stop reason. None of that was covered by a test, so a change to any of it would land invisibly.

These tests capture the behaviour as it stands, deliberately including the parts that are wrong: `getTools()` omitting provider built-ins that `getToolCalls()` does report, a refusal replacing the entire message rather than the blocked call, the refusal text block taking a content-block index a `tool_use` block already holds, and a streamed turn closing as `end_turn` while a `tool_result` is still owed for a call the client can see. Pinning them first means the forthcoming fix demonstrates its behaviour change in its own diff instead of asserting it in prose.

Two fixture changes reach beyond this PR. `evaluatePolicies` was mocked with its arguments discarded, so no test in that file could assert the availability set the handler builds — only that evaluation happened; arguments are now forwarded. The Anthropic stream stub gained an optional terminal stop reason, because it previously always ended as `end_turn`, which left the proxy's override of that field unobservable.

No product code changes.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>