### PR TITLE
fix(chat): recover from Anthropic-family context-overflow rejections

### DIFF
--- a/platform/backend/src/agents/agent-run-stream.test.ts
+++ b/platform/backend/src/agents/agent-run-stream.test.ts
@@ -447,6 +447,43 @@ describe("runAgentStream", () => {
     expect(await result.text).toBe("hi");
   });
 
+  test("trims and retries when Bedrock relays the model's over-length rejection", async () => {
+    // The failure this guards: a long Claude-on-Bedrock conversation is
+    // rejected mid-turn, and because the message never matched the shapes the
+    // retry knew about, the run surfaced a hard 400 to the user instead of
+    // recovering. The body is the proxy envelope the chat actually receives.
+    const messages: ModelMessage[] = [
+      { role: "user", content: "a".repeat(400) },
+      { role: "assistant", content: "b".repeat(400) },
+      { role: "user", content: "c".repeat(400) },
+    ];
+    const model = modelFor(
+      errorChunks(
+        new Error(
+          '{"error":{"message":"Bedrock API error (400): The model returned the following errors: prompt is too long: 1000034 tokens > 1000000 maximum","type":"api_validation_error"}}',
+        ),
+      ),
+      renderableChunks(),
+    );
+
+    const { result } = await runAgentStream({
+      config: { model, messages },
+    });
+    await drain(result);
+
+    expect(model.doStreamCalls).toHaveLength(2);
+    // The provider reports both counts here, so the retry sizes itself from the
+    // payload's real chars-per-token ratio rather than the 4-chars default.
+    // Message count is not the signal — a trim note replaces what it drops — so
+    // compare what the retry actually weighs.
+    const promptChars = (call: (typeof model.doStreamCalls)[number]) =>
+      JSON.stringify(call.prompt).length;
+    expect(promptChars(model.doStreamCalls[1])).toBeLessThan(
+      promptChars(model.doStreamCalls[0]),
+    );
+    expect(await result.text).toBe("hi");
+  });
+
   test("strips reasoningSummary and retries when the OpenAI org is not verified for summaries", async () => {
     const model = modelFor(
       errorChunks(reasoningSummaryVerificationError()),

--- a/platform/backend/src/clients/bedrock-client.test.ts
+++ b/platform/backend/src/clients/bedrock-client.test.ts
@@ -71,6 +71,28 @@ describe("BedrockClient non-OK error messages", () => {
       expect(err.message).toBe("Bedrock API error (400): prompt is too long");
     });
 
+    it("preserves the token counts in a relayed over-length rejection", async () => {
+      // Claude's own message reaches us verbatim inside AWS's, and the numbers
+      // in it are what lets the chat retry resize itself instead of failing the
+      // turn (parsed by parseContextLengthError in routes/chat/context-trimming).
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            message:
+              "The model returned the following errors: prompt is too long: 1000034 tokens > 1000000 maximum",
+            __type: "ValidationException",
+          }),
+          { status: 400 },
+        ),
+      );
+
+      const err = await catchError(makeClient().converse("model", {}));
+
+      expect(err.message).toBe(
+        "Bedrock API error (400): The model returned the following errors: prompt is too long: 1000034 tokens > 1000000 maximum",
+      );
+    });
+
     it("uses a non-JSON body verbatim as the detail", async () => {
       fetchMock.mockResolvedValue(
         new Response("Rate exceeded", { status: 429 }),

--- a/platform/backend/src/routes/chat/context-compaction.ts
+++ b/platform/backend/src/routes/chat/context-compaction.ts
@@ -345,6 +345,7 @@ export async function invalidateConversationCompactions(
 
 export function __testEstimateChatMessagesTokens(params: {
   provider: SupportedProvider;
+  model?: string;
   systemPrompt?: string;
   messages: ChatMessage[];
 }): number {
@@ -524,7 +525,10 @@ async function shouldAutoCompact(params: {
   systemPrompt?: string;
   messages: ChatMessage[];
 }): Promise<{ shouldCompact: boolean; estimatedTokens: number }> {
-  const estimatedTokens = estimateChatMessagesTokens(params);
+  const estimatedTokens = estimateChatMessagesTokens({
+    ...params,
+    model: params.selectedModel,
+  });
   const model = await ModelModel.findByProviderAndModelId(
     params.provider,
     params.selectedModel,
@@ -865,6 +869,7 @@ async function hasContextHeadroomForRetry(params: {
 
   const estimate = estimateChatMessagesTokens({
     provider: params.provider,
+    model: params.selectedModel,
     systemPrompt: params.systemPrompt,
     messages: params.compactionMessages,
   });
@@ -886,12 +891,14 @@ async function createCompactionRecord(params: {
 }): Promise<ConversationCompaction | null> {
   const originalTokenEstimate = estimateChatMessagesTokens({
     provider: params.tokenEstimateProvider,
+    model: params.model,
     messages: params.originalMessages,
   });
   // mirrors the message list the caller will send to the model next turn:
   // summary + the same "recent" slice that was kept verbatim
   const compactedTokenEstimate = estimateChatMessagesTokens({
     provider: params.tokenEstimateProvider,
+    model: params.model,
     messages: [buildSummaryMessage(params.summary), ...params.recentMessages],
   });
 
@@ -1216,10 +1223,18 @@ async function serializeMessagesForSummary(
 
 function estimateChatMessagesTokens(params: {
   provider: SupportedProvider;
+  /**
+   * The model the estimate is for. Optional because a few call sites only ever
+   * compare two estimates against each other (where a consistent yardstick is
+   * all that matters), but pass it wherever the number is compared against the
+   * context window — a reseller's provider id alone picks the wrong tokenizer
+   * for Claude on Bedrock.
+   */
+  model?: string;
   systemPrompt?: string;
   messages: ChatMessage[];
 }): number {
-  const tokenizer = getTokenizer(params.provider);
+  const tokenizer = getTokenizer(params.provider, params.model);
   let extraTokens = 0;
   const providerMessages = params.messages.map((message) => {
     const estimate = getMessageTextForTokenEstimate(message);

--- a/platform/backend/src/routes/chat/context-trimming.test.ts
+++ b/platform/backend/src/routes/chat/context-trimming.test.ts
@@ -40,6 +40,46 @@ describe("parseContextLengthError", () => {
     });
   });
 
+  test("parses the Anthropic over-length shape relayed by Bedrock", () => {
+    // Shape the chat sees: an APICallError whose responseBody is the proxy's
+    // JSON envelope wrapping Bedrock's relay of the model's own message.
+    const error = new Error(
+      JSON.stringify({
+        error: {
+          message:
+            "Bedrock API error (400): The model returned the following errors: prompt is too long: 1000034 tokens > 1000000 maximum",
+          type: "api_validation_error",
+        },
+      }),
+    );
+    expect(parseContextLengthError(error)).toEqual({
+      maxInputTokens: 1000000,
+      requestedTokens: 1000034,
+    });
+  });
+
+  test("parses the Anthropic over-length shape from the native API", () => {
+    const error = new Error(
+      '{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 219974 tokens > 199999 maximum"}}',
+    );
+    expect(parseContextLengthError(error)).toEqual({
+      maxInputTokens: 199999,
+      requestedTokens: 219974,
+    });
+  });
+
+  test("subtracts the output reservation when it is what overflows the window", () => {
+    const error = new Error(
+      "input length and max_tokens exceed context limit: 190000 + 20000 > 200000",
+    );
+    // Trimming to the bare 200000 window would be rejected again, because the
+    // 20000-token output reservation is counted against it too.
+    expect(parseContextLengthError(error)).toEqual({
+      maxInputTokens: 180000,
+      requestedTokens: 190000,
+    });
+  });
+
   test("returns null for unrelated errors", () => {
     expect(
       parseContextLengthError(new Error("rate limit exceeded")),
@@ -61,6 +101,40 @@ describe("shouldProbeTextStreamForContextTrimRetry", () => {
   test("keeps the textStream probe enabled for OpenAI-compatible flows", () => {
     expect(shouldProbeTextStreamForContextTrimRetry("openai")).toBe(true);
     expect(shouldProbeTextStreamForContextTrimRetry("vllm")).toBe(true);
+  });
+});
+
+describe("Bedrock context-overflow recovery", () => {
+  test("a rejected over-length Bedrock turn trims down to something that fits", () => {
+    // A conversation whose real token count the provider put just over a 1M
+    // window. The retry has to bring it under the reported limit, keep the
+    // user's latest request, and leave the payload structurally valid.
+    const history: ModelMessage[] = Array.from({ length: 40 }, (_, i) =>
+      msg(i % 2 === 0 ? "user" : "assistant", `turn ${i} ${"x".repeat(2000)}`),
+    );
+    const messages = [...history, msg("user", "now use the reporting tool")];
+
+    const parsed = parseContextLengthError(
+      new Error(
+        "Bedrock API error (400): The model returned the following errors: prompt is too long: 1000034 tokens > 1000000 maximum",
+      ),
+    );
+    expect(parsed).not.toBeNull();
+
+    const trimmed = trimMessagesToTokenLimit({
+      messages,
+      maxTokens: parsed?.maxInputTokens ?? 0,
+      requestedTokens: parsed?.requestedTokens,
+    });
+
+    // The provider counted the original at ~1.00M tokens against a 1M limit, so
+    // the retry must be strictly smaller than what was rejected.
+    const charsOf = (list: ModelMessage[]) =>
+      list.reduce((sum, m) => sum + JSON.stringify(m.content).length, 0);
+    expect(charsOf(trimmed)).toBeLessThan(charsOf(messages));
+    expect(trimmed[trimmed.length - 1].content).toBe(
+      "now use the reporting tool",
+    );
   });
 });
 

--- a/platform/backend/src/routes/chat/context-trimming.ts
+++ b/platform/backend/src/routes/chat/context-trimming.ts
@@ -42,6 +42,16 @@ export interface ContextLengthError {
  * - vLLM/LiteLLM: "You passed 8193 input tokens ... maximum input length of 8192 tokens"
  * - OpenRouter-style gateways: "maximum context length is 262144 tokens.
  *   However, you requested about 285869 tokens"
+ * - Anthropic family: "prompt is too long: 1000034 tokens > 1000000 maximum"
+ * - Anthropic family: "input length and max_tokens exceed context limit:
+ *   190000 + 20000 > 200000"
+ *
+ * The Anthropic shapes arrive both from the native API and from resellers that
+ * relay the model's own message verbatim — Bedrock wraps it as "The model
+ * returned the following errors: prompt is too long: …". Matching on the
+ * message rather than the envelope therefore covers every host of a Claude
+ * model at once, which is what makes the trim-and-retry recovery reachable for
+ * Bedrock at all.
  */
 export function parseContextLengthError(
   error: unknown,
@@ -75,6 +85,35 @@ export function parseContextLengthError(
       requestedTokens: requested
         ? Number.parseInt(requested[1], 10)
         : undefined,
+    };
+  }
+
+  const anthropicPromptMatch = body.match(
+    /prompt is too long:\s*(\d+)\s*tokens\s*>\s*(\d+)\s*maximum/i,
+  );
+  if (anthropicPromptMatch) {
+    return {
+      maxInputTokens: Number.parseInt(anthropicPromptMatch[2], 10),
+      requestedTokens: Number.parseInt(anthropicPromptMatch[1], 10),
+    };
+  }
+
+  // The output reservation is counted against the window alongside the input,
+  // so the budget the retry has to fit into is the window minus that
+  // reservation — trimming to the bare window would be rejected again.
+  const anthropicMaxTokensMatch = body.match(
+    /input length and max_tokens exceed context limit:\s*(\d+)\s*\+\s*(\d+)\s*>\s*(\d+)/i,
+  );
+  if (anthropicMaxTokensMatch) {
+    const inputTokens = Number.parseInt(anthropicMaxTokensMatch[1], 10);
+    const reservedOutputTokens = Number.parseInt(
+      anthropicMaxTokensMatch[2],
+      10,
+    );
+    const contextLimit = Number.parseInt(anthropicMaxTokensMatch[3], 10);
+    return {
+      maxInputTokens: Math.max(contextLimit - reservedOutputTokens, 1),
+      requestedTokens: inputTokens,
     };
   }
 

--- a/platform/backend/src/routes/chat/context-window-breakdown.ts
+++ b/platform/backend/src/routes/chat/context-window-breakdown.ts
@@ -44,7 +44,7 @@ export function buildContextWindowBreakdown(params: {
   tools?: Record<string, unknown>;
   messages: ChatMessage[];
 }): ContextWindowBreakdown {
-  const tokenizer = getTokenizer(params.provider);
+  const tokenizer = getTokenizer(params.provider, params.model);
   const accumulators = emptyAccumulators();
 
   if (params.systemPrompt) {

--- a/platform/backend/src/tokenizers/index.ts
+++ b/platform/backend/src/tokenizers/index.ts
@@ -8,7 +8,21 @@ export { BaseTokenizer, type ProviderMessage, type Tokenizer } from "./base";
 export { TiktokenTokenizer } from "./tiktoken";
 
 /**
- * Get the tokenizer for a given provider.
+ * Get the tokenizer for a given provider, and — for resellers that front more
+ * than one vendor's models — the specific model being counted.
+ *
+ * A reseller's provider id says who serves the model, not who built it, so the
+ * provider alone cannot pick the right encoder: Bedrock and OpenRouter both
+ * serve Claude. The two encoders agree on plain English and diverge on the
+ * code, identifiers and other non-prose that dominate long tool-using
+ * conversations — by up to ~17% in either direction, depending on the content.
+ * That gap is load-bearing rather than cosmetic: the same estimate decides when
+ * auto-compaction fires and whether a turn is let through to the provider, and
+ * both comparisons are against *that model's* context window. Measuring Claude
+ * with cl100k_base means neither check is answering the question it asks.
+ *
+ * `modelId` is optional and unknown ids keep the provider default, so a caller
+ * that has no model in hand is no worse off than before.
  *
  * Tokenizer instances are cached and shared process-wide. This matters for
  * {@link TiktokenTokenizer}: its constructor allocates a `tiktoken` encoding
@@ -16,7 +30,13 @@ export { TiktokenTokenizer } from "./tiktoken";
  * re-pays the encoding init cost and leaks native memory. The tokenizers carry
  * no per-call state beyond that encoding, so a single shared instance is safe.
  */
-export function getTokenizer(provider: SupportedProvider): Tokenizer {
+export function getTokenizer(
+  provider: SupportedProvider,
+  modelId?: string | null,
+): Tokenizer {
+  if (modelId && isAnthropicModelOnReseller(provider, modelId)) {
+    return getAnthropicTokenizer();
+  }
   return tokenizerCache[provider]();
 }
 
@@ -29,6 +49,32 @@ const getTiktokenTokenizer = (): TiktokenTokenizer =>
   (tiktokenTokenizer ??= new TiktokenTokenizer());
 const getAnthropicTokenizer = (): AnthropicTokenizer =>
   (anthropicTokenizer ??= new AnthropicTokenizer());
+
+/**
+ * Whether a reseller-hosted model is an Anthropic one.
+ *
+ * Bedrock ids carry the vendor as the segment after an optional region prefix
+ * (`us.anthropic.claude-opus-4-8`, `global.anthropic.…`, or bare
+ * `anthropic.claude-…`); OpenRouter uses a `anthropic/…` vendor path. Providers
+ * that front a single vendor are deliberately absent — Azure serves OpenAI
+ * models, which cl100k_base already counts correctly.
+ */
+function isAnthropicModelOnReseller(
+  provider: SupportedProvider,
+  modelId: string,
+): boolean {
+  const id = modelId.toLowerCase();
+  if (provider === "bedrock") {
+    return id.replace(BEDROCK_REGION_PREFIX, "").startsWith("anthropic.");
+  }
+  if (provider === "openrouter") {
+    return id.startsWith("anthropic/");
+  }
+  return false;
+}
+
+/** Optional region/geography prefix on a Bedrock inference-profile id. */
+const BEDROCK_REGION_PREFIX = /^(us-gov|us|eu|apac|ap|sa|ca|jp|au|global)\./;
 
 /**
  * Maps each provider to a cached tokenizer accessor.

--- a/platform/backend/src/tokenizers/tokenizers.test.ts
+++ b/platform/backend/src/tokenizers/tokenizers.test.ts
@@ -140,6 +140,71 @@ describe("Tokenizers", () => {
       expect(getTokenizer("openai")).not.toBe(getTokenizer("anthropic"));
     });
 
+    test("should count Claude served by a reseller with the Anthropic tokenizer", () => {
+      // Bedrock and OpenRouter front several vendors, so the provider id alone
+      // picks the wrong encoder for a Claude model — and that estimate is what
+      // decides when auto-compaction fires and whether a turn is let through to
+      // the provider, both measured against that model's own context window.
+      expect(getTokenizer("bedrock", "us.anthropic.claude-opus-4-8")).toBe(
+        getTokenizer("anthropic"),
+      );
+      expect(getTokenizer("bedrock", "anthropic.claude-opus-4-8")).toBe(
+        getTokenizer("anthropic"),
+      );
+      expect(
+        getTokenizer("bedrock", "global.anthropic.claude-sonnet-4-6"),
+      ).toBe(getTokenizer("anthropic"));
+      expect(getTokenizer("openrouter", "anthropic/claude-opus-4-8")).toBe(
+        getTokenizer("anthropic"),
+      );
+    });
+
+    test("should keep the provider default for non-Anthropic reseller models", () => {
+      expect(getTokenizer("bedrock", "us.amazon.nova-pro-v1:0")).toBe(
+        getTokenizer("openai"),
+      );
+      expect(getTokenizer("bedrock", "us.meta.llama3-70b-instruct-v1:0")).toBe(
+        getTokenizer("openai"),
+      );
+      expect(getTokenizer("openrouter", "openai/gpt-5.5")).toBe(
+        getTokenizer("openai"),
+      );
+      // Azure fronts a single vendor whose models cl100k_base already fits.
+      expect(getTokenizer("azure", "gpt-5.5")).toBe(getTokenizer("openai"));
+    });
+
+    test("should fall back to the provider default when no model is given", () => {
+      expect(getTokenizer("bedrock")).toBe(getTokenizer("openai"));
+      expect(getTokenizer("bedrock", null)).toBe(getTokenizer("openai"));
+    });
+
+    test("should count code-dense text differently for Claude than cl100k_base", () => {
+      // Why the reseller mapping is load-bearing rather than cosmetic: the two
+      // encoders agree on prose and diverge on the code/identifier-heavy
+      // payloads that dominate long tool-using conversations. The direction of
+      // the gap depends on the content, so what matters is that a Claude model
+      // is measured on Claude's own yardstick — the estimate is compared
+      // against that model's context window.
+      const message: ProviderMessage = {
+        role: "user",
+        content:
+          `export function resolveTargets(modelId: string) {\n  const withoutRegion = modelId.replace(REGION_PREFIX, "");\n  return withoutRegion;\n}\n`.repeat(
+            60,
+          ),
+      };
+      const claudeOnBedrock = getTokenizer(
+        "bedrock",
+        "us.anthropic.claude-opus-4-8",
+      ).countTokens(message);
+      const cl100k = getTokenizer("bedrock").countTokens(message);
+
+      expect(claudeOnBedrock).not.toBe(cl100k);
+      // Same text, same provider — only the model-aware mapping changes it.
+      expect(claudeOnBedrock).toBe(
+        getTokenizer("anthropic").countTokens(message),
+      );
+    });
+
     test("should return consistent token counts for same input", () => {
       const anthropicTokenizer = getTokenizer("anthropic");
       const openaiTokenizer = getTokenizer("openai");


### PR DESCRIPTION
## Problem

A conversation on a Claude model served through Bedrock could grow past the model's context window and then fail the turn outright — the provider's 400 surfaced to the user with no recovery:

```
Bedrock API error (400): The model returned the following errors:
prompt is too long: 1000034 tokens > 1000000 maximum
```

From the user's side this reads as "compaction doesn't actually run": the compaction indicator appears, then the turn dies anyway.

## Root causes

**1. The trim-and-retry recovery never engaged for Anthropic wording.**

`parseContextLengthError` drives the one-shot trim-and-retry in `runAgentStream`, and it only matched the vLLM/LiteLLM (`maximum input length of N`) and OpenRouter (`maximum context length is N`) phrasings. Anthropic says `prompt is too long: N tokens > M maximum`, and Bedrock relays the model's own message verbatim inside its envelope — so the parser returned `null` and the retry was inert for every Claude host.

That made an over-length turn unrecoverable regardless of *why* it was over: whether auto-compaction had been skipped, had failed (on failure the flow returns the uncompacted list and sends it anyway), or had run and still not fit because the retained recent turns were large on their own.

**2. The estimate that gates compaction used the wrong tokenizer for Bedrock.**

`getTokenizer` keyed off the provider id. Bedrock fronts several vendors, so Claude there was counted with `cl100k_base` instead of Claude's own tokenizer. The two agree on prose and diverge by up to ~17% on the code/identifier-dense payloads typical of long tool-using conversations — in *either* direction depending on content. That estimate is what decides when auto-compaction fires (0.8 of the window) and whether a turn passes the pre-flight gate, both measured against that model's window, so neither check was answering the question it asks. The proxy's own Bedrock adapter already used the Anthropic tokenizer; the chat estimation path had not been updated to match.

## Changes

- `parseContextLengthError` now also matches `prompt is too long: N tokens > M maximum` and `input length and max_tokens exceed context limit: A + B > C`. For the latter the retry budget is the window *minus* the output reservation, since trimming to the bare window would be rejected again. Both counts are captured, so the trim sizes itself from the payload's real chars-per-token ratio rather than the 4-chars default.
- `getTokenizer(provider, modelId?)` picks the tokenizer per model for resellers that front multiple vendors (Bedrock `[region.]anthropic.*`, OpenRouter `anthropic/*`). The argument is optional and unknown ids keep the provider default, so callers with no model in hand are unaffected. Single-vendor resellers are deliberately excluded — Azure serves OpenAI models, which `cl100k_base` already fits.
- The chat estimation path (`shouldAutoCompact`, the retry-headroom check, the stored compaction estimates, and the context-window breakdown) threads the model through.

## Testing

- **End-to-end recovery** (`agent-run-stream.test.ts`): a run whose first attempt errors with the exact production error body now retries with a smaller payload and completes, using the real `streamText` loop against a mock model. This is the behaviour that was broken.
- **Parsing** (`context-trimming.test.ts`): both Anthropic shapes, from the native API and from the Bedrock-relayed proxy envelope; plus a case asserting a rejected over-length turn trims to something smaller while keeping the user's latest message.
- **Seam between the layers** (`bedrock-client.test.ts`): the client composes the relayed AWS message with its token counts intact — the input the parser depends on.
- **Tokenizer selection** (`tokenizers.test.ts`): Claude on Bedrock/OpenRouter resolves to the Anthropic tokenizer; non-Anthropic reseller models and the no-model call keep the provider default; the counts genuinely differ on code-dense text.

All six new tests fail on `main` and pass here. Affected-area sweep: 979 passed, 3 pre-existing failures unrelated to this change (an unbuilt native binding in a fresh worktree, identical on `main`). Type-check passes across all 8 workspaces; lint findings unchanged from `main` (20 before, 20 after).

## Note on live verification

Live Bedrock calls could not be exercised from this machine — the AWS account is not authorised for Bedrock model access (`authorizationStatus: NOT_AUTHORIZED`), which is an account-level agreement rather than an IAM setting. The error body used throughout the tests is the verbatim one observed in production, and the parsing, the retry loop, and the client seam are each covered in-process against it.

## Follow-up worth considering (not in this PR)

When compaction fails, `buildModelMessages` proceeds with the uncompacted list and sends it. The retry now recovers that case, but failing closed (or compacting harder) would avoid the wasted round trip. Separately, the chat path applies no per-tool-result size cap, unlike the A2A step guard's 100k-char cap, so a few large results in the retained recent window can exceed the model's context on their own.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>