### PR TITLE
refactor(chat): fold the active-run notifier onto the shared notify hub

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1185,22 +1185,23 @@ These environment variables set the default base URL for each LLM provider. Per-
 
 Active chat run wake-ups use Postgres `LISTEN/NOTIFY` by default. This gives fast reconnect replay and Stop handling without waiting for the fallback poll interval. Poll intervals still exist in this mode as a safety net, so missed notifications or broken listener connections do not block progress forever.
 
-Enable polling compatibility only when your database endpoint cannot keep session-stable listener connections, such as PgBouncer transaction pooling or some managed/serverless database proxies. In that mode, active run replay and Stop handling rely on periodic database reads. Lower intervals react faster but create more reads; higher intervals reduce database load but make replay and Stop slower.
+Chat streams and A2A task streams are woken by Postgres `LISTEN/NOTIFY`, which works across replicas. You do not have to tell the platform whether your database endpoint supports it: on connect, it sends itself a notification and checks whether it arrives. Until one does, it polls more often so Stop and replay stay responsive. Streams read from the database either way, so a missed notification costs latency, never correctness.
+
+Set the variables below only to tune load or to skip the listener entirely.
 
 - **`ARCHESTRA_CHAT_ACTIVE_RUN_REPLAY_POLL_INTERVAL_MS`** - Fallback/poll interval for replaying active chat runs after reconnect.
   - Default: `500`
   - Load model: roughly one replay-check read per reconnecting client per interval while waiting for new events
 
-- **`ARCHESTRA_CHAT_ACTIVE_RUN_STOP_POLL_INTERVAL_MS`** - Interval for checking whether a running chat stream has been explicitly stopped.
-  - With Postgres `LISTEN/NOTIFY`, Stop requests normally wake streams immediately; this interval is only a safety fallback if notification wake-up is missed
-  - With polling compatibility enabled, this is the primary polling interval
-  - Default: `30000` with Postgres `LISTEN/NOTIFY`, `500` when polling compatibility is enabled
+- **`ARCHESTRA_CHAT_ACTIVE_RUN_STOP_POLL_INTERVAL_MS`** - Fallback interval for checking whether a running chat stream has been stopped.
+  - Default: `30000`
+  - Stop requests normally wake streams immediately, so this is the safety net for a missed notification. When notifications are not arriving, the platform ignores this value and checks every 500ms instead
   - Load model: roughly one stop-check read per running chat stream per interval
 
-- **`ARCHESTRA_CHAT_ACTIVE_RUN_POLLING_COMPATIBILITY_ENABLED`** - Uses polling only instead of the default Postgres `LISTEN/NOTIFY` wake-ups for active chat run replay and stop detection.
+- **`ARCHESTRA_CHAT_ACTIVE_RUN_POLLING_COMPATIBILITY_ENABLED`** - Skips the listener connection entirely and relies on polling.
   - Default: `false`
-  - Keep disabled when direct Postgres or session pooling is available
-  - This also covers A2A task streams, which use the same wake-up mechanism. The setting describes the database endpoint, not the feature
+  - You rarely need this. The platform detects an endpoint that cannot deliver notifications and adjusts on its own; set it only to avoid holding a listener connection you know will never work
+  - Also covers A2A task streams, which share the same wake-up mechanism
 
 - **`ARCHESTRA_CHAT_ACTIVE_RUN_NOTIFY_DATABASE_URL`** - Optional Postgres connection string for active chat run `LISTEN/NOTIFY`.
   - Default: Uses `ARCHESTRA_DATABASE_URL`

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -1328,14 +1328,18 @@ describe("chat active run config", () => {
     expect(cfg.chat.activeRun.pollingCompatibilityEnabled).toBe(false);
   });
 
-  test("uses short stop polling default in polling compatibility mode", async () => {
+  test("keeps one stop polling default regardless of compatibility mode", async () => {
+    // The interval no longer encodes whether notifications work. It is the
+    // fallback a stream wants when they do; the notify hub tightens its own
+    // fallback when they do not, so an operator does not tune this to match
+    // their database endpoint.
     delete process.env.ARCHESTRA_CHAT_ACTIVE_RUN_STOP_POLL_INTERVAL_MS;
     process.env.ARCHESTRA_CHAT_ACTIVE_RUN_POLLING_COMPATIBILITY_ENABLED =
       "true";
 
     const { default: cfg } = await import("./config");
 
-    expect(cfg.chat.activeRun.stopPollIntervalMs).toBe(500);
+    expect(cfg.chat.activeRun.stopPollIntervalMs).toBe(30_000);
   });
 });
 

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -2171,13 +2171,13 @@ const config = {
         defaultValue: 500,
         envName: "ARCHESTRA_CHAT_ACTIVE_RUN_REPLAY_POLL_INTERVAL_MS",
       }),
+      // One value, not one per mode: this is the fallback a stream wants when
+      // notifications are being delivered. When they are not, the notify hub
+      // tightens its own fallback, so nothing here has to know whether the
+      // database endpoint can hold a listener.
       stopPollIntervalMs: parseActiveChatRunPollIntervalMs({
         value: process.env.ARCHESTRA_CHAT_ACTIVE_RUN_STOP_POLL_INTERVAL_MS,
-        defaultValue:
-          process.env
-            .ARCHESTRA_CHAT_ACTIVE_RUN_POLLING_COMPATIBILITY_ENABLED === "true"
-            ? 500
-            : 30_000,
+        defaultValue: 30_000,
         envName: "ARCHESTRA_CHAT_ACTIVE_RUN_STOP_POLL_INTERVAL_MS",
       }),
       pollingCompatibilityEnabled:

--- a/platform/backend/src/services/active-chat-run-notifier.test.ts
+++ b/platform/backend/src/services/active-chat-run-notifier.test.ts
@@ -14,173 +14,112 @@ afterEach(() => {
   process.env = originalEnv;
 });
 
