### PR TITLE
fix(frontend): close out the machine-translation crash class

### DIFF
--- a/.claude/skills/archestra-dev-frontend/SKILL.md
+++ b/.claude/skills/archestra-dev-frontend/SKILL.md
@@ -54,6 +54,28 @@ pnpm knip   # flags unused exports; part of frontend check:ci
 - Keep frontend files flat where practical and avoid barrel files.
 - Only export what is needed externally.
 
+## Text nodes and machine translation
+
+Chrome page-translate re-parents bare text nodes into `<font>` wrappers. React still holds the original nodes, so deleting one — or inserting an element before it — throws `NotFoundError` and crashes the page (facebook/react#11538, no upstream fix). Never let React add, remove, or replace a **bare** text node: wrap conditional text in an element so only elements move.
+
+`biome-plugins/no-conditional-bare-jsx-text.grit` fails the build on the shapes below, and its diagnostics cannot be suppressed with `biome-ignore` — write them wrapped in the first place:
+
+- `{cond ? <Icon /> : "More"}` → `{cond ? <Icon /> : <span>More</span>}`.
+- `{cond ? (<><Loader2 />Loading…</>) : ("Load more")}` → wrap both branches; the fragment's own bare text is deleted when the branch flips, so `<span>Loading…</span>` inside it and `<span>Load more</span>` for the string.
+- `{saved && "Saved!"}` → `{saved && <span>Saved!</span>}`.
+- `{n > 0 ? " and more" : ""}` → `{n > 0 ? <span> and more</span> : null}` — return `null`, never `""`, and keep the padding spaces inside the span.
+- `<Button>{pending ? <Loader2 /> : <Icon />} Save</Button>` → wrap the label: `<span>Save</span>`. Same for a label expression: `<span>{agent ? "Update" : "Create"}</span>`.
+
+The rule cannot see these; apply the convention by hand:
+
+- A `ReactNode` prop or variable rendered next to a conditional sibling (`{icon}{label}`) — wrap it: `{icon}<span>{label}</span>` (`app/messaging-channels/layout.tsx`).
+- Loading/empty/data branches whose roots are the **same tag** — React reconciles the element and deletes the bare status text in place. Wrap each branch's text (`<span>Loading tools…</span>`) or give the branches distinct `key`s.
+- A shared component rendering a `ReactNode` slot inside an element that persists across content changes — key the wrapper by the content, as `components/form-dialog.tsx` and `components/ui/searchable-select.tsx` do.
+
+Safe, do not churn: text→text updates (`{saving ? "Saving…" : "Save"}`), whole-element unmounts, and strings in attributes.
+
+Wrapping splits a string across sibling elements, so Testing Library's default `getByText` stops matching. Scope to a container with `toHaveTextContent`, or use a function matcher constrained by tag — do not unwrap the span to satisfy a test.
+
 ## Forms
 
 - Prefer `useForm` from `react-hook-form` over multiple `useState` hooks for form state.

--- a/platform/biome-plugins/no-conditional-bare-jsx-text.grit
+++ b/platform/biome-plugins/no-conditional-bare-jsx-text.grit
@@ -1,0 +1,119 @@
+// Project-specific Biome (GritQL) lint plugin — machine-translation crash guard.
+//
+// Chrome's page translate (and similar machine-translation features)
+// re-parents DOM text nodes into injected <font> wrappers. React keeps
+// references to the original text nodes, so a commit that deletes such a
+// text node, or inserts before it, throws
+// "NotFoundError: Failed to execute 'removeChild'/'insertBefore' on 'Node'"
+// and crashes the page (facebook/react#11538). React has no upstream fix;
+// the project convention is to never let React add/remove/replace a BARE
+// text node — conditional text must be wrapped in an element (usually a
+// <span>), so React only ever swaps elements, which translation never moves.
+// Whole-element removals and text-to-text in-place updates are safe.
+//
+// Three rules, matching the crash shapes found in the July 2026 audit:
+//   1. TERNARY — a JSX-child ternary with a (possibly parenthesized,
+//      non-empty) string branch whose other branch is definitely not the
+//      same text node: an element/fragment, null/undefined/boolean, or the
+//      EMPTY string (renders no node, so the flip creates/deletes one).
+//      e.g. {a ? <Icon/> : "More"}   {a ? "shown" : null}
+//           {a ? <><Loader2/>Loading…</> : ("Load more")}
+//           {n > 0 ? " and N more" : ""}
+//   2. LOGICAL — {cond && "text"}: the text node appears/disappears.
+//   3. SIBLING — a conditional-ELEMENT expression immediately followed by
+//      literal label text in the same parent: flipping the condition makes
+//      React insertBefore the new element in front of the translated text.
+//      e.g. <Button>{pending ? <Loader2/> : <Icon/>} Save</Button>
+//
+// Deliberately NOT flagged (plugin diagnostics cannot be suppressed with
+// biome-ignore, so false positives would hard-block CI): ternaries whose
+// branches are both non-empty text at runtime (string vs string/template/
+// expression — React updates the text node in place), and string branches
+// against unknowable variables (if the variable can be a ReactNode, apply
+// the span convention manually).
+//
+// Fix: wrap the bare text in an element, e.g.
+//   {active ? <Icon/> : <span>More</span>}    {saved && <span>Saved!</span>}
+//   <Button>{pending ? <Loader2/> : <Icon/>}<span>Save</span></Button>
+// If both branches render elements of the same type, key them differently so
+// React swaps the elements instead of reconciling their text children.
+language js
+
+pattern text_branch() {
+  or {
+    and { string(), not `""` },
+    `($ps)` where { $ps <: string(), $ps <: not `""` }
+  }
+}
+
+pattern nontext_branch() {
+  or {
+    contains jsx_element(),
+    contains jsx_self_closing_element(),
+    contains `<>$pfc</>`,
+    `null`,
+    `undefined`,
+    `false`,
+    `true`
+  }
+}
+
+pattern empty_text_branch() {
+  or { `""`, `("")` }
+}
+
+pattern element_conditional() {
+  or {
+    `$pc ? $pa : $pb` where {
+      or {
+        $pa <: or { contains jsx_element(), contains jsx_self_closing_element() },
+        $pb <: or { contains jsx_element(), contains jsx_self_closing_element() }
+      }
+    },
+    `$pc && $pel` where {
+      $pel <: or { contains jsx_element(), contains jsx_self_closing_element() }
+    }
+  }
+}
+
+or {
+  `$cond ? $then : $else` as $ternary where {
+    $ternary <: within jsx_expression(),
+    $ternary <: not within jsx_attribute(),
+    or {
+      and { $then <: text_branch(), $else <: or { nontext_branch(), empty_text_branch() } },
+      and { $else <: text_branch(), $then <: or { nontext_branch(), empty_text_branch() } }
+    },
+    register_diagnostic(
+      span = $ternary,
+      message = "Conditional bare text in JSX crashes React when the page is machine-translated (Chrome translate re-parents text nodes, facebook/react#11538): wrap the string branch in an element, e.g. <span>text</span>."
+    )
+  },
+  `$cond && $text` as $logical where {
+    $logical <: within jsx_expression(),
+    $logical <: not within jsx_attribute(),
+    $text <: text_branch(),
+    register_diagnostic(
+      span = $logical,
+      message = "Conditional bare text in JSX crashes React when the page is machine-translated (Chrome translate re-parents text nodes, facebook/react#11538): wrap the string in an element, e.g. {cond && <span>text</span>}."
+    )
+  },
+  `<$tag $attrs>$children</$tag>` where {
+    $children <: [..., jsx_expression() as $expr, jsx_text() as $label, ...],
+    $expr <: contains element_conditional(),
+    $label <: not r"^\s*$",
+    register_diagnostic(
+      span = $label,
+      message = "Bare label text after a conditional element crashes React when the page is machine-translated (Chrome translate re-parents text nodes, facebook/react#11538): flipping the condition inserts the new element before this translated text node — wrap the text in a <span>."
+    )
+  },
+  `<>$fchildren</>` where {
+    $fchildren <: [..., jsx_expression() as $fexpr, jsx_text() as $flabel, ...],
+    $fexpr <: contains element_conditional(),
+    $flabel <: not r"^\s*$",
+    register_diagnostic(
+      span = $flabel,
+      message = "Bare label text after a conditional element crashes React when the page is machine-translated (Chrome translate re-parents text nodes, facebook/react#11538): flipping the condition inserts the new element before this translated text node — wrap the text in a <span>."
+    )
+  }
+}

--- a/platform/biome.json
+++ b/platform/biome.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
-  "plugins": ["./biome-plugins/icon-button-aria-label.grit"],
+  "plugins": [
+    "./biome-plugins/icon-button-aria-label.grit",
+    "./biome-plugins/no-conditional-bare-jsx-text.grit"
+  ],
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
+++ b/platform/frontend/src/app/_parts/chat-sidebar-section.tsx
@@ -416,11 +416,14 @@ export function ChatSidebarSection({
                   <AISparkleIcon isAnimating />
                 )}
                 {isRegenerating ? (
-                  <span className="text-muted-foreground text-sm truncate">
+                  <span
+                    key="regenerating"
+                    className="text-muted-foreground text-sm truncate"
+                  >
                     Generating...
                   </span>
                 ) : hasRecentlyGeneratedTitle ? (
-                  <span className="truncate">
+                  <span key="typing" className="truncate">
                     <TypingText
                       text={
                         displayTitle.length > MAX_TITLE_LENGTH

--- a/platform/frontend/src/app/a/catalog/[catalogId]/page.client.tsx
+++ b/platform/frontend/src/app/a/catalog/[catalogId]/page.client.tsx
@@ -208,7 +208,7 @@ function NeedsInputHandoff({
         ) : (
           <MessageSquare className="h-4 w-4" />
         )}
-        Open in chat
+        <span>Open in chat</span>
       </Button>
     </div>
   );

--- a/platform/frontend/src/app/account/_components/change-password-dialog.tsx
+++ b/platform/frontend/src/app/account/_components/change-password-dialog.tsx
@@ -90,7 +90,7 @@ export function ChangePasswordDialog({
               {changePassword.isPending && (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               )}
-              Submit
+              <span>Submit</span>
             </Button>
           </>
         }

--- a/platform/frontend/src/app/account/_components/two-factor-card.tsx
+++ b/platform/frontend/src/app/account/_components/two-factor-card.tsx
@@ -165,7 +165,7 @@ function TwoFactorPasswordDialog({
             </Button>
             <Button type="submit" disabled={isPending}>
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Continue
+              <span>Continue</span>
             </Button>
           </>
         }

--- a/platform/frontend/src/app/agents/convert-to-skill-dialog.tsx
+++ b/platform/frontend/src/app/agents/convert-to-skill-dialog.tsx
@@ -153,7 +153,7 @@ export function ConvertToSkillDialog({
                     ) : (
                       <Sparkles className="h-3.5 w-3.5" />
                     )}
-                    Generate
+                    <span>Generate</span>
                   </Button>
                 </div>
                 <Textarea

--- a/platform/frontend/src/app/apps/_parts/app-card.tsx
+++ b/platform/frontend/src/app/apps/_parts/app-card.tsx
@@ -114,7 +114,7 @@ function PinMenuItem({
       onSelect={() => pinAppMutation.mutate({ pinned: !pinned, target })}
     >
       {pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
-      {pinned ? "Unpin" : "Pin"}
+      <span>{pinned ? "Unpin" : "Pin"}</span>
     </DropdownMenuItem>
   );
 }

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-detail-dialog.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-detail-dialog.tsx
@@ -201,7 +201,7 @@ function ResourceBlock({ event }: { event: AuditLog }) {
                 {formatResourceType(event.resourceType)}
               </span>
             )}
-            {event.resourceType && name ? ": " : ""}
+            {event.resourceType && name ? <span>: </span> : null}
             {name && <span>{name}</span>}
           </span>
         </Badge>

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-diff-view.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-diff-view.tsx
@@ -60,7 +60,7 @@ export function AuditLogDiffView({
   if (bothNull) {
     return (
       <div className="rounded-md border border-dashed bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
-        {emptyMessage}
+        <span>{emptyMessage}</span>
       </div>
     );
   }
@@ -68,7 +68,7 @@ export function AuditLogDiffView({
   if (lines.length === 0 || lines.every((l) => l.kind === "context")) {
     return (
       <div className="rounded-md border border-dashed bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
-        No field-level differences between the snapshots.
+        <span>No field-level differences between the snapshots.</span>
       </div>
     );
   }

--- a/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
+++ b/platform/frontend/src/app/audit/logs/_components/audit-log-table.tsx
@@ -497,7 +497,7 @@ export function AuditLogTable() {
                     {formatResourceType(rt)}
                   </span>
                 )}
-                {rt && name ? ": " : ""}
+                {rt && name ? <span>: </span> : null}
                 {name && <span title={name}>{displayName}</span>}
               </span>
             </Badge>

--- a/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
+++ b/platform/frontend/src/app/auth/_components/auth-view-with-error-handling.tsx
@@ -552,7 +552,7 @@ function SignInView({ callbackURL }: { callbackURL?: string }) {
                 Learn how to reset admin password.
               </ExternalDocsLink>
             ) : (
-              "Ask your administrator to reset it."
+              <span>Ask your administrator to reset it.</span>
             )}
           </AlertDescription>
         </Alert>
@@ -615,7 +615,7 @@ function SignInView({ callbackURL }: { callbackURL?: string }) {
                 {signIn.isPending && (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 )}
-                Sign In
+                <span>Sign In</span>
               </Button>
             </form>
           </Form>

--- a/platform/frontend/src/app/auth/_components/recover-account-view.tsx
+++ b/platform/frontend/src/app/auth/_components/recover-account-view.tsx
@@ -93,7 +93,7 @@ export function RecoverAccountView() {
               {verifyBackupCode.isPending && (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               )}
-              Recover Account
+              <span>Recover Account</span>
             </Button>
           </form>
         </Form>

--- a/platform/frontend/src/app/auth/_components/two-factor-view.tsx
+++ b/platform/frontend/src/app/auth/_components/two-factor-view.tsx
@@ -141,7 +141,7 @@ export function TwoFactorView() {
               {verifyTotp.isPending && (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               )}
-              Verify
+              <span>Verify</span>
             </Button>
             {!isSetup && (
               <div className="text-center text-sm">

--- a/platform/frontend/src/app/chat/prompt-input-tools.tsx
+++ b/platform/frontend/src/app/chat/prompt-input-tools.tsx
@@ -451,7 +451,7 @@ const ChatPromptInputTools = memo(function ChatPromptInputTools({
                 </a>
               </span>
             ) : (
-              "File uploads are disabled by your administrator"
+              <span>File uploads are disabled by your administrator</span>
             )}
           </TooltipContent>
         </Tooltip>

--- a/platform/frontend/src/app/chat/prompt-input.tsx
+++ b/platform/frontend/src/app/chat/prompt-input.tsx
@@ -980,7 +980,9 @@ const PromptInputContent = ({
               </TooltipTrigger>
               <TooltipContent side="top">
                 {subscriptionConnectRequired ? (
-                  "Connect the subscription or choose another credential"
+                  <span>
+                    Connect the subscription or choose another credential
+                  </span>
                 ) : isResponseInFlight && onStop ? (
                   <span className="flex items-center gap-1.5">
                     Stop <Kbd>Esc</Kbd>

--- a/platform/frontend/src/app/connection/connect-command-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.test.tsx
@@ -171,7 +171,12 @@ describe("ConnectCommandPanel", () => {
     // the summary reflects the defaults without any clicks
     expect(screen.getByText(/My Gateway/)).toBeInTheDocument();
     expect(screen.getByText(/My Proxy/)).toBeInTheDocument();
-    expect(screen.getByText(/2 shared skills/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_, el) =>
+          el?.tagName === "SPAN" && el.textContent === "2 shared skills",
+      ),
+    ).toBeInTheDocument();
     // single endpoint: not worth naming
     expect(
       screen.queryByText("http://localhost:9000/v1"),
@@ -317,7 +322,12 @@ describe("ConnectCommandPanel", () => {
         /skill-0, skill-1, skill-2, skill-3, skill-4, skill-5 and 2 more/,
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText(/8 shared skills/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_, el) =>
+          el?.tagName === "SPAN" && el.textContent === "8 shared skills",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("lists the MCP servers behind the selected gateway", async () => {

--- a/platform/frontend/src/app/connection/connect-command-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-command-panel.tsx
@@ -559,16 +559,27 @@ export function ConnectCommandPanel({
           <p className="text-xs text-muted-foreground">
             {effectiveProxyAuth === "provider-key" ? (
               passthroughAttributes ? (
-                "Passthrough — the command only rewires the base URL, so you reuse your own API key or existing subscription (e.g. Claude or ChatGPT plan). Your personal auth key is created for you and wired into the command via ANTHROPIC_CUSTOM_HEADERS."
+                <span>
+                  Passthrough — the command only rewires the base URL, so you
+                  reuse your own API key or existing subscription (e.g. Claude
+                  or ChatGPT plan). Your personal auth key is created for you
+                  and wired into the command via ANTHROPIC_CUSTOM_HEADERS.
+                </span>
               ) : (
-                "Passthrough — the command only rewires the base URL, so you reuse your own API key or existing subscription (e.g. Claude or ChatGPT plan)."
+                <span>
+                  Passthrough — the command only rewires the base URL, so you
+                  reuse your own API key or existing subscription (e.g. Claude
+                  or ChatGPT plan).
+                </span>
               )
             ) : providerIsPerUser && provider ? (
-              `${providerDisplayNames[provider]} runs through a personal virtual key — connect your own account below.`
+              <span>
+                {`${providerDisplayNames[provider]} runs through a personal virtual key — connect your own account below.`}
+              </span>
             ) : providers.length === 0 ? (
               canCreateProviderKey ? (
                 <>
-                  {noVirtualKeyReason}{" "}
+                  <span>{noVirtualKeyReason} </span>
                   <button
                     type="button"
                     className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
@@ -576,14 +587,18 @@ export function ConnectCommandPanel({
                     data-testid="connect-auth-add-provider-key"
                   >
                     Add {addKeyPhrase}
-                  </button>{" "}
-                  or switch to your provider key.
+                  </button>
+                  <span> or switch to your provider key.</span>
                 </>
               ) : (
-                `${noVirtualKeyReason} Switch to your provider key, or ask an admin to add ${addKeyPhrase}.`
+                <span>
+                  {`${noVirtualKeyReason} Switch to your provider key, or ask an admin to add ${addKeyPhrase}.`}
+                </span>
               )
             ) : (
-              "A virtual key is created for you and wired into the command."
+              <span>
+                A virtual key is created for you and wired into the command.
+              </span>
             )}
           </p>
         </div>
@@ -785,15 +800,20 @@ export function ConnectCommandPanel({
             >
               {includeSkills ? (
                 <>
-                  Install{" "}
+                  <span>Install </span>
                   <ResourceLink href="/skills">
-                    {selectedSkills.length === allSkills.length
-                      ? `${allSkills.length} shared skill${allSkills.length === 1 ? "" : "s"}`
-                      : `${selectedSkills.length} of ${allSkills.length} shared skills`}
+                    {selectedSkills.length === allSkills.length ? (
+                      <span>
+                        <span>{allSkills.length} shared skill</span>
+                        {allSkills.length === 1 ? null : <span>s</span>}
+                      </span>
+                    ) : (
+                      <span>{`${selectedSkills.length} of ${allSkills.length} shared skills`}</span>
+                    )}
                   </ResourceLink>
                 </>
               ) : (
-                "Shared skills not installed"
+                <span>Shared skills not installed</span>
               )}
             </SummaryRow>
           )}
@@ -1077,10 +1097,12 @@ function ProviderKeyGate({
   return (
     <div className="flex flex-col gap-3 px-5 py-4">
       <p className="text-[13px] text-[#e5e7eb]">
-        {reason}{" "}
-        {canAddKey
-          ? `Add ${addKeyPhrase} to mint one from, or switch to your provider key in the review above.`
-          : `Ask an admin to add ${addKeyPhrase}, or switch to your provider key in the review above.`}
+        <span>{reason} </span>
+        {canAddKey ? (
+          <span>{`Add ${addKeyPhrase} to mint one from, or switch to your provider key in the review above.`}</span>
+        ) : (
+          <span>{`Ask an admin to add ${addKeyPhrase}, or switch to your provider key in the review above.`}</span>
+        )}
       </p>
       {canAddKey && (
         <div>
@@ -1096,7 +1118,7 @@ function ProviderKeyGate({
             ) : (
               <KeyRound className="size-4" />
             )}
-            Add {addKeyPhrase}
+            <span>Add {addKeyPhrase}</span>
           </Button>
         </div>
       )}

--- a/platform/frontend/src/app/connection/connect-config-panel.test.tsx
+++ b/platform/frontend/src/app/connection/connect-config-panel.test.tsx
@@ -172,7 +172,11 @@ describe("ConnectConfigPanel — shared skills marketplace", () => {
     renderPanel();
 
     expect(screen.getByText(/Install/)).toBeInTheDocument();
-    expect(screen.getByText(/2 shared skills/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_, el) => el?.tagName === "A" && el.textContent === "2 shared skills",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Blog editor, Release notes/)).toBeInTheDocument();
   });
 

--- a/platform/frontend/src/app/connection/connect-config-panel.tsx
+++ b/platform/frontend/src/app/connection/connect-config-panel.tsx
@@ -234,15 +234,16 @@ export function ConnectConfigPanel({
               }
             >
               {includeSkills ? (
-                <>
+                <span key="skills">
                   Install{" "}
                   <ResourceLink href="/skills">
-                    {skills.length} shared skill{skills.length === 1 ? "" : "s"}
+                    {skills.length} shared skill
+                    {skills.length === 1 ? null : <span>s</span>}
                   </ResourceLink>{" "}
                   as a marketplace
-                </>
+                </span>
               ) : (
-                "Shared skills not installed"
+                <span key="none">Shared skills not installed</span>
               )}
             </SummaryRow>
           )}
@@ -661,7 +662,7 @@ function ConfigDownloadStep({
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 className="size-3.5 animate-spin" />
-        Provisioning your keys…
+        <span>Provisioning your keys…</span>
       </div>
     );
   }
@@ -821,7 +822,7 @@ function SkillNamesLine({ skills }: { skills: ConnectSkill[] }) {
   return (
     <p className="text-xs text-muted-foreground/80">
       {shown.map((s) => s.name).join(", ")}
-      {more > 0 ? ` and ${more} more` : ""}
+      {more > 0 ? <span> and {more} more</span> : null}
     </p>
   );
 }

--- a/platform/frontend/src/app/connection/gateway-servers-summary.test.tsx
+++ b/platform/frontend/src/app/connection/gateway-servers-summary.test.tsx
@@ -85,8 +85,8 @@ describe("GatewayServersSummary", () => {
     render(<GatewayServersSummary gatewayId="g1" />);
 
     // header count: 2 servers, 3 tools total
-    expect(screen.getByText(/2 MCP servers/)).toBeInTheDocument();
-    expect(screen.getByText(/3 tools/)).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveTextContent(/2 MCP servers/);
+    expect(screen.getByRole("button")).toHaveTextContent(/3 tools/);
 
     await expandList();
 
@@ -137,14 +137,16 @@ describe("GatewayServersSummary", () => {
 
     render(<GatewayServersSummary gatewayId="g1" />);
 
-    expect(screen.getByText(/All 2 MCP servers/)).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveTextContent(/All 2 MCP servers/);
     expect(
       screen.getByText(/new servers included automatically/),
     ).toBeInTheDocument();
 
     await expandList();
     // catalog tool counts are used (91), and rows link to detail pages
-    expect(screen.getByText(/91 tools/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /GitHub/ })).toHaveTextContent(
+      /91 tools/,
+    );
     expect(screen.getByRole("link", { name: /GitHub/ })).toHaveAttribute(
       "href",
       "/mcp/registry/c-github",

--- a/platform/frontend/src/app/connection/gateway-servers-summary.tsx
+++ b/platform/frontend/src/app/connection/gateway-servers-summary.tsx
@@ -137,10 +137,12 @@ export function GatewayServersSummary({
               !expanded && "-rotate-90",
             )}
           />
-          {accessAll ? "All " : ""}
-          {servers.length} MCP server{servers.length === 1 ? "" : "s"}
-          {" · "}
-          {totalTools} tool{totalTools === 1 ? "" : "s"}
+          {accessAll ? <span>All </span> : null}
+          <span>{servers.length} MCP server</span>
+          {servers.length === 1 ? null : <span>s</span>}
+          <span> · </span>
+          <span>{totalTools} tool</span>
+          {totalTools === 1 ? null : <span>s</span>}
         </button>
         {accessAll && (
           <span className="text-muted-foreground/70">
@@ -184,7 +186,8 @@ function ServerRowItem({ server }: { server: ServerRow }) {
         {server.name}
       </span>
       <span className="shrink-0 text-muted-foreground">
-        {server.toolCount} tool{server.toolCount === 1 ? "" : "s"}
+        <span>{server.toolCount} tool</span>
+        {server.toolCount === 1 ? null : <span>s</span>}
       </span>
       {server.description && (
         <span className="min-w-0 truncate text-muted-foreground/70">

--- a/platform/frontend/src/app/connection/proxy-client-instructions.tsx
+++ b/platform/frontend/src/app/connection/proxy-client-instructions.tsx
@@ -441,7 +441,7 @@ function GenericProxyInstructions({
           <p className="text-xs text-muted-foreground">
             {authMethod === "provider-key" ? (
               canCreateVirtualKey && !providerHasKey ? (
-                <>
+                <span key="needs-provider-key">
                   Passthrough — you keep using your own {providerLabel} key. A
                   virtual key needs a configured {providerLabel} provider key
                   first
@@ -459,14 +459,20 @@ function GenericProxyInstructions({
                       ).
                     </>
                   ) : (
-                    " (ask an admin to add one)."
+                    <span> (ask an admin to add one).</span>
                   )}
-                </>
+                </span>
               ) : (
-                "Passthrough — you keep using your own provider API key; only the base URL changes."
+                <span key="passthrough">
+                  Passthrough — you keep using your own provider API key; only
+                  the base URL changes.
+                </span>
               )
             ) : (
-              "A personal virtual key mapped to your provider key is created automatically and shown below."
+              <span key="virtual">
+                A personal virtual key mapped to your provider key is created
+                automatically and shown below.
+              </span>
             )}
           </p>
           {authMethod === "virtual-key" &&
@@ -487,7 +493,7 @@ function GenericProxyInstructions({
             ) : (
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <Loader2 className="size-3.5 animate-spin" />
-                Creating your virtual key…
+                <span>Creating your virtual key…</span>
               </div>
             ))}
         </div>
@@ -647,9 +653,9 @@ function ModelRouterInstructions() {
               )}
               <p className="text-xs text-muted-foreground">
                 A personal virtual key mapped to your
-                {mappedProvider
-                  ? ` ${providerDisplayNames[mappedProvider]}`
-                  : ""}{" "}
+                {mappedProvider ? (
+                  <span> {providerDisplayNames[mappedProvider]}</span>
+                ) : null}{" "}
                 provider key is created automatically and shown below. Models
                 from other providers need a key mapped to that provider.
               </p>
@@ -670,7 +676,7 @@ function ModelRouterInstructions() {
               ) : (
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <Loader2 className="size-3.5 animate-spin" />
-                  Creating your virtual key…
+                  <span>Creating your virtual key…</span>
                 </div>
               )}
             </div>
@@ -1034,7 +1040,7 @@ function PassthroughKeyField({
     return (
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <Loader2 className="size-3.5 animate-spin" />
-        Creating your passthrough key…
+        <span>Creating your passthrough key…</span>
       </div>
     );
   }

--- a/platform/frontend/src/app/connection/skills-marketplace-step.test.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.test.tsx
@@ -140,7 +140,13 @@ describe("SkillsMarketplaceStep", () => {
     await waitFor(() =>
       expect(screen.getByTestId("skills-marketplace-create")).toBeVisible(),
     );
-    expect(screen.getByText(/Snapshot 2 skills/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_, el) =>
+          el?.tagName === "P" &&
+          /Snapshot 2 skills/i.test(el.textContent ?? ""),
+      ),
+    ).toBeInTheDocument();
   });
 
   it("creates a link with the full org skill set and shows snippets", async () => {

--- a/platform/frontend/src/app/connection/skills-marketplace-step.tsx
+++ b/platform/frontend/src/app/connection/skills-marketplace-step.tsx
@@ -86,7 +86,7 @@ function SkillsMarketplaceBody({ client }: { client: ConnectClient }) {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin" />
-        Loading…
+        <span>Loading…</span>
       </div>
     );
   }
@@ -158,9 +158,9 @@ function CreateLinkPanel({
   return (
     <div className="flex flex-col gap-4">
       <p className="text-sm text-muted-foreground">
-        Snapshot {totalSkills} skill{totalSkills === 1 ? "" : "s"} into a single
-        marketplace URL. New skills added later won't appear until you refresh
-        the link.
+        Snapshot {totalSkills} skill
+        {totalSkills === 1 ? null : <span>s</span>} into a single marketplace
+        URL. New skills added later won't appear until you refresh the link.
       </p>
       <div className="flex flex-wrap items-center gap-3">
         <label className="text-sm font-medium" htmlFor="skill-marketplace-ttl">

--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.test.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.test.tsx
@@ -769,7 +769,11 @@ describe("ConnectorDetailPage", () => {
 
       expect(screen.getByText("Permissions Coverage")).toBeInTheDocument();
       expect(
-        screen.getByText(/40 documents awaiting permission sync/),
+        screen.getAllByText(
+          (_, el) =>
+            el?.tagName === "DIV" &&
+            el.textContent === "40 documents awaiting permission sync",
+        )[0],
       ).toBeInTheDocument();
       // The permissions row mirrors the content row's Last/cadence items.
       expect(screen.getByText("Last Permissions Sync")).toBeInTheDocument();

--- a/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
+++ b/platform/frontend/src/app/knowledge/connectors/[id]/page.client.tsx
@@ -620,9 +620,13 @@ function ConnectorDetail({ connectorId }: { connectorId: string }) {
                       className="text-amber-600"
                       title="Access-restricted until a permission sync tags them with their source permissions"
                     >
-                      {coverage.failClosedDocuments.toLocaleString()} document
-                      {coverage.failClosedDocuments === 1 ? "" : "s"} awaiting
-                      permission sync
+                      <span>
+                        {coverage.failClosedDocuments.toLocaleString()} document
+                      </span>
+                      {coverage.failClosedDocuments === 1 ? null : (
+                        <span>s</span>
+                      )}
+                      <span> awaiting permission sync</span>
                     </div>
                   </MetadataItem>
                 )}

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-status-badge.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/connector-status-badge.tsx
@@ -72,7 +72,7 @@ export function ConnectorStatusBadge({
       {config.animated && (
         <span className="mr-1.5 h-2 w-2 rounded-full bg-current animate-pulse" />
       )}
-      {config.label}
+      <span>{config.label}</span>
     </Badge>
   );
 }

--- a/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
+++ b/platform/frontend/src/app/knowledge/knowledge-bases/_parts/create-connector-dialog.tsx
@@ -249,7 +249,7 @@ export function CreateConnectorDialog({
                     <ArrowLeft className="h-4 w-4" />
                   </Button>
                 )}
-                Add Connector
+                <span>Add Connector</span>
               </DialogTitle>
               <DialogDescription>
                 Select a Connector type to get started.
@@ -313,12 +313,16 @@ export function CreateConnectorDialog({
                     <ArrowLeft className="h-4 w-4" />
                   </Button>
                   Configure{" "}
-                  {selectedType ? getConnectorTypeLabel(selectedType) : ""}{" "}
+                  {selectedType ? (
+                    <span>{getConnectorTypeLabel(selectedType)}</span>
+                  ) : null}{" "}
                   Connector
                 </DialogTitle>
                 <DialogDescription>
                   Enter the connection details for your{" "}
-                  {selectedType ? getConnectorTypeLabel(selectedType) : ""}{" "}
+                  {selectedType ? (
+                    <span>{getConnectorTypeLabel(selectedType)}</span>
+                  ) : null}{" "}
                   instance.{" "}
                   <ExternalDocsLink
                     href={connectorDocsUrl}

--- a/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
+++ b/platform/frontend/src/app/llm/logs/session/[sessionId]/page.client.tsx
@@ -198,7 +198,7 @@ export default function SessionDetailPage({
           ) : (
             <Download className="h-4 w-4 mr-2" />
           )}
-          Export JSON
+          <span>Export JSON</span>
         </Button>
       </div>
 
@@ -255,7 +255,7 @@ export default function SessionDetailPage({
                 />
               </TooltipProvider>
             ) : (
-              "-"
+              <span>-</span>
             )}
           </div>
         </MetadataItem>

--- a/platform/frontend/src/app/llm/model-providers/page.tsx
+++ b/platform/frontend/src/app/llm/model-providers/page.tsx
@@ -776,7 +776,7 @@ export default function ApiKeysPage() {
                 {updateMutation.isPending && (
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                 )}
-                Test & Save
+                <span>Test & Save</span>
               </Button>
             </DialogStickyFooter>
           </DialogForm>
@@ -878,8 +878,13 @@ function DeleteApiKeyDescription({
           </ul>
           {totalVirtualKeys > virtualKeys.length && (
             <p className="text-muted-foreground">
-              {totalVirtualKeys - virtualKeys.length} more virtual API key
-              {totalVirtualKeys - virtualKeys.length === 1 ? "" : "s"} matched.
+              <span>
+                {totalVirtualKeys - virtualKeys.length} more virtual API key
+              </span>
+              {totalVirtualKeys - virtualKeys.length === 1 ? null : (
+                <span>s</span>
+              )}
+              <span> matched.</span>
             </p>
           )}
         </div>
@@ -911,8 +916,9 @@ function DeleteApiKeyDescription({
           </ul>
           {oauthClients.length > 5 && (
             <p className="text-muted-foreground">
-              {oauthClients.length - 5} more OAuth client
-              {oauthClients.length - 5 === 1 ? "" : "s"} matched.
+              <span>{oauthClients.length - 5} more OAuth client</span>
+              {oauthClients.length - 5 === 1 ? null : <span>s</span>}
+              <span> matched.</span>
             </p>
           )}
         </div>

--- a/platform/frontend/src/app/mcp/registry/[id]/page.client.tsx
+++ b/platform/frontend/src/app/mcp/registry/[id]/page.client.tsx
@@ -614,7 +614,7 @@ function CatalogItemDetails({ item }: { item: CatalogItem }) {
                     ) : connectionsCount > 0 ? (
                       <DeploymentStatusDot state="running" />
                     ) : null}
-                    {statusText}
+                    <span>{statusText}</span>
                   </span>
                 </OverviewField>
                 {variant !== "builtin" && (

--- a/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/archestra-catalog-tab.tsx
@@ -282,10 +282,10 @@ export function ArchestraCatalogTab({
                     {isFetchingNextPage ? (
                       <>
                         <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        Loading more...
+                        <span>Loading more...</span>
                       </>
                     ) : (
-                      "Load more"
+                      <span>Load more</span>
                     )}
                   </Button>
                 </div>

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
@@ -550,7 +550,7 @@ export function ToolsAndGuardrailsStep({ item }: { item: CatalogItem }) {
       ) : (
         <RefreshCw className="h-4 w-4" />
       )}
-      Refresh Tools
+      <span>Refresh Tools</span>
     </PermissionButton>
   );
 

--- a/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/custom-server-request-dialog.tsx
@@ -328,7 +328,7 @@ export function CustomServerRequestDialog({
                 {createRequest.isPending && (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 )}
-                Submit Request
+                <span>Submit Request</span>
               </Button>
             </DialogStickyFooter>
           </DialogForm>

--- a/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/manage-users-dialog.tsx
@@ -919,7 +919,9 @@ function AgentConnectionsSection({
               <>
                 Agents connect as{" "}
                 <span className="font-medium text-foreground">
-                  {pinnedConnection ? connectionLabel(pinnedConnection) : ""}
+                  {pinnedConnection ? (
+                    <span>{connectionLabel(pinnedConnection)}</span>
+                  ) : null}
                 </span>
                 , no matter who is calling. Applies in Auto mode and to Custom
                 tool assignments that resolve at call time.

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-catalog-form.tsx
@@ -1209,8 +1209,8 @@ export function McpCatalogForm({
                   <div className="space-y-1 text-foreground/90">
                     <div className="font-semibold text-foreground">
                       {envRuleViolations.length} value
-                      {envRuleViolations.length === 1 ? "" : "s"} not allowed in
-                      “{boundEnvironmentName}”
+                      {envRuleViolations.length === 1 ? null : <span>s</span>}{" "}
+                      not allowed in “{boundEnvironmentName}”
                     </div>
                     <div>
                       Edit or remove{" "}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-exec-terminal.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-exec-terminal.tsx
@@ -283,7 +283,7 @@ export function McpExecTerminal({ serverId, isActive }: McpExecTerminalProps) {
               className="absolute top-1/2 -translate-y-1/2 right-1 text-slate-400 hover:text-slate-200 hover:bg-slate-800"
             >
               <Copy className="h-3 w-3" />
-              {commandCopied ? " Copied!" : ""}
+              {commandCopied ? <span> Copied!</span> : null}
             </Button>
           </div>
         </div>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-inspector.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-inspector.tsx
@@ -308,7 +308,7 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
           ) : (
             <RefreshCw className="h-3 w-3" />
           )}
-          Refresh Tools
+          <span>Refresh Tools</span>
         </Button>
       </div>
 
@@ -474,7 +474,7 @@ export function McpInspector({ serverId, isActive }: McpInspectorProps) {
                   ) : (
                     <Play className="h-3.5 w-3.5 fill-current" />
                   )}
-                  Call Tool
+                  <span>Call Tool</span>
                 </Button>
 
                 {/* Latest response for this tool */}

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-logs-dialog.tsx
@@ -622,7 +622,7 @@ export function McpLogsContent({
                         <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
                         <span className="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
                       </span>
-                      Streaming
+                      <span>Streaming</span>
                     </div>
                   ) : (
                     <div />
@@ -657,7 +657,7 @@ export function McpLogsContent({
                     className="absolute top-1/2 -translate-y-1/2 right-1 text-slate-400 hover:text-slate-200 hover:bg-slate-800"
                   >
                     <Copy className="h-3 w-3" />
-                    {commandCopied ? " Copied!" : ""}
+                    {commandCopied ? <span> Copied!</span> : null}
                   </Button>
                 </div>
               </div>

--- a/platform/frontend/src/app/mcp/registry/_parts/mcp-tools-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/mcp-tools-dialog.tsx
@@ -199,11 +199,11 @@ export function McpToolsDialog({
 
       {isLoading ? (
         <div className="py-8 text-center text-muted-foreground">
-          Loading tools...
+          <span>Loading tools...</span>
         </div>
       ) : tools.length === 0 ? (
         <div className="py-8 text-center text-muted-foreground">
-          No tools found for this server
+          <span>No tools found for this server</span>
         </div>
       ) : filteredTools.length === 0 ? (
         <div className="flex flex-col items-center justify-center space-y-4 py-8">

--- a/platform/frontend/src/app/mcp/registry/_parts/request-installation-dialog.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/request-installation-dialog.tsx
@@ -50,7 +50,7 @@ export function RequestInstallationDialog({
             {createRequest.isPending && (
               <Loader2 className="h-4 w-4 animate-spin" />
             )}
-            Submit Request
+            <span>Submit Request</span>
           </Button>
         </>
       }

--- a/platform/frontend/src/app/mcp/registry/installation-requests/[id]/page.tsx
+++ b/platform/frontend/src/app/mcp/registry/installation-requests/[id]/page.tsx
@@ -410,7 +410,7 @@ export default function InstallationRequestDetailPage({
                           {approveMutation.isPending && (
                             <Loader2 className="h-4 w-4 animate-spin" />
                           )}
-                          Confirm Approval
+                          <span>Confirm Approval</span>
                         </PermissionButton>
                         <Button
                           variant="outline"
@@ -447,7 +447,7 @@ export default function InstallationRequestDetailPage({
                           {declineMutation.isPending && (
                             <Loader2 className="h-4 w-4 animate-spin" />
                           )}
-                          Confirm Decline
+                          <span>Confirm Decline</span>
                         </PermissionButton>
                         <Button
                           variant="outline"
@@ -488,7 +488,7 @@ export default function InstallationRequestDetailPage({
                     ) : (
                       <Send className="h-4 w-4" />
                     )}
-                    Add Note
+                    <span>Add Note</span>
                   </Button>
                 </div>
 

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/tool-call-policies.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/tool-call-policies.tsx
@@ -163,7 +163,7 @@ export function ToolCallPolicies({ tool }: { tool: ToolForPolicies }) {
                     className="flex items-center gap-2"
                   >
                     <span className="text-sm text-muted-foreground w-2">
-                      {index === 0 ? "If" : ""}
+                      {index === 0 ? <span>If</span> : null}
                     </span>
                     <ToolCallPolicyCondition
                       condition={condition}

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/tool-result-policies.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/tool-result-policies.tsx
@@ -296,7 +296,7 @@ export function ToolResultPolicies({ tool }: { tool: ToolForPolicies }) {
                     className="flex items-center gap-2"
                   >
                     <span className="text-sm text-muted-foreground w-2">
-                      {index === 0 ? "If" : ""}
+                      {index === 0 ? <span>If</span> : null}
                     </span>
                     <ToolResultPolicyCondition
                       condition={condition}

--- a/platform/frontend/src/app/messaging-channels/_components/channels-empty-state.tsx
+++ b/platform/frontend/src/app/messaging-channels/_components/channels-empty-state.tsx
@@ -45,10 +45,10 @@ export function ChannelsEmptyState({
           {isRefreshing ? (
             <>
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Refreshing…
+              <span>Refreshing…</span>
             </>
           ) : (
-            "Refresh"
+            <span>Refresh</span>
           )}
         </Button>
       </EmptyContent>

--- a/platform/frontend/src/app/messaging-channels/_components/channels-section.tsx
+++ b/platform/frontend/src/app/messaging-channels/_components/channels-section.tsx
@@ -404,7 +404,7 @@ export function ChannelsSection({
                 onClick={() => handleStatusChange("all")}
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
-                All{counts ? ` (${totalCount})` : ""}
+                All{counts ? <span> ({totalCount})</span> : null}
               </Button>
               <Button
                 variant="ghost"
@@ -418,7 +418,7 @@ export function ChannelsSection({
                 onClick={() => handleStatusChange("configured")}
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                Configured{counts ? ` (${counts.configured})` : ""}
+                Configured{counts ? <span> ({counts.configured})</span> : null}
               </Button>
               <Button
                 variant="ghost"
@@ -432,7 +432,7 @@ export function ChannelsSection({
                 onClick={() => handleStatusChange("unassigned")}
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
-                Unassigned{counts ? ` (${counts.unassigned})` : ""}
+                Unassigned{counts ? <span> ({counts.unassigned})</span> : null}
               </Button>
 
               {hasMultipleWorkspaces && (

--- a/platform/frontend/src/app/messaging-channels/a2a/page.tsx
+++ b/platform/frontend/src/app/messaging-channels/a2a/page.tsx
@@ -33,10 +33,12 @@ export default function A2APage() {
               <Link href="/agents" className="underline hover:text-foreground">
                 Create an agent
               </Link>{" "}
-              to expose it via A2A.
+              <span>to expose it via A2A.</span>
             </>
           ) : (
-            "Ask an admin to create an agent so it can be exposed via A2A."
+            <span>
+              Ask an admin to create an agent so it can be exposed via A2A.
+            </span>
           )}
         </p>
       </div>

--- a/platform/frontend/src/app/messaging-channels/email/page.tsx
+++ b/platform/frontend/src/app/messaging-channels/email/page.tsx
@@ -209,7 +209,7 @@ export default function EmailPage() {
                   {renewMutation.isPending && (
                     <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
                   )}
-                  Renew subscription
+                  <span>Renew subscription</span>
                 </PermissionButton>
                 <PermissionButton
                   permissions={{ agentTrigger: ["delete"] }}

--- a/platform/frontend/src/app/projects/[id]/page.client.tsx
+++ b/platform/frontend/src/app/projects/[id]/page.client.tsx
@@ -199,7 +199,7 @@ function ProjectDetail() {
                       ) : (
                         <Pin className="h-4 w-4" />
                       )}
-                      {project.pinnedAt ? "Unpin" : "Pin"}
+                      <span>{project.pinnedAt ? "Unpin" : "Pin"}</span>
                     </DropdownMenuItem>
                   )}
                   {canManage && (

--- a/platform/frontend/src/app/projects/[id]/schedules/[triggerId]/runs-client.tsx
+++ b/platform/frontend/src/app/projects/[id]/schedules/[triggerId]/runs-client.tsx
@@ -71,7 +71,7 @@ export function ProjectScheduleRunsClient() {
           ) : (
             <Play className="mr-1.5 h-3.5 w-3.5" />
           )}
-          Run now
+          <span>Run now</span>
         </Button>
       </div>
 

--- a/platform/frontend/src/app/projects/project-actions-menu.tsx
+++ b/platform/frontend/src/app/projects/project-actions-menu.tsx
@@ -43,7 +43,7 @@ export function ProjectActionsMenu({
             ) : (
               <Pin className="h-4 w-4" />
             )}
-            {pinned ? "Unpin" : "Pin"}
+            <span>{pinned ? "Unpin" : "Pin"}</span>
           </DropdownMenuItem>
         )}
         {canManage && (

--- a/platform/frontend/src/app/review/page.client.tsx
+++ b/platform/frontend/src/app/review/page.client.tsx
@@ -148,7 +148,7 @@ export default function ReviewPage({
               pull request
             </a>
           ) : (
-            "pull request"
+            <span>pull request</span>
           )}{" "}
           / Slack card.
         </p>

--- a/platform/frontend/src/app/settings/knowledge/page.tsx
+++ b/platform/frontend/src/app/settings/knowledge/page.tsx
@@ -246,7 +246,7 @@ function AddApiKeyDialog({
             {createMutation.isPending && (
               <Loader2 className="h-4 w-4 animate-spin" />
             )}
-            Test & Create
+            <span>Test & Create</span>
           </Button>
         </DialogStickyFooter>
       </DialogForm>

--- a/platform/frontend/src/app/settings/secrets/page.tsx
+++ b/platform/frontend/src/app/settings/secrets/page.tsx
@@ -39,7 +39,7 @@ export default function SecretsSettingsPage() {
         {checkConnectivityMutation.isPending && (
           <RefreshCw className="h-4 w-4 animate-spin" />
         )}
-        Check Vault Connectivity
+        <span>Check Vault Connectivity</span>
       </PermissionButton>,
     );
 
@@ -100,7 +100,10 @@ export default function SecretsSettingsPage() {
                 <AlertTitle>Connection Successful</AlertTitle>
                 <AlertDescription>
                   Found {checkConnectivityMutation.data.secretCount} secret
-                  {checkConnectivityMutation.data.secretCount === 1 ? "" : "s"}.
+                  {checkConnectivityMutation.data.secretCount === 1 ? null : (
+                    <span>s</span>
+                  )}
+                  .
                 </AlertDescription>
               </Alert>
             )}

--- a/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
+++ b/platform/frontend/src/app/settings/service-accounts/[id]/page.client.tsx
@@ -376,7 +376,7 @@ export default function ServiceAccountDetailPage({
                     platform API
                   </ExternalDocsLink>
                 ) : (
-                  "platform API"
+                  <span>platform API</span>
                 )}{" "}
                 as this service account.
               </p>
@@ -480,7 +480,7 @@ function CreateTokenDialog({
             disabled={isPending || !form.watch("name").trim()}
           >
             {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
-            Create
+            <span>Create</span>
           </Button>
         </DialogStickyFooter>
       </DialogForm>

--- a/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-editor-dialog.tsx
@@ -430,7 +430,7 @@ export function SkillEditorDialog({
     >
       {(isPreview && isPreviewLoading) || (isEdit && isLoading) ? (
         <div className="py-10 text-center text-sm text-muted-foreground">
-          Loading skill...
+          <span>Loading skill...</span>
         </div>
       ) : (
         <div className="flex h-full min-h-0 flex-col gap-4">
@@ -447,7 +447,7 @@ export function SkillEditorDialog({
                       {githubSourceRepo}
                     </code>
                   ) : (
-                    "GitHub"
+                    <span>GitHub</span>
                   )}{" "}
                   as a one-time copy. Saving changes here won’t update the repo,
                   and {appName} won’t pull later changes from it.
@@ -1232,7 +1232,7 @@ function TemplatedManifestHint() {
           for available variables.
         </>
       ) : (
-        "."
+        <span>.</span>
       )}
     </p>
   );

--- a/platform/frontend/src/app/skills/_parts/skill-usage-dialog.tsx
+++ b/platform/frontend/src/app/skills/_parts/skill-usage-dialog.tsx
@@ -100,11 +100,11 @@ export function SkillUsageDialog({
     >
       {isPending ? (
         <div className="py-10 text-center text-sm text-muted-foreground">
-          Loading usage...
+          <span>Loading usage...</span>
         </div>
       ) : totalUses === 0 ? (
         <div className="py-10 text-center text-sm text-muted-foreground">
-          No uses in the last {WINDOW_DAYS} days.
+          <span>No uses in the last {WINDOW_DAYS} days.</span>
         </div>
       ) : (
         <div className="flex flex-col gap-4">

--- a/platform/frontend/src/app/skills/new/page.client.tsx
+++ b/platform/frontend/src/app/skills/new/page.client.tsx
@@ -148,15 +148,17 @@ function NewSkillChooser() {
                   {isSearchingSkills ? (
                     catalogSearch.isLoading ? (
                       <div className="px-6 py-10 text-center text-sm text-muted-foreground">
-                        Searching the skill index…
+                        <span>Searching the skill index…</span>
                       </div>
                     ) : catalogSearch.isError ? (
                       <div className="px-6 py-10 text-center text-sm text-muted-foreground">
-                        Could not search the skill index. Try again.
+                        <span>
+                          Could not search the skill index. Try again.
+                        </span>
                       </div>
                     ) : skillResults.length === 0 ? (
                       <div className="px-6 py-10 text-center text-sm text-muted-foreground">
-                        No indexed skills match “{search}”.
+                        <span>No indexed skills match “{search}”.</span>
                       </div>
                     ) : (
                       <ul>

--- a/platform/frontend/src/components/agent-dialog.tsx
+++ b/platform/frontend/src/components/agent-dialog.tsx
@@ -2180,9 +2180,19 @@ export function AgentDialog({
                                     const totalSelected =
                                       knowledgeBaseIds.length +
                                       connectorIds.length;
-                                    return totalSelected === 0
-                                      ? "Select connectors or knowledge bases"
-                                      : `${totalSelected} source${totalSelected > 1 ? "s" : ""} selected`;
+                                    return totalSelected === 0 ? (
+                                      <span>
+                                        Select connectors or knowledge bases
+                                      </span>
+                                    ) : (
+                                      <span>
+                                        {totalSelected} source
+                                        {totalSelected > 1 ? (
+                                          <span>s</span>
+                                        ) : null}{" "}
+                                        selected
+                                      </span>
+                                    );
                                   })()}
                                   <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
                                 </Button>
@@ -2827,8 +2837,8 @@ export function AgentDialog({
                 <AlertTriangle className="h-4 w-4" />
                 <AlertTitle>
                   {mcpEnvConflicts.length} MCP server
-                  {mcpEnvConflicts.length === 1 ? "" : "s"} not in this
-                  environment
+                  {mcpEnvConflicts.length === 1 ? null : <span>s</span>} not in
+                  this environment
                 </AlertTitle>
                 <AlertDescription>
                   <p>
@@ -2874,7 +2884,7 @@ export function AgentDialog({
                     updateAgent.isPending) && (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   )}
-                  {agent ? "Update" : "Create"}
+                  <span>{agent ? "Update" : "Create"}</span>
                 </Button>
               )}
             </DialogStickyFooter>

--- a/platform/frontend/src/components/agent-hooks-editor.tsx
+++ b/platform/frontend/src/components/agent-hooks-editor.tsx
@@ -646,7 +646,7 @@ function HookEditorPanel({
           disabled={saving}
         >
           {saving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
-          {initial ? "Save hook" : "Add hook"}
+          <span>{initial ? "Save hook" : "Add hook"}</span>
         </Button>
       </div>
     </div>

--- a/platform/frontend/src/components/agent-tool-exclusions-editor.tsx
+++ b/platform/frontend/src/components/agent-tool-exclusions-editor.tsx
@@ -536,7 +536,7 @@ function ExclusionPill({
         </div>
         {tools.length === 0 ? (
           <div className="p-4 text-sm text-muted-foreground">
-            No tools available for this server.
+            <span>No tools available for this server.</span>
           </div>
         ) : (
           <div className="flex-1 min-h-0 flex flex-col overflow-hidden">

--- a/platform/frontend/src/components/agent-tools-editor.tsx
+++ b/platform/frontend/src/components/agent-tools-editor.tsx
@@ -1230,7 +1230,7 @@ function McpServerPill({
         </div>
       ) : totalCount === 0 ? (
         <div className="p-4 text-sm text-muted-foreground">
-          No tools available for this server.
+          <span>No tools available for this server.</span>
         </div>
       ) : (
         <div className="flex-1 min-h-0 flex flex-col overflow-hidden">

--- a/platform/frontend/src/components/app-session-recording/app-recording-controls.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-recording-controls.tsx
@@ -149,7 +149,7 @@ export function AppRecordingControls() {
                   Disable in settings.
                 </Link>
               ) : (
-                "Ask your admin to disable this."
+                <span>Ask your admin to disable this.</span>
               )}
             </p>
           </HoverCardContent>

--- a/platform/frontend/src/components/app-session-recording/app-session-player.tsx
+++ b/platform/frontend/src/components/app-session-recording/app-session-player.tsx
@@ -927,17 +927,22 @@ export function AppSessionPlayer({
                       </TooltipTrigger>
                       <TooltipContent className="max-w-[260px] text-xs">
                         {rendering ? (
-                          "Preparing your video — click to cancel."
+                          <span>Preparing your video — click to cancel.</span>
                         ) : tooLongToExport ? (
                           <>
-                            This cut runs {formatMs(finalCutMs)}. Trim it to{" "}
-                            {finalCutLimitLabel} or less to export a video.
+                            <span>
+                              This cut runs {formatMs(finalCutMs)}. Trim it to{" "}
+                              {finalCutLimitLabel} or less to export a video.
+                            </span>
                             {trimPill}
                           </>
                         ) : descriptionEditing || surfaceEditing ? (
-                          "Finish editing to export a video."
+                          <span>Finish editing to export a video.</span>
                         ) : (
-                          "Downloads a video of this session with your edits applied. Takes up to a minute."
+                          <span>
+                            Downloads a video of this session with your edits
+                            applied. Takes up to a minute.
+                          </span>
                         )}
                       </TooltipContent>
                     </Tooltip>
@@ -3104,7 +3109,7 @@ function ReplayPromptEditorCard({
             ) : (
               <Sparkles className="size-3" />
             )}
-            {editor.generating ? "Regenerating…" : "Regenerate"}
+            <span>{editor.generating ? "Regenerating…" : "Regenerate"}</span>
           </Button>
           <Button
             type="button"
@@ -3314,7 +3319,7 @@ function ReplayDescriptionRow({
               ) : (
                 <Sparkles className="size-3" />
               )}
-              {generate.isPending ? "Regenerating…" : "Regenerate"}
+              <span>{generate.isPending ? "Regenerating…" : "Regenerate"}</span>
             </Button>
             <Button
               type="button"
@@ -4664,7 +4669,9 @@ export function ReplayChatEditPane({
                 ) : (
                   <Sparkles className="size-3" />
                 )}
-                {promptEditor.generating ? "Drafting…" : "Draft AI prompt"}
+                <span>
+                  {promptEditor.generating ? "Drafting…" : "Draft AI prompt"}
+                </span>
               </Button>
               <Button
                 type="button"
@@ -4775,7 +4782,7 @@ function ReplayAiResponseBubble({
         ) : (
           <Sparkles className="size-3" />
         )}
-        AI-generated response
+        <span>AI-generated response</span>
       </div>
       <Message from="assistant" className="group/row">
         <MessageContent className="relative ring-2 ring-primary/50">
@@ -4910,7 +4917,7 @@ function ReplayAiPromptBubble({
           ) : (
             <Sparkles className="size-3" />
           )}
-          AI-generated prompt
+          <span>AI-generated prompt</span>
         </div>
         {/* The bubble itself is the edit control, like the description and
             every captured message: click it, edit and regenerate in the card

--- a/platform/frontend/src/components/chat/browser-preview-content.tsx
+++ b/platform/frontend/src/components/chat/browser-preview-content.tsx
@@ -438,7 +438,7 @@ export function BrowserPreviewContent({
             {isNavigating || isCreatingConversation ? (
               <Loader2 className="h-3 w-3 animate-spin" />
             ) : (
-              "Go"
+              <span>Go</span>
             )}
           </Button>
         </form>
@@ -521,10 +521,10 @@ export function BrowserPreviewContent({
                     {isInstallingBrowser ? (
                       <>
                         <Loader2 className="h-4 w-4 animate-spin" />
-                        Installing
+                        <span>Installing</span>
                       </>
                     ) : (
-                      "Install Browser"
+                      <span>Install Browser</span>
                     )}
                   </Button>
                   <p className="text-xs text-muted-foreground">
@@ -573,10 +573,10 @@ export function BrowserPreviewContent({
                     {isInstallingBrowser ? (
                       <>
                         <Loader2 className="h-4 w-4 animate-spin" />
-                        Reinstalling
+                        <span>Reinstalling</span>
                       </>
                     ) : (
-                      "Reinstall Browser"
+                      <span>Reinstall Browser</span>
                     )}
                   </Button>
                   <p className="text-xs text-muted-foreground">

--- a/platform/frontend/src/components/chat/compact-tool-call.tsx
+++ b/platform/frontend/src/components/chat/compact-tool-call.tsx
@@ -187,18 +187,18 @@ function CompactCircle({
           </button>
         </TooltipTrigger>
         <TooltipContent side="top" className="text-xs">
-          {parseFullToolName(toolName).toolName.replace(/_/g, " ")}
-          {isCancelled
-            ? " (cancelled)"
-            : isBackground
-              ? ` (running in the background · ${formatElapsed(elapsed)})`
-              : state === "running"
-                ? " (running)"
-                : state === "error"
-                  ? " (error)"
-                  : state === "denied"
-                    ? " (denied)"
-                    : ""}
+          <span>{parseFullToolName(toolName).toolName.replace(/_/g, " ")}</span>
+          {isCancelled ? (
+            <span>{" (cancelled)"}</span>
+          ) : isBackground ? (
+            <span>{` (running in the background · ${formatElapsed(elapsed)})`}</span>
+          ) : state === "running" ? (
+            <span>{" (running)"}</span>
+          ) : state === "error" ? (
+            <span>{" (error)"}</span>
+          ) : state === "denied" ? (
+            <span>{" (denied)"}</span>
+          ) : null}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/platform/frontend/src/components/chat/initial-agent-selector.tsx
+++ b/platform/frontend/src/components/chat/initial-agent-selector.tsx
@@ -722,7 +722,7 @@ function AgentSettingsView({
   if (!agent) {
     return (
       <div className="p-6 text-center text-muted-foreground">
-        No agent selected
+        <span>No agent selected</span>
       </div>
     );
   }
@@ -971,7 +971,7 @@ function AgentSettingsView({
             disabled={isSaving}
           >
             {isSaving && <Loader2 className="size-3 animate-spin mr-1.5" />}
-            Save
+            <span>Save</span>
           </Button>
         )}
       </div>
@@ -1274,7 +1274,7 @@ function AddToolView({
         {isPending ? (
           <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
-            Loading...
+            <span>Loading...</span>
           </div>
         ) : filteredCatalogs.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-8">
@@ -1541,6 +1541,11 @@ function ConfigureToolView({
   const newToolCount = useMemo(() => {
     return [...selectedToolIds].filter((id) => !assignedToolIds.has(id)).length;
   }, [selectedToolIds, assignedToolIds]);
+  const saveButtonLabel = isEditing
+    ? `Save (${selectedToolIds.size} tool${selectedToolIds.size !== 1 ? "s" : ""})`
+    : newToolCount === 0
+      ? "Add"
+      : `Add ${newToolCount} tool${newToolCount !== 1 ? "s" : ""}`;
   return (
     <div className="flex flex-col h-full">
       <DialogHeader
@@ -1581,11 +1586,11 @@ function ConfigureToolView({
         {isLoading ? (
           <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
-            Loading tools...
+            <span>Loading tools...</span>
           </div>
         ) : allTools.length === 0 ? (
           <div className="p-4 text-sm text-muted-foreground text-center">
-            No tools available.
+            <span>No tools available.</span>
           </div>
         ) : (
           <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
@@ -1608,11 +1613,7 @@ function ConfigureToolView({
             }
           >
             {isSaving ? <Loader2 className="size-4 animate-spin mr-2" /> : null}
-            {isEditing
-              ? `Save (${selectedToolIds.size} tool${selectedToolIds.size !== 1 ? "s" : ""})`
-              : newToolCount === 0
-                ? "Add"
-                : `Add ${newToolCount} tool${newToolCount !== 1 ? "s" : ""}`}
+            <span>{saveButtonLabel}</span>
           </Button>
         </div>
       </div>
@@ -1905,7 +1906,8 @@ function EditKnowledgeSourcesView({
               />
             </div>
             <div className="text-xs text-muted-foreground">
-              {totalSelected} source{totalSelected !== 1 ? "s" : ""} selected
+              {totalSelected} source
+              {totalSelected !== 1 ? <span>s</span> : null} selected
             </div>
           </div>
           <div className="flex-1 min-h-0 overflow-y-auto px-4 py-2 space-y-1">

--- a/platform/frontend/src/components/chat/inline-chat-error.tsx
+++ b/platform/frontend/src/components/chat/inline-chat-error.tsx
@@ -295,7 +295,7 @@ export function InlineChatError({
                     ) : (
                       <ChevronRight className="h-3 w-3 mr-1" />
                     )}
-                    Error Details
+                    <span>Error Details</span>
                   </Button>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="space-y-2 mt-1">

--- a/platform/frontend/src/components/chat/llm-provider-api-key-selector.test.tsx
+++ b/platform/frontend/src/components/chat/llm-provider-api-key-selector.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@/components/llm-provider-api-key-dropdown", () => ({
       {availableKeys.map((key) => (
         <button key={key.id} type="button" onClick={() => onSelectKey(key.id)}>
           {key.name} {key.connectRequired ? "Connect" : "Connected"}
-          {selectedApiKeyId === key.id ? " Selected" : ""}
+          {selectedApiKeyId === key.id ? <span> Selected</span> : null}
         </button>
       ))}
     </div>
@@ -174,7 +174,7 @@ describe("LlmProviderApiKeySelector subscriptions", () => {
 
     expect(
       screen.getByRole("button", {
-        name: "GitHub Copilot Connect Selected",
+        name: /^GitHub Copilot Connect\s*Selected$/,
       }),
     ).toBeInTheDocument();
     expect(
@@ -212,12 +212,12 @@ describe("LlmProviderApiKeySelector subscriptions", () => {
 
     expect(
       screen.getByRole("button", {
-        name: "ChatGPT Subscription Connect Selected",
+        name: /^ChatGPT Subscription Connect\s*Selected$/,
       }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", {
-        name: "ChatGPT Subscription Connected Selected",
+        name: /^ChatGPT Subscription Connected\s*Selected$/,
       }),
     ).not.toBeInTheDocument();
   });

--- a/platform/frontend/src/components/chat/mcp-app-container.tsx
+++ b/platform/frontend/src/components/chat/mcp-app-container.tsx
@@ -394,7 +394,7 @@ export function McpAppEntryContent({
     if (surface === "panel") {
       return (
         <div className="flex h-full w-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
-          This app rendered nothing to display.
+          <span>This app rendered nothing to display.</span>
         </div>
       );
     }

--- a/platform/frontend/src/components/chat/playwright-install-dialog.tsx
+++ b/platform/frontend/src/components/chat/playwright-install-dialog.tsx
@@ -332,10 +332,10 @@ function PlaywrightInstallContent({
               {isDisabling ? (
                 <>
                   <Loader2 className="size-4 animate-spin" />
-                  Disabling...
+                  <span>Disabling...</span>
                 </>
               ) : (
-                "Disable Browser Tools"
+                <span>Disable Browser Tools</span>
               )}
             </Button>
           </div>

--- a/platform/frontend/src/components/clone-agent-dialog.tsx
+++ b/platform/frontend/src/components/clone-agent-dialog.tsx
@@ -168,7 +168,7 @@ export function CloneAgentDialog({
                 {cloneAgent.isPending && (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 )}
-                Clone
+                <span>Clone</span>
               </Button>
             </DialogFooter>
           </DialogForm>

--- a/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
+++ b/platform/frontend/src/components/create-llm-provider-api-key-dialog.tsx
@@ -181,7 +181,7 @@ export function CreateLlmProviderApiKeyDialog({
               {createMutation.isPending && (
                 <Loader2 className="h-4 w-4 animate-spin" />
               )}
-              Test & Create
+              <span>Test & Create</span>
             </Button>
           )}
         </DialogStickyFooter>

--- a/platform/frontend/src/components/create-virtual-key-dialog.tsx
+++ b/platform/frontend/src/components/create-virtual-key-dialog.tsx
@@ -446,7 +446,7 @@ export function CreateVirtualKeyDialog({
               {createMutation.isPending && (
                 <Loader2 className="h-4 w-4 animate-spin" />
               )}
-              Create
+              <span>Create</span>
             </Button>
           )}
         </DialogStickyFooter>

--- a/platform/frontend/src/components/default-credentials-warning.tsx
+++ b/platform/frontend/src/components/default-credentials-warning.tsx
@@ -104,11 +104,10 @@ export function DefaultCredentialsWarning({
             Set ENV
           </ExternalDocsLink>
           {alwaysShow ? (
-            " to change"
+            <span>{" to change"}</span>
           ) : (
             <>
-              {" "}
-              or{" "}
+              <span>{" or "}</span>
               <a
                 href="/account?highlight=change-password"
                 className="inline-flex items-center underline"

--- a/platform/frontend/src/components/edit-virtual-key-dialog.tsx
+++ b/platform/frontend/src/components/edit-virtual-key-dialog.tsx
@@ -210,7 +210,7 @@ export function EditVirtualKeyDialog({
             {updateMutation.isPending && (
               <Loader2 className="h-4 w-4 animate-spin" />
             )}
-            Save Changes
+            <span>Save Changes</span>
           </Button>
         </DialogStickyFooter>
       </DialogForm>

--- a/platform/frontend/src/components/email-not-configured-message.tsx
+++ b/platform/frontend/src/components/email-not-configured-message.tsx
@@ -24,18 +24,21 @@ export function EmailNotConfiguredMessage({
       Email invocation of Agents is not configured for your organization.
       {docsUrl ? (
         <>
-          {" "}
-          See the{" "}
+          <span>{" See the "}</span>
           <ExternalDocsLink
             href={docsUrl}
             className="inline-flex items-center gap-1 text-primary hover:underline"
           >
             setup guide
-          </ExternalDocsLink>{" "}
-          for supported email providers and configuration.
+          </ExternalDocsLink>
+          <span>{" for supported email providers and configuration."}</span>
         </>
       ) : (
-        " Supported email providers and configuration are managed by your administrator."
+        <span>
+          {
+            " Supported email providers and configuration are managed by your administrator."
+          }
+        </span>
       )}
     </p>
   );

--- a/platform/frontend/src/components/environment-variables-read-only-table.tsx
+++ b/platform/frontend/src/components/environment-variables-read-only-table.tsx
@@ -197,7 +197,7 @@ function ValueCell({
     return (
       <span className="font-mono">
         {value || hasStoredSecret ? (
-          "••••••••"
+          <span>••••••••</span>
         ) : (
           <span className="text-muted-foreground italic">not set</span>
         )}

--- a/platform/frontend/src/components/form-dialog.tsx
+++ b/platform/frontend/src/components/form-dialog.tsx
@@ -78,9 +78,26 @@ export function FormDialog({
         >
           <DialogDismissProvider requestClose={guard.requestClose}>
             <DialogHeader className={headerClassName}>
-              <DialogTitle>{title}</DialogTitle>
+              {/* The DialogTitle/DialogDescription elements persist across
+                  wizard steps, so a title that switches between a string and
+                  an element would delete a bare text node in place — which
+                  crashes React once Chrome page-translate has re-parented it
+                  into a <font> wrapper (facebook/react#11538). Keying the
+                  wrapper span by the string content swaps a whole element on
+                  every string<->element or string<->string change instead. */}
+              <DialogTitle>
+                <span key={typeof title === "string" ? title : "node"}>
+                  {title}
+                </span>
+              </DialogTitle>
               {description && (
-                <DialogDescription>{description}</DialogDescription>
+                <DialogDescription>
+                  <span
+                    key={typeof description === "string" ? description : "node"}
+                  >
+                    {description}
+                  </span>
+                </DialogDescription>
               )}
             </DialogHeader>
             {children}

--- a/platform/frontend/src/components/github-copilot-sign-in.tsx
+++ b/platform/frontend/src/components/github-copilot-sign-in.tsx
@@ -193,7 +193,7 @@ export function GithubCopilotSignIn({
         ) : (
           <Github className="mr-2 h-4 w-4" />
         )}
-        Sign in with GitHub
+        <span>Sign in with GitHub</span>
       </Button>
       {expired && (
         <p className="text-xs text-destructive">

--- a/platform/frontend/src/components/inline-vault-secret-selector.ee.tsx
+++ b/platform/frontend/src/components/inline-vault-secret-selector.ee.tsx
@@ -93,7 +93,7 @@ export default function InlineVaultSecretSelector({
   if (!teamId) {
     return (
       <div className="text-sm text-muted-foreground italic">
-        {noTeamMessage}
+        <span>{noTeamMessage}</span>
       </div>
     );
   }
@@ -103,7 +103,7 @@ export default function InlineVaultSecretSelector({
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin" />
-        Loading secrets...
+        <span>Loading secrets...</span>
       </div>
     );
   }

--- a/platform/frontend/src/components/invite-by-link-card.tsx
+++ b/platform/frontend/src/components/invite-by-link-card.tsx
@@ -160,7 +160,7 @@ function InviteByLinkCardContent({
               ) : (
                 <Copy className="h-4 w-4" />
               )}
-              Copy Link
+              <span>Copy Link</span>
             </Button>
           </>
         ) : (
@@ -175,7 +175,7 @@ function InviteByLinkCardContent({
               {createMutation.isPending && (
                 <Loader2 className="h-4 w-4 animate-spin" />
               )}
-              Generate Invitation Link
+              <span>Generate Invitation Link</span>
             </PermissionButton>
           </>
         )}

--- a/platform/frontend/src/components/llm-provider-api-key-form.tsx
+++ b/platform/frontend/src/components/llm-provider-api-key-form.tsx
@@ -1124,9 +1124,11 @@ export function LlmProviderApiKeyForm({
                             : provider === "microsoft-365-copilot"
                               ? "Your Microsoft 365 Copilot license is linked through your Microsoft account."
                               : "Your Codex/ChatGPT subscription is linked through your ChatGPT account."}
-                          {isEditMode && !isOpenaiChatgptSub
-                            ? " Sign in again below to refresh the token."
-                            : ""}
+                          {isEditMode && !isOpenaiChatgptSub ? (
+                            <span>
+                              {" Sign in again below to refresh the token."}
+                            </span>
+                          ) : null}
                         </p>
                       </div>
                     </div>

--- a/platform/frontend/src/components/mcp-oauth-management.tsx
+++ b/platform/frontend/src/components/mcp-oauth-management.tsx
@@ -105,7 +105,7 @@ export function McpOauthManagement({
                 <tr key={client.id} className="border-b last:border-0">
                   <td className="px-3 py-1.5 font-medium">
                     {client.name}
-                    {client.disabled ? " (disabled)" : ""}
+                    {client.disabled ? <span>{" (disabled)"}</span> : null}
                   </td>
                   <td className="px-3 py-1.5">
                     <span className="flex items-center gap-1 font-mono">

--- a/platform/frontend/src/components/microsoft-365-copilot-sign-in.tsx
+++ b/platform/frontend/src/components/microsoft-365-copilot-sign-in.tsx
@@ -198,7 +198,7 @@ export function Microsoft365CopilotSignIn({
         ) : (
           <MicrosoftLogo className="mr-2 h-4 w-4" />
         )}
-        Sign in with Microsoft
+        <span>Sign in with Microsoft</span>
       </Button>
       {expired && (
         <p className="text-xs text-destructive">

--- a/platform/frontend/src/components/ms-teams-setup-dialog.tsx
+++ b/platform/frontend/src/components/ms-teams-setup-dialog.tsx
@@ -620,7 +620,7 @@ function StepManifest({
           ) : (
             <Download className="mr-2 h-4 w-4" />
           )}
-          Download {configuredAppName.toLowerCase()}-teams-app.zip
+          <span>Download {configuredAppName.toLowerCase()}-teams-app.zip</span>
         </Button>
 
         {!effectiveAppId && (

--- a/platform/frontend/src/components/openai-codex-sign-in.tsx
+++ b/platform/frontend/src/components/openai-codex-sign-in.tsx
@@ -224,7 +224,7 @@ export function OpenaiCodexSignIn({
         ) : (
           <OpenAiLogo className="mr-2 h-4 w-4" />
         )}
-        Sign in with ChatGPT
+        <span>Sign in with ChatGPT</span>
       </Button>
       <div className="flex items-start gap-2 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
         <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />

--- a/platform/frontend/src/components/post-create-connect-dialog.tsx
+++ b/platform/frontend/src/components/post-create-connect-dialog.tsx
@@ -133,7 +133,7 @@ export function PostCreateConnectDialog({
           {navigating ? (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           ) : null}
-          Open connection guide
+          <span>Open connection guide</span>
           <ArrowRight className="ml-2 h-4 w-4" />
         </Button>
       </DialogStickyFooter>

--- a/platform/frontend/src/components/reinstall-confirm-bar.tsx
+++ b/platform/frontend/src/components/reinstall-confirm-bar.tsx
@@ -119,7 +119,8 @@ export function ReinstallConfirmBar({
           Your change needs a new value. The {installNoun}{" "}
           {isPlural ? "keep" : "keeps"} running on the old config until someone
           clicks <strong>Reinstall</strong>
-          {isPlural ? " on each" : ""} and provides the value.
+          {isPlural ? <span>{" on each"}</span> : null}
+          <span>{" and provides the value."}</span>
         </>
       )
     ) : (

--- a/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
+++ b/platform/frontend/src/components/roles/role-permission-builder.ee.tsx
@@ -247,9 +247,9 @@ export function RolePermissionBuilder({
             <p className="text-sm font-medium">Selected Permissions</p>
             <p className="text-xs text-muted-foreground">
               {getTotalPermissionCount()} permission
-              {getTotalPermissionCount() !== 1 ? "s" : ""} across{" "}
+              {getTotalPermissionCount() !== 1 ? <span>s</span> : null} across{" "}
               {Object.keys(permission).length} resource
-              {Object.keys(permission).length !== 1 ? "s" : ""}
+              {Object.keys(permission).length !== 1 ? <span>s</span> : null}
             </p>
           </div>
           <Tooltip>

--- a/platform/frontend/src/components/service-logo-picker.tsx
+++ b/platform/frontend/src/components/service-logo-picker.tsx
@@ -549,11 +549,11 @@ export function ServiceLogoPicker({ onSelect }: ServiceLogoPickerProps) {
       >
         {loading ? (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-            Loading logos...
+            <span>Loading logos...</span>
           </div>
         ) : filtered.length === 0 ? (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-            No logos found
+            <span>No logos found</span>
           </div>
         ) : (
           <>

--- a/platform/frontend/src/components/settings/role-permissions-card.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.tsx
@@ -280,7 +280,8 @@ function CategorySection({
         )}
         <span className="font-semibold text-sm">{category}</span>
         <span className="ml-auto text-xs text-muted-foreground">
-          {resources.length} resource{resources.length !== 1 ? "s" : ""}
+          {resources.length} resource
+          {resources.length !== 1 ? <span>s</span> : null}
         </span>
       </CollapsibleTrigger>
       <CollapsibleContent>

--- a/platform/frontend/src/components/system-prompt-editor.test.tsx
+++ b/platform/frontend/src/components/system-prompt-editor.test.tsx
@@ -49,7 +49,12 @@ describe("SystemPromptEditor", () => {
     expect(
       screen.queryByRole("link", { name: "docs(opens in new tab)" }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText(/templating\./)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_, el) =>
+          el?.tagName === "P" && /templating\./.test(el.textContent ?? ""),
+      ),
+    ).toBeInTheDocument();
   });
 
   it("expands and collapses the shared editor height", async () => {

--- a/platform/frontend/src/components/system-prompt-editor.tsx
+++ b/platform/frontend/src/components/system-prompt-editor.tsx
@@ -70,19 +70,18 @@ export function SystemPromptEditor({
             templating
             {docsUrl ? (
               <>
-                {" "}
-                — see{" "}
+                <span>{" — see "}</span>
                 <ExternalDocsLink
                   href={docsUrl}
                   className="underline hover:text-foreground"
                   showIcon={false}
                 >
                   docs
-                </ExternalDocsLink>{" "}
-                for available variables.
+                </ExternalDocsLink>
+                <span>{" for available variables."}</span>
               </>
             ) : (
-              "."
+              <span>.</span>
             )}
           </p>
         </div>

--- a/platform/frontend/src/components/teams/team-management-dialog.tsx
+++ b/platform/frontend/src/components/teams/team-management-dialog.tsx
@@ -752,7 +752,7 @@ function TokenSection({ token }: { token?: TeamToken }) {
   if (!token) {
     return (
       <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-        No token found for this team.
+        <span>No token found for this team.</span>
       </div>
     );
   }

--- a/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
+++ b/platform/frontend/src/components/teams/team-management-external-sync.ee.tsx
@@ -155,7 +155,10 @@ export function TeamManagementExternalSyncSection({
             before configuring external group sync.
           </>
         ) : (
-          "Ask your admin to add an identity provider before configuring external group sync."
+          <span>
+            Ask your admin to add an identity provider before configuring
+            external group sync.
+          </span>
         )}
       </div>
     );
@@ -212,9 +215,13 @@ export function TeamManagementExternalSyncSection({
               />
               <p className="text-sm text-muted-foreground">
                 {selectedGroupsExpression ? (
-                  "Configured on the selected identity provider. Use the decoded claims below to find a group value that this template extracts."
+                  <span key="configured">
+                    Configured on the selected identity provider. Use the
+                    decoded claims below to find a group value that this
+                    template extracts.
+                  </span>
                 ) : (
-                  <>
+                  <span key="not-configured">
                     No custom template is configured on this identity provider
                     {canUpdateIdentityProviders ? (
                       <>
@@ -227,11 +234,13 @@ export function TeamManagementExternalSyncSection({
                         </Link>
                       </>
                     ) : (
-                      ", ask your admin to configure it"
+                      <span>, ask your admin to configure it</span>
                     )}
-                    . {appName} will look for common group claims in the decoded
-                    token.
-                  </>
+                    <span>
+                      . {appName} will look for common group claims in the
+                      decoded token.
+                    </span>
+                  </span>
                 )}
               </p>
             </div>
@@ -289,7 +298,7 @@ export function TeamManagementExternalSyncSection({
           <Label>Linked External Groups ({externalGroups.length})</Label>
           {isLoading ? (
             <div className="py-4 text-center text-sm text-muted-foreground">
-              Loading...
+              <span>Loading...</span>
             </div>
           ) : externalGroups.length === 0 ? (
             <div className="rounded-lg border border-dashed p-4 text-center">

--- a/platform/frontend/src/components/teams/team-management-vault-folder.ee.tsx
+++ b/platform/frontend/src/components/teams/team-management-vault-folder.ee.tsx
@@ -219,12 +219,12 @@ export function TeamManagementVaultFolderSection({
               {setFolderMutation.isPending ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  Saving...
+                  <span>Saving...</span>
                 </>
               ) : hasExistingFolder ? (
-                "Update Path"
+                <span>Update Path</span>
               ) : (
-                "Save Path"
+                <span>Save Path</span>
               )}
             </Button>
 
@@ -238,10 +238,10 @@ export function TeamManagementVaultFolderSection({
                 {checkConnectivityMutation.isPending ? (
                   <>
                     <Loader2 className="h-4 w-4 animate-spin" />
-                    Testing...
+                    <span>Testing...</span>
                   </>
                 ) : (
-                  "Test Connection"
+                  <span>Test Connection</span>
                 )}
               </Button>
             )}
@@ -274,9 +274,19 @@ export function TeamManagementVaultFolderSection({
                   : "Connection Failed"}
               </AlertTitle>
               <AlertDescription>
-                {connectivityResult.connected
-                  ? `Found ${connectivityResult.secretCount} secret${connectivityResult.secretCount !== 1 ? "s" : ""} in this folder.`
-                  : connectivityResult.error || "Unable to connect to Vault"}
+                {connectivityResult.connected ? (
+                  <span>
+                    Found {connectivityResult.secretCount} secret
+                    {connectivityResult.secretCount !== 1 ? (
+                      <span>s</span>
+                    ) : null}{" "}
+                    in this folder.
+                  </span>
+                ) : (
+                  <span>
+                    {connectivityResult.error || "Unable to connect to Vault"}
+                  </span>
+                )}
               </AlertDescription>
             </Alert>
           )}

--- a/platform/frontend/src/components/teams/teams-list.tsx
+++ b/platform/frontend/src/components/teams/teams-list.tsx
@@ -187,7 +187,7 @@ export function TeamsList() {
         const count = row.original.members?.length || 0;
         return (
           <div className="text-sm">
-            {count} member{count !== 1 ? "s" : ""}
+            {count} member{count !== 1 ? <span>s</span> : null}
           </div>
         );
       },

--- a/platform/frontend/src/components/ui/chart.tsx
+++ b/platform/frontend/src/components/ui/chart.tsx
@@ -346,7 +346,7 @@ function ChartLegendContent({
                   }}
                 />
               )}
-              {itemConfig?.label}
+              <span>{itemConfig?.label}</span>
             </div>
           );
         })}

--- a/platform/frontend/src/components/ui/select.tsx
+++ b/platform/frontend/src/components/ui/select.tsx
@@ -19,9 +19,27 @@ function SelectGroup({
 }
 
 function SelectValue({
+  placeholder,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      // A string placeholder renders as a bare text child of the value span
+      // and Radix removes it when the first value is selected — which crashes
+      // React once Chrome page-translate has re-parented that text into a
+      // <font> wrapper (facebook/react#11538). Wrapping it keeps the removed
+      // unit an element.
+      placeholder={
+        typeof placeholder === "string" ? (
+          <span>{placeholder}</span>
+        ) : (
+          placeholder
+        )
+      }
+      {...props}
+    />
+  );
 }
 
 function SelectTrigger({


### PR DESCRIPTION
## What

Follow-up to #6988 and #7015. An audit of the whole frontend for the crash shapes those PRs fixed turned up ~85 more latent sites: Chrome page-translate re-parents bare text nodes into `<font>` wrappers, and React crashes (`NotFoundError`) when it later deletes one or inserts an element before it (facebook/react#11538).

Three commits:

1. **Shared primitives** — `FormDialog` title/description (unkeyed slot that persists across wizard steps), `SelectValue` string placeholder (removed when a select gets its first value), chart legend label. Each fed the bad shape to every caller.
2. **Site sweep** (~95 files) — spinner/icon conditionals before bare button labels (~40 buttons: OAuth sign-ins, agent save, copy buttons that revert on a timer); loading/empty/data branches sharing a root tag whose status text is deleted in place when data arrives (chat sidebar title generation, connect key provisioning, tool/skill dialogs); paragraph ternaries swapping a sentence for a fragment; count/pluralization fragments next to translated siblings.
3. **Lint rule** — the GritQL guard, upgraded to unwrap parenthesized branches (the gap that hid the fragment-vs-string button class) and to catch empty-string branches and bare labels after a conditional element.
4. **Convention docs** — a "Text nodes and machine translation" section in the `archestra-dev-frontend` skill: the shapes the rule fails the build on with their fixes, the three it deliberately cannot see, what is safe so nobody churns it, and the Testing Library consequence of splitting a string across elements.

## Notes

- The rule only fires where a bare text node provably appears, disappears, or is replaced. Both-text ternaries (React updates in place) and unknowable variable branches stay unflagged — plugin diagnostics can't be `biome-ignore`d, so a false positive would hard-block CI.
- Wrapping splits some strings across sibling elements. Verified in Chrome that `textContent` and rendered width are unchanged; a few Testing Library queries needed scoping to their container.

## Testing

- Rule reports zero hits across `frontend/src`; `lint` and `type-check` clean; 3388 unit tests pass (the 2 failures in `llm/(costs)/limits/page.test.tsx` are pre-existing locale assertions that fail on main too).
- Browser-verified under real Chrome translation plus text-node instrumentation: Create Limit dialog scope change (the reported repro), Costs → Limits/Optimization Rules, messaging-channel tabs, invite-link copy timer, settings and registry pages — zero parent-mismatched DOM operations, no console errors.

https://claude.ai/code/session_013jXTnRb1u5zDikFM9SAj6U

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
