### PR TITLE
fix(guardrails): apply trusted-data policies to progressive run_tool dispatches

### DIFF
--- a/platform/backend/src/agents/context-trust.ts
+++ b/platform/backend/src/agents/context-trust.ts
@@ -3,6 +3,7 @@ import { evaluateIfContextIsTrusted } from "@/guardrails/trusted-data";
 import { AgentTeamModel } from "@/models";
 import type { PolicyEvaluationContext } from "@/models/tool-invocation-policy";
 import type { CommonMessage, UnsafeContextBoundary } from "@/types";
+import { extractCommonToolCallArguments } from "@/types";
 
 // === Exports ===
 
@@ -42,6 +43,7 @@ export async function evaluateToolExecutionContextTrust(params: {
 function toCommonMessages(
   messages: ToolExecutionOptions["messages"],
 ): CommonMessage[] {
+  const argumentsByToolCallId = collectToolCallArguments(messages ?? []);
   return (messages ?? []).map((message) => {
     const commonMessage: CommonMessage = {
       role: normalizeMessageRole(message.role),
@@ -52,7 +54,8 @@ function toCommonMessages(
       commonMessage.content = textContent;
     }
 
-    const toolCalls = extractToolResults(message.content) ?? [];
+    const toolCalls =
+      extractToolResults(message.content, argumentsByToolCallId) ?? [];
     if (toolCalls.length > 0) {
       commonMessage.toolCalls = toolCalls;
     }
@@ -61,7 +64,40 @@ function toCommonMessages(
   });
 }
 
-function extractToolResults(content: unknown): CommonMessage["toolCalls"] {
+/**
+ * Arguments live on the assistant `tool-call` parts while results are separate
+ * `tool-result` parts; pair them by id so a `run_tool` result can be resolved
+ * to the target tool its arguments name (trusted-data evaluation).
+ */
+function collectToolCallArguments(
+  messages: NonNullable<ToolExecutionOptions["messages"]>,
+): Map<string, Record<string, unknown>> {
+  const argumentsByToolCallId = new Map<string, Record<string, unknown>>();
+  for (const message of messages) {
+    const content: unknown = message.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    for (const part of content) {
+      if (
+        isRecord(part) &&
+        part.type === "tool-call" &&
+        typeof part.toolCallId === "string"
+      ) {
+        const input = extractCommonToolCallArguments(part.input);
+        if (input) {
+          argumentsByToolCallId.set(part.toolCallId, input);
+        }
+      }
+    }
+  }
+  return argumentsByToolCallId;
+}
+
+function extractToolResults(
+  content: unknown,
+  argumentsByToolCallId: Map<string, Record<string, unknown>>,
+): CommonMessage["toolCalls"] {
   if (!Array.isArray(content)) {
     return [];
   }
@@ -87,6 +123,11 @@ function extractToolResults(content: unknown): CommonMessage["toolCalls"] {
       {
         id: toolCallId,
         name: toolName,
+        arguments:
+          argumentsByToolCallId.get(toolCallId) ??
+          extractCommonToolCallArguments(
+            "input" in part ? part.input : undefined,
+          ),
         content: output,
         isError,
       },

--- a/platform/backend/src/archestra-mcp-server/dynamic-tools.ts
+++ b/platform/backend/src/archestra-mcp-server/dynamic-tools.ts
@@ -1,8 +1,5 @@
 import {
   ARCHESTRA_MCP_CATALOG_ID,
-  ARCHESTRA_TOOL_SHORT_NAMES,
-  type ArchestraToolShortName,
-  getArchestraToolFullName,
   isSandboxArchestraToolShortName,
   TOOL_QUERY_KNOWLEDGE_SOURCES_SHORT_NAME,
   TOOL_RUN_TOOL_SHORT_NAME,
@@ -34,19 +31,6 @@ import { filterToolNamesByPermission } from "./rbac";
 // per-call, so no agent-modify permission is involved. Tool RBAC, invocation
 // policies, and per-conversation tool selections still gate every call. The
 // per-agent "access all tools" setting is the sole gate.
-
-/**
- * Resolve a run_tool target name to its canonical form (Archestra short names
- * like `run_command` → `archestra__run_command`; everything else unchanged),
- * mirroring run_tool's own resolution so dispatch and access checks line up.
- */
-export function resolveRunToolTargetName(requestedName: string): string {
-  const isArchestraPrefixed = archestraMcpBranding.isToolName(requestedName);
-  if (!isArchestraPrefixed && ARCHESTRA_SHORT_NAME_SET.has(requestedName)) {
-    return getArchestraToolFullName(requestedName as ArchestraToolShortName);
-  }
-  return requestedName;
-}
 
 /**
  * Resolve an unassigned third-party tool name to the catalog tool row the user
@@ -308,8 +292,6 @@ export async function dynamicAccessContext(params: {
 }
 
 // === Internal helpers ===
-
-const ARCHESTRA_SHORT_NAME_SET = new Set<string>(ARCHESTRA_TOOL_SHORT_NAMES);
 
 // Whether at least one knowledge connector is queryable by the user (org-wide
 // or auto-sync-permissions visibility, or team-scoped to one of their teams;

--- a/platform/backend/src/archestra-mcp-server/run-tool-target.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool-target.ts
@@ -1,10 +1,11 @@
-import { TOOL_RUN_TOOL_SHORT_NAME } from "@archestra/shared";
+import {
+  ARCHESTRA_TOOL_SHORT_NAMES,
+  type ArchestraToolShortName,
+  getArchestraToolFullName,
+  TOOL_RUN_TOOL_SHORT_NAME,
+} from "@archestra/shared";
 
 import { archestraMcpBranding } from "./branding";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 /**
  * Unwrap a `run_tool` dispatch to the underlying tool it targets and that
@@ -39,4 +40,60 @@ export function resolveRunToolTarget(
     toolName: targetToolName,
     toolInput: targetToolInput,
   };
+}
+
+type RunToolDispatch =
+  /** Not a `run_tool` call — the tool name is its own identity. */
+  | { kind: "not_dispatch" }
+  /** A `run_tool` dispatch whose target resolved to a canonical tool name. */
+  | { kind: "target"; toolName: string }
+  /**
+   * A `run_tool` call whose target cannot be recovered — the call's arguments
+   * were not captured, or carry no usable `tool_name`. The caller cannot know
+   * which tool produced the result, so trust decisions must fail closed.
+   */
+  | { kind: "unresolved" };
+
+/**
+ * Classify a tool call for trust/policy purposes: pass-through for ordinary
+ * tools, and for `run_tool` dispatches recover the target tool's canonical
+ * name (bare Archestra short names like `run_command` are expanded to their
+ * full `archestra__…` form, mirroring run_tool's own dispatch resolution) so
+ * policies evaluate the tool that actually produced the data instead of the
+ * built-in wrapper.
+ */
+export function resolveRunToolDispatch(
+  toolName: string,
+  args: unknown,
+): RunToolDispatch {
+  const shortName = archestraMcpBranding.getToolShortName(toolName);
+  if (shortName !== TOOL_RUN_TOOL_SHORT_NAME) {
+    return { kind: "not_dispatch" };
+  }
+
+  const targetToolName = isRecord(args) ? args.tool_name : undefined;
+  if (typeof targetToolName !== "string" || targetToolName.length === 0) {
+    return { kind: "unresolved" };
+  }
+
+  return { kind: "target", toolName: resolveRunToolTargetName(targetToolName) };
+}
+
+/**
+ * Resolve a run_tool target name to its canonical form (Archestra short names
+ * like `run_command` → `archestra__run_command`; everything else unchanged),
+ * mirroring run_tool's own resolution so dispatch and access checks line up.
+ */
+export function resolveRunToolTargetName(requestedName: string): string {
+  const isArchestraPrefixed = archestraMcpBranding.isToolName(requestedName);
+  if (!isArchestraPrefixed && ARCHESTRA_SHORT_NAME_SET.has(requestedName)) {
+    return getArchestraToolFullName(requestedName as ArchestraToolShortName);
+  }
+  return requestedName;
+}
+
+const ARCHESTRA_SHORT_NAME_SET = new Set<string>(ARCHESTRA_TOOL_SHORT_NAMES);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/platform/backend/src/archestra-mcp-server/run-tool.test.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.test.ts
@@ -1363,6 +1363,15 @@ describe("run_tool", () => {
     expect(text).toContain("search_tools");
     expect(text).not.toContain("not enabled for this conversation");
     expect(mcpClient.executeToolCallForOwner).not.toHaveBeenCalled();
+    // A refusal never reached an upstream tool: the tool_state envelope tells
+    // trusted-data evaluation not to flip the session over platform text.
+    expect(result._meta).toMatchObject({
+      archestraError: {
+        type: "tool_state",
+        code: "unknown_tool",
+        toolName: "giphy__image_search_tool",
+      },
+    });
   });
 
   test("recovery message wins over the policy refusal when the agent has other tools", async ({

--- a/platform/backend/src/archestra-mcp-server/run-tool.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool.ts
@@ -20,15 +20,14 @@ import {
   dynamicAccessContext,
   getUnassignedDiscoverableTools,
   resolveDynamicTool,
-  resolveRunToolTargetName,
 } from "./dynamic-tools";
 import {
   defineArchestraTool,
   defineArchestraTools,
-  errorResult,
   structuredToolErrorResult,
 } from "./helpers";
 import { filterToolNamesByPermission } from "./rbac";
+import { resolveRunToolTargetName } from "./run-tool-target";
 import { placeholderForSchema, safeJsonStringify } from "./tool-args-skeleton";
 import {
   ambiguousShortNameMessage,
@@ -96,9 +95,11 @@ async function runToolHandler({
   const requestedName = args.tool_name;
   const recovery = await resolveShortName({ requestedName, context });
   if (recovery.kind === "ambiguous") {
-    return errorResult(
-      ambiguousShortNameMessage(requestedName, recovery.candidates),
-    );
+    return dispatchRefusalResult({
+      code: "ambiguous_tool",
+      message: ambiguousShortNameMessage(requestedName, recovery.candidates),
+      toolName: requestedName,
+    });
   }
 
   // Built-in recovery keeps the original short name as the effective name:
@@ -287,9 +288,11 @@ async function dispatchTool({
 
   const runToolFullName = getArchestraToolFullName(TOOL_RUN_TOOL_SHORT_NAME);
   if (resolvedName === runToolFullName) {
-    return errorResult(
-      `${TOOL_RUN_TOOL_SHORT_NAME} cannot invoke itself. Call ${TOOL_RUN_TOOL_SHORT_NAME} once, with tool_name set to the target tool's exact name (from search_tools) and the target's arguments in tool_args — never set tool_name to ${TOOL_RUN_TOOL_SHORT_NAME}.`,
-    );
+    return dispatchRefusalResult({
+      code: "invalid_target",
+      message: `${TOOL_RUN_TOOL_SHORT_NAME} cannot invoke itself. Call ${TOOL_RUN_TOOL_SHORT_NAME} once, with tool_name set to the target tool's exact name (from search_tools) and the target's arguments in tool_args — never set tool_name to ${TOOL_RUN_TOOL_SHORT_NAME}.`,
+      toolName: resolvedName,
+    });
   }
 
   // Per-conversation enabled-tool gate: in a chat with a custom tool
@@ -318,7 +321,11 @@ async function dispatchTool({
       { agentId: context.agentId, requestedName, resolvedName: name },
       `${TOOL_RUN_TOOL_SHORT_NAME} dispatched to a tool disabled for this conversation`,
     );
-    return errorResult(toolNotEnabledForConversationMessage(name));
+    return dispatchRefusalResult({
+      code: "tool_disabled",
+      message: toolNotEnabledForConversationMessage(name),
+      toolName: name,
+    });
   };
 
   if (route === "archestra") {
@@ -356,9 +363,11 @@ async function dispatchTool({
   // bogus agent-<id> delegations are handled by the "archestra" route above
   // (executeArchestraTool / checkToolAssignedToAgent), not this check.
   if (!context.agentId) {
-    return errorResult(
-      `${TOOL_RUN_TOOL_SHORT_NAME} requires agent context to dispatch to third-party MCP tools`,
-    );
+    return dispatchRefusalResult({
+      code: "missing_agent_context",
+      message: `${TOOL_RUN_TOOL_SHORT_NAME} requires agent context to dispatch to third-party MCP tools`,
+      toolName: resolvedName,
+    });
   }
 
   // Gate dispatch on the assigned-tool set, then fall back to dynamic
@@ -381,7 +390,11 @@ async function dispatchTool({
     // agent's assigned tools, so an unassigned tool can never be enabled in
     // it — return the same unavailable recovery search_tools shows.
     if (await checkConversationGate(resolvedName)) {
-      return errorResult(unavailableThirdPartyToolMessage(resolvedName));
+      return dispatchRefusalResult({
+        code: "unknown_tool",
+        message: unavailableThirdPartyToolMessage(resolvedName),
+        toolName: resolvedName,
+      });
     }
     availableTool = await resolveDynamicTool({
       toolName: resolvedName,
@@ -400,7 +413,11 @@ async function dispatchTool({
       `${TOOL_RUN_TOOL_SHORT_NAME} dispatched to an unassigned tool`,
     );
     if (!availableTool) {
-      return errorResult(unavailableThirdPartyToolMessage(resolvedName));
+      return dispatchRefusalResult({
+        code: "unknown_tool",
+        message: unavailableThirdPartyToolMessage(resolvedName),
+        toolName: resolvedName,
+      });
     }
   } else {
     // The tool is assigned — enforce the per-conversation selection.
@@ -646,7 +663,33 @@ function checkThirdPartyToolArgs(params: {
   messageLines.push(
     `The tool's full input schema is:\n${safeJsonStringify(schema, 2)}`,
   );
-  return errorResult(messageLines.join("\n"));
+  return dispatchRefusalResult({
+    code: "invalid_arguments",
+    message: messageLines.join("\n"),
+    toolName,
+  });
+}
+
+/**
+ * A dispatch refusal the platform authored before any upstream tool ran.
+ * Same prose an errorResult would carry, plus the `tool_state` envelope in
+ * `_meta`/`structuredContent` so trust evaluation can tell "no upstream data"
+ * apart from a real tool error — a refused dispatch must not flip the session
+ * to sensitive.
+ */
+function dispatchRefusalResult(params: {
+  code: string;
+  message: string;
+  toolName?: string;
+}): CallToolResult {
+  return structuredToolErrorResult({
+    error: {
+      type: "tool_state",
+      code: params.code,
+      message: params.message,
+      toolName: params.toolName,
+    },
+  });
 }
 
 /** Param types the repair may unwrap to — a literal declared `type` only. */

--- a/platform/backend/src/clients/chat-tool-builder.ts
+++ b/platform/backend/src/clients/chat-tool-builder.ts
@@ -33,7 +33,10 @@ import {
   executeArchestraTool,
 } from "@/archestra-mcp-server";
 import { resolveDynamicTool } from "@/archestra-mcp-server/dynamic-tools";
-import { resolveRunToolTarget } from "@/archestra-mcp-server/run-tool-target";
+import {
+  resolveRunToolDispatch,
+  resolveRunToolTarget,
+} from "@/archestra-mcp-server/run-tool-target";
 import type { ChatMcpElicitationBridge } from "@/clients/chat-mcp-elicitation";
 import type { ChatTaskBridge } from "@/clients/chat-task-bridge";
 import mcpClient, { type TokenAuthContext } from "@/clients/mcp-client";
@@ -297,6 +300,26 @@ export function buildMcpGatewayTool(params: {
                 userId: ctx.userId,
               }),
             });
+
+            // A run_tool dispatch result is the target tool's output, so its
+            // trusted-data boundary must be evaluated exactly like the direct
+            // path (executeMcpTool) does — otherwise a "sensitive" result
+            // policy never flips the session (and the divider never shows)
+            // under progressive tool loading. Built-in targets auto-trust
+            // inside the evaluation, so only real external data attaches one.
+            const dispatch = resolveRunToolDispatch(
+              mcpTool.name,
+              toolArguments,
+            );
+            if (dispatch.kind === "target") {
+              toolResult = await attachDispatchUnsafeContextBoundary({
+                toolResult,
+                toolCallId: options.toolCallId,
+                targetToolName: dispatch.toolName,
+                agentId: ctx.agentId,
+                considerContextUntrusted: ctx.considerContextUntrusted,
+              });
+            }
           } else {
             // Execute non-Archestra tools via shared helper with browser sync
             toolResult = await executeMcpTool({
@@ -1474,10 +1497,49 @@ function toolProvidesUiResource(tool: CatalogTool): boolean {
   return metaProvidesUiResource(meta);
 }
 
+/**
+ * Evaluate and attach the unsafe-context boundary for a `run_tool` dispatch
+ * result, against the dispatched *target* tool. Mirrors what the direct path
+ * (executeMcpTool) does for ordinary tool calls: the boundary lands both
+ * top-level on the result (the chat stream/persisted part the divider reads)
+ * and inside `_meta`. A result that stays trusted is returned unchanged.
+ */
+async function attachDispatchUnsafeContextBoundary(params: {
+  toolResult: string | { content: string; [key: string]: unknown };
+  toolCallId: string;
+  targetToolName: string;
+  agentId: string;
+  considerContextUntrusted: boolean;
+}): Promise<string | { content: string; [key: string]: unknown }> {
+  const result =
+    typeof params.toolResult === "string"
+      ? { content: params.toolResult }
+      : params.toolResult;
+
+  const boundaryResult = await buildUnsafeContextBoundaryResult({
+    resultMeta: result._meta as Record<string, unknown> | undefined,
+    toolCallId: params.toolCallId,
+    toolName: params.targetToolName,
+    isRunToolDispatchTarget: true,
+    toolOutput:
+      (result.structuredContent as Record<string, unknown> | undefined) ??
+      result.content,
+    agentId: params.agentId,
+    considerContextUntrusted: params.considerContextUntrusted,
+  });
+
+  if (!boundaryResult.unsafeContextBoundary) {
+    return params.toolResult;
+  }
+  return { ...result, ...boundaryResult };
+}
+
 async function buildUnsafeContextBoundaryResult(params: {
   resultMeta?: Record<string, unknown>;
   toolCallId: string;
   toolName: string;
+  /** True when toolName is a run_tool dispatch target (see evaluateBulk). */
+  isRunToolDispatchTarget?: boolean;
   toolOutput: unknown;
   agentId: string;
   considerContextUntrusted: boolean;
@@ -1521,6 +1583,7 @@ async function buildUnsafeContextBoundaryResult(params: {
 async function evaluateUnsafeContextBoundaryForToolResult(params: {
   toolCallId: string;
   toolName: string;
+  isRunToolDispatchTarget?: boolean;
   toolOutput: unknown;
   agentId: string;
   considerContextUntrusted: boolean;
@@ -1536,6 +1599,7 @@ async function evaluateUnsafeContextBoundaryForToolResult(params: {
       {
         toolName: params.toolName,
         toolOutput: params.toolOutput,
+        isRunToolDispatchTarget: params.isRunToolDispatchTarget,
       },
     ],
     {

--- a/platform/backend/src/guardrails/run-tool-invocation-chain.test.ts
+++ b/platform/backend/src/guardrails/run-tool-invocation-chain.test.ts
@@ -1,0 +1,357 @@
+import {
+  getArchestraToolFullName,
+  TOOL_RUN_TOOL_SHORT_NAME,
+} from "@archestra/shared";
+import { ToolInvocationPolicyModel } from "@/models";
+import { describe, expect, test } from "@/test";
+import type { CommonMessage } from "@/types";
+import {
+  evaluateIfContextIsTrusted,
+  sensitiveContextOriginFromBoundary,
+} from "./trusted-data";
+
+const RUN_TOOL_FULL_NAME = getArchestraToolFullName(TOOL_RUN_TOOL_SHORT_NAME);
+
+// End-to-end regression test for T-978: with progressive tool loading
+// (toolExposureMode "search_and_run_only") every third-party tool call is a
+// `run_tool` dispatch, so the tool-call name the trusted-data evaluation sees
+// is the built-in wrapper, not the tool that actually produced the result.
+// The wrapper must not inherit the built-ins' policy bypass — the dispatch
+// target's own trusted-data policies decide, exactly as they do when the same
+// tool is called directly with tools exposed. The individual behaviors
+// (untrusted-by-default results, untrusted-context blocking, policy
+// overrides) are pinned in trusted-data.test.ts, trusted-data-policy.test.ts
+// and tool-invocation-policy.test.ts — this file only pins the dispatch
+// unwrapping chain.
+describe("guardrails: run_tool dispatch -> target tool's trusted data policies apply", () => {
+  test("a dispatch result flips the context via the target's default policy and blocks a subsequent restricted invocation", async ({
+    makeAgent,
+    makeTool,
+    makeAgentTool,
+  }) => {
+    const agent = await makeAgent();
+
+    // The dispatch target: default policies from tool creation apply
+    // (trusted-data mark_as_untrusted, invocation block_when_context_is_untrusted).
+    const shellTool = await makeTool({
+      agentId: agent.id,
+      name: "run_shell_command",
+    });
+    await makeAgentTool(agent.id, shellTool.id);
+
+    const guardedTool = await makeTool({
+      agentId: agent.id,
+      name: "exfiltrate_data",
+    });
+    await makeAgentTool(agent.id, guardedTool.id);
+
+    // The history a progressive-load session produces: the only tool call is
+    // the run_tool wrapper; the real tool rides in its arguments.
+    const commonMessages: CommonMessage[] = [
+      { role: "user", content: "List my repo files" },
+      {
+        role: "tool",
+        toolCalls: [
+          {
+            id: "call_run_tool_1",
+            name: RUN_TOOL_FULL_NAME,
+            arguments: {
+              tool_name: "run_shell_command",
+              tool_args: { command: "ls" },
+            },
+            content: { output: "…" },
+            isError: false,
+          },
+        ],
+      },
+    ];
+
+    const trustEval = await evaluateIfContextIsTrusted(
+      commonMessages,
+      agent.id,
+      agent.organizationId,
+      undefined,
+      false,
+      { teamIds: [] },
+    );
+
+    expect(trustEval.contextIsTrusted).toBe(false);
+    // The boundary names the tool that produced the data (for the divider and
+    // the refusal), anchored to the run_tool call that carried it.
+    expect(trustEval.unsafeContextBoundary).toMatchObject({
+      kind: "tool_result",
+      toolCallId: "call_run_tool_1",
+      toolName: "run_shell_command",
+    });
+
+    const invocationEval = await ToolInvocationPolicyModel.evaluateBatch(
+      agent.id,
+      [{ toolCallName: "exfiltrate_data", toolInput: {} }],
+      {
+        teamIds: [],
+        sensitiveContextOrigin: sensitiveContextOriginFromBoundary(
+          trustEval.unsafeContextBoundary,
+        ),
+      },
+      trustEval.contextIsTrusted,
+    );
+
+    expect(invocationEval.isAllowed).toBe(false);
+    expect(invocationEval.reason).toBe(
+      '"Block in sensitive context" tool call policy violated: this session contains sensitive data, introduced by an earlier "run_shell_command" tool result',
+    );
+  });
+
+  test("a dispatch whose target cannot be recovered fails closed to untrusted", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+
+    // No `arguments` captured (e.g. a source format that lost the pairing):
+    // the evaluator cannot know which tool produced the data, so the wrapper
+    // must not inherit the built-ins' auto-trust.
+    const commonMessages: CommonMessage[] = [
+      { role: "user", content: "Run it" },
+      {
+        role: "tool",
+        toolCalls: [
+          {
+            id: "call_run_tool_3",
+            name: RUN_TOOL_FULL_NAME,
+            content: { output: "…" },
+            isError: false,
+          },
+        ],
+      },
+    ];
+
+    const trustEval = await evaluateIfContextIsTrusted(
+      commonMessages,
+      agent.id,
+      agent.organizationId,
+      undefined,
+      false,
+      { teamIds: [] },
+    );
+
+    expect(trustEval.contextIsTrusted).toBe(false);
+    expect(trustEval.unsafeContextBoundary).toMatchObject({
+      kind: "tool_result",
+      toolCallId: "call_run_tool_3",
+      toolName: RUN_TOOL_FULL_NAME,
+    });
+  });
+
+  test("a dispatch to a name with no tool row keeps the context trusted (run_tool refuses such dispatches)", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+
+    // The realistic history shape: platform refusal prose only — the
+    // tool_state envelope in _meta does NOT survive the model-message round
+    // trip, so the exemption must come from the unknown-target rule itself.
+    // A typo'd dispatch never reached any upstream tool; poisoning the
+    // session over it blocks the user's next legitimate call.
+    const commonMessages: CommonMessage[] = [
+      { role: "user", content: "Call the ghost tool" },
+      {
+        role: "tool",
+        toolCalls: [
+          {
+            id: "call_run_tool_6",
+            name: RUN_TOOL_FULL_NAME,
+            arguments: { tool_name: "deepwiki__list_all_pages", tool_args: {} },
+            content:
+              'Error: No tool named "deepwiki__list_all_pages" is available to this agent.',
+            isError: true,
+          },
+        ],
+      },
+    ];
+
+    const trustEval = await evaluateIfContextIsTrusted(
+      commonMessages,
+      agent.id,
+      agent.organizationId,
+      undefined,
+      false,
+      { teamIds: [] },
+    );
+
+    expect(trustEval.contextIsTrusted).toBe(true);
+    expect(trustEval.unsafeContextBoundary).toBeUndefined();
+  });
+
+  test("a dispatch to an unknown delegation-surface name stays untrusted", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+
+    // Agent/skill delegation tools execute without a matching tools-table
+    // row, so "no row" does not prove a refusal for them — their results are
+    // real child-agent output and must keep the fail-closed default.
+    const commonMessages: CommonMessage[] = [
+      { role: "user", content: "Delegate this" },
+      {
+        role: "tool",
+        toolCalls: [
+          {
+            id: "call_run_tool_7",
+            name: RUN_TOOL_FULL_NAME,
+            arguments: { tool_name: "agent-12345", tool_args: {} },
+            content: { answer: "…" },
+            isError: false,
+          },
+        ],
+      },
+    ];
+
+    const trustEval = await evaluateIfContextIsTrusted(
+      commonMessages,
+      agent.id,
+      agent.organizationId,
+      undefined,
+      false,
+      { teamIds: [] },
+    );
+
+    expect(trustEval.contextIsTrusted).toBe(false);
+    expect(trustEval.unsafeContextBoundary).toMatchObject({
+      kind: "tool_result",
+      toolCallId: "call_run_tool_7",
+      toolName: "agent-12345",
+    });
+  });
+
+  test("a platform-authored dispatch refusal (tool_state envelope) keeps the context trusted", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+
+    // run_tool refused the dispatch before any upstream tool ran (e.g. a
+    // hallucinated tool name). The refusal carries the platform's tool_state
+    // envelope, so it must not poison the session — even though the named
+    // target resolves to no known tool.
+    const message = 'Tool "ghost__do_thing" is not available.';
+    const commonMessages: CommonMessage[] = [
+      { role: "user", content: "Run the ghost tool" },
+      {
+        role: "tool",
+        toolCalls: [
+          {
+            id: "call_run_tool_4",
+            name: RUN_TOOL_FULL_NAME,
+            arguments: { tool_name: "ghost__do_thing", tool_args: {} },
+            content: message,
+            isError: true,
+            _meta: {
+              archestraError: {
+                type: "tool_state",
+                code: "unknown_tool",
+                message,
+                toolName: "ghost__do_thing",
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const trustEval = await evaluateIfContextIsTrusted(
+      commonMessages,
+      agent.id,
+      agent.organizationId,
+      undefined,
+      false,
+      { teamIds: [] },
+    );
+
+    expect(trustEval.contextIsTrusted).toBe(true);
+    expect(trustEval.unsafeContextBoundary).toBeUndefined();
+  });
+
+  test("a dispatch to a policy-bypassed built-in keeps the context trusted", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+
+    // Built-ins reached through run_tool (bare short name form) keep their
+    // auto-trust — the unwrap must not blanket-untrust every dispatch.
+    const commonMessages: CommonMessage[] = [
+      { role: "user", content: "What skills exist?" },
+      {
+        role: "tool",
+        toolCalls: [
+          {
+            id: "call_run_tool_5",
+            name: RUN_TOOL_FULL_NAME,
+            arguments: { tool_name: "list_skills", tool_args: {} },
+            content: { skills: [] },
+            isError: false,
+          },
+        ],
+      },
+    ];
+
+    const trustEval = await evaluateIfContextIsTrusted(
+      commonMessages,
+      agent.id,
+      agent.organizationId,
+      undefined,
+      false,
+      { teamIds: [] },
+    );
+
+    expect(trustEval.contextIsTrusted).toBe(true);
+    expect(trustEval.unsafeContextBoundary).toBeUndefined();
+  });
+
+  test("a dispatch result matching the target's mark_as_trusted policy keeps the context trusted", async ({
+    makeAgent,
+    makeTool,
+    makeAgentTool,
+    makeTrustedDataPolicy,
+  }) => {
+    const agent = await makeAgent();
+
+    const safeTool = await makeTool({
+      agentId: agent.id,
+      name: "list_endpoints",
+    });
+    await makeAgentTool(agent.id, safeTool.id);
+    // A specific policy trusting this exact result shape; evaluated before the
+    // default mark_as_untrusted policy tool creation added.
+    await makeTrustedDataPolicy(safeTool.id, {
+      conditions: [{ key: "status", operator: "equal", value: "ok" }],
+      action: "mark_as_trusted",
+    });
+
+    const commonMessages: CommonMessage[] = [
+      { role: "user", content: "What endpoints exist?" },
+      {
+        role: "tool",
+        toolCalls: [
+          {
+            id: "call_run_tool_2",
+            name: RUN_TOOL_FULL_NAME,
+            arguments: { tool_name: "list_endpoints", tool_args: {} },
+            content: { status: "ok" },
+            isError: false,
+          },
+        ],
+      },
+    ];
+
+    const trustEval = await evaluateIfContextIsTrusted(
+      commonMessages,
+      agent.id,
+      agent.organizationId,
+      undefined,
+      false,
+      { teamIds: [] },
+    );
+
+    expect(trustEval.contextIsTrusted).toBe(true);
+    expect(trustEval.unsafeContextBoundary).toBeUndefined();
+  });
+});

--- a/platform/backend/src/guardrails/trusted-data.ts
+++ b/platform/backend/src/guardrails/trusted-data.ts
@@ -6,6 +6,7 @@ import {
 } from "@archestra/shared";
 import { DualLlmSubagent } from "@/agents/subagents/dual-llm";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
+import { resolveRunToolDispatch } from "@/archestra-mcp-server/run-tool-target";
 import logger from "@/logging";
 import { TrustedDataPolicyModel } from "@/models";
 import type { PolicyEvaluationContext } from "@/models/tool-invocation-policy";
@@ -91,17 +92,31 @@ export async function evaluateIfContextIsTrusted(
   const allToolCalls: Array<{
     toolCallId: string;
     toolName: string;
+    isRunToolDispatchTarget: boolean;
     // biome-ignore lint/suspicious/noExplicitAny: tool outputs can be any shape
     toolResult: any;
     isPlatformAuthoredResult: boolean;
+    isUnresolvedDispatch: boolean;
   }> = [];
 
   for (const message of messages) {
     if (message.toolCalls && message.toolCalls.length > 0) {
       for (const toolCall of message.toolCalls) {
+        // A run_tool call carries the *target* tool's output (progressive
+        // tool loading routes every third-party call through it). Evaluate
+        // the target's trusted-data policies — the wrapper's built-in name
+        // would be auto-trusted and the target's "sensitive" policy would
+        // never fire. A dispatch whose target cannot be recovered from the
+        // call's arguments is flagged to fail closed below.
+        const dispatch = resolveRunToolDispatch(
+          toolCall.name,
+          toolCall.arguments,
+        );
         allToolCalls.push({
           toolCallId: toolCall.id,
-          toolName: toolCall.name,
+          toolName:
+            dispatch.kind === "target" ? dispatch.toolName : toolCall.name,
+          isRunToolDispatchTarget: dispatch.kind === "target",
           toolResult: toolCall.content,
           // Results the platform itself authored carry no external data and
           // must not flip the context to untrusted:
@@ -113,6 +128,7 @@ export async function evaluateIfContextIsTrusted(
           isPlatformAuthoredResult:
             extractMcpToolError(toolCall)?.type === "tool_state" ||
             isSeededAppRenderToolResult(toolCall.content),
+          isUnresolvedDispatch: dispatch.kind === "unresolved",
         });
       }
     }
@@ -144,9 +160,10 @@ export async function evaluateIfContextIsTrusted(
   );
   const evaluationResults = await TrustedDataPolicyModel.evaluateBulk(
     agentId,
-    allToolCalls.map(({ toolName, toolResult }) => ({
+    allToolCalls.map(({ toolName, toolResult, isRunToolDispatchTarget }) => ({
       toolName,
       toolOutput: toolResult,
+      isRunToolDispatchTarget,
     })),
     policyContext,
   );
@@ -158,13 +175,30 @@ export async function evaluateIfContextIsTrusted(
 
   // Process evaluation results
   for (let i = 0; i < allToolCalls.length; i++) {
-    const { toolCallId, toolResult, toolName, isPlatformAuthoredResult } =
-      allToolCalls[i];
+    const {
+      toolCallId,
+      toolResult,
+      toolName,
+      isPlatformAuthoredResult,
+      isUnresolvedDispatch,
+    } = allToolCalls[i];
     // A platform-authored result (dispatch error or seeded app render) never
     // carries upstream data. Skip it — otherwise it has no trusted-data
     // evaluation (or no matching policy) and falls through to the untrusted
     // branch below, poisoning the session over a benign platform message.
     if (isPlatformAuthoredResult) {
+      continue;
+    }
+    // A run_tool call whose target tool cannot be recovered: we cannot know
+    // which tool produced this data, so its policies cannot be consulted —
+    // fail closed rather than inherit the wrapper's built-in auto-trust.
+    if (isUnresolvedDispatch) {
+      hasUntrustedData = true;
+      unsafeContextBoundary ??= createToolResultBoundary({
+        reason: "tool_result_marked_untrusted",
+        toolCallId,
+        toolName,
+      });
       continue;
     }
     // evaluateBulk() returns a Map keyed by the stringified input index, so we

--- a/platform/backend/src/models/trusted-data-policy.ts
+++ b/platform/backend/src/models/trusted-data-policy.ts
@@ -1,4 +1,9 @@
-import { CONTEXT_EXTERNAL_AGENT_ID, CONTEXT_TEAM_IDS } from "@archestra/shared";
+import {
+  CONTEXT_EXTERNAL_AGENT_ID,
+  CONTEXT_TEAM_IDS,
+  isAgentTool,
+  isSkillTool,
+} from "@archestra/shared";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { get } from "lodash-es";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
@@ -12,6 +17,21 @@ import type { AutonomyPolicyOperator, TrustedData } from "@/types";
 /**
  * Check if a policy is a default policy (applies to all results)
  */
+/**
+ * Names that execute through delegation surfaces without a tools-table row:
+ * agent delegations (`agent__<slug>` rows exist, but the `agent-<id>` alias
+ * run_tool accepts does not) and skill delegation tools (synthesized per
+ * accessible skill). Their results are real child-agent output, so an
+ * unknown-name row lookup must not read as "the platform refused this".
+ */
+function isDelegationSurfaceName(toolName: string): boolean {
+  return (
+    isAgentTool(toolName) ||
+    toolName.startsWith("agent-") ||
+    isSkillTool(toolName)
+  );
+}
+
 function isDefaultPolicy(conditions: ResultPolicyCondition[]): boolean {
   return conditions.length === 0;
 }
@@ -379,6 +399,14 @@ class TrustedDataPolicyModel {
       toolName: string;
       // biome-ignore lint/suspicious/noExplicitAny: tool outputs can be any shape
       toolOutput: any;
+      /**
+       * True when `toolName` is the target of a `run_tool` dispatch (resolved
+       * from the wrapper call's arguments) rather than a directly-called tool.
+       * Changes the unknown-tool verdict: run_tool refuses dispatches to
+       * names it cannot resolve, so an unknown dispatch target means the
+       * result is the platform's own refusal text, not upstream data.
+       */
+      isRunToolDispatchTarget?: boolean;
     }>,
     context: PolicyEvaluationContext,
   ): Promise<
@@ -528,6 +556,24 @@ class TrustedDataPolicyModel {
 
       // If tool doesn't exist in the database, treat as untrusted
       if (!knownTools.has(toolName)) {
+        // A run_tool dispatch target with no tool row anywhere cannot have
+        // produced upstream data: run_tool refuses dispatches to names it
+        // cannot resolve, so the result is the platform's own refusal text —
+        // it must not poison the session over a hallucinated name. Delegation
+        // surfaces (agent/skill tools) execute without needing a matching row
+        // here, so they stay on the fail-closed path below.
+        if (
+          toolCalls[i].isRunToolDispatchTarget &&
+          !isDelegationSurfaceName(toolName)
+        ) {
+          results.set(i.toString(), {
+            isTrusted: true,
+            isBlocked: false,
+            shouldSanitizeWithDualLlm: false,
+            reason: `Dispatch target ${toolName} is unknown to the platform — run_tool refuses such dispatches, so the result is platform-authored text`,
+          });
+          continue;
+        }
         results.set(i.toString(), {
           isTrusted: false,
           isBlocked: false,

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -32,7 +32,10 @@ import type {
   ToolCompressionStats,
   UsageView,
 } from "@/types";
-import { extractCommonMessageText } from "@/types";
+import {
+  extractCommonMessageText,
+  extractCommonToolCallArguments,
+} from "@/types";
 import { isAnthropicBillingBlock } from "@/utils/anthropic-billing-error";
 import {
   hasImageContent,
@@ -112,8 +115,11 @@ class AnthropicRequestAdapter
       if (message.role === "user" && Array.isArray(message.content)) {
         for (const contentBlock of message.content) {
           if (contentBlock.type === "tool_result") {
-            // Find tool name from previous assistant messages
-            const toolName = this.findToolName(contentBlock.tool_use_id);
+            // Find the paired tool_use from previous assistant messages
+            const toolUse = this.findToolUse(
+              this.request.messages,
+              contentBlock.tool_use_id,
+            );
 
             let content: unknown;
             if (typeof contentBlock.content === "string") {
@@ -128,7 +134,8 @@ class AnthropicRequestAdapter
 
             results.push({
               id: contentBlock.tool_use_id,
-              name: toolName ?? "unknown",
+              name: toolUse?.name ?? "unknown",
+              arguments: toolUse?.arguments,
               content,
               isError: contentBlock.is_error ?? false,
             });
@@ -268,9 +275,12 @@ class AnthropicRequestAdapter
   // Private Helpers
   // ---------------------------------------------------------------------------
 
-  private findToolName(toolUseId: string): string | null {
-    for (let i = this.request.messages.length - 1; i >= 0; i--) {
-      const message = this.request.messages[i];
+  private findToolUse(
+    messages: AnthropicMessages,
+    toolUseId: string,
+  ): { name: string; arguments?: Record<string, unknown> } | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
       if (
         message.role === "assistant" &&
         Array.isArray(message.content) &&
@@ -278,7 +288,10 @@ class AnthropicRequestAdapter
       ) {
         for (const content of message.content) {
           if (content.type === "tool_use" && content.id === toolUseId) {
-            return content.name;
+            return {
+              name: content.name,
+              arguments: extractCommonToolCallArguments(content.input),
+            };
           }
         }
       }
@@ -308,15 +321,15 @@ class AnthropicRequestAdapter
 
         for (const contentBlock of message.content) {
           if (contentBlock.type === "tool_result") {
-            // Find the tool name from previous assistant messages
-            const toolName = this.findToolNameInMessages(
+            // Find the paired tool_use from previous assistant messages
+            const toolUse = this.findToolUse(
               messages,
               contentBlock.tool_use_id,
             );
 
-            if (toolName) {
+            if (toolUse) {
               logger.debug(
-                { toolUseId: contentBlock.tool_use_id, toolName },
+                { toolUseId: contentBlock.tool_use_id, toolName: toolUse.name },
                 "[AnthropicAdapter] toCommonFormat: found tool result",
               );
               // Parse the tool result
@@ -333,7 +346,8 @@ class AnthropicRequestAdapter
 
               toolCalls.push({
                 id: contentBlock.tool_use_id,
-                name: toolName,
+                name: toolUse.name,
+                arguments: toolUse.arguments,
                 content: toolResult,
                 isError: false,
               });
@@ -358,31 +372,6 @@ class AnthropicRequestAdapter
       "[AnthropicAdapter] toCommonFormat: conversion complete",
     );
     return commonMessages;
-  }
-
-  /**
-   * Extract tool name from messages by finding the assistant message
-   * that contains the tool_use_id
-   */
-  private findToolNameInMessages(
-    messages: AnthropicMessages,
-    toolUseId: string,
-  ): string | null {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const message = messages[i];
-      if (
-        message.role === "assistant" &&
-        Array.isArray(message.content) &&
-        message.content.length > 0
-      ) {
-        for (const content of message.content) {
-          if (content.type === "tool_use" && content.id === toolUseId) {
-            return content.name;
-          }
-        }
-      }
-    }
-    return null;
   }
 
   /**

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.test.ts
@@ -105,6 +105,7 @@ describe("azureResponsesAdapterFactory", () => {
       {
         id: "call_123",
         name: "read_file",
+        arguments: { file_path: "/tmp/test" },
         content: '{"value":1}',
         isError: false,
       },

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -37,7 +37,11 @@ import type {
   ToolCompressionStats,
   UsageView,
 } from "@/types";
-import { ApiError, createStreamAccumulatorState } from "@/types";
+import {
+  ApiError,
+  createStreamAccumulatorState,
+  extractCommonToolCallArguments,
+} from "@/types";
 
 type AzureResponsesRequest = Azure.Types.ResponsesRequest;
 type AzureResponsesResponse = Azure.Types.ResponsesResponse;
@@ -221,17 +225,19 @@ class AzureResponsesRequestAdapter
       return [];
     }
 
-    const toolNamesByCallId = getToolNamesByCallId(this.request.input);
+    const toolCallsByCallId = getToolCallsByCallId(this.request.input);
 
     return this.request.input.flatMap((item) => {
       if (!isFunctionCallOutputItem(item)) {
         return [];
       }
 
+      const toolCall = toolCallsByCallId.get(item.call_id);
       return [
         {
           id: item.call_id,
-          name: toolNamesByCallId.get(item.call_id) ?? "unknown",
+          name: toolCall?.name ?? "unknown",
+          arguments: toolCall?.arguments,
           content: item.output,
           isError: false,
         },
@@ -908,14 +914,24 @@ function toSse(event: unknown): string {
   return `data: ${JSON.stringify(event)}\n\n`;
 }
 
-function getToolNamesByCallId(input: ResponseInputItem[]): Map<string, string> {
+function getToolCallsByCallId(
+  input: ResponseInputItem[],
+): Map<string, { name: string; arguments?: Record<string, unknown> }> {
   return new Map(
     input.flatMap((item) => {
       if (!isResponseInputFunctionCall(item)) {
         return [];
       }
 
-      return [[item.call_id, item.name] as const];
+      return [
+        [
+          item.call_id,
+          {
+            name: item.name,
+            arguments: extractCommonToolCallArguments(item.arguments),
+          },
+        ] as const,
+      ];
     }),
   );
 }

--- a/platform/backend/src/routes/proxy/adapters/bedrock.ts
+++ b/platform/backend/src/routes/proxy/adapters/bedrock.ts
@@ -34,7 +34,10 @@ import type {
   ToolCompressionStats,
   UsageView,
 } from "@/types";
-import { extractCommonMessageText } from "@/types";
+import {
+  extractCommonMessageText,
+  extractCommonToolCallArguments,
+} from "@/types";
 import {
   type SamplingParam,
   withSamplingParamFallback,
@@ -566,8 +569,11 @@ class BedrockRequestAdapter
           if (isToolResultBlock(contentBlock)) {
             const toolResult = contentBlock.toolResult;
             const toolUseId = toolResult.toolUseId ?? "";
-            // Find tool name from previous assistant messages
-            const toolName = this.findToolName(toolUseId);
+            // Find the paired tool use from previous assistant messages
+            const toolUse = this.findToolUse(
+              this.request.messages ?? [],
+              toolUseId,
+            );
 
             let content: unknown;
             // Extract content from tool result
@@ -588,7 +594,8 @@ class BedrockRequestAdapter
 
             results.push({
               id: toolUseId,
-              name: toolName ?? "unknown",
+              name: toolUse?.name ?? "unknown",
+              arguments: toolUse?.arguments,
               content,
               isError: toolResult.status === "error",
             });
@@ -680,8 +687,10 @@ class BedrockRequestAdapter
   // Private Helpers
   // ---------------------------------------------------------------------------
 
-  private findToolName(toolUseId: string): string | null {
-    const messages = this.request.messages ?? [];
+  private findToolUse(
+    messages: BedrockMessages,
+    toolUseId: string,
+  ): { name: string; arguments?: Record<string, unknown> } | null {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
       if (message.role === "assistant" && Array.isArray(message.content)) {
@@ -691,7 +700,13 @@ class BedrockRequestAdapter
             content.toolUse.toolUseId === toolUseId
           ) {
             const name = content.toolUse.name ?? null;
-            return name ? decodeToolName(name, this.toolNameMapping) : null;
+            if (!name) {
+              return null;
+            }
+            return {
+              name: decodeToolName(name, this.toolNameMapping),
+              arguments: extractCommonToolCallArguments(content.toolUse.input),
+            };
           }
         }
       }
@@ -723,11 +738,11 @@ class BedrockRequestAdapter
           if (isToolResultBlock(contentBlock)) {
             const toolResult = contentBlock.toolResult;
             const toolUseId = toolResult.toolUseId ?? "";
-            const toolName = this.findToolNameInMessages(messages, toolUseId);
+            const toolUse = this.findToolUse(messages, toolUseId);
 
-            if (toolName) {
+            if (toolUse) {
               logger.debug(
-                { toolUseId, toolName },
+                { toolUseId, toolName: toolUse.name },
                 "[BedrockAdapter] toCommonFormat: found tool result",
               );
 
@@ -747,7 +762,8 @@ class BedrockRequestAdapter
 
               toolCalls.push({
                 id: toolUseId,
-                name: toolName,
+                name: toolUse.name,
+                arguments: toolUse.arguments,
                 content: parsedResult,
                 isError: false,
               });
@@ -778,27 +794,6 @@ class BedrockRequestAdapter
    * Extract tool name from messages by finding the assistant message
    * that contains the tool_use_id
    */
-  private findToolNameInMessages(
-    messages: BedrockMessages,
-    toolUseId: string,
-  ): string | null {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const message = messages[i];
-      if (message.role === "assistant" && Array.isArray(message.content)) {
-        for (const content of message.content) {
-          if (
-            isToolUseBlock(content) &&
-            content.toolUse.toolUseId === toolUseId
-          ) {
-            const name = content.toolUse.name ?? null;
-            return name ? decodeToolName(name, this.toolNameMapping) : null;
-          }
-        }
-      }
-    }
-    return null;
-  }
-
   /**
    * Apply tool result updates back to Bedrock messages
    */

--- a/platform/backend/src/routes/proxy/adapters/cohere.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere.test.ts
@@ -449,6 +449,7 @@ describe("CohereRequestAdapter", () => {
         {
           id: "call_123",
           name: "get_weather",
+          arguments: { location: "NYC" },
           content: { temperature: 72, unit: "fahrenheit" },
           isError: false,
         },
@@ -487,6 +488,7 @@ describe("CohereRequestAdapter", () => {
       expect(results[0]).toEqual({
         id: "call_123",
         name: "get_weather",
+        arguments: { location: "NYC" },
         content: { temperature: 72 },
         isError: false,
       });

--- a/platform/backend/src/routes/proxy/adapters/cohere.ts
+++ b/platform/backend/src/routes/proxy/adapters/cohere.ts
@@ -23,7 +23,10 @@ import type {
   ToolCompressionStats,
   UsageView,
 } from "@/types";
-import { extractCommonMessageText } from "@/types";
+import {
+  extractCommonMessageText,
+  extractCommonToolCallArguments,
+} from "@/types";
 import type { ToolCompressionStats as CompressionStats } from "../utils/toon-conversion";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
 
@@ -90,14 +93,15 @@ class CohereRequestAdapter
       // Cohere uses "tool" role for tool results (similar to OpenAI)
       if (message.role === "tool") {
         const toolMsg = message as Cohere.Types.ToolMessage;
-        const toolName = this.findToolName(toolMsg.tool_call_id);
+        const toolCall = this.findToolCall(toolMsg.tool_call_id);
 
         const parsed = safeJsonParse(toolMsg.content);
         const content = parsed.ok ? parsed.value : toolMsg.content;
 
         results.push({
           id: toolMsg.tool_call_id,
-          name: toolName ?? "unknown",
+          name: toolCall?.name ?? "unknown",
+          arguments: toolCall?.arguments,
           content,
           isError: false,
         });
@@ -195,7 +199,9 @@ class CohereRequestAdapter
   // Private Helpers
   // ---------------------------------------------------------------------------
 
-  private findToolName(toolCallId: string): string | null {
+  private findToolCall(
+    toolCallId: string,
+  ): { name: string; arguments?: Record<string, unknown> } | null {
     for (let i = this.request.messages.length - 1; i >= 0; i--) {
       const message = this.request.messages[i];
       if (message.role === "assistant") {
@@ -203,7 +209,12 @@ class CohereRequestAdapter
         if (assistantMsg.tool_calls) {
           for (const toolCall of assistantMsg.tool_calls) {
             if (toolCall.id === toolCallId) {
-              return toolCall.function.name;
+              return {
+                name: toolCall.function.name,
+                arguments: extractCommonToolCallArguments(
+                  toolCall.function.arguments,
+                ),
+              };
             }
           }
         }
@@ -224,16 +235,17 @@ class CohereRequestAdapter
       // Handle tool messages
       if (message.role === "tool") {
         const toolMsg = message as Cohere.Types.ToolMessage;
-        const toolName = this.findToolName(toolMsg.tool_call_id);
+        const toolCall = this.findToolCall(toolMsg.tool_call_id);
 
-        if (toolName) {
+        if (toolCall) {
           const parsed = safeJsonParse(toolMsg.content);
           const toolResult = parsed.ok ? parsed.value : toolMsg.content;
 
           commonMessage.toolCalls = [
             {
               id: toolMsg.tool_call_id,
-              name: toolName,
+              name: toolCall.name,
+              arguments: toolCall.arguments,
               content: toolResult,
               isError: false,
             },

--- a/platform/backend/src/routes/proxy/adapters/gemini.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.test.ts
@@ -395,6 +395,7 @@ describe("GeminiRequestAdapter", () => {
         {
           id: "call_123",
           name: "get_weather",
+          arguments: { location: "NYC" },
           content: { temperature: 72, unit: "fahrenheit" },
           isError: false,
         },

--- a/platform/backend/src/routes/proxy/adapters/gemini.ts
+++ b/platform/backend/src/routes/proxy/adapters/gemini.ts
@@ -34,7 +34,10 @@ import type {
   ToolCompressionStats,
   UsageView,
 } from "@/types";
-import { extractCommonMessageText } from "@/types";
+import {
+  extractCommonMessageText,
+  extractCommonToolCallArguments,
+} from "@/types";
 import {
   hasImageContent,
   isImageTooLarge,
@@ -129,6 +132,13 @@ class GeminiRequestAdapter
             toolCalls.push({
               id,
               name: functionResponse.name as string,
+              arguments: this.findFunctionCallArguments(
+                functionResponse.name as string,
+                "id" in functionResponse &&
+                  typeof functionResponse.id === "string"
+                  ? functionResponse.id
+                  : undefined,
+              ),
               content: functionResponse.response,
               isError: false,
             });
@@ -173,6 +183,13 @@ class GeminiRequestAdapter
             results.push({
               id,
               name: functionResponse.name as string,
+              arguments: this.findFunctionCallArguments(
+                functionResponse.name as string,
+                "id" in functionResponse &&
+                  typeof functionResponse.id === "string"
+                  ? functionResponse.id
+                  : undefined,
+              ),
               content: functionResponse.response,
               isError: false,
             });
@@ -182,6 +199,43 @@ class GeminiRequestAdapter
     }
 
     return results;
+  }
+
+  /**
+   * Arguments of the functionCall paired with a functionResponse. Gemini
+   * correlates by `id` when the caller supplies ids, and by function name
+   * otherwise (the wire format's own convention), so the lookup prefers an
+   * exact id match and falls back to the nearest preceding call of that name.
+   */
+  private findFunctionCallArguments(
+    name: string,
+    id: string | undefined,
+  ): Record<string, unknown> | undefined {
+    const contents = this.request.contents || [];
+    let nameMatch: Record<string, unknown> | undefined;
+    for (let i = contents.length - 1; i >= 0; i--) {
+      for (const part of contents[i].parts || []) {
+        if (
+          !("functionCall" in part) ||
+          !part.functionCall ||
+          typeof part.functionCall !== "object"
+        ) {
+          continue;
+        }
+        const functionCall = part.functionCall as {
+          id?: string;
+          name?: string;
+          args?: unknown;
+        };
+        if (id && functionCall.id === id) {
+          return extractCommonToolCallArguments(functionCall.args);
+        }
+        if (functionCall.name === name) {
+          nameMatch ??= extractCommonToolCallArguments(functionCall.args);
+        }
+      }
+    }
+    return id ? undefined : nameMatch;
   }
 
   getTools(): CommonMcpToolDefinition[] {

--- a/platform/backend/src/routes/proxy/adapters/minimax.ts
+++ b/platform/backend/src/routes/proxy/adapters/minimax.ts
@@ -20,7 +20,10 @@ import type {
   StreamAccumulatorState,
   UsageView,
 } from "@/types";
-import { extractCommonMessageText } from "@/types";
+import {
+  extractCommonMessageText,
+  extractCommonToolCallArguments,
+} from "@/types";
 import type { Minimax } from "@/types/llm-providers";
 import type { ToolCompressionStats } from "../utils/toon-conversion";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
@@ -249,7 +252,7 @@ class MinimaxRequestAdapter
 
     for (const message of this.request.messages) {
       if (message.role === "tool") {
-        const toolName = this.findToolNameInMessages(
+        const toolCall = this.findToolCallInMessages(
           this.request.messages,
           message.tool_call_id,
         );
@@ -267,7 +270,8 @@ class MinimaxRequestAdapter
 
         results.push({
           id: message.tool_call_id,
-          name: toolName ?? "unknown",
+          name: toolCall?.name ?? "unknown",
+          arguments: toolCall?.arguments,
           content,
           isError: false,
         });
@@ -397,12 +401,12 @@ class MinimaxRequestAdapter
       };
 
       if (message.role === "tool") {
-        const toolName = this.findToolNameInMessages(
+        const toolCall = this.findToolCallInMessages(
           messages,
           message.tool_call_id,
         );
 
-        if (toolName) {
+        if (toolCall) {
           let toolResult: unknown;
           if (typeof message.content === "string") {
             try {
@@ -417,7 +421,8 @@ class MinimaxRequestAdapter
           commonMessage.toolCalls = [
             {
               id: message.tool_call_id,
-              name: toolName,
+              name: toolCall.name,
+              arguments: toolCall.arguments,
               content: toolResult,
               isError: false,
             },
@@ -432,12 +437,13 @@ class MinimaxRequestAdapter
   }
 
   /**
-   * Find tool name from tool_call_id by looking at previous assistant messages
+   * Find the paired tool call from tool_call_id by looking at previous
+   * assistant messages
    */
-  private findToolNameInMessages(
+  private findToolCallInMessages(
     messages: MinimaxMessages,
     toolCallId: string,
-  ): string | null {
+  ): { name: string; arguments?: Record<string, unknown> } | null {
     // Search backwards through messages
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
@@ -446,7 +452,12 @@ class MinimaxRequestAdapter
           (tc) => "id" in tc && tc.id === toolCallId,
         );
         if (toolCall && toolCall.type === "function") {
-          return toolCall.function.name;
+          return {
+            name: toolCall.function.name,
+            arguments: extractCommonToolCallArguments(
+              toolCall.function.arguments,
+            ),
+          };
         }
       }
     }

--- a/platform/backend/src/routes/proxy/adapters/ollama-native.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama-native.test.ts
@@ -120,6 +120,7 @@ describe("request adapter", () => {
       {
         id: "call_1",
         name: "read_file",
+        arguments: { path: "a" },
         content: { ok: true },
         isError: false,
       },

--- a/platform/backend/src/routes/proxy/adapters/ollama-native.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama-native.ts
@@ -40,6 +40,7 @@ import type {
   ToolCompressionStats,
   UsageView,
 } from "@/types";
+import { extractCommonToolCallArguments } from "@/types";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
 
 // =============================================================================
@@ -165,11 +166,14 @@ class OllamaNativeRequestAdapter
     const results: CommonToolResult[] = [];
     this.request.messages.forEach((message, index) => {
       if (message.role !== "tool") return;
+      const toolCall = this.findToolCallInMessages(
+        this.request.messages,
+        message,
+      );
       results.push({
         id: this.toolResultId(message, index),
-        name:
-          this.findToolNameInMessages(this.request.messages, message) ??
-          "unknown",
+        name: toolCall?.name ?? "unknown",
+        arguments: toolCall?.arguments,
         content: parseMaybeJson(nativeContentToText(message.content)),
         isError: false,
       });
@@ -257,10 +261,10 @@ class OllamaNativeRequestAdapter
     return message.tool_call_id ?? `${SYNTHETIC_TOOL_RESULT_ID_PREFIX}${index}`;
   }
 
-  private findToolNameInMessages(
+  private findToolCallInMessages(
     messages: NativeMessages,
     toolMessage: NativeMessage,
-  ): string | null {
+  ): { name: string; arguments?: Record<string, unknown> } | null {
     const toolCallId = toolMessage.tool_call_id;
     if (toolCallId) {
       for (let i = messages.length - 1; i >= 0; i--) {
@@ -268,15 +272,41 @@ class OllamaNativeRequestAdapter
         if (message.role === "assistant" && message.tool_calls) {
           for (const toolCall of message.tool_calls) {
             if (toolCall.id === toolCallId) {
-              return toolCall.function.name;
+              return {
+                name: toolCall.function.name,
+                arguments: extractCommonToolCallArguments(
+                  toolCall.function.arguments,
+                ),
+              };
             }
           }
         }
       }
     }
     // The native shape: results name the tool directly instead of referencing
-    // a call id. Ollama's own clients send only this.
-    return toolMessage.tool_name ?? null;
+    // a call id. Ollama's own clients send only this, so the arguments come
+    // from the nearest preceding call of that tool — the same correlation the
+    // wire format itself implies.
+    const toolName = toolMessage.tool_name;
+    if (!toolName) {
+      return null;
+    }
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.role === "assistant" && message.tool_calls) {
+        for (const toolCall of message.tool_calls) {
+          if (toolCall.function.name === toolName) {
+            return {
+              name: toolName,
+              arguments: extractCommonToolCallArguments(
+                toolCall.function.arguments,
+              ),
+            };
+          }
+        }
+      }
+    }
+    return { name: toolName };
   }
 
   private toCommonFormat(messages: NativeMessages): CommonMessage[] {
@@ -291,10 +321,12 @@ class OllamaNativeRequestAdapter
       // purely from an empty tool-call list, so dropping one here disables
       // trusted-data policies and dual-LLM sanitization with no other signal.
       if (message.role === "tool") {
+        const toolCall = this.findToolCallInMessages(messages, message);
         common.toolCalls = [
           {
             id: this.toolResultId(message, index),
-            name: this.findToolNameInMessages(messages, message) ?? "unknown",
+            name: toolCall?.name ?? "unknown",
+            arguments: toolCall?.arguments,
             content: parseMaybeJson(nativeContentToText(message.content)),
             isError: false,
           },

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -32,7 +32,11 @@ import type {
   ToolCompressionStats,
   UsageView,
 } from "@/types";
-import { ApiError, createStreamAccumulatorState } from "@/types";
+import {
+  ApiError,
+  createStreamAccumulatorState,
+  extractCommonToolCallArguments,
+} from "@/types";
 import { createOpenAiCodexResponsesClient } from "./openai-codex-responses-client";
 
 type OpenAiResponsesRequest = OpenAi.Types.ResponsesRequest;
@@ -208,17 +212,19 @@ class OpenAiResponsesRequestAdapter
       return [];
     }
 
-    const toolNamesByCallId = getToolNamesByCallId(this.request.input);
+    const toolCallsByCallId = getToolCallsByCallId(this.request.input);
 
     return this.request.input.flatMap((item) => {
       if (!isFunctionCallOutputItem(item)) {
         return [];
       }
 
+      const toolCall = toolCallsByCallId.get(item.call_id);
       return [
         {
           id: item.call_id,
-          name: toolNamesByCallId.get(item.call_id) ?? "unknown",
+          name: toolCall?.name ?? "unknown",
+          arguments: toolCall?.arguments,
           content: item.output,
           isError: false,
         },
@@ -914,14 +920,24 @@ function toSse(event: unknown): string {
   return `data: ${JSON.stringify(event)}\n\n`;
 }
 
-function getToolNamesByCallId(input: ResponseInputItem[]): Map<string, string> {
+function getToolCallsByCallId(
+  input: ResponseInputItem[],
+): Map<string, { name: string; arguments?: Record<string, unknown> }> {
   return new Map(
     input.flatMap((item) => {
       if (!isResponseInputFunctionCall(item)) {
         return [];
       }
 
-      return [[item.call_id, item.name] as const];
+      return [
+        [
+          item.call_id,
+          {
+            name: item.name,
+            arguments: extractCommonToolCallArguments(item.arguments),
+          },
+        ] as const,
+      ];
     }),
   );
 }

--- a/platform/backend/src/routes/proxy/adapters/openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.test.ts
@@ -498,6 +498,7 @@ describe("OpenAIRequestAdapter", () => {
         {
           id: "call_123",
           name: "get_weather",
+          arguments: { location: "NYC" },
           content: { temperature: 72, unit: "fahrenheit" },
           isError: false,
         },

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -35,7 +35,10 @@ import type {
   ToolCompressionStats,
   UsageView,
 } from "@/types";
-import { extractCommonMessageText } from "@/types";
+import {
+  extractCommonMessageText,
+  extractCommonToolCallArguments,
+} from "@/types";
 import { estimateMessagesSize } from "@/utils/message-size";
 import {
   estimateToolResultContentLength,
@@ -328,7 +331,7 @@ export class OpenAIRequestAdapter
 
     for (const message of this.request.messages) {
       if (message.role === "tool") {
-        const toolName = this.findToolNameInMessages(
+        const toolCall = this.findToolCallInMessages(
           this.request.messages,
           message.tool_call_id,
         );
@@ -346,7 +349,8 @@ export class OpenAIRequestAdapter
 
         results.push({
           id: message.tool_call_id,
-          name: toolName ?? "unknown",
+          name: toolCall?.name ?? "unknown",
+          arguments: toolCall?.arguments,
           content,
           isError: false,
         });
@@ -438,10 +442,10 @@ export class OpenAIRequestAdapter
           contentPatternSample.includes('"data":"');
 
         // Find tool name from previous assistant message
-        const toolName = this.findToolNameInMessages(
+        const toolName = this.findToolCallInMessages(
           messages,
           message.tool_call_id,
-        );
+        )?.name;
 
         logger.info(
           {
@@ -617,10 +621,10 @@ export class OpenAIRequestAdapter
   // Private Helpers (copied from utils/adapters/openai.ts)
   // ---------------------------------------------------------------------------
 
-  private findToolNameInMessages(
+  private findToolCallInMessages(
     messages: OpenAiMessages,
     toolCallId: string,
-  ): string | null {
+  ): { name: string; arguments?: Record<string, unknown> } | null {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
 
@@ -628,9 +632,14 @@ export class OpenAIRequestAdapter
         for (const toolCall of message.tool_calls) {
           if (toolCall.id === toolCallId) {
             if (toolCall.type === "function") {
-              return toolCall.function.name;
+              return {
+                name: toolCall.function.name,
+                arguments: extractCommonToolCallArguments(
+                  toolCall.function.arguments,
+                ),
+              };
             } else {
-              return toolCall.custom.name;
+              return { name: toolCall.custom.name };
             }
           }
         }
@@ -655,14 +664,14 @@ export class OpenAIRequestAdapter
 
       // Handle tool messages (tool results)
       if (message.role === "tool") {
-        const toolName = this.findToolNameInMessages(
+        const toolCall = this.findToolCallInMessages(
           messages,
           message.tool_call_id,
         );
 
-        if (toolName) {
+        if (toolCall) {
           logger.debug(
-            { toolCallId: message.tool_call_id, toolName },
+            { toolCallId: message.tool_call_id, toolName: toolCall.name },
             "[OpenAIAdapter] toCommonFormat: found tool message",
           );
           let toolResult: unknown;
@@ -679,7 +688,8 @@ export class OpenAIRequestAdapter
           commonMessage.toolCalls = [
             {
               id: message.tool_call_id,
-              name: toolName,
+              name: toolCall.name,
+              arguments: toolCall.arguments,
               content: toolResult,
               isError: false,
             },

--- a/platform/backend/src/routes/proxy/adapters/zhipuai.ts
+++ b/platform/backend/src/routes/proxy/adapters/zhipuai.ts
@@ -25,7 +25,10 @@ import type {
   UsageView,
   Zhipuai,
 } from "@/types";
-import { extractCommonMessageText } from "@/types";
+import {
+  extractCommonMessageText,
+  extractCommonToolCallArguments,
+} from "@/types";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
 
 // =============================================================================
@@ -246,7 +249,7 @@ class ZhipuaiRequestAdapter
 
     for (const message of this.request.messages) {
       if (message.role === "tool") {
-        const toolName = this.findToolNameInMessages(
+        const toolCall = this.findToolCallInMessages(
           this.request.messages,
           message.tool_call_id,
         );
@@ -264,7 +267,8 @@ class ZhipuaiRequestAdapter
 
         results.push({
           id: message.tool_call_id,
-          name: toolName ?? "unknown",
+          name: toolCall?.name ?? "unknown",
+          arguments: toolCall?.arguments,
           content,
           isError: false,
         });
@@ -356,10 +360,10 @@ class ZhipuaiRequestAdapter
   // Private Helpers
   // ---------------------------------------------------------------------------
 
-  private findToolNameInMessages(
+  private findToolCallInMessages(
     messages: ZhipuaiMessages,
     toolCallId: string,
-  ): string | null {
+  ): { name: string; arguments?: Record<string, unknown> } | null {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
 
@@ -367,7 +371,12 @@ class ZhipuaiRequestAdapter
         for (const toolCall of message.tool_calls) {
           if (toolCall.id === toolCallId) {
             if (toolCall.type === "function") {
-              return toolCall.function.name;
+              return {
+                name: toolCall.function.name,
+                arguments: extractCommonToolCallArguments(
+                  toolCall.function.arguments,
+                ),
+              };
             }
           }
         }
@@ -391,14 +400,14 @@ class ZhipuaiRequestAdapter
       };
 
       if (message.role === "tool") {
-        const toolName = this.findToolNameInMessages(
+        const toolCall = this.findToolCallInMessages(
           messages,
           message.tool_call_id,
         );
 
-        if (toolName) {
+        if (toolCall) {
           logger.debug(
-            { toolCallId: message.tool_call_id, toolName },
+            { toolCallId: message.tool_call_id, toolName: toolCall.name },
             "[ZhipuaiAdapter] toCommonFormat: found tool message",
           );
           let toolResult: unknown;
@@ -415,7 +424,8 @@ class ZhipuaiRequestAdapter
           commonMessage.toolCalls = [
             {
               id: message.tool_call_id,
-              name: toolName,
+              name: toolCall.name,
+              arguments: toolCall.arguments,
               content: toolResult,
               isError: false,
             },

--- a/platform/backend/src/types/common-llm-format.ts
+++ b/platform/backend/src/types/common-llm-format.ts
@@ -28,6 +28,13 @@ export type CommonToolCall = z.infer<typeof CommonToolCallSchema>;
 export type CommonToolResult = {
   id: string;
   name: string;
+  /**
+   * The arguments of the paired tool call, when the source format carries
+   * them. Required to resolve a `run_tool` dispatch to its target tool so
+   * trusted-data policies evaluate the tool that actually produced the
+   * result instead of the built-in wrapper.
+   */
+  arguments?: Record<string, unknown>;
   content: unknown;
   isError: boolean;
   error?: string;
@@ -48,6 +55,30 @@ export interface CommonMessage {
   content?: string;
   /** Tool calls if this message contains them */
   toolCalls?: CommonToolResult[];
+}
+
+/**
+ * Normalize a provider-format tool-call arguments value to the record shape
+ * `CommonToolResult.arguments` carries. Providers carry arguments either as an
+ * object (Anthropic `input`, Gemini `args`) or as a JSON string (OpenAI-family
+ * `function.arguments`); anything unparsable yields undefined so a malformed
+ * value is indistinguishable from an uncaptured one (both fail closed where it
+ * matters — run_tool dispatch resolution).
+ */
+export function extractCommonToolCallArguments(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (typeof value === "string") {
+    try {
+      return extractCommonToolCallArguments(JSON.parse(value));
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
 }
 
 export function extractCommonMessageText(message: unknown): string | undefined {


### PR DESCRIPTION
## Problem

With progressive tool loading (`toolExposureMode: "search_and_run_only"`) every third-party tool call reaches the model as an `archestra__run_tool` dispatch. The trusted-data evaluation only ever saw the built-in wrapper name — which is policy-bypassed — so the dispatch target's trusted-data policies never fired: results marked "Sensitive" produced no **Sensitive context below** boundary, and "Block in sensitive context" invocation policies never engaged. The same policies worked correctly with tools exposed.

## Fix

- **Capture tool-call arguments alongside tool results** (`CommonToolResult.arguments`) in every proxy adapter (anthropic, openai, openai/azure-responses, gemini, bedrock, cohere, zhipuai, minimax, ollama-native) and in the chat history path, so a `run_tool` dispatch can be unwrapped to the tool that actually produced the data.
- **Evaluate trusted-data policies against the dispatch target** instead of the wrapper; the unsafe-context boundary names the target tool. A dispatch whose target cannot be recovered fails closed to untrusted.
- **Refused dispatches don't poison the session**: a dispatch naming a tool the platform doesn't know is a platform refusal (`run_tool` never forwards those), so it keeps the context trusted instead of blocking the user's next legitimate call. Delegation surfaces (agents/skills) are exempt from this rule and stay fail-closed. Pre-dispatch refusals now carry the structured `tool_state` error envelope.
- **Chat path renders the divider too**: the chat completion path attaches the same unsafe-context boundary to dispatched tool results, so progressive sessions show **Sensitive context below** exactly as exposed sessions do.

## Testing

- New end-to-end regression suite `guardrails/run-tool-invocation-chain.test.ts` pinning the dispatch-unwrapping chain: target's default policy flips context + blocks a restricted follow-up, unresolved dispatch fails closed, unknown-target refusal stays trusted, unknown delegation name stays untrusted, `tool_state` envelope exempt, built-in bare-name target trusted, `mark_as_trusted` target trusted.
- Adapter tests updated for the captured `arguments` field.
- Verified live on a dev stack in both modes: exposed and progressive agents against a DeepWiki MCP server with a "Sensitive" result policy and a "Block in sensitive context" invocation policy — divider placement, block refusals naming the real tool, and refusal non-poisoning all confirmed in the chat UI.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>