### PR TITLE
feat(k8s): report measured NetworkPolicy enforcement, not inferred

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -204126,6 +204126,26 @@
                         "message": {
                           "nullable": true,
                           "type": "string"
+                        },
+                        "enforcementSource": {
+                          "type": "string",
+                          "enum": [
+                            "probe",
+                            "api-discovery"
+                          ]
+                        },
+                        "probe": {
+                          "type": "string",
+                          "enum": [
+                            "enforced",
+                            "not-enforced",
+                            "inconclusive",
+                            "absent"
+                          ]
+                        },
+                        "probedAt": {
+                          "nullable": true,
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -204136,7 +204156,10 @@
                         "provider",
                         "supportsFqdn",
                         "supportsHttpMethods",
-                        "message"
+                        "message",
+                        "enforcementSource",
+                        "probe",
+                        "probedAt"
                       ],
                       "additionalProperties": false
                     }

--- a/platform/backend/src/k8s/capabilities.test.ts
+++ b/platform/backend/src/k8s/capabilities.test.ts
@@ -196,4 +196,125 @@ describe("Kubernetes capability inspection", () => {
 
     expect(customObjectsApi.getAPIResources).toHaveBeenCalledTimes(8);
   });
+
+  describe("with a behavioural enforcement probe", () => {
+    // Verdicts age out, so fixtures are dated relative to now rather than pinned.
+    const PROBED_AT = new Date(Date.now() - 60_000).toISOString();
+
+    function crdsFor(group: string | null, resource?: string) {
+      return {
+        getAPIResources: vi.fn(async ({ group: g }: { group: string }) => ({
+          resources: g === group && resource ? [{ name: resource }] : [],
+        })),
+      };
+    }
+
+    function probeSource(control: string, treatment: string) {
+      return {
+        coreApi: {
+          listNamespacedPod: vi.fn(async () => ({
+            items: [
+              ["control", control],
+              ["treatment", treatment],
+            ].map(([role, message]) => ({
+              metadata: { labels: { "archestra.io/netpol-probe-role": role } },
+              status: {
+                containerStatuses: [
+                  {
+                    state: {
+                      terminated: { message, finishedAt: PROBED_AT },
+                    },
+                  },
+                ],
+              },
+            })),
+          })),
+        } as never,
+        namespace: "archestra",
+      };
+    }
+
+    test("credits enforcement on a cluster whose dataplane publishes no CRD", async () => {
+      // GKE Dataplane V2, kindnet and the EKS VPC CNI enforce the standard API
+      // and advertise nothing, which inference alone reads as "no enforcer" and
+      // uses to disable the egress controls.
+      const capabilities = await getK8sCapabilitiesFromApi(
+        crdsFor(null) as never,
+        probeSource("reachable", "blocked"),
+      );
+
+      expect(capabilities.networkPolicy).toMatchObject({
+        kubernetesNetworkPolicy: true,
+        provider: "kubernetes",
+        supportsFqdn: false,
+        enforcementSource: "probe",
+        probe: "enforced",
+        probedAt: PROBED_AT,
+      });
+    });
+
+    test("overrides installed Calico CRDs when a probe shows nothing enforces", async () => {
+      // GKE serves these CRDs with node enforcement switched off, which is the
+      // state that let egress rules be accepted and silently ignored.
+      const capabilities = await getK8sCapabilitiesFromApi(
+        crdsFor("crd.projectcalico.org", "felixconfigurations") as never,
+        probeSource("reachable", "reachable"),
+      );
+
+      expect(capabilities.networkPolicy).toMatchObject({
+        kubernetesNetworkPolicy: false,
+        provider: "none",
+        supportsFqdn: false,
+        enforcementSource: "probe",
+        probe: "not-enforced",
+      });
+    });
+
+    test("ignores the probe on AWS, where the kind it measures is never enforced", async () => {
+      // The probe uses a plain NetworkPolicy, which the AWS VPC CNI accepts and
+      // ignores, so the treatment arm gets through on a cluster that enforces
+      // via ApplicationNetworkPolicy. Letting that count would drop the provider
+      // to "none" and make the runtime delete the baseline doing the work.
+      const capabilities = await getK8sCapabilitiesFromApi(
+        crdsFor("networking.k8s.aws", "applicationnetworkpolicies") as never,
+        probeSource("reachable", "reachable"),
+      );
+
+      expect(capabilities.networkPolicy).toMatchObject({
+        kubernetesNetworkPolicy: true,
+        provider: "aws-application-network-policy",
+        supportsFqdn: true,
+        awsApplicationNetworkPolicy: true,
+        enforcementSource: "api-discovery",
+      });
+    });
+
+    test("falls back to inference when the probe reached no conclusion", async () => {
+      const capabilities = await getK8sCapabilitiesFromApi(
+        crdsFor("cilium.io", "ciliumnetworkpolicies") as never,
+        probeSource("blocked", "blocked"),
+      );
+
+      expect(capabilities.networkPolicy).toMatchObject({
+        kubernetesNetworkPolicy: true,
+        provider: "cilium",
+        supportsFqdn: true,
+        enforcementSource: "api-discovery",
+        probe: "inconclusive",
+      });
+    });
+
+    test("reports inference when no probe ran at all", async () => {
+      const capabilities = await getK8sCapabilitiesFromApi(
+        crdsFor("cilium.io", "ciliumnetworkpolicies") as never,
+      );
+
+      expect(capabilities.networkPolicy).toMatchObject({
+        provider: "cilium",
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
+      });
+    });
+  });
 });

--- a/platform/backend/src/k8s/capabilities.ts
+++ b/platform/backend/src/k8s/capabilities.ts
@@ -1,6 +1,10 @@
 import type * as k8s from "@kubernetes/client-node";
 import logger from "@/logging";
 import type { K8sCapabilities } from "@/types";
+import {
+  type NetworkPolicyProbeVerdict,
+  networkPolicyProbeReader,
+} from "./network-policy-probe";
 import { createK8sClients, isK8sNotFoundError, loadKubeConfig } from "./shared";
 
 // === Public API ===
