### PR TITLE
fix(security): stop exporting plaintext content on OTel spans when encryption at rest is on

### DIFF
--- a/docs/pages/platform-deployment.md
+++ b/docs/pages/platform-deployment.md
@@ -1371,7 +1371,7 @@ A2A task streams work across replicas. A client can subscribe on one replica whi
   - Example: `your-bearer-token`
 
 - **`ARCHESTRA_OTEL_CAPTURE_CONTENT`** - Enable or disable prompt/completion content capture in trace spans.
-  - Default: `true` (enabled)
+  - Default: `true` (enabled) — **unless [content encryption at rest](/docs/platform-secrets-management#content-encryption-at-rest-enterprise) is configured, in which case the default flips to `false`**: exporting the same content in plaintext to a telemetry backend would bypass the at-rest guarantee. Setting `true` explicitly still enables capture (for telemetry pipelines protected to the same standard) and logs a startup warning.
   - Set to `false` to disable content capture for privacy or to reduce span sizes
 
 - **`ARCHESTRA_OTEL_CONTENT_MAX_LENGTH`** - Maximum character length for captured content in span events (prompt messages, completions, tool arguments, tool results).

--- a/docs/pages/platform-observability.md
+++ b/docs/pages/platform-observability.md
@@ -139,7 +139,7 @@ If none of the authentication environment variables are configured, traces will 
 
 ### Content Capture
 
-Archestra can capture prompt/completion content and tool call arguments/results as span events for full audit trail visibility. This is enabled by default and can be disabled via the `ARCHESTRA_OTEL_CAPTURE_CONTENT` [environment variable](/docs/platform-deployment#observability--metrics).
+Archestra can capture prompt/completion content and tool call arguments/results as span events for full audit trail visibility. This is enabled by default and can be disabled via the `ARCHESTRA_OTEL_CAPTURE_CONTENT` [environment variable](/docs/platform-deployment#observability--metrics). When [content encryption at rest](/docs/platform-secrets-management#content-encryption-at-rest-enterprise) is configured, capture defaults to **off** instead — encrypted database content should not leave for the telemetry backend in plaintext — and only an explicit `ARCHESTRA_OTEL_CAPTURE_CONTENT=true` re-enables it (with a startup warning).
 
 When enabled, traces include:
 

--- a/docs/pages/platform-secrets-management.md
+++ b/docs/pages/platform-secrets-management.md
@@ -43,10 +43,11 @@ See [`ARCHESTRA_SECRETS_ENCRYPTION_SECRET`](./platform-deployment#authentication
 
 Beyond stored secrets, Archestra can encrypt conversation content at rest: LLM proxy request/response payloads (the LLM Logs records) and chat message bodies. Set `ARCHESTRA_CONTENT_ENCRYPTION_SECRET` — a key separate from the stored-secrets key, so a security team can hold it in their own vault and map it to the environment variable at deploy time. Encryption and decryption are transparent; rows written before enablement are encrypted by a background sweep.
 
-Two behaviors change while encryption is on:
+Three behaviors change while encryption is on:
 
 - Conversation search matches titles only — message bodies are ciphertext.
 - Claude Code request delta-compression is disabled for new records, so LLM log storage grows faster. Pair encryption with [data retention](./platform-deployment#data-retention).
+- OTel spans stop carrying message/tool content by default — the [`ARCHESTRA_OTEL_CAPTURE_CONTENT`](./platform-deployment#observability--metrics) default flips to `false` so plaintext content does not reach the telemetry backend while the database copies are encrypted. An explicit `true` re-enables capture (see the [observability docs](./platform-observability)) and logs a startup warning.
 
 **Enabling on a running deployment** takes two rollouts, so replicas never mix encrypted writes with readers that lack the key: first deploy with the key in `ARCHESTRA_CONTENT_ENCRYPTION_SECRET_PREVIOUS` (decrypt-capable everywhere, writes unchanged), then move it to `ARCHESTRA_CONTENT_ENCRYPTION_SECRET`. After the second rollout finishes, run `pnpm --filter backend db:reencrypt-content` once: replicas that had not yet restarted during the rollout may have written a few plaintext rows behind the background sweep, and an explicit run always re-verifies the full table.
 

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -152,6 +152,11 @@ ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_USERNAME=""
 ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_PASSWORD=""
 # OTEL Authentication - Bearer token (takes precedence over basic auth if provided)
 ARCHESTRA_OTEL_EXPORTER_OTLP_AUTH_BEARER=""
+# Prompt/completion/tool content on trace spans. Defaults to true — unless
+# content encryption at rest (ARCHESTRA_CONTENT_ENCRYPTION_SECRET) is
+# configured, which flips the default to false. An explicit true always wins
+# and logs a startup warning under encryption.
+# ARCHESTRA_OTEL_CAPTURE_CONTENT=true
 
 # TCP port for the metrics server (defaults to 9050). Override if the default port collides with another local service.
 # ARCHESTRA_METRICS_PORT=9050

--- a/platform/backend/src/config.test.ts
+++ b/platform/backend/src/config.test.ts
@@ -50,6 +50,7 @@ import config, {
   parseMetricsPort,
   parseNonNegativeInt,
   parseOptionalPort,
+  parseOtelCaptureContent,
   parseProcessType,
   parseRefreshTokenReuseGraceSeconds,
   parseRetentionDays,
@@ -2866,5 +2867,46 @@ describe("parseNonNegativeInt", () => {
   test("accepts positive values and rejects negative ones", () => {
     expect(parseNonNegativeInt("30", 90)).toBe(30);
     expect(parseNonNegativeInt("-5", 90)).toBe(90);
+  });
+});
+
+describe("parseOtelCaptureContent", () => {
+  test("defaults on without content encryption, off with it", () => {
+    expect(
+      parseOtelCaptureContent({
+        envValue: undefined,
+        contentEncryptionConfigured: false,
+      }),
+    ).toBe(true);
+    expect(
+      parseOtelCaptureContent({
+        envValue: undefined,
+        contentEncryptionConfigured: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("an explicit value always wins over the encryption default", () => {
+    expect(
+      parseOtelCaptureContent({
+        envValue: "true",
+        contentEncryptionConfigured: true,
+      }),
+    ).toBe(true);
+    expect(
+      parseOtelCaptureContent({
+        envValue: "false",
+        contentEncryptionConfigured: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("junk values take the default path, not the explicit one", () => {
+    expect(
+      parseOtelCaptureContent({
+        envValue: "yes",
+        contentEncryptionConfigured: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/platform/backend/src/config.ts
+++ b/platform/backend/src/config.ts
@@ -1176,6 +1176,30 @@ export const parseRetentionDays = (
   return Number.parseInt(value, 10);
 };
 
+// SPDX-SnippetBegin
+// SPDX-SnippetCopyrightText: 2026 Archestra Inc.
+// SPDX-License-Identifier: LicenseRef-Archestra-Enterprise
+/**
+ * Whether OTel spans may carry message/tool content (gen_ai.content.*).
+ *
+ * Content encryption at rest flips the DEFAULT to false: exporting the same
+ * content in plaintext to a telemetry backend would bypass the at-rest
+ * guarantee through a side door. An EXPLICIT `true` still wins — the operator
+ * may run an equally protected telemetry pipeline — and the encryption boot
+ * guard logs a warning for that combination so the choice is always visible.
+ * @public — exported for testability
+ */
+export const parseOtelCaptureContent = (params: {
+  envValue: string | undefined;
+  contentEncryptionConfigured: boolean;
+}): boolean => {
+  const value = params.envValue?.trim();
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return !params.contentEncryptionConfigured;
+};
+// SPDX-SnippetEnd
+
 /**
  * Parse a Kubernetes resource quantity (memory/CPU/ephemeral-storage) from an
  * environment variable, falling back to the default when unset or invalid.
@@ -2497,7 +2521,12 @@ const config = {
   },
   observability: {
     otel: {
-      captureContent: process.env.ARCHESTRA_OTEL_CAPTURE_CONTENT !== "false",
+      captureContent: parseOtelCaptureContent({
+        envValue: process.env.ARCHESTRA_OTEL_CAPTURE_CONTENT,
+        contentEncryptionConfigured: Boolean(
+          process.env.ARCHESTRA_CONTENT_ENCRYPTION_SECRET,
+        ),
+      }),
       contentMaxLength: parseContentMaxLength(
         process.env.ARCHESTRA_OTEL_CONTENT_MAX_LENGTH,
       ),

--- a/platform/backend/src/content-encryption/content-encryption.test.ts
+++ b/platform/backend/src/content-encryption/content-encryption.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/logging");
 import { sql } from "drizzle-orm";
 import config from "@/config";
 import db, { schema } from "@/database";
+import logger from "@/logging";
 // biome-ignore lint/style/noRestrictedImports: dual-licensed code under test
 import ContentEncryptionStateModel from "@/models/content-encryption-state.ee";
 import EncryptionKeyCanaryModel from "@/models/encryption-key-canary";
@@ -306,6 +307,27 @@ describe("content encryption", () => {
       setKeys(SECRET_A);
       await verifyContentEncryptionKey();
       expect(await EncryptionKeyCanaryModel.get("content")).not.toBeNull();
+    });
+
+    test("explicit OTel content capture under encryption warns at boot", async () => {
+      const originalCapture = config.observability.otel.captureContent;
+      try {
+        setKeys(SECRET_A);
+        config.observability.otel.captureContent = true;
+        await verifyContentEncryptionKey();
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining("ARCHESTRA_OTEL_CAPTURE_CONTENT"),
+        );
+
+        vi.clearAllMocks();
+        config.observability.otel.captureContent = false;
+        await verifyContentEncryptionKey();
+        expect(logger.warn).not.toHaveBeenCalledWith(
+          expect.stringContaining("ARCHESTRA_OTEL_CAPTURE_CONTENT"),
+        );
+      } finally {
+        config.observability.otel.captureContent = originalCapture;
+      }
     });
 
     test("canary present but key removed fails startup (fail-closed)", async () => {

--- a/platform/backend/src/content-encryption/guard.ee.ts
+++ b/platform/backend/src/content-encryption/guard.ee.ts
@@ -46,6 +46,18 @@ export async function verifyContentEncryptionKey(): Promise<void> {
     );
   }
 
+  // Encryption flips the content-capture DEFAULT off (config.ts); reaching
+  // here with capture on means the operator explicitly opted back in. Keep
+  // that visible: plaintext prompts/completions/tool payloads are leaving for
+  // the telemetry backend while the database copies are encrypted.
+  if (secret && config.observability.otel.captureContent) {
+    logger.warn(
+      "ARCHESTRA_OTEL_CAPTURE_CONTENT=true overrides the encryption-at-rest " +
+        "default: message and tool content is exported in plaintext on OTel " +
+        "spans. Ensure the telemetry backend is protected accordingly.",
+    );
+  }
+
   const canary = await EncryptionKeyCanaryModel.get("content");
 
   if (!canary) {


### PR DESCRIPTION
## Summary

Span content capture reads the live in-memory request, so with content encryption at rest enabled, the same prompts/completions/tool payloads the database stores encrypted were still exported to the OTLP endpoint in plaintext by default — a side door around the at-rest guarantee.

Now, when `ARCHESTRA_CONTENT_ENCRYPTION_SECRET` is configured, the `ARCHESTRA_OTEL_CAPTURE_CONTENT` default flips to `false` (no `gen_ai.content.*` prompt/completion events, no MCP tool input/output events). An **explicit** `ARCHESTRA_OTEL_CAPTURE_CONTENT=true` still wins — an operator may run a telemetry pipeline protected to the same standard — and the encryption boot guard logs a startup warning for that combination so the choice is always visible. Junk values take the default path rather than counting as an explicit opt-in.

Docs updated and cross-linked: the deployment page's env-var entry, the observability page's content-capture section, and the secrets-management encryption section (its behavior-changes list). `.env.example` gains the previously-missing `ARCHESTRA_OTEL_CAPTURE_CONTENT` entry.

## Test plan
- `parseOtelCaptureContent` matrix: default on without encryption, off with it; explicit true/false always win; junk values take the default path.
- Boot-guard test: explicit capture under encryption warns; capture off does not.
- Full config + content-encryption suites pass; type-check, lint, knip clean.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>