### PR TITLE
fix(account): stop the account card flashing content before the role loads

### DIFF
--- a/platform/frontend/src/components/settings/role-permissions-card.test.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.test.tsx
@@ -46,6 +46,63 @@ describe("RolePermissionsCard", () => {
     } as unknown as ReturnType<typeof useSession>);
   });
 
+  it("keeps the skeleton up while the organization is still resolving", () => {
+    vi.mocked(useActiveOrganization).mockReturnValue({
+      data: undefined,
+      isPending: true,
+    } as unknown as ReturnType<typeof useActiveOrganization>);
+    // A dependent query that is still disabled reports isLoading false with no
+    // data, so the gate cannot rely on isLoading alone.
+    vi.mocked(useActiveMemberRole).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isPending: true,
+    } as unknown as ReturnType<typeof useActiveMemberRole>);
+
+    const { container } = render(<RolePermissionsCard />);
+
+    expect(
+      container.querySelectorAll('[data-slot="skeleton"]').length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("Original Name")).toBeNull();
+  });
+
+  it("keeps the skeleton up until the role arrives for a resolved organization", () => {
+    // isLoading false with no data covers both halves of the wait: the query
+    // still disabled, and the moment it enables. Gating on isLoading renders
+    // the card here and then snaps it back to a skeleton.
+    vi.mocked(useActiveMemberRole).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isPending: true,
+    } as unknown as ReturnType<typeof useActiveMemberRole>);
+
+    const { container } = render(<RolePermissionsCard />);
+
+    expect(
+      container.querySelectorAll('[data-slot="skeleton"]').length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("Original Name")).toBeNull();
+  });
+
+  it("renders the account details when the user has no active organization", () => {
+    vi.mocked(useActiveOrganization).mockReturnValue({
+      data: null,
+      isPending: false,
+    } as unknown as ReturnType<typeof useActiveOrganization>);
+    // With no organization id the role query never enables, so it stays pending
+    // forever — the card must not wait on it.
+    vi.mocked(useActiveMemberRole).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isPending: true,
+    } as unknown as ReturnType<typeof useActiveMemberRole>);
+
+    render(<RolePermissionsCard />);
+
+    expect(screen.getByText("Original Name")).toBeInTheDocument();
+  });
+
   it("updates the account name from the top account section", async () => {
     render(<RolePermissionsCard />);
 

--- a/platform/frontend/src/components/settings/role-permissions-card.tsx
+++ b/platform/frontend/src/components/settings/role-permissions-card.tsx
@@ -72,14 +72,20 @@ const actionLabels: Record<Action, string> = {
 
 export function RolePermissionsCard() {
   const { data: session } = useSession();
-  const { data: activeOrg } = useActiveOrganization();
-  const { data: role, isLoading: isRoleLoading } = useActiveMemberRole(
+  const { data: activeOrg, isPending: isOrgPending } = useActiveOrganization();
+  const { data: role, isPending: isRolePending } = useActiveMemberRole(
     activeOrg?.id,
   );
   const { data: permissions, isLoading: isPermissionsLoading } =
     useAllPermissions();
 
-  const isLoading = isRoleLoading || isPermissionsLoading;
+  // The role query only enables once the organization resolves, and a disabled
+  // query reports isLoading false with no data — gating on that renders the
+  // card, then snaps it back to a skeleton when the role finally fetches.
+  // isPending stays true across both waits; guard it on the organization id so
+  // a user without one is not stuck on a skeleton the role can never clear.
+  const isLoading =
+    isOrgPending || (!!activeOrg?.id && isRolePending) || isPermissionsLoading;
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary

The first card on `/account` (Name / Email / Role plus the permissions list) rendered its content, reverted to a loading skeleton, then rendered again on every page load. Because the card sits at the top of the stack, each swing moved it between 226px and 531px and shoved API Keys, MCP Gateway/A2A Gateway Token and Sessions down and back up with it — the page visibly settles twice before it is usable.

The cause is a dependent-query gate. `useActiveMemberRole` is `enabled: !!organizationId` and only turns on once `useActiveOrganization` resolves, but in TanStack Query `isLoading` is `isPending && isFetching`, so a query that is still *disabled* reports `isLoading: false` with no data. Gating the skeleton on that made the card treat "the role has not been requested yet" as "the role is loaded", render with `role` falling back to `—`, and then snap back to a skeleton once the query enabled and began fetching.

`isPending` stays true across both the disabled wait and the fetch, so gating on it renders the card exactly once. It is guarded on the organization id: a user with no active organization never enables the role query, and an unguarded `isPending` would leave them on a skeleton nothing can ever clear.

The card's single remaining skeleton-to-content growth is unchanged, as is the sidebar footer shift; neither oscillates.

---
<!-- archestra-banner:v1 -->
<a href="https://archestra.ai/contributor-onboard" rel="nofollow noreferrer noopener" target="_blank">

<img alt="Archestra Contributor" src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/archestra-contributor-banner.webp"/>

</a>