### PR TITLE
fix(frontend): global DOM guard against machine-translation crashes

### DIFF
--- a/platform/frontend/src/app/_parts/machine-translation-dom-guard.test.ts
+++ b/platform/frontend/src/app/_parts/machine-translation-dom-guard.test.ts
@@ -1,0 +1,69 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { installMachineTranslationDomGuard } from "./machine-translation-dom-guard";
+
+// Simulates what Chrome page translation does to the DOM: text nodes React
+// created get re-parented into injected <font> wrappers, so React's own
+// removeChild/insertBefore calls later reference nodes whose parent changed.
+
+function translatedTextNode(parent: HTMLElement) {
+  const text = document.createTextNode("hello");
+  parent.appendChild(text);
+  const font = document.createElement("font");
+  font.appendChild(text);
+  parent.appendChild(font);
+  return text;
+}
+
+describe("installMachineTranslationDomGuard", () => {
+  beforeAll(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    installMachineTranslationDomGuard();
+  });
+
+  it("removeChild no longer throws for a node a translator re-parented", () => {
+    const parent = document.createElement("div");
+    const text = translatedTextNode(parent);
+    expect(() => parent.removeChild(text)).not.toThrow();
+    expect(parent.removeChild(text)).toBe(text);
+  });
+
+  it("removeChild still removes an actual child", () => {
+    const parent = document.createElement("div");
+    const child = document.createElement("span");
+    parent.appendChild(child);
+    expect(parent.removeChild(child)).toBe(child);
+    expect(parent.contains(child)).toBe(false);
+  });
+
+  it("insertBefore skips the insertion when the reference node was re-parented", () => {
+    const parent = document.createElement("div");
+    const reference = translatedTextNode(parent);
+    const inserted = document.createElement("span");
+    expect(parent.insertBefore(inserted, reference)).toBe(inserted);
+    expect(inserted.parentNode).toBeNull();
+  });
+
+  it("installs only once", () => {
+    const removeChild = Node.prototype.removeChild;
+    const insertBefore = Node.prototype.insertBefore;
+    installMachineTranslationDomGuard();
+    expect(Node.prototype.removeChild).toBe(removeChild);
+    expect(Node.prototype.insertBefore).toBe(insertBefore);
+  });
+
+  it("insertBefore still inserts before an actual child", () => {
+    const parent = document.createElement("div");
+    const reference = document.createElement("span");
+    parent.appendChild(reference);
+    const inserted = document.createElement("b");
+    expect(parent.insertBefore(inserted, reference)).toBe(inserted);
+    expect(parent.firstChild).toBe(inserted);
+  });
+
+  it("insertBefore with a null reference still appends", () => {
+    const parent = document.createElement("div");
+    const inserted = document.createElement("span");
+    expect(parent.insertBefore(inserted, null)).toBe(inserted);
+    expect(parent.lastChild).toBe(inserted);
+  });
+});

--- a/platform/frontend/src/app/_parts/machine-translation-dom-guard.tsx
+++ b/platform/frontend/src/app/_parts/machine-translation-dom-guard.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// Chrome's built-in page translation (and similar machine-translation
+// browser features) rewrites the text nodes it translates by re-parenting
+// them into injected <font> wrappers. React still holds references to the
+// original nodes, so its next commit that unmounts affected DOM throws
+// "NotFoundError: Failed to execute 'removeChild' on 'Node'" and crashes
+// the whole page (facebook/react#11538) — e.g. any route change after the
+// user translates the app. React upstream does not handle this; the
+// established mitigation is to make the two DOM operations React relies on
+// tolerant of nodes a translator has moved.
+//
+// Accepted trade-off: the guard suppresses EVERY parent-mismatch on these
+// two methods, not just translator-caused ones, so a genuine DOM bug
+// (React's or any other consumer's) that would have thrown now no-ops.
+// The warnOnce below keeps such cases observable in the console.
+let installed = false;
+let warned = false;
+
+function warnOnce(operation: string) {
+  if (warned) return;
+  warned = true;
+  console.warn(
+    `Skipped DOM ${operation} on a node re-parented by machine translation (e.g. Chrome page translate). Suppressing to avoid crashing React; translated text may render stale until the next navigation.`,
+  );
+}
+
+export function installMachineTranslationDomGuard() {
+  if (installed || typeof Node === "undefined") return;
+  installed = true;
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function <T extends Node>(
+    this: Node,
+    child: T,
+  ): T {
+    if (child.parentNode !== this) {
+      warnOnce("removeChild");
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function <T extends Node>(
+    this: Node,
+    node: T,
+    reference: Node | null,
+  ): T {
+    if (reference && reference.parentNode !== this) {
+      warnOnce("insertBefore");
+      return node;
+    }
+    return originalInsertBefore.call(this, node, reference) as T;
+  };
+}
+
+// Install at module evaluation, not in an effect: effects run after the
+// hydration commit, which would leave a window where auto-translation of the
+// server-rendered HTML could still crash React. Chunk evaluation happens
+// before hydration starts, and the typeof Node guard makes this a no-op
+// during SSR.
+installMachineTranslationDomGuard();
+
+export function MachineTranslationDomGuard() {
+  return null;
+}

--- a/platform/frontend/src/app/layout.tsx
+++ b/platform/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import { PublicEnvScript } from "next-runtime-env";
 import { AppShell } from "./_parts/app-shell";
+import { MachineTranslationDomGuard } from "./_parts/machine-translation-dom-guard";
 import { MswInit } from "./_parts/msw-init";
 import { PostHogProviderWrapper } from "./_parts/posthog-provider";
 import { ArchestraQueryClientProvider } from "./_parts/query-client-provider";
@@ -200,6 +201,7 @@ export default function RootLayout({
         <link rel="icon" href="/favicon.ico" />
       </head>
       <body className="font-sans antialiased">
+        <MachineTranslationDomGuard />
         <VisualViewportHeight />
         <MswInit>
           <ArchestraQueryClientProvider>


### PR DESCRIPTION
## What

Chrome's page translate re-parents React-rendered text nodes into injected `<font>` wrappers. React still holds references to the original nodes, so any later commit that removes such a text node or inserts before it throws `NotFoundError` and crashes the whole app (facebook/react#11538) — e.g. any client-side navigation after translating the UI.

This applies the standard global mitigation, authored by Dan Abramov in https://github.com/facebook/react/issues/11538#issuecomment-417504600: patch `Node.prototype.removeChild`/`insertBefore` to tolerate nodes a translator has moved (one-time console warning). Well-formed calls take the original code path unchanged. Installed at module evaluation from a root-layout client component, so it's active before hydration.

## Notes

- Alternative to #6988, which fixes the same crash with targeted span-wrapping at each crash site instead of a global patch. This branch covers the whole class in one place (including future code); #6988 avoids touching DOM prototypes. Pick one.

## Testing

- Unit tests for the guard (jsdom): tolerant paths, preserved normal behavior, idempotent install.
- Manually verified earlier in this session: with the guard, translated navigation across every app screen produced no crashes and no console errors.
- `type-check`, `lint` clean.

https://claude.ai/code/session_013jXTnRb1u5zDikFM9SAj6U

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>