@@ -14,6 +18,7 @@ export async function getK8sCapabilities(): Promise<K8sCapabilities> {
     const clients = createK8sClients(kubeConfig, namespace);
     const capabilities = await getK8sCapabilitiesFromApi(
       clients.customObjectsApi,
+      { coreApi: clients.coreApi, namespace: clients.namespace },
     );
     globalCapabilitiesCache = createCacheEntry(capabilities);
     return capabilities;
@@ -23,8 +28,13 @@ export async function getK8sCapabilities(): Promise<K8sCapabilities> {
   }
 }
 
+/**
+ * `probeSource` points at the namespace the chart's enforcement probe runs in.
+ * It is optional so callers without a CoreV1Api still get the inferred answer.
+ */
 export async function getK8sCapabilitiesFromApi(
   customObjectsApi: k8s.CustomObjectsApi,
+  probeSource?: { coreApi: k8s.CoreV1Api; namespace: string },
 ): Promise<K8sCapabilities> {
   const cached = getValidCacheEntry(apiCapabilitiesCache.get(customObjectsApi));
   if (cached) return cached;
@@ -34,24 +44,43 @@ export async function getK8sCapabilitiesFromApi(
     ciliumNetworkPolicy,
     gkeFqdnNetworkPolicy,
     awsApplicationNetworkPolicy,
+    probe,
   ] = await Promise.all([
     hasCalicoNetworkPolicyResource(customObjectsApi),
     hasCiliumNetworkPolicyResource(customObjectsApi),
     hasGkeFqdnNetworkPolicyResource(customObjectsApi),
     hasAwsApplicationNetworkPolicyResource(customObjectsApi),
+    probeSource
+      ? networkPolicyProbeReader.readVerdict(
+          probeSource.coreApi,
+          probeSource.namespace,
+        )
+      : Promise.resolve(NO_PROBE),
   ]);
   const supportsFqdn =
     ciliumNetworkPolicy || gkeFqdnNetworkPolicy || awsApplicationNetworkPolicy;
-  // A NetworkPolicy is only enforced if a dataplane agent backs it. Calico,
-  // Cilium, and the FQDN providers each install a provider-exclusive CRD group
-  // we can discover; absent all of them — e.g. GKE with the NetworkPolicy addon
-  // off, only `netd` running — the API accepts NetworkPolicy objects but nothing
-  // enforces them, so we report "none" rather than a false promise of isolation.
-  // Known limitation: plain GKE Dataplane V2 enforces standard NetworkPolicy but
-  // exposes no discoverable CRD (its FQDN CRD is feature-gated), so it is not
-  // detected here and would report "none". Acceptable while no environment runs
-  // plain Dataplane V2; revisit (probe the `anetd` DaemonSet) if one does.
-  const enforced = supportsFqdn || calicoNetworkPolicy;
+  // Which CRD group the API serves tells us which policy dialect this cluster
+  // speaks, not whether anything acts on the objects. Those come apart in both
+  // directions: GKE serves the Calico CRDs with node enforcement switched off,
+  // while Dataplane V2, kindnet and the EKS VPC CNI enforce the standard API
+  // and publish nothing. So inference only stands in when the probe has no
+  // answer, and it stays the source of the dialect either way.
+  const inferredEnforced = supportsFqdn || calicoNetworkPolicy;
+  // The probe exercises a plain networking.k8s.io NetworkPolicy, so it only
+  // speaks for clusters whose enforcing policy is that kind. On the AWS VPC CNI
+  // a plain NetworkPolicy is accepted and never enforced (see
+  // `shouldUseAwsApplicationNetworkPolicy`), so its verdict there describes a
+  // dialect the runtime deliberately does not use — and letting it win would
+  // drop the provider to "none" and tear down the ApplicationNetworkPolicy
+  // baseline that is doing the actual enforcing.
+  const probeMeasuresTheEnforcingKind = !awsApplicationNetworkPolicy;
+  const probeDecided =
+    probeMeasuresTheEnforcingKind &&
+    (probe.result === "enforced" || probe.result === "not-enforced");
+  const enforced = probeDecided
+    ? probe.result === "enforced"
+    : inferredEnforced;
+  const enforcementSource = probeDecided ? "probe" : "api-discovery";
   const provider = !enforced
     ? "none"
     : ciliumNetworkPolicy
@@ -62,6 +91,15 @@ export async function getK8sCapabilitiesFromApi(
           ? "aws-application-network-policy"
           : "kubernetes";
 
+  if (probeDecided && enforced !== inferredEnforced) {
+    logger.warn(
+      { probe: probe.result, detail: probe.detail, provider },
+      enforced
+        ? "Network policy enforcement was measured on this cluster even though no policy CRD advertises it"
+        : "Network policy CRDs are installed on this cluster but a probe found egress rules are not enforced",
+    );
+  }
+
   const capabilities: K8sCapabilities = {
     networkPolicy: {
       kubernetesNetworkPolicy: enforced,
@@ -69,15 +107,21 @@ export async function getK8sCapabilitiesFromApi(
       gkeFqdnNetworkPolicy,
       awsApplicationNetworkPolicy,
       provider,
-      supportsFqdn,
+      // Only a provider CRD can carry domain rules, so a probe that proves the
+      // standard API is enforced says nothing about FQDN support.
+      supportsFqdn: enforced && supportsFqdn,
       supportsHttpMethods: false,
       message: capabilityMessage({
         enforced,
         ciliumNetworkPolicy,
         gkeFqdnNetworkPolicy,
         awsApplicationNetworkPolicy,
-        supportsFqdn,
+        supportsFqdn: enforced && supportsFqdn,
+        probe: probe.result,
       }),
+      enforcementSource,
+      probe: probe.result,
+      probedAt: probe.probedAt,
     },
   };
   apiCapabilitiesCache.set(customObjectsApi, createCacheEntry(capabilities));
@@ -88,11 +132,19 @@ export async function getK8sCapabilitiesFromApi(
 export function clearK8sCapabilitiesCache(): void {
   globalCapabilitiesCache = null;
   apiCapabilitiesCache = new WeakMap();
+  networkPolicyProbeReader.clearCache();
 }
 
 // === Internal helpers ===
 
 const K8S_CAPABILITIES_CACHE_TTL_MS = 5 * 60 * 1000;
+const PENDING_PROBE_CACHE_TTL_MS = 30 * 1000;
+
+const NO_PROBE: NetworkPolicyProbeVerdict = {
+  result: "absent",
+  probedAt: null,
+  detail: null,
+};
 
 type CacheEntry = {
   expiresAt: number;
@@ -102,7 +154,18 @@ type CacheEntry = {
 let globalCapabilitiesCache: CacheEntry | null = null;
 let apiCapabilitiesCache = new WeakMap<k8s.CustomObjectsApi, CacheEntry>();
 
+/**
+ * A pending verdict expires quickly. The probe runs as a post-install hook, so
+ * the platform starts up before it reports; caching the inferred answer for the
+ * full interval would leave the measured one unused long after it arrived.
+ */
 function createCacheEntry(value: K8sCapabilities): CacheEntry {
+  if (value.networkPolicy.probe === "absent") {
+    return {
+      value,
+      expiresAt: Date.now() + PENDING_PROBE_CACHE_TTL_MS,
+    };
+  }
   return {
     value,
     expiresAt: Date.now() + K8S_CAPABILITIES_CACHE_TTL_MS,
@@ -147,7 +210,16 @@ function capabilityMessage(params: {
   gkeFqdnNetworkPolicy: boolean;
   awsApplicationNetworkPolicy: boolean;
   supportsFqdn: boolean;
+  probe: NetworkPolicyProbeVerdict["result"];
 }): string {
+  // A measured answer is stated as measured; the inferred wording below has to
+  // hedge because serving a policy CRD is not evidence that anything enforces.
+  if (params.probe === "not-enforced") {
+    return "A test pod under a deny-all policy still reached the cluster, so NetworkPolicy objects are accepted but not enforced here.";
+  }
+  if (params.probe === "enforced" && !params.supportsFqdn) {
+    return "NetworkPolicy enforcement confirmed by a test pod. IP/CIDR egress is enforced; domain allowlists require a supported FQDN policy provider.";
+  }
   if (params.ciliumNetworkPolicy) {
     return "CiliumNetworkPolicy API detected. Domain allowlists can be enforced by Cilium.";
   }
@@ -253,6 +325,9 @@ function unavailableCapabilities(): K8sCapabilities {
       supportsHttpMethods: false,
       message:
         "Kubernetes capabilities could not be inspected. Network policy enforcement is unavailable until Kubernetes access is configured.",
+      enforcementSource: "api-discovery",
+      probe: "absent",
+      probedAt: null,
     },
   };
 }

--- a/platform/backend/src/k8s/dagger-environment-runtime/network-policy.test.ts
+++ b/platform/backend/src/k8s/dagger-environment-runtime/network-policy.test.ts
@@ -38,6 +38,9 @@ function caps(
     supportsFqdn: false,
     supportsHttpMethods: false,
     message: null,
+    enforcementSource: "api-discovery",
+    probe: "absent",
+    probedAt: null,
     ...overrides,
   };
 }

--- a/platform/backend/src/k8s/mcp-server-runtime/egress-baseline.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/egress-baseline.test.ts
@@ -18,6 +18,9 @@ function makeCapabilities(
     supportsFqdn: false,
     supportsHttpMethods: false,
     message: null,
+    enforcementSource: "api-discovery",
+    probe: "absent",
+    probedAt: null,
   };
 }
 

--- a/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/k8s-deployment.test.ts
@@ -7,7 +7,11 @@ import { vi } from "vitest";
 import type { z } from "zod";
 import config from "@/config";
 import { describe, expect, test } from "@/test";
-import type { EffectiveNetworkPolicy, McpServer } from "@/types";
+import type {
+  EffectiveNetworkPolicy,
+  K8sNetworkPolicyCapabilities,
+  McpServer,
+} from "@/types";
 import K8sDeployment, {
   fetchPlatformPodNodeSelector,
   fetchPlatformPodTolerations,
@@ -3927,20 +3931,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     customObjectsApi?: Partial<k8s.CustomObjectsApi>;
     coreApi?: Partial<k8s.CoreV1Api>;
     effectiveNetworkPolicy: EffectiveNetworkPolicy;
-    networkPolicyCapabilities: {
-      kubernetesNetworkPolicy: boolean;
-      ciliumNetworkPolicy: boolean;
-      gkeFqdnNetworkPolicy: boolean;
-      awsApplicationNetworkPolicy: boolean;
-      provider:
-        | "kubernetes"
-        | "cilium"
-        | "gke-fqdn"
-        | "aws-application-network-policy";
-      supportsFqdn: boolean;
-      supportsHttpMethods: boolean;
-      message: string | null;
-    };
+    networkPolicyCapabilities: K8sNetworkPolicyCapabilities;
     multitenant?: boolean;
   }): K8sDeployment {
     return new K8sDeployment({
@@ -4191,6 +4182,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
         supportsFqdn: true,
         supportsHttpMethods: false,
         message: null,
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
       },
     });
 
@@ -4249,6 +4243,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
         supportsFqdn: false,
         supportsHttpMethods: false,
         message: null,
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
       },
     });
 
@@ -4287,6 +4284,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
         supportsFqdn: false,
         supportsHttpMethods: false,
         message: null,
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
       },
     });
 
