### PR TITLE
fix(account): show why the sessions list is unavailable instead of an empty card

### DIFF
--- a/platform/backend/src/auth/list-sessions-freshness.test.ts
+++ b/platform/backend/src/auth/list-sessions-freshness.test.ts
@@ -1,0 +1,66 @@
+import { APIError } from "better-auth/api";
+import { makeSignature } from "better-auth/crypto";
+import { betterAuth } from "@/auth";
+import config from "@/config";
+import { describe, expect, test } from "@/test";
+
+const DAY_MS = 86_400_000;
+
+async function sessionCookieHeaders(sessionToken: string) {
+  if (!config.auth.secret) {
+    throw new Error("Auth secret is not configured");
+  }
+  const ctx = await betterAuth.$context;
+  const signature = await makeSignature(sessionToken, config.auth.secret);
+  return new Headers({
+    cookie: `${ctx.authCookies.sessionToken.name}=${encodeURIComponent(
+      `${sessionToken}.${signature}`,
+    )}`,
+  });
+}
+
+/**
+ * `/list-sessions` returns every session's raw token, so Better Auth guards it
+ * with a freshness check: a session older than `freshAge` (24h by default) is
+ * refused even though it is still valid for everything else. Sessions live 7
+ * days, so an account spends most of its life in that state — which is why the
+ * Sessions card has a re-authentication state rather than just a list.
+ */
+describe("listSessions session freshness", () => {
+  test("refuses a session older than freshAge", async ({
+    makeUser,
+    makeSession,
+  }) => {
+    const user = await makeUser();
+    const session = await makeSession(user.id, {
+      createdAt: new Date(Date.now() - 2 * DAY_MS),
+      expiresAt: new Date(Date.now() + 5 * DAY_MS),
+    });
+
+    const listStale = betterAuth.api.listSessions({
+      headers: await sessionCookieHeaders(session.token),
+    });
+
+    await expect(listStale).rejects.toThrow(APIError);
+    await expect(listStale).rejects.toMatchObject({
+      body: { code: "SESSION_NOT_FRESH" },
+    });
+  });
+
+  test("lists sessions for a session within freshAge", async ({
+    makeUser,
+    makeSession,
+  }) => {
+    const user = await makeUser();
+    const session = await makeSession(user.id, {
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 7 * DAY_MS),
+    });
+
+    const sessions = await betterAuth.api.listSessions({
+      headers: await sessionCookieHeaders(session.token),
+    });
+
+    expect(sessions.map((s) => s.id)).toContain(session.id);
+  });
+});

--- a/platform/backend/src/test/fixtures.ts
+++ b/platform/backend/src/test/fixtures.ts
@@ -823,6 +823,7 @@ async function makeSession(
       | "userAgent"
       | "activeOrganizationId"
       | "impersonatedBy"
+      | "createdAt"
     >
   > = {},
 ) {

--- a/platform/frontend/src/app/account/_components/sessions-card.test.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRouter } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authQueryKeys } from "@/lib/auth/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
 import { SessionsCard } from "./sessions-card";
 
