### PR TITLE
fix(chatops): make a reaction-mute stick in answer-all channels

### DIFF
--- a/platform/backend/src/agents/chatops/channel-activation.test.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.test.ts
@@ -182,6 +182,24 @@ describe("muteChannelThread (mute side-effects)", () => {
       await getThreadMuteMarker({ ...TEAMS, provider: "slack" }),
     ).toBeNull();
   });
+
+  test("persists the answer-all mute marker, so a mute survives in a channel with no activation to clear", async () => {
+    expect(await isChannelThreadMuted(TEAMS)).toBe(false);
+
+    // No prior activation — the case an answer-all channel is always in.
+    expect(await muteChannelThread(TEAMS)).toBe(false);
+
+    // Without this the thread would resume replying on the very next message.
+    expect(await isChannelThreadMuted(TEAMS)).toBe(true);
+  });
+
+  test("a re-mention lifts the mute", async () => {
+    await muteChannelThread(TEAMS);
+
+    await clearChannelThreadMuted(TEAMS);
+
+    expect(await isChannelThreadMuted(TEAMS)).toBe(false);
+  });
 });
 
 describe("claimThreadMuteHint", () => {

--- a/platform/backend/src/agents/chatops/channel-activation.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.ts
@@ -77,6 +77,13 @@ export async function clearChannelThreadActive(params: {
  *     requests immediately instead of letting them finish unseen.
  *  3. Drops the sticky auto-reply activation, so future un-mentioned messages
  *     stay quiet.
+ *  4. Records the answer-all mute marker, which is what keeps an answer-all
+ *     channel quiet — it has no mention-driven activation for step 3 to clear.
+ *     Set unconditionally: the marker is only read when a channel answers all
+ *     messages (see resolveChannelGateAction), so it is inert in a
+ *     mentions-only channel and already correct if the setting is later
+ *     enabled. Doing it here means every mute path — command, reaction, or
+ *     "Mute this thread" button — persists the mute by construction.
  *
  * Returns whether the thread was active (i.e. whether this actually muted it),
  * so callers post the "muted" confirmation ONLY on a true active→muted
@@ -89,6 +96,7 @@ export async function muteChannelThread(params: {
 }): Promise<boolean> {
   await recordThreadMute(params);
   chatOpsRunRegistry.cancelThread(params);
+  await markChannelThreadMuted(params);
   return await clearChannelThreadActive(params);
 }
 
@@ -136,6 +144,9 @@ export async function invalidateChannelAnswerAll(params: {
  * is that memory: the gate consults isChannelThreadMuted for un-mentioned
  * messages and stays quiet while it is set, and a fresh @mention clears it (see
  * clearChannelThreadMuted).
+ *
+ * @public — muteChannelThread is the only production caller; also exercised
+ * directly in channel-activation.test.ts (knip --production can't see tests).
  */
 export async function markChannelThreadMuted(params: {
   provider: ChatOpsProviderType;

--- a/platform/backend/src/agents/chatops/slack-provider.test.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.test.ts
@@ -1135,6 +1135,40 @@ describe("SlackProvider.parseWebhookNotification — mute reaction", () => {
     expect(result).toBeNull();
     expect(postMessage).not.toHaveBeenCalled();
   });
+
+  test("🔇 keeps an answer-all thread quiet on the following message", async () => {
+    const { provider } = createReactionProvider();
+    const binding = await ChatOpsChannelBindingModel.create({
+      organizationId: "org-react-answer-all",
+      provider: "slack",
+      channelId: CHANNEL,
+      workspaceId: "T12345",
+    });
+    await ChatOpsChannelBindingModel.update(binding.id, {
+      answerAllMessages: true,
+    });
+
+    await provider.parseWebhookNotification(reactionPayload("mute"), {});
+
+    // An answer-all channel has no activation for the mute to clear, so the
+    // reaction has to leave a marker behind or the next un-mentioned message
+    // gets answered as if nothing was asked.
+    const next = await provider.parseWebhookNotification(
+      makeEventPayload(
+        {},
+        {
+          type: "message",
+          channel: CHANNEL,
+          text: "still talking after the mute",
+          ts: "7777777777.000099",
+          thread_ts: ROOT,
+        },
+      ),
+      {},
+    );
+
+    expect(next).toBeNull();
+  });
 });
 
 // =============================================================================

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -53,7 +53,6 @@ import {
   isMuteReaction,
   isThreadMuteCommand,
   markChannelThreadActive,
-  markChannelThreadMuted,
   mightBeAddressedMuteCommand,
   muteChannelThread,
   resolveChannelGateAction,
@@ -379,21 +378,22 @@ class SlackProvider implements ChatOpsProvider {
         })
       ) {
         case "mute": {
+          // muteThreadAndNotify persists the mute marker, so the thread's prior
+          // state has to be read before it.
+          const alreadyMuted = answerAll
+            ? await isChannelThreadMuted(activation)
+            : false;
           const wasActive = await this.muteThreadAndNotify(
             event.channel,
             threadTs,
           );
           // An answer-all channel replies without a mention, so clearing the
-          // mention-driven activation isn't enough — remember the mute on the
-          // thread itself so it stays quiet until re-mentioned. Confirm it once
-          // (muteThreadAndNotify only confirms an active→muted transition, and a
-          // fresh answer-all thread isn't "active").
-          if (answerAll) {
-            const alreadyMuted = await isChannelThreadMuted(activation);
-            await markChannelThreadMuted(activation);
-            if (!wasActive && !alreadyMuted) {
-              await this.postThreadMutedNotice(event.channel, threadTs);
-            }
+          // mention-driven activation isn't enough — the mute is remembered on
+          // the thread itself so it stays quiet until re-mentioned. Confirm it
+          // once (muteThreadAndNotify only confirms an active→muted transition,
+          // and a fresh answer-all thread isn't "active").
+          if (answerAll && !wasActive && !alreadyMuted) {
+            await this.postThreadMutedNotice(event.channel, threadTs);
           }
           return null;
         }


### PR DESCRIPTION
## Summary

In a Slack channel set to **All messages**, reacting 🔇 to one of the bot's replies quieted the thread and then the bot answered the very next message anyway.

Muting worked by clearing the sticky activation a thread gets when someone @mentions the bot. A channel that answers every message never has one, so there was nothing to clear and nothing left behind to remember the mute by — the gate saw an ordinary un-mentioned message and replied. The mute command path avoided this by writing a mute marker itself; the reaction and "Mute this thread" button paths did not.

The marker is now written inside `muteChannelThread`, the single entry point every mute path already goes through, so all three persist the mute by construction rather than by each remembering to. It is only ever read for answer-all channels, so writing it unconditionally changes nothing for mentions-only channels and is already correct if that setting is turned on later.

One ordering consequence worth noting for review: the gate decides whether to post the "muted" confirmation by checking whether the thread was already muted. That read now has to happen before the mute, or the marker it just wrote makes every mute look like a repeat and swallows the one confirmation the user should see.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>