### PR TITLE
fix(chat): stop a stranded assistant message from rendering the turn twice

### DIFF
--- a/platform/backend/src/routes/chat/routes.ts
+++ b/platform/backend/src/routes/chat/routes.ts
@@ -1222,6 +1222,14 @@ const chatRoutes: FastifyPluginAsyncZod = async (fastify) => {
                         writer.write({
                           type: CONTEXT_WINDOW_BREAKDOWN_EVENT,
                           data: updatedBreakdown satisfies ContextWindowBreakdown,
+                          // Transient like the pre-stream estimate above: the
+                          // panel reads it from onData state, so keeping it out
+                          // of the message list is what the client expects. A
+                          // non-transient copy would be appended to the
+                          // assistant message once per tool step — persisted,
+                          // re-appended on every replay, and one more chance for
+                          // the SDK to open a message of its own to hold it.
+                          transient: true,
                         });
                       } catch (error) {
                         logger.warn(

--- a/platform/backend/src/routes/chat/stream-route.test.ts
+++ b/platform/backend/src/routes/chat/stream-route.test.ts
@@ -2511,6 +2511,51 @@ describe("POST /api/chat handler composition", () => {
     );
   });
 
+  test("marks every context-window data part transient, including the per-step re-emit", async ({
+    expect,
+  }) => {
+    const response = await postMessage();
+    expect(response.statusCode).toBe(200);
+    await executionPromise;
+
+    // A tool-call step re-emits the breakdown with the provider's real input
+    // count. onStepFinish only emits once a result is committed, which the
+    // awaited execution above has done.
+    const streamConfig = mockStreamText.mock.calls.at(-1)?.[0] as {
+      onStepFinish?: (step: unknown) => Promise<void> | void;
+    };
+    await streamConfig.onStepFinish?.({
+      usage: { inputTokens: 1200, outputTokens: 10, totalTokens: 1210 },
+      finishReason: "tool-calls",
+      toolCalls: [],
+    });
+
+    const breakdownWrites = writerEvents.filter(
+      (event) =>
+        event.kind === "write" &&
+        (event.value as { type?: string })?.type ===
+          "data-context-window-breakdown",
+    );
+    // Both the pre-stream breakdown and the post-step re-emit.
+    expect(breakdownWrites.length).toBeGreaterThan(1);
+
+    // Every one of these carries UI state the client reads via onData. A
+    // non-transient copy lands in the assistant message instead, where it is
+    // persisted, re-appended on each replay, and — when it arrives before the
+    // stream's `start` chunk — makes the AI SDK open a message of its own to
+    // hold it, which renders the turn twice.
+    const uiStateWrites = writerEvents.filter(
+      (event) =>
+        event.kind === "write" &&
+        /^data-context-(window|compaction)/.test(
+          (event.value as { type?: string })?.type ?? "",
+        ),
+    );
+    for (const write of uiStateWrites) {
+      expect(write.value).toMatchObject({ transient: true });
+    }
+  });
+
   test("emits compaction start/finish and context-window-estimate events in order, before the stream merge", async () => {
     mockCompactMessagesForChat.mockImplementation(
       async ({

--- a/platform/frontend/src/lib/chat/chat-session-utils.test.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.test.ts
@@ -2,6 +2,7 @@ import type { UIMessage } from "@ai-sdk/react";
 import { describe, expect, test } from "vitest";
 import {
   pruneEmptyTrailingAssistantMessage,
+  pruneStrandedAssistantMessages,
   restoreRenderableAssistantParts,
   shouldFreezeChatMessages,
 } from "./chat-session-utils";
@@ -381,6 +382,60 @@ describe("pruneEmptyTrailingAssistantMessage", () => {
     ] as UIMessage[];
 
     expect(pruneEmptyTrailingAssistantMessage(messages)).toEqual(messages);
+  });
+});
+
+describe("pruneStrandedAssistantMessages", () => {
+  const userMessage = {
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "how much was spent on ads?" }],
+  } as UIMessage;
+  // What the AI SDK opens under a client-generated id to hold a data part that
+  // arrives before the stream's `start` chunk, then abandons when `start` names
+  // the real message.
+  const telemetryOnlyAssistant = {
+    id: "client-generated",
+    role: "assistant",
+    parts: [
+      { type: "data-context-window-estimate", data: { estimatedTokens: 12 } },
+      { type: "data-context-window-breakdown", data: { totalTokens: 12 } },
+    ],
+  } as unknown as UIMessage;
+  const answeredAssistant = {
+    id: "srv-1",
+    role: "assistant",
+    parts: [
+      { type: "reasoning", text: "weighing" },
+      { type: "text", text: "about $4,000" },
+    ],
+  } as UIMessage;
+
+  test("drops a telemetry-only assistant message the turn has moved past", () => {
+    expect(
+      pruneStrandedAssistantMessages([
+        userMessage,
+        telemetryOnlyAssistant,
+        answeredAssistant,
+      ]),
+    ).toEqual([userMessage, answeredAssistant]);
+  });
+
+  test("keeps a content-free assistant message while it is the turn in flight", () => {
+    // The live message legitimately has no renderable content yet: the stream
+    // has only sent `start`/`step-start` so far.
+    const streaming = [
+      userMessage,
+      { id: "srv-1", role: "assistant", parts: [{ type: "step-start" }] },
+    ] as UIMessage[];
+
+    expect(pruneStrandedAssistantMessages(streaming)).toBe(streaming);
+  });
+
+  test("returns the same reference when nothing is stranded", () => {
+    const messages = [userMessage, answeredAssistant];
+
+    expect(pruneStrandedAssistantMessages(messages)).toBe(messages);
   });
 });
 

--- a/platform/frontend/src/lib/chat/chat-session-utils.ts
+++ b/platform/frontend/src/lib/chat/chat-session-utils.ts
@@ -122,6 +122,44 @@ export function shouldFreezeChatMessages(params: {
 }
 
 /**
+ * Drops assistant messages that carry no renderable content and can no longer be
+ * the turn in flight.
+ *
+ * The AI SDK opens an assistant message to hold any non-transient data part that
+ * arrives before a stream's `start` chunk, keyed by a client-generated id. When
+ * `start` then names the real message, the SDK renames its streaming state and
+ * pushes a *second* message, abandoning the first — which is left holding only
+ * telemetry parts (context-window estimate/breakdown, compaction events, token
+ * usage). It renders nothing, so the turn still looks right, but it stays in
+ * chat state as a real message: the next request sends it as the trailing
+ * message and a recovery's `regenerate()` anchors on it, so the backend reuses
+ * its id (`getResponseUIMessageId` reuses a trailing assistant's id) and streams
+ * the whole turn into a second message beside the first. Every further attach
+ * adds another, which is how one turn ends up rendered twice over.
+ *
+ * The backend never persists a content-free assistant message, which is why a
+ * reload clears the duplicates; this keeps the live list on that same rule. The
+ * last message is exempt — a turn that is still streaming legitimately has no
+ * renderable content yet.
+ */
+export function pruneStrandedAssistantMessages(
+  messages: UIMessage[],
+): UIMessage[] {
+  const isStranded = (message: UIMessage, index: number) =>
+    index < messages.length - 1 &&
+    message.role === "assistant" &&
+    !hasRenderableAssistantContent(message);
+
+  // Returning the same reference when nothing is stranded keeps the caller's
+  // message identity stable, so this never churns a render on its own.
+  if (!messages.some(isStranded)) {
+    return messages;
+  }
+
+  return messages.filter((message, index) => !isStranded(message, index));
+}
+
+/**
  * Drops a trailing assistant message left with no renderable content. Mirrors the
  * backend's persist behavior (an empty last message is not stored), keeping the live
  * view consistent with what a reload would show — used after stripping dangling tool

--- a/platform/frontend/src/lib/chat/global-chat.context.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.test.tsx
@@ -1078,9 +1078,14 @@ describe("ChatProvider retries", () => {
     // regenerate({messageId}) synchronously truncates it up to and including
     // the user anchor before requesting (AbstractChat.regenerate slices
     // state.messages in the same task).
-    mocks.setMessages.mockImplementation((next: UIMessage[]) => {
-      liveMessages.current = next;
-    });
+    mocks.setMessages.mockImplementation(
+      (next: UIMessage[] | ((current: UIMessage[]) => UIMessage[])) => {
+        // Both forms, like the SDK: callers pass a list or an updater run
+        // against the live list.
+        liveMessages.current =
+          typeof next === "function" ? next(liveMessages.current) : next;
+      },
+    );
     mocks.regenerate.mockImplementation(
       async ({ messageId }: { messageId: string }) => {
         const index = liveMessages.current.findIndex((m) => m.id === messageId);

--- a/platform/frontend/src/lib/chat/global-chat.context.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.context.tsx
@@ -54,6 +54,7 @@ import {
 } from "@/lib/chat/chat-retry.utils";
 import {
   pruneEmptyTrailingAssistantMessage,
+  pruneStrandedAssistantMessages,
   restoreRenderableAssistantParts,
   shouldFreezeChatMessages,
 } from "@/lib/chat/chat-session-utils";
@@ -1045,6 +1046,31 @@ function ChatSessionHook({
       recordResponseProgress();
     }
   }, [messages, status, recordResponseProgress]);
+
+  // A content-free assistant message the SDK opened to hold a data part that
+  // arrived before the stream's `start` chunk must not outlive the turn: left in
+  // chat state it becomes what the next request sends as its trailing message
+  // and what a recovery's regenerate() anchors on, and the backend then reuses
+  // its id — streaming the whole turn into a second message beside the first
+  // (see pruneStrandedAssistantMessages). Pruning only once the stream has
+  // settled keeps this off the live stream's back: nothing is writing to the
+  // message list then, so it cannot fight the turn in flight.
+  useEffect(() => {
+    if (status === "submitted" || status === "streaming") {
+      return;
+    }
+    setMessages((current) => {
+      const pruned = pruneStrandedAssistantMessages(current);
+      if (pruned === current) {
+        return current;
+      }
+      // restoreRenderableAssistantParts reads previousMessagesRef to spot a
+      // streaming regression; sync it so this deliberate shrink is not mistaken
+      // for one and resurrected on the next render.
+      previousMessagesRef.current = pruned;
+      return pruned;
+    });
+  }, [status, setMessages]);
 
   const resumeAttemptedRef = useRef(false);
   useEffect(() => {

--- a/platform/frontend/src/lib/chat/global-chat.phantom-assistant-message.test.tsx
+++ b/platform/frontend/src/lib/chat/global-chat.phantom-assistant-message.test.tsx
@@ -1,0 +1,329 @@
+import type { UIMessage } from "@ai-sdk/react";
+import { render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppName } from "@/lib/hooks/use-app-name";
+import { ChatProvider, useGlobalChat } from "./global-chat.context";
+
+// These exercise the REAL `ai` / `@ai-sdk/react` against a scripted stream: the
+// defect lives in how the SDK turns wire chunks into its message list, which a
+// mocked `useChat` (see global-chat.context.test.tsx) cannot reproduce. Only
+// `fetch` is stubbed.
+
+const mocks = vi.hoisted(() => ({
+  clearChatErrors: vi.fn(),
+  getQueryData: vi.fn(),
+  invalidateQueries: vi.fn(),
+  mutate: vi.fn(),
+  mutateAsync: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+vi.mock("@tanstack/react-query", () => {
+  const queryClient = {
+    getQueryData: mocks.getQueryData,
+    invalidateQueries: mocks.invalidateQueries,
+  };
+  return {
+    useQueryClient: () => queryClient,
+    useMutation: () => ({ mutateAsync: mocks.mutateAsync }),
+  };
+});
+
+vi.mock("@/lib/chat/chat.query", () => ({
+  useGenerateConversationTitle: () => ({
+    isPending: false,
+    mutate: mocks.mutate,
+  }),
+  useResolveChatMcpElicitation: () => ({
+    isPending: false,
+    mutateAsync: mocks.mutateAsync,
+  }),
+  useClearChatErrors: () => ({ mutateAsync: mocks.clearChatErrors }),
+  useConversation: () => ({ data: null }),
+  useConversationUpdatedCacheSync: () => {},
+}));
+
+vi.mock("@/components/chat/mcp-elicitation-dialog", () => ({
+  McpElicitationDialog: () => null,
+}));
+
+vi.mock("@/lib/hooks/use-app-name");
+
+vi.mock("@/lib/config/config", () => ({
+  default: { enterpriseFeatures: { fullWhiteLabeling: false } },
+}));
+
+vi.mock("@/lib/config/config.query", () => ({ useFeature: () => false }));
+
+const CONVERSATION_ID = "conversation-phantom";
+const SERVER_MESSAGE_ID = "srv-assistant-1";
+
+type ScriptedStream = {
+  emit: (chunk: Record<string, unknown>) => void;
+  close: () => void;
+  fail: (error: Error) => void;
+};
+
+function sseResponse(): { response: Response; stream: ScriptedStream } {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    response: new Response(body, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    }),
+    stream: {
+      emit: (chunk) =>
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`),
+        ),
+      close: () => controller.close(),
+      fail: (error) => controller.error(error),
+    },
+  };
+}
+
+/** The turn the backend streams: telemetry data parts, then the real content. */
+function emitPreStartTelemetry(stream: ScriptedStream) {
+  // Written by the route before the model stream's `start` chunk. Non-transient
+  // here on purpose: that is the shape this regression is about, and the client
+  // must survive it whatever a given backend build marks.
+  stream.emit({
+    type: "data-context-window-estimate",
+    data: { estimatedTokens: 1234 },
+  });
+  stream.emit({
+    type: "data-context-window-breakdown",
+    data: { totalTokens: 1234, categories: [] },
+  });
+}
+
+function emitTurn(stream: ScriptedStream, messageId: string) {
+  stream.emit({ type: "start", messageId });
+  stream.emit({ type: "start-step" });
+  stream.emit({ type: "reasoning-start", id: "reasoning-0" });
+  stream.emit({
+    type: "reasoning-delta",
+    id: "reasoning-0",
+    delta: "weighing",
+  });
+  stream.emit({ type: "reasoning-end", id: "reasoning-0" });
+  stream.emit({ type: "text-start", id: "txt-0" });
+  stream.emit({ type: "text-delta", id: "txt-0", delta: "the answer" });
+}
+
+function finishTurn(stream: ScriptedStream) {
+  stream.emit({ type: "text-end", id: "txt-0" });
+  stream.emit({ type: "finish-step" });
+  stream.emit({ type: "finish" });
+  stream.close();
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const assistantMessages = (messages: UIMessage[]) =>
+  messages.filter((message) => message.role === "assistant");
+
+function RegisterAndSend({ prompt }: { prompt: string }) {
+  const { registerSession, getSession } = useGlobalChat();
+  const session = getSession(CONVERSATION_ID);
+
+  useEffect(() => {
+    registerSession({ conversationId: CONVERSATION_ID, initialMessages: [] });
+  }, [registerSession]);
+
+  const sendMessage = session?.sendMessage;
+  useEffect(() => {
+    if (!sendMessage) {
+      return;
+    }
+    sendMessage({ role: "user", parts: [{ type: "text", text: prompt }] });
+  }, [sendMessage, prompt]);
+
+  return null;
+}
+
+describe("phantom assistant messages", () => {
+  let sessions: Array<
+    ReturnType<ReturnType<typeof useGlobalChat>["getSession"]>
+  >;
+  let chatRequests: Array<{ url: string; body: Record<string, unknown> }>;
+
+  const latestMessages = () => sessions.at(-1)?.messages ?? [];
+
+  function CaptureSession() {
+    const { getSession } = useGlobalChat();
+    const session = getSession(CONVERSATION_ID);
+    useEffect(() => {
+      if (session) {
+        sessions.push(session);
+      }
+    }, [session]);
+    return null;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAppName).mockReturnValue("Archestra");
+    mocks.clearChatErrors.mockResolvedValue({ success: true });
+    mocks.mutateAsync.mockResolvedValue({});
+    sessions = [];
+    chatRequests = [];
+  });
+
+  it("keeps a single assistant message when telemetry arrives before the stream's start chunk", async () => {
+    const first = sseResponse();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown, init?: RequestInit) => {
+        const url = String(
+          typeof input === "string" ? input : (input as Request)?.url,
+        );
+        chatRequests.push({
+          url,
+          body: JSON.parse(String(init?.body ?? "{}")),
+        });
+        return first.response;
+      }),
+    );
+
+    render(
+      <ChatProvider>
+        <RegisterAndSend prompt="how much was spent on ads?" />
+        <CaptureSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(chatRequests).toHaveLength(1));
+
+    emitPreStartTelemetry(first.stream);
+    emitTurn(first.stream, SERVER_MESSAGE_ID);
+    await waitFor(() =>
+      expect(
+        latestMessages().some((message) =>
+          message.parts.some(
+            (part) => part.type === "text" && part.text === "the answer",
+          ),
+        ),
+      ).toBe(true),
+    );
+    finishTurn(first.stream);
+
+    await waitFor(() => expect(sessions.at(-1)?.status).toBe("ready"));
+
+    // One user turn answered once: the message the SDK opened to hold the
+    // pre-start telemetry must not survive beside the real one.
+    await waitFor(() => {
+      const assistants = assistantMessages(latestMessages());
+      expect(assistants.map((message) => message.id)).toEqual([
+        SERVER_MESSAGE_ID,
+      ]);
+    });
+  });
+
+  it("renders the turn once when a severed stream is recovered by the active-run replay", async () => {
+    const first = sseResponse();
+    let replay: ScriptedStream | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown, init?: RequestInit) => {
+        const url = String(
+          typeof input === "string" ? input : (input as Request)?.url,
+        );
+        chatRequests.push({
+          url,
+          body: JSON.parse(String(init?.body ?? "{}")),
+        });
+        if (chatRequests.length === 1) {
+          return first.response;
+        }
+        // The auto-retry re-POSTs into the still-live run, so the backend
+        // answers the duplicate-run 409 and the session reattaches to the
+        // active-run replay — which re-sends the run from its first chunk.
+        if (url.includes("/active-run")) {
+          const replayed = sseResponse();
+          replay = replayed.stream;
+          return replayed.response;
+        }
+        return new Response(
+          JSON.stringify({
+            error: {
+              message:
+                "This conversation already has an active response. Stop it before sending another message.",
+              type: "api_conflict_error",
+            },
+          }),
+          { status: 409, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+
+    render(
+      <ChatProvider>
+        <RegisterAndSend prompt="how much was spent on ads?" />
+        <CaptureSession />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(chatRequests).toHaveLength(1));
+
+    emitPreStartTelemetry(first.stream);
+    emitTurn(first.stream, SERVER_MESSAGE_ID);
+    await waitFor(() =>
+      expect(
+        latestMessages().some((message) =>
+          message.parts.some(
+            (part) => part.type === "text" && part.text === "the answer",
+          ),
+        ),
+      ).toBe(true),
+    );
+
+    // The connection dies while the backend keeps generating.
+    first.stream.fail(new TypeError("network error"));
+
+    // The session auto-retries 1.5s later; that resend must re-run the user's
+    // turn, not adopt a telemetry-only assistant message as the turn to
+    // continue — the server would then reuse its id and stream the whole turn
+    // into a second message beside the first.
+    await waitFor(() => expect(chatRequests.length).toBeGreaterThan(1), {
+      timeout: 5000,
+    });
+    const resentMessages = chatRequests[1].body.messages as UIMessage[];
+    expect(resentMessages.at(-1)?.role).toBe("user");
+
+    // The replay re-sends the run from its first chunk, telemetry included.
+    await waitFor(() => expect(replay).toBeDefined());
+    if (!replay) {
+      throw new Error("replay stream was never opened");
+    }
+    emitPreStartTelemetry(replay);
+    emitTurn(replay, SERVER_MESSAGE_ID);
+    finishTurn(replay);
+
+    await waitFor(() => expect(sessions.at(-1)?.status).toBe("ready"));
+
+    // One user turn, one assistant turn: the recovered run must land in the
+    // message the replay names, not beside a copy left over from the severed
+    // attempt or from a telemetry-only message the SDK opened for either.
+    await waitFor(() => {
+      const messages = latestMessages();
+      expect(assistantMessages(messages).map((message) => message.id)).toEqual([
+        SERVER_MESSAGE_ID,
+      ]);
+      const answerParts = messages.flatMap((message) =>
+        message.parts.filter(
+          (part) => part.type === "text" && part.text === "the answer",
+        ),
+      );
+      expect(answerParts).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

A chat turn sometimes rendered **twice, both copies visibly progressing**, and a page refresh cleared it. Reported against both Ollama and vLLM.

Nothing was ever duplicated in the database — the extra copy came from the client's own message list.

## Root cause

The AI SDK opens an assistant message to hold any **non-transient data part that arrives before a stream's `start` chunk**, keyed by a client-generated id. When `start` then names the real message, the SDK renames its streaming state and *pushes a second message*, abandoning the first.

That abandoned message holds only telemetry parts, so it renders nothing and the turn still looks right. The damage is that it survives in chat state:

- the next request sends it as the trailing message, and
- a recovery's `regenerate()` anchors on it,

so the backend reuses its id (`getResponseUIMessageId` reuses a trailing assistant's id) and streams the whole turn into a message *beside* the first. Every further attach — refresh, reconnect, backend restart mid-run — adds another. That is how one turn ends up rendered two and three times over, one copy delivered in a burst ("Thought for a few seconds") beside one streaming live ("Thought for 1 seconds").

Persistence never doubles, which is exactly why a reload clears it.

## Fix

The client now holds the same rule the backend persists by: **an assistant message with no renderable content is dropped once the turn has moved past it**, so the live list matches what a reload would show. The last message stays exempt — a turn still streaming legitimately has no content yet. Pruning runs only once the stream has settled, so it can never fight the turn in flight.

Also makes the per-tool-step context-window re-emit `transient`, like the pre-stream estimate beside it. It carries panel state the client reads from `onData`, so a non-transient copy only ever added a blob to the assistant message once per tool step — persisted, re-appended on every replay, and one more chance for the SDK to open a message of its own to hold it.

## Verification

#6956 already made the three pre-`start` writers transient, so the symptom cannot reproduce on current `main`. To prove the cause and the fix, I flipped those flags back and ran against a backend deliberately writing those parts non-transiently:

- the stranded message is minted and then dropped,
- a severed-stream recovery resend anchors on the **user** message (not the artifact), and
- the replayed run lands in **one** message.

New regression test `global-chat.phantom-assistant-message.test.tsx` drives the real `ai` / `@ai-sdk/react` packages with only `fetch` stubbed, covering both the pre-`start` telemetry case and the sever-and-replay recovery.

Green locally against this base: `pnpm type-check`, `pnpm lint`, `knip` (dev + production), 444 frontend and 907 backend tests.

Resolves T-985.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>