### PR TITLE
fix(helm): let the migrate job start on the upgrade that introduces the content-encryption key

### DIFF
--- a/platform/e2e-tests/utils/tool-assignments.ts
+++ b/platform/e2e-tests/utils/tool-assignments.ts
@@ -31,15 +31,14 @@ export async function openGatewayCatalogToolAssignment(params: {
 }
 
 export async function saveOpenProfileDialog(page: Page): Promise<void> {
-  const saveButton = page.getByRole("button", { name: "Save" });
-  const updateButton = page.getByRole("button", { name: "Update" });
-
-  if (await saveButton.isVisible().catch(() => false)) {
-    await saveButton.click();
-  } else {
-    await expect(updateButton).toBeVisible({ timeout: 15_000 });
-    await updateButton.click();
-  }
+  // One combined locator: sampling Save's visibility at a single instant and
+  // falling back to Update races the dialog's render (isVisible() does not
+  // wait). A dialog has exactly one submit — wait for whichever it is.
+  const submitButton = page
+    .getByRole("button", { name: /^(Save|Update)$/ })
+    .first();
+  await expect(submitButton).toBeVisible({ timeout: 15_000 });
+  await submitButton.click();
 
   await page.waitForLoadState("domcontentloaded");
 }
@@ -56,7 +55,15 @@ async function confirmPersonalCredentialPinIfPrompted(
   const confirmButton = page
     .getByRole("button", { name: /^Use th(is|ese) connections?$/ })
     .first();
-  if (await confirmButton.isVisible({ timeout: 1500 }).catch(() => false)) {
+  // waitFor, not isVisible: isVisible ignores `timeout` and samples one
+  // instant, so a prompt that renders a beat later was routinely missed —
+  // and the caller's fallback Escape then landed on the edit dialog itself,
+  // wedging the flow with no submit button left to click.
+  const appeared = await confirmButton
+    .waitFor({ state: "visible", timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (appeared) {
     // Force past the actionability wait: the dialog's entrance animation keeps
     // the button from being "stable" long enough for a normal click to land.
     await confirmButton.click({ force: true });
@@ -79,7 +86,9 @@ export async function selectCredentialOption(
   // DOM-detach guard: the option list re-renders as the dropdown opens.
   await credentialOption.click({ force: true });
   const confirmed = await confirmPersonalCredentialPinIfPrompted(page);
-  if (!confirmed) {
+  // Close the dropdown only when it is demonstrably still open — a blind
+  // Escape after the dropdown already closed dismisses the edit dialog.
+  if (!confirmed && (await credentialOption.isVisible().catch(() => false))) {
     await page.keyboard.press("Escape");
   }
   await page.waitForTimeout(200);

--- a/platform/helm/archestra/templates/_helpers.tpl
+++ b/platform/helm/archestra/templates/_helpers.tpl
@@ -246,6 +246,18 @@ An explicit archestra.env value overrides the injection.
     secretKeyRef:
       name: {{ include "archestra-platform.authSecretName" $ }}
       key: {{ $key | lower | replace "_" "-" }}
+{{- /*
+optional: the pre-upgrade migrate Job renders from the NEW templates but runs
+BEFORE the upgraded Secret is applied, so on the upgrade that first introduces
+one of these keys the referenced Secret key does not exist yet and a required
+ref would wedge the Job in CreateContainerConfigError until its deadline.
+Migrations don't need the key; app pods start after the Secret update in the
+same apply, and the application's own fail-closed key check (canary) catches a
+genuinely missing key loudly at startup.
+*/}}
+{{- if has $key (list "ARCHESTRA_CONTENT_ENCRYPTION_SECRET" "ARCHESTRA_CONTENT_ENCRYPTION_SECRET_PREVIOUS") }}
+      optional: true
+{{- end }}
 {{- else }}
 - name: {{ $key }}
   value: {{ $value | quote }}


### PR DESCRIPTION
## Summary

The staging deploy for the content-encryption enablement failed: the `pre-upgrade` migrate Job renders from the new templates but runs **before** helm applies the upgraded Secret, so on the first upgrade that sets `ARCHESTRA_CONTENT_ENCRYPTION_SECRET` the Job referenced a Secret key that didn't exist yet. It sat in `CreateContainerConfigError` for its full 600s deadline and `--atomic` rolled the release back. Any deployment enabling content encryption via `archestra.env` would hit the same wedge on its enablement rollout.

Fix: the two content-encryption `secretKeyRef`s are now `optional: true`. Migrations don't need the key; app pods start after the Secret update within the same apply (helm orders Secrets before Deployments); and a genuinely missing key on a database that has encryption enabled is still a loud startup failure via the application's fail-closed canary check — which is the layer that owns that guarantee.

## Test plan
- `helm lint` clean; `helm template` with staging values renders `optional: true` on exactly these refs, valid YAML, value still never plaintext in pod specs.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>

## Also: the merge-queue flake that kicked this PR (twice)

Both ejections failed inside the credential-assignment e2e helpers, on tests untouched by this diff. Root cause: `locator.isVisible()` **ignores** its deprecated `timeout` option and samples one instant, so the personal-credential confirm prompt was caught or missed by render luck — and when missed, the fallback `Escape` closed the edit dialog itself, leaving no Save/Update button to find. The helpers now wait for the prompt properly, only press Escape while the dropdown is demonstrably still open, and wait for the dialog's single submit button with one combined locator. (Four more instant-sample `isVisible({ timeout })` call sites exist in `utils/auth.ts` — left for a follow-up since they haven't kicked anyone yet.)
