### PR TITLE
fix(environments): scope the agent-facing control-plane MCP tools to the agent's environment

### DIFF
--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -63,6 +63,8 @@ Matching is strict for tools, knowledge, and subagents: a Production resource ma
 
 An agent creates in its own environment. When an agent adds an MCP server to the registry, or builds an [app](/docs/platform-apps), that resource lands in the agent's environment — so the agent can still see it afterwards. You can name a different environment explicitly when adding a server.
 
+An agent also configures only its own environment. It can assign and remove tools on agents and gateways in that environment, and nowhere else.
+
 This applies to both explicitly assigned resources and the implicit **Auto** access modes — in both cases cross-environment resources are filtered out before they are listed or executed. In the agent dialog's explicit assignment pickers, resources from another environment are shown disabled. Skill filtering covers `list_skills`, `load_skill`, chat slash commands, and the skills offered on the [connect page](/docs/platform-llm-proxy#environment); a [skill that runs in a subagent](/docs/platform-agent-skills#running-a-skill-in-a-subagent) additionally requires its designated agent in the same environment.
 
 ## Network egress policies

--- a/docs/pages/platform-environments.md
+++ b/docs/pages/platform-environments.md
@@ -54,11 +54,14 @@ Acme wants engineers to install MCP servers only from its own image registry. An
 An agent, MCP gateway, or LLM proxy assigned to **Production** can only see and use:
 
 - MCP tools whose server (catalog item) is in Production
