### PR TITLE
fix(chatops): let the bot answer to the name people actually see

### DIFF
--- a/platform/backend/src/agents/chatops/channel-activation.test.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.test.ts
@@ -712,6 +712,28 @@ describe.each([
     expect(postMutedNotice).not.toHaveBeenCalled();
   });
 
+  test("a mute addressed by the bot's display name is honored", async () => {
+    await markChannelThreadActive(activation);
+
+    // The org app name is white-labelled to something else entirely — people
+    // still address the bot by the name their chat client shows them.
+    expect(
+      await gate({ text: "SupportBot mute", botDisplayName: "SupportBot" }),
+    ).toEqual({ proceed: false, addressed: false });
+    expect(postMutedNotice).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unrelated name before a mute command is not a mute", async () => {
+    await markChannelThreadActive(activation);
+
+    // Only the names the bot answers to are stripped — "joey mute" is aimed at
+    // a person, and must reach the agent rather than silencing the thread.
+    expect(
+      await gate({ text: "joey mute", botDisplayName: "SupportBot" }),
+    ).toEqual({ proceed: true, addressed: true });
+    expect(postMutedNotice).not.toHaveBeenCalled();
+  });
+
   test("a mute addressed by app name rather than @mention is honored", async () => {
     await markChannelThreadActive(activation);
 

--- a/platform/backend/src/agents/chatops/channel-activation.test.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.test.ts
@@ -336,7 +336,7 @@ describe("isThreadMuteCommand", () => {
     });
 
     test.each([
-      "joey shut up", // aimed at a person, not the bot
+      "everyone shut up", // aimed at the room, not the bot
       "Archestra shut up the alerts channel", // not an exact command after the name
       "Archestra what's the status", // addressed, but not a mute
       "shut up Archestra", // name not a leading prefix
@@ -726,10 +726,10 @@ describe.each([
   test("an unrelated name before a mute command is not a mute", async () => {
     await markChannelThreadActive(activation);
 
-    // Only the names the bot answers to are stripped — "joey mute" is aimed at
-    // a person, and must reach the agent rather than silencing the thread.
+    // Only the names the bot answers to are stripped — "everyone mute" is aimed
+    // at the room, and must reach the agent rather than silencing the thread.
     expect(
-      await gate({ text: "joey mute", botDisplayName: "SupportBot" }),
+      await gate({ text: "everyone mute", botDisplayName: "SupportBot" }),
     ).toEqual({ proceed: true, addressed: true });
     expect(postMutedNotice).not.toHaveBeenCalled();
   });

--- a/platform/backend/src/agents/chatops/channel-activation.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.ts
@@ -441,6 +441,12 @@ export async function applyChannelGate(params: {
   threadId: string;
   botMentioned: boolean;
   text: string;
+  /**
+   * The bot's name as the provider displays it, so it answers to the name people
+   * actually see. Distinct from the organization's app name, which is a branding
+   * setting and can differ (or be white-labelled to something else entirely).
+   */
+  botDisplayName?: string | null;
   postMutedNotice: () => Promise<void>;
   resolveAnswerAllWorkspaceId: () => Promise<string | null>;
 }): Promise<{ proceed: boolean; addressed: boolean }> {
@@ -451,6 +457,7 @@ export async function applyChannelGate(params: {
   if (!wantsMute && mightBeAddressedMuteCommand(text)) {
     wantsMute = isThreadMuteCommand(text, [
       await OrganizationModel.getAppName(),
+      ...(params.botDisplayName ? [params.botDisplayName] : []),
     ]);
   }
   const isActive = botMentioned

--- a/platform/backend/src/agents/chatops/channel-activation.ts
+++ b/platform/backend/src/agents/chatops/channel-activation.ts
@@ -319,8 +319,8 @@ export async function claimThreadMuteHint(params: {
  * `addressableNames` lets a command be prefixed by a name the bot answers to
  * (e.g. the app name: "Archestra shut up", "Acme mute") without an explicit
  * @mention — a leading addressable name is stripped before matching. Only those
- * specific names are stripped, never an arbitrary word, so "joey shut up" (aimed
- * at a person) is not treated as a mute.
+ * specific names are stripped, never an arbitrary word, so "everyone shut up"
+ * (aimed at the room) is not treated as a mute.
  *
  * @public — applyChannelGate is the only production caller; the phrase matching
  * has its own suite in channel-activation.test.ts (knip can't see tests).

--- a/platform/backend/src/agents/chatops/slack-provider.ts
+++ b/platform/backend/src/agents/chatops/slack-provider.ts
@@ -78,6 +78,13 @@ class SlackProvider implements ChatOpsProvider {
 
   private client: WebClient | null = null;
   private botUserId: string | null = null;
+  /**
+   * The bot's name as Slack shows it, which is what someone types when they
+   * address it without an @mention ("Archestra mute"). auth.test can't provide
+   * it — for a bot token its `user` field is the literal string "bot" — so it is
+   * resolved from the bot's own profile.
+   */
+  private botDisplayName: string | null = null;
   private teamId: string | null = null;
   private teamName: string | null = null;
   private config: SlackDbConfig;
@@ -161,8 +168,16 @@ class SlackProvider implements ChatOpsProvider {
       this.botUserId = (body.user_id as string) || null;
       this.teamId = (body.team_id as string) || null;
       this.teamName = (body.team as string) || null;
+      // Best-effort: without it the bot simply stops answering to its own name.
+      this.botDisplayName = this.botUserId
+        ? await this.getUserName(this.botUserId)
+        : null;
       logger.info(
-        { botUserId: this.botUserId, teamId: this.teamId },
+        {
+          botUserId: this.botUserId,
+          botDisplayName: this.botDisplayName,
+          teamId: this.teamId,
+        },
         "[SlackProvider] Authenticated successfully",
       );
 
@@ -205,6 +220,7 @@ class SlackProvider implements ChatOpsProvider {
     this.socketDedup.clear();
     this.client = null;
     this.botUserId = null;
+    this.botDisplayName = null;
     this.teamId = null;
     this.teamName = null;
     logger.info("[SlackProvider] Cleaned up");
@@ -329,6 +345,7 @@ class SlackProvider implements ChatOpsProvider {
         threadId: threadTs,
         botMentioned: hasBotMention,
         text: cleanedText,
+        botDisplayName: this.botDisplayName,
         postMutedNotice: () =>
           this.postThreadMutedNotice(event.channel, threadTs),
         resolveAnswerAllWorkspaceId: async () => body.team_id || null,

--- a/platform/backend/src/routes/chatops.ts
+++ b/platform/backend/src/routes/chatops.ts
@@ -326,6 +326,8 @@ export const msTeamsWebhookRoutes: FastifyPluginAsyncZod = async (fastify) => {
                 threadId: message.threadId ?? message.channelId,
                 botMentioned,
                 text: message.text,
+                // Teams stamps the bot's display name on every activity.
+                botDisplayName: context.activity.recipient?.name,
                 postMutedNotice: async () => {
                   await context.sendActivity(buildThreadMutedNotice());
                 },


### PR DESCRIPTION
## Summary

Muting the bot by name without an @mention — `Archestra mute` — only worked when the message matched the organization's **App Name**. That is a branding field, described in Settings as the browser tab title, and it has nothing to do with what a chat client calls the bot. The two diverge the moment anyone white-labels: an install whose App Name is "Archestra Staging" ignored `archestra mute` entirely and passed it to the agent, which replied asking what the user wanted. Since the bot displays as "Archestra" in Slack, nobody would guess they had to type "archestra staging mute".

The bot now also answers to the display name the provider gives it, so the example the docs already use works whatever the branding is set to. The App Name keeps working too — an organization that white-labels to "Acme" can still say `acme mute`.

Slack cannot supply that name from `auth.test`: with a bot token its `user` field is the literal string `"bot"`, so reading it there would have made the bot answer only to `bot mute`. It comes from the bot's own profile instead, which the already-required `users:read` scope covers. Teams stamps the name on every activity, so no extra call. Resolution is best-effort — if the lookup fails the bot simply keeps answering to the App Name exactly as before.

Only names the bot answers to are stripped before matching, so `joey mute` still reaches the agent rather than silencing the thread.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>