### PR TITLE
fix(llm-proxy): restore two Azure Responses behaviours the OpenAI copy already has

### DIFF
--- a/platform/backend/src/routes/proxy/adapters/azure-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.test.ts
@@ -58,6 +58,29 @@ describe("azureResponsesAdapterFactory", () => {
     expect(client._options?.defaultQuery).toBeUndefined();
   });
 
+  test("reads messages that omit `type` (the AI SDK's easy input message shape)", () => {
+    // The Responses API defaults an input item's `type` to "message", and the AI
+    // SDK relies on that, sending bare `{role, content}`. Dropping those left
+    // getMessages() empty, so trusted-data / Dual LLM policy evaluation ran
+    // against an empty conversation instead of the user's actual prompt.
+    const adapter = azureResponsesAdapterFactory.createRequestAdapter({
+      model: "gpt-4.1",
+      input: [
+        { role: "user", content: "what is my account balance?" },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "checking" }],
+        },
+      ],
+    } as never);
+
+    expect(adapter.getMessages()).toEqual([
+      { role: "user", content: "what is my account balance?" },
+      { role: "assistant", content: "checking" },
+    ]);
+  });
+
   test("maps response tools and tool outputs from the request", () => {
     const adapter = azureResponsesAdapterFactory.createRequestAdapter({
       model: "gpt-4.1",
@@ -320,5 +343,35 @@ describe("azureResponsesAdapterFactory", () => {
         name: "read_file",
       }),
     ]);
+  });
+
+  test("keeps accumulated output when the completed envelope carries none", () => {
+    // Reasoning turns finish with an empty `output` even though the text
+    // arrived over `response.output_text.delta`. Persisting the envelope
+    // verbatim dropped the whole assistant side, leaving LLM Logs with
+    // "No message" to render.
+    const adapter = azureResponsesAdapterFactory.createStreamAdapter();
+
+    adapter.processChunk({
+      type: "response.output_text.delta",
+      delta: "the answer",
+    } as never);
+    adapter.processChunk({
+      type: "response.completed",
+      response: {
+        id: "resp_1",
+        object: "response",
+        created_at: 1,
+        model: "gpt-4.1",
+        status: "completed",
+        output: [],
+      },
+    } as never);
+
+    const persisted = adapter.toProviderResponse();
+
+    expect(persisted.id).toBe("resp_1");
+    expect(persisted.output).toHaveLength(1);
+    expect(JSON.stringify(persisted.output)).toContain("the answer");
   });
 });

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -667,10 +667,6 @@ class AzureResponsesStreamAdapter
   }
 
   toProviderResponse(): AzureResponsesResponse {
-    if (this.replacedText === null && this.completedResponse) {
-      return this.completedResponse;
-    }
-
     const outputItems: AzureResponsesResponse["output"] = [];
 
     const messageText = this.replacedText ?? this.state.text;
@@ -701,6 +697,24 @@ class AzureResponsesStreamAdapter
           status: "completed" as const,
         })),
       );
+    }
+
+    // The upstream `response.completed` envelope is the richest record (it
+    // echoes tools, reasoning config and the real ids), so it wins — but only
+    // when it actually carries the turn. Reasoning turns finish with an empty
+    // `output` even though the text arrived in `response.output_text.delta`
+    // chunks; persisting that verbatim lost the whole assistant side of the
+    // interaction, leaving LLM Logs with nothing to render. Keep the envelope
+    // and restore the items we accumulated.
+    if (this.replacedText === null && this.completedResponse) {
+      const upstreamOutput = this.completedResponse.output;
+      if (
+        (Array.isArray(upstreamOutput) && upstreamOutput.length > 0) ||
+        outputItems.length === 0
+      ) {
+        return this.completedResponse;
+      }
+      return { ...this.completedResponse, output: outputItems };
     }
 
     return {
@@ -789,7 +803,11 @@ function createEmptyToolCompressionStats(): ToolCompressionStats {
 }
 
 function toCommonMessages(item: ResponseInputItem): CommonMessage[] {
-  if (item.type === "message") {
+  // "easy input message" items carry role/content and omit `type` (it defaults
+  // to "message"); the AI SDK emits this shape. Without handling it here,
+  // getMessages() drops the user's prompt and trusted-data / Dual LLM policy
+  // evaluation (llm-proxy-handler) silently sees an empty conversation.
+  if ((item.type === "message" || item.type === undefined) && "role" in item) {
     return [
       {
         role: normalizeResponseMessageRole(item.role),


### PR DESCRIPTION
`routes/proxy/adapters/azure-responses.ts` was forked from `openai-responses.ts` and has drifted behind two fixes made there. Found while adding a Responses-shaped provider in #6996 — which is precisely why that one **composes** from `openAiResponsesAdapterFactory` rather than forking it.

Both are reachable: [`proxy/routes/azure.ts`](platform/backend/src/routes/proxy/routes/azure.ts) registers `/responses` and `/:agentId/responses` against this adapter.

## 1. `getMessages()` returned nothing for SDK-shaped input — policy evaluated an empty conversation

`toCommonMessages` matched only `item.type === "message"`. But the Responses API **defaults** an input item's `type` to `"message"`, and the AI SDK relies on that, sending bare `{role, content}`. Those items fell straight through.

Everything that reads the conversation off the request then read *nothing* — including **trusted-data and Dual-LLM policy evaluation**, which ran against an empty conversation instead of the user's actual prompt. A security evaluation on no input.

The OpenAI adapter carries both the fix and a comment naming this exact consequence:

> *"Without handling it here, `getMessages()` drops the user's prompt and trusted-data / Dual LLM policy evaluation (llm-proxy-handler) silently sees an empty conversation."*

## 2. `toProviderResponse()` discarded reasoning turns — LLM Logs showed "No message"

It returned the upstream `response.completed` envelope unconditionally, *before* the accumulated output items were built. A reasoning turn finishes with an empty `output` even though its text arrived over `response.output_text.delta` chunks — so persisting the envelope verbatim dropped the whole assistant side of the interaction.

The envelope still wins when it actually carries the turn (it holds the real ids, tools and reasoning config); it now falls back to the accumulated items only when it is empty. Same shape as the OpenAI copy. This is the same class as the known `openai:responses` logs-preview gap.

## Verification

Two regression tests, each **verified red against the previous implementation** (2 failed / 9 passed before, 11 passed after). Full proxy suite green: **1173 tests across 63 files**. `pnpm type-check` and `pnpm lint` clean.

No behaviour change for requests that already worked — the first fix only adds a shape that was being dropped, the second only changes what happens when the upstream envelope is empty.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>