### PR TITLE
fix(mcp): honor the configured injection header for enterprise-managed credentials

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -3476,6 +3476,131 @@ describe("McpClient", () => {
         fetchMock.mockRestore();
       });
 
+      // Regression: a catalog configured to inject into a custom header must
+      // send the brokered credential under that header only. Emitting it as
+      // `Authorization: Bearer` — or letting a leftover install secret add an
+      // `Authorization` alongside it — hands the upstream a credential it never
+      // asked for and drops the one it did.
+      test("injects the brokered managed credential into the configured custom header", async ({
+        makeIdentityProvider,
+        makeOrganization,
+        makeUser,
+      }) => {
+        const organization = await makeOrganization();
+        const user = await makeUser({ email: "managed-header@example.com" });
+        const managedConfig = {
+          requestedCredentialType: "secret" as const,
+          resourceIdentifier: "orn:okta:pam:github-secret",
+          tokenInjectionMode: "header" as const,
+          headerName: "x-provider-api-token",
+          responseFieldPath: "token",
+        };
+        const identityProvider = await makeIdentityProvider(organization.id, {
+          providerId: "okta-managed-header",
+          issuer: "https://example.okta.com",
+          oidcConfig: {
+            clientId: "web-client-id",
+            tokenEndpoint: "https://example.okta.com/oauth2/v1/token",
+            enterpriseManagedCredentials: {
+              exchangeStrategy: "okta_managed",
+              clientId: "ai-agent-client-id",
+              tokenEndpoint: "https://example.okta.com/oauth2/v1/token",
+              tokenEndpointAuthentication: "client_secret_post",
+              clientSecret: "ai-agent-client-secret",
+            },
+          },
+        });
+
+        await AgentModel.update(agentId, {
+          organizationId: organization.id,
+          identityProviderId: identityProvider.id,
+        });
+
+        // A leftover static credential from before the catalog moved to
+        // enterprise-managed mode. It must not ride along on the request.
+        const staleSecret = await secretManager().createSecret(
+          { access_token: "stale-install-token" },
+          "managed-header-stale-secret",
+        );
+        await McpServerModel.update(mcpServerId, { secretId: staleSecret.id });
+        await InternalMcpCatalogModel.update(catalogId, {
+          enterpriseManagedConfig: managedConfig,
+        });
+
+        const tool = await ToolModel.createToolIfNotExists({
+          name: "github-mcp-server__managed_header_tool",
+          description: "Managed credential tool using a custom header",
+          parameters: {},
+          catalogId,
+        });
+
+        await AgentToolModel.create(agentId, tool.id, {
+          credentialResolutionMode: "enterprise_managed",
+        });
+
+        await db.insert(schema.accountsTable).values({
+          id: randomUUID(),
+          accountId: "acct-managed-header",
+          providerId: identityProvider.providerId,
+          userId: user.id,
+          idToken: createJwt({ exp: futureExpSeconds() }),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              issued_token_type: "urn:okta:params:oauth:token-type:secret",
+              secret: { token: "ghu_managed_header_token" },
+              expires_in: 300,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+
+        mockCallTool.mockResolvedValue({
+          content: [{ type: "text", text: "Managed header result" }],
+          isError: false,
+        });
+
+        const headerResult = await mcpClient.executeToolCallForOwner(
+          {
+            id: "call_enterprise_managed_header",
+            name: "github-mcp-server__managed_header_tool",
+            arguments: {},
+          },
+          agentOwner(agentId),
+          {
+            tokenId: "session-token",
+            teamId: null,
+            isOrganizationToken: false,
+            userId: user.id,
+          },
+          { conversationId: "enterprise-managed-header-conv" },
+        );
+
+        expect(headerResult.isError).toBe(false);
+
+        const { StreamableHTTPClientTransport: HeaderModeTransport } =
+          await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+        const [, headerOptions] =
+          vi.mocked(HeaderModeTransport).mock.calls.at(-1) ?? [];
+        const outgoingHeaders =
+          headerOptions?.requestInit?.headers instanceof Headers
+            ? headerOptions.requestInit.headers
+            : new Headers(headerOptions?.requestInit?.headers);
+
+        // The exchanged credential goes to the configured header, bare — the
+        // upstream expects the token itself, not a `Bearer `-prefixed value.
+        expect(outgoingHeaders.get("x-provider-api-token")).toBe(
+          "ghu_managed_header_token",
+        );
+        expect(outgoingHeaders.get("authorization")).toBeNull();
+
+        fetchMock.mockRestore();
+      });
+
       // Regression: assignments created before enterprise mode existed still
       // carry the default "static" mode. The catalog-level config must win,
       // otherwise runtime calls hit the protected server with no credential.

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -2111,8 +2111,10 @@ class McpClient {
           secrets,
         });
         if (enterpriseTransportCredential) {
-          localHeaders[enterpriseTransportCredential.headerName] =
-            enterpriseTransportCredential.headerValue;
+          applyEnterpriseCredentialHeader(
+            localHeaders,
+            enterpriseTransportCredential,
+          );
         } else if (
           !hasStaticAuthorizationCredential(secrets) &&
           tokenAuth?.isExternalIdp &&
@@ -2163,8 +2165,10 @@ class McpClient {
           secrets,
         });
         if (enterpriseTransportCredential) {
-          headers[enterpriseTransportCredential.headerName] =
-            enterpriseTransportCredential.headerValue;
+          applyEnterpriseCredentialHeader(
+            headers,
+            enterpriseTransportCredential,
+          );
         } else if (
           !hasStaticAuthorizationCredential(secrets) &&
           tokenAuth?.isExternalIdp &&
@@ -3309,8 +3313,21 @@ class McpClient {
     mcpServerId: string;
     secrets: Record<string, unknown>;
     secretId?: string;
+    /**
+     * Credential resolved from the catalog's enterprise-managed config, already
+     * mapped onto the header its injection mode asks for. Passing the raw token
+     * as a `secrets.access_token` instead would force `Authorization: Bearer`
+     * and ignore a configured custom header.
+     */
+    enterpriseTransportCredential?: ResolvedEnterpriseTransportCredential;
   }): Promise<CommonMcpToolDefinition[]> {
-    const { catalogItem, mcpServerId, secrets, secretId } = params;
+    const {
+      catalogItem,
+      mcpServerId,
+      secrets,
+      secretId,
+      enterpriseTransportCredential,
+    } = params;
 
     // Local stdio servers can report a ready pod before the MCP process accepts
     // JSON-RPC, especially while the runtime is still pulling or starting Node.
@@ -3328,6 +3345,9 @@ class McpClient {
           mcpServerId,
           secrets,
           secretId,
+          undefined,
+          undefined,
+          enterpriseTransportCredential ?? undefined,
         );
 
         // No `roots` — see the identical omission above.
@@ -3967,6 +3987,23 @@ class McpClient {
     }
     const { secrets, secretId } = secretResult;
 
+    // Resource reads hit the same upstream as tool calls, so they must carry
+    // the same enterprise-managed credential. Without it the transport falls
+    // back to forwarding the caller's raw IdP token as `Authorization: Bearer`,
+    // bypassing the catalog's configured injection mode entirely.
+    const enterpriseTransportCredential = catalogItem.enterpriseManagedConfig
+      ? await this.resolveCachedEnterpriseTransportCredential({
+          owner: agentOwner(agentId),
+          tokenAuth,
+          enterpriseManagedConfig: catalogItem.enterpriseManagedConfig,
+        })
+      : null;
+    if (catalogItem.enterpriseManagedConfig && !enterpriseTransportCredential) {
+      throw new Error(
+        `Enterprise-managed credential could not be resolved for ${catalogItem.name}`,
+      );
+    }
+
     const transport = await this.getTransport(
       catalogItem,
       server.id,
@@ -3974,6 +4011,7 @@ class McpClient {
       secretId,
       undefined,
       tokenAuth,
+      enterpriseTransportCredential ?? undefined,
     );
     const connectionKey = `${catalogItem.id}:${server.id}:${agentId}`;
     const client = await this.getOrCreateClient(
@@ -4760,6 +4798,30 @@ function getStaticCredentialHeaderValue(params: {
   }
 
   return params.secretValue;
+}
+
+/**
+ * Apply an enterprise-managed credential as the outbound auth header, dropping
+ * any `Authorization` the install's own static secrets already contributed.
+ *
+ * The enterprise exchange is authoritative once it runs, so a leftover
+ * `Authorization` from a stale `access_token` must not ride along: when the
+ * catalog injects into a custom header the upstream would otherwise receive
+ * two credentials and typically authenticate as the stale one.
+ */
+function applyEnterpriseCredentialHeader(
+  headers: Record<string, string>,
+  credential: { headerName: string; headerValue: string },
+): void {
+  if (credential.headerName.toLowerCase() !== "authorization") {
+    for (const headerName of Object.keys(headers)) {
+      if (headerName.toLowerCase() === "authorization") {
+        delete headers[headerName];
+      }
+    }
+  }
+
+  headers[credential.headerName] = credential.headerValue;
 }
 
 function buildDefaultAuthorizationHeaders(

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -2078,8 +2078,95 @@ describe("mcp server inspect route", () => {
     });
     expect(connectAndGetToolsMock).toHaveBeenCalledTimes(1);
     expect(connectAndGetToolsMock.mock.calls[0][0]).toMatchObject({
-      secrets: { access_token: "exchanged-github-token" },
+      enterpriseTransportCredential: {
+        headerName: "Authorization",
+        headerValue: "Bearer exchanged-github-token",
+      },
     });
+    // The exchanged credential travels as a resolved header, never as a static
+    // secret — the static path would ignore the catalog's injection mode.
+    expect(connectAndGetToolsMock.mock.calls[0][0].secrets).not.toHaveProperty(
+      "access_token",
+    );
+  });
+
+  // Regression: install-time discovery used to hand the exchanged credential to
+  // the transport as a static `access_token`, which always emits
+  // `Authorization: Bearer` and silently ignores a configured custom header.
+  test("enterprise-managed install discovery honors a custom injection header", async ({
+    makeAccount,
+    makeIdentityProvider,
+    makeInternalMcpCatalog,
+  }) => {
+    const identityProvider = await makeIdentityProvider(user.id, {
+      providerId: "keycloak",
+      issuer: "http://localhost:30081/realms/archestra",
+      oidcConfig: {
+        clientId: "archestra-oidc",
+        clientSecret: "archestra-oidc-secret",
+        tokenEndpoint:
+          "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
+        tokenEndpointAuthentication: "client_secret_post",
+        enterpriseManagedCredentials: {
+          exchangeStrategy: "rfc8693",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+        },
+      },
+    });
+
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "Custom Header Remote",
+      serverType: "remote",
+      serverUrl: "https://internal.example.com/mcp",
+      enterpriseManagedConfig: {
+        identityProviderId: identityProvider.id,
+        requestedCredentialType: "bearer_token",
+        tokenInjectionMode: "header",
+        headerName: "x-provider-api-token",
+      },
+    });
+
+    await makeAccount(user.id, {
+      providerId: "keycloak",
+      accessToken: "session-access-token",
+    });
+
+    exchangeEnterpriseManagedCredentialMock.mockResolvedValueOnce({
+      credentialType: "bearer_token",
+      expiresInSeconds: null,
+      issuedTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+      value: "exchanged-custom-header-token",
+    });
+
+    connectAndGetToolsMock.mockResolvedValueOnce([
+      {
+        name: "get-server-info",
+        description: "Returns server details",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/mcp_server",
+      payload: {
+        name: "Custom Header Remote",
+        catalogId: catalog.id,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(connectAndGetToolsMock).toHaveBeenCalledTimes(1);
+
+    const [discoveryParams] = connectAndGetToolsMock.mock.calls[0];
+    // Bare value under the configured header — not `Bearer …`, and not
+    // `Authorization`.
+    expect(discoveryParams.enterpriseTransportCredential).toMatchObject({
+      headerName: "x-provider-api-token",
+      headerValue: "exchanged-custom-header-token",
+    });
+    expect(discoveryParams.secrets).not.toHaveProperty("access_token");
   });
 
   // Regression: enterprise-managed catalogs with install-time userConfig used
@@ -2176,7 +2263,10 @@ describe("mcp server inspect route", () => {
     expect(callsForCatalog[0][0]).toMatchObject({
       secrets: {
         header_x_tenant: "tenant-a",
-        access_token: "exchanged-downstream-token",
+      },
+      enterpriseTransportCredential: {
+        headerName: "Authorization",
+        headerValue: "Bearer exchanged-downstream-token",
       },
     });
   });
@@ -2271,7 +2361,10 @@ describe("mcp server inspect route", () => {
     );
     expect(callsForCatalog).toHaveLength(1);
     expect(callsForCatalog[0][0]).toMatchObject({
-      secrets: { access_token: "exchanged-local-token" },
+      enterpriseTransportCredential: {
+        headerName: "Authorization",
+        headerValue: "Bearer exchanged-local-token",
+      },
     });
   });
 
@@ -2348,7 +2441,10 @@ describe("mcp server inspect route", () => {
       }),
     });
     expect(connectAndGetToolsMock.mock.calls[0][0]).toMatchObject({
-      secrets: { access_token: "downstream-user-token" },
+      enterpriseTransportCredential: {
+        headerName: "Authorization",
+        headerValue: "Bearer downstream-user-token",
+      },
     });
   });
 
