### PR TITLE
fix(frontend): key SearchableSelect trigger content for machine translation

### DIFF
--- a/platform/frontend/src/components/ui/searchable-select.tsx
+++ b/platform/frontend/src/components/ui/searchable-select.tsx
@@ -151,7 +151,16 @@ export function SearchableSelect({
             className,
           )}
         >
-          <span className="min-w-0 flex-1 truncate text-left">
+          {/* Keyed by the selection so changing it swaps this whole element
+              instead of reconciling its children in place. Selected content is
+              typically an icon beside a bare label, and reconciling that pair
+              inserts the new icon before the label's text node — which crashes
+              React once Chrome page-translate has re-parented that text into a
+              <font> wrapper (facebook/react#11538). */}
+          <span
+            key={selectedItem?.value ?? value ?? ""}
+            className="min-w-0 flex-1 truncate text-left"
+          >
             {selectedItem
               ? (selectedItem.selectedContent ??
                 selectedItem.content ??


### PR DESCRIPTION
## What

Follow-up to #6988 (merged), same bug class. `SearchableSelect`'s trigger renders the selected item as an icon beside a bare label text node. Changing the selection reconciles that span in place, so React inserts the new icon *before* the old label's text node — which throws `NotFoundError: Failed to execute 'insertBefore' on 'Node'` and crashes the app once Chrome page-translate has re-parented that text into a `<font>` wrapper (facebook/react#11538).

Reproduced on the Create Limit dialog (`/llm/limits` → Add Limit → change "Apply to" to User) with Chrome translation active. Fix: key the trigger's content span by the selected value, so a selection change swaps the whole element instead of reconciling bare text. Covers every `SearchableSelect` usage.

## Testing

- Reproduced the crash live with Chrome translation, then re-ran the same flow with the fix: scope changes to User cleanly, user picker appears, zero parent-mismatched DOM operations recorded by instrumentation.
- `type-check`, lint, and the component's unit tests pass.

https://claude.ai/code/session_013jXTnRb1u5zDikFM9SAj6U

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>