### PR TITLE
fix(proxy): withhold tool calls until the invocation policy gate decides

### DIFF
--- a/platform/backend/src/archestra-mcp-server/run-tool-target.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool-target.ts
@@ -62,7 +62,7 @@ type RunToolDispatch =
  * built-in wrapper.
  */
 /** True when the (canonical) tool name is the `run_tool` dispatch wrapper. */
-export function isRunToolName(toolName: string): boolean {
+function isRunToolName(toolName: string): boolean {
   return (
     archestraMcpBranding.getToolShortName(toolName) === TOOL_RUN_TOOL_SHORT_NAME
   );

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai.test.ts
@@ -132,3 +132,35 @@ describe("AnthropicOpenaiStreamAdapter.getRawToolCallEvents", () => {
     expect(JSON.parse(byIndex.get(1)?.args ?? "")).toEqual({ cmd: "pwd" });
   });
 });
+
+// toProviderResponse() is the persisted record, and it delegates to the inner
+// Anthropic adapter, which lists tool calls only once they have been handed
+// over. This wrapper keeps its own buffer and returns OpenAI-shaped events, so
+// reading them has to reach the inner adapter too or the record silently drops
+// calls the client did receive — with no type error and no failing wire
+// assertion.
+describe("AnthropicOpenaiStreamAdapter tool-call release", () => {
+  it("records the delivered tool calls once they are read", () => {
+    const adapter = makeAdapter();
+    feedParallelToolCalls(adapter);
+
+    adapter.getRawToolCallEvents();
+
+    expect(
+      adapter
+        .toProviderResponse()
+        .content.filter((block) => block.type === "tool_use"),
+    ).toMatchObject([{ id: "toolu_A" }, { id: "toolu_B" }]);
+  });
+
+  it("records no tool calls for a turn that ended before the gate", () => {
+    const adapter = makeAdapter();
+    feedParallelToolCalls(adapter);
+
+    expect(
+      adapter
+        .toProviderResponse()
+        .content.some((block) => block.type === "tool_use"),
+    ).toBe(false);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/anthropic-openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic-openai.ts
@@ -159,12 +159,16 @@ class AnthropicOpenaiStreamAdapter
   }
 
   getRawToolCallEvents(): string[] {
-    // Snapshot, never drain: the proxy handler calls this repeatedly and
-    // dedupes replayed events by array index, so indices must stay stable
-    // across calls (the base anthropic adapter behaves the same way).
-    // Draining here re-based later tool calls to index 0, so with parallel
-    // tool calls the second call's start chunk (id + name) was skipped as
-    // already streamed and the client received a dangling tool call.
+    // Snapshot, never drain (the base anthropic adapter behaves the same way).
+    // Draining re-based later tool calls to index 0, so with parallel tool
+    // calls the second call's start chunk lost its id and name and the client
+    // received a dangling tool call.
+    //
+    // The inner read is for its side effect only — the events themselves are
+    // the OpenAI-shaped ones below. toProviderResponse() delegates to that
+    // inner adapter, which names tool calls in the reconstructed turn only
+    // once it has handed them over, and this is that moment.
+    this.inner.getRawToolCallEvents();
     return [...this.pendingToolCallEvents];
   }
 

--- a/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.test.ts
@@ -226,6 +226,80 @@ describe("declared tools vs called tools", () => {
 });
 
 describe("AnthropicRequestAdapter", () => {
+  describe("declared tools", () => {
+    const messages = [
+      { role: "user", content: "Hello" },
+    ] as Anthropic.Types.MessagesRequest["messages"];
+
+    const tools = [
+      {
+        name: "github__list_issues",
+        description: "list issues",
+        input_schema: { type: "object", properties: {} },
+      },
+      // Provider built-ins carry a `type` and no input schema.
+      { type: "bash_20250124", name: "bash" },
+      { type: "text_editor_20250124", name: "str_replace_editor" },
+    ] as unknown as Anthropic.Types.MessagesRequest["tools"];
+
+    // The availability set is built from the declared names, so built-ins are
+    // counted even though getTools() drops them. The two must not converge:
+    // getTools() feeds persistence and other callers that want schemas.
+    test("getDeclaredToolNames counts built-ins that getTools drops", () => {
+      const adapter = anthropicAdapterFactory.createRequestAdapter(
+        createMockRequest(messages, { tools }),
+      );
+
+      expect(adapter.getDeclaredToolNames?.()).toEqual([
+        "github__list_issues",
+        "bash",
+        "str_replace_editor",
+      ]);
+      expect(adapter.getTools().map((t) => t.name)).toEqual([
+        "github__list_issues",
+      ]);
+    });
+
+    test("a request declaring only built-ins still names them", () => {
+      const adapter = anthropicAdapterFactory.createRequestAdapter(
+        createMockRequest(messages, {
+          tools: [
+            { type: "bash_20250124", name: "bash" },
+          ] as unknown as Anthropic.Types.MessagesRequest["tools"],
+        }),
+      );
+
+      expect(adapter.getDeclaredToolNames?.()).toEqual(["bash"]);
+      expect(adapter.getTools()).toEqual([]);
+    });
+
+    test("is empty when no tools are declared", () => {
+      const adapter = anthropicAdapterFactory.createRequestAdapter(
+        createMockRequest(messages),
+      );
+
+      expect(adapter.getDeclaredToolNames?.()).toEqual([]);
+      expect(adapter.hasTools()).toBe(false);
+    });
+
+    // These names become availability-set members, so an entry with no usable
+    // name must not land in the set — nothing a model can call would match it,
+    // and it would make an otherwise-empty set look populated.
+    test("skips entries carrying no usable name", () => {
+      const adapter = anthropicAdapterFactory.createRequestAdapter(
+        createMockRequest(messages, {
+          tools: [
+            { type: "bash_20250124" },
+            { name: "" },
+            { name: "kept", input_schema: { type: "object", properties: {} } },
+          ] as unknown as Anthropic.Types.MessagesRequest["tools"],
+        }),
+      );
+
+      expect(adapter.getDeclaredToolNames?.()).toEqual(["kept"]);
+    });
+  });
+
   describe("toProviderRequest - tool results handling", () => {
     test("handles empty tool results (no tool_result blocks)", () => {
       const messages = [
@@ -622,6 +696,8 @@ describe("anthropicAdapterFactory.executeStream", () => {
       adapter.processChunk(event);
     }
 
+    // Reading the buffered events is what hands them to the client.
+    adapter.getRawToolCallEvents();
     const response = adapter.toProviderResponse();
     const toolUse = response.content.find((block) => block.type === "tool_use");
     expect(toolUse).toBeDefined();
@@ -678,6 +754,8 @@ describe("anthropicAdapterFactory.executeStream", () => {
       adapter.processChunk(event);
     }
 
+    // Reading the buffered events is what hands them to the client.
+    adapter.getRawToolCallEvents();
     const response = adapter.toProviderResponse();
     const toolUse = response.content.find((block) => block.type === "tool_use");
     expect((toolUse as { input: unknown }).input).toEqual({ city: "SF" });
@@ -783,6 +861,191 @@ describe("AnthropicStreamAdapter content block forwarding", () => {
   });
 });
 
+// A client applies deltas by index but appends blocks in arrival order, so the
+// indices it is given must be contiguous and in the order it receives them —
+// whatever the upstream numbering was, and whichever blocks were withheld.
+describe("AnthropicStreamAdapter content-block renumbering", () => {
+  type Chunk = Parameters<
+    ReturnType<
+      typeof anthropicAdapterFactory.createStreamAdapter
+    >["processChunk"]
+  >[0];
+
+  function indicesIn(
+    events: (string | Uint8Array | null | undefined)[],
+  ): number[] {
+    return events
+      .filter((e): e is string => typeof e === "string")
+      .flatMap((e) =>
+        [...e.matchAll(/"index":(\d+)/g)].map((m) => Number(m[1])),
+      );
+  }
+
+  /** Upstream: text@0, tool_use@1 (withheld), text@2. */
+  function streamTextAroundToolCall() {
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+    const live: (string | Uint8Array | null | undefined)[] = [];
+    const push = (chunk: Chunk) => {
+      live.push(adapter.processChunk(chunk).sseData);
+    };
+    push({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    } as Chunk);
+    push({ type: "content_block_stop", index: 0 } as Chunk);
+    push({
+      type: "content_block_start",
+      index: 1,
+      content_block: {
+        type: "tool_use",
+        id: "toolu_1",
+        name: "list",
+        input: {},
+      },
+    } as Chunk);
+    push({ type: "content_block_stop", index: 1 } as Chunk);
+    push({
+      type: "content_block_start",
+      index: 2,
+      content_block: { type: "text", text: "" },
+    } as Chunk);
+    push({ type: "content_block_stop", index: 2 } as Chunk);
+    return { adapter, live };
+  }
+
+  test("a withheld tool block leaves no gap in the indices the client sees", () => {
+    const { live } = streamTextAroundToolCall();
+
+    // Upstream numbered these 0 and 2; the client must see 0 and 1.
+    expect(indicesIn(live)).toEqual([0, 0, 1, 1]);
+  });
+
+  test("a released tool block takes the next free index, not its upstream one", () => {
+    const { adapter, live } = streamTextAroundToolCall();
+
+    const flushed = adapter.getRawToolCallEvents();
+
+    expect(indicesIn(live)).toEqual([0, 0, 1, 1]);
+    expect(indicesIn(flushed)).toEqual([2, 2]);
+  });
+
+  test("reading the buffered events twice keeps the same index", () => {
+    const { adapter } = streamTextAroundToolCall();
+
+    const first = adapter.getRawToolCallEvents();
+    const second = adapter.getRawToolCallEvents();
+
+    expect(indicesIn(second)).toEqual(indicesIn(first));
+  });
+
+  test("a refusal block takes the next free index after the live blocks", () => {
+    const { adapter } = streamTextAroundToolCall();
+
+    const refusal = adapter.formatCompleteTextSSE("blocked").join("");
+
+    // The tool block was never released, so 2 is free for the refusal.
+    expect(indicesIn([refusal])).toEqual([2, 2, 2]);
+  });
+
+  // A thinking block and its signature have to be replayed verbatim on the next
+  // turn or the upstream API rejects the conversation, so renumbering must move
+  // its index without touching its payload — and it must not inherit the index
+  // of the tool block withheld after it.
+  test("a thinking block keeps its signature and is renumbered around a withheld call", () => {
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+    const live: (string | Uint8Array | null | undefined)[] = [];
+    const push = (chunk: Chunk) => {
+      live.push(adapter.processChunk(chunk).sseData);
+    };
+
+    push({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "thinking", thinking: "" },
+    } as Chunk);
+    push({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "signature_delta", signature: "sig_abc123" },
+    } as Chunk);
+    push({ type: "content_block_stop", index: 0 } as Chunk);
+    push({
+      type: "content_block_start",
+      index: 1,
+      content_block: {
+        type: "tool_use",
+        id: "toolu_1",
+        name: "list",
+        input: {},
+      },
+    } as Chunk);
+    push({ type: "content_block_stop", index: 1 } as Chunk);
+    push({
+      type: "content_block_start",
+      index: 2,
+      content_block: { type: "text", text: "" },
+    } as Chunk);
+    push({ type: "content_block_stop", index: 2 } as Chunk);
+
+    const wire = live
+      .filter((e): e is string => typeof e === "string")
+      .join("");
+    expect(wire).toContain("sig_abc123");
+    expect(wire).toContain('"type":"thinking"');
+    // Thinking at 0, the text that followed the withheld call at 1.
+    expect(indicesIn(live)).toEqual([0, 0, 0, 1, 1]);
+  });
+
+  // One withheld block can only ever be off by one, which several bugs survive.
+  // Two withheld blocks split by live text is where an index is reused or
+  // skipped: each released block has to take the next free index in flush
+  // order, and the text between them must not inherit either one's number.
+  test("several withheld blocks each take their own index in flush order", () => {
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+    const live: (string | Uint8Array | null | undefined)[] = [];
+    const push = (chunk: Chunk) => {
+      live.push(adapter.processChunk(chunk).sseData);
+    };
+    // Upstream: text@0, tool@1, text@2, tool@3, text@4.
+    for (const [index, kind] of [
+      [0, "text"],
+      [1, "tool"],
+      [2, "text"],
+      [3, "tool"],
+      [4, "text"],
+    ] as const) {
+      push({
+        type: "content_block_start",
+        index,
+        content_block:
+          kind === "text"
+            ? { type: "text", text: "" }
+            : {
+                type: "tool_use",
+                id: `toolu_${index}`,
+                name: "list",
+                input: {},
+              },
+      } as Chunk);
+      push({ type: "content_block_stop", index } as Chunk);
+    }
+
+    // The three text blocks are the only ones live, so they must be 0, 1, 2.
+    expect(indicesIn(live)).toEqual([0, 0, 1, 1, 2, 2]);
+
+    // Both calls then take the next two free indices, in the order they were
+    // buffered — never reusing an index the client already applied text to.
+    const flushed = adapter.getRawToolCallEvents();
+    expect(indicesIn(flushed)).toEqual([3, 3, 4, 4]);
+
+    adapter.getRawToolCallEvents();
+    expect(
+      adapter.toProviderResponse().content.filter((b) => b.type === "tool_use"),
+    ).toMatchObject([{ id: "toolu_1" }, { id: "toolu_3" }]);
+  });
+});
+
 describe("AnthropicStreamAdapter policy refusal terminal", () => {
   type Chunk = Parameters<
     ReturnType<
@@ -851,9 +1114,9 @@ describe("AnthropicStreamAdapter policy refusal terminal", () => {
     expect(endEvents).not.toContain('"stop_reason":"tool_use"');
   });
 
-  // The refusal block index is derived only from non-tool blocks, so it can
-  // land on an index a tool_use block already occupies. Harmless while those
-  // blocks stay buffered; a collision on the wire once they are forwarded.
+  // The refusal takes the next index the client has not been given. A withheld
+  // tool block never took one, so the number it would have had upstream is
+  // still free.
   test("formatCompleteTextSSE ignores tool_use indices when choosing its own", () => {
     const adapter = anthropicAdapterFactory.createStreamAdapter();
     adapter.processChunk({
@@ -876,7 +1139,7 @@ describe("AnthropicStreamAdapter policy refusal terminal", () => {
 
     const refusal = adapter.formatCompleteTextSSE("blocked").join("");
 
-    // 2 would clear the tool_use block; 1 reuses its index.
+    // Withheld tool blocks leave their index free, so 1 is correct here.
     expect(refusal).toContain('"index":1');
     expect(refusal).not.toContain('"index":2');
   });
@@ -889,6 +1152,82 @@ describe("AnthropicStreamAdapter policy refusal terminal", () => {
     // index 0 was already streamed (the text block); the refusal must use index 1.
     expect(refusalEvents).toContain('"index":1');
     expect(refusalEvents).not.toContain('"index":0');
+  });
+
+  // A turn cut short before the gate ran — an upstream drop, an abort —
+  // delivered no tool calls, so recording them would assert a delivery, and a
+  // policy decision, that never happened.
+  test("toProviderResponse omits tool calls that were never released", () => {
+    const adapter = streamBlockedToolTurn();
+
+    const response = adapter.toProviderResponse();
+
+    expect(response.content.some((block) => block.type === "tool_use")).toBe(
+      false,
+    );
+  });
+
+  // Upstream reported `tool_use` because it did emit calls, but they were
+  // withheld, so the recorded turn holds none. Keeping the upstream reason
+  // would leave a record that contradicts its own content and reads as though
+  // a tool result is owed for a call nobody can point to.
+  test("a turn whose calls were never released is not recorded as owing a result", () => {
+    const adapter = streamBlockedToolTurn();
+
+    const response = adapter.toProviderResponse();
+
+    expect(response.content.some((block) => block.type === "tool_use")).toBe(
+      false,
+    );
+    expect(response.stop_reason).toBe("end_turn");
+  });
+
+  test("a turn whose calls were released keeps the tool_use stop reason", () => {
+    const adapter = streamBlockedToolTurn();
+
+    adapter.getRawToolCallEvents();
+    const response = adapter.toProviderResponse();
+
+    expect(response.content.some((block) => block.type === "tool_use")).toBe(
+      true,
+    );
+    expect(response.stop_reason).toBe("tool_use");
+  });
+
+  // Only `tool_use` is ever rewritten, and only when the content disagrees with
+  // it. Every other reason is the upstream's to state — a turn truncated by
+  // max_tokens still has to say so, or a client cannot tell it was cut off.
+  test("a stop reason other than tool_use is passed through untouched", () => {
+    const adapter = anthropicAdapterFactory.createStreamAdapter();
+
+    adapter.processChunk({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    } as Chunk);
+    adapter.processChunk({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "truncated" },
+    } as Chunk);
+    adapter.processChunk({
+      type: "message_delta",
+      delta: { stop_reason: "max_tokens", stop_sequence: null },
+      usage: { output_tokens: 5 },
+    } as Chunk);
+
+    expect(adapter.toProviderResponse().stop_reason).toBe("max_tokens");
+  });
+
+  test("toProviderResponse records tool calls once they are released", () => {
+    const adapter = streamBlockedToolTurn();
+
+    adapter.getRawToolCallEvents();
+    const response = adapter.toProviderResponse();
+
+    expect(
+      response.content.filter((block) => block.type === "tool_use"),
+    ).toMatchObject([{ id: "toolu_1", name: "list" }]);
   });
 
   test("toProviderResponse persists the refusal, not the blocked tool call", () => {

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -175,6 +175,14 @@ class AnthropicRequestAdapter
     return result;
   }
 
+  getDeclaredToolNames(): string[] {
+    return (this.request.tools ?? [])
+      .map((tool) => (tool as { name?: unknown }).name)
+      .filter(
+        (name): name is string => typeof name === "string" && name !== "",
+      );
+  }
+
   hasTools(): boolean {
     return (this.request.tools?.length ?? 0) > 0;
   }
@@ -604,10 +612,17 @@ class AnthropicStreamAdapter
   readonly state: StreamAccumulatorState;
   private toolUseBlockIndices = new Set<number>();
   private currentToolCallIndex = -1;
-  // Highest content-block index actually forwarded to the client, so a refusal
-  // block appended after a guardrail hit does not collide with (reuse) an index
-  // the client has already seen.
-  private maxStreamedBlockIndex = -1;
+  // Upstream content-block index -> the index the client is given, assigned in
+  // the order blocks are actually emitted. Withholding a tool block, or holding
+  // it back and releasing it after later text, would otherwise leave the client
+  // a gap or a rewind: it applies deltas by index but appends blocks in arrival
+  // order, so either one silently mis-assigns every block that follows.
+  private outIndexByUpstream = new Map<number, number>();
+  private nextOutIndex = 0;
+  // Whether the buffered tool-call events were actually written to the client.
+  // They are held until the gate decides, so a turn that ends before that — an
+  // upstream drop, an abort — delivered none of them.
+  private toolCallsReleased = false;
   // Set to the refusal text when the streamed response was replaced by a policy
   // refusal. formatEndSSE then closes the turn as end_turn instead of replaying
   // the upstream tool_use stop reason (which would leave a text-only turn ending
@@ -683,11 +698,9 @@ class AnthropicStreamAdapter
           // unmodified. Thinking blocks in particular must reach the client:
           // it has to replay them (with signature) on the next turn or the
           // upstream API rejects the conversation.
-          this.maxStreamedBlockIndex = Math.max(
-            this.maxStreamedBlockIndex,
-            chunk.index,
-          );
-          sseData = `event: content_block_start\ndata: ${JSON.stringify(chunk)}\n\n`;
+          sseData = `event: content_block_start\ndata: ${JSON.stringify(
+            this.withOutIndex(chunk),
+          )}\n\n`;
         }
         break;
 
@@ -709,13 +722,17 @@ class AnthropicStreamAdapter
           if (chunk.delta.type === "text_delta") {
             this.state.text += chunk.delta.text;
           }
-          sseData = `event: content_block_delta\ndata: ${JSON.stringify(chunk)}\n\n`;
+          sseData = `event: content_block_delta\ndata: ${JSON.stringify(
+            this.withOutIndex(chunk),
+          )}\n\n`;
         }
         break;
 
       case "content_block_stop":
         if (!this.toolUseBlockIndices.has(chunk.index)) {
-          sseData = `event: content_block_stop\ndata: ${JSON.stringify(chunk)}\n\n`;
+          sseData = `event: content_block_stop\ndata: ${JSON.stringify(
+            this.withOutIndex(chunk),
+          )}\n\n`;
         } else {
           // Store raw event for replay after policy approval
           this.state.rawToolCallEvents.push(chunk);
@@ -776,15 +793,22 @@ class AnthropicStreamAdapter
   }
 
   getRawToolCallEvents(): string[] {
-    return this.state.rawToolCallEvents.map(
-      (event) =>
-        `event: ${(event as { type: string }).type}\ndata: ${JSON.stringify(event)}\n\n`,
-    );
+    // Reached only when the gate allowed the calls, which is the moment these
+    // blocks become the client's: they earn an index, and the reconstructed
+    // turn may name them. Idempotent — the mapping is memoised, so the
+    // handler's repeated reads stay stable.
+    this.toolCallsReleased = true;
+    return this.state.rawToolCallEvents.map((event) => {
+      const renumbered = this.withOutIndex(
+        event as { type: string; index: number },
+      );
+      return `event: ${renumbered.type}\ndata: ${JSON.stringify(renumbered)}\n\n`;
+    });
   }
 
   formatCompleteTextSSE(text: string): string[] {
     this.replacedText = text;
-    const index = this.maxStreamedBlockIndex + 1;
+    const index = this.nextOutIndex++;
     return [
       `event: content_block_start\ndata: ${JSON.stringify({
         type: "content_block_start",
@@ -860,8 +884,8 @@ class AnthropicStreamAdapter
       });
     }
 
-    // Add tool use blocks
-    for (const toolCall of this.state.toolCalls) {
+    // Only tool calls the client actually received.
+    for (const toolCall of this.toolCallsReleased ? this.state.toolCalls : []) {
       let parsedInput: Record<string, unknown> = {};
       try {
         parsedInput = JSON.parse(toolCall.arguments);
@@ -877,21 +901,44 @@ class AnthropicStreamAdapter
       });
     }
 
+    const upstreamStopReason = this.state
+      .stopReason as AnthropicResponse["stop_reason"];
+    // A turn that delivered no tool call cannot owe a tool result. Upstream may
+    // still have said `tool_use` — it emitted calls that were withheld, or the
+    // stream died after the stop reason — and keeping it would leave a record
+    // that contradicts its own content.
+    const hasToolUse = content.some((block) => block.type === "tool_use");
+    const stopReason =
+      upstreamStopReason === "tool_use" && !hasToolUse
+        ? "end_turn"
+        : (upstreamStopReason ?? "end_turn");
+
     return {
       id: this.state.responseId,
       type: "message",
       role: "assistant",
       content,
       model: this.state.model,
-      stop_reason:
-        (this.state.stopReason as AnthropicResponse["stop_reason"]) ??
-        "end_turn",
+      stop_reason: stopReason,
       stop_sequence: null,
       usage: {
         input_tokens: this.state.usage?.inputTokens ?? 0,
         output_tokens: this.state.usage?.outputTokens ?? 0,
       },
     };
+  }
+
+  /** Rewrite a block event's index to the one the client knows it by. */
+  private withOutIndex<T extends { index: number }>(event: T): T {
+    return { ...event, index: this.outIndexFor(event.index) };
+  }
+
+  private outIndexFor(upstreamIndex: number): number {
+    const existing = this.outIndexByUpstream.get(upstreamIndex);
+    if (existing !== undefined) return existing;
+    const assigned = this.nextOutIndex++;
+    this.outIndexByUpstream.set(upstreamIndex, assigned);
+    return assigned;
   }
 }
 

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.test.ts
@@ -6,9 +6,11 @@
  * 2. recordBlockedToolSpans is called when tool invocation policies block tool calls
  */
 
+import { MessageStream } from "@anthropic-ai/sdk/lib/MessageStream";
 import {
   CHAT_API_KEY_ID_HEADER,
   PROVIDER_BASE_URL_HEADER,
+  UNTRUSTED_CONTEXT_HEADER,
 } from "@archestra/shared";
 import { eq } from "drizzle-orm";
 import Fastify, { type FastifyInstance } from "fastify";
@@ -114,6 +116,30 @@ import bedrockProxyRoutes from "./routes/bedrock";
 import geminiProxyRoutes from "./routes/gemini";
 import githubCopilotProxyRoutes from "./routes/github-copilot";
 import openAiProxyRoutes from "./routes/openai";
+
+/**
+ * Reconstruct a streamed turn the way a client does, using the SDK's own
+ * accumulator rather than a model of it: it appends content blocks in arrival
+ * order while applying deltas by index, so anything that disturbs the index
+ * sequence shows up here and nowhere in the raw SSE.
+ *
+ * `fromReadableStream` consumes newline-delimited events, so the SSE `data:`
+ * payloads are lifted out and handed over — the framing is not under test.
+ */
+async function reconstructWithSdk(sseBody: string) {
+  const events = sseBody
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice("data: ".length))
+    .join("\n");
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(events));
+      controller.close();
+    },
+  });
+  return MessageStream.fromReadableStream(stream).finalMessage();
+}
 
 describe("LLM Proxy Handler Prometheus Metrics", () => {
   let app: FastifyInstance;
@@ -1013,7 +1039,7 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
     // Same refusal condition as the Anthropic streaming case, on the other axis
     // of the matrix: OpenAI forces `stop` through the same replaced-response
     // path, so the turn reads as finished while a tool_call is on the wire.
-    test("a refusal after streamed tool calls closes the turn as stop", async () => {
+    test("a refusal leaves no tool call on the wire", async () => {
       openAiStubOptions.includeToolCalls = true;
 
       mockEvaluatePolicies.mockResolvedValue({
@@ -1040,11 +1066,100 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.body).toContain("call_test_weather");
+      // Nothing is released before the gate, so a refusal leaves no call on the
+      // wire and the turn is genuinely finished.
+      expect(response.body).not.toContain("call_test_weather");
       expect(response.body).toContain("Tool get_weather is not enabled here");
-      // Upstream closed as tool_calls; the refusal overrides it.
       expect(response.body).toContain('"finish_reason":"stop"');
       expect(response.body).not.toContain('"finish_reason":"tool_calls"');
+    });
+
+    // Only the Anthropic adapter names its declared tools; every other one
+    // falls back to getTools(). The fallback is what keeps the availability
+    // check running for those providers, and a regression that yielded an empty
+    // set here would disable filtering rather than fail loudly.
+    test("a provider that cannot name its declared tools falls back to getTools", async () => {
+      openAiStubOptions.includeToolCalls = true;
+      mockEvaluatePolicies.mockResolvedValue(null);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "weather",
+                parameters: { type: "object", properties: {} },
+              },
+            },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const enabledToolNames = mockEvaluatePolicies.mock
+        .calls[0][4] as Set<string>;
+      expect([...enabledToolNames]).toEqual(["get_weather"]);
+    });
+
+    // The refusal sibling above only pins that a refused call is absent, which
+    // stays true if allowed calls are dropped too, so the release needs its own
+    // test: id, arguments and finish_reason all have to survive the wait, or a
+    // client can neither run the tool nor know one is owed.
+    test("an allowed tool call still reaches the client after the gate", async () => {
+      openAiStubOptions.includeToolCalls = true;
+      mockEvaluatePolicies.mockResolvedValue(null);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/openai/${testAgent.id}/chat/completions`,
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+        },
+        payload: {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      // Reassemble the way a client does: ids and argument fragments arrive as
+      // separate deltas keyed by index.
+      const deltas = response.body
+        .split("\n")
+        .filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
+        .map((line) => JSON.parse(line.slice("data: ".length)));
+      const call = deltas.reduce<{ id?: string; name?: string; args: string }>(
+        (acc, chunk) => {
+          for (const tc of chunk.choices?.[0]?.delta?.tool_calls ?? []) {
+            if (tc.id) acc.id = tc.id;
+            if (tc.function?.name) acc.name = tc.function.name;
+            if (tc.function?.arguments) acc.args += tc.function.arguments;
+          }
+          return acc;
+        },
+        { args: "" },
+      );
+
+      expect(call).toEqual({
+        id: "call_test_weather",
+        name: "get_weather",
+        args: '{"location":"SF"}',
+      });
+      expect(response.body).toContain('"finish_reason":"tool_calls"');
     });
 
     // Buffered turns can still be edited when the refusal lands, and the whole
@@ -1196,6 +1311,170 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       });
     });
 
+    // Driven through the real SDK accumulator, not a hand-rolled one: it pushes
+    // content blocks in arrival order while applying deltas by index, so a gap
+    // in the indices silently empties every block after it — invisible in the
+    // raw SSE.
+    test("the SDK reconstructs every block when a tool call is withheld", async () => {
+      anthropicStubOptions.toolUseBetweenText = true;
+      anthropicStubOptions.streamStopReason = "tool_use";
+
+      mockEvaluatePolicies.mockResolvedValue({
+        refusalMessage: "Tool get_weather is not enabled here",
+        contentMessage: "Tool get_weather is not enabled here",
+        reason: "Tool invocation blocked: disabled for conversation",
+        blockedToolName: "get_weather",
+        toolInput: {},
+        allToolCallNames: ["get_weather"],
+      } satisfies PolicyBlockResult);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+        },
+      });
+
+      const final = await reconstructWithSdk(response.body);
+
+      const texts = final.content.flatMap((block) =>
+        block.type === "text" ? [block.text] : [],
+      );
+
+      // The withheld call must not cost the client the blocks around it.
+      expect(texts).toEqual([
+        "Let me check.",
+        "Then I will summarise.",
+        "Tool get_weather is not enabled here",
+      ]);
+      expect(final.content.some((block) => block.type === "tool_use")).toBe(
+        false,
+      );
+    });
+
+    // A refusal replaces the recorded turn with the refusal text alone, so the
+    // text the client already saw streaming is not in the record. Pinned as the
+    // existing behaviour: withholding tool calls does not change it either way.
+    test("a streamed refusal records the refusal text alone", async () => {
+      anthropicStubOptions.toolUseBetweenText = true;
+      anthropicStubOptions.streamStopReason = "tool_use";
+
+      mockEvaluatePolicies.mockResolvedValue({
+        refusalMessage: "Tool get_weather is not enabled here",
+        contentMessage: "Tool get_weather is not enabled here",
+        reason: "Tool invocation blocked: disabled for conversation",
+        blockedToolName: "get_weather",
+        toolInput: {},
+        allToolCallNames: ["get_weather"],
+      } satisfies PolicyBlockResult);
+
+      await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+        },
+      });
+
+      const [interaction] = await InteractionModel.getAllInteractionsForProfile(
+        testAgent.id,
+      );
+      const logged = interaction.response as {
+        content: { type: string; text?: string }[];
+      };
+      expect(logged.content.map((block) => block.text)).toEqual([
+        "Tool get_weather is not enabled here",
+      ]);
+    });
+
+    // Holding tool calls until the gate decides moves them behind any text that
+    // streamed while they waited, so the client sees them in a different order
+    // than the model produced. Pinned because it is a real, deliberate cost of
+    // the design, not an accident to be silently changed back.
+    test("the SDK sees released tool calls after the text they were interleaved with", async () => {
+      anthropicStubOptions.toolUseBetweenText = true;
+      anthropicStubOptions.streamStopReason = "tool_use";
+      mockEvaluatePolicies.mockResolvedValue(null);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+        },
+      });
+
+      const final = await reconstructWithSdk(response.body);
+
+      // Upstream order was text, tool_use, text.
+      expect(final.content.map((block) => block.type)).toEqual([
+        "text",
+        "text",
+        "tool_use",
+      ]);
+    });
+
+    // A released call has to survive reassembly whole: the id the client answers
+    // with, and the arguments it runs. Those arrive as deltas keyed by index, so
+    // they are exactly what a disturbed index sequence corrupts.
+    test("the SDK reconstructs a released tool call's id and arguments intact", async () => {
+      anthropicStubOptions.toolUseBetweenText = true;
+      anthropicStubOptions.streamStopReason = "tool_use";
+      mockEvaluatePolicies.mockResolvedValue(null);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+        },
+      });
+
+      const final = await reconstructWithSdk(response.body);
+      const toolUse = final.content.find((block) => block.type === "tool_use");
+
+      expect(toolUse).toMatchObject({
+        id: "toolu_test_weather",
+        name: "get_weather",
+        input: { location: "SF" },
+      });
+      // The client owes a tool_result, and the turn has to say so.
+      expect(final.stop_reason).toBe("tool_use");
+    });
+
     // Billed spend is derived by filtering on billing_mode, so the value the
     // handler stamps on the interaction decides whether a call is charged.
     // It is classified from the credential format alone.