@@ -23,11 +24,14 @@ function renderCard() {
     },
   });
 
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <SessionsCard />
-    </QueryClientProvider>,
-  );
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <SessionsCard />
+      </QueryClientProvider>,
+    ),
+    queryClient,
+  };
 }
 
 describe("SessionsCard", () => {
@@ -64,6 +68,111 @@ describe("SessionsCard", () => {
       data: {},
       error: null,
     } as Awaited<ReturnType<typeof authClient.revokeSession>>);
+  });
+
+  it("shows loading skeletons while sessions are still being fetched", () => {
+    vi.mocked(authClient.listSessions).mockReturnValue(
+      new Promise(() => {}) as ReturnType<typeof authClient.listSessions>,
+    );
+
+    const { container } = renderCard();
+
+    expect(
+      container.querySelectorAll('[data-slot="skeleton"]').length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Revoke" })).toBeNull();
+  });
+
+  it("asks the user to sign in again when the session is too old to list sessions", async () => {
+    vi.mocked(authClient.listSessions).mockResolvedValue({
+      data: null,
+      error: { message: "Session is not fresh", code: "SESSION_NOT_FRESH" },
+    } as Awaited<ReturnType<typeof authClient.listSessions>>);
+
+    renderCard();
+
+    expect(
+      await screen.findByText(/sign in again to manage your sessions/i),
+    ).toBeInTheDocument();
+    // The failure must not be presented as "you have no other sessions".
+    expect(screen.queryByRole("button", { name: "Revoke" })).toBeNull();
+
+    // The panel tells the user to sign out, so it has to offer the way there.
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Sign Out" }));
+    expect(mockRouterPush).toHaveBeenCalledWith("/auth/sign-out");
+  });
+
+  it("offers a retry when sessions fail to load for any other reason", async () => {
+    vi.mocked(authClient.listSessions).mockResolvedValue({
+      data: null,
+      error: { message: "Internal Server Error", status: 500 },
+    } as Awaited<ReturnType<typeof authClient.listSessions>>);
+
+    const user = userEvent.setup();
+    renderCard();
+
+    const retry = await screen.findByRole("button", { name: /retry/i });
+    expect(screen.queryByRole("button", { name: "Revoke" })).toBeNull();
+
+    // Retrying must re-hit the API, and a recovered request must render rows.
+    vi.mocked(authClient.listSessions).mockResolvedValue({
+      data: [
+        {
+          id: "session-other",
+          token: "token-other",
+          userAgent: CHROME_MAC_UA,
+          ipAddress: "10.0.0.2",
+        },
+      ],
+      error: null,
+    } as Awaited<ReturnType<typeof authClient.listSessions>>);
+
+    await user.click(retry);
+
+    expect(
+      await screen.findByRole("button", { name: "Revoke" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps showing the list when a background refetch fails", async () => {
+    const { queryClient } = renderCard();
+    await screen.findByText("Current session");
+
+    vi.mocked(authClient.listSessions).mockResolvedValue({
+      data: null,
+      error: { message: "Session is not fresh", code: "SESSION_NOT_FRESH" },
+    } as Awaited<ReturnType<typeof authClient.listSessions>>);
+    await queryClient.refetchQueries({ queryKey: authQueryKeys.sessions() });
+
+    await waitFor(() => {
+      expect(authClient.listSessions).toHaveBeenCalledTimes(2);
+    });
+    // A refetch failure must not swap a working card for an error panel.
+    expect(screen.getByText("Current session")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/sign in again to manage your sessions/i),
+    ).toBeNull();
+  });
+
+  it("removes a revoked session even if the follow-up refetch fails", async () => {
+    const user = userEvent.setup();
+    renderCard();
+    const revoke = await screen.findByRole("button", { name: "Revoke" });
+
+    // The invalidation refetch that follows the revoke fails.
+    vi.mocked(authClient.listSessions).mockResolvedValue({
+      data: null,
+      error: { message: "Internal Server Error", status: 500 },
+    } as Awaited<ReturnType<typeof authClient.listSessions>>);
+    await user.click(revoke);
+
+    // The revoked row must not survive as "signed in" after we said it was gone.
+    await waitFor(() => {
+      expect(screen.queryByText("10.0.0.2")).toBeNull();
+    });
+    expect(screen.getByText("Current session")).toBeInTheDocument();
   });
 
   it("labels the current session and describes devices from the user agent", async () => {

--- a/platform/frontend/src/app/account/_components/sessions-card.tsx
+++ b/platform/frontend/src/app/account/_components/sessions-card.tsx
@@ -1,14 +1,24 @@
 "use client";
 
-import { Laptop, Loader2, Smartphone } from "lucide-react";
+import { KeyRound, Laptop, Loader2, Smartphone } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { UAParser } from "ua-parser-js";
 import { LoadingSkeletons } from "@/components/loading";
+import { QueryLoadError } from "@/components/query-load-error";
 import { SettingsCardHeader } from "@/components/settings/settings-block";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import { useSession } from "@/lib/auth/auth.query";
 import {
+  StaleSessionError,
   useListSessions,
   useRevokeSessionMutation,
 } from "@/lib/auth/sessions.query";
@@ -20,7 +30,15 @@ import {
 export function SessionsCard() {
   const router = useRouter();
   const { data: session } = useSession();
-  const { data: sessions, isPending } = useListSessions();
+  // isLoadingError, not isError: a failed background refetch keeps the last
+  // good list on screen rather than replacing a working card with an error.
+  const {
+    data: sessions,
+    isPending,
+    isLoadingError,
+    error,
+    refetch,
+  } = useListSessions();
   const revokeSession = useRevokeSessionMutation();
 
   return (
@@ -32,6 +50,34 @@ export function SessionsCard() {
       <CardContent className="space-y-3">
         {isPending ? (
           <LoadingSkeletons rows={2} />
+        ) : isLoadingError && error instanceof StaleSessionError ? (
+          <Empty className="py-6">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <KeyRound />
+              </EmptyMedia>
+              <EmptyTitle>Sign in again to manage your sessions</EmptyTitle>
+              <EmptyDescription>
+                For your security, this list is only available shortly after you
+                sign in. Sign out and back in to see where your account is
+                signed in.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button
+                variant="outline"
+                onClick={() => router.push("/auth/sign-out")}
+              >
+                Sign Out
+              </Button>
+            </EmptyContent>
+          </Empty>
+        ) : isLoadingError ? (
+          <QueryLoadError
+            className="py-6"
+            title="Couldn't load your sessions"
+            onRetry={() => refetch()}
+          />
         ) : (
           (sessions ?? []).map((accountSession) => {
             const isCurrentSession = accountSession.id === session?.session?.id;

--- a/platform/frontend/src/lib/auth/sessions.query.ts
+++ b/platform/frontend/src/lib/auth/sessions.query.ts
@@ -2,16 +2,30 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { authQueryKeys } from "@/lib/auth/auth.query";
 import { authClient } from "@/lib/clients/auth/auth-client";
+import { throwOnApiError } from "@/lib/utils";
+
+/**
+ * Better Auth refuses `/list-sessions` for a session older than its freshness
+ * window. Only signing in again clears it, so callers surface it as its own
+ * state rather than offering a retry that is guaranteed to fail.
+ */
+export class StaleSessionError extends Error {
+  constructor() {
+    super("Session is not fresh");
+    this.name = "StaleSessionError";
+  }
+}
 
 export function useListSessions() {
   return useQuery({
     queryKey: authQueryKeys.sessions(),
     queryFn: async () => {
       const { data, error } = await authClient.listSessions();
-      if (error) {
-        toast.error(error.message ?? "Failed to load sessions");
-        return [];
+      if (isSessionNotFreshError(error)) {
+        throw new StaleSessionError();
       }
+      // The card renders its own error state, so skip the toast.
+      throwOnApiError(error, { toastOnError: false });
       return data ?? [];
     },
   });
@@ -35,12 +49,29 @@ export function useRevokeSessionMutation() {
       }
       return true;
     },
-    onSuccess: async (revoked) => {
+    onSuccess: async (revoked, { token }) => {
       if (!revoked) return;
       toast.success("Session revoked");
+      // Drop the row up front: the refetch below can fail, and the card keeps
+      // its last good list on a refetch failure, which would otherwise leave a
+      // session we just told the user was revoked still showing as signed in.
+      queryClient.setQueryData(
+        authQueryKeys.sessions(),
+        (current: { token: string }[] | undefined) =>
+          current?.filter((session) => session.token !== token),
+      );
       await queryClient.invalidateQueries({
         queryKey: authQueryKeys.sessions(),
       });
     },
   });
+}
+
+function isSessionNotFreshError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "SESSION_NOT_FRESH"
+  );
 }


### PR DESCRIPTION
## Summary

The Sessions card on `/account` rendered a blank panel whenever its request failed, because `useListSessions` collapsed any API error into `return []`. TanStack Query stored that as a *successful* query holding an empty array, so `isPending` went false and the card fell through to its normal list branch with nothing to render — a failed fetch was indistinguishable from "this account has no sessions", with no error, no retry, and no explanation.

This is reachable in ordinary use rather than an edge case. Better Auth guards `/list-sessions` with a freshness check — the response body carries every session's raw token — and `freshAge` defaults to 24h while sessions here live 7 days. A session older than a day gets `403 SESSION_NOT_FRESH` while remaining perfectly valid for everything else, so the card was broken for six of every seven days. `/revoke-session` is not freshness-gated, which is why revoking still worked while listing did not.

`useListSessions` now fails loud via `throwOnApiError` and tags the freshness refusal as `StaleSessionError`. The card renders a panel naming that specific cause with a sign-out button, since signing in again is the only thing that clears it, and a retry panel for any other failure. Both are gated on `isLoadingError` rather than `isError`, so a failed *background* refetch keeps an already-rendered list on screen instead of replacing a working card. `useRevokeSessionMutation` drops the revoked row from the cache before invalidating, so a session the user was just told was revoked cannot linger as "signed in" if that follow-up refetch fails.

The backend is unchanged: the freshness gate stays exactly as upstream intends, and nothing new is sent to the browser.

## Screenshots

<img width="718" height="456" alt="image" src="https://github.com/user-attachments/assets/48d2d258-5b2a-4328-aaee-b8730c9672b3" />


---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>