@@ -4323,6 +4323,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
         supportsFqdn: true,
         supportsHttpMethods: false,
         message: null,
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
       },
     });
 
@@ -4369,6 +4372,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
         supportsFqdn: true,
         supportsHttpMethods: false,
         message: null,
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
       },
     });
 
@@ -4429,6 +4435,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
         supportsFqdn: true,
         supportsHttpMethods: false,
         message: null,
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
       },
     });
 
@@ -4455,7 +4464,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
   test("updates an existing Kubernetes NetworkPolicy and cleans up stale duplicate managed policies", async () => {
     const policyName = "mcp-egress-mcp-mcp-test-server";
     const { api, policies } = makeStatefulNetworkingApi();
-    const capabilities = {
+    const capabilities: K8sNetworkPolicyCapabilities = {
       kubernetesNetworkPolicy: true,
       ciliumNetworkPolicy: false,
       gkeFqdnNetworkPolicy: false,
@@ -4464,6 +4473,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
       supportsFqdn: false,
       supportsHttpMethods: false,
       message: null,
+      enforcementSource: "api-discovery",
+      probe: "absent",
+      probedAt: null,
     };
 
     await makeNetworkPolicyDeployment({
@@ -4516,7 +4528,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
         spec: { clusterIP: "172.20.0.10", clusterIPs: ["172.20.0.10"] },
       })),
     };
-    const capabilities = {
+    const capabilities: K8sNetworkPolicyCapabilities = {
       kubernetesNetworkPolicy: true,
       ciliumNetworkPolicy: false,
       gkeFqdnNetworkPolicy: false,
@@ -4525,6 +4537,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
       supportsFqdn: true,
       supportsHttpMethods: false,
       message: null,
+      enforcementSource: "api-discovery",
+      probe: "absent",
+      probedAt: null,
     };
 
     await makeNetworkPolicyDeployment({
@@ -4613,7 +4628,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
         plural: "ciliumnetworkpolicies",
       },
     });
-    const capabilities = {
+    const capabilities: K8sNetworkPolicyCapabilities = {
       kubernetesNetworkPolicy: true,
       ciliumNetworkPolicy: true,
       gkeFqdnNetworkPolicy: false,
@@ -4622,6 +4637,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
       supportsFqdn: true,
       supportsHttpMethods: false,
       message: null,
+      enforcementSource: "api-discovery",
+      probe: "absent",
+      probedAt: null,
     };
 
     await makeNetworkPolicyDeployment({
@@ -4679,7 +4697,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
           plural: "fqdnnetworkpolicies",
         },
       });
-    const capabilities = {
+    const capabilities: K8sNetworkPolicyCapabilities = {
       kubernetesNetworkPolicy: true,
       ciliumNetworkPolicy: false,
       gkeFqdnNetworkPolicy: true,
@@ -4688,6 +4706,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
       supportsFqdn: true,
       supportsHttpMethods: false,
       message: null,
+      enforcementSource: "api-discovery",
+      probe: "absent",
+      probedAt: null,
     };
 
     await makeNetworkPolicyDeployment({
@@ -4761,7 +4782,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
   test("deleting managed network policy also cleans up stale duplicate managed policies", async () => {
     const policyName = "mcp-egress-mcp-mcp-test-server";
     const { api: networkingApi, policies } = makeStatefulNetworkingApi();
-    const capabilities = {
+    const capabilities: K8sNetworkPolicyCapabilities = {
       kubernetesNetworkPolicy: true,
       ciliumNetworkPolicy: false,
       gkeFqdnNetworkPolicy: false,
@@ -4770,6 +4791,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
       supportsFqdn: false,
       supportsHttpMethods: false,
       message: null,
+      enforcementSource: "api-discovery",
+      probe: "absent",
+      probedAt: null,
     };
 
     const deployment = makeNetworkPolicyDeployment({
@@ -4800,7 +4824,7 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     });
   });
 
-  const PLAIN_CAPS = {
+  const PLAIN_CAPS: K8sNetworkPolicyCapabilities = {
     kubernetesNetworkPolicy: true,
     ciliumNetworkPolicy: false,
     gkeFqdnNetworkPolicy: false,
@@ -4809,8 +4833,11 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     supportsFqdn: false,
     supportsHttpMethods: false,
     message: null,
+    enforcementSource: "api-discovery",
+    probe: "absent",
+    probedAt: null,
   };
-  const AWS_CAPS = {
+  const AWS_CAPS: K8sNetworkPolicyCapabilities = {
     kubernetesNetworkPolicy: true,
     ciliumNetworkPolicy: false,
     gkeFqdnNetworkPolicy: false,
@@ -4819,8 +4846,11 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     supportsFqdn: true,
     supportsHttpMethods: false,
     message: null,
+    enforcementSource: "api-discovery",
+    probe: "absent",
+    probedAt: null,
   };
-  const CILIUM_CAPS = {
+  const CILIUM_CAPS: K8sNetworkPolicyCapabilities = {
     kubernetesNetworkPolicy: true,
     ciliumNetworkPolicy: true,
     gkeFqdnNetworkPolicy: false,
@@ -4829,6 +4859,9 @@ describe("K8sDeployment.applyK8sNetworkPolicy", () => {
     supportsFqdn: true,
     supportsHttpMethods: false,
     message: null,
+    enforcementSource: "api-discovery",
+    probe: "absent",
+    probedAt: null,
   };
   const POLICY_NAME = "mcp-egress-mcp-mcp-test-server";
   const DNS_PORTS = [

--- a/platform/backend/src/k8s/mcp-server-runtime/manager.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/manager.ts
@@ -220,7 +220,10 @@ export class McpServerRuntimeManager {
       }
 
       const networkPolicyCapabilities = (
-        await getK8sCapabilitiesFromApi(this.k8sCustomObjectsApi)
+        await getK8sCapabilitiesFromApi(
+          this.k8sCustomObjectsApi,
+          this.networkPolicyProbeSource(),
+        )
       ).networkPolicy;
       const networkPolicyResolutionCache =
         await this.buildNetworkPolicyResolutionCache(localCatalogItems);
@@ -644,8 +647,12 @@ export class McpServerRuntimeManager {
       );
       const networkPolicyCapabilities =
         options?.networkPolicyCapabilities ??
-        (await getK8sCapabilitiesFromApi(this.k8sCustomObjectsApi))
-          .networkPolicy;
+        (
+          await getK8sCapabilitiesFromApi(
+            this.k8sCustomObjectsApi,
+            this.networkPolicyProbeSource(),
+          )
+        ).networkPolicy;
 
       // Ensure the namespace default-deny baseline before the pod exists, so an
       // un-reconciled or apply-failed pod is denied by default rather than open.
@@ -875,7 +882,10 @@ export class McpServerRuntimeManager {
           catalogItem,
         }),
         networkPolicyCapabilities: (
-          await getK8sCapabilitiesFromApi(this.k8sCustomObjectsApi)
+          await getK8sCapabilitiesFromApi(
+            this.k8sCustomObjectsApi,
+            this.networkPolicyProbeSource(),
+          )
         ).networkPolicy,
         k8sExec: this.k8sExec,
       });
@@ -1914,6 +1924,19 @@ export class McpServerRuntimeManager {
       }
     }
     return deploymentsBySelectorId;
+  }
+
+  /**
+   * Where the chart's enforcement probe left its verdict. Threading it through
+   * here keeps the policies this runtime applies and the capabilities the UI
+   * reports based on the same answer about the same cluster.
+   */
+  private networkPolicyProbeSource():
+    | { coreApi: k8s.CoreV1Api; namespace: string }
+    | undefined {
+    return this.k8sApi
+      ? { coreApi: this.k8sApi, namespace: this.namespace }
+      : undefined;
   }
 }
 

--- a/platform/backend/src/k8s/mcp-server-runtime/network-policy.test.ts
+++ b/platform/backend/src/k8s/mcp-server-runtime/network-policy.test.ts
@@ -351,6 +351,9 @@ describe("managed MCP Kubernetes NetworkPolicy", () => {
           supportsFqdn: true,
           supportsHttpMethods: false,
           message: null,
+          enforcementSource: "api-discovery",
+          probe: "absent",
+          probedAt: null,
         },
       }),
     ).toBe(true);
@@ -366,6 +369,9 @@ describe("managed MCP Kubernetes NetworkPolicy", () => {
           supportsFqdn: false,
           supportsHttpMethods: false,
           message: null,
+          enforcementSource: "api-discovery",
+          probe: "absent",
+          probedAt: null,
         },
       }),
     ).toBe(false);
@@ -389,6 +395,9 @@ describe("managed MCP Kubernetes NetworkPolicy", () => {
           supportsFqdn: true,
           supportsHttpMethods: false,
           message: null,
+          enforcementSource: "api-discovery",
+          probe: "absent",
+          probedAt: null,
         },
       }),
     ).toBe(true);
@@ -404,6 +413,9 @@ describe("managed MCP Kubernetes NetworkPolicy", () => {
           supportsFqdn: true,
           supportsHttpMethods: false,
           message: null,
+          enforcementSource: "api-discovery",
+          probe: "absent",
+          probedAt: null,
         },
       }),
     ).toBe(false);
@@ -427,6 +439,9 @@ describe("managed MCP Kubernetes NetworkPolicy", () => {
           supportsFqdn: true,
           supportsHttpMethods: false,
           message: null,
+          enforcementSource: "api-discovery",
+          probe: "absent",
+          probedAt: null,
         },
       }),
     ).toBe(true);
@@ -442,6 +457,9 @@ describe("managed MCP Kubernetes NetworkPolicy", () => {
           supportsFqdn: true,
           supportsHttpMethods: false,
           message: null,
+          enforcementSource: "api-discovery",
+          probe: "absent",
+          probedAt: null,
         },
       }),
     ).toBe(false);
@@ -457,6 +475,9 @@ describe("managed MCP Kubernetes NetworkPolicy", () => {
       supportsFqdn: true,
       supportsHttpMethods: false,
       message: null,
+      enforcementSource: "api-discovery" as const,
+      probe: "absent" as const,
+      probedAt: null,
     };
     expect(
       shouldUseAwsApplicationNetworkPolicy({

--- a/platform/backend/src/k8s/network-policy-probe.test.ts
+++ b/platform/backend/src/k8s/network-policy-probe.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { networkPolicyProbeReader } from "./network-policy-probe";
+
+// Verdicts age out, so fixtures are dated relative to now rather than pinned.
+const RECENTLY = new Date(Date.now() - 60_000).toISOString();
+
+function probePod(role: "control" | "treatment", message?: string) {
+  return {
+    metadata: { labels: { "archestra.io/netpol-probe-role": role } },
+    status: {
+      containerStatuses: [
+        {
+          state: {
+            terminated:
+              message === undefined
+                ? undefined
+                : { message, finishedAt: RECENTLY },
+          },
+        },
+      ],
+    },
+  };
+}
+
+function coreApiReturning(items: unknown[]) {
+  return {
+    listNamespacedPod: vi.fn(async () => ({ items })),
+  };
+}
+
+describe("network policy enforcement probe", () => {
+  afterEach(() => {
+    networkPolicyProbeReader.clearCache();
+  });
+
+  test("a deny-all that blocks a path the control reached proves enforcement", async () => {
+    const coreApi = coreApiReturning([
+      probePod("control", "reachable"),
+      probePod("treatment", "blocked"),
+    ]);
+
+    const verdict = await networkPolicyProbeReader.readVerdict(
+      coreApi as never,
+      "archestra",
+    );
+
+    expect(coreApi.listNamespacedPod).toHaveBeenCalledWith({
+      namespace: "archestra",
+      labelSelector: "app.kubernetes.io/component=netpol-probe",
+    });
+    expect(verdict.result).toBe("enforced");
+    expect(verdict.probedAt).toBe(RECENTLY);
+    expect(verdict.detail).toBe("control=reachable treatment=blocked");
+  });
+
+  test("reaching the target through a deny-all proves nothing enforces", async () => {
+    const coreApi = coreApiReturning([
+      probePod("control", "reachable"),
+      probePod("treatment", "reachable"),
+    ]);
+
+    const verdict = await networkPolicyProbeReader.readVerdict(
+      coreApi as never,
+      "archestra",
+    );
+
+    expect(verdict.result).toBe("not-enforced");
+  });
+
+  test("a control that never reached the target settles nothing either way", async () => {
+    const coreApi = coreApiReturning([
+      probePod("control", "blocked"),
+      probePod("treatment", "blocked"),
+    ]);
+
+    const verdict = await networkPolicyProbeReader.readVerdict(
+      coreApi as never,
+      "archestra",
+    );
+
+    // The treatment arm was never offered a path that worked, so its silence
+    // carries no information about enforcement.
+    expect(verdict.result).toBe("inconclusive");
+    expect(verdict.result).not.toBe("enforced");
+    expect(verdict.result).not.toBe("not-enforced");
+  });
+
+  test.each([
+    ["no probe has run", []],
+    ["only one arm reported", [probePod("control", "reachable")]],
+    [
+      "an arm was killed before writing its result",
+      [probePod("control", "reachable"), probePod("treatment")],
+    ],
+    [
+      "an arm wrote something unrecognised",
+      [probePod("control", "reachable"), probePod("treatment", "¯\\_(ツ)_/¯")],
+    ],
+  ])("reports absent when %s", async (_case, items) => {
+    const verdict = await networkPolicyProbeReader.readVerdict(
+      coreApiReturning(items) as never,
+      "archestra",
+    );
+
+    expect(verdict.result).toBe("absent");
+    expect(verdict.probedAt).toBeNull();
+  });
+
+  test("a cluster it cannot read is never reported as unenforced", async () => {
+    const coreApi = {
+      listNamespacedPod: vi.fn().mockRejectedValue({ statusCode: 403 }),
+    };
+
+    const verdict = await networkPolicyProbeReader.readVerdict(
+      coreApi as never,
+      "archestra",
+    );
+
+    // Calling a cluster nobody could reach "not enforced" would be a confident
+    // claim on no evidence.
+    expect(verdict.result).toBe("absent");
+    expect(verdict.result).not.toBe("not-enforced");
+  });
+
+  test("stops trusting a verdict once it is too old to describe the cluster", async () => {
+    const stale = {
+      metadata: { labels: { "archestra.io/netpol-probe-role": "treatment" } },
+      status: {
+        containerStatuses: [
+          {
+            state: {
+              terminated: {
+                message: "blocked",
+                finishedAt: new Date(
+                  Date.now() - 8 * 24 * 60 * 60 * 1000,
+                ).toISOString(),
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const verdict = await networkPolicyProbeReader.readVerdict(
+      coreApiReturning([probePod("control", "reachable"), stale]) as never,
+      "archestra",
+    );
+
+    // An aged "enforced" would keep hiding the warning on a cluster that has
+    // since lost enforcement.
+    expect(verdict.result).toBe("inconclusive");
+    expect(verdict.result).not.toBe("enforced");
+  });
+
+  test("answers from the newest run when an old release left its pods behind", async () => {
+    const retired = (role: "control" | "treatment", message: string) => ({
+      metadata: { labels: { "archestra.io/netpol-probe-role": role } },
+      status: {
+        containerStatuses: [
+          {
+            state: {
+              terminated: {
+                message,
+                finishedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const verdict = await networkPolicyProbeReader.readVerdict(
+      coreApiReturning([
+        // Hook pods survive `helm uninstall`, so both runs can coexist.
+        retired("control", "reachable"),
+        retired("treatment", "blocked"),
+        probePod("control", "reachable"),
+        probePod("treatment", "reachable"),
+      ]) as never,
+      "archestra",
+    );
+
+    expect(verdict.result).toBe("not-enforced");
+    expect(verdict.probedAt).toBe(RECENTLY);
+  });
+
+  test("rechecks sooner while no verdict has landed yet", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-31T00:00:00.000Z"));
+    const coreApi = coreApiReturning([]);
+
+    await networkPolicyProbeReader.readVerdict(coreApi as never, "archestra");
+    vi.advanceTimersByTime(31_000);
+    await networkPolicyProbeReader.readVerdict(coreApi as never, "archestra");
+
+    // The probe reports after the platform is already up, so a pending result
+    // must not be held for the full interval.
+    expect(coreApi.listNamespacedPod).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  test("caches the verdict per API client", async () => {
+    const coreApi = coreApiReturning([
+      probePod("control", "reachable"),
+      probePod("treatment", "blocked"),
+    ]);
+
+    await networkPolicyProbeReader.readVerdict(coreApi as never, "archestra");
+    await networkPolicyProbeReader.readVerdict(coreApi as never, "archestra");
+
+    expect(coreApi.listNamespacedPod).toHaveBeenCalledTimes(1);
+  });
+});

--- a/platform/backend/src/k8s/network-policy-probe.ts
+++ b/platform/backend/src/k8s/network-policy-probe.ts
@@ -1,0 +1,179 @@
+import type * as k8s from "@kubernetes/client-node";
+import logger from "@/logging";
+
+// === Public API ===
+
+export type NetworkPolicyProbeResult =
+  | "enforced"
+  | "not-enforced"
+  | "inconclusive"
+  | "absent";
+
+export interface NetworkPolicyProbeVerdict {
+  result: NetworkPolicyProbeResult;
+  /** When the treatment arm ran, for reporting how current the answer is. */
+  probedAt: string | null;
+  /** Short human summary of the two arms, e.g. "control=reachable treatment=blocked". */
+  detail: string | null;
+}
+
+/**
+ * Reads the verdict left behind by the chart's NetworkPolicy enforcement probe.
+ *
+ * The chart runs two pods after each install/upgrade against the same target,
+ * with a deny-all egress policy selecting only one of them. Comparing the arms
+ * answers a question no API surface can: the Kubernetes API accepts
+ * NetworkPolicy objects whether or not a dataplane enforces them, GKE serves the
+ * Calico CRDs with node enforcement switched off, and Dataplane V2, kindnet and
+ * the EKS VPC CNI all enforce while publishing no CRD at all.
+ *
+ * Each pod records its own arm in its container's termination message, because
+ * the treatment pod is network-isolated by construction and cannot reach the API
+ * server to report; the kubelet copies the message into pod status on its behalf.
+ */
+class NetworkPolicyProbeReader {
+  private cache = new WeakMap<
+    k8s.CoreV1Api,
+    { expiresAt: number; value: NetworkPolicyProbeVerdict }
+  >();
+
+  async readVerdict(
+    coreApi: k8s.CoreV1Api,
+    namespace: string,
+  ): Promise<NetworkPolicyProbeVerdict> {
+    const cached = this.cache.get(coreApi);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    const verdict = await this.loadVerdict(coreApi, namespace);
+    // The probe runs as a post-install hook, so the platform is already serving
+    // by the time it reports. Holding "no result yet" for the full interval
+    // would keep the inferred answer in place well after the real one landed.
+    this.cache.set(coreApi, {
+      value: verdict,
+      expiresAt:
+        Date.now() +
+        (verdict.result === "absent"
+          ? PENDING_PROBE_CACHE_TTL_MS
+          : PROBE_CACHE_TTL_MS),
+    });
+    return verdict;
+  }
+
+  /** @internal exported for tests */
+  clearCache(): void {
+    this.cache = new WeakMap();
+  }
+
+  // === Private helpers ===
+
+  private async loadVerdict(
+    coreApi: k8s.CoreV1Api,
+    namespace: string,
+  ): Promise<NetworkPolicyProbeVerdict> {
+    let pods: k8s.V1Pod[];
+    try {
+      const list = await coreApi.listNamespacedPod({
+        namespace,
+        labelSelector: PROBE_LABEL_SELECTOR,
+      });
+      pods = list.items ?? [];
+    } catch (error) {
+      // Reporting "not enforced" here would state, on no evidence, that a
+      // cluster nobody could reach is insecure.
+      logger.debug(
+        { err: error, namespace },
+        "Failed to list network policy probe pods",
+      );
+      return absent("probe pods could not be listed");
+    }
+
+    const control = armOutcome(pods, "control");
+    const treatment = armOutcome(pods, "treatment");
+    const detail = `control=${control ?? "none"} treatment=${treatment ?? "none"}`;
+
+    if (control === null || treatment === null) {
+      return absent(detail);
+    }
+    const measuredAt = probedAt(pods);
+    // A verdict only describes the cluster as it was when the probe ran. Left to
+    // stand indefinitely, an old "enforced" would keep the warning hidden on a
+    // cluster that has since lost enforcement, so an aged result gives way to
+    // whatever the API can still be asked directly.
+    if (
+      measuredAt &&
+      Date.now() - Date.parse(measuredAt) > MAX_VERDICT_AGE_MS
+    ) {
+      return { result: "inconclusive", probedAt: measuredAt, detail };
+    }
+    if (control === "blocked") {
+      // The target never came up, so the treatment arm was never given a
+      // reachable path to be denied and its result carries no information.
+      return { result: "inconclusive", probedAt: measuredAt, detail };
+    }
+    return {
+      result: treatment === "reachable" ? "not-enforced" : "enforced",
+      probedAt: measuredAt,
+      detail,
+    };
+  }
+}
+
+export const networkPolicyProbeReader = new NetworkPolicyProbeReader();
+
+// === Internal helpers ===
+
+const PROBE_CACHE_TTL_MS = 5 * 60 * 1000;
+const PENDING_PROBE_CACHE_TTL_MS = 30 * 1000;
+
+/**
+ * How long a verdict is trusted. The probe reruns on every install and upgrade,
+ * so anything older than this belongs to a cluster nobody has deployed to in a
+ * week and should no longer speak for its current state.
+ */
+const MAX_VERDICT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Must match `archestra-platform.networkPolicyProbeLabels` in the chart. */
+const PROBE_LABEL_SELECTOR = "app.kubernetes.io/component=netpol-probe";
+const PROBE_ROLE_LABEL = "archestra.io/netpol-probe-role";
+
+type ArmOutcome = "reachable" | "blocked";
+
+function absent(detail: string): NetworkPolicyProbeVerdict {
+  return { result: "absent", probedAt: null, detail };
+}
+
+/**
+ * The arm's own report, or null when it has not finished. A pod that was
+ * evicted, OOM-killed or deadline-exceeded leaves no message, and a half-run
+ * probe must not be scored.
+ */
+function armOutcome(pods: k8s.V1Pod[], role: string): ArmOutcome | null {
+  const message = terminatedState(pods, role)?.message?.trim();
+  return message === "reachable" || message === "blocked" ? message : null;
+}
+
+function probedAt(pods: k8s.V1Pod[]): string | null {
+  const finishedAt = terminatedState(pods, "treatment")?.finishedAt;
+  return finishedAt ? new Date(finishedAt).toISOString() : null;
+}
+
+/**
+ * The latest run of an arm. Hook pods survive `helm uninstall`, so a namespace
+ * can hold pods from a release that is no longer installed; taking the newest
+ * keeps a retired run from answering for the cluster as it is now.
+ */
+function terminatedState(
+  pods: k8s.V1Pod[],
+  role: string,
+): k8s.V1ContainerStateTerminated | undefined {
+  return pods
+    .filter((pod) => pod.metadata?.labels?.[PROBE_ROLE_LABEL] === role)
+    .map((pod) => pod.status?.containerStatuses?.[0]?.state?.terminated)
+    .filter((state) => state?.finishedAt)
+    .sort(
+      (a, b) =>
+        Date.parse(String(b?.finishedAt)) - Date.parse(String(a?.finishedAt)),
+    )[0];
+}

--- a/platform/backend/src/routes/k8s-capabilities.test.ts
+++ b/platform/backend/src/routes/k8s-capabilities.test.ts
@@ -68,6 +68,9 @@ describe("k8s capabilities routes", () => {
         supportsFqdn: true,
         supportsHttpMethods: false,
         message: "CiliumNetworkPolicy API detected.",
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
       },
     });
     const user = await makeUser();
@@ -90,6 +93,9 @@ describe("k8s capabilities routes", () => {
         supportsFqdn: true,
         supportsHttpMethods: false,
         message: "CiliumNetworkPolicy API detected.",
+        enforcementSource: "api-discovery",
+        probe: "absent",
+        probedAt: null,
       },
     });
   });

--- a/platform/backend/src/types/environment.ts
+++ b/platform/backend/src/types/environment.ts
@@ -102,6 +102,13 @@ export const K8sNetworkPolicyCapabilitiesSchema = z.object({
   supportsFqdn: z.boolean(),
   supportsHttpMethods: z.boolean(),
   message: z.string().nullable(),
+  // Whether enforcement was measured by the chart's probe or merely inferred
+  // from which policy CRDs the API serves. Inference cannot distinguish a
+  // cluster that enforces from one that only stores the objects, so the UI
+  // words its warning differently depending on which answer it has.
+  enforcementSource: z.enum(["probe", "api-discovery"]),
+  probe: z.enum(["enforced", "not-enforced", "inconclusive", "absent"]),
+  probedAt: z.string().nullable(),
 });
 
 export const K8sCapabilitiesSchema = z.object({

--- a/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
+++ b/platform/frontend/src/app/mcp/registry/_parts/environments-section.tsx
@@ -2,7 +2,7 @@
 
 import { DocsPage, getDocsUrl } from "@archestra/shared";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Info, Pencil, Plus, Trash2, X } from "lucide-react";
+import { Info, Pencil, Plus, Trash2, TriangleAlert, X } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog";
@@ -838,6 +838,10 @@ function EnvironmentEditorDialog({
             }}
             supportsFqdn={supportsFqdn}
             provider={capabilities?.networkPolicy.provider ?? null}
+            enforcementMeasured={
+              capabilities?.networkPolicy.enforcementSource === "probe"
+            }
+            probedAt={capabilities?.networkPolicy.probedAt ?? null}
             baselineLoaded={egressBaselineLoaded}
             disabled={isPending || !egressBaselineLoaded}
           />
@@ -880,6 +884,8 @@ function NetworkPolicyFields({
   setAllowedCidrsText,
   supportsFqdn,
   provider,
+  enforcementMeasured,
+  probedAt,
   baselineLoaded,
   disabled,
 }: {
@@ -893,6 +899,8 @@ function NetworkPolicyFields({
   setAllowedCidrsText: (value: string) => void;
   supportsFqdn: boolean;
   provider: string | null;
+  enforcementMeasured: boolean;
+  probedAt: string | null;
   baselineLoaded: boolean;
   disabled: boolean;
 }) {
@@ -902,7 +910,30 @@ function NetworkPolicyFields({
   const enforcementUnavailable = provider === "none";
   return (
     <div className="space-y-4">
-      {enforcementUnavailable ? (
+      {enforcementUnavailable && enforcementMeasured ? (
+        <Alert variant="warning">
+          <TriangleAlert className="h-4 w-4" />
+          <AlertTitle>This cluster does not enforce network policy</AlertTitle>
+          <AlertDescription className="block leading-6">
+            A test pod under a deny-all policy still reached the network
+            {probedAt ? (
+              <>
+                {" on "}
+                {/* Rendered as the raw date rather than a locale string, which
+                    would differ between the server pass and the browser. */}
+                <time dateTime={probedAt}>{probedAt.slice(0, 10)}</time>
+              </>
+            ) : null}
+            <span>
+              , so egress rules would be accepted and then ignored. These
+              controls stay disabled until the cluster enforces NetworkPolicy.
+            </span>{" "}
+            <ExternalDocsLink href={NETWORK_POLICY_DOCS_URL}>
+              View docs
+            </ExternalDocsLink>
+          </AlertDescription>
+        </Alert>
+      ) : enforcementUnavailable ? (
         <Alert variant="info">
           <Info className="h-4 w-4" />
           <AlertTitle>Network policy enforcement unavailable</AlertTitle>

--- a/platform/frontend/src/mocks/handlers.ts
+++ b/platform/frontend/src/mocks/handlers.ts
@@ -176,6 +176,9 @@ export const handlers: HttpHandler[] = [
       supportsFqdn: false,
       supportsHttpMethods: false,
       message: null,
+      enforcementSource: "probe",
+      probe: "enforced",
+      probedAt: "2026-01-01T00:00:00.000Z",
     },
   }),
 

--- a/platform/shared/hey-api/clients/api/types.gen.ts
+++ b/platform/shared/hey-api/clients/api/types.gen.ts
@@ -52114,6 +52114,9 @@ export type GetK8sCapabilitiesResponses = {
             supportsFqdn: boolean;
             supportsHttpMethods: boolean;
             message: string | null;
+            enforcementSource: 'probe' | 'api-discovery';
+            probe: 'enforced' | 'not-enforced' | 'inconclusive' | 'absent';
+            probedAt: string | null;
         };
     };
 };


### PR DESCRIPTION
Whether a cluster enforces `NetworkPolicy` was inferred from which policy CRD it served. That answers which dialect a cluster speaks, not whether anything acts on the objects, and it was wrong in both directions: GKE with the Calico addon on but node enforcement off looked healthy while storing and ignoring every egress rule, and Dataplane V2, kindnet and the EKS VPC CNI enforce while publishing no CRD, so the egress controls were greyed out on clusters that work.

#7026 measures it instead. This reads that verdict from the probe pods' container termination messages and lets it decide whether enforcement exists, while CRD discovery keeps deciding the dialect and FQDN support. `GET /api/k8s/capabilities` gains `enforcementSource`, `probe` and `probedAt`, and the environments editor now states that a test pod under a deny-all policy still reached the network instead of hedging that no enforcer was detected "or Kubernetes access isn't configured".

With no verdict — probe disabled, pods reaped, an inconclusive run, or an API error — the response is byte-identical to before, so clusters that never run the probe are unaffected. No RBAC changes; the platform ServiceAccount already has `pods get/list` in its namespace.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>