@@ -1227,9 +1506,6 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       expect(interactions[0].billingMode).toBe(expected);
     });
 
-    // The buffered counterpart on the incident's own provider: the assistant
-    // message is discarded down to the refusal text, taking the model's prose
-    // and the tool call with it.
     test("a refusal replaces the entire buffered message", async () => {
       anthropicStubOptions.includeToolUseNonStreaming = true;
 
@@ -1266,14 +1542,17 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
           citations: null,
         },
       ]);
+      expect(
+        body.content.some((b: { type: string }) => b.type === "tool_use"),
+      ).toBe(false);
       expect(body.stop_reason).toBe("end_turn");
     });
 
     // The set the handler hands to evaluatePolicies decides which model tool
-    // calls count as available. It is built from getTools(), which drops
-    // provider built-ins, so a caller that declares `bash` alongside a custom
-    // tool has `bash` judged unavailable.
-    test("the availability set passed to evaluatePolicies omits declared built-ins", async () => {
+    // calls count as available. Provider built-ins carry no input schema, so
+    // sourcing it from getTools() would leave them out and refuse every call a
+    // caller makes to its own `bash`.
+    test("the availability set passed to evaluatePolicies includes declared built-ins", async () => {
       anthropicStubOptions.includeToolUse = true;
       mockEvaluatePolicies.mockResolvedValue(null);
 
@@ -1304,15 +1583,70 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       expect(mockEvaluatePolicies).toHaveBeenCalled();
       const enabledToolNames = mockEvaluatePolicies.mock
         .calls[0][4] as Set<string>;
-      expect([...enabledToolNames]).toEqual(["get_weather"]);
+      expect([...enabledToolNames]).toEqual(["get_weather", "bash"]);
     });
 
-    // The shape the client actually receives when a refusal lands after tool
-    // calls have already been written to the wire. Every assertion here is the
-    // current behavior, including the parts that make the turn unanswerable:
-    // the tool_use survives with no way to resolve it, and the turn is closed
-    // as finished even though a tool_result is still owed.
-    test("a refusal after streamed tool calls leaves the tool_use on the wire and closes the turn", async () => {
+    // A caller that declares only built-ins still has an availability set — it
+    // is those built-ins — so the check runs and admits exactly what was
+    // declared, rather than seeing an empty set and skipping entirely.
+    test("declaring only built-ins still yields an availability set", async () => {
+      anthropicStubOptions.includeToolUse = true;
+      mockEvaluatePolicies.mockResolvedValue(null);
+
+      await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "run it" }],
+          stream: true,
+          tools: [{ type: "bash_20250124", name: "bash" }],
+        },
+      });
+
+      const enabledToolNames = mockEvaluatePolicies.mock
+        .calls[0][4] as Set<string>;
+      expect([...enabledToolNames]).toEqual(["bash"]);
+    });
+
+    // A request with no tools at all is a different case: there is nothing to
+    // filter against, and forcing a check would refuse calls on providers whose
+    // adapters surface tools some other way.
+    test("declaring no tools leaves the availability set untouched", async () => {
+      anthropicStubOptions.includeToolUse = true;
+      mockEvaluatePolicies.mockResolvedValue(null);
+
+      await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "hello" }],
+          stream: true,
+        },
+      });
+
+      const enabledToolNames = mockEvaluatePolicies.mock
+        .calls[0][4] as Set<string>;
+      expect([...enabledToolNames]).toEqual([]);
+    });
+
+    // No tool call is released before the gate decides, so a refusal cannot
+    // leave one stranded: there is nothing on the wire to owe a tool_result
+    // for, and the turn is genuinely finished.
+    test("a refusal leaves no tool call on the wire", async () => {
       anthropicStubOptions.includeToolUse = true;
       anthropicStubOptions.streamStopReason = "tool_use";
 
@@ -1342,9 +1676,60 @@ describe("LLM Proxy Handler — recordBlockedToolSpans", () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.body).toContain("toolu_test_weather");
+      expect(response.body).not.toContain("toolu_test_weather");
       expect(response.body).toContain("Tool get_weather is not enabled here");
-      // Upstream said tool_use; the refusal overrides it.
+      expect(response.body).toContain('"stop_reason":"end_turn"');
+      expect(response.body).not.toContain('"stop_reason":"tool_use"');
+
+      const [interaction] = await InteractionModel.getAllInteractionsForProfile(
+        testAgent.id,
+      );
+      const logged = interaction.response as {
+        content: { type: string }[];
+        stop_reason: string;
+      };
+      expect(logged.stop_reason).toBe("end_turn");
+      expect(logged.content.some((b) => b.type === "tool_use")).toBe(false);
+    });
+
+    // The caller's untrusted marking has to survive the handler and arrive as
+    // the `contextIsTrusted` argument, or the gate evaluates the wrong turn.
+    test("an untrusted request reaches the gate marked untrusted", async () => {
+      anthropicStubOptions.includeToolUse = true;
+      anthropicStubOptions.streamStopReason = "tool_use";
+
+      mockEvaluatePolicies.mockResolvedValue({
+        refusalMessage: "Blocked: sensitive context",
+        contentMessage: "Blocked: sensitive context",
+        reason: "Tool invocation blocked: sensitive context",
+        blockedToolName: "get_weather",
+        toolInput: {},
+        allToolCallNames: ["get_weather"],
+      } satisfies PolicyBlockResult);
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/anthropic/${testAgent.id}/v1/messages`,
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+          [UNTRUSTED_CONTEXT_HEADER]: "true",
+        },
+        payload: {
+          model: "claude-3-5-sonnet-20241022",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "What's the weather?" }],
+          stream: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      // Arg 3 is `contextIsTrusted`; the header must have flipped it.
+      expect(mockEvaluatePolicies.mock.calls[0][3]).toBe(false);
+      expect(response.body).not.toContain("toolu_test_weather");
+      expect(response.body).toContain("Blocked: sensitive context");
+      // Nothing is owed, so the turn is genuinely finished.
       expect(response.body).toContain('"stop_reason":"end_turn"');
       expect(response.body).not.toContain('"stop_reason":"tool_use"');
     });

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -25,8 +25,6 @@ import {
   propagation,
 } from "@opentelemetry/api";
 import type { FastifyReply, FastifyRequest } from "fastify";
-import { isRunToolName } from "@/archestra-mcp-server/run-tool-target";
-import { LRUCacheManager } from "@/cache-manager";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
 import { isVertexAiEnabled } from "@/clients/gemini-client";
@@ -41,7 +39,6 @@ import {
   ModelModel,
   OrganizationModel,
   TeamModel,
-  ToolInvocationPolicyModel,
   UserModel,
 } from "@/models";
 import { metrics } from "@/observability";
@@ -107,16 +104,6 @@ const {
     otel: { captureContent, contentMaxLength },
   },
 } = config;
-
-/**
- * Module-level LRU cache for per-tool blocking policy lookups.
- * Keyed by `${agentId}:${toolName}:${contextIsTrusted}` to scope per agent/trust context.
- * Shared across requests to avoid repeated DB queries for the same tool.
- */
-const toolPolicyCache = new LRUCacheManager<boolean>({
-  maxSize: 500,
-  defaultTtl: 60_000, // 60 seconds
-});
 
 /**
  * Shared context passed to streaming and non-streaming handlers.
@@ -1091,12 +1078,23 @@ export async function handleLLMProxy<
     // Build final request
     const finalRequest = requestAdapter.toProviderRequest();
 
-    // Extract enabled tool names for filtering in evaluatePolicies —
-    // canonicalized so they compare against canonicalized tool-call names.
+    // Which called tool names count as available to evaluatePolicies, in the
+    // canonical form tool-call names are compared in. Declared names rather
+    // than `getTools()`, which keeps only schema-carrying custom tools: a
+    // provider built-in the caller declared and executes itself (Anthropic's
+    // bash/text_editor/computer) is absent from that list, so every call to
+    // one would be refused.
+    //
+    // Those names resolve to no `toolsTable` row, so no policy speaks for them
+    // and this set is the only thing that could refuse them. Counting them
+    // keeps them reachable, which is what the caller asked for by declaring
+    // them, and leaves the client — which is the one executing them — as the
+    // boundary that governs them.
     const enabledToolNames = new Set(
-      requestAdapter
-        .getTools()
-        .map((t) => t.name)
+      (
+        requestAdapter.getDeclaredToolNames?.() ??
+        requestAdapter.getTools().map((t) => t.name)
+      )
         .filter(Boolean)
         .map(canonicalizeToolName),
     );
@@ -1280,11 +1278,6 @@ async function handleStreaming<
   // us to record llm_request_duration_seconds. Guard against a second (error-path)
   // observation once the stream has been established.
   let requestDurationRecorded = false;
-  const streamedEventIndices = new Set<number>();
-  // Once a blocking tool is encountered, buffer all subsequent tool call chunks
-  // to prevent streaming data for tools that appear after a blocked tool.
-  let bufferAllToolCalls = false;
-
   // The finally-block persist is gated on usage, so any stream that ends without
   // the provider ever reporting usage — a mid-stream failure, or a stream the
   // provider truncates cleanly — would otherwise leave no trace in LLM logs /
@@ -1376,8 +1369,6 @@ async function handleStreaming<
         }
 
         // Process chunks
-        // Per-tool buffer/stream decisions: only "Allow always" tools stream immediately.
-        // Policy lookups are cached in the module-level toolPolicyCache (LRU with TTL).
 
         for await (const chunk of stream) {
           // Track first chunk time
@@ -1395,85 +1386,24 @@ async function handleStreaming<
 
           const result = streamAdapter.processChunk(chunk);
 
-          // Stream text deltas immediately. For tool call chunks, check
-          // the specific tool's policy to decide buffer vs stream:
-          //  - "Allow always" tools: stream immediately for low latency
-          //    (important for MCP Apps streaming UX).
-          //  - Tools with blocking policies: buffer until policy evaluation
-          //    completes so blocked call data is never exposed.
+          // An adapter reports a tool-call chunk by withholding `sseData`, so
+          // the call accumulates and is released, or discarded, once
+          // `evaluatePolicies` has run. Releasing one earlier would mean
+          // predicting the gate's verdict from cheaper signals, and any
+          // disagreement hands the client a runnable call the gate refused —
+          // the MCP gateway's re-check resolves against the agent's assigned
+          // tools and does not re-apply this turn's decision. A refusal covers
+          // the whole batch too, so a call released before its siblings arrive
+          // could not be taken back.
+          //
+          // Whatever an adapter does put in `sseData` is forwarded verbatim,
+          // so an adapter that emits a chunk carrying both text and a tool call
+          // defeats this (gemini.ts, minimax.ts, and openai.ts's `delta.content`
+          // branch still do; zhipuai.ts guards it), as does one whose terminal
+          // frame echoes the turn's calls (the Responses adapters).
           if (result.sseData) {
             ensureStreamHeaders();
             reply.raw.write(result.sseData);
-          } else if (result.isToolCallChunk) {
-            // Determine whether the accumulated tool calls can be streamed.
-            // Tools with no blocking policy stream immediately for low latency;
-            // tools with blocking policies buffer until evaluation completes.
-            //
-            // Every known tool call is checked, not just the most recent one: a
-            // single chunk can carry several calls (Ollama's native wire
-            // delivers parallel calls in one `tool_calls` array rather than as
-            // per-index deltas), and streaming on the last one alone would
-            // write a blocked call's arguments to the client before
-            // `evaluatePolicies` ever ran. Repeat lookups are served by
-            // `toolPolicyCache`, so re-checking earlier calls is free.
-            let shouldStream = false;
-            if (!bufferAllToolCalls) {
-              let anyBlocking = false;
-              let sawNamedToolCall = false;
-              for (const toolCall of streamAdapter.state.toolCalls) {
-                if (!toolCall?.name) {
-                  continue;
-                }
-                sawNamedToolCall = true;
-                const canonicalToolName = canonicalizeToolName(toolCall.name);
-                // A run_tool dispatch's target only becomes known once its
-                // arguments finish streaming, so the wrapper always buffers —
-                // the target's blocking policies cannot be consulted yet.
-                if (isRunToolName(canonicalToolName)) {
-                  anyBlocking = true;
-                  continue;
-                }
-                const cacheKey = `${agent.id}:${canonicalToolName}:${contextIsTrusted}`;
-                let hasBlocking = toolPolicyCache.get(cacheKey);
-                if (hasBlocking === undefined) {
-                  try {
-                    hasBlocking =
-                      await ToolInvocationPolicyModel.hasBlockingPolicy(
-                        canonicalToolName,
-                        contextIsTrusted,
-                      );
-                  } catch (err) {
-                    logger.warn(
-                      { err, toolName: canonicalToolName },
-                      "hasBlockingPolicy lookup failed, defaulting to buffer",
-                    );
-                    hasBlocking = true;
-                  }
-                  toolPolicyCache.set(cacheKey, hasBlocking);
-                }
-                if (hasBlocking) {
-                  anyBlocking = true;
-                }
-              }
-              if (anyBlocking) {
-                bufferAllToolCalls = true;
-              }
-              shouldStream = sawNamedToolCall && !anyBlocking;
-            }
-
-            if (shouldStream) {
-              const allEvents = streamAdapter.getRawToolCallEvents();
-              ensureStreamHeaders();
-              for (let i = 0; i < allEvents.length; i++) {
-                if (!streamedEventIndices.has(i)) {
-                  reply.raw.write(allEvents[i]);
-                  streamedEventIndices.add(i);
-                }
-              }
-            }
-            // Buffered tools: events accumulate in
-            // streamAdapter.state.rawToolCallEvents and are flushed
-            // (or discarded) after policy evaluation below.
           }
 
           if (result.isFinal) {
@@ -1617,10 +1547,8 @@ async function handleStreaming<
       const { contentMessage, reason, allToolCallNames } =
         toolInvocationRefusal;
 
-      // When not buffering, tool call chunks were already streamed — append
-      // refusal so clients know not to execute them. When buffering,
-      // tool call chunks were held back and discarded — send only the refusal
-      // so blocked tool call data is never exposed.
+      // The tool-call events were held back, so they are simply dropped and
+      // the client is sent the refusal alone.
       ensureStreamHeaders();
       const refusalEvents = streamAdapter.formatCompleteTextSSE(contentMessage);
       for (const event of refusalEvents) {
@@ -1641,17 +1569,19 @@ async function handleStreaming<
         source,
       });
     } else if (toolCalls.length > 0) {
-      // Some tool call chunks were buffered during streaming (per-tool
-      // blocking policies). Policy allowed them, so flush un-streamed events
-      // now. Read the events once: getRawToolCallEvents must not be called in
-      // a condition and again for the flush, or a snapshot-per-call adapter
-      // would still work but a draining one would silently discard events.
-      const allEvents = streamAdapter.getRawToolCallEvents();
-      if (streamedEventIndices.size < allEvents.length) {
-        ensureStreamHeaders();
-        for (let i = 0; i < allEvents.length; i++) {
-          if (!streamedEventIndices.has(i)) {
-            reply.raw.write(allEvents[i]);
+      // Policy allowed them, so hand the buffered events over now. Read once:
+      // getRawToolCallEvents must not be called in a condition and again for
+      // the flush, or a snapshot-per-call adapter would still work but a
+      // draining one would silently discard events. Reading is also what tells
+      // the adapter these calls became the client's, so a turn whose client
+      // already hung up must not read at all — the write would go to a closed
+      // socket and the reconstructed turn would claim a delivery.
+      if (!reply.raw.destroyed) {
+        const allEvents = streamAdapter.getRawToolCallEvents();
+        if (allEvents.length > 0) {
+          ensureStreamHeaders();
+          for (const event of allEvents) {
+            reply.raw.write(event);
           }
         }
       }

--- a/platform/backend/src/routes/proxy/responses-refusal-order.test.ts
+++ b/platform/backend/src/routes/proxy/responses-refusal-order.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The Responses adapters end a turn with `response.completed`, and that
+ * envelope echoes the turn's `function_call` items. A client keeps the LAST
+ * completed frame it sees — the SDK's accumulator overwrites its snapshot on
+ * each one and `finalResponse()` returns the survivor — so the order the proxy
+ * writes those frames in decides what the turn reconstructs to.
+ *
+ * The refusal path synthesises its own `response.completed` carrying the
+ * refusal text alone. It has to be the last one, or the client rebuilds the
+ * turn as the very call the gate refused and dispatches it.
+ */
+
+import { CHAT_API_KEY_ID_HEADER } from "@archestra/shared";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { afterEach, beforeEach, vi } from "vitest";
+import type { PolicyBlockResult } from "@/guardrails/tool-invocation";
+import { describe, expect, test } from "@/test";
+
+const mockEvaluatePolicies = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+vi.mock("@/guardrails/tool-invocation", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/guardrails/tool-invocation")>();
+  return {
+    ...original,
+    evaluatePolicies: (...args: unknown[]) => mockEvaluatePolicies(...args),
+  };
+});
+
+vi.mock("@/guardrails/trusted-data", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/guardrails/trusted-data")>();
+  return {
+    ...original,
+    evaluateIfContextIsTrusted: async () => ({
+      toolResultUpdates: {},
+      contextIsTrusted: true,
+      usedDualLlm: false,
+      dualLlmAnalyses: [],
+      unsafeContextBoundary: undefined,
+    }),
+  };
+});
+
+import { openAiResponsesAdapterFactory } from "./adapters/openai-responses";
+import openAiProxyRoutes from "./routes/openai";
+
+const CALL_ID = "call_refused_1";
+
+/** A turn whose only output is a function call, ending with `response.completed`. */
+function responsesStreamChunks() {
+  const functionCall = {
+    type: "function_call",
+    id: "fc_1",
+    call_id: CALL_ID,
+    name: "get_weather",
+    arguments: '{"location":"SF"}',
+    status: "completed",
+  };
+  return [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      sequence_number: 1,
+      item: functionCall,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 2,
+      item: functionCall,
+    },
+    {
+      type: "response.completed",
+      sequence_number: 3,
+      response: {
+        id: "resp_1",
+        object: "response",
+        status: "completed",
+        model: "gpt-5.6",
+        output: [functionCall],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      },
+    },
+  ];
+}
+
+describe("Responses refusal terminal ordering", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.spyOn(openAiResponsesAdapterFactory, "createClient").mockImplementation(
+      () =>
+        ({
+          responses: {
+            create: async () => ({
+              async *[Symbol.asyncIterator]() {
+                for (const chunk of responsesStreamChunks()) {
+                  yield chunk;
+                }
+              },
+            }),
+          },
+        }) as never,
+    );
+
+    app = Fastify().withTypeProvider<ZodTypeProvider>();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    await app.register(openAiProxyRoutes);
+  });
+
+  afterEach(async () => {
+    await app?.close();
+    vi.restoreAllMocks();
+  });
+
+  test("the turn a client rebuilds after a refusal carries no tool call", async ({
+    makeAgent,
+  }) => {
+    const agent = await makeAgent();
+    mockEvaluatePolicies.mockResolvedValue({
+      refusalMessage: "Tool get_weather is not enabled here",
+      contentMessage: "Tool get_weather is not enabled here",
+      reason: "Tool invocation blocked: disabled for conversation",
+      blockedToolName: "get_weather",
+      toolInput: {},
+      allToolCallNames: ["get_weather"],
+    } satisfies PolicyBlockResult);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/openai/${agent.id}/responses`,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-key",
+        [CHAT_API_KEY_ID_HEADER]: "",
+      },
+      payload: {
+        model: "gpt-5.6",
+        input: [{ role: "user", content: "weather?" }],
+        stream: true,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    // Reconstruct the way a Responses client does: last `response.completed`
+    // wins, and that snapshot is what the agentic loop dispatches from.
+    const completed = response.body
+      .split("\n")
+      .filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
+      .map((line) => {
+        try {
+          return JSON.parse(line.slice("data: ".length));
+        } catch {
+          return null;
+        }
+      })
+      .filter((event) => event?.type === "response.completed");
+
+    expect(completed.length).toBeGreaterThan(0);
+    const finalOutput = completed[completed.length - 1].response?.output ?? [];
+    expect(
+      finalOutput.some(
+        (item: { type?: string }) => item?.type === "function_call",
+      ),
+    ).toBe(false);
+    expect(JSON.stringify(finalOutput)).not.toContain(CALL_ID);
+
+    // The turn also has to end as a turn: a client that never sees a terminal
+    // frame cannot finalize at all.
+    expect(response.body).toContain('"type":"response.completed"');
+  });
+});

