### PR TITLE
feat(chatops): per-channel answer-all for MS Teams

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -111126,6 +111126,12 @@
                     },
                     "hasDmBinding": {
                       "type": "boolean"
+                    },
+                    "workspacesWithUnmentionedTraffic": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -111133,7 +111139,8 @@
                     "pagination",
                     "counts",
                     "workspaces",
-                    "hasDmBinding"
+                    "hasDmBinding",
+                    "workspacesWithUnmentionedTraffic"
                   ],
                   "additionalProperties": false
                 }

--- a/docs/pages/platform-ms-teams.md
+++ b/docs/pages/platform-ms-teams.md
@@ -3,7 +3,7 @@ title: MS Teams
 category: Agents
 order: 7
 description: Connect Archestra agents to Microsoft Teams channels
-lastUpdated: 2026-07-14
+lastUpdated: 2026-07-30
 ---
 
 <!-- Renaming/deleting this file? Add a redirect in docs/redirects.json. -->
@@ -49,6 +49,14 @@ The bot responds with an **Adaptive Card dropdown** to select which agent handle
 In channels the bot stays silent until it is @mentioned. Once mentioned in a thread, it keeps replying to every message in that thread without further mentions. Starting a new thread needs a fresh mention. Direct messages and group chats always get a reply, no mention required.
 
 To stop the bot replying in a thread, send `mute` (you can address it by name with no @mention, e.g. `Archestra mute`), or react to one of its replies with the mute (🔇) or shushing-face (🤫) emoji. It goes quiet until the thread is @mentioned again. Muting also cancels any reply the bot is already working on, so a late answer never lands after you ask for quiet. As a reminder, the bot adds a short hint about this to its first reply in each thread.
+
+### Answering Every Message
+
+By default the bot answers only when @mentioned in a channel. You can switch a single channel to answer every message instead — no mention needed. On the **Agent Triggers** → **MS Teams** page, set that channel's **Replies to** toggle to **All messages**. Other channels stay mentions-only.
+
+Mute still works per thread: send `mute` in a thread to silence it until you @mention the bot there again. Direct messages and group chats already answer every message, so the toggle does not apply to them.
+
+This needs the `ChannelMessage.Read.Group` permission, which the team owner consents to when the app is installed. If the toggle appears to do nothing, reinstall the app so the owner is asked again.
 
 ### Commands
 

--- a/platform/backend/src/agents/chatops/channel-activation.test.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, type Mock, test, vi } from "vitest";
 import { cacheManager } from "@/cache-manager";
 
 // The canonical Map-backed fake from src/__mocks__/cache-manager.ts stands in
@@ -12,13 +12,20 @@ vi.mock("@/models/chatops-channel-binding", () => ({
   default: { findByChannel: vi.fn() },
 }));
 
+// applyChannelGate resolves the app name to match "<app name> mute" commands.
+vi.mock("@/models/organization", () => ({
+  default: { getAppName: vi.fn(async () => "Archestra") },
+}));
+
 const setSpy = vi.spyOn(cacheManager, "set");
 
 import ChatOpsChannelBindingModel from "@/models/chatops-channel-binding";
 import {
+  applyChannelGate,
   claimThreadMuteHint,
   clearChannelThreadActive,
   clearChannelThreadMuted,
+  findWorkspacesWithUnmentionedTraffic,
   getThreadMuteMarker,
   invalidateChannelAnswerAll,
   isChannelAnswerAllEnabled,
@@ -30,6 +37,7 @@ import {
   markChannelThreadMuted,
   mightBeAddressedMuteCommand,
   muteChannelThread,
+  recordUnmentionedChannelTraffic,
   resolveChannelGateAction,
 } from "./channel-activation";
 import { chatOpsRunRegistry } from "./chatops-run-registry";
@@ -516,5 +524,246 @@ describe("isChannelAnswerAllEnabled", () => {
     } as never);
     expect(await isChannelAnswerAllEnabled(CHANNEL_PARAMS)).toBe(true);
     expect(ChatOpsChannelBindingModel.findByChannel).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("un-mentioned channel traffic markers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The per-pod write throttle is module-level and outlives clearAllMocks, so
+  // each test needs its own workspace id or a sibling's throttle entry would
+  // suppress its write and leave the (per-test) fake cache store empty.
+  test("only reports workspaces that actually delivered an un-mentioned message", async () => {
+    await recordUnmentionedChannelTraffic({
+      provider: "ms-teams",
+      workspaceId: "team-reported",
+    });
+
+    expect(
+      await findWorkspacesWithUnmentionedTraffic({
+        provider: "ms-teams",
+        workspaceIds: ["team-reported", "team-silent"],
+      }),
+    ).toEqual(["team-reported"]);
+  });
+
+  test("is scoped per provider", async () => {
+    await recordUnmentionedChannelTraffic({
+      provider: "ms-teams",
+      workspaceId: "team-scoped",
+    });
+
+    expect(
+      await findWorkspacesWithUnmentionedTraffic({
+        provider: "slack",
+        workspaceIds: ["team-scoped"],
+      }),
+    ).toEqual([]);
+  });
+
+  test("reports nothing when asked about no workspaces", async () => {
+    expect(
+      await findWorkspacesWithUnmentionedTraffic({
+        provider: "ms-teams",
+        workspaceIds: [],
+      }),
+    ).toEqual([]);
+  });
+
+  test("writes once per workspace instead of once per message", async () => {
+    // The per-pod dedupe is module-level and outlives clearAllMocks, so this
+    // workspace id must not be reused by another test.
+    const params = {
+      provider: "ms-teams",
+      workspaceId: "team-write-once",
+    } as const;
+
+    await recordUnmentionedChannelTraffic(params);
+    await recordUnmentionedChannelTraffic(params);
+    await recordUnmentionedChannelTraffic(params);
+
+    // Every un-mentioned channel message calls this; without the dedupe each one
+    // would upsert the same Postgres-backed row.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(
+      await findWorkspacesWithUnmentionedTraffic({
+        provider: "ms-teams",
+        workspaceIds: ["team-write-once"],
+      }),
+    ).toEqual(["team-write-once"]);
+  });
+
+  test("a failed write is retried by the next message, not throttled away", async () => {
+    const params = {
+      provider: "ms-teams",
+      workspaceId: "team-write-fails",
+    } as const;
+    setSpy.mockRejectedValueOnce(new Error("cache unavailable"));
+
+    await expect(recordUnmentionedChannelTraffic(params)).rejects.toThrow();
+
+    // Throttling on a failed write would hide the workspace for the whole
+    // window; the next message has to be able to record it.
+    await recordUnmentionedChannelTraffic(params);
+    expect(
+      await findWorkspacesWithUnmentionedTraffic({
+        provider: "ms-teams",
+        workspaceIds: ["team-write-fails"],
+      }),
+    ).toEqual(["team-write-fails"]);
+  });
+});
+
+describe.each([
+  "slack",
+  "ms-teams",
+] as const)("applyChannelGate (%s)", (provider) => {
+  const activation = { ...TEAMS, provider };
+  let postMutedNotice: Mock<() => Promise<void>>;
+  let resolveAnswerAllWorkspaceId: Mock<() => Promise<string | null>>;
+
+  const gate = (overrides: Record<string, unknown> = {}) =>
+    applyChannelGate({
+      ...activation,
+      botMentioned: false,
+      text: "how do I deploy this?",
+      postMutedNotice,
+      resolveAnswerAllWorkspaceId,
+      ...overrides,
+    });
+
+  const enableAnswerAll = (enabled: boolean) =>
+    vi
+      .mocked(ChatOpsChannelBindingModel.findByChannel)
+      .mockResolvedValue(
+        enabled ? ({ answerAllMessages: true } as never) : null,
+      );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postMutedNotice = vi.fn(async () => {});
+    resolveAnswerAllWorkspaceId = vi.fn(async () => "T123");
+    enableAnswerAll(false);
+  });
+
+  test("a mention activates the thread and is treated as addressed", async () => {
+    expect(await gate({ botMentioned: true })).toEqual({
+      proceed: true,
+      addressed: true,
+    });
+    expect(await isChannelThreadActive(activation)).toBe(true);
+  });
+
+  test("an un-mentioned message in an inactive mentions-only channel is ignored", async () => {
+    expect(await gate()).toEqual({ proceed: false, addressed: false });
+  });
+
+  test("an un-mentioned message in an active thread is processed as addressed", async () => {
+    await markChannelThreadActive(activation);
+
+    expect(await gate()).toEqual({ proceed: true, addressed: true });
+  });
+
+  test("an un-mentioned message in an answer-all channel is processed but NOT addressed", async () => {
+    enableAnswerAll(true);
+
+    // `addressed: false` is what keeps the bot from announcing itself to
+    // someone who never spoke to it (see the Teams webhook route).
+    expect(await gate()).toEqual({ proceed: true, addressed: false });
+  });
+
+  test("an answer-all thread that was muted stays ignored until re-mentioned", async () => {
+    enableAnswerAll(true);
+    await markChannelThreadMuted(activation);
+
+    expect(await gate()).toEqual({ proceed: false, addressed: false });
+
+    // A fresh mention lifts the mute, and the next un-mentioned message flows.
+    expect(await gate({ botMentioned: true })).toEqual({
+      proceed: true,
+      addressed: true,
+    });
+    expect(await isChannelThreadMuted(activation)).toBe(false);
+  });
+
+  test("a mute command silences the thread and confirms exactly once", async () => {
+    enableAnswerAll(true);
+
+    expect(await gate({ text: "mute" })).toEqual({
+      proceed: false,
+      addressed: false,
+    });
+    expect(postMutedNotice).toHaveBeenCalledTimes(1);
+    expect(await isChannelThreadMuted(activation)).toBe(true);
+
+    // A redelivered / repeated mute must not spam the thread.
+    await gate({ text: "mute" });
+    expect(postMutedNotice).toHaveBeenCalledTimes(1);
+  });
+
+  test("a mute command in an inactive mentions-only channel stays silent", async () => {
+    // The bot was not talking, so there is nothing to confirm.
+    expect(await gate({ text: "mute" })).toEqual({
+      proceed: false,
+      addressed: false,
+    });
+    expect(postMutedNotice).not.toHaveBeenCalled();
+  });
+
+  test("a mute addressed by app name rather than @mention is honored", async () => {
+    await markChannelThreadActive(activation);
+
+    expect(await gate({ text: "Archestra shut up" })).toEqual({
+      proceed: false,
+      addressed: false,
+    });
+    expect(postMutedNotice).toHaveBeenCalledTimes(1);
+  });
+
+  test("still mutes when the answer-all setting cannot be read", async () => {
+    resolveAnswerAllWorkspaceId.mockRejectedValue(
+      new Error("TeamsInfo unavailable"),
+    );
+    await markChannelThreadActive(activation);
+    const run = chatOpsRunRegistry.register(activation);
+
+    expect(await gate({ text: "mute" })).toEqual({
+      proceed: false,
+      addressed: false,
+    });
+
+    // Silencing the bot must survive a failed lookup — otherwise an in-flight
+    // reply lands after the user asked for quiet.
+    expect(run.signal.aborted).toBe(true);
+    expect(await isChannelThreadActive(activation)).toBe(false);
+    run.unregister();
+  });
+
+  test("falls back to mentions-only when the answer-all setting cannot be read", async () => {
+    vi.mocked(ChatOpsChannelBindingModel.findByChannel).mockRejectedValue(
+      new Error("database unavailable"),
+    );
+
+    // Quiet is the safe default: a failed read must not make the bot answer
+    // messages it would otherwise ignore.
+    expect(await gate()).toEqual({ proceed: false, addressed: false });
+  });
+
+  test("does not resolve the answer-all workspace id when the outcome cannot change", async () => {
+    // Mentioned: resolves to "activate" regardless of the setting.
+    await gate({ botMentioned: true });
+    expect(resolveAnswerAllWorkspaceId).not.toHaveBeenCalled();
+
+    // Already active: resolves to "process" regardless of the setting.
+    await gate();
+    expect(resolveAnswerAllWorkspaceId).not.toHaveBeenCalled();
+
+    // Un-mentioned and inactive is the only case the setting decides — and
+    // for Teams resolving it costs a Bot Framework round trip.
+    await clearChannelThreadActive(activation);
+    await gate();
+    expect(resolveAnswerAllWorkspaceId).toHaveBeenCalledTimes(1);
   });
 });

