### PR TITLE
test: reset enterpriseTier singleton between tests to fix flaky enterprise gate

### DIFF
--- a/platform/backend/src/test/setup.ts
+++ b/platform/backend/src/test/setup.ts
@@ -63,12 +63,21 @@ let pgliteClient: PGlite | null = null;
 // the baseline the way a first-file beforeAll capture could.
 let liveConfig: Record<string, unknown> | null = null;
 let pristineConfig: Record<string, unknown> | null = null;
+// enterpriseTier is a module-level singleton whose userCount is shared across
+// every clean-project file in an isolate:false worker. Nothing resets it
+// between tests (unlike config), so a file that bumps it via
+// setUserCountForTesting leaks its enterprise gate into later files. Captured
+// via deferred import for the same reason as config: a static top-level import
+// would pull config.ts before the env above is set.
+type EnterpriseTierRef = typeof import("../enterprise-tier.js").enterpriseTier;
+let enterpriseTier: EnterpriseTierRef | null = null;
 if (process.env.ARCHESTRA_TEST_SHARED_WORKERS === "true") {
   liveConfig = (await import("../config.js")).default as unknown as Record<
     string,
     unknown
   >;
   pristineConfig = structuredClone(liveConfig);
+  enterpriseTier = (await import("../enterprise-tier.js")).enterpriseTier;
 }
 let testDb: ReturnType<typeof drizzle> | null = null;
 const originalConsoleWarn = console.warn;
@@ -151,6 +160,15 @@ beforeEach(async () => {
   // test or, in shared workers, the next file.
   if (liveConfig && pristineConfig) {
     restoreConfig(liveConfig, structuredClone(pristineConfig));
+  }
+
+  // Reset the enterpriseTier singleton to userCount 0 (small-team => enterprise
+  // active), its pristine default. Nothing else clears it between tests, so a
+  // userCount another clean file left at 9999 would flip the enterprise gate
+  // off here; shuffle makes which test loses the race random => flaky. The gate
+  // is read at request time, so a beforeEach reset closes the whole window.
+  if (enterpriseTier) {
+    enterpriseTier.setUserCountForTesting(0);
   }
 
   // Get all user tables from the database (excluding system tables)


### PR DESCRIPTION
## Summary

`Backend Unit Tests` intermittently failed in `teams.test.ts` — an external-group-sync test would hit the `"Team Sync is an enterprise feature"` licensing gate instead of the business error it asserts. It reproduced on unrelated PRs in the merge queue, so it was blocking integration.

`enterpriseTier` (`src/enterprise-tier.ts`) is a module-level singleton. Its enterprise "core" gate is active when `config.enterpriseFeatures.core` is set **or** `userCount < 30` (small-team); in tests only the small-team path applies, so every enterprise-dependent test silently relies on `userCount` staying low. But `teams.test.ts` has no `vi.mock`, so it runs in the `isolate:false` "clean" vitest project where worker threads **share the module cache** — making `enterpriseTier.userCount` process-shared across files.

The shared test setup restores `config` before every test but never reset `enterpriseTier`. So a `userCount` another clean file left at `9999` (e.g. `better-auth.test.ts`'s `setEnterpriseLicense(false)`, which has no reset) leaked in and deactivated the gate. With `sequence.shuffle` enabled, which enterprise test observed the stale value was random run-to-run — hence the flakiness, and why only a single test failed each time.

The fix resets `enterpriseTier` to its pristine default (`userCount` 0 → small-team → enterprise active) in the shared `beforeEach`, mirroring the existing per-test `config` restore. The gate is read at request time, so a `beforeEach` reset closes the whole window; the singleton is captured via a deferred import for the same reason `config` is (a static top-level import would load `config.ts` before the setup file sets its env).

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>