--- a/platform/backend/src/test/llm-provider-stubs.ts
+++ b/platform/backend/src/test/llm-provider-stubs.ts
@@ -28,6 +28,11 @@ export interface AnthropicStubOptions {
   /** Terminal `message_delta` stop reason. A real turn carrying tool_use ends as `tool_use`. */
   streamStopReason?: "end_turn" | "tool_use" | "max_tokens" | "stop_sequence";
   /**
+   * Stream text, then a tool_use, then more text. Withholding the middle block
+   * is what exposes whether the indices the client receives stay contiguous.
+   */
+  toolUseBetweenText?: boolean;
+  /**
    * Return a tool_use block from the buffered (non-streaming) response. Separate
    * from `includeToolUse`, which existing tests set while making buffered calls
    * that expect text.
@@ -430,7 +435,49 @@ function createAnthropicStream(options: AnthropicStubOptions) {
     },
   ];
 
-  if (options.includeToolUse) {
+  if (options.toolUseBetweenText) {
+    chunks.push(
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "", citations: [] },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Let me check." },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "content_block_start",
+        index: 1,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_test_weather",
+          caller: { type: "direct" },
+          name: "get_weather",
+          input: {},
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 1,
+        delta: { type: "input_json_delta", partial_json: '{"location":"SF"}' },
+      },
+      { type: "content_block_stop", index: 1 },
+      {
+        type: "content_block_start",
+        index: 2,
+        content_block: { type: "text", text: "", citations: [] },
+      },
+      {
+        type: "content_block_delta",
+        index: 2,
+        delta: { type: "text_delta", text: "Then I will summarise." },
+      },
+      { type: "content_block_stop", index: 2 },
+    );
+  } else if (options.includeToolUse) {
     chunks.push(
       {
         type: "content_block_start",

--- a/platform/backend/src/types/llm-provider.ts
+++ b/platform/backend/src/types/llm-provider.ts
@@ -110,6 +110,15 @@ export interface LLMRequestAdapter<TRequest, TMessages = unknown> {
   /** Get tool definitions (for persistence, hasTools check) */
   getTools(): CommonMcpToolDefinition[];
 
+  /**
+   * Every tool name the caller declared, including provider built-ins that
+   * `getTools()` omits because they carry no input schema (Anthropic's
+   * `bash`/`text_editor`/`computer`). The caller executes those itself, so an
+   * availability check has to count them or every call to one is refused.
+   * Adapters that don't implement it fall back to `getTools()`.
+   */
+  getDeclaredToolNames?(): string[];
+
   /** Check if request has tools */
   hasTools(): boolean;
 


### PR DESCRIPTION
## Summary

A refused tool call still reached the client. The proxy forwarded the `tool_use`, appended a refusal as plain text, and rewrote `stop_reason` to `end_turn` — so a client running its own agentic loop read the turn as finished and never sent a `tool_result`. The unanswered `tool_use` stayed in history and poisoned every later request: *"This model does not support assistant message prefill. The conversation must end with a user message."*

Tool-call events are now held until `evaluatePolicies` has run. A refused call is discarded and never reaches the client, so nothing is owed and `end_turn` is true. An allowed call is released intact and the turn still closes as `tool_use`.

This replaces predicting the gate's verdict from cheaper per-tool signals. Any disagreement between the prediction and the gate handed the client a runnable call the gate had refused, and the MCP gateway resolves against the agent's assigned tools rather than re-applying the turn's decision, so nothing downstream caught it.

Content blocks are renumbered on the way out. The Anthropic SDK's accumulator appends blocks in arrival order while applying deltas by index, so withholding one would leave a gap that silently empties every block after it — including the refusal text the client is meant to read.

Availability counts every declared tool name rather than only schema-carrying ones, so a caller's own built-ins (`bash`, `text_editor`, `computer`) stay usable instead of being refused as unknown.

## Costs

Tool calls arrive after any text they were interleaved with — bounded by the gate itself, ~8ms locally, with text streaming live throughout, so a turn carrying no tool call pays nothing.

A refusal covers the whole batch, so a turn mixing allowed and refused calls returns none of them and the model retries after reading why.

## Scope

The guarantee holds for a chunk carrying only a tool call. A chunk carrying text and a call together, or a terminal frame echoing the turn's calls, still puts that call on the wire before the gate sees it — the OpenAI chat `delta.content` branch, Gemini, MiniMax, and the OpenAI/Azure Responses `response.completed` envelope. Both reproduce identically against `main` and are unaddressed here.