+- MCP servers in the [private registry](/docs/platform-private-registry) that are in Production, including their deployments
 - knowledge connectors in Production
 - [Agent Skills](/docs/platform-agent-skills#environments) restricted to Production, or restricted to no environment at all
 - [subagent delegation targets](/docs/platform-agents#delegation) in Production
 
 Matching is strict for tools, knowledge, and subagents: a Production resource matches only other Production resources, a Dev resource matches only Dev, and Default matches only Default. Skills differ — a skill can be restricted to any number of environments, and a skill with none is available everywhere. [MCP Apps](/docs/platform-apps) differ too: an app accepts Default-environment tools alongside its own environment's, so Default acts as a shared baseline for apps. Built-in servers (the Archestra control-plane server and Playwright) and built-in skills are exempt and always available.
+
+An agent creates in its own environment. When an agent adds an MCP server to the registry, or builds an [app](/docs/platform-apps), that resource lands in the agent's environment — so the agent can still see it afterwards. You can name a different environment explicitly when adding a server.
 
 This applies to both explicitly assigned resources and the implicit **Auto** access modes — in both cases cross-environment resources are filtered out before they are listed or executed. In the agent dialog's explicit assignment pickers, resources from another environment are shown disabled. Skill filtering covers `list_skills`, `load_skill`, chat slash commands, and the skills offered on the [connect page](/docs/platform-llm-proxy#environment); a [skill that runs in a subagent](/docs/platform-agent-skills#running-a-skill-in-a-subagent) additionally requires its designated agent in the same environment.
 

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
@@ -251,7 +251,7 @@ describe("mcp server tool execution", () => {
   test("create_mcp_server persists environmentId", async () => {
     const env = await EnvironmentModel.create({
       organizationId,
-      name: "Production",
+      name: "production",
     });
 
     const result = await executeArchestraTool(
@@ -1102,8 +1102,8 @@ describe("mcp server tools respect the agent's environment", () => {
     `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${shortName}`;
 
   let orgId: string;
-  let exploreContext: ArchestraContext;
-  let exploreEnvId: string;
+  let stagingContext: ArchestraContext;
+  let stagingEnvId: string;
   let prodEnvId: string;
 
   beforeEach(async ({ makeAgent, makeUser, makeOrganization, makeMember }) => {
@@ -1112,24 +1112,24 @@ describe("mcp server tools respect the agent's environment", () => {
     const user = await makeUser();
     await makeMember(user.id, org.id, { role: "admin" });
 
-    const explore = await EnvironmentModel.create({
+    const staging = await EnvironmentModel.create({
       organizationId: org.id,
-      name: "Explore",
+      name: "staging",
     });
     const prod = await EnvironmentModel.create({
       organizationId: org.id,
-      name: "Production",
+      name: "production",
     });
-    exploreEnvId = explore.id;
+    stagingEnvId = staging.id;
     prodEnvId = prod.id;
 
-    const exploreAgent = await makeAgent({
-      name: "Explore Agent",
+    const stagingAgent = await makeAgent({
+      name: "Staging Agent",
       organizationId: org.id,
-      environmentId: explore.id,
+      environmentId: staging.id,
     });
-    exploreContext = {
-      agent: { id: exploreAgent.id, name: exploreAgent.name },
+    stagingContext = {
+      agent: { id: stagingAgent.id, name: stagingAgent.name },
       userId: user.id,
       organizationId: org.id,
     };
@@ -1138,10 +1138,10 @@ describe("mcp server tools respect the agent's environment", () => {
   test("get_mcp_servers lists only the agent's environment", async ({
     makeInternalMcpCatalog,
   }) => {
-    const exploreCatalog = await makeInternalMcpCatalog({
-      name: "Explore Server",
+    const stagingCatalog = await makeInternalMcpCatalog({
+      name: "Staging Server",
       organizationId: orgId,
-      environmentId: exploreEnvId,
+      environmentId: stagingEnvId,
     });
     const prodCatalog = await makeInternalMcpCatalog({
       name: "Production Server",
@@ -1157,14 +1157,14 @@ describe("mcp server tools respect the agent's environment", () => {
     const result = await executeArchestraTool(
       tool(TOOL_GET_MCP_SERVERS_SHORT_NAME),
       {},
-      exploreContext,
+      stagingContext,
     );
 
     expect(result.isError).toBe(false);
     const ids = (
       result.structuredContent as { items: { id: string }[] }
     ).items.map((item) => item.id);
-    expect(ids).toContain(exploreCatalog.id);
+    expect(ids).toContain(stagingCatalog.id);
     expect(ids).not.toContain(prodCatalog.id);
     expect(ids).not.toContain(defaultCatalog.id);
   });
@@ -1172,10 +1172,10 @@ describe("mcp server tools respect the agent's environment", () => {
   test("search_private_mcp_registry does not surface other environments", async ({
     makeInternalMcpCatalog,
   }) => {
-    const exploreCatalog = await makeInternalMcpCatalog({
-      name: "grafana explore",
+    const stagingCatalog = await makeInternalMcpCatalog({
+      name: "grafana staging",
       organizationId: orgId,
-      environmentId: exploreEnvId,
+      environmentId: stagingEnvId,
     });
     const prodCatalog = await makeInternalMcpCatalog({
       name: "grafana prod",
@@ -1186,14 +1186,14 @@ describe("mcp server tools respect the agent's environment", () => {
     const result = await executeArchestraTool(
       tool(TOOL_SEARCH_PRIVATE_MCP_REGISTRY_SHORT_NAME),
       { query: "grafana" },
-      exploreContext,
+      stagingContext,
     );
 
     expect(result.isError).toBe(false);
     const ids = (
       result.structuredContent as { items: { id: string }[] }
     ).items.map((item) => item.id);
-    expect(ids).toEqual([exploreCatalog.id]);
+    expect(ids).toEqual([stagingCatalog.id]);
     expect(ids).not.toContain(prodCatalog.id);
   });
 
@@ -1209,7 +1209,7 @@ describe("mcp server tools respect the agent's environment", () => {
     const result = await executeArchestraTool(
       tool(TOOL_GET_MCP_SERVER_TOOLS_SHORT_NAME),
       { mcpServerId: prodCatalog.id },
-      exploreContext,
+      stagingContext,
     );
 
     expect(result.isError).toBe(true);
@@ -1224,13 +1224,13 @@ describe("mcp server tools respect the agent's environment", () => {
         serverType: "remote",
         serverUrl: "https://example.com/mcp",
       },
-      exploreContext,
+      stagingContext,
     );
 
     expect(result.isError).toBe(false);
     const created = await InternalMcpCatalogModel.findByName(
       "Agent Authored Server",
     );
-    expect(created?.environmentId).toBe(exploreEnvId);
+    expect(created?.environmentId).toBe(stagingEnvId);
   });
 });

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.test.ts
@@ -3,7 +3,10 @@ import {
   ADMIN_ROLE_NAME,
   ARCHESTRA_MCP_SERVER_NAME,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
+  TOOL_CREATE_MCP_SERVER_SHORT_NAME,
+  TOOL_GET_MCP_SERVER_TOOLS_SHORT_NAME,
   TOOL_GET_MCP_SERVERS_SHORT_NAME,
+  TOOL_SEARCH_PRIVATE_MCP_REGISTRY_SHORT_NAME,
 } from "@archestra/shared";
 import {
   EnvironmentModel,
@@ -1085,5 +1088,149 @@ describe("mcp-server tools — team-scope RBAC", () => {
     );
     expect(denied.isError).toBe(true);
     expect(bodyText(denied)).toMatch(/teams you are a member of/i);
+  });
+});
+
+/**
+ * Environment isolation on the agent-facing MCP server tools: an agent bound to
+ * environment E must only discover and act on servers in E, matching the tools
+ * it can actually call. Without this the registry tools enumerated the whole
+ * organization's catalog regardless of the agent's environment.
+ */
+describe("mcp server tools respect the agent's environment", () => {
+  const tool = (shortName: string) =>
+    `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${shortName}`;
+
+  let orgId: string;
+  let exploreContext: ArchestraContext;
+  let exploreEnvId: string;
+  let prodEnvId: string;
+
+  beforeEach(async ({ makeAgent, makeUser, makeOrganization, makeMember }) => {
+    const org = await makeOrganization();
+    orgId = org.id;
+    const user = await makeUser();
+    await makeMember(user.id, org.id, { role: "admin" });
+
+    const explore = await EnvironmentModel.create({
+      organizationId: org.id,
+      name: "Explore",
+    });
+    const prod = await EnvironmentModel.create({
+      organizationId: org.id,
+      name: "Production",
+    });
+    exploreEnvId = explore.id;
+    prodEnvId = prod.id;
+
+    const exploreAgent = await makeAgent({
+      name: "Explore Agent",
+      organizationId: org.id,
+      environmentId: explore.id,
+    });
+    exploreContext = {
+      agent: { id: exploreAgent.id, name: exploreAgent.name },
+      userId: user.id,
+      organizationId: org.id,
+    };
+  });
+
+  test("get_mcp_servers lists only the agent's environment", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const exploreCatalog = await makeInternalMcpCatalog({
+      name: "Explore Server",
+      organizationId: orgId,
+      environmentId: exploreEnvId,
+    });
+    const prodCatalog = await makeInternalMcpCatalog({
+      name: "Production Server",
+      organizationId: orgId,
+      environmentId: prodEnvId,
+    });
+    const defaultCatalog = await makeInternalMcpCatalog({
+      name: "Default Server",
+      organizationId: orgId,
+      environmentId: null,
+    });
+
+    const result = await executeArchestraTool(
+      tool(TOOL_GET_MCP_SERVERS_SHORT_NAME),
+      {},
+      exploreContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const ids = (
+      result.structuredContent as { items: { id: string }[] }
+    ).items.map((item) => item.id);
+    expect(ids).toContain(exploreCatalog.id);
+    expect(ids).not.toContain(prodCatalog.id);
+    expect(ids).not.toContain(defaultCatalog.id);
+  });
+
+  test("search_private_mcp_registry does not surface other environments", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const exploreCatalog = await makeInternalMcpCatalog({
+      name: "grafana explore",
+      organizationId: orgId,
+      environmentId: exploreEnvId,
+    });
+    const prodCatalog = await makeInternalMcpCatalog({
+      name: "grafana prod",
+      organizationId: orgId,
+      environmentId: prodEnvId,
+    });
+
+    const result = await executeArchestraTool(
+      tool(TOOL_SEARCH_PRIVATE_MCP_REGISTRY_SHORT_NAME),
+      { query: "grafana" },
+      exploreContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const ids = (
+      result.structuredContent as { items: { id: string }[] }
+    ).items.map((item) => item.id);
+    expect(ids).toEqual([exploreCatalog.id]);
+    expect(ids).not.toContain(prodCatalog.id);
+  });
+
+  test("get_mcp_server_tools reports a cross-environment server as not found", async ({
+    makeInternalMcpCatalog,
+  }) => {
+    const prodCatalog = await makeInternalMcpCatalog({
+      name: "Production Only",
+      organizationId: orgId,
+      environmentId: prodEnvId,
+    });
+
+    const result = await executeArchestraTool(
+      tool(TOOL_GET_MCP_SERVER_TOOLS_SHORT_NAME),
+      { mcpServerId: prodCatalog.id },
+      exploreContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain("not found");
+  });
+
+  test("create_mcp_server defaults to the calling agent's environment", async () => {
+    const result = await executeArchestraTool(
+      tool(TOOL_CREATE_MCP_SERVER_SHORT_NAME),
+      {
+        name: "Agent Authored Server",
+        serverType: "remote",
+        serverUrl: "https://example.com/mcp",
+      },
+      exploreContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const created = await InternalMcpCatalogModel.findByName(
+      "Agent Authored Server",
+    );
+    expect(created?.environmentId).toBe(exploreEnvId);
   });
 });

--- a/platform/backend/src/archestra-mcp-server/mcp-servers.ts
+++ b/platform/backend/src/archestra-mcp-server/mcp-servers.ts
@@ -26,6 +26,7 @@ import { userHasPermission } from "@/auth/utils";
 import McpServerRuntimeManager from "@/k8s/mcp-server-runtime/manager";
 import logger from "@/logging";
 import {
+  AgentModel,
   AgentToolModel,
   InternalMcpCatalogModel,
   McpServerModel,
@@ -33,6 +34,7 @@ import {
   ToolModel,
 } from "@/models";
 import { assertCanAssignEnvironment } from "@/services/environments/environment";
+import { catalogVisibleInEnvironment } from "@/services/environments/environment-isolation";
 import { assertInstallAllowedOrBlock } from "@/services/mcp-install-policy";
 import { reloadToolsForServer } from "@/services/mcp-reinstall";
 import {
@@ -539,6 +541,9 @@ async function handleSearchPrivateMcpRegistry(
       "admin",
     );
     const query = args.query;
+    // Environment isolation: the registry an agent searches must match the
+    // tools it can actually call, so scope to the agent's own environment.
+    const environmentId = await AgentModel.findEnvironmentId(contextAgent.id);
 
     let catalogItems: InternalMcpCatalog[];
 
@@ -548,6 +553,7 @@ async function handleSearchPrivateMcpRegistry(
         userId: context.userId,
         isAdmin,
         organizationId,
+        environmentId,
       });
     } else {
       catalogItems = await InternalMcpCatalogModel.findAll({
@@ -555,6 +561,7 @@ async function handleSearchPrivateMcpRegistry(
         userId: context.userId,
         isAdmin,
         organizationId,
+        environmentId,
       });
     }
 
@@ -619,11 +626,14 @@ async function handleGetMcpServers(
       "mcpServerInstallation",
       "admin",
     );
+    // Environment isolation: only list servers from the agent's environment.
+    const environmentId = await AgentModel.findEnvironmentId(contextAgent.id);
     const catalogItems = await InternalMcpCatalogModel.findAll({
       expandSecrets: false,
       userId: context.userId,
       isAdmin,
       organizationId,
+      environmentId,
     });
 
     const items = catalogItems.map((c) => ({
@@ -672,7 +682,13 @@ async function handleGetMcpServerTools(
         organizationId,
       },
     );
-    if (!catalogItem) {
+    if (
+      !catalogItem ||
+      !(await catalogReachableByAgent({
+        catalogItem,
+        agentId: contextAgent.id,
+      }))
+    ) {
       const getMcpServersName = archestraMcpBranding.getToolName(
         TOOL_GET_MCP_SERVERS_SHORT_NAME,
       );
@@ -714,7 +730,13 @@ async function handleEditMcpDescription(
       isAdmin: checker.isAdmin,
       organizationId,
     });
-    if (!existing) {
+    if (
+      !existing ||
+      !(await catalogReachableByAgent({
+        catalogItem: existing,
+        agentId: contextAgent.id,
+      }))
+    ) {
       return errorResult("MCP server not found.");
     }
 
@@ -863,7 +885,13 @@ async function handleEditMcpConfig(
       isAdmin: checker.isAdmin,
       organizationId,
     });
-    if (!existing) {
+    if (
+      !existing ||
+      !(await catalogReachableByAgent({
+        catalogItem: existing,
+        agentId: contextAgent.id,
+      }))
+    ) {
       return errorResult("MCP server not found.");
     }
     // App-backed catalogs have no deployable config and are managed through the
@@ -1004,6 +1032,14 @@ async function handleCreateMcpServer(
       return errorResult("user/organization context not available.");
     }
 
+    // A server created by an agent lands in that agent's environment unless the
+    // caller names one explicitly, so the creator can still see it through the
+    // environment-scoped registry tools (mirrors `scaffold_app`).
+    const targetEnvironmentId =
+      args.environmentId !== undefined
+        ? args.environmentId
+        : await AgentModel.findEnvironmentId(contextAgent.id);
+
     try {
       // Deploying a catalog item to a restricted environment requires
       // mcpRegistry:deploy-to-restricted.
@@ -1014,7 +1050,7 @@ async function handleCreateMcpServer(
         "deploy-to-restricted",
       );
       await assertCanAssignEnvironment({
-        environmentId: args.environmentId ?? null,
+        environmentId: targetEnvironmentId,
         organizationId,
         canDeployToRestricted: hasDeploy,
       });
@@ -1123,8 +1159,7 @@ async function handleCreateMcpServer(
     }
     if (args.userConfig !== undefined)
       createParams.userConfig = args.userConfig;
-    if (args.environmentId !== undefined)
-      createParams.environmentId = args.environmentId;
+    createParams.environmentId = targetEnvironmentId;
     if (labels) createParams.labels = labels;
     if (teamIdsForScope.length > 0) createParams.teams = teamIdsForScope;
 
@@ -1189,7 +1224,13 @@ async function handleDeployMcpServer(
       isAdmin,
       organizationId,
     });
-    if (!catalogItem) {
+    if (
+      !catalogItem ||
+      !(await catalogReachableByAgent({
+        catalogItem,
+        agentId: contextAgent.id,
+      }))
+    ) {
       return errorResult("catalog item not found.");
     }
 
@@ -1378,7 +1419,15 @@ async function handleListMcpServerDeployments(
       "mcpServerInstallation",
       "admin",
     );
-    const servers = await McpServerModel.findAll(context.userId, isAdmin);
+    // Environment isolation: a deployment inherits its environment from its
+    // catalog item, so only the agent's own environment is listed.
+    const environmentId = await AgentModel.findEnvironmentId(contextAgent.id);
+    const servers = await McpServerModel.findAll(
+      context.userId,
+      isAdmin,
+      organizationId,
+      environmentId,
+    );
 
     if (servers.length === 0) {
       return successResult("No MCP server deployments found.");
@@ -1434,7 +1483,10 @@ async function handleGetMcpServerLogs(
       context.userId,
       isAdmin,
     );
-    if (!server) {
+    if (
+      !server ||
+      !(await serverReachableByAgent({ server, agentId: contextAgent.id }))
+    ) {
       return errorResult("MCP server not found or you don't have access.");
     }
     if (server.serverType !== "local") {
@@ -1492,7 +1544,10 @@ async function handleReloadMcpServerTools(
       context.userId,
       isAdmin,
     );
-    if (!server) {
+    if (
+      !server ||
+      !(await serverReachableByAgent({ server, agentId: contextAgent.id }))
+    ) {
       return errorResult("MCP server not found or you don't have access.");
     }
     // Only local/remote servers have a live upstream to re-discover from.
@@ -1657,6 +1712,45 @@ async function assignDiscoveredToolsToAgents(params: {
  * Mirrors the canonical rule from routes/mcp-server.ts:validateScopeAndAuthorization.
  * Returns an error message string if rejected, or null if allowed.
  */
+/**
+ * Environment isolation fence for the by-id MCP server tools: an agent may only
+ * reach catalog items in its own environment (built-ins exempt, since their
+ * tools are callable everywhere). Callers report a false result exactly like a
+ * missing item, so the fence never confirms that an out-of-environment server
+ * exists — the same rule `load_skill` applies to cross-environment skills.
+ */
+async function catalogReachableByAgent(params: {
+  catalogItem: { id: string; environmentId: string | null };
+  agentId: string;
+}): Promise<boolean> {
+  const agentEnvironmentId = await AgentModel.findEnvironmentId(params.agentId);
+  return catalogVisibleInEnvironment(params.catalogItem, agentEnvironmentId);
+}
+
+/**
+ * Deployment counterpart of {@link catalogReachableByAgent}. An MCP server has
+ * no environment of its own — it inherits its catalog item's — and a
+ * catalog-less (custom/legacy) deployment counts as the Default environment.
+ */
+async function serverReachableByAgent(params: {
+  server: { catalogId: string | null };
+  agentId: string;
+}): Promise<boolean> {
+  const agentEnvironmentId = await AgentModel.findEnvironmentId(params.agentId);
+  if (!params.server.catalogId) {
+    return agentEnvironmentId === null;
+  }
+  const environmentId = await InternalMcpCatalogModel.findEnvironmentIdById(
+    params.server.catalogId,
+  );
+  // A dangling catalog reference leaves the deployment environment-less, which
+  // is the Default environment — same rule as a catalog-less row above.
+  return catalogVisibleInEnvironment(
+    { id: params.server.catalogId, environmentId: environmentId ?? null },
+    agentEnvironmentId,
+  );
+}
+
 async function authorizeDeployScope(params: {
   scope: ResourceVisibilityScope;
   teamId: string | null;

--- a/platform/backend/src/archestra-mcp-server/tool-assignment.test.ts
+++ b/platform/backend/src/archestra-mcp-server/tool-assignment.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@archestra/shared";
 import { and, eq } from "drizzle-orm";
 import db, { schema } from "@/database";
+import { EnvironmentModel } from "@/models";
 import { beforeEach, describe, expect, test } from "@/test";
 import type { Agent } from "@/types";
 import { type ArchestraContext, executeArchestraTool } from ".";
@@ -627,5 +628,201 @@ describe("tool assignment with late-bound resolution", () => {
         ),
       );
     expect(updated.credentialResolutionMode).toBe("dynamic");
+  });
+});
+
+/**
+ * Environment isolation on the assignment writes: assigning or removing a tool
+ * is a configuration change on the target, so it must stay inside the calling
+ * agent's environment. Otherwise an agent in one environment rewrites another
+ * environment's toolset — and unlike a cross-environment tool, that assignment
+ * is fully effective, because the target and the tool then agree.
+ */
+describe("tool assignment respects the agent's environment", () => {
+  let orgId: string;
+  let userId: string;
+  let stagingEnvId: string;
+  let prodEnvId: string;
+  let stagingContext: ArchestraContext;
+
+  beforeEach(async ({ makeAgent, makeUser, makeOrganization, makeMember }) => {
+    const org = await makeOrganization();
+    orgId = org.id;
+    const user = await makeUser();
+    userId = user.id;
+    await makeMember(user.id, org.id, { role: "admin" });
+
+    const staging = await EnvironmentModel.create({
+      organizationId: org.id,
+      name: "staging",
+    });
+    const prod = await EnvironmentModel.create({
+      organizationId: org.id,
+      name: "production",
+    });
+    stagingEnvId = staging.id;
+    prodEnvId = prod.id;
+
+    const caller = await makeAgent({
+      name: "Staging Caller",
+      organizationId: org.id,
+      environmentId: staging.id,
+    });
+    stagingContext = {
+      agent: { id: caller.id, name: caller.name },
+      userId: user.id,
+      organizationId: org.id,
+    };
+  });
+
+  test("bulk_assign_tools_to_agents refuses a target in another environment", async ({
+    makeAgent,
+    makeTool,
+  }) => {
+    const prodAgent = await makeAgent({
+      name: "Production Target",
+      organizationId: orgId,
+      environmentId: prodEnvId,
+    });
+    const tool = await makeTool({ name: "prod_target_tool" });
+
+    const result = await executeArchestraTool(
+      AGENTS_TOOL,
+      { assignments: [{ agentId: prodAgent.id, toolId: tool.id }] },
+      stagingContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.succeeded).toEqual([]);
+    expect(parsed.failed[0].error).toContain("different environment");
+
+    // The write must not have landed.
+    const rows = await db
+      .select()
+      .from(schema.agentToolsTable)
+      .where(
+        and(
+          eq(schema.agentToolsTable.agentId, prodAgent.id),
+          eq(schema.agentToolsTable.toolId, tool.id),
+        ),
+      );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("bulk_assign_tools_to_agents allows a target in the same environment", async ({
+    makeAgent,
+    makeTool,
+  }) => {
+    const peer = await makeAgent({
+      name: "Staging Peer",
+      organizationId: orgId,
+      environmentId: stagingEnvId,
+    });
+    const tool = await makeTool({ name: "staging_peer_tool" });
+
+    const result = await executeArchestraTool(
+      AGENTS_TOOL,
+      { assignments: [{ agentId: peer.id, toolId: tool.id }] },
+      stagingContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.failed).toEqual([]);
+    expect(parsed.succeeded).toEqual([{ agentId: peer.id, toolId: tool.id }]);
+  });
+
+  test("bulk_remove_tools_from_agents refuses a target in another environment", async ({
+    makeAgent,
+    makeTool,
+    makeAgentTool,
+  }) => {
+    const prodAgent = await makeAgent({
+      name: "Production Removal Target",
+      organizationId: orgId,
+      environmentId: prodEnvId,
+    });
+    const tool = await makeTool({ name: "prod_removal_tool" });
+    await makeAgentTool(prodAgent.id, tool.id);
+
+    const result = await executeArchestraTool(
+      REMOVE_TOOL,
+      { removals: [{ agentId: prodAgent.id, toolId: tool.id }] },
+      stagingContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.succeeded).toEqual([]);
+    expect(parsed.failed[0].error).toContain("different environment");
+
+    // The existing assignment must survive.
+    const rows = await db
+      .select()
+      .from(schema.agentToolsTable)
+      .where(
+        and(
+          eq(schema.agentToolsTable.agentId, prodAgent.id),
+          eq(schema.agentToolsTable.toolId, tool.id),
+        ),
+      );
+    expect(rows).toHaveLength(1);
+  });
+
+  test("bulk_assign_tools_to_mcp_gateways refuses a gateway in another environment", async ({
+    makeAgent,
+    makeTool,
+  }) => {
+    const prodGateway = await makeAgent({
+      name: "Production Gateway",
+      organizationId: orgId,
+      environmentId: prodEnvId,
+      agentType: "mcp_gateway",
+    });
+    const tool = await makeTool({ name: "prod_gateway_tool" });
+
+    const result = await executeArchestraTool(
+      GATEWAYS_TOOL,
+      { assignments: [{ mcpGatewayId: prodGateway.id, toolId: tool.id }] },
+      stagingContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.succeeded).toEqual([]);
+    expect(parsed.failed[0].error).toContain("different environment");
+  });
+
+  test("a Default-environment agent cannot assign into a named environment", async ({
+    makeAgent,
+    makeTool,
+  }) => {
+    const defaultAgent = await makeAgent({
+      name: "Default Caller",
+      organizationId: orgId,
+      environmentId: null,
+    });
+    const prodAgent = await makeAgent({
+      name: "Production Peer",
+      organizationId: orgId,
+      environmentId: prodEnvId,
+    });
+    const tool = await makeTool({ name: "default_caller_tool" });
+
+    const result = await executeArchestraTool(
+      AGENTS_TOOL,
+      { assignments: [{ agentId: prodAgent.id, toolId: tool.id }] },
+      {
+        agent: { id: defaultAgent.id, name: defaultAgent.name },
+        userId,
+        organizationId: orgId,
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.succeeded).toEqual([]);
+    expect(parsed.failed[0].error).toContain("different environment");
   });
 });

--- a/platform/backend/src/archestra-mcp-server/tool-assignment.ts
+++ b/platform/backend/src/archestra-mcp-server/tool-assignment.ts
@@ -246,13 +246,21 @@ async function handleBulkAssignTool(params: {
         assignments.map((assignment) => getBulkAssignmentTargetId(assignment)),
       ),
     ];
-    const [targetAgents, checker] = await Promise.all([
+    const [targetAgents, checker, callerEnvironmentId] = await Promise.all([
       AgentModel.findByIdsForPermissionCheck(uniqueTargetIds),
       getAgentTypePermissionChecker({
         userId,
         organizationId,
       }),
+      AgentModel.findEnvironmentId(contextAgent.id),
     ]);
+    // Environment isolation: writing an assignment is a configuration change,
+    // so the TARGET must be in the calling agent's environment — otherwise an
+    // agent in one environment reconfigures another. The tool end is
+    // deliberately not fenced: a cross-environment tool assigned to an
+    // in-environment agent is inert (the call-time gate drops it), so fencing
+    // it would buy no isolation while refusing catalog-less legacy rows, which
+    // no environment predicate matches.
 
     const requiresTeamIds = [...targetAgents.values()].some(
       (target) => target && !checker.isAdmin(target.agentType),
@@ -265,6 +273,11 @@ async function handleBulkAssignTool(params: {
         const targetId = getBulkAssignmentTargetId(assignment);
         const target = targetAgents.get(targetId);
         if (target) {
+          if (target.environmentId !== callerEnvironmentId) {
+            throw new Error(
+              `${bulkAssignType === "agent" ? "Agent" : "MCP gateway"} ${targetId} is in a different environment; you can only assign tools within your own environment.`,
+            );
+          }
           checker.require(target.agentType, "update");
           requireAgentModifyPermission({
             checker,
@@ -342,9 +355,10 @@ async function handleBulkRemoveTool(params: {
     const { organizationId, userId } = context;
 
     const uniqueAgentIds = [...new Set(removals.map((r) => r.agentId))];
-    const [targetAgents, checker] = await Promise.all([
+    const [targetAgents, checker, callerEnvironmentId] = await Promise.all([
       AgentModel.findByIdsForPermissionCheck(uniqueAgentIds),
       getAgentTypePermissionChecker({ userId, organizationId }),
+      AgentModel.findEnvironmentId(contextAgent.id),
     ]);
 
     // Prefetch Auto-tool mode once per agent so the per-removal loop doesn't
@@ -370,6 +384,13 @@ async function handleBulkRemoveTool(params: {
         const target = targetAgents.get(removal.agentId);
         if (!target) {
           throw new Error(`Agent with ID ${removal.agentId} not found`);
+        }
+        // Environment isolation: removing an assignment is a configuration
+        // change on the target, so it stays inside the caller's environment.
+        if (target.environmentId !== callerEnvironmentId) {
+          throw new Error(
+            `Agent ${removal.agentId} is in a different environment; you can only remove tools within your own environment.`,
+          );
         }
         checker.require(target.agentType, "update");
         requireAgentModifyPermission({

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -1802,6 +1802,10 @@ class AgentModel {
    * Returns a Map of agentId -> { agentType, scope, authorId, teamIds }.
    * Much lighter than findById (no tool/label/knowledgeBase/connector joins).
    */
+  /**
+   * Includes `environmentId` so callers can apply the environment fence beside
+   * the permission checks, without a second round-trip per target.
+   */
   static async findByIdsForPermissionCheck(ids: string[]): Promise<
     Map<
       string,
@@ -1810,6 +1814,7 @@ class AgentModel {
         scope: AgentScope;
         authorId: string | null;
         teamIds: string[];
+        environmentId: string | null;
       }
     >
   > {
@@ -1824,6 +1829,7 @@ class AgentModel {
           agentType: schema.agentsTable.agentType,
           scope: schema.agentsTable.scope,
           authorId: schema.agentsTable.authorId,
+          environmentId: schema.agentsTable.environmentId,
         })
         .from(schema.agentsTable)
         .where(
@@ -1842,6 +1848,7 @@ class AgentModel {
         scope: AgentScope;
         authorId: string | null;
         teamIds: string[];
+        environmentId: string | null;
       }
     >();
     for (const agent of agents) {
@@ -1851,6 +1858,7 @@ class AgentModel {
         scope: agent.scope,
         authorId: agent.authorId,
         teamIds: teams.map((t) => t.id),
+        environmentId: agent.environmentId,
       });
     }
 

--- a/platform/backend/src/models/internal-mcp-catalog.ts
+++ b/platform/backend/src/models/internal-mcp-catalog.ts
@@ -19,6 +19,7 @@ import {
 } from "@/k8s/shared";
 import logger from "@/logging";
 import { secretManager } from "@/secrets-manager";
+import { catalogInEnvironmentPredicate } from "@/services/environments/environment-isolation";
 import {
   type CatalogItemApprovalStatus,
   ENTERPRISE_MANAGED_CLIENT_SECRET_OVERRIDE_SECRET_KEY,
@@ -34,6 +35,20 @@ import McpCatalogTeamModel from "./mcp-catalog-team";
 import McpServerModel from "./mcp-server";
 import SecretModel from "./secret";
 import ToolModel, { toolUiResourceUriSql } from "./tool";
+
+type CatalogListOptions = {
+  expandSecrets?: boolean;
+  userId?: string;
+  isAdmin?: boolean;
+  organizationId?: string;
+  /**
+   * When set (null = Default environment), restricts results to catalog items
+   * visible from that environment: strict match, built-in catalogs exempt.
+   * Omit for management surfaces that list every environment (the registry UI,
+   * which filters by environment client-side).
+   */
+  environmentId?: string | null;
+};
 
 /**
  * Data-access layer for `internal_mcp_catalog` — the org's private registry
@@ -132,12 +147,9 @@ class InternalMcpCatalogModel {
       .where(eq(schema.internalMcpCatalogTable.id, params.id));
   }
 
-  static async findAll(options?: {
-    expandSecrets?: boolean;
-    userId?: string;
-    isAdmin?: boolean;
-    organizationId?: string;
-  }): Promise<ListInternalMcpCatalog[]> {
+  static async findAll(
+    options?: CatalogListOptions,
+  ): Promise<ListInternalMcpCatalog[]> {
     return InternalMcpCatalogModel.listAll(options, false);
   }
 
@@ -148,24 +160,14 @@ class InternalMcpCatalogModel {
    * any other tool. Apps stay hidden from the registry list and the
    * agent-callable {@link InternalMcpCatalogModel.searchByQuery}.
    */
-  static async findAllWithApps(options?: {
-    expandSecrets?: boolean;
-    userId?: string;
-    isAdmin?: boolean;
-    organizationId?: string;
-  }): Promise<ListInternalMcpCatalog[]> {
+  static async findAllWithApps(
+    options?: CatalogListOptions,
+  ): Promise<ListInternalMcpCatalog[]> {
     return InternalMcpCatalogModel.listAll(options, true);
   }
 
   private static async listAll(
-    options:
-      | {
-          expandSecrets?: boolean;
-          userId?: string;
-          isAdmin?: boolean;
-          organizationId?: string;
-        }
-      | undefined,
+    options: CatalogListOptions | undefined,
     includeApps: boolean,
   ): Promise<ListInternalMcpCatalog[]> {
     const {
@@ -173,6 +175,7 @@ class InternalMcpCatalogModel {
       userId,
       isAdmin,
       organizationId,
+      environmentId,
     } = options ?? {};
 
     let dbItems: Array<typeof schema.internalMcpCatalogTable.$inferSelect>;
@@ -181,6 +184,9 @@ class InternalMcpCatalogModel {
       // Legacy preset rows (non-NULL parentCatalogItemId) are never surfaced.
       isNull(schema.internalMcpCatalogTable.parentCatalogItemId),
     ];
+    if (environmentId !== undefined) {
+      listConditions.push(catalogInEnvironmentPredicate(environmentId));
+    }
     if (!includeApps) {
       // App backing catalogs are managed on the Apps page, never surfaced in the
       // MCP registry (UI list or the agent-callable registry search).
@@ -267,18 +273,14 @@ class InternalMcpCatalogModel {
 
   static async searchByQuery(
     query: string,
-    options?: {
-      expandSecrets?: boolean;
-      userId?: string;
-      isAdmin?: boolean;
-      organizationId?: string;
-    },
+    options?: CatalogListOptions,
   ): Promise<ListInternalMcpCatalog[]> {
     const {
       expandSecrets = true,
       userId,
       isAdmin,
       organizationId,
+      environmentId,
     } = options ?? {};
 
     let dbItems: Array<typeof schema.internalMcpCatalogTable.$inferSelect>;
@@ -294,6 +296,9 @@ class InternalMcpCatalogModel {
       isNull(schema.internalMcpCatalogTable.parentCatalogItemId),
       // App backing catalogs are never surfaced via registry search.
       ne(schema.internalMcpCatalogTable.serverType, "app"),
+      ...(environmentId !== undefined
+        ? [catalogInEnvironmentPredicate(environmentId)]
+        : []),
     );
 
     if (userId && !isAdmin && !organizationId) {
@@ -426,6 +431,23 @@ class InternalMcpCatalogModel {
     ]);
 
     return catalogItem;
+  }
+
+  /**
+   * The environment a catalog item belongs to (null = Default), without the
+   * secret expansion and metadata joins {@link InternalMcpCatalogModel.findById}
+   * performs. Returns undefined when no such row exists.
+   */
+  static async findEnvironmentIdById(
+    id: string,
+  ): Promise<string | null | undefined> {
+    const [row] = await db
+      .select({ environmentId: schema.internalMcpCatalogTable.environmentId })
+      .from(schema.internalMcpCatalogTable)
+      .where(eq(schema.internalMcpCatalogTable.id, id))
+      .limit(1);
+
+    return row?.environmentId;
   }
 
   static async findByEnvironmentId(

--- a/platform/backend/src/models/mcp-server.ts
+++ b/platform/backend/src/models/mcp-server.ts
@@ -8,6 +8,7 @@ import {
   isNull,
   ne,
   or,
+  type SQL,
   sql,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
@@ -18,6 +19,7 @@ import { constructFrozenMcpDeploymentName } from "@/k8s/shared";
 import logger from "@/logging";
 import { secretManager } from "@/secrets-manager";
 import { computeSecretStorageType } from "@/secrets-manager/utils";
+import { catalogInEnvironmentPredicate } from "@/services/environments/environment-isolation";
 import type {
   InsertMcpServer,
   McpServer,
@@ -272,10 +274,18 @@ class McpServerModel {
       );
   }
 
+  /**
+   * @param environmentId when set (null = Default environment), restricts
+   * results to deployments whose catalog item is visible from that environment.
+   * An MCP server has no environment column of its own — it inherits one from
+   * `catalogId`, and a catalog-less (custom/legacy) row counts as Default.
+   * Omit for management surfaces that list every environment.
+   */
   static async findAll(
     userId?: string,
     isMcpServerAdmin?: boolean,
     organizationId?: string,
+    environmentId?: string | null,
   ): Promise<McpServer[]> {
     // Single query with LEFT JOINs for all related data including assigned users,
     // eliminating the consecutive DB query for user details.
@@ -318,6 +328,15 @@ class McpServerModel {
       )
       .$dynamic();
 
+    const conditions: SQL[] = [];
+
+    if (environmentId !== undefined) {
+      // A server inherits its environment from the joined catalog row; the LEFT
+      // JOIN leaves that NULL for catalog-less rows, which `is not distinct
+      // from` then matches only for the Default environment.
+      conditions.push(catalogInEnvironmentPredicate(environmentId));
+    }
+
     // Apply access control filtering for non-MCP server admins
     if (userId && !isMcpServerAdmin) {
       // Get MCP servers accessible through:
@@ -347,9 +366,13 @@ class McpServerModel {
         return [];
       }
 
-      query = query.where(
+      conditions.push(
         inArray(schema.mcpServersTable.id, accessibleMcpServerIds),
       );
+    }
+
+    if (conditions.length > 0) {
+      query = query.where(and(...conditions));
     }
 
     const results = await query;

--- a/platform/backend/src/routes/mcp-gateway/environment-isolation.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/environment-isolation.test.ts
@@ -39,8 +39,8 @@ import mcpGatewayRoutes from "./index";
  * environment decision and never RBAC masking one.
  */
 
-const LAUNCH = "Launch";
-const EXPLORE = "Explore";
+const PRODUCTION = "production";
+const STAGING = "staging";
 
 function makeMcpHeaders(token: string): Record<string, string> {
   return {
@@ -111,31 +111,31 @@ test("gateway: get_mcp_servers lists only the calling agent's environment", asyn
   const org = await makeOrganization();
   const user = await makeUser();
   await makeMember(user.id, org.id, { role: "admin" });
-  const launch = await EnvironmentModel.create({
+  const production = await EnvironmentModel.create({
     organizationId: org.id,
-    name: LAUNCH,
+    name: PRODUCTION,
   });
-  const explore = await EnvironmentModel.create({
+  const staging = await EnvironmentModel.create({
     organizationId: org.id,
-    name: EXPLORE,
+    name: STAGING,
   });
   const agent = await makeAgent({
-    name: "Launch Agent",
+    name: "Production Agent",
     organizationId: org.id,
-    environmentId: launch.id,
+    environmentId: production.id,
   });
   await seedAndAssignArchestraTools(agent.id);
   const token = await UserTokenModel.create(user.id, org.id);
 
-  const launchCatalog = await makeInternalMcpCatalog({
-    name: "Launch Server",
+  const productionCatalog = await makeInternalMcpCatalog({
+    name: "Production Server",
     organizationId: org.id,
-    environmentId: launch.id,
+    environmentId: production.id,
   });
-  const exploreCatalog = await makeInternalMcpCatalog({
-    name: "Explore Server",
+  const stagingCatalog = await makeInternalMcpCatalog({
+    name: "Staging Server",
     organizationId: org.id,
-    environmentId: explore.id,
+    environmentId: staging.id,
   });
   const defaultCatalog = await makeInternalMcpCatalog({
     name: "Default Server",
@@ -154,8 +154,8 @@ test("gateway: get_mcp_servers lists only the calling agent's environment", asyn
   const ids = (body.result.structuredContent?.items ?? []).map(
     (item) => item.id,
   );
-  expect(ids).toContain(launchCatalog.id);
-  expect(ids).not.toContain(exploreCatalog.id);
+  expect(ids).toContain(productionCatalog.id);
+  expect(ids).not.toContain(stagingCatalog.id);
   expect(ids).not.toContain(defaultCatalog.id);
 });
 
@@ -170,31 +170,31 @@ test("gateway: search_private_mcp_registry does not surface other environments",
   const org = await makeOrganization();
   const user = await makeUser();
   await makeMember(user.id, org.id, { role: "admin" });
-  const launch = await EnvironmentModel.create({
+  const production = await EnvironmentModel.create({
     organizationId: org.id,
-    name: LAUNCH,
+    name: PRODUCTION,
   });
-  const explore = await EnvironmentModel.create({
+  const staging = await EnvironmentModel.create({
     organizationId: org.id,
-    name: EXPLORE,
+    name: STAGING,
   });
   const agent = await makeAgent({
-    name: "Launch Agent",
+    name: "Production Agent",
     organizationId: org.id,
-    environmentId: launch.id,
+    environmentId: production.id,
   });
   await seedAndAssignArchestraTools(agent.id);
   const token = await UserTokenModel.create(user.id, org.id);
 
-  const launchCatalog = await makeInternalMcpCatalog({
-    name: "observability launch",
+  const productionCatalog = await makeInternalMcpCatalog({
+    name: "observability production",
     organizationId: org.id,
-    environmentId: launch.id,
+    environmentId: production.id,
   });
-  const exploreCatalog = await makeInternalMcpCatalog({
-    name: "observability explore",
+  const stagingCatalog = await makeInternalMcpCatalog({
+    name: "observability staging",
     organizationId: org.id,
-    environmentId: explore.id,
+    environmentId: staging.id,
   });
 
   const body = await callTool({
@@ -208,9 +208,9 @@ test("gateway: search_private_mcp_registry does not surface other environments",
   const ids = (body.result.structuredContent?.items ?? []).map(
     (item) => item.id,
   );
-  expect(ids).toEqual([launchCatalog.id]);
-  expect(ids).not.toContain(exploreCatalog.id);
-  expect(resultText(body)).not.toContain("observability explore");
+  expect(ids).toEqual([productionCatalog.id]);
+  expect(ids).not.toContain(stagingCatalog.id);
+  expect(resultText(body)).not.toContain("observability staging");
 });
 
 test("gateway: get_mcp_server_tools hides a server from another environment", async ({
@@ -225,41 +225,41 @@ test("gateway: get_mcp_server_tools hides a server from another environment", as
   const org = await makeOrganization();
   const user = await makeUser();
   await makeMember(user.id, org.id, { role: "admin" });
-  const launch = await EnvironmentModel.create({
+  const production = await EnvironmentModel.create({
     organizationId: org.id,
-    name: LAUNCH,
+    name: PRODUCTION,
   });
-  const explore = await EnvironmentModel.create({
+  const staging = await EnvironmentModel.create({
     organizationId: org.id,
-    name: EXPLORE,
+    name: STAGING,
   });
   const agent = await makeAgent({
-    name: "Launch Agent",
+    name: "Production Agent",
     organizationId: org.id,
-    environmentId: launch.id,
+    environmentId: production.id,
   });
   await seedAndAssignArchestraTools(agent.id);
   const token = await UserTokenModel.create(user.id, org.id);
 
-  const exploreCatalog = await makeInternalMcpCatalog({
-    name: "Explore Only",
+  const stagingCatalog = await makeInternalMcpCatalog({
+    name: "Staging Only",
     organizationId: org.id,
-    environmentId: explore.id,
+    environmentId: staging.id,
   });
-  await makeTool({ catalogId: exploreCatalog.id, name: "explore_only_tool" });
+  await makeTool({ catalogId: stagingCatalog.id, name: "staging_only_tool" });
 
   const body = await callTool({
     agentId: agent.id,
     token: token.value,
     name: toolName(TOOL_GET_MCP_SERVER_TOOLS_SHORT_NAME),
-    arguments: { mcpServerId: exploreCatalog.id },
+    arguments: { mcpServerId: stagingCatalog.id },
   });
 
   expect(body.result.isError).toBe(true);
   const text = resultText(body);
   expect(text).toContain("not found");
   // The fence must not leak the out-of-environment server's tools.
-  expect(text).not.toContain("explore_only_tool");
+  expect(text).not.toContain("staging_only_tool");
 });
 
 test("gateway: create_mcp_server lands in the calling agent's environment", async ({
@@ -272,14 +272,14 @@ test("gateway: create_mcp_server lands in the calling agent's environment", asyn
   const org = await makeOrganization();
   const user = await makeUser();
   await makeMember(user.id, org.id, { role: "admin" });
-  const launch = await EnvironmentModel.create({
+  const production = await EnvironmentModel.create({
     organizationId: org.id,
-    name: LAUNCH,
+    name: PRODUCTION,
   });
   const agent = await makeAgent({
-    name: "Launch Agent",
+    name: "Production Agent",
     organizationId: org.id,
-    environmentId: launch.id,
+    environmentId: production.id,
   });
   await seedAndAssignArchestraTools(agent.id);
   const token = await UserTokenModel.create(user.id, org.id);
@@ -299,7 +299,7 @@ test("gateway: create_mcp_server lands in the calling agent's environment", asyn
   const created = await InternalMcpCatalogModel.findByName(
     "Gateway Authored Server",
   );
-  expect(created?.environmentId).toBe(launch.id);
+  expect(created?.environmentId).toBe(production.id);
 });
 
 test("gateway: scaffold_app binds the app to the calling agent's environment", async ({
@@ -312,14 +312,14 @@ test("gateway: scaffold_app binds the app to the calling agent's environment", a
   const org = await makeOrganization();
   const user = await makeUser();
   await makeMember(user.id, org.id, { role: "admin" });
-  const launch = await EnvironmentModel.create({
+  const production = await EnvironmentModel.create({
     organizationId: org.id,
-    name: LAUNCH,
+    name: PRODUCTION,
   });
   const agent = await makeAgent({
-    name: "Launch Agent",
+    name: "Production Agent",
     organizationId: org.id,
-    environmentId: launch.id,
+    environmentId: production.id,
   });
   await seedAndAssignArchestraTools(agent.id);
   const token = await UserTokenModel.create(user.id, org.id);
@@ -328,7 +328,7 @@ test("gateway: scaffold_app binds the app to the calling agent's environment", a
     agentId: agent.id,
     token: token.value,
     name: toolName(TOOL_SCAFFOLD_APP_SHORT_NAME),
-    arguments: { name: "Launch Dashboard" },
+    arguments: { name: "Ops Dashboard" },
   });
 
   expect(body.result.isError).toBeFalsy();
@@ -338,5 +338,5 @@ test("gateway: scaffold_app binds the app to the calling agent's environment", a
   // An app's environment is owned by its backing catalog row, not the apps
   // table — `AppModel.findById` joins it back in.
   const scaffolded = await AppModel.findById(appId as string);
-  expect(scaffolded?.environmentId).toBe(launch.id);
+  expect(scaffolded?.environmentId).toBe(production.id);
 });

--- a/platform/backend/src/routes/mcp-gateway/environment-isolation.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/environment-isolation.test.ts
@@ -1,0 +1,342 @@
+import {
+  ARCHESTRA_MCP_SERVER_NAME,
+  MCP_SERVER_TOOL_NAME_SEPARATOR,
+  TOOL_CREATE_MCP_SERVER_SHORT_NAME,
+  TOOL_GET_MCP_SERVER_TOOLS_SHORT_NAME,
+  TOOL_GET_MCP_SERVERS_SHORT_NAME,
+  TOOL_SCAFFOLD_APP_SHORT_NAME,
+  TOOL_SEARCH_PRIVATE_MCP_REGISTRY_SHORT_NAME,
+} from "@archestra/shared";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import {
+  AppModel,
+  EnvironmentModel,
+  InternalMcpCatalogModel,
+  UserTokenModel,
+} from "@/models";
+import { afterEach, beforeEach, expect, test } from "@/test";
+import mcpGatewayRoutes from "./index";
+
+/**
+ * Route-level environment isolation for the agent-facing surface. Everything an
+ * agent reaches goes through `POST /v1/mcp/:agentId`, so these drive the real
+ * gateway (auth, tool resolution, dispatch) rather than calling handlers
+ * directly. An agent bound to environment E must only discover, act on, and
+ * create resources in E — matching the tools it can actually call.
+ *
+ * Regressions these pin:
+ * - the registry tools listed the whole organization's catalog regardless of
+ *   the calling agent's environment;
+ * - a server or app the agent created landed in the Default environment instead
+ *   of the agent's, leaving its author unable to see it afterwards.
+ *
+ * The caller is an org admin throughout, so a missing result is always an
+ * environment decision and never RBAC masking one.
+ */
+
+const LAUNCH = "Launch";
+const EXPLORE = "Explore";
+
+function makeMcpHeaders(token: string): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    authorization: `Bearer ${token}`,
+  };
+}
+
+function toolName(shortName: string): string {
+  return `${ARCHESTRA_MCP_SERVER_NAME}${MCP_SERVER_TOOL_NAME_SEPARATOR}${shortName}`;
+}
+
+let app: FastifyInstance;
+
+beforeEach(async () => {
+  app = Fastify().withTypeProvider<ZodTypeProvider>();
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  await app.register(mcpGatewayRoutes);
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+type ToolCallBody = {
+  result: {
+    isError?: boolean;
+    structuredContent?: { items?: { id: string }[]; id?: string };
+    content: Array<{ type: string; text?: string }>;
+  };
+};
+
+async function callTool(params: {
+  agentId: string;
+  token: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}): Promise<ToolCallBody> {
+  const response = await app.inject({
+    method: "POST",
+    url: `/v1/mcp/${params.agentId}`,
+    headers: makeMcpHeaders(params.token),
+    payload: {
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { name: params.name, arguments: params.arguments },
+      id: 1,
+    },
+  });
+  expect(response.statusCode).toBe(200);
+  return response.json() as ToolCallBody;
+}
+
+function resultText(body: ToolCallBody): string {
+  return body.result.content.map((item) => item.text ?? "").join("\n");
+}
+
+test("gateway: get_mcp_servers lists only the calling agent's environment", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  seedAndAssignArchestraTools,
+  makeInternalMcpCatalog,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  await makeMember(user.id, org.id, { role: "admin" });
+  const launch = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: LAUNCH,
+  });
+  const explore = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: EXPLORE,
+  });
+  const agent = await makeAgent({
+    name: "Launch Agent",
+    organizationId: org.id,
+    environmentId: launch.id,
+  });
+  await seedAndAssignArchestraTools(agent.id);
+  const token = await UserTokenModel.create(user.id, org.id);
+
+  const launchCatalog = await makeInternalMcpCatalog({
+    name: "Launch Server",
+    organizationId: org.id,
+    environmentId: launch.id,
+  });
+  const exploreCatalog = await makeInternalMcpCatalog({
+    name: "Explore Server",
+    organizationId: org.id,
+    environmentId: explore.id,
+  });
+  const defaultCatalog = await makeInternalMcpCatalog({
+    name: "Default Server",
+    organizationId: org.id,
+    environmentId: null,
+  });
+
+  const body = await callTool({
+    agentId: agent.id,
+    token: token.value,
+    name: toolName(TOOL_GET_MCP_SERVERS_SHORT_NAME),
+    arguments: {},
+  });
+
+  expect(body.result.isError).toBeFalsy();
+  const ids = (body.result.structuredContent?.items ?? []).map(
+    (item) => item.id,
+  );
+  expect(ids).toContain(launchCatalog.id);
+  expect(ids).not.toContain(exploreCatalog.id);
+  expect(ids).not.toContain(defaultCatalog.id);
+});
+
+test("gateway: search_private_mcp_registry does not surface other environments", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  seedAndAssignArchestraTools,
+  makeInternalMcpCatalog,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  await makeMember(user.id, org.id, { role: "admin" });
+  const launch = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: LAUNCH,
+  });
+  const explore = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: EXPLORE,
+  });
+  const agent = await makeAgent({
+    name: "Launch Agent",
+    organizationId: org.id,
+    environmentId: launch.id,
+  });
+  await seedAndAssignArchestraTools(agent.id);
+  const token = await UserTokenModel.create(user.id, org.id);
+
+  const launchCatalog = await makeInternalMcpCatalog({
+    name: "observability launch",
+    organizationId: org.id,
+    environmentId: launch.id,
+  });
+  const exploreCatalog = await makeInternalMcpCatalog({
+    name: "observability explore",
+    organizationId: org.id,
+    environmentId: explore.id,
+  });
+
+  const body = await callTool({
+    agentId: agent.id,
+    token: token.value,
+    name: toolName(TOOL_SEARCH_PRIVATE_MCP_REGISTRY_SHORT_NAME),
+    arguments: { query: "observability" },
+  });
+
+  expect(body.result.isError).toBeFalsy();
+  const ids = (body.result.structuredContent?.items ?? []).map(
+    (item) => item.id,
+  );
+  expect(ids).toEqual([launchCatalog.id]);
+  expect(ids).not.toContain(exploreCatalog.id);
+  expect(resultText(body)).not.toContain("observability explore");
+});
+
+test("gateway: get_mcp_server_tools hides a server from another environment", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  seedAndAssignArchestraTools,
+  makeInternalMcpCatalog,
+  makeTool,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  await makeMember(user.id, org.id, { role: "admin" });
+  const launch = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: LAUNCH,
+  });
+  const explore = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: EXPLORE,
+  });
+  const agent = await makeAgent({
+    name: "Launch Agent",
+    organizationId: org.id,
+    environmentId: launch.id,
+  });
+  await seedAndAssignArchestraTools(agent.id);
+  const token = await UserTokenModel.create(user.id, org.id);
+
+  const exploreCatalog = await makeInternalMcpCatalog({
+    name: "Explore Only",
+    organizationId: org.id,
+    environmentId: explore.id,
+  });
+  await makeTool({ catalogId: exploreCatalog.id, name: "explore_only_tool" });
+
+  const body = await callTool({
+    agentId: agent.id,
+    token: token.value,
+    name: toolName(TOOL_GET_MCP_SERVER_TOOLS_SHORT_NAME),
+    arguments: { mcpServerId: exploreCatalog.id },
+  });
+
+  expect(body.result.isError).toBe(true);
+  const text = resultText(body);
+  expect(text).toContain("not found");
+  // The fence must not leak the out-of-environment server's tools.
+  expect(text).not.toContain("explore_only_tool");
+});
+
+test("gateway: create_mcp_server lands in the calling agent's environment", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  seedAndAssignArchestraTools,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  await makeMember(user.id, org.id, { role: "admin" });
+  const launch = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: LAUNCH,
+  });
+  const agent = await makeAgent({
+    name: "Launch Agent",
+    organizationId: org.id,
+    environmentId: launch.id,
+  });
+  await seedAndAssignArchestraTools(agent.id);
+  const token = await UserTokenModel.create(user.id, org.id);
+
+  const body = await callTool({
+    agentId: agent.id,
+    token: token.value,
+    name: toolName(TOOL_CREATE_MCP_SERVER_SHORT_NAME),
+    arguments: {
+      name: "Gateway Authored Server",
+      serverType: "remote",
+      serverUrl: "https://example.com/mcp",
+    },
+  });
+
+  expect(body.result.isError).toBeFalsy();
+  const created = await InternalMcpCatalogModel.findByName(
+    "Gateway Authored Server",
+  );
+  expect(created?.environmentId).toBe(launch.id);
+});
+
+test("gateway: scaffold_app binds the app to the calling agent's environment", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  seedAndAssignArchestraTools,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  await makeMember(user.id, org.id, { role: "admin" });
+  const launch = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: LAUNCH,
+  });
+  const agent = await makeAgent({
+    name: "Launch Agent",
+    organizationId: org.id,
+    environmentId: launch.id,
+  });
+  await seedAndAssignArchestraTools(agent.id);
+  const token = await UserTokenModel.create(user.id, org.id);
+
+  const body = await callTool({
+    agentId: agent.id,
+    token: token.value,
+    name: toolName(TOOL_SCAFFOLD_APP_SHORT_NAME),
+    arguments: { name: "Launch Dashboard" },
+  });
+
+  expect(body.result.isError).toBeFalsy();
+  const appId = body.result.structuredContent?.id;
+  expect(appId).toBeTruthy();
+
+  // An app's environment is owned by its backing catalog row, not the apps
+  // table — `AppModel.findById` joins it back in.
+  const scaffolded = await AppModel.findById(appId as string);
+  expect(scaffolded?.environmentId).toBe(launch.id);
+});

--- a/platform/backend/src/routes/mcp-gateway/environment-isolation.test.ts
+++ b/platform/backend/src/routes/mcp-gateway/environment-isolation.test.ts
@@ -1,6 +1,7 @@
 import {
   ARCHESTRA_MCP_SERVER_NAME,
   MCP_SERVER_TOOL_NAME_SEPARATOR,
+  TOOL_BULK_ASSIGN_TOOLS_TO_AGENTS_SHORT_NAME,
   TOOL_CREATE_MCP_SERVER_SHORT_NAME,
   TOOL_GET_MCP_SERVER_TOOLS_SHORT_NAME,
   TOOL_GET_MCP_SERVERS_SHORT_NAME,
@@ -14,6 +15,7 @@ import {
   type ZodTypeProvider,
 } from "fastify-type-provider-zod";
 import {
+  AgentToolModel,
   AppModel,
   EnvironmentModel,
   InternalMcpCatalogModel,
@@ -339,4 +341,61 @@ test("gateway: scaffold_app binds the app to the calling agent's environment", a
   // table — `AppModel.findById` joins it back in.
   const scaffolded = await AppModel.findById(appId as string);
   expect(scaffolded?.environmentId).toBe(production.id);
+});
+
+test("gateway: bulk tool assignment cannot reconfigure another environment's agent", async ({
+  makeOrganization,
+  makeUser,
+  makeMember,
+  makeAgent,
+  seedAndAssignArchestraTools,
+  makeTool,
+}) => {
+  const org = await makeOrganization();
+  const user = await makeUser();
+  await makeMember(user.id, org.id, { role: "admin" });
+  const production = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: PRODUCTION,
+  });
+  const staging = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: STAGING,
+  });
+  const agent = await makeAgent({
+    name: "Production Agent",
+    organizationId: org.id,
+    environmentId: production.id,
+  });
+  await seedAndAssignArchestraTools(agent.id);
+  const token = await UserTokenModel.create(user.id, org.id);
+
+  const stagingAgent = await makeAgent({
+    name: "Staging Agent",
+    organizationId: org.id,
+    environmentId: staging.id,
+  });
+  const tool = await makeTool({ name: "cross_env_assignment_tool" });
+
+  const body = await callTool({
+    agentId: agent.id,
+    token: token.value,
+    name: toolName(TOOL_BULK_ASSIGN_TOOLS_TO_AGENTS_SHORT_NAME),
+    arguments: {
+      assignments: [{ agentId: stagingAgent.id, toolId: tool.id }],
+    },
+  });
+
+  // Bulk assignment reports per-item outcomes rather than failing the call.
+  expect(body.result.isError).toBeFalsy();
+  const parsed = JSON.parse(resultText(body)) as {
+    succeeded: unknown[];
+    failed: { error: string }[];
+  };
+  expect(parsed.succeeded).toEqual([]);
+  expect(parsed.failed[0].error).toContain("different environment");
+
+  // The other environment's agent must be untouched.
+  const assigned = await AgentToolModel.exists(stagingAgent.id, tool.id);
+  expect(assigned).toBe(false);
 });

--- a/platform/backend/src/services/environments/environment-isolation.test.ts
+++ b/platform/backend/src/services/environments/environment-isolation.test.ts
@@ -1,6 +1,8 @@
 import { ARCHESTRA_MCP_CATALOG_ID } from "@archestra/shared";
 import EnvironmentModel from "@/models/environment";
+import InternalMcpCatalogModel from "@/models/internal-mcp-catalog";
 import KnowledgeBaseConnectorModel from "@/models/knowledge-base-connector";
+import McpServerModel from "@/models/mcp-server";
 import ToolModel from "@/models/tool";
 import { expect, test } from "@/test";
 
@@ -280,4 +282,150 @@ test("KnowledgeBaseConnectorModel.findByOrganization: filters connectors by envi
   ).map((connector) => connector.id);
   expect(allIds).toContain(prodConnector.id);
   expect(allIds).toContain(defaultConnector.id);
+});
+
+test("InternalMcpCatalogModel.findAll: filters catalog items by environment", async ({
+  makeOrganization,
+  makeInternalMcpCatalog,
+}) => {
+  const org = await makeOrganization();
+  const prod = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: "production",
+  });
+
+  const prodCatalog = await makeInternalMcpCatalog({
+    organizationId: org.id,
+    environmentId: prod.id,
+  });
+  const defaultCatalog = await makeInternalMcpCatalog({
+    organizationId: org.id,
+    environmentId: null,
+  });
+  // Built-ins are exempt: their tools are callable from every environment, so
+  // hiding the server that owns them would be incoherent.
+  const builtIn = await makeInternalMcpCatalog({
+    id: ARCHESTRA_MCP_CATALOG_ID,
+    organizationId: org.id,
+    environmentId: null,
+  });
+
+  const prodIds = (
+    await InternalMcpCatalogModel.findAll({
+      expandSecrets: false,
+      isAdmin: true,
+      organizationId: org.id,
+      environmentId: prod.id,
+    })
+  ).map((item) => item.id);
+  expect(prodIds).toContain(prodCatalog.id);
+  expect(prodIds).toContain(builtIn.id);
+  expect(prodIds).not.toContain(defaultCatalog.id);
+
+  const defaultIds = (
+    await InternalMcpCatalogModel.findAll({
+      expandSecrets: false,
+      isAdmin: true,
+      organizationId: org.id,
+      environmentId: null,
+    })
+  ).map((item) => item.id);
+  expect(defaultIds).toContain(defaultCatalog.id);
+  expect(defaultIds).not.toContain(prodCatalog.id);
+
+  // No environment filter → both returned (the registry UI, which filters
+  // by environment client-side).
+  const allIds = (
+    await InternalMcpCatalogModel.findAll({
+      expandSecrets: false,
+      isAdmin: true,
+      organizationId: org.id,
+    })
+  ).map((item) => item.id);
+  expect(allIds).toContain(prodCatalog.id);
+  expect(allIds).toContain(defaultCatalog.id);
+});
+
+test("InternalMcpCatalogModel.searchByQuery: filters catalog items by environment", async ({
+  makeOrganization,
+  makeInternalMcpCatalog,
+}) => {
+  const org = await makeOrganization();
+  const prod = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: "production",
+  });
+
+  const prodCatalog = await makeInternalMcpCatalog({
+    name: "shared-name prod",
+    organizationId: org.id,
+    environmentId: prod.id,
+  });
+  const defaultCatalog = await makeInternalMcpCatalog({
+    name: "shared-name default",
+    organizationId: org.id,
+    environmentId: null,
+  });
+
+  const prodIds = (
+    await InternalMcpCatalogModel.searchByQuery("shared-name", {
+      expandSecrets: false,
+      isAdmin: true,
+      organizationId: org.id,
+      environmentId: prod.id,
+    })
+  ).map((item) => item.id);
+  expect(prodIds).toEqual([prodCatalog.id]);
+
+  const unfilteredIds = (
+    await InternalMcpCatalogModel.searchByQuery("shared-name", {
+      expandSecrets: false,
+      isAdmin: true,
+      organizationId: org.id,
+    })
+  ).map((item) => item.id);
+  expect(unfilteredIds).toContain(prodCatalog.id);
+  expect(unfilteredIds).toContain(defaultCatalog.id);
+});
+
+test("McpServerModel.findAll: filters deployments by their catalog's environment", async ({
+  makeOrganization,
+  makeInternalMcpCatalog,
+  makeMcpServer,
+}) => {
+  const org = await makeOrganization();
+  const prod = await EnvironmentModel.create({
+    organizationId: org.id,
+    name: "production",
+  });
+
+  const prodCatalog = await makeInternalMcpCatalog({
+    organizationId: org.id,
+    environmentId: prod.id,
+  });
+  const defaultCatalog = await makeInternalMcpCatalog({
+    organizationId: org.id,
+    environmentId: null,
+  });
+  const prodServer = await makeMcpServer({ catalogId: prodCatalog.id });
+  const defaultServer = await makeMcpServer({ catalogId: defaultCatalog.id });
+
+  const prodIds = (
+    await McpServerModel.findAll(undefined, true, org.id, prod.id)
+  ).map((server) => server.id);
+  expect(prodIds).toContain(prodServer.id);
+  expect(prodIds).not.toContain(defaultServer.id);
+
+  const defaultIds = (
+    await McpServerModel.findAll(undefined, true, org.id, null)
+  ).map((server) => server.id);
+  expect(defaultIds).toContain(defaultServer.id);
+  expect(defaultIds).not.toContain(prodServer.id);
+
+  // No environment filter → both returned (management listing).
+  const allIds = (await McpServerModel.findAll(undefined, true, org.id)).map(
+    (server) => server.id,
+  );
+  expect(allIds).toContain(prodServer.id);
+  expect(allIds).toContain(defaultServer.id);
 });

--- a/platform/backend/src/services/environments/environment-isolation.ts
+++ b/platform/backend/src/services/environments/environment-isolation.ts
@@ -50,6 +50,44 @@ export function toolInEnvironmentPredicate(
 }
 
 /**
+ * SQL predicate selecting `internal_mcp_catalog` rows visible from
+ * `agentEnvironmentId`'s environment: strict equality (null = Default), with the
+ * built-in catalogs exempt for the same reason {@link toolInEnvironmentPredicate}
+ * exempts them — their tools are callable from every environment, so hiding the
+ * server that owns them would be incoherent.
+ *
+ * This is the catalog-row counterpart of the tool predicate: use it on surfaces
+ * that list or resolve MCP *servers* for an agent, so registry discovery agrees
+ * with the tool discovery that follows it.
+ *
+ * @param catalog pass an aliased catalog table when the query aliases it.
+ */
+export function catalogInEnvironmentPredicate(
+  agentEnvironmentId: string | null,
+  catalog = schema.internalMcpCatalogTable,
+): SQL {
+  return or(
+    inArray(catalog.id, ENVIRONMENT_EXEMPT_CATALOG_IDS),
+    sql`${catalog.environmentId} is not distinct from ${agentEnvironmentId}`,
+  ) as SQL;
+}
+
+/**
+ * JS counterpart of {@link catalogInEnvironmentPredicate} for callers that
+ * already hold the catalog row — the by-id fences, which must treat a
+ * cross-environment server as if it did not exist.
+ */
+export function catalogVisibleInEnvironment(
+  catalog: { id: string; environmentId: string | null },
+  agentEnvironmentId: string | null,
+): boolean {
+  return (
+    ENVIRONMENT_EXEMPT_CATALOG_IDS.includes(catalog.id) ||
+    catalog.environmentId === agentEnvironmentId
+  );
+}
+
+/**
  * App-surface variant of {@link toolInEnvironmentPredicate}: a tool matches when
  * it belongs to `environmentId` OR to the Default environment (catalog
  * `environment_id` null) — Default is the org-wide baseline every app may draw


### PR DESCRIPTION
## Problem

Environment isolation guarantees that an agent bound to environment `E` only sees and uses resources in `E`. Tool discovery, knowledge connectors, skills, and subagent delegation all enforce it. Two control-plane surfaces did not.

**Registry discovery.** `archestra-mcp-server/mcp-servers.ts` never resolved the calling agent's environment — `environmentId` appeared in it solely on the create path. So an agent enumerated the entire organization's registry through `get_mcp_servers` / `search_private_mcp_registry`, while the registry UI's Environment filter correctly showed only that environment's servers. The result is incoherent rather than merely noisy: the registry an agent could see disagreed with the tools it could actually call, so the model would offer servers it has no access to.

**Assignment writes.** `bulk_assign_tools_to_agents`, `bulk_assign_tools_to_mcp_gateways`, and `bulk_remove_tools_from_agents` accepted arbitrary target ids with no environment check, so an agent in one environment could rewrite another environment's toolset. This one is not inert: when the tool and the target agent are both in the other environment they agree, so the call-time gate passes and the assignment takes full effect.

RBAC does not close either gap, because **it has no environment dimension**. `environment` is a resource you can hold permissions on, and there are coarse `deploy-to-restricted` permissions, but no role can express "manage MCP servers, but only in staging". If environment does not gate the control plane, nothing does — which leaves a capability boundary with a hole exactly where an agent operates, the component most likely to be steered by untrusted input in its context.

Neither gap is a privilege escalation: results stay RBAC-scoped to the calling user.

## Principle

**Environment gates state changes and capability; RBAC gates who can act at all.** Mutations are fenced first, discovery second. Pure management listings (`list_agents`) are deliberately left alone — no capability, no mutation.

## Changes

`environment-isolation.ts` gains the catalog-row counterpart of the existing tool predicate — strict matching (`null` = Default, a peer rather than a wildcard), with the built-in catalogs (Archestra, Playwright) exempt for the same reason the tool predicate exempts them: their tools are callable from every environment, so hiding the server that owns them would be incoherent.

**MCP registry**

- **Listing** — `get_mcp_servers`, `search_private_mcp_registry`, and `list_mcp_server_deployments` filter on the agent's environment. A deployment has no environment column of its own, so it inherits its catalog item's; a catalog-less (custom/legacy) row counts as Default.
- **By-id fences** — `get_mcp_server_tools`, `edit_mcp_description`, `edit_mcp_config`, `deploy_mcp_server`, `get_mcp_server_logs`, and `reload_mcp_server_tools` apply the same rule and report an out-of-environment server exactly like a missing one. Without this, passing an id walks straight around the list filter; reporting it as "not found" also avoids confirming the server exists, the rule `load_skill` already applies to cross-environment skills.
- **Creation** — `create_mcp_server` defaults to the calling agent's environment instead of Default, so an agent can still see what it just created. An explicit `environmentId` is still honoured, subject to the existing restricted-environment gate. Mirrors `scaffold_app` (#6981).

**Tool assignment**

- The **target** of a bulk assign/remove must be in the calling agent's environment.
- The **tool** end is deliberately not fenced: a cross-environment tool assigned to an in-environment agent is dropped by the call-time gate, so fencing it would buy no isolation while refusing catalog-less legacy rows, which no environment predicate matches.
- `findByIdsForPermissionCheck` returns `environmentId`, so the fence is evaluated beside the existing permission checks without another round-trip per target. Failures stay per-item, so a bulk call still reports partial success.

The model-level filters are opt-in: omitting `environmentId` lists every environment, which is what the registry REST route and UI rely on (the UI filters client-side).

## Behaviour change

Only organizations that have assigned a non-default environment are affected — everything starts in Default, and Default-to-Default behaviour is unchanged.

Where it does apply, an agent can no longer manage another environment's servers or toolsets, so there is no longer a way to have a single cross-environment management **agent**. That is the intended trade: the UI and REST paths are not environment-fenced, so a human admin with the right permissions still manages every environment. Agents are fenced because they are the ones acting on model-controlled input.

## Tests

`McpServerModel.findAll` previously applied its one condition with a bare `.where()`; conditions are now collected and `and()`-ed, so adding the environment filter cannot silently drop the access-control clause.

- **Route-level integration tests** (`routes/mcp-gateway/environment-isolation.test.ts`) drive the real `POST /v1/mcp/:agentId` gateway — real bearer-token auth, real tool dispatch — covering listing, search, the by-id fence, creation, and the assignment fence. The caller is an org admin throughout, so a missing result is always an environment decision and never RBAC masking one.
- The same file pins **`scaffold_app` binding an app to the authoring agent's environment**, so that guarantee (fixed in #6981) cannot regress. Verified sensitive: forcing the pre-#6981 behaviour fails it with `expected <env-id>, received null`.
- Handler-level tests in `archestra-mcp-server/mcp-servers.test.ts` and `archestra-mcp-server/tool-assignment.test.ts` (including a Default-environment caller, and assertions that the rejected write did not land), plus model-level tests in `services/environments/environment-isolation.test.ts` covering the built-in-catalog exemption and the unfiltered management listing.
- Every new test was verified to fail without its fix, by reverting the handler in question.

Full backend suite green under the CI environment file.
