### PR TITLE
fix(mcp): send the enterprise-managed credential from the inspector

### DIFF
--- a/platform/backend/src/clients/mcp-client.test.ts
+++ b/platform/backend/src/clients/mcp-client.test.ts
@@ -403,6 +403,46 @@ describe("McpClient", () => {
     expect(mockCallTool).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: inspectServer built its transport without the enterprise
+  // credential, so an enterprise-managed catalog was inspected with no auth
+  // header at all and the configured injection mode was never applied.
+  test("inspectServer puts the enterprise credential on the outgoing request", async () => {
+    const catalogItem = await InternalMcpCatalogModel.findById(catalogId);
+    if (!catalogItem) throw new Error("expected catalog item");
+
+    mockListTools.mockResolvedValueOnce({ tools: [] });
+    mockClose.mockResolvedValueOnce(undefined);
+
+    await mcpClient.inspectServer({
+      catalogItem: {
+        ...catalogItem,
+        serverType: "remote",
+        serverUrl: "https://internal.example.com/mcp",
+      },
+      mcpServerId,
+      secrets: {},
+      method: "tools/list",
+      enterpriseTransportCredential: {
+        headerName: "x-provider-api-token",
+        headerValue: "exchanged-inspect-token",
+        expiresInSeconds: null,
+      },
+    });
+
+    const { StreamableHTTPClientTransport } = await import(
+      "@modelcontextprotocol/sdk/client/streamableHttp.js"
+    );
+    const [, options] =
+      vi.mocked(StreamableHTTPClientTransport).mock.calls.at(-1) ?? [];
+    const headers =
+      options?.requestInit?.headers instanceof Headers
+        ? options.requestInit.headers
+        : new Headers(options?.requestInit?.headers);
+
+    expect(headers.get("x-provider-api-token")).toBe("exchanged-inspect-token");
+    expect(headers.get("authorization")).toBeNull();
+  });
+
   test("connectAndGetTools synthesizes read-resource tools when upstream has no tools/list", async () => {
     mockListTools.mockRejectedValueOnce(new Error("Method not found"));
     mockListResources.mockResolvedValueOnce({

--- a/platform/backend/src/clients/mcp-client.ts
+++ b/platform/backend/src/clients/mcp-client.ts
@@ -3473,14 +3473,29 @@ class McpClient {
     method: "tools/list" | "tools/call";
     toolName?: string;
     toolArguments?: Record<string, unknown>;
+    /**
+     * Credential resolved from the catalog's enterprise-managed config, already
+     * mapped onto the header its injection mode asks for. The inspector reaches
+     * the same upstream as a tool call, so it must present the same credential.
+     */
+    enterpriseTransportCredential?: ResolvedEnterpriseTransportCredential;
   }): Promise<unknown> {
-    const { catalogItem, mcpServerId, secrets, method } = params;
+    const {
+      catalogItem,
+      mcpServerId,
+      secrets,
+      method,
+      enterpriseTransportCredential,
+    } = params;
 
     const transport = await this.getTransport(
       catalogItem,
       mcpServerId,
       secrets,
       undefined,
+      undefined,
+      undefined,
+      enterpriseTransportCredential,
     );
 
     const client = new Client(buildMcpClientInfo("archestra-inspector"), {

--- a/platform/backend/src/routes/mcp-server.inspect-enterprise-credential.test.ts
+++ b/platform/backend/src/routes/mcp-server.inspect-enterprise-credential.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Wire-level coverage for the inspector's outbound credential.
+ *
+ * Unlike the rest of the inspect-route tests, nothing between the route and the
+ * socket is mocked here: a real HTTP server stands in for both the IdP token
+ * endpoint and the upstream MCP server, and the real transport makes the
+ * request. That is the only way to assert what the upstream actually receives —
+ * the regression this guards against was a missing header, which every
+ * mock-level assertion happily reported as success.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { OAUTH_TOKEN_TYPE } from "@archestra/shared";
+import { vi } from "vitest";
+import { hasPermission, userHasPermission } from "@/auth/utils";
+import type { FastifyInstanceWithZod } from "@/server";
+import { createFastifyInstance } from "@/server";
+import { afterEach, beforeEach, describe, expect, test } from "@/test";
+import type { User } from "@/types";
+
+vi.mock("@/auth/utils", () => ({
+  hasPermission: vi.fn(),
+  userHasPermission: vi.fn(),
+}));
+
+describe("mcp server inspect route — outbound enterprise credential", () => {
+  let app: FastifyInstanceWithZod;
+  let user: User;
+  let organizationId: string;
+  let server: Server;
+  let baseUrl: string;
+  let upstreamRequestHeaders: Array<Record<string, string | undefined>>;
+
+  beforeEach(async ({ makeUser, makeOrganization, makeMember }) => {
+    upstreamRequestHeaders = [];
+    user = await makeUser();
+    const organization = await makeOrganization();
+    organizationId = organization.id;
+    await makeMember(user.id, organization.id);
+    vi.mocked(hasPermission).mockResolvedValue({ success: true, error: null });
+    vi.mocked(userHasPermission).mockResolvedValue(true);
+
+    server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        // The IdP's token endpoint, exchanging the caller's assertion.
+        if (req.url?.startsWith("/token")) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              access_token: "exchanged-upstream-token",
+              issued_token_type: OAUTH_TOKEN_TYPE.AccessToken,
+              token_type: "Bearer",
+              expires_in: 300,
+            }),
+          );
+          return;
+        }
+
+        // The upstream MCP server.
+        upstreamRequestHeaders.push({
+          ...(req.headers as Record<string, string | undefined>),
+        });
+        const message = JSON.parse(Buffer.concat(chunks).toString() || "{}");
+
+        if (message.method === "initialize") {
+          res.writeHead(200, {
+            "Content-Type": "application/json",
+            "mcp-session-id": "inspect-session",
+          });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                protocolVersion:
+                  message.params?.protocolVersion ?? "2025-06-18",
+                capabilities: { tools: {} },
+                serverInfo: { name: "upstream", version: "1.0.0" },
+              },
+            }),
+          );
+          return;
+        }
+
+        if (message.method === "tools/list") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                tools: [
+                  {
+                    name: "get_application",
+                    description: "Reads one application",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                ],
+              },
+            }),
+          );
+          return;
+        }
+
+        res.writeHead(202).end();
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+    app = createFastifyInstance();
+    app.addHook("onRequest", async (request) => {
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).user = user;
+      (
+        request as typeof request & { user: User; organizationId: string }
+      ).organizationId = organizationId;
+    });
+    const { default: mcpServerRoutes } = await import("./mcp-server");
+    await app.register(mcpServerRoutes);
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    vi.mocked(hasPermission).mockReset();
+    vi.mocked(userHasPermission).mockReset();
+  });
+
+  test("every upstream request carries the configured custom header", async ({
+    makeAccount,
+    makeIdentityProvider,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const identityProvider = await makeIdentityProvider(user.id, {
+      providerId: "keycloak",
+      issuer: `${baseUrl}/realms/archestra`,
+      oidcConfig: {
+        clientId: "archestra-oidc",
+        clientSecret: "archestra-oidc-secret",
+        tokenEndpoint: `${baseUrl}/token`,
+        tokenEndpointAuthentication: "client_secret_post",
+        enterpriseManagedCredentials: {
+          exchangeStrategy: "rfc8693",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+          tokenEndpoint: `${baseUrl}/token`,
+        },
+      },
+    });
+
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "Custom Header Upstream",
+      serverType: "remote",
+      serverUrl: `${baseUrl}/mcp`,
+      enterpriseManagedConfig: {
+        identityProviderId: identityProvider.id,
+        requestedCredentialType: "bearer_token",
+        tokenInjectionMode: "header",
+        headerName: "x-provider-api-token",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+    await makeAccount(user.id, {
+      providerId: "keycloak",
+      accessToken: "session-access-token",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/inspect`,
+      payload: { method: "tools/list" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      tools: [expect.objectContaining({ name: "get_application" })],
+    });
+
+    // The `initialize` handshake is where this regressed — it reached the
+    // upstream with no credential at all — so assert on every request the
+    // inspection made, not just the one carrying tools/list.
+    expect(upstreamRequestHeaders.length).toBeGreaterThan(0);
+    for (const headers of upstreamRequestHeaders) {
+      expect(headers["x-provider-api-token"]).toBe("exchanged-upstream-token");
+      expect(headers.authorization).toBeUndefined();
+    }
+  });
+});

--- a/platform/backend/src/routes/mcp-server.test.ts
+++ b/platform/backend/src/routes/mcp-server.test.ts
@@ -3120,6 +3120,228 @@ describe("mcp server inspect route", () => {
     expect(connectAndGetToolsMock).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: the inspector reaches the same upstream as the MCP Gateway, but
+  // connected with only the install's static secrets. For an enterprise-managed
+  // catalog that meant no auth header at all — the configured injection mode
+  // was never consulted, so a custom-header server saw an unauthenticated call.
+  test("inspect sends the enterprise-managed credential under the configured custom header", async ({
+    makeAccount,
+    makeIdentityProvider,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const identityProvider = await makeIdentityProvider(user.id, {
+      providerId: "keycloak",
+      issuer: "http://localhost:30081/realms/archestra",
+      oidcConfig: {
+        clientId: "archestra-oidc",
+        clientSecret: "archestra-oidc-secret",
+        tokenEndpoint:
+          "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
+        tokenEndpointAuthentication: "client_secret_post",
+        enterpriseManagedCredentials: {
+          exchangeStrategy: "rfc8693",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+        },
+      },
+    });
+
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "Inspect Custom Header",
+      serverType: "remote",
+      serverUrl: "https://internal.example.com/mcp",
+      enterpriseManagedConfig: {
+        identityProviderId: identityProvider.id,
+        requestedCredentialType: "bearer_token",
+        tokenInjectionMode: "header",
+        headerName: "x-provider-api-token",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+
+    await makeAccount(user.id, {
+      providerId: "keycloak",
+      accessToken: "session-access-token",
+    });
+
+    exchangeEnterpriseManagedCredentialMock.mockResolvedValueOnce({
+      credentialType: "bearer_token",
+      expiresInSeconds: null,
+      issuedTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+      value: "exchanged-inspect-token",
+    });
+
+    inspectServerMock.mockResolvedValueOnce({ tools: [] });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/inspect`,
+      payload: { method: "tools/list" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(inspectServerMock).toHaveBeenCalledTimes(1);
+    expect(inspectServerMock.mock.calls[0][0]).toMatchObject({
+      method: "tools/list",
+      enterpriseTransportCredential: {
+        headerName: "x-provider-api-token",
+        headerValue: "exchanged-inspect-token",
+      },
+    });
+  });
+
+  test("inspect sends a bearer Authorization for the default injection mode", async ({
+    makeAccount,
+    makeIdentityProvider,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const identityProvider = await makeIdentityProvider(user.id, {
+      providerId: "keycloak",
+      issuer: "http://localhost:30081/realms/archestra",
+      oidcConfig: {
+        clientId: "archestra-oidc",
+        clientSecret: "archestra-oidc-secret",
+        tokenEndpoint:
+          "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
+        tokenEndpointAuthentication: "client_secret_post",
+        enterpriseManagedCredentials: {
+          exchangeStrategy: "rfc8693",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+        },
+      },
+    });
+
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "Inspect Bearer",
+      serverType: "remote",
+      serverUrl: "https://internal.example.com/mcp",
+      enterpriseManagedConfig: {
+        identityProviderId: identityProvider.id,
+        requestedCredentialType: "bearer_token",
+        tokenInjectionMode: "authorization_bearer",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+
+    await makeAccount(user.id, {
+      providerId: "keycloak",
+      accessToken: "session-access-token",
+    });
+
+    exchangeEnterpriseManagedCredentialMock.mockResolvedValueOnce({
+      credentialType: "bearer_token",
+      expiresInSeconds: null,
+      issuedTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+      value: "exchanged-inspect-bearer",
+    });
+
+    inspectServerMock.mockResolvedValueOnce({ tools: [] });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/inspect`,
+      payload: { method: "tools/list" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(inspectServerMock.mock.calls[0][0]).toMatchObject({
+      enterpriseTransportCredential: {
+        headerName: "Authorization",
+        headerValue: "Bearer exchanged-inspect-bearer",
+      },
+    });
+  });
+
+  // Fail closed: connecting anyway would reach the upstream with no credential,
+  // which is the unauthenticated call this fix exists to stop.
+  test("inspect returns 401 when the enterprise-managed credential cannot be resolved", async ({
+    makeIdentityProvider,
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const identityProvider = await makeIdentityProvider(user.id, {
+      providerId: "keycloak",
+      issuer: "http://localhost:30081/realms/archestra",
+      oidcConfig: {
+        clientId: "archestra-oidc",
+        clientSecret: "archestra-oidc-secret",
+        tokenEndpoint:
+          "http://localhost:30081/realms/archestra/protocol/openid-connect/token",
+        tokenEndpointAuthentication: "client_secret_post",
+        enterpriseManagedCredentials: {
+          exchangeStrategy: "rfc8693",
+          subjectTokenType: OAUTH_TOKEN_TYPE.AccessToken,
+        },
+      },
+    });
+
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      name: "Inspect Unlinked",
+      serverType: "remote",
+      serverUrl: "https://internal.example.com/mcp",
+      enterpriseManagedConfig: {
+        identityProviderId: identityProvider.id,
+        requestedCredentialType: "bearer_token",
+        tokenInjectionMode: "header",
+        headerName: "x-provider-api-token",
+      },
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+
+    // No linked account for the caller, so no assertion to exchange.
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/inspect`,
+      payload: { method: "tools/list" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json().error.message).toContain("keycloak");
+    expect(inspectServerMock).not.toHaveBeenCalled();
+  });
+
+  // Non-enterprise catalogs must keep inspecting with their static secrets.
+  test("inspect leaves non-enterprise catalogs without an enterprise credential", async ({
+    makeInternalMcpCatalog,
+    makeMcpServer,
+  }) => {
+    const catalog = await makeInternalMcpCatalog({
+      organizationId,
+      serverType: "remote",
+      serverUrl: "https://plain.example.com/mcp",
+    });
+    const mcpServer = await makeMcpServer({
+      ownerId: user.id,
+      catalogId: catalog.id,
+    });
+
+    inspectServerMock.mockResolvedValueOnce({ tools: [] });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/mcp_server/${mcpServer.id}/inspect`,
+      payload: { method: "tools/list" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(
+      inspectServerMock.mock.calls[0][0].enterpriseTransportCredential,
+    ).toBeUndefined();
+  });
+
   test("returns 409 when the MCP server is not running yet", async ({
     makeInternalMcpCatalog,
     makeMcpServer,

--- a/platform/backend/src/routes/mcp-server.ts
+++ b/platform/backend/src/routes/mcp-server.ts
@@ -34,6 +34,7 @@ import { refreshLinkedIdentityProviderAccessToken } from "@/services/identity-pr
 import {
   buildEnterpriseCredentialHeader,
   exchangeIdJagAtProtectedResource,
+  type ResolvedEnterpriseTransportCredential,
 } from "@/services/identity-providers/enterprise-managed/broker";
 import { exchangeEnterpriseManagedCredential } from "@/services/identity-providers/enterprise-managed/exchange";
 import {
@@ -51,6 +52,7 @@ import {
   ApiError,
   constructResponseSchema,
   DeleteObjectResponseSchema,
+  type EnterpriseManagedCredentialConfig,
   InsertMcpServerSchema,
   type InternalMcpCatalogServerType,
   LocalMcpServerInstallationStatusSchema,
@@ -1650,6 +1652,37 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
         }
       }
 
+      // The inspector talks to the same upstream as the MCP Gateway, so it has
+      // to present the same credential. Without this it connected with only the
+      // install's static secrets — for an enterprise-managed catalog that means
+      // no auth header at all, and none of the configured injection mode.
+      const enterpriseTransportCredential = buildDiscoveryTransportCredential({
+        enterpriseManagedConfig: catalogItem.enterpriseManagedConfig,
+        accessToken: catalogItem.enterpriseManagedConfig
+          ? await getInstallDiscoveryAccessToken({
+              catalogItem,
+              userId: user.id,
+            })
+          : undefined,
+      });
+      if (
+        catalogItem.enterpriseManagedConfig &&
+        !enterpriseTransportCredential
+      ) {
+        const identityProvider = catalogItem.enterpriseManagedConfig
+          .identityProviderId
+          ? await findExternalIdentityProviderById(
+              catalogItem.enterpriseManagedConfig.identityProviderId,
+            )
+          : null;
+        throw new ApiError(
+          401,
+          identityProvider
+            ? `Connect ${identityProvider.providerId} before inspecting this MCP server.`
+            : "Sign in with SSO to link your identity provider before inspecting this MCP server.",
+        );
+      }
+
       try {
         const result = await mcpClient.inspectServer({
           catalogItem,
@@ -1658,6 +1691,7 @@ const mcpServerRoutes: FastifyPluginAsyncZod = async (fastify) => {
           method: body.method,
           toolName: body.toolName,
           toolArguments: body.toolArguments,
+          enterpriseTransportCredential,
         });
 
         return reply.send(result as Record<string, unknown>);
@@ -2322,20 +2356,10 @@ async function connectAndGetToolsForInstallation(params: {
           userId: params.userId,
         })
       : undefined;
-  // Route the exchanged credential through the catalog's injection mode rather
-  // than folding it into `access_token`: the static-secret path always emits
-  // `Authorization: Bearer`, which silently ignores a configured custom header
-  // and sends discovery traffic with a credential the upstream never expects.
-  const installDiscoveryCredential =
-    installDiscoveryAccessToken && catalogItem.enterpriseManagedConfig
-      ? {
-          ...buildEnterpriseCredentialHeader({
-            config: catalogItem.enterpriseManagedConfig,
-            value: installDiscoveryAccessToken,
-          }),
-          expiresInSeconds: null,
-        }
-      : undefined;
+  const installDiscoveryCredential = buildDiscoveryTransportCredential({
+    enterpriseManagedConfig: catalogItem.enterpriseManagedConfig,
+    accessToken: installDiscoveryAccessToken,
+  });
 
   if (catalogItem.enterpriseManagedConfig && !installDiscoveryAccessToken) {
     const identityProvider = catalogItem.enterpriseManagedConfig
@@ -2405,6 +2429,32 @@ async function getCurrentIdentityProviderAccessToken(
   const account =
     await AccountModel.getLatestSsoAccountWithAccessTokenByUserId(userId);
   return account ? ensureFreshSsoAccessToken(account) : undefined;
+}
+
+/**
+ * Route an exchanged credential through the catalog's injection mode.
+ *
+ * Handing the value to the transport as a static `access_token` instead always
+ * emits `Authorization: Bearer`, which silently ignores a configured custom
+ * header and sends traffic with a credential the upstream never expects.
+ * Shared by install-time discovery and the inspector so both reach the upstream
+ * with the same header the MCP Gateway uses.
+ */
+function buildDiscoveryTransportCredential(params: {
+  enterpriseManagedConfig: EnterpriseManagedCredentialConfig | null;
+  accessToken: string | undefined;
+}): ResolvedEnterpriseTransportCredential | undefined {
+  if (!params.enterpriseManagedConfig || !params.accessToken) {
+    return undefined;
+  }
+
+  return {
+    ...buildEnterpriseCredentialHeader({
+      config: params.enterpriseManagedConfig,
+      value: params.accessToken,
+    }),
+    expiresInSeconds: null,
+  };
 }
 
 async function getInstallDiscoveryAccessToken(params: {


### PR DESCRIPTION
Follow-up to #7000, which fixed install-time discovery and left the inspector listed as a known gap. This closes that gap.

## Problem

`POST /api/mcp_server/:id/inspect` built its transport from the install's static secrets alone:

```ts
const transport = await this.getTransport(catalogItem, mcpServerId, secrets, undefined);
```

For an enterprise-managed catalog those secrets are empty, so the inspector reached the upstream with **no auth header at all** — not the configured custom header, and not an `Authorization` either. Every request in the inspection went out unauthenticated, starting with the `initialize` handshake.

Tool calls through the MCP Gateway were unaffected; this was specific to the inspector.

## Changes

- The inspect route resolves the same credential install discovery resolves, and threads it through `inspectServer` into the transport.
- When the catalog is enterprise-managed and no credential can be resolved, the route now returns **401** naming the identity provider to connect, instead of connecting anyway and reaching the upstream with nothing.
- The mode-mapping is factored into `buildDiscoveryTransportCredential`, shared by install discovery and the inspector so the two cannot drift apart again.
- Non-enterprise catalogs are untouched — they keep inspecting with their static secrets, covered by a test.

## Verification

Verified end-to-end against a real upstream, not just mocks. A local HTTP server stood in for both the IdP token endpoint and the MCP server, with the real route, real token exchange, and real `StreamableHTTPClientTransport` in between.

Before — the `initialize` request arrives with no credential:

```
accept: application/json, text/event-stream
content-length: 169
content-type: application/json
sec-fetch-mode: cors
user-agent: node
```

After — every request in the inspection carries the configured header:

```
accept: application/json, text/event-stream
content-length: 169
content-type: application/json
sec-fetch-mode: cors
user-agent: node
x-provider-api-token: exchanged-upstream-token
```

## Tests

Three levels, each verified to fail without this change:

- **Route** (`mcp-server.test.ts`) — the inspect endpoint passes the resolved credential for custom-header mode and for the default bearer mode; returns 401 when it cannot resolve one; and leaves non-enterprise catalogs with no enterprise credential.
- **Client** (`mcp-client.test.ts`) — `inspectServer` puts the credential on the outgoing transport headers and emits no `Authorization`.
- **Wire** (`mcp-server.inspect-enterprise-credential.test.ts`, new) — nothing between the route and the socket is mocked; asserts every request the inspection makes carries the configured header. This is the only level that would have caught the original bug, since the defect was a *missing* header that mock-level assertions reported as success. Ran it repeatedly to confirm it is not flaky.