### PR TITLE
fix(llm-proxy): enforce guardrails on client-decorated gateway tool names

### DIFF
--- a/platform/backend/src/archestra-mcp-server/run-tool-target.ts
+++ b/platform/backend/src/archestra-mcp-server/run-tool-target.ts
@@ -23,8 +23,7 @@ export function resolveRunToolTarget(
   args: unknown,
 ): { toolName: string; toolInput: Record<string, unknown> } {
   const toolInput = isRecord(args) ? args : {};
-  const shortName = archestraMcpBranding.getToolShortName(toolName);
-  if (shortName !== TOOL_RUN_TOOL_SHORT_NAME) {
+  if (!isRunToolName(toolName)) {
     return { toolName, toolInput };
   }
 
@@ -62,12 +61,18 @@ type RunToolDispatch =
  * policies evaluate the tool that actually produced the data instead of the
  * built-in wrapper.
  */
+/** True when the (canonical) tool name is the `run_tool` dispatch wrapper. */
+export function isRunToolName(toolName: string): boolean {
+  return (
+    archestraMcpBranding.getToolShortName(toolName) === TOOL_RUN_TOOL_SHORT_NAME
+  );
+}
+
 export function resolveRunToolDispatch(
   toolName: string,
   args: unknown,
 ): RunToolDispatch {
-  const shortName = archestraMcpBranding.getToolShortName(toolName);
-  if (shortName !== TOOL_RUN_TOOL_SHORT_NAME) {
+  if (!isRunToolName(toolName)) {
     return { kind: "not_dispatch" };
   }
 

--- a/platform/backend/src/guardrails/tool-invocation.test.ts
+++ b/platform/backend/src/guardrails/tool-invocation.test.ts
@@ -112,6 +112,44 @@ describe("evaluatePolicies", () => {
     expect(result).toBeNull();
   });
 
+  test("a run_tool dispatch target is blocked by its sensitive-context policy even when only the wrapper was enabled", async ({
+    makeAgent,
+    makeTool,
+    makeAgentTool,
+    makeToolPolicy,
+  }) => {
+    const agent = await makeAgent();
+    const tool = await makeTool({ name: "github__create_or_update_file" });
+    await makeAgentTool(agent.id, tool.id);
+    await makeToolPolicy(tool.id, {
+      conditions: [],
+      action: "block_when_context_is_untrusted",
+      reason: "No writes from a sensitive context",
+    });
+
+    // An external MCP client's request only enables the gateway's dispatch
+    // wrapper; the target reached through it must still be policy-evaluated
+    // rather than refused as disabled or skipped as unknown (T-996).
+    const enabledTools = new Set(["archestra__run_tool"]);
+
+    const result = await evaluatePolicies(
+      [
+        {
+          toolCallName: "github__create_or_update_file",
+          toolCallArgs: JSON.stringify({ path: "README.md" }),
+          isRunToolDispatchTarget: true,
+        },
+      ],
+      agent.id,
+      { teamIds: [] },
+      false,
+      enabledTools,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.blockedToolName).toBe("github__create_or_update_file");
+  });
+
   test("returns block result when policy has block_always action", async ({
     makeAgent,
     makeTool,

--- a/platform/backend/src/guardrails/tool-invocation.ts
+++ b/platform/backend/src/guardrails/tool-invocation.ts
@@ -181,7 +181,17 @@ export async function evaluateSingleMcpToolInvocationPolicy(params: {
  *                      the session id to reference; defaults to the LLM proxy.
  */
 export const evaluatePolicies = async (
-  toolCalls: Array<{ toolCallName: string; toolCallArgs: string }>,
+  toolCalls: Array<{
+    toolCallName: string;
+    toolCallArgs: string;
+    /**
+     * True when this entry is the resolved target of a `run_tool` dispatch
+     * rather than a directly-requested tool. The target is reachable through
+     * the enabled wrapper, so it is exempt from the enabled-tools filter —
+     * the gateway enforces the target's own availability at dispatch time.
+     */
+    isRunToolDispatchTarget?: boolean;
+  }>,
   agentId: string,
   context: PolicyEvaluationContext,
   contextIsTrusted: boolean,
@@ -206,19 +216,18 @@ export const evaluatePolicies = async (
   // This is required because otherwise the tool invocation policies will be evaluated
   // for tools that are disabled during chat session.
   // Note: archestra__* tools are always enabled (built-in tools that bypass policies)
-  const isToolEnabled = (toolName: string) =>
-    archestraMcpBranding.isToolName(toolName) ||
-    enabledToolNames?.has(toolName);
+  const isToolEnabled = (toolCall: (typeof toolCalls)[number]) =>
+    archestraMcpBranding.isToolName(toolCall.toolCallName) ||
+    toolCall.isRunToolDispatchTarget === true ||
+    enabledToolNames?.has(toolCall.toolCallName);
 
   let disabledToolNames: string[] = [];
   let filteredToolCalls = toolCalls;
   if (enabledToolNames && enabledToolNames.size > 0) {
     disabledToolNames = toolCalls
-      .filter((tc) => !isToolEnabled(tc.toolCallName))
+      .filter((tc) => !isToolEnabled(tc))
       .map((tc) => tc.toolCallName);
-    filteredToolCalls = toolCalls.filter((tc) =>
-      isToolEnabled(tc.toolCallName),
-    );
+    filteredToolCalls = toolCalls.filter((tc) => isToolEnabled(tc));
     if (disabledToolNames.length > 0) {
       logger.info(
         { disabledTools: disabledToolNames },

--- a/platform/backend/src/models/agent.ts
+++ b/platform/backend/src/models/agent.ts
@@ -44,15 +44,16 @@ import {
 import logger from "@/logging";
 import { registerProcessLocalCache } from "@/process-local-cache-registry";
 import { isSkillSandboxAvailableForAgent } from "@/skills/skill-sandbox-availability";
-import type {
-  Agent,
-  AgentScope,
-  AgentScopeFilter,
-  AgentType,
-  GatewayAgent,
-  InsertAgent,
-  SortingQuery,
-  UpdateAgent,
+import {
+  type Agent,
+  type AgentScope,
+  type AgentScopeFilter,
+  type AgentType,
+  GATEWAY_CAPABLE_AGENT_TYPES,
+  type GatewayAgent,
+  type InsertAgent,
+  type SortingQuery,
+  type UpdateAgent,
 } from "@/types";
 import { isUniqueConstraintError } from "@/utils/db";
 import { isUuid } from "@/utils/uuid";
@@ -1600,6 +1601,31 @@ class AgentModel {
       .from(schema.agentsTable)
       .where(eq(schema.agentsTable.id, id))
       .for("update");
+  }
+
+  /**
+   * Names of every live agent that can serve as an MCP gateway in this
+   * organization. External clients register gateways under a server name
+   * derived from these (see `toMcpClientServerName`), so the LLM proxy uses
+   * them to recognize client-decorated gateway tool names.
+   */
+  static async findGatewayNamesByOrganizationId(
+    organizationId: string,
+  ): Promise<string[]> {
+    const agents = await db
+      .select({ name: schema.agentsTable.name })
+      .from(schema.agentsTable)
+      .where(
+        and(
+          eq(schema.agentsTable.organizationId, organizationId),
+          notDeleted(schema.agentsTable),
+          inArray(schema.agentsTable.agentType, [
+            ...GATEWAY_CAPABLE_AGENT_TYPES,
+          ]),
+        ),
+      );
+
+    return agents.map((agent) => agent.name);
   }
 
   static async findIdsByOrganizationId(

--- a/platform/backend/src/routes/connection-setup/connection-setup.routes.ts
+++ b/platform/backend/src/routes/connection-setup/connection-setup.routes.ts
@@ -5,6 +5,7 @@ import {
   RouteId,
   type SupportedProvider,
   SupportedProvidersSchema,
+  toMcpClientServerName,
   VIRTUAL_KEY_HEADER,
 } from "@archestra/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
@@ -46,6 +47,7 @@ import {
   ConnectionSetupPlatformSchema,
   ConnectionSetupProxyAuthSchema,
   constructResponseSchema,
+  GATEWAY_CAPABLE_AGENT_TYPES,
   type Organization,
 } from "@/types";
 import {
@@ -658,7 +660,7 @@ export default connectionSetupRoutes;
 // Internal helpers
 // ===================================================================
 
-const GATEWAY_AGENT_TYPES = new Set(["mcp_gateway", "profile"]);
+const GATEWAY_AGENT_TYPES = new Set<string>(GATEWAY_CAPABLE_AGENT_TYPES);
 const PROXY_AGENT_TYPES = new Set(["llm_proxy", "profile"]);
 
 /**
@@ -702,7 +704,8 @@ async function buildScriptContext(setup: ConnectionSetup): Promise<{
     });
     if (!gateway) throw GONE();
     mcp = {
-      serverName: toServerName(gateway.name) || toMcpServerSlug(appName),
+      serverName:
+        toMcpClientServerName(gateway.name) || toMcpServerSlug(appName),
       url: `${setup.baseUrl}/mcp/${gateway.slug ?? gateway.id}`,
     };
   }
@@ -965,11 +968,6 @@ function normalizeBaseUrl(
     hostname,
     path,
   };
-}
-
-/** Gateway name → MCP server name, e.g. "Prod Gateway" → "prod_gateway". */
-function toServerName(name: string): string {
-  return name.trim().toLowerCase().replace(/\s+/g, "_");
 }
 
 /** Proxy name → TOML-safe provider id, e.g. "Default Proxy" → "default_proxy". */

--- a/platform/backend/src/routes/proxy/adapters/anthropic.ts
+++ b/platform/backend/src/routes/proxy/adapters/anthropic.ts
@@ -47,6 +47,7 @@ import {
   type SamplingParam,
   withSamplingParamFallback,
 } from "./sampling-param-fallback";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
 // TYPE ALIASES
@@ -1246,6 +1247,7 @@ export const anthropicAdapterFactory: LLMProvider<
 
     if (!apiKey && isAnthropicAzureFoundryEntraIdEnabled()) {
       return new AnthropicProvider({
+        maxRetries: PROXY_SDK_MAX_RETRIES,
         apiKey: null,
         authToken: null,
         baseURL: options.baseUrl,
@@ -1261,6 +1263,7 @@ export const anthropicAdapterFactory: LLMProvider<
 
     if (!apiKey && anthropicWorkloadIdentity.isEnabled()) {
       return new AnthropicProvider({
+        maxRetries: PROXY_SDK_MAX_RETRIES,
         apiKey: null,
         authToken: null,
         baseURL: options.baseUrl,
@@ -1275,6 +1278,7 @@ export const anthropicAdapterFactory: LLMProvider<
     }
 
     return new AnthropicProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey: regularApiKey,
       authToken: token,
       baseURL: options.baseUrl,

--- a/platform/backend/src/routes/proxy/adapters/archestra.ts
+++ b/platform/backend/src/routes/proxy/adapters/archestra.ts
@@ -13,6 +13,7 @@ import config from "@/config";
 import { metrics } from "@/observability";
 import type { CreateClientOptions } from "@/types";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 export const archestraAdapterFactory = createOpenAiCompatibleAdapterFactory({
   provider: "archestra",
@@ -31,6 +32,7 @@ export const archestraAdapterFactory = createOpenAiCompatibleAdapterFactory({
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl ?? config.llm.archestra.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/azure-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure-responses.ts
@@ -42,6 +42,7 @@ import {
   createStreamAccumulatorState,
   extractCommonToolCallArguments,
 } from "@/types";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 type AzureResponsesRequest = Azure.Types.ResponsesRequest;
 type AzureResponsesResponse = Azure.Types.ResponsesResponse;
@@ -115,6 +116,7 @@ export const azureResponsesAdapterFactory: LLMProvider<
 
     if (!apiKey && isAzureOpenAiEntraIdEnabled()) {
       return new OpenAIProvider({
+        maxRetries: PROXY_SDK_MAX_RETRIES,
         apiKey: getAzureOpenAiBearerTokenProvider(options.baseUrl),
         baseURL: resolvedBaseUrl,
         defaultQuery: getAzureResponsesDefaultQuery(options.baseUrl),
@@ -130,6 +132,7 @@ export const azureResponsesAdapterFactory: LLMProvider<
     const normalizedApiKey = normalizeAzureApiKey(apiKey);
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey: normalizedApiKey,
       baseURL: resolvedBaseUrl,
       defaultQuery: getAzureResponsesDefaultQuery(options.baseUrl),

--- a/platform/backend/src/routes/proxy/adapters/azure.ts
+++ b/platform/backend/src/routes/proxy/adapters/azure.ts
@@ -44,6 +44,7 @@ import {
   OpenAIResponseAdapter,
   OpenAIStreamAdapter,
 } from "./openai";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
 // TYPE ALIASES
@@ -245,6 +246,7 @@ export const azureAdapterFactory: LLMProvider<
 
     if (!apiKey && isAzureOpenAiEntraIdEnabled()) {
       const client = new OpenAIProvider({
+        maxRetries: PROXY_SDK_MAX_RETRIES,
         apiKey: getAzureOpenAiBearerTokenProvider(options.baseUrl),
         baseURL: options.baseUrl,
         defaultQuery: getAzureDefaultQuery(options.baseUrl),
@@ -275,6 +277,7 @@ export const azureAdapterFactory: LLMProvider<
     };
 
     const client = new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey: normalizedApiKey,
       baseURL: options.baseUrl,
       defaultQuery: getAzureDefaultQuery(options.baseUrl),
@@ -400,6 +403,7 @@ function getAzureClientForRequest(
   }
 
   return new OpenAIProvider({
+    maxRetries: PROXY_SDK_MAX_RETRIES,
     apiKey:
       azureClient.apiKey ??
       getAzureOpenAiBearerTokenProvider(deploymentBaseUrl),

--- a/platform/backend/src/routes/proxy/adapters/cerebras.ts
+++ b/platform/backend/src/routes/proxy/adapters/cerebras.ts
@@ -10,6 +10,7 @@ import config from "@/config";
 import { metrics } from "@/observability";
 import type { CreateClientOptions } from "@/types";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 export const cerebrasAdapterFactory = createOpenAiCompatibleAdapterFactory({
   provider: "cerebras",
@@ -28,6 +29,7 @@ export const cerebrasAdapterFactory = createOpenAiCompatibleAdapterFactory({
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/deepseek.ts
+++ b/platform/backend/src/routes/proxy/adapters/deepseek.ts
@@ -12,6 +12,7 @@ import config from "@/config";
 import { metrics } from "@/observability";
 import type { CreateClientOptions } from "@/types";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 export const deepseekAdapterFactory = createOpenAiCompatibleAdapterFactory({
   provider: "deepseek",
@@ -30,6 +31,7 @@ export const deepseekAdapterFactory = createOpenAiCompatibleAdapterFactory({
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl ?? config.llm.deepseek.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/github-copilot.ts
+++ b/platform/backend/src/routes/proxy/adapters/github-copilot.ts
@@ -14,6 +14,7 @@ import { metrics } from "@/observability";
 import { createGithubCopilotFetch } from "@/services/github-copilot-token";
 import type { CreateClientOptions } from "@/types";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 export const githubCopilotAdapterFactory = createOpenAiCompatibleAdapterFactory(
   {
@@ -33,6 +34,7 @@ export const githubCopilotAdapterFactory = createOpenAiCompatibleAdapterFactory(
         : undefined;
 
       return new OpenAIProvider({
+        maxRetries: PROXY_SDK_MAX_RETRIES,
         // Placeholder satisfies the SDK; the wrapper sets the real bearer.
         apiKey: apiKey ?? "github-copilot",
         baseURL: options.baseUrl ?? config.llm["github-copilot"].baseUrl,

--- a/platform/backend/src/routes/proxy/adapters/groq.ts
+++ b/platform/backend/src/routes/proxy/adapters/groq.ts
@@ -31,6 +31,7 @@ import {
   OpenAIResponseAdapter,
   OpenAIStreamAdapter,
 } from "./openai";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
 // TYPE ALIASES (reuse OpenAI types since Groq is OpenAI-compatible)
@@ -228,6 +229,7 @@ export const groqAdapterFactory: LLMProvider<
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/kimi.ts
+++ b/platform/backend/src/routes/proxy/adapters/kimi.ts
@@ -11,6 +11,7 @@ import config from "@/config";
 import { metrics } from "@/observability";
 import type { CreateClientOptions } from "@/types";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 export const kimiAdapterFactory = createOpenAiCompatibleAdapterFactory({
   provider: "kimi",
@@ -25,6 +26,7 @@ export const kimiAdapterFactory = createOpenAiCompatibleAdapterFactory({
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl ?? config.llm.kimi.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/mistral.ts
+++ b/platform/backend/src/routes/proxy/adapters/mistral.ts
@@ -31,6 +31,7 @@ import {
   OpenAIResponseAdapter,
   OpenAIStreamAdapter,
 } from "./openai";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
 // TYPE ALIASES (reuse OpenAI types since Mistral is OpenAI-compatible)
@@ -233,6 +234,7 @@ export const mistralAdapterFactory: LLMProvider<
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl ?? config.llm.mistral.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/ollama.ts
+++ b/platform/backend/src/routes/proxy/adapters/ollama.ts
@@ -10,6 +10,7 @@ import config from "@/config";
 import { metrics } from "@/observability";
 import type { CreateClientOptions } from "@/types";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 export const ollamaAdapterFactory = createOpenAiCompatibleAdapterFactory({
   provider: "ollama",
@@ -25,6 +26,7 @@ export const ollamaAdapterFactory = createOpenAiCompatibleAdapterFactory({
 
     // Ollama typically runs without auth; the OpenAI SDK still requires a non-empty key.
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey: apiKey || "EMPTY",
       baseURL: options.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/openai-codex-client.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-codex-client.ts
@@ -29,6 +29,7 @@ import {
   codexResponsesStreamToChatChunks,
   foldChatChunksToResponse,
 } from "./openai-codex-translator";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 type ChatCompletionsRequest = OpenAi.Types.ChatCompletionsRequest;
 type ChatCompletionsResponse = OpenAi.Types.ChatCompletionsResponse;
@@ -76,6 +77,7 @@ class OpenAiCodexClient {
   }) {
     const { credential, options, innerFetch } = params;
     this.openai = new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       // The Codex backend authenticates via the fetch wrapper's OAuth bearer;
       // the SDK still needs a non-empty key.
       apiKey: "chatgpt-oauth",

--- a/platform/backend/src/routes/proxy/adapters/openai-codex-responses-client.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-codex-responses-client.ts
@@ -25,6 +25,7 @@ import {
 } from "@/services/openai-codex-credentials";
 import { createOpenAiCodexFetch } from "@/services/openai-codex-token";
 import { ApiError, type CreateClientOptions, type OpenAi } from "@/types";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 type ResponsesRequest = OpenAi.Types.ResponsesRequest;
 type ResponsesResponse = OpenAi.Types.ResponsesResponse;
@@ -66,6 +67,7 @@ class OpenAiCodexResponsesClient {
   }) {
     const { credential, options, innerFetch } = params;
     this.openai = new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       // The Codex backend authenticates via the fetch wrapper's OAuth bearer;
       // the SDK still needs a non-empty key.
       apiKey: "chatgpt-oauth",

--- a/platform/backend/src/routes/proxy/adapters/openai-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai-responses.ts
@@ -38,6 +38,7 @@ import {
   extractCommonToolCallArguments,
 } from "@/types";
 import { createOpenAiCodexResponsesClient } from "./openai-codex-responses-client";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 type OpenAiResponsesRequest = OpenAi.Types.ResponsesRequest;
 type OpenAiResponsesResponse = OpenAi.Types.ResponsesResponse;
@@ -129,6 +130,7 @@ export const openAiResponsesAdapterFactory: LLMProvider<
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: resolvedBaseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/openai.ts
+++ b/platform/backend/src/routes/proxy/adapters/openai.ts
@@ -53,6 +53,7 @@ import {
 import { stripBrowserToolsResults } from "../utils/summarize-tool-results";
 import { unwrapToolContent } from "../utils/unwrap-tool-content";
 import { createOpenAiCodexClient } from "./openai-codex-client";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
 // TYPE ALIASES
@@ -1579,6 +1580,7 @@ export const openaiAdapterFactory: LLMProvider<
     };
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/openrouter.ts
+++ b/platform/backend/src/routes/proxy/adapters/openrouter.ts
@@ -29,6 +29,7 @@ import {
   OpenAIResponseAdapter,
   OpenAIStreamAdapter,
 } from "./openai";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
 // TYPE ALIASES (reuse OpenAI types since OpenRouter is OpenAI-compatible)
@@ -249,6 +250,7 @@ export const openrouterAdapterFactory: LLMProvider<
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey: rawApiKey,
       baseURL: options.baseUrl ?? config.llm.openrouter.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/perplexity-responses.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity-responses.ts
@@ -29,6 +29,7 @@ import { metrics } from "@/observability";
 import type { CreateClientOptions, LLMProvider, Perplexity } from "@/types";
 import { ApiError } from "@/types";
 import { openAiResponsesAdapterFactory } from "./openai-responses";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 type PerplexityResponsesRequest = Perplexity.Types.ResponsesRequest;
 type PerplexityResponsesResponse = Perplexity.Types.ResponsesResponse;
@@ -78,6 +79,7 @@ export const perplexityResponsesAdapterFactory: LLMProvider<
     }
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: perplexityAgentApiBaseUrl(options.baseUrl),
       fetch: options.agent

--- a/platform/backend/src/routes/proxy/adapters/perplexity.ts
+++ b/platform/backend/src/routes/proxy/adapters/perplexity.ts
@@ -47,6 +47,7 @@ import type {
   UsageView,
 } from "@/types";
 import { extractCommonMessageText } from "@/types";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
 // TYPE ALIASES
@@ -594,6 +595,7 @@ export const perplexityAdapterFactory: LLMProvider<
 
     // Use OpenAI SDK with Perplexity base URL (OpenAI-compatible API)
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/sdk-retry-policy.test.ts
+++ b/platform/backend/src/routes/proxy/adapters/sdk-retry-policy.test.ts
@@ -1,0 +1,114 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, test } from "@/test";
+import { anthropicAdapterFactory } from "./anthropic";
+import { archestraAdapterFactory } from "./archestra";
+import { cerebrasAdapterFactory } from "./cerebras";
+import { deepseekAdapterFactory } from "./deepseek";
+import { groqAdapterFactory } from "./groq";
+import { kimiAdapterFactory } from "./kimi";
+import { mistralAdapterFactory } from "./mistral";
+import { ollamaAdapterFactory } from "./ollama";
+import { openaiAdapterFactory } from "./openai";
+import { openrouterAdapterFactory } from "./openrouter";
+import { vllmAdapterFactory } from "./vllm";
+import { xaiAdapterFactory } from "./xai";
+
+/**
+ * The incident this pins: Moonshot answered a chat stream with a
+ * tokens-per-day 429 whose Retry-After pointed at the daily quota reset,
+ * hours away. The openai SDK honors Retry-After with no upper bound, so with
+ * SDK retries enabled the request slept inside `executeStream` instead of
+ * rejecting — the proxy request never resolved and the chat UI spun forever.
+ * The proxy must relay the 429 immediately; retry policy belongs to callers.
+ */
+describe("proxy SDK clients do not retry upstream errors", () => {
+  let server: Server;
+  let baseUrl: string;
+  let requestCount: number;
+
+  beforeAll(async () => {
+    requestCount = 0;
+    server = createServer((_req, res) => {
+      requestCount += 1;
+      res.writeHead(429, {
+        "content-type": "application/json",
+        // Daily-quota reset far in the future; an SDK that obeys this
+        // header before retrying hangs the request for hours.
+        "retry-after": "86400",
+      });
+      res.end(
+        JSON.stringify({
+          error: {
+            message: "request reached organization TPD rate limit",
+            type: "rate_limit_reached_error",
+          },
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}/v1`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  test("a rate-limited streaming request rejects immediately instead of sleeping on Retry-After", {
+    timeout: 5000,
+  }, async () => {
+    const client = kimiAdapterFactory.createClient("test-key", {
+      baseUrl,
+      source: "api",
+    });
+
+    const startTime = Date.now();
+    await expect(
+      kimiAdapterFactory.executeStream(client, {
+        model: "kimi-k2.6",
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      }),
+    ).rejects.toMatchObject({ status: 429 });
+
+    // Well under the 86400s Retry-After and the SDK's own backoff floor.
+    expect(Date.now() - startTime).toBeLessThan(2000);
+    expect(requestCount).toBe(1);
+  });
+
+  test("every OpenAI-based adapter client is constructed with retries disabled", () => {
+    const factories = [
+      archestraAdapterFactory,
+      cerebrasAdapterFactory,
+      deepseekAdapterFactory,
+      groqAdapterFactory,
+      kimiAdapterFactory,
+      mistralAdapterFactory,
+      ollamaAdapterFactory,
+      openaiAdapterFactory,
+      openrouterAdapterFactory,
+      vllmAdapterFactory,
+      xaiAdapterFactory,
+    ];
+    for (const factory of factories) {
+      const client = factory.createClient("test-key", {
+        baseUrl,
+        source: "api",
+      }) as { maxRetries: number };
+      expect(client.maxRetries, factory.provider).toBe(0);
+    }
+  });
+
+  test("the Anthropic adapter client is constructed with retries disabled", () => {
+    const client = anthropicAdapterFactory.createClient("test-key", {
+      baseUrl,
+      source: "api",
+    }) as { maxRetries: number };
+    expect(client.maxRetries).toBe(0);
+  });
+});

--- a/platform/backend/src/routes/proxy/adapters/sdk-retry-policy.ts
+++ b/platform/backend/src/routes/proxy/adapters/sdk-retry-policy.ts
@@ -1,0 +1,10 @@
+/**
+ * The proxy relays provider errors instead of retrying them: callers (chat's
+ * AI SDK, native Anthropic/OpenAI clients) run their own bounded retry policy
+ * on the relayed status, and SDK-internal retries stack multiplicatively on
+ * top of that while keeping the request silently open. The openai SDK (v6)
+ * also honors a 429's Retry-After verbatim with no upper bound, so a
+ * daily-quota rate limit whose reset lies hours away slept inside the request
+ * and hung chat streams indefinitely instead of surfacing the error.
+ */
+export const PROXY_SDK_MAX_RETRIES = 0;

--- a/platform/backend/src/routes/proxy/adapters/vllm.ts
+++ b/platform/backend/src/routes/proxy/adapters/vllm.ts
@@ -10,6 +10,7 @@ import config from "@/config";
 import { metrics } from "@/observability";
 import type { CreateClientOptions } from "@/types";
 import { createOpenAiCompatibleAdapterFactory } from "./openai-compatible-adapter";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 export const vllmAdapterFactory = createOpenAiCompatibleAdapterFactory({
   provider: "vllm",
@@ -25,6 +26,7 @@ export const vllmAdapterFactory = createOpenAiCompatibleAdapterFactory({
 
     // vLLM typically runs without auth; the OpenAI SDK still requires a non-empty key.
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey: apiKey || "EMPTY",
       baseURL: options.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/adapters/xai.ts
+++ b/platform/backend/src/routes/proxy/adapters/xai.ts
@@ -27,6 +27,7 @@ import {
   OpenAIResponseAdapter,
   OpenAIStreamAdapter,
 } from "./openai";
+import { PROXY_SDK_MAX_RETRIES } from "./sdk-retry-policy";
 
 // =============================================================================
 // TYPE ALIASES (reuse OpenAI types since xAI is OpenAI-compatible)
@@ -222,6 +223,7 @@ export const xaiAdapterFactory: LLMProvider<
       : undefined;
 
     return new OpenAIProvider({
+      maxRetries: PROXY_SDK_MAX_RETRIES,
       apiKey,
       baseURL: options.baseUrl,
       fetch: customFetch,

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.gateway-guardrails.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.gateway-guardrails.test.ts
@@ -1,0 +1,214 @@
+/**
+ * End-to-end regression pin for T-996: guardrails must fire for external MCP
+ * clients (Claude Code connected via the connect page) whose tool traffic
+ * reaches the proxy under client-decorated names and run_tool envelopes.
+ *
+ * Mirrors the captured incident request: only the gateway meta-tools are in
+ * the request's tool list (decorated `mcp__<gateway>__archestra__…`), a prior
+ * `run_tool`-dispatched `notion__notion-fetch` result sits in the
+ * conversation (its trusted-data policy marks the context untrusted), and the
+ * model responds with a `run_tool` dispatch to `github__issue_write`, whose
+ * "block in sensitive context" invocation policy must block the turn.
+ *
+ * Deliberately does NOT mock the guardrail chain — this exercises the real
+ * canonicalizer, trusted-data evaluation, and policy evaluation end to end.
+ */
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import { archestraMcpBranding } from "@/archestra-mcp-server/branding";
+import { ModelModel } from "@/models";
+import { afterEach, beforeEach, describe, expect, test, vi } from "@/test";
+import {
+  type AnthropicStubOptions,
+  createAnthropicTestClient,
+} from "@/test/llm-provider-stubs";
+import type { Agent } from "@/types";
+import { anthropicAdapterFactory } from "./adapters";
+import anthropicProxyRoutes from "./routes/anthropic";
+
+const GATEWAY_NAME = "My Gateway";
+const DECORATED_RUN_TOOL = "mcp__my_gateway__archestra__run_tool";
+const DECORATED_SEARCH_TOOLS = "mcp__my_gateway__archestra__search_tools";
+const NOTION_FETCH = "notion__notion-fetch";
+const GITHUB_ISSUE_WRITE = "github__issue_write";
+
+describe("LLM Proxy guardrails for gateway-connected clients (T-996)", () => {
+  let app: FastifyInstance;
+  let anthropicStubOptions: AnthropicStubOptions;
+  let proxyAgent: Agent;
+
+  beforeEach(
+    async ({
+      makeAgent,
+      makeTool,
+      makeAgentTool,
+      makeToolPolicy,
+      makeTrustedDataPolicy,
+    }) => {
+      archestraMcpBranding.syncFromOrganization(null);
+
+      app = Fastify().withTypeProvider<ZodTypeProvider>();
+      app.setValidatorCompiler(validatorCompiler);
+      app.setSerializerCompiler(serializerCompiler);
+      await app.register(anthropicProxyRoutes);
+
+      anthropicStubOptions = {};
+      vi.spyOn(anthropicAdapterFactory, "createClient").mockImplementation(
+        () => createAnthropicTestClient(anthropicStubOptions) as never,
+      );
+
+      await ModelModel.upsert({
+        externalId: "anthropic/claude-3-5-sonnet-20241022",
+        provider: "anthropic",
+        modelId: "claude-3-5-sonnet-20241022",
+        inputModalities: null,
+        outputModalities: null,
+        customPricePerMillionInput: "3.00",
+        customPricePerMillionOutput: "15.00",
+        lastSyncedAt: new Date(),
+      });
+
+      proxyAgent = await makeAgent({ name: "T996 Proxy Agent" });
+      // The gateway whose client server name anchors the canonicalizer.
+      await makeAgent({
+        organizationId: proxyAgent.organizationId,
+        agentType: "mcp_gateway",
+        name: GATEWAY_NAME,
+      });
+
+      const notionTool = await makeTool({ name: NOTION_FETCH });
+      const githubTool = await makeTool({ name: GITHUB_ISSUE_WRITE });
+      await makeAgentTool(proxyAgent.id, notionTool.id);
+      await makeAgentTool(proxyAgent.id, githubTool.id);
+      // notion-fetch results are external data; issue_write is blocked once
+      // the session context is sensitive — the incident's exact config.
+      await makeTrustedDataPolicy(notionTool.id, {
+        conditions: [],
+        action: "mark_as_untrusted",
+      });
+      await makeToolPolicy(githubTool.id, {
+        conditions: [],
+        action: "block_when_context_is_untrusted",
+        reason: "No writes from a sensitive context",
+      });
+    },
+  );
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  const gatewayMetaTools = [
+    {
+      name: DECORATED_RUN_TOOL,
+      description: "Run a tool by name",
+      input_schema: { type: "object", properties: {} },
+    },
+    {
+      name: DECORATED_SEARCH_TOOLS,
+      description: "Search tools",
+      input_schema: { type: "object", properties: {} },
+    },
+  ];
+
+  const conversationWithNotionFetch = [
+    { role: "user", content: "Find the Notion doc and file a GitHub issue" },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_notion_fetch",
+          name: DECORATED_RUN_TOOL,
+          input: { tool_name: NOTION_FETCH, tool_args: { id: "hello" } },
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_notion_fetch",
+          content: "Notion page 'hello': some external document content",
+        },
+      ],
+    },
+  ];
+
+  test("blocks a run_tool-dispatched sensitive write after an untrusted fetch", async () => {
+    anthropicStubOptions.nonStreamingToolUse = {
+      name: DECORATED_RUN_TOOL,
+      input: {
+        tool_name: GITHUB_ISSUE_WRITE,
+        tool_args: { method: "create", title: "hello" },
+      },
+    };
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/anthropic/${proxyAgent.id}/v1/messages`,
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "test-key",
+        "anthropic-version": "2023-06-01",
+      },
+      payload: {
+        model: "claude-3-5-sonnet-20241022",
+        max_tokens: 1024,
+        messages: conversationWithNotionFetch,
+        tools: gatewayMetaTools,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    const types = body.content.map((block: { type: string }) => block.type);
+    // The dispatch is discarded; the client gets only the refusal text, which
+    // names the real target tool rather than the run_tool wrapper.
+    expect(types).toEqual(["text"]);
+    expect(body.content[0].text).toContain(GITHUB_ISSUE_WRITE);
+    expect(body.stop_reason).toBe("end_turn");
+  });
+
+  test("allows the same dispatch when the context is clean", async () => {
+    anthropicStubOptions.nonStreamingToolUse = {
+      name: DECORATED_RUN_TOOL,
+      input: {
+        tool_name: GITHUB_ISSUE_WRITE,
+        tool_args: { method: "create", title: "hello" },
+      },
+    };
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/anthropic/${proxyAgent.id}/v1/messages`,
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "test-key",
+        "anthropic-version": "2023-06-01",
+      },
+      payload: {
+        model: "claude-3-5-sonnet-20241022",
+        max_tokens: 1024,
+        messages: [
+          { role: "user", content: "File a GitHub issue titled hello" },
+        ],
+        tools: gatewayMetaTools,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    const toolUses = body.content.filter(
+      (block: { type: string }) => block.type === "tool_use",
+    );
+    expect(toolUses).toHaveLength(1);
+    expect(toolUses[0].name).toBe(DECORATED_RUN_TOOL);
+  });
+});

--- a/platform/backend/src/routes/proxy/llm-proxy-handler.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-handler.ts
@@ -25,6 +25,7 @@ import {
   propagation,
 } from "@opentelemetry/api";
 import type { FastifyReply, FastifyRequest } from "fastify";
+import { isRunToolName } from "@/archestra-mcp-server/run-tool-target";
 import { LRUCacheManager } from "@/cache-manager";
 import { anthropicWorkloadIdentity } from "@/clients/anthropic-workload-identity";
 import { isAzureOpenAiEntraIdEnabled } from "@/clients/azure-openai-credentials";
@@ -90,6 +91,7 @@ import {
   applyInputTokenFallback,
   buildInteractionRecord,
   calculateInteractionCosts,
+  canonicalizeCommonMessageToolNames,
   handleError,
   normalizeToolCallsForPolicy,
   recordBlockedToolCallMetrics,
@@ -128,6 +130,8 @@ export interface LLMProxyContext<TRequest> {
   actualModel: string;
   contextIsTrusted: boolean;
   enabledToolNames: Set<string>;
+  /** Maps client-decorated gateway tool names to the platform's own names. */
+  canonicalizeToolName: utils.gatewayToolNames.ToolNameCanonicalizer;
   toonStats: ToolCompressionStats;
   toonSkipReason: ToonSkipReason | null;
   dualLlmAnalyses: DualLlmAnalysis[];
@@ -887,7 +891,19 @@ export async function handleLLMProxy<
       `[${providerName}Proxy] Evaluating trusted data policies`,
     );
 
-    const commonMessages = requestAdapter.getMessages();
+    // Map client-decorated gateway tool names (e.g. Claude Code's
+    // `mcp__<gateway>__archestra__run_tool`) back to the platform's own names
+    // before any guardrail evaluation — trusted-data and tool-invocation
+    // lookups otherwise miss the real tool behind the decoration and the
+    // dispatch wrapper.
+    const canonicalizeToolName =
+      await utils.gatewayToolNames.buildGatewayToolNameCanonicalizer(
+        resolvedAgent.organizationId,
+      );
+    const commonMessages = canonicalizeCommonMessageToolNames(
+      requestAdapter.getMessages(),
+      canonicalizeToolName,
+    );
     const effectiveConsiderContextUntrusted =
       resolvedAgent.considerContextUntrusted || inheritedContextUntrusted;
     const initialUntrustedReason = resolvedAgent.considerContextUntrusted
@@ -1075,12 +1091,14 @@ export async function handleLLMProxy<
     // Build final request
     const finalRequest = requestAdapter.toProviderRequest();
 
-    // Extract enabled tool names for filtering in evaluatePolicies
+    // Extract enabled tool names for filtering in evaluatePolicies —
+    // canonicalized so they compare against canonicalized tool-call names.
     const enabledToolNames = new Set(
       requestAdapter
         .getTools()
         .map((t) => t.name)
-        .filter(Boolean),
+        .filter(Boolean)
+        .map(canonicalizeToolName),
     );
 
     // Convert headers to Record<string, string> for policy evaluation context
@@ -1110,6 +1128,7 @@ export async function handleLLMProxy<
       actualModel,
       contextIsTrusted,
       enabledToolNames,
+      canonicalizeToolName,
       toonStats,
       toonSkipReason,
       dualLlmAnalyses,
@@ -1230,6 +1249,7 @@ async function handleStreaming<
     actualModel,
     contextIsTrusted,
     enabledToolNames,
+    canonicalizeToolName,
     toonStats,
     toonSkipReason,
     dualLlmAnalyses,
@@ -1405,18 +1425,26 @@ async function handleStreaming<
                   continue;
                 }
                 sawNamedToolCall = true;
-                const cacheKey = `${agent.id}:${toolCall.name}:${contextIsTrusted}`;
+                const canonicalToolName = canonicalizeToolName(toolCall.name);
+                // A run_tool dispatch's target only becomes known once its
+                // arguments finish streaming, so the wrapper always buffers —
+                // the target's blocking policies cannot be consulted yet.
+                if (isRunToolName(canonicalToolName)) {
+                  anyBlocking = true;
+                  continue;
+                }
+                const cacheKey = `${agent.id}:${canonicalToolName}:${contextIsTrusted}`;
                 let hasBlocking = toolPolicyCache.get(cacheKey);
                 if (hasBlocking === undefined) {
                   try {
                     hasBlocking =
                       await ToolInvocationPolicyModel.hasBlockingPolicy(
-                        toolCall.name,
+                        canonicalToolName,
                         contextIsTrusted,
                       );
                   } catch (err) {
                     logger.warn(
-                      { err, toolName: toolCall.name },
+                      { err, toolName: canonicalToolName },
                       "hasBlockingPolicy lookup failed, defaulting to buffer",
                     );
                     hasBlocking = true;
@@ -1564,7 +1592,7 @@ async function handleStreaming<
       );
 
       toolInvocationRefusal = await utils.toolInvocation.evaluatePolicies(
-        normalizeToolCallsForPolicy(toolCalls),
+        normalizeToolCallsForPolicy(toolCalls, canonicalizeToolName),
         agent.id,
         {
           teamIds: teamIds ?? [],
@@ -1807,6 +1835,7 @@ async function handleNonStreaming<
     actualModel,
     contextIsTrusted,
     enabledToolNames,
+    canonicalizeToolName,
     toonStats,
     toonSkipReason,
     dualLlmAnalyses,
@@ -1984,7 +2013,7 @@ async function handleNonStreaming<
   // Evaluate tool invocation policies
   if (toolCalls.length > 0) {
     const toolInvocationRefusal = await utils.toolInvocation.evaluatePolicies(
-      normalizeToolCallsForPolicy(toolCalls),
+      normalizeToolCallsForPolicy(toolCalls, canonicalizeToolName),
       agent.id,
       {
         teamIds: teamIds ?? [],

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.test.ts
@@ -160,6 +160,60 @@ describe("normalizeToolCallsForPolicy", () => {
       },
     ]);
   });
+
+  test("unwraps a run_tool dispatch to the target tool it names", () => {
+    const result = normalizeToolCallsForPolicy([
+      {
+        name: "archestra__run_tool",
+        arguments: JSON.stringify({
+          tool_name: "github__create_or_update_file",
+          tool_args: { path: "README.md" },
+        }),
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        toolCallName: "github__create_or_update_file",
+        toolCallArgs: '{"path":"README.md"}',
+        isRunToolDispatchTarget: true,
+      },
+    ]);
+  });
+
+  test("canonicalizes client-decorated names before dispatch resolution", () => {
+    const canonicalize = (name: string) =>
+      name.startsWith("mcp__gw__") ? name.slice("mcp__gw__".length) : name;
+    const result = normalizeToolCallsForPolicy(
+      [
+        {
+          name: "mcp__gw__archestra__run_tool",
+          arguments: JSON.stringify({
+            tool_name: "github__create_issue",
+            tool_args: {},
+          }),
+        },
+        { name: "mcp__gw__github__direct_tool", arguments: "{}" },
+      ],
+      canonicalize,
+    );
+    expect(result).toEqual([
+      {
+        toolCallName: "github__create_issue",
+        toolCallArgs: "{}",
+        isRunToolDispatchTarget: true,
+      },
+      { toolCallName: "github__direct_tool", toolCallArgs: "{}" },
+    ]);
+  });
+
+  test("keeps an unresolvable run_tool dispatch under the wrapper name", () => {
+    const result = normalizeToolCallsForPolicy([
+      { name: "archestra__run_tool", arguments: '{"tool_args":{}}' },
+    ]);
+    expect(result).toEqual([
+      { toolCallName: "archestra__run_tool", toolCallArgs: '{"tool_args":{}}' },
+    ]);
+  });
 });
 
 // --------------------------------------------------------------------------

--- a/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
+++ b/platform/backend/src/routes/proxy/llm-proxy-helpers.ts
@@ -15,6 +15,10 @@ import {
 } from "@archestra/shared";
 import { context as otelContext } from "@opentelemetry/api";
 import type { FastifyReply } from "fastify";
+import {
+  resolveRunToolDispatch,
+  resolveRunToolTarget,
+} from "@/archestra-mcp-server/run-tool-target";
 import { isNativeAnthropicModelShape } from "@/clients/anthropic-endpoint";
 import logger from "@/logging";
 import { metrics } from "@/observability";
@@ -23,6 +27,7 @@ import type { SpanTeamInfo, SpanUserInfo } from "@/observability/tracing";
 import { getTokenizer } from "@/tokenizers";
 import type {
   CommonMcpToolDefinition,
+  CommonMessage,
   DualLlmAnalysis,
   GatewayAgent,
   InsertInteraction,
@@ -41,6 +46,7 @@ import {
 } from "@/utils/network-errors";
 import * as utils from "./utils";
 import { estimateToolTokens } from "./utils/cost-optimization";
+import type { ToolNameCanonicalizer } from "./utils/gateway-tool-names";
 import type { SessionSource } from "./utils/headers/session-id";
 
 /**
@@ -75,23 +81,72 @@ export function shouldForwardAnthropicBeta(
  *
  * - String arguments: validated as JSON, wrapped in `{ raw: ... }` if invalid
  * - Object arguments: serialized with JSON.stringify
+ * - Names are canonicalized (client-decorated gateway names stripped back to
+ *   the platform's own names), and a `run_tool` dispatch is unwrapped to the
+ *   target tool it names — policies must evaluate the tool that will actually
+ *   execute, not the opaque wrapper (whose name matches no `tools` row and
+ *   would fail open as "no policies found").
  */
 export function normalizeToolCallsForPolicy(
   toolCalls: Array<{ name: string; arguments: string | object }>,
-): Array<{ toolCallName: string; toolCallArgs: string }> {
+  canonicalizeToolName: ToolNameCanonicalizer = (name) => name,
+): Array<{
+  toolCallName: string;
+  toolCallArgs: string;
+  isRunToolDispatchTarget?: boolean;
+}> {
   return toolCalls.map((tc) => {
+    let args: unknown;
     let argsString: string;
     if (typeof tc.arguments === "string") {
       try {
-        JSON.parse(tc.arguments);
+        args = JSON.parse(tc.arguments);
         argsString = tc.arguments;
       } catch {
+        args = undefined;
         argsString = JSON.stringify({ raw: tc.arguments });
       }
     } else {
+      args = tc.arguments;
       argsString = JSON.stringify(tc.arguments);
     }
-    return { toolCallName: tc.name, toolCallArgs: argsString };
+
+    const canonicalName = canonicalizeToolName(tc.name);
+    const dispatch = resolveRunToolDispatch(canonicalName, args);
+    if (dispatch.kind === "target") {
+      const { toolInput } = resolveRunToolTarget(canonicalName, args);
+      return {
+        toolCallName: dispatch.toolName,
+        toolCallArgs: JSON.stringify(toolInput),
+        isRunToolDispatchTarget: true,
+      };
+    }
+    return { toolCallName: canonicalName, toolCallArgs: argsString };
+  });
+}
+
+/**
+ * Return a copy of the request's common messages with every tool-call name
+ * canonicalized, so trusted-data evaluation sees the platform's own tool
+ * names instead of the client-decorated twins (which match no tool row and
+ * would flip every gateway conversation to untrusted — including over
+ * platform-authored built-in results like `search_tools`).
+ */
+export function canonicalizeCommonMessageToolNames(
+  messages: CommonMessage[],
+  canonicalizeToolName: ToolNameCanonicalizer,
+): CommonMessage[] {
+  return messages.map((message) => {
+    if (!message.toolCalls || message.toolCalls.length === 0) {
+      return message;
+    }
+    return {
+      ...message,
+      toolCalls: message.toolCalls.map((toolCall) => ({
+        ...toolCall,
+        name: canonicalizeToolName(toolCall.name),
+      })),
+    };
   });
 }
 

--- a/platform/backend/src/routes/proxy/utils/gateway-tool-names.test.ts
+++ b/platform/backend/src/routes/proxy/utils/gateway-tool-names.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "@/test";
+import { buildGatewayToolNameCanonicalizer } from "./gateway-tool-names";
+
+describe("buildGatewayToolNameCanonicalizer", () => {
+  test("strips a Claude Code style decoration for the org's own gateway", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      name: "Prod Gateway",
+    });
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+
+    expect(canonicalize("mcp__prod_gateway__archestra__run_tool")).toBe(
+      "archestra__run_tool",
+    );
+    expect(canonicalize("mcp__prod_gateway__github__create_issue")).toBe(
+      "github__create_issue",
+    );
+  });
+
+  test("strips a decoration whose gateway label sits first", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      name: "Prod Gateway",
+    });
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+
+    expect(canonicalize("prod_gateway__archestra__search_tools")).toBe(
+      "archestra__search_tools",
+    );
+  });
+
+  test("expands a bare built-in short name left after stripping", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      name: "Prod Gateway",
+    });
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+
+    expect(canonicalize("mcp__prod_gateway__run_tool")).toBe(
+      "archestra__run_tool",
+    );
+  });
+
+  test("leaves foreign server labels and undecorated names untouched", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const org = await makeOrganization();
+    await makeAgent({
+      organizationId: org.id,
+      agentType: "mcp_gateway",
+      name: "Prod Gateway",
+    });
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+
+    // A hostile or unrelated MCP server connected directly to the client must
+    // not get its tools canonicalized into platform names.
+    expect(canonicalize("mcp__evil__archestra__run_tool")).toBe(
+      "mcp__evil__archestra__run_tool",
+    );
+    expect(canonicalize("github__create_issue")).toBe("github__create_issue");
+    expect(canonicalize("plain_tool")).toBe("plain_tool");
+  });
+
+  test("is the identity when the organization has no gateways", async ({
+    makeOrganization,
+  }) => {
+    const org = await makeOrganization();
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+
+    expect(canonicalize("mcp__prod_gateway__archestra__run_tool")).toBe(
+      "mcp__prod_gateway__archestra__run_tool",
+    );
+  });
+
+  test("does not treat another organization's gateway name as a label", async ({
+    makeOrganization,
+    makeAgent,
+  }) => {
+    const otherOrg = await makeOrganization();
+    await makeAgent({
+      organizationId: otherOrg.id,
+      agentType: "mcp_gateway",
+      name: "Other Gateway",
+    });
+    const org = await makeOrganization();
+
+    const canonicalize = await buildGatewayToolNameCanonicalizer(org.id);
+
+    expect(canonicalize("mcp__other_gateway__archestra__run_tool")).toBe(
+      "mcp__other_gateway__archestra__run_tool",
+    );
+  });
+});

--- a/platform/backend/src/routes/proxy/utils/gateway-tool-names.ts
+++ b/platform/backend/src/routes/proxy/utils/gateway-tool-names.ts
@@ -1,0 +1,99 @@
+import {
+  MCP_SERVER_TOOL_NAME_SEPARATOR,
+  toMcpClientServerName,
+} from "@archestra/shared";
+import { resolveRunToolTargetName } from "@/archestra-mcp-server/run-tool-target";
+import { LRUCacheManager } from "@/cache-manager";
+import { AgentModel } from "@/models";
+
+/**
+ * Maps a tool name as an external MCP client presents it to the canonical
+ * name the platform knows it by, or returns it unchanged when it is not a
+ * decorated gateway tool name.
+ */
+export type ToolNameCanonicalizer = (toolName: string) => string;
+
+/**
+ * Build a canonicalizer for tool names decorated by external MCP clients.
+ *
+ * A client connected to an MCP gateway namespaces the gateway's tools with
+ * its own label when presenting them to the model — Claude Code turns
+ * `archestra__run_tool` into `mcp__<server_name>__archestra__run_tool`, where
+ * `<server_name>` is the name the gateway was registered under. Those
+ * decorated names are what reach the LLM proxy in tool definitions, tool
+ * results, and tool calls, and they match neither the built-in recognizers
+ * nor any `tools` row — so guardrail evaluation used to find nothing to
+ * enforce (tool-invocation policies fail open on an unknown name).
+ *
+ * The decoration is only stripped when the label segment is the client server
+ * name of one of the organization's own gateways (`toMcpClientServerName` of
+ * a live gateway-capable agent). Anchoring on the org's real gateway names is
+ * what keeps this safe: a hostile MCP server connected directly to the client
+ * cannot get its tools canonicalized into platform built-ins or policied
+ * tools by merely naming them to look like ours — its label won't match a
+ * gateway, so its tools keep their foreign names and stay on the fail-closed
+ * paths (unknown result = untrusted context, discovered-tool policies).
+ *
+ * A bare built-in short name left after stripping (a client that decorates
+ * the listed name down to its short form) is expanded to the full built-in
+ * name, mirroring run_tool's own dispatch resolution.
+ */
+export async function buildGatewayToolNameCanonicalizer(
+  organizationId: string,
+): Promise<ToolNameCanonicalizer> {
+  const serverNames = await getGatewayServerNames(organizationId);
+  if (serverNames.size === 0) {
+    return (toolName) => toolName;
+  }
+
+  return (toolName) => {
+    const segments = toolName.split(MCP_SERVER_TOOL_NAME_SEPARATOR);
+    // The gateway's server-name label sits first, or second behind a fixed
+    // client prefix (Claude Code's `mcp`). Require at least one segment after
+    // the label to form the canonical name.
+    const labelLimit = Math.min(
+      GATEWAY_LABEL_MAX_INDEX + 1,
+      segments.length - 1,
+    );
+    for (let i = 0; i < labelLimit; i++) {
+      if (!serverNames.has(segments[i])) {
+        continue;
+      }
+      const canonicalName = segments
+        .slice(i + 1)
+        .join(MCP_SERVER_TOOL_NAME_SEPARATOR);
+      return resolveRunToolTargetName(canonicalName);
+    }
+    return toolName;
+  };
+}
+
+// === Internal helpers ===
+
+/** How deep into the segments a client's gateway label may sit (0 or 1). */
+const GATEWAY_LABEL_MAX_INDEX = 1;
+
+async function getGatewayServerNames(
+  organizationId: string,
+): Promise<Set<string>> {
+  const cached = gatewayServerNamesCache.get(organizationId);
+  if (cached) {
+    return cached;
+  }
+  const gatewayNames =
+    await AgentModel.findGatewayNamesByOrganizationId(organizationId);
+  const serverNames = new Set(
+    gatewayNames.map(toMcpClientServerName).filter(Boolean),
+  );
+  gatewayServerNamesCache.set(organizationId, serverNames);
+  return serverNames;
+}
+
+/**
+ * Per-organization cache of gateway client server names. Gateway renames are
+ * rare; a short TTL keeps proxy requests from querying agents on every call.
+ */
+const gatewayServerNamesCache = new LRUCacheManager<Set<string>>({
+  maxSize: 500,
+  defaultTtl: 60_000,
+});

--- a/platform/backend/src/routes/proxy/utils/index.ts
+++ b/platform/backend/src/routes/proxy/utils/index.ts
@@ -4,6 +4,7 @@ export * as tracing from "@/observability/tracing";
 export * as tokenizers from "@/tokenizers";
 export { resolveInteractionBillingMode } from "./billing-mode";
 export * as costOptimization from "./cost-optimization";
+export * as gatewayToolNames from "./gateway-tool-names";
 export * as headers from "./headers";
 export { checkModelTeamAccess } from "./model-team-access";
 export * as tools from "./tools";

--- a/platform/backend/src/test/llm-provider-stubs.ts
+++ b/platform/backend/src/test/llm-provider-stubs.ts
@@ -33,6 +33,12 @@ export interface AnthropicStubOptions {
    * that expect text.
    */
   includeToolUseNonStreaming?: boolean;
+  /**
+   * Emit this tool_use block (instead of the fixed `get_weather` one) from the
+   * buffered (non-streaming) response, e.g. a gateway `run_tool` dispatch with
+   * a client-decorated name. Implies a `tool_use` stop reason.
+   */
+  nonStreamingToolUse?: { name: string; input: Record<string, unknown> };
 }
 
 export interface GeminiStubOptions {
@@ -126,27 +132,35 @@ export function createAnthropicTestClient(options: AnthropicStubOptions = {}) {
           type: "message",
           container: null,
           role: "assistant",
-          content: options.includeToolUseNonStreaming
-            ? [
-                { type: "text", text: "Checking the weather.", citations: [] },
-                {
-                  type: "tool_use",
-                  id: "toolu_test_weather",
-                  name: "get_weather",
-                  input: { location: "SF" },
-                },
-              ]
-            : [
-                {
-                  type: "text",
-                  text: "Hello! How can I help you today?",
-                  citations: [],
-                },
-              ],
+          content:
+            options.includeToolUseNonStreaming || options.nonStreamingToolUse
+              ? [
+                  {
+                    type: "text",
+                    text: "Checking the weather.",
+                    citations: [],
+                  },
+                  {
+                    type: "tool_use",
+                    id: "toolu_test_weather",
+                    name: options.nonStreamingToolUse?.name ?? "get_weather",
+                    input: options.nonStreamingToolUse?.input ?? {
+                      location: "SF",
+                    },
+                  },
+                ]
+              : [
+                  {
+                    type: "text",
+                    text: "Hello! How can I help you today?",
+                    citations: [],
+                  },
+                ],
           model: "claude-3-5-sonnet-20241022",
-          stop_reason: options.includeToolUseNonStreaming
-            ? "tool_use"
-            : "end_turn",
+          stop_reason:
+            options.includeToolUseNonStreaming || options.nonStreamingToolUse
+              ? "tool_use"
+              : "end_turn",
           stop_sequence: null,
           usage: {
             input_tokens: options.zeroInputTokens ? 0 : 12,

--- a/platform/backend/src/types/agent.ts
+++ b/platform/backend/src/types/agent.ts
@@ -38,6 +38,16 @@ export const AgentTypeSchema = z.enum([
 ]);
 export type AgentType = z.infer<typeof AgentTypeSchema>;
 
+/**
+ * Agent types that can serve as an MCP gateway — the agents external MCP
+ * clients register via the connect page (legacy `profile` agents serve both
+ * gateway and proxy surfaces).
+ */
+export const GATEWAY_CAPABLE_AGENT_TYPES = [
+  "mcp_gateway",
+  "profile",
+] as const satisfies readonly AgentType[];
+
 export const AgentScopeSchema = ResourceVisibilityScopeSchema;
 export type AgentScope = ResourceVisibilityScope;
 

--- a/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/catalog-setup-wizard.tsx
@@ -13,7 +13,6 @@ import {
   Loader2,
   PlugZap,
   RefreshCw,
-  Wand2,
   Wrench,
 } from "lucide-react";
 import Link from "next/link";
@@ -27,8 +26,11 @@ import {
   type OAuthInstallResult,
 } from "@/components/oauth-confirmation-dialog";
 import { WithPermissions } from "@/components/roles/with-permissions";
+import { SearchInput } from "@/components/search-input";
+import { ToolPolicyBulkActionsBar } from "@/components/tool-policy-bulk-actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Collapsible,
   CollapsibleContent,
@@ -41,7 +43,7 @@ import {
   EmptyHeader,
   EmptyMedia,
 } from "@/components/ui/empty";
-import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { PermissionButton } from "@/components/ui/permission-button";
 import {
   Select,
@@ -51,7 +53,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useAutoConfigurePolicies } from "@/lib/agent-tools.query";
 import { useSession } from "@/lib/auth/auth.query";
 import { useInitiateOAuth } from "@/lib/auth/oauth.query";
 import {
@@ -446,43 +447,15 @@ export function ToolsAndGuardrailsStep({ item }: { item: CatalogItem }) {
   const { data: resultPolicies } = useToolResultPolicies();
   const callPolicyMutation = useCallPolicyMutation();
   const resultPolicyMutation = useResultPolicyMutation();
-  const autoConfigureMutation = useAutoConfigurePolicies();
   // Same install the Test Connection step reports on — the reload endpoint
   // needs a concrete server install, not the catalog item.
   const { target: reloadTarget } = useTestConnectionTarget(item);
   const reloadTools = useReloadMcpServerTools();
   // `${toolId}:${field}` entries for in-flight policy updates.
   const [updating, setUpdating] = useState<ReadonlySet<string>>(new Set());
-
-  // Let a subagent pick sensible default policies for every tool on this
-  // server in one shot (custom policies are preserved). Replaces the bulk
-  // "Configure with Subagent" action from the full guardrails table.
-  const configureWithSubagent = async (toolIds: string[]) => {
-    if (toolIds.length === 0) return;
-    try {
-      const result = await autoConfigureMutation.mutateAsync(toolIds);
-      if (!result) return;
-      const successCount = result.results.filter(
-        (r: { success: boolean }) => r.success,
-      ).length;
-      const failureCount = result.results.length - successCount;
-      if (failureCount === 0) {
-        toast.success(
-          `Default policies configured for ${successCount} tool(s). Custom policies are preserved.`,
-        );
-      } else {
-        toast.warning(
-          `Configured ${successCount} tool(s), failed ${failureCount}. Custom policies are preserved.`,
-        );
-      }
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to auto-configure policies",
-      );
-    }
-  };
+  const [selectedToolIds, setSelectedToolIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
 
   const updatePolicy = async (
     toolId: string,
@@ -576,45 +549,86 @@ export function ToolsAndGuardrailsStep({ item }: { item: CatalogItem }) {
     ? tools.filter((tool) => tool.name.toLowerCase().includes(normalizedSearch))
     : tools;
 
+  // Selection may reference tools removed by a refresh; count only live ones.
+  const selectedTools = tools.filter((tool) => selectedToolIds.has(tool.id));
+  const selectedVisibleCount = visibleTools.filter((tool) =>
+    selectedToolIds.has(tool.id),
+  ).length;
+  const allVisibleSelected =
+    visibleTools.length > 0 && selectedVisibleCount === visibleTools.length;
+  const selectAllLabel = normalizedSearch
+    ? `Select all matching (${visibleTools.length})`
+    : `Select all (${visibleTools.length})`;
+
+  // Select-all toggles the currently visible (filtered) tools, keeping any
+  // selection made outside the filter intact.
+  const toggleAllVisible = (checked: boolean) => {
+    setSelectedToolIds((prev) => {
+      const next = new Set(prev);
+      for (const tool of visibleTools) {
+        if (checked) {
+          next.add(tool.id);
+        } else {
+          next.delete(tool.id);
+        }
+      }
+      return next;
+    });
+  };
+
+  const toggleTool = (toolId: string, checked: boolean) => {
+    setSelectedToolIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(toolId);
+      } else {
+        next.delete(toolId);
+      }
+      return next;
+    });
+  };
+
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="text-sm text-muted-foreground">
           {tools.length} {tools.length === 1 ? "tool" : "tools"} discovered. Set
-          guardrails per tool, or let a subagent configure sensible defaults.
+          guardrails per tool, in bulk for a selection, or let a subagent
+          configure sensible defaults.
         </p>
-        <div className="flex flex-wrap items-center gap-2">
-          {refreshToolsButton}
-          <PermissionButton
-            permissions={{ agent: ["update"], toolPolicy: ["update"] }}
-            variant="outline"
-            size="sm"
-            onClick={() => configureWithSubagent(tools.map((tool) => tool.id))}
-            disabled={autoConfigureMutation.isPending}
-          >
-            {autoConfigureMutation.isPending ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Configuring...
-              </>
-            ) : (
-              <>
-                <Wand2 className="h-4 w-4" />
-                Configure with Subagent
-              </>
-            )}
-          </PermissionButton>
-        </div>
+        {refreshToolsButton}
       </div>
       {tools.length > 5 && (
-        <Input
+        <SearchInput
           placeholder="Filter tools by name"
-          aria-label="Filter tools"
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
           className="max-w-xs"
+          value={search}
+          onSearchChange={setSearch}
+          syncQueryParams={false}
+          debounceMs={0}
         />
       )}
+      <ToolPolicyBulkActionsBar
+        selectedToolIds={selectedTools.map((tool) => tool.id)}
+      />
+      {/* 1px card border + p-4, so the checkbox column lines up with the cards */}
+      <div className="flex items-center gap-2 text-sm pl-[calc(1rem+1px)]">
+        <Checkbox
+          id="select-all-tools"
+          aria-label="Select all tools"
+          checked={
+            allVisibleSelected
+              ? true
+              : selectedVisibleCount > 0
+                ? "indeterminate"
+                : false
+          }
+          onCheckedChange={(checked) => toggleAllVisible(checked === true)}
+        />
+        <Label htmlFor="select-all-tools" className="font-normal">
+          {selectAllLabel}
+        </Label>
+      </div>
       {total > tools.length && (
         <p className="text-sm text-muted-foreground">
           Showing the first {tools.length} of {total} tools.{" "}
@@ -632,6 +646,8 @@ export function ToolsAndGuardrailsStep({ item }: { item: CatalogItem }) {
         <ToolReviewCard
           key={tool.id}
           tool={tool}
+          selected={selectedToolIds.has(tool.id)}
+          onSelectedChange={(checked) => toggleTool(tool.id, checked)}
           callAction={getCallPolicyActionFromPolicies(
             tool.id,
             invocationPolicies ?? { byProfileToolId: {} },
@@ -682,6 +698,8 @@ const ANNOTATION_BADGES: Array<{
 
 function ToolReviewCard({
   tool,
+  selected,
+  onSelectedChange,
   callAction,
   resultAction,
   hasCustomCallPolicy,
@@ -692,6 +710,8 @@ function ToolReviewCard({
   onOpenDetails,
 }: {
   tool: ToolWithAssignmentsData;
+  selected: boolean;
+  onSelectedChange: (checked: boolean) => void;
   callAction: CallPolicyAction;
   resultAction: ResultPolicyAction;
   hasCustomCallPolicy: boolean;
@@ -731,6 +751,12 @@ function ToolReviewCard({
   return (
     <div className="rounded-lg border">
       <div className="flex flex-wrap items-start justify-between gap-4 p-4">
+        <Checkbox
+          aria-label={`Select ${displayName}`}
+          className="mt-0.5"
+          checked={selected}
+          onCheckedChange={(checked) => onSelectedChange(checked === true)}
+        />
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex flex-wrap items-center gap-2">
             <code className="text-sm font-semibold">{displayName}</code>

--- a/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
+++ b/platform/frontend/src/app/mcp/tool-guardrails/_parts/assigned-tools-table.tsx
@@ -12,17 +12,8 @@ import type {
   RowSelectionState,
   SortingState,
 } from "@tanstack/react-table";
-import {
-  Bot,
-  ChevronDown,
-  ChevronUp,
-  Loader2,
-  Network,
-  Pencil,
-  Wand2,
-} from "lucide-react";
+import { Bot, ChevronDown, ChevronUp, Network, Pencil } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
-import { toast } from "sonner";
 import { CallPolicyToggle } from "@/components/call-policy-toggle";
 import { LoadingSpinner } from "@/components/loading";
 import { McpCatalogIcon } from "@/components/mcp-catalog-icon";
@@ -30,20 +21,13 @@ import { ResultPolicyToggle } from "@/components/result-policy-toggle";
 import { WithPermissions } from "@/components/roles/with-permissions";
 import { SearchInput } from "@/components/search-input";
 import { TableRowActions } from "@/components/table-row-actions";
+import { ToolPolicyBulkActionsBar } from "@/components/tool-policy-bulk-actions";
 import { TruncatedText } from "@/components/truncated-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { DataTable } from "@/components/ui/data-table";
-import { PermissionButton } from "@/components/ui/permission-button";
 import { SearchableSelect } from "@/components/ui/searchable-select";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -59,12 +43,9 @@ import {
   DEFAULT_SORT_BY,
   DEFAULT_TABLE_LIMIT,
 } from "@/consts";
-import { useAutoConfigurePolicies } from "@/lib/agent-tools.query";
 import { useDataTableQueryParams } from "@/lib/hooks/use-data-table-query-params";
 import { useInternalMcpCatalog } from "@/lib/mcp/internal-mcp-catalog.query";
 import {
-  useBulkCallPolicyMutation,
-  useBulkResultPolicyMutation,
   useCallPolicyMutation,
   useResultPolicyMutation,
   useToolInvocationPolicies,
@@ -74,7 +55,6 @@ import {
   type CallPolicyAction,
   getCallPolicyActionFromPolicies,
   getResultPolicyActionFromPolicies,
-  RESULT_POLICY_ACTION_OPTIONS,
   type ResultPolicyAction,
 } from "@/lib/policy.utils";
 import {
@@ -129,9 +109,6 @@ export function AssignedToolsTable({
 }: AssignedToolsTableProps) {
   const callPolicyMutation = useCallPolicyMutation();
   const resultPolicyMutation = useResultPolicyMutation();
-  const bulkCallPolicyMutation = useBulkCallPolicyMutation();
-  const bulkResultPolicyMutation = useBulkResultPolicyMutation();
-  const autoConfigureMutation = useAutoConfigurePolicies();
   const { data: invocationPolicies } = useToolInvocationPolicies(
     initialData?.toolInvocationPolicies,
   );
@@ -183,10 +160,6 @@ export function AssignedToolsTable({
   const [updatingRows, setUpdatingRows] = useState<
     Set<{ id: string; field: string }>
   >(new Set());
-  const [isBulkUpdating, setIsBulkUpdating] = useState(false);
-  const [bulkCallPolicyValue, setBulkCallPolicyValue] = useState<string>("");
-  const [bulkResultPolicyValue, setBulkResultPolicyValue] =
-    useState<string>("");
 
   // The user/client attribution filters only make sense for observed tools —
   // MCP-server-sourced tools never appear in LLM proxy requests under their
@@ -245,8 +218,6 @@ export function AssignedToolsTable({
     (newPagination: { pageIndex: number; pageSize: number }) => {
       setRowSelection({});
       setSelectedTools([]);
-      setBulkCallPolicyValue("");
-      setBulkResultPolicyValue("");
 
       setPagination(newPagination);
     },
@@ -256,8 +227,6 @@ export function AssignedToolsTable({
   const handleRowSelectionChange = useCallback(
     (newRowSelection: RowSelectionState) => {
       setRowSelection(newRowSelection);
-      setBulkCallPolicyValue("");
-      setBulkResultPolicyValue("");
 
       const newSelectedTools = Object.keys(newRowSelection)
         .map((rowId) => tools.find((tool) => tool.id === rowId))
@@ -271,8 +240,6 @@ export function AssignedToolsTable({
   const handleSearchChange = useCallback(() => {
     setRowSelection({});
     setSelectedTools([]);
-    setBulkCallPolicyValue("");
-    setBulkResultPolicyValue("");
   }, []);
 
   const handleOriginFilterChange = useCallback(
@@ -292,8 +259,6 @@ export function AssignedToolsTable({
       });
       setRowSelection({});
       setSelectedTools([]);
-      setBulkCallPolicyValue("");
-      setBulkResultPolicyValue("");
     },
     [updateQueryParams],
   );
@@ -307,8 +272,6 @@ export function AssignedToolsTable({
       });
       setRowSelection({});
       setSelectedTools([]);
-      setBulkCallPolicyValue("");
-      setBulkResultPolicyValue("");
     },
     [updateQueryParams],
   );
@@ -322,8 +285,6 @@ export function AssignedToolsTable({
       });
       setRowSelection({});
       setSelectedTools([]);
-      setBulkCallPolicyValue("");
-      setBulkResultPolicyValue("");
     },
     [updateQueryParams],
   );
@@ -359,102 +320,6 @@ export function AssignedToolsTable({
     },
     [updateQueryParams, rowSelection, tools],
   );
-
-  const handleBulkAction = useCallback(
-    async (
-      field: "callPolicy" | "resultPolicyAction",
-      value: CallPolicyAction | ResultPolicyAction,
-    ) => {
-      // Filter out tools with custom policies (non-empty conditions)
-      const toolIds = selectedTools
-        .filter((tool) => {
-          const policies =
-            field === "callPolicy"
-              ? invocationPolicies?.byProfileToolId[tool.id] || []
-              : resultPolicies?.byProfileToolId[tool.id] || [];
-
-          // Check if tool has custom policies (non-empty conditions array)
-          const hasCustomPolicy = policies.some(
-            (policy) => policy.conditions.length > 0,
-          );
-
-          return !hasCustomPolicy;
-        })
-        .map((tool) => tool.id);
-
-      if (toolIds.length === 0) {
-        return;
-      }
-      try {
-        setIsBulkUpdating(true);
-
-        if (field === "callPolicy") {
-          await bulkCallPolicyMutation.mutateAsync({
-            toolIds,
-            action: value as CallPolicyAction,
-          });
-        } else {
-          await bulkResultPolicyMutation.mutateAsync({
-            toolIds,
-            action: value as ResultPolicyAction,
-          });
-        }
-      } finally {
-        setIsBulkUpdating(false);
-        setBulkCallPolicyValue("");
-        setBulkResultPolicyValue("");
-      }
-    },
-    [
-      selectedTools,
-      bulkCallPolicyMutation,
-      bulkResultPolicyMutation,
-      invocationPolicies,
-      resultPolicies,
-    ],
-  );
-
-  const handleAutoConfigurePolicies = useCallback(async () => {
-    // Get tool IDs from selected tools (policies are per tool)
-    const toolIds = selectedTools.map((tool) => tool.id);
-
-    if (toolIds.length === 0) {
-      toast.error("No tools selected to configure");
-      return;
-    }
-
-    try {
-      const result = await autoConfigureMutation.mutateAsync(toolIds);
-      if (!result) return;
-
-      const successCount = result.results.filter(
-        (r: { success: boolean }) => r.success,
-      ).length;
-      const failureCount = result.results.filter(
-        (r: { success: boolean }) => !r.success,
-      ).length;
-
-      if (failureCount === 0) {
-        toast.success(
-          `Default policies configured for ${successCount} tool(s). Custom policies are preserved.`,
-        );
-      } else {
-        toast.warning(
-          `Default policies configured for ${successCount} tool(s), failed ${failureCount}. Custom policies are preserved.`,
-        );
-      }
-
-      // Reset bulk action dropdowns to placeholder
-      setBulkCallPolicyValue("");
-      setBulkResultPolicyValue("");
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error
-          ? error.message
-          : "Failed to auto-configure policies";
-      toast.error(errorMessage);
-    }
-  }, [selectedTools, autoConfigureMutation]);
 
   const clearFilters = useCallback(() => {
     setOriginFilter(DEFAULT_FILTER_ALL);
@@ -843,8 +708,6 @@ export function AssignedToolsTable({
     ],
   );
 
-  const hasSelection = selectedTools.length > 0;
-
   const visibleCatalogSources = useMemo(
     () => getVisibleCatalogSources(internalMcpCatalogItems),
     [internalMcpCatalogItems],
@@ -948,289 +811,9 @@ export function AssignedToolsTable({
           )}
       </div>
 
-      {/* Bulk actions - Desktop */}
-      <div className="hidden lg:flex flex-wrap items-center gap-4 p-4 bg-muted/50 border border-border rounded-lg">
-        <div className="flex items-center gap-3">
-          {hasSelection ? (
-            <>
-              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
-                <span className="text-sm font-semibold text-primary">
-                  {selectedTools.length}
-                </span>
-              </div>
-              <span className="text-sm font-medium whitespace-nowrap">
-                {selectedTools.length === 1
-                  ? "tool selected"
-                  : "tools selected"}
-              </span>
-              {isBulkUpdating && (
-                <LoadingSpinner className="h-4 w-4 text-muted-foreground" />
-              )}
-            </>
-          ) : (
-            <span className="text-sm text-muted-foreground whitespace-nowrap">
-              Select tools to apply bulk actions
-            </span>
-          )}
-        </div>
-        <div className="ml-auto flex flex-wrap items-end gap-4">
-          <WithPermissions
-            permissions={{ toolPolicy: ["update"] }}
-            noPermissionHandle="tooltip"
-          >
-            {({ hasPermission }) => (
-              <div className="flex flex-col gap-1">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Call Policy:
-                </span>
-                <Select
-                  disabled={!hasSelection || isBulkUpdating || !hasPermission}
-                  value={bulkCallPolicyValue}
-                  onValueChange={(value: CallPolicyAction) => {
-                    setBulkCallPolicyValue(value);
-                    handleBulkAction("callPolicy", value);
-                  }}
-                >
-                  <SelectTrigger
-                    aria-label="Bulk call policy action"
-                    className="h-8 w-[168px] text-sm"
-                    size="sm"
-                  >
-                    <SelectValue placeholder="Select action" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="allow_when_context_is_untrusted">
-                      Allow always
-                    </SelectItem>
-                    <SelectItem value="block_when_context_is_untrusted">
-                      Block in sensitive context
-                    </SelectItem>
-                    <SelectItem
-                      value="require_approval"
-                      description="Requires user confirmation before executing in chat. In autonomous agent sessions (A2A, API, MS Teams, subagents), the tool call is blocked."
-                    >
-                      Require approval
-                    </SelectItem>
-                    <SelectItem value="block_always">Block always</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </WithPermissions>
-          <WithPermissions
-            permissions={{ toolPolicy: ["update"] }}
-            noPermissionHandle="tooltip"
-          >
-            {({ hasPermission }) => (
-              <div className="flex flex-col gap-1">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Results are:
-                </span>
-                <Select
-                  disabled={!hasSelection || isBulkUpdating || !hasPermission}
-                  value={bulkResultPolicyValue}
-                  onValueChange={(value: ResultPolicyAction) => {
-                    setBulkResultPolicyValue(value);
-                    handleBulkAction("resultPolicyAction", value);
-                  }}
-                >
-                  <SelectTrigger
-                    aria-label="Bulk result policy action"
-                    className="h-8 w-[150px] text-sm"
-                    size="sm"
-                  >
-                    <SelectValue placeholder="Select action" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {RESULT_POLICY_ACTION_OPTIONS.map(({ value, label }) => (
-                      <SelectItem key={value} value={value}>
-                        {label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </WithPermissions>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <PermissionButton
-                permissions={{ agent: ["update"], toolPolicy: ["update"] }}
-                size="sm"
-                variant="outline"
-                onClick={handleAutoConfigurePolicies}
-                disabled={
-                  !hasSelection ||
-                  isBulkUpdating ||
-                  autoConfigureMutation.isPending
-                }
-              >
-                {autoConfigureMutation.isPending ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Configuring...
-                  </>
-                ) : (
-                  <>
-                    <Wand2 className="h-4 w-4" />
-                    Configure with Subagent
-                  </>
-                )}
-              </PermissionButton>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Automatically configure default policies using AI analysis</p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
-
-      {/* Bulk actions - Mobile */}
-      <div className="flex flex-col gap-3 rounded-lg border border-border bg-muted/50 p-3 lg:hidden">
-        {/* Title / selection info */}
-        <div className="flex items-center gap-2">
-          {hasSelection ? (
-            <>
-              <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10">
-                <span className="text-xs font-semibold text-primary">
-                  {selectedTools.length}
-                </span>
-              </div>
-              <span className="text-sm font-medium">
-                {selectedTools.length === 1
-                  ? "tool selected"
-                  : "tools selected"}
-              </span>
-              {isBulkUpdating && (
-                <LoadingSpinner className="h-3.5 w-3.5 text-muted-foreground" />
-              )}
-            </>
-          ) : (
-            <span className="text-xs text-muted-foreground">
-              Select tools to apply bulk actions
-            </span>
-          )}
-        </div>
-
-        <div className="flex flex-col gap-3">
-          {/* Call Policy */}
-          <WithPermissions
-            permissions={{ toolPolicy: ["update"] }}
-            noPermissionHandle="tooltip"
-          >
-            {({ hasPermission }) => (
-              <div className="flex flex-col gap-1.5">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Call Policy
-                </span>
-                <Select
-                  disabled={!hasSelection || isBulkUpdating || !hasPermission}
-                  value={bulkCallPolicyValue}
-                  onValueChange={(value: CallPolicyAction) => {
-                    setBulkCallPolicyValue(value);
-                    handleBulkAction("callPolicy", value);
-                  }}
-                >
-                  <SelectTrigger
-                    aria-label="Bulk call policy action"
-                    className="h-9 w-full text-sm"
-                    size="sm"
-                  >
-                    <SelectValue placeholder="Select action" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="allow_when_context_is_untrusted">
-                      Allow always
-                    </SelectItem>
-                    <SelectItem value="block_when_context_is_untrusted">
-                      Block in sensitive context
-                    </SelectItem>
-                    <SelectItem
-                      value="require_approval"
-                      description="Requires user confirmation before executing in chat. In autonomous agent sessions (A2A, API, MS Teams, subagents), the tool call is blocked."
-                    >
-                      Require approval
-                    </SelectItem>
-                    <SelectItem value="block_always">Block always</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </WithPermissions>
-
-          {/* Results are */}
-          <WithPermissions
-            permissions={{ toolPolicy: ["update"] }}
-            noPermissionHandle="tooltip"
-          >
-            {({ hasPermission }) => (
-              <div className="flex flex-col gap-1.5">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Results are
-                </span>
-                <Select
-                  disabled={!hasSelection || isBulkUpdating || !hasPermission}
-                  value={bulkResultPolicyValue}
-                  onValueChange={(value: ResultPolicyAction) => {
-                    setBulkResultPolicyValue(value);
-                    handleBulkAction("resultPolicyAction", value);
-                  }}
-                >
-                  <SelectTrigger
-                    aria-label="Bulk result policy action"
-                    className="h-9 w-full text-sm"
-                    size="sm"
-                  >
-                    <SelectValue placeholder="Select action" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {RESULT_POLICY_ACTION_OPTIONS.map(({ value, label }) => (
-                      <SelectItem key={value} value={value}>
-                        {label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </WithPermissions>
-        </div>
-
-        {/* Action buttons */}
-        <div className="flex flex-col gap-2 pt-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <PermissionButton
-                permissions={{ agent: ["update"], toolPolicy: ["update"] }}
-                size="sm"
-                variant="outline"
-                className="w-full justify-center"
-                onClick={handleAutoConfigurePolicies}
-                disabled={
-                  !hasSelection ||
-                  isBulkUpdating ||
-                  autoConfigureMutation.isPending
-                }
-              >
-                {autoConfigureMutation.isPending ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Configuring...
-                  </>
-                ) : (
-                  <>
-                    <Wand2 className="h-4 w-4" />
-                    Configure with Subagent
-                  </>
-                )}
-              </PermissionButton>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Automatically configure default policies using AI analysis</p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
+      <ToolPolicyBulkActionsBar
+        selectedToolIds={selectedTools.map((tool) => tool.id)}
+      />
 
       <DataTable
         columns={columns}

--- a/platform/frontend/src/components/tool-policy-bulk-actions.tsx
+++ b/platform/frontend/src/components/tool-policy-bulk-actions.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { Loader2, Wand2 } from "lucide-react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { LoadingSpinner } from "@/components/loading";
+import { WithPermissions } from "@/components/roles/with-permissions";
+import { PermissionButton } from "@/components/ui/permission-button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useAutoConfigurePolicies } from "@/lib/agent-tools.query";
+import {
+  useBulkCallPolicyMutation,
+  useBulkResultPolicyMutation,
+  useToolInvocationPolicies,
+  useToolResultPolicies,
+} from "@/lib/policy.query";
+import {
+  type CallPolicyAction,
+  RESULT_POLICY_ACTION_OPTIONS,
+  type ResultPolicyAction,
+} from "@/lib/policy.utils";
+
+/**
+ * Bulk policy actions for a selection of tools: apply a call policy or a
+ * result policy to every selected tool (skipping tools that carry custom
+ * conditioned policies), or let a subagent configure sensible defaults.
+ *
+ * Shared between the full guardrails table and the MCP server setup wizard's
+ * Tools & Guardrails step. Renders its own desktop and mobile layouts and
+ * owns the mutation/in-flight state; callers only supply the selected tool
+ * ids.
+ */
+export function ToolPolicyBulkActionsBar({
+  selectedToolIds,
+}: {
+  selectedToolIds: readonly string[];
+}) {
+  const bulkCallPolicyMutation = useBulkCallPolicyMutation();
+  const bulkResultPolicyMutation = useBulkResultPolicyMutation();
+  const autoConfigureMutation = useAutoConfigurePolicies();
+  const { data: invocationPolicies } = useToolInvocationPolicies();
+  const { data: resultPolicies } = useToolResultPolicies();
+
+  const [isBulkUpdating, setIsBulkUpdating] = useState(false);
+  const [bulkCallPolicyValue, setBulkCallPolicyValue] = useState<string>("");
+  const [bulkResultPolicyValue, setBulkResultPolicyValue] =
+    useState<string>("");
+
+  const hasSelection = selectedToolIds.length > 0;
+
+  const handleBulkAction = useCallback(
+    async (
+      field: "callPolicy" | "resultPolicyAction",
+      value: CallPolicyAction | ResultPolicyAction,
+    ) => {
+      // Filter out tools with custom policies (non-empty conditions)
+      const toolIds = selectedToolIds.filter((toolId) => {
+        const policies =
+          field === "callPolicy"
+            ? invocationPolicies?.byProfileToolId[toolId] || []
+            : resultPolicies?.byProfileToolId[toolId] || [];
+
+        // Check if tool has custom policies (non-empty conditions array)
+        const hasCustomPolicy = policies.some(
+          (policy) => policy.conditions.length > 0,
+        );
+
+        return !hasCustomPolicy;
+      });
+
+      if (toolIds.length === 0) {
+        return;
+      }
+      try {
+        setIsBulkUpdating(true);
+
+        if (field === "callPolicy") {
+          await bulkCallPolicyMutation.mutateAsync({
+            toolIds,
+            action: value as CallPolicyAction,
+          });
+        } else {
+          await bulkResultPolicyMutation.mutateAsync({
+            toolIds,
+            action: value as ResultPolicyAction,
+          });
+        }
+      } finally {
+        setIsBulkUpdating(false);
+        setBulkCallPolicyValue("");
+        setBulkResultPolicyValue("");
+      }
+    },
+    [
+      selectedToolIds,
+      bulkCallPolicyMutation,
+      bulkResultPolicyMutation,
+      invocationPolicies,
+      resultPolicies,
+    ],
+  );
+
+  const handleAutoConfigurePolicies = useCallback(async () => {
+    if (selectedToolIds.length === 0) {
+      toast.error("No tools selected to configure");
+      return;
+    }
+
+    try {
+      const result = await autoConfigureMutation.mutateAsync([
+        ...selectedToolIds,
+      ]);
+      if (!result) return;
+
+      const successCount = result.results.filter(
+        (r: { success: boolean }) => r.success,
+      ).length;
+      const failureCount = result.results.filter(
+        (r: { success: boolean }) => !r.success,
+      ).length;
+
+      if (failureCount === 0) {
+        toast.success(
+          `Default policies configured for ${successCount} tool(s). Custom policies are preserved.`,
+        );
+      } else {
+        toast.warning(
+          `Default policies configured for ${successCount} tool(s), failed ${failureCount}. Custom policies are preserved.`,
+        );
+      }
+
+      // Reset bulk action dropdowns to placeholder
+      setBulkCallPolicyValue("");
+      setBulkResultPolicyValue("");
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Failed to auto-configure policies";
+      toast.error(errorMessage);
+    }
+  }, [selectedToolIds, autoConfigureMutation]);
+
+  const configureWithSubagentButton = (className?: string) => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <PermissionButton
+          permissions={{ agent: ["update"], toolPolicy: ["update"] }}
+          size="sm"
+          variant="outline"
+          className={className}
+          onClick={handleAutoConfigurePolicies}
+          disabled={
+            !hasSelection || isBulkUpdating || autoConfigureMutation.isPending
+          }
+        >
+          {autoConfigureMutation.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Configuring...
+            </>
+          ) : (
+            <>
+              <Wand2 className="h-4 w-4" />
+              Configure with Subagent
+            </>
+          )}
+        </PermissionButton>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>Automatically configure default policies using AI analysis</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+
+  const callPolicySelect = (triggerClassName: string) => (
+    <WithPermissions
+      permissions={{ toolPolicy: ["update"] }}
+      noPermissionHandle="tooltip"
+    >
+      {({ hasPermission }) => (
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-muted-foreground">
+            Call Policy:
+          </span>
+          <Select
+            disabled={!hasSelection || isBulkUpdating || !hasPermission}
+            value={bulkCallPolicyValue}
+            onValueChange={(value: CallPolicyAction) => {
+              setBulkCallPolicyValue(value);
+              handleBulkAction("callPolicy", value);
+            }}
+          >
+            <SelectTrigger
+              aria-label="Bulk call policy action"
+              className={triggerClassName}
+              size="sm"
+            >
+              <SelectValue placeholder="Select action" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="allow_when_context_is_untrusted">
+                Allow always
+              </SelectItem>
+              <SelectItem value="block_when_context_is_untrusted">
+                Block in sensitive context
+              </SelectItem>
+              <SelectItem
+                value="require_approval"
+                description="Requires user confirmation before executing in chat. In autonomous agent sessions (A2A, API, MS Teams, subagents), the tool call is blocked."
+              >
+                Require approval
+              </SelectItem>
+              <SelectItem value="block_always">Block always</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </WithPermissions>
+  );
+
+  const resultPolicySelect = (triggerClassName: string) => (
+    <WithPermissions
+      permissions={{ toolPolicy: ["update"] }}
+      noPermissionHandle="tooltip"
+    >
+      {({ hasPermission }) => (
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-muted-foreground">
+            Results are:
+          </span>
+          <Select
+            disabled={!hasSelection || isBulkUpdating || !hasPermission}
+            value={bulkResultPolicyValue}
+            onValueChange={(value: ResultPolicyAction) => {
+              setBulkResultPolicyValue(value);
+              handleBulkAction("resultPolicyAction", value);
+            }}
+          >
+            <SelectTrigger
+              aria-label="Bulk result policy action"
+              className={triggerClassName}
+              size="sm"
+            >
+              <SelectValue placeholder="Select action" />
+            </SelectTrigger>
+            <SelectContent>
+              {RESULT_POLICY_ACTION_OPTIONS.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </WithPermissions>
+  );
+
+  return (
+    <>
+      {/* Bulk actions - Desktop */}
+      <div className="hidden lg:flex flex-wrap items-center gap-4 p-4 bg-muted/50 border border-border rounded-lg">
+        <div className="flex items-center gap-3">
+          {hasSelection ? (
+            <>
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+                <span className="text-sm font-semibold text-primary">
+                  {selectedToolIds.length}
+                </span>
+              </div>
+              <span className="text-sm font-medium whitespace-nowrap">
+                {selectedToolIds.length === 1
+                  ? "tool selected"
+                  : "tools selected"}
+              </span>
+              {isBulkUpdating && (
+                <LoadingSpinner className="h-4 w-4 text-muted-foreground" />
+              )}
+            </>
+          ) : (
+            <span className="text-sm text-muted-foreground whitespace-nowrap">
+              Select tools to apply bulk actions
+            </span>
+          )}
+        </div>
+        <div className="ml-auto flex flex-wrap items-end gap-4">
+          {callPolicySelect("h-8 w-[168px] text-sm")}
+          {resultPolicySelect("h-8 w-[150px] text-sm")}
+          {configureWithSubagentButton()}
+        </div>
+      </div>
+
+      {/* Bulk actions - Mobile */}
+      <div className="flex flex-col gap-3 rounded-lg border border-border bg-muted/50 p-3 lg:hidden">
+        <div className="flex items-center gap-2">
+          {hasSelection ? (
+            <>
+              <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10">
+                <span className="text-xs font-semibold text-primary">
+                  {selectedToolIds.length}
+                </span>
+              </div>
+              <span className="text-sm font-medium">
+                {selectedToolIds.length === 1
+                  ? "tool selected"
+                  : "tools selected"}
+              </span>
+              {isBulkUpdating && (
+                <LoadingSpinner className="h-3.5 w-3.5 text-muted-foreground" />
+              )}
+            </>
+          ) : (
+            <span className="text-xs text-muted-foreground">
+              Select tools to apply bulk actions
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-3">
+          {callPolicySelect("h-9 w-full text-sm")}
+          {resultPolicySelect("h-9 w-full text-sm")}
+        </div>
+
+        <div className="flex flex-col gap-2 pt-1">
+          {configureWithSubagentButton("w-full justify-center")}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/platform/shared/archestra-mcp-server.ts
+++ b/platform/shared/archestra-mcp-server.ts
@@ -1030,6 +1030,17 @@ export function getArchestraToolPrefix(
   return `${getArchestraMcpServerName(options)}${MCP_SERVER_TOOL_NAME_SEPARATOR}`;
 }
 
+/**
+ * The MCP server name a gateway is registered under in an external client
+ * (`claude mcp add <this> <url>`, `codex mcp add <this> …`). Clients build
+ * their model-facing tool names from it (Claude Code: `mcp__<this>__<tool>`),
+ * so everything that needs to recognize a gateway's decorated tool names must
+ * derive the name exactly like the connection-setup script does.
+ */
+export function toMcpClientServerName(gatewayName: string): string {
+  return gatewayName.trim().toLowerCase().replace(/\s+/g, "_");
+}
+
 function parseArchestraToolName(params: {
   toolName: string;
   options?: ArchestraMcpIdentityOptions & { includeDefaultPrefix?: boolean };


### PR DESCRIPTION
## Summary

Three related fixes surfaced by the T-996 incident (guardrails not enforced for Claude Code connected via the connect page), one commit each:

**1. Enforce guardrails on client-decorated gateway tool names (T-996).** External MCP clients namespace gateway tools with their own label (`mcp__<gateway>__archestra__run_tool`) and route every third-party call through the `run_tool` dispatcher. The proxy's tool-invocation policy evaluation looked tools up by that literal name, found no `tools` row, and allowed everything — a sensitive-context block that fires in Archestra chat passed straight through Claude Code. Tool names are now canonicalized before guardrail evaluation (anchored to the org's own gateway names so a hostile MCP server cannot spoof platform tool identities), `run_tool` dispatches are unwrapped so the target tool's policies are evaluated, and run_tool-shaped calls always buffer during streaming so a blocked dispatch's arguments never reach the client. The incident is pinned end to end by a regression test replaying the captured request against the real guardrail chain (verified red pre-fix).

**2. Bulk tool selection and policy actions on the server setup Tools & Guardrails step.** Per-tool checkboxes with select-all and the guardrails table's bulk actions bar (call/result policy, configure with subagent), extracted into the shared `ToolPolicyBulkActionsBar` and reused by both surfaces.

**3. Surface upstream provider errors instead of sleeping on Retry-After (T-1002).** The openai SDK (v6) honors a 429's Retry-After verbatim with no upper bound, so a provider daily-quota rate limit whose reset lies hours away slept inside the in-flight request and chat turns hung indefinitely with no error shown. All proxy provider clients are now constructed with SDK retries disabled — the proxy is a relay; `handleError` forwards status/body/retry-after and callers own bounded retry policy. Pinned by a test that a stubbed 429 rejects in under 2s with exactly one upstream request.

## Manual QA (dev stack, DB-verified)

- Claude Code via connect page, incident prompt: LLM Proxy blocks the GitHub dispatch in the notion-tainted session with the full policy message; zero GitHub side effects; notion reads keep working post-taint (block is scoped).
- Chat control run: same block at the same point; clean context passes.
- Kimi with exhausted upstream quota: chat surfaces a structured rate-limit error in ~7s (was: infinite spinner).

Tasks: T-996, T-1002.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>