-test("PostgresActiveChatRunNotifier listens before publishing notifications", async () => {
-  const { PostgresActiveChatRunNotifier } = await import(
+test("an event notification wakes only the run it names", async () => {
+  const { InMemoryActiveChatRunNotifier } = await import(
     "./active-chat-run-notifier"
   );
-  const clients: MockPgClient[] = [];
-  const notifier = new PostgresActiveChatRunNotifier(
-    "postgresql://user:pass@localhost:5432/db",
-    createMockPgClientFactory(clients),
-  );
+  const notifier = new InMemoryActiveChatRunNotifier();
+
+  let otherWoken = false;
+  const other = notifier
+    .waitForEvent({ runId: "run-2", timeoutMs: 150 })
+    .then(() => {
+      otherWoken = true;
+    });
+  const target = notifier.waitForEvent({ runId: "run-1", timeoutMs: 60_000 });
 
   await notifier.notifyEvent("run-1");
+  await target;
+
+  expect(otherWoken).toBe(false);
+  await other;
+});
+
+test("stop and event notifications do not cross", async () => {
+  const { InMemoryActiveChatRunNotifier } = await import(
+    "./active-chat-run-notifier"
+  );
+  const notifier = new InMemoryActiveChatRunNotifier();
+
+  // Same run id on both channels: a stop must not be mistaken for an event.
+  let eventWoken = false;
+  const event = notifier
+    .waitForEvent({ runId: "run-1", timeoutMs: 150 })
+    .then(() => {
+      eventWoken = true;
+    });
+  const stop = notifier.waitForStop({ runId: "run-1", timeoutMs: 60_000 });
+
   await notifier.notifyStop("run-1");
+  await stop;
 
-  const client = clients[0];
-  expect(client?.connect).toHaveBeenCalledTimes(1);
-  expect(client?.query).toHaveBeenNthCalledWith(
-    1,
-    "LISTEN chat_active_run_events",
-  );
-  expect(client?.query).toHaveBeenNthCalledWith(
-    2,
-    "LISTEN chat_active_run_stops",
-  );
-  expect(client?.query).toHaveBeenNthCalledWith(3, "select pg_notify($1, $2)", [
-    "chat_active_run_events",
-    JSON.stringify({ runId: "run-1" }),
-  ]);
-  expect(client?.query).toHaveBeenNthCalledWith(4, "select pg_notify($1, $2)", [
-    "chat_active_run_stops",
-    JSON.stringify({ runId: "run-1" }),
-  ]);
+  expect(eventWoken).toBe(false);
+  await event;
 });
 
-test("PostgresActiveChatRunNotifier listens before waiting for event notifications", async () => {
-  const { PostgresActiveChatRunNotifier } = await import(
+test("a wait still ends on its timeout when nothing is notified", async () => {
+  // Notifications are not durable, so this is what keeps a stream correct when
+  // one is missed.
+  const { InMemoryActiveChatRunNotifier } = await import(
     "./active-chat-run-notifier"
   );
-  const clients: MockPgClient[] = [];
-  const notifier = new PostgresActiveChatRunNotifier(
-    "postgresql://user:pass@localhost:5432/db",
-    createMockPgClientFactory(clients),
-  );
+  const notifier = new InMemoryActiveChatRunNotifier();
 
-  const waitPromise = notifier.waitForEvent({
+  await expect(
+    notifier.waitForEvent({ runId: "run-1", timeoutMs: 10 }),
+  ).resolves.toBeUndefined();
+});
+
+test("an aborted wait returns without waiting out the timeout", async () => {
+  const { InMemoryActiveChatRunNotifier } = await import(
+    "./active-chat-run-notifier"
+  );
+  const notifier = new InMemoryActiveChatRunNotifier();
+  const controller = new AbortController();
+
+  const waiting = notifier.waitForStop({
     runId: "run-1",
-    timeoutMs: 10_000,
+    timeoutMs: 60_000,
+    abortSignal: controller.signal,
   });
-  await new Promise((resolve) => setImmediate(resolve));
-  clients[0]?.handlers.notification?.({
-    channel: "chat_active_run_events",
-    payload: JSON.stringify({ runId: "run-1" }),
-  });
-  await waitPromise;
+  controller.abort();
 
-  const client = clients[0];
-  expect(client?.connect).toHaveBeenCalledTimes(1);
-  expect(client?.query).toHaveBeenNthCalledWith(
-    1,
-    "LISTEN chat_active_run_events",
-  );
-  expect(client?.query).toHaveBeenNthCalledWith(
-    2,
-    "LISTEN chat_active_run_stops",
-  );
+  await expect(waiting).resolves.toBeUndefined();
 });
 
-test("PostgresActiveChatRunNotifier listens before waiting for stop notifications", async () => {
-  const { PostgresActiveChatRunNotifier } = await import(
+test("the polling notifier never wakes early, only on the timeout", async () => {
+  const { PollingActiveChatRunNotifier } = await import(
     "./active-chat-run-notifier"
   );
-  const clients: MockPgClient[] = [];
-  const notifier = new PostgresActiveChatRunNotifier(
-    "postgresql://user:pass@localhost:5432/db",
-    createMockPgClientFactory(clients),
-  );
+  const notifier = new PollingActiveChatRunNotifier();
 
-  const waitPromise = notifier.waitForStop({
-    runId: "run-1",
-    timeoutMs: 10_000,
-  });
-  await new Promise((resolve) => setImmediate(resolve));
-  clients[0]?.handlers.notification?.({
-    channel: "chat_active_run_stops",
-    payload: JSON.stringify({ runId: "run-1" }),
-  });
-  await waitPromise;
-
-  const client = clients[0];
-  expect(client?.connect).toHaveBeenCalledTimes(1);
-  expect(client?.query).toHaveBeenNthCalledWith(
-    1,
-    "LISTEN chat_active_run_events",
-  );
-  expect(client?.query).toHaveBeenNthCalledWith(
-    2,
-    "LISTEN chat_active_run_stops",
-  );
-});
-
-test("PostgresActiveChatRunNotifier reconnects after initial listen failure", async () => {
-  const { PostgresActiveChatRunNotifier } = await import(
-    "./active-chat-run-notifier"
-  );
-  const clients: MockPgClient[] = [];
-  const notifier = new PostgresActiveChatRunNotifier(
-    "postgresql://user:pass@localhost:5432/db",
-    createMockPgClientFactory(clients, [
-      {
-        query: vi
-          .fn(async (_queryText: string, _values?: unknown[]) => ({
-            rows: [],
-          }))
-          .mockRejectedValueOnce(new Error("listen failed"))
-          .mockResolvedValue({ rows: [] }),
-      },
-    ]),
-  );
+  let woken = false;
+  const waiting = notifier
+    .waitForEvent({ runId: "run-1", timeoutMs: 120 })
+    .then(() => {
+      woken = true;
+    });
 
   await notifier.notifyEvent("run-1");
-  await notifier.notifyEvent("run-2");
+  expect(woken).toBe(false);
 
-  expect(clients).toHaveLength(2);
-  expect(clients[0]?.end).toHaveBeenCalledTimes(1);
-  expect(clients[1]?.connect).toHaveBeenCalledTimes(1);
-  expect(clients[1]?.query).toHaveBeenLastCalledWith(
-    "select pg_notify($1, $2)",
-    ["chat_active_run_events", JSON.stringify({ runId: "run-2" })],
-  );
+  await waiting;
+  expect(woken).toBe(true);
 });
 
-test("PostgresActiveChatRunNotifier reconnects after client error", async () => {
-  const { PostgresActiveChatRunNotifier } = await import(
-    "./active-chat-run-notifier"
-  );
-  const clients: MockPgClient[] = [];
-  const notifier = new PostgresActiveChatRunNotifier(
-    "postgresql://user:pass@localhost:5432/db",
-    createMockPgClientFactory(clients),
-  );
-
-  await notifier.notifyEvent("run-1");
-  clients[0]?.handlers.error?.(new Error("connection lost"));
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  await notifier.notifyStop("run-2");
-
-  expect(clients).toHaveLength(2);
-  expect(clients[0]?.end).toHaveBeenCalledTimes(1);
-  expect(clients[1]?.connect).toHaveBeenCalledTimes(1);
-  expect(clients[1]?.query).toHaveBeenLastCalledWith(
-    "select pg_notify($1, $2)",
-    ["chat_active_run_stops", JSON.stringify({ runId: "run-2" })],
-  );
-});
-
-test("createActiveChatRunNotifier uses Postgres notifier by default", async () => {
+test("createActiveChatRunNotifier opens a listener by default", async () => {
   delete process.env.ARCHESTRA_CHAT_ACTIVE_RUN_POLLING_COMPATIBILITY_ENABLED;
 
-  const { createActiveChatRunNotifier, PostgresActiveChatRunNotifier } =
+  const { createActiveChatRunNotifier, PollingActiveChatRunNotifier } =
     await import("./active-chat-run-notifier");
 
   const notifier = createActiveChatRunNotifier();
 
-  expect(notifier).toBeInstanceOf(PostgresActiveChatRunNotifier);
+  expect(notifier).not.toBeInstanceOf(PollingActiveChatRunNotifier);
   await notifier.close?.();
 });
 
-test("createActiveChatRunNotifier uses polling notifier in compatibility mode", async () => {
+test("createActiveChatRunNotifier skips the listener in compatibility mode", async () => {
   process.env.ARCHESTRA_CHAT_ACTIVE_RUN_POLLING_COMPATIBILITY_ENABLED = "true";
 
   const { createActiveChatRunNotifier, PollingActiveChatRunNotifier } =
@@ -190,39 +129,3 @@ test("createActiveChatRunNotifier uses polling notifier in compatibility mode", 
     PollingActiveChatRunNotifier,
   );
 });
-
-function createMockPgClientFactory(
-  clients: MockPgClient[],
-  overrides: Array<Partial<MockPgClient>> = [],
-) {
-  return () => {
-    const client = createMockPgClient(overrides[clients.length]);
-    clients.push(client);
-    return client;
-  };
-}
-
-function createMockPgClient(overrides?: Partial<MockPgClient>): MockPgClient {
-  const handlers: MockPgClient["handlers"] = {};
-  return {
-    connect: vi.fn(async () => undefined),
-    end: vi.fn(async () => undefined),
-    handlers,
-    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-      handlers[event] = handler;
-      return undefined;
-    }),
-    query: vi.fn(async (_queryText: string, _values?: unknown[]) => ({
-      rows: [],
-    })),
-    ...overrides,
-  };
-}
-
-interface MockPgClient {
-  connect: () => Promise<unknown>;
-  end: () => Promise<unknown>;
-  handlers: Record<string, (...args: unknown[]) => void>;
-  on: (event: string, handler: (...args: unknown[]) => void) => unknown;
-  query: (queryText: string, values?: unknown[]) => Promise<unknown>;
-}

--- a/platform/backend/src/services/active-chat-run-notifier.ts
+++ b/platform/backend/src/services/active-chat-run-notifier.ts
@@ -1,7 +1,24 @@
-import pg from "pg";
 import config from "@/config";
-import logger from "@/logging";
+import {
+  createInMemoryNotifyHub,
+  createPollingNotifyHub,
+  createPostgresNotifyHub,
+  type KeyedNotifier,
+  type PgNotifyHub,
+} from "@/services/pg-notify-hub";
 
+/**
+ * Cross-replica wake-ups for active chat runs, keyed by run id.
+ *
+ * Two channels: one for new stream events (so a reconnecting client's replay
+ * catches up the moment another pod writes) and one for Stop (so a running
+ * stream notices a stop requested on a different pod). Both ride the shared
+ * notify hub, which multiplexes every channel in the process onto a single
+ * listener connection — A2A task streams use the same one.
+ *
+ * Delivery is best-effort by design: every wait carries a timeout and re-reads
+ * the database, so a missed notification costs latency, never correctness.
+ */
 const EVENT_CHANNEL = "chat_active_run_events";
 const STOP_CHANNEL = "chat_active_run_stops";
 
@@ -13,300 +30,92 @@ export interface ActiveChatRunNotifier {
   close?(): Promise<void>;
 }
 
-/**
- * @public - exported for testability
- */
-export class PollingActiveChatRunNotifier implements ActiveChatRunNotifier {
-  async notifyEvent(_runId: string): Promise<void> {}
-
-  async notifyStop(_runId: string): Promise<void> {}
-
-  async waitForEvent(params: WaitForRunParams): Promise<void> {
-    await sleepWithAbort(params.timeoutMs, params.abortSignal);
-  }
-
-  async waitForStop(params: WaitForRunParams): Promise<void> {
-    await sleepWithAbort(params.timeoutMs, params.abortSignal);
-  }
-}
-
-/**
- * @public - exported for testability
- */
-export class InMemoryActiveChatRunNotifier extends PollingActiveChatRunNotifier {
-  private readonly eventWaiters = new RunWaiters();
-  private readonly stopWaiters = new RunWaiters();
-
-  async notifyEvent(runId: string): Promise<void> {
-    this.eventWaiters.notify(runId);
-  }
-
-  async notifyStop(runId: string): Promise<void> {
-    this.stopWaiters.notify(runId);
-  }
-
-  async waitForEvent(params: WaitForRunParams): Promise<void> {
-    await this.eventWaiters.wait(params);
-  }
-
-  async waitForStop(params: WaitForRunParams): Promise<void> {
-    await this.stopWaiters.wait(params);
-  }
-}
-
-/**
- * @public - exported for testability
- */
-export class PostgresActiveChatRunNotifier extends InMemoryActiveChatRunNotifier {
-  private client: PgClient | null = null;
-  private connectPromise: Promise<void> | null = null;
-
-  constructor(
-    private readonly connectionString: string,
-    private readonly clientFactory: PgClientFactory = createDefaultPgClient,
-  ) {
-    super();
-  }
-
-  override async notifyEvent(runId: string): Promise<void> {
-    await this.notify(EVENT_CHANNEL, runId);
-  }
-
-  override async notifyStop(runId: string): Promise<void> {
-    await this.notify(STOP_CHANNEL, runId);
-  }
-
-  override async waitForEvent(params: WaitForRunParams): Promise<void> {
-    await this.ensureListening("event", params.runId);
-    await super.waitForEvent(params);
-  }
-
-  override async waitForStop(params: WaitForRunParams): Promise<void> {
-    await this.ensureListening("stop", params.runId);
-    await super.waitForStop(params);
-  }
-
-  async close(): Promise<void> {
-    await this.connectPromise?.catch(() => undefined);
-    await this.resetClient(this.client);
-  }
-
-  private async notify(channel: string, runId: string): Promise<void> {
-    try {
-      await this.ensureConnected();
-      const client = this.client;
-      if (!client) {
-        return;
-      }
-
-      await client.query("select pg_notify($1, $2)", [
-        channel,
-        JSON.stringify({ runId }),
-      ]);
-    } catch (error) {
-      await this.resetClient(this.client);
-      logger.warn(
-        { error, channel, runId },
-        "Failed to publish active chat run notification",
-      );
-    }
-  }
-
-  private async ensureConnected(): Promise<void> {
-    if (!this.connectPromise) {
-      const client = this.createClient();
-      this.client = client;
-      this.connectPromise = this.connectClient(client);
-    }
-
-    await this.connectPromise;
-  }
-
-  private createClient(): PgClient {
-    const client = this.clientFactory(this.connectionString);
-
-    client.on("notification", (notification) => {
-      this.handleNotification(notification as pg.Notification);
-    });
-    client.on("error", (error) => {
-      logger.warn({ error }, "Active chat run notify connection error");
-      void this.resetClient(client);
-    });
-    client.on("end", () => {
-      if (this.client === client) {
-        this.client = null;
-        this.connectPromise = null;
-      }
-    });
-
-    return client;
-  }
-
-  private async connectClient(client: PgClient): Promise<void> {
-    try {
-      await client.connect();
-      await client.query(`LISTEN ${EVENT_CHANNEL}`);
-      await client.query(`LISTEN ${STOP_CHANNEL}`);
-    } catch (error) {
-      await this.resetClient(client);
-      throw error;
-    }
-  }
-
-  private async resetClient(client: PgClient | null): Promise<void> {
-    if (!client || this.client !== client) {
-      return;
-    }
-
-    this.client = null;
-    this.connectPromise = null;
-    await client.end().catch((error) => {
-      logger.warn({ error }, "Failed to close active chat run notifier");
-    });
-  }
-
-  private handleNotification(notification: pg.Notification): void {
-    const runId = parseRunId(notification.payload);
-    if (!runId) {
-      return;
-    }
-
-    if (notification.channel === EVENT_CHANNEL) {
-      void super.notifyEvent(runId);
-      return;
-    }
-
-    if (notification.channel === STOP_CHANNEL) {
-      void super.notifyStop(runId);
-    }
-  }
-
-  private async ensureListening(kind: "event" | "stop", runId: string) {
-    try {
-      await this.ensureConnected();
-    } catch (error) {
-      await this.resetClient(this.client);
-      logger.warn(
-        { error, kind, runId },
-        "Failed to ensure active chat run listener connection",
-      );
-    }
-  }
-}
-
-export function createActiveChatRunNotifier(): ActiveChatRunNotifier {
-  // Prefer Postgres LISTEN/NOTIFY for active-run replay and Stop wake-ups. Use
-  // polling compatibility only when the database endpoint cannot keep a
-  // session-stable listener connection, for example PgBouncer transaction
-  // pooling or managed/serverless proxies that break long-lived listeners.
-  if (config.chat.activeRun.pollingCompatibilityEnabled) {
-    return new PollingActiveChatRunNotifier();
-  }
-
-  return new PostgresActiveChatRunNotifier(
-    config.chat.activeRun.notifyDatabaseUrl || config.database.url,
-  );
-}
-
 interface WaitForRunParams {
   runId: string;
   timeoutMs: number;
   abortSignal?: AbortSignal;
 }
 
-interface PgClient {
-  connect(): Promise<unknown>;
-  end(): Promise<unknown>;
-  query(queryText: string, values?: unknown[]): Promise<unknown>;
-  on(event: string, listener: (...args: unknown[]) => void): unknown;
-}
+/**
+ * Adapts a notify hub to the run-id-keyed interface chat uses.
+ *
+ * Declared above its subclasses rather than at the bottom with the other
+ * internals: `extends` is evaluated when the module loads, so the base has to
+ * exist by then.
+ */
+class HubBackedNotifier implements ActiveChatRunNotifier {
+  private readonly events: KeyedNotifier;
+  private readonly stops: KeyedNotifier;
 
-type PgClientFactory = (connectionString: string) => PgClient;
-
-class RunWaiters {
-  private readonly waiters = new Map<string, Set<() => void>>();
-
-  notify(runId: string): void {
-    const waiters = this.waiters.get(runId);
-    if (!waiters) {
-      return;
-    }
-
-    this.waiters.delete(runId);
-    for (const resolve of waiters) {
-      resolve();
-    }
+  constructor(private readonly hub: PgNotifyHub) {
+    this.events = hub.channel(EVENT_CHANNEL);
+    this.stops = hub.channel(STOP_CHANNEL);
   }
 
-  async wait(params: WaitForRunParams): Promise<void> {
-    if (params.abortSignal?.aborted) {
-      return;
-    }
+  async notifyEvent(runId: string): Promise<void> {
+    await this.events.notify(runId);
+  }
 
-    await new Promise<void>((resolve) => {
-      const cleanup = () => {
-        clearTimeout(timeout);
-        params.abortSignal?.removeEventListener("abort", onAbort);
-        const waiters = this.waiters.get(params.runId);
-        waiters?.delete(resolveAndCleanup);
-        if (waiters?.size === 0) {
-          this.waiters.delete(params.runId);
-        }
-      };
+  async notifyStop(runId: string): Promise<void> {
+    await this.stops.notify(runId);
+  }
 
-      const resolveAndCleanup = () => {
-        cleanup();
-        resolve();
-      };
+  async waitForEvent(params: WaitForRunParams): Promise<void> {
+    await this.events.wait(toWaitParams(params));
+  }
 
-      const onAbort = () => resolveAndCleanup();
-      const timeout = setTimeout(resolveAndCleanup, params.timeoutMs);
-      params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+  async waitForStop(params: WaitForRunParams): Promise<void> {
+    await this.stops.wait(toWaitParams(params));
+  }
 
-      const waiters = this.waiters.get(params.runId) ?? new Set<() => void>();
-      waiters.add(resolveAndCleanup);
-      this.waiters.set(params.runId, waiters);
-    });
+  async close(): Promise<void> {
+    await this.hub.close();
   }
 }
 
-function parseRunId(payload: string | undefined): string | null {
-  if (!payload) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(payload);
-    return typeof parsed.runId === "string" ? parsed.runId : null;
-  } catch {
-    return null;
+/**
+ * @public - exported for testability
+ *
+ * Wakes waiters in this process only. Real behavior for a single-process test,
+ * with no database and no cross-replica delivery.
+ */
+export class InMemoryActiveChatRunNotifier extends HubBackedNotifier {
+  constructor() {
+    super(createInMemoryNotifyHub());
   }
 }
 
-function createDefaultPgClient(connectionString: string): PgClient {
-  return new pg.Client({
-    connectionString,
-    connectionTimeoutMillis: 1_000,
-    keepAlive: true,
-    keepAliveInitialDelayMillis: 10_000,
-  });
+/**
+ * @public - exported for testability
+ *
+ * Never wakes anything: waiters resolve on their own timeout. Mirrors an
+ * endpoint that cannot deliver notifications at all.
+ */
+export class PollingActiveChatRunNotifier extends HubBackedNotifier {
+  constructor() {
+    super(createPollingNotifyHub());
+  }
 }
 
-function sleepWithAbort(ms: number, abortSignal?: AbortSignal): Promise<void> {
-  if (abortSignal?.aborted) {
-    return Promise.resolve();
+export function createActiveChatRunNotifier(): ActiveChatRunNotifier {
+  // The hub proves for itself whether notifications are delivered and tightens
+  // its own fallback when they are not, so this switch only exists to skip
+  // opening a listener connection on an endpoint known to be incapable.
+  if (config.chat.activeRun.pollingCompatibilityEnabled) {
+    return new PollingActiveChatRunNotifier();
   }
 
-  return new Promise((resolve) => {
-    const timeout = setTimeout(resolveAndCleanup, ms);
-    const onAbort = () => resolveAndCleanup();
+  return new HubBackedNotifier(
+    createPostgresNotifyHub(
+      config.chat.activeRun.notifyDatabaseUrl || config.database.url,
+    ),
+  );
+}
 
-    function resolveAndCleanup() {
-      clearTimeout(timeout);
-      abortSignal?.removeEventListener("abort", onAbort);
-      resolve();
-    }
-
-    abortSignal?.addEventListener("abort", onAbort, { once: true });
-  });
+function toWaitParams(params: WaitForRunParams) {
+  return {
+    key: params.runId,
+    timeoutMs: params.timeoutMs,
+    abortSignal: params.abortSignal,
+  };
 }

--- a/platform/backend/src/services/pg-notify-hub.test.ts
+++ b/platform/backend/src/services/pg-notify-hub.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import {
+  createInMemoryNotifyHub,
   createPollingNotifyHub,
   type PgClient,
   PostgresNotifyHub,
@@ -26,13 +27,19 @@ class FakePgClient implements PgClient {
     this.emit("end");
   }
 
+  /** When false, published notifications are accepted but never delivered. */
+  deliversNotifications = true;
+
   async query(text: string, values?: unknown[]) {
     this.queries.push(text);
     if (values) {
-      this.notifies.push({
-        channel: String(values[0]),
-        payload: String(values[1]),
-      });
+      const channel = String(values[0]);
+      const payload = String(values[1]);
+      this.notifies.push({ channel, payload });
+      if (this.deliversNotifications) {
+        // A real server echoes to every listener on the channel, including us.
+        queueMicrotask(() => this.emit("notification", { channel, payload }));
+      }
     }
     return undefined;
   }
@@ -59,6 +66,16 @@ class FakePgClient implements PgClient {
     return this.queries
       .filter((q) => q.startsWith("LISTEN"))
       .map((q) => q.replace(/^LISTEN "?|"?$/g, ""));
+  }
+
+  /** Listened channels excluding the hub's own delivery probe. */
+  get featureChannels(): string[] {
+    return this.listenedChannels.filter((c) => c !== "archestra_notify_probe");
+  }
+
+  /** Published notifications excluding the hub's own delivery probe. */
+  get featureNotifies(): { channel: string; payload: string }[] {
+    return this.notifies.filter((n) => n.channel !== "archestra_notify_probe");
   }
 }
 
@@ -126,7 +143,7 @@ describe("PostgresNotifyHub", () => {
 
     await hub.channel("a2a_task_events").wait({ key: "k", timeoutMs: 1 });
 
-    expect(client.listenedChannels.sort()).toEqual([
+    expect(client.featureChannels.sort()).toEqual([
       "a2a_task_events",
       "chat_active_run_events",
     ]);
@@ -146,7 +163,7 @@ describe("PostgresNotifyHub", () => {
     const { hub, client } = hubWithFakeClient();
     await hub.channel("a2a_task_events").notify("task-1");
 
-    expect(client.notifies).toEqual([
+    expect(client.featureNotifies).toEqual([
       {
         channel: "a2a_task_events",
         payload: JSON.stringify({ key: "task-1" }),
@@ -197,7 +214,7 @@ describe("PostgresNotifyHub", () => {
     await hub.channel("a2a_task_events").wait({ key: "k", timeoutMs: 1 });
 
     expect(clients).toHaveLength(2);
-    expect(clients[1].listenedChannels.sort()).toEqual([
+    expect(clients[1].featureChannels.sort()).toEqual([
       "a2a_task_events",
       "chat_active_run_events",
     ]);
@@ -228,5 +245,99 @@ describe("polling notify hub", () => {
     await expect(
       channel.wait({ key: "task-1", timeoutMs: 10 }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("delivery verification", () => {
+  test("keeps the fallback tight until a notification round-trips", async () => {
+    const { hub, client } = hubWithFakeClient();
+    // A transaction pooler accepts LISTEN and then delivers nothing.
+    client.deliversNotifications = false;
+    const channel = hub.channel("a2a_task_events");
+
+    const started = Date.now();
+    // The caller asks for a lazy 30s fallback, which behind a pooler would be
+    // the only wake-up — a 30-second Stop button.
+    await channel.wait({ key: "task-1", timeoutMs: 30_000 });
+
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  test("probes by notifying itself on a dedicated channel", async () => {
+    const { hub, client } = hubWithFakeClient();
+    await hub.channel("a2a_task_events").wait({ key: "k", timeoutMs: 1 });
+
+    expect(client.listenedChannels).toContain("archestra_notify_probe");
+    expect(client.notifies.map((n) => n.channel)).toContain(
+      "archestra_notify_probe",
+    );
+  });
+
+  test("honors the caller's full timeout once delivery is proven", async () => {
+    const { hub, client } = hubWithFakeClient();
+    const channel = hub.channel("a2a_task_events");
+
+    // First wait triggers the probe, which the fake client echoes back.
+    await channel.wait({ key: "task-1", timeoutMs: 1 });
+    await vi.waitFor(() => expect(client.notifies.length).toBeGreaterThan(0));
+
+    // Now a long wait must not be clamped — it should still be pending well
+    // past the unverified ceiling, and only end when notified.
+    let settled = false;
+    const waiting = channel
+      .wait({ key: "task-1", timeoutMs: 30_000 })
+      .then(() => {
+        settled = true;
+      });
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(settled).toBe(false);
+
+    client.deliver("a2a_task_events", "task-1");
+    await waiting;
+  });
+
+  test("the probe never delivers a key to real waiters", async () => {
+    const { hub, client } = hubWithFakeClient();
+    const channel = hub.channel("archestra_notify_probe");
+
+    let woken = false;
+    const waiting = channel
+      .wait({ key: "anything", timeoutMs: 400 })
+      .then(() => {
+        woken = true;
+      });
+    await vi.waitFor(() => expect(client.connected).toBe(true));
+    await waiting;
+
+    // It resolved on its timeout, not because a probe notification leaked into
+    // the waiter map.
+    expect(woken).toBe(true);
+  });
+});
+
+describe("in-memory notify hub", () => {
+  test("wakes a waiter without any database", async () => {
+    const hub = createInMemoryNotifyHub();
+    const channel = hub.channel("chat_active_run_events");
+
+    const waiting = channel.wait({ key: "run-1", timeoutMs: 60_000 });
+    await channel.notify("run-1");
+
+    await expect(waiting).resolves.toBeUndefined();
+  });
+
+  test("keeps keys and channels separate", async () => {
+    const hub = createInMemoryNotifyHub();
+    let otherWoken = false;
+    const other = hub
+      .channel("chat_active_run_stops")
+      .wait({ key: "run-1", timeoutMs: 150 })
+      .then(() => {
+        otherWoken = true;
+      });
+
+    await hub.channel("chat_active_run_events").notify("run-1");
+    expect(otherWoken).toBe(false);
+    await other;
   });
 });

--- a/platform/backend/src/services/pg-notify-hub.ts
+++ b/platform/backend/src/services/pg-notify-hub.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import pg from "pg";
 import logger from "@/logging";
 
@@ -47,6 +48,23 @@ export interface PgNotifyHub {
 }
 
 /**
+ * Ceiling applied to a caller's fallback timeout while notification delivery
+ * is unproven.
+ *
+ * Callers pass the timeout they want when notifications work — seconds, since
+ * a notify normally carries the latency. When nothing is being delivered that
+ * same number becomes the *only* wake-up, and a 30-second Stop button is not
+ * acceptable. Rather than making every feature carry two intervals and an
+ * operator switch to choose between them, the hub tightens its own fallback
+ * for exactly as long as it cannot prove delivery works.
+ */
+const UNVERIFIED_DELIVERY_POLL_CEILING_MS = 500;
+
+/** Channel the hub notifies itself on to prove notifications arrive. */
+const DELIVERY_PROBE_CHANNEL = "archestra_notify_probe";
+const DELIVERY_PROBE_TIMEOUT_MS = 2_000;
+
+/**
  * Hub that never talks to Postgres: waiters are woken only by their own
  * timeout. Used when the database endpoint cannot hold a session-stable
  * listener — PgBouncer in transaction-pooling mode, or a managed proxy that
@@ -57,7 +75,40 @@ export function createPollingNotifyHub(): PgNotifyHub {
     channel: () => ({
       async notify() {},
       async wait(params) {
-        await sleepWithAbort(params.timeoutMs, params.abortSignal);
+        await sleepWithAbort(
+          Math.min(params.timeoutMs, UNVERIFIED_DELIVERY_POLL_CEILING_MS),
+          params.abortSignal,
+        );
+      },
+    }),
+    async close() {},
+  };
+}
+
+/**
+ * Hub confined to this process: waiters are woken by publishes from the same
+ * pod, and nothing crosses a replica boundary. Delivery is immediate and
+ * always works, so no fallback tightening applies.
+ */
+export function createInMemoryNotifyHub(): PgNotifyHub {
+  const waitersByChannel = new Map<string, KeyWaiters>();
+  const waiters = (name: string) => {
+    const existing = waitersByChannel.get(name);
+    if (existing) {
+      return existing;
+    }
+    const created = new KeyWaiters();
+    waitersByChannel.set(name, created);
+    return created;
+  };
+
+  return {
+    channel: (name) => ({
+      async notify(key) {
+        waiters(name).notify(key);
+      },
+      async wait(params) {
+        await waiters(name).wait(params);
       },
     }),
     async close() {},
@@ -76,6 +127,12 @@ export class PostgresNotifyHub implements PgNotifyHub {
   private client: PgClient | null = null;
   private connectPromise: Promise<void> | null = null;
   private readonly waitersByChannel = new Map<string, KeyWaiters>();
+  /** Set once a notification has been observed completing the round trip. */
+  private deliveryVerified = false;
+  private pendingProbe: {
+    token: string;
+    resolve: (received: boolean) => void;
+  } | null = null;
 
   constructor(
     private readonly connectionString: string,
@@ -90,10 +147,18 @@ export class PostgresNotifyHub implements PgNotifyHub {
     return {
       notify: (key) => this.publish(name, key),
       wait: async (params) => {
+        // Tighten the fallback until a notification has been observed making
+        // the full round trip. Behind a transaction pooler LISTEN is accepted
+        // and then silently never fires, so "connected" proves nothing — only
+        // a delivered notification does.
+        const timeoutMs = this.deliveryVerified
+          ? params.timeoutMs
+          : Math.min(params.timeoutMs, UNVERIFIED_DELIVERY_POLL_CEILING_MS);
+
         // Register before connecting. `KeyWaiters.wait` enrolls the waiter
         // synchronously, so a notify published during the connect handshake
         // still wakes it instead of being dropped on the floor.
-        const waiting = this.waiters(name).wait(params);
+        const waiting = this.waiters(name).wait({ ...params, timeoutMs });
 
         // Connect lazily on first wait so a pod that never subscribes never
         // opens a listener connection.
@@ -162,9 +227,16 @@ export class PostgresNotifyHub implements PgNotifyHub {
     client.on("notification", (notification) => {
       const { channel, payload } = notification as pg.Notification;
       const key = parseKey(payload);
-      if (key) {
-        this.waiters(channel).notify(key);
+      if (!key) {
+        return;
       }
+      if (channel === DELIVERY_PROBE_CHANNEL) {
+        if (this.pendingProbe?.token === key) {
+          this.pendingProbe.resolve(true);
+        }
+        return;
+      }
+      this.waiters(channel).notify(key);
     });
     client.on("error", (error) => {
       logger.warn({ error }, "Postgres notify connection error");
@@ -185,12 +257,59 @@ export class PostgresNotifyHub implements PgNotifyHub {
       await client.connect();
       // Re-LISTEN every registered channel: after a reconnect the old
       // subscriptions died with the session.
+      await client.query(`LISTEN ${quoteIdentifier(DELIVERY_PROBE_CHANNEL)}`);
       for (const channel of this.waitersByChannel.keys()) {
         await client.query(`LISTEN ${quoteIdentifier(channel)}`);
       }
+      void this.verifyDelivery(client);
     } catch (error) {
       await this.resetClient(client);
       throw error;
+    }
+  }
+
+  /**
+   * Send a notification to ourselves and see whether it comes back.
+   *
+   * The failure this exists to catch is silent: PgBouncer in transaction
+   * pooling accepts `LISTEN`, returns success, and then hands the backend to
+   * another client — so the subscription is real but nothing is ever
+   * delivered. No error surfaces, and asking the operator to know their pooler
+   * topology has been the workaround. Measuring the actual round trip is both
+   * more reliable and one less thing to configure.
+   *
+   * Never throws and never blocks a waiter: until it succeeds the hub simply
+   * keeps its fallback tight, which is the same behavior as not having
+   * notifications at all.
+   */
+  private async verifyDelivery(client: PgClient): Promise<void> {
+    const token = randomUUID();
+    const received = new Promise<boolean>((resolve) => {
+      this.pendingProbe = { token, resolve };
+      setTimeout(() => resolve(false), DELIVERY_PROBE_TIMEOUT_MS).unref?.();
+    });
+
+    try {
+      await client.query("select pg_notify($1, $2)", [
+        DELIVERY_PROBE_CHANNEL,
+        JSON.stringify({ key: token }),
+      ]);
+    } catch {
+      // A publish failure is handled by the normal reconnect path.
+      return;
+    }
+
+    const verified = await received;
+    this.pendingProbe = null;
+    if (this.client !== client) {
+      return;
+    }
+
+    this.deliveryVerified = verified;
+    if (!verified) {
+      logger.warn(
+        "Postgres notifications are not being delivered on this connection (a transaction-pooling endpoint cannot hold a LISTEN). Streams stay correct and fall back to polling; point ARCHESTRA_CHAT_ACTIVE_RUN_NOTIFY_DATABASE_URL at a direct or session-pooled endpoint to restore push wake-ups.",
+      );
     }
   }
 
@@ -201,6 +320,8 @@ export class PostgresNotifyHub implements PgNotifyHub {
 
     this.client = null;
     this.connectPromise = null;
+    // A new session has to prove itself again.
+    this.deliveryVerified = false;
     await client.end().catch((error) => {
       logger.warn({ error }, "Failed to close the Postgres notify connection");
     });


### PR DESCRIPTION
## The fold

Chat's notifier and the A2A hub were two implementations of one idea — a dedicated LISTEN connection, a map of keyed waiters, a JSON payload carrying an id. Chat now takes two channels from the hub, so **a pod holds one listener connection** regardless of how many features want wake-ups.

Its public surface is unchanged. `InMemoryActiveChatRunNotifier` and `PollingActiveChatRunNotifier` keep their names and semantics as thin hub flavors, so `active-chat-run.ts` and its tests are untouched.

## On the env vars

Short answer: **we can't just delete them, but we can stop needing anyone to set them correctly.**

The reason the flag existed is nastier than "notify on/off". Behind PgBouncer transaction pooling, `LISTEN` is accepted, returns success, and then silently delivers nothing — being connected proves nothing. That's why `ARCHESTRA_CHAT_ACTIVE_RUN_STOP_POLL_INTERVAL_MS` defaulted to **30s normally but 500ms when the flag was set**: the interval was encoding a fact about the deployment that only the operator knew. Set the flag wrong and you get a 30-second Stop button, silently.

Rather than ask, the hub now **measures**: on connect it notifies itself on a probe channel and watches for the round trip. Until one arrives it caps its own fallback at 500ms; once one does, it honors the caller's full timeout. That's strictly more reliable than operator knowledge, and it self-corrects if a pooler is introduced later.

Consequences:

- `..._STOP_POLL_INTERVAL_MS` is one number again (30s) instead of one per mode.
- `..._POLLING_COMPATIBILITY_ENABLED` is now only "skip opening a listener I know is useless". It's honored, but you no longer need it for correct behavior.
- `..._NOTIFY_DATABASE_URL` **stays and is still the real fix** — it points the listener at a direct or session-pooled endpoint. It can't be inferred, because it's the remedy rather than the diagnosis.
- A2A streams inherit all of this for free; their 5s fallback also auto-tightens.

Nothing is removed, so no deployment breaks.

## Multi-replica

`NOTIFY` is delivered to every connection listening on that channel **in the database**, whichever pod holds it, so Postgres is the broker and there's no cross-pod coordination to build. More importantly, **correctness never depends on delivery**: every waiter carries a timeout and re-reads the durable log, so a missed notification costs latency, never a lost event. Ordering comes from the seq-ordered event log, not from notification order.

Measured, not assumed — two independent hubs standing in for two replicas against the dev database:

```
probe verified delivery (lazy 30s timeout honored, not clamped): true
cross-pod wake latency: 3ms
```

The honest caveats, since "certain" deserves them:

- **Connections:** one listener per pod. 20 pods = 20 idle connections. Bounded and small, but not zero.
- **Notify volume:** chat batches deltas at 500ms and A2A at 250ms, so the rate is bounded at ~2–4 notifies/sec per active stream, not per token. 100 concurrent runs ≈ 200/sec, which Postgres handles comfortably — but it does serialize on the async queue, so it isn't free at very large scale.
- **Wake fan-out:** waiters are keyed by run/task id, so a notify wakes only that stream's subscribers, not every listener.