@@ -2394,7 +2490,10 @@ describe("mcp server inspect route", () => {
     expect(exchangeEnterpriseManagedCredentialMock).not.toHaveBeenCalled();
     expect(connectAndGetToolsMock).toHaveBeenCalledTimes(1);
     expect(connectAndGetToolsMock.mock.calls[0][0]).toMatchObject({
-      secrets: { access_token: "raw-session-access-token" },
+      enterpriseTransportCredential: {
+        headerName: "Authorization",
+        headerValue: "Bearer raw-session-access-token",
+      },
     });
   });
 
@@ -2487,7 +2586,10 @@ describe("mcp server inspect route", () => {
     });
     expect(connectAndGetToolsMock).toHaveBeenCalledTimes(1);
     expect(connectAndGetToolsMock.mock.calls[0][0]).toMatchObject({
-      secrets: { access_token: "shared-install-discovery-token" },
+      enterpriseTransportCredential: {
+        headerName: "Authorization",
+        headerValue: "Bearer shared-install-discovery-token",
+      },
     });
   });
 
@@ -2614,7 +2716,10 @@ describe("mcp server inspect route", () => {
       }),
     });
     expect(connectAndGetToolsMock.mock.calls[0][0]).toMatchObject({
-      secrets: { access_token: "mcp-server-access-token" },
+      enterpriseTransportCredential: {
+        headerName: "Authorization",
+        headerValue: "Bearer mcp-server-access-token",
+      },
     });
 
     const persistedTool = await ToolModel.findByName(

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -31,7 +31,10 @@ import { isByosEnabled, secretManager } from "@/secrets-manager";
 import { filterMcpServersAssignableToTarget } from "@/services/agent-tool-assignment";
 import { assertValuesMatchEnvironmentRegex } from "@/services/environments/environment";
 import { refreshLinkedIdentityProviderAccessToken } from "@/services/identity-providers/access-token-refresh";
-import { exchangeIdJagAtProtectedResource } from "@/services/identity-providers/enterprise-managed/broker";
+import {
+  buildEnterpriseCredentialHeader,
+  exchangeIdJagAtProtectedResource,
+} from "@/services/identity-providers/enterprise-managed/broker";
 import { exchangeEnterpriseManagedCredential } from "@/services/identity-providers/enterprise-managed/exchange";
 import {
   findExternalIdentityProviderById,
@@ -2319,9 +2322,20 @@ async function connectAndGetToolsForInstallation(params: {
           userId: params.userId,
         })
       : undefined;
-  const discoverySecrets = installDiscoveryAccessToken
-    ? { ...secrets, access_token: installDiscoveryAccessToken }
-    : secrets;
+  // Route the exchanged credential through the catalog's injection mode rather
+  // than folding it into `access_token`: the static-secret path always emits
+  // `Authorization: Bearer`, which silently ignores a configured custom header
+  // and sends discovery traffic with a credential the upstream never expects.
+  const installDiscoveryCredential =
+    installDiscoveryAccessToken && catalogItem.enterpriseManagedConfig
+      ? {
+          ...buildEnterpriseCredentialHeader({
+            config: catalogItem.enterpriseManagedConfig,
+            value: installDiscoveryAccessToken,
+          }),
+          expiresInSeconds: null,
+        }
+      : undefined;
 
   if (catalogItem.enterpriseManagedConfig && !installDiscoveryAccessToken) {
     const identityProvider = catalogItem.enterpriseManagedConfig
@@ -2340,8 +2354,9 @@ async function connectAndGetToolsForInstallation(params: {
     return await mcpClient.connectAndGetTools({
       catalogItem,
       mcpServerId: params.mcpServerId,
-      secrets: discoverySecrets,
+      secrets,
       secretId: params.secretId,
+      enterpriseTransportCredential: installDiscoveryCredential,
     });
   } catch (error) {
     if (
@@ -2356,7 +2371,10 @@ async function connectAndGetToolsForInstallation(params: {
       catalogItem,
       userId: params.userId,
     });
-    if (!accessToken || discoverySecrets.access_token === accessToken) {
+    // Only non-enterprise catalogs reach the retry (the guard above rethrows
+    // when an enterprise config is set), so the token already tried is the
+    // install's own stored one.
+    if (!accessToken || secrets.access_token === accessToken) {
       throw error;
     }
 
@@ -2373,7 +2391,7 @@ async function connectAndGetToolsForInstallation(params: {
       catalogItem,
       mcpServerId: params.mcpServerId,
       secrets: {
-        ...discoverySecrets,
+        ...secrets,
         access_token: accessToken,
       },
       secretId: params.secretId,

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.test.ts
@@ -5,7 +5,10 @@ import { vi } from "vitest";
 import db, { schema } from "@/database";
 import { describe, expect, test } from "@/test";
 import { agentOwner } from "@/types";
-import { resolveEnterpriseTransportCredential } from "./broker";
+import {
+  buildEnterpriseCredentialHeader,
+  resolveEnterpriseTransportCredential,
+} from "./broker";
 
 describe("resolveEnterpriseTransportCredential", () => {
   test("exchanges a session IdP token for a managed secret and builds an authorization header", async ({
@@ -959,6 +962,76 @@ describe("resolveEnterpriseTransportCredential", () => {
     );
 
     fetchMock.mockRestore();
+  });
+});
+
+describe("buildEnterpriseCredentialHeader", () => {
+  test("sends the credential under the configured custom header, unprefixed", () => {
+    expect(
+      buildEnterpriseCredentialHeader({
+        config: {
+          tokenInjectionMode: "header",
+          headerName: "X-Provider-Token",
+        },
+        value: "downstream-token",
+      }),
+    ).toEqual({
+      headerName: "X-Provider-Token",
+      headerValue: "downstream-token",
+    });
+  });
+
+  test("does not fall back to Authorization when a custom header is configured", () => {
+    const { headerName } = buildEnterpriseCredentialHeader({
+      config: { tokenInjectionMode: "header", headerName: "X-Provider-Token" },
+      value: "downstream-token",
+    });
+
+    expect(headerName.toLowerCase()).not.toBe("authorization");
+  });
+
+  test("rejects custom-header mode that is missing a header name", () => {
+    expect(() =>
+      buildEnterpriseCredentialHeader({
+        config: { tokenInjectionMode: "header" },
+        value: "downstream-token",
+      }),
+    ).toThrow(
+      "Enterprise-managed credential injection mode 'header' requires headerName",
+    );
+  });
+
+  test.each([
+    "env",
+    "body_field",
+  ] as const)("refuses to smuggle a %s-mode credential into an Authorization header", (tokenInjectionMode) => {
+    expect(() =>
+      buildEnterpriseCredentialHeader({
+        config: { tokenInjectionMode },
+        value: "downstream-token",
+      }),
+    ).toThrow(/is not supported for HTTP MCP transports/);
+  });
+
+  test("sends the raw value for raw_authorization mode", () => {
+    expect(
+      buildEnterpriseCredentialHeader({
+        config: { tokenInjectionMode: "raw_authorization" },
+        value: "token abc123",
+      }),
+    ).toEqual({ headerName: "Authorization", headerValue: "token abc123" });
+  });
+
+  test("defaults to a bearer Authorization header", () => {
+    expect(
+      buildEnterpriseCredentialHeader({
+        config: {},
+        value: "downstream-token",
+      }),
+    ).toEqual({
+      headerName: "Authorization",
+      headerValue: "Bearer downstream-token",
+    });
   });
 });
 

--- a/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
+++ b/platform/backend/src/services/identity-providers/enterprise-managed/broker.ts
@@ -17,6 +17,44 @@ export type ResolvedEnterpriseTransportCredential = {
   expiresInSeconds: number | null;
 };
 
+/**
+ * Map an already-resolved credential value onto the outbound header the
+ * catalog's injection mode asks for.
+ *
+ * Exported so every caller that obtains an enterprise-managed credential
+ * injects it the same way. Handing the value to the transport as a static
+ * `access_token` secret instead would silently force `Authorization: Bearer`
+ * and ignore a configured custom header.
+ */
+export function buildEnterpriseCredentialHeader(params: {
+  config: EnterpriseManagedCredentialConfig;
+  value: string;
+}): { headerName: string; headerValue: string } {
+  const { config, value } = params;
+
+  switch (config.tokenInjectionMode) {
+    case "header":
+      if (!config.headerName) {
+        throw new Error(
+          "Enterprise-managed credential injection mode 'header' requires headerName",
+        );
+      }
+      return { headerName: config.headerName, headerValue: value };
+    case "raw_authorization":
+      return { headerName: "Authorization", headerValue: value };
+    case "env":
+    case "body_field":
+      // Both describe a non-header carrier that an HTTP MCP transport cannot
+      // express. Falling through to `Authorization: Bearer` would put the
+      // credential somewhere the operator never asked for, so refuse instead.
+      throw new Error(
+        `Enterprise-managed credential injection mode '${config.tokenInjectionMode}' is not supported for HTTP MCP transports`,
+      );
+    default:
+      return { headerName: "Authorization", headerValue: `Bearer ${value}` };
+  }
+}
+
 export async function resolveEnterpriseTransportCredential(params: {
   owner: ToolOwner;
   tokenAuth?: TokenAuthContext;
@@ -303,62 +341,23 @@ function normalizeEnterpriseTransportCredential(params: {
     responseFieldPath: config.responseFieldPath,
   });
 
-  switch (config.tokenInjectionMode) {
-    case "header":
-      if (!config.headerName) {
-        throw new Error(
-          "Enterprise-managed credential injection mode 'header' requires headerName",
-        );
-      }
-      return {
-        headerName: config.headerName,
-        headerValue: scalarValue,
-        expiresInSeconds: credential.expiresInSeconds,
-      };
-    case "raw_authorization":
-      return {
-        headerName: "Authorization",
-        headerValue: scalarValue,
-        expiresInSeconds: credential.expiresInSeconds,
-      };
-    default:
-      return {
-        headerName: "Authorization",
-        headerValue: `Bearer ${scalarValue}`,
-        expiresInSeconds: credential.expiresInSeconds,
-      };
-  }
+  return {
+    ...buildEnterpriseCredentialHeader({ config, value: scalarValue }),
+    expiresInSeconds: credential.expiresInSeconds,
+  };
 }
 
 function normalizeEnterprisePassthroughCredential(params: {
   config: EnterpriseManagedCredentialConfig;
   assertion: string;
 }): ResolvedEnterpriseTransportCredential {
-  switch (params.config.tokenInjectionMode) {
-    case "header":
-      if (!params.config.headerName) {
-        throw new Error(
-          "Enterprise-managed credential injection mode 'header' requires headerName",
-        );
-      }
-      return {
-        headerName: params.config.headerName,
-        headerValue: params.assertion,
-        expiresInSeconds: null,
-      };
-    case "raw_authorization":
-      return {
-        headerName: "Authorization",
-        headerValue: params.assertion,
-        expiresInSeconds: null,
-      };
-    default:
-      return {
-        headerName: "Authorization",
-        headerValue: `Bearer ${params.assertion}`,
-        expiresInSeconds: null,
-      };
-  }
+  return {
+    ...buildEnterpriseCredentialHeader({
+      config: params.config,
+      value: params.assertion,
+    }),
+    expiresInSeconds: null,
+  };
 }
 
 function extractInjectionValue(params: {


### PR DESCRIPTION
## Problem

A catalog item using **Identity Provider Token Exchange** can choose how the exchanged credential reaches the upstream MCP server — `Authorization: Bearer`, a raw `Authorization`, or a **custom header** with an operator-chosen name. The docs state that Header Name "sets the exact upstream header name."

Only tool calls honored that choice.

**Install-time tool discovery** performed the exchange and then handed the credential to the transport as a static `secrets.access_token`:

```ts
const discoverySecrets = installDiscoveryAccessToken
  ? { ...secrets, access_token: installDiscoveryAccessToken }
  : secrets;
```

`connectAndGetTools` then called `getTransport` without the `enterpriseTransportCredential` argument, so the value fell through to `buildDefaultAuthorizationHeaders` and went out as `Authorization: Bearer …` — the injection mode was never consulted, and `normalizeEnterpriseTransportCredential` was never invoked on this path.

A server configured to receive its credential in a custom header therefore saw discovery traffic carrying an `Authorization` header it never asked for, and no custom header at all. Against a permissive upstream this silently "works" and masks the misconfiguration; against a strict one, install fails.

## Changes

- **Install discovery honors the injection mode.** The exchanged credential is mapped through the same broker logic tool calls use and threaded into `connectAndGetTools` as a resolved header instead of a secret. Non-enterprise installs are untouched — `installDiscoveryAccessToken` is only ever populated when the catalog has an enterprise config, so the retry path keeps its existing `access_token` behavior.
- **`doReadResource` resolves the enterprise credential.** It previously resolved none while still passing `tokenAuth`, so it hit the fallback that forwards the caller's **raw IdP token** as `Authorization: Bearer`. It now resolves the credential and fails closed when it cannot.
- **A leftover install secret no longer rides along.** Once the exchange has run it is authoritative, so applying the credential to a custom header clears any `Authorization` the static secrets contributed. Previously the upstream could receive two credentials and would typically authenticate as the stale one.
- **`env` and `body_field` fail closed.** Both are accepted by the config schema but describe a non-header carrier an HTTP MCP transport cannot express, and both silently fell through to `Authorization: Bearer`, putting the credential somewhere the operator never asked for.

The mode→header mapping is extracted into an exported `buildEnterpriseCredentialHeader`, so the two broker normalizers and install discovery all share one implementation.

## Tests

`tokenInjectionMode: "header"` had **zero** test coverage anywhere in the repo — the `case "header"` branch was entirely unexercised, which is why this shipped. Now covered:

- `broker.test.ts` — the mapping for every injection mode, the missing-`headerName` error, and the new `env` / `body_field` refusals.
- `mcp-client.test.ts` — a tool call on a custom-header catalog sends the bare credential under the configured header and **no** `Authorization`, with a stale install secret present. Verified this fails without the fix (`Bearer stale-install-token`).
- `mcp-server.test.ts` — install discovery passes a custom-header credential through as a resolved header and never as `secrets.access_token`. Four existing assertions that encoded the old behavior were updated to the corrected contract.

## Verification

`pnpm type-check`, `pnpm knip` (dev + production), and biome all clean. Backend suites for the touched areas pass: `mcp-server.test.ts` (82), `mcp-client.test.ts` + `install-secret-routing` + `identity-providers/**` (196), `broker.test.ts` (18).

## Known remaining gaps (not addressed here)

`inspectServer`, the app-runner connect path, and the model-layer tool-refresh callers also build transports without an enterprise credential. Unlike the paths fixed here they carry no caller identity, so a per-user exchange isn't possible without a broader change — and with no `tokenAuth` they cannot leak a caller token; they simply connect without the enterprise credential. Worth a follow-up.

No docs change: `mcp-authentication.md` already describes the intended behavior, and the code now matches it.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>