--- a/platform/backend/src/agents/chatops/channel-activation.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.ts
@@ -17,13 +17,27 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
+import { TimeInMs } from "@archestra/shared";
+import {
+  type AllowedCacheKey,
+  CacheKey,
+  cacheManager,
+  LRUCacheManager,
+} from "@/cache-manager";
+import logger from "@/logging";
 import ChatOpsChannelBindingModel from "@/models/chatops-channel-binding";
+import OrganizationModel from "@/models/organization";
 import type { ChatOpsProviderType } from "@/types/chatops";
 import { chatOpsRunRegistry } from "./chatops-run-registry";
 import { CHATOPS_CHANNEL_AUTO_REPLY } from "./constants";
+import { errorMessage } from "./utils";
 
-/** Mark a channel thread active so the bot keeps replying without a mention. */
+/**
+ * Mark a channel thread active so the bot keeps replying without a mention.
+ *
+ * @public — applyChannelGate is the only production caller; also exercised
+ * directly in channel-activation.test.ts (knip --production can't see tests).
+ */
 export async function markChannelThreadActive(params: {
   provider: ChatOpsProviderType;
   channelId: string;
@@ -36,7 +50,12 @@ export async function markChannelThreadActive(params: {
   );
 }
 
-/** Whether the bot was @mentioned in this channel thread recently enough to keep replying. */
+/**
+ * Whether the bot was @mentioned in this channel thread recently enough to keep replying.
+ *
+ * @public — applyChannelGate is the only production caller; also exercised
+ * directly in channel-activation.test.ts (knip --production can't see tests).
+ */
 export async function isChannelThreadActive(params: {
   provider: ChatOpsProviderType;
   channelId: string;
@@ -110,6 +129,9 @@ export async function muteChannelThread(params: {
  * message the gate would otherwise ignore. The default — no binding, or the flag
  * off — is false (mentions-only). The cache is short-lived and also invalidated
  * on toggle (see invalidateChannelAnswerAll), so a change takes effect promptly.
+ *
+ * @public — applyChannelGate is the only production caller; also exercised
+ * directly in channel-activation.test.ts (knip --production can't see tests).
  */
 export async function isChannelAnswerAllEnabled(params: {
   provider: ChatOpsProviderType;
@@ -132,6 +154,52 @@ export async function invalidateChannelAnswerAll(params: {
   workspaceId: string | null;
 }): Promise<void> {
   await cacheManager.delete(answerAllKey(params));
+}
+
+/**
+ * Remember that a workspace delivered an un-mentioned channel message.
+ *
+ * On MS Teams that delivery is only possible once a team owner has consented to
+ * the RSC permission for reading channel messages, so it is positive proof the
+ * consent exists — which is what "answer all messages" depends on. Recording it
+ * lets the UI point at a channel whose setting may be silently inert.
+ *
+ * The signal is one-directional: its absence is NOT evidence consent is missing,
+ * only that nothing has arrived yet. A quiet channel looks identical, and so
+ * does a busy one whose messages all land in threads the bot was already
+ * @mentioned in — those resolve without consulting the setting, so they never
+ * reach this. Callers must never disable the setting on that basis.
+ */
+export async function recordUnmentionedChannelTraffic(params: {
+  provider: ChatOpsProviderType;
+  workspaceId: string | null;
+}): Promise<void> {
+  const key = unmentionedTrafficKey(params);
+  // Every un-mentioned channel message reaches this, and the distributed cache
+  // is Postgres-backed — so an unconditional write would serialize a busy team's
+  // traffic on one row's lock to re-assert a fact that lasts a month. Refreshing
+  // at most once per pod per window keeps the marker fresh at negligible cost.
+  if (recentlyRecordedTraffic.get(key)) return;
+  // Throttle only after the write lands, so a failed one is retried by the next
+  // message rather than suppressed for the whole window.
+  await cacheManager.set(key, true, UNMENTIONED_TRAFFIC_TTL_MS);
+  recentlyRecordedTraffic.set(key, true);
+}
+
+export async function findWorkspacesWithUnmentionedTraffic(params: {
+  provider: ChatOpsProviderType;
+  workspaceIds: string[];
+}): Promise<string[]> {
+  const seen = await Promise.all(
+    params.workspaceIds.map(async (workspaceId) =>
+      (await cacheManager.get<boolean>(
+        unmentionedTrafficKey({ provider: params.provider, workspaceId }),
+      )) === true
+        ? workspaceId
+        : null,
+    ),
+  );
+  return seen.filter((id): id is string => id !== null);
 }
 
 /**
@@ -160,7 +228,12 @@ export async function markChannelThreadMuted(params: {
   );
 }
 
-/** Whether an answer-all channel thread was muted and not yet re-mentioned. */
+/**
+ * Whether an answer-all channel thread was muted and not yet re-mentioned.
+ *
+ * @public — applyChannelGate is the only production caller; also exercised
+ * directly in channel-activation.test.ts (knip --production can't see tests).
+ */
 export async function isChannelThreadMuted(params: {
   provider: ChatOpsProviderType;
   channelId: string;
@@ -248,6 +321,9 @@ export async function claimThreadMuteHint(params: {
  * @mention — a leading addressable name is stripped before matching. Only those
  * specific names are stripped, never an arbitrary word, so "joey shut up" (aimed
  * at a person) is not treated as a mute.
+ *
+ * @public — applyChannelGate is the only production caller; the phrase matching
+ * has its own suite in channel-activation.test.ts (knip can't see tests).
  */
 export function isThreadMuteCommand(
   text: string,
@@ -270,6 +346,9 @@ export function isThreadMuteCommand(
  * "<addressable name> <mute command>" — i.e. it ends with a mute command after
  * a prefix. Lets the gate resolve the (DB-backed) app name only when it might
  * matter, instead of on every channel message.
+ *
+ * @public — applyChannelGate is the only production caller; also exercised
+ * directly in channel-activation.test.ts (knip --production can't see tests).
  */
 export function mightBeAddressedMuteCommand(text: string): boolean {
   const normalized = normalizeMuteText(text);
@@ -292,6 +371,8 @@ export function isMuteReaction(reactionId: string): boolean {
   return THREAD_MUTE_REACTIONS.has(reactionId.trim().toLowerCase());
 }
 
+type ChannelGateAction = "mute" | "activate" | "process" | "ignore";
+
 /**
  * Decide what an inbound channel message should trigger, given whether the bot
  * was @mentioned, whether the message is a mute command, and whether the thread
@@ -309,9 +390,11 @@ export function isMuteReaction(reactionId: string): boolean {
  * processed unless the thread has been muted (`isMuted`), and a mute command is
  * still honored. Mention/active behavior is unchanged, so a mentions-only
  * channel (answerAll false, the default) keeps its exact prior semantics.
+ *
+ * @public — kept separate from applyChannelGate (its only production caller) so
+ * the branching stays pure and testable; its truth table lives in
+ * channel-activation.test.ts, which knip --production cannot see.
  */
-type ChannelGateAction = "mute" | "activate" | "process" | "ignore";
-
 export function resolveChannelGateAction(params: {
   botMentioned: boolean;
   wantsMute: boolean;
@@ -326,6 +409,111 @@ export function resolveChannelGateAction(params: {
     return params.isMuted ? "ignore" : "process";
   }
   return "ignore";
+}
+
+/**
+ * Run the full channel gate for an inbound message: decide via
+ * resolveChannelGateAction and apply that action's state transitions.
+ *
+ * Every provider gates channel messages the same way, so this owns the whole
+ * sequence — the reads, the branch, and all cache writes (muteChannelThread,
+ * markChannelThreadActive, clearChannelThreadMuted). Callers supply only what
+ * is provider-specific: how to post the "muted" confirmation, and how to reach
+ * the workspace id the "answer all messages" setting is stored under.
+ *
+ * Reads are ordered so a mentions-only channel — the default — does no work
+ * beyond the single activation lookup: the app name is resolved only for a
+ * message that might be an addressed mute command, the activation only when the
+ * bot wasn't mentioned, the answer-all setting only when it could change the
+ * outcome, and the thread's mute marker only when answer-all is in play.
+ *
+ * `text` must already have the bot mention stripped, so a bare "@bot mute"
+ * matches the mute commands.
+ *
+ * Returns `proceed` — whether the message should be handled at all — and
+ * `addressed`, which is false when the message reached the agent ONLY because
+ * the channel answers every message. Callers use `addressed` to stay quiet
+ * about things the sender never asked for (see the Teams webhook route).
+ */
+export async function applyChannelGate(params: {
+  provider: ChatOpsProviderType;
+  channelId: string;
+  threadId: string;
+  botMentioned: boolean;
+  text: string;
+  postMutedNotice: () => Promise<void>;
+  resolveAnswerAllWorkspaceId: () => Promise<string | null>;
+}): Promise<{ proceed: boolean; addressed: boolean }> {
+  const { provider, channelId, threadId, botMentioned, text } = params;
+  const activation = { provider, channelId, threadId };
+
+  let wantsMute = isThreadMuteCommand(text);
+  if (!wantsMute && mightBeAddressedMuteCommand(text)) {
+    wantsMute = isThreadMuteCommand(text, [
+      await OrganizationModel.getAppName(),
+    ]);
+  }
+  const isActive = botMentioned
+    ? false
+    : await isChannelThreadActive(activation);
+  // Reading the setting needs the DB and, for Teams, a Bot Framework call. Treat
+  // a failure as mentions-only rather than letting it throw: quiet is the safe
+  // default, and it must never abort a mute before muteChannelThread has
+  // cancelled the in-flight runs — a lost confirmation notice beats a late reply
+  // arriving after someone asked for quiet.
+  let answerAll = false;
+  if ((!botMentioned && !isActive) || wantsMute) {
+    try {
+      answerAll = await isChannelAnswerAllEnabled({
+        provider,
+        channelId,
+        workspaceId: await params.resolveAnswerAllWorkspaceId(),
+      });
+    } catch (error) {
+      logger.warn(
+        { error: errorMessage(error), provider, channelId },
+        "[ChatOps] Could not read the answer-all setting; treating the channel as mentions-only",
+      );
+    }
+  }
+  const isMuted =
+    answerAll && !botMentioned && !isActive && !wantsMute
+      ? await isChannelThreadMuted(activation)
+      : false;
+
+  switch (
+    resolveChannelGateAction({
+      botMentioned,
+      wantsMute,
+      isActive,
+      answerAll,
+      isMuted,
+    })
+  ) {
+    case "mute": {
+      // muteChannelThread persists the mute marker, so the thread's prior state
+      // has to be read before it — the confirmation is one-shot per mute, and an
+      // answer-all thread that was never "active" still deserves one. Only the
+      // notice depends on this, so a read failure must not hold up the mute.
+      const alreadyMuted = answerAll
+        ? await isChannelThreadMuted(activation).catch(() => false)
+        : false;
+      const wasActive = await muteChannelThread(activation);
+      if (wasActive || (answerAll && !alreadyMuted)) {
+        await params.postMutedNotice();
+      }
+      return { proceed: false, addressed: false };
+    }
+    case "activate":
+      await markChannelThreadActive(activation);
+      // A re-mention lifts an answer-all mute.
+      await clearChannelThreadMuted(activation);
+      return { proceed: true, addressed: true };
+    case "process":
+      return { proceed: true, addressed: isActive };
+    case "ignore":
+      return { proceed: false, addressed: false };
+  }
 }
 
 // =============================================================================
@@ -383,6 +571,32 @@ function answerAllKey(params: {
 }): AllowedCacheKey {
   return `${CacheKey.ChatOpsChannelAnswerAll}-${params.provider}::${params.workspaceId ?? ""}::${params.channelId}`;
 }
+
+function unmentionedTrafficKey(params: {
+  provider: ChatOpsProviderType;
+  workspaceId: string | null;
+}): AllowedCacheKey {
+  return `${CacheKey.TeamsUnmentionedChannelTraffic}-${params.provider}::${params.workspaceId ?? ""}`;
+}
+
+/**
+ * How long the "this workspace delivers un-mentioned messages" proof lives. Long
+ * enough that a workspace which chats on most days keeps the marker fresh, so a
+ * normally-active team never sees the hint; short enough that the marker cannot
+ * outlive an app being reinstalled without consent.
+ */
+const UNMENTIONED_TRAFFIC_TTL_MS = 30 * TimeInMs.Day;
+
+/**
+ * Per-pod record of workspaces whose marker was refreshed recently, so a busy
+ * team writes to the distributed cache once an hour instead of once a message
+ * (see recordUnmentionedChannelTraffic). Sized for far more workspaces than one
+ * deployment has; an eviction only costs one redundant write.
+ */
+const recentlyRecordedTraffic = new LRUCacheManager<boolean>({
+  maxSize: 1_000,
+  defaultTtl: TimeInMs.Hour,
+});
 
 /**
  * How long the per-channel "answer all messages" flag stays cached. Short enough

--- a/platform/backend/src/agents/chatops/chatops-manager.test.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.test.ts
@@ -358,6 +358,107 @@ describe("ChatOpsManager security validation", () => {
     );
   });
 
+  /**
+   * A sender who lacks access to the channel's agent normally gets told so. In a
+   * channel that answers every message that reply would land in a conversation
+   * the sender never addressed to the bot, so the caller can ask for a silent
+   * denial. Access itself is unaffected either way.
+   */
+  async function denyAccessFor(params: {
+    org: { id: string };
+    agentId: string;
+    senderEmail: string;
+  }) {
+    await ChatOpsChannelBindingModel.create({
+      organizationId: params.org.id,
+      provider: "ms-teams",
+      channelId: "test-channel-id",
+      workspaceId: "test-workspace-id",
+      agentId: params.agentId,
+    });
+    const sendReplySpy = vi.fn().mockResolvedValue("reply-id");
+    const provider = createMockProvider({
+      getUserEmail: async () => params.senderEmail,
+      sendReply: sendReplySpy,
+    });
+    return { provider, sendReplySpy };
+  }
+
+  test("announces an access denial by default", async ({
+    makeOrganization,
+    makeUser,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const owner = await makeUser({ email: "owner@example.com" });
+    const team = await makeTeam(org.id, owner.id);
+    await makeTeamMember(team.id, owner.id);
+    // Team-scoped: an org-scoped agent is open to everyone, so it could never
+    // reach the denial branch.
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      scope: "team",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+    // The sender is not on the agent's team.
+    await makeUser({ email: "outsider@example.com" });
+    const { provider, sendReplySpy } = await denyAccessFor({
+      org,
+      agentId: agent.id,
+      senderEmail: "outsider@example.com",
+    });
+
+    const result = await makeManagerWith(provider).processMessage({
+      message: createMockMessage({ senderEmail: "outsider@example.com" }),
+      provider,
+    });
+
+    expect(result.success).toBe(false);
+    expect(sendReplySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("Access Denied"),
+      }),
+    );
+  });
+
+  test("denies silently when the sender never addressed the bot", async ({
+    makeOrganization,
+    makeUser,
+    makeTeam,
+    makeTeamMember,
+    makeInternalAgent,
+  }) => {
+    const org = await makeOrganization();
+    const owner = await makeUser({ email: "owner2@example.com" });
+    const team = await makeTeam(org.id, owner.id);
+    await makeTeamMember(team.id, owner.id);
+    const agent = await makeInternalAgent({
+      organizationId: org.id,
+      scope: "team",
+      teams: [team.id],
+    });
+    await AgentTeamModel.assignTeamsToAgent(agent.id, [team.id]);
+    await makeUser({ email: "outsider2@example.com" });
+    const { provider, sendReplySpy } = await denyAccessFor({
+      org,
+      agentId: agent.id,
+      senderEmail: "outsider2@example.com",
+    });
+
+    const result = await makeManagerWith(provider).processMessage({
+      message: createMockMessage({ senderEmail: "outsider2@example.com" }),
+      provider,
+      announceAccessErrors: false,
+    });
+
+    // Still denied — only the public explanation is withheld.
+    expect(result.success).toBe(false);
+    expect(sendReplySpy).not.toHaveBeenCalled();
+  });
+
   test("per-user provider not connected - replies with a connect link", async ({
     makeUser,
     makeOrganization,

--- a/platform/backend/src/agents/chatops/chatops-manager.ts
+++ b/platform/backend/src/agents/chatops/chatops-manager.ts
@@ -661,8 +661,20 @@ export class ChatOpsManager {
     message: IncomingChatMessage;
     provider: ChatOpsProvider;
     sendReply?: boolean;
+    /**
+     * Whether an access failure is explained in the conversation. Pass false for
+     * a message the sender never addressed to the bot — it reached us only
+     * because the channel answers every message, so a public "Access Denied"
+     * would be the bot interrupting a conversation it wasn't part of.
+     */
+    announceAccessErrors?: boolean;
   }): Promise<ChatOpsProcessingResult> {
-    const { message, provider, sendReply = true } = params;
+    const {
+      message,
+      provider,
+      sendReply = true,
+      announceAccessErrors = true,
+    } = params;
 
     // Deduplication check
     const isNew = await ChatOpsProcessedMessageModel.tryMarkAsProcessed(
@@ -738,6 +750,7 @@ export class ChatOpsManager {
       agentId: agentToUse.id,
       agentName: agentToUse.name,
       organizationId: agent.organizationId,
+      announceAccessErrors,
     });
 
     if (!authResult.success) {
@@ -1311,10 +1324,19 @@ export class ChatOpsManager {
     agentId: string;
     agentName: string;
     organizationId: string;
+    announceAccessErrors: boolean;
   }): Promise<
     { success: true; userId: string } | { success: false; error: string }
   > {
-    const { message, provider, agentId, agentName, organizationId } = params;
+    const {
+      message,
+      provider,
+      agentId,
+      agentName,
+      organizationId,
+      announceAccessErrors,
+    } = params;
+    const denyQuietly = !announceAccessErrors;
 
     // Try pre-resolved email first (from Bot Framework TeamsInfo, no Graph API needed)
     let userEmail = message.senderEmail || null;
@@ -1336,11 +1358,13 @@ export class ChatOpsManager {
         { senderId: message.senderId },
         "[ChatOps] Could not resolve user email via TeamsInfo or Graph API",
       );
-      await this.sendSecurityErrorReply(
-        provider,
-        message,
-        "Could not verify your identity. Please ensure the bot is properly installed in your team or chat.",
-      );
+      if (!denyQuietly) {
+        await this.sendSecurityErrorReply(
+          provider,
+          message,
+          "Could not verify your identity. Please ensure the bot is properly installed in your team or chat.",
+        );
+      }
       return {
         success: false,
         error: "Could not resolve user email for security validation",
@@ -1403,11 +1427,13 @@ export class ChatOpsManager {
         },
         "[ChatOps] User does not have access to agent",
       );
-      await this.sendSecurityErrorReply(
-        provider,
-        message,
-        `You don't have access to the agent "${agentName}". Contact your administrator for access.`,
-      );
+      if (!denyQuietly) {
+        await this.sendSecurityErrorReply(
+          provider,
+          message,
+          `You don't have access to the agent "${agentName}". Contact your administrator for access.`,
+        );
+      }
       return {
         success: false,
         error: "Unauthorized: user does not have access to this agent",

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -47,16 +47,9 @@ import {
   isSsoConfigured,
 } from "./auto-provision";
 import {
-  clearChannelThreadMuted,
-  isChannelAnswerAllEnabled,
-  isChannelThreadActive,
-  isChannelThreadMuted,
+  applyChannelGate,
   isMuteReaction,
-  isThreadMuteCommand,
-  markChannelThreadActive,
-  mightBeAddressedMuteCommand,
   muteChannelThread,
-  resolveChannelGateAction,
 } from "./channel-activation";
 import {
   buildThreadMutedNotice,
@@ -328,86 +321,19 @@ class SlackProvider implements ChatOpsProvider {
     //
     // A channel can also opt into answering EVERY message (a per-channel
     // "answer all messages" binding setting): a message the gate would normally
-    // ignore is processed instead, unless that thread was muted. That flag is
-    // only consulted when the message would otherwise be ignored, so mentions-
-    // only channels (the default) do no extra work.
+    // ignore is processed instead, unless that thread was muted.
     if (!isDM) {
-      const activation = {
+      const { proceed } = await applyChannelGate({
         provider: this.providerId,
         channelId: event.channel,
         threadId: threadTs,
-      };
-      // "mute" / "shut up" etc., optionally prefixed by a name the bot answers
-      // to ("Archestra shut up") with no explicit @mention. The app name is
-      // DB-backed, so only resolve it when the message might be such a command.
-      let wantsMute = isThreadMuteCommand(cleanedText);
-      if (!wantsMute && mightBeAddressedMuteCommand(cleanedText)) {
-        wantsMute = isThreadMuteCommand(cleanedText, [
-          await OrganizationModel.getAppName(),
-        ]);
-      }
-      // isActive is only consulted when the bot wasn't mentioned (see
-      // resolveChannelGateAction), so skip the cache read on mentions.
-      const isActive = hasBotMention
-        ? false
-        : await isChannelThreadActive(activation);
-      // Consult the per-channel "answer all messages" flag only for the cases it
-      // can change: a message the base gate would ignore (un-mentioned +
-      // inactive), or any mute we may need to persist on the thread (an
-      // answer-all channel has no mention-driven activation to clear). Mentioned
-      // or already-active messages resolve without it, so mentions-only channels
-      // (the default) do no extra work.
-      const answerAll =
-        (!hasBotMention && !isActive) || wantsMute
-          ? await isChannelAnswerAllEnabled({
-              provider: this.providerId,
-              channelId: event.channel,
-              workspaceId: body.team_id || null,
-            })
-          : false;
-      const isMuted =
-        answerAll && !hasBotMention && !isActive && !wantsMute
-          ? await isChannelThreadMuted(activation)
-          : false;
-      switch (
-        resolveChannelGateAction({
-          botMentioned: hasBotMention,
-          wantsMute,
-          isActive,
-          answerAll,
-          isMuted,
-        })
-      ) {
-        case "mute": {
-          // muteThreadAndNotify persists the mute marker, so the thread's prior
-          // state has to be read before it.
-          const alreadyMuted = answerAll
-            ? await isChannelThreadMuted(activation)
-            : false;
-          const wasActive = await this.muteThreadAndNotify(
-            event.channel,
-            threadTs,
-          );
-          // An answer-all channel replies without a mention, so clearing the
-          // mention-driven activation isn't enough — the mute is remembered on
-          // the thread itself so it stays quiet until re-mentioned. Confirm it
-          // once (muteThreadAndNotify only confirms an active→muted transition,
-          // and a fresh answer-all thread isn't "active").
-          if (answerAll && !wasActive && !alreadyMuted) {
-            await this.postThreadMutedNotice(event.channel, threadTs);
-          }
-          return null;
-        }
-        case "activate":
-          await markChannelThreadActive(activation);
-          // A re-mention lifts an answer-all mute (see the "mute" case).
-          await clearChannelThreadMuted(activation);
-          break;
-        case "ignore":
-          return null;
-        case "process":
-          break;
-      }
+        botMentioned: hasBotMention,
+        text: cleanedText,
+        postMutedNotice: () =>
+          this.postThreadMutedNotice(event.channel, threadTs),
+        resolveAnswerAllWorkspaceId: async () => body.team_id || null,
+      });
+      if (!proceed) return null;
     }
 
     // Download file attachments first (we're already in an addressed context —

--- a/platform/backend/src/cache-manager.ts
+++ b/platform/backend/src/cache-manager.ts
@@ -80,6 +80,10 @@ export const CacheKey = {
   SlackThreadMuted: "slack-thread-muted",
   /** Per-channel "answer all messages" flag, briefly cached to spare the gate a DB read per message */
   ChatOpsChannelAnswerAll: "chatops-channel-answer-all",
+  /** MS Teams thread-format team id → aadGroupId, so the gate resolves it without a Bot Framework call per message */
+  TeamsTeamAadGroupId: "teams-team-aad-group-id",
+  /** MS Teams teams that have delivered an un-mentioned channel message — proof the RSC consent for reading channel messages exists */
+  TeamsUnmentionedChannelTraffic: "teams-unmentioned-channel-traffic",
   /** Telegram approval-button payloads (callback_data is capped at 64 bytes) */
   TelegramApprovalCallback: "chatops-telegram-approval",
   /** One-shot codes linking a Telegram chat to a signed-in user */

--- a/platform/backend/src/models/chatops-channel-binding.test.ts
+++ b/platform/backend/src/models/chatops-channel-binding.test.ts
@@ -513,6 +513,51 @@ describe("ChatOpsChannelBindingModel", () => {
       const binding = await ChatOpsChannelBindingModel.findById(created.id);
       expect(binding).toBeDefined();
     });
+
+    test("returns the deleted row so callers can drop caches keyed on it", async ({
+      makeOrganization,
+    }) => {
+      const org = await makeOrganization();
+      const created = await ChatOpsChannelBindingModel.create({
+        organizationId: org.id,
+        provider: "ms-teams",
+        channelId: "channel-cache-key",
+        workspaceId: "team-uuid",
+      });
+
+      const deleted =
+        await ChatOpsChannelBindingModel.deleteByIdAndOrganization(
+          created.id,
+          org.id,
+        );
+
+      // The delete route needs these three to invalidate the answer-all cache;
+      // a bare boolean would leave a deleted channel answering until the TTL.
+      expect(deleted).toMatchObject({
+        provider: "ms-teams",
+        channelId: "channel-cache-key",
+        workspaceId: "team-uuid",
+      });
+    });
+
+    test("returns null when there was nothing to delete", async ({
+      makeOrganization,
+    }) => {
+      const org1 = await makeOrganization();
+      const org2 = await makeOrganization();
+      const created = await ChatOpsChannelBindingModel.create({
+        organizationId: org1.id,
+        provider: "ms-teams",
+        channelId: "channel-other-org",
+      });
+
+      expect(
+        await ChatOpsChannelBindingModel.deleteByIdAndOrganization(
+          created.id,
+          org2.id,
+        ),
+      ).toBeNull();
+    });
   });
 
   describe("ensureChannelsExist", () => {

--- a/platform/backend/src/models/chatops-channel-binding.ts
+++ b/platform/backend/src/models/chatops-channel-binding.ts
@@ -520,22 +520,25 @@ class ChatOpsChannelBindingModel {
   }
 
   /**
-   * Delete a binding by ID and organization
+   * Delete a binding by ID and organization, returning the deleted row (null if
+   * there was nothing to delete). Callers need its channel identity to drop
+   * caches keyed on the binding.
    */
   static async deleteByIdAndOrganization(
     id: string,
     organizationId: string,
-  ): Promise<boolean> {
-    const result = await db
+  ): Promise<ChatOpsChannelBinding | null> {
+    const [deleted] = await db
       .delete(schema.chatopsChannelBindingsTable)
       .where(
         and(
           eq(schema.chatopsChannelBindingsTable.id, id),
           eq(schema.chatopsChannelBindingsTable.organizationId, organizationId),
         ),
-      );
+      )
+      .returning();
 
-    return (result.rowCount ?? 0) > 0;
+    return (deleted as ChatOpsChannelBinding) || null;
   }
 
   /**

--- a/platform/backend/src/routes/chatops.ts
+++ b/platform/backend/src/routes/chatops.ts
@@ -4,6 +4,7 @@ import {
   createPaginatedResponseSchema,
   PaginationQuerySchema,
   RouteId,
+  TimeInMs,
 } from "@archestra/shared";
 import { WebClient } from "@slack/web-api";
 import { ActivityTypes, TeamsInfo, TurnContext } from "botbuilder";
@@ -16,13 +17,11 @@ import {
   isSsoConfigured,
 } from "@/agents/chatops/auto-provision";
 import {
+  applyChannelGate,
+  findWorkspacesWithUnmentionedTraffic,
   invalidateChannelAnswerAll,
-  isChannelThreadActive,
-  isThreadMuteCommand,
-  markChannelThreadActive,
-  mightBeAddressedMuteCommand,
   muteChannelThread,
-  resolveChannelGateAction,
+  recordUnmentionedChannelTraffic,
 } from "@/agents/chatops/channel-activation";
 import { chatOpsManager } from "@/agents/chatops/chatops-manager";
 import {
@@ -32,7 +31,7 @@ import {
   SLACK_DEFAULT_CONNECTION_MODE,
   TELEGRAM_LINK_CODE_TTL_MS,
 } from "@/agents/chatops/constants";
-import { EventDedupMap } from "@/agents/chatops/utils";
+import { EventDedupMap, errorMessage } from "@/agents/chatops/utils";
 import { isRateLimited } from "@/agents/utils";
 import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
 import { type AllowedCacheKey, CacheKey, cacheManager } from "@/cache-manager";
@@ -221,11 +220,13 @@ export const msTeamsWebhookRoutes: FastifyPluginAsyncZod = async (fastify) => {
               };
               // Resolve sender email and verify they are a registered Archestra user
               if (
-                !(await resolveAndVerifySenderForMSTeams(
+                !(await resolveAndVerifySenderForMSTeams({
                   context,
                   provider,
-                  cardMessage,
-                ))
+                  message: cardMessage,
+                  // A card submit is a direct interaction with the bot.
+                  announce: true,
+                }))
               ) {
                 return;
               }
@@ -307,53 +308,57 @@ export const msTeamsWebhookRoutes: FastifyPluginAsyncZod = async (fastify) => {
 
             // Team-channel auto-reply gate: in channels the bot stays quiet
             // until @mentioned, then keeps replying to that thread without
-            // further mentions. Group chats and DMs always reply (no gate).
-            // Runs before sender resolution so we don't do Graph lookups for
-            // the many un-mentioned channel messages the bot now receives.
+            // further mentions, unless the channel opted into answering every
+            // message. Group chats and DMs always reply (no gate). Runs before
+            // sender resolution so we don't do Graph lookups for the many
+            // un-mentioned channel messages the bot now receives.
             //
             // A mute command (e.g. "@bot mute") ends the sticky behavior early —
             // honored both when the bot is mentioned and when the thread is
             // already active (so muting needs no re-mention) — after which the
             // bot stays quiet until @mentioned again.
+            let addressed = true;
             if (context.activity.conversation?.conversationType === "channel") {
-              const activation = {
-                provider: "ms-teams" as const,
+              const botMentioned = provider.wasBotMentioned(context.activity);
+              const gate = await applyChannelGate({
+                provider: "ms-teams",
                 channelId: message.channelId,
                 threadId: message.threadId ?? message.channelId,
-              };
-              const botMentioned = provider.wasBotMentioned(context.activity);
-              // "mute" / "shut up" etc., optionally prefixed by a name the bot
-              // answers to ("Archestra shut up") with no explicit @mention. The
-              // app name is DB-backed, so only resolve it when it might matter.
-              let wantsMute = isThreadMuteCommand(message.text);
-              if (!wantsMute && mightBeAddressedMuteCommand(message.text)) {
-                wantsMute = isThreadMuteCommand(message.text, [
-                  await OrganizationModel.getAppName(),
-                ]);
-              }
-              // isActive is only consulted when the bot wasn't mentioned (see
-              // resolveChannelGateAction), so skip the cache read on mentions.
-              const isActive = botMentioned
-                ? false
-                : await isChannelThreadActive(activation);
-              switch (
-                resolveChannelGateAction({
-                  botMentioned,
-                  wantsMute,
-                  isActive,
-                })
-              ) {
-                case "mute":
-                  await muteTeamsThreadAndNotify(context, activation);
-                  return;
-                case "activate":
-                  await markChannelThreadActive(activation);
-                  break;
-                case "ignore":
-                  return;
-                case "process":
-                  break;
-              }
+                botMentioned,
+                text: message.text,
+                postMutedNotice: async () => {
+                  await context.sendActivity(buildThreadMutedNotice());
+                },
+                resolveAnswerAllWorkspaceId: async () => {
+                  const teamId = await resolveTeamsWorkspaceId(
+                    context,
+                    message,
+                  );
+                  // Teams only delivers an un-mentioned channel message once a
+                  // team owner consented to the channel-message RSC permission,
+                  // so arriving here without a mention proves that consent —
+                  // which is what "answer all messages" silently depends on.
+                  //
+                  // Skipped unless the team id canonicalized: bindings store the
+                  // aadGroupId, so a marker under the thread-format fallback
+                  // would never be found again. And a failure here only costs a
+                  // stale hint, so it must never disturb the gate.
+                  if (!botMentioned && teamId && isUuid(teamId)) {
+                    await recordUnmentionedChannelTraffic({
+                      provider: "ms-teams",
+                      workspaceId: teamId,
+                    }).catch((error) => {
+                      logger.warn(
+                        { error: errorMessage(error), teamId },
+                        "[ChatOps] Could not record un-mentioned channel traffic",
+                      );
+                    });
+                  }
+                  return teamId;
+                },
+              });
+              if (!gate.proceed) return;
+              addressed = gate.addressed;
             }
 
             // Attach TurnContext so the provider can send typing indicators
@@ -365,27 +370,19 @@ export const msTeamsWebhookRoutes: FastifyPluginAsyncZod = async (fastify) => {
               turnContext: context,
             };
 
-            // Resolve workspaceId to proper UUID (aadGroupId) for team channels.
-            // Bot Framework may provide team.id (thread format) instead of aadGroupId.
-            // TeamsInfo.getTeamDetails() uses RSC permissions — no Azure AD app permissions needed.
-            if (message.workspaceId && !isUuid(message.workspaceId)) {
-              try {
-                const teamDetails = await TeamsInfo.getTeamDetails(context);
-                if (teamDetails?.aadGroupId) {
-                  message.workspaceId = teamDetails.aadGroupId;
-                }
-              } catch {
-                // Non-fatal — group chats don't have team details
-              }
-            }
+            // Bindings are stored under the team's aadGroupId, which Bot
+            // Framework often withholds in favour of the thread-format team.id.
+            // A no-op when the gate above already resolved it.
+            await resolveTeamsWorkspaceId(context, message);
 
             // Resolve sender email and verify they are a registered Archestra user
             if (
-              !(await resolveAndVerifySenderForMSTeams(
+              !(await resolveAndVerifySenderForMSTeams({
                 context,
                 provider,
                 message,
-              ))
+                announce: addressed,
+              }))
             ) {
               return;
             }
@@ -597,15 +594,20 @@ export const msTeamsWebhookRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 }
               }
 
-              // Discover channels + show agent selection
+              // Discover channels + show agent selection. The card is a prompt to
+              // pick an agent, so it only makes sense for someone who addressed
+              // the bot — in an answer-all channel with no agent assigned it would
+              // otherwise be posted publicly on every message.
               await awaitDiscovery(provider, context);
-              await sendAgentSelectionCard({
-                provider,
-                message,
-                isWelcome: true,
-                providerContext: context,
-                isDm: isTeamsDm,
-              });
+              if (addressed) {
+                await sendAgentSelectionCard({
+                  provider,
+                  message,
+                  isWelcome: true,
+                  providerContext: context,
+                  isDm: isTeamsDm,
+                });
+              }
               return;
             }
 
@@ -620,6 +622,7 @@ export const msTeamsWebhookRoutes: FastifyPluginAsyncZod = async (fastify) => {
               message,
               provider,
               sendReply: true,
+              announceAccessErrors: addressed,
             });
           },
         );
@@ -1035,6 +1038,12 @@ const chatopsRoutes: FastifyPluginAsyncZod = async (fastify) => {
             }),
             workspaces: z.array(z.object({ id: z.string(), name: z.string() })),
             hasDmBinding: z.boolean(),
+            /**
+             * Workspaces on this page known to deliver un-mentioned channel
+             * messages. Absence means "nothing seen yet", never "consent
+             * missing" — see recordUnmentionedChannelTraffic.
+             */
+            workspacesWithUnmentionedTraffic: z.array(z.string()),
           }),
         ),
       },
@@ -1069,6 +1078,18 @@ const chatopsRoutes: FastifyPluginAsyncZod = async (fastify) => {
         counts: result.counts,
         workspaces: result.workspaces,
         hasDmBinding: result.hasDmBinding,
+        workspacesWithUnmentionedTraffic: provider
+          ? await findWorkspacesWithUnmentionedTraffic({
+              provider,
+              workspaceIds: [
+                ...new Set(
+                  result.data.flatMap((b) =>
+                    b.workspaceId ? [b.workspaceId] : [],
+                  ),
+                ),
+              ],
+            })
+          : [],
       });
     },
   );
@@ -1101,6 +1122,14 @@ const chatopsRoutes: FastifyPluginAsyncZod = async (fastify) => {
       if (!deleted) {
         throw new ApiError(404, "Binding not found");
       }
+
+      // Otherwise a deleted answer-all channel keeps replying to every message
+      // until the cached flag lapses.
+      await invalidateChannelAnswerAll({
+        provider: deleted.provider,
+        channelId: deleted.channelId,
+        workspaceId: deleted.workspaceId,
+      });
 
       return reply.send({ success: true });
     },
@@ -2101,6 +2130,55 @@ function isCommand(text: string): boolean {
 }
 
 /**
+ * Canonicalize a Teams message's workspaceId to the team's aadGroupId — the id
+ * channel bindings are stored under — assigning it onto the message and
+ * returning it.
+ *
+ * Bot Framework frequently delivers the thread-format `team.id` instead, and
+ * only a Bot Framework call can map it. The mapping never changes for a team, so
+ * it is cached: the channel gate consults it for every un-mentioned message, and
+ * a network round trip per message would defeat the point of gating early.
+ * Already-canonical ids and group chats (no team at all) short-circuit.
+ */
+async function resolveTeamsWorkspaceId(
+  context: TurnContext,
+  message: IncomingChatMessage,
+): Promise<string | null> {
+  const raw = message.workspaceId;
+  if (!raw || isUuid(raw)) return raw ?? null;
+
+  const cacheKey: AllowedCacheKey = `${CacheKey.TeamsTeamAadGroupId}-${raw}`;
+  const cached = await cacheManager.get<string>(cacheKey);
+  if (cached) {
+    message.workspaceId = cached;
+    return cached;
+  }
+
+  let resolved = raw;
+  try {
+    // Uses RSC permissions — no Azure AD app permissions needed.
+    const teamDetails = await TeamsInfo.getTeamDetails(context);
+    if (teamDetails?.aadGroupId) resolved = teamDetails.aadGroupId;
+  } catch {
+    // Non-fatal — group chats don't have team details
+  }
+
+  // A team whose details can't be read (RSC consent not granted yet) is cached
+  // too, on a much shorter TTL. Without that it would pay a Bot Framework round
+  // trip on every un-mentioned message; with a short window it still picks up
+  // the real id soon after an owner consents.
+  await cacheManager.set(
+    cacheKey,
+    resolved,
+    resolved === raw
+      ? TEAMS_AAD_GROUP_ID_RETRY_TTL_MS
+      : TEAMS_AAD_GROUP_ID_TTL_MS,
+  );
+  message.workspaceId = resolved;
+  return resolved;
+}
+
+/**
  * Mute a Teams channel thread, confirming ONLY on a real active→muted
  * transition. Redelivered reaction activities / repeat mutes find the key
  * already gone and stay silent, so no duplicate "muted" notices.
@@ -2116,13 +2194,26 @@ async function muteTeamsThreadAndNotify(
 
 /**
  * Resolve sender email (TeamsInfo → Graph API fallback) and verify they are a registered Archestra user.
- * Sets message.senderEmail and returns true if verified, false if rejected (with error sent to Teams).
+ * Sets message.senderEmail and returns true if verified, false if rejected.
+ *
+ * `announce` controls whether a rejection or a first-time auto-provision is
+ * explained in the conversation. It must be false for a message that reached us
+ * only because the channel answers every message: Teams has no ephemeral
+ * messages, so every notice is public, and someone who never addressed the bot
+ * has not asked to be onboarded by it. Provisioning still happens either way —
+ * only the announcements are withheld.
  */
-async function resolveAndVerifySenderForMSTeams(
-  context: TurnContext,
-  provider: { getUserEmail(aadObjectId: string): Promise<string | null> },
-  message: IncomingChatMessage,
-): Promise<boolean> {
+async function resolveAndVerifySenderForMSTeams(params: {
+  context: TurnContext;
+  provider: { getUserEmail(aadObjectId: string): Promise<string | null> };
+  message: IncomingChatMessage;
+  announce: boolean;
+}): Promise<boolean> {
+  const { context, provider, message, announce } = params;
+  const notify = async (text: string) => {
+    if (announce) await context.sendActivity(text);
+  };
+
   // Try Bot Framework first (no Graph API permissions needed)
   try {
     const member = await TeamsInfo.getMember(context, context.activity.from.id);
@@ -2149,7 +2240,7 @@ async function resolveAndVerifySenderForMSTeams(
     logger.warn(
       "[ChatOps] Could not resolve sender email for early auth check",
     );
-    await context.sendActivity(
+    await notify(
       "Could not verify your identity. Please ensure the bot is properly installed in your team or chat.",
     );
     return false;
@@ -2170,7 +2261,7 @@ async function resolveAndVerifySenderForMSTeams(
           { senderEmail: message.senderEmail },
           "[ChatOps] Auto-provisioned user not found after creation",
         );
-        await context.sendActivity(
+        await notify(
           "Something went wrong while setting up your account. Please try again.",
         );
         return false;
@@ -2181,7 +2272,7 @@ async function resolveAndVerifySenderForMSTeams(
       // Skip entirely when SSO is enabled — users just sign in via their IdP.
       const isDm =
         context.activity.conversation?.conversationType === "personal";
-      if (!isDm && !(await isSsoConfigured())) {
+      if (announce && !isDm && !(await isSsoConfigured())) {
         const botId = context.activity.recipient.id;
         const dmDeepLink = `https://teams.microsoft.com/l/chat/0/0?users=${encodeURIComponent(botId)}`;
         const appName = await OrganizationModel.getAppName();
@@ -2203,7 +2294,7 @@ async function resolveAndVerifySenderForMSTeams(
         { error: error instanceof Error ? error.message : String(error) },
         "[ChatOps] Failed to auto-provision user from Teams",
       );
-      await context.sendActivity(
+      await notify(
         "Something went wrong while setting up your account. Please try again.",
       );
       return false;
@@ -2352,3 +2443,17 @@ function collectWorkspaceIds(teamData: {
   if (teamData.aadGroupId) ids.add(teamData.aadGroupId);
   return [...ids];
 }
+
+/**
+ * How long a team's resolved aadGroupId stays cached (see
+ * resolveTeamsWorkspaceId). A team's aadGroupId is immutable, so this can be
+ * generous.
+ */
+const TEAMS_AAD_GROUP_ID_TTL_MS = TimeInMs.Day;
+
+/**
+ * How long an UNRESOLVED team id stays cached. Short, because the next attempt
+ * may succeed — it bounds both how often a team with no readable details costs a
+ * Bot Framework round trip and how long it keeps using the fallback id.
+ */
+const TEAMS_AAD_GROUP_ID_RETRY_TTL_MS = 5 * TimeInMs.Minute;

--- a/platform/frontend/src/app/messaging-channels/_components/channels-section.tsx
+++ b/platform/frontend/src/app/messaging-channels/_components/channels-section.tsx
@@ -9,6 +9,7 @@ import {
   Hash,
   Plus,
   Search,
+  TriangleAlert,
   X,
 } from "lucide-react";
 import Image from "next/image";
@@ -45,6 +46,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TablePagination } from "@/components/ui/table-pagination";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { DEFAULT_TABLE_LIMIT } from "@/consts";
 import { useProfiles } from "@/lib/agent.query";
 import { useSession } from "@/lib/auth/auth.query";
@@ -157,6 +163,10 @@ export function ChannelsSection({
   const counts = bindingsResponse?.counts;
   const workspaces = bindingsResponse?.workspaces ?? [];
   const hasDmBinding = bindingsResponse?.hasDmBinding ?? false;
+  const workspacesWithUnmentionedTraffic = useMemo(
+    () => new Set(bindingsResponse?.workspacesWithUnmentionedTraffic ?? []),
+    [bindingsResponse?.workspacesWithUnmentionedTraffic],
+  );
   const hasMultipleWorkspaces = workspaces.length > 1;
 
   const totalCount = (counts?.configured ?? 0) + (counts?.unassigned ?? 0);
@@ -561,6 +571,9 @@ export function ChannelsSection({
                     providerStatus={providerStatus}
                     onAssignAgent={handleAssignAgent}
                     onToggleAnswerAll={handleToggleAnswerAll}
+                    workspacesWithUnmentionedTraffic={
+                      workspacesWithUnmentionedTraffic
+                    }
                     isUpdating={updateMutation.isPending}
                     selectedIds={selectedIds}
                     onToggleSelected={toggleSelected}
@@ -614,6 +627,7 @@ function ChannelRows({
   providerStatus,
   onAssignAgent,
   onToggleAnswerAll,
+  workspacesWithUnmentionedTraffic,
   isUpdating,
   selectedIds,
   onToggleSelected,
@@ -640,6 +654,7 @@ function ChannelRows({
   } | null;
   onAssignAgent: (bindingId: string, agentId: string | null) => void;
   onToggleAnswerAll: (bindingId: string, answerAll: boolean) => void;
+  workspacesWithUnmentionedTraffic: Set<string>;
   isUpdating: boolean;
   selectedIds: Set<string>;
   onToggleSelected: (id: string) => void;
@@ -774,6 +789,12 @@ function ChannelRows({
                   checked={!!binding.answerAllMessages}
                   disabled={isUpdating}
                   onToggle={(value) => onToggleAnswerAll(binding.id, value)}
+                  unverified={
+                    !!providerConfig.answerAllNeedsConsent &&
+                    !workspacesWithUnmentionedTraffic.has(
+                      binding.workspaceId ?? "",
+                    )
+                  }
                 />
               </TableCell>
             )}
@@ -947,11 +968,19 @@ function AnswerAllCell({
   checked = false,
   disabled = false,
   onToggle,
+  unverified = false,
 }: {
   isDm?: boolean;
   checked?: boolean;
   disabled?: boolean;
   onToggle?: (value: boolean) => void;
+  /**
+   * Answer-all is on, but no un-mentioned message has arrived from this
+   * workspace yet — so the setting may be inert for want of the provider-side
+   * permission. Only ever a hint: a channel nobody has posted in looks the same,
+   * so the toggle stays usable.
+   */
+  unverified?: boolean;
 }) {
   // DMs always reply to every message, so the per-channel toggle doesn't apply.
   if (isDm) {
@@ -968,6 +997,26 @@ function AnswerAllCell({
       <span className="text-xs text-muted-foreground">
         {checked ? "All messages" : "Mentions only"}
       </span>
+      {checked && unverified && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {/* A bare svg can't take focus, and the tooltip is the only place
+                the fix is written down — so this needs a real button. */}
+            <button
+              type="button"
+              className="shrink-0 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="No un-mentioned messages received from this workspace yet — how to fix"
+            >
+              <TriangleAlert className="h-3.5 w-3.5 text-amber-500" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            No un-mentioned messages have arrived from this workspace yet. If
+            the bot stays quiet here, reinstall the app so a team owner is asked
+            to grant permission for it to read channel messages.
+          </TooltipContent>
+        </Tooltip>
+      )}
     </div>
   );
 }

--- a/platform/frontend/src/app/messaging-channels/_components/types.ts
+++ b/platform/frontend/src/app/messaging-channels/_components/types.ts
@@ -15,11 +15,16 @@ export interface ProviderConfig {
    */
   showVirtualDmRow?: boolean;
   /**
-   * Show the per-channel "answer all messages" toggle. Only Slack honors it in
-   * the message gate today, so other providers leave it off and the column is
-   * hidden for them.
+   * Show the per-channel "answer all messages" toggle. Telegram leaves it off —
+   * its message gate ignores the setting, so the column is hidden for it.
    */
   supportsAnswerAll?: boolean;
+  /**
+   * The provider only delivers un-mentioned channel messages after someone
+   * grants a permission at install time, so "answer all messages" can be on and
+   * still do nothing. MS Teams turns this on to hint at that where we can tell.
+   */
+  answerAllNeedsConsent?: boolean;
   docsUrl: string | null;
   slashCommand: string;
   /**

--- a/platform/frontend/src/app/messaging-channels/ms-teams/page.tsx
+++ b/platform/frontend/src/app/messaging-channels/ms-teams/page.tsx
@@ -25,6 +25,8 @@ const msTeamsProviderConfig: ProviderConfig = {
   providerLabel: "MS Teams",
   providerIcon: "/icons/ms-teams.png",
   webhookPath: "/api/webhooks/chatops/ms-teams",
+  supportsAnswerAll: true,
+  answerAllNeedsConsent: true,
   docsUrl: getFrontendDocsUrl("platform-ms-teams"),
   slashCommand: "/select-agent",
   buildDeepLink: (binding) => {

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -30652,6 +30652,7 @@ export type ListChatOpsBindingsResponses = {
             name: string;
         }>;
         hasDmBinding: boolean;
+        workspacesWithUnmentionedTraffic: Array<string>;
     };
 };
 


### PR DESCRIPTION
## Summary

MS Teams channels could only ever reply when @mentioned. The **Replies to** column now appears on the MS Teams channels page, so a channel can be switched to **All messages** the way Slack channels already could — the bot answers everyone in that channel, no mention needed. Mute still works per thread, and direct messages are unaffected since they always reply.

Nothing in the data model or API needed to change for this: `answer_all_messages` is on the shared binding table and the update route already accepted it for any provider. What was missing was the orchestration around the gate decision — and that had already drifted between the two providers, with Teams having lost the step that lifts a mute on a re-mention. Both providers now run one shared gate that owns the read ordering and every state transition, so they cannot diverge again. Slack's behavior is unchanged.

A channel that answers everything changes who the bot talks to, and that matters more on Teams than on Slack because Teams has no ephemeral messages — anything the bot says is public and permanent. A message that arrives only because the channel answers everything no longer produces bot chatter aimed at someone who never addressed it: no "we created an account for you" onboarding post, no agent-selection card, no access denial. Those people are still provisioned and still denied; only the public explanation is withheld.

Answer-all also depends on a Teams permission (`ChannelMessage.Read.Group`) that a team owner grants when the app is installed, so the setting can be on and silently do nothing for an install that predates it. When a workspace has never delivered an un-mentioned message, the toggle carries a note that the app may need reinstalling. That signal only proves consent in one direction — a quiet channel looks the same as one without permission — so it is only ever a hint and never